### PR TITLE
Encourage to write documentation as it is now part of the same repository

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,6 +2,9 @@
 Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.
 
 Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/communtiy).
+
+Do your changes need to be mentioned in the documentation?
+Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
 -->
 
 ### 1. Why is this change necessary?
@@ -16,10 +19,7 @@ Please make sure to fulfil our contribution guideline (https://docs.shopware.com
 ### 4. Please link to the relevant issues (if any).
 
 
-### 5. Which documentation changes (if any) need to be made because of this PR?
-
-
-### 6. Checklist
+### 5. Checklist
 
 - [ ] I have written tests and verified that they fail without my change
 - [ ] I have squashed any insignificant commits

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,7 @@
 <!--
 Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.
 
-Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/communtiy).
+Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/community).
 
 Do your changes need to be mentioned in the documentation?
 Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
@@ -23,5 +23,6 @@ Add notes on your change right now in the documentation files in /src/Docs/Resou
 
 - [ ] I have written tests and verified that they fail without my change
 - [ ] I have squashed any insignificant commits
+- [ ] I have written or adjusted the documentation according to my changes
 - [ ] This change has comments for package types, values, functions, and non-obvious lines of code
 - [ ] I have read the contribution requirements and fulfil them.


### PR DESCRIPTION
### 1. Why is this change necessary?
As this PR template is taken from shopware 5 it should be amend to match shopware platform/6

### 2. What does this change do, exactly?
It adds an encouraging hint to write documentation as this is now part of the monorepository.

### 3. Describe each step to reproduce the issue or behaviour.
Shopware 5:
1. Make almost breaking or groud breaking PR
2. Make a second PR in hope the first one gets merged
3. Try to keep up both PRs

Shopware 6:
1. Make almost breaking or groud breaking PR and add documentation
2. Profit
3. Nothing has to be changed

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
