### PR TITLE
fix: missing quote for aria-label of sorting select

### DIFF
--- a/src/Storefront/Resources/views/storefront/component/sorting.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/sorting.html.twig
@@ -1,7 +1,7 @@
 {% set config = { sorting: current } %}
 
 <div class="sorting" data-listing-sorting="true" data-listing-sorting-options='{{ config|json_encode }}'>
-    <select class="sorting custom-select" aria-label="{{ 'general.sortingLabel'|trans|striptags }}>
+    <select class="sorting custom-select" aria-label="{{ 'general.sortingLabel'|trans|striptags }}">
         {% for sorting in sortings %}
             {% set key = sorting.key %}
             <option value="{{ key }}"{% if key == current %} selected{% endif %}>{{ sorting.snippet|trans|sw_sanitize }}</option>


### PR DESCRIPTION
(cherry picked from commit da85cd0edd1e1490418226d307e7bf415f97487e)

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/community).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
There is a missing quote in the template for the sorting select of products. By that the option for Name, Ascending i not shown in storefront.

### 2. What does this change do, exactly?
It adds the missing quote.

### 3. Describe each step to reproduce the issue or behaviour.
Go on category page and watch out for the sorting select.

### 4. Please link to the relevant issues (if any).
---

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.
