### PR TITLE
Moved reorder button into its block and added more blocks for hidden inputs

### DIFF
--- a/src/Storefront/Resources/views/page/account/order-history/order-detail-list.html.twig
+++ b/src/Storefront/Resources/views/page/account/order-history/order-detail-list.html.twig
@@ -21,35 +21,39 @@
                                 <input type="hidden" name="redirectTo" value="frontend.cart.offcanvas"/>
                             {% endblock %}
 
-                            {% block page_account_order_item_detail_reorder_button %}
+                            {% block page_account_order_item_detail_reorder_lineitems_input %}
                                 {% for lineItem in orderDetails %}
-                                    {% if lineItem.type == 'product' %}
-                                        <input type="hidden"
-                                               name="lineItems[{{ lineItem.identifier }}][id]"
-                                               value="{{ lineItem.identifier }}">
-                                        <input type="hidden"
-                                               name="lineItems[{{ lineItem.identifier }}][referencedId]"
-                                               value="{{ lineItem.identifier }}">
-                                        <input type="hidden"
-                                               name="lineItems[{{ lineItem.identifier }}][type]"
-                                               value="{{ lineItem.type }}">
-                                        <input type="hidden"
-                                               name="lineItems[{{ lineItem.identifier }}][stackable]"
-                                               value="1">
-                                        <input type="hidden"
-                                               name="lineItems[{{ lineItem.identifier }}][removable]"
-                                               value="1">
-                                        <input type="hidden"
-                                               name="lineItems[{{ lineItem.identifier }}][quantity]"
-                                               value="{{ lineItem.quantity }}">
-                                    {% endif %}
+                                    {% block page_account_order_item_detail_reorder_lineitem_input %}
+                                        {% if lineItem.type == 'product' %}
+                                            <input type="hidden"
+                                                   name="lineItems[{{ lineItem.identifier }}][id]"
+                                                   value="{{ lineItem.identifier }}">
+                                            <input type="hidden"
+                                                   name="lineItems[{{ lineItem.identifier }}][referencedId]"
+                                                   value="{{ lineItem.identifier }}">
+                                            <input type="hidden"
+                                                   name="lineItems[{{ lineItem.identifier }}][type]"
+                                                   value="{{ lineItem.type }}">
+                                            <input type="hidden"
+                                                   name="lineItems[{{ lineItem.identifier }}][stackable]"
+                                                   value="1">
+                                            <input type="hidden"
+                                                   name="lineItems[{{ lineItem.identifier }}][removable]"
+                                                   value="1">
+                                            <input type="hidden"
+                                                   name="lineItems[{{ lineItem.identifier }}][quantity]"
+                                                   value="{{ lineItem.quantity }}">
+                                        {% endif %}
+                                    {% endblock %}
                                 {% endfor %}
                             {% endblock %}
-
-                            <button class="btn btn-buy order-item-detail-reorder-btn"
-                                    title="{{ "account.orderLinkRepeat"|trans }}">
-                                {{ "account.orderLinkRepeat"|trans }}
-                            </button>
+                                
+                            {% block page_account_order_item_detail_reorder_button %}
+                                <button class="btn btn-buy order-item-detail-reorder-btn"
+                                        title="{{ "account.orderLinkRepeat"|trans }}">
+                                    {{ "account.orderLinkRepeat"|trans }}
+                                </button>
+                            {% endblock %}
                         </form>
                     {% endblock %}
                 </div>


### PR DESCRIPTION
### 1. Why is this change necessary?

There is a block named like it could contain the reorder button. It doesn't. Now it does. There is also a block for the redirect hidden input. There is no dedicated block for the hidden inputs for all the old line items. In case of adding new hidden inputs for new specific line item types you have to loop over all items again without taking advantage of the existing loop. Therefore I added a new block in the loop body for easier input manipulation and addition of inputs.

### 2. What does this change do, exactly?

Add twig blocks and move existing ones around

### 3. Describe each step to reproduce the issue or behaviour.

Work with new line item types and press on reorder without the custom line item types in the cart.

### 4. Which documentation changes (if any) need to be made because of this PR?

This is a BC as a block is now wrapping a different element. Either mark it as change or we have to rename it completely and make an "obsolete" placeholder block. I prefer first as shopware 6 is still able to break things without caring too much.

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
