### PR TITLE
Docs say there is a read but its not

### DIFF
--- a/src/Docs/Resources/current/2-internals/1-core/20-data-abstraction-layer/010-read.md
+++ b/src/Docs/Resources/current/2-internals/1-core/20-data-abstraction-layer/010-read.md
@@ -7,20 +7,21 @@ The entity reader always works in batch mode, which means that you should not re
 
 ## Reading entities
 
-The entity repositories provide a `read()` method which takes two arguments:
+The entity repositories provide a `search()` method which takes two arguments:
 
 1. The `Criteria` object, which holds a list of ids in hex format.
 2. The `Context` object to be read with.
 
 ```php
-$productRepository->read(
+/** @var \Shopware\Core\Content\Product\ProductCollection $products */
+$products = $productRepository->search(
     new Criteria([
         'f8d36562c5614c5994aecb9c73d2b13e',
         '67a8a047b638493d95bb2a4cdf351cf3',
         'b94055962e4b49ceb86f55f8d1932607',
     ]),
     $context
-);
+)->getEntities();
 ```
 
-The return value will be a collection containing all found entities as hydrated objects.
+The return value is a search result which has the entity collection containing all found entities as hydrated objects.


### PR DESCRIPTION
### 1. Why is this change necessary?
You see in the docs that you can read from a repository. But you can't. 

### 2. What does this change do, exactly?
Say to use search instead of read.

### 3. Describe each step to reproduce the issue or behaviour.
1. Show others the docs
2. They want to read like in doctrine
3. Mentioned read method not found
4. Confusion

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
