### PR TITLE
Use custom name prefix for nested routes

### DIFF
--- a/changelog/_unreleased/2020-11-06-use-custom-name-prefix-for-nested-routes.md
+++ b/changelog/_unreleased/2020-11-06-use-custom-name-prefix-for-nested-routes.md
@@ -1,0 +1,7 @@
+---
+title: Use custom name prefix for nested routes
+issue: NEXT-7453
+author_github: @313
+---
+# Administration
+* Changed the naming of nested routes to make them consistent with their respective top level routes

--- a/src/Administration/Resources/app/administration/src/core/factory/module.factory.js
+++ b/src/Administration/Resources/app/administration/src/core/factory/module.factory.js
@@ -129,7 +129,7 @@ function registerModule(moduleId, module) {
 
             // Support for children routes
             if (hasOwnProperty(route, 'children') && Object.keys(route.children).length) {
-                route = iterateChildRoutes(route, splitModuleId, routeKey);
+                route = iterateChildRoutes(route);
                 moduleRoutes = registerChildRoutes(route, moduleRoutes);
             }
 
@@ -234,11 +234,9 @@ function registerChildRoutes(routeDefinition, moduleRoutes) {
  * Recursively iterates over the route children definitions and converts the format to the vue-router route definition.
  *
  * @param {Object} routeDefinition
- * @param {Array} moduleName
- * @param {String} parentKey
  * @returns {Object}
  */
-function iterateChildRoutes(routeDefinition, moduleName, parentKey) {
+function iterateChildRoutes(routeDefinition) {
     routeDefinition.children = Object.keys(routeDefinition.children).map((key) => {
         let child = routeDefinition.children[key];
 
@@ -248,11 +246,11 @@ function iterateChildRoutes(routeDefinition, moduleName, parentKey) {
             child.path = `${routeDefinition.path}/${child.path}`;
         }
 
-        child.name = `${moduleName.join('.')}.${parentKey}.${key}`;
+        child.name = `${routeDefinition.name}.${key}`;
         child.isChildren = true;
 
         if (hasOwnProperty(child, 'children') && Object.keys(child.children).length) {
-            child = iterateChildRoutes(child, moduleName, `${parentKey}.${key}`);
+            child = iterateChildRoutes(child);
         }
 
         return child;


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/community).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
It is possible to define a custom name prefix for administration routes using the module's `routePrefixName` property, but nested routes still use the default auto-generated value.

### 2. What does this change do, exactly?
Make the naming of nested routes consistent with their respective top-level routes.

### 3. Describe each step to reproduce the issue or behaviour.
```javascript
Shopware.Module.register('foo', {

    // ...

    routePrefixName: 'bar',

    routes: {
        parent: {
            // ...

            children: {
                child: {
                    // ...
                },
            },
        },
    },
};
```

Without this change the parent route's name will be `bar.parent` while its child will have the name `foo.parent.child`.

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.