### PR TITLE
Make strip tags in DAL optional

### DIFF
--- a/src/Core/Content/Category/Aggregate/CategoryTranslation/CategoryTranslationDefinition.php
+++ b/src/Core/Content/Category/Aggregate/CategoryTranslation/CategoryTranslationDefinition.php
@@ -5,11 +5,12 @@ namespace Shopware\Core\Content\Category\Aggregate\CategoryTranslation;
 use Shopware\Core\Content\Category\CategoryDefinition;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityTranslationDefinition;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\CustomFields;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\AllowHtml;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\Required;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\WriteProtected;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\JsonField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\ListField;
-use Shopware\Core\Framework\DataAbstractionLayer\Field\LongTextWithHtmlField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\LongTextField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\StringField;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 
@@ -44,10 +45,10 @@ class CategoryTranslationDefinition extends EntityTranslationDefinition
             (new ListField('breadcrumb', 'breadcrumb', StringField::class))->addFlags(new WriteProtected()),
             new JsonField('slot_config', 'slotConfig'),
             new StringField('external_link', 'externalLink'),
-            new LongTextWithHtmlField('description', 'description'),
-            new LongTextWithHtmlField('meta_title', 'metaTitle'),
-            new LongTextWithHtmlField('meta_description', 'metaDescription'),
-            new LongTextWithHtmlField('keywords', 'keywords'),
+            (new LongTextField('description', 'description'))->addFlags(new AllowHtml()),
+            (new LongTextField('meta_title', 'metaTitle'))->addFlags(new AllowHtml()),
+            (new LongTextField('meta_description', 'metaDescription'))->addFlags(new AllowHtml()),
+            (new LongTextField('keywords', 'keywords'))->addFlags(new AllowHtml()),
 
             new CustomFields(),
         ]);

--- a/src/Core/Content/ImportExport/Mapping/FieldValueParser.php
+++ b/src/Core/Content/ImportExport/Mapping/FieldValueParser.php
@@ -12,7 +12,6 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\FloatField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\IntField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\JsonField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\LongTextField;
-use Shopware\Core\Framework\DataAbstractionLayer\Field\LongTextWithHtmlField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\ManyToManyAssociationField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\ManyToOneAssociationField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\OneToManyAssociationField;
@@ -105,7 +104,6 @@ class FieldValueParser
                 return (int) $value;
             case $field instanceof StringField:
             case $field instanceof LongTextField:
-            case $field instanceof LongTextWithHtmlField:
             case $field instanceof FkField:
                 return (string) $value;
             case $field instanceof DateField:

--- a/src/Core/Content/MailTemplate/Aggregate/MailHeaderFooterTranslation/MailHeaderFooterTranslationDefinition.php
+++ b/src/Core/Content/MailTemplate/Aggregate/MailHeaderFooterTranslation/MailHeaderFooterTranslationDefinition.php
@@ -4,9 +4,9 @@ namespace Shopware\Core\Content\MailTemplate\Aggregate\MailHeaderFooterTranslati
 
 use Shopware\Core\Content\MailTemplate\Aggregate\MailHeaderFooter\MailHeaderFooterDefinition;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityTranslationDefinition;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\AllowHtml;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\Required;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\LongTextField;
-use Shopware\Core\Framework\DataAbstractionLayer\Field\LongTextWithHtmlField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\StringField;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 
@@ -39,9 +39,9 @@ class MailHeaderFooterTranslationDefinition extends EntityTranslationDefinition
         return new FieldCollection([
             (new StringField('name', 'name'))->setFlags(new Required()),
             new StringField('description', 'description'),
-            new LongTextWithHtmlField('header_html', 'headerHtml'),
+            (new LongTextField('header_html', 'headerHtml'))->addFlags(new AllowHtml()),
             new LongTextField('header_plain', 'headerPlain'),
-            new LongTextWithHtmlField('footer_html', 'footerHtml'),
+            (new LongTextField('footer_html', 'footerHtml'))->addFlags(new AllowHtml()),
             new LongTextField('footer_plain', 'footerPlain'),
         ]);
     }

--- a/src/Core/Content/MailTemplate/Aggregate/MailTemplateTranslation/MailTemplateTranslationDefinition.php
+++ b/src/Core/Content/MailTemplate/Aggregate/MailTemplateTranslation/MailTemplateTranslationDefinition.php
@@ -5,9 +5,9 @@ namespace Shopware\Core\Content\MailTemplate\Aggregate\MailTemplateTranslation;
 use Shopware\Core\Content\MailTemplate\MailTemplateDefinition;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityTranslationDefinition;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\CustomFields;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\AllowHtml;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\Required;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\LongTextField;
-use Shopware\Core\Framework\DataAbstractionLayer\Field\LongTextWithHtmlField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\StringField;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 
@@ -41,7 +41,7 @@ class MailTemplateTranslationDefinition extends EntityTranslationDefinition
             new StringField('sender_name', 'senderName'),
             new LongTextField('description', 'description'),
             (new StringField('subject', 'subject'))->setFlags(new Required()),
-            (new LongTextWithHtmlField('content_html', 'contentHtml'))->setFlags(new Required()),
+            (new LongTextField('content_html', 'contentHtml'))->setFlags(new Required(), new AllowHtml()),
             (new LongTextField('content_plain', 'contentPlain'))->setFlags(new Required()),
 
             new CustomFields(),

--- a/src/Core/Content/Product/Aggregate/ProductManufacturerTranslation/ProductManufacturerTranslationDefinition.php
+++ b/src/Core/Content/Product/Aggregate/ProductManufacturerTranslation/ProductManufacturerTranslationDefinition.php
@@ -5,8 +5,9 @@ namespace Shopware\Core\Content\Product\Aggregate\ProductManufacturerTranslation
 use Shopware\Core\Content\Product\Aggregate\ProductManufacturer\ProductManufacturerDefinition;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityTranslationDefinition;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\CustomFields;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\AllowHtml;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\Required;
-use Shopware\Core\Framework\DataAbstractionLayer\Field\LongTextWithHtmlField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\LongTextField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\StringField;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 
@@ -38,7 +39,7 @@ class ProductManufacturerTranslationDefinition extends EntityTranslationDefiniti
     {
         return new FieldCollection([
             (new StringField('name', 'name'))->addFlags(new Required()),
-            new LongTextWithHtmlField('description', 'description'),
+            (new LongTextField('description', 'description'))->addFlags(new AllowHtml()),
 
             new CustomFields(),
         ]);

--- a/src/Core/Content/Product/Aggregate/ProductReview/ProductReviewDefinition.php
+++ b/src/Core/Content/Product/Aggregate/ProductReview/ProductReviewDefinition.php
@@ -9,6 +9,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\BoolField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\CreatedAtField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\FkField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\AllowHtml;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\PrimaryKey;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\ReadProtected;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\Required;
@@ -16,7 +17,6 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\SearchRanking;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\FloatField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\IdField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\LongTextField;
-use Shopware\Core\Framework\DataAbstractionLayer\Field\LongTextWithHtmlField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\ManyToOneAssociationField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\ReferenceVersionField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\StringField;
@@ -61,7 +61,7 @@ class ProductReviewDefinition extends EntityDefinition
             (new StringField('external_user', 'externalUser'))->addFlags(new SearchRanking(SearchRanking::MIDDLE_SEARCH_RANKING)),
             (new StringField('external_email', 'externalEmail'))->addFlags(new SearchRanking(SearchRanking::MIDDLE_SEARCH_RANKING)),
             (new StringField('title', 'title'))->addFlags(new Required(), new SearchRanking(SearchRanking::LOW_SEARCH_RAKING)),
-            (new LongTextWithHtmlField('content', 'content'))->addFlags(new Required(), new SearchRanking(SearchRanking::LOW_SEARCH_RAKING)),
+            (new LongTextField('content', 'content'))->addFlags(new Required(), new SearchRanking(SearchRanking::LOW_SEARCH_RAKING), new AllowHtml()),
             new FloatField('points', 'points'),
             new BoolField('status', 'status'),
             new LongTextField('comment', 'comment'),

--- a/src/Core/Content/Product/Aggregate/ProductTranslation/ProductTranslationDefinition.php
+++ b/src/Core/Content/Product/Aggregate/ProductTranslation/ProductTranslationDefinition.php
@@ -5,9 +5,9 @@ namespace Shopware\Core\Content\Product\Aggregate\ProductTranslation;
 use Shopware\Core\Content\Product\ProductDefinition;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityTranslationDefinition;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\CustomFields;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\AllowHtml;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\Required;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\LongTextField;
-use Shopware\Core\Framework\DataAbstractionLayer\Field\LongTextWithHtmlField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\StringField;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 
@@ -46,7 +46,7 @@ class ProductTranslationDefinition extends EntityTranslationDefinition
             new StringField('meta_description', 'metaDescription'),
             (new StringField('name', 'name'))->addFlags(new Required()),
             new LongTextField('keywords', 'keywords'),
-            new LongTextWithHtmlField('description', 'description'),
+            (new LongTextField('description', 'description'))->addFlags(new AllowHtml()),
             new StringField('meta_title', 'metaTitle'),
             new StringField('pack_unit', 'packUnit'),
 

--- a/src/Core/Content/ProductExport/ProductExportDefinition.php
+++ b/src/Core/Content/ProductExport/ProductExportDefinition.php
@@ -7,11 +7,11 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\BoolField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\DateTimeField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\FkField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\AllowHtml;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\PrimaryKey;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\Required;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\IdField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\IntField;
-use Shopware\Core\Framework\DataAbstractionLayer\Field\LongTextWithHtmlField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\ManyToOneAssociationField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\StringField;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
@@ -55,9 +55,9 @@ class ProductExportDefinition extends EntityDefinition
             (new BoolField('generate_by_cronjob', 'generateByCronjob'))->addFlags(new Required()),
             new DateTimeField('generated_at', 'generatedAt'),
             (new IntField('interval', 'interval'))->addFlags(new Required()),
-            new LongTextWithHtmlField('header_template', 'headerTemplate'),
-            new LongTextWithHtmlField('body_template', 'bodyTemplate'),
-            new LongTextWithHtmlField('footer_template', 'footerTemplate'),
+            (new LongTextField('header_template', 'headerTemplate'))->addFlags(new AllowHtml()),
+            (new LongTextField('body_template', 'bodyTemplate'))->addFlags(new AllowHtml()),
+            (new LongTextField('footer_template', 'footerTemplate'))->addFlags(new AllowHtml()),
 
             new ManyToOneAssociationField('productStream', 'product_stream_id', ProductStreamDefinition::class, 'id', false),
             new ManyToOneAssociationField('storefrontSalesChannel', 'storefront_sales_channel_id', SalesChannelDefinition::class, 'id', false),

--- a/src/Core/Framework/Api/ApiDefinition/Generator/EntitySchemaGenerator.php
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/EntitySchemaGenerator.php
@@ -213,7 +213,6 @@ class EntitySchemaGenerator implements ApiDefinitionGeneratorInterface
             // long text fields
             case $field instanceof TreePathField:
             case $field instanceof LongTextField:
-            case $field instanceof LongTextWithHtmlField:
                 return ['type' => 'text', 'flags' => $flags];
 
             // date fields

--- a/src/Core/Framework/DataAbstractionLayer/EntityGenerator.php
+++ b/src/Core/Framework/DataAbstractionLayer/EntityGenerator.php
@@ -22,7 +22,6 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\IntField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\JsonField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\ListingPriceField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\LongTextField;
-use Shopware\Core\Framework\DataAbstractionLayer\Field\LongTextWithHtmlField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\ManyToManyAssociationField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\ManyToOneAssociationField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\OneToManyAssociationField;
@@ -52,7 +51,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityIdTrait;
 class #entity#Entity extends Entity
 {
     use EntityIdTrait;
-    
+
     #properties#
 
 #functions#
@@ -242,7 +241,6 @@ EOF;
 
                 break;
             case $field instanceof LongTextField:
-            case $field instanceof LongTextWithHtmlField:
                 $type = 'string';
 
                 break;

--- a/src/Core/Framework/DataAbstractionLayer/Field/Flag/AllowHtml.php
+++ b/src/Core/Framework/DataAbstractionLayer/Field/Flag/AllowHtml.php
@@ -1,0 +1,14 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\DataAbstractionLayer\Field\Flag;
+
+/**
+ * In case a column is allowed to contain HTML-esque data. Beware of injection possibilities
+ */
+class AllowHtml extends Flag
+{
+    public function parse(): \Generator
+    {
+        yield 'allow_html' => true;
+    }
+}

--- a/src/Core/Framework/DataAbstractionLayer/Field/LongTextWithHtmlField.php
+++ b/src/Core/Framework/DataAbstractionLayer/Field/LongTextWithHtmlField.php
@@ -2,28 +2,18 @@
 
 namespace Shopware\Core\Framework\DataAbstractionLayer\Field;
 
-use Shopware\Core\Framework\DataAbstractionLayer\FieldSerializer\LongTextWithHtmlFieldSerializer;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\AllowHtml;
 
-class LongTextWithHtmlField extends Field implements StorageAware
+/**
+ * @deprecated Use LongTextField with AllowHtml flag instead
+ * @see AllowHtml
+ * @see LongTextField
+ */
+class LongTextWithHtmlField extends LongTextField
 {
-    /**
-     * @var string
-     */
-    private $storageName;
-
     public function __construct(string $storageName, string $propertyName)
     {
-        $this->storageName = $storageName;
-        parent::__construct($propertyName);
-    }
-
-    public function getStorageName(): string
-    {
-        return $this->storageName;
-    }
-
-    protected function getSerializerClass(): string
-    {
-        return LongTextWithHtmlFieldSerializer::class;
+        parent::__construct($storageName, $propertyName);
+        $this->addFlags(new AllowHtml());
     }
 }

--- a/src/Core/Framework/DataAbstractionLayer/FieldSerializer/LongTextFieldSerializer.php
+++ b/src/Core/Framework/DataAbstractionLayer/FieldSerializer/LongTextFieldSerializer.php
@@ -5,6 +5,7 @@ namespace Shopware\Core\Framework\DataAbstractionLayer\FieldSerializer;
 
 use Shopware\Core\Framework\DataAbstractionLayer\Exception\InvalidSerializerFieldException;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Field;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\AllowHtml;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\LongTextField;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\DataStack\KeyValuePair;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\EntityExistence;
@@ -31,7 +32,7 @@ class LongTextFieldSerializer extends AbstractFieldSerializer
         $this->validateIfNeeded($field, $existence, $data, $parameters);
 
         $value = $data->getValue();
-        if ($value !== null) {
+        if ($value !== null && !$field->is(AllowHtml::class)) {
             $value = strip_tags((string) $value);
         }
 

--- a/src/Core/Framework/DataAbstractionLayer/FieldSerializer/LongTextWithHtmlFieldSerializer.php
+++ b/src/Core/Framework/DataAbstractionLayer/FieldSerializer/LongTextWithHtmlFieldSerializer.php
@@ -5,11 +5,16 @@ namespace Shopware\Core\Framework\DataAbstractionLayer\FieldSerializer;
 
 use Shopware\Core\Framework\DataAbstractionLayer\Exception\InvalidSerializerFieldException;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Field;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\AllowHtml;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\LongTextWithHtmlField;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\DataStack\KeyValuePair;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\EntityExistence;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\WriteParameterBag;
 
+/**
+ * @deprecated Use the flag AllowHtml instead to prevent strip_tags
+ * @see AllowHtml
+ */
 class LongTextWithHtmlFieldSerializer extends AbstractFieldSerializer
 {
     public function encode(

--- a/src/Core/Framework/DataAbstractionLayer/FieldSerializer/StringFieldSerializer.php
+++ b/src/Core/Framework/DataAbstractionLayer/FieldSerializer/StringFieldSerializer.php
@@ -5,7 +5,7 @@ namespace Shopware\Core\Framework\DataAbstractionLayer\FieldSerializer;
 
 use Shopware\Core\Framework\DataAbstractionLayer\Exception\InvalidSerializerFieldException;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Field;
-use Shopware\Core\Framework\DataAbstractionLayer\Field\LongTextField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\AllowHtml;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\StringField;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\DataStack\KeyValuePair;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\EntityExistence;
@@ -32,8 +32,14 @@ class StringFieldSerializer extends AbstractFieldSerializer
 
         $this->validateIfNeeded($field, $existence, $data, $parameters);
 
-        /* @var LongTextField $field */
-        yield $field->getStorageName() => $data->getValue() !== null ? strip_tags((string) $data->getValue()) : null;
+        $value = $data->getValue();
+
+        if ($value !== null && !$field->is(AllowHtml::class)) {
+            $value = strip_tags((string)$value);
+        }
+
+        /* @var StringField $field */
+        yield $field->getStorageName() => $value !== null ? (string)$value : null;
     }
 
     public function decode(Field $field, $value): ?string

--- a/src/Core/Framework/DataAbstractionLayer/SchemaGenerator.php
+++ b/src/Core/Framework/DataAbstractionLayer/SchemaGenerator.php
@@ -27,7 +27,6 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\JsonField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\ListField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\ListingPriceField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\LongTextField;
-use Shopware\Core\Framework\DataAbstractionLayer\Field\LongTextWithHtmlField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\ManyToOneAssociationField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\OneToManyAssociationField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\ParentAssociationField;
@@ -153,7 +152,6 @@ EOL;
 
             case $field instanceof TreePathField:
             case $field instanceof LongTextField:
-            case $field instanceof LongTextWithHtmlField:
                 $type = 'LONGTEXT';
 
                 break;

--- a/src/Core/System/CustomField/CustomFieldService.php
+++ b/src/Core/System/CustomField/CustomFieldService.php
@@ -7,11 +7,11 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityRepositoryInterface;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\BoolField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\DateTimeField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Field;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\AllowHtml;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\FloatField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\IntField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\JsonField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\LongTextField;
-use Shopware\Core\Framework\DataAbstractionLayer\Field\LongTextWithHtmlField;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
@@ -57,7 +57,7 @@ class CustomFieldService implements EventSubscriberInterface
                 return new LongTextField($attributeName, $attributeName);
 
             case CustomFieldTypes::HTML:
-                return new LongTextWithHtmlField($attributeName, $attributeName);
+                return (new LongTextField($attributeName, $attributeName))->addFlags(new AllowHtml());
 
             case CustomFieldTypes::JSON:
             default:

--- a/src/Core/System/SalesChannel/Aggregate/SalesChannelTypeTranslation/SalesChannelTypeTranslationDefinition.php
+++ b/src/Core/System/SalesChannel/Aggregate/SalesChannelTypeTranslation/SalesChannelTypeTranslationDefinition.php
@@ -4,8 +4,9 @@ namespace Shopware\Core\System\SalesChannel\Aggregate\SalesChannelTypeTranslatio
 
 use Shopware\Core\Framework\DataAbstractionLayer\EntityTranslationDefinition;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\CustomFields;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\AllowHtml;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\Required;
-use Shopware\Core\Framework\DataAbstractionLayer\Field\LongTextWithHtmlField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\LongTextField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\StringField;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\System\SalesChannel\Aggregate\SalesChannelType\SalesChannelTypeDefinition;
@@ -40,7 +41,7 @@ class SalesChannelTypeTranslationDefinition extends EntityTranslationDefinition
             (new StringField('name', 'name'))->addFlags(new Required()),
             new StringField('manufacturer', 'manufacturer'),
             new StringField('description', 'description'),
-            new LongTextWithHtmlField('description_long', 'descriptionLong'),
+            (new LongTextField('description_long', 'descriptionLong'))->addFlags(new AllowHtml()),
             new CustomFields(),
         ]);
     }

--- a/src/Core/System/Snippet/SnippetDefinition.php
+++ b/src/Core/System/Snippet/SnippetDefinition.php
@@ -5,11 +5,12 @@ namespace Shopware\Core\System\Snippet;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\CustomFields;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\FkField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\AllowHtml;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\PrimaryKey;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\Required;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\SearchRanking;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\IdField;
-use Shopware\Core\Framework\DataAbstractionLayer\Field\LongTextWithHtmlField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\LongTextField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\ManyToOneAssociationField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\StringField;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
@@ -45,7 +46,7 @@ class SnippetDefinition extends EntityDefinition
             (new IdField('id', 'id'))->addFlags(new PrimaryKey(), new Required()),
             (new FkField('snippet_set_id', 'setId', SnippetSetDefinition::class))->addFlags(new Required()),
             (new StringField('translation_key', 'translationKey'))->addFlags(new Required(), new SearchRanking(SearchRanking::HIGH_SEARCH_RANKING)),
-            (new LongTextWithHtmlField('value', 'value'))->addFlags(new Required(), new SearchRanking(SearchRanking::HIGH_SEARCH_RANKING)),
+            (new LongTextField('value', 'value'))->addFlags(new Required(), new SearchRanking(SearchRanking::HIGH_SEARCH_RANKING), new AllowHtml()),
             (new StringField('author', 'author'))->addFlags(new Required(), new SearchRanking(SearchRanking::HIGH_SEARCH_RANKING)),
             new CustomFields(),
             new ManyToOneAssociationField('set', 'snippet_set_id', SnippetSetDefinition::class, 'id', false),

--- a/src/Elasticsearch/Framework/Indexing/EntityMapper.php
+++ b/src/Elasticsearch/Framework/Indexing/EntityMapper.php
@@ -22,7 +22,6 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\JsonField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\ListField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\ListingPriceField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\LongTextField;
-use Shopware\Core\Framework\DataAbstractionLayer\Field\LongTextWithHtmlField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\ManyToManyAssociationField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\ManyToOneAssociationField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\ObjectField;
@@ -129,7 +128,6 @@ class EntityMapper
                 return ['type' => 'object', 'properties' => $properties];
 
             case $field instanceof LongTextField:
-            case $field instanceof LongTextWithHtmlField:
                 return ['type' => 'text'];
 
             case $field instanceof TranslatedField:


### PR DESCRIPTION
### 1. Why is this change necessary?
If you want to add something like `party <alarm>` into the database in a normal string field it is impossible using DAL because string fields are strip_tagged by default. 

### 2. What does this change do, exactly?
Makes the strip tags dependent on the flag allow html so it is more flexible.

### 3. Describe each step to reproduce the issue or behaviour.
1. Make new char(255) column
2. Store email recipient like user names (`party <alarm>`)
3. Reload page and only see `party ` (beware of free-range spaces)
4. Where is the `alarm` part?

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
