### PR TITLE
google-storage can be configured with inline keyFile

### DIFF
--- a/src/Core/Framework/Adapter/Filesystem/Adapter/GoogleStorageFactory.php
+++ b/src/Core/Framework/Adapter/Filesystem/Adapter/GoogleStorageFactory.php
@@ -36,15 +36,17 @@ class GoogleStorageFactory implements AdapterFactoryInterface
         $options = new OptionsResolver();
 
         $options->setRequired(['projectId', 'bucket']);
-        $options->setDefined(['root', 'keyFilePath', 'keyFile']);
+        $options->setDefined(['root', 'keyFilePath', 'keyFile', 'options']);
 
         $options->setAllowedTypes('projectId', 'string');
         $options->setAllowedTypes('keyFilePath', 'string');
         $options->setAllowedTypes('keyFile', 'array');
         $options->setAllowedTypes('bucket', 'string');
         $options->setAllowedTypes('root', 'string');
+        $options->setAllowedTypes('options', 'array');        
 
         $options->setDefault('root', '');
+        $options->setDefault('options', []);
 
         return $options->resolve($definition);
     }

--- a/src/Core/Framework/Adapter/Filesystem/Adapter/GoogleStorageFactory.php
+++ b/src/Core/Framework/Adapter/Filesystem/Adapter/GoogleStorageFactory.php
@@ -12,11 +12,14 @@ class GoogleStorageFactory implements AdapterFactoryInterface
     public function create(array $config): AdapterInterface
     {
         $options = $this->resolveStorageConfig($config);
+        $storageConfig = ['projectId' => $options['projectId']];
+        if (isset($config['keyFile'])) {
+          $storageConfig['keyFile'] = $options['keyFile'];
+        } else {
+          $storageConfig['keyFilePath'] = $options['keyFilePath'];
+        }
 
-        $storageClient = new StorageClient([
-            'projectId' => $options['projectId'],
-            'keyFilePath' => $options['keyFilePath'],
-        ]);
+        $storageClient = new StorageClient($storageConfig);
 
         $bucket = $storageClient->bucket($options['bucket']);
 
@@ -32,11 +35,12 @@ class GoogleStorageFactory implements AdapterFactoryInterface
     {
         $options = new OptionsResolver();
 
-        $options->setRequired(['projectId', 'keyFilePath', 'bucket']);
-        $options->setDefined(['root']);
+        $options->setRequired(['projectId', 'bucket']);
+        $options->setDefined(['root', 'keyFilePath', 'keyFile']);
 
         $options->setAllowedTypes('projectId', 'string');
         $options->setAllowedTypes('keyFilePath', 'string');
+        $options->setAllowedTypes('keyFile', 'array');
         $options->setAllowedTypes('bucket', 'string');
         $options->setAllowedTypes('root', 'string');
 


### PR DESCRIPTION
### 1. Why is this change necessary?

So you can do this in your configuration `keyFile: '%env(json:GCP_KEY_FILE)%'` and have the configuration in a string and must not deal with a config file.

### 2. What does this change do, exactly?

The Google StorageClient accepts either a `keyFilePath` or the content of the `service-account.json` file as json-decoded array.
This change extends the `GoogleStorageFactory` to support both options of the underlying `StorageClient`.

### 3. Describe each step to reproduce the issue or behavior

Up until now, only this was possible:

```yaml
shopware:
  filesystem:
    public:
      type: 'google-storage'
      config:
        projectId: '%env(GCP_PROJECT_ID)%'
        keyFile: '/path/to/service-account.json'
```

Now it's possible to have this:

```shell
export GCP_KEY_FILE={"type":"service_account","project_id":"... 
```

```yaml
shopware:
  filesystem:
    public:
      type: 'google-storage'
      config:
        projectId: '%env(GCP_PROJECT_ID)%'
        keyFile: '%env(json:GCP_KEY_FILE)%'
        bucket: '%env(GCP_PUBLIC_BUCKET)%'
        root: '%env(GCP_PUBLIC_ROOT)%'
```

### 4. Please link to the relevant issues (if any).

### 5. Checklist

- [ ]  I have written tests and verified that they fail without my change
- [x]  I have squashed any insignificant commits
- [ ]  I have written or adjusted the documentation according to my changes
- [ ]  This change has comments for package types, values, functions, and non-obvious lines of code
- [x]  I have read the contribution requirements and fulfill them.
