### PR TITLE
fix local fonts source in hot reload mode

### DIFF
--- a/src/Storefront/Resources/build/webpack.hot.config.js
+++ b/src/Storefront/Resources/build/webpack.hot.config.js
@@ -59,6 +59,18 @@ const modules = {
                 },
             ],
         },
+        {
+            test: /\.(woff(2)?|ttf|eot|svg|otf)(\?v=\d+\.\d+\.\d+)?$/,
+            use: [
+                {
+                    loader: 'file-loader',
+                    options: {
+                        name: '[name].[ext]',
+                        outputPath: 'fonts/'
+                    }
+                }
+            ]
+        }
     ],
 };
 


### PR DESCRIPTION
### 1. Why is this change necessary?
When importing fonts from local source in scss files, in hotreload mode, webpack shows an error.


### 2. What does this change do, exactly?
Solution is to add fileloader to npm (npm install file-loader --save-dev) and add configuration to webpack.hot.config.js file

### 3. Describe each step to reproduce the issue or behaviour.
1. create new theme, install and activate
2. set environment to hot reload mode
3. import any local font in scss file

### 4. Please link to the relevant issues (if any).
N/A

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.
