### PR TITLE
fix/asset-package-base-path

### DIFF
--- a/src/Core/Framework/Asset/AssetPackageService.php
+++ b/src/Core/Framework/Asset/AssetPackageService.php
@@ -12,16 +12,22 @@ class AssetPackageService
      */
     private $packages;
 
-    public function __construct(Packages $packages)
+    /**
+     * @var string
+     */
+    private $basePath = '';
+
+    public function __construct(Packages $packages, string $basePath)
     {
         $this->packages = $packages;
+        $this->basePath = $basePath;
     }
 
     public function addAssetPackage(string $bundleName, string $bundlePath): void
     {
         $this->packages->addPackage(
             '@' . $bundleName,
-            new PathPackage('/bundles/' . mb_strtolower($bundleName), new LastModifiedVersionStrategy($bundlePath))
+            new PathPackage(rtrim($this->basePath, '/') . '/bundles/' . mb_strtolower($bundleName), new LastModifiedVersionStrategy($bundlePath))
         );
     }
 }

--- a/src/Core/Framework/DependencyInjection/services.xml
+++ b/src/Core/Framework/DependencyInjection/services.xml
@@ -11,6 +11,8 @@
             <parameter key="lowercase">false</parameter>
         </parameter>
 
+        <parameter key="env(APP_BASE_PATH)"></parameter>
+
         <!-- Migration config -->
         <parameter key="migration.directories" type="collection" />
         <parameter key="migration.active" type="collection"/>
@@ -44,6 +46,7 @@
         <!-- Asset -->
         <service id="Shopware\Core\Framework\Asset\AssetPackageService" public="true">
             <argument type="service" id="assets.packages"/>
+            <argument>%env(APP_BASE_PATH)%</argument>
         </service>
 
         <!-- Database / Doctrine -->


### PR DESCRIPTION
### 1. Why is this change necessary?

The path of asset packages is set without prepending a possible base path. Hence resources will fail to load, e.g. in the administration.

### 2. What does this change do, exactly?

Proposition to use an environment variable to optionally define a base path through dotEnv.

Prepends that environment variable to asset package paths.

### 3. Describe each step to reproduce the issue or behaviour.

Setup an installation within a subdirectory of the web root and try to login into administration.

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
