### PR TITLE
Allows plugins to register controllers

### DIFF
--- a/src/Core/Framework/Plugin.php
+++ b/src/Core/Framework/Plugin.php
@@ -31,11 +31,13 @@ use Shopware\Core\Framework\Plugin\Context\DeactivateContext;
 use Shopware\Core\Framework\Plugin\Context\InstallContext;
 use Shopware\Core\Framework\Plugin\Context\UninstallContext;
 use Shopware\Core\Framework\Plugin\Context\UpdateContext;
+use Shopware\Core\Kernel;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 use Symfony\Component\HttpKernel\Bundle\BundleInterface;
+use Symfony\Component\Routing\RouteCollectionBuilder;
 
 class Plugin extends Bundle
 {
@@ -117,6 +119,15 @@ class Plugin extends Bundle
     {
         $this->registerFilesystem($container, 'private');
         $this->registerFilesystem($container, 'public');
+    }
+
+    public function configureRoutes(RouteCollectionBuilder $routes, string $environment): void
+    {
+        $confDir = $this->getPath() . '/Resources';
+
+        $routes->import($confDir . '/{routes}/*' . Kernel::CONFIG_EXTS, '/', 'glob');
+        $routes->import($confDir . '/{routes}/' . $environment . '/**/*' . Kernel::CONFIG_EXTS, '/', 'glob');
+        $routes->import($confDir . '/{routes}' . Kernel::CONFIG_EXTS, '/', 'glob');
     }
 
     public function getContainerPrefix(): string

--- a/src/Core/Kernel.php
+++ b/src/Core/Kernel.php
@@ -152,6 +152,7 @@ class Kernel extends HttpKernel
         $routes->import($confDir . '/{routes}' . self::CONFIG_EXTS, '/', 'glob');
 
         $this->addApiRoutes($routes);
+        $this->addPluginRoutes($routes);
     }
 
     /**
@@ -274,6 +275,13 @@ class Kernel extends HttpKernel
         $route->setDefault('_controller', $class . '::create');
         $route->addRequirements(['path' => '.*', 'version' => '\d+']);
         $routes->addRoute($route, 'api_controller.create');
+    }
+
+    private function addPluginRoutes(RouteCollectionBuilder $routes): void
+    {
+        foreach (static::$plugins->getActives() as $plugin) {
+            $plugin->configureRoutes($routes, (string)$this->environment);
+        }
     }
 
     private function initializePluginSystem(): void


### PR DESCRIPTION
Fixes #2.

The configureRoutes method on the Plugin-definition can be
overwritten/extended as desired. By default, it adds all
route-like files within the Resources directory, in a similar
manner the Kernel does so for the global routes within
/config/routes.