### PR TITLE
Fix Google Cloud Storage upload bug.

### DIFF
--- a/src/Core/Content/Media/File/FileSaver.php
+++ b/src/Core/Content/Media/File/FileSaver.php
@@ -257,7 +257,11 @@ class FileSaver
         try {
             $this->filesystem->putStream($path, $stream);
         } finally {
-            fclose($stream);
+            // The Google Cloud Storage filesystem closes the stream even though it should not. To prevent a fatal
+            // error, we therefore need to check whether the stream has been closed yet.
+            if (is_resource($stream)) {
+                fclose($stream);
+            }
         }
     }
 


### PR DESCRIPTION
When uploading an image, the `FileSaver` expects the filesystem not to close the put stream. While that is true for the local and the S3 file system, it is not true when using the Google Cloud Storage file system. Since it uses curl, the stream is closed by the filesystem which in turn leads to a php error when uploading.

So here is a fix for the error.