### PR TITLE
Consider OneToOneAssociationFields in the EntityForeignKeyResolver

### DIFF
--- a/src/Core/Framework/DataAbstractionLayer/Dbal/EntityForeignKeyResolver.php
+++ b/src/Core/Framework/DataAbstractionLayer/Dbal/EntityForeignKeyResolver.php
@@ -13,6 +13,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\RestrictDelete;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\ManyToManyAssociationField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\ManyToOneAssociationField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\OneToManyAssociationField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\OneToOneAssociationField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\TranslationsAssociationField;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Doctrine\FetchModeHelper;
@@ -175,7 +176,7 @@ class EntityForeignKeyResolver
                 continue;
             }
 
-            if ($cascade instanceof ManyToOneAssociationField) {
+            if ($cascade instanceof ManyToOneAssociationField || $cascade instanceof OneToOneAssociationField) {
                 $this->queryHelper->resolveField($cascade, $definition, $root, $query, $context);
 
                 $query->addSelect(

--- a/src/Core/Framework/Test/DataAbstractionLayer/Field/TestDefinition/RootDefinition.php
+++ b/src/Core/Framework/Test/DataAbstractionLayer/Field/TestDefinition/RootDefinition.php
@@ -6,6 +6,8 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\FkField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\PrimaryKey;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\Required;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\CascadeDelete;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\RestrictDelete;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\IdField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\IntField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\ManyToOneAssociationField;
@@ -31,7 +33,8 @@ class RootDefinition extends EntityDefinition
             (new IdField('id', 'id'))->addFlags(new PrimaryKey(), new Required()),
             new VersionField(),
             new StringField('name', 'name'),
-            new OneToOneAssociationField('sub', 'id', 'root_id', SubDefinition::class),
+            (new OneToOneAssociationField('sub', 'id', 'root_id', SubDefinition::class))->addFlags(new RestrictDelete()),
+            (new OneToOneAssociationField('subCascade', 'id', 'root_id', SubCascadeDefinition::class))->addFlags(new CascadeDelete()),
         ]);
     }
 }
@@ -56,6 +59,30 @@ class SubDefinition extends EntityDefinition
             (new ReferenceVersionField(RootDefinition::class))->addFlags(new Required()),
             new OneToOneAssociationField('root', 'root_id', 'id', RootDefinition::class, false),
             new OneToManyAssociationField('manies', SubManyDefinition::class, 'root_sub_id'),
+        ]);
+    }
+}
+
+
+class SubCascadeDefinition extends EntityDefinition
+{
+    public const ENTITY_NAME = 'root_sub_cascade';
+
+    public function getEntityName(): string
+    {
+        return self::ENTITY_NAME;
+    }
+
+    protected function defineFields(): FieldCollection
+    {
+        return new FieldCollection([
+            (new IdField('id', 'id'))->addFlags(new PrimaryKey(), new Required()),
+            new VersionField(),
+            new StringField('name', 'name'),
+            new IntField('stock', 'stock'),
+            new FkField('root_id', 'rootId', RootDefinition::class, 'id'),
+            (new ReferenceVersionField(RootDefinition::class))->addFlags(new Required()),
+            new OneToOneAssociationField('root', 'root_id', 'id', RootDefinition::class, false),
         ]);
     }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/communtiy).
-->

### 1. Why is this change necessary?
The `EntityForeignKeyResolver` doesn't consider `OneToOneAssociationFields` when evaluating the `CascadeDelete` and `RestrictDelete` flags.

### 2. What does this change do, exactly?
Let the code responsible for `ManyToOneAssociationFields` handle `OneToOneAssociationFields` too. The corresponding if-block was already modified in commit cf92c8aa3df916f36b60d6bd3e62e86c9f1774b5.

### 3. Describe each step to reproduce the issue or behaviour.
1. Create an `EntityDefinition` with an `OneToOneAssociationField` and add the `RestrictDelete` flag
1. Send a delete request for an entity that can't be deleted due to this constraint
1. The `DELETE` won't get caught at framework-level and gets passed to the database instead

### 4. Please link to the relevant issues (if any).

### 5. Which documentation changes (if any) need to be made because of this PR?

### 6. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
