### PR TITLE
isCanonical is nullable

### DIFF
--- a/src/Core/Content/Seo/SeoUrl/SeoUrlEntity.php
+++ b/src/Core/Content/Seo/SeoUrl/SeoUrlEntity.php
@@ -146,12 +146,12 @@ class SeoUrlEntity extends Entity
         $this->seoPathInfo = $seoPathInfo;
     }
 
-    public function getIsCanonical(): bool
+    public function getIsCanonical(): ?bool
     {
         return $this->isCanonical;
     }
 
-    public function setIsCanonical(bool $isCanonical): void
+    public function setIsCanonical(?bool $isCanonical): void
     {
         $this->isCanonical = $isCanonical;
     }


### PR DESCRIPTION
### 1. Why is this change necessary?
The field isCanonical is nullable in many cases

### 2. What does this change do, exactly?
Make it possible that the field can be null in the struct

### 3. Describe each step to reproduce the issue or behaviour.

-
### 4. Please link to the relevant issues (if any).
-

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.
