### PR TITLE
Improve routing lite

### DIFF
--- a/src/Administration/Resources/views/administration/index.html.twig
+++ b/src/Administration/Resources/views/administration/index.html.twig
@@ -6,7 +6,7 @@
     <title>
         Shopware Administration (c) shopware AG
     </title>
-    {% set baseUrl = app.getRequest().baseUrl %}
+    {% set baseUrl = app.getRequest().basePath %}
 
     {% block administration_favicons %}
         <link rel="apple-touch-icon" sizes="180x180" href="{{ baseUrl }}{{ asset('static/img/favicon/apple-touch-icon.png', '@Administration') }}">

--- a/src/Core/Content/Seo/SeoUrlGenerator.php
+++ b/src/Core/Content/Seo/SeoUrlGenerator.php
@@ -54,23 +54,16 @@ class SeoUrlGenerator
      */
     private $definitionRegistry;
 
-    /**
-     * @var RequestStack
-     */
-    private $requestStack;
-
     public function __construct(
         DefinitionInstanceRegistry $definitionRegistry,
         Slugify $slugify,
-        RouterInterface $router,
-        RequestStack $requestStack
+        RouterInterface $router
     ) {
         $this->definitionRegistry = $definitionRegistry;
 
         $this->router = $router;
 
         $this->initTwig($slugify);
-        $this->requestStack = $requestStack;
     }
 
     /**
@@ -133,9 +126,7 @@ class SeoUrlGenerator
 
     private function generate(SeoUrlRouteInterface $seoUrlRoute, SeoUrlRouteConfig $config, array $salesChannels, EntityCollection $entities): iterable
     {
-        $request = $this->requestStack->getMasterRequest();
-
-        $basePath = $request ? $request->getBasePath() : '';
+        $baseUrl = $this->router->getContext()->getBaseUrl();
 
         /** @var Entity $entity */
         foreach ($entities as $entity) {
@@ -152,7 +143,7 @@ class SeoUrlGenerator
 
                 $mapping = $seoUrlRoute->getMapping($entity, $salesChannel);
                 $pathInfo = $this->router->generate($config->getRouteName(), $mapping->getInfoPathContext());
-                $pathInfo = $this->removePrefix($pathInfo, $basePath);
+                $pathInfo = $this->removePrefix($pathInfo, $baseUrl);
 
                 $copy->setPathInfo($pathInfo);
 

--- a/src/Core/Content/Seo/SeoUrlPlaceholderHandler.php
+++ b/src/Core/Content/Seo/SeoUrlPlaceholderHandler.php
@@ -26,25 +26,17 @@ class SeoUrlPlaceholderHandler implements SeoUrlPlaceholderHandlerInterface
      */
     private $seoUrlRepository;
 
-    /**
-     * @var RequestStack
-     */
-    private $requestStack;
-
-    public function __construct(RequestStack $requestStack, Router $router, SalesChannelRepositoryInterface $seoUrlRepository)
+    public function __construct(Router $router, SalesChannelRepositoryInterface $seoUrlRepository)
     {
         $this->router = $router;
         $this->seoUrlRepository = $seoUrlRepository;
-        $this->requestStack = $requestStack;
     }
 
     public function generate($name, $parameters = []): string
     {
         $path = $this->router->generate($name, $parameters, Router::ABSOLUTE_PATH);
 
-        $request = $this->requestStack->getMasterRequest();
-        $basePath = $request ? $request->getBasePath() : '';
-        $path = $this->removePrefix($path, $basePath);
+        $path = $this->removePrefix($path, $this->router->getContext()->getBaseUrl());
 
         return self::DOMAIN_PLACEHOLDER . $path . '#';
     }

--- a/src/Core/Framework/Api/Response/Type/JsonFactoryBase.php
+++ b/src/Core/Framework/Api/Response/Type/JsonFactoryBase.php
@@ -93,7 +93,7 @@ abstract class JsonFactoryBase implements ResponseFactoryInterface
 
     protected function getBaseUrl(Request $request): string
     {
-        return $request->getSchemeAndHttpHost() . $request->getBasePath();
+        return $request->getSchemeAndHttpHost() . $request->getBaseUrl();
     }
 
     protected function camelCaseToSnailCase(string $input): string

--- a/src/Core/Framework/DependencyInjection/seo.xml
+++ b/src/Core/Framework/DependencyInjection/seo.xml
@@ -58,7 +58,6 @@
             <argument type="service" id="Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry"/>
             <argument type="service" id="slugify"/>
             <argument type="service" id="router.default"/>
-            <argument type="service" id="request_stack"/>
         </service>
 
         <service id="Shopware\Core\Content\Seo\SeoUrlPersister">
@@ -108,7 +107,6 @@
         </service>
 
         <service id="Shopware\Core\Content\Seo\SeoUrlPlaceholderHandlerInterface" class="Shopware\Core\Content\Seo\SeoUrlPlaceholderHandler" public="true">
-            <argument type="service" id="request_stack"/>
             <argument type="service" id="router.default"/>
             <argument type="service" id="sales_channel.seo_url.repository"/>
         </service>

--- a/src/Core/Framework/Update/Api/UpdateController.php
+++ b/src/Core/Framework/Update/Api/UpdateController.php
@@ -224,7 +224,7 @@ class UpdateController extends AbstractController
             $this->systemConfig->set(self::UPDATE_PREVIOUS_VERSION_KEY, $update->version);
 
             return new JsonResponse([
-                'redirectTo' => $request->getBaseUrl() . '/recovery/update/index.php',
+                'redirectTo' => $request->getBasePath() . '/recovery/update/index.php',
             ]);
         }
 

--- a/src/Storefront/Framework/Routing/RequestTransformer.php
+++ b/src/Storefront/Framework/Routing/RequestTransformer.php
@@ -98,8 +98,14 @@ class RequestTransformer implements RequestTransformerInterface
             throw new SalesChannelMappingException($request->getUri());
         }
 
-        $absoluteBaseUrl = $this->getSchemeAndHttpHost($request) . $request->getBaseUrl();
-        $baseUrl = str_replace($absoluteBaseUrl, '', $salesChannel['url']);
+        $originalBaseUrl = $request->getBaseUrl();
+        $absoluteBaseUrl = $this->getSchemeAndHttpHost($request) . $originalBaseUrl;
+        $baseUrl = parse_url($salesChannel['url'], PHP_URL_PATH) ?? '';
+        if ($originalBaseUrl !== '') {
+            if (strpos($baseUrl, $originalBaseUrl) === 0) {
+                $baseUrl = substr($baseUrl, strlen($originalBaseUrl));
+            }
+        }
 
         $resolved = $this->resolveSeoUrl(
             $request,


### PR DESCRIPTION
### 1. Why is this change necessary?

1. baseUrl and basePath are not the same!

2. Urls are generated wrong, if the baseUrl are missing in sales channel config.

### 2. What does this change do, exactly?

1. It fixed the usage of baseUrl and basePath.

2. It's doesn't use sales channel config to find the right baseUrl.

### 3. Describe each step to reproduce the issue or behaviour.

1. Install shopware 6 in sub dir. (try https://github.com/hlohaus/shopware-subdir-project)
2. Forget to set the right sales channel url.
3. Open the storefront.

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.
