### PR TITLE
Fixed typo in custom-cms-element how-to

### DIFF
--- a/src/Docs/Resources/current/4-how-to/300-custom-cms-element.md
+++ b/src/Docs/Resources/current/4-how-to/300-custom-cms-element.md
@@ -105,7 +105,7 @@ Shopware.Application.getContainer('service').cmsService.registerCmsElement({
 ```
 
 The properties `name` and `label` do not require further explanation.
-For all three fields `compoent`, `configComponent` and `previewComponent`, components that do not **yet** exist were applied. Those will be created
+For all three fields `component`, `configComponent` and `previewComponent`, components that do not **yet** exist were applied. Those will be created
 in the next few steps as well.
 The `defaultConfig` defines the default values for the element's configurations. There will be a text field to enter a YouTube video's ID, `videoSrc`, and a
 toggle to en-/disable the option to show the control elements in the YouTube video, `showControls`.


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/communtiy).
-->

### 1. Why is this change necessary?
For a better documentation

### 2. What does this change do, exactly?
It changes `compoent` to `component`.

### 3. Describe each step to reproduce the issue or behaviour.
Add an `a` after the letter `o` in the word `compoent`.


### 4. Please link to the relevant issues (if any).
- 

### 5. Which documentation changes (if any) need to be made because of this PR?
-

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
