### PR TITLE
Fix symlinking of plugins / instantiate plugins at most once

### DIFF
--- a/src/Core/Kernel.php
+++ b/src/Core/Kernel.php
@@ -53,15 +53,13 @@ class Kernel extends HttpKernel
         /** @var array $bundles */
         $bundles = require $this->getProjectDir() . '/config/bundles.php';
 
-        foreach (self::$plugins->getActives() as $plugin) {
-            $bundles[\get_class($plugin)] = ['all' => true];
-        }
-
         foreach ($bundles as $class => $envs) {
             if (isset($envs['all']) || isset($envs[$this->environment])) {
                 yield new $class();
             }
         }
+
+        yield from self::$plugins->getActives();
     }
 
     public function boot($withPlugins = true): void


### PR DESCRIPTION
# Why is this PR needed?

At the moment, plugins classes are instantiated twice during kernel boot. This leads to the plugin path being canonicalized, which breaks plugin resource path resolution for plugins which are symlinked into `custom/plugins`.

Since symlinking plugins into multiple Shopware installations is an essential workflow component for some plugin developers, this PR fixes the issue by ensuring that each plugin's main class is instantiated at most once and knows its correct installation path instead of the canonicalized form of the path.

Also: Sorry for the wall of text 😅 . Feel free to skip ahead to the "How to test" section if you trust that I've analyzed the root cause of the problem correctly.

# The problem

The way plugin loading works right now, active plugins' classes are instantiated twice during kernel boot. First here while rehydrating from the database:  https://github.com/shopware/platform/blob/feb737c3e17d16f3b33b8c6891e2da6ef65347be/src/Core/Kernel.php#L247
Then the code in `registerBundles()` takes the existing instances' class names and instantiates them again: https://github.com/shopware/platform/blob/feb737c3e17d16f3b33b8c6891e2da6ef65347be/src/Core/Kernel.php#L56-L64

I suspect that this is an unintentional consequence of the way the other bundles are loaded, but doing it this way seems unnecessary. Also note that while instantiating the plugin the first time around, the plugin gets the directory it was loaded from as its `$path` argument. On the second constructor call, the plugin is instantiated with default arguments, which means its `$path` argument is `null`, which in turn leads to this method in the Symfony kernel re-computing the path by asking the runtime for the plugin's main class' containing directory: https://github.com/symfony/http-kernel/blob/040ed007ea633967b3d5ca90dbcc75027c6e1681/Bundle/Bundle.php#L110-L118

Unfortunately, the PHP runtime canonicalizes paths for the classes it loads. This in turn leads to the `administration:dump:bundles` command producing the following, broken output:

```json
{
  "AdministrationExamplePlugin": {
    "base": "/Users/jannik/pickware/shopware-next/01_plugins/AdministrationExamplePlugin/",
    "entry": "Users/jannik/pickware/shopware-next/01_plugins/AdministrationExamplePlugin/Resources/views/administration/main.js",
    "webpackConfig": false
  }
}
```

While the correct output should look like this:


```json
{
  "AdministrationExamplePlugin": {
    "base": "/Users/jannik/pickware/shopware-next/development/custom/plugins/AdministrationExamplePlugin/",
    "entry": "custom/plugins/AdministrationExamplePlugin/Resources/views/administration/main.js",
    "webpackConfig": false
  }
}
```

This in turn causes the webpack build performed as part of `./psh.phar administration:build` to fail and prevents the `assets:install` command from finding the plugin's resource directory.

# The fix

The fix is pretty easy: During `registerBundles()`, instead of mingling the plugins in with the rest of the yet-to-be-instantiated system bundles from `config/bundles.php`, just instantiate and `yield` the system bundles, and afterwards directly `yield` all of the active plugin instances which were created while plugins were loaded from the database.

# How to test

1. Decompress
[AdministrationExamplePlugin.zip](https://github.com/shopware/platform/files/3035807/AdministrationExamplePlugin.zip) somewhere outside the Shopware folder hierarchy.
2. Symlink the plugin into `custom/plugins`.
3. Run `rm -rf var/cache`.
4. Run `./psh.phar adminstration:build`.
 
Without the change in this PR, you should now get an error similar to:

```
ERROR in Entry module not found: Error: Can't resolve '/Users/jannik/pickware/shopware-next/development/Users/jannik/pickware/shopware-next/01_plugins/AdministrationExamplePlugin/Resources/views/administration/main.js' in '/Users/jannik/pickware/shopware-next/development/platform/src/Administration/Resources/administration'
	  Build complete.
```

After checkout out this PR, perform steps 3 and 4 again. Everything should work fine now. You can verify that the plugin was loaded by loading the administration and opening DevTools, where "Hello Showpare!" should have been printed to the console. I've verified that `./psh.phar administration:watch` works, too.