### PR TITLE
fix plugin loading if composer is optimized

### DIFF
--- a/src/Core/Framework/Plugin/KernelPluginLoader/KernelPluginLoader.php
+++ b/src/Core/Framework/Plugin/KernelPluginLoader/KernelPluginLoader.php
@@ -3,6 +3,7 @@
 namespace Shopware\Core\Framework\Plugin\KernelPluginLoader;
 
 use Composer\Autoload\ClassLoader;
+use Composer\Autoload\ClassMapGenerator;
 use Shopware\Core\Framework\Plugin;
 use Shopware\Core\Framework\Plugin\Exception\KernelPluginLoaderException;
 use Shopware\Core\Framework\Plugin\KernelPluginCollection;
@@ -193,6 +194,11 @@ abstract class KernelPluginLoader extends Bundle
                 }
                 $mappedPaths = $this->mapPsrPaths($pluginName, $paths, $projectDir, $plugin['path']);
                 $this->classLoader->addPsr4($namespace, $mappedPaths);
+                if ($this->classLoader->isClassMapAuthoritative()) {
+                    foreach ($mappedPaths as $mappedPath) {
+                        $this->classLoader->addClassMap(ClassMapGenerator::createMap($mappedPath));
+                    }
+                }
             }
 
             foreach ($psr0 as $namespace => $paths) {
@@ -202,6 +208,11 @@ abstract class KernelPluginLoader extends Bundle
                 $mappedPaths = $this->mapPsrPaths($pluginName, $paths, $projectDir, $plugin['path']);
 
                 $this->classLoader->add($namespace, $mappedPaths);
+                if ($this->classLoader->isClassMapAuthoritative()) {
+                    foreach ($mappedPaths as $mappedPath) {
+                        $this->classLoader->addClassMap(ClassMapGenerator::createMap($mappedPath));
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
Resolves #315

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/community).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
So you can use composer with the `optimize` flag and plugins are still working.

### 2. What does this change do, exactly?
It generates a classmap for the plugins and adds them to the classloader if its classmap is authoritative.

### 3. Describe each step to reproduce the issue or behaviour.
`composer install -nao` for the project and try to install plugins.

### 4. Please link to the relevant issues (if any).
https://github.com/shopware/platform/issues/315

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
