### PR TITLE
Set api to lowercase in sw-theme-manager

### DIFF
--- a/src/Storefront/Resources/app/administration/src/modules/sw-theme-manager/component/sw-theme-list-item/index.js
+++ b/src/Storefront/Resources/app/administration/src/modules/sw-theme-manager/component/sw-theme-list-item/index.js
@@ -35,9 +35,7 @@ Component.register('sw-theme-list-item', {
         },
 
         defaultThemeAsset() {
-            const context = Shopware.Context.Api;
-
-            return `url('${context.assetsPath}/administration/static/img/theme/default_theme_preview.jpg')`;
+            return `url('${Shopware.Context.api.assetsPath}/administration/static/img/theme/default_theme_preview.jpg')`;
         },
 
         lockToolTip() {

--- a/src/Storefront/Resources/app/administration/src/modules/sw-theme-manager/page/sw-theme-manager-detail/index.js
+++ b/src/Storefront/Resources/app/administration/src/modules/sw-theme-manager/page/sw-theme-manager-detail/index.js
@@ -54,7 +54,7 @@ Component.register('sw-theme-manager-detail', {
         },
 
         defaultThemeAsset() {
-            return `url('${Shopware.Context.Api.assetsPath}/administration/static/img/theme/default_theme_preview.jpg')`;
+            return `url('${Shopware.Context.api.assetsPath}/administration/static/img/theme/default_theme_preview.jpg')`;
         },
 
         deleteDisabledToolTip() {


### PR DESCRIPTION
### 1. Why is this change necessary?
Fix preview image in theme manager

### 2. What does this change do, exactly?
Set api to lowercase so preview images work again

### 3. Describe each step to reproduce the issue or behaviour.

### 4. Please link to the relevant issues (if any).

### 5. Checklist


- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
