### PR TITLE
Add route scope to custom storefront controller examples

### DIFF
--- a/src/Docs/Resources/current/4-how-to/580-custom-storefront-controller.md
+++ b/src/Docs/Resources/current/4-how-to/580-custom-storefront-controller.md
@@ -18,10 +18,14 @@ You need a own route for every controller action, you will use Symfony's `@Route
 
 namespace Swag\StorefrontController\Storefront\Controller;
 
+use Shopware\Core\Framework\Routing\Annotation\RouteScope;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Storefront\Controller\StorefrontController;
 use Symfony\Component\Routing\Annotation\Route;
 
+/**
+ * @RouteScope(scopes={"storefront"})
+ */
 class ClearCartController extends StorefrontController
 {
     /**
@@ -64,10 +68,14 @@ Your controller now looks like this:
 namespace Swag\StorefrontController\Storefront\Controller;
 
 use Shopware\Core\Checkout\Cart\SalesChannel\CartService;
+use Shopware\Core\Framework\Routing\Annotation\RouteScope;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Storefront\Controller\StorefrontController;
 use Symfony\Component\Routing\Annotation\Route;
 
+/**
+ * @RouteScope(scopes={"storefront"})
+ */
 class ClearCartController extends StorefrontController
 {
     /**


### PR DESCRIPTION
### 1. Why is this change necessary?
As version `v6.0.0+ea1.1` introduced obligatory `RouteScope` annotations on controllers, those requirements should at least be represented in the code examples of the how-to articles.

### 2. What does this change do, exactly?
Fixes the examples to work with the latest release.

### 3. Describe each step to reproduce the issue or behaviour.
Just try it without the annotations.

### 4. Please link to the relevant issues (if any).
None.

### 5. Which documentation changes (if any) need to be made because of this PR?
Maybe one should actually mention this annotation and what is is used for at least once throughout this article. If any other documentation articles show more code examples of controllers without the `RouteScope` annotation, those articles will have to be fixed as well.

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
