### PR TITLE
Call getDefaults only for new entities

### DIFF
--- a/src/Core/Checkout/Promotion/PromotionDefinition.php
+++ b/src/Core/Checkout/Promotion/PromotionDefinition.php
@@ -57,10 +57,6 @@ class PromotionDefinition extends EntityDefinition
      */
     public function getDefaults(EntityExistence $existence): array
     {
-        if ($existence->exists()) {
-            return [];
-        }
-
         return [
             'active' => false,
             'exclusive' => false,

--- a/src/Core/Content/Category/CategoryDefinition.php
+++ b/src/Core/Content/Category/CategoryDefinition.php
@@ -69,14 +69,10 @@ class CategoryDefinition extends EntityDefinition
 
     public function getDefaults(EntityExistence $existence): array
     {
-        $defaults = parent::getDefaults($existence);
-
-        if (!$existence->exists()) {
-            $defaults['displayNestedProducts'] = true;
-            $defaults['type'] = self::TYPE_PAGE;
-        }
-
-        return $defaults;
+        return [
+            'displayNestedProducts' => true,
+            'type' => self::TYPE_PAGE,
+        ];
     }
 
     protected function defineFields(): FieldCollection

--- a/src/Core/Content/Media/Aggregate/MediaFolder/MediaFolderDefinition.php
+++ b/src/Core/Content/Media/Aggregate/MediaFolder/MediaFolderDefinition.php
@@ -45,9 +45,6 @@ class MediaFolderDefinition extends EntityDefinition
 
     public function getDefaults(EntityExistence $existence): array
     {
-        if ($existence->exists()) {
-            return [];
-        }
         if ($existence->isChild()) {
             return [];
         }

--- a/src/Core/Content/Media/Aggregate/MediaFolderConfiguration/MediaFolderConfigurationDefinition.php
+++ b/src/Core/Content/Media/Aggregate/MediaFolderConfiguration/MediaFolderConfigurationDefinition.php
@@ -43,10 +43,6 @@ class MediaFolderConfigurationDefinition extends EntityDefinition
 
     public function getDefaults(EntityExistence $existence): array
     {
-        if ($existence->exists()) {
-            return [];
-        }
-
         return [
             'createThumbnails' => true,
             'keepAspectRatio' => true,

--- a/src/Core/Content/Product/ProductDefinition.php
+++ b/src/Core/Content/Product/ProductDefinition.php
@@ -86,9 +86,6 @@ class ProductDefinition extends EntityDefinition
 
     public function getDefaults(EntityExistence $existence): array
     {
-        if ($existence->exists()) {
-            return [];
-        }
         if ($existence->isChild()) {
             return [];
         }

--- a/src/Core/Content/Property/Aggregate/PropertyGroupOptionTranslation/PropertyGroupOptionTranslationDefinition.php
+++ b/src/Core/Content/Property/Aggregate/PropertyGroupOptionTranslation/PropertyGroupOptionTranslationDefinition.php
@@ -32,10 +32,9 @@ class PropertyGroupOptionTranslationDefinition extends EntityTranslationDefiniti
 
     public function getDefaults(EntityExistence $existence): array
     {
-        $defaults = parent::getDefaults($existence);
-        $defaults['position'] = 1;
-
-        return $defaults;
+        return [
+            'position' => 1,
+        ];
     }
 
     protected function getParentDefinitionClass(): string

--- a/src/Core/Content/Property/PropertyGroupDefinition.php
+++ b/src/Core/Content/Property/PropertyGroupDefinition.php
@@ -50,16 +50,10 @@ class PropertyGroupDefinition extends EntityDefinition
 
     public function getDefaults(EntityExistence $existence): array
     {
-        $defaults = parent::getDefaults($existence);
-
-        if ($existence->exists()) {
-            return $defaults;
-        }
-
-        $defaults['displayType'] = self::DISPLAY_TYPE_TEXT;
-        $defaults['sortingType'] = self::SORTING_TYPE_ALPHANUMERIC;
-
-        return $defaults;
+        return [
+            'displayType' => self::DISPLAY_TYPE_TEXT,
+            'sortingType' => self::SORTING_TYPE_ALPHANUMERIC,
+        ];
     }
 
     protected function defineFields(): FieldCollection

--- a/src/Core/Framework/DataAbstractionLayer/Write/WriteCommandExtractor.php
+++ b/src/Core/Framework/DataAbstractionLayer/Write/WriteCommandExtractor.php
@@ -68,7 +68,9 @@ class WriteCommandExtractor
             $existence = $this->entityExistenceGateway->getExistence($definition, $pkData, $rawData, $parameters->getCommandQueue());
         }
 
-        $rawData = $this->integrateDefaults($definition, $rawData, $existence);
+        if (!$existence->exists()) {
+            $rawData = $this->integrateDefaults($definition, $rawData, $existence);
+        }
 
         $mainFields = $this->getMainFields($fields);
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/community).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
The method `Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition::getDefaults` is currently called not only for newly created entities but also for existing ones.

Applying default values to existing entities makes no sense, so this behavior leads to the following problem:

You have to copy this code part to every override of the method:
```
if ($existence->exists()) {
    return [];
}
```

If you forget this code part, you will get errors during runtime, that are hard to debug. (See 3. for an example)

**I predict this will happen very often because the most developers out here will NOT expect the method `getDefaults` to be called for existing entities.** 

You can see examples even in  code of this repo:

  * `Shopware\Core\Checkout\Order\Aggregate\OrderDelivery\OrderDeliveryDefinition::getDefaults`
  * `Shopware\Core\Content\Property\Aggregate\PropertyGroupOptionTranslation\PropertyGroupOptionTranslationDefinition::getDefaults`
  * `Shopware\Core\Framework\MessageQueue\DeadMessage\DeadMessageDefinition::getDefaults`
  * `Shopware\Core\Framework\MessageQueue\MessageQueueStatsDefinition::getDefaults`
  * `Shopware\Core\Framework\ScheduledTask\ScheduledTaskDefinition::getDefaults`
  * `Shopware\Core\Framework\Version\Aggregate\VersionCommit\VersionCommitDefinition::getDefaults`
  * `Shopware\Core\Framework\Version\VersionDefinition::getDefaults`

### 2. What does this change do, exactly?

The method `Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition::getDefaults` is now called for new entities only.
 
### 3. Describe each step to reproduce the issue or behaviour.
You can reproduce the error as follows:

Create an entity and implement the method `getDefaults` like this:

```
    public function getDefaults(EntityExistence $existence): array
    {
        return [
            'position' => 1,
        ];
    }
```
This is how most developers will expect the method to be implemented.

Now create an entity like this:

```
$id = Uuid::getRandomHex();
$repository->create([[
    'id' => $id,
    'name' => 'Some name',
    'position' => 3,
]], $context);
```

Change the name without providing the position:
```
$repository->update([[
    'id' => $id,
    'name' => 'Some name',
]], $context);
```

The value of `position` is now `1`, even though you never wanted to set it to 1.

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
