### PR TITLE
Use component helpers instead directly import helper

### DIFF
--- a/src/Administration/Resources/administration/src/module/sw-product/component/sw-product-packaging-form/index.js
+++ b/src/Administration/Resources/administration/src/module/sw-product/component/sw-product-packaging-form/index.js
@@ -1,7 +1,7 @@
 import { Component, Mixin } from 'src/core/shopware';
-import { mapState, mapGetters } from 'vuex';
-import { mapApiErrors } from 'src/app/service/map-errors.service';
 import template from './sw-product-packaging-form.html.twig';
+
+const { mapState, mapGetters, mapApiErrors } = Component.getComponentHelper();
 
 Component.register('sw-product-packaging-form', {
     template,


### PR DESCRIPTION
### 1. Why is this change necessary?
At every other component except `sw-product-packaging-form` help services are used from a service collector instead directly importing the services. This is now normalized.

### 2. What does this change do, exactly?
Request the helpers from the component service collector instead of importing them directly

### 3. Describe each step to reproduce the issue or behaviour.
1. Look out why the usage of the service collector is not working in a plugin script
2. Look out for examples
3. Find two patterns
4. Realize one pattern is only used once

### 4. Which documentation changes (if any) need to be made because of this PR?

Add a hint that the component helpers are not available in a plugin script as neither vuex nor executing the initializers manually are working.

### . Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
