### PR TITLE
fixing rel=0 in cms-element-youtube-video

### DIFF
--- a/src/Storefront/Resources/views/storefront/element/cms-element-youtube-video.html.twig
+++ b/src/Storefront/Resources/views/storefront/element/cms-element-youtube-video.html.twig
@@ -8,7 +8,7 @@
         {% set videoUrl = 'https://www.youtube.com/embed/' %}        
     {% endif %}
     
-    {% set videoUrl = videoUrl ~ config.videoID.value ~ '?' ~ videoUrl ~ 'rel=0' ~ '&'  %}
+    {% set videoUrl = videoUrl ~ config.videoID.value ~ '?' ~ 'rel=0' ~ '&'  %}
 
     {% if config.autoPlay.value %}
        {% set videoUrl = videoUrl ~ 'autoplay=1' ~ '&' %}   


### PR DESCRIPTION
The second videoUrl in the concatenated string disabled the rel=0 configuration.

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/community).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
The option "rel=0" configures the embeded youtube-player to show related videos only from the own channel. With the videoUrl in front this option is ignored and the list of related videos contains any kind of youtube videos.

### 2. What does this change do, exactly?
It activates the rel=0 option to only list videos from the own channel.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
