### PR TITLE
Fixes customer cannot checkout as guest

### DIFF
--- a/src/Storefront/Controller/RegisterController.php
+++ b/src/Storefront/Controller/RegisterController.php
@@ -230,7 +230,7 @@ class RegisterController extends StorefrontController
             ]));
         }
 
-        if ($this->systemConfigService->get('core.loginRegistration.requirePasswordConfirmation', $context->getSalesChannel()->getId())) {
+        if (!$data->has('guest') && $this->systemConfigService->get('core.loginRegistration.requirePasswordConfirmation', $context->getSalesChannel()->getId())) {
             $definition->add('passwordConfirmation', new NotBlank(), new EqualTo([
                 'value' => $data->get('password'),
             ]));


### PR DESCRIPTION
Fixes customer cannot checkout as guest when password confirmation is enabled.

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/community).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
Customer cannot checkout as guest when password confirmation is enabled.

### 2. What does this change do, exactly?
If customer is checking out as guest it will disable password confirmation validation.

### 3. Describe each step to reproduce the issue or behaviour.
Enable password confirmation and try to checkout as guest user.

### 4. Please link to the relevant issues (if any).
https://github.com/shopware/platform/issues/546

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
