### PR TITLE
Add product_detail_price_content twig block.

### DIFF
--- a/src/Storefront/Resources/views/page/product-detail/buy-widget-price.html.twig
+++ b/src/Storefront/Resources/views/page/product-detail/buy-widget-price.html.twig
@@ -82,9 +82,12 @@
 
         <meta itemprop="price"
               content="{{ price.unitPrice }}">
-        <p class="product-detail-price">
-            {{ price.unitPrice|currency }}{{ "general.star"|trans }}
-        </p>
+
+        {% block page_product_detail_price_content %}
+            <p class="product-detail-price">
+                {{ price.unitPrice|currency }}{{ "general.star"|trans }}
+            </p>
+        {% endblock %}
 
         {% if page.product.purchaseUnit %}
             {% block page_product_detail_price_unit %}


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/communtiy).
-->

### 1. Why is this change necessary?
There was no twig block for overwriting the price in the product detail page.

### 2. What does this change do, exactly?
It adds a twig block for that named `page_product_detail_price_content`. I needed to append `_content`, because `page_product_detail_price` was already taken by `buy-widget.html.twig`.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
