### PR TITLE
Add support for arbitrary price calculators based on price definitions.

### DIFF
--- a/src/Core/Checkout/Cart/Price/AbsolutePriceCalculator.php
+++ b/src/Core/Checkout/Cart/Price/AbsolutePriceCalculator.php
@@ -2,13 +2,15 @@
 
 namespace Shopware\Core\Checkout\Cart\Price;
 
+use Shopware\Core\Checkout\Cart\Price\Struct\AbsolutePriceDefinition;
 use Shopware\Core\Checkout\Cart\Price\Struct\Price;
 use Shopware\Core\Checkout\Cart\Price\Struct\PriceCollection;
+use Shopware\Core\Checkout\Cart\Price\Struct\PriceDefinitionInterface;
 use Shopware\Core\Checkout\Cart\Price\Struct\QuantityPriceDefinition;
 use Shopware\Core\Checkout\Cart\Tax\PercentageTaxRuleBuilder;
 use Shopware\Core\Checkout\CheckoutContext;
 
-class AbsolutePriceCalculator
+class AbsolutePriceCalculator implements PriceCalculatorInterface
 {
     /**
      * @var QuantityPriceCalculator
@@ -26,11 +28,23 @@ class AbsolutePriceCalculator
         $this->percentageTaxRuleBuilder = $percentageTaxRuleBuilder;
     }
 
-    public function calculate(float $price, PriceCollection $prices, CheckoutContext $context): Price
+    public function supports(PriceDefinitionInterface $priceDefinition): bool
+    {
+        return $priceDefinition instanceof AbsolutePriceDefinition;
+    }
+
+    /**
+     * @param AbsolutePriceDefinition $priceDefinition
+     * @param PriceCollection         $prices
+     * @param CheckoutContext         $context
+     *
+     * @return Price
+     */
+    public function calculate(PriceDefinitionInterface $priceDefinition, PriceCollection $prices, CheckoutContext $context): Price
     {
         $taxRules = $this->percentageTaxRuleBuilder->buildRules($prices->sum());
 
-        $priceDefinition = new QuantityPriceDefinition($price, $taxRules, 1, true);
+        $priceDefinition = new QuantityPriceDefinition($priceDefinition->getPrice(), $taxRules, 1, true);
 
         return $this->priceCalculator->calculate($priceDefinition, $context);
     }

--- a/src/Core/Checkout/Cart/Price/PercentagePriceCalculator.php
+++ b/src/Core/Checkout/Cart/Price/PercentagePriceCalculator.php
@@ -2,13 +2,15 @@
 
 namespace Shopware\Core\Checkout\Cart\Price;
 
+use Shopware\Core\Checkout\Cart\Price\Struct\PercentagePriceDefinition;
 use Shopware\Core\Checkout\Cart\Price\Struct\Price;
 use Shopware\Core\Checkout\Cart\Price\Struct\PriceCollection;
+use Shopware\Core\Checkout\Cart\Price\Struct\PriceDefinitionInterface;
 use Shopware\Core\Checkout\Cart\Price\Struct\QuantityPriceDefinition;
 use Shopware\Core\Checkout\Cart\Tax\PercentageTaxRuleBuilder;
 use Shopware\Core\Checkout\CheckoutContext;
 
-class PercentagePriceCalculator
+class PercentagePriceCalculator implements PriceCalculatorInterface
 {
     /**
      * @var PriceRounding
@@ -35,18 +37,25 @@ class PercentagePriceCalculator
         $this->percentageTaxRuleBuilder = $percentageTaxRuleBuilder;
     }
 
+    public function supports(PriceDefinitionInterface $priceDefinition): bool
+    {
+        return $priceDefinition instanceof PercentagePriceDefinition;
+    }
+
     /**
      * Provide a negative percentage value for discount or a positive percentage value for a surcharge
      *
-     * @param float           $percentage 10.00 for 10%, -10.0 for -10%
-     * @param PriceCollection $prices
-     * @param CheckoutContext $context
+     * @param PercentagePriceDefinition $priceDefinition
+     * @param PriceCollection           $prices
+     * @param CheckoutContext           $context
      *
      * @return Price
      */
-    public function calculate($percentage, PriceCollection $prices, CheckoutContext $context): Price
+    public function calculate(PriceDefinitionInterface $priceDefinition, PriceCollection $prices, CheckoutContext $context): Price
     {
         $price = $prices->sum();
+
+        $percentage = $priceDefinition->getPercentage();
 
         $discount = $this->rounding->round($price->getTotalPrice() / 100 * $percentage);
 

--- a/src/Core/Checkout/Cart/Price/PriceCalculatorInterface.php
+++ b/src/Core/Checkout/Cart/Price/PriceCalculatorInterface.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Checkout\Cart\Price;
+
+use Shopware\Core\Checkout\Cart\Price\Struct\Price;
+use Shopware\Core\Checkout\Cart\Price\Struct\PriceCollection;
+use Shopware\Core\Checkout\Cart\Price\Struct\PriceDefinitionInterface;
+use Shopware\Core\Checkout\CheckoutContext;
+
+interface PriceCalculatorInterface
+{
+    public function supports(PriceDefinitionInterface $priceDefinition): bool;
+
+    public function calculate(PriceDefinitionInterface $priceDefinition, PriceCollection $prices, CheckoutContext $context): Price;
+}

--- a/src/Core/Checkout/Cart/Price/Struct/PercentagePriceDefinition.php
+++ b/src/Core/Checkout/Cart/Price/Struct/PercentagePriceDefinition.php
@@ -8,7 +8,7 @@ use Shopware\Core\Framework\Struct\Struct;
 class PercentagePriceDefinition extends Struct implements PriceDefinitionInterface
 {
     /**
-     * @var float
+     * @var float 10.00 for 10%, -10.0 for -10%
      */
     protected $percentage;
 

--- a/src/Core/Checkout/Cart/Price/Struct/PriceDefinitionInterface.php
+++ b/src/Core/Checkout/Cart/Price/Struct/PriceDefinitionInterface.php
@@ -2,6 +2,9 @@
 
 namespace Shopware\Core\Checkout\Cart\Price\Struct;
 
+use Shopware\Core\Framework\Rule\Rule;
+
 interface PriceDefinitionInterface
 {
+    public function getFilter(): ?Rule;
 }

--- a/src/Core/Checkout/Cart/Price/Struct/QuantityPriceDefinition.php
+++ b/src/Core/Checkout/Cart/Price/Struct/QuantityPriceDefinition.php
@@ -3,6 +3,7 @@
 namespace Shopware\Core\Checkout\Cart\Price\Struct;
 
 use Shopware\Core\Checkout\Cart\Tax\Struct\TaxRuleCollection;
+use Shopware\Core\Framework\Rule\Rule;
 use Shopware\Core\Framework\Struct\Struct;
 
 class QuantityPriceDefinition extends Struct implements PriceDefinitionInterface
@@ -62,5 +63,10 @@ class QuantityPriceDefinition extends Struct implements PriceDefinitionInterface
     public function setQuantity(int $quantity): void
     {
         $this->quantity = $quantity;
+    }
+
+    public function getFilter(): ?Rule
+    {
+        return null;
     }
 }

--- a/src/Core/Checkout/DependencyInjection/cart.xml
+++ b/src/Core/Checkout/DependencyInjection/cart.xml
@@ -51,12 +51,14 @@
         </service>
 
         <service class="Shopware\Core\Checkout\Cart\Price\PercentagePriceCalculator" id="Shopware\Core\Checkout\Cart\Price\PercentagePriceCalculator">
+            <tag name="Shopware\Core\Checkout\Cart\Price\PriceCalculatorInterface"/>
             <argument type="service" id="Shopware\Core\Checkout\Cart\Price\PriceRounding"/>
             <argument type="service" id="Shopware\Core\Checkout\Cart\Price\QuantityPriceCalculator"/>
             <argument type="service" id="Shopware\Core\Checkout\Cart\Tax\PercentageTaxRuleBuilder"/>
         </service>
 
         <service class="Shopware\Core\Checkout\Cart\Price\AbsolutePriceCalculator" id="Shopware\Core\Checkout\Cart\Price\AbsolutePriceCalculator">
+            <tag name="Shopware\Core\Checkout\Cart\Price\PriceCalculatorInterface"/>
             <argument type="service" id="Shopware\Core\Checkout\Cart\Price\QuantityPriceCalculator"/>
             <argument type="service" id="Shopware\Core\Checkout\Cart\Tax\PercentageTaxRuleBuilder"/>
         </service>
@@ -131,8 +133,7 @@
 
         <service class="Shopware\Core\Checkout\Cart\Calculator" id="Shopware\Core\Checkout\Cart\Calculator" public="true">
             <argument type="service" id="Shopware\Core\Checkout\Cart\Price\QuantityPriceCalculator"/>
-            <argument type="service" id="Shopware\Core\Checkout\Cart\Price\PercentagePriceCalculator"/>
-            <argument type="service" id="Shopware\Core\Checkout\Cart\Price\AbsolutePriceCalculator"/>
+            <argument type="tagged" tag="Shopware\Core\Checkout\Cart\Price\PriceCalculatorInterface"/>
         </service>
 
         <service class="Shopware\Core\Checkout\Cart\Enrichment" id="Shopware\Core\Checkout\Cart\Enrichment" public="true">

--- a/src/Core/Checkout/Test/Cart/Price/AbsolutePriceCalculatorTest.php
+++ b/src/Core/Checkout/Test/Cart/Price/AbsolutePriceCalculatorTest.php
@@ -8,6 +8,7 @@ use Shopware\Core\Checkout\Cart\Price\GrossPriceCalculator;
 use Shopware\Core\Checkout\Cart\Price\NetPriceCalculator;
 use Shopware\Core\Checkout\Cart\Price\PriceRounding;
 use Shopware\Core\Checkout\Cart\Price\QuantityPriceCalculator;
+use Shopware\Core\Checkout\Cart\Price\Struct\AbsolutePriceDefinition;
 use Shopware\Core\Checkout\Cart\Price\Struct\Price;
 use Shopware\Core\Checkout\Cart\Price\Struct\PriceCollection;
 use Shopware\Core\Checkout\Cart\Tax\PercentageTaxRuleBuilder;
@@ -54,8 +55,10 @@ class AbsolutePriceCalculatorTest extends TestCase
             new PercentageTaxRuleBuilder()
         );
 
+        $priceDefinition = new AbsolutePriceDefinition($price);
+
         $calculatedPrice = $calculator->calculate(
-            $price,
+            $priceDefinition,
             $prices,
             Generator::createCheckoutContext()
         );

--- a/src/Core/Checkout/Test/Cart/Price/PercentagePriceCalculatorTest.php
+++ b/src/Core/Checkout/Test/Cart/Price/PercentagePriceCalculatorTest.php
@@ -8,6 +8,7 @@ use Shopware\Core\Checkout\Cart\Price\NetPriceCalculator;
 use Shopware\Core\Checkout\Cart\Price\PercentagePriceCalculator;
 use Shopware\Core\Checkout\Cart\Price\PriceRounding;
 use Shopware\Core\Checkout\Cart\Price\QuantityPriceCalculator;
+use Shopware\Core\Checkout\Cart\Price\Struct\PercentagePriceDefinition;
 use Shopware\Core\Checkout\Cart\Price\Struct\Price;
 use Shopware\Core\Checkout\Cart\Price\Struct\PriceCollection;
 use Shopware\Core\Checkout\Cart\Tax\PercentageTaxRuleBuilder;
@@ -52,8 +53,10 @@ class PercentagePriceCalculatorTest extends TestCase
             new PercentageTaxRuleBuilder()
         );
 
+        $priceDefinition = new PercentagePriceDefinition($percentage);
+
         $price = $calculator->calculate(
-            $percentage,
+            $priceDefinition,
             $prices,
             Generator::createCheckoutContext()
         );


### PR DESCRIPTION
Unfortunately the `QuantityPriceCalculator` currently takes on a rather special role in the whole application, so I thought it more prudent to enable arbitrary calculators first and leave a refactoring for "later" ;-)