### PR TITLE
Fix missing unix socket usage in DatabaseConnectionInformation

### DIFF
--- a/src/Recovery/Install/src/app.php
+++ b/src/Recovery/Install/src/app.php
@@ -279,6 +279,7 @@ $app->any('/database-configuration/', function (ServerRequestInterface $request,
     $connectionInfo->port = $databaseParameters['port'];
     $connectionInfo->databaseName = $databaseParameters['database'];
     $connectionInfo->password = $databaseParameters['password'];
+    $connectionInfo->socket = $databaseParameters['socket'];
 
     try {
         try {


### PR DESCRIPTION
### 1. Why is this change necessary?
We tried to install Shopware 6 on Google Cloud Run with Google Cloud SQL.
The default Google Cloud SQL Proxy runs over UNIX Socket.

But the installation doesn't add the socket to the DatabaseConnectionInformation.
So the Factory can't create the correct connection.

### 2. What does this change do, exactly?
Add unix socket input from installation form to DatabaseConnectionInformation.

### 3. Describe each step to reproduce the issue or behaviour.
Create a MySQL database with unix socket, not TCP. Start recovery installation and fill the optional unix socket input field. Clickt next. Then an error appears with SQLSTATE2002 Not path or file found

### 4. Please link to the relevant issues (if any).
x

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
