### PR TITLE
Fix typo accounTypeRequired to accountTypeRequired

### DIFF
--- a/src/Storefront/Resources/views/storefront/component/address/address-form.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/address/address-form.html.twig
@@ -9,6 +9,8 @@
 
     {% block component_address_form_company %}
         {% if shopware.config.core.loginRegistration.showAccountTypeSelection %}
+            {% set accountTypeRequired = true %}
+            {# @deprecated tag:6.4.0 - Variable "accounTypeRequired" will be removed. Use "accountTypeRequired" instead #}
             {% set accounTypeRequired = true %}
         {% endif %}
 
@@ -27,7 +29,7 @@
                                 {% block component_address_form_company_name_label %}
                                     <label class="form-label"
                                            for="{{ prefix }}company">
-                                        {{ "address.companyNameLabel"|trans|sw_sanitize }}{% if prefix != "shippingAddress" and accounTypeRequired %}{{ "general.required"|trans|sw_sanitize }}{% endif %}
+                                        {{ "address.companyNameLabel"|trans|sw_sanitize }}{% if prefix != "shippingAddress" and accountTypeRequired %}{{ "general.required"|trans|sw_sanitize }}{% endif %}
                                     </label>
                                 {% endblock %}
 
@@ -35,10 +37,10 @@
                                     <input type="text"
                                            class="form-control{% if violationPath %} is-invalid{% endif %}"
                                            id="{{ prefix }}company"
-                                           placeholder="{{ "address.companyNamePlaceholder"|trans|striptags }}{% if prefix != "shippingAddress" and accounTypeRequired %}{{ "general.required"|trans|striptags }}{% endif %}"
+                                           placeholder="{{ "address.companyNamePlaceholder"|trans|striptags }}{% if prefix != "shippingAddress" and accountTypeRequired %}{{ "general.required"|trans|striptags }}{% endif %}"
                                            name="{{ prefix }}[company]"
                                            value="{{ data.get('company') }}"
-                                           {% if prefix != "shippingAddress" and accounTypeRequired %}required="required"{% endif %}>
+                                           {% if prefix != "shippingAddress" and accountTypeRequired %}required="required"{% endif %}>
                                 {% endblock %}
 
                                 {% block component_address_form_company_name_input_error %}


### PR DESCRIPTION
### 1. Why is this change necessary?
Just a variable with a typo.

### 2. What does this change do, exactly?
Rename a variable and keep the old one with a deprecation mark.

### 3. Describe each step to reproduce the issue or behaviour.
1. Read the code
2. See the typo

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
