### PR TITLE
Remove duplicate loader config

### DIFF
--- a/src/Administration/Resources/administration/build/utils.js
+++ b/src/Administration/Resources/administration/build/utils.js
@@ -296,8 +296,7 @@ exports.cssLoaders = function (options) {
                 loader: `${loader}-loader`,
                 options: Object.assign({}, loaderOptions, {
                     sourceMap: options.sourceMap
-                }),
-                loader: `${loader}-loader`
+                })
             });
         }
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/communtiy).
-->

### 1. Why is this change necessary?
There is a duplicate `loader` config property.

### 2. What does this change do, exactly?
This removes the duplicate `loader` property in the config.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
