### PR TITLE
Add unique constraint to column `technical_name` of table `document_type`

### DIFF
--- a/src/Core/Migration/Migration1572273565AddUniqueConstraintToTechnicalNameOfDocumentType.php
+++ b/src/Core/Migration/Migration1572273565AddUniqueConstraintToTechnicalNameOfDocumentType.php
@@ -1,0 +1,49 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Migration;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Framework\Migration\MigrationStep;
+
+/**
+ * Adds a missing unique constraint to column `technical_name` of table `document_type`.
+ * Before that, it removes rows with duplicated `technical_name` from table `document_type`
+ */
+class Migration1572273565AddUniqueConstraintToTechnicalNameOfDocumentType extends MigrationStep
+{
+    public function getCreationTimestamp(): int
+    {
+        return 1572273565;
+    }
+
+    public function update(Connection $connection): void
+    {
+        $duplicatedDocumentTypes = $connection->fetchAll(
+            'SELECT `id`
+            FROM `document_type`
+            WHERE (`technical_name`, `created_at`) NOT IN (
+                SELECT
+                    `technical_name`,
+                    MIN(`created_at`)
+                FROM `document_type`
+                GROUP BY `technical_name`
+            )'
+        );
+
+        foreach ($duplicatedDocumentTypes as $duplicatedDocumentType) {
+            $connection->executeQuery(
+                'DELETE FROM `document_type`
+                WHERE `id` = :id',
+                $duplicatedDocumentType
+            );
+        }
+
+        $connection->executeQuery(
+            'ALTER TABLE `document_type` ADD CONSTRAINT `uniq.document_type.technical_name` UNIQUE (`technical_name`)'
+        );
+    }
+
+    public function updateDestructive(Connection $connection): void
+    {
+    }
+}


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/community).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
There is no unique constraint for column `technical_name` in table `document_type`.

### 2. What does this change do, exactly?
This adds a unique constraint to column `technical_name` of table `document_type`.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
