### PR TITLE
Restore $useCache property to previous Value

### DIFF
--- a/src/Core/Framework/Context.php
+++ b/src/Core/Framework/Context.php
@@ -212,9 +212,10 @@ class Context extends Struct
 
     public function disableCache(callable $function)
     {
+        $previous = $this->useCache;
         $this->useCache = false;
         $result = $function($this);
-        $this->useCache = true;
+        $this->useCache = $previous;
 
         return $result;
     }


### PR DESCRIPTION
We should not assume, that the context allowed the usage of the cache before we are calling the disableCache method of the Context object

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/community).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
The current implementation of the Context::disableCache() method, makes the wrong assumption, that the usage of the cache was enabled, before the method was called. This is a problem, since the $context object is passed around a lot, and NESTED calls to the disableCache() method reENABLE the cache, which ist not the expected behavior.

### 2. What does this change do, exactly?
The proposed change stores the useCache state of the object, BEFORE the cache is being disabled. After the callable function is being executed, this state is being restored, instead of blindly reenabling the cache.

### 3. Describe each step to reproduce the issue or behaviour.
The Problem arises, once the Context::disableCache() method is being called within a context, where the cache has already been previously disabled.

````php
class SomeService {
    public function doStuff(Context $context) {
         $context->disableCache(function($context){
            // We expect the cache to be disabled, and it is. Good job!
        });
    }
}
$someService = new SomeService();
$context->disableCache(function($context) use ($someService) {
    $someService->doStuff($context);
    // We expect the cache to be disabled. But it was reENABLEd due to 
   // the call to the Context::disableCache method in the SomeService class
   // THIS IS NOT GOOD!
});
````
### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.
