### PR TITLE
Add the shipping method price to the calculated price as reference

### DIFF
--- a/src/Core/Checkout/Cart/Delivery/DeliveryCalculator.php
+++ b/src/Core/Checkout/Cart/Delivery/DeliveryCalculator.php
@@ -109,6 +109,8 @@ class DeliveryCalculator
                 $context
             );
 
+            $costs->setShippingMethodPrice($price);
+
             break;
         }
 

--- a/src/Core/Checkout/Cart/Price/Struct/CalculatedPrice.php
+++ b/src/Core/Checkout/Cart/Price/Struct/CalculatedPrice.php
@@ -4,6 +4,7 @@ namespace Shopware\Core\Checkout\Cart\Price\Struct;
 
 use Shopware\Core\Checkout\Cart\Tax\Struct\CalculatedTaxCollection;
 use Shopware\Core\Checkout\Cart\Tax\Struct\TaxRuleCollection;
+use Shopware\Core\Checkout\Shipping\Aggregate\ShippingMethodPrice\ShippingMethodPriceEntity;
 use Shopware\Core\Framework\Struct\Struct;
 
 class CalculatedPrice extends Struct
@@ -38,13 +39,19 @@ class CalculatedPrice extends Struct
      */
     protected $referencePrice;
 
+    /**
+     * @var ShippingMethodPriceEntity
+     */
+    protected $shippingMethodPrice;
+
     public function __construct(
         float $unitPrice,
         float $totalPrice,
         CalculatedTaxCollection $calculatedTaxes,
         TaxRuleCollection $taxRules,
         int $quantity = 1,
-        ?ReferencePrice $referencePrice = null
+        ?ReferencePrice $referencePrice = null,
+        ?ShippingMethodPriceEntity $shippingMethodPrice = null
     ) {
         $this->unitPrice = $unitPrice;
         $this->totalPrice = $totalPrice;
@@ -52,6 +59,7 @@ class CalculatedPrice extends Struct
         $this->taxRules = $taxRules;
         $this->quantity = $quantity;
         $this->referencePrice = $referencePrice;
+        $this->shippingMethodPrice = $shippingMethodPrice;
     }
 
     public function getTotalPrice(): float
@@ -83,4 +91,15 @@ class CalculatedPrice extends Struct
     {
         return $this->referencePrice;
     }
+
+    public function getShippingMethodPrice()
+    {
+        return $this->shippingMethodPrice;
+    }
+
+    public function setShippingMethodPrice($shippingMethodPrice)
+    {
+        $this->shippingMethodPrice = $shippingMethodPrice;
+    }
+
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/community).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
I want to build a plugin which shows the free shipping limit at certain places, since Shopware do not yet have a default solution for this. To achieve this I'm trying to fetch the correct and actually used shipping price matrix to calculate the price before the shipping gets free.

At this point I don't want to completely rewrite the logic in `DeliveryCalculator::calculateDelivery` due compatibility reasons.

### 2. What does this change do, exactly?
It extends `Shopware\Core\Checkout\Cart\Price\Struct\CalculatedPrice` by a new optional attribute called `$shippingMethodPrice` which will be filled in the method mentioned above. After this change I can simply fetch the used price matrix from the SalesChannelsContext-object.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
