### PR TITLE
Use correct md5 implementation for administration utils

### DIFF
--- a/src/Administration/Resources/app/administration/src/core/service/util.service.js
+++ b/src/Administration/Resources/app/administration/src/core/service/util.service.js
@@ -57,7 +57,7 @@ export const string = {
     capitalizeString: stringUtils.capitalizeString,
     camelCase: stringUtils.camelCase,
     kebabCase: stringUtils.kebabCase,
-    md5: stringUtils.md5,
+    md5: md5,
     isEmptyOrSpaces: stringUtils.isEmptyOrSpaces,
     isUrl: stringUtils.isUrl,
     isValidIp: stringUtils.isValidIp


### PR DESCRIPTION
### 1. Why is this change necessary?
`Shopware.Utils.format.md5` and `Shopware.Utils.string.md5` should refer to the same implementation. Unfortunately the latter one has the value `undefined`

### 2. What does this change do, exactly?
Change the implementation from `Shopware.Utils.string.md5` to the sameone as `Shopware.Utils.format.md5`.

### 3. Describe each step to reproduce the issue or behaviour.
1. Look out for an easy way to generate an md5-hash
2. See both ways
3. Take the `Shopware.Utils.string.md5` as it is about a string I need
4. `TypeError: Shopware.Utils.string.md5 is not a function`

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
