### PR TITLE
Fix dead link in PULL_REQUEST_TEMPLATE

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,7 @@
 <!--
 Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.
 
-Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/communtiy).
+Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/community).
 -->
 
 ### 1. Why is this change necessary?


### PR DESCRIPTION
### 1. Why is this change necessary?
The template

> Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.
>
> Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/communtiy).

contains the link
https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/communtiy

which is dead at the end:

![image](https://user-images.githubusercontent.com/1133593/66601570-83d02480-eba8-11e9-854c-03691db08230.png)

### 2. What does this change do, exactly?
Change the link to https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/community

### 3. Describe each step to reproduce the issue or behaviour.
1. Create PR
2. See guideline link
3. Click on it
4. 04

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
