### PR TITLE
Prevent crash on product variants without settings

### DIFF
--- a/src/Storefront/Page/Product/Configurator/ProductPageConfiguratorLoader.php
+++ b/src/Storefront/Page/Product/Configurator/ProductPageConfiguratorLoader.php
@@ -132,7 +132,7 @@ class ProductPageConfiguratorLoader
         return $groups;
     }
 
-    private function sortSettings(array $groups): PropertyGroupCollection
+    private function sortSettings(?array $groups): PropertyGroupCollection
     {
         if (!$groups) {
             return new PropertyGroupCollection();


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/community).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?

If, for whatever reason, a product variant without settings exists (e.g. by creating the variant programmatically), the storefront will crash. Since the loadSettings function already handles variants without settings, passing a null argument to sortSettings should be a valid thing to do.

### 2. What does this change do, exactly?

sortSettings allows `null` arguments. The function will behave the same as if an empty array was passed.

### 3. Describe each step to reproduce the issue or behaviour.

Remove settings from a variant in the database, try to view it in storefront.

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
