### PR TITLE
Add hint about limitations on javascript class fields

### DIFF
--- a/src/Docs/Resources/current/4-how-to/560-js-storefront-plugin.md
+++ b/src/Docs/Resources/current/4-how-to/560-js-storefront-plugin.md
@@ -152,6 +152,13 @@ As the value of this attribute use the options you want to override as a json ob
 {% endblock %}
 ```
 
+<p class="alert is--error">
+    IMPORTANT: Please note that a JavaScript class can have variables.
+    These variables get `undefined` on `this` when used in an event listener.
+    If you don't declare them in the JavaScript class they won't reset to `undefined`.
+    To keep type hints add a `@property {Type} variable` to the class documentation.
+</p>
+
 ## Configuring your plugins script path
 
 This can be ignored if you are on version 6.0.0 EA2 or newer. 


### PR DESCRIPTION
### 1. Why is this change necessary?
If you use the full potential of js classes you find yourself in a pitfall where it is unclear how to get out.

### 2. What does this change do, exactly?
Adds a hint not to use class variables.

### 3. Describe each step to reproduce the issue or behaviour.
You use class variables?
```
import Plugin from 'src/script/plugin-system/plugin.class';

class Spannend extends Plugin {
    /**
     * @type {HTMLSpanElement} _spanElement
     */
    _spanElement;

    init() {
        this._spanElement = this.el.querySelector('span');
        this._spanElement.addEventListener('click', this._onSpanClick.bind(this));
    }

    _onSpanClick() {
        console.log(this._spanElement); // logs undefined
    }
}
PluginManager.register('Spannend', Spannend, '[data-spannend]');
```

Use class type hints!
```
import Plugin from 'src/script/plugin-system/plugin.class';

/**
 * @property {HTMLSpanElement} _spanElement
 */
class Spannend extends Plugin {
    init() {
        this._spanElement = this.el.querySelector('span');
        this._spanElement.addEventListener('click', this._onSpanClick.bind(this));
    }

    _onSpanClick() {
        console.log(this._spanElement); // logs <span>spannend</span>
    }
}
PluginManager.register('Spannend', Spannend, '[data-spannend]');
```

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
