### PR TITLE
Remove inheritdoc from renderStorefront

### DIFF
--- a/src/Storefront/Controller/StorefrontController.php
+++ b/src/Storefront/Controller/StorefrontController.php
@@ -14,9 +14,6 @@ use Symfony\Component\HttpFoundation\Response;
 
 abstract class StorefrontController extends AbstractController
 {
-    /**
-     * {@inheritdoc}
-     */
     protected function renderStorefront($view, array $parameters = [], ?Response $response = null): Response
     {
         $view = $this->resolveView($view);


### PR DESCRIPTION
inheritdoc is not needed in renderStorefront; there is no overwrite and its confusing ide