### PR TITLE
Fix grammar in migration command

### DIFF
--- a/src/Core/Framework/Migration/Command/MigrationCommand.php
+++ b/src/Core/Framework/Migration/Command/MigrationCommand.php
@@ -123,7 +123,7 @@ class MigrationCommand extends Command
         $this->io->table(
             ['Action', 'Number of migrations'],
             [
-                ['Migrated', $migrated . ' from ' . $total],
+                ['Migrated', $migrated . ' out of ' . $total],
             ]
         );
     }


### PR DESCRIPTION
### 1. Why is this change necessary?
It is not.

### 2. What does this change do, exactly?
Change the word `from` to the words `out of` as in `4 out of 6`.

### 3. Describe each step to reproduce the issue or behaviour.
1. Create a migration.
2. Execute `database:migrate`.
3. See the output `Migrated 1 from 1`.

### 4. Please link to the relevant issues (if any).
None.

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
