### PR TITLE
Escape "like" value in ContainsFilter correctly

### DIFF
--- a/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php
+++ b/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php
@@ -152,7 +152,7 @@ class SqlQueryParser
         $result = new ParseResult();
         $result->addWhere($field . ' LIKE :' . $key . '');
 
-        $escaped = str_replace('%', '\\%', $query->getValue());
+        $escaped = addcslashes($query->getValue(), '\\_%');
         $result->addParameter($key, '%' . $escaped . '%');
 
         return $result;

--- a/src/Core/Framework/Test/DataAbstractionLayer/Search/Parser/SqlQueryParserTest.php
+++ b/src/Core/Framework/Test/DataAbstractionLayer/Search/Parser/SqlQueryParserTest.php
@@ -1,0 +1,72 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\Test\DataAbstractionLayer\Search\Parser;
+
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepositoryInterface;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\ContainsFilter;
+use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
+use Shopware\Core\Framework\Uuid\Uuid;
+
+class SqlQueryParserTest extends TestCase
+{
+    use IntegrationTestBehaviour;
+
+    /**
+     * @var EntityRepositoryInterface
+     */
+    private $manufacturerRepository;
+
+    protected function setUp(): void
+    {
+        $this->manufacturerRepository = $this->getContainer()->get('product_manufacturer.repository');
+    }
+
+    public function testContainsFilterFindUnderscore(): void
+    {
+        $targetId = $this->createManufacturer(['link' => 'target_to_find']);
+        $errournousId = $this->createManufacturer(['link' => 'target to find']);
+        $criteria = (new Criteria())->addFilter(new ContainsFilter('link', 'target_to_find'));
+        $foundIds = $this->manufacturerRepository->searchIds($criteria, Context::createDefaultContext());
+
+        static::assertContains($targetId, $foundIds->getIds());
+        static::assertNotContains($errournousId, $foundIds->getIds());
+    }
+
+    public function testContainsFilterFindPercentageSign(): void
+    {
+        $targetId = $this->createManufacturer(['link' => 'target%find']);
+        $errournousId = $this->createManufacturer(['link' => 'target to find']);
+        $criteria = (new Criteria())->addFilter(new ContainsFilter('link', 'target%find'));
+        $foundIds = $this->manufacturerRepository->searchIds($criteria, Context::createDefaultContext());
+
+        static::assertContains($targetId, $foundIds->getIds());
+        static::assertNotContains($errournousId, $foundIds->getIds());
+    }
+
+    public function testContainsFilterFindBackslash(): void
+    {
+        $targetId = $this->createManufacturer(['link' => 'target \\ find']);
+        $errournousId = $this->createManufacturer(['link' => 'target \\find']);
+        $criteria = (new Criteria())->addFilter(new ContainsFilter('link', ' \\ '));
+        $foundIds = $this->manufacturerRepository->searchIds($criteria, Context::createDefaultContext());
+
+        static::assertContains($targetId, $foundIds->getIds());
+        static::assertNotContains($errournousId, $foundIds->getIds());
+    }
+
+    private function createManufacturer(array $parameters = []): string
+    {
+        $id = Uuid::randomHex();
+
+        $defaults = ['id' => $id, 'name' => 'Test'];
+
+        $parameters = array_merge($defaults, $parameters);
+
+        $this->manufacturerRepository->create([$parameters], Context::createDefaultContext());
+
+        return $id;
+    }
+}


### PR DESCRIPTION
If a `ContainsFilter` is used it is transformed into a LIKE-statement. As the existing code is escaping `%` it suggests that it tries to hide the implementation (:+1:).

As I played with `bin/console plugin:install \\` I noticed that it did not find a plugin with a backslash in its name. This is weird as I had to escape it once for bash to php. So I have the ContainsFilter checking for one backslash. But as a backslash is also used to escape things in the like pattern it generated an unsuited like pattern and the SQL request was unsuccesful finding entries. If you use four backslashes it works as one has to escape it twice.

Regarding the implementation this should not be the case. So I escape all special chars that are known to me for MySQL like patterns. With this PR it is a real ContainsFilter