### PR TITLE
Add RemoteAddressField

### DIFF
--- a/src/Core/Framework/DataAbstractionLayer/SchemaGenerator.php
+++ b/src/Core/Framework/DataAbstractionLayer/SchemaGenerator.php
@@ -36,6 +36,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\PasswordField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\PriceDefinitionField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\PriceField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\ReferenceVersionField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\RemoteAddressField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\StorageAware;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\StringField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\TranslatedField;

--- a/src/Core/Framework/DataAbstractionLayer/SchemaGenerator.php
+++ b/src/Core/Framework/DataAbstractionLayer/SchemaGenerator.php
@@ -187,6 +187,12 @@ EOL;
                 $type = 'LONGBLOB';
 
                 break;
+
+            case $field instanceof RemoteAddressField:
+                $type = 'VARCHAR(255)';
+
+                break;
+
             default:
                 throw new \RuntimeException(sprintf('Unknown field %s', get_class($field)));
         }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/community).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
Without it the `dal:create:schema` command fails.

### 2. What does this change do, exactly?
It adds an existing, yet forgotten, field to the schema generator.


### 3. Describe each step to reproduce the issue or behaviour.
Install a shop from `shopware/development:v6.1-rc3` and run the command, you'll receive the following output:
```

DAL generate schema
===================


In SchemaGenerator.php line 191:
                                                                                       
  Unknown field Shopware\Core\Framework\DataAbstractionLayer\Field\RemoteAddressField  
                                                                                       

dal:create:schema [-h|--help] [-q|--quiet] [-v|vv|vvv|--verbose] [-V|--version] [--ansi] [--no-ansi] [-n|--no-interaction] [-e|--env ENV] [--no-debug] [--] <command>

```

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
