### PR TITLE
Add gravatar to administration

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/base/sw-avatar/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/base/sw-avatar/index.js
@@ -33,6 +33,10 @@ const colors = [
  * <sw-avatar size="48px"
  *            imageUrl="https://randomuser.me/api/portraits/women/68.jpg"></sw-avatar>
  * </div>
+ *
+ * <sw-avatar size="48px"
+ *            gravatarEmail="info@example.com"></sw-avatar>
+ * </div>
  */
 Component.register('sw-avatar', {
     template,

--- a/src/Administration/Resources/app/administration/src/app/component/base/sw-user-card/sw-user-card.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/base/sw-user-card/sw-user-card.html.twig
@@ -16,7 +16,8 @@
                                     <sw-avatar :color="moduleColor"
                                                size="80px"
                                                :firstName="user.firstName"
-                                               :lastName="user.lastName">
+                                               :lastName="user.lastName"
+                                               :gravatarEmail="user.email">
                                     </sw-avatar>
                                 {% endblock %}
 

--- a/src/Administration/Resources/app/administration/src/app/component/media/sw-media-gravatar-form/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/media/sw-media-gravatar-form/index.js
@@ -1,0 +1,89 @@
+import './sw-media-gravatar-form.scss';
+import template from './sw-media-gravatar-form.html.twig';
+
+const { Component } = Shopware;
+
+/**
+ * @status ready
+ * @description The <u>sw-media-gravatar-form</u> component is used to preview gravatar avatars.
+ * @example-type static
+ * @component-example
+ * <sw-media-gravatar-form variant="inline">
+ * </sw-media-gravatar-form>
+ */
+Component.register('sw-media-gravatar-form', {
+    template,
+
+    inject: [
+        'ExternalApiGravatarService'
+    ],
+
+    props: {
+        variant: {
+            type: String,
+            required: true,
+            validValues: ['modal', 'inline'],
+            validator(value) {
+                return ['modal', 'inline'].includes(value);
+            },
+            default: 'inline'
+        },
+        email: {
+            type: String,
+            required: false,
+            default: null
+        }
+    },
+
+    data() {
+        return {
+            loading: false,
+            url: ''
+        };
+    },
+
+    created() {
+        this.loadUrl();
+    },
+
+    watch: {
+        email() {
+            this.loadUrl();
+        }
+    },
+
+    computed: {
+        isValid() {
+            return !this.loading && this.url;
+        }
+    },
+
+    methods: {
+        loadUrl() {
+            this.loading = true;
+            this.ExternalApiGravatarService.requestAvatarUrl(this.email, 240)
+                .then(url => {
+                    this.url = url;
+                    this.loading = false;
+                });
+        },
+
+        emitUrl(originalDomEvent) {
+            if (this.isValid) {
+                this.$emit('media-gravatar-form-submit', {
+                    originalDomEvent,
+                    url: new URL(this.url),
+                    fileExtension: 'jpg'
+                });
+
+                if (this.variant === 'modal') {
+                    this.closeModal();
+                }
+            }
+        },
+
+        closeModal() {
+            this.$emit('modal-close');
+        }
+    }
+});

--- a/src/Administration/Resources/app/administration/src/app/component/media/sw-media-gravatar-form/sw-media-gravatar-form.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/media/sw-media-gravatar-form/sw-media-gravatar-form.html.twig
@@ -1,0 +1,98 @@
+{% block sw_media_gravatar_form %}
+    <sw-modal v-if="variant === 'modal'"
+        class="sw-media-gravatar-form"
+        variant="small"
+        :title="$tc('global.sw-media-gravatar-form.title')"
+        v-on="$listeners">
+        {% block sw_media_gravatar_form_loader %}
+            <sw-loader
+                v-if="loading"
+                size="50px">
+                {{ $tc('global.sw-media-gravatar-form.loader') }}
+            </sw-loader>
+        {% endblock %}
+
+        <template v-if="!loading">
+            <template v-if="url">
+                {% block sw_media_gravatar_form_avatar %}
+                    <sw-avatar
+                        class="sw-media-gravatar-form__avatar"
+                        size="240px"
+                        color="transparent"
+                        :imageUrl="url">
+                    </sw-avatar>
+                {% endblock %}
+            </template>
+
+            <template v-else>
+                {% block sw_media_gravatar_form_not_found_alert %}
+                    <sw-alert
+                        variant="error"
+                        appearance="default"
+                        :showIcon="true"
+                        :closable="false">
+                        {{ $t('global.sw-media-gravatar-form.notFoundAlert', { email }) }}
+                    </sw-alert>
+                {% endblock %}
+            </template>
+
+            {% block sw_media_gravatar_form_values %}
+                <sw-description-list
+                    grid="auto 1fr"
+                    class="sw-media-gravatar-form__values">
+                    {% block sw_media_gravatar_form_values_email %}
+                        <dt>
+                            {{ $tc('global.sw-media-gravatar-form.email') }}
+                        </dt>
+                        <dd>
+                            {{ email }}
+                        </dd>
+                    {% endblock %}
+
+                    {% block sw_media_gravatar_form_values_url %}
+                        <template v-if="url">
+                            <dt>
+                                {{ $tc('global.sw-media-gravatar-form.url') }}
+                            </dt>
+                            <dd>
+                                {{ url }}
+                            </dd>
+                        </template>
+                    {% endblock %}
+                </sw-description-list>
+            {% endblock %}
+        </template>
+
+        {% block sw_media_gravatar_form_footer %}
+            <template slot="modal-footer">
+                {% block sw_media_gravatar_form_cancel_button %}
+                    <sw-button size="small" @click="closeModal">
+                        {{ $tc('global.default.cancel') }}
+                    </sw-button>
+                {% endblock %}
+
+                {% block sw_media_gravatar_form_submit_button %}
+                    <sw-button
+                        class="sw-media-gravatar-form__submit-button"
+                        variant="primary"
+                        size="small"
+                        :disabled="!isValid"
+                        @click.prevent="emitUrl">
+                        {{ $tc('global.sw-media-gravatar-form.import') }}
+                    </sw-button>
+                {% endblock %}
+            </template>
+        {% endblock %}
+    </sw-modal>
+
+    <div v-else-if="variant === 'inline'">
+        {% block sw_media_gravatar_form_values %}{% endblock %}
+
+        <sw-button class="sw-media-gravatar-form__submit-button"
+                   size="small"
+                   variant="primary"
+                   @click="emitUrl">
+            {{ $tc('global.sw-media-gravatar-form.import') }}
+        </sw-button>
+    </div>
+{% endblock %}

--- a/src/Administration/Resources/app/administration/src/app/component/media/sw-media-gravatar-form/sw-media-gravatar-form.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/media/sw-media-gravatar-form/sw-media-gravatar-form.html.twig
@@ -1,6 +1,6 @@
 {% block sw_media_gravatar_form %}
     <sw-modal v-if="variant === 'modal'"
-        class="sw-media-gravatar-form"
+        class="sw-media-gravatar-form is--modal"
         variant="small"
         :title="$tc('global.sw-media-gravatar-form.title')"
         v-on="$listeners">
@@ -85,14 +85,41 @@
         {% endblock %}
     </sw-modal>
 
-    <div v-else-if="variant === 'inline'">
-        {% block sw_media_gravatar_form_values %}{% endblock %}
+    <div
+        v-else-if="variant === 'inline'"
+        class="sw-media-gravatar-form is--inline">
+        <template v-if="url">
+            {% block sw_media_gravatar_form_avatar %}
+                <sw-avatar
+                    class="sw-media-gravatar-form__avatar"
+                    size="96px"
+                    color="transparent"
+                    :imageUrl="url">
+                </sw-avatar>
+            {% endblock %}
+        </template>
 
-        <sw-button class="sw-media-gravatar-form__submit-button"
-                   size="small"
-                   variant="primary"
-                   @click="emitUrl">
-            {{ $tc('global.sw-media-gravatar-form.import') }}
-        </sw-button>
+        <template v-else>
+            {% block sw_media_gravatar_form_not_found_alert %}
+                <sw-alert
+                    variant="error"
+                    appearance="default"
+                    :showIcon="true"
+                    :closable="false">
+                    {{ $t('global.sw-media-gravatar-form.notFoundAlert', { email }) }}
+                </sw-alert>
+            {% endblock %}
+        </template>
+
+        {% block sw_media_gravatar_form_submit_button %}
+            <sw-button
+                class="sw-media-gravatar-form__submit-button"
+                size="small"
+                variant="primary"
+                :disabled="!isValid"
+                @click="emitUrl">
+                {{ $t('global.sw-media-gravatar-form.import') }}
+            </sw-button>
+        {% endblock %}
     </div>
 {% endblock %}

--- a/src/Administration/Resources/app/administration/src/app/component/media/sw-media-gravatar-form/sw-media-gravatar-form.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/media/sw-media-gravatar-form/sw-media-gravatar-form.scss
@@ -8,4 +8,11 @@
     .sw-media-gravatar-form__values {
         display: grid;
     }
+
+    &.is--inline {
+        .sw-media-gravatar-form__avatar {
+            max-height: 96px;
+            max-width: 96px;
+        }
+    }
 }

--- a/src/Administration/Resources/app/administration/src/app/component/media/sw-media-gravatar-form/sw-media-gravatar-form.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/media/sw-media-gravatar-form/sw-media-gravatar-form.scss
@@ -1,0 +1,11 @@
+.sw-media-gravatar-form {
+    .sw-media-gravatar-form__avatar {
+        border-radius: 0;
+        display: block;
+        margin: 0 auto;
+    }
+
+    .sw-media-gravatar-form__values {
+        display: grid;
+    }
+}

--- a/src/Administration/Resources/app/administration/src/app/component/media/sw-media-upload/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/media/sw-media-upload/index.js
@@ -11,7 +11,7 @@ const inputTypeGravatarImport = 'gravatar-import';
 /**
  * @status ready
  * @description The <u>sw-media-upload</u> component is used wherever an upload is needed. It supports drag & drop-,
- * file- and url-upload and comes in various forms.
+ * file-, url-upload, gravatar import and comes in various forms.
  * @example-type code-only
  * @component-example
  * <sw-media-upload

--- a/src/Administration/Resources/app/administration/src/app/component/media/sw-media-upload/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/media/sw-media-upload/index.js
@@ -37,9 +37,9 @@ Component.register('sw-media-upload', {
         variant: {
             type: String,
             required: false,
-            validValues: ['compact', 'regular'],
+            validValues: ['compact', 'regular', 'gravatar'],
             validator(value) {
-                return ['compact', 'regular'].includes(value);
+                return ['compact', 'regular', 'gravatar'].includes(value);
             },
             default: 'regular'
         },
@@ -79,6 +79,12 @@ Component.register('sw-media-upload', {
             type: String,
             required: false,
             default: null
+        },
+
+        gravatarEmail: {
+            type: String,
+            required: false,
+            default: null
         }
     },
 
@@ -86,6 +92,7 @@ Component.register('sw-media-upload', {
         return {
             multiSelect: this.allowMultiSelect,
             showUrlInput: false,
+            showGravatarImport: false,
             preview: null,
             isDragActive: false,
             defaultFolderId: null
@@ -263,6 +270,18 @@ Component.register('sw-media-upload', {
             this.showUrlInput = !this.showUrlInput;
         },
 
+        openGravatarModal() {
+            this.showGravatarImport = true;
+        },
+
+        closeGravatarModal() {
+            this.showGravatarImport = false;
+        },
+
+        toggleShowGravatarImport() {
+            this.showGravatarImport = !this.showGravatarImport;
+        },
+
         onClickOpenMediaSidebar() {
             this.$emit('media-upload-sidebar-open');
         },
@@ -292,6 +311,28 @@ Component.register('sw-media-upload', {
             });
 
             this.closeUrlModal();
+        },
+
+        /*
+         * entry points
+         */
+        onGravatarImport({ url, fileExtension }) {
+            if (!this.multiSelect) {
+                this.uploadStore.removeByTag(this.uploadTag);
+                this.preview = url;
+            }
+
+            const fileInfo = fileReader.getNameAndExtensionFromUrl(url);
+            if (fileExtension) {
+                fileInfo.extension = fileExtension;
+            }
+
+            const targetEntity = this.getMediaEntityForUpload();
+            targetEntity.save().then(() => {
+                this.uploadStore.addUpload(this.uploadTag, { src: url, targetId: targetEntity.id, ...fileInfo });
+            });
+
+            this.closeGravatarModal();
         },
 
         onFileInputChange() {

--- a/src/Administration/Resources/app/administration/src/app/component/media/sw-media-upload/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/media/sw-media-upload/index.js
@@ -4,6 +4,9 @@ import './sw-media-upload.scss';
 
 const { Component, Mixin, StateDeprecated } = Shopware;
 const { fileReader } = Shopware.Utils;
+const inputTypeFileUpload = 'file-upload';
+const inputTypeUrlUpload = 'url-upload';
+const inputTypeGravatarImport = 'gravatar-import';
 
 /**
  * @status ready
@@ -37,9 +40,9 @@ Component.register('sw-media-upload', {
         variant: {
             type: String,
             required: false,
-            validValues: ['compact', 'regular', 'gravatar'],
+            validValues: ['compact', 'regular'],
             validator(value) {
-                return ['compact', 'regular', 'gravatar'].includes(value);
+                return ['compact', 'regular'].includes(value);
             },
             default: 'regular'
         },
@@ -91,8 +94,7 @@ Component.register('sw-media-upload', {
     data() {
         return {
             multiSelect: this.allowMultiSelect,
-            showUrlInput: false,
-            showGravatarImport: false,
+            urlInputType: inputTypeFileUpload,
             preview: null,
             isDragActive: false,
             defaultFolderId: null
@@ -151,6 +153,18 @@ Component.register('sw-media-upload', {
 
         mediaFolderId() {
             return this.defaultFolderId || this.targetFolderId;
+        },
+
+        isUrlUpload() {
+            return this.urlInputType === inputTypeUrlUpload;
+        },
+
+        isFileUpload() {
+            return this.urlInputType === inputTypeFileUpload;
+        },
+
+        isGravatarImport() {
+            return this.urlInputType === inputTypeGravatarImport;
         }
     },
 
@@ -252,24 +266,16 @@ Component.register('sw-media-upload', {
             this.$refs.fileInput.click();
         },
 
-        openUrlModal() {
-            this.showUrlInput = true;
+        useUrlUpload() {
+            this.urlInputType = inputTypeUrlUpload;
         },
 
-        closeUrlModal() {
-            this.showUrlInput = false;
+        useFileUpload() {
+            this.urlInputType = inputTypeFileUpload;
         },
 
-        openGravatarModal() {
-            this.showGravatarImport = true;
-        },
-
-        closeGravatarModal() {
-            this.showGravatarImport = false;
-        },
-
-        toggleShowGravatarImport() {
-            this.showGravatarImport = !this.showGravatarImport;
+        useGravatarImport() {
+            this.urlInputType = inputTypeGravatarImport;
         },
 
         onClickOpenMediaSidebar() {

--- a/src/Administration/Resources/app/administration/src/app/component/media/sw-media-upload/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/media/sw-media-upload/index.js
@@ -132,12 +132,6 @@ Component.register('sw-media-upload', {
             return this.preview !== null;
         },
 
-        toggleButtonCaption() {
-            return this.showUrlInput ?
-                this.$tc('global.sw-media-upload.buttonSwitchToFileUpload') :
-                this.$tc('global.sw-media-upload.buttonSwitchToUrlUpload');
-        },
-
         hasOpenMediaButtonListener() {
             return Object.keys(this.$listeners).includes('media-upload-sidebar-open');
         },
@@ -264,10 +258,6 @@ Component.register('sw-media-upload', {
 
         closeUrlModal() {
             this.showUrlInput = false;
-        },
-
-        toggleShowUrlFields() {
-            this.showUrlInput = !this.showUrlInput;
         },
 
         openGravatarModal() {

--- a/src/Administration/Resources/app/administration/src/app/component/media/sw-media-upload/sw-media-upload.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/media/sw-media-upload/sw-media-upload.html.twig
@@ -50,9 +50,23 @@
                         {% endblock %}
 
                         {% block sw_media_upload_regular_header_switch %}
-                            <a v-if="!source" class="sw-media-upload__switch-mode" @click="toggleShowUrlFields">
-                                {{ toggleButtonCaption }}
-                            </a>
+                            <sw-context-button
+                                v-if="!source"
+                                class="sw-media-upload__switch-mode">
+                                <sw-context-menu-item
+                                    v-if="showUrlInput"
+                                    @click="closeUrlModal"
+                                    class="sw-media-upload__button-file-upload">
+                                    {{ $tc('global.sw-media-upload.buttonFileUpload') }}
+                                </sw-context-menu-item>
+
+                                <sw-context-menu-item
+                                    v-if="!showUrlInput"
+                                    @click="openUrlModal"
+                                    class="sw-media-upload__button-url-upload">
+                                    {{ $tc('global.sw-media-upload.buttonUrlUpload') }}
+                                </sw-context-menu-item>
+                            </sw-context-button>
                         {% endblock %}
                     </div>
                 {% endblock %}

--- a/src/Administration/Resources/app/administration/src/app/component/media/sw-media-upload/sw-media-upload.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/media/sw-media-upload/sw-media-upload.html.twig
@@ -17,8 +17,12 @@
                                 </sw-button>
                             </template>
 
-                            <sw-context-menu-item @click="openUrlModal" class="sw-media-upload__button-url-upload">
+                            <sw-context-menu-item @click="useUrlUpload" class="sw-media-upload__button-url-upload">
                                 {{ $tc('global.sw-media-upload.buttonUrlUpload') }}
+                            </sw-context-menu-item>
+
+                            <sw-context-menu-item v-if="gravatarEmail" @click="useGravatarImport" class="sw-media-upload__button-gravatar-import">
+                                {{ $tc('global.sw-media-upload.buttonGravatarImport') }}
                             </sw-context-menu-item>
                         </sw-context-button>
                     {% endblock %}
@@ -26,11 +30,21 @@
 
                 {% block sw_media_upload_compact_url_form %}
                     <sw-media-url-form
-                        v-if="showUrlInput"
+                        v-if="isUrlUpload"
                         variant="modal"
-                        @modal-close="closeUrlModal"
+                        @modal-close="useFileUpload"
                         @media-url-form-submit="onUrlUpload">
                     </sw-media-url-form>
+                {% endblock %}
+
+                {% block sw_media_upload_compact_gravatar_form %}
+                    <sw-media-gravatar-form
+                        v-if="isGravatarImport"
+                        :email="gravatarEmail"
+                        variant="modal"
+                        @modal-close="useFileUpload"
+                        @media-gravatar-form-submit="onUrlUpload">
+                    </sw-media-gravatar-form>
                 {% endblock %}
             </div>
         {% endblock %}
@@ -54,17 +68,24 @@
                                 v-if="!source"
                                 class="sw-media-upload__switch-mode">
                                 <sw-context-menu-item
-                                    v-if="showUrlInput"
-                                    @click="closeUrlModal"
+                                    v-if="!isFileUpload"
+                                    @click="useFileUpload"
                                     class="sw-media-upload__button-file-upload">
                                     {{ $tc('global.sw-media-upload.buttonFileUpload') }}
                                 </sw-context-menu-item>
 
                                 <sw-context-menu-item
-                                    v-if="!showUrlInput"
-                                    @click="openUrlModal"
+                                    v-if="!isUrlUpload"
+                                    @click="useUrlUpload"
                                     class="sw-media-upload__button-url-upload">
                                     {{ $tc('global.sw-media-upload.buttonUrlUpload') }}
+                                </sw-context-menu-item>
+
+                                <sw-context-menu-item
+                                    v-if="gravatarEmail && !isGravatarImport"
+                                    @click="useGravatarImport"
+                                    class="sw-media-upload__button-gravatar-import">
+                                    {{ $tc('global.sw-media-upload.buttonGravatarImport') }}
                                 </sw-context-menu-item>
                             </sw-context-button>
                         {% endblock %}
@@ -121,14 +142,14 @@
                                     {% block sw_media_upload_regular_actions_url %}
                                         <sw-media-url-form
                                             class="sw-media-upload__url-form"
-                                            v-if="showUrlInput"
+                                            v-if="isUrlUpload"
                                             variant="inline"
                                             @media-url-form-submit="onUrlUpload">
                                         </sw-media-url-form>
                                     {% endblock %}
 
                                     {% block sw_media_upload_regular_actions_add %}
-                                        <template v-if="!showUrlInput">
+                                        <template v-if="isFileUpload">
                                             {% block sw_media_upload_regular_upload_button %}
                                                 <sw-button class="sw-media-upload__button upload"
                                                             variant="ghost"
@@ -147,6 +168,17 @@
                                                     {{ $tc('global.sw-media-upload.buttonOpenMedia') }}
                                                 </sw-button>
                                             {% endblock %}
+                                        </template>
+                                    {% endblock %}
+
+                                    {% block sw_media_upload_regular_actions_gravatar %}
+                                        <template v-if="isGravatarImport">
+                                            <sw-media-gravatar-form
+                                                class="sw-media-upload__gravatar-form"
+                                                variant="inline"
+                                                :email="gravatarEmail"
+                                                @media-gravatar-form-submit="onUrlUpload">
+                                            </sw-media-gravatar-form>
                                         </template>
                                     {% endblock %}
                                 </template>

--- a/src/Administration/Resources/app/administration/src/app/component/media/sw-media-upload/sw-media-upload.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/media/sw-media-upload/sw-media-upload.scss
@@ -133,6 +133,13 @@ $sw-media-upload-caption-icon-color:           $color-steam-cloud;
         }
     }
 
+    .sw-media-upload__gravatar-form {
+        display: flex;
+        flex-direction: row;
+        align-items: center;
+        width: 100%;
+    }
+
     .sw-media-upload__button-compact-upload {
         margin-right: 0 !important;
     }

--- a/src/Administration/Resources/app/administration/src/app/component/structure/sw-admin-menu/sw-admin-menu.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/structure/sw-admin-menu/sw-admin-menu.html.twig
@@ -75,7 +75,8 @@
                             <sw-avatar class="sw-admin-menu__avatar"
                                        :imageUrl="avatarUrl"
                                        :firstName="firstName"
-                                       :lastName="lastName">
+                                       :lastName="lastName"
+                                       :gravatarEmail="currentUser.email">
                             </sw-avatar>
                         {% endblock %}
 

--- a/src/Administration/Resources/app/administration/src/app/init/external-api.init.js
+++ b/src/Administration/Resources/app/administration/src/app/init/external-api.init.js
@@ -1,0 +1,6 @@
+import Axios from 'axios';
+import ExternalApiGravatarService from 'src/core/service/external/gravatar.service';
+
+export default function initExternalApis() {
+    this.addServiceProvider('ExternalApiGravatarService', () => new ExternalApiGravatarService(Axios.create()));
+}

--- a/src/Administration/Resources/app/administration/src/app/init/index.js
+++ b/src/Administration/Resources/app/administration/src/app/init/index.js
@@ -17,6 +17,7 @@ import initComponents from 'src/app/init/component.init';
 import initSvgIcons from 'src/app/init/svg-icons.init';
 import initShortcut from 'src/app/init/shortcut.init';
 import initStateDeprecated from 'src/app/init/state-deprecated.init';
+import initExternalApi from 'src/app/init/external-api.init';
 
 export default {
     coreMixin: initMixin,
@@ -33,5 +34,6 @@ export default {
     httpClient: initHttpClient,
     componentHelper: initComponentHelper,
     entity: initEntity,
-    stateDeprecated: initStateDeprecated
+    stateDeprecated: initStateDeprecated,
+    externalApi: initExternalApi
 };

--- a/src/Administration/Resources/app/administration/src/app/snippet/de-DE.json
+++ b/src/Administration/Resources/app/administration/src/app/snippet/de-DE.json
@@ -256,6 +256,7 @@
     "sw-media-upload": {
       "buttonFileUpload": "Dateien hochladen",
       "buttonUrlUpload": "Über URL hochladen",
+      "buttonGravatarImport": "Von Gravatar importieren",
       "buttonSwitchToFileUpload": "Datei von Deinem Computer hochladen",
       "buttonSwitchToUrlUpload": "Datei von URL hochladen",
       "buttonOpenMedia": "Medien öffnen",

--- a/src/Administration/Resources/app/administration/src/app/snippet/de-DE.json
+++ b/src/Administration/Resources/app/administration/src/app/snippet/de-DE.json
@@ -281,6 +281,15 @@
       "labelFileExtension": "Dateiendung",
       "missingFileExtension": "In der angegebenen URL konnte keine Dateiendung gefunden werden. Bitte gib eine Dateiendung an."
     },
+    "sw-media-gravatar-form": {
+      "title": "Avatar aus Gravatar importieren",
+      "import": "Importieren",
+      "example": "info@beispiel.de",
+      "email": "E-Mail",
+      "url": "URL",
+      "notFoundAlert": "Es wurde kein Avatar für die E-Mail-Adresse \"{email}\" gefunden",
+      "loader": "Warten auf Antwort von gravatar.com"
+    },
     "sw-media-modal-folder-settings": {
       "labelSettings": "Einstellungen",
       "labelSystem": "Systemordner",

--- a/src/Administration/Resources/app/administration/src/app/snippet/en-GB.json
+++ b/src/Administration/Resources/app/administration/src/app/snippet/en-GB.json
@@ -256,6 +256,7 @@
     "sw-media-upload": {
       "buttonFileUpload": "Upload file",
       "buttonUrlUpload": "Upload file from URL",
+      "buttonGravatarImport": "Import from Gravatar",
       "buttonSwitchToFileUpload": "Upload file from your computer",
       "buttonSwitchToUrlUpload": "Upload file from url",
       "buttonOpenMedia": "Open media",

--- a/src/Administration/Resources/app/administration/src/app/snippet/en-GB.json
+++ b/src/Administration/Resources/app/administration/src/app/snippet/en-GB.json
@@ -281,6 +281,15 @@
       "labelFileExtension": "File extension",
       "missingFileExtension": "The URL does not contain a file extension. Please enter a file extension above."
     },
+    "sw-media-gravatar-form": {
+      "title": "Import avatar from Gravatar",
+      "import": "Import",
+      "example": "info@example.com",
+      "email": "E-mail",
+      "url": "URL",
+      "notFoundAlert": "No avatar for email address \"{email}\" found",
+      "loader": "Waiting for gravatar.com to respond"
+    },
     "sw-media-modal-folder-settings": {
       "labelSettings": "Settings",
       "labelSystem": "System folder",

--- a/src/Administration/Resources/app/administration/src/core/service/external/gravatar.service.js
+++ b/src/Administration/Resources/app/administration/src/core/service/external/gravatar.service.js
@@ -1,0 +1,38 @@
+import { md5 } from '../utils/format.utils';
+
+/**
+ * Http client for gravatar
+ * @class
+ */
+class ExternalApiGravatarService {
+    /**
+     * @var {AxiosInstance}
+     */
+    _httpClient;
+
+    /**
+     * @param httpClient {AxiosInstance}
+     */
+    constructor(httpClient) {
+        this._httpClient = httpClient;
+    }
+
+    /**
+     * @param email {String}
+     * @param size {Number} Any sidelength between 1 and 2048
+     * @param rating {String} Any of g, pg, r, x
+     * @param fallback {String} Any of 404, mp, identicon, monsterid, wavatar, retro, robohash, blank or any URI to graphics
+     * @returns {PromiseLike<String> | Promise<String> | String}
+     */
+    requestAvatarUrl(email, size, rating, fallback) {
+        size = size || 80;
+        rating = rating || 'g';
+        fallback = fallback || '404';
+        const url = `https://s.gravatar.com/avatar/${md5(email)}`;
+        const params = { size, rating, default: fallback };
+
+        return this._httpClient.get(url, { params }).then(() => url).catch(() => null);
+    }
+}
+
+export default ExternalApiGravatarService;

--- a/src/Administration/Resources/app/administration/src/module/sw-customer/component/sw-customer-card/sw-customer-card.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-customer/component/sw-customer-card/sw-customer-card.html.twig
@@ -10,7 +10,8 @@
                                     {% block sw_customer_card_avatar %}
                                         <sw-avatar size="80px"
                                                    :firstName="customer.firstName"
-                                                   :lastName="customer.lastName">
+                                                   :lastName="customer.lastName"
+                                                   :gravatarEmail="customer.email">
                                         </sw-avatar>
                                     {% endblock %}
 

--- a/src/Administration/Resources/app/administration/src/module/sw-customer/page/sw-customer-list/sw-customer-list.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-customer/page/sw-customer-list/sw-customer-list.html.twig
@@ -61,7 +61,8 @@
                                         <sw-avatar
                                             :size="compact ? '32px' : '48px'"
                                             :firstName="item.firstName"
-                                            :lastName="item.lastName">
+                                            :lastName="item.lastName"
+                                            :gravatarEmail="item.email">
                                         </sw-avatar>
                                     </template>
                                 {% endblock %}

--- a/src/Administration/Resources/app/administration/src/module/sw-profile/page/sw-profile-index/sw-profile-index.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-profile/page/sw-profile-index/sw-profile-index.html.twig
@@ -90,6 +90,7 @@
                                 <sw-media-upload
                                     variant="regular"
                                     class="sw-profile-index__user-image-upload"
+                                    :gravatarEmail="user.email"
                                     :uploadTag="uploadTag"
                                     :source="avatarMediaItem"
                                     :allowMultiSelect="false"

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-user/page/sw-settings-user-detail/sw-settings-user-detail.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-user/page/sw-settings-user-detail/sw-settings-user-detail.html.twig
@@ -86,6 +86,7 @@
                                             :label="$tc('sw-settings-user.user-detail.labelProfilePicture')"
                                             :uploadTag="user.id"
                                             :allowMultiSelect="false"
+                                            :gravatarEmail="user.email"
                                             variant="regular"
                                             defaultFolder="user"
                                             @media-upload-remove-image="onUnlinkLogo">

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-user/page/sw-settings-user-list/sw-settings-user-list.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-user/page/sw-settings-user-list/sw-settings-user-list.html.twig
@@ -67,6 +67,17 @@
                             </template>
                         {% endblock %}
 
+                        {% block sw_settings_user_list_column_avatar %}
+                            <template #preview-username="{ item, compact }">
+                                <sw-avatar
+                                    :size="compact ? '32px' : '48px'"
+                                    :firstName="item.firstName"
+                                    :lastName="item.lastName"
+                                    :gravatarEmail="item.email">
+                                </sw-avatar>
+                            </template>
+                        {% endblock %}
+
                         {% block sw_settings_user_list_column_username %}
                             <template #column-username="{ item }">
                                 {% block sw_settings_user_list_column_username_content %}


### PR DESCRIPTION
### 1. Why is this change necessary?
The customers have a sort-of avatar but you can't upload an avatar? You can set an avatar for an admin user but only see it in the bottom left corner? This is super weird.

There is one product that serves the whole internets avatars for every forum, chat app or enterprise application. The product out of the application stash from [automattic](https://automattic.com/) that is surpassing any other of their products.

It can be so easy. Have a look at it:

![pr-gravatar-low](https://user-images.githubusercontent.com/1133593/73229141-04775880-4179-11ea-9674-175dfb98e0c1.gif)

### 2. What does this change do, exactly?
* Add gravatar to sw-avatar for preview
* Add gravatar to sw-media-upload for import
* Add avatar column to admin users
* Prepare used sw-avatar to use new gravatar feature
* Prepare used sw-media-upload to use new gravatar feature

### 3. Describe each step to reproduce the issue or behaviour.
1. Have admin account in inferior multi-purpose system
2. See my face
3. Am happy
4. Have admin account in master-race ecommerce platform
5. Being unrecognized
6. Am sad

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
