### PR TITLE
Use module title translation instead of name in sw-page

### DIFF
--- a/src/Administration/Resources/administration/src/app/component/structure/sw-page/sw-page.html.twig
+++ b/src/Administration/Resources/administration/src/app/component/structure/sw-page/sw-page.html.twig
@@ -47,8 +47,8 @@
                                     <div class="smart-bar__header">
                                         <slot name="smart-bar-header">
                                             {% block sw_page_slot_smart_bar_header %}
-                                                <h2 v-if="module && module.name">
-                                                    {{ module.name }}
+                                                <h2 v-if="module && module.title">
+                                                    {{ $t(module.title) }}
                                                 </h2>
                                             {% endblock %}
                                         </slot>


### PR DESCRIPTION
### 1. Why is this change necessary?
The [documentation](https://docs.shopware.com/en/shopware-platform-dev-en/getting-started/indepth-guide-bundle/administration?category=shopware-platform-dev-en/getting-started/indepth-guide-bundle#additional-meta-info) states:
> The `name` should be a technical unique one, the type would be 'plugin' here

### 2. What does this change do, exactly?
Uses the translated title translation key instead of the name of a module.

### 3. Describe each step to reproduce the issue or behaviour.
1. Follow the [tutorial](https://docs.shopware.com/en/shopware-platform-dev-en/getting-started/indepth-guide-bundle/administration)
2. Use a technical name as name value
3. Open up the new administration module
4. See an h2-tag with a technical name instead of something human readable

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
