### PR TITLE
Fix quantity translation

### DIFF
--- a/src/Storefront/Resources/views/page/checkout/checkout-aside-item.html.twig
+++ b/src/Storefront/Resources/views/page/checkout/checkout-aside-item.html.twig
@@ -53,7 +53,7 @@
                     {% block page_checkout_aside_item_quantity %}
                         <div class="checkout-aside-item-link-quantity">
                             {% if lineItem.quantity %}
-                                Quantity: {{ lineItem.quantity }}
+                                {{ "checkout.cartHeaderQuantity"|trans }}: {{ lineItem.quantity }}
                             {% endif %}
                         </div>
                     {% endblock %}


### PR DESCRIPTION
### 1. Why is this change necessary?
In checkout/register page on sidebar ,"quantity" text is untranslated.

### 2. What does this change do, exactly?
The change adds a translation in twig file.

### 3. Describe each step to reproduce the issue or behaviour.
1. Change the language to not English
2. Add product do cart
3. Go to cart
4. Go to next checkout step
5. in checkout/register page, in sidebar, in section "cart" there is untranslated text "quantity"

### 4. Please link to the relevant issues (if any).
N/A

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.
