### PR TITLE
Moved line item payload key type check

### DIFF
--- a/src/Core/Checkout/Cart/LineItem/LineItem.php
+++ b/src/Core/Checkout/Cart/LineItem/LineItem.php
@@ -261,7 +261,7 @@ class LineItem extends Struct
      */
     public function setPayloadValue(string $key, $value): self
     {
-        if (!is_string($key) || ($value !== null && !is_scalar($value) && !is_array($value))) {
+        if ($value !== null && !is_scalar($value) && !is_array($value)) {
             throw new InvalidPayloadException($key, $this->getId());
         }
 
@@ -276,6 +276,10 @@ class LineItem extends Struct
     public function setPayload(array $payload): self
     {
         foreach ($payload as $key => $value) {
+            if (!is_string($key)) {
+                throw new InvalidPayloadException("$key", $this->getId());
+            }
+            
             $this->setPayloadValue($key, $value);
         }
 


### PR DESCRIPTION
### 1. Why is this change necessary?
The `is_string` check is always true as the type hint is already validating the type of the key parameter. In the `setPayload` method instead can the key can have a different type. Why did I put an other throw in there as well? A type mismatch due to a wrong type in a parameter is less easier to recover than from an exception:
![image](https://user-images.githubusercontent.com/1133593/64718054-c1686180-d4c5-11e9-8542-e282d376bbc5.png)

### 2. What does this change do, exactly?
Move a condition check a method up a possible call stack

### 3. Describe each step to reproduce the issue or behaviour.
* `$lineItem->setPayload(['a']);`

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
