### PR TITLE
Fix invalid selector

### DIFF
--- a/src/Administration/Resources/administration/src/app/component/form/sw-datepicker/sw-datepicker.scss
+++ b/src/Administration/Resources/administration/src/app/component/form/sw-datepicker/sw-datepicker.scss
@@ -8,7 +8,7 @@ $sw-datepicker-color-selected: $color-shopware-blue;
 $sw-datepicker-color-text-selected: $color-white;
 
 .sw-field--datepicker {
-    &:not(is--diabled) {
+    &:not(.is--disabled) {
         .sw-field__addition {
             cursor: pointer;
         }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/communtiy).
-->

### 1. Why is this change necessary?
`is--diabled` is not a valid CSS selector and also contains a small typo.

### 2. What does this change do, exactly?
Fix the wrong selector (`.is--disabled`).

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
