### PR TITLE
Add access modifiers to constants

### DIFF
--- a/src/Core/Checkout/Customer/Validation/Constraint/CustomerPasswordMatches.php
+++ b/src/Core/Checkout/Customer/Validation/Constraint/CustomerPasswordMatches.php
@@ -8,7 +8,7 @@ use Symfony\Component\Validator\Exception\MissingOptionsException;
 
 class CustomerPasswordMatches extends Constraint
 {
-    const CUSTOMER_PASSWORD_NOT_CORRECT = 'fe2faa88-34d9-4c3b-99b3-8158b1ed8dc7';
+    public const CUSTOMER_PASSWORD_NOT_CORRECT = 'fe2faa88-34d9-4c3b-99b3-8158b1ed8dc7';
 
     public $message = 'Your password is wrong';
 

--- a/src/Core/Content/Test/ImportExport/Commands/ImportEntityCommandTest.php
+++ b/src/Core/Content/Test/ImportExport/Commands/ImportEntityCommandTest.php
@@ -21,8 +21,8 @@ class ImportEntityCommandTest extends TestCase
 {
     use IntegrationTestBehaviour;
 
-    const DEFAULT_CUSTOMER_IMPORT_PROFILE = 'Default customer';
-    const TEST_IMPORT_FILE_PATH = '/tmp/file.csv';
+    private const DEFAULT_CUSTOMER_IMPORT_PROFILE = 'Default customer';
+    private const TEST_IMPORT_FILE_PATH = '/tmp/file.csv';
 
     /**
      * @var EntityRepositoryInterface

--- a/src/Core/Framework/DataAbstractionLayer/Field/Flag/ReadProtected.php
+++ b/src/Core/Framework/DataAbstractionLayer/Field/Flag/ReadProtected.php
@@ -7,7 +7,7 @@ use Shopware\Core\Framework\Context\SalesChannelApiSource;
 
 class ReadProtected extends Flag
 {
-    const BASE_URLS = [
+    private const BASE_URLS = [
         AdminApiSource::class => '/api/v',
         SalesChannelApiSource::class => '/sales-channel-api/v',
     ];

--- a/src/Storefront/Test/Page/SearchPageTest.php
+++ b/src/Storefront/Test/Page/SearchPageTest.php
@@ -14,7 +14,7 @@ class SearchPageTest extends TestCase
     use IntegrationTestBehaviour;
     use StorefrontPageTestBehaviour;
 
-    const TEST_TERM = 'foo';
+    private const TEST_TERM = 'foo';
 
     public function testitRequiresSearchParam(): void
     {

--- a/src/Storefront/Theme/StorefrontPluginRegistry.php
+++ b/src/Storefront/Theme/StorefrontPluginRegistry.php
@@ -10,7 +10,7 @@ use Symfony\Component\HttpKernel\KernelInterface;
 
 class StorefrontPluginRegistry
 {
-    const BASE_THEME_NAME = 'Storefront';
+    public const BASE_THEME_NAME = 'Storefront';
 
     /**
      * @var StorefrontPluginConfigurationCollection|null

--- a/src/Storefront/Theme/ThemeDefinition.php
+++ b/src/Storefront/Theme/ThemeDefinition.php
@@ -27,7 +27,7 @@ use Shopware\Storefront\Theme\Aggregate\ThemeTranslationDefinition;
 
 class ThemeDefinition extends EntityDefinition
 {
-    const ENTITY_NAME = 'theme';
+    private const ENTITY_NAME = 'theme';
 
     public function getEntityName(): string
     {


### PR DESCRIPTION
### 1. Why is this change necessary?

To prevent usage of constants that should only be called from the defining class itself.

### 2. What does this change do, exactly?

It adds access modifiers to constants, which is available since PHP 7.1.0.

### 3. Describe each step to reproduce the issue or behaviour.

➖ 

### 4. Please link to the relevant issues (if any).

➖ 

### 5. Which documentation changes (if any) need to be made because of this PR?

➖ 

### 6. Checklist

- [X] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.
