### PR TITLE
Amend type hint to match default value

### DIFF
--- a/src/Storefront/Controller/CmsController.php
+++ b/src/Storefront/Controller/CmsController.php
@@ -51,7 +51,7 @@ class CmsController extends StorefrontController
      * Route for cms data (used in XmlHttpRequest)
      *
      * @HttpCache()
-     * @Route("/widgets/cms/{id}", name="frontend.cms.page", methods={"GET", "POST"}, defaults={"id"=null, "XmlHttpRequest"=true})
+     * @Route("/widgets/cms/{id}", name="frontend.cms.page", methods={"GET", "POST"}, defaults={"XmlHttpRequest"=true})
      *
      * @throws InconsistentCriteriaIdsException
      * @throws MissingRequestParameterException
@@ -59,10 +59,6 @@ class CmsController extends StorefrontController
      */
     public function page(string $id, Request $request, SalesChannelContext $salesChannelContext): Response
     {
-        if (!$id) {
-            throw new MissingRequestParameterException('Parameter id missing');
-        }
-
         $cmsPage = $this->cmsRoute->load($id, $request, $salesChannelContext)->getCmsPage();
 
         return $this->renderStorefront('@Storefront/storefront/page/content/detail.html.twig', ['cmsPage' => $cmsPage]);
@@ -72,7 +68,7 @@ class CmsController extends StorefrontController
      * Route to load a cms page which assigned to the provided navigation id.
      * Navigation id is required to load the slot config for the navigation
      *
-     * @Route("/widgets/cms/navigation/{navigationId}", name="frontend.cms.navigation.page", methods={"GET", "POST"}, defaults={"navigationId"=null, "XmlHttpRequest"=true})
+     * @Route("/widgets/cms/navigation/{navigationId}", name="frontend.cms.navigation.page", methods={"GET", "POST"}, defaults={"XmlHttpRequest"=true})
      *
      * @throws CategoryNotFoundException
      * @throws MissingRequestParameterException
@@ -81,10 +77,6 @@ class CmsController extends StorefrontController
      */
     public function category(string $navigationId, Request $request, SalesChannelContext $salesChannelContext): Response
     {
-        if (!$navigationId) {
-            throw new MissingRequestParameterException('Parameter navigationId missing');
-        }
-
         $category = $this->categoryRoute->load($navigationId, $request, $salesChannelContext)->getCategory();
 
         if (!$category->getCmsPageId()) {


### PR DESCRIPTION
### 1. Why is this change necessary?
The phpdocs for the route defaults does not match the typehint in the arguments. This results in an an exception on the php side as the type constraint is not fulfilled. So the validity check whether the parameter is ok is never reached and no readable exception is thrown/logged.

### 2. What does this change do, exactly?
Loosen up the typehint by adding nullability. 

### 3. Describe each step to reproduce the issue or behaviour.
1. Do not configure contact layout page
2. Click on contact in storefront
3. Do not get a contact form
4. Look in logs
5. `Uncaught PHP Exception TypeError: "Argument 1 passed to Shopware\Storefront\Controller\CmsController::page() must be of the type string, null given`
6. Expecting `Parameter "Parameter id missing" is missing.`
7. Wut?
8. Check message concatenation for `MissingRequestParameterException`
9. See weird refactoring result
10. Take notes for next pull request

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
