### PR TITLE
[Docs]Fix searchable in all languages 2

### DIFF
--- a/src/Docs/Convert/DocumentMetadata.php
+++ b/src/Docs/Convert/DocumentMetadata.php
@@ -98,7 +98,7 @@ class DocumentMetadata
             'locale' => [
                 'de_DE' => [
                     'seoUrl' => $this->getPrefixedUrlDe(),
-                    'searchableInAllLanguages' => true,
+                    'searchableInAllLanguages' => false,
                 ],
                 'en_GB' => [
                     'seoUrl' => $this->getPrefixedUrlEn(),
@@ -110,7 +110,7 @@ class DocumentMetadata
                     'title' => $this->requireMetadata('titleEn'),
                     'navigationTitle' => $this->requireMetadata('titleEn'),
                     'content' => '<p>Die Entwicklerdokumentation ist nur auf Englisch verfügbar.</p>',
-                    'searchableInAllLanguages' => true,
+                    'searchableInAllLanguages' => false,
                     'fromProductVersion' => self::INITIAL_VERSION,
                     'active' => $this->isActive(),
                     'metaTitle' => $this->getMetaTitleDe(),

--- a/src/Docs/Convert/WikiApiService.php
+++ b/src/Docs/Convert/WikiApiService.php
@@ -60,7 +60,7 @@ class WikiApiService
             $articleInfoDe,
             [
                 'seoUrl' => $documentMetadata->getUrlDe(),
-                'searchableInAllLanguages' => true,
+                'searchableInAllLanguages' => false,
             ]
         );
 
@@ -265,7 +265,7 @@ class WikiApiService
             'title' => $documentMetadata->getTitleDe(),
             'navigationTitle' => $documentMetadata->getTitleDe(),
             'content' => '<p>Die Entwicklerdokumentation ist nur auf Englisch verfügbar.</p>',
-            'searchableInAllLanguages' => true,
+            'searchableInAllLanguages' => false,
             'seoUrl' => $documentMetadata->getUrlDe(),
             'metaDescription' => $documentMetadata->getMetaDescriptionDe(),
         ];
@@ -379,7 +379,7 @@ class WikiApiService
                             'metaTitle' => '',
                             'metaDescription' => '',
                             'media' => null,
-                            'searchableInAllLanguages' => false,
+                            'searchableInAllLanguages' => true,
                         ],
                     ],
                 ],


### PR DESCRIPTION
fix searchable in all languages

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/communtiy).
-->

### 1. Why is this change necessary?
Follow up to https://github.com/shopware/platform/pull/119
Since the docs are updated multiple times during the sync process, this change was not sufficient. I changed every occurence of "SearchableInAllLanguages" now to false for every german version of a docs article.

### 2. What does this change do, exactly?
Changing the "SearchableInAllLanguages" parameter to false for german articles

### 3. Describe each step to reproduce the issue or behaviour.
Have a look at the previous PR

### 4. Please link to the relevant issues (if any).
/

### 5. Which documentation changes (if any) need to be made because of this PR?
/

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.