### PR TITLE
Remove migration removal in plugin uninstall

### DIFF
--- a/src/Core/Framework/Plugin/PluginLifecycleService.php
+++ b/src/Core/Framework/Plugin/PluginLifecycleService.php
@@ -228,10 +228,6 @@ class PluginLifecycleService
 
         $pluginBaseClass->uninstall($uninstallContext);
 
-        if ($keepUserData === false) {
-            $this->removeMigrations($pluginBaseClass);
-        }
-
         $this->updatePluginData(
             [
                 'id' => $plugin->getId(),


### PR DESCRIPTION
### 1. Why is this change necessary?
This just removes the migrations without removing their actions.

### 2. What does this change do, exactly?
Stop removing migrations on a plugin uninstall.

### 3. Describe each step to reproduce the issue or behaviour.
1. Migrate it like it is 🔥 
2. Uninstall plugin later
3. Reinstall plugin later
4. `Plugin konnte auf Grund der Fehlermeldung "SQL error basically stating that this already happened in the past" nicht installiert werden`
5. Seeing the plugin migrations were removed from migration table
6. Dafuq? Did anyone ask me to remove user data? No. Did anyone ask me to undo stuff? No. There is **no down** in a migration.

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
