### PR TITLE
Allow multiple tracking codes in order_delivery

### DIFF
--- a/UPGRADE-6.1.md
+++ b/UPGRADE-6.1.md
@@ -143,6 +143,8 @@ Core
 * If you invalidated the entity cache over the `shopware.cache` service, use the `\Shopware\Core\Framework\Cache\CacheClearer` instead.
 * All customer events in `Shopware\Core\Checkout\Customer\Event` now get the `Shopware\Core\Syste\SalesChannel\SalesChannelContext` instead of `Shopware\Core\Framework\Context` and a `salesChannelId`
 * Implement `getName` for classes that implement `\Shopware\Core\Framework\DataAbstractionLayer\Indexing\IndexerInterface`
+ * `\Shopware\Core\Checkout\Order\Aggregate\OrderDelivery\OrderDeliveryEntity::$trackingCode` has been replaced with 
+   `\Shopware\Core\Checkout\Order\Aggregate\OrderDelivery\OrderDeliveryEntity::$trackingCodes`.
 
 Administration
 --------------

--- a/src/Administration/Resources/administration/src/module/sw-order/component/sw-order-user-card/index.js
+++ b/src/Administration/Resources/administration/src/module/sw-order/component/sw-order-user-card/index.js
@@ -83,7 +83,7 @@ Component.register('sw-order-user-card', {
         },
 
         hasDeliveryTrackingCode() {
-            return this.hasDeliveries && this.delivery.trackingCode;
+            return this.hasDeliveries && this.delivery.trackingCodes.length;
         },
 
         hasDifferentBillingAndShippingAddress() {

--- a/src/Administration/Resources/administration/src/module/sw-order/component/sw-order-user-card/sw-order-user-card.html.twig
+++ b/src/Administration/Resources/administration/src/module/sw-order/component/sw-order-user-card/sw-order-user-card.html.twig
@@ -228,9 +228,9 @@
                                             <dd>{{ lastChangedDate }}</dd>
                                         {% endblock %}
 
-                                        {% block sw_order_detail_base_secondary_info_tracking_code %}
-                                            <dt>{{ $tc('sw-order.detailBase.labelTrackingCode') }}</dt>
-                                            <dd>{{ hasDeliveryTrackingCode ? delivery.trackingCode :$tc('sw-order.detailBase.labelNoDeliveryTrackingCodeYet') }}</dd>
+                                        {% block sw_order_detail_base_secondary_info_tracking_codes %}
+                                            <dt>{{ $tc('sw-order.detailBase.labelTrackingCodes') }}</dt>
+                                            <dd>{{ hasDeliveryTrackingCode ? delivery.trackingCodes.join(', ') :$tc('sw-order.detailBase.labelNoDeliveryTrackingCodeYet') }}</dd>
                                         {% endblock %}
 
                                         {% block sw_order_detail_base_secondary_info_order_overview_right_column_slot %}

--- a/src/Administration/Resources/administration/src/module/sw-order/snippet/de-DE.json
+++ b/src/Administration/Resources/administration/src/module/sw-order/snippet/de-DE.json
@@ -88,7 +88,7 @@
       "labelNoDeliveryTrackingCodeYet" : "Keine",
       "labelLastChange" : "Zuletzt geändert",
       "labelNoChangesYet" : "Bisher keine Änderungen",
-      "labelTrackingCode" : "Sendungsnummer",
+      "labelTrackingCodes" : "Sendungsnummer(n)",
       "buttonContinueOnVersionedOrder" : "Laden",
       "buttonAddDeliveryAddress" : "Neue Addresse hinzufügen",
       "labelSameDeliveryAndBillingAddress" : "Rechnungs- und Lieferadresse sind identisch",

--- a/src/Administration/Resources/administration/src/module/sw-order/snippet/en-GB.json
+++ b/src/Administration/Resources/administration/src/module/sw-order/snippet/en-GB.json
@@ -88,7 +88,7 @@
       "labelNoDeliveryTrackingCodeYet": "None",
       "labelLastChange" : "Last changed",
       "labelNoChangesYet" : "No changes yet",
-      "labelTrackingCode" : "Track and trace code",
+      "labelTrackingCodes" : "Track and trace code(s)",
       "buttonAddDeliveryAddress" : "Add new address",
       "labelSameDeliveryAndBillingAddress" : "Billing and shipping address identical",
       "buttonContinueOnVersionedOrder" : "Load",

--- a/src/Core/Checkout/Order/Aggregate/OrderDelivery/OrderDeliveryDefinition.php
+++ b/src/Core/Checkout/Order/Aggregate/OrderDelivery/OrderDeliveryDefinition.php
@@ -16,12 +16,14 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\PrimaryKey;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\Required;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\SearchRanking;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\IdField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\ListField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\ManyToOneAssociationField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\OneToManyAssociationField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\ReferenceVersionField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\StringField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\VersionField;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
+use Shopware\Core\Framework\DataAbstractionLayer\Write\EntityExistence;
 use Shopware\Core\System\StateMachine\Aggregation\StateMachineState\StateMachineStateDefinition;
 
 class OrderDeliveryDefinition extends EntityDefinition
@@ -65,7 +67,7 @@ class OrderDeliveryDefinition extends EntityDefinition
             (new FkField('state_id', 'stateId', StateMachineStateDefinition::class))->addFlags(new Required()),
             new ManyToOneAssociationField('stateMachineState', 'state_id', StateMachineStateDefinition::class, 'id', false),
 
-            (new StringField('tracking_code', 'trackingCode'))->addFlags(new SearchRanking(SearchRanking::HIGH_SEARCH_RANKING)),
+            (new ListField('tracking_codes', 'trackingCodes', StringField::class))->addFlags(new Required(), new SearchRanking(SearchRanking::HIGH_SEARCH_RANKING)),
             (new DateTimeField('shipping_date_earliest', 'shippingDateEarliest'))->addFlags(new Required(), new SearchRanking(SearchRanking::MIDDLE_SEARCH_RANKING)),
             (new DateTimeField('shipping_date_latest', 'shippingDateLatest'))->addFlags(new Required(), new SearchRanking(SearchRanking::MIDDLE_SEARCH_RANKING)),
             new CalculatedPriceField('shipping_costs', 'shippingCosts'),
@@ -76,5 +78,12 @@ class OrderDeliveryDefinition extends EntityDefinition
             (new ManyToOneAssociationField('shippingMethod', 'shipping_method_id', ShippingMethodDefinition::class, 'id'))->addFlags(new SearchRanking(SearchRanking::ASSOCIATION_SEARCH_RANKING)),
             (new OneToManyAssociationField('positions', OrderDeliveryPositionDefinition::class, 'order_delivery_id', 'id'))->addFlags(new CascadeDelete(), new SearchRanking(SearchRanking::ASSOCIATION_SEARCH_RANKING)),
         ]);
+    }
+
+    public function getDefaults(EntityExistence $existence): array
+    {
+        return [
+            'trackingCodes' => [],
+        ];
     }
 }

--- a/src/Core/Checkout/Order/Aggregate/OrderDelivery/OrderDeliveryEntity.php
+++ b/src/Core/Checkout/Order/Aggregate/OrderDelivery/OrderDeliveryEntity.php
@@ -31,9 +31,9 @@ class OrderDeliveryEntity extends Entity
     protected $shippingMethodId;
 
     /**
-     * @var string|null
+     * @var string[]
      */
-    protected $trackingCode;
+    protected $trackingCodes;
 
     /**
      * @var \DateTimeInterface
@@ -115,14 +115,20 @@ class OrderDeliveryEntity extends Entity
         $this->shippingMethodId = $shippingMethodId;
     }
 
-    public function getTrackingCode(): ?string
+    /**
+     * @return string[]
+     */
+    public function getTrackingCodes(): array
     {
-        return $this->trackingCode;
+        return $this->trackingCodes;
     }
 
-    public function setTrackingCode(?string $trackingCode): void
+    /**
+     * @param string[] $trackingCodes
+     */
+    public function setTrackingCodes(array $trackingCodes): void
     {
-        $this->trackingCode = $trackingCode;
+        $this->trackingCodes = $trackingCodes;
     }
 
     public function getShippingDateEarliest(): \DateTimeInterface

--- a/src/Core/Migration/Migration1565194094MultipleTrackingCodesInOrderDelivery.php
+++ b/src/Core/Migration/Migration1565194094MultipleTrackingCodesInOrderDelivery.php
@@ -1,0 +1,35 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Migration;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Framework\Migration\MigrationStep;
+
+class Migration1565194094MultipleTrackingCodesInOrderDelivery extends MigrationStep
+{
+    public function getCreationTimestamp(): int
+    {
+        return 1565194094;
+    }
+
+    public function update(Connection $connection): void
+    {
+        $connection->executeQuery('
+            ALTER TABLE `order_delivery`
+            ADD COLUMN `tracking_codes` JSON NOT NULL AFTER `shipping_method_id`,
+            ADD CONSTRAINT `json.order_delivery.tracking_codes` CHECK (JSON_VALID(`tracking_codes`));
+        ');
+        $connection->executeQuery('
+            UPDATE `order_delivery`
+            SET `tracking_codes` = IF(`tracking_code` IS NULL OR `tracking_code` = "", JSON_ARRAY(), JSON_ARRAY(`tracking_code`));
+        ');
+    }
+
+    public function updateDestructive(Connection $connection): void
+    {
+        $connection->executeQuery('
+            ALTER TABLE `order_delivery`
+            DROP COLUMN `tracking_code`;
+        ');
+    }
+}

--- a/src/Docs/Resources/current/2-internals/1-core/10-erd/_puml/erd-all.puml
+++ b/src/Docs/Resources/current/2-internals/1-core/10-erd/_puml/erd-all.puml
@@ -1443,7 +1443,7 @@ Table(ShopwareCoreCheckoutOrderAggregateOrderDeliveryOrderDeliveryDefinition, "o
    not_null(shippingOrderAddressVersionId) referenceVersion
    not_null(shippingMethodId) foreignKey
    not_null(stateId) foreignKey
-   trackingCode string
+   trackingCodes json
    not_null(shippingDateEarliest) dateTime
    not_null(shippingDateLatest) dateTime
    shippingCosts calculatedPrice

--- a/src/Docs/Resources/current/2-internals/1-core/10-erd/_puml/erd-shopware-core-checkout-order.puml
+++ b/src/Docs/Resources/current/2-internals/1-core/10-erd/_puml/erd-shopware-core-checkout-order.puml
@@ -98,7 +98,7 @@ Table(ShopwareCoreCheckoutOrderAggregateOrderDeliveryOrderDeliveryDefinition, "o
    not_null(shippingOrderAddressVersionId) referenceVersion
    not_null(shippingMethodId) foreignKey
    not_null(stateId) foreignKey
-   trackingCode string
+   trackingCodes json
    not_null(shippingDateEarliest) dateTime
    not_null(shippingDateLatest) dateTime
    shippingCosts calculatedPrice


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/communtiy).
-->

### 1. Why is this change necessary?
Currently an `order_delivery` can only have one tracking code. There are multiple reason why it is possible that an `order_delivery` can have more than one tracking codes:

Multi-package shipments: The content of an `order_delivery` is too much for one parcel and is packed into two parcels during the packing process. Depending on the shipping service provider, there is then one code per parcel, even though it is a single delivery.
Another case where there may be several tracking codes is when a shipment is shipped and then returns to sender. Shop operators then often simply create another label and send the package again with a second label. 
And the third case would be that there is one tracking code for the first package sent to the customer and one for the return package (so called "Beilegretoure", the return label with tracking code is already included in the package). 

### 2. What does this change do, exactly?
Changes the field `string OrderDeliveryEntity::$trackingCode` to `string[] OrderDeliveryEntity::$trackingCodes`

### 5. Checklist

- [X] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [X] I have written or adjusted the documentation according to my changes
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.