### PR TITLE
Update 110-sales-channel-context-api.md

### DIFF
--- a/src/Docs/Resources/current/3-api/110-sales-channel-context-api.md
+++ b/src/Docs/Resources/current/3-api/110-sales-channel-context-api.md
@@ -3,11 +3,16 @@
 The `context` endpoint is used to obtain information about various entities like currency, language or country which are assigned to a
 sales channel.
 
+## Get salutations
+
+**GET  /sales-channel-api/v1/salutation**
+
+**Response:** Returns a list of salutations defined in the settings of your shop.
+
 ## Get currencies
 
 **GET  /sales-channel-api/v1/currency**
 
-**Header:** sw-context-token is required  
 **Response:** Returns a list of currencies assigned to the sales channel.
 All filter, sorting, limit, and search operations are supported.
 You find more information about these operations [here](./050-filter-search-limit.md).
@@ -16,7 +21,6 @@ You find more information about these operations [here](./050-filter-search-limi
 
 **GET  /sales-channel-api/v1/language**
 
-**Header:** sw-context-token is required  
 **Response:** Returns a list of languages assigned to the sales channel.
 All filter, sorting, limit, and search operations are supported.
 You find more information about these operations [here](./050-filter-search-limit.md).
@@ -25,7 +29,6 @@ You find more information about these operations [here](./050-filter-search-limi
 
 **GET  /sales-channel-api/v1/country**
 
-**Header:** sw-context-token is required  
 **Response:** Returns a list of countries assigned to the sales channel.
 All filter, sorting, limit, and search operations are supported.
 You find more information about these operations [here](./050-filter-search-limit.md).
@@ -34,7 +37,6 @@ You find more information about these operations [here](./050-filter-search-limi
 
 **GET  /sales-channel-api/v1/country/{countryId}/state**
 
-**Header:** sw-context-token is required  
 **Response:** Returns a list of country states assigned to the sales channel and country.
 All filter, sorting, limit, and search operations are supported.
 You find more information about these operations [here](./050-filter-search-limit.md).


### PR DESCRIPTION
Fix missing `salutation` API Endpoint in the Docs
Fix wrong docs: `sw-context-token` is not required for every context endpoint.

### 1. Why is this change necessary?

API Endpoint is missing in the Docs and `sw-context-token` is not required on every context endpoint.

### 2. What does this change do, exactly?

Add Docs

### 3. Describe each step to reproduce the issue or behaviour.

Test Endpoints without `sw-context-token` like in https://github.com/shopware/platform/blob/fb4bc791e185512bfde8cd0ea462b0cf527cf82f/src/Core/System/Test/SalesChannel/SalesChannel/SalesChannelControllerTest.php
