### PR TITLE
remove second level logic and use all the categories to build category tree

### DIFF
--- a/src/Core/Content/Category/Service/NavigationLoader.php
+++ b/src/Core/Content/Category/Service/NavigationLoader.php
@@ -10,7 +10,6 @@ use Shopware\Core\Content\Category\Tree\Tree;
 use Shopware\Core\Content\Category\Tree\TreeItem;
 use Shopware\Core\Framework\DataAbstractionLayer\Exception\InconsistentCriteriaIdsException;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
-use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsAnyFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\MultiFilter;
 use Shopware\Core\System\SalesChannel\Entity\SalesChannelRepositoryInterface;
@@ -50,12 +49,7 @@ class NavigationLoader
     public function load(string $activeId, SalesChannelContext $context, string $rootId): Tree
     {
         $criteria = new Criteria();
-        $criteria->addFilter(
-            new MultiFilter(MultiFilter::CONNECTION_OR, [
-                new EqualsFilter('id', $activeId),
-                new EqualsFilter('parentId', $rootId),
-            ])
-        );
+
         $criteria->addFilter(new EqualsFilter('category.visible', true));
         $criteria->addAssociation('media');
 
@@ -65,20 +59,6 @@ class NavigationLoader
         $active = $rootLevel->get($activeId);
         if (!$active) {
             throw new CategoryNotFoundException($activeId);
-        }
-
-        $ids = $rootLevel->getIds();
-        $ids = array_flip($ids);
-
-        $criteria = new Criteria();
-        $criteria->addFilter(new EqualsAnyFilter('parentId', $ids));
-        $criteria->addFilter(new EqualsFilter('category.visible', true));
-
-        /** @var CategoryCollection $secondLevel */
-        $secondLevel = $this->categoryRepository->search($criteria, $context)->getEntities();
-
-        foreach ($secondLevel as $category) {
-            $rootLevel->add($category);
         }
 
         $navigation = $this->getTree($rootId, $rootLevel, $active);


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/communtiy).
-->

### 1. Why is this change necessary?
category will not be complete loaded in the navigation flyout, just first and second level

### 2. What does this change do, exactly?
remove first, second level logic, load all the categories to build navigation tree

### 3. Describe each step to reproduce the issue or behaviour.
create a third level category in backend, go to shop frontend, hover over the navigation and the third level category will not be displayed in the flyout

### 4. Please link to the relevant issues (if any).
https://github.com/shopware/platform/issues/102
https://issues.shopware.com/issues/NEXT-4311

### 5. Which documentation changes (if any) need to be made because of this PR?
no

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.
