### PR TITLE
Add border settings to sw-color-badge for contrast options

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/utils/sw-color-badge/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/utils/sw-color-badge/index.js
@@ -17,6 +17,8 @@ const { Component } = Shopware;
  *     <sw-color-badge color="green"></sw-color-badge>
  *     <!-- red circle -->
  *     <sw-color-badge color="red" rounded></sw-color-badge>
+ *     <!-- white circle with black border (readability on light backgrounds) -->
+ *     <sw-color-badge color="red" borderColor="black" borderWidth="1px" rounded></sw-color-badge>
  * </div>
  */
 Component.register('sw-color-badge', {
@@ -33,6 +35,21 @@ Component.register('sw-color-badge', {
             required: false,
             default: ''
         },
+        borderColor: {
+            type: String,
+            required: false,
+            default: ''
+        },
+        borderWidth: {
+            type: String,
+            required: false,
+            default: ''
+        },
+        borderStyle: {
+            type: String,
+            required: false,
+            default: ''
+        },
         rounded: {
             type: Boolean,
             required: false,
@@ -42,10 +59,16 @@ Component.register('sw-color-badge', {
 
     computed: {
         colorStyle() {
-            if (!this.color.length) {
-                return '';
+            const colorSetter = this.color.length ? `background:${this.color};` : '';
+            const borderColorSetter = this.borderColor.length ? `border-color:${this.borderColor};` : '';
+            const borderWidthSetter = this.borderWidth.length ? `border-width:${this.borderWidth};` : '';
+            let borderStyleSetter = '';
+
+            if (this.borderColor.length && this.borderWidth.length) {
+                borderStyleSetter = `border-style:${this.borderStyle.length ? this.borderStyle : 'solid'};`;
             }
-            return `background:${this.color}`;
+
+            return colorSetter + borderColorSetter + borderWidthSetter + borderStyleSetter;
         },
         variantClass() {
             return {


### PR DESCRIPTION
### 1. Why is this change necessary?
The color badge can be used anywhere. If used on the admin menu sidebar it will be displayed on a dark background. Used within a page you have a light background. To maintain readability of the color a border can be used to have a readability contrast.

### 2. What does this change do, exactly?
Add options to influence border-width, border-style and border-color style properties.

### 3. Describe each step to reproduce the issue or behaviour.
Display the same color badge either on a page or the admin menu sidebar. You will see that a yellow indicator is not readable in both occasions.

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
