### PR TITLE
Implement environment variable to disable ESLint during storefront builds

### DIFF
--- a/CHANGELOG-6.0.md
+++ b/CHANGELOG-6.0.md
@@ -123,6 +123,7 @@ This can be useful when validate your commands in `PreWriteValidateEvent`s when 
     * Added twig helper function `seoUrl` that returns a seo url if possible, otherwise just calls `url`. 
     * Deprecated twig helper functions `productUrl` and `navigationUrl`, use `seoUrl` instead.
     * Added ErrorPage, ErrorpageLoader and ErrorPageLoaderEvent which is used in the `ErrorController` to load the CMS error layout if a 404 layout is assigned.
+    * Added an option to disable eslint for storefront:build
 
 **Removals**
 

--- a/src/Storefront/Resources/app/storefront/build/webpack.base.config.js
+++ b/src/Storefront/Resources/app/storefront/build/webpack.base.config.js
@@ -33,6 +33,12 @@ const output = {
 };
 
 /**
+ * Option to disable ESLint during storefront build process.
+ * @type {boolean}
+ */
+const eslintDisable = (process.env.ESLINT_DISABLE === 'true');
+
+/**
  * Webpack module configuration and how them will be treated
  * https://webpack.js.org/configuration/module
  * @type {{rules: *[]}}
@@ -47,13 +53,13 @@ const modules = {
                     loader: 'babel-loader',
                     options: babelrc,
                 },
-                {
+                (eslintDisable ? {} : {
                     loader: 'eslint-loader',
                     options: {
                         configFile: utils.getPath('.eslintrc.js'),
                         fix: true,
                     },
-                },
+                }),
             ],
         },
         {


### PR DESCRIPTION

### 1. Why is this change necessary?
Inside the administration webpack.base.config.js, the option to disable linting already exists, so it seems sensible to provide this for storefront as well. This is helpful, once you use a custom eslint configuration inside a plugin that is not compatible with the shopware linting process. This can occur, when a custom eslint config relies on a plugin (like eslint-plugin-jest) that is not installed in the shopware node_modules, but only in the respective plugin/theme it is used.

### 2. What does this change do, exactly?
This change enables you to set the environment variable `ESLINT_DISABLE=true` to prevent the ESLint-loader in the storefront webpack build to become active. You can now rely on your own linting processes, instead of having to use the shopware provided ones.

This is already implemented in the administration build.
https://github.com/shopware/platform/blob/master/src/Administration/Resources/app/administration/build/webpack.base.conf.js#L10

```
$ ESLINT_DISABLE=true ./psh.phar storefront:build
```

### 3. Describe each step to reproduce the issue or behaviour.

1. Create a custom plugin including entry points for storefront and administration (main.js)
2. Install eslint locally inside the plugin and i.e. a plugin like eslint-plugin-jest
3. Create the following basic `.eslintrc.js` inside the plugin root

```
module.exports = {
  plugins: ['jest']
};
```

4. Run `./psh.phar storefront:build`

The command should fail with an error stating the eslint-plugin cannot be found.

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
