### PR TITLE
Add new twig template block around block category options

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-sidebar/sw-cms-sidebar.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-sidebar/sw-cms-sidebar.html.twig
@@ -78,13 +78,15 @@
                             <div class="sw-cms-sidebar__block-category">
                                 <sw-select-field :label="$tc('sw-cms.detail.label.blockCategorySelection')"
                                                  v-model="currentBlockCategory">
-                                    <option value="text">{{ $tc('sw-cms.detail.label.blockCategoryText') }}</option>
-                                    <option value="image">{{ $tc('sw-cms.detail.label.blockCategoryImage') }}</option>
-                                    <option value="video">{{ $tc('sw-cms.detail.label.blockCategoryVideo') }}</option>
-                                    <option value="text-image">{{ $tc('sw-cms.detail.label.blockCategoryTextImage') }}</option>
-                                    <option value="commerce">{{ $tc('sw-cms.detail.label.blockCategoryCommerce') }}</option>
-                                    <option value="sidebar">{{ $tc('sw-cms.detail.label.blockCategorySidebar') }}</option>
-                                    <option value="form">{{ $tc('sw-cms.detail.label.blockCategoryForm') }}</option>
+                                    {% block sw_cms_sidebar_block_overview_category_options %}
+                                        <option value="text">{{ $tc('sw-cms.detail.label.blockCategoryText') }}</option>
+                                        <option value="image">{{ $tc('sw-cms.detail.label.blockCategoryImage') }}</option>
+                                        <option value="video">{{ $tc('sw-cms.detail.label.blockCategoryVideo') }}</option>
+                                        <option value="text-image">{{ $tc('sw-cms.detail.label.blockCategoryTextImage') }}</option>
+                                        <option value="commerce">{{ $tc('sw-cms.detail.label.blockCategoryCommerce') }}</option>
+                                        <option value="sidebar">{{ $tc('sw-cms.detail.label.blockCategorySidebar') }}</option>
+                                        <option value="form">{{ $tc('sw-cms.detail.label.blockCategoryForm') }}</option>
+                                   {% endblock %}
                                 </sw-select-field>
                             </div>
                         {% endblock %}


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/community).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
In order to allow developers to easily add their own block categories, the options should be surrounded by their own twig template block. This allows the developer to call on the parent template and to only add his or her own categories. The existing implementation would require the developer to replace the entire selection field, which my cause problems, when the core adds future options in the future.

### 2. What does this change do, exactly?
It adds a twig template block around the options

### 3. Describe each step to reproduce the issue or behaviour.
n.a.

### 4. Please link to the relevant issues (if any).
n.a.

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.
