### PR TITLE
NEXT-4676 | Medien: "Neuer Ordner hinzufügen" teilweise nicht möglich

### DIFF
--- a/src/Administration/Resources/administration/src/module/sw-media/component/sw-media-library/index.js
+++ b/src/Administration/Resources/administration/src/module/sw-media/component/sw-media-library/index.js
@@ -319,7 +319,7 @@ Component.register('sw-media-library', {
             newFolder.name = '';
             newFolder.parentId = this.folderId;
             if (this.folderId !== null) {
-                newFolder.configurationId = this.currentFolder.configuration.id;
+                newFolder.configurationId = this.currentFolder.configurationId;
                 newFolder.useParentConfiguration = true;
             } else {
                 const configuration = this.mediaFolderConfigurationStore.create();


### PR DESCRIPTION
This patchset fixes the problem of creating a new media folder and
also fixes the problem of creating nested media folders.

 *  Fixed wrong 'configurationId' attribute access for
    'this.currentFolder' object in 'sw-media" component.
    Changed 'configuration.Id' to 'configurationId' .

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/communtiy).
-->

### 1. Why is this change necessary?

This change fixes [NEXT-4676](https://issues.shopware.com/issues/NEXT-4676).

### 2. What does this change do, exactly?

Basically fixed a little type regarding the 'configurationId' from the 'currentFolder' object.

### 3. Describe each step to reproduce the issue or behaviour.

See [NEXT-4676](https://issues.shopware.com/issues/NEXT-4676).


### 4. Please link to the relevant issues (if any).

 [NEXT-4676](https://issues.shopware.com/issues/NEXT-4676).

### 5. Which documentation changes (if any) need to be made because of this PR?

None

### 6. Checklist

- [x] I have written tests and verified that they fail without my change
I did a manuell UI test.
- [x] I have squashed any insignificant commits
Was not really needed.
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
Was not really needed.
- [x] I have read the contribution requirements and fulfil them.
