### PR TITLE
Validation with sales channel context

### DIFF
--- a/CHANGELOG-6.0.md
+++ b/CHANGELOG-6.0.md
@@ -87,6 +87,7 @@ This can be useful when validate your commands in `PreWriteValidateEvent`s when 
         - `\Shopware\Core\Framework\Plugin::deactivate` is now always called before `\Shopware\Core\Framework\Plugin::uninstall`
     * Renamed container service id `shopware.cache` to `cache.object` 
     * Added new function to `\Shopware\Core\Framework\Cache\CacheClearer`. Please use this service to invalidate or delete cache items.
+    * We changed the type hint of `Shopware\Core\Framework\Validation\ValidationServiceInterface::buildCreateValidation` and `Shopware\Core\Framework\Validation\ValidationServiceInterface::buildUpdateValidation` to `SalesChannelContext`
 * Storefront
     * Changed the default storefront script path in `Bundle` to `Resources/dist/storefront/js`
     * Changed the name of `messages.<locale>.json` to `storefront.<locale>.json` and changed to **not** be a base file anymore.

--- a/UPGRADE-6.1.md
+++ b/UPGRADE-6.1.md
@@ -176,6 +176,8 @@ SHOPWARE_HTTP_DEFAULT_TTL=7200
 
 * All customer events in `Shopware\Core\Checkout\Customer\Event` now get the `Shopware\Core\Syste\SalesChannel\SalesChannelContext` instead of `Shopware\Core\Framework\Context` and a `salesChannelId`
 
+* We changed the type hint of `Shopware\Core\Framework\Validation\ValidationServiceInterface::buildCreateValidation` and `Shopware\Core\Framework\Validation\ValidationServiceInterface::buildUpdateValidation` to `SalesChannelContext`
+
 Administration
 --------------
 

--- a/src/Core/Checkout/Customer/SalesChannel/AccountRegistrationService.php
+++ b/src/Core/Checkout/Customer/SalesChannel/AccountRegistrationService.php
@@ -81,7 +81,7 @@ class AccountRegistrationService
 
     public function register(DataBag $data, bool $isGuest, SalesChannelContext $context, ?DataValidationDefinition $additionalValidationDefinitions = null): string
     {
-        $this->validateRegistrationData($data, $isGuest, $context->getContext(), $additionalValidationDefinitions);
+        $this->validateRegistrationData($data, $isGuest, $context, $additionalValidationDefinitions);
 
         $customer = $this->mapCustomerData($data, $isGuest, $context);
 
@@ -124,7 +124,7 @@ class AccountRegistrationService
         return $customer['id'];
     }
 
-    private function validateRegistrationData(DataBag $data, bool $isGuest, Context $context, ?DataValidationDefinition $additionalValidations = null): void
+    private function validateRegistrationData(DataBag $data, bool $isGuest, SalesChannelContext $context, ?DataValidationDefinition $additionalValidations = null): void
     {
         /** @var DataBag $addressData */
         $addressData = $data->get('billingAddress');
@@ -261,20 +261,20 @@ class AccountRegistrationService
         return $customer;
     }
 
-    private function getCreateAddressValidationDefinition(string $accountType, bool $isBillingAddress, Context $context): DataValidationDefinition
+    private function getCreateAddressValidationDefinition(string $accountType, bool $isBillingAddress, SalesChannelContext $context): DataValidationDefinition
     {
         $validation = $this->addressValidationService->buildCreateValidation($context);
         if ($isBillingAddress && $accountType === CustomerEntity::ACCOUNT_TYPE_BUSINESS && $this->systemConfigService->get('core.loginRegistration.showAccountTypeSelection')) {
             $validation->add('company', new NotBlank());
         }
 
-        $validationEvent = new BuildValidationEvent($validation, $context);
+        $validationEvent = new BuildValidationEvent($validation, $context->getContext());
         $this->eventDispatcher->dispatch($validationEvent, $validationEvent->getName());
 
         return $validation;
     }
 
-    private function getCustomerCreateValidationDefinition(bool $isGuest, Context $context): DataValidationDefinition
+    private function getCustomerCreateValidationDefinition(bool $isGuest, SalesChannelContext $context): DataValidationDefinition
     {
         $validation = $this->accountValidationService->buildCreateValidation($context);
 
@@ -284,7 +284,7 @@ class AccountRegistrationService
             $validation->add('email', new CustomerEmailUnique(['context' => $context]));
         }
 
-        $validationEvent = new BuildValidationEvent($validation, $context);
+        $validationEvent = new BuildValidationEvent($validation, $context->getContext());
         $this->eventDispatcher->dispatch($validationEvent, $validationEvent->getName());
 
         return $validation;

--- a/src/Core/Checkout/Customer/SalesChannel/AddressService.php
+++ b/src/Core/Checkout/Customer/SalesChannel/AddressService.php
@@ -10,7 +10,6 @@ use Shopware\Core\Checkout\Customer\CustomerEvents;
 use Shopware\Core\Checkout\Customer\Exception\AddressNotFoundException;
 use Shopware\Core\Checkout\Customer\Exception\CannotDeleteDefaultAddressException;
 use Shopware\Core\Checkout\Customer\Validation\AddressValidationService;
-use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepositoryInterface;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
@@ -111,7 +110,7 @@ class AddressService
         $this->validateCustomerIsLoggedIn($context);
 
         $accountType = $data->get('accountType', CustomerEntity::ACCOUNT_TYPE_PRIVATE);
-        $definition = $this->getCreateValidationDefinition($accountType, $context->getContext());
+        $definition = $this->getCreateValidationDefinition($accountType, $context);
         $this->validator->validate($data->all(), $definition);
 
         if ($id = $data->get('id')) {
@@ -206,7 +205,7 @@ class AddressService
         return $address;
     }
 
-    private function getCreateValidationDefinition(string $accountType, Context $context): DataValidationDefinition
+    private function getCreateValidationDefinition(string $accountType, SalesChannelContext $context): DataValidationDefinition
     {
         $validation = $this->addressValidationService->buildCreateValidation($context);
 
@@ -214,7 +213,7 @@ class AddressService
             $validation->add('company', new NotBlank());
         }
 
-        $validationEvent = new BuildValidationEvent($validation, $context);
+        $validationEvent = new BuildValidationEvent($validation, $context->getContext());
         $this->eventDispatcher->dispatch($validationEvent, $validationEvent->getName());
 
         return $validation;

--- a/src/Core/Checkout/Customer/Validation/AddressValidationService.php
+++ b/src/Core/Checkout/Customer/Validation/AddressValidationService.php
@@ -2,10 +2,10 @@
 
 namespace Shopware\Core\Checkout\Customer\Validation;
 
-use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Validation\EntityExists;
 use Shopware\Core\Framework\Validation\DataValidationDefinition;
 use Shopware\Core\Framework\Validation\ValidationServiceInterface;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
 use Symfony\Component\Validator\Constraints\NotBlank;
 
@@ -21,7 +21,7 @@ class AddressValidationService implements ValidationServiceInterface
         $this->systemConfigService = $systemConfigService;
     }
 
-    public function buildCreateValidation(Context $context): DataValidationDefinition
+    public function buildCreateValidation(SalesChannelContext $context): DataValidationDefinition
     {
         $definition = new DataValidationDefinition('address.create');
 
@@ -45,22 +45,22 @@ class AddressValidationService implements ValidationServiceInterface
         return $definition;
     }
 
-    public function buildUpdateValidation(Context $context): DataValidationDefinition
+    public function buildUpdateValidation(SalesChannelContext $context): DataValidationDefinition
     {
         $definition = new DataValidationDefinition('address.update');
 
         $this->buildCommonValidation($definition, $context)
-            ->add('id', new NotBlank(), new EntityExists(['context' => $context, 'entity' => 'customer_address']));
+            ->add('id', new NotBlank(), new EntityExists(['context' => $context->getContext(), 'entity' => 'customer_address']));
 
         return $definition;
     }
 
-    private function buildCommonValidation(DataValidationDefinition $definition, Context $context): DataValidationDefinition
+    private function buildCommonValidation(DataValidationDefinition $definition, SalesChannelContext $context): DataValidationDefinition
     {
         $definition
-            ->add('salutationId', new EntityExists(['entity' => 'salutation', 'context' => $context]))
-            ->add('countryId', new EntityExists(['entity' => 'country', 'context' => $context]))
-            ->add('countryStateId', new EntityExists(['entity' => 'country_state', 'context' => $context]));
+            ->add('salutationId', new EntityExists(['entity' => 'salutation', 'context' => $context->getContext()]))
+            ->add('countryId', new EntityExists(['entity' => 'country', 'context' => $context->getContext()]))
+            ->add('countryStateId', new EntityExists(['entity' => 'country_state', 'context' => $context->getContext()]));
 
         return $definition;
     }

--- a/src/Core/Checkout/Customer/Validation/CustomerProfileValidationService.php
+++ b/src/Core/Checkout/Customer/Validation/CustomerProfileValidationService.php
@@ -2,10 +2,10 @@
 
 namespace Shopware\Core\Checkout\Customer\Validation;
 
-use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Validation\EntityExists;
 use Shopware\Core\Framework\Validation\DataValidationDefinition;
 use Shopware\Core\Framework\Validation\ValidationServiceInterface;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\System\Salutation\SalutationDefinition;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
 use Symfony\Component\Validator\Constraints\GreaterThanOrEqual;
@@ -32,7 +32,7 @@ class CustomerProfileValidationService implements ValidationServiceInterface
         $this->systemConfigService = $systemConfigService;
     }
 
-    public function buildCreateValidation(Context $context): DataValidationDefinition
+    public function buildCreateValidation(SalesChannelContext $context): DataValidationDefinition
     {
         $definition = new DataValidationDefinition('customer.profile.create');
 
@@ -41,7 +41,7 @@ class CustomerProfileValidationService implements ValidationServiceInterface
         return $definition;
     }
 
-    public function buildUpdateValidation(Context $context): DataValidationDefinition
+    public function buildUpdateValidation(SalesChannelContext $context): DataValidationDefinition
     {
         $definition = new DataValidationDefinition('customer.profile.update');
 
@@ -50,10 +50,10 @@ class CustomerProfileValidationService implements ValidationServiceInterface
         return $definition;
     }
 
-    private function addConstraints(DataValidationDefinition $definition, Context $context): void
+    private function addConstraints(DataValidationDefinition $definition, SalesChannelContext $context): void
     {
         $definition
-            ->add('salutationId', new NotBlank(), new EntityExists(['entity' => $this->salutationDefinition->getEntityName(), 'context' => $context]))
+            ->add('salutationId', new NotBlank(), new EntityExists(['entity' => $this->salutationDefinition->getEntityName(), 'context' => $context->getContext()]))
             ->add('firstName', new NotBlank())
             ->add('lastName', new NotBlank());
 

--- a/src/Core/Checkout/Customer/Validation/CustomerValidationService.php
+++ b/src/Core/Checkout/Customer/Validation/CustomerValidationService.php
@@ -2,9 +2,9 @@
 
 namespace Shopware\Core\Checkout\Customer\Validation;
 
-use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Validation\DataValidationDefinition;
 use Shopware\Core\Framework\Validation\ValidationServiceInterface;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\Validator\Constraints\Email;
 use Symfony\Component\Validator\Constraints\NotBlank;
 use Symfony\Component\Validator\Constraints\Type;
@@ -23,7 +23,7 @@ class CustomerValidationService implements ValidationServiceInterface
         $this->profileValidation = $profileValidation;
     }
 
-    public function buildCreateValidation(Context $context): DataValidationDefinition
+    public function buildCreateValidation(SalesChannelContext $context): DataValidationDefinition
     {
         $definition = new DataValidationDefinition('customer.create');
 
@@ -36,7 +36,7 @@ class CustomerValidationService implements ValidationServiceInterface
         return $definition;
     }
 
-    public function buildUpdateValidation(Context $context): DataValidationDefinition
+    public function buildUpdateValidation(SalesChannelContext $context): DataValidationDefinition
     {
         $definition = new DataValidationDefinition('customer.update');
 
@@ -49,7 +49,7 @@ class CustomerValidationService implements ValidationServiceInterface
         return $definition;
     }
 
-    private function addConstraints(DataValidationDefinition $definition, Context $context): void
+    private function addConstraints(DataValidationDefinition $definition, SalesChannelContext $context): void
     {
         $definition
             ->add('email', new NotBlank(), new Email())

--- a/src/Core/Checkout/Order/SalesChannel/OrderService.php
+++ b/src/Core/Checkout/Order/SalesChannel/OrderService.php
@@ -4,7 +4,6 @@ namespace Shopware\Core\Checkout\Order\SalesChannel;
 
 use Shopware\Core\Checkout\Cart\SalesChannel\CartService;
 use Shopware\Core\Checkout\Order\Validation\OrderValidationService;
-use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Validation\BuildValidationEvent;
 use Shopware\Core\Framework\Validation\DataBag\DataBag;
 use Shopware\Core\Framework\Validation\DataValidationDefinition;
@@ -52,7 +51,7 @@ class OrderService
      */
     public function createOrder(DataBag $data, SalesChannelContext $context): string
     {
-        $this->validateOrderData($data, $context->getContext());
+        $this->validateOrderData($data, $context);
 
         $cart = $this->cartService->getCart($context->getToken(), $context);
 
@@ -62,7 +61,7 @@ class OrderService
     /**
      * @throws ConstraintViolationException
      */
-    private function validateOrderData(DataBag $data, Context $context): void
+    private function validateOrderData(DataBag $data, SalesChannelContext $context): void
     {
         $definition = $this->getOrderCreateValidationDefinition($context);
         $violations = $this->dataValidator->getViolations($data->all(), $definition);
@@ -72,11 +71,11 @@ class OrderService
         }
     }
 
-    private function getOrderCreateValidationDefinition(Context $context): DataValidationDefinition
+    private function getOrderCreateValidationDefinition(SalesChannelContext $context): DataValidationDefinition
     {
         $validation = $this->orderValidationService->buildCreateValidation($context);
 
-        $validationEvent = new BuildValidationEvent($validation, $context);
+        $validationEvent = new BuildValidationEvent($validation, $context->getContext());
         $this->eventDispatcher->dispatch($validationEvent, $validationEvent->getName());
 
         return $validation;

--- a/src/Core/Checkout/Order/Validation/OrderValidationService.php
+++ b/src/Core/Checkout/Order/Validation/OrderValidationService.php
@@ -2,14 +2,14 @@
 
 namespace Shopware\Core\Checkout\Order\Validation;
 
-use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Validation\DataValidationDefinition;
 use Shopware\Core\Framework\Validation\ValidationServiceInterface;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\Validator\Constraints\NotBlank;
 
 class OrderValidationService implements ValidationServiceInterface
 {
-    public function buildCreateValidation(Context $context): DataValidationDefinition
+    public function buildCreateValidation(SalesChannelContext $context): DataValidationDefinition
     {
         $definition = new DataValidationDefinition('order.create');
 
@@ -18,7 +18,7 @@ class OrderValidationService implements ValidationServiceInterface
         return $definition;
     }
 
-    public function buildUpdateValidation(Context $context): DataValidationDefinition
+    public function buildUpdateValidation(SalesChannelContext $context): DataValidationDefinition
     {
         return $this->buildCreateValidation($context);
     }

--- a/src/Core/Content/ContactForm/ContactFormService.php
+++ b/src/Core/Content/ContactForm/ContactFormService.php
@@ -68,7 +68,7 @@ class ContactFormService
 
     private function validateContactForm(DataBag $data, SalesChannelContext $context): void
     {
-        $definition = $this->contactFormValidationService->buildCreateValidation($context->getContext());
+        $definition = $this->contactFormValidationService->buildCreateValidation($context);
         $violations = $this->validator->getViolations($data->all(), $definition);
 
         if ($violations->count() > 0) {

--- a/src/Core/Content/ContactForm/Validation/ContactFormValidationService.php
+++ b/src/Core/Content/ContactForm/Validation/ContactFormValidationService.php
@@ -2,20 +2,20 @@
 
 namespace Shopware\Core\Content\ContactForm\Validation;
 
-use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Validation\EntityExists;
 use Shopware\Core\Framework\Validation\DataValidationDefinition;
 use Shopware\Core\Framework\Validation\ValidationServiceInterface;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\Validator\Constraints\Email;
 use Symfony\Component\Validator\Constraints\NotBlank;
 
 class ContactFormValidationService implements ValidationServiceInterface
 {
-    public function buildCreateValidation(Context $context): DataValidationDefinition
+    public function buildCreateValidation(SalesChannelContext $context): DataValidationDefinition
     {
         $definition = new DataValidationDefinition('contact_form.create');
 
-        $definition->add('salutationId', new NotBlank(), new EntityExists(['entity' => 'salutation', 'context' => $context]))
+        $definition->add('salutationId', new NotBlank(), new EntityExists(['entity' => 'salutation', 'context' => $context->getContext()]))
             ->add('firstName', new NotBlank())
             ->add('lastName', new NotBlank())
             ->add('email', new NotBlank(), new Email())
@@ -26,7 +26,7 @@ class ContactFormValidationService implements ValidationServiceInterface
         return $definition;
     }
 
-    public function buildUpdateValidation(Context $context): DataValidationDefinition
+    public function buildUpdateValidation(SalesChannelContext $context): DataValidationDefinition
     {
         return $this->buildCreateValidation($context);
     }

--- a/src/Core/Framework/Validation/ValidationServiceInterface.php
+++ b/src/Core/Framework/Validation/ValidationServiceInterface.php
@@ -2,11 +2,11 @@
 
 namespace Shopware\Core\Framework\Validation;
 
-use Shopware\Core\Framework\Context;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
 
 interface ValidationServiceInterface
 {
-    public function buildCreateValidation(Context $context): DataValidationDefinition;
+    public function buildCreateValidation(SalesChannelContext $context): DataValidationDefinition;
 
-    public function buildUpdateValidation(Context $context): DataValidationDefinition;
+    public function buildUpdateValidation(SalesChannelContext $context): DataValidationDefinition;
 }

--- a/src/Docs/Resources/platform-updates/2019-10-01-breaking-change-validation-service-context.md
+++ b/src/Docs/Resources/platform-updates/2019-10-01-breaking-change-validation-service-context.md
@@ -1,0 +1,3 @@
+[titleEn]: <>(ValidationServiceInterface method signature changes)
+
+We have made changes to the method signature of all ValidationServiceInterface functions by requiring that the last parameter be a SalesChannelContext object and not a Context object.

--- a/src/Storefront/Framework/Seo/Validation/SeoUrlValidationService.php
+++ b/src/Storefront/Framework/Seo/Validation/SeoUrlValidationService.php
@@ -6,6 +6,7 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Validation\EntityExists;
 use Shopware\Core\Framework\Validation\DataValidationDefinition;
 use Shopware\Core\Framework\Validation\ValidationServiceInterface;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Storefront\Framework\Seo\SeoUrlRoute\SeoUrlRouteConfig;
 use Symfony\Component\Validator\Constraints\NotBlank;
 use Symfony\Component\Validator\Constraints\Type;
@@ -22,20 +23,20 @@ class SeoUrlValidationService implements ValidationServiceInterface
         $this->routeConfig = $config;
     }
 
-    public function buildCreateValidation(Context $context): DataValidationDefinition
+    public function buildCreateValidation(SalesChannelContext $context): DataValidationDefinition
     {
         $definition = new DataValidationDefinition('seo_url.create');
 
-        $this->addConstraints($definition, $context);
+        $this->addConstraints($definition, $context->getContext());
 
         return $definition;
     }
 
-    public function buildUpdateValidation(Context $context): DataValidationDefinition
+    public function buildUpdateValidation(SalesChannelContext $context): DataValidationDefinition
     {
         $definition = new DataValidationDefinition('seo_url.update');
 
-        $this->addConstraints($definition, $context);
+        $this->addConstraints($definition, $context->getContext());
 
         return $definition;
     }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/communtiy).
-->

### 1. Why is this change necessary?
There is currently no way to add SalesChannelContext depending validations for example, based on the selected payment method. By changing the method signature, this is now possible via decoration of the actual OrderValidationService.

### 2. What does this change do, exactly?
Changes the method signature of all ValidationServices

### 3. Describe each step to reproduce the issue or behaviour.
Try to add a validator based on a payment method

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.
