### PR TITLE
Fix undefined assets path

### DIFF
--- a/src/Administration/Resources/administration/config/index.js
+++ b/src/Administration/Resources/administration/config/index.js
@@ -2,7 +2,7 @@
 const path = require('path');
 const process = require('process');
 
-const appPath = process.argv.slice(2)[0];
+const appPath = process.argv.slice(2)[0] || '';
 const appEnv = process.env.APP_ENV;
 
 module.exports = {


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/communtiy).
-->

### 1. Why is this change necessary?
Import of images in components are not working without it.

### 2. What does this change do, exactly?
Fix a undefined variable which is included in the assets public path. 

### 3. Describe each step to reproduce the issue or behaviour.
1. Create a custom component
2. Import an image in the custom component
3. Use the component in an administration module or i.e. as a custom component in the plugin config xml
4. Run the administration build process: ./psh.phar administration:build
5. Check the component and the url/path for the imported image. You will see that the path begins with "undefined/..."

### 4. Please link to the relevant issues (if any).
-

### 5. Which documentation changes (if any) need to be made because of this PR?
-

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
