### PR TITLE
[Docs]Set searchable in all languages to false for german articles

### DIFF
--- a/src/Docs/Convert/WikiApiService.php
+++ b/src/Docs/Convert/WikiApiService.php
@@ -70,7 +70,7 @@ class WikiApiService
                 'title' => $documentMetadata->getTitleDe(),
                 'navigationTitle' => $documentMetadata->getTitleDe(),
                 'content' => '<p>Die Entwicklerdokumentation ist nur auf Englisch verfügbar.</p>',
-                'searchableInAllLanguages' => true,
+                'searchableInAllLanguages' => false,
                 'fromProductVersion' => self::INITIAL_VERSION,
                 'active' => $documentMetadata->isActive(),
                 'metaTitle' => $documentMetadata->getMetaTitleDe(),


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/communtiy).
-->

### 1. Why is this change necessary?
German articles are listed in the english search form, because this flag is set to true for german articles. Since the german articles only are a hint, that there is no german translation of the artilces, it makes no sense to show them in the search.

### 2. What does this change do, exactly?
Set the flag to false for the german version of the article


### 3. Describe each step to reproduce the issue or behaviour.
Search for "elasticsearch" on https://docs.shopware.com/en/search?query=elasticsearch
You will see "Die Entwicklerdokumentation ist nur auf Englisch verfügbar" on the english search page.

### 4. Please link to the relevant issues (if any).
/

### 5. Which documentation changes (if any) need to be made because of this PR?
/

### 6. Checklist

- [] I have written tests and verified that they fail without my change
- [] I have squashed any insignificant commits
- [] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.