### PR TITLE
Amend type hint of Collection::reduce

### DIFF
--- a/src/Core/Framework/Struct/Collection.php
+++ b/src/Core/Framework/Struct/Collection.php
@@ -73,7 +73,7 @@ abstract class Collection extends Struct implements \IteratorAggregate, \Countab
         return array_map($closure, $this->elements);
     }
 
-    public function reduce(\Closure $closure, $initial = null): array
+    public function reduce(\Closure $closure, $initial = null)
     {
         return array_reduce($this->elements, $closure, $initial);
     }


### PR DESCRIPTION
### 1. Why is this change necessary?
The type hint on the return value of `Collection::reduce` is just right on the only used occasion: 
https://github.com/shopware/platform/blob/f9ff2d73cd975570128221b18fcaf4696d310614/src/Core/Framework/DataAbstractionLayer/Indexing/Indexer/TreeIndexer.php#L318
where it is used in a not really reducing way (following the definition of reduce as collection to scalar value).

### 2. What does this change do, exactly?
Removes the return value type hint. As php does not support generics (yet).

### 3. Describe each step to reproduce the issue or behaviour.
1. Use an entity collection and compute a scalar value without the API computation functionality.
2. Get a `scalar is not array` sort of exception

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
