### PR TITLE
Use snake_case to avoid confusion

### DIFF
--- a/src/Docs/20-data-abstraction-layer/1-definition.md
+++ b/src/Docs/20-data-abstraction-layer/1-definition.md
@@ -37,7 +37,7 @@ public static function getEntityName(): string
 The method should return the name of the definition, which will be used in the system.
 This will be your alias for search queries, too.
 
-**Convention:** The name should match exactly the table name and should be lower-snake-case!
+**Convention:** The name should match exactly the table name and should be lower_snake_case!
 
 ### Method: defineFields()
 


### PR DESCRIPTION
Saying one should use `lower-snake-case` might come across as confusing, as snake_case usually (always?) uses underscores. 

This PR takes away any possible confusion in that area. 