### PR TITLE
Added missing getter for sales channel id to customer login event

### DIFF
--- a/src/Core/Checkout/Customer/Event/CustomerLoginEvent.php
+++ b/src/Core/Checkout/Customer/Event/CustomerLoginEvent.php
@@ -63,6 +63,11 @@ class CustomerLoginEvent extends Event implements BusinessEventInterface
         return $this->contextToken;
     }
 
+    public function getSalesChannelId(): string
+    {
+        return $this->salesChannelId;
+    }
+
     public static function getAvailableData(): EventDataCollection
     {
         return (new EventDataCollection())


### PR DESCRIPTION
### 1. Why is this change necessary?
If you want to react to this event and depend on the sales channel then you need the sales channel id in the event but can't read it.

### 2. What does this change do, exactly?
Adds a getter for this private field.

### 3. Describe each step to reproduce the issue or behaviour.
1. Subscribe event
2. Use sales channel in further steps
3. Can't acquire sales channel id from event although it is passed in its constructor

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

### 5. Quickfix

```
private function getSalesChannelIdFromEvent(CustomerLoginEvent $event): string
{
    $getter = Closure::bind(function (CustomerLoginEvent $instance): string {
        return $instance->{'salesChannelId'};
    }, null, $event);
    return $getter($event);
}
```