### PR TITLE
Add plugin zip import command

### DIFF
--- a/src/Core/Framework/DependencyInjection/plugin.xml
+++ b/src/Core/Framework/DependencyInjection/plugin.xml
@@ -99,9 +99,10 @@
         </service>
 
         <service id="Shopware\Core\Framework\Plugin\Command\PluginZipImportCommand">
-            <tag name="console.command"/>
             <argument type="service" id="Shopware\Core\Framework\Plugin\PluginManagementService"/>
             <argument type="service" id="Shopware\Core\Framework\Plugin\PluginService"/>
+
+            <tag name="console.command"/>
         </service>
 
         <service id="Shopware\Core\Framework\Plugin\Command\Lifecycle\PluginInstallCommand">

--- a/src/Core/Framework/DependencyInjection/plugin.xml
+++ b/src/Core/Framework/DependencyInjection/plugin.xml
@@ -98,6 +98,12 @@
             <tag name="console.command"/>
         </service>
 
+        <service id="Shopware\Core\Framework\Plugin\Command\PluginZipImportCommand">
+            <tag name="console.command"/>
+            <argument type="service" id="Shopware\Core\Framework\Plugin\PluginManagementService"/>
+            <argument type="service" id="Shopware\Core\Framework\Plugin\PluginService"/>
+        </service>
+
         <service id="Shopware\Core\Framework\Plugin\Command\Lifecycle\PluginInstallCommand">
             <argument type="service" id="Shopware\Core\Framework\Plugin\PluginLifecycleService"/>
             <argument type="service" id="plugin.repository"/>

--- a/src/Core/Framework/Plugin/Command/PluginZipImportCommand.php
+++ b/src/Core/Framework/Plugin/Command/PluginZipImportCommand.php
@@ -43,7 +43,8 @@ class PluginZipImportCommand extends Command
     {
         $this->setDescription('Import plugin zip file.')
             ->addArgument('zip-file', InputArgument::REQUIRED, 'Zip file that contains a shopware platform plugin.')
-            ->addOption('no-refresh', null, InputOption::VALUE_OPTIONAL, 'Do not refresh plugin list.');
+            ->addOption('no-refresh', null, InputOption::VALUE_OPTIONAL, 'Do not refresh plugin list.')
+            ->addOption('delete', null, InputOption::VALUE_OPTIONAL, 'Delete the zip file after importing successfully.');
     }
 
     /**
@@ -56,7 +57,7 @@ class PluginZipImportCommand extends Command
         $io->title('Shopware Plugin Zip Import');
 
         try {
-            $this->pluginManagementService->extractPluginZip($zipFile, false);
+            $this->pluginManagementService->extractPluginZip($zipFile, (bool) $input->getOption('delete'));
         } catch (NoPluginFoundInZipException $e) {
             $io->error($e->getMessage());
 

--- a/src/Core/Framework/Plugin/Command/PluginZipImportCommand.php
+++ b/src/Core/Framework/Plugin/Command/PluginZipImportCommand.php
@@ -1,0 +1,78 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\Plugin\Command;
+
+use Composer\IO\ConsoleIO;
+use Shopware\Core\Framework\Adapter\Console\ShopwareStyle;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Plugin\Exception\NoPluginFoundInZipException;
+use Shopware\Core\Framework\Plugin\PluginManagementService;
+use Shopware\Core\Framework\Plugin\PluginService;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\HelperSet;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class PluginZipImportCommand extends Command
+{
+    protected static $defaultName = 'plugin:zip-import';
+
+    /**
+     * @var PluginManagementService
+     */
+    private $pluginManagementService;
+
+    /**
+     * @var PluginService
+     */
+    private $pluginService;
+
+    public function __construct(PluginManagementService $pluginManagementService, PluginService $pluginService)
+    {
+        parent::__construct();
+        $this->pluginManagementService = $pluginManagementService;
+        $this->pluginService = $pluginService;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure(): void
+    {
+        $this->setDescription('Import plugin zip file.')
+            ->addArgument('zip-file', InputArgument::REQUIRED, 'Zip file that contains a shopware platform plugin.')
+            ->addOption('no-refresh', null, InputOption::VALUE_OPTIONAL, 'Do not refresh plugin list.');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $zipFile = $input->getArgument('zip-file');
+        $io = new ShopwareStyle($input, $output);
+        $io->title('Shopware Plugin Zip Import');
+
+        try {
+            $this->pluginManagementService->extractPluginZip($zipFile, false);
+        } catch (NoPluginFoundInZipException $e) {
+            $io->error($e->getMessage());
+
+            return 1;
+        }
+
+        $io->success('Successfully import zip file ' . basename($zipFile));
+
+        if (!$input->getOption('no-refresh')) {
+            $this->pluginService->refreshPlugins(
+                Context::createDefaultContext(),
+                new ConsoleIO($input, $output, new HelperSet())
+            );
+            $io->success('Plugin list refreshed');
+        }
+
+        return 0;
+    }
+}

--- a/src/Core/Framework/Plugin/PluginExtractor.php
+++ b/src/Core/Framework/Plugin/PluginExtractor.php
@@ -26,7 +26,7 @@ class PluginExtractor
     /**
      * Extracts the provided zip file to the plugin directory
      */
-    public function extract(\ZipArchive $archive): void
+    public function extract(\ZipArchive $archive, bool $delete = true): void
     {
         $destination = $this->pluginDir;
 
@@ -47,7 +47,9 @@ class PluginExtractor
                 $this->filesystem->remove($backupFile);
             }
 
-            unlink($archive->filename);
+            if ($delete) {
+                unlink($archive->filename);
+            }
         } catch (\Exception $e) {
             if ($backupFile !== '') {
                 $this->filesystem->rename($backupFile, $oldFile);

--- a/src/Core/Framework/Plugin/PluginManagementService.php
+++ b/src/Core/Framework/Plugin/PluginManagementService.php
@@ -60,15 +60,12 @@ class PluginManagementService
         $this->cacheClearer = $cacheClearer;
     }
 
-    /**
-     * @deprecated tag:v6.3.0 - Will be private
-     */
-    public function extractPluginZip(string $file): void
+    public function extractPluginZip(string $file, bool $delete = true): void
     {
         $archive = ZipUtils::openZip($file);
 
         if ($this->pluginZipDetector->isPlugin($archive)) {
-            $this->pluginExtractor->extract($archive);
+            $this->pluginExtractor->extract($archive, $delete);
         } else {
             throw new NoPluginFoundInZipException($file);
         }

--- a/src/Core/Framework/Test/Plugin/PluginManagementServiceTest.php
+++ b/src/Core/Framework/Test/Plugin/PluginManagementServiceTest.php
@@ -67,6 +67,30 @@ class PluginManagementServiceTest extends TestCase
         static::assertFileExists(self::PLUGIN_FASHION_THEME_PATH . '/SwagFashionTheme.php');
     }
 
+    public function testExtractPluginZip(): void
+    {
+        $this->getPluginManagementService()->extractPluginZip(__DIR__ . '/_fixture/SwagFashionTheme.zip', true);
+
+        $extractedPlugin = $this->filesystem->exists(__DIR__ . '/_fixture/plugins/SwagFashionTheme');
+        $extractedPluginBaseClass = $this->filesystem->exists(__DIR__ . '/_fixture/plugins/SwagFashionTheme/SwagFashionTheme.php');
+        $pluginZipExists = $this->filesystem->exists(__DIR__ . '/_fixture/SwagFashionTheme.zip');
+        static::assertTrue($extractedPlugin);
+        static::assertTrue($extractedPluginBaseClass);
+        static::assertFalse($pluginZipExists);
+    }
+
+    public function testExtractPluginZipWithoutDeletion(): void
+    {
+        $this->getPluginManagementService()->extractPluginZip(__DIR__ . '/_fixture/SwagFashionTheme.zip', false);
+
+        $extractedPlugin = $this->filesystem->exists(__DIR__ . '/_fixture/plugins/SwagFashionTheme');
+        $extractedPluginBaseClass = $this->filesystem->exists(__DIR__ . '/_fixture/plugins/SwagFashionTheme/SwagFashionTheme.php');
+        $pluginZipExists = $this->filesystem->exists(__DIR__ . '/_fixture/SwagFashionTheme.zip');
+        static::assertTrue($extractedPlugin);
+        static::assertTrue($extractedPluginBaseClass);
+        static::assertTrue($pluginZipExists);
+    }
+
     private function createTestCacheDirectory(): string
     {
         $kernelClass = KernelLifecycleManager::getKernelClass();

--- a/src/Docs/Resources/deprecated/2-internals/4-plugins/030-plugin-commands.md
+++ b/src/Docs/Resources/deprecated/2-internals/4-plugins/030-plugin-commands.md
@@ -15,6 +15,7 @@ Below you'll find a list of each command and its usage.
 | plugin:update     | plugins   | clearCache                      | Updates one or multiple plugins                                        |
 | plugin:list       | N/A       | filter                          | Prints a list of all available plugins filtering with the given filter |
 | plugin:refresh    | N/A       | skipPluginList                  | Refreshes the plugin list                                              |
+| plugin:zip-import | zip-file  | no-refresh                      | Import plugin zip file                                                 |
 
 *List of all plugin commands*
 
@@ -103,3 +104,33 @@ $ ./bin/console plugin:activate YourPluginWithNamespace ThirdPartyPluginWithName
 $ ./bin/console plugin:deactivate YourPluginWithNamespace ThirdPartyPluginWithNamespace
 ```
 *Plugin de-, activate command*
+
+### Importing plugins
+
+There are multiple way to import a plugin that is already existing on the filesystem.
+You can either make a composer repository and use composer require:
+
+```js
+{
+    /* ... */
+    "repositories": [
+        {
+            "type": "path",
+            "url": "YourPluginDirectory",
+            "options": {
+                "symlink": true
+            }
+        }
+    ]
+}
+```
+```
+$ composer require your-plugin-technical-name
+$ ./bin/console plugin:refresh
+```
+
+Or you can provide a pre-packaged plugin file like they are distributed at the [community store](https://store.shopware.com).
+
+```
+$ ./bin/console plugin:zip-import YourPluginFile.zip
+```


### PR DESCRIPTION
### 1. Why is this change necessary?
There is still no really good way to version community store plugins.
1. sw:store:download is not available in shopware 6 yet
2. packages.friendsofshopware.com is not officially supported

Now you can at least version a downloaded plugin file and simply do:
`bin/console plugin:zip-import SwagBundle.zip && bin/console plugin:install --activate SwagBundle`

### 2. What does this change do, exactly?
Add a new command to import plugin zip files. Add optional parameter to disable file deletion on import via CLI.

### 3. Describe each step to reproduce the issue or behaviour.
1. Have a previously downloaded plugin zip file
2. Open /admin
3. Open plugin management
4. Upload zip file
5. Install plugin
6. Activate plugin
7. Be annoyed that it is not possible via CLI in an easy way to do the same

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
