### PR TITLE
Update base.html.twig

### DIFF
--- a/src/Storefront/Resources/views/storefront/base.html.twig
+++ b/src/Storefront/Resources/views/storefront/base.html.twig
@@ -6,7 +6,7 @@
 {% endblock %}
 
 {% block base_html %}
-<html lang="{{ "meta.xmlLang"|trans|striptags }}"
+<html lang="{{ app.request.locale }}"
       itemscope="itemscope"
       itemtype="https://schema.org/WebPage">
 {% endblock %}


### PR DESCRIPTION
### 1. Why is this change necessary?
There was a missing translation key for the lang attribute

### 2. What does this change do, exactly?
Use the app context lang instead of translating it

### 3. Describe each step to reproduce the issue or behaviour.
Load any page, take a look at the missing translations
