### PR TITLE
Currently api request http://192.168.33.10/api/v1/product-manufacture…

### DIFF
--- a/src/Core/Migration/Migration1560264755AddedMissingIdColumn.php
+++ b/src/Core/Migration/Migration1560264755AddedMissingIdColumn.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Migration;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Framework\Migration\MigrationStep;
+
+class Migration1560264755AddedMissingIdColumn extends MigrationStep
+{
+    public function getCreationTimestamp(): int
+    {
+        return 1560264755;
+    }
+
+    public function update(Connection $connection): void
+    {
+        $connection->executeQuery('
+                ALTER TABLE `product_manufacturer_translation`
+                ADD `id` binary(16) NOT NULL FIRST;
+        ');
+    }
+
+    public function updateDestructive(Connection $connection): void
+    {
+        // implement update destructive
+    }
+}
+


### PR DESCRIPTION
…r/01f4b5bf9fef4561b8a9ce3906472136/translations is broken because of missing id column in product_manufacturer_translation table.

This migration adds the missing column to the database.

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/communtiy).
-->

### 1. Why is this change necessary?


### 2. What does this change do, exactly?


### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.
