### PR TITLE
Fix "./psh.phar storefront:hot-proxy"

### DIFF
--- a/src/Storefront/Resources/app/storefront/build/proxy-server-hot/index.js
+++ b/src/Storefront/Resources/app/storefront/build/proxy-server-hot/index.js
@@ -79,7 +79,12 @@ function openBrowserWithUrl(url) {
 
     try {
         const start = (process.platform === 'darwin' ? 'open' : process.platform === 'win32' ? 'start' : 'xdg-open');
-        spawn(start, [url], childProcessOptions);
+        const child = spawn(start, [url], childProcessOptions);
+
+        child.on('error', error => {
+            console.log('Unable to open browser! Details:');
+            console.log(error);
+        })
     } catch (ex) {
         console.log(ex);
     }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/community).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
Otherwise you can't use `storefront:hot-proxy` inside a docker container because the process exits.

### 2. What does this change do, exactly?
It fixes the existing error handling.

### 3. Describe each step to reproduce the issue or behaviour.
Setup shopware installation in a docker container and run `./psh.phar storefront:hot-proxy` inside the container. After compilation and starting of the proxy server the process exits.

The actual output:
```

###################

SHOPWARE Developer Version

       _
      | |
   ___| |__   ___  _ ____      ____ _ _ __ ___
  / __| '_ \ / _ \| '_ \ \ /\ / / _` | '__/ _ \
  \__ \ | | | (_) | |_) \ V  V / (_| | | |  __/
  |___/_| |_|\___/| .__/ \_/\_/ \__,_|_|  \___|
                  | |
                  |_|

Using .psh.yaml.dist extended by .psh.yaml.override 

Starting Execution of 'storefront:hot-proxy' ('/var/www/html/dev-ops/storefront/actions/hot-proxy.sh')


(1/2) Starting
> bin/console theme:dump
	
(2/2) Starting
> APP_URL=https://shopware.dev.localhost PROJECT_ROOT=/var/www/html/  npm --prefix vendor/shopware/platform/src/Storefront/Resources/app/storefront/ run-script hot-proxy
	
	> sw-next-storefront@1.0.0 hot-proxy /var/www/html/vendor/shopware/platform/src/Storefront/Resources/app/storefront
	> NODE_ENV=development MODE=hot node ./build/start-hot-reload.js
	
	ℹ USING WEBPACK CONFIG FILE: ./build/webpack.hot.config.js
	
	Starting the hot reload server: 
	
	ℹ Compiling Shopware 6 Storefront
	✔ Shopware 6 Storefront: Compiled successfully in 7.06s
	 DONE  Compiled successfully in 8352ms11:48:12 AM
	
	############
	Storefront proxy server started at http://localhost:9998
	############
	
	
	events.js:174
	      throw er; // Unhandled 'error' event
	      ^
	
	Error: spawn xdg-open ENOENT
	    at Process.ChildProcess._handle.onexit (internal/child_process.js:240:19)
	    at onErrorNT (internal/child_process.js:415:16)
	    at process._tickCallback (internal/process/next_tick.js:63:19)
	Emitted 'error' event at:
	    at Process.ChildProcess._handle.onexit (internal/child_process.js:246:12)
	    at onErrorNT (internal/child_process.js:415:16)
	    at process._tickCallback (internal/process/next_tick.js:63:19)
	npm ERR! code ELIFECYCLE
	npm ERR! errno 1
	npm ERR! sw-next-storefront@1.0.0 hot-proxy: `NODE_ENV=development MODE=hot node ./build/start-hot-reload.js`
	npm ERR! Exit status 1
	npm ERR! 
	npm ERR! Failed at the sw-next-storefront@1.0.0 hot-proxy script.
	npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
	
	npm ERR! A complete log of this run can be found in:
	npm ERR!     /var/www/.npm/_logs/2019-12-06T11_48_12_431Z-debug.log
	
Execution aborted, a subcommand failed!
```

### 4. Please link to the relevant issues (if any).
https://github.com/shopware/platform/issues/343

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
