### PR TITLE
Adding hint how to add administration snippets without module registration

### DIFF
--- a/src/Docs/Resources/current/4-how-to/245-adding-snippets.md
+++ b/src/Docs/Resources/current/4-how-to/245-adding-snippets.md
@@ -111,6 +111,20 @@ Shopware.Module.register('custom-module', {
 });
 ```
 
+In case of just adding snippets without registering a module you can also feed the snippet objects directly to the locale service:
+
+```
+import deDE from './snippet/de-DE.json';
+import enGB from './snippet/en-GB.json';
+
+Shopware.Application.addInitializerDecorator('locale', locale => {
+    locale.extend('de-DE', deDE);
+    locale.extend('en-GB', enGB);
+
+    return locale;
+});
+```
+
 ## Extending Storefront snippets
 
 #### SnippetFile


### PR DESCRIPTION
### 1. Why is this change necessary?
I prefer the way to add global snippets like `global.entities.custom_entity` without module registration.

### 2. What does this change do, exactly?
Adds a code snippet how to add snippet to the snippet set in the administration

### 3. Describe each step to reproduce the issue or behaviour.
1. Have a look at SwagPayPal
2. Oh that is how you interact with administration services
3. We need more documentation!

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
