### PR TITLE
Fix null value for array flip

### DIFF
--- a/src/Core/System/SalesChannel/Context/SalesChannelContextFactory.php
+++ b/src/Core/System/SalesChannel/Context/SalesChannelContextFactory.php
@@ -268,7 +268,7 @@ class SalesChannelContextFactory
         $origin = new SalesChannelApiSource($salesChannelId);
 
         //explode all available languages for the provided sales channel
-        $languageIds = $data['sales_channel_language_ids'] ? explode(',', $data['sales_channel_language_ids']) : null;
+        $languageIds = $data['sales_channel_language_ids'] ? explode(',', $data['sales_channel_language_ids']) : [];
         $languageIds = array_keys(array_flip($languageIds));
 
         //check which language should be used in the current request (request header set, or context already contains a language - stored in `sales_channel_api_context`)


### PR DESCRIPTION
### 1. Why is this change necessary?
It gives a `Type Error` due to null value being passed in the `array_flip` function

### 2. What does this change do, exactly?
This fix changes the `null` value to be an empty `array` to avoid the `Type Error`

### 3. Describe each step to reproduce the issue or behaviour.
1. Create a `Shopware\Core\System\SalesChannel\Context\SalesChannelContext` instance from the `Shopware\Core\System\SalesChannel\Context\SalesChannelContextFactory`.
2. If there is no `language_id` set for the sales channel provided, it will throw this error
```
TypeError : array_flip() expects parameter 1 to be array, null given
```

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
