### PR TITLE
Added bundle specific logger

### DIFF
--- a/src/Core/Framework/DependencyInjection/services.xml
+++ b/src/Core/Framework/DependencyInjection/services.xml
@@ -265,5 +265,10 @@
             <argument type="service" id="filesystem"/>
             <argument>%kernel.cache_dir%</argument>
         </service>
+
+        <!-- Util -->
+        <service id="Shopware\Core\Framework\Util\LoggerFactory">
+            <argument type="string">%kernel.logs_dir%/%%s_%kernel.environment%.log</argument>
+        </service>
     </services>
 </container>

--- a/src/Core/Framework/Util/LoggerFactory.php
+++ b/src/Core/Framework/Util/LoggerFactory.php
@@ -1,0 +1,29 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\Util;
+
+use Monolog\Handler\RotatingFileHandler;
+use Monolog\Logger;
+use Monolog\Processor\PsrLogMessageProcessor;
+use Psr\Log\LoggerInterface;
+
+class LoggerFactory
+{
+    private $rotatingFilePathPattern = '';
+
+    public function __construct(string $rotatingFilePathPattern)
+    {
+        $this->rotatingFilePathPattern = $rotatingFilePathPattern;
+    }
+
+    public function createRotating(string $filePrefix, ?int $fileRotationCount = null): LoggerInterface
+    {
+        $filepath = sprintf($this->rotatingFilePathPattern, $filePrefix);
+
+        $result = new Logger($filePrefix);
+        $result->pushHandler((new RotatingFileHandler($filepath, $fileRotationCount ?? 14)));
+        $result->pushProcessor((new PsrLogMessageProcessor()));
+
+        return $result;
+    }
+}

--- a/src/Docs/_new/2-internals/4-plugins/010-plugin-quick-start.md
+++ b/src/Docs/_new/2-internals/4-plugins/010-plugin-quick-start.md
@@ -431,6 +431,32 @@ Your `services.xml` should now look like this:
 </container>
 ```
 
+# Helpful plugin services
+
+## Logging
+
+There is a logging service factory that can create loggers for any case.
+The logging service has to be registered manually like this:
+```
+<?xml version="1.0" ?>
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    <services>
+        <service id="plugin_quick_start.logger" class="Monolog\Logger">
+            <factory service="Shopware\Core\Framework\Util\LoggerFactory" method="createRotating"/>
+            <argument type="string">plugin_quick_start</argument>
+        </service>
+        <service id="plugin_quick_start.foobar.logger" class="Monolog\Logger">
+            <factory service="Shopware\Core\Framework\Util\LoggerFactory" method="createRotating"/>
+            <argument type="string">plugin_quick_start_foobar</argument>
+        </service>
+    </services>
+</container>
+
+```
+It is a rotating file logger that has its specific file prefix (e.g. `var/logs/plugin_quick_start_dev-2019-03-15.log`).
+
 ## Source
 
 There's a GitHub repository available, containing this example source.


### PR DESCRIPTION
### 1. Why is this change necessary?

Shopware 5 [has these](https://github.com/shopware/shopware/pull/2048) and shopware 6 not.

When writing a plugin that has to log a lot I always have to create an own logger service to collect all my logged data at one place without any other logged data.
Separate logged data by logging source makes it far easier to read logs.

### 2. What does this change do, exactly?
It adds a new service for each bundle with its own file pattern:
```
"var/logs/{$bundleServicePrefix}_{$environment}-{$dateRotation}.log"
```

The service id is
```
"{$bundleServicePrefix}.logger"
```

Therefore there will be at least these new loggers in a default installation:

* `framework.logger`
* `system.logger`
* `content.logger`
* `checkout.logger`
* `administration.logger`
* `storefront.logger`

### 3. Describe each step to reproduce the issue or behaviour.
1. Build something that works with huge payloads and logs processes on it.
2. Have to read the log files on that payload processing
3. Copy your last logger definition from the other plugin where you had that issue before
4. Profit? Not really

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.