### PR TITLE
Fix wrong assumptions about the Primary Key of an Entity Definition in CriteriaQueryHelper

### DIFF
--- a/src/Core/Framework/DataAbstractionLayer/Dbal/CriteriaQueryHelper.php
+++ b/src/Core/Framework/DataAbstractionLayer/Dbal/CriteriaQueryHelper.php
@@ -95,18 +95,29 @@ trait CriteriaQueryHelper
 
     protected function addIdCondition(Criteria $criteria, EntityDefinition $definition, QueryBuilder $query): void
     {
-        $primaryKey = $criteria->getIds();
+        $primaryKeys = $criteria->getIds();
 
-        $primaryKey = array_values($primaryKey);
+        $primaryKeys = array_values($primaryKeys);
 
-        if (!\is_array($primaryKey[0]) || \count($primaryKey[0]) === 1) {
-            $bytes = array_map(function (string $id) {
-                return Uuid::fromHexToBytes($id);
-            }, $criteria->getIds());
+        if (!\is_array($primaryKeys[0]) || \count($primaryKeys[0]) === 1) {
+            $primaryKeyField = $definition->getPrimaryKeys()->first();
+            if ($primaryKeyField instanceof IdField) {
+                $primaryKeys = array_map(function ($id) {
+                    if (is_array($id)) {
+                        return Uuid::fromHexToBytes($id[0]);
+                    }
 
-            $query->andWhere(EntityDefinitionQueryHelper::escape($definition->getEntityName()) . '.`id` IN (:ids)');
+                    return Uuid::fromHexToBytes($id);
+                }, $primaryKeys);
+            }
 
-            $query->setParameter('ids', array_values($bytes), Connection::PARAM_STR_ARRAY);
+            $query->andWhere(sprintf(
+                '%s.%s IN (:ids)',
+                EntityDefinitionQueryHelper::escape($definition->getEntityName()),
+                EntityDefinitionQueryHelper::escape($primaryKeyField->getStorageName())
+            ));
+
+            $query->setParameter('ids', array_values($primaryKeys), Connection::PARAM_STR_ARRAY);
 
             return;
         }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/communtiy).
-->

### 1. Why is this change necessary?
There is a code part in the CriteriaQueryHelper which still makes the assumption that the primary key of every entity is named `id` and is a UUID. This assumption is wrong as you can define every field as a primary key with the `PrimaryKey` flag.

### 2. What does this change do, exactly?
This refactors the code and removes the wrong assumptions. This allows to create entity definitions with primary keys that are not a UUID.

### 3. Describe each step to reproduce the issue or behaviour.
Create an entity definition that uses a primary key that is not a UUID.

```php
protected function defineFields(): FieldCollection
{
    return new FieldCollection([
        (new StringField('technical_name', 'technicalName'))->addFlags(new Required(), new PrimaryKey()),
        (new StringField('description', 'description'))->addFlags(new Required()),
    ]);
}
```

Query an entity using that definition via API. You'll get an error.
### 4. Please link to the relevant issues (if any).
N/A

### 5. Which documentation changes (if any) need to be made because of this PR?
N/A


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
