### PR TITLE
NEXT-6111 - Refactor API Unit Test Auth Browser

### DIFF
--- a/src/Core/Framework/Test/Api/Controller/AuthControllerTest.php
+++ b/src/Core/Framework/Test/Api/Controller/AuthControllerTest.php
@@ -46,10 +46,6 @@ class AuthControllerTest extends TestCase
         ];
 
         $client = $this->getBrowser();
-        $client->setServerParameters([
-            'CONTENT_TYPE' => 'application/json',
-            'HTTP_ACCEPT' => ['application/vnd.api+json,application/json'],
-        ]);
         $client->request('POST', '/api/oauth/token', $authPayload);
 
         static::assertEquals(Response::HTTP_UNAUTHORIZED, $client->getResponse()->getStatusCode());
@@ -66,8 +62,6 @@ class AuthControllerTest extends TestCase
     {
         $client = $this->getBrowser();
         $client->setServerParameters([
-            'CONTENT_TYPE' => 'application/json',
-            'HTTP_ACCEPT' => ['application/vnd.api+json,application/json'],
             'HTTP_Authorization' => 'Bearer invalid_token_provided',
         ]);
         $client->request('GET', '/api/v' . PlatformRequest::API_VERSION . '/tax');
@@ -122,10 +116,6 @@ class AuthControllerTest extends TestCase
     public function testInvalidRefreshToken(): void
     {
         $client = $this->getBrowser();
-        $client->setServerParameters([
-            'CONTENT_TYPE' => 'application/json',
-            'HTTP_ACCEPT' => ['application/vnd.api+json,application/json'],
-        ]);
 
         $refreshPayload = [
             'grant_type' => 'refresh_token',
@@ -150,11 +140,7 @@ class AuthControllerTest extends TestCase
 
     public function testRefreshToken(): void
     {
-        $client = $this->getBrowser();
-        $client->setServerParameters([
-            'CONTENT_TYPE' => 'application/json',
-            'HTTP_ACCEPT' => ['application/vnd.api+json,application/json'],
-        ]);
+        $client = $this->getBrowser(false);
 
         $username = Uuid::randomHex();
         $password = Uuid::randomHex();
@@ -241,11 +227,7 @@ class AuthControllerTest extends TestCase
         if (next3722()) {
             static::markTestSkipped('Reactivate if Integrations can have their own acls');
         }
-        $client = $this->getBrowser();
-        $client->setServerParameters([
-            'CONTENT_TYPE' => 'application/json',
-            'HTTP_ACCEPT' => ['application/vnd.api+json,application/json'],
-        ]);
+        $client = $this->getBrowser(false);
 
         $accessKey = AccessKeyHelper::generateAccessKey('integration');
         $secretKey = AccessKeyHelper::generateSecretAccessKey();

--- a/src/Core/Framework/Test/TestCaseBase/AdminApiTestBehaviour.php
+++ b/src/Core/Framework/Test/TestCaseBase/AdminApiTestBehaviour.php
@@ -70,8 +70,10 @@ trait AdminApiTestBehaviour
 
     public function createClient(
         ?KernelInterface $kernel = null,
-        bool $enableReboot = false
-    ): KernelBrowser {
+        bool $enableReboot = false,
+        bool $authorized = true
+    ): KernelBrowser
+    {
         if (!$kernel) {
             $kernel = $this->getKernel();
         }
@@ -84,7 +86,9 @@ trait AdminApiTestBehaviour
             'HTTP_ACCEPT' => ['application/vnd.api+json,application/json'],
         ]);
 
-        $this->authorizeBrowser($apiBrowser);
+        if ($authorized) {
+            $this->authorizeBrowser($apiBrowser);
+        }
 
         return $this->kernelBrowser = $apiBrowser;
     }
@@ -216,13 +220,17 @@ trait AdminApiTestBehaviour
 
     abstract protected function getKernel(): KernelInterface;
 
-    protected function getBrowser(): KernelBrowser
+    protected function getBrowser(bool $authorized = true): KernelBrowser
     {
         if ($this->kernelBrowser) {
             return $this->kernelBrowser;
         }
 
-        return $this->kernelBrowser = $this->createClient();
+        return $this->kernelBrowser = $this->createClient(
+            null,
+            false,
+            $authorized
+        );
     }
 
     protected function getBrowserAuthenticatedWithIntegration(): KernelBrowser


### PR DESCRIPTION
### 1. Why is this change necessary?
Api authentication tests are slow

### 2. What does this change do, exactly?
Before every test, a user mock is inserted into the database and an authorized OAuth access token is generated and attached to the test client. But in some test cases, we need to explicitly test the generation of a access token / refresh token. Therefore an authorized test client is not needed before and we can speed up the tests.

This PR adds the possibility to skip the creation of a user mock and an authorized token, if this is done in the test explicitly.

Additionally: Removed some extra CONTENT-TYPE and HTTP-ACCEPT headers in the tests. These are always set before when the api auth test client is created

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
[NEXT-6111](https://issues.shopware.com/issues/NEXT-6111)

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.
