### PR TITLE
Add twig block to be able to extend the category overview

### DIFF
--- a/src/Administration/Resources/administration/src/module/sw-cms/page/sw-cms-detail/sw-cms-detail.html.twig
+++ b/src/Administration/Resources/administration/src/module/sw-cms/page/sw-cms-detail/sw-cms-detail.html.twig
@@ -253,6 +253,7 @@
                                                             <option value="image">{{ $tc('sw-cms.detail.labelBlockCategoryImage') }}</option>
                                                             <option value="text-image">{{ $tc('sw-cms.detail.labelBlockCategoryTextImage') }}</option>
                                                             <option value="commerce">{{ $tc('sw-cms.detail.labelBlockCategoryCommerce') }}</option>
+                                                            {% block sw_cms_detail_sidebar_block_overview_category_element_after %}{% endblock %}
                                                         </sw-select-field>
                                                     </div>
                                                 {% endblock %}


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/communtiy).
-->

### 1. Why is this change necessary?
If you want to extend the category overview element for the shopping experience in the administration, you currently would need to overwrite the whole twig block 
[administration/src/module/sw-cms/page/sw-cms-detail/sw-cms-detail.html.twig](https://github.com/shopware/platform/blob/9ca79950cb85a32887aefdc5c27612041bd5c2a1/src/Administration/Resources/administration/src/module/sw-cms/page/sw-cms-detail/sw-cms-detail.html.twig#L249-L258)
```
{% block sw_cms_detail_sidebar_block_overview_category %}
   <div class="sw-cms-detail__block-category">
      <sw-select-field :label="$tc('sw-cms.detail.labelBlockCategorySelection')" v-model="currentBlockCategory">
         <option value="text"> .....
          .....
{% endblock %}
```

### 2. What does this change do, exactly?
Adds a new twig block `sw_cms_detail_sidebar_block_overview_category_element_after` to be able to extend the current category elements. Adding a `sw_cms_detail_sidebar_block_overview_category_element_after` block prevents the user from overriding the whole core categories.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
