### PR TITLE
Replace deprecated Symfony "spaceless" token parser with apply token

### DIFF
--- a/src/Storefront/Resources/views/storefront/element/cms-element-form/form-components/cms-element-form-textarea.html.twig
+++ b/src/Storefront/Resources/views/storefront/element/cms-element-form/form-components/cms-element-form-textarea.html.twig
@@ -7,7 +7,7 @@
         {% endblock %}
 
         {% block cms_element_form_textarea_textarea %}
-            {% spaceless %}
+            {% apply spaceless %}
                 <textarea name="{{ fieldName }}"
                           id="form-{{ fieldName }}"
                           placeholder="{{ placeholder|trans }}"
@@ -16,7 +16,7 @@
                           class="form-control{% if formViolations.getViolations( '/' ~ fieldName ) %} is-invalid{% endif %}">
                     {{ data.get(fieldName) }}
                 </textarea>
-            {% endspaceless %}
+            {% endapply %}
 
             {% if formViolations.getViolations( '/' ~ fieldName ) is not empty %}
                 {% sw_include '@Storefront/storefront/utilities/form-violation.html.twig' with {


### PR DESCRIPTION
`spaceless` token parser id deprecated and must replace with `apply spaceless`, its rightly used in other template but one file is still using it.

```
 * @deprecated since Twig 2.7, to be removed in 3.0 (use the spaceless filter instead)
 * @deprecated since Twig 2.9, to be removed in 3.0 (use the "apply" tag instead)
```