### PR TITLE
Fix missing slash in server url

### DIFF
--- a/src/Core/Framework/Api/ApiDefinition/Generator/OpenApi3Generator.php
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/OpenApi3Generator.php
@@ -52,7 +52,7 @@ class OpenApi3Generator implements ApiDefinitionGeneratorInterface
         $openapi = [
             'openapi' => '3.0.0',
             'servers' => [
-                ['url' => $url . ($forSalesChannel ? 'sales-channel-api/v1' : 'api/v1')],
+                ['url' => rtrim($url, '/') . ($forSalesChannel ? '/sales-channel-api/v1' : '/api/v1')],
             ],
             'info' => [
                 'title' => 'Shopware ' . ($forSalesChannel ? 'Sales-Channel' : 'Management') . ' API',


### PR DESCRIPTION
### 1. Why is this change necessary?
Having a look at the recent https://demo.shopwaredemo.de/api/v1/_info/openapi3.json you can see the following servers block:
```
{
    "servers": [
        {
            "url":"http:\/\/demo.shopwaredemo.deapi\/v1"
        }
    ]
}
```
There is obviously a `/` missing

### 2. What does this change do, exactly?
Makes sure that there is a `/` by adding it to the concatenation. It also makes sure that there is no duplicate `/`

### 3. Describe each step to reproduce the issue or behaviour.

1. Parse `https://demo.shopwaredemo.de/api/v1/_info/openapi3.json`
2. Fail to connect to server
3. See weird DNS lookup of a `.deapi` domain
4. :thinking: :man_facepalming: 

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
