### PR TITLE
Fix wrong path in "add-admin-new-field" docs

### DIFF
--- a/src/Docs/Resources/current/4-how-to/200-add-admin-new-field.md
+++ b/src/Docs/Resources/current/4-how-to/200-add-admin-new-field.md
@@ -43,7 +43,7 @@ Time to create the referenced twig template for your plugin now.
 *Note: We're dealing with a [TwigJS](https://github.com/twigjs/twig.js/wiki) template here.* 
 
 Create a file called `sw-product-settings-form.html.twig` in the following directory:
-`<plugin root>/src/Resources/views/administration/src/extension/sw-product-settings-form`
+`<plugin root>/src/Resources/administration/src/extension/sw-product-settings-form`
 
 *Note: The path starting from 'src' is fully customizable, yet we recommend choosing a pattern like this one.*
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/communtiy).
-->

### 1. Why is this change necessary?

Because the path, that is written in the documentation is wrong.

### 2. What does this change do, exactly?

Fixing a path in the "add-admin-new-field" docs

### 3. Describe each step to reproduce the issue or behaviour.

Link to the docs: https://docs.shopware.com/en/shopware-platform-dev-en/how-to/add-admin-new-field

### 4. Please link to the relevant issues (if any).

➖ 

### 5. Which documentation changes (if any) need to be made because of this PR?

➖ 

### 6. Checklist

- [X] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.
