### PR TITLE
Allow searching for manufacturer name

### DIFF
--- a/src/Core/Content/Product/SearchKeyword/ProductSearchKeywordIndexer.php
+++ b/src/Core/Content/Product/SearchKeyword/ProductSearchKeywordIndexer.php
@@ -224,7 +224,7 @@ class ProductSearchKeywordIndexer implements IndexerInterface
         $products = $context->disableCache(function (Context $context) use ($ids) {
             $context->setConsiderInheritance(true);
 
-            return $this->productRepository->search(new Criteria($ids), $context);
+            return $this->productRepository->search((new Criteria($ids))->addAssociation('manufacturer'), $context);
         });
 
         $versionId = Uuid::fromHexToBytes($context->getVersionId());


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/community).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?

The `ProductSearchKeywordAnalyzer` was already trying to add keywords for the product's manufacturer name, but because of a missing association this never succeeded. By adding the necessary association to the `ProductSearchKeywordIndexer`, the analyzer can successfully create a keyword for the manufacturer.

### 2. What does this change do, exactly?

`addAssociation('manufacturer')` in `ProductSearchKeywordIndexer`

### 3. Describe each step to reproduce the issue or behaviour.

Assign a product to a manufacturer, go to frontend, search for manufacturer name. Product will not show up in the search results.

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.
