### PR TITLE
added several assocations needed in payment plugins

### DIFF
--- a/src/Core/Checkout/Payment/Cart/PaymentTransactionChainProcessor.php
+++ b/src/Core/Checkout/Payment/Cart/PaymentTransactionChainProcessor.php
@@ -80,7 +80,11 @@ class PaymentTransactionChainProcessor
         $criteria->addAssociation('transactions.paymentMethod');
         $criteria->addAssociation('lineItems');
 
-        $criteria->addAssociation('deliveries');
+        $criteria->addAssociation('deliveries.shippingMethod');
+        $criteria->addAssociation('deliveries.shippingOrderAddress.country');
+        $criteria->addAssociation('addresses.country');
+        $criteria->addAssociation('addresses.salutation');
+
         $criteria->addAssociationPath('deliveries.shippingMethod');
         $criteria->addAssociationPath('deliveries.shippingOrderAddress.country');
         $criteria->addAssociation('addresses');

--- a/src/Core/Checkout/Payment/Cart/PaymentTransactionChainProcessor.php
+++ b/src/Core/Checkout/Payment/Cart/PaymentTransactionChainProcessor.php
@@ -85,12 +85,6 @@ class PaymentTransactionChainProcessor
         $criteria->addAssociation('addresses.country');
         $criteria->addAssociation('addresses.salutation');
 
-        $criteria->addAssociationPath('deliveries.shippingMethod');
-        $criteria->addAssociationPath('deliveries.shippingOrderAddress.country');
-        $criteria->addAssociation('addresses');
-        $criteria->addAssociationPath('addresses.country');
-        $criteria->addAssociationPath('addresses.salutation');
-
         /** @var OrderEntity|null $order */
         $order = $this->orderRepository->search($criteria, $salesChannelContext->getContext())->first();
 

--- a/src/Core/Checkout/Payment/Cart/PaymentTransactionChainProcessor.php
+++ b/src/Core/Checkout/Payment/Cart/PaymentTransactionChainProcessor.php
@@ -80,6 +80,13 @@ class PaymentTransactionChainProcessor
         $criteria->addAssociation('transactions.paymentMethod');
         $criteria->addAssociation('lineItems');
 
+        $criteria->addAssociation('deliveries');
+        $criteria->addAssociationPath('deliveries.shippingMethod');
+        $criteria->addAssociationPath('deliveries.shippingOrderAddress.country');
+        $criteria->addAssociation('addresses');
+        $criteria->addAssociationPath('addresses.country');
+        $criteria->addAssociationPath('addresses.salutation');
+
         /** @var OrderEntity|null $order */
         $order = $this->orderRepository->search($criteria, $salesChannelContext->getContext())->first();
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/communtiy).
-->

### 1. Why is this change necessary?

Most payment modules may need additional data for payment processing. The currently included PayPal module is very basic and transmits only little data, but even PayPal usually wants more data than what is currently transmitted for several reasons.

The ratepay plugin I am currently developing does need the added entitys from this pull-request. These are:

* Shipping Address
* Shipping Method
* Shipping Country
* Billing Address
* Billing Country
* Billing Salutation

However, other plugins may need different data, so probably an event would be better so that plugins can add dependencies dynamically.

### 2. What does this change do, exactly?

The change does add additional entities, which are missing in the current implementation and thus, cannot be transmitted to payment providers without loading them seperately in each plugin (which is tedious).

### 3. Describe each step to reproduce the issue or behaviour.

Create payment module. Try to get each of the entities from the OrderCustomerEntity object.

### 4. Please link to the relevant issues (if any).

none

### 5. Which documentation changes (if any) need to be made because of this PR?

none

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
