### PR TITLE
Fix sourcemaps for HMR mode

### DIFF
--- a/src/Storefront/Resources/app/storefront/build/webpack.hot.config.js
+++ b/src/Storefront/Resources/app/storefront/build/webpack.hot.config.js
@@ -56,10 +56,14 @@ const modules = {
                 },
                 {
                     loader: 'css-loader',
+                    options: {
+                        sourceMap: true,
+                    },
                 },
                 {
                     loader: 'postcss-loader', // needs to be AFTER css/style-loader and BEFORE sass-loader
                     options: {
+                        sourceMap: true,
                         config: {
                             path: join(__dirname, '..'),
                         },
@@ -67,6 +71,9 @@ const modules = {
                 },
                 {
                     loader: 'sass-loader',
+                    options: {
+                        sourceMap: true,
+                    },
                 },
                 // Provides our theme variables to the hot replacement mode
                 {


### PR DESCRIPTION
Must be specified explicitly or it won't be properly generated

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/community).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?

Because you don't have style sourcemaps in HMR mode.

### 2. What does this change do, exactly?

It activates the sourceMaps for the loaders. According to the webpack documentation they should be activated by the `devTools` option, but the `css-loader` and `postcss-loader` don't respect that. Therefore you don't have a sourcemap.

### 3. Describe each step to reproduce the issue or behaviour.

Open frontend in HMR mode and try to inspect a style.

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
