### PR TITLE
NEXT-6212 - Added additional check before adding mediaId

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-cms/service/cms.service.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/service/cms.service.js
@@ -93,7 +93,7 @@ function getEntityData(element, configKey) {
     if (Array.isArray(configValue)) {
         const entityIds = [];
 
-        if (configValue[0].mediaId) {
+        if (configValue.length && configValue[0].mediaId) {
             configValue.forEach((val) => {
                 entityIds.push(val.mediaId);
             });


### PR DESCRIPTION
### 1. Why is this change necessary?
If you use the media entity in your cms element and it is not required you will always get the following js error as long as it is empty.

`index.js?8ca6:281 Uncaught (in promise) TypeError: Cannot read property 'statusText' of undefined`

### 2. What does this change do, exactly?
This change adds an additional check to avoid that empty config values are added to the entity search criteria.

### 3. Describe each step to reproduce the issue or behaviour.
- remove 'required: true' from the default image slider cms element
- add slider element to your cms page
- save
- enjoy error

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/NEXT-6212
https://issues.shopware.com/issues/NEXT-6188

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
