### PR TITLE
length property value can never be smaller than 0

### DIFF
--- a/src/Administration/Resources/administration/src/module/sw-integration/page/sw-integration-list/index.js
+++ b/src/Administration/Resources/administration/src/module/sw-integration/page/sw-integration-list/index.js
@@ -89,7 +89,7 @@ Component.register('sw-integration-list', {
         },
 
         createIntegration() {
-            if (!this.currentIntegration.label || this.currentIntegration.label.length < 0) {
+            if (!this.currentIntegration.label || !this.currentIntegration.label.length) {
                 this.createSavedErrorNotification();
                 return;
             }

--- a/src/Administration/Resources/administration/src/module/sw-settings-country/page/sw-settings-country-detail/index.js
+++ b/src/Administration/Resources/administration/src/module/sw-settings-country/page/sw-settings-country-detail/index.js
@@ -94,7 +94,7 @@ Component.register('sw-settings-country-detail', {
         onDeleteCountryStates() {
             const selection = this.$refs.countryStateGrid.selection;
 
-            if (Object.keys(selection).length < 0) {
+            if (!Object.keys(selection).length) {
                 return;
             }
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/communtiy).
-->

### 1. Why is this change necessary?
`.length` can be never smaller than 0. It can be only 0 or greater than 0.


### 2. What does this change do, exactly?
Improve the length check and check if length is > 0 by coercing to a boolean.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
