### PR TITLE
Fix config reader file name processing

### DIFF
--- a/src/Core/System/SystemConfig/Util/ConfigReader.php
+++ b/src/Core/System/SystemConfig/Util/ConfigReader.php
@@ -23,7 +23,7 @@ class ConfigReader extends XmlReader
         if ($bundleConfigName === null) {
             $bundleConfigName = $bundle->getConfigPath() . '/config.xml';
         } else {
-            $bundleConfigName = $bundle->getConfigPath() . '/' . rtrim($bundleConfigName, '.xml') . '.xml';
+            $bundleConfigName = $bundle->getConfigPath() . '/' . preg_replace('/\\.xml$/i', '', $bundleConfigName) . '.xml';
         }
         $configPath = $bundle->getPath() . '/' . ltrim($bundleConfigName, '/');
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/communtiy).
-->

### 1. Why is this change necessary?
The code `rtrim($bundleConfigName, '.xml')` does not trim '.xml' from the right side of a string, but every character that is one of `.`, `x`,`m` or `l`. The second parameter of `rtrim` works as a char-LIST.

As an example: `dhl.xml` would be trimmed to `dh`.

### 2. What does this change do, exactly?
Replace the `rtrim` with a `preg_replace` that shows the intended behaviour.

