### PR TITLE
Property group reordering

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-property/component/sw-property-detail-base/sw-property-detail-base.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-property/component/sw-property-detail-base/sw-property-detail-base.html.twig
@@ -31,6 +31,16 @@
                         <option slot="options" v-for="option in sortingTypes" :key="option.value" :value="option.value">{{ option.label }}</option>
                     </sw-field>
                 {% endblock %}
+
+                {% block sw_property_detail_position %}
+                    <sw-number-field
+                            v-model="propertyGroup.position"
+                            pattern="[0-9]"
+                            :step="1"
+                            :label="$tc('sw-property.detail.labelPosition')"
+                            :placeholder="$tc('sw-property.detail.placeholderPosition')">
+                    </sw-number-field>
+                {% endblock %}
             </sw-container>
         {% endblock %}
     </sw-card>

--- a/src/Administration/Resources/app/administration/src/module/sw-property/page/sw-property-create/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-property/page/sw-property-create/index.js
@@ -20,6 +20,7 @@ Component.extend('sw-property-create', 'sw-property-detail', {
             this.propertyGroup = this.propertyRepository.create(Shopware.Context.api);
             this.propertyGroup.sortingType = 'alphanumeric';
             this.propertyGroup.displayType = 'text';
+            this.propertyGroup.position = 1;
             this.newId = this.propertyGroup.id;
 
             this.isLoading = false;

--- a/src/Administration/Resources/app/administration/src/module/sw-property/snippet/de-DE.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-property/snippet/de-DE.json
@@ -35,6 +35,8 @@
       "labelOptionName": "Name",
       "labelOptionColor": "Farbe",
       "labelOptionMedia": "Bild",
+      "labelPosition": "Position",
+      "placeholderPosition": "Gib einen Rang für diese Gruppe ein...",
       "placeholderOptionName": "Namen eingeben",
       "labelOptionPosition": "Position",
       "placeholderOptionPosition":  "Gib einen Rang für diese Option ein ...",

--- a/src/Administration/Resources/app/administration/src/module/sw-property/snippet/en-GB.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-property/snippet/en-GB.json
@@ -35,6 +35,8 @@
       "labelOptionName": "Name",
       "labelOptionColor": "Color",
       "labelOptionMedia": "Image",
+      "labelPosition": "Position",
+      "placeholderPosition": "Rank this group...",
       "placeholderOptionName": "Enter name...",
       "labelOptionPosition":  "Position",
       "placeholderOptionPosition":  "Rank this option...",

--- a/src/Core/Content/Product/ProductDefinition.php
+++ b/src/Core/Content/Product/ProductDefinition.php
@@ -122,7 +122,7 @@ class ProductDefinition extends EntityDefinition
             (new JsonField('variant_restrictions', 'variantRestrictions'))->addFlags(new ReadProtected(SalesChannelApiSource::class)),
             (new StringField('display_group', 'displayGroup'))->addFlags(new WriteProtected()),
 
-            (new JsonField('configurator_group_config', 'configuratorGroupConfig'))->addFlags(new ReadProtected(SalesChannelApiSource::class)),
+            (new JsonField('configurator_group_config', 'configuratorGroupConfig'))->addFlags(new ReadProtected(SalesChannelApiSource::class), new Inherited()),
 
             //inherited foreign keys with version fields
             (new FkField('product_manufacturer_id', 'manufacturerId', ProductManufacturerDefinition::class))->addFlags(new Inherited()),

--- a/src/Core/Content/Product/SalesChannel/Listing/ProductListingFeaturesSubscriber.php
+++ b/src/Core/Content/Product/SalesChannel/Listing/ProductListingFeaturesSubscriber.php
@@ -377,6 +377,7 @@ class ProductListingFeaturesSubscriber implements EventSubscriberInterface
 
         // group options by their property-group
         $grouped = $options->groupByPropertyGroups();
+        $grouped->sortByPositions();
 
         // remove id results to prevent wrong usages
         $event->getResult()->getAggregations()->remove('properties');

--- a/src/Core/Content/Property/Aggregate/PropertyGroupTranslation/PropertyGroupTranslationDefinition.php
+++ b/src/Core/Content/Property/Aggregate/PropertyGroupTranslation/PropertyGroupTranslationDefinition.php
@@ -6,6 +6,7 @@ use Shopware\Core\Content\Property\PropertyGroupDefinition;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityTranslationDefinition;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\CustomFields;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\Required;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\IntField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\LongTextField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\StringField;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
@@ -39,6 +40,7 @@ class PropertyGroupTranslationDefinition extends EntityTranslationDefinition
         return new FieldCollection([
             (new StringField('name', 'name'))->addFlags(new Required()),
             new LongTextField('description', 'description'),
+            new IntField('position', 'position'),
             new CustomFields(),
         ]);
     }

--- a/src/Core/Content/Property/Aggregate/PropertyGroupTranslation/PropertyGroupTranslationDefinition.php
+++ b/src/Core/Content/Property/Aggregate/PropertyGroupTranslation/PropertyGroupTranslationDefinition.php
@@ -30,6 +30,13 @@ class PropertyGroupTranslationDefinition extends EntityTranslationDefinition
         return PropertyGroupTranslationEntity::class;
     }
 
+    public function getDefaults(): array
+    {
+        return [
+            'position' => 1,
+        ];
+    }
+
     protected function getParentDefinitionClass(): string
     {
         return PropertyGroupDefinition::class;

--- a/src/Core/Content/Property/Aggregate/PropertyGroupTranslation/PropertyGroupTranslationEntity.php
+++ b/src/Core/Content/Property/Aggregate/PropertyGroupTranslation/PropertyGroupTranslationEntity.php
@@ -23,7 +23,7 @@ class PropertyGroupTranslationEntity extends TranslationEntity
     protected $description;
 
     /**
-     * @var int|null
+     * @var int
      */
     protected $position;
 
@@ -77,7 +77,7 @@ class PropertyGroupTranslationEntity extends TranslationEntity
         $this->description = $description;
     }
 
-    public function getPosition(): ?int
+    public function getPosition(): int
     {
         return $this->position;
     }

--- a/src/Core/Content/Property/Aggregate/PropertyGroupTranslation/PropertyGroupTranslationEntity.php
+++ b/src/Core/Content/Property/Aggregate/PropertyGroupTranslation/PropertyGroupTranslationEntity.php
@@ -23,6 +23,11 @@ class PropertyGroupTranslationEntity extends TranslationEntity
     protected $description;
 
     /**
+     * @var int|null
+     */
+    protected $position;
+
+    /**
      * @var PropertyGroupEntity|null
      */
     protected $propertyGroup;
@@ -70,6 +75,16 @@ class PropertyGroupTranslationEntity extends TranslationEntity
     public function setDescription(?string $description): void
     {
         $this->description = $description;
+    }
+
+    public function getPosition(): ?int
+    {
+        return $this->position;
+    }
+
+    public function setPosition(int $position): void
+    {
+        $this->position = $position;
     }
 
     public function getCustomFields(): ?array

--- a/src/Core/Content/Property/PropertyGroupCollection.php
+++ b/src/Core/Content/Property/PropertyGroupCollection.php
@@ -32,6 +32,18 @@ class PropertyGroupCollection extends EntityCollection
         return $map;
     }
 
+    public function sortByPositions(): void
+    {
+        usort($this->elements, function(PropertyGroupEntity $a, PropertyGroupEntity $b) {
+            $posA = $a->getTranslation('position');
+            $posB = $b->getTranslation('position');
+            if ($posA === $posB) {
+                return strnatcmp($a->getTranslation('name'), $b->getTranslation('name'));
+            }
+            return $posA <=> $posB;
+        });
+    }
+
     protected function getExpectedClass(): string
     {
         return PropertyGroupEntity::class;

--- a/src/Core/Content/Property/PropertyGroupDefinition.php
+++ b/src/Core/Content/Property/PropertyGroupDefinition.php
@@ -63,6 +63,7 @@ class PropertyGroupDefinition extends EntityDefinition
             new TranslatedField('description'),
             (new StringField('display_type', 'displayType'))->setFlags(new Required()),
             (new StringField('sorting_type', 'sortingType'))->setFlags(new Required()),
+            new TranslatedField('position'),
             new TranslatedField('customFields'),
             (new OneToManyAssociationField('options', PropertyGroupOptionDefinition::class, 'property_group_id', 'id'))->addFlags(new CascadeDelete(), new SearchRanking(SearchRanking::ASSOCIATION_SEARCH_RANKING)),
             (new TranslationsAssociationField(PropertyGroupTranslationDefinition::class, 'property_group_id'))->addFlags(new Required(), new CascadeDelete()),

--- a/src/Core/Content/Property/PropertyGroupEntity.php
+++ b/src/Core/Content/Property/PropertyGroupEntity.php
@@ -91,7 +91,7 @@ class PropertyGroupEntity extends Entity
         $this->description = $description;
     }
 
-    public function getPosition(): int
+    public function getPosition(): ?int
     {
         return $this->position;
     }

--- a/src/Core/Content/Property/PropertyGroupEntity.php
+++ b/src/Core/Content/Property/PropertyGroupEntity.php
@@ -32,6 +32,11 @@ class PropertyGroupEntity extends Entity
     protected $description;
 
     /**
+     * @var int
+     */
+    protected $position;
+
+    /**
      * @var PropertyGroupOptionCollection|null
      */
     protected $options;
@@ -84,6 +89,16 @@ class PropertyGroupEntity extends Entity
     public function setDescription(?string $description): void
     {
         $this->description = $description;
+    }
+
+    public function getPosition(): int
+    {
+        return $this->position;
+    }
+
+    public function setPosition(int $position): void
+    {
+        $this->position = $position;
     }
 
     public function getDisplayType(): string

--- a/src/Core/Content/Property/PropertyGroupEntity.php
+++ b/src/Core/Content/Property/PropertyGroupEntity.php
@@ -91,7 +91,7 @@ class PropertyGroupEntity extends Entity
         $this->description = $description;
     }
 
-    public function getPosition(): ?int
+    public function getPosition(): int
     {
         return $this->position;
     }

--- a/src/Core/Migration/Migration1578590702AddedPropertyGroupPosition.php
+++ b/src/Core/Migration/Migration1578590702AddedPropertyGroupPosition.php
@@ -19,6 +19,5 @@ class Migration1578590702AddedPropertyGroupPosition extends MigrationStep
 
     public function updateDestructive(Connection $connection): void
     {
-        $connection->executeUpdate('ALTER TABLE `property_group_translation` DROP COLUMN `position`;');
     }
 }

--- a/src/Core/Migration/Migration1578590702AddedPropertyGroupPosition.php
+++ b/src/Core/Migration/Migration1578590702AddedPropertyGroupPosition.php
@@ -1,0 +1,24 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Migration;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Framework\Migration\MigrationStep;
+
+class Migration1578590702AddedPropertyGroupPosition extends MigrationStep
+{
+    public function getCreationTimestamp(): int
+    {
+        return 1578590702;
+    }
+
+    public function update(Connection $connection): void
+    {
+        $connection->executeUpdate('ALTER TABLE `property_group_translation` ADD `position` INT(11) NULL AFTER `description`;');
+    }
+
+    public function updateDestructive(Connection $connection): void
+    {
+        $connection->executeUpdate('ALTER TABLE `property_group_translation` DROP COLUMN `position`;');
+    }
+}

--- a/src/Core/Migration/Migration1578590702AddedPropertyGroupPosition.php
+++ b/src/Core/Migration/Migration1578590702AddedPropertyGroupPosition.php
@@ -14,7 +14,7 @@ class Migration1578590702AddedPropertyGroupPosition extends MigrationStep
 
     public function update(Connection $connection): void
     {
-        $connection->executeUpdate('ALTER TABLE `property_group_translation` ADD `position` INT(11) NULL AFTER `description`;');
+        $connection->executeUpdate('ALTER TABLE `property_group_translation` ADD `position` INT(11) NULL DEFAULT 1 AFTER `description`;');
     }
 
     public function updateDestructive(Connection $connection): void

--- a/src/Storefront/DependencyInjection/services.xml
+++ b/src/Storefront/DependencyInjection/services.xml
@@ -229,6 +229,7 @@
 
         <service id="Shopware\Storefront\Page\Product\Configurator\ProductPageConfiguratorLoader">
             <argument type="service" id="product_configurator_setting.repository"/>
+            <argument type="service" id="product.repository"/>
             <argument type="service" id="Shopware\Storefront\Page\Product\Configurator\AvailableCombinationLoader"/>
         </service>
 

--- a/src/Storefront/Page/Product/Configurator/ProductPageConfiguratorLoader.php
+++ b/src/Storefront/Page/Product/Configurator/ProductPageConfiguratorLoader.php
@@ -189,14 +189,9 @@ class ProductPageConfiguratorLoader
         }
 
         $groupCollection = new PropertyGroupCollection($sorted);
-        // check if the parent product has a configuratorGroupConfig
-        $criteria = (new Criteria([$product->getParentId() ?? $product->getId()]));
-        /** @var ProductEntity $parentProduct */
-        $parentProduct = $this->productRepository
-            ->search($criteria, $context->getContext())
-            ->first();
 
-        $configuratorGroupConfig = $parentProduct->getConfiguratorGroupConfig();
+        // check if the parent product has a configuratorGroupConfig
+        $configuratorGroupConfig = $product->getConfiguratorGroupConfig();
         if ($configuratorGroupConfig) {
             // sort groups by configuratorGroupConfig
             $sortedGroupIds = array_map(function (array $configuratorGroupConfigEntry) {

--- a/src/Storefront/Page/Product/Configurator/ProductPageConfiguratorLoader.php
+++ b/src/Storefront/Page/Product/Configurator/ProductPageConfiguratorLoader.php
@@ -154,7 +154,12 @@ class ProductPageConfiguratorLoader
         usort(
             $sorted,
             static function (PropertyGroupEntity $a, PropertyGroupEntity $b) {
-                return strnatcmp($a->getTranslation('name'), $b->getTranslation('name'));
+                $posA = $a->getTranslation('position');
+                $posB = $b->getTranslation('position');
+                if ($posA === $posB) {
+                    return strnatcmp($a->getTranslation('name'), $b->getTranslation('name'));
+                }
+                return ($posA < $posB) ? -1 : 1;
             }
         );
 

--- a/src/Storefront/Test/Page/Product/Configurator/ProductConfiguratorOrderTest.php
+++ b/src/Storefront/Test/Page/Product/Configurator/ProductConfiguratorOrderTest.php
@@ -1,0 +1,216 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Storefront\Test\Page\Product\Configurator;
+
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Product\Aggregate\ProductVisibility\ProductVisibilityDefinition;
+use Shopware\Core\Content\Property\PropertyGroupCollection;
+use Shopware\Core\Content\Property\PropertyGroupEntity;
+use Shopware\Core\Defaults;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepositoryInterface;
+use Shopware\Core\Framework\DataAbstractionLayer\Event\EntityWrittenContainerEvent;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
+use Shopware\Core\Framework\Test\TestCaseBase\TaxAddToSalesChannelTestBehaviour;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\System\SalesChannel\Context\SalesChannelContextFactory;
+use Shopware\Core\System\SalesChannel\Entity\SalesChannelRepositoryInterface;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Shopware\Storefront\Page\Product\Configurator\ProductCombinationFinder;
+use Shopware\Storefront\Page\Product\Configurator\ProductPageConfiguratorLoader;
+
+class ProductConfiguratorOrderTest extends TestCase
+{
+    use IntegrationTestBehaviour;
+    use TaxAddToSalesChannelTestBehaviour;
+
+    /**
+     * @var EntityRepositoryInterface
+     */
+    private $repository;
+
+    /**
+     * @var SalesChannelRepositoryInterface
+     */
+    private $salesChannelProductRepository;
+
+    /**
+     * @var string
+     */
+    private $productId;
+
+    /**
+     * @var SalesChannelContext
+     */
+    private $context;
+
+    /**
+     * @var ProductCombinationFinder
+     */
+    private $combinationFinder;
+
+    /**
+     * @var ProductPageConfiguratorLoader
+     */
+    private $productPageConfiguratorLoader;
+
+    protected function setUp(): void
+    {
+        $this->repository = $this->getContainer()->get('product.repository');
+
+        $this->salesChannelProductRepository = $this->getContainer()->get('sales_channel.product.repository');
+
+        $this->context = $this->getContainer()->get(SalesChannelContextFactory::class)
+            ->create('test', Defaults::SALES_CHANNEL);
+
+        $this->combinationFinder = $this->getContainer()->get(ProductCombinationFinder::class);
+
+        $this->productPageConfiguratorLoader = $this->getContainer()->get(ProductPageConfiguratorLoader::class);
+
+        parent::setUp();
+    }
+
+    public function testDefaultOrder(): void
+    {
+        $groupNames = $this->getOrder();
+        static::assertEquals(['a', 'b', 'c', 'd', 'e', 'f'], $groupNames);
+    }
+
+    public function testGroupPositionOrder(): void
+    {
+        $groupNames = $this->getOrder(['f', 'e', 'd', 'c', 'b', 'a']);
+        static::assertEquals(['f', 'e', 'd', 'c', 'b', 'a'], $groupNames);
+    }
+
+    public function testConfiguratorGroupConfigOrder(): void
+    {
+        $groupNames = $this->getOrder(null, ['f', 'e', 'd', 'c', 'b', 'a']);
+        static::assertEquals(['f', 'e', 'd', 'c', 'b', 'a'], $groupNames);
+    }
+
+    public function testConfiguratorGroupConfigOverrideOrder(): void
+    {
+        $groupNames = $this->getOrder(['f', 'b', 'c', 'd', 'a', 'e'], ['f', 'e', 'd', 'c', 'b', 'a']);
+        static::assertEquals(['f', 'e', 'd', 'c', 'b', 'a'], $groupNames);
+    }
+
+    private static function ashuffle(array &$a)
+    {
+        $keys = array_keys($a);
+        shuffle($keys);
+        $shuffled = [];
+        foreach ($keys as $key) {
+            $shuffled[$key] = $a[$key];
+        }
+        $a = $shuffled;
+
+        return true;
+    }
+
+    private function getOrder(?array $groupPositionOrder = null, ?array $configuratorGroupConfigOrder = null): array
+    {
+        // create product with property groups and 1 variant and get its configurator settings
+        $productId = Uuid::randomHex();
+        $variantId = Uuid::randomHex();
+
+        $groupIds = [
+            'a' => Uuid::randomHex(),
+            'b' => Uuid::randomHex(),
+            'c' => Uuid::randomHex(),
+            'd' => Uuid::randomHex(),
+            'e' => Uuid::randomHex(),
+            'f' => Uuid::randomHex(),
+        ];
+
+        $optionIds = [];
+
+        self::ashuffle($groupIds);
+
+        $configuratorSettings = [];
+        foreach ($groupIds as $groupName => $groupId) {
+            $group = [
+                'id' => $groupId,
+                'name' => $groupName,
+            ];
+
+            if ($groupPositionOrder) {
+                $group['position'] = array_search($groupName, $groupPositionOrder);
+            }
+
+            // 2 options for each group
+            $optionIds[$groupId] = [];
+            for ($i = 0; $i < 2; $i++) {
+                $id = Uuid::randomHex();
+                $optionIds[$groupId][] = $id;
+                $configuratorSettings[] = [
+                    'option' => [
+                        'id' => $id,
+                        'name' => $groupName . $i,
+                        'group' => $group,
+                    ],
+                ];
+            }
+        }
+
+        $configuratorGroupConfig = null;
+        if ($configuratorGroupConfigOrder) {
+            $configuratorGroupConfig = [];
+            foreach ($configuratorGroupConfigOrder as $groupName) {
+                $configuratorGroupConfig[] = [
+                    'expressionForListings' => false,
+                    'id' => $groupIds[$groupName],
+                    'representation' => 'box',
+                ];
+            }
+        }
+
+        $data = [
+            [
+                'id' => $productId,
+                'name' => 'Test product',
+                'productNumber' => 'a.0',
+                'manufacturer' => ['name' => 'test'],
+                'tax' => ['id' => UUid::randomHex(), 'taxRate' => 19, 'name' => 'test'],
+                'stock' => 10,
+                'active' => true,
+                'price' => [['currencyId' => Defaults::CURRENCY, 'gross' => 10, 'net' => 9, 'linked' => true]],
+                'configuratorSettings' => $configuratorSettings,
+                'configuratorGroupConfig' => $configuratorGroupConfig,
+                'visibilities' => [
+                    [
+                        'salesChannelId' => Defaults::SALES_CHANNEL,
+                        'visibility' => ProductVisibilityDefinition::VISIBILITY_ALL,
+                    ],
+                ],
+            ],
+            [
+                'id' => $variantId,
+                'productNumber' => 'variant',
+                'stock' => 10,
+                'active' => true,
+                'parentId' => $productId,
+                'options' => array_map(function (array $group) {
+                    // Assign first option from each group
+                    return ['id' => $group[0]];
+                }, $optionIds),
+            ],
+        ];
+
+
+        $this->repository->create($data, Context::createDefaultContext());
+        $this->addTaxDataToSalesChannel($this->context, $data[0]['tax']);
+
+        $criteria = (new Criteria())->addFilter(new EqualsFilter('product.parentId', $productId));
+        $salesChannelProduct = $this->salesChannelProductRepository->search($criteria, $this->context)->first();
+
+        // get ordered PropertyGroupCollection
+        $groups = $this->productPageConfiguratorLoader->load($salesChannelProduct, $this->context);
+
+        // return array of group names
+        return array_values(array_map(function (PropertyGroupEntity $propertyGroupEntity) {
+            return $propertyGroupEntity->getName();
+        }, $groups->getElements()));
+    }
+}


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/community).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?

Options already support custom ordering using either a "position" field or by ordering them in the "Storefront presentation" modal on a per-product level. Property groups however do not support custom ordering, they are always ordered alphabetically in the configurator.

### 2. What does this change do, exactly?

If a custom order was set through the "Storefront presentation" modal for the product, the property groups will be sorted according to that order.

A new `position` field on the `PropertyGroup` (similar to `PropertyGroupOption`) is used as a fallback if no product-level order is specified for the product. By sorting `PropertyGroup` with the same `position` by their translated name, the default behaviour will be backwards compatible. So if no `position` is set, the ordering will be the same as without this feature.

The property filters are also sorted according to the `position` field, as it makes no sense to use product-specific ordering there (the displayed products might be using different property group orders).

### 3. Describe each step to reproduce the issue or behaviour.

- Create or edit a PropertyGroup
- Assign a `position` to the group or change the order on product-level
- Create variations
- The `PropertyGroup`s in the configurator will be ordered correctly

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.