### PR TITLE
fix typo in classname | cms-breadcrumb container

### DIFF
--- a/src/Storefront/Resources/views/storefront/page/content/index.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/content/index.html.twig
@@ -3,7 +3,7 @@
 {% block base_main_inner %}
     <div class="container-main">
         {% block page_content %}
-            <div class="breadcrumb cms-breadcrump container">
+            <div class="breadcrumb cms-breadcrumb container">
                 {% block cms_breadcrumb %}
                     {% sw_include '@Storefront/storefront/component/listing/breadcrumb.html.twig' with {
                         navigationTree: page.header.navigation.tree,

--- a/src/Storefront/Resources/views/storefront/page/content/index.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/content/index.html.twig
@@ -3,7 +3,8 @@
 {% block base_main_inner %}
     <div class="container-main">
         {% block page_content %}
-            <div class="breadcrumb cms-breadcrumb container">
+            {# @deprecated tag:v6.4.0 class `cms-breadcrump` use `cms-breadcrumb` instead #}
+            <div class="breadcrumb cms-breadcrumb cms-breadcrump container">
                 {% block cms_breadcrumb %}
                     {% sw_include '@Storefront/storefront/component/listing/breadcrumb.html.twig' with {
                         navigationTree: page.header.navigation.tree,


### PR DESCRIPTION
### 1. Why is this change necessary?
fixed a typo in classname definition in cms-breadcrumb container

### 2. What does this change do, exactly?


### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
