### PR TITLE
Add twig block to body class

### DIFF
--- a/src/Storefront/Resources/views/storefront/base.html.twig
+++ b/src/Storefront/Resources/views/storefront/base.html.twig
@@ -16,7 +16,7 @@
 {% endblock %}
 
 {% block base_body %}
-    <body class="is-ctl-{{ controllerName|lower }} is-act-{{ controllerAction|lower }}">
+    <body class="{% block base_body_classes %}is-ctl-{{ controllerName|lower }} is-act-{{ controllerAction|lower }}{% endblock %}">
     {% block base_body_inner %}
         {% block base_noscript %}
             <noscript class="noscript-main">

--- a/src/Storefront/Resources/views/storefront/page/content/single-cms-page.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/content/single-cms-page.html.twig
@@ -13,7 +13,7 @@
 {% endblock %}
 
 {% block single_cms_page_body %}
-    <body class="is-ctl-{{ controllerName|lower }} is-act-{{ controllerAction|lower }}">
+    <body class="{% block base_body_classes %}is-ctl-{{ controllerName|lower }} is-act-{{ controllerAction|lower }}{% endblock %}">
         {% block single_cms_page_body_inner %}
             {% block single_cms_page_noscript %}
                 <noscript class="noscript-main">

--- a/src/Storefront/Resources/views/storefront/page/content/single-cms-page.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/content/single-cms-page.html.twig
@@ -13,7 +13,7 @@
 {% endblock %}
 
 {% block single_cms_page_body %}
-    <body class="{% block base_body_classes %}is-ctl-{{ controllerName|lower }} is-act-{{ controllerAction|lower }}{% endblock %}">
+    <body class="{% block single_cms_page_body_classes %}is-ctl-{{ controllerName|lower }} is-act-{{ controllerAction|lower }}{% endblock %}">
         {% block single_cms_page_body_inner %}
             {% block single_cms_page_noscript %}
                 <noscript class="noscript-main">

--- a/src/Storefront/Resources/views/storefront/page/error/error-maintenance.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/error/error-maintenance.html.twig
@@ -13,7 +13,7 @@
 {% endblock %}
 
 {% block error_maintenance_body %}
-    <body class="{% block base_body_classes %}is-ctl-{{ controllerName|lower }} is-act-{{ controllerAction|lower }}{% endblock %}">
+    <body class="{% block error_maintenance_body_classes %}is-ctl-{{ controllerName|lower }} is-act-{{ controllerAction|lower }}{% endblock %}">
         {% block error_maintenance_body_inner %}
             {% block error_maintenance_noscript %}
                 <noscript class="noscript-main">

--- a/src/Storefront/Resources/views/storefront/page/error/error-maintenance.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/error/error-maintenance.html.twig
@@ -13,7 +13,7 @@
 {% endblock %}
 
 {% block error_maintenance_body %}
-    <body class="is-ctl-{{ controllerName|lower }} is-act-{{ controllerAction|lower }}">
+    <body class="{% block base_body_classes %}is-ctl-{{ controllerName|lower }} is-act-{{ controllerAction|lower }}{% endblock %}">
         {% block error_maintenance_body_inner %}
             {% block error_maintenance_noscript %}
                 <noscript class="noscript-main">


### PR DESCRIPTION
### 1. Why is this change necessary?
Currently there is no easy way to extend classes in body tag like in sw5

### 2. What does this change do, exactly?
Add twig block to body class

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
