### PR TITLE
Add base key to determine base filesystem on registration

### DIFF
--- a/src/Core/Framework/Bundle.php
+++ b/src/Core/Framework/Bundle.php
@@ -115,17 +115,18 @@ abstract class Bundle extends SymfonyBundle
         return 'Resources/config/services.xml';
     }
 
-    protected function registerFilesystem(ContainerBuilder $container, string $key): void
+    protected function registerFilesystem(ContainerBuilder $container, string $key, ?string $baseKey = null): void
     {
         $containerPrefix = $this->getContainerPrefix();
-        $parameterKey = sprintf('shopware.filesystem.%s', $key);
+        $parameterKey = sprintf('shopware.filesystem.%s', $baseKey ?? $key);
         $serviceId = sprintf('%s.filesystem.%s', $containerPrefix, $key);
+        $suffix = empty($baseKey) ? '' : '-' . $key;
 
         $filesystem = new Definition(
             PrefixFilesystem::class,
             [
                 new Reference($parameterKey),
-                'plugins/' . $containerPrefix,
+                'plugins/' . $containerPrefix . $suffix,
             ]
         );
 

--- a/src/Core/Framework/Framework.php
+++ b/src/Core/Framework/Framework.php
@@ -91,7 +91,7 @@ class Framework extends Bundle
         $container->setParameter('migration.directories', $directories);
     }
 
-    protected function registerFilesystem(ContainerBuilder $container, string $key): void
+    protected function registerFilesystem(ContainerBuilder $container, string $key, ?string $baseKey = null): void
     {
         // empty body intended to prevent circular filesystem references
     }


### PR DESCRIPTION
### 1. Why is this change necessary?
To be able to register more plugin specific filesystems without previously defining this in shopware:
`$this->registerFilesystem($container, 'upload', 'private')`

### 2. What does this change do, exactly?
Adds an optional parameter to choose from a shopware known filesystem but adding it with an other key to the plugin.

### 3. Describe each step to reproduce the issue or behaviour.
* `$this->registerFilesystem($container, 'upload')`
* The service has a dependency on a non-existent service `shopware.filesystem.upload`.

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
