### PR TITLE
Use new cache directory on plugin lifecycle change

### DIFF
--- a/src/Core/Framework/Plugin.php
+++ b/src/Core/Framework/Plugin.php
@@ -3,6 +3,7 @@
 namespace Shopware\Core\Framework;
 
 use Composer\Autoload\ClassLoader;
+use DateTimeInterface;
 use Shopware\Core\Framework\Plugin\Context\ActivateContext;
 use Shopware\Core\Framework\Plugin\Context\DeactivateContext;
 use Shopware\Core\Framework\Plugin\Context\InstallContext;
@@ -22,8 +23,17 @@ abstract class Plugin extends Bundle
      */
     private $basePath;
 
-    final public function __construct(bool $active, string $basePath, ?string $projectDir = null)
-    {
+    /**
+     * @var DateTimeInterface|null
+     */
+    private $changedAt;
+
+    final public function __construct(
+        bool $active,
+        string $basePath,
+        ?string $projectDir = null,
+        ?DateTimeInterface $changedAt = null
+    ) {
         $this->active = $active;
         $this->basePath = $basePath;
 
@@ -32,11 +42,17 @@ abstract class Plugin extends Bundle
         }
 
         $this->path = $this->computePluginClassPath();
+        $this->changedAt = $changedAt;
     }
 
     final public function isActive(): bool
     {
         return $this->active;
+    }
+
+    final public function getChangedAt(): ?DateTimeInterface
+    {
+        return $this->changedAt;
     }
 
     public function install(InstallContext $installContext): void

--- a/src/Core/Framework/Plugin/KernelPluginLoader/DbalKernelPluginLoader.php
+++ b/src/Core/Framework/Plugin/KernelPluginLoader/DbalKernelPluginLoader.php
@@ -3,6 +3,7 @@
 namespace Shopware\Core\Framework\Plugin\KernelPluginLoader;
 
 use Composer\Autoload\ClassLoader;
+use DateTime;
 use Doctrine\DBAL\Connection;
 
 class DbalKernelPluginLoader extends KernelPluginLoader
@@ -22,7 +23,13 @@ class DbalKernelPluginLoader extends KernelPluginLoader
     protected function loadPluginInfos(): void
     {
         $sql = <<<SQL
-            SELECT `base_class` AS baseClass, IF(`active` = 1 AND `installed_at` IS NOT NULL, 1, 0) AS active, `path`, `autoload`, `managed_by_composer` AS managedByComposer 
+            SELECT
+                `base_class` AS baseClass,
+                IF(`active` = 1 AND `installed_at` IS NOT NULL, 1, 0) AS active,
+                `path`,
+                `autoload`,
+                `managed_by_composer` AS managedByComposer,
+                COALESCE(`updated_at`, `installed_at`, `created_at`) `changedAt`
             FROM `plugin`
 SQL;
 
@@ -31,6 +38,7 @@ SQL;
             $plugins[$i]['active'] = (bool) $plugin['active'];
             $plugins[$i]['managedByComposer'] = (bool) $plugin['managedByComposer'];
             $plugins[$i]['autoload'] = json_decode($plugin['autoload'], true);
+            $plugins[$i]['changedAt'] = empty($plugin['changedAt']) ? null : new DateTime($plugin['changedAt']);
         }
 
         $this->pluginInfos = $plugins;

--- a/src/Core/Framework/Plugin/KernelPluginLoader/KernelPluginLoader.php
+++ b/src/Core/Framework/Plugin/KernelPluginLoader/KernelPluginLoader.php
@@ -248,7 +248,12 @@ abstract class KernelPluginLoader extends Bundle
             }
 
             /** @var Plugin $plugin */
-            $plugin = new $className((bool) $pluginData['active'], $pluginData['path'], $projectDir);
+            $plugin = new $className(
+                (bool) $pluginData['active'],
+                $pluginData['path'],
+                $projectDir,
+                $pluginData['changedAt'] ?? null
+            );
 
             if (!$plugin instanceof Plugin) {
                 $reason = sprintf('Plugin class "%s" must extend "%s"', \get_class($plugin), Plugin::class);

--- a/src/Core/Kernel.php
+++ b/src/Core/Kernel.php
@@ -8,6 +8,7 @@ use Doctrine\DBAL\DriverManager;
 use Doctrine\DBAL\FetchMode;
 use Shopware\Core\Framework\Api\Controller\FallbackController;
 use Shopware\Core\Framework\Migration\MigrationStep;
+use Shopware\Core\Framework\Plugin;
 use Shopware\Core\Framework\Plugin\KernelPluginLoader\KernelPluginLoader;
 use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
 use Symfony\Component\Config\Loader\LoaderInterface;
@@ -139,7 +140,11 @@ class Kernel extends HttpKernel
 
     public function getCacheDir(): string
     {
-        $pluginHash = md5(implode('', array_keys($this->pluginLoader->getPluginInstances()->getActives())));
+        $pluginFeatures = array_map(function (Plugin $plugin): string {
+            return $plugin->getClassName() . ($plugin->getChangedAt() ? $plugin->getChangedAt()->getTimestamp() : '');
+        }, $this->pluginLoader->getPluginInstances()->getActives());
+        sort($pluginFeatures);
+        $pluginHash = md5(implode($pluginFeatures));
 
         return sprintf(
             '%s/var/cache/%s_k%s_p%s',


### PR DESCRIPTION
### 1. Why is this change necessary?
Generate the hash for the cache directory in a different way.

### 2. What does this change do, exactly?
Use the timestamp, when the plugin was last changed, as part of the hash source as well

### 3. Describe each step to reproduce the issue or behaviour.
1. Activate plugin
2. Clear cache
3. wörk wörk wörk on different content
4. Snap this plugin was not so good
5. Deactivate plugin
6. Hey where are my changes? (old cache from step 0 was served)
7. Clear cache
8. Aah

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
