### PR TITLE
Remove wrong -moz-background-clip property

### DIFF
--- a/src/Administration/Resources/nuxt-component-library/assets/css/components/tip.scss
+++ b/src/Administration/Resources/nuxt-component-library/assets/css/components/tip.scss
@@ -17,7 +17,6 @@
     border-radius: 3px;
     -moz-background-clip: padding;
     -webkit-background-clip: padding-box;
-    -moz-background-clip: padding-box;
     background-clip: padding-box;
     -webkit-touch-callout: none;
     -webkit-user-select: none;


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/communtiy).
-->

### 1. Why is this change necessary?
There is a wrong `-moz-background-clip` rule.

### 2. What does this change do, exactly?
Remove the wrong `-moz-background-clip` rule.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
