### PR TITLE
HMRMode controlled via ENV variable

### DIFF
--- a/src/Storefront/DependencyInjection/services.xml
+++ b/src/Storefront/DependencyInjection/services.xml
@@ -10,6 +10,9 @@
 
         <parameter key="shopware_http_cache_default_ttl_default">7200</parameter>
         <parameter key="shopware.http.cache.default_ttl">%env(default:shopware_http_cache_default_ttl_default:SHOPWARE_HTTP_DEFAULT_TTL)%</parameter>
+
+        <parameter key="storefront.hmr_mode_enabled_default">0</parameter>
+        <parameter key="storefront.hmr_mode_enabled">%env(default:storefront.hmr_mode_enabled_default:SHOPWARE_STOREFRONT_HMR_MODE)%</parameter>
     </parameters>
 
     <services>
@@ -37,6 +40,7 @@
             <argument type="service" id="Shopware\Storefront\Theme\ThemeService"/>
             <argument>%storefront.csrf.enabled%</argument>
             <argument>%storefront.csrf.mode%</argument>
+            <argument>%storefront.hmr_mode_enabled%</argument>
 
             <tag name="twig.extension"/>
         </service>

--- a/src/Storefront/Framework/Twig/TemplateDataExtension.php
+++ b/src/Storefront/Framework/Twig/TemplateDataExtension.php
@@ -41,18 +41,25 @@ class TemplateDataExtension extends AbstractExtension implements GlobalsInterfac
      */
     private $csrfMode;
 
+    /**
+     * @var bool
+     */
+    private $hmrModeEnabled;
+
     public function __construct(
         RequestStack $requestStack,
         SystemConfigService $systemConfigService,
         ThemeService $themeService,
         bool $csrfEnabled,
-        string $csrfMode
+        string $csrfMode,
+        bool $hmrModeEnabled
     ) {
         $this->requestStack = $requestStack;
         $this->systemConfigService = $systemConfigService;
         $this->themeService = $themeService;
         $this->csrfEnabled = $csrfEnabled;
         $this->csrfMode = $csrfMode;
+        $this->hmrModeEnabled = $hmrModeEnabled;
     }
 
     public function getGlobals(): array
@@ -90,6 +97,7 @@ class TemplateDataExtension extends AbstractExtension implements GlobalsInterfac
             'context' => $context,
             'activeRoute' => $request->attributes->get('_route'),
             'formViolations' => $request->attributes->get('formViolations'),
+            'isHMRMode' => $this->hmrModeEnabled,
         ];
     }
 

--- a/src/Storefront/README.md
+++ b/src/Storefront/README.md
@@ -27,8 +27,7 @@ $ ./psh.phar storefront:dev
 It's recommended to use the `storefront:watch` command when developing, so the files will be compiled as soon as they change.
 
 It's also possible to use the webpack-dev-server with hot module reloading (HMR) activated.
-To be able to use HMR you have to run the command `storefront:hot` and set the `isHMRMode` variable,
-located in `platform/src/Storefront/Resources/views/storefront/base.html.twig`, to true.
+To be able to use HMR you have to run the command `storefront:hot` and set the ENV variable `SHOPWARE_STOREFRONT_HMR_MODE=1`.
 
 
 Resources

--- a/src/Storefront/Resources/views/storefront/base.html.twig
+++ b/src/Storefront/Resources/views/storefront/base.html.twig
@@ -1,6 +1,3 @@
-{# Set variable to "true" to enable HMR (hot page reloading) mode #}
-{% set isHMRMode = false %}
-
 {% block base_doctype %}
 <!DOCTYPE html>
 {% endblock %}


### PR DESCRIPTION
### 1. Why is this change necessary?

Because you don't want to touch an external dependency in the `vendor` folder during template development.

### 2. What does this change do, exactly?

It introduces an ENV variable `SHOPWARE_STOREFRONT_HMR_MODE` which can be used instead of modifying the template and setting `isHMRMode = true` in the template file.

### 3. Describe each step to reproduce the issue or behaviour.

Set `SHOPWARE_STOREFRONT_HMR_MODE=1` to enable hot module reloading during template development.

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
