### PR TITLE
Fix: used translation to set content in MailTemplate

### DIFF
--- a/src/Core/Content/MailTemplate/Subscriber/MailSendSubscriber.php
+++ b/src/Core/Content/MailTemplate/Subscriber/MailSendSubscriber.php
@@ -95,12 +95,12 @@ class MailSendSubscriber implements EventSubscriberInterface
 
         $data = new DataBag();
         $data->set('recipients', $mailEvent->getMailStruct()->getRecipients());
-        $data->set('senderName', $mailTemplate->getSenderName());
+        $data->set('senderName', $mailTemplate->getTranslation('senderName'));
         $data->set('salesChannelId', $mailEvent->getSalesChannelId());
 
-        $data->set('contentHtml', $mailTemplate->getContentHtml());
-        $data->set('contentPlain', $mailTemplate->getContentPlain());
-        $data->set('subject', $mailTemplate->getSubject());
+        $data->set('contentHtml', $mailTemplate->getTranslation('contentHtml'));
+        $data->set('contentPlain', $mailTemplate->getTranslation('contentPlain'));
+        $data->set('subject', $mailTemplate->getTranslation('subject'));
         $data->set('mediaIds', []);
 
         $this->mailService->send(


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/community).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
Contact form throws an error becaus of missing subject.
Unfortunately, the MailTemplate Entity has just like the contact form a field "subject". Therefore when a Constraint Violation in MailTemplate exists, the Contact Form displays it as an error in the input field. 

### 2. What does this change do, exactly?
Uses translation object to fill in senderName, contentHtml, contentPlain and subject. The default values are all null, therefore the NotBlankConstraint throws an error.


### 3. Describe each step to reproduce the issue or behaviour.
Fill out the contact page under /contact and submit the form.

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
