### PR TITLE
Update node-sass to version 4.13.0

### DIFF
--- a/src/Administration/Resources/app/administration/package-lock.json
+++ b/src/Administration/Resources/app/administration/package-lock.json
@@ -6424,9 +6424,9 @@
 			"dev": true
 		},
 		"globule": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/globule/-/globule-1.2.1.tgz",
-			"integrity": "sha512-g7QtgWF4uYSL5/dn71WxubOrS7JVGCnFPEnoeChJmBnyR9Mw8nGoEwOgJL/RC2Te0WhbsEUCejfH8SZNJ+adYQ==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/globule/-/globule-1.3.0.tgz",
+			"integrity": "sha512-YlD4kdMqRCQHrhVdonet4TdRtv1/sZKepvoxNT4Nrhrp5HI8XFfc8kFlGlBn2myBo80aGp8Eft259mbcUJhgSg==",
 			"dev": true,
 			"requires": {
 				"glob": "~7.1.1",
@@ -9346,9 +9346,9 @@
 			}
 		},
 		"node-sass": {
-			"version": "4.12.0",
-			"resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.12.0.tgz",
-			"integrity": "sha512-A1Iv4oN+Iel6EPv77/HddXErL2a+gZ4uBeZUy+a8O35CFYTXhgA8MgLCWBtwpGZdCvTvQ9d+bQxX/QC36GDPpQ==",
+			"version": "4.13.0",
+			"resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.13.0.tgz",
+			"integrity": "sha512-W1XBrvoJ1dy7VsvTAS5q1V45lREbTlZQqFbiHb3R3OTTCma0XBtuG6xZ6Z4506nR4lmHPTqVRwxT6KgtWC97CA==",
 			"dev": true,
 			"requires": {
 				"async-foreach": "^0.1.3",
@@ -9358,7 +9358,7 @@
 				"get-stdin": "^4.0.1",
 				"glob": "^7.0.3",
 				"in-publish": "^2.0.0",
-				"lodash": "^4.17.11",
+				"lodash": "^4.17.15",
 				"meow": "^3.7.0",
 				"mkdirp": "^0.5.1",
 				"nan": "^2.13.2",

--- a/src/Administration/Resources/app/administration/package.json
+++ b/src/Administration/Resources/app/administration/package.json
@@ -121,7 +121,7 @@
         "launch-editor-middleware": "2.2.1",
         "less": "3.9.0",
         "less-loader": "5.0.0",
-        "node-sass": "4.12.0",
+        "node-sass": "4.13.0",
         "opn": "6.0.0",
         "prismjs": "1.17.1",
         "sass-loader": "7.1.0",

--- a/src/Storefront/Resources/app/storefront/package-lock.json
+++ b/src/Storefront/Resources/app/storefront/package-lock.json
@@ -5735,9 +5735,9 @@
       "dev": true
     },
     "globule": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/globule/-/globule-1.2.1.tgz",
-      "integrity": "sha512-g7QtgWF4uYSL5/dn71WxubOrS7JVGCnFPEnoeChJmBnyR9Mw8nGoEwOgJL/RC2Te0WhbsEUCejfH8SZNJ+adYQ==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/globule/-/globule-1.3.0.tgz",
+      "integrity": "sha512-YlD4kdMqRCQHrhVdonet4TdRtv1/sZKepvoxNT4Nrhrp5HI8XFfc8kFlGlBn2myBo80aGp8Eft259mbcUJhgSg==",
       "dev": true,
       "requires": {
         "glob": "~7.1.1",
@@ -8840,9 +8840,9 @@
       }
     },
     "node-sass": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.12.0.tgz",
-      "integrity": "sha512-A1Iv4oN+Iel6EPv77/HddXErL2a+gZ4uBeZUy+a8O35CFYTXhgA8MgLCWBtwpGZdCvTvQ9d+bQxX/QC36GDPpQ==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.13.0.tgz",
+      "integrity": "sha512-W1XBrvoJ1dy7VsvTAS5q1V45lREbTlZQqFbiHb3R3OTTCma0XBtuG6xZ6Z4506nR4lmHPTqVRwxT6KgtWC97CA==",
       "dev": true,
       "requires": {
         "async-foreach": "^0.1.3",
@@ -8852,7 +8852,7 @@
         "get-stdin": "^4.0.1",
         "glob": "^7.0.3",
         "in-publish": "^2.0.0",
-        "lodash": "^4.17.11",
+        "lodash": "^4.17.15",
         "meow": "^3.7.0",
         "mkdirp": "^0.5.1",
         "nan": "^2.13.2",

--- a/src/Storefront/Resources/app/storefront/package.json
+++ b/src/Storefront/Resources/app/storefront/package.json
@@ -69,7 +69,7 @@
     "jest": "24.8.0",
     "jest-junit": "6.3.0",
     "mdn-polyfills": "5.18.0",
-    "node-sass": "4.12.0",
+    "node-sass": "4.13.0",
     "picturefill": "3.0.3",
     "postcss-loader": "3.0.0",
     "postcss-pxtorem": "4.0.1",


### PR DESCRIPTION
### 1. Why is this change necessary?
If you try to install the dependencies for the storefront and administration component with Node 13 it crashes as node-sass v4.12.0 is not compatible yet with Node 13.

### 2. What does this change do, exactly?
It changes the version of the node-sass dependency to 4.13.0.

### 3. Describe each step to reproduce the issue or behaviour.
Just run `npm clean_install` inside the `app/storefront` or `app/administration` folder while node 13 is installed.

### 4. Please link to the relevant issues (if any).
https://github.com/sass/node-sass/issues/2770

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.
