### PR TITLE
[fix/change-assign-mail] Bugfix if there is no email template found

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-state-change-modal/sw-order-state-change-modal-assign-mail-template/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-state-change-modal/sw-order-state-change-modal-assign-mail-template/index.js
@@ -137,9 +137,15 @@ Component.register('sw-order-state-change-modal-assign-mail-template', {
         fillValues() {
             const searchTerm = this.searchTerm;
             const criteria = this.mailTemplateSelectionCriteria().setLimit(10);
+            const fallBackCriteria = new Criteria();
+
+            fallBackCriteria.addAssociation('mailTemplateType');
 
             if (searchTerm) {
                 criteria.addFilter(
+                    Criteria.contains('description', searchTerm)
+                );
+                fallBackCriteria.addFilter(
                     Criteria.contains('description', searchTerm)
                 );
             }
@@ -156,6 +162,14 @@ Component.register('sw-order-state-change-modal-assign-mail-template', {
                 this.total = items.total;
                 this.mailTemplates = items;
                 this.isLoading = false;
+            }).finally(() => {
+                if (!this.total) {
+                    this.mailTemplateRepository.search(fallBackCriteria, Shopware.Context.api).then((items) => {
+                        this.total = items.total;
+                        this.mailTemplates = items;
+                        this.isLoading = false;
+                    });
+                }
             });
         },
 


### PR DESCRIPTION
### 1. Why is this change necessary?
To assign a mail template if none is found.

### 2. What does this change do, exactly?
Queries for every existing mail template if none is found bevore

### 3. Describe each step to reproduce the issue or behaviour.
For me the error popped up as I tried to switch the delivery state from cancelled to open.
There was no template visible for this so I couldn't change the state.

### 4. Please link to the relevant issues (if any).
///

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
