### PR TITLE
Add module resolving for shipped administration node_modules folder

### DIFF
--- a/src/Administration/Resources/administration/build/webpack.base.conf.js
+++ b/src/Administration/Resources/administration/build/webpack.base.conf.js
@@ -32,6 +32,10 @@ module.exports = {
     },
     resolve: {
         extensions: ['.js', '.vue', '.json', '.less', '.twig'],
+        modules: [
+            // statically add the administration node_modules folder, so sw plugins can resolve it
+            resolve('node_modules'),
+        ],
         alias: {
             vue$: 'vue/dist/vue.esm.js',
             src: resolve('src'),


### PR DESCRIPTION
### 1. Why is this change necessary?
In case you want to use `vuex` or other modules, that are already shipped by the administration, in a bundle that changes the administration, you can't use `import foo from 'bar'` as the `node_modules` folder is not resolvable for the plugins.

### 2. What does this change do, exactly?
Add `node_modules` as folder for the module resolving in webpack. The same way like it is done in the storefront.

### 3. Describe each step to reproduce the issue or behaviour.
1. Make component that wants to map a state
2. Copy state mapping from shopware components
3. Realize that you can't use `mapState` from `Component.getComponentHelper()` as this is not initialized in my `plugin.js` runtime and therefore can only be used within the application
4. Look up `mapState`s origin
5. `import { mapState } from 'vuex'`
6. `Cannot find module 'vuex'` :confounded: 
7. Find used `webpack.config` in build process
8. Compare to others
9. See `node_modules` reference in storefront bundle
10. Find undocumented feature to add own `webpack.config.js`
11. Try to add missing `node_modules` reference in `<admin>/build/webpack.config.js`
12. Instructions unclear - :duck: stuck in toaster

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
