### PR TITLE
Multiple arguments to $super

### DIFF
--- a/src/Administration/Resources/app/administration/src/core/factory/component.factory.js
+++ b/src/Administration/Resources/app/administration/src/core/factory/component.factory.js
@@ -385,7 +385,7 @@ function updateSuperRegistry(superRegistry, methodName, method, methodOrComputed
  */
 function addSuperBehaviour(inheritedFrom, superRegistry) {
     return {
-        $super(name, args) {
+        $super(name, ...args) {
             this._initVirtualCallStack(name);
 
             const superStack = this._findInSuperRegister(name);
@@ -393,7 +393,7 @@ function addSuperBehaviour(inheritedFrom, superRegistry) {
 
             this._virtualCallStack[name] = superFuncObject.parent;
 
-            const result = superFuncObject.func.bind(this)(args);
+            const result = superFuncObject.func.bind(this)(...args);
 
             // reset the virtual call-stack
             if (superFuncObject.parent) {


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/community).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?

When extending an admin component, we can use `$super('methodName', foo) to call a method or access a computed property from the parent component. The current implementation does not allow us to pass multiple arguments to the parent method.

### 2. What does this change do, exactly?

Use the rest parameter syntax in combination with the spread operator to pass arbitrarily many arguments to the parent method.

### 3. Describe each step to reproduce the issue or behaviour.

Try to invoke a method with multiple arguments through `$super`.

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
