### PR TITLE
Fix documentation for adding items to search results

### DIFF
--- a/src/Docs/Resources/current/4-how-to/660-add-custom-entity-to-administration-search.md
+++ b/src/Docs/Resources/current/4-how-to/660-add-custom-entity-to-administration-search.md
@@ -60,7 +60,7 @@ In order to declare a search result view the `sw-search-bar-item` template has t
 `sw-search-bar-item.html.twig`
 ```twig
 {% block sw_search_bar_item_cms_page %}
-    {{ parent }}
+    {% parent %}
 
     <router-link v-else-if="type === 'foo_bar'"
                  v-bind:to="{ name: 'foo.bar.detail', params: { id: item.id } }"


### PR DESCRIPTION
### 1. Why is this change necessary?
Former code does not work.

### 2. What does this change do, exactly?
It fixes the twig syntax for a parent call, so it actually works.

### 3. Describe each step to reproduce the issue or behaviour.
1. Follow how-to tutorial for adding a custom entity to the administration search
2. Find the twig code is not working.
3. Figure out that it is due to a syntax error.

### 4. Please link to the relevant issues (if any).
None.

### 5. Which documentation changes (if any) need to be made because of this PR?
Well, this one is a documentation change itself, sooo...

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
