### PR TITLE
Add unit tests for EntityReader that assert bidirectional associations are handled correctly

### DIFF
--- a/src/Core/Framework/Test/DataAbstractionLayer/Reader/EntityReaderTest.php
+++ b/src/Core/Framework/Test/DataAbstractionLayer/Reader/EntityReaderTest.php
@@ -1737,4 +1737,118 @@ class EntityReaderTest extends TestCase
         $product = $products->get($productId);
         static::assertInstanceOf(ProductEntity::class, $product);
     }
+
+    public function testBidirectionalAssociations(): void
+    {
+        $parentId = Uuid::randomHex();
+        $context = Context::createDefaultContext();
+
+        $productsPayload = [
+            [
+                'id' => $parentId,
+                'manufacturer' => ['name' => 'test'],
+                'productNumber' => Uuid::randomHex(),
+                'price' => [['currencyId' => Defaults::CURRENCY, 'gross' => 10, 'net' => 9, 'linked' => false]],
+                'tax' => ['taxRate' => 13, 'name' => 'green'],
+                'stock' => 1,
+                'name' => 'red',
+            ],
+            [
+                'id' => Uuid::randomHex(),
+                'manufacturer' => ['name' => 'test'],
+                'productNumber' => Uuid::randomHex(),
+                'price' => [['currencyId' => Defaults::CURRENCY, 'gross' => 10, 'net' => 9, 'linked' => false]],
+                'tax' => ['taxRate' => 13, 'name' => 'green'],
+                'stock' => 1,
+                'parentId' => $parentId,
+                'name' => 'blue',
+            ],
+        ];
+
+        $this->productRepository->create($productsPayload, $context);
+
+        $criteria = new Criteria([$parentId]);
+        $criteria->addAssociation('children');
+        /** @var ProductEntity $parentProduct */
+        $parentProduct = $this->productRepository->search($criteria, $context)->first();
+
+        static::assertNotNull($parentProduct->getChildren()->first()->getParent());
+    }
+
+    public function testBidirectionalAssociations2(): void
+    {
+        $parentId = Uuid::randomHex();
+        $context = Context::createDefaultContext();
+
+        $productsPayload = [
+            [
+                'id' => $parentId,
+                'manufacturer' => ['name' => 'test'],
+                'productNumber' => Uuid::randomHex(),
+                'price' => [['currencyId' => Defaults::CURRENCY, 'gross' => 10, 'net' => 9, 'linked' => false]],
+                'tax' => ['taxRate' => 13, 'name' => 'green'],
+                'stock' => 1,
+                'name' => 'red',
+            ],
+            [
+                'id' => Uuid::randomHex(),
+                'manufacturer' => ['name' => 'test'],
+                'productNumber' => Uuid::randomHex(),
+                'price' => [['currencyId' => Defaults::CURRENCY, 'gross' => 10, 'net' => 9, 'linked' => false]],
+                'tax' => ['taxRate' => 13, 'name' => 'green'],
+                'stock' => 1,
+                'parentId' => $parentId,
+                'name' => 'blue',
+            ],
+        ];
+
+        $this->productRepository->create($productsPayload, $context);
+
+        $criteria = new Criteria([$parentId]);
+        $criteria->addAssociation('children');
+        $criteria->addAssociation('children.parent');
+        /** @var ProductEntity $parentProduct */
+        $parentProduct = $this->productRepository->search($criteria, $context)->first();
+
+        static::assertSame($parentProduct, $parentProduct->getChildren()->first()->getParent());
+    }
+
+    public function testBidirectionalAssociations3(): void
+    {
+        $parentId = Uuid::randomHex();
+        $context = Context::createDefaultContext();
+
+        $productsPayload = [
+            [
+                'id' => $parentId,
+                'manufacturer' => ['name' => 'test'],
+                'productNumber' => Uuid::randomHex(),
+                'price' => [['currencyId' => Defaults::CURRENCY, 'gross' => 10, 'net' => 9, 'linked' => false]],
+                'tax' => ['taxRate' => 13, 'name' => 'green'],
+                'stock' => 1,
+                'name' => 'red',
+            ],
+            [
+                'id' => Uuid::randomHex(),
+                'manufacturer' => ['name' => 'test'],
+                'productNumber' => Uuid::randomHex(),
+                'price' => [['currencyId' => Defaults::CURRENCY, 'gross' => 10, 'net' => 9, 'linked' => false]],
+                'tax' => ['taxRate' => 13, 'name' => 'green'],
+                'stock' => 1,
+                'parentId' => $parentId,
+                'name' => 'blue',
+            ],
+        ];
+
+        $this->productRepository->create($productsPayload, $context);
+
+        $criteria = new Criteria([$parentId]);
+        $criteria->addAssociation('children');
+        $criteria->addAssociationPath('children.parent');
+        $criteria->addAssociationPath('children.parent.children');
+        /** @var ProductEntity $parentProduct */
+        $parentProduct = $this->productRepository->search($criteria, $context)->first();
+
+        static::assertNotNull($parentProduct->getChildren()->first()->getParent()->getChildren());
+    }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?
When fetching entities with bidirectional associations the associations are not correctly re-built in the fetched entities.

Explanation with an example:
Products have an association `children` that is one-to-many to another product. This association is mapped/inversed by the property `parent` in the product, because it is a bi-directional association.
So if a product is fetched with children the parent product of the children can be accessed via the property parent (or `getParent()`).


If a product is fetched with its children, every child product should have the property `parent` set to the fetched product.

The DAL currently just sets this association to `NULL`.

```php
$criteria = new Criteria([$parentId]);
$criteria->addAssociation('children');
$parentProduct->getChildren()->first()->getParent() === null // true, should be $parentProduct
```


Also if you try to add the product as another association criteria you run into another problem, that leads to the product being fetched twice as independent entities:

```php
$criteria = new Criteria([$parentId]);
$criteria->addAssociation('children');
$criteria->addAssociationPath('children.parent');
$criteria->addAssociationPath('children.parent.children');
$parentProduct->getChildren()->first()->getParent() === $parentProduct // false, because the entities are copies of each other not the same entity
```

### 2. What does this change do, exactly?
This change just adds unit tests (that currently are failing) that assert that fetching bidirectional associations will work as expected.

### 3. Describe each step to reproduce the issue or behaviour.
See the unit tests.
