### PR TITLE
Syntax error in sw-plugin administration snippet json files.

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-plugin/snippet/de-DE.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-plugin/snippet/de-DE.json
@@ -148,7 +148,7 @@
   "sw-plugin-config": {
     "titleSaveSuccess": "Konfiguration gespeichert",
     "messageSaveSuccess": "Die Konfiguration wurde erfolgreich gespeichert.",
-    "titleSaveError": "Fehler beim Speichern der Konfiguration",
+    "titleSaveError": "Fehler beim Speichern der Konfiguration"
   },
   "sw-plugin-description": {
     "buttonBack": "Zurück"

--- a/src/Administration/Resources/app/administration/src/module/sw-plugin/snippet/en-GB.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-plugin/snippet/en-GB.json
@@ -148,7 +148,7 @@
   "sw-plugin-config": {
     "titleSaveSuccess": "Success",
     "messageSaveSuccess": "Configuration has been saved.",
-    "titleSaveError": "Unable to save the configuration.",
+    "titleSaveError": "Unable to save the configuration."
   },
   "sw-plugin-description": {
     "buttonBack": "Back"


### PR DESCRIPTION
### 1. Why is this change necessary?
The syntax in the administration sw-plugin module's snippet file is broken.
administration/src/module/sw-plugin/snippet/en-GB.json and
administration/src/module/sw-plugin/snippet/de-DE.json have an invalid trailing comma.

That's why the snippet files are not loaded at all because following check fails:
https://github.com/shopware/platform/blob/master/src/Administration/Snippet/SnippetFinder.php#L80
```
$snippets[] = json_decode(file_get_contents($file), true) ?? [];
```

### 2. What does this change do, exactly?
Remove the trailing comma.

### 3. Describe each step to reproduce the issue or behaviour.
See following screenshot:
![image](https://user-images.githubusercontent.com/1859343/74878255-3ee2a880-5367-11ea-844f-9315ac24b0dc.png)


### 4. Please link to the relevant issues (if any).
-

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.
