### PR TITLE
Prefer role Manufacturer in composer authors

### DIFF
--- a/src/Core/Framework/Plugin/PluginService.php
+++ b/src/Core/Framework/Plugin/PluginService.php
@@ -3,6 +3,7 @@
 namespace Shopware\Core\Framework\Plugin;
 
 use Composer\IO\IOInterface;
+use Composer\Package\CompletePackageInterface;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepositoryInterface;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
@@ -96,13 +97,7 @@ class PluginService
 
             $pluginVersion = $this->versionSanitizer->sanitizePluginVersion($info->getVersion());
             $extra = $info->getExtra();
-
-            $authors = null;
-            $composerAuthors = $info->getAuthors();
-            if ($composerAuthors !== null) {
-                $authorNames = array_column($info->getAuthors(), 'name');
-                $authors = implode(', ', $authorNames);
-            }
+            $authors = $this->getAuthors($info);
             $license = $info->getLicense();
             $pluginIconPath = $extra['plugin-icon'] ?? 'src/Resources/config/plugin.png';
 
@@ -237,5 +232,26 @@ class PluginService
         }
 
         return file_get_contents($pluginIconPath);
+    }
+
+    private function getAuthors(CompletePackageInterface $info): string
+    {
+        $authors = null;
+        $composerAuthors = $info->getAuthors();
+
+        if ($composerAuthors !== null) {
+            $manufacturersAuthors = array_filter($composerAuthors, function (array $author): bool {
+                return ($author['role'] ?? '') === 'Manufacturer';
+            });
+
+            if (empty($manufacturersAuthors)) {
+                $manufacturersAuthors = $composerAuthors;
+            }
+
+            $authorNames = array_column($manufacturersAuthors, 'name');
+            $authors = implode(', ', $authorNames);
+        }
+
+        return $authors;
     }
 }

--- a/src/Core/Framework/Test/Plugin/Requirement/_fixture/SwagRequirementInvalidTest/composer.json
+++ b/src/Core/Framework/Test/Plugin/Requirement/_fixture/SwagRequirementInvalidTest/composer.json
@@ -6,7 +6,8 @@
     "license": "MIT",
     "authors": [
         {
-            "name": "shopware AG"
+            "name": "shopware AG",
+            "role": "Manufacturer"
         }
     ],
     "require": {

--- a/src/Core/Framework/Test/Plugin/Requirement/_fixture/SwagRequirementValidSubpackageTest/composer.json
+++ b/src/Core/Framework/Test/Plugin/Requirement/_fixture/SwagRequirementValidSubpackageTest/composer.json
@@ -6,7 +6,8 @@
     "license": "MIT",
     "authors": [
         {
-            "name": "shopware AG"
+            "name": "shopware AG",
+            "role": "Manufacturer"
         }
     ],
     "require": {

--- a/src/Core/Framework/Test/Plugin/Requirement/_fixture/SwagRequirementValidSubpackageWildcardTest/composer.json
+++ b/src/Core/Framework/Test/Plugin/Requirement/_fixture/SwagRequirementValidSubpackageWildcardTest/composer.json
@@ -6,7 +6,8 @@
     "license": "MIT",
     "authors": [
         {
-            "name": "shopware AG"
+            "name": "shopware AG",
+            "role": "Manufacturer"
         }
     ],
     "require": {

--- a/src/Core/Framework/Test/Plugin/Requirement/_fixture/SwagRequirementValidTest/composer.json
+++ b/src/Core/Framework/Test/Plugin/Requirement/_fixture/SwagRequirementValidTest/composer.json
@@ -6,7 +6,8 @@
     "license": "MIT",
     "authors": [
         {
-            "name": "shopware AG"
+            "name": "shopware AG",
+            "role": "Manufacturer"
         }
     ],
     "require": {

--- a/src/Core/Framework/Test/Plugin/Util/_fixture/Composer/composer.json
+++ b/src/Core/Framework/Test/Plugin/Util/_fixture/Composer/composer.json
@@ -6,7 +6,8 @@
     "license": "MIT",
     "authors": [
         {
-            "name": "shopware AG"
+            "name": "shopware AG",
+            "role": "Manufacturer"
         }
     ],
     "require": {

--- a/src/Core/Framework/Test/Plugin/_fixture/plugins/SwagTest/composer.json
+++ b/src/Core/Framework/Test/Plugin/_fixture/plugins/SwagTest/composer.json
@@ -6,7 +6,12 @@
     "license": "MIT",
     "authors": [
         {
-            "name": "shopware AG"
+            "name": "shopware AG",
+            "role": "Manufacturer"
+        },
+        {
+            "name": "John Doe",
+            "role": "Developer"
         }
     ],
     "require": {

--- a/src/Core/System/Test/SystemConfig/_fixtures/SwagExampleTest/composer.json
+++ b/src/Core/System/Test/SystemConfig/_fixtures/SwagExampleTest/composer.json
@@ -6,7 +6,8 @@
     "license": "MIT",
     "authors": [
         {
-            "name": "shopware AG"
+            "name": "shopware AG",
+            "role": "Manufacturer"
         }
     ],
     "require": {

--- a/src/Core/System/Test/SystemConfig/_fixtures/SwagInvalidTest/composer.json
+++ b/src/Core/System/Test/SystemConfig/_fixtures/SwagInvalidTest/composer.json
@@ -6,7 +6,8 @@
     "license": "MIT",
     "authors": [
         {
-            "name": "shopware AG"
+            "name": "shopware AG",
+            "role": "Manufacturer"
         }
     ],
     "require": {

--- a/src/Docs/Resources/current/1-getting-started/35-indepth-guide-bundle/020-setup.md
+++ b/src/Docs/Resources/current/1-getting-started/35-indepth-guide-bundle/020-setup.md
@@ -44,7 +44,8 @@ After having a look at the [composer schema](https://getcomposer.org/doc/04-sche
     "license": "MIT",
     "authors": [
         {
-            "name": "shopware AG"
+            "name": "shopware AG",
+            "role": "Manufacturer"
         }
     ]
 }
@@ -150,7 +151,8 @@ Here's what the final `composer.json` looks like once all values described were 
     "license": "MIT",
     "authors": [
         {
-            "name": "shopware AG"
+            "name": "shopware AG",
+            "role": "Manufacturer"
         }
     ],
     "type": "shopware-platform-plugin",

--- a/src/Docs/Resources/current/2-internals/4-plugins/010-plugin-quick-start.md
+++ b/src/Docs/Resources/current/2-internals/4-plugins/010-plugin-quick-start.md
@@ -89,7 +89,8 @@ Here's a brief example of how this file could look like:
     "license": "MIT",
     "authors": [
         {
-            "name": "shopware AG"
+            "name": "shopware AG",
+            "role": "Manufacturer"
         }
     ],
     "require": {

--- a/src/Docs/Resources/current/2-internals/4-plugins/050-plugin-information.md
+++ b/src/Docs/Resources/current/2-internals/4-plugins/050-plugin-information.md
@@ -17,7 +17,8 @@ Have a look at the [composer schema](https://getcomposer.org/doc/04-schema.md), 
     "authors": [
         {
             "name": "Example Company",
-            "homepage": "https://my.example.com"
+            "homepage": "https://my.example.com",
+            "role": "Manufacturer"
         }
     ],
     "require": {
@@ -62,7 +63,7 @@ Have a look at the [composer schema](https://getcomposer.org/doc/04-schema.md), 
 | version                         | Current version of your plugin                                                                                                   |
 | type                            | Set the type to `shopware-platform-plugin`. Otherwise Shopware won't be able to recognize your plugin                            |
 | license                         | Provide the license model of your plugin, e.g. `MIT` or `proprietary`                                                            |
-| authors                         | Collection of the authors of your plugin                                                                                         |
+| authors                         | Collection of the authors of your plugin (preferred role `Manufacturer`)                                                         |
 | require                         | Add your dependencies here. This should be `shopware/platform`, but could also be another plugin or composer package             |
 | extra                           | The `extra` property is used to provide some Shopware specific information                                                       |
 | extra - shopware-plugin-class   | The fully qualified class name of your plugin's base class                                                                       |

--- a/src/Docs/Resources/current/4-how-to/120-plugin-dependencies.md
+++ b/src/Docs/Resources/current/4-how-to/120-plugin-dependencies.md
@@ -40,7 +40,8 @@ own `composer.json` as a key value pair:
     "license": "MIT",
     "authors": [
         {
-            "name": "shopware AG"
+            "name": "shopware AG",
+            "role": "Manufacturer"
         }
     ],
     "require": {


### PR DESCRIPTION
### 1. Why is this change necessary?
The composer specification allows any entry in the authors block. So anyone can be an author of a plugin. Like those who test it, those who add translations for various languages or those who code. It is really nice that shopware tries to honour everyone and shows them in the plugin list but in the end the company is important. To have both options (list everyone, just the company) a specific role is preferred for display.

### 2. What does this change do, exactly?
It checks the author list whether the role `Manufacturer` is used and takes these entries instead of all. If the role is not used everyone is still in the list.

### 3. Describe each step to reproduce the issue or behaviour.
Have multiple authors
```json
{
    "authors": [
        { "name": "ACME", "role": "Manufacturer" },
        { "name": "Niklas Dzösch", "role": "Shopware Evangelist" },
        { "name": "Joshua Behrens", "role": "Developer" }
    ]
}
```
1. Run `bin/console plugin:refresh`
2. See author list: `ACME, Niklas Dzösch, Joshua Behrens`
3. Wait I just want to thank Niklas Dzösch for his help and his code. He is not part of ACME and I am not the one licensing the plugin!

### 4. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
