### PR TITLE
Fix mailer

### DIFF
--- a/src/Core/Content/DependencyInjection/mail_template.xml
+++ b/src/Core/Content/DependencyInjection/mail_template.xml
@@ -93,12 +93,14 @@
             <tag name="console.command"/>
         </service>
 
-        <service id="core_mailer" class="Swift_Mailer">
-            <factory service="Shopware\Core\Content\MailTemplate\Service\MailerFactory" method="create" />
-            <argument type="service" id="Shopware\Core\System\SystemConfig\SystemConfigService"/>
-            <argument type="service" id="mailer"/>
-        </service>
+        <service id="core_mailer" alias="mailer" />
 
         <service id="Shopware\Core\Content\MailTemplate\Service\MailerFactory" />
+
+        <service id="core_mailer_transport" class="\Swift_Transport" decorates="swiftmailer.mailer.default.transport.dynamic">
+            <factory service="Shopware\Core\Content\MailTemplate\Service\MailerFactory" method="create"/>
+            <argument type="service" id="Shopware\Core\System\SystemConfig\SystemConfigService"/>
+            <argument type="service" id="core_mailer_transport.inner"/>
+        </service>
     </services>
 </container>

--- a/src/Core/Content/MailTemplate/Service/MailerFactory.php
+++ b/src/Core/Content/MailTemplate/Service/MailerFactory.php
@@ -3,15 +3,16 @@
 namespace Shopware\Core\Content\MailTemplate\Service;
 
 use Shopware\Core\System\SystemConfig\SystemConfigService;
+use Swift_Transport;
 
 class MailerFactory
 {
-    public function create(SystemConfigService $configService, \Swift_Mailer $mailer): \Swift_Mailer
+    public function create(SystemConfigService $configService, Swift_Transport $innerTransport): Swift_Transport
     {
         $emailAgent = $configService->get('core.mailerSettings.emailAgent');
 
         if ($emailAgent !== 'smtp') {
-            return $mailer;
+            return $innerTransport;
         }
 
         $transport = new \Swift_SmtpTransport(
@@ -32,9 +33,7 @@ class MailerFactory
             (string) $configService->get('core.mailerSettings.password')
         );
 
-        $mailer = new \Swift_Mailer($transport);
-
-        return $mailer;
+        return $transport;
     }
 
     private function getEncryption(SystemConfigService $configService): ?string

--- a/src/Core/Content/Test/MailTemplate/Service/MailerFactoryTest.php
+++ b/src/Core/Content/Test/MailTemplate/Service/MailerFactoryTest.php
@@ -10,8 +10,7 @@ class MailerFactoryTest extends TestCase
 {
     public function testFactoryWithoutConfig(): void
     {
-        $original = new \Swift_Mailer(new \Swift_NullTransport());
-
+        $original = new \Swift_NullTransport();
         $factory = new MailerFactory();
 
         $mailer = $factory->create(
@@ -26,11 +25,10 @@ class MailerFactoryTest extends TestCase
 
     public function testFactoryWithConfig(): void
     {
-        $original = new \Swift_Mailer(new \Swift_NullTransport());
-
+        $original = new \Swift_NullTransport();
         $factory = new MailerFactory();
 
-        $mailer = $factory->create(
+        $transport = $factory->create(
             new ConfigService([
                 'core.mailerSettings.emailAgent' => 'smtp',
                 'core.mailerSettings.host' => 'localhost',
@@ -43,9 +41,7 @@ class MailerFactoryTest extends TestCase
             $original
         );
 
-        static::assertNotSame($original, $mailer);
-
-        $transport = $mailer->getTransport();
+        static::assertNotSame($original, $transport);
 
         /** @var \Swift_SmtpTransport $transport */
         static::assertSame('localhost', $transport->getHost());


### PR DESCRIPTION
### 1. Why is this change necessary?

Swift plugins are not registered because the mailer is overwritten.

### 2. What does this change do, exactly?

Fix it.

### 3. Describe each step to reproduce the issue or behaviour.

Example: 
https://github.com/hlohaus/SheMailer/blob/master/src/Resources/config/services.xml#L9

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
