### PR TITLE
NEXT-4274 - Domains for headless sales channels

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/view/sw-sales-channel-detail-base/sw-sales-channel-detail-base.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/view/sw-sales-channel-detail-base/sw-sales-channel-detail-base.html.twig
@@ -213,7 +213,7 @@
 
         {% block sw_sales_channel_detail_base_options_domains %}
             <sw-sales-channel-detail-domains
-                v-if="salesChannel && isStoreFront"
+                v-if="salesChannel"
                 :salesChannel="salesChannel"
                 :isLoading="isLoading">
             </sw-sales-channel-detail-domains>

--- a/src/Core/Framework/DependencyInjection/services.xml
+++ b/src/Core/Framework/DependencyInjection/services.xml
@@ -291,6 +291,7 @@
             <argument type="service" id="Shopware\Core\System\SalesChannel\Context\SalesChannelContextService"/>
             <argument type="service" id="event_dispatcher"/>
             <argument type="service" id="Shopware\Core\Framework\Routing\RouteScopeRegistry"/>
+            <argument type="service" id="Doctrine\DBAL\Connection"/>
         </service>
 
         <service id="Shopware\Core\Framework\Api\Controller\SalesChannelProxyController" public="true">

--- a/src/Core/Framework/Routing/SalesChannelApiRouteScope.php
+++ b/src/Core/Framework/Routing/SalesChannelApiRouteScope.php
@@ -3,7 +3,6 @@
 namespace Shopware\Core\Framework\Routing;
 
 use Shopware\Core\Framework\Api\Context\SalesChannelApiSource;
-use Shopware\Core\Framework\Api\Context\SystemSource;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\PlatformRequest;
 use Symfony\Component\HttpFoundation\Request;
@@ -21,10 +20,6 @@ class SalesChannelApiRouteScope extends AbstractRouteScope implements SalesChann
     {
         /** @var Context $requestContext */
         $requestContext = $request->attributes->get(PlatformRequest::ATTRIBUTE_CONTEXT_OBJECT);
-
-        if (!$request->attributes->get('auth_required', true)) {
-            return $requestContext->getSource() instanceof SystemSource;
-        }
 
         return $requestContext->getSource() instanceof SalesChannelApiSource;
     }


### PR DESCRIPTION
### 1. Why is this change necessary?
Headless sales channels can not have associated domains.

### 2. What does this change do, exactly?
Add domains to headless sales channel edit admin page.
Resolve sales channel via domain for sales-channel-api calls.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
[Ticket](https://issues.shopware.com/issues/NEXT-4274)

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.
