### PR TITLE
Recover cart after payment errors

### DIFF
--- a/src/Core/Checkout/Cart/Order/OrderPersister.php
+++ b/src/Core/Checkout/Cart/Order/OrderPersister.php
@@ -55,7 +55,7 @@ class OrderPersister implements OrderPersisterInterface
         $order = $this->converter->convertToOrder($cart, $context, new OrderConversionContext());
 
         $context->getContext()->scope(Context::SYSTEM_SCOPE, function (Context $context) use ($order): void {
-            $this->orderRepository->create([$order], $context);
+            $this->orderRepository->upsert([$order], $context);
         });
 
         return $order['id'];

--- a/src/Core/Checkout/DependencyInjection/payment.xml
+++ b/src/Core/Checkout/DependencyInjection/payment.xml
@@ -24,6 +24,8 @@
             <argument type="service" id="Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PaymentHandlerRegistry"/>
             <argument type="service" id="order_transaction.repository"/>
             <argument type="service" id="Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionStateHandler"/>
+            <argument type="service" id="Shopware\Core\Checkout\Cart\Order\OrderConverter"/>
+            <argument type="service" id="Shopware\Core\Checkout\Cart\SalesChannel\CartService"/>
         </service>
 
         <service id="Shopware\Core\Checkout\Payment\Controller\PaymentController" public="true">

--- a/src/Core/Checkout/Test/Cart/Common/Generator.php
+++ b/src/Core/Checkout/Test/Cart/Common/Generator.php
@@ -129,6 +129,7 @@ class Generator extends TestCase
             $customer = (new CustomerEntity())->assign(['id' => Uuid::randomHex()]);
             $customer->setId(Uuid::randomHex());
             $customer->setGroup($currentCustomerGroup);
+            $customer->setActiveBillingAddress($shipping);
         }
 
         return new SalesChannelContext(

--- a/src/Core/Checkout/Test/Cart/Common/Generator.php
+++ b/src/Core/Checkout/Test/Cart/Common/Generator.php
@@ -90,6 +90,7 @@ class Generator extends TestCase
             $country = new CountryEntity();
             $country->setId('5cff02b1029741a4891c430bcd9e3603');
             $country->setTaxFree(false);
+            $country->setShippingAvailable(true);
             $country->setName('Germany');
         }
         if (!$state) {
@@ -129,7 +130,8 @@ class Generator extends TestCase
             $customer = (new CustomerEntity())->assign(['id' => Uuid::randomHex()]);
             $customer->setId(Uuid::randomHex());
             $customer->setGroup($currentCustomerGroup);
-            $customer->setActiveBillingAddress($shipping);
+            $customer->setDefaultBillingAddress($shipping);
+            $customer->setDefaultShippingAddress($shipping);
         }
 
         return new SalesChannelContext(

--- a/src/Core/Checkout/Test/Payment/Handler/AsyncTestExceptionPaymentHandler.php
+++ b/src/Core/Checkout/Test/Payment/Handler/AsyncTestExceptionPaymentHandler.php
@@ -1,0 +1,31 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Checkout\Test\Payment\Handler;
+
+use Shopware\Core\Checkout\Payment\Cart\AsyncPaymentTransactionStruct;
+use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandlerInterface;
+use Shopware\Core\Checkout\Payment\Exception\AsyncPaymentProcessException;
+use Shopware\Core\Checkout\Payment\Exception\CustomerCanceledAsyncPaymentException;
+use Shopware\Core\Framework\Validation\DataBag\RequestDataBag;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+
+class AsyncTestExceptionPaymentHandler implements AsynchronousPaymentHandlerInterface
+{
+    public const REDIRECT_URL = 'https://shopware.com';
+
+    public function pay(AsyncPaymentTransactionStruct $transaction, RequestDataBag $dataBag, SalesChannelContext $salesChannelContext): RedirectResponse
+    {
+        if ($dataBag->has('fail')) {
+            throw new AsyncPaymentProcessException($transaction->getOrderTransaction()->getId(), 'fail');
+        }
+
+        return new RedirectResponse(self::REDIRECT_URL);
+    }
+
+    public function finalize(AsyncPaymentTransactionStruct $transaction, Request $request, SalesChannelContext $salesChannelContext): void
+    {
+        throw new CustomerCanceledAsyncPaymentException($transaction->getOrderTransaction()->getId(), '');
+    }
+}

--- a/src/Core/Checkout/Test/Payment/PaymentServiceTest.php
+++ b/src/Core/Checkout/Test/Payment/PaymentServiceTest.php
@@ -270,6 +270,7 @@ class PaymentServiceTest extends TestCase
 
         $order = [
             'id' => $orderId,
+            'orderNumber' => 'some-number',
             'orderDateTime' => (new \DateTimeImmutable())->format(Defaults::STORAGE_DATE_TIME_FORMAT),
             'price' => new CartPrice(10, 10, 10, new CalculatedTaxCollection(), new TaxRuleCollection(), CartPrice::TAX_STATE_NET),
             'shippingCosts' => new CalculatedPrice(10, 10, new CalculatedTaxCollection(), new TaxRuleCollection()),

--- a/src/Core/Checkout/Test/Payment/PaymentServiceTest.php
+++ b/src/Core/Checkout/Test/Payment/PaymentServiceTest.php
@@ -235,7 +235,8 @@ class PaymentServiceTest extends TestCase
             null,
             null,
             null,
-            (new PaymentMethodEntity())->assign(['id' => $paymentMethodId])
+            (new PaymentMethodEntity())->assign(['id' => $paymentMethodId]),
+            $this->getAvailableShippingMethod()
         );
     }
 

--- a/src/Core/Framework/DependencyInjection/services_test.xml
+++ b/src/Core/Framework/DependencyInjection/services_test.xml
@@ -29,6 +29,10 @@
             <tag name="shopware.payment.method.sync"/>
         </service>
 
+        <service id="Shopware\Core\Checkout\Test\Payment\Handler\AsyncTestExceptionPaymentHandler">
+            <tag name="shopware.payment.method.async"/>
+        </service>
+
         <service id="Shopware\Core\Framework\Test\Filesystem\Adapter\MemoryAdapterFactory">
             <tag name="shopware.filesystem.factory"/>
         </service>

--- a/src/Docs/Resources/platform-updates/2019-12-04-cart-recovery.md
+++ b/src/Docs/Resources/platform-updates/2019-12-04-cart-recovery.md
@@ -1,0 +1,5 @@
+[titleEn]: <>(Recovering carts on payment errors)
+
+On payment errors previously there was only a thrown exception. The cart of the customer was lost during the transformation to an order and the checkout needed to be restarted.
+
+Now the order will be transformed back to a cart so the customer can for example retry their order with a different payment method.

--- a/src/Storefront/Controller/CheckoutController.php
+++ b/src/Storefront/Controller/CheckoutController.php
@@ -166,8 +166,13 @@ class CheckoutController extends StorefrontController
             return new RedirectResponse($finishUrl);
         } catch (ConstraintViolationException $formViolations) {
         } catch (Error $blockedError) {
-        } catch (AsyncPaymentProcessException | InvalidOrderException | SyncPaymentProcessException | UnknownPaymentMethodException $e) {
-            // TODO: Handle errors which might occur during payment process
+        } catch (AsyncPaymentProcessException | SyncPaymentProcessException $e) {
+            $this->addFlash('danger', $this->trans(sprintf('error.%s', $e->getErrorCode())));
+
+            return $this->redirectToRoute('frontend.checkout.confirm.page');
+        } catch (InvalidOrderException | UnknownPaymentMethodException $e) {
+            // TODO: Handle errors which might occur during order process
+
             throw $e;
         }
 

--- a/src/Storefront/Resources/snippet/de_DE/storefront.de-DE.json
+++ b/src/Storefront/Resources/snippet/de_DE/storefront.de-DE.json
@@ -56,6 +56,8 @@
         "addToCartError": "Beim Hinzufügen zum Warenkorb ist ein Fehler aufgetreten.",
         "FRAMEWORK__INVALID_UUID": "Die gewählte Zahlungsart konnte nicht gefunden werden.",
         "CHECKOUT__UNKNOWN_PAYMENT_METHOD": "Die gewählte Zahlungsart konnte nicht gefunden werden.",
+        "CHECKOUT__ASYNC_PAYMENT_PROCESS_INTERRUPTED": "Während der Bezahlung ist ein Fehler aufgetreten.",
+        "CHECKOUT__SYNC_PAYMENT_PROCESS_INTERRUPTED": "Während der Bezahlung ist ein Fehler aufgetreten.",
         "productNotFound": "Produkt mit der Nummer \"%number%\" konnte nicht gefunden werden.",
         "payment-method-blocked": "Die gewählte Zahlungsart %name% ist nicht verfügbar.",
         "shipping-method-blocked": "Die gewählte Versandart %name% ist nicht verfügbar.",

--- a/src/Storefront/Resources/snippet/en_GB/storefront.en-GB.json
+++ b/src/Storefront/Resources/snippet/en_GB/storefront.en-GB.json
@@ -56,6 +56,8 @@
         "addToCartError": "An error occurred while trying to add item(s) to the shopping cart.",
         "FRAMEWORK__INVALID_UUID": "The selected payment method does not exist.",
         "CHECKOUT__UNKNOWN_PAYMENT_METHOD": "The selected payment method does not exist.",
+        "CHECKOUT__ASYNC_PAYMENT_PROCESS_INTERRUPTED": "An error occurred during payment.",
+        "CHECKOUT__SYNC_PAYMENT_PROCESS_INTERRUPTED": "An error occurred during payment.",
         "productNotFound": "Product \"%number%\" not found.",
         "payment-method-blocked": "Payment method %name% not available.",
         "shipping-method-blocked": "Shipping method %name% not available.",


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/community).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
Currently the cart is lost if anything goes wrong during payments (be it actual errors or a customer cancellation on async payments). This PR recovers the cart from the created order. If the customer then retries the order, the previous order ID and order number will be transparently reused (thanks to the OrderConverter).

### 2. What does this change do, exactly?
It restores the cart from the cancelled order and redirects the customer back to the checkout (on Storefront sales channels).

### 3. Describe each step to reproduce the issue or behaviour.
* Add product to cart and go to checkout
* Force an error during payment (either by throwing it in DefaultPaymentHandler or cancelling e.g. in PayPal)
* Be sad because your cart is now gone

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
