### PR TITLE
added salutation to OrderCustomerEntity for payment processing / risk checking

### DIFF
--- a/src/Core/Checkout/Payment/Cart/PaymentTransactionChainProcessor.php
+++ b/src/Core/Checkout/Payment/Cart/PaymentTransactionChainProcessor.php
@@ -139,6 +139,7 @@ class PaymentTransactionChainProcessor
         $criteria = new Criteria();
         $criteria->addFilter(new EqualsFilter('orderId', $orderId));
         $criteria->addAssociation('customer');
+        $criteria->addAssociation('salutation');
 
         return $this->orderCustomerRepository
             ->search($criteria, $context)


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/communtiy).
-->

### 1. Why is this change necessary?

Payment modules may need the salutation for further processing.

### 2. What does this change do, exactly?

This change adds the salutation to OrderCustomerEntity. The salutation may be needed in payment modules for risk checking purposes to determine the gender of the customer. 

### 3. Describe each step to reproduce the issue or behaviour.

Create payment module. Try to get the saluation from the OrderCustomerEntity object.

### 4. Please link to the relevant issues (if any).

none 

### 5. Which documentation changes (if any) need to be made because of this PR?

none

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
