### PR TITLE
refactor: moving sales-channels criteria to computed property

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/page/sw-sales-channel-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/page/sw-sales-channel-detail/index.js
@@ -57,6 +57,19 @@ Component.register('sw-sales-channel-detail', {
                 message: `${systemKey} + S`,
                 appearance: 'light'
             };
+        },
+
+        salesChannelCriteria() {
+            const criteria = new Criteria();
+
+            criteria.addAssociation('paymentMethods');
+            criteria.addAssociation('shippingMethods');
+            criteria.addAssociation('countries');
+            criteria.addAssociation('currencies');
+            criteria.addAssociation('languages');
+            criteria.addAssociation('domains');
+
+            return criteria;
         }
     },
 
@@ -93,18 +106,9 @@ Component.register('sw-sales-channel-detail', {
         },
 
         loadSalesChannel() {
-            const criteria = new Criteria();
-
-            criteria.addAssociation('paymentMethods');
-            criteria.addAssociation('shippingMethods');
-            criteria.addAssociation('countries');
-            criteria.addAssociation('currencies');
-            criteria.addAssociation('languages');
-            criteria.addAssociation('domains');
-
             this.isLoading = true;
             this.salesChannelRepository
-                .get(this.$route.params.id, Shopware.Context.api, criteria)
+                .get(this.$route.params.id, Shopware.Context.api, this.salesChannelCriteria)
                 .then((entity) => {
                     this.salesChannel = entity;
                     this.isLoading = false;

--- a/src/Storefront/Resources/app/administration/src/extension/sw-sales-channel/page/sw-sales-channel-detail/index.js
+++ b/src/Storefront/Resources/app/administration/src/extension/sw-sales-channel/page/sw-sales-channel-detail/index.js
@@ -1,30 +1,14 @@
 import template from './sw-sales-channel-detail.html.twig';
 
 const { Component } = Shopware;
-const Criteria = Shopware.Data.Criteria;
 
 Component.override('sw-sales-channel-detail', {
     template,
 
-    methods: {
-        loadSalesChannel() {
-            const criteria = new Criteria();
-
-            criteria.addAssociation('paymentMethods');
-            criteria.addAssociation('shippingMethods');
-            criteria.addAssociation('countries');
-            criteria.addAssociation('currencies');
-            criteria.addAssociation('languages');
-            criteria.addAssociation('domains');
-            criteria.addAssociation('themes');
-
-            this.isLoading = true;
-            this.salesChannelRepository
-                .get(this.$route.params.id, Shopware.Context.api, criteria)
-                .then((entity) => {
-                    this.salesChannel = entity;
-                    this.isLoading = false;
-                });
-        }
-    }
+    computed: {
+        salesChannelCriteria: function () {
+            return this.$super('salesChannelCriteria')
+                .addAssociation('themes');
+        },
+    },
 });


### PR DESCRIPTION
### 1. Why is this change necessary?
In order to keep core extension maintainable all properties and variables that may be extendable (In this example a criteria) should be computed properties. This way it's easy to override a component and extend the value that is used in a more complex method. It's not necessary to override a method to add one line, and risk that when code changes in the original method it may not take effect.

### 2. What does this change do, exactly?
Refactor the generation of criteria to be less redundant .

### 3. Describe each step to reproduce the issue or behaviour.
 *-*

### 4. Please link to the relevant issues (if any).
 *No issue*
> https://gitter.im/shopware/platform?at=5dd406bd92a84f79fe96e835

### 5. Checklist

- [-] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [-] I have written or adjusted the documentation according to my changes
- [-] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
