### PR TITLE
Fix typo in documentation of bundle example from to to two

### DIFF
--- a/src/Docs/Resources/current/1-getting-started/35-indepth-guide-bundle/090-checkout.md
+++ b/src/Docs/Resources/current/1-getting-started/35-indepth-guide-bundle/090-checkout.md
@@ -535,7 +535,7 @@ Now all bundle line items are enriched with all necessary information and can be
 Implementing the `\Shopware\Core\Checkout\Cart\CartProcessorInterface` requires to implement the `process` function.
 
 In this method, it is your task to calculate the prices of the bundle and move the bundle from the previous cart to a new cart.
-But what does that even mean? The `process` method receives to instances of an cart.
+But what does that even mean? The `process` method receives two instances of a cart.
 The first one `Cart $original` contains all the original information, such as your bundle line item and all its children.
 The second instance, `Cart $toCalculate`, is actually an empty cart instance, only containing line items that were added from previous **processors**, not collectors, already. It is the one, which will be used when all the calculating is done.
 This prevents line items from sneaking through the cart process that were not considered by any processor and thus will be automatically dropped.


### PR DESCRIPTION
### 1. Why is this change necessary?
The sentence is not correct in context.

### 2. What does this change do, exactly?
Add a `w` and remove an `n`

### 3. Describe each step to reproduce the issue or behaviour.
Read *Bundle example: An InDepth guide - Step 9: Checkout logic*

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
