### PR TITLE
Custom fields in category entity

### DIFF
--- a/src/Administration/Resources/administration/src/app/service/custom-field.service.js
+++ b/src/Administration/Resources/administration/src/app/service/custom-field.service.js
@@ -84,6 +84,7 @@ export default function createCustomFieldService() {
     };
 
     const $entityNameStore = [
+        'category',
         'product',
         'product_manufacturer',
         'customer',

--- a/src/Administration/Resources/administration/src/module/sw-category/page/sw-category-detail/index.js
+++ b/src/Administration/Resources/administration/src/module/sw-category/page/sw-category-detail/index.js
@@ -86,6 +86,21 @@ Component.register('sw-category-detail', {
             return this.category ? this.category.cmsPageId : null;
         },
 
+        customFieldSetRepository() {
+            return this.repositoryFactory.create('custom_field_set');
+        },
+
+        customFieldSetCriteria() {
+            const criteria = new Criteria(1, 100);
+
+            criteria.addFilter(Criteria.equals('relations.entityName', 'category'));
+            criteria
+                .getAssociation('customFields')
+                .addSorting(Criteria.sort('config.customFieldPosition'));
+
+            return criteria;
+        },
+
         mediaRepository() {
             return this.repositoryFactory.create('media');
         },
@@ -243,9 +258,20 @@ Component.register('sw-category-detail', {
                 id: this.categoryId
             }).then(() => this.$store.dispatch('cmsPageState/resetCmsPageState'))
                 .then(this.getAssignedCmsPage)
+                .then(this.loadAttributeSet)
                 .then(() => {
                     this.isLoading = false;
                 });
+        },
+
+        loadAttributeSet() {
+            this.$store.commit('swCategoryDetail/setLoading', ['customFieldSets', true]);
+
+            return this.customFieldSetRepository.search(this.customFieldSetCriteria, this.apiContext).then((res) => {
+                this.$store.commit('swCategoryDetail/setAttributeSet', res);
+            }).then(() => {
+                this.$store.commit('swCategoryDetail/setLoading', ['customFieldSets', false]);
+            });
         },
 
         onSaveCategories() {

--- a/src/Administration/Resources/administration/src/module/sw-category/page/sw-category-detail/state.js
+++ b/src/Administration/Resources/administration/src/module/sw-category/page/sw-category-detail/state.js
@@ -5,13 +5,42 @@ export default {
 
     state() {
         return {
-            category: null
+            category: null,
+            customFieldSets: [],
+            loading: {
+                customFieldSets: false
+            }
         };
+    },
+
+    getters: {
+        isLoading: (state) => {
+            return Object.values(state.loading).some((loadState) => loadState);
+        }
     },
 
     mutations: {
         setActiveCategory(state, { category }) {
             state.category = category;
+        },
+
+        setLoading(state, value) {
+            const name = value[0];
+            const data = value[1];
+
+            if (typeof data !== 'boolean') {
+                return false;
+            }
+
+            if (state.loading[name] !== undefined) {
+                state.loading[name] = data;
+                return true;
+            }
+            return false;
+        },
+
+        setAttributeSet(state, newAttributeSets) {
+            state.customFieldSets = newAttributeSets;
         }
     },
 

--- a/src/Administration/Resources/administration/src/module/sw-category/view/sw-category-detail-base/index.js
+++ b/src/Administration/Resources/administration/src/module/sw-category/view/sw-category-detail-base/index.js
@@ -3,7 +3,7 @@ import './sw-category-detail-base.scss';
 
 const { Component, Mixin } = Shopware;
 const { Criteria } = Shopware.Data;
-const { mapApiErrors } = Shopware.Component.getComponentHelper();
+const { mapState, mapGetters, mapApiErrors } = Shopware.Component.getComponentHelper();
 
 Component.register('sw-category-detail-base', {
     template,
@@ -69,6 +69,24 @@ Component.register('sw-category-detail-base', {
                 .addFilter(Criteria.equals('parentId', null));
             return productCriteria;
         },
+
+        ...mapState('swCategoryDetail', [
+            'customFieldSets',
+            'loading'
+        ]),
+
+        ...mapGetters('swCategoryDetail', [
+            'isLoading'
+        ]),
+
+        ...mapState('swCategoryDetail', {
+            customFieldSetsArray: state => {
+                if (!state.customFieldSets) {
+                    return [];
+                }
+                return state.customFieldSets;
+            }
+        }),
 
         ...mapApiErrors('category', ['name'])
     }

--- a/src/Administration/Resources/administration/src/module/sw-category/view/sw-category-detail-base/sw-category-detail-base.html.twig
+++ b/src/Administration/Resources/administration/src/module/sw-category/view/sw-category-detail-base/sw-category-detail-base.html.twig
@@ -120,6 +120,17 @@
                             :urls="category.seoUrls">
                 </sw-seo-url>
             {% endblock %}
+            
+            {% block sw_category_detail_attribute_sets %}
+                <sw-card :title="$tc('sw-settings-custom-field.general.mainMenuItemGeneral')"
+                         v-if="customFieldSetsArray.length > 0"
+                         :isLoading="isLoading || loading.customFieldSets">
+                    <sw-custom-field-set-renderer
+                            :entity="category"
+                            :sets="customFieldSetsArray">
+                    </sw-custom-field-set-renderer>
+                </sw-card>
+            {% endblock %}
         </template>
     </div>
 {% endblock %}


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/community).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
At the moment, its not possible to create custom fields for the category entity.


### 2. What does this change do, exactly?
- Added custom field twig template and js logic to the shopware component sw-category
- Added the category to the entityNameStore in the custom-field.service


### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
https://github.com/shopware/platform/issues/278

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
