### PR TITLE
Cms video elements css typo

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/video/vimeo-video/preview/sw-cms-preview-vimeo-video.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/video/vimeo-video/preview/sw-cms-preview-vimeo-video.scss
@@ -13,9 +13,9 @@
 
     &__icon {
         $icon-width: 50px;
-        $icon-heigth: $icon-width;
+        $icon-height: $icon-width;
 
-        height: $icon-heigth;
+        height: $icon-height;
         width: $icon-width;
         position: absolute;
     }

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/video/youtube-video/preview/sw-cms-preview-youtube-video.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/video/youtube-video/preview/sw-cms-preview-youtube-video.scss
@@ -12,9 +12,9 @@
     }
 
     &__icon {
-        $icon-heigth: 50px;
+        $icon-height: 50px;
 
-        height: $icon-heigth;
+        height: $icon-height;
         position: absolute;
     }
 }

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/vimeo-video/preview/sw-cms-el-preview-vimeo-video.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/vimeo-video/preview/sw-cms-el-preview-vimeo-video.scss
@@ -12,10 +12,10 @@
 
     &__icon {
         $icon-width: 35px;
-        $icon-heigth: 35px;
+        $icon-height: 35px;
 
         width: $icon-width;
-        height: $icon-heigth;
+        height: $icon-height;
         position: absolute;
     }
 }

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/youtube-video/preview/sw-cms-el-preview-youtube-video.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/youtube-video/preview/sw-cms-el-preview-youtube-video.scss
@@ -11,9 +11,9 @@
     }
 
     &__icon {
-        $icon-heigth: 35px;
+        $icon-height: 35px;
 
-        height: $icon-heigth;
+        height: $icon-height;
         position: absolute;
     }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/community).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?


### 2. What does this change do, exactly?
Change scss variables typo from heigth to height in youtube and vimeo cms block / element.


### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
