### PR TITLE
Remove duplicate add select call

### DIFF
--- a/src/Core/Framework/DataAbstractionLayer/Dbal/EntityWriteGateway.php
+++ b/src/Core/Framework/DataAbstractionLayer/Dbal/EntityWriteGateway.php
@@ -314,8 +314,6 @@ class EntityWriteGateway implements EntityWriteGatewayInterface
 
         if ($definition->isChildrenAware()) {
             $query->addSelect('parent_id');
-        } elseif (!$definition->isInheritanceAware()) {
-            $query->addSelect('1 as `exists`');
         } else {
             $parent = $this->getParentField($definition);
 


### PR DESCRIPTION
### 1. Why is this change necessary?
You don't need the select twice in there.

### 2. What does this change do, exactly?
Remove an addSelect call that does the same as the call 5 lines above.

### 3. Describe each step to reproduce the issue or behaviour.
1. Analyze SQL statements
2. See a duplicate select part

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
