### PR TITLE
Fix delay for AjaxOffCanvas

### DIFF
--- a/src/Storefront/Resources/app/storefront/src/plugin/offcanvas/ajax-offcanvas.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/offcanvas/ajax-offcanvas.plugin.js
@@ -19,7 +19,7 @@ export default class AjaxOffCanvas extends OffCanvas {
      * @param {boolean} fullwidth
      * @param {array|string} cssClass
      */
-    static open(url = false, data = false, callback = null, position = 'left', closable = true, delay = OffCanvas.REMOVE_OFF_CANVAS_DELAY, fullwidth = false, cssClass = '') {
+    static open(url = false, data = false, callback = null, position = 'left', closable = true, delay = OffCanvas.REMOVE_OFF_CANVAS_DELAY(), fullwidth = false, cssClass = '') {
         if (!url) {
             throw new Error('A url must be given!');
         }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/community).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?

OffCanvas elements have a `delay` parameter to delay the removal of the DOM elements. AjaxOffCanvas (like the cart) received a function instead of a number for their close delay. As a result, they closed instantly without giving the CSS animations time to finish.

### 2. What does this change do, exactly?

Fix the AjaxOffCanvas default arguments.

### 3. Describe each step to reproduce the issue or behaviour.

Open the cart and close it. There was no closing animation.

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.
