### PR TITLE
fix typo `pvivacy` (`privacy`)

### DIFF
--- a/src/Storefront/Resources/views/storefront/element/cms-element-form/form-components/cms-element-form-privacy.html.twig
+++ b/src/Storefront/Resources/views/storefront/element/cms-element-form/form-components/cms-element-form-privacy.html.twig
@@ -8,12 +8,12 @@
             <input name="privacy"
                    type="checkbox"
                    class="custom-control-input"
-                   id="form-pvivacy-opt-in-{{ _key }}"
+                   id="form-privacy-opt-in-{{ _key }}"
                    required>
         {% endblock %}
 
         {% block cms_form_privacy_opt_in_label %}
-            <label for="form-pvivacy-opt-in-{{ _key }}" class=" custom-control-label">
+            <label for="form-privacy-opt-in-{{ _key }}" class=" custom-control-label">
                 {{ "general.privacyNotice"|trans({
                     '%url%': path('frontend.cms.page',{ id: shopware.config.core.basicInformation.privacyPage })
                 })|raw }}


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/community).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
There is a typo

### 2. What does this change do, exactly?
Changes `pvivacy` to `privacy` in `cms-element-form-privacy.html.twig`

### 3. Describe each step to reproduce the issue or behaviour.
👀 
https://github.com/shopware/platform/blob/72c25d4c1b25e39607e87b99257c4ef0d3772174/src/Storefront/Resources/views/storefront/element/cms-element-form/form-components/cms-element-form-privacy.html.twig#L11

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
