### PR TITLE
Fixed the snippet text for Product Number in Storefront

### DIFF
--- a/src/Storefront/Resources/app/storefront/src/scss/page/product-detail/_product-detail.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/page/product-detail/_product-detail.scss
@@ -32,6 +32,6 @@
     margin-bottom: $spacer;
 }
 
-.product-detail-ordernumber-container {
+.product-detail-product-number-container {
     margin-bottom: $spacer;
 }

--- a/src/Storefront/Resources/app/storefront/src/scss/skin/shopware/page/product-detail/_product-detail.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/skin/shopware/page/product-detail/_product-detail.scss
@@ -13,7 +13,7 @@
     font-weight: $font-weight-bold;
 }
 
-.product-detail-ordernumber-label {
+.product-detail-product-number-label {
     font-weight: $font-weight-bold;
 }
 

--- a/src/Storefront/Resources/snippet/de_DE/storefront.de-DE.json
+++ b/src/Storefront/Resources/snippet/de_DE/storefront.de-DE.json
@@ -394,7 +394,7 @@
       "headline": "Zu \"%searchTerm%\" wurden %totalCount% Produkt(e) gefunden"
     },
     "detail": {
-        "ordernumberLabel": "Produkt-Nr.:",
+        "productNumberLabel": "Produkt-Nr.:",
         "addProduct": "In den Warenkorb",
         "tabsDescription": "Beschreibung",
         "tabsPreviewMore": "mehr",

--- a/src/Storefront/Resources/snippet/en_GB/storefront.en-GB.json
+++ b/src/Storefront/Resources/snippet/en_GB/storefront.en-GB.json
@@ -394,7 +394,7 @@
       "headline": "%totalCount% products found for \"%searchTerm%\""
     },
     "detail": {
-        "ordernumberLabel": "Order number: ",
+        "productNumberLabel": "Product number: ",
         "addProduct": "Add to shopping cart",
         "tabsDescription": "Description",
         "tabsPreviewMore": "More",

--- a/src/Storefront/Resources/views/storefront/component/product/quickview/minimal.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/product/quickview/minimal.html.twig
@@ -40,7 +40,7 @@
 
                         {% block component_product_quickview_minimal_product_number %}
                             <p class="quickview-minimal-product-number">
-                                {{ "detail.ordernumberLabel"|trans|sw_sanitize }} {{ page.product.productNumber }}
+                                {{ "detail.productNumberLabel"|trans|sw_sanitize }} {{ page.product.productNumber }}
                             </p>
                         {% endblock %}
 

--- a/src/Storefront/Resources/views/storefront/page/product-detail/buy-widget.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/product-detail/buy-widget.html.twig
@@ -170,19 +170,19 @@
             </div>
         {% endblock %}
 
-        {% block page_product_detail_ordernumber_container %}
+        {% block page_product_detail_product_number_container %}
             {% if page.product.productNumber %}
-                <div class="product-detail-ordernumber-container">
+                <div class="product-detail-product-number-container">
                     {% block page_product_detail_ordernumber_label %}
-                        <span class="product-detail-ordernumber-label">
-                            {{ "detail.ordernumberLabel"|trans|sw_sanitize }}
+                        <span class="product-detail-product-number-label">
+                            {{ "detail.productNumberLabel"|trans|sw_sanitize }}
                         </span>
                     {% endblock %}
 
-                    {% block page_product_detail_ordernumber %}
+                    {% block page_product_detail_product_number %}
                         <meta itemprop="productID"
                               content="{{ page.product.id }}"/>
-                        <span class="product-detail-ordernumber"
+                        <span class="product-detail-product-number"
                               itemprop="sku">
                             {{ page.product.productNumber }}
                         </span>


### PR DESCRIPTION
 1. Why is this change necessary?
To display a product number on the product details page in the storefront.

 2. What does this change do, exactly?
The label changed order number to product number.

3. Describe each step to reproduce the issue or behaviour.
Try to view the product details page in the storefront.

 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/NEXT-6206

 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [x] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
