### PR TITLE
Add Plugin::getExtraBundles() method

### DIFF
--- a/src/Core/Framework/Plugin.php
+++ b/src/Core/Framework/Plugin.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Core\Framework;
 
+use Composer\Autoload\ClassLoader;
 use Shopware\Core\Framework\Plugin\Context\ActivateContext;
 use Shopware\Core\Framework\Plugin\Context\DeactivateContext;
 use Shopware\Core\Framework\Plugin\Context\InstallContext;
@@ -68,6 +69,14 @@ abstract class Plugin extends Bundle
         }
 
         parent::configureRoutes($routes, $environment);
+    }
+
+    /**
+     * @return Bundle[]
+     */
+    public function getExtraBundles(ClassLoader $classLoader): array
+    {
+        return [];
     }
 
     public function getBasePath(): string

--- a/src/Core/Kernel.php
+++ b/src/Core/Kernel.php
@@ -86,7 +86,10 @@ class Kernel extends HttpKernel
             }
         }
 
-        yield from self::$plugins->getActives();
+        foreach (self::$plugins->getActives() as $plugin) {
+            yield $plugin;
+            yield from $plugin->getExtraBundles($this->classLoader);
+        }
     }
 
     public function boot($withPlugins = true): void


### PR DESCRIPTION
This PR does two things:

1.  It makes Shopware's Composer `ClassLoader` available using a getter on the `Kernel`, and
2. it adds a method to `Plugin::getExtraBundles()` which allows a plugin to return any number of bundles which the kernel then registers along with the plugin's bundle.

I've discussed the rationale for this PR with @janbuecker. In short, this is a minimal set of changes which allows us (and other tech-savvy developers with interdependent plugin portfolios) to add their own logic for resolving and registering shared bundles. We've implemented a prototype for this on the plugin side and verified that this PR works for our use case.

I've deviated minimally from the variant we originally discussed (cf. https://github.com/shopware/platform/compare/master...VIISON:pickware/add-post-register-plugin-lifecycle-method) by having a method which returns bundles for the `Kernel` to register. This allows us to implement the dependency loading on our side without having to resort to using reflection. I hope that is acceptable - if not, we're fine with reverting to the original variant.