### PR TITLE
Amend plugin path for storefront plugins

### DIFF
--- a/src/Docs/Resources/current/4-how-to/560-js-storefront-plugin.md
+++ b/src/Docs/Resources/current/4-how-to/560-js-storefront-plugin.md
@@ -16,7 +16,7 @@ To get started create a `Resources/storefront/example-plugin` folder and put an 
 Inside that file create and export a ExamplePlugin class that extends the base Plugin class:
 
 ```js
-import Plugin from 'src/script/plugin-system/plugin.class';
+import Plugin from 'src/plugin-system/plugin.class';
 
 export default class ExamplePlugin extends Plugin {
 }
@@ -27,7 +27,7 @@ In your case you add an callback to the onScroll event from the window and check
 Your full plugin now looks like this:
 
 ```js
-import Plugin from 'src/script/plugin-system/plugin.class';
+import Plugin from 'src/plugin-system/plugin.class';
 
 export default class ExamplePlugin extends Plugin {
     init() {
@@ -113,7 +113,7 @@ In your case define a text option and as a default value use the text you previo
 And instead of the hard coded string inside the `alert()` use your new option value.
 
 ```js
-import Plugin from 'src/script/plugin-system/plugin.class';
+import Plugin from 'src/plugin-system/plugin.class';
 
 export default class ExamplePlugin extends Plugin {
     static options = {


### PR DESCRIPTION
### 1. Why is this change necessary?
`src/plugin-system/plugin.class` is the right path but the docs state an older version.

### 2. What does this change do, exactly?
Change the path in the docs.

### 3. Describe each step to reproduce the issue or behaviour.
1. 📋 🍝  from docs
2. Is not working

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
