### PR TITLE
NEXT-5387 | Image gallery only supports 'cover' as displayMode.

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image-gallery/config/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image-gallery/config/index.js
@@ -145,7 +145,7 @@ Component.register('sw-cms-el-config-image-gallery', {
         },
 
         onChangeDisplayMode(value) {
-            if (value === 'cover') {
+            if (['cover', 'contain'].includes(value)) {
                 this.element.config.verticalAlign.value = null;
             } else {
                 this.element.config.minHeight.value = '';

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image-gallery/config/sw-cms-el-config-image-gallery.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image-gallery/config/sw-cms-el-config-image-gallery.html.twig
@@ -63,13 +63,14 @@
                                                              class="sw-cms-el-config-image-gallery__setting-display-mode">
                                                 <option value="standard">{{ $tc('sw-cms.elements.general.config.label.displayModeStandard') }}</option>
                                                 <option value="cover">{{ $tc('sw-cms.elements.general.config.label.displayModeCover') }}</option>
+                                                <option value="contain">{{ $tc('sw-cms.elements.general.config.label.displayModeContain') }}</option>
                                             </sw-select-field>
                                         {% endblock %}
 
                                         {% block sw_cms_element_image_gallery_config_settings_min_height %}
                                             <sw-text-field :label="$tc('sw-cms.elements.image.config.label.minHeight')"
                                                            :placeholder="$tc('sw-cms.elements.image.config.placeholder.enterMinHeight')"
-                                                           :disabled="element.config.displayMode.value !== 'cover'"
+                                                           :disabled="!['cover', 'contain'].includes(element.config.displayMode.value)"
                                                            v-model="element.config.minHeight.value"
                                                            @input="onChangeMinHeight">
                                             </sw-text-field>
@@ -79,7 +80,7 @@
                                             <sw-select-field :label="$tc('sw-cms.elements.general.config.label.verticalAlign')"
                                                              v-model="element.config.verticalAlign.value"
                                                              :placeholder="$tc('sw-cms.elements.general.config.label.verticalAlign')"
-                                                             :disabled="element.config.displayMode.value === 'cover'">
+                                                             :disabled="['cover', 'contain'].includes(element.config.displayMode.value)">
                                                 <option value="flex-start">{{ $tc('sw-cms.elements.general.config.label.verticalAlignTop') }}</option>
                                                 <option value="center">{{ $tc('sw-cms.elements.general.config.label.verticalAlignCenter') }}</option>
                                                 <option value="flex-end">{{ $tc('sw-cms.elements.general.config.label.verticalAlignBottom') }}</option>

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image-slider/config/sw-cms-el-config-image-slider.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image-slider/config/sw-cms-el-config-image-slider.html.twig
@@ -63,6 +63,7 @@
                                                              class="sw-cms-el-config-image-slider__setting-display-mode">
                                                 <option value="standard">{{ $tc('sw-cms.elements.general.config.label.displayModeStandard') }}</option>
                                                 <option value="cover">{{ $tc('sw-cms.elements.general.config.label.displayModeCover') }}</option>
+                                                <option value="contain">{{ $tc('sw-cms.elements.general.config.label.displayModeContain') }}</option>
                                             </sw-select-field>
                                         {% endblock %}
 

--- a/src/Storefront/Resources/app/storefront/src/scss/component/_gallery-slider.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/component/_gallery-slider.scss
@@ -44,7 +44,8 @@ based on "base-slider" component and "tiny-slider" (https://github.com/ganlanyua
     height: 100%;
     max-width: 100%;
 
-    &.is-cover {
+    &.is-cover,
+    &.is-contain {
         height: 100%;
 
         .gallery-slider-image {
@@ -56,6 +57,18 @@ based on "base-slider" component and "tiny-slider" (https://github.com/ganlanyua
             bottom: 0;
             left: 0;
             margin: 0 auto;
+        }
+    }
+
+    &.is-cover {
+        .gallery-slider-image {
+            object-fit: cover;
+        }
+    }
+
+    &.is-contain {
+        .gallery-slider-image {
+            object-fit: contain;
         }
     }
 }
@@ -168,7 +181,8 @@ based on "base-slider" component and "tiny-slider" (https://github.com/ganlanyua
 @include media-breakpoint-down(xs) {
     // override inline style on mobile devices
     .gallery-slider-item {
-        &.is-cover {
+        &.is-cover,
+        &.is-contain {
             min-height: 225px !important;
         }
     }
@@ -176,7 +190,8 @@ based on "base-slider" component and "tiny-slider" (https://github.com/ganlanyua
 
 @include media-breakpoint-down(sm) {
     .gallery-slider-single-image {
-        &.is-cover {
+        &.is-cover,
+        &.is-contain {
             min-height: 225px !important;
         }
     }

--- a/src/Storefront/Resources/views/storefront/element/cms-element-image-gallery.html.twig
+++ b/src/Storefront/Resources/views/storefront/element/cms-element-image-gallery.html.twig
@@ -97,7 +97,7 @@
                                                             {% for image in mediaItems %}
                                                                 {% block element_image_gallery_inner_item %}
                                                                     <div class="gallery-slider-item-container">
-                                                                        <div class="gallery-slider-item is-{{ displayMode }} js-magnifier-container"{% if minHeight and  displayMode == "cover" %} style="min-height: {{ minHeight }}"{% endif %}>
+                                                                        <div class="gallery-slider-item is-{{ displayMode }} js-magnifier-container"{% if minHeight and  (displayMode == "cover" or displayMode == "contain" ) %} style="min-height: {{ minHeight }}"{% endif %}>
                                                                             {% set attributes = {
                                                                                 'class': 'img-fluid gallery-slider-image magnifier-image js-magnifier-image',
                                                                                 'alt': (image.translated.alt ?: ''),


### PR DESCRIPTION
Add support for displayMode : 'contain' for image gallary.

 * added is-contain check for gallery-slider-single-image css element.
 * added is-contain check in cms-element-image-gallery.html.twig file.
 * added contain option to image gallery in cms block in administration.

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/community).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?

It would good to have the option to use displayMode: 'contain', which would make sure that the whole image would fit into the given image box in the image gallery.

### 2. What does this change do, exactly?

It add support for displayMode: 'contain' for images in the image gallery.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).

[NEXT-5387 | Image gallery only supports 'cover' as displayMode](https://issues.shopware.com/issues/NEXT-5387)

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
        I did a manual test by changing the displayMode to 'contain'.
- [x] I have squashed any insignificant commits
- [x] I have written or adjusted the documentation according to my changes
        Not sure if this is needed by this change.
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
