### PR TITLE
fix webpack hot proxy response headers

### DIFF
--- a/src/Storefront/Resources/app/storefront/build/proxy-server-hot/index.js
+++ b/src/Storefront/Resources/app/storefront/build/proxy-server-hot/index.js
@@ -37,6 +37,7 @@ module.exports = function createProxyServer({ appPort, originalHost, proxyHost, 
                     return;
                 }
 
+                client_res.writeHead(response.statusCode, response.headers);
                 response.pipe(client_res, {  end: true });
             }),
             {  end: true }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/community).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?

If you have e.g. a svg loaded via the proxy, it's missing the original headers.
That causes the browser not to display the image.

### 2. What does this change do, exactly?

It keeps the response headers from the client request to the proxy response.

### 3. Describe each step to reproduce the issue or behaviour.

Include an asset in the template e.g. `<img src="{{ asset('/bundles/mytheme/assets/logo/logo.svg')}}" />` and it will not be visible in the browser via the hot reload proxy.

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
