### PR TITLE
Fix: Duplicating a Theme does not copy the style of the parent theme

### DIFF
--- a/src/Storefront/Theme/ThemeService.php
+++ b/src/Storefront/Theme/ThemeService.php
@@ -343,9 +343,17 @@ class ThemeService
 
         // Is inherited Theme -> get Plugin
         if ($pluginConfig === null) {
-            $pluginConfig = $this->pluginRegistry->getConfigurations()->getByTechnicalName(StorefrontPluginRegistry::BASE_THEME_NAME);
+            if ($theme->getParentThemeId() !== null) {
+                $criteria = (new Criteria())->addFilter(new EqualsFilter('id', $theme->getParentThemeId()));
+                /** @var ThemeEntity $parentTheme */
+                $parentTheme = $this->themeRepository->search($criteria, $context)->first();
+                $pluginConfig = $this->pluginRegistry->getConfigurations()->getByTechnicalName($parentTheme->getTechnicalName());
+            } else {
+                $parentTheme = false;
+                $pluginConfig = $this->pluginRegistry->getConfigurations()->getByTechnicalName(StorefrontPluginRegistry::BASE_THEME_NAME);
+            }
             if (!$pluginConfig) {
-                throw new InvalidThemeException(StorefrontPluginRegistry::BASE_THEME_NAME);
+                throw new InvalidThemeException($parentTheme ? $parentTheme->getTechnicalName() : StorefrontPluginRegistry::BASE_THEME_NAME);
             }
         }
 


### PR DESCRIPTION
### 1. Why is this change necessary?
When you duplicate a custom theme it uses the default Storefront style. It should use the style of the duplicated parent theme.

### 2. What does this change do, exactly?
In theme compiling it checks if the theme has a parent theme and gets the config of it, instead of the default storefront config.

### 3. Describe each step to reproduce the issue or behaviour.
- Create a custom theme with custom styles
- Duplicate this theme and assign it to a saleschannel
- Load frontend page of saleschannel

### 4. Please link to the relevant issues (if any).
No Issue.

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
