### PR TITLE
UpdatedAtField should not be required

### DIFF
--- a/src/Core/Framework/DataAbstractionLayer/Field/UpdatedAtField.php
+++ b/src/Core/Framework/DataAbstractionLayer/Field/UpdatedAtField.php
@@ -10,7 +10,6 @@ class UpdatedAtField extends DateTimeField
     public function __construct()
     {
         parent::__construct('updated_at', 'updatedAt');
-        $this->addFlags(new Required());
     }
 
     protected function getSerializerClass(): string

--- a/src/Core/Framework/DataAbstractionLayer/Write/WriteCommandExtractor.php
+++ b/src/Core/Framework/DataAbstractionLayer/Write/WriteCommandExtractor.php
@@ -5,6 +5,7 @@ namespace Shopware\Core\Framework\DataAbstractionLayer\Write;
 use Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\ChildrenAssociationField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\CreatedAtField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Field;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\FkField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\Computed;
@@ -337,7 +338,11 @@ class WriteCommandExtractor
      */
     private function getMainFields(array $fields): array
     {
-        $main = [];
+        $main = [
+            new CreatedAtField(),
+            new UpdatedAtField()
+        ];
+
         foreach ($fields as $field) {
             if ($field instanceof ChildrenAssociationField) {
                 continue;

--- a/src/Core/Framework/DataAbstractionLayer/Write/WriteCommandExtractor.php
+++ b/src/Core/Framework/DataAbstractionLayer/Write/WriteCommandExtractor.php
@@ -338,10 +338,7 @@ class WriteCommandExtractor
      */
     private function getMainFields(array $fields): array
     {
-        $main = [
-            new CreatedAtField(),
-            new UpdatedAtField()
-        ];
+        $main = [];
 
         foreach ($fields as $field) {
             if ($field instanceof ChildrenAssociationField) {
@@ -358,7 +355,11 @@ class WriteCommandExtractor
                 continue;
             }
 
-            if ($field instanceof FkField) {
+            if (
+                $field instanceof FkField
+                || $field instanceof CreatedAtField
+                || $field instanceof UpdatedAtField
+            ) {
                 $main[] = $field;
             }
         }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/community).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
I don't understand why this field is yet required. When you use `dal:create:schema` to generate your schema and entities the column is declared as "NOT NULL" but will not be automatically filled when creating the entity using the administration. Why so?

Alternative solution: Add a default value when saving an entity using the API.

### 2. What does this change do, exactly?
It removes the required flag.

### 3. Describe each step to reproduce the issue or behaviour.
Define a new entity with the UpdatedAtField, create a migration with the schema from `dal:create:schema` and create a new row using the API.

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
