### PR TITLE
Only change the administration editing language if needed

### DIFF
--- a/src/Administration/Resources/administration/src/module/sw-manufacturer/page/sw-manufacturer-detail/index.js
+++ b/src/Administration/Resources/administration/src/module/sw-manufacturer/page/sw-manufacturer-detail/index.js
@@ -110,7 +110,10 @@ Component.register('sw-manufacturer-detail', {
                 return;
             }
 
-            this.languageStore.setCurrentId(this.languageStore.systemLanguageId);
+            if (this.languageStore.getCurrentId() !== this.languageStore.systemLanguageId) {
+                this.languageStore.setCurrentId(this.languageStore.systemLanguageId);
+            }
+
             this.manufacturer = this.manufacturerRepository.create(this.context);
         },
 

--- a/src/Administration/Resources/administration/src/module/sw-promotion/page/sw-promotion-detail/index.js
+++ b/src/Administration/Resources/administration/src/module/sw-promotion/page/sw-promotion-detail/index.js
@@ -141,7 +141,10 @@ Component.register('sw-promotion-detail', {
         createdComponent() {
             this.isLoading = true;
             if (!this.promotionId) {
-                this.languageStore.setCurrentId(this.languageStore.systemLanguageId);
+                if (this.languageStore.getCurrentId() !== this.languageStore.systemLanguageId) {
+                    this.languageStore.setCurrentId(this.languageStore.systemLanguageId);
+                }
+
                 this.promotion = this.promotionRepository.create(this.context);
                 // hydrate and extend promotion with additional data
                 entityHydrator.hydrate(this.promotion);

--- a/src/Administration/Resources/administration/src/module/sw-settings-currency/page/sw-settings-currency-detail/index.js
+++ b/src/Administration/Resources/administration/src/module/sw-settings-currency/page/sw-settings-currency-detail/index.js
@@ -96,7 +96,10 @@ Component.register('sw-settings-currency-detail', {
                 return;
             }
 
-            this.languageStore.setCurrentId(this.languageStore.systemLanguageId);
+            if (this.languageStore.getCurrentId() !== this.languageStore.systemLanguageId) {
+                this.languageStore.setCurrentId(this.languageStore.systemLanguageId);
+            }
+
             this.currency = this.currencyRepository.create(this.context);
             this.isLoading = false;
         },

--- a/src/Administration/Resources/administration/src/module/sw-settings-customer-group/page/sw-settings-customer-group-detail/index.js
+++ b/src/Administration/Resources/administration/src/module/sw-settings-customer-group/page/sw-settings-customer-group-detail/index.js
@@ -104,7 +104,10 @@ Component.register('sw-settings-customer-group-detail', {
                 return;
             }
 
-            this.languageStore.setCurrentId(this.languageStore.systemLanguageId);
+            if (this.languageStore.getCurrentId() !== this.languageStore.systemLanguageId) {
+                this.languageStore.setCurrentId(this.languageStore.systemLanguageId);
+            }
+
             this.customerGroup = this.customerGroupRepository.create(this.context);
             this.isLoading = false;
         },

--- a/src/Administration/Resources/administration/src/module/sw-settings-language/page/sw-settings-language-detail/index.js
+++ b/src/Administration/Resources/administration/src/module/sw-settings-language/page/sw-settings-language-detail/index.js
@@ -113,7 +113,10 @@ Component.register('sw-settings-language-detail', {
     methods: {
         createdComponent() {
             if (!this.languageId) {
-                this.languageStore.setCurrentId(this.languageStore.systemLanguageId);
+                if (this.languageStore.getCurrentId() !== this.languageStore.systemLanguageId) {
+                    this.languageStore.setCurrentId(this.languageStore.systemLanguageId);
+                }
+
                 this.language = this.languageRepository.create(this.context);
             } else {
                 this.loadEntityData();

--- a/src/Administration/Resources/administration/src/module/sw-settings-salutation/page/sw-settings-salutation-detail/index.js
+++ b/src/Administration/Resources/administration/src/module/sw-settings-salutation/page/sw-settings-salutation-detail/index.js
@@ -117,7 +117,10 @@ Component.register('sw-settings-salutation-detail', {
                 return;
             }
 
-            this.languageStore.setCurrentId(this.languageStore.systemLanguageId);
+            if (this.languageStore.getCurrentId() !== this.languageStore.systemLanguageId) {
+                this.languageStore.setCurrentId(this.languageStore.systemLanguageId);
+            }
+
             this.salutation = this.salutationRepository.create(this.context);
             this.isLoading = false;
         },


### PR DESCRIPTION
### 1. Why is this change necessary?
Although the language store is marked deprecated it should still be used in a consistent manner.
I'd rather change the store to change to system language as it is a quite common use case but as it is deprecated I keep it as it is.
In the future I'd like to see this feature built-in.

### 2. What does this change do, exactly?
Replace
```javascript
this.languageStore.setCurrentId(this.languageStore.systemLanguageId);
```
with
```javascript
if (this.languageStore.getCurrentId() !== this.languageStore.systemLanguageId) {
    this.languageStore.setCurrentId(this.languageStore.systemLanguageId);
}
```

### 3. Describe each step to reproduce the issue or behaviour.
1. Check how to create a create page for entities
2. See two ways how the initial language switch is done
3. This has to be normalized

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
