### PR TITLE
Fix loading document modal

### DIFF
--- a/src/Administration/Resources/administration/src/module/sw-order/component/sw-order-document-card/index.js
+++ b/src/Administration/Resources/administration/src/module/sw-order/component/sw-order-document-card/index.js
@@ -53,9 +53,9 @@ Component.register('sw-order-document-card', {
             return State.getStore('document_type');
         },
         documentModal() {
-            const subComponentName = this.currentDocumentType.technicalName.replace('_', '-');
+            const subComponentName = this.currentDocumentType.technicalName.replace(/_/g, '-');
             if (this.$options.components[`sw-order-document-settings-${subComponentName}-modal`]) {
-                return `sw-order-document-settings-${this.currentDocumentType.technicalName.replace('_', '-')}-modal`;
+                return `sw-order-document-settings-${subComponentName}-modal`;
             }
             return 'sw-order-document-settings-modal';
         }


### PR DESCRIPTION
This PR fixes the conversion of the document's technical_name from snake case to kebab case.

The problem is that the javascript method `replace` only replaces the first occurrence of the search string. But in this specific case all occurrences of `"_"` need to be replaced with `"-"`.