### PR TITLE
Fix order documents typehint to be a collection instead of single entity

### DIFF
--- a/src/Core/Checkout/Order/OrderEntity.php
+++ b/src/Core/Checkout/Order/OrderEntity.php
@@ -4,7 +4,7 @@ namespace Shopware\Core\Checkout\Order;
 
 use Shopware\Core\Checkout\Cart\Price\Struct\CalculatedPrice;
 use Shopware\Core\Checkout\Cart\Price\Struct\CartPrice;
-use Shopware\Core\Checkout\Document\DocumentEntity;
+use Shopware\Core\Checkout\Document\DocumentCollection;
 use Shopware\Core\Checkout\Order\Aggregate\OrderAddress\OrderAddressCollection;
 use Shopware\Core\Checkout\Order\Aggregate\OrderCustomer\OrderCustomerEntity;
 use Shopware\Core\Checkout\Order\Aggregate\OrderDelivery\OrderDeliveryCollection;
@@ -162,7 +162,7 @@ class OrderEntity extends Entity
     protected $customFields;
 
     /**
-     * @var DocumentEntity|null
+     * @var DocumentCollection|null
      */
     protected $documents;
 
@@ -441,12 +441,12 @@ class OrderEntity extends Entity
         $this->shippingTotal = $shippingTotal;
     }
 
-    public function getDocuments(): ?DocumentEntity
+    public function getDocuments(): ?DocumentCollection
     {
         return $this->documents;
     }
 
-    public function setDocuments(?DocumentEntity $documents): void
+    public function setDocuments(?DocumentCollection $documents): void
     {
         $this->documents = $documents;
     }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/communtiy).
-->

### 1. Why is this change necessary?
An order may have more than a single document referenced to it (OneToMany association), therefore it's required to obtain a collection inside the order entity.

### 2. What does this change do, exactly?
Fixes the type hint for documents within an order

### 3. Describe each step to reproduce the issue or behaviour.
Try to call order->getDocuments(); This tries to return a collection (which is correct!) but the typehint does not match and that results in an exception.

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?
None I guess.

### 6. Checklist

- [ X] I have written tests and verified that they fail without my change
- [X ] I have squashed any insignificant commits
- [ X] This change has comments for package types, values, functions, and non-obvious lines of code
- [ X] I have read the contribution requirements and fulfil them.
