### PR TITLE
Updated npm requirements

### DIFF
--- a/src/Docs/1-getting-started/10-dev-setup.md
+++ b/src/Docs/1-getting-started/10-dev-setup.md
@@ -38,7 +38,7 @@ xmlwriter, zip
 - mysql >= 5.7 or mariadb >= 10.3
 - composer >= 1.6
 - nodejs >= 8.10.0
-- npm >= 3.5.2
+- npm >= 6.5.0
 - bash
 - a webserver with url rewrite
 


### PR DESCRIPTION
A command `npm clean-install` is being used in the code, this
backcronym was added starting from npm version `6.5.0` and above.

See https://github.com/npm/cli/commit/fc1a8d185fc678cdf3784d9df9eef9094e0b2dec

Reference: https://gitter.im/shopware/platform?at=5c6be3187667931e2fc76a3d