### PR TITLE
Require vendor/autoload.php of plugins if it exists

### DIFF
--- a/src/Core/Kernel.php
+++ b/src/Core/Kernel.php
@@ -367,6 +367,10 @@ SQL;
                 $this->classLoader->add($namespace, $path);
             }
         }
+
+        // Re-register the Shopware class loader to enforce it to be always the first one
+        $this->classLoader->unregister();
+        $this->classLoader->register(true);
     }
 
     private function mapPsrPaths(array $psr, string $pluginPath): array

--- a/src/Core/Kernel.php
+++ b/src/Core/Kernel.php
@@ -389,12 +389,7 @@ SQL;
         foreach ($plugins as $pluginData) {
             $className = $pluginData['base_class'];
 
-            $pluginClassFilePath = $this->classLoader->findFile($className);
-            if ($pluginClassFilePath === false) {
-                continue;
-            }
-
-            if (!file_exists($pluginClassFilePath)) {
+            if (!class_exists($className)) {
                 continue;
             }
 

--- a/src/Core/Kernel.php
+++ b/src/Core/Kernel.php
@@ -328,6 +328,15 @@ SQL;
                 continue;
             }
 
+            // If a plugin ships a composer autoload.php file, load this to register the namespaces of the plugin and
+            // its dependencies
+            $pluginAutoLoaderFile = $this->getProjectDir() . '/' . $plugin['path'] . '/vendor/autoload.php';
+            if (file_exists($pluginAutoLoaderFile)) {
+                require_once $pluginAutoLoaderFile;
+
+                continue;
+            }
+
             if (empty($plugin['autoload'])) {
                 throw new \RuntimeException(sprintf('Unable to register plugin "%s" in autoload.', $plugin['base_class']));
             }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/communtiy).
-->

### 1. Why is this change necessary?
If a plugin is not installed via composer but still comes with own dependencies, currently the plugin has to take cake to require this dependencies itself. In particular this means it has to 
 require its own`vendor/autoload.php`. 

This has two disadvantages:

* This code is duplicated in every plugin.
* The plugin itself has to decide whether it has to load its `vendor/autoload.php`. In case the plugin is managed by composer, there is no need for the plugin to require its `vendor/autoload.php`. The plugin can currently not decide this because it has no access to the `managed_by_composer` flag.

### 2. What does this change do, exactly?
This PR changes the method `\Shopware\Core\Kernel::registerPluginNamespaces` to automatically load the file `vendor/autoload.php` of each plugin if present instead of registering only the namespaces listed in the plugin's `composer.json`.
Registering the namespaces this way has the advantage that also the namespaces of all shipped dependencies are registered.

In case there is no `vendor/autoload.php` bundles with the plugin, the namespaces from the plugin's `composer.json` are still loaded.

### 3. Describe each step to reproduce the issue or behaviour.
N/A

### 4. Please link to the relevant issues (if any).
N/A

### 5. Which documentation changes (if any) need to be made because of this PR?

N/A

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
