### PR TITLE
Remove alphanumeric filter for product numbers

### DIFF
--- a/src/Storefront/Controller/CartLineItemController.php
+++ b/src/Storefront/Controller/CartLineItemController.php
@@ -179,7 +179,7 @@ class CartLineItemController extends StorefrontController
      */
     public function addProductByNumber(Request $request, SalesChannelContext $salesChannelContext): Response
     {
-        $number = $request->request->getAlnum('number');
+        $number = $request->request->get('number');
         if (!$number) {
             throw new MissingRequestParameterException('number');
         }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/community).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
Product number can contain non alphanumerical char. E.g. dots for variants created from the administration. Basically it's possible to use any char as product number. This filter removes chars and therefore the product can not be found. It's also possible that the user accidentally adds the wrong product.

### 2. What does this change do, exactly?
Replace alphanumerical get with simple get.

### 3. Describe each step to reproduce the issue or behaviour.
Create a product with any non alphanumerical char in the product number and try to add it to the cart via the quick add function in the cart.

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
