### PR TITLE
Fix JS source maps for production builds

### DIFF
--- a/src/Administration/Resources/app/administration/build/webpack.prod.conf.js
+++ b/src/Administration/Resources/app/administration/build/webpack.prod.conf.js
@@ -32,7 +32,7 @@ let webpackConfig = merge(baseWebpackConfig, {
                 },
                 cache: true,
                 parallel: true,
-                sourceMap: false
+                sourceMap: config.build.productionSourceMap
             }),
             new OptimizeCSSAssetsPlugin()
         ]


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/community).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
The JS source maps are currently not working for the production builds of the administration. This makes debugging pretty hard.

### 2. What does this change do, exactly?
This re-enables the source maps (depending on the config set in `src/Administration/Resources/app/administration/config/index.js`)

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
