### PR TITLE
Implemented completion aware interface for stecman symfony console completion

### DIFF
--- a/src/Core/Content/Media/Commands/GenerateThumbnailsCommand.php
+++ b/src/Core/Content/Media/Commands/GenerateThumbnailsCommand.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Core\Content\Media\Commands;
 
+use Shopware\Core\Content\Media\Aggregate\MediaFolder\MediaFolderEntity;
 use Shopware\Core\Content\Media\Message\UpdateThumbnailsMessage;
 use Shopware\Core\Content\Media\Thumbnail\ThumbnailService;
 use Shopware\Core\Framework\Console\ShopwareStyle;
@@ -9,9 +10,12 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Dbal\Common\RepositoryIterator;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepositoryInterface;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\ContainsFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsAnyFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\Filter;
+use Stecman\Component\Symfony\Console\BashCompletion\Completion\CompletionAwareInterface;
+use Stecman\Component\Symfony\Console\BashCompletion\CompletionContext;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -19,7 +23,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Messenger\MessageBusInterface;
 
-class GenerateThumbnailsCommand extends Command
+class GenerateThumbnailsCommand extends Command implements CompletionAwareInterface
 {
     /**
      * @var ThumbnailService
@@ -73,6 +77,34 @@ class GenerateThumbnailsCommand extends Command
         $this->mediaRepository = $mediaRepository;
         $this->mediaFolderRepository = $mediaFolderRepository;
         $this->messageBus = $messageBus;
+    }
+
+    public function completeOptionValues($optionName, CompletionContext $context)
+    {
+        if ($optionName === 'folder-name') {
+            $criteria = new Criteria();
+
+            if (!empty($context->getCurrentWord())) {
+                $criteria->addFilter(new ContainsFilter('name', $context->getCurrentWord()));
+            }
+
+            $searchResult = $this->mediaFolderRepository->search($criteria, Context::createDefaultContext());
+            $result = [];
+
+            /** @var MediaFolderEntity $mediaFolder */
+            foreach ($searchResult->getEntities() as $mediaFolder) {
+                $result[] = $mediaFolder->getName();
+            }
+
+            return $result;
+        }
+
+        return [];
+    }
+
+    public function completeArgumentValues($argumentName, CompletionContext $context)
+    {
+        return [];
     }
 
     /**

--- a/src/Core/Framework/Api/Command/DumpSchemaCommand.php
+++ b/src/Core/Framework/Api/Command/DumpSchemaCommand.php
@@ -3,13 +3,16 @@
 namespace Shopware\Core\Framework\Api\Command;
 
 use Shopware\Core\Framework\Api\ApiDefinition\DefinitionService;
+use Stecman\Component\Symfony\Console\BashCompletion\Completion\CompletionAwareInterface;
+use Stecman\Component\Symfony\Console\BashCompletion\Completion\ShellPathCompletion;
+use Stecman\Component\Symfony\Console\BashCompletion\CompletionContext;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class DumpSchemaCommand extends Command
+class DumpSchemaCommand extends Command implements CompletionAwareInterface
 {
     /**
      * @var DefinitionService
@@ -21,6 +24,27 @@ class DumpSchemaCommand extends Command
         parent::__construct();
 
         $this->definitionService = $definitionService;
+    }
+
+    public function completeOptionValues($optionName, CompletionContext $context)
+    {
+        if ($optionName === 'schema-format') {
+            return [
+                'simple',
+                'openapi3',
+            ];
+        }
+
+        return [];
+    }
+
+    public function completeArgumentValues($argumentName, CompletionContext $context)
+    {
+        if ($argumentName === 'outfile') {
+            exit(ShellPathCompletion::PATH_COMPLETION_EXIT_CODE);
+        }
+
+        return [];
     }
 
     protected function configure(): void

--- a/src/Core/Framework/DependencyInjection/services.xml
+++ b/src/Core/Framework/DependencyInjection/services.xml
@@ -66,6 +66,7 @@
             <tag name="console.command"/>
             <argument>%kernel.project_dir%</argument>
             <argument>%kernel.plugin_dir%</argument>
+            <argument type="service" id="plugin.repository"/>
         </service>
 
         <service id="Shopware\Core\Framework\Migration\Command\RefreshMigrationCommand">
@@ -264,6 +265,11 @@
             <argument type="service" id="cache_clearer"/>
             <argument type="service" id="filesystem"/>
             <argument>%kernel.cache_dir%</argument>
+        </service>
+
+        <!-- Utility -->
+        <service id="Stecman\Component\Symfony\Console\BashCompletion\CompletionCommand">
+            <tag name="console.command"/>
         </service>
     </services>
 </container>

--- a/src/Core/Framework/Migration/Command/RefreshMigrationCommand.php
+++ b/src/Core/Framework/Migration/Command/RefreshMigrationCommand.php
@@ -2,13 +2,39 @@
 
 namespace Shopware\Core\Framework\Migration\Command;
 
+use Stecman\Component\Symfony\Console\BashCompletion\Completion\CompletionAwareInterface;
+use Stecman\Component\Symfony\Console\BashCompletion\CompletionContext;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Finder\Finder;
 
-class RefreshMigrationCommand extends Command
+class RefreshMigrationCommand extends Command implements CompletionAwareInterface
 {
+    public function completeOptionValues($optionName, CompletionContext $context)
+    {
+        return [];
+    }
+
+    public function completeArgumentValues($argumentName, CompletionContext $context)
+    {
+        $finder = new Finder();
+        $finder->in(getcwd())
+            ->name('Migration*.php')
+            ->exclude('vendor')
+            ->exclude(['dev-ops', 'test*', 'Test*'])
+        ;
+
+        $result = [];
+
+        foreach ($finder as $migrationFile) {
+            $result[] = $migrationFile->getRelativePathname();
+        }
+
+        return $result;
+    }
+
     protected function configure(): void
     {
         $this->setName('database:refresh-migration')

--- a/src/Core/Framework/Plugin/Command/Lifecycle/AbstractPluginLifecycleCommand.php
+++ b/src/Core/Framework/Plugin/Command/Lifecycle/AbstractPluginLifecycleCommand.php
@@ -9,6 +9,8 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\ContainsFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\MultiFilter;
 use Shopware\Core\Framework\Plugin\PluginCollection;
 use Shopware\Core\Framework\Plugin\PluginLifecycleService;
+use Stecman\Component\Symfony\Console\BashCompletion\Completion\CompletionAwareInterface;
+use Stecman\Component\Symfony\Console\BashCompletion\CompletionContext;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
@@ -18,7 +20,7 @@ use Symfony\Component\Console\Input\StringInput;
 use Symfony\Component\Console\Output\NullOutput;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
-abstract class AbstractPluginLifecycleCommand extends Command
+abstract class AbstractPluginLifecycleCommand extends Command implements CompletionAwareInterface
 {
     /**
      * @var PluginLifecycleService
@@ -38,6 +40,28 @@ abstract class AbstractPluginLifecycleCommand extends Command
 
         $this->pluginLifecycleService = $pluginLifecycleService;
         $this->pluginRepo = $pluginRepo;
+    }
+
+    public function completeOptionValues($optionName, CompletionContext $context)
+    {
+        return [];
+    }
+
+    public function completeArgumentValues($argumentName, CompletionContext $context)
+    {
+        if ($argumentName === 'plugins') {
+            $plugins = $this->pluginRepo->search(new Criteria(), Context::createDefaultContext())->getEntities();
+            $result = [];
+
+            foreach ($plugins as $plugin) {
+                $cleanName = preg_replace('/\\W/', ' ', $plugin->getName());
+                $result = array_merge($result, explode(' ', $cleanName));
+            }
+
+            return $result;
+        }
+
+        return [];
     }
 
     protected function configureCommand(string $lifecycleMethod): void

--- a/src/Core/System/DependencyInjection/sales_channel.xml
+++ b/src/Core/System/DependencyInjection/sales_channel.xml
@@ -101,6 +101,8 @@
             <argument type="service" id="shipping_method.repository"/>
             <argument type="service" id="country.repository"/>
             <argument type="service" id="snippet_set.repository"/>
+            <argument type="service" id="customer_group.repository"/>
+            <argument type="service" id="currency.repository"/>
 
             <tag name="console.command"/>
         </service>

--- a/src/Core/System/DependencyInjection/state_machine.xml
+++ b/src/Core/System/DependencyInjection/state_machine.xml
@@ -14,6 +14,7 @@
         </service>
         <service id="Shopware\Core\System\StateMachine\Command\WorkflowDumpCommand">
             <argument type="service" id="Shopware\Core\System\StateMachine\StateMachineRegistry"/>
+            <argument type="service" id="state_machine.repository"/>
             <tag name="console.command"/>
         </service>
         <service id="Shopware\Core\System\StateMachine\StateMachineDefinition">

--- a/src/Core/System/SalesChannel/Command/SalesChannelCreateCommand.php
+++ b/src/Core/System/SalesChannel/Command/SalesChannelCreateCommand.php
@@ -14,13 +14,15 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Sorting\FieldSorting;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\FieldException\InvalidFieldException;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\FieldException\WriteStackException;
 use Shopware\Core\Framework\Uuid\Uuid;
+use Stecman\Component\Symfony\Console\BashCompletion\Completion\CompletionAwareInterface;
+use Stecman\Component\Symfony\Console\BashCompletion\CompletionContext;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class SalesChannelCreateCommand extends Command
+class SalesChannelCreateCommand extends Command implements CompletionAwareInterface
 {
     /**
      * @var EntityRepositoryInterface
@@ -51,13 +53,25 @@ class SalesChannelCreateCommand extends Command
      */
     private $definitionRegistry;
 
+    /**
+     * @var EntityRepositoryInterface
+     */
+    private $customerGroupRepository;
+
+    /**
+     * @var EntityRepositoryInterface
+     */
+    private $currencyRepository;
+
     public function __construct(
         DefinitionInstanceRegistry $definitionRegistry,
         EntityRepositoryInterface $salesChannelRepository,
         EntityRepositoryInterface $paymentMethodRepository,
         EntityRepositoryInterface $shippingMethodRepository,
         EntityRepositoryInterface $countryRepository,
-        EntityRepositoryInterface $snippetSetRepository
+        EntityRepositoryInterface $snippetSetRepository,
+        EntityRepositoryInterface $customerGroupRepository,
+        EntityRepositoryInterface $currencyRepository
     ) {
         $this->definitionRegistry = $definitionRegistry;
         $this->salesChannelRepository = $salesChannelRepository;
@@ -65,8 +79,46 @@ class SalesChannelCreateCommand extends Command
         $this->shippingMethodRepository = $shippingMethodRepository;
         $this->countryRepository = $countryRepository;
         $this->snippetSetRepository = $snippetSetRepository;
+        $this->customerGroupRepository = $customerGroupRepository;
+        $this->currencyRepository = $currencyRepository;
 
         parent::__construct();
+    }
+
+    public function completeOptionValues($optionName, CompletionContext $context)
+    {
+        if ($optionName === 'languageId') {
+        } elseif ($optionName === 'snippetSetId') {
+            return $this->snippetSetRepository->searchIds(new Criteria(), Context::createDefaultContext())->getIds();
+        } elseif ($optionName === 'currencyId') {
+            return $this->currencyRepository->searchIds(new Criteria(), Context::createDefaultContext())->getIds();
+        } elseif ($optionName === 'paymentMethodId') {
+            $criteria = (new Criteria())->addFilter(new EqualsFilter('active', true));
+
+            return $this->paymentMethodRepository->searchIds($criteria, Context::createDefaultContext())->getIds();
+        } elseif ($optionName === 'shippingMethodId') {
+            $criteria = (new Criteria())->addFilter(new EqualsFilter('active', true));
+
+            return $this->shippingMethodRepository->searchIds($criteria, Context::createDefaultContext())->getIds();
+        } elseif ($optionName === 'countryId') {
+            $criteria = (new Criteria())->addFilter(new EqualsFilter('active', true));
+
+            return $this->countryRepository->searchIds($criteria, Context::createDefaultContext())->getIds();
+        } elseif ($optionName === 'typeId') {
+            return [
+                Defaults::SALES_CHANNEL_TYPE_API,
+                Defaults::SALES_CHANNEL_TYPE_STOREFRONT,
+            ];
+        } elseif ($optionName === 'customerGroupId') {
+            return $this->customerGroupRepository->searchIds(new Criteria(), Context::createDefaultContext())->getIds();
+        }
+
+        return [];
+    }
+
+    public function completeArgumentValues($argumentName, CompletionContext $context)
+    {
+        return [];
     }
 
     protected function configure(): void

--- a/src/Docs/Command/ConvertMarkdownDocsCommand.php
+++ b/src/Docs/Command/ConvertMarkdownDocsCommand.php
@@ -5,6 +5,8 @@ namespace Shopware\Docs\Command;
 use Shopware\Docs\Convert\Document;
 use Shopware\Docs\Convert\DocumentTree;
 use Shopware\Docs\Convert\WikiApiService;
+use Stecman\Component\Symfony\Console\BashCompletion\Completion\CompletionAwareInterface;
+use Stecman\Component\Symfony\Console\BashCompletion\CompletionContext;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -13,13 +15,43 @@ use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Finder\SplFileInfo;
 
-class ConvertMarkdownDocsCommand extends Command
+class ConvertMarkdownDocsCommand extends Command implements CompletionAwareInterface
 {
     private const CATEGORY_SITE_FILENAME = '__categoryInfo.md';
 
     private const BLACKLIST = 'article.blacklist';
 
     private const CREDENTIAL_PATH = __DIR__ . '/wiki.secret';
+
+    public function completeOptionValues($optionName, CompletionContext $context)
+    {
+        if ($optionName === 'input' || $optionName === 'output') {
+            $result = [];
+            $finder = (new Finder())
+                ->in(getcwd())
+                ->directories()
+                ->exclude([
+                    'vendor',
+                    'dev-ops',
+                    'Test*',
+                    'test*',
+                ])
+            ;
+
+            foreach ($finder as $directory) {
+                $result[] = $directory->getRelativePathname();
+            }
+
+            return $result;
+        }
+
+        return [];
+    }
+
+    public function completeArgumentValues($argumentName, CompletionContext $context)
+    {
+        return [];
+    }
 
     protected function configure(): void
     {

--- a/src/Docs/_new/4-how-to/090-plugin-commands.md
+++ b/src/Docs/_new/4-how-to/090-plugin-commands.md
@@ -56,7 +56,9 @@ class ExampleCommand extends Command
 ```
 
 In this example, it would be located in the directory `<plugin root>/src/Command`.
-After installing, you can now execute your command by running this command: `bin/console plugin-commands:example`
+After installing, you can now execute your command by running this command: `bin/console plugin-commands:example`.
+The auto completion is done automatically for command names and option names.
+If you have a defined set of values for an argument or option you can implement the [CompletionAwareInterface](https://github.com/stecman/symfony-console-completion#implementing-completionawareinterface).
 
 Make sure to read the full guide about [Symfony commands](https://symfony.com/doc/current/console.html) to understand, how to deal with commands and how they can be configured.
 

--- a/src/Storefront/DependencyInjection/services.xml
+++ b/src/Storefront/DependencyInjection/services.xml
@@ -36,6 +36,8 @@
             <argument type="service" id="country.repository"/>
             <argument type="service" id="snippet_set.repository"/>
             <argument type="service" id="category.repository"/>
+            <argument type="service" id="customer_group.repository"/>
+            <argument type="service" id="currency.repository"/>
 
             <tag name="console.command"/>
         </service>

--- a/src/Storefront/Framework/Command/SalesChannelCreateStorefrontCommand.php
+++ b/src/Storefront/Framework/Command/SalesChannelCreateStorefrontCommand.php
@@ -28,9 +28,20 @@ class SalesChannelCreateStorefrontCommand extends SalesChannelCreateCommand
         EntityRepositoryInterface $shippingMethodRepository,
         EntityRepositoryInterface $countryRepository,
         EntityRepositoryInterface $snippetSetRepository,
-        EntityRepositoryInterface $categoryRepository
+        EntityRepositoryInterface $categoryRepository,
+        EntityRepositoryInterface $customerGroupRepository,
+        EntityRepositoryInterface $currencyRepository
     ) {
-        parent::__construct($definitionRegistry, $salesChannelRepository, $paymentMethodRepository, $shippingMethodRepository, $countryRepository, $snippetSetRepository);
+        parent::__construct(
+            $definitionRegistry,
+            $salesChannelRepository,
+            $paymentMethodRepository,
+            $shippingMethodRepository,
+            $countryRepository,
+            $snippetSetRepository,
+            $customerGroupRepository,
+            $currencyRepository
+        );
         $this->categoryRepository = $categoryRepository;
     }
 


### PR DESCRIPTION
### 1. Why is this change necessary?
For easier usability of console commands.

Did you ever recognized a whole uuid? Do you know by heart what the plugin was spelled?

Examples in usage were already shown in the [pull request for shopware 5](https://github.com/shopware/shopware/pull/1488).

### 2. What does this change do, exactly?
Implements for all core/shipped commands the CompletionAwareInterface
Adds hints in the documentation

### 3. Describe each step to reproduce the issue or behaviour.
Press tab to complete your shopware console commands. It just does not work.

### 4. Which documentation changes (if any) need to be made because of this PR?
☑  https://docs.shopware.com should get a hint on the setup and pros.
There is a complementary pull request to https://github.com/shopware/development/pull/20 to ensure this features is ready in the default docker container.

