### PR TITLE
Do not re-route when searching in route-disabled listing

### DIFF
--- a/src/Administration/Resources/administration/src/app/mixin/listing.mixin.js
+++ b/src/Administration/Resources/administration/src/app/mixin/listing.mixin.js
@@ -185,14 +185,14 @@ Mixin.register('listing', {
             if (value.length === 0) {
                 value = undefined;
             }
+            this.term = value;
 
             if (this.disableRouteParams) {
-                this.term = value;
                 this.page = 1;
                 this.getList();
+                return;
             }
 
-            this.term = value;
             this.updateRoute({
                 term: this.term,
                 page: 1


### PR DESCRIPTION
When using a grid in a component with the `listing` mixin, the `onSearch` method of the `listing` mixin will always re-route the page in the `updateRoute` method even if `disableRouteParams` is set `true`.

https://github.com/shopware/platform/blob/5453c5a7c5a2194b65b4a123696389e570e5a512/src/Administration/Resources/administration/src/app/mixin/listing.mixin.js#L189-L199

This PR fixes this by returning early, if `disableRouteParams` is set true, which does not re-route the page. This behaviour is similar to the methods `onPageChange` or `onSortColumn` which also return early. https://github.com/shopware/platform/blob/5453c5a7c5a2194b65b4a123696389e570e5a512/src/Administration/Resources/administration/src/app/mixin/listing.mixin.js#L175-L178  https://github.com/shopware/platform/blob/5453c5a7c5a2194b65b4a123696389e570e5a512/src/Administration/Resources/administration/src/app/mixin/listing.mixin.js#L209-L218 