### PR TITLE
fix doc about removed  getServicesFilePath in Bundle.php

### DIFF
--- a/src/Docs/Resources/current/4-how-to/070-add-service.md
+++ b/src/Docs/Resources/current/4-how-to/070-add-service.md
@@ -9,9 +9,8 @@ Make sure to have a look at the [Symfony documentation](https://symfony.com/doc/
 
 ## Registering your service
 
-The main requirement here is to have a `services.xml` file loaded in your plugin.
-This can be achieved by placing the file into a `Resources/config` directory relative to your plugin's base class location.
-Make sure to also have a look at the method [getServicesFilePath](./../2-internals/4-plugins/020-plugin-base-class.md#getServicesFilePath)
+The main requirement here is to have a `services.xml` file placed into `Resources/config/` folder.
+The services are automatically registered via autoloading.
 
 From here on, everything works exactly like in Symfony itself.
 


### PR DESCRIPTION
### 1. Why is this change necessary?
In Version 6.1.0 function Bundle::getServicesFilePath was removed
![Bildschirmfoto 2020-01-20 um 13 38 20](https://user-images.githubusercontent.com/4529135/72727045-393c4c00-3b8a-11ea-9050-0c23f36e4e38.png)

### 2. What does this change do, exactly?
Documentation is improved and helps other developers do not implement this unnecessary step.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
