### PR TITLE
Update 100-plugin-themes.md

### DIFF
--- a/src/Docs/Resources/current/2-internals/4-plugins/100-plugin-themes.md
+++ b/src/Docs/Resources/current/2-internals/4-plugins/100-plugin-themes.md
@@ -156,7 +156,7 @@ path to your theme.json.
 
 To trigger the build process of javascript, you can call 
 ```bash
-bin/console storefront:build
+./psh.phar storefront:build
 ``` 
 
 This will compile the javascript and trigger a rebuild of the theme, so all your script and style changes


### PR DESCRIPTION
Updated theme build command to the proper one

### 1. Why is this change necessary?
There are no commands defined in the "storefront" namespace. in bin/console

### 2. What does this change do, exactly?
Shows correct storefront:build command

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [x] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
