### PR TITLE
Support keys in collection constructor

### DIFF
--- a/src/Core/Framework/DataAbstractionLayer/EntityCollection.php
+++ b/src/Core/Framework/DataAbstractionLayer/EntityCollection.php
@@ -6,6 +6,17 @@ use Shopware\Core\Framework\Struct\Collection;
 
 class EntityCollection extends Collection
 {
+    public function __construct(iterable $elements = [])
+    {
+        parent::__construct([]);
+
+        foreach ($elements as $element) {
+            $this->validateType($element);
+            /* @var Entity $element */
+            $this->set($element->getUniqueIdentifier(), $element);
+        }
+    }
+
     /**
      * @param Entity $entity
      */

--- a/src/Core/Framework/DataAbstractionLayer/Pricing/PriceCollection.php
+++ b/src/Core/Framework/DataAbstractionLayer/Pricing/PriceCollection.php
@@ -15,6 +15,16 @@ use Shopware\Core\Framework\Struct\Collection;
  */
 class PriceCollection extends Collection
 {
+    public function __construct(iterable $elements = [])
+    {
+        parent::__construct([]);
+
+        /* @var Price $element */
+        foreach ($elements as $element) {
+            $this->set($element->getCurrencyId(), $element);
+        }
+    }
+
     public function add($element): void
     {
         $this->validateType($element);

--- a/src/Core/Framework/Struct/Collection.php
+++ b/src/Core/Framework/Struct/Collection.php
@@ -11,8 +11,8 @@ abstract class Collection extends Struct implements \IteratorAggregate, \Countab
 
     public function __construct(iterable $elements = [])
     {
-        foreach ($elements as $element) {
-            $this->add($element);
+        foreach ($elements as $key => $element) {
+            $this->set($key, $element);
         }
     }
 

--- a/src/Core/Framework/Test/Struct/CollectionTest.php
+++ b/src/Core/Framework/Test/Struct/CollectionTest.php
@@ -18,6 +18,14 @@ class CollectionTest extends TestCase
         static::assertEquals($elements, $collection->getElements());
     }
 
+    public function testConstructorKeepingKeys(): void
+    {
+        $elements = ['z' => 'a', 'y' => 'b'];
+        $collection = new TestCollection($elements);
+
+        static::assertEquals($elements, $collection->getElements());
+    }
+
     public function testClear(): void
     {
         $collection = new TestCollection();


### PR DESCRIPTION
### 1. Why is this change necessary?
This prevents data loss.

### 2. What does this change do, exactly?
On constructing a collection it takes the same keys from the iteratable input for storing the elements internally.

### 3. Describe each step to reproduce the issue or behaviour.
1. Have a dataset indexed by a key so you can easily look that up
2. Add static types by wrapping in typed collection
3. Use get to get item by indexed key
4. Retrieved item is null
![grafik](https://user-images.githubusercontent.com/1133593/73165785-c33d6500-40f4-11ea-8f86-5f4c5b382f71.png)

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
