### PR TITLE
Remove empty string concatenations

### DIFF
--- a/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php
+++ b/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php
@@ -153,7 +153,7 @@ class SqlQueryParser
         $field = $this->queryHelper->getFieldAccessor($query->getField(), $definition, $root, $context);
 
         $result = new ParseResult();
-        $result->addWhere($field . ' LIKE :' . $key . '');
+        $result->addWhere($field . ' LIKE :' . $key);
 
         $escaped = addcslashes($query->getValue(), '\\_%');
         $result->addParameter($key, '%' . $escaped . '%');

--- a/src/Core/System/NumberRange/ValueGenerator/Pattern/IncrementStorage/IncrementSqlStorage.php
+++ b/src/Core/System/NumberRange/ValueGenerator/Pattern/IncrementStorage/IncrementSqlStorage.php
@@ -37,9 +37,7 @@ class IncrementSqlStorage implements IncrementStorageInterface
             ]
         );
 
-        $stmt = $this->connection->executeQuery(
-            'SELECT @nr' . $varname . ''
-        );
+        $stmt = $this->connection->executeQuery('SELECT @nr' . $varname);
 
         $lastNumber = $stmt->fetchColumn();
 

--- a/src/Docs/Convert/DocsParsedownExtra.php
+++ b/src/Docs/Convert/DocsParsedownExtra.php
@@ -68,7 +68,7 @@ class DocsParsedownExtra extends \ParsedownExtra
     {
         $includeParts = explode('#', $parts[1]);
 
-        $includeFile = \dirname($this->sourceFile->getRealPath()) . '' . substr($includeParts[0], 1);
+        $includeFile = \dirname($this->sourceFile->getRealPath()) . substr($includeParts[0], 1);
         $namespace = $includeParts[1];
 
         if (!file_exists($includeFile)) {


### PR DESCRIPTION
### 1. Why is this change necessary?
These are unnecessary operations

### 2. What does this change do, exactly?
Removes ` . ''` and `'' . ` 

### 3. Describe each step to reproduce the issue or behaviour.
1. Skim the code
2. Be :confused: 
3. :eyes: 
4. Yes, these operations really don't do anything

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
