### PR TITLE
Use ProductStreamBuilderInterface

### DIFF
--- a/src/Core/Content/Product/SalesChannel/CrossSelling/SalesChannelCrossSellingController.php
+++ b/src/Core/Content/Product/SalesChannel/CrossSelling/SalesChannelCrossSellingController.php
@@ -7,7 +7,7 @@ use Shopware\Core\Content\Product\Aggregate\ProductCrossSelling\ProductCrossSell
 use Shopware\Core\Content\Product\Aggregate\ProductCrossSelling\ProductCrossSellingEntity;
 use Shopware\Core\Content\Product\ProductCollection;
 use Shopware\Core\Content\Product\ProductDefinition;
-use Shopware\Core\Content\ProductStream\Service\ProductStreamBuilder;
+use Shopware\Core\Content\ProductStream\Service\ProductStreamBuilderInterface;
 use Shopware\Core\Framework\Api\Converter\ApiVersionConverter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
@@ -46,7 +46,7 @@ class SalesChannelCrossSellingController extends AbstractController
     private $crossSellingDefinition;
 
     /**
-     * @var ProductStreamBuilder
+     * @var ProductStreamBuilderInterface
      */
     private $productStreamBuilder;
 
@@ -55,7 +55,7 @@ class SalesChannelCrossSellingController extends AbstractController
         ApiVersionConverter $apiVersionConverter,
         ProductDefinition $productDefinition,
         ProductCrossSellingDefinition $crossSellingDefinition,
-        ProductStreamBuilder $productStreamBuilder
+        ProductStreamBuilderInterface $productStreamBuilder
     ) {
         $this->productRepository = $productRepository;
         $this->apiVersionConverter = $apiVersionConverter;

--- a/src/Storefront/Page/Product/CrossSelling/CrossSellingLoader.php
+++ b/src/Storefront/Page/Product/CrossSelling/CrossSellingLoader.php
@@ -6,7 +6,7 @@ use Shopware\Core\Content\Product\Aggregate\ProductCrossSelling\ProductCrossSell
 use Shopware\Core\Content\Product\Aggregate\ProductCrossSelling\ProductCrossSellingEntity;
 use Shopware\Core\Content\Product\ProductCollection;
 use Shopware\Core\Content\Product\ProductEntity;
-use Shopware\Core\Content\ProductStream\Service\ProductStreamBuilder;
+use Shopware\Core\Content\ProductStream\Service\ProductStreamBuilderInterface;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepositoryInterface;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
@@ -30,7 +30,7 @@ class CrossSellingLoader
     private $crossSellingRepository;
 
     /**
-     * @var ProductStreamBuilder
+     * @var ProductStreamBuilderInterface
      */
     private $productStreamBuilder;
 
@@ -45,7 +45,7 @@ class CrossSellingLoader
     public function __construct(
         EntityRepositoryInterface $crossSellingRepository,
         EventDispatcherInterface $eventDispatcher,
-        ProductStreamBuilder $productStreamBuilder,
+        ProductStreamBuilderInterface $productStreamBuilder,
         SalesChannelRepositoryInterface $productRepository
     ) {
         $this->eventDispatcher = $eventDispatcher;


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/community).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well.
-->

### 1. Why is this change necessary?
Some classes expect an instance of `ProductStreamBuilder` instead of the corresponding interface which makes it hard to decorate said service.

### 2. What does this change do, exactly?
Modify the constructors of the `SalesChannelCrossSellingController` and `CrossSellingLoader` accordingly.

### 3. Describe each step to reproduce the issue or behaviour.

### 4. Please link to the relevant issues (if any).

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
