### PR TITLE
Added .gitkeep for ftp/sftp upload

### DIFF
--- a/src/Storefront/Theme/Command/ThemeCreateCommand.php
+++ b/src/Storefront/Theme/Command/ThemeCreateCommand.php
@@ -108,6 +108,7 @@ class ThemeCreateCommand extends Command
         file_put_contents($themeConfigFile, $themeConfig);
         file_put_contents($variableOverridesFile, $this->getVariableOverridesTemplate());
 
+        touch($directory . '/src/Resources/app/storefront/src/assets/.gitkeep');
         touch($directory . '/src/Resources/app/storefront/src/scss/base.scss');
         touch($directory . '/src/Resources/app/storefront/src/main.js');
         touch($directory . '/src/Resources/app/storefront/dist/storefront/js/' . $snakeCaseName . '.js');


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/community).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
When creating a theme and simple uploading it in phpstorm for example, the IDE will not upload the empty folder. This will cause a fatal error, which is not displayed in the administration but only on the cli.

### 2. What does this change do, exactly?
It adds a .gitkeep file to the assets folder

### 3. Describe each step to reproduce the issue or behaviour.
Use **php bin/console theme:create** and upload the created theme directly in phpstorm to your server. When choosing the theme in the admin it will show the following error:

![Auswahl_154](https://user-images.githubusercontent.com/8600299/73431525-e78d8180-4340-11ea-9aac-8e15eb2fc682.png)

in the CLI it will throw a error like this

![Auswahl_153](https://user-images.githubusercontent.com/8600299/73431559-fecc6f00-4340-11ea-8762-6b890aa025f9.png)


### 4. Please link to the relevant issues (if any).
-

### 5. Checklist

- [x] I have squashed any insignificant commits
- [x] I have read the contribution requirements and fulfil them.
