### PR TITLE
Make avatars and media-upload in administration extendable

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/base/sw-avatar/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/base/sw-avatar/index.js
@@ -33,6 +33,11 @@ const colors = [
  * <sw-avatar size="48px"
  *            imageUrl="https://randomuser.me/api/portraits/women/68.jpg"></sw-avatar>
  * </div>
+ *
+ * <sw-avatar size="48px"
+ *            imageUrl="https://randomuser.me/api/portraits/men/68.jpg"
+ *            :sourceContext="user"></sw-avatar>
+ * </div>
  */
 Component.register('sw-avatar', {
     template,
@@ -65,6 +70,12 @@ Component.register('sw-avatar', {
             type: Boolean,
             required: false,
             default: false
+        },
+
+        sourceContext: {
+            type: Object,
+            required: false,
+            default: null
         }
     },
 

--- a/src/Administration/Resources/app/administration/src/app/component/base/sw-avatar/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/base/sw-avatar/index.js
@@ -120,7 +120,7 @@ Component.register('sw-avatar', {
 
         avatarImage() {
             if (!this.imageUrl) {
-                return '';
+                return null;
             }
 
             return {
@@ -147,11 +147,11 @@ Component.register('sw-avatar', {
         },
 
         showPlaceholder() {
-            return this.placeholder && (!this.imageUrl || !this.imageUrl.length);
+            return this.placeholder && (!this.avatarImage || !this.avatarImage['background-image']);
         },
 
         showInitials() {
-            return !this.placeholder && (!this.imageUrl || !this.imageUrl.length);
+            return !this.placeholder && (!this.avatarImage || !this.avatarImage['background-image']);
         }
     },
 

--- a/src/Administration/Resources/app/administration/src/app/component/base/sw-user-card/sw-user-card.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/base/sw-user-card/sw-user-card.html.twig
@@ -15,6 +15,7 @@
                                 {% block sw_user_card_avatar %}
                                     <sw-avatar :color="moduleColor"
                                                size="80px"
+                                               :sourceContext="user"
                                                :firstName="user.firstName"
                                                :lastName="user.lastName">
                                     </sw-avatar>

--- a/src/Administration/Resources/app/administration/src/app/component/media/sw-media-upload/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/media/sw-media-upload/index.js
@@ -79,6 +79,12 @@ Component.register('sw-media-upload', {
             type: String,
             required: false,
             default: null
+        },
+
+        sourceContext: {
+            type: Object,
+            required: false,
+            default: null
         }
     },
 

--- a/src/Administration/Resources/app/administration/src/app/component/media/sw-media-upload/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/media/sw-media-upload/index.js
@@ -4,6 +4,8 @@ import './sw-media-upload.scss';
 
 const { Component, Mixin, StateDeprecated } = Shopware;
 const { fileReader } = Shopware.Utils;
+const INPUT_TYPE_FILE_UPLOAD = 'file-upload';
+const INPUT_TYPE_URL_UPLOAD = 'url-upload';
 
 /**
  * @status ready
@@ -91,7 +93,7 @@ Component.register('sw-media-upload', {
     data() {
         return {
             multiSelect: this.allowMultiSelect,
-            showUrlInput: false,
+            inputType: INPUT_TYPE_FILE_UPLOAD,
             preview: null,
             isDragActive: false,
             defaultFolderId: null
@@ -131,12 +133,6 @@ Component.register('sw-media-upload', {
             return this.preview !== null;
         },
 
-        toggleButtonCaption() {
-            return this.showUrlInput ?
-                this.$tc('global.sw-media-upload.buttonSwitchToFileUpload') :
-                this.$tc('global.sw-media-upload.buttonSwitchToUrlUpload');
-        },
-
         hasOpenMediaButtonListener() {
             return Object.keys(this.$listeners).includes('media-upload-sidebar-open');
         },
@@ -156,6 +152,14 @@ Component.register('sw-media-upload', {
 
         mediaFolderId() {
             return this.defaultFolderId || this.targetFolderId;
+        },
+
+        isUrlUpload() {
+            return this.inputType === INPUT_TYPE_URL_UPLOAD;
+        },
+
+        isFileUpload() {
+            return this.inputType === INPUT_TYPE_FILE_UPLOAD;
         }
     },
 
@@ -257,16 +261,12 @@ Component.register('sw-media-upload', {
             this.$refs.fileInput.click();
         },
 
-        openUrlModal() {
-            this.showUrlInput = true;
+        useUrlUpload() {
+            this.inputType = INPUT_TYPE_URL_UPLOAD;
         },
 
-        closeUrlModal() {
-            this.showUrlInput = false;
-        },
-
-        toggleShowUrlFields() {
-            this.showUrlInput = !this.showUrlInput;
+        useFileUpload() {
+            this.inputType = INPUT_TYPE_FILE_UPLOAD;
         },
 
         onClickOpenMediaSidebar() {

--- a/src/Administration/Resources/app/administration/src/app/component/media/sw-media-upload/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/media/sw-media-upload/index.js
@@ -3,7 +3,7 @@ import template from './sw-media-upload.html.twig';
 import './sw-media-upload.scss';
 
 const { Component, Mixin, StateDeprecated } = Shopware;
-const { fileReader } = Shopware.Utils;
+const { fileReader, debug } = Shopware.Utils;
 const INPUT_TYPE_FILE_UPLOAD = 'file-upload';
 const INPUT_TYPE_URL_UPLOAD = 'url-upload';
 
@@ -160,6 +160,31 @@ Component.register('sw-media-upload', {
 
         isFileUpload() {
             return this.inputType === INPUT_TYPE_FILE_UPLOAD;
+        },
+
+        // @deprecated tag:v6.4.0
+        showUrlInput: {
+            get() {
+                debug.warn(
+                    'sw-media-upload',
+                    'showUrlInput is deprecated and will be removed in 6.4.0. Use isFileUpload or isUrlUpload instead'
+                );
+
+                return this.isUrlUpload();
+            },
+
+            set(value) {
+                debug.warn(
+                    'sw-media-upload',
+                    'showUrlInput is deprecated and will be removed in 6.4.0. Use useFileUpload or useUrlUpload instead'
+                );
+
+                if (value) {
+                    this.useUrlUpload();
+                } else {
+                    this.useFileUpload();
+                }
+            }
         }
     },
 
@@ -259,6 +284,40 @@ Component.register('sw-media-upload', {
          */
         onClickUpload() {
             this.$refs.fileInput.click();
+        },
+
+        // @deprecated tag:v6.4.0
+        closeUrlModal() {
+            debug.warn(
+                'sw-media-upload',
+                'closeUrlModal is deprecated and will be removed in 6.4.0. Use useUrlUpload instead'
+            );
+
+            return this.useUrlUpload();
+        },
+
+        // @deprecated tag:v6.4.0
+        openUrlModal() {
+            debug.warn(
+                'sw-media-upload',
+                'openUrlModal is deprecated and will be removed in 6.4.0. Use useFileUpload instead'
+            );
+
+            return this.useFileUpload();
+        },
+
+        // @deprecated tag:v6.4.0
+        toggleShowUrlFields() {
+            debug.warn(
+                'sw-media-upload',
+                'toggleShowUrlFields is deprecated and will be removed in 6.4.0. Use useUrlUpload or useFileUpload instead'
+            );
+
+            if (this.isUrlUpload()) {
+                return this.useFileUpload();
+            }
+
+            return this.useUrlUpload();
         },
 
         useUrlUpload() {

--- a/src/Administration/Resources/app/administration/src/app/component/media/sw-media-upload/sw-media-upload.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/media/sw-media-upload/sw-media-upload.html.twig
@@ -17,18 +17,20 @@
                                 </sw-button>
                             </template>
 
-                            <sw-context-menu-item @click="openUrlModal" class="sw-media-upload__button-url-upload">
-                                {{ $tc('global.sw-media-upload.buttonUrlUpload') }}
-                            </sw-context-menu-item>
+                            {% block sw_media_upload_compact_button_context_menu_actions %}
+                                <sw-context-menu-item @click="useUrlUpload" class="sw-media-upload__button-url-upload">
+                                    {{ $tc('global.sw-media-upload.buttonUrlUpload') }}
+                                </sw-context-menu-item>
+                            {% endblock %}
                         </sw-context-button>
                     {% endblock %}
                 </sw-button-group>
 
                 {% block sw_media_upload_compact_url_form %}
                     <sw-media-url-form
-                        v-if="showUrlInput"
+                        v-if="isUrlUpload"
                         variant="modal"
-                        @modal-close="closeUrlModal"
+                        @modal-close="useFileUpload"
                         @media-url-form-submit="onUrlUpload">
                     </sw-media-url-form>
                 {% endblock %}
@@ -50,9 +52,27 @@
                         {% endblock %}
 
                         {% block sw_media_upload_regular_header_switch %}
-                            <a v-if="!source" class="sw-media-upload__switch-mode" @click="toggleShowUrlFields">
-                                {{ toggleButtonCaption }}
-                            </a>
+                            <sw-context-button
+                                v-if="!source"
+                                class="sw-media-upload__switch-mode">
+                                {% block sw_media_upload_regular_header_switch_file_upload %}
+                                    <sw-context-menu-item
+                                        v-if="!isFileUpload"
+                                        @click="useFileUpload"
+                                        class="sw-media-upload__button-file-upload">
+                                        {{ $t('global.sw-media-upload.buttonFileUpload') }}
+                                    </sw-context-menu-item>
+                                {% endblock %}
+
+                                {% block sw_media_upload_regular_header_switch_url_upload %}
+                                    <sw-context-menu-item
+                                        v-if="!isUrlUpload"
+                                        @click="useUrlUpload"
+                                        class="sw-media-upload__button-url-upload">
+                                        {{ $t('global.sw-media-upload.buttonUrlUpload') }}
+                                    </sw-context-menu-item>
+                                {% endblock %}
+                            </sw-context-button>
                         {% endblock %}
                     </div>
                 {% endblock %}
@@ -107,14 +127,14 @@
                                     {% block sw_media_upload_regular_actions_url %}
                                         <sw-media-url-form
                                             class="sw-media-upload__url-form"
-                                            v-if="showUrlInput"
+                                            v-if="isUrlUpload"
                                             variant="inline"
                                             @media-url-form-submit="onUrlUpload">
                                         </sw-media-url-form>
                                     {% endblock %}
 
                                     {% block sw_media_upload_regular_actions_add %}
-                                        <template v-if="!showUrlInput">
+                                        <template v-if="isFileUpload">
                                             {% block sw_media_upload_regular_upload_button %}
                                                 <sw-button class="sw-media-upload__button upload"
                                                             variant="ghost"

--- a/src/Administration/Resources/app/administration/src/app/component/structure/sw-admin-menu/sw-admin-menu.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/structure/sw-admin-menu/sw-admin-menu.html.twig
@@ -74,6 +74,7 @@
                         {% block sw_admin_menu_user_actions_avatar %}
                             <sw-avatar class="sw-admin-menu__avatar"
                                        :imageUrl="avatarUrl"
+                                       :sourceContext="currentUser"
                                        :firstName="firstName"
                                        :lastName="lastName">
                             </sw-avatar>

--- a/src/Administration/Resources/app/administration/src/module/sw-customer/component/sw-customer-card/sw-customer-card.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-customer/component/sw-customer-card/sw-customer-card.html.twig
@@ -9,6 +9,7 @@
                                 <sw-container columns="80px 1fr max-content" gap="0px 30px">
                                     {% block sw_customer_card_avatar %}
                                         <sw-avatar size="80px"
+                                                   :sourceContext="customer"
                                                    :firstName="customer.firstName"
                                                    :lastName="customer.lastName">
                                         </sw-avatar>

--- a/src/Administration/Resources/app/administration/src/module/sw-customer/page/sw-customer-list/sw-customer-list.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-customer/page/sw-customer-list/sw-customer-list.html.twig
@@ -61,6 +61,7 @@
                                     <template #preview-firstName="{ item, compact }">
                                         <sw-avatar
                                             :size="compact ? '32px' : '48px'"
+                                            :sourceContext="item"
                                             :firstName="item.firstName"
                                             :lastName="item.lastName">
                                         </sw-avatar>

--- a/src/Administration/Resources/app/administration/src/module/sw-profile/page/sw-profile-index/sw-profile-index.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-profile/page/sw-profile-index/sw-profile-index.html.twig
@@ -95,6 +95,7 @@
                                     :allowMultiSelect="false"
                                     :label="$tc('sw-profile.index.labelUploadAvatar')"
                                     :defaultFolder="userRepository.schema.entity"
+                                    :sourceContext="user"
                                     @media-drop="onDropMedia"
                                     @media-upload-sidebar-open="openMediaSidebar"
                                     @media-upload-remove-image="onUnlinkAvatar">

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-user/page/sw-settings-user-detail/sw-settings-user-detail.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-user/page/sw-settings-user-detail/sw-settings-user-detail.html.twig
@@ -86,6 +86,7 @@
                                             :label="$tc('sw-settings-user.user-detail.labelProfilePicture')"
                                             :uploadTag="user.id"
                                             :allowMultiSelect="false"
+                                            :sourceContext="user"
                                             variant="regular"
                                             defaultFolder="user"
                                             @media-upload-remove-image="onUnlinkLogo">

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-user/page/sw-settings-user-list/sw-settings-user-list.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-user/page/sw-settings-user-list/sw-settings-user-list.html.twig
@@ -67,6 +67,17 @@
                             </template>
                         {% endblock %}
 
+                        {% block sw_settings_user_list_column_username_preview %}
+                            <template #preview-username="{ item, compact }">
+                                <sw-avatar
+                                    :size="compact ? '32px' : '48px'"
+                                    :firstName="item.firstName"
+                                    :lastName="item.lastName"
+                                    :sourceContext="item">
+                                </sw-avatar>
+                            </template>
+                        {% endblock %}
+
                         {% block sw_settings_user_list_column_username %}
                             <template #column-username="{ item }">
                                 {% block sw_settings_user_list_column_username_content %}


### PR DESCRIPTION
### 1. Why is this change necessary?
This is a follow up to #474 . This splits up the previous pull request from the changes to add new media upload strategies and the gravatar integration. The gravatar integration is now part of [FriendsOfShopware](https://github.com/FriendsOfShopware/FroshPlatformAvatar).

The new avatar column for users
![grafik](https://user-images.githubusercontent.com/1133593/73637024-985c8f00-4667-11ea-90ab-2dc29bf4abb3.png)

The changed strategy switch
<img width="441" alt="grafik" src="https://user-images.githubusercontent.com/1133593/73615794-8220e580-460b-11ea-8fb1-bb62fdad8c88.png">

### 2. What does this change do, exactly?
* Change sw-media-upload strategy changing to bool to state machine
* Add avatar to user list
* Add blocks to sw-media-upload
* Add contextSource prop to sw-avatar and sw-media-upload to get further information for everyone extending the uploading options

### 3. Describe each step to reproduce the issue or behaviour.
* Propose #474 
* Get declined due to undesired binding to external services

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
