### PR TITLE
WIP: Feature/glide media scaling integration

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -91,7 +91,8 @@
         "twig/extensions": "1.5.4",
         "twig/twig": "2.7.4",
         "voku/stop-words": "2.0.1",
-        "league/glide": "1.5.0"
+        "league/glide": "1.5.0",
+        "league/flysystem-memory": "1.0.1"
     },
     "require-dev": {
         "ext-tokenizer": "*",

--- a/composer.json
+++ b/composer.json
@@ -90,7 +90,8 @@
         "symfony/yaml": "4.2.4",
         "twig/extensions": "1.5.4",
         "twig/twig": "2.7.4",
-        "voku/stop-words": "2.0.1"
+        "voku/stop-words": "2.0.1",
+        "league/glide": "1.5.0"
     },
     "require-dev": {
         "ext-tokenizer": "*",

--- a/src/Core/Content/DependencyInjection/media.xml
+++ b/src/Core/Content/DependencyInjection/media.xml
@@ -267,5 +267,19 @@
             <argument type="service" id="Shopware\Core\Content\Media\Pathname\UrlGeneratorInterface"/>
             <argument type="service" id="media_folder.repository"/>
         </service>
+
+        <service id="Shopware\Core\Content\Media\Resize\ServerFactory">
+            <argument type="service" id="shopware.filesystem.public"/>
+            <argument>%kernel.cache_dir%</argument>
+        </service>
+
+        <service id="League\Glide\Server">
+            <factory service="Shopware\Core\Content\Media\Resize\ServerFactory" method="create"/>
+        </service>
+
+        <service id="Shopware\Core\Content\Media\Storefront\MediaResizeController" public="true">
+            <argument type="service" id="League\Glide\Server"/>
+            <argument type="service" id="shopware.filesystem.public"/>
+        </service>
     </services>
 </container>

--- a/src/Core/Content/Media/Resize/ServerFactory.php
+++ b/src/Core/Content/Media/Resize/ServerFactory.php
@@ -1,0 +1,73 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Content\Media\Resize;
+
+use Intervention\Image\ImageManager;
+use League\Flysystem\Adapter\Local;
+use League\Flysystem\Filesystem;
+use League\Flysystem\FilesystemInterface;
+use League\Glide\Api\Api;
+use League\Glide\Manipulators;
+use League\Glide\Server;
+
+class ServerFactory
+{
+    /**
+     * @var FilesystemInterface
+     */
+    private $source;
+
+    /**
+     * @var string
+     */
+    private $cacheDir;
+
+    public function __construct(FilesystemInterface $source, string $cacheDir)
+    {
+        $this->source = $source;
+        $this->cacheDir = $cacheDir;
+    }
+
+    public function create(): Server
+    {
+        $server = new Server(
+            $this->source,
+            $this->createCache(),
+            $this->createApi()
+        );
+
+        return $server;
+    }
+
+    private function createImageManager(): ImageManager
+    {
+        return new ImageManager([
+            'driver' => 'gd',
+        ]);
+    }
+
+    /**
+     * @return Manipulators\ManipulatorInterface[]
+     */
+    private function createManipulators(): array
+    {
+        return [
+            new Manipulators\Size(600 * 600),
+        ];
+    }
+
+    private function createApi(): Api
+    {
+        return new Api(
+            $this->createImageManager(),
+            $this->createManipulators()
+        );
+    }
+
+    private function createCache(): Filesystem
+    {
+        return new Filesystem(
+            new Local($this->cacheDir . '/glide/')
+        );
+    }
+}

--- a/src/Core/Content/Media/Storefront/MediaResizeController.php
+++ b/src/Core/Content/Media/Storefront/MediaResizeController.php
@@ -1,0 +1,50 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Content\Media\Storefront;
+
+use League\Flysystem\Filesystem;
+use League\Glide\Server;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+
+class MediaResizeController extends AbstractController
+{
+    /**
+     * @var Server
+     */
+    private $resizeServer;
+
+    /**
+     * @var Filesystem
+     */
+    private $sourceFolder;
+
+    public function __construct(Server $resizeServer, Filesystem $sourceFolder)
+    {
+        $this->resizeServer = $resizeServer;
+        $this->sourceFolder = $sourceFolder;
+    }
+
+    /**
+     * @Route("/media/resize/{fileName}", name="storefront.action.media.resize", methods={"GET"}, requirements={"fileName"=".+"})
+     */
+    public function resize(?string $fileName): Response
+    {
+        if (!$this->sourceFolder->has($fileName)) {
+            return new Response(
+                'File not found!',
+                404
+            );
+        }
+
+        $this->resizeServer->outputImage($fileName, [
+            'w' => 100,
+        ]);
+
+        /* could also be handeled by a response-factory
+         * @see https://glide.thephpleague.com/1.0/config/responses/
+         */
+        exit;
+    }
+}


### PR DESCRIPTION
This is supposed to be a solution for dynamic image scaling on demand. This directly integrates within shopware platform and would be a nice addition to Shopware.

For production it would be best to put a cdn in front ;)

This is based on the opensource library glide (https://glide.thephpleague.com/). All of the listed image-manipulations should also be available in this integration. Also configuration made to shopware media-albums should have a limit on thumbnails requestable.

Route for now is HOST/media/resize/media/IMAGE.png?w=100

Still has some problems in rendering the images. A redirection rule for nginx and apache would be nice.

Just putting it here for documentation purposes ;)

- [ ] Images have size of 0
- [ ] Needs url rewriting (nginx / apache)
- [ ] Should integrate with album thumbnail config