### PR TITLE
Fix sorting of order listing

### DIFF
--- a/src/Administration/Resources/administration/src/module/sw-order/page/sw-order-list/sw-order-list.html.twig
+++ b/src/Administration/Resources/administration/src/module/sw-order/page/sw-order-list/sw-order-list.html.twig
@@ -64,7 +64,7 @@
                                         {% block sw_order_list_grid_columns_customer_name %}
                                             <sw-grid-column flex="minmax(100px, 1fr)"
                                                             :label="$tc('sw-order.list.columnCustomerName')"
-                                                            dataIndex="customer.firstName,customer.lastName"
+                                                            dataIndex="orderCustomer.firstName,orderCustomer.lastName"
                                                             truncate
                                                             sortable>
                                                 {% block sw_order_list_grid_columns_customer_name_label %}


### PR DESCRIPTION
Currently sorting the order listing by _Customer name_ results in an `HTTP 400` because the `dataIndex` defined in the respective grid column does not exist.

This PR fixes the wrong `dataIndex`.