### PR TITLE
useless class

### DIFF
--- a/src/Storefront/Resources/views/page/product-detail/properties.html.twig
+++ b/src/Storefront/Resources/views/page/product-detail/properties.html.twig
@@ -2,7 +2,7 @@
     <div class="product-detail-properties">
         {% block page_product_detail_properties_container %}
             <div class="row product-detail-properties-container">
-                <div class="col-md-10 col-md-8 col-lg-6">
+                <div class="col-md-10 col-lg-6">
                     {% block page_product_detail_properties_table %}
                         <table class="table table-striped product-detail-properties-table">
                             <tbody>


### PR DESCRIPTION
### 1. Why is this change necessary?
The "col-md-8" class is useless becouse it is overwritten by the "col-md-10" class

### 2. What does this change do, exactly?
Change removes "col-md-8" class from src\Storefront\Resources\views\page\product-detail\properties.html.twig file

### 3. Describe each step to reproduce the issue or behaviour.
On the product page you can see that the class "col-md-10" overrides class "cold-md-8", it refers to the same breakpoint so its is useless 

### 4. Please link to the relevant issues (if any).
N/A

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.
