### PR TITLE
Make global search listing route optional

### DIFF
--- a/src/Administration/Resources/administration/src/app/component/structure/sw-search-bar/sw-search-bar.html.twig
+++ b/src/Administration/Resources/administration/src/app/component/structure/sw-search-bar/sw-search-bar.html.twig
@@ -97,7 +97,8 @@
                                                         {{ $tc(`global.entities.${entity.entity}`, entity.total) }}
                                                     </span>
                                                 </template>
-                                                <router-link class="sw-search-bar__types-header-link"
+                                                <router-link v-if="getSearchTypeProperty(entity.entity, 'listingRoute')"
+                                                             class="sw-search-bar__types-header-link"
                                                              :to="{ name: getSearchTypeProperty(entity.entity, 'listingRoute'),
                                                               query: { term: searchTerm }}">
                                                     {{ $tc(`global.sw-search-bar.labelShowResultsInModule`, 0, { count: entity.total }) }}

--- a/src/Administration/Resources/administration/src/app/component/structure/sw-search-bar/sw-search-bar.html.twig
+++ b/src/Administration/Resources/administration/src/app/component/structure/sw-search-bar/sw-search-bar.html.twig
@@ -97,12 +97,10 @@
                                                         {{ $tc(`global.entities.${entity.entity}`, entity.total) }}
                                                     </span>
                                                 </template>
-                                                <router-link v-if="getSearchTypeProperty(entity.entity, 'listingRoute')"
-                                                             class="sw-search-bar__types-header-link"
-                                                             :to="{ name: getSearchTypeProperty(entity.entity, 'listingRoute'),
-                                                              query: { term: searchTerm }}">
-                                                    {{ $tc(`global.sw-search-bar.labelShowResultsInModule`, 0, { count: entity.total }) }}
-                                                </router-link>
+                                                {% block sw_search_bar_results_list_column_header_more_results %}
+                                                    <sw-search-more-results :result="entity" :term="searchTerm">
+                                                    </sw-search-more-results>
+                                                {% endblock %}
                                             </div>
                                         {% endblock %}
                                         <ul class="sw-search-bar__results-list">

--- a/src/Administration/Resources/administration/src/app/component/structure/sw-search-bar/sw-search-bar.scss
+++ b/src/Administration/Resources/administration/src/app/component/structure/sw-search-bar/sw-search-bar.scss
@@ -154,11 +154,6 @@ $sw-search-bar-types-item-border-radius: $border-radius-default;
             font-weight: bold;
             margin-left: 5px;
         }
-
-        .sw-search-bar__types-header-link {
-            color: $color-shopware-blue;
-            margin-left: 5px;
-        }
 	}
 
 	.sw-search-bar__results {

--- a/src/Administration/Resources/administration/src/app/component/structure/sw-search-more-results/index.js
+++ b/src/Administration/Resources/administration/src/app/component/structure/sw-search-more-results/index.js
@@ -1,0 +1,53 @@
+import template from './sw-search-more-results.html.twig';
+import './sw-search-more-results.scss';
+
+const {Component} = Shopware;
+/**
+ * @public
+ * @description
+ * Renders the search result show more based on the item type.
+ * @status ready
+ * @example-type code-only
+ * @component-example
+ * <sw-search-more-results :result="{entity: 'customer', total: 5}" :term="query">
+ * </sw-search-more-results>
+ */
+Component.register('sw-search-more-results', {
+    template,
+
+    inject: [
+        'searchTypeService'
+    ],
+
+    props: {
+        result: {
+            required: true,
+            type: String
+        },
+        term: {
+            type: String,
+            required: false,
+            default: null
+        }
+    },
+
+    computed: {
+        /**
+         * @return {string}
+         */
+        searchTypeRoute() {
+            if (!this.result ||
+                !this.result.entity ||
+                !this.searchTypes[this.result.entity] ||
+                !this.searchTypes[this.result.entity].listingRoute) {
+                return '';
+            }
+
+            return this.searchTypes[this.type].listingRoute;
+        },
+
+        searchTypes() {
+            return this.searchTypeService.getTypes();
+        }
+    }
+});

--- a/src/Administration/Resources/administration/src/app/component/structure/sw-search-more-results/sw-search-more-results.html.twig
+++ b/src/Administration/Resources/administration/src/app/component/structure/sw-search-more-results/sw-search-more-results.html.twig
@@ -1,0 +1,13 @@
+{% block sw_search_more_results %}
+    <router-link v-if="searchTypeRoute"
+                 :to="{ name: searchTypeRoute, query: { term: searchTerm }}"
+                 class="sw-search-more-results__link">
+        {% block sw_search_more_results_content %}
+            <slot name="content">
+                {% block sw_search_more_results_slot_content %}
+                    {{ $tc('global.sw-search-more-results.labelShowResultsInModule', 0, { count: result.total }) }}
+                {% endblock %}
+            </slot>
+        {% endblock %}
+    </router-link>
+{% endblock %}

--- a/src/Administration/Resources/administration/src/app/component/structure/sw-search-more-results/sw-search-more-results.scss
+++ b/src/Administration/Resources/administration/src/app/component/structure/sw-search-more-results/sw-search-more-results.scss
@@ -1,0 +1,6 @@
+@import "~scss/variables";
+
+.sw-search-more-results__link {
+    color: $color-shopware-blue;
+    margin-left: 5px;
+}

--- a/src/Administration/Resources/administration/src/app/snippet/de-DE.json
+++ b/src/Administration/Resources/administration/src/app/snippet/de-DE.json
@@ -386,8 +386,7 @@
       "messageNoTypeResults": "Es wurde kein passender Typ gefunden.",
       "placeholderSearchField": "Finde Produkte, Kunden, Bestellungen",
       "placeholderTypeSearchField": "Durchsuche alle {entity} ...",
-      "placeholderShortcutInfo": "Tipp: Nutze die \"f\" Taste, um die Suche schneller zu öffnen.",
-      "labelShowResultsInModule": "Ergebnisse im Modul anzeigen({count})"
+      "placeholderShortcutInfo": "Tipp: Nutze die \"f\" Taste, um die Suche schneller zu öffnen."
     },
     "sw-search-bar-item": {
       "typeLabelCustomer": "Kunde",
@@ -396,6 +395,9 @@
       "typeLabelMedia": "Medium",
       "typeLabelCategory": "Kategorie",
       "typeLabelCms": "CMS"
+    },
+    "sw-search-more-results": {
+      "labelShowResultsInModule": "Ergebnisse im Modul anzeigen({count})"
     },
     "sw-condition": {
       "operator": {

--- a/src/Administration/Resources/administration/src/app/snippet/en-GB.json
+++ b/src/Administration/Resources/administration/src/app/snippet/en-GB.json
@@ -385,8 +385,7 @@
       "messageNoTypeResults": "No type found.",
       "placeholderSearchField": "Find products, customers, orders...",
       "placeholderTypeSearchField": "Search \"{entity}\"...",
-      "placeholderShortcutInfo": "Tip: Press the \"f\" key to get to the search bar faster.",
-      "labelShowResultsInModule": "Show results in module({count})"
+      "placeholderShortcutInfo": "Tip: Press the \"f\" key to get to the search bar faster."
     },
     "sw-search-bar-item": {
       "typeLabelCustomer": "Customer",
@@ -395,6 +394,9 @@
       "typeLabelMedia": "Media",
       "typeLabelCategory": "Category",
       "typeLabelCms": "CMS"
+    },
+    "sw-search-more-results": {
+      "labelShowResultsInModule": "Show results in module({count})"
     },
     "sw-condition": {
       "operator": {

--- a/src/Docs/Resources/current/4-how-to/660-add-custom-entity-to-administration-search.md
+++ b/src/Docs/Resources/current/4-how-to/660-add-custom-entity-to-administration-search.md
@@ -89,6 +89,39 @@ Shopware.Component.override('sw-search-bar-item', {
 The `sw_search_bar_item_cms_page` block is used as it is the last block but it is not important which shopware type is extended as long as the vue else-if structure is kept working.
 
 
+### Add custom show more results link
+
+By default the search bar tries to resolve to the registered listing route.
+If your entity can be searched externally you can edit the `sw-search-more-results` or `sw-search` components as well:
+
+`sw-search-more-results.html.twig`
+```twig
+{% block sw_search_more_results %}
+    <template v-if="result.entity === 'foo_bar'">
+        There are so many hits.
+        <a :href="'https://my.erp.localhost/?q=' + searchTerm"
+           class="sw-search-bar-item__link"
+           target="_blank">
+             Look it directly up
+        </a>
+        in the ERP instead.
+    </template>
+    <template v-else>
+        {% parent %}
+    </template>
+{% endblock %}
+```
+
+```javascript
+`index.js`
+import template from './sw-search-more-results.html.twig';
+
+Shopware.Component.override('sw-search-more-results', {
+    template
+})
+```
+
+
 ### Potential pitfalls
 
 In case of a tag with a technical name the translation is missing:


### PR DESCRIPTION
### 1. Why is this change necessary?
In case you want just the global search to look for an entity without a listing view.

### 2. What does this change do, exactly?
Hide the "Show all in module" if no listing route is given.

### 3. Describe each step to reproduce the issue or behaviour.
1. Have a pre-defined set of entities
2. Want to make them searchable and modifiable 
3. They just have a name and some checkboxes
4. I still have to make a listing

### 4. Which documentation changes (if any) need to be made because of this PR?
https://github.com/shopware/platform/pull/221 - part of this PR

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
