### PR TITLE
fix config `v-model` in custom cms element example

### DIFF
--- a/src/Docs/Resources/current/4-how-to/300-custom-cms-element.md
+++ b/src/Docs/Resources/current/4-how-to/300-custom-cms-element.md
@@ -440,7 +440,7 @@ Quite simple, right?
 {% block sw_cms_element_image_config %}
 <div class="sw-cms-el-config-youtube">
     <sw-field class="swag-youtube-field"
-          v-model="element.config.showControls.value"
+          v-model="element.config.videoSrc.value"
           type="text"
           label="YouTube Video ID"
           placeholder="Enter ID...">


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/community).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
In the example for a custom CMS element the wrong `v-model` value for the YouTube video ID is used in the config.

### 2. What does this change do, exactly?
Use the correct `v-model` (`videoSrc` instead of `showControls`)

### 3. Describe each step to reproduce the issue or behaviour.
Follow the tutorial and the the config field will look like this, showing the value of `showControls` instead of the Video ID:

![grafik](https://user-images.githubusercontent.com/13335308/73852970-64809580-4830-11ea-8137-6d15aa3e19ba.png)


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
