### PR TITLE
added external links for shop footer

### DIFF
--- a/src/Storefront/Resources/views/storefront/layout/footer/footer.html.twig
+++ b/src/Storefront/Resources/views/storefront/layout/footer/footer.html.twig
@@ -80,7 +80,7 @@
                                                         <li class="footer-link-item">
                                                             {% block layout_footer_navigation_information_link %}
                                                                 <a class="footer-link"
-                                                                   href="{{ seoUrl('frontend.navigation.page', { navigationId: treeItem.category.id }) }}"
+                                                                   href="{% if treeItem.category.externalLink %}{{ treeItem.category.externalLink }}{% else %}{{ seoUrl('frontend.navigation.page', { navigationId: treeItem.category.id }) }}{% endif %}"
                                                                    title="{{ treeItem.category.translated.name }}">
                                                                     {{ treeItem.category.translated.name }}
                                                                 </a>
@@ -168,7 +168,7 @@
                                 {% block layout_footer_service_menu_item %}
                                     <li class="footer-service-menu-item">
                                         <a class="footer-service-menu-link"
-                                           href="{{ seoUrl('frontend.navigation.page', { navigationId: serviceMenuItem.id }) }}"
+                                           href="{% if serviceMenuItem.externalLink %}{{ serviceMenuItem.externalLink }}{% else %}{{ seoUrl('frontend.navigation.page', { navigationId: serviceMenuItem.id }) }}{% endif %}"
                                            title="{{ serviceMenuItem.translated.name }}">
                                             {{ serviceMenuItem.translated.name }}
                                         </a>

--- a/src/Storefront/Resources/views/storefront/layout/header/actions/service-menu-widget.html.twig
+++ b/src/Storefront/Resources/views/storefront/layout/header/actions/service-menu-widget.html.twig
@@ -21,7 +21,7 @@
                              aria-labelledby="serviceMenuDropdown-{{ position }}">
                             {% for category in page.header.serviceMenu %}
                                 <a class="top-bar-list-item dropdown-item"
-                                   href="{{ seoUrl('frontend.navigation.page', { navigationId: category.id }) }}"
+                                   href="{% if category.externalLink %}{{ category.externalLink }}{% else %}{{ seoUrl('frontend.navigation.page', { navigationId: category.id }) }}{% endif %}"
                                    title="{{ category.translated.name }}">{{ category.translated.name }}</a>
                             {% endfor %}
                         </div>


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/community).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
- you are not able to set custom links for the shop footer pages

### 2. What does this change do, exactly?
- includes the external links into footer

### 3. Describe each step to reproduce the issue or behaviour.
- admin -> category -> set customizeable link -> custom links not displaying in the footer

### 4. Please link to the relevant issues (if any).
-

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
