### PR TITLE
Fixed bug in multiselect which caused the element to not show up if n…

### DIFF
--- a/src/Administration/Resources/administration/src/app/component/form/select/base/sw-multi-select/index.js
+++ b/src/Administration/Resources/administration/src/app/component/form/select/base/sw-multi-select/index.js
@@ -38,7 +38,7 @@ Component.register('sw-multi-select', {
         },
         value: {
             type: Array,
-            required: true
+            required: false
         },
         labelProperty: {
             type: String,
@@ -123,7 +123,7 @@ Component.register('sw-multi-select', {
 
         currentValue: {
             get() {
-                return [...this.value];
+                return this.value ? [...this.value] : this.value;
             },
             set(newValue) {
                 /** @deprecated Html select don't have an onInput event */


### PR DESCRIPTION
### 1. Why is this change necessary?
sw-multi-select is requiring a value, while this is not always needed. Empty value causes exceptions, which makes the field silently fail and not show up in the administration.

### 2. What does this change do, exactly?
It sets the value property to false and checks in the current value if value is set before adding it to the array, else it just returns the value as is.

### 3. Describe each step to reproduce the issue or behaviour.
Use sw-multi-select in any administration page.
`<sw-multi-select :label="$t('sw.example.label')"
                                 :options="computedValueLabelArray"
                                 v-model="entity.exampleField">
</sw-multi-select>`

### 4. Please link to the relevant issues (if any).
-

### 5. Checklist

- [-] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
