### PR TITLE
NEXT-3755 - Fallback to global configuration if sales channel specific value is empty.

### DIFF
--- a/src/Core/System/Test/SystemConfig/SystemConfigServiceTest.php
+++ b/src/Core/System/Test/SystemConfig/SystemConfigServiceTest.php
@@ -69,6 +69,10 @@ class SystemConfigServiceTest extends TestCase
         $this->systemConfigService->set('foo.bar', 'override', Defaults::SALES_CHANNEL);
         $actual = $this->systemConfigService->get('foo.bar', Defaults::SALES_CHANNEL);
         static::assertEquals('override', $actual);
+
+        $this->systemConfigService->set('foo.bar', '', Defaults::SALES_CHANNEL);
+        $actual = $this->systemConfigService->get('foo.bar', Defaults::SALES_CHANNEL);
+        static::assertEquals('test', $actual);
     }
 
     public function testSetGetSalesChannelNoInherit(): void
@@ -124,6 +128,18 @@ class SystemConfigServiceTest extends TestCase
             'foo.c' => 'c override',
         ];
         $actual = $this->systemConfigService->getDomain('foo', Defaults::SALES_CHANNEL, false);
+        static::assertEquals($expected, $actual);
+    }
+
+    public function testGetDomainInherit(): void
+    {
+        $this->systemConfigService->set('foo.bar', 'test');
+        $this->systemConfigService->set('foo.bar', 'override', Defaults::SALES_CHANNEL);
+        $this->systemConfigService->set('foo.bar', '', Defaults::SALES_CHANNEL);
+
+        $expected = ['foo.bar' => 'test'];
+        $actual = $this->systemConfigService->getDomain('foo', Defaults::SALES_CHANNEL, true);
+
         static::assertEquals($expected, $actual);
     }
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/communtiy).
-->

### 1. Why is this change necessary?
A removal of a sales channel specific configuration value results in an empty string in the database for this value. Fetching this configuration key includes the empty string instead of the fallback value.
The administration is misleading as it's showing the placeholder in the sales channel specific input field.

### 2. What does this change do, exactly?
It only fetches a given value into the configuration array if there is no fallback value _or_ if the value is not empty. The same applies for fetching a singular configuration value where the values (which are sorted by sales channel ID, so the global value comes first) are only overridden if there is an actual value.

### 3. Describe each step to reproduce the issue or behaviour.
* Add a plugin with a configuration setting.
* Set this setting globally and for a sales channel
* Remove the value for the sales channel
* Try and fetch the configuration setting for the sales channel with inheritance

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/NEXT-3755

### 5. Which documentation changes (if any) need to be made because of this PR?
None as far as I see

### 6. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
