### PR TITLE
Use correct link to icon set

### DIFF
--- a/src/Docs/Resources/current/4-how-to/270-custom-module.md
+++ b/src/Docs/Resources/current/4-how-to/270-custom-module.md
@@ -62,7 +62,7 @@ Also, the property `type` should have the value `plugin`. This can be used e.g. 
 
 Additional to those basic meta information, each module comes with a custom color and a custom icon.
 Those will be used in the whole module and all components related to it, even in the title of your browser's tab.
-A list of all available icons can be found [here](https://component-library.shopware.com/components/sw-icon).
+A list of all available icons can be found [here](https://component-library.shopware.com/icons/).
 
 ```js
 import { Module } from 'src/core/shopware';

--- a/src/Docs/Resources/current/4-how-to/270-custom-module.md
+++ b/src/Docs/Resources/current/4-how-to/270-custom-module.md
@@ -62,7 +62,7 @@ Also, the property `type` should have the value `plugin`. This can be used e.g. 
 
 Additional to those basic meta information, each module comes with a custom color and a custom icon.
 Those will be used in the whole module and all components related to it, even in the title of your browser's tab.
-A list of all available icons can be found [here](https://component-library.shopware.com/#/icons/).
+A list of all available icons can be found [here](https://component-library.shopware.com/components/sw-icon).
 
 ```js
 import { Module } from 'src/core/shopware';


### PR DESCRIPTION
### 1. Why is this change necessary?
The reference in the documentation is just showing the component library.

### 2. What does this change do, exactly?
Use an other link.

### 3. Describe each step to reproduce the issue or behaviour.
1. Click icon set link 
2. See component library
3. Still have to go through the menu to the icon set

### 4. Which documentation changes (if any) need to be made because of this PR?
It IS a documentation change

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
