### PR TITLE
Change logging for production mode

### DIFF
--- a/src/Core/Framework/Resources/config/packages/prod/monolog.yaml
+++ b/src/Core/Framework/Resources/config/packages/prod/monolog.yaml
@@ -5,9 +5,9 @@ monolog:
             action_level: error
             handler: nested
         nested:
-            type: stream
+            type: rotating_file
             path: "%kernel.logs_dir%/%kernel.environment%.log"
-            level: debug
+            level: error
         console:
             type:   console
             process_psr_3_messages: false


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/community).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?

Currently when using production mode for Shopware it is logging all debug and info logs. It is also logging to one file which if left unmanaged can use a lot of resources and disk space.

### 2. What does this change do, exactly?

This does two things. The first is that it only logs errors and the second is that it create a new log file each day. This makes it easier for developers to find logs based on the day and also the log file never becomes too large. 

Additionally a server administrator can then delete older log files via a CRON.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.
