### PR TITLE
Multiple bundles, Plugin interface / abstract

### DIFF
--- a/src/Administration/Command/AdministrationDumpBundlesCommand.php
+++ b/src/Administration/Command/AdministrationDumpBundlesCommand.php
@@ -3,7 +3,7 @@
 namespace Shopware\Administration\Command;
 
 use Shopware\Core\Framework\Bundle;
-use Shopware\Core\Framework\Plugin;
+use Shopware\Core\Framework\PluginInterface;
 use Shopware\Core\Kernel;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -52,7 +52,7 @@ class AdministrationDumpBundlesCommand extends Command
                 continue;
             }
             // dont include deactivated plugins
-            if ($bundle instanceof Plugin && !$bundle->isActive()) {
+            if ($bundle instanceof PluginInterface && !$bundle->isActive()) {
                 continue;
             }
             $bundleName = $bundle->getName();

--- a/src/Core/Framework/Bundle.php
+++ b/src/Core/Framework/Bundle.php
@@ -16,7 +16,7 @@ use Symfony\Component\HttpKernel\Bundle\Bundle as SymfonyBundle;
 use Symfony\Component\Routing\RouteCollectionBuilder;
 use Symfony\Component\Serializer\NameConverter\CamelCaseToSnakeCaseNameConverter;
 
-abstract class Bundle extends SymfonyBundle
+abstract class Bundle extends SymfonyBundle implements BundleRouteInterface
 {
     public function build(ContainerBuilder $container): void
     {

--- a/src/Core/Framework/BundleRouteInterface.php
+++ b/src/Core/Framework/BundleRouteInterface.php
@@ -1,0 +1,10 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework;
+
+use Symfony\Component\Routing\RouteCollectionBuilder;
+
+interface BundleRouteInterface
+{
+    public function configureRoutes(RouteCollectionBuilder $routes, string $environment): void;
+}

--- a/src/Core/Framework/DummyPlugin.php
+++ b/src/Core/Framework/DummyPlugin.php
@@ -1,0 +1,7 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework;
+
+class DummyPlugin extends SimplePlugin
+{
+}

--- a/src/Core/Framework/Plugin.php
+++ b/src/Core/Framework/Plugin.php
@@ -9,23 +9,9 @@ use Shopware\Core\Framework\Plugin\Context\UninstallContext;
 use Shopware\Core\Framework\Plugin\Context\UpdateContext;
 use Symfony\Component\Routing\RouteCollectionBuilder;
 
-abstract class Plugin extends Bundle
+abstract class Plugin extends Bundle implements PluginLifecycleInterface
 {
-    /**
-     * @var bool
-     */
-    private $active;
-
-    final public function __construct(bool $active = true, ?string $path = null)
-    {
-        $this->active = $active;
-        $this->path = $path;
-    }
-
-    final public function isActive(): bool
-    {
-        return $this->active;
-    }
+    use PluginTrait;
 
     public function install(InstallContext $context): void
     {

--- a/src/Core/Framework/Plugin/Context/InstallContext.php
+++ b/src/Core/Framework/Plugin/Context/InstallContext.php
@@ -3,12 +3,12 @@
 namespace Shopware\Core\Framework\Plugin\Context;
 
 use Shopware\Core\Framework\Context;
-use Shopware\Core\Framework\Plugin;
+use Shopware\Core\Framework\PluginInterface;
 
 class InstallContext
 {
     /**
-     * @var Plugin
+     * @var PluginInterface
      */
     private $plugin;
 
@@ -28,7 +28,7 @@ class InstallContext
     private $currentPluginVersion;
 
     public function __construct(
-        Plugin $plugin,
+        PluginInterface $plugin,
         Context $context,
         string $currentShopwareVersion,
         string $currentPluginVersion
@@ -39,7 +39,7 @@ class InstallContext
         $this->currentPluginVersion = $currentPluginVersion;
     }
 
-    public function getPlugin(): Plugin
+    public function getPlugin(): PluginInterface
     {
         return $this->plugin;
     }

--- a/src/Core/Framework/Plugin/Context/UninstallContext.php
+++ b/src/Core/Framework/Plugin/Context/UninstallContext.php
@@ -3,7 +3,7 @@
 namespace Shopware\Core\Framework\Plugin\Context;
 
 use Shopware\Core\Framework\Context;
-use Shopware\Core\Framework\Plugin;
+use Shopware\Core\Framework\PluginInterface;
 
 class UninstallContext extends InstallContext
 {
@@ -13,7 +13,7 @@ class UninstallContext extends InstallContext
     private $keepUserData;
 
     public function __construct(
-        Plugin $plugin,
+        PluginInterface $plugin,
         Context $context,
         string $currentShopwareVersion,
         string $currentPluginVersion,

--- a/src/Core/Framework/Plugin/Context/UpdateContext.php
+++ b/src/Core/Framework/Plugin/Context/UpdateContext.php
@@ -3,7 +3,7 @@
 namespace Shopware\Core\Framework\Plugin\Context;
 
 use Shopware\Core\Framework\Context;
-use Shopware\Core\Framework\Plugin;
+use Shopware\Core\Framework\PluginInterface;
 
 class UpdateContext extends InstallContext
 {
@@ -13,7 +13,7 @@ class UpdateContext extends InstallContext
     private $updatePluginVersion;
 
     public function __construct(
-        Plugin $plugin,
+        PluginInterface $plugin,
         Context $context,
         string $currentShopwareVersion,
         string $currentPluginVersion,

--- a/src/Core/Framework/Plugin/KernelPluginCollection.php
+++ b/src/Core/Framework/Plugin/KernelPluginCollection.php
@@ -2,27 +2,32 @@
 
 namespace Shopware\Core\Framework\Plugin;
 
-use Shopware\Core\Framework\Plugin;
+use Shopware\Core\Framework\DummyPlugin;
+use Shopware\Core\Framework\PluginInterface;
 
 class KernelPluginCollection
 {
     /**
-     * @var Plugin[]
+     * @var PluginInterface[]
      */
     private $bundles;
 
     /**
-     * @param Plugin[] $bundles
+     * @param PluginInterface[] $bundles
      */
     public function __construct(array $bundles = [])
     {
         $this->bundles = $bundles;
     }
 
-    public function add(Plugin $bundle): void
+    public function add(PluginInterface $bundle): void
     {
-        /** @var string|false $class */
-        $class = \get_class($bundle);
+        if ($bundle instanceof DummyPlugin) {
+            $class = $bundle->getName();
+        } else {
+            /** @var string|false $class */
+            $class = \get_class($bundle);
+        }
 
         if ($class === false) {
             return;
@@ -36,7 +41,7 @@ class KernelPluginCollection
     }
 
     /**
-     * @param Plugin[] $bundle
+     * @param PluginInterface[] $bundle
      */
     public function addList(array $bundle): void
     {
@@ -48,13 +53,13 @@ class KernelPluginCollection
         return array_key_exists($name, $this->bundles);
     }
 
-    public function get($name): ?Plugin
+    public function get($name): ?PluginInterface
     {
         return $this->has($name) ? $this->bundles[$name] : null;
     }
 
     /**
-     * @return Plugin[]
+     * @return PluginInterface[]
      */
     public function all(): array
     {
@@ -62,11 +67,11 @@ class KernelPluginCollection
     }
 
     /**
-     * @return Plugin[]
+     * @return PluginInterface[]
      */
     public function getActives(): array
     {
-        return array_filter($this->bundles, function (Plugin $plugin) {
+        return array_filter($this->bundles, function (PluginInterface $plugin) {
             return $plugin->isActive();
         });
     }

--- a/src/Core/Framework/Plugin/PluginZipDetector.php
+++ b/src/Core/Framework/Plugin/PluginZipDetector.php
@@ -9,12 +9,10 @@ class PluginZipDetector
         $entry = $archive->statIndex(0);
 
         $pluginName = explode('/', $entry['name'])[0];
-        $baseClass = $pluginName . '/' . $pluginName . '.php';
         $composerFile = $pluginName . '/composer.json';
 
-        $statBaseClass = $archive->statName($baseClass);
         $statComposerFile = $archive->statName($composerFile);
 
-        return $statBaseClass !== false && $statComposerFile !== false;
+        return $statComposerFile !== false;
     }
 }

--- a/src/Core/Framework/Plugin/Util/AssetService.php
+++ b/src/Core/Framework/Plugin/Util/AssetService.php
@@ -2,7 +2,6 @@
 
 namespace Shopware\Core\Framework\Plugin\Util;
 
-use Shopware\Core\Framework\Plugin\Exception\PluginNotFoundException;
 use Shopware\Core\Framework\Plugin\KernelPluginCollection;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Finder\Finder;
@@ -36,13 +35,8 @@ class AssetService
         $this->pluginCollection = $pluginCollection;
     }
 
-    /**
-     * @throws PluginNotFoundException
-     */
-    public function copyAssetsFromBundle(string $bundleName): void
+    public function copyAssetsFromBundle(BundleInterface $bundle): void
     {
-        $bundle = $this->getBundle($bundleName);
-
         $originDir = $bundle->getPath() . '/Resources/public';
         if (!is_dir($originDir)) {
             return;
@@ -55,13 +49,8 @@ class AssetService
         $this->copy($originDir, $targetDirectory);
     }
 
-    /**
-     * @throws PluginNotFoundException
-     */
-    public function removeAssetsOfBundle(string $bundleName): void
+    public function removeAssetsOfBundle(BundleInterface $bundle): void
     {
-        $bundle = $this->getBundle($bundleName);
-
         $targetDirectory = $this->getTargetDirectory($bundle);
 
         $this->filesystem->remove($targetDirectory);
@@ -78,23 +67,5 @@ class AssetService
     {
         $this->filesystem->mkdir($targetDir, 0777);
         $this->filesystem->mirror($originDir, $targetDir, Finder::create()->ignoreDotFiles(false)->in($originDir));
-    }
-
-    /**
-     * @throws PluginNotFoundException
-     */
-    private function getBundle(string $bundleName): BundleInterface
-    {
-        try {
-            $bundle = $this->kernel->getBundle($bundleName);
-        } catch (\InvalidArgumentException $e) {
-            $bundle = $this->pluginCollection->get($bundleName);
-        }
-
-        if ($bundle === null) {
-            throw new PluginNotFoundException($bundleName);
-        }
-
-        return $bundle;
     }
 }

--- a/src/Core/Framework/Plugin/Util/PluginFinder.php
+++ b/src/Core/Framework/Plugin/Util/PluginFinder.php
@@ -73,14 +73,16 @@ class PluginFinder
 
     private function isShopwarePluginPackage(PackageInterface $package): bool
     {
-        return $package->getType() === self::COMPOSER_TYPE
-            && isset($package->getExtra()[self::SHOPWARE_PLUGIN_CLASS_EXTRA_IDENTIFIER])
-            && $package->getExtra()[self::SHOPWARE_PLUGIN_CLASS_EXTRA_IDENTIFIER] !== '';
+        return $package->getType() === self::COMPOSER_TYPE;
     }
 
-    private function getPluginNameFromPackage(PackageInterface $pluginPackage): string
+    private function getPluginNameFromPackage(PackageInterface $pluginPackage, string $pluginPath): string
     {
-        return $pluginPackage->getExtra()[self::SHOPWARE_PLUGIN_CLASS_EXTRA_IDENTIFIER];
+        if (isset($pluginPackage->getExtra()[self::SHOPWARE_PLUGIN_CLASS_EXTRA_IDENTIFIER])) {
+            return $pluginPackage->getExtra()[self::SHOPWARE_PLUGIN_CLASS_EXTRA_IDENTIFIER];
+        }
+
+        return basename($pluginPath);
     }
 
     private function getVendorPluginPath(PackageInterface $pluginPackage, Composer $composer): string
@@ -110,6 +112,6 @@ class PluginFinder
             );
         }
 
-        return $this->getPluginNameFromPackage($rootPackage);
+        return $this->getPluginNameFromPackage($rootPackage, $pluginPath);
     }
 }

--- a/src/Core/Framework/PluginInterface.php
+++ b/src/Core/Framework/PluginInterface.php
@@ -1,0 +1,10 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework;
+
+interface PluginInterface
+{
+    public function isActive(): bool;
+
+    public function registerBundles(): \Generator;
+}

--- a/src/Core/Framework/PluginLifecycleInterface.php
+++ b/src/Core/Framework/PluginLifecycleInterface.php
@@ -1,0 +1,26 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework;
+
+use Shopware\Core\Framework\Plugin\Context\ActivateContext;
+use Shopware\Core\Framework\Plugin\Context\DeactivateContext;
+use Shopware\Core\Framework\Plugin\Context\InstallContext;
+use Shopware\Core\Framework\Plugin\Context\UninstallContext;
+use Shopware\Core\Framework\Plugin\Context\UpdateContext;
+
+interface PluginLifecycleInterface
+{
+    public function install(InstallContext $context): void;
+
+    public function postInstall(InstallContext $context): void;
+
+    public function update(UpdateContext $context): void;
+
+    public function postUpdate(UpdateContext $context): void;
+
+    public function activate(ActivateContext $context): void;
+
+    public function deactivate(DeactivateContext $context): void;
+
+    public function uninstall(UninstallContext $context): void;
+}

--- a/src/Core/Framework/PluginTrait.php
+++ b/src/Core/Framework/PluginTrait.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework;
+
+trait PluginTrait
+{
+    /**
+     * @var bool
+     */
+    private $active;
+
+    final public function __construct(bool $active = true, ?string $path = null, ?string $name = null)
+    {
+        $this->active = $active;
+        $this->path = $path;
+        $this->name = $name;
+    }
+
+    final public function isActive(): bool
+    {
+        return $this->active;
+    }
+
+    public function registerBundles(): \Generator
+    {
+        yield $this;
+    }
+}

--- a/src/Core/Framework/SimplePlugin.php
+++ b/src/Core/Framework/SimplePlugin.php
@@ -1,0 +1,39 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework;
+
+use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\HttpKernel\Bundle\Bundle;
+
+class SimplePlugin extends Bundle implements PluginInterface
+{
+    use PluginTrait;
+
+    public function build(ContainerBuilder $container): void
+    {
+        parent::build($container);
+
+        $this->registerContainerFile($container);
+    }
+
+    protected function getServicesFilePath(): string
+    {
+        return 'Resources/config/services.xml';
+    }
+
+    protected function registerContainerFile(ContainerBuilder $container): void
+    {
+        $fileSystem = new Filesystem();
+        $containerFilePath = ltrim($this->getServicesFilePath(), '/');
+
+        if (!$fileSystem->exists($this->getPath() . '/' . $containerFilePath)) {
+            return;
+        }
+
+        $loader = new XmlFileLoader($container, new FileLocator($this->getPath()));
+        $loader->load($containerFilePath);
+    }
+}


### PR DESCRIPTION
1. PluginInterface: You doesn't have to extends the plugin class. you can use PluginInterface.
1b. PluginLifecycleInterface. You doesn't have to implement the plugin lifecycle methods in your bootstrap.
2. registerBundles: You can define multiple bundles in a plugin. Example:
```
    public function registerBundles(): Generator
    {
        yield form parent::registerBundles();
        yield new MyFancyBundle();
    }
```
3. SimplePlugin wich is not a Shopware bundle, but have for example services.
4. No bootstrap file. You doesn't have to create a plugin bootstrap file. It use the dummy plugin class.