### PR TITLE
Fix wrong tag name in Rule doc

### DIFF
--- a/src/Docs/Resources/current/4-how-to/210-custom-rule.md
+++ b/src/Docs/Resources/current/4-how-to/210-custom-rule.md
@@ -85,7 +85,7 @@ As you might have noticed, there's already several methods implemented:
 Time to register it in the DI container via the `services.xml` of your plugin.
 If your plugin does not have a `services.xml` file yet, make sure to read [here](./../2-internals/4-plugins/010-plugin-quick-start.md#The services.xml) to understand how it can be created in the first place.
 
-Your rule has to be defined as a service together with the tag `rule.definition`:
+Your rule has to be defined as a service together with the tag `shopware.rule.definition`:
 ```xml
 <?xml version="1.0" ?>
 
@@ -95,7 +95,7 @@ Your rule has to be defined as a service together with the tag `rule.definition`
 
     <services>
         <service id="Swag\CustomRule\Core\Rule\LunarEclipseRule">
-            <tag name="rule.definition"/>
+            <tag name="shopware.rule.definition"/>
         </service>
     </services>
 </container>


### PR DESCRIPTION
### 1. Why is this change necessary?
The tag name mentioned in the custom rule doc is wrong. 

### 2. What does this change do, exactly?
It changes the name of the tag in the custom rule howto from `rule.definition` to `shopware.rule.definition`.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
