### PR TITLE
Add hint about composer usage for plugin changes

### DIFF
--- a/src/Core/Framework/Plugin/Command/Lifecycle/AbstractPluginLifecycleCommand.php
+++ b/src/Core/Framework/Plugin/Command/Lifecycle/AbstractPluginLifecycleCommand.php
@@ -96,7 +96,7 @@ abstract class AbstractPluginLifecycleCommand extends Command
 
         if ($plugins->count() === 0) {
             $io->warning('No plugins found');
-            $io->text('Try the plugin:refresh command first, or change your search term');
+            $io->text('Try the plugin:refresh command first, run composer update for changes in the plugin\'s composer.json, or change your search term');
 
             return $plugins;
         }


### PR DESCRIPTION
### 1. Why is this change necessary?
As the complete `composer.json` of any dependency is part of the `composer.lock` file, any plugin will not update correctly with an `plugin:refresh` if changes were made locally (if it is a local composer repository) e.g. the extra part for the plugin class as they have to be moved to the projects `composer.lock` again.

### 2. What does this change do, exactly?
Adds a hint to think about composer

### 3. Describe each step to reproduce the issue or behaviour.
1. Create a plugin with a plugin class `Foo\Bar\Fuzz\Plugin`
2. Run `composer require foo/bar-fuzz` and `bin/console plugin:refresh`
3. See the plugin named `Plugin` :confused: 
4. Recall that the vendor namespace is not unique already but the plugin class has to be named in a unique way as just the class name is the plugin name :confounded: 
5. Rename the plugin class and change the extra information in `composer.json` and run `bin/console plugin:refresh` and `bin/console plugin:list`
6. No visible changes
7. Change plugin version and run `bin/console plugin:refresh` and `bin/console plugin:list`
8. No visible changes
9. Run `composer update foo/bar-fuzz`, `bin/console plugin:refresh` and `bin/console plugin:list`
10. See `git diff` in `composer.lock`
```
            "extra": {
+               "shopware-plugin-class": "Foo\\Bar\\Fuzz\\FooBarFuzz",
-               "shopware-plugin-class": "Foo\\Bar\\Fuzz\\Plugin",
                "label": {
```

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
