### PR TITLE
Replace router item of listing component while it is being mounted

### DIFF
--- a/src/Administration/Resources/administration/src/app/mixin/listing.mixin.js
+++ b/src/Administration/Resources/administration/src/app/mixin/listing.mixin.js
@@ -71,10 +71,18 @@ Mixin.register('listing', {
                 delete params.criteria;
             }
 
-            this.$router.push({
+            const route = {
                 name: this.routeName,
                 query: params
-            });
+            };
+
+            // Don't push another item onto the stack, if the component has not been mounted yet, to prevent duplicate
+            // items that effectively load the same list
+            if (typeof this.$el === 'undefined') {
+                this.$router.replace(route);
+            } else {
+                this.$router.push(route);
+            }
         },
 
         getListingParams() {


### PR DESCRIPTION
Currently opening any listing component (customers, orders, product etc.) pushes two routing items onto the stack:

1. `/sw/<listing_type>/index` and
2. `/sw/<listing_type>/index?limit=25&page=1`.

This breaks the browser navigation because going back one page from the listing just results in the listing again.

This PR fixes the described behaviour by changing the listing mixin to replace the last routing item instead of pushing another one while the component is being mounted, since `updateRoute()` is first called in `created()` to setup the default query parameters.