### PR TITLE
Assert that ProductStockIndexer is updating stock or available stock in several situations

### DIFF
--- a/src/Core/Content/Test/Product/DataAbstractionLayer/Indexing/ProductStockIndexerTest.php
+++ b/src/Core/Content/Test/Product/DataAbstractionLayer/Indexing/ProductStockIndexerTest.php
@@ -29,7 +29,7 @@ class ProductStockIndexerTest extends TestCase
     /**
      * @var EntityRepositoryInterface
      */
-    private $repository;
+    private $productRepository;
 
     /**
      * @var CartService
@@ -54,7 +54,7 @@ class ProductStockIndexerTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->repository = $this->getContainer()->get('product.repository');
+        $this->productRepository = $this->getContainer()->get('product.repository');
         $this->orderLineItemRepository = $this->getContainer()->get('order_line_item.repository');
         $this->cartService = $this->getContainer()->get(CartService::class);
         $this->contextFactory = $this->getContainer()->get(SalesChannelContextFactory::class);
@@ -84,10 +84,10 @@ class ProductStockIndexerTest extends TestCase
         ];
 
         $context = Context::createDefaultContext();
-        $this->repository->create([$product], $context);
+        $this->productRepository->create([$product], $context);
 
         /** @var ProductEntity $product */
-        $product = $this->repository->search(new Criteria([$id]), $context)->get($id);
+        $product = $this->productRepository->search(new Criteria([$id]), $context)->get($id);
 
         static::assertTrue($product->getAvailable());
         static::assertSame(10, $product->getAvailableStock());
@@ -109,10 +109,10 @@ class ProductStockIndexerTest extends TestCase
         ];
 
         $context = Context::createDefaultContext();
-        $this->repository->create([$product], $context);
+        $this->productRepository->create([$product], $context);
 
         /** @var ProductEntity $product */
-        $product = $this->repository->search(new Criteria([$id]), $context)->get($id);
+        $product = $this->productRepository->search(new Criteria([$id]), $context)->get($id);
 
         static::assertTrue($product->getIsCloseout());
         static::assertFalse($product->getAvailable());
@@ -135,18 +135,18 @@ class ProductStockIndexerTest extends TestCase
         ];
 
         $context = Context::createDefaultContext();
-        $this->repository->create([$product], $context);
+        $this->productRepository->create([$product], $context);
 
         /** @var ProductEntity $product */
-        $product = $this->repository->search(new Criteria([$id]), $context)->get($id);
+        $product = $this->productRepository->search(new Criteria([$id]), $context)->get($id);
 
         static::assertTrue($product->getAvailable());
         static::assertSame(10, $product->getAvailableStock());
 
-        $this->repository->update([['id' => $id, 'stock' => 0]], $context);
+        $this->productRepository->update([['id' => $id, 'stock' => 0]], $context);
 
         /** @var ProductEntity $product */
-        $product = $this->repository->search(new Criteria([$id]), $context)->get($id);
+        $product = $this->productRepository->search(new Criteria([$id]), $context)->get($id);
 
         static::assertTrue($product->getIsCloseout());
         static::assertFalse($product->getAvailable());
@@ -159,7 +159,7 @@ class ProductStockIndexerTest extends TestCase
 
         $context = Context::createDefaultContext();
 
-        $product = $this->repository->search(new Criteria([$id]), $context)->get($id);
+        $product = $this->productRepository->search(new Criteria([$id]), $context)->get($id);
 
         static::assertTrue($product->getAvailable());
         static::assertSame(5, $product->getAvailableStock());
@@ -167,7 +167,7 @@ class ProductStockIndexerTest extends TestCase
         $this->orderProduct($id, 1);
 
         /** @var ProductEntity $product */
-        $product = $this->repository->search(new Criteria([$id]), $context)->get($id);
+        $product = $this->productRepository->search(new Criteria([$id]), $context)->get($id);
 
         static::assertTrue($product->getAvailable());
         static::assertSame(4, $product->getAvailableStock());
@@ -180,14 +180,14 @@ class ProductStockIndexerTest extends TestCase
 
         $context = Context::createDefaultContext();
 
-        $product = $this->repository->search(new Criteria([$id]), $context)->get($id);
+        $product = $this->productRepository->search(new Criteria([$id]), $context)->get($id);
 
         static::assertSame(5, $product->getStock());
 
         $orderId = $this->orderProduct($id, 1);
 
         /** @var ProductEntity $product */
-        $product = $this->repository->search(new Criteria([$id]), $context)->get($id);
+        $product = $this->productRepository->search(new Criteria([$id]), $context)->get($id);
 
         static::assertTrue($product->getAvailable());
         static::assertSame(5, $product->getStock());
@@ -197,7 +197,7 @@ class ProductStockIndexerTest extends TestCase
         $this->transitionOrder($orderId, 'complete');
 
         /** @var ProductEntity $product */
-        $product = $this->repository->search(new Criteria([$id]), $context)->get($id);
+        $product = $this->productRepository->search(new Criteria([$id]), $context)->get($id);
 
         static::assertTrue($product->getAvailable());
         static::assertSame(4, $product->getStock());
@@ -210,14 +210,14 @@ class ProductStockIndexerTest extends TestCase
 
         $context = Context::createDefaultContext();
 
-        $product = $this->repository->search(new Criteria([$id]), $context)->get($id);
+        $product = $this->productRepository->search(new Criteria([$id]), $context)->get($id);
 
         static::assertSame(5, $product->getStock());
 
         $orderId = $this->orderProduct($id, 5);
 
         /** @var ProductEntity $product */
-        $product = $this->repository->search(new Criteria([$id]), $context)->get($id);
+        $product = $this->productRepository->search(new Criteria([$id]), $context)->get($id);
 
         static::assertFalse($product->getAvailable());
         static::assertSame(5, $product->getStock());
@@ -227,7 +227,7 @@ class ProductStockIndexerTest extends TestCase
         $this->transitionOrder($orderId, 'complete');
 
         /** @var ProductEntity $product */
-        $product = $this->repository->search(new Criteria([$id]), $context)->get($id);
+        $product = $this->productRepository->search(new Criteria([$id]), $context)->get($id);
 
         static::assertFalse($product->getAvailable());
         static::assertSame(0, $product->getStock());
@@ -242,8 +242,9 @@ class ProductStockIndexerTest extends TestCase
             'stock' => 5,
         ]);
         $orderId = $this->orderProduct($productId, 1);
+
         /** @var ProductEntity $product */
-        $product = $this->repository->search(new Criteria([$productId]), $context)->first();
+        $product = $this->productRepository->search(new Criteria([$productId]), $context)->first();
         static::assertSame(4, $product->getAvailableStock());
 
         $criteria = new Criteria();
@@ -257,7 +258,7 @@ class ProductStockIndexerTest extends TestCase
             ],
         ], $context);
 
-        $product = $this->repository->search(new Criteria([$productId]), $context)->first();
+        $product = $this->productRepository->search(new Criteria([$productId]), $context)->first();
         static::assertSame(3, $product->getAvailableStock());
     }
 
@@ -269,8 +270,9 @@ class ProductStockIndexerTest extends TestCase
             'stock' => 5,
         ]);
         $orderId = $this->orderProduct($productId, 1);
+
         /** @var ProductEntity $product */
-        $product = $this->repository->search(new Criteria([$productId]), $context)->first();
+        $product = $this->productRepository->search(new Criteria([$productId]), $context)->first();
         static::assertSame(4, $product->getAvailableStock());
 
         $criteria = new Criteria();
@@ -283,7 +285,7 @@ class ProductStockIndexerTest extends TestCase
             ],
         ], $context);
 
-        $product = $this->repository->search(new Criteria([$productId]), $context)->first();
+        $product = $this->productRepository->search(new Criteria([$productId]), $context)->first();
         static::assertSame(5, $product->getAvailableStock());
     }
 
@@ -300,9 +302,9 @@ class ProductStockIndexerTest extends TestCase
         $orderId = $this->orderProduct($originalProductId, 1);
 
         /** @var ProductEntity $originalProduct */
-        $originalProduct = $this->repository->search(new Criteria([$originalProductId]), $context)->first();
+        $originalProduct = $this->productRepository->search(new Criteria([$originalProductId]), $context)->first();
         /** @var ProductEntity $newProduct */
-        $newProduct = $this->repository->search(new Criteria([$newProductId]), $context)->first();
+        $newProduct = $this->productRepository->search(new Criteria([$newProductId]), $context)->first();
         static::assertSame(4, $originalProduct->getAvailableStock());
         static::assertSame(5, $newProduct->getAvailableStock());
 
@@ -317,8 +319,8 @@ class ProductStockIndexerTest extends TestCase
             ],
         ], $context);
 
-        $newProduct = $this->repository->search(new Criteria([$newProductId]), $context)->first();
-        $originalProduct = $this->repository->search(new Criteria([$originalProductId]), $context)->first();
+        $newProduct = $this->productRepository->search(new Criteria([$newProductId]), $context)->first();
+        $originalProduct = $this->productRepository->search(new Criteria([$originalProductId]), $context)->first();
         static::assertSame(5, $originalProduct->getAvailableStock());
         static::assertSame(4, $newProduct->getAvailableStock());
     }
@@ -335,7 +337,7 @@ class ProductStockIndexerTest extends TestCase
         $this->transitionOrder($orderId, 'complete');
 
         /** @var ProductEntity $product */
-        $product = $this->repository->search(new Criteria([$productId]), $context)->first();
+        $product = $this->productRepository->search(new Criteria([$productId]), $context)->first();
         static::assertSame(4, $product->getStock());
 
         $criteria = new Criteria();
@@ -349,7 +351,7 @@ class ProductStockIndexerTest extends TestCase
             ],
         ], $context);
 
-        $product = $this->repository->search(new Criteria([$productId]), $context)->first();
+        $product = $this->productRepository->search(new Criteria([$productId]), $context)->first();
         static::assertSame(3, $product->getStock());
     }
 
@@ -417,7 +419,7 @@ class ProductStockIndexerTest extends TestCase
 
         $product = array_replace_recursive($product, $config);
 
-        $this->repository->create([$product], Context::createDefaultContext());
+        $this->productRepository->create([$product], Context::createDefaultContext());
 
         return $id;
     }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/communtiy).
-->

### 1. Why is this change necessary?

The `ProductStockIndexer` (`\Shopware\Core\Content\Product\DataAbstractionLayer\Indexing\ProductStockIndexer`) currently cannot adjust the stock and the available stock in all situations where this would be necessary because the relevant events are not generated by the system.

For example:

* Updating the quantity of an order line item
* Deleting an order line item
* Changing the product of an order line item

### 2. What does this change do, exactly?

This PR just adds unit tests for expected behaviour.

### 3. Describe each step to reproduce the issue or behaviour.

The unit tests describe the steps to reproduce the behaviour.

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [X] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.
