### PR TITLE
Fix currency precision in administration

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-settings-currency/page/sw-settings-currency-detail/sw-settings-currency-detail.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-currency/page/sw-settings-currency-detail/sw-settings-currency-detail.html.twig
@@ -94,14 +94,14 @@
                             {% endblock %}
 
                             {% block sw_settings_currency_detail_content_field_factor %}
-                                <sw-field type="number"
-                                          required
-                                          :label="$tc('sw-settings-currency.detail.labelFactor')"
-                                          :placeholder="$tc('sw-settings-currency.detail.placeholderFactor')"
-                                          :error="currencyFactorError"
-                                          v-model="currency.factor"
-                                          :disabled="currency.isDefault">
-                                </sw-field>
+                                <sw-number-field required
+                                                 :digits="14"
+                                                 :label="$tc('sw-settings-currency.detail.labelFactor')"
+                                                 :placeholder="$tc('sw-settings-currency.detail.placeholderFactor')"
+                                                 :error="currencyFactorError"
+                                                 v-model="currency.factor"
+                                                 :disabled="currency.isDefault">
+                                </sw-number-field>
                             {% endblock %}
 
                             {% block sw_settings_currency_detail_content_field_decimal_precision %}


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/community).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
You currently can currently enter the currency factor with a precision of only 2 decimals. That is not enough for a currency factor.


### 2. What does this change do, exactly?
It rises the precision for the field of the currency factor to 14 decimals.

### 3. Describe each step to reproduce the issue or behaviour.
Try to enter a currency factor with more that 2 decimals.

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
