### PR TITLE
Fix payment handler retrieval

### DIFF
--- a/src/Core/Checkout/DependencyInjection/payment.xml
+++ b/src/Core/Checkout/DependencyInjection/payment.xml
@@ -46,8 +46,8 @@
         </service>
 
         <service id="Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PaymentHandlerRegistry">
-            <argument type="tagged" tag="shopware.payment.method.sync"/>
-            <argument type="tagged" tag="shopware.payment.method.async"/>
+            <argument type="tagged_locator" tag="shopware.payment.method.sync"/>
+            <argument type="tagged_locator" tag="shopware.payment.method.async"/>
         </service>
 
         <service id="Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PrePayment">

--- a/src/Core/Checkout/Payment/DataAbstractionLayer/PaymentHandlerIdentifierSubscriber.php
+++ b/src/Core/Checkout/Payment/DataAbstractionLayer/PaymentHandlerIdentifierSubscriber.php
@@ -22,6 +22,12 @@ class PaymentHandlerIdentifierSubscriber implements EventSubscriberInterface
         foreach ($event->getEntities() as $entity) {
             $explodedHandlerIdentifier = explode('\\', $entity->getHandlerIdentifier());
 
+            if (count($explodedHandlerIdentifier) < 2) {
+                $entity->setFormattedHandlerIdentifier($entity->getHandlerIdentifier());
+
+                continue;
+            }
+
             $formattedHandlerIdentifier = 'handler_'
                 . mb_strtolower(array_shift($explodedHandlerIdentifier))
                 . '_'


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/community).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?

Currently Shopware expects that the service ids of payment handers are always the name of the payment handler class. Since payment handlers are just services in the dependency injection container this assumption is wrong.

Due to this assumption, the following problems occur when a payment handler's service `id` is not a fully-qualified class name:
- The formatted handler identifier cannot be generated because it expects a class namespace as handler identifier, and
- The `PaymentHandlerRegistry` retrieves the payment handlers via the `tagged` selector, which does not include the `id` of a payment handler and thus retrieving a payment handler by `id` does not work.

This also means we can not use the same payment handler class to handle different payment methods. We currently need to use one idiosyncratic class per payment method, which to us is undesirable from a software design perspective.

### 2. What does this change do, exactly?

This change uses the handler identifier as formatted handler identifier in case it is not splittable by `\`. Furthermore the `PaymentHandlerRegistry` retrieves the payment handlers via the `tagged_locator` selector which include the `id` of the payment handler.

### 3. Describe each step to reproduce the issue or behaviour.

1. Create a new payment handler with the following service configuration:

```xml
<service 
  id="vendor_example_plugin.handler_name"
  class="ExampleVendor\SomeNamespace\MyHandler">
    <tag name="shopware.payment.method.sync"/>
</service>
```

2. Create a payment method for the payment handler

3. Create an order with the payment method associated with the new payment handler


### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
