### PR TITLE
[noticket] Fix `NotFilter` call in the docs

### DIFF
--- a/src/Docs/Resources/current/2-internals/1-core/20-data-abstraction-layer/020-search.md
+++ b/src/Docs/Resources/current/2-internals/1-core/20-data-abstraction-layer/020-search.md
@@ -190,7 +190,7 @@ The nested query groups multiple queries into one and concat them using the `AND
 ```php
 $criteria->addFilter(new NotFilter(
     NotFilter::CONNECTION_AND,
-    new EqualsAnyFilter('product.name', ['Sword', 'Axe']),
+    [new EqualsAnyFilter('product.name', ['Sword', 'Axe'])]
 ));
 ```
 


### PR DESCRIPTION
### 1. Why is this change necessary?
Because the current example in the documentation is invalid

### 2. What does this change do, exactly?
Corrects the usage example of `NotFilter`

### 3. Describe each step to reproduce the issue or behaviour.
Try to use `NotFilter` like in the provided by the documentation

### 4. Please link to the relevant issues (if any).
///

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
