### PR TITLE
fix missing company names on documents

### DIFF
--- a/src/Core/Framework/Resources/views/documents/base.html.twig
+++ b/src/Core/Framework/Resources/views/documents/base.html.twig
@@ -129,7 +129,9 @@
                             {{ config.companyAddress }}<br><br>
                         {% endblock %}
                     </span>
-                    {# todo support companys #}
+                    {% if billingAddress.company %}
+                        {{ billingAddress.company }}<br>
+                    {% endif %}
                     {{ customer.salutation.letterName }} {{ customer.firstName }} {{ customer.lastName }}<br>
                     {{ billingAddress.street }}<br>
                     {{ billingAddress.zipcode }} {{ billingAddress.city }}<br>


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/community).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
The company name is missing on invoices

### 2. What does this change do, exactly?
add the company name to invoices

### 3. Describe each step to reproduce the issue or behaviour.
create a new account as company, make an order and create a document

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
