### PR TITLE
Use referenced id as product id more consistently in cart template

### DIFF
--- a/src/Storefront/Resources/views/component/checkout/offcanvas-item.html.twig
+++ b/src/Storefront/Resources/views/component/checkout/offcanvas-item.html.twig
@@ -22,7 +22,7 @@
                                         } %}
                                     </div>
                                 {% else %}
-                                    <a href="{{ canonicalUrl(lineItem, path('frontend.detail.page', {'productId': lineItem.id})) }}"
+                                    <a href="{{ canonicalUrl(lineItem, path('frontend.detail.page', {'productId': lineItem.referencedId})) }}"
                                        class="cart-item-img-link"
                                        title="{{ lineItem.label }}">
                                         {% if lineItem.cover.url %}
@@ -56,7 +56,7 @@
                                 {% block component_offcanvas_product_label %}
                                     <div class="cart-item-details">
                                         {% if lineItem.type == 'product' %}
-                                            <a href="{{ canonicalUrl(lineItem, path('frontend.detail.page', {'productId': lineItem.id})) }}"
+                                            <a href="{{ canonicalUrl(lineItem, path('frontend.detail.page', {'productId': lineItem.referencedId})) }}"
                                                class="cart-item-label"
                                                title="{{ lineItem.label }}">
                                                 {{ lineItem.quantity }}{{ "checkout.quantityTimes"|trans }} {{ lineItem.label|truncate(60) }}

--- a/src/Storefront/Resources/views/page/checkout/checkout-item.html.twig
+++ b/src/Storefront/Resources/views/page/checkout/checkout-item.html.twig
@@ -39,7 +39,7 @@
                                                             } %}
                                                         </div>
                                                     {% else %}
-                                                        <a href="{{ canonicalUrl(lineItem, path('frontend.detail.page', {'productId': lineItem.id})) }}"
+                                                        <a href="{{ canonicalUrl(lineItem, path('frontend.detail.page', {'productId': lineItem.referencedId})) }}"
                                                            class="cart-item-img-link"
                                                            title="{{ lineItem.label }}"
                                                            {% if controllerAction is same as('confirmPage') %}


### PR DESCRIPTION
### 1. Why is this change necessary?
If you use line items that still refer to products but use a different way to handle ids, then every generated URL that I had to change in this PR was pointing to a wrong resource.

### 2. What does this change do, exactly?
Use `referencedId` from a `LineItem` instead of the `Linetem.id` which is in the default case the same as the `product.id`.

### 3. Describe each step to reproduce the issue or behaviour.
Use line items that still refer to products but use a different way to handle ids

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
