### PR TITLE
Typo in cookie consent documentation

### DIFF
--- a/src/Docs/Resources/current/4-how-to/730-add-plugin-cookies.md
+++ b/src/Docs/Resources/current/4-how-to/730-add-plugin-cookies.md
@@ -101,7 +101,7 @@ The event only contains the changeset for the cookie configuration as an object.
 You can listen for this event using the following lines:
 
 ```JavaScript
-import { COOKIE_CONFIGURATION_UPDATE } from 'src/plugin/cookie/cookie-confiugration';
+import { COOKIE_CONFIGURATION_UPDATE } from 'src/plugin/cookie/cookie-configuration.plugin';
 
 function eventCallback(updatedCookies) {    
     if (typeof updatedCookies.myCookie !== 'undefined') {


### PR DESCRIPTION
fixed confiugration -> configuration and it has to end with .plugin

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/community).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
Typo in documentation

### 2. What does this change do, exactly?


### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [X] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.
