### PR TITLE
NEXT-3849 - Fix hostname in hot reload URL

### DIFF
--- a/src/Storefront/Resources/build/utils.js
+++ b/src/Storefront/Resources/build/utils.js
@@ -110,8 +110,12 @@ function getAppUrl() {
  * @return {string}
  */
 function getHostname() {
-    let url = new URL(process.env.APP_URL);
-    return url.protocol + '//' + url.hostname;
+    try {
+        const url = new URL(process.env.APP_URL);
+        return url.protocol + '//' + url.hostname;
+    } catch {
+        return undefined;
+    }
 }
 
 /**

--- a/src/Storefront/Resources/build/utils.js
+++ b/src/Storefront/Resources/build/utils.js
@@ -1,4 +1,5 @@
 const path = require('path');
+const url = require('url');
 
 module.exports = {
     getBuildPath,
@@ -40,7 +41,7 @@ function getProjectRootPath() {
  * @return {String}
  */
 function getPublicPath() {
-    return `${getAppUrl()}${(isHotModuleReplacementMode()) ? ':9999' : ''}/`;
+    return `${getHostname()}${(isHotModuleReplacementMode()) ? ':9999' : ''}/`;
 }
 
 /**
@@ -102,6 +103,15 @@ function isProductionEnvironment() {
  */
 function getAppUrl() {
     return process.env.APP_URL;
+}
+
+/**
+ * Returns the public application URL without port number
+ * @return {string}
+ */
+function getHostname() {
+    let url = new URL(process.env.APP_URL);
+    return url.protocol + '//' + url.hostname;
 }
 
 /**


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/communtiy).
-->

### 1. Why is this change necessary?

Hot Reload is broken when the APP_URL contains a port (eg http://localhost:8888) as it generates an invalid publicPath for the devServer (eg http://localhost:8888:9999). The devServer will not serve all necessary files with this configuration.

### 2. What does this change do, exactly?

Only use the host protocol and name when building the publicPath.

### 3. Describe each step to reproduce the issue or behaviour.

Set up an environment where shopware runs on a non-default port (not 80 or 443) and enable hot reload.

### 4. Please link to the relevant issues (if any).

https://issues.shopware.com/issues/NEXT-3849

### 5. Which documentation changes (if any) need to be made because of this PR?

None

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.