### PR TITLE
Storefront: Specify corejs version in .babelrc.js

### DIFF
--- a/src/Storefront/Resources/.babelrc.js
+++ b/src/Storefront/Resources/.babelrc.js
@@ -1,7 +1,8 @@
 module.exports = {
     presets: [
         ['@babel/preset-env', {
-            'useBuiltIns': 'usage'
+            'useBuiltIns': 'usage',
+            'corejs': 3,
         }],
     ],
     plugins: [

--- a/src/Storefront/Resources/package-lock.json
+++ b/src/Storefront/Resources/package-lock.json
@@ -833,6 +833,14 @@
       "requires": {
         "core-js": "^2.6.5",
         "regenerator-runtime": "^0.13.2"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.9.tgz",
+          "integrity": "sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A==",
+          "dev": true
+        }
       }
     },
     "@babel/preset-env": {
@@ -3177,10 +3185,9 @@
       }
     },
     "core-js": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.9.tgz",
-      "integrity": "sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A==",
-      "dev": true
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.2.1.tgz",
+      "integrity": "sha512-Qa5XSVefSVPRxy2XfUC13WbvqkxhkwB3ve+pgCQveNgYzbM/UxZeu1dcOX/xr4UmfUd+muuvsaxilQzCyUurMw=="
     },
     "core-js-compat": {
       "version": "3.1.4",

--- a/src/Storefront/Resources/package.json
+++ b/src/Storefront/Resources/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "bootstrap": "4.3.1",
     "copy-webpack-plugin": "5.0.4",
+    "core-js": "^3.2.1",
     "deepmerge": "4.0.0",
     "eslint-plugin-cypress": "2.6.0",
     "exports-loader": "0.7.0",


### PR DESCRIPTION
### 1. Why is this change necessary?
This change eliminates a warning babel gives, when building the storefront js, saying that no corejs version is specified for the `useBuiltIns` options of babel. This is useful, to gain more control over the used polyfill versions, since babel uses its own defaults, which might change.

### 2. What does this change do, exactly?
The change installs core-js@3 and integrates it into the .babelrc.js of the storefront.

### 3. Describe each step to reproduce the issue or behaviour.
Execute the command `psh.phar storefront:watch` inside your Shopware 6 project.

### 4. Please link to the relevant issues (if any).
-

### 5. Which documentation changes (if any) need to be made because of this PR?
-
