### PR TITLE
Provide PhpStorm iteration support for LineItemCollection

### DIFF
--- a/src/Core/Checkout/Cart/LineItem/LineItemCollection.php
+++ b/src/Core/Checkout/Cart/LineItem/LineItemCollection.php
@@ -6,6 +6,9 @@ use Shopware\Core\Checkout\Cart\Exception\MixedLineItemTypeException;
 use Shopware\Core\Checkout\Cart\Price\Struct\PriceCollection;
 use Shopware\Core\Framework\Struct\Collection;
 
+/**
+ * @method LineItem[] getIterator
+ */
 class LineItemCollection extends Collection
 {
     /**


### PR DESCRIPTION
I was just "playing" with the cart. stacking class together as i noticed collections do not provide ide support. This is just a example for one collection to support autocompletion.

So also how this was implemented in Symfony: https://github.com/symfony/symfony/pull/19036

```
        $cart = new \Shopware\Core\Checkout\Cart\Cart();

        $cart->getLineItems()[0]->getDescription();
        foreach ($cart->getLineItems() as $item) {
            $item->getDescription();
        }
```