### PR TITLE
Fix storefront namespace for PhpStorm

### DIFF
--- a/src/Storefront/Resources/views/ide-twig.json
+++ b/src/Storefront/Resources/views/ide-twig.json
@@ -1,8 +1,7 @@
 {
   "namespaces": [
     {
-      "namespace": "Storefront",
-      "path": "."
+      "namespace": "Storefront"
     }
   ]
 }


### PR DESCRIPTION
All templates in storefront namespace are currently not known out of box for PhpStorm because of wrong json file. The idea for same folder was not to provide a `path`. its now supported by Symfony plugin, but removing will directly support it for all dev without any update. ref commit https://github.com/Haehnchen/idea-php-symfony2-plugin/commit/553e1800e2098a7d7128406c16b11cf55a09d8d9
