### PR TITLE
fix order editting event management

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-order/view/sw-order-detail-base/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/view/sw-order-detail-base/index.js
@@ -215,9 +215,9 @@ Component.register('sw-order-detail-base', {
 
         destroyedComponent() {
             this.$root.$off('language-change', this.reloadEntityData);
-            this.$root.$on('order-edit-start', this.onStartEditing);
-            this.$root.$on('order-edit-save', this.onSaveEdits);
-            this.$root.$on('order-edit-cancel', this.onCancelEditing);
+            this.$root.$off('order-edit-start', this.onStartEditing);
+            this.$root.$off('order-edit-save', this.onSaveEdits);
+            this.$root.$off('order-edit-cancel', this.onCancelEditing);
         },
 
         reloadEntityData() {


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/community).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?

`sw-order-detail-base` does not properly remove the events needed for editting orders. As a result, the event listeners pile up when an administrator opens/closes multiple orders before performing an action. This can pollute the orders table with "dead" versions.

### 2. What does this change do, exactly?

Properly remove the event listeners whenever the component is destroyed.

### 3. Describe each step to reproduce the issue or behaviour.

Open an order in the admin panel. Use the in-page navigation to go back to the order overview and open another order. Click the "Edit" button at the top of the page. Observe that two version requests are sent, one for the second order and one for the first order.

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
