### PR TITLE
Allow plugins to import 'vue' and fix vue-loader config

### DIFF
--- a/src/Administration/Resources/administration/build/webpack.base.conf.js
+++ b/src/Administration/Resources/administration/build/webpack.base.conf.js
@@ -1,4 +1,6 @@
+/* eslint-disable import/no-extraneous-dependencies */
 const path = require('path');
+const VueLoaderPlugin = require('vue-loader/lib/plugin');
 const utils = require('./utils');
 const config = require('../config');
 const vueLoaderConfig = require('./vue-loader.conf');
@@ -49,7 +51,7 @@ module.exports = {
     resolve: {
         extensions: ['.js', '.vue', '.json', '.less', '.twig'],
         alias: {
-            vue$: 'vue/dist/vue.esm.js',
+            vue$: require.resolve('vue/dist/vue.esm.js'),
             src: resolve('src'),
             module: resolve('src/module'),
             scss: resolve('src/app/assets/scss'),
@@ -141,5 +143,8 @@ module.exports = {
                 }
             }
         ]
-    }
+    },
+    plugins: [
+        new VueLoaderPlugin()
+    ]
 };

--- a/src/Administration/Resources/administration/build/webpack.prod.conf.js
+++ b/src/Administration/Resources/administration/build/webpack.prod.conf.js
@@ -16,6 +16,17 @@ const baseWebpackConfig = require('./webpack.base.conf');
 
 let webpackConfig = merge(baseWebpackConfig, {
     mode: 'production',
+    entry: {
+        commons: [
+            // Ensure vue-loader's runtime components will always be packaged into vendors-node, even if no single file
+            // components are present. This is required because when packaging a plugin using administration:build, the
+            // SplitChunksPlugin configuration in webpack.base.conf.js will force the vue-loader runtime into the
+            // vendors-node chunk, which will prevent it from being packaged in the plugin bundle, which will in turn
+            // prevent that plugin bundle from loading on a Shopware instance which does not have the vue-loader runtime
+            // in its vendors-node bundle. Because of this, stock Shopware must ship the runtime.
+            require.resolve('vue-loader/lib/runtime/componentNormalizer.js')
+        ]
+    },
     module: {
         rules: utils.styleLoaders({
             sourceMap: config.build.productionSourceMap


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/communtiy).
-->

### 1. Why is this change necessary?

Since plugins live outside the hierarchy which contains vue as a dependency, doing `import Vue from 'vue';` inside a plugin's JS code fails to resolve the dependency. This is for example a problem when using `vue-loader` to `import` single-file components. In addition to this, while `webpack.base.conf` declares `vue-loader`, it does not load the associated plugin, leaving `vue-loader` in a non-functional state.

### 2. What does this change do, exactly?

1. It replaces the `vue$` alias with the resolved absolute path for the Vue ESM "binary".
2. It adds the `VueLoaderPlugin` to the webpack configuration.

### 3. Describe each step to reproduce the issue or behaviour.

Place `import Vue from 'vue';` in the `main.js` of any plugin. You can then observe this error when running the webpack build:

```
ERROR in /path/to/my-plugin/src/Resources/administration/main.js
	Module not found: Error: Can't resolve 'vue' in '/path/to/my-plugin/src/Resources/administration'
```

If you add a single file component and try to `import MyComponent from './my-component.vue'`, you will also get this WARNING and the component will fail to load:

```
WARNING in /path/to/my-plugin/src/Resources/administration/my-component.vue
	Module Error (from ./node_modules/vue-loader/lib/index.js):
	vue-loader was used without the corresponding plugin. Make sure to include VueLoaderPlugin in your webpack config.
```

### 4. Please link to the relevant issues (if any).

none

### 5. Which documentation changes (if any) need to be made because of this PR?

none

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.
