### PR TITLE
Fix plugin upload unknown language bug

### DIFF
--- a/src/Core/Framework/Plugin/PluginService.php
+++ b/src/Core/Framework/Plugin/PluginService.php
@@ -136,6 +136,10 @@ class PluginService
                         $this->changelogService->getLocaleFromChangelogFile($file),
                         $shopwareContext
                     );
+                    
+                    if ($languageId === '') {
+                        continue;
+                    }
 
                     try {
                         $pluginData['translations'][$languageId]['changelog'] = $this->changelogService->parseChangelog($file);


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/community).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
When uploading a plugin with a changelog which has an unknown language, the system will crash.


### 2. What does this change do, exactly?
Skip the changelog if the language is unknown.

### 3. Describe each step to reproduce the issue or behaviour.
1. Change en-GB language to nl-NL
2. Upload plugin with CHANGELOG_nl-NL.md file
3. Crash and burn

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
