### PR TITLE
NEXT-3678 - Fixed reference unit in product detail

### DIFF
--- a/src/Storefront/Resources/views/page/product-detail/buy-widget-price.html.twig
+++ b/src/Storefront/Resources/views/page/product-detail/buy-widget-price.html.twig
@@ -104,7 +104,7 @@
                     {% if price.referencePrice is not null %}
                         {% block page_product_detail_price_unit_refrence_content %}
                             <span class="price-unit-reference-content">
-                                ({{ price.referencePrice.price|currency }}{{ "general.star"|trans }} / {{ price.referencePrice.purchaseUnit }} {{ price.referencePrice.unitName }})
+                                ({{ price.referencePrice.price|currency }}{{ "general.star"|trans }} / {{ price.referencePrice.referenceUnit }} {{ price.referencePrice.unitName }})
                             </span>
                         {% endblock %}
                     {% endif %}


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/communtiy).
-->

### 1. Why is this change necessary?
The reference unit is wrong in product detail

### 2. What does this change do, exactly?
Replace `price.referencePrice.purchaseUnit` with `price.referencePrice.referenceUnit`

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
