### PR TITLE
Throw specific exception when autoloading has been configured wrong

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-plugin/service/plugin-error-handler.service.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-plugin/service/plugin-error-handler.service.js
@@ -29,6 +29,10 @@ const errorCodes = {
     FRAMEWORK__STORE_NOT_AVAILABLE: new StoreError(
         'sw-plugin.errors.titleStoreNotAvailable',
         'sw-plugin.errors.messageStoreNotAvailable'
+    ),
+    FRAMEWORK__PLUGIN_BASE_CLASS_NOT_FOUND: new StoreError(
+        'sw-plugin.errors.titlePluginBaseClassNotFound',
+        'sw-plugin.errors.messagePluginBaseClassNotFound'
     )
 };
 

--- a/src/Administration/Resources/app/administration/src/module/sw-plugin/snippet/de-DE.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-plugin/snippet/de-DE.json
@@ -36,7 +36,9 @@
       "titleStoreHostMissing": "Fehler",
       "messageStoreLicenseDomainMissing": "Um Dich erfolgreich anmelden zu können, musst Du zunächst in \"Einstellungen/Shopware Account\" Deine Lizenzdomain angeben.",
       "titleStoreNotAvailable": "Verbindung gescheitert",
-      "messageStoreNotAvailable": "Der Shopware Store ist nicht erreichbar."
+      "messageStoreNotAvailable": "Der Shopware Store ist nicht erreichbar.",
+      "titlePluginBaseClassNotFound": "Fehler beim Laden des Plugins",
+      "messagePluginBaseClassNotFound": "Der Plugineinstiegspunkt konnte nicht geladen werden. Stelle sicher, dass die Basisklasse korrekt geladen werden kann."
     },
     "fileUpload":{
       "buttonFileUpload":"Plugin hochladen",

--- a/src/Administration/Resources/app/administration/src/module/sw-plugin/snippet/en-GB.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-plugin/snippet/en-GB.json
@@ -36,7 +36,9 @@
       "titleStoreHostMissing": "Error",
       "messageStoreLicenseDomainMissing": "Login failed. Did you provide the correct license domain from your Shopware Account in \"Settings/Shopware Account\"?",
       "titleStoreNotAvailable": "Connection refused",
-      "messageStoreNotAvailable": "The Shopware Store is not available."
+      "messageStoreNotAvailable": "The Shopware Store is not available.",
+      "titlePluginBaseClassNotFound": "Error on loading the plugin",
+      "messagePluginBaseClassNotFound": "The plugin base class could not be loaded. Check your plugin composer.json regarding the class autoloading"
     },
     "fileUpload":{
       "buttonFileUpload":"Upload plugin",

--- a/src/Core/Framework/Plugin/Exception/PluginBaseClassNotFoundException.php
+++ b/src/Core/Framework/Plugin/Exception/PluginBaseClassNotFoundException.php
@@ -1,0 +1,27 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\Plugin\Exception;
+
+use Shopware\Core\Framework\ShopwareHttpException;
+use Symfony\Component\HttpFoundation\Response;
+
+class PluginBaseClassNotFoundException extends ShopwareHttpException
+{
+    public function __construct(string $baseClass)
+    {
+        parent::__construct(
+            'The class "{{ baseClass }}" is not found. Probably an class loader error. Check your plugin composer.json',
+            ['baseClass' => $baseClass]
+        );
+    }
+
+    public function getErrorCode(): string
+    {
+        return 'FRAMEWORK__PLUGIN_BASE_CLASS_NOT_FOUND';
+    }
+
+    public function getStatusCode(): int
+    {
+        return Response::HTTP_BAD_REQUEST;
+    }
+}

--- a/src/Core/Framework/Plugin/PluginLifecycleService.php
+++ b/src/Core/Framework/Plugin/PluginLifecycleService.php
@@ -27,6 +27,7 @@ use Shopware\Core\Framework\Plugin\Event\PluginPreDeactivateEvent;
 use Shopware\Core\Framework\Plugin\Event\PluginPreInstallEvent;
 use Shopware\Core\Framework\Plugin\Event\PluginPreUninstallEvent;
 use Shopware\Core\Framework\Plugin\Event\PluginPreUpdateEvent;
+use Shopware\Core\Framework\Plugin\Exception\PluginBaseClassNotFoundException;
 use Shopware\Core\Framework\Plugin\Exception\PluginNotActivatedException;
 use Shopware\Core\Framework\Plugin\Exception\PluginNotInstalledException;
 use Shopware\Core\Framework\Plugin\KernelPluginLoader\KernelPluginLoader;
@@ -427,6 +428,11 @@ class PluginLifecycleService
     {
         /** @var Plugin|ContainerAwareTrait $baseClass */
         $baseClass = $this->pluginCollection->get($pluginBaseClassString);
+
+        if ($baseClass === null) {
+            throw new PluginBaseClassNotFoundException($pluginBaseClassString);
+        }
+
         // set container because the plugin has not been initialized yet and therefore has no container set
         $baseClass->setContainer($this->container);
 


### PR DESCRIPTION
### 1. Why is this change necessary?
When you configure your plugin wrong by having a typo or other autoloading issues you just get:

> Call to a member function setContainer() on null

Also the administration just fails to do anything.

### 2. What does this change do, exactly?
Adds a new exception and translation for it. And of course throwing the exception.

### 3. Describe each step to reproduce the issue or behaviour.
1. Have a valid looking composer.json
2. Make a typo in the namespace
3. Plugin gets detected in the admin
4. Install plugin

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
