### PR TITLE
Generic s3 support

### DIFF
--- a/src/Core/Framework/Adapter/Filesystem/Adapter/S3v3Factory.php
+++ b/src/Core/Framework/Adapter/Filesystem/Adapter/S3v3Factory.php
@@ -1,0 +1,66 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\Adapter\Filesystem\Adapter;
+
+use Aws\S3\S3Client;
+use League\Flysystem\AdapterInterface;
+use League\Flysystem\AwsS3v3\AwsS3Adapter;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class S3v3Factory implements AdapterFactoryInterface
+{
+    public function create(array $config): AdapterInterface
+    {
+        $options = $this->resolveS3Options($config);
+
+        $client = new S3Client($options);
+
+        return new AwsS3Adapter($client, $options['bucket'], $options['root'], $options['options']);
+    }
+
+    public function getType(): string
+    {
+        return 's3';
+    }
+
+    private function resolveS3Options(array $definition): array
+    {
+        $options = new OptionsResolver();
+
+        $options->setRequired(['bucket', 'region', 'endpoint']);
+        $options->setDefined(['credentials', 'use_path_style_endpoint', 'version', 'root', 'options']);
+
+        $options->setAllowedTypes('credentials', 'array');
+        $options->setAllowedTypes('endpoint', 'string');
+        $options->setAllowedTypes('use_path_style_endpoint', 'bool');
+        $options->setAllowedTypes('region', 'string');
+        $options->setAllowedTypes('version', 'string');
+        $options->setAllowedTypes('root', 'string');
+        $options->setAllowedTypes('options', 'array');
+
+        $options->setDefault('version', 'latest');
+        $options->setDefault('use_path_style_endpoint', true);
+        $options->setDefault('root', '');
+        $options->setDefault('options', []);
+
+        $config = $options->resolve($definition);
+
+        if (array_key_exists('credentials', $config)) {
+            $config['credentials'] = $this->resolveCredentialsOptions($config['credentials']);
+        }
+
+        return $config;
+    }
+
+    private function resolveCredentialsOptions(array $credentials): array
+    {
+        $options = new OptionsResolver();
+
+        $options->setRequired(['key', 'secret']);
+
+        $options->setAllowedTypes('key', 'string');
+        $options->setAllowedTypes('secret', 'string');
+
+        return $options->resolve($credentials);
+    }
+}

--- a/src/Core/Framework/DependencyInjection/filesystem.xml
+++ b/src/Core/Framework/DependencyInjection/filesystem.xml
@@ -28,6 +28,10 @@
             <tag name="shopware.filesystem.factory"/>
         </service>
 
+        <service class="Shopware\Core\Framework\Adapter\Filesystem\Adapter\S3v3Factory" id="Shopware\Core\Framework\Adapter\Filesystem\FilesystemFactory.s3">
+            <tag name="shopware.filesystem.factory"/>
+        </service>
+
         <service class="Shopware\Core\Framework\Adapter\Filesystem\Adapter\GoogleStorageFactory" id="Shopware\Core\Framework\Adapter\Filesystem\FilesystemFactory.google_storage">
             <tag name="shopware.filesystem.factory"/>
         </service>

--- a/src/Docs/Resources/current/4-how-to/310-use-s3-datastorage.md
+++ b/src/Docs/Resources/current/4-how-to/310-use-s3-datastorage.md
@@ -1,4 +1,4 @@
-[titleEn]: <>(Using AWS S3 as file storage)
+[titleEn]: <>(Using S3 as file storage)
 [metaDescriptionEn]: <>(Cloud solutions are often the preferred way to store large amounts of files. This article shows you how to configure a cloud file storage, in this example two S3 buckets.)
 
 ## Overview
@@ -33,6 +33,9 @@ The configuration for file storage of Shopware 6 resides in the general bundle c
 To set up a non default filesystem for your shop you need to add the `filesystem:` map to 
 the `shopware.yml`. Under this key you can separately define your storage for the public and private
 filesystem like this:
+
+### AWS
+
 ```yaml
 shopware:
   filesystem:
@@ -57,7 +60,39 @@ set of values in the `shopware.yml`:
 ```yaml
 shopware:
   cdn:
-    url: "https://s3.{your-bucket-region}.amazonaws.com/{your-private-bucket-name}"
+    url: "https://s3.{your-bucket-region}.amazonaws.com/{your-public-bucket-name}"
+    strategy: "md5"
+```
+
+### Other S3 Provider
+
+```yaml
+shopware:
+  filesystem:
+    public:
+      type: "s3"
+      config:
+        bucket: "{your-public-bucket-name}"
+        region: "{your-bucket-region}"
+        endpoint: "{your-s3-provider-endpoint}"
+        options:
+          visibility: "public"
+    private:
+      type: "s3"
+      config:
+        bucket: "{your-private-bucket-name}"
+        region: "{your-bucket-region}"
+        endpoint: "{your-s3-provider-endpoint}"
+        options:
+          visibility: "private"
+```
+
+To utilize your public bucket you have to add its URL as the CDN for your shop, this is just another
+set of values in the `shopware.yml`:
+```yaml
+shopware:
+  cdn:
+    url: "https://s3.{your-bucket-region}.{your-s3-provider-endpoint}/{your-public-bucket-name}"
     strategy: "md5"
 ```
 
@@ -71,4 +106,4 @@ Note: make sure your IAM user has read/write permissions for both Buckets.
 
 ## Final notes
 
-Although this example uses AWS S3, Shopware 6 also supports using Google Cloud Storage as an external filesystem.
+Although this example uses AWS S3, Shopware 6 also supports using Google Cloud Storage or Other S3 Providers as an external filesystem.


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/community).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
To use MinIO or another S3 provider

### 2. What does this change do, exactly?
It adds a new filesystem provider named s3 where you can set the S3 `endpoint` URL and tell the aws-php-sdk to `use_path_style_endpoint`  in addition to the `bucket` and `region`.

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code -- There are only tivial changes
- [x] I have read the contribution requirements and fulfil them.


I've tested my changes with a Quobyte-S3 bucket. But MinIO or DigitalOcean Spaces should also work. 
There are currently no tests for the amazon-s3 and google-storage filesystem tests. I don't know how I should actually implement one. What would you require the test to cover?

Best regards,

Christian Struck