### PR TITLE
Fix typo in german translation of the plugin unzip failure message

### DIFF
--- a/src/Administration/Resources/administration/src/module/sw-plugin/snippet/de-DE.json
+++ b/src/Administration/Resources/administration/src/module/sw-plugin/snippet/de-DE.json
@@ -29,7 +29,7 @@
       "messageGenericFailure": "Es ist ein unbekannter Fehler aufgetreten",
       "titleUploadFailure": "Hochladen fehlgeschlagen",
       "messageUploadFailureNotAZipFile": "Die hochgeladenen Datei ist keine Zip-Datei",
-      "messageUploadFailureUnzipFailed": "Die Zip-Datei konnt nicht entpackt werden",
+      "messageUploadFailureUnzipFailed": "Die Zip-Datei konnte nicht entpackt werden",
       "messageUploadFailureNoPluginFoundInZipFile": "In der hochgeladenen Zip-Datei wurde kein Plugin gefunden",
       "titleLoginDataInvalid": "Logindaten unvollständig",
       "messageLoginDataInvalid": "Logindaten wurden nicht vollständig angegeben",


### PR DESCRIPTION
### 1. Why is this change necessary?
Fix a typo in some snippet. 

### 2. What does this change do, exactly?
Adds an `e` which corrects the typo.

### 3. Describe each step to reproduce the issue or behaviour.
Try to upload a plugin where the zip extension is not loaded, and you will get the wrong message (only in the German version of the administration). 

### 4. Please link to the relevant issues (if any).
\-

### 5. Which documentation changes (if any) need to be made because of this PR?
\-

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
