### PR TITLE
Extract hardcoded options in cms administration

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,3 +309,4 @@ Shopware 6 is completely free and released under the [MIT License](LICENSE).
 [![](https://s3.eu-central-1.amazonaws.com/shopware-platform-assets/github-platform/readme/avatars/fabianhueske.png)](https://github.com/fabianhueske)
 [![](https://s3.eu-central-1.amazonaws.com/shopware-platform-assets/github-platform/readme/avatars/hanneswernery.png)](https://github.com/hanneswernery)
 [![](https://s3.eu-central-1.amazonaws.com/shopware-platform-assets/github-platform/readme/avatars/hlohaus.png)](https://github.com/hlohaus)
+[![](https://s3.eu-central-1.amazonaws.com/shopware-platform-assets/github-platform/readme/avatars/joshuabehrens.png)](https://github.com/JoshuaBehrens)

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-block/sw-cms-block-config/sw-cms-block-config.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-block/sw-cms-block-config/sw-cms-block-config.html.twig
@@ -57,9 +57,15 @@
                         <sw-select-field :label="$tc('sw-cms.detail.label.backgroundMediaMode')"
                                          v-model="block.backgroundMediaMode"
                                          :disabled="!block.backgroundMediaId">
-                            <option value="auto">{{ $tc('sw-cms.detail.label.backgroundMediaModeAuto') }}</option>
-                            <option value="contain">{{ $tc('sw-cms.detail.label.backgroundMediaModeContain') }}</option>
-                            <option value="cover">{{ $tc('sw-cms.detail.label.backgroundMediaModeCover') }}</option>
+                            {% block sw_cms_block_config_background_image_position_field_options %}
+                                <option
+                                    v-for="(config, mode) in cmsPageState.fieldOptions.mediaBackgroundMode"
+                                    :key="mode"
+                                    :value="mode"
+                                >
+                                    {{ $t(config.label) }}
+                                </option>
+                            {% endblock %}
                         </sw-select-field>
                     {% endblock %}
                 {% endblock %}

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-section/sw-cms-section-config/sw-cms-section-config.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-section/sw-cms-section-config/sw-cms-section-config.html.twig
@@ -39,8 +39,15 @@
 
                 {% block sw_cms_sidebar_section_config_sizing_field %}
                     <sw-select-field :label="$tc('sw-cms.detail.label.sizingField')" v-model="section.sizingMode">
-                        <option value="boxed">{{ $tc('sw-cms.detail.label.sizingOptionBoxed') }}</option>
-                        <option value="full_width">{{ $tc('sw-cms.detail.label.sizingOptionFull') }}</option>
+                        {% block sw_cms_sidebar_section_config_sizing_field_options %}
+                            <option
+                                v-for="(config, mode) in cmsPageState.fieldOptions.sectionSizingMode"
+                                :key="mode"
+                                :value="mode"
+                            >
+                                {{ $t(config.label) }}
+                            </option>
+                        {% endblock %}
                     </sw-select-field>
                 {% endblock %}
 

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-section/sw-cms-section-config/sw-cms-section-config.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-section/sw-cms-section-config/sw-cms-section-config.html.twig
@@ -80,9 +80,15 @@
                         <sw-select-field :label="$tc('sw-cms.detail.label.backgroundMediaMode')"
                                          v-model="section.backgroundMediaMode"
                                          :disabled="!section.backgroundMediaId">
-                            <option value="auto">{{ $tc('sw-cms.detail.label.backgroundMediaModeAuto') }}</option>
-                            <option value="contain">{{ $tc('sw-cms.detail.label.backgroundMediaModeContain') }}</option>
-                            <option value="cover">{{ $tc('sw-cms.detail.label.backgroundMediaModeCover') }}</option>
+                            {% block sw_cms_section_config_background_image_position_field_options %}
+                                <option
+                                    v-for="(config, mode) in cmsPageState.fieldOptions.mediaBackgroundMode"
+                                    :key="mode"
+                                    :value="mode"
+                                >
+                                    {{ $t(config.label) }}
+                                </option>
+                            {% endblock %}
                         </sw-select-field>
                     {% endblock %}
                 {% endblock %}

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-section/sw-cms-section-config/sw-cms-section-config.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-section/sw-cms-section-config/sw-cms-section-config.html.twig
@@ -55,8 +55,15 @@
                     <sw-select-field v-if="section.type === 'sidebar'"
                                      :label="$tc('sw-cms.detail.sidebar.mobile')"
                                      v-model="section.mobileBehavior">
-                        <option value="hidden">{{ $tc('sw-cms.detail.sidebar.mobileOptionHidden') }}</option>
-                        <option value="wrap">{{ $tc('sw-cms.detail.sidebar.mobileOptionWrap') }}</option>
+                        {% block sw_cms_sidebar_section_config_sidebar_mobile_options %}
+                            <option
+                                v-for="(config, behaviour) in cmsPageState.fieldOptions.sectionMobileBehaviour"
+                                :key="behaviour"
+                                :value="behaviour"
+                            >
+                                {{ $t(config.label) }}
+                            </option>
+                        {% endblock %}
                     </sw-select-field>
                 {% endblock %}
 

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-sidebar/sw-cms-sidebar.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-sidebar/sw-cms-sidebar.html.twig
@@ -30,21 +30,15 @@
                                         :disabled="!isSystemDefaultLanguage"
                                         v-model="page.type"
                                         @change="onPageTypeChange">
-                                            {% block sw_cms_sidebar_page_settings_type_field_options %}
-                                                <option value="page">
-                                                    {{ $tc('sw-cms.detail.label.pageTypeShopPage') }}
-                                                </option>
-                                                <option value="landingpage">
-                                                    {{ $tc('sw-cms.detail.label.pageTypeLandingpage') }}
-                                                </option>
-                                                <option value="product_list">
-                                                    {{ $tc('sw-cms.detail.label.pageTypeCategory') }}
-                                                </option>
-                                                {# Will be implemented in the future #}
-{#                                                <option value="product_detail" disabled>#}
-{#                                                    {{ $tc('sw-cms.detail.label.pageTypeProduct') }}#}
-{#                                                </option>#}
-                                            {% endblock %}
+                                        {% block sw_cms_sidebar_page_settings_type_field_options %}
+                                            <option
+                                                v-for="(config, type) in cmsPageState.fieldOptions.pageType"
+                                                :key="type"
+                                                :value="type"
+                                            >
+                                                {{ $t(config.label) }}
+                                            </option>
+                                        {% endblock %}
                                     </sw-select-field>
                                 {% endblock %}
 

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-sidebar/sw-cms-sidebar.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-sidebar/sw-cms-sidebar.html.twig
@@ -73,13 +73,13 @@
                                 <sw-select-field :label="$tc('sw-cms.detail.label.blockCategorySelection')"
                                                  v-model="currentBlockCategory">
                                     {% block sw_cms_sidebar_block_overview_category_options %}
-                                        <option value="text">{{ $tc('sw-cms.detail.label.blockCategoryText') }}</option>
-                                        <option value="image">{{ $tc('sw-cms.detail.label.blockCategoryImage') }}</option>
-                                        <option value="video">{{ $tc('sw-cms.detail.label.blockCategoryVideo') }}</option>
-                                        <option value="text-image">{{ $tc('sw-cms.detail.label.blockCategoryTextImage') }}</option>
-                                        <option value="commerce">{{ $tc('sw-cms.detail.label.blockCategoryCommerce') }}</option>
-                                        <option value="sidebar">{{ $tc('sw-cms.detail.label.blockCategorySidebar') }}</option>
-                                        <option value="form">{{ $tc('sw-cms.detail.label.blockCategoryForm') }}</option>
+                                        <option
+                                            v-for="(config, category) in cmsPageState.fieldOptions.blockCategory"
+                                            :key="category"
+                                            :value="category"
+                                        >
+                                            {{ $t(config.label) }}
+                                        </option>
                                     {% endblock %}
                                 </sw-select-field>
                             </div>

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/form/config/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/form/config/index.js
@@ -9,6 +9,7 @@ Component.register('sw-cms-el-config-form', {
     inject: ['systemConfigApiService'],
 
     mixins: [
+        Mixin.getByName('cms-state'),
         Mixin.getByName('cms-element')
     ],
 

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/form/config/sw-cms-el-config-form.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/form/config/sw-cms-el-config-form.html.twig
@@ -29,9 +29,16 @@
                     {% block sw_cms_el_form_config_content_form_type %}
                         <sw-select-field :label="$tc('sw-cms.elements.form.config.label.type')"
                                          v-model="element.config.type.value">
-                            <option value="" disabled>{{ $tc('sw-cms.elements.form.config.label.type') }}</option>
-                            <option value="contact">{{ $tc('sw-cms.elements.form.config.label.typeContact') }}</option>
-                            <option value="newsletter">{{ $tc('sw-cms.elements.form.config.label.typeNewsletter') }}</option>
+                            {% block sw_cms_el_form_config_content_form_type_options %}
+                                <option :value="null" disabled>{{ $tc('sw-cms.elements.form.config.label.type') }}</option>
+                                <option
+                                    v-for="(config, type) in cmsPageState.fieldOptions.formType"
+                                    :key="type"
+                                    :value="type"
+                                >
+                                    {{ $t(config.label) }}
+                                </option>
+                            {% endblock %}
                         </sw-select-field>
                     {% endblock %}
 

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image-gallery/config/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image-gallery/config/index.js
@@ -46,8 +46,11 @@ Component.register('sw-cms-el-config-image-gallery', {
         },
 
         imageDisplayModes() {
-            // can also be directly access in the template without computed getter
             return State.getters['cmsPageState/imageDisplayModes'];
+        },
+
+        verticalAlignments() {
+            return State.getters['cmsPageState/verticalAlignments'];
         }
     },
 

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image-gallery/config/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image-gallery/config/index.js
@@ -9,6 +9,7 @@ Component.register('sw-cms-el-config-image-gallery', {
     template,
 
     mixins: [
+        Mixin.getByName('cms-state'),
         Mixin.getByName('cms-element')
     ],
 

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image-gallery/config/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image-gallery/config/index.js
@@ -1,7 +1,7 @@
 import template from './sw-cms-el-config-image-gallery.html.twig';
 import './sw-cms-el-config-image-gallery.scss';
 
-const { Component, Mixin } = Shopware;
+const { Component, Mixin, State } = Shopware;
 const { cloneDeep } = Shopware.Utils.object;
 const Criteria = Shopware.Data.Criteria;
 
@@ -43,6 +43,11 @@ Component.register('sw-cms-el-config-image-gallery', {
             }
 
             return [];
+        },
+
+        imageDisplayModes() {
+            // can also be directly access in the template without computed getter
+            return State.getters['cmsPageState/imageDisplayModes'];
         }
     },
 

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image-gallery/config/sw-cms-el-config-image-gallery.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image-gallery/config/sw-cms-el-config-image-gallery.html.twig
@@ -87,9 +87,15 @@
                                                              v-model="element.config.verticalAlign.value"
                                                              :placeholder="$tc('sw-cms.elements.general.config.label.verticalAlign')"
                                                              :disabled="['cover', 'contain'].includes(element.config.displayMode.value)">
-                                                <option value="flex-start">{{ $tc('sw-cms.elements.general.config.label.verticalAlignTop') }}</option>
-                                                <option value="center">{{ $tc('sw-cms.elements.general.config.label.verticalAlignCenter') }}</option>
-                                                <option value="flex-end">{{ $tc('sw-cms.elements.general.config.label.verticalAlignBottom') }}</option>
+                                                {% block sw_cms_element_image_gallery_config_settings_vertical_align_options %}
+                                                    <option
+                                                        v-for="(config, alignment) in verticalAlignments"
+                                                        :key="alignment"
+                                                        :value="alignment"
+                                                    >
+                                                        {{ $t(config.label) }}
+                                                    </option>
+                                                {% endblock %}
                                             </sw-select-field>
                                         {% endblock %}
                                     </div>

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image-gallery/config/sw-cms-el-config-image-gallery.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image-gallery/config/sw-cms-el-config-image-gallery.html.twig
@@ -111,15 +111,18 @@
                                                           @change="emitUpdateEl"
                                                           :label="$tc('sw-cms.elements.imageSlider.config.label.navigationArrows')">
 
-                                                    <option :value="null">
-                                                        {{ $tc('sw-cms.elements.imageSlider.config.label.navigationPositionNone') }}
-                                                    </option>
-                                                    <option value="inside">
-                                                        {{ $tc('sw-cms.elements.imageSlider.config.label.navigationPositionInside') }}
-                                                    </option>
-                                                    <option value="outside">
-                                                        {{ $tc('sw-cms.elements.imageSlider.config.label.navigationPositionOutside') }}
-                                                    </option>
+                                                    {% block sw_cms_element_image_gallery_config_settings_navigation_arrow_position_options %}
+                                                        <option :value="null">
+                                                            {{ $tc('sw-cms.elements.imageSlider.config.label.navigationPositionNone') }}
+                                                        </option>
+                                                        <option
+                                                            v-for="(config, position) in cmsPageState.fieldOptions.mediaSliderNavigationPosition"
+                                                            :key="position"
+                                                            :value="position"
+                                                        >
+                                                            {{ $t(config.label) }}
+                                                        </option>
+                                                    {% endblock %}
                                                 </sw-field>
                                             {% endblock %}
                                         </div>
@@ -131,16 +134,18 @@
                                                           v-model="element.config.navigationDots.value"
                                                           @change="emitUpdateEl"
                                                           :label="$tc('sw-cms.elements.imageSlider.config.label.navigationDots')">
-
-                                                    <option :value="null">
-                                                        {{ $tc('sw-cms.elements.imageSlider.config.label.navigationPositionNone') }}
-                                                    </option>
-                                                    <option value="inside">
-                                                        {{ $tc('sw-cms.elements.imageSlider.config.label.navigationPositionInside') }}
-                                                    </option>
-                                                    <option value="outside">
-                                                        {{ $tc('sw-cms.elements.imageSlider.config.label.navigationPositionOutside') }}
-                                                    </option>
+                                                    {% block sw_cms_element_image_gallery_config_settings_navigation_dots_position_options %}
+                                                        <option :value="null">
+                                                            {{ $tc('sw-cms.elements.imageSlider.config.label.navigationPositionNone') }}
+                                                        </option>
+                                                        <option
+                                                            v-for="(config, position) in cmsPageState.fieldOptions.mediaSliderNavigationPosition"
+                                                            :key="position"
+                                                            :value="position"
+                                                        >
+                                                            {{ $t(config.label) }}
+                                                        </option>
+                                                    {% endblock %}
                                                 </sw-field>
                                             {% endblock %}
                                         </div>

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image-gallery/config/sw-cms-el-config-image-gallery.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image-gallery/config/sw-cms-el-config-image-gallery.html.twig
@@ -157,13 +157,15 @@
                                                           v-model="element.config.galleryPosition.value"
                                                           @change="emitUpdateEl"
                                                           :label="$tc('sw-cms.elements.imageGallery.config.label.navigationPreview')">
-
-                                                    <option value="left">
-                                                        {{ $tc('sw-cms.elements.imageGallery.config.label.navigationPreviewPositionLeft') }}
-                                                    </option>
-                                                    <option value="underneath">
-                                                        {{ $tc('sw-cms.elements.imageGallery.config.label.navigationPreviewPositionUnderneath') }}
-                                                    </option>
+                                                    {% block sw_cms_element_image_gallery_config_settings_navigation_preview_position_options %}
+                                                        <option
+                                                            v-for="(config, position) in cmsPageState.fieldOptions.mediaGalleryNavigationPreviewPosition"
+                                                            :key="position"
+                                                            :value="position"
+                                                        >
+                                                            {{ $t(config.label) }}
+                                                        </option>
+                                                    {% endblock %}
                                                 </sw-field>
                                             {% endblock %}
                                         </div>

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image-gallery/config/sw-cms-el-config-image-gallery.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image-gallery/config/sw-cms-el-config-image-gallery.html.twig
@@ -61,9 +61,15 @@
                                                              v-model="element.config.displayMode.value"
                                                              @change="onChangeDisplayMode"
                                                              class="sw-cms-el-config-image-gallery__setting-display-mode">
-                                                <option value="standard">{{ $tc('sw-cms.elements.general.config.label.displayModeStandard') }}</option>
-                                                <option value="cover">{{ $tc('sw-cms.elements.general.config.label.displayModeCover') }}</option>
-                                                <option value="contain">{{ $tc('sw-cms.elements.general.config.label.displayModeContain') }}</option>
+                                                {% block sw_cms_element_image_gallery_config_settings_display_mode_select_options %}
+                                                    <option
+                                                        v-for="(config, mode) in cmsPageState.fieldOptions.mediaDisplayMode"
+                                                        :key="mode"
+                                                        :value="mode"
+                                                    >
+                                                        {{ $t(config.label) }}
+                                                    </option>
+                                                {% endblock %}
                                             </sw-select-field>
                                         {% endblock %}
 

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image-gallery/config/sw-cms-el-config-image-gallery.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image-gallery/config/sw-cms-el-config-image-gallery.html.twig
@@ -63,7 +63,7 @@
                                                              class="sw-cms-el-config-image-gallery__setting-display-mode">
                                                 {% block sw_cms_element_image_gallery_config_settings_display_mode_select_options %}
                                                     <option
-                                                        v-for="(config, mode) in cmsPageState.fieldOptions.mediaDisplayMode"
+                                                        v-for="(config, mode) in imageDisplayModes"
                                                         :key="mode"
                                                         :value="mode"
                                                     >

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image-slider/config/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image-slider/config/index.js
@@ -46,8 +46,11 @@ Component.register('sw-cms-el-config-image-slider', {
         },
 
         imageDisplayModes() {
-            // can also be directly access in the template without computed getter
             return State.getters['cmsPageState/imageDisplayModes'];
+        },
+
+        verticalAlignments() {
+            return State.getters['cmsPageState/verticalAlignments'];
         }
     },
 

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image-slider/config/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image-slider/config/index.js
@@ -9,6 +9,7 @@ Component.register('sw-cms-el-config-image-slider', {
     template,
 
     mixins: [
+        Mixin.getByName('cms-state'),
         Mixin.getByName('cms-element')
     ],
 

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image-slider/config/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image-slider/config/index.js
@@ -1,7 +1,7 @@
 import template from './sw-cms-el-config-image-slider.html.twig';
 import './sw-cms-el-config-image-slider.scss';
 
-const { Component, Mixin } = Shopware;
+const { Component, Mixin, State } = Shopware;
 const { cloneDeep } = Shopware.Utils.object;
 const Criteria = Shopware.Data.Criteria;
 
@@ -43,6 +43,11 @@ Component.register('sw-cms-el-config-image-slider', {
             }
 
             return [];
+        },
+
+        imageDisplayModes() {
+            // can also be directly access in the template without computed getter
+            return State.getters['cmsPageState/imageDisplayModes'];
         }
     },
 

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image-slider/config/sw-cms-el-config-image-slider.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image-slider/config/sw-cms-el-config-image-slider.html.twig
@@ -61,9 +61,15 @@
                                                              v-model="element.config.displayMode.value"
                                                              @change="onChangeDisplayMode"
                                                              class="sw-cms-el-config-image-slider__setting-display-mode">
-                                                <option value="standard">{{ $tc('sw-cms.elements.general.config.label.displayModeStandard') }}</option>
-                                                <option value="cover">{{ $tc('sw-cms.elements.general.config.label.displayModeCover') }}</option>
-                                                <option value="contain">{{ $tc('sw-cms.elements.general.config.label.displayModeContain') }}</option>
+                                                {% block sw_cms_element_image_gallery_config_settings_display_mode_select_options %}
+                                                    <option
+                                                        v-for="(config, mode) in cmsPageState.fieldOptions.mediaDisplayMode"
+                                                        :key="mode"
+                                                        :value="mode"
+                                                    >
+                                                        {{ $t(config.label) }}
+                                                    </option>
+                                                {% endblock %}
                                             </sw-select-field>
                                         {% endblock %}
 

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image-slider/config/sw-cms-el-config-image-slider.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image-slider/config/sw-cms-el-config-image-slider.html.twig
@@ -111,16 +111,18 @@
                                                           v-model="element.config.navigationArrows.value"
                                                           @change="emitUpdateEl"
                                                           :label="$tc('sw-cms.elements.imageSlider.config.label.navigationArrows')">
-
-                                                    <option :value="null">
-                                                        {{ $tc('sw-cms.elements.imageSlider.config.label.navigationPositionNone') }}
-                                                    </option>
-                                                    <option value="inside">
-                                                        {{ $tc('sw-cms.elements.imageSlider.config.label.navigationPositionInside') }}
-                                                    </option>
-                                                    <option value="outside">
-                                                        {{ $tc('sw-cms.elements.imageSlider.config.label.navigationPositionOutside') }}
-                                                    </option>
+                                                    {% block sw_cms_element_image_slider_config_settings_navigation_arrow_position_options %}
+                                                        <option :value="null">
+                                                            {{ $tc('sw-cms.elements.imageSlider.config.label.navigationPositionNone') }}
+                                                        </option>
+                                                        <option
+                                                            v-for="(config, position) in cmsPageState.fieldOptions.mediaSliderNavigationPosition"
+                                                            :key="position"
+                                                            :value="position"
+                                                        >
+                                                            {{ $t(config.label) }}
+                                                        </option>
+                                                    {% endblock %}
                                                 </sw-field>
                                             {% endblock %}
                                         </div>
@@ -132,16 +134,18 @@
                                                           v-model="element.config.navigationDots.value"
                                                           @change="emitUpdateEl"
                                                           :label="$tc('sw-cms.elements.imageSlider.config.label.navigationDots')">
-
-                                                    <option :value="null">
-                                                        {{ $tc('sw-cms.elements.imageSlider.config.label.navigationPositionNone') }}
-                                                    </option>
-                                                    <option value="inside">
-                                                        {{ $tc('sw-cms.elements.imageSlider.config.label.navigationPositionInside') }}
-                                                    </option>
-                                                    <option value="outside">
-                                                        {{ $tc('sw-cms.elements.imageSlider.config.label.navigationPositionOutside') }}
-                                                    </option>
+                                                    {% block sw_cms_element_image_slider_config_settings_navigation_dots_position_options %}
+                                                        <option :value="null">
+                                                            {{ $tc('sw-cms.elements.imageSlider.config.label.navigationPositionNone') }}
+                                                        </option>
+                                                        <option
+                                                            v-for="(config, position) in cmsPageState.fieldOptions.mediaSliderNavigationPosition"
+                                                            :key="position"
+                                                            :value="position"
+                                                        >
+                                                            {{ $t(config.label) }}
+                                                        </option>
+                                                    {% endblock %}
                                                 </sw-field>
                                             {% endblock %}
                                         </div>

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image-slider/config/sw-cms-el-config-image-slider.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image-slider/config/sw-cms-el-config-image-slider.html.twig
@@ -87,9 +87,15 @@
                                                              v-model="element.config.verticalAlign.value"
                                                              :placeholder="$tc('sw-cms.elements.general.config.label.verticalAlign')"
                                                              :disabled="element.config.displayMode.value === 'cover'">
-                                                <option value="flex-start">{{ $tc('sw-cms.elements.general.config.label.verticalAlignTop') }}</option>
-                                                <option value="center">{{ $tc('sw-cms.elements.general.config.label.verticalAlignCenter') }}</option>
-                                                <option value="flex-end">{{ $tc('sw-cms.elements.general.config.label.verticalAlignBottom') }}</option>
+                                                {% block sw_cms_element_image_gallery_config_settings_vertical_align_options %}
+                                                    <option
+                                                        v-for="(config, alignment) in verticalAlignments"
+                                                        :key="alignment"
+                                                        :value="alignment"
+                                                    >
+                                                        {{ $t(config.label) }}
+                                                    </option>
+                                                {% endblock %}
                                             </sw-select-field>
                                         {% endblock %}
                                     </div>

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image-slider/config/sw-cms-el-config-image-slider.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image-slider/config/sw-cms-el-config-image-slider.html.twig
@@ -63,7 +63,7 @@
                                                              class="sw-cms-el-config-image-slider__setting-display-mode">
                                                 {% block sw_cms_element_image_gallery_config_settings_display_mode_select_options %}
                                                     <option
-                                                        v-for="(config, mode) in cmsPageState.fieldOptions.mediaDisplayMode"
+                                                        v-for="(config, mode) in imageDisplayModes"
                                                         :key="mode"
                                                         :value="mode"
                                                     >

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image/config/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image/config/index.js
@@ -1,7 +1,7 @@
 import template from './sw-cms-el-config-image.html.twig';
 import './sw-cms-el-config-image.scss';
 
-const { Component, Mixin } = Shopware;
+const { Component, Mixin, State } = Shopware;
 
 Component.register('sw-cms-el-config-image', {
     template,
@@ -35,6 +35,11 @@ Component.register('sw-cms-el-config-image', {
             }
 
             return this.element.config.media.value;
+        },
+
+        imageDisplayModes() {
+            // can also be directly access in the template without computed getter
+            return State.getters['cmsPageState/imageDisplayModes'];
         }
     },
 

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image/config/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image/config/index.js
@@ -38,8 +38,11 @@ Component.register('sw-cms-el-config-image', {
         },
 
         imageDisplayModes() {
-            // can also be directly access in the template without computed getter
             return State.getters['cmsPageState/imageDisplayModes'];
+        },
+
+        verticalAlignments() {
+            return State.getters['cmsPageState/verticalAlignments'];
         }
     },
 

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image/config/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image/config/index.js
@@ -7,6 +7,7 @@ Component.register('sw-cms-el-config-image', {
     template,
 
     mixins: [
+        Mixin.getByName('cms-state'),
         Mixin.getByName('cms-element')
     ],
 

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image/config/sw-cms-el-config-image.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image/config/sw-cms-el-config-image.html.twig
@@ -31,9 +31,15 @@
             <sw-select-field :label="$tc('sw-cms.elements.general.config.label.displayMode')"
                              v-model="element.config.displayMode.value"
                              @change="onChangeDisplayMode">
-                <option value="standard">{{ $tc('sw-cms.elements.general.config.label.displayModeStandard') }}</option>
-                <option value="cover">{{ $tc('sw-cms.elements.general.config.label.displayModeCover') }}</option>
-                <option value="stretch">{{ $tc('sw-cms.elements.general.config.label.displayModeStretch') }}</option>
+                {% block sw_cms_element_image_config_display_mode_options %}
+                    <option
+                        v-for="(config, mode) in cmsPageState.fieldOptions.mediaDisplayMode"
+                        :key="mode"
+                        :value="mode"
+                    >
+                        {{ $t(config.label) }}
+                    </option>
+                {% endblock %}
             </sw-select-field>
         {% endblock %}
 

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image/config/sw-cms-el-config-image.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image/config/sw-cms-el-config-image.html.twig
@@ -58,9 +58,15 @@
                              v-model="element.config.verticalAlign.value"
                              :placeholder="$tc('sw-cms.elements.general.config.label.verticalAlign')"
                              :disabled="element.config.displayMode.value === 'cover'">
-                <option value="flex-start">{{ $tc('sw-cms.elements.general.config.label.verticalAlignTop') }}</option>
-                <option value="center">{{ $tc('sw-cms.elements.general.config.label.verticalAlignCenter') }}</option>
-                <option value="flex-end">{{ $tc('sw-cms.elements.general.config.label.verticalAlignBottom') }}</option>
+                {% block sw_cms_element_image_config_vertical_align_options %}
+                    <option
+                        v-for="(config, alignment) in verticalAlignments"
+                        :key="alignment"
+                        :value="alignment"
+                    >
+                        {{ $t(config.label) }}
+                    </option>
+                {% endblock %}
             </sw-select-field>
         {% endblock %}
 

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image/config/sw-cms-el-config-image.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image/config/sw-cms-el-config-image.html.twig
@@ -33,7 +33,7 @@
                              @change="onChangeDisplayMode">
                 {% block sw_cms_element_image_config_display_mode_options %}
                     <option
-                        v-for="(config, mode) in cmsPageState.fieldOptions.mediaDisplayMode"
+                        v-for="(config, mode) in imageDisplayModes"
                         :key="mode"
                         :value="mode"
                     >

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/product-box/config/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/product-box/config/index.js
@@ -8,6 +8,7 @@ Component.register('sw-cms-el-config-product-box', {
     template,
 
     mixins: [
+        Mixin.getByName('cms-state'),
         Mixin.getByName('cms-element')
     ],
 

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/product-box/config/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/product-box/config/index.js
@@ -27,8 +27,11 @@ Component.register('sw-cms-el-config-product-box', {
         },
 
         imageDisplayModes() {
-            // can also be directly access in the template without computed getter
             return State.getters['cmsPageState/imageDisplayModes'];
+        },
+
+        verticalAlignments() {
+            return State.getters['cmsPageState/verticalAlignments'];
         }
     },
 

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/product-box/config/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/product-box/config/index.js
@@ -2,7 +2,7 @@ import Criteria from 'src/core/data-new/criteria.data';
 import template from './sw-cms-el-config-product-box.html.twig';
 import './sw-cms-el-config-product-box.scss';
 
-const { Component, Mixin } = Shopware;
+const { Component, Mixin, State } = Shopware;
 
 Component.register('sw-cms-el-config-product-box', {
     template,
@@ -24,6 +24,11 @@ Component.register('sw-cms-el-config-product-box', {
             context.inheritance = true;
 
             return context;
+        },
+
+        imageDisplayModes() {
+            // can also be directly access in the template without computed getter
+            return State.getters['cmsPageState/imageDisplayModes'];
         }
     },
 

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/product-box/config/sw-cms-el-config-product-box.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/product-box/config/sw-cms-el-config-product-box.html.twig
@@ -37,9 +37,15 @@
         {% block sw_cms_element_product_box_config_displaymode_select %}
             <sw-select-field :label="$tc('sw-cms.elements.general.config.label.displayMode')"
                              v-model="element.config.displayMode.value">
-                <option value="standard">{{ $tc('sw-cms.elements.general.config.label.displayModeStandard') }}</option>
-                <option value="cover">{{ $tc('sw-cms.elements.general.config.label.displayModeCover') }}</option>
-                <option value="contain">{{ $tc('sw-cms.elements.general.config.label.displayModeContain') }}</option>
+                {% block sw_cms_element_product_box_config_displaymode_select_options %}
+                    <option
+                        v-for="(config, mode) in cmsPageState.fieldOptions.mediaDisplayMode"
+                        :key="mode"
+                        :value="mode"
+                    >
+                        {{ $t(config.label) }}
+                    </option>
+                {% endblock %}
             </sw-select-field>
         {% endblock %}
 

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/product-box/config/sw-cms-el-config-product-box.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/product-box/config/sw-cms-el-config-product-box.html.twig
@@ -53,9 +53,15 @@
             <sw-select-field :label="$tc('sw-cms.elements.general.config.label.verticalAlign')"
                              v-model="element.config.verticalAlign.value"
                              :placeholder="$tc('sw-cms.elements.general.config.label.verticalAlign')">
-                <option value="flex-start">{{ $tc('sw-cms.elements.general.config.label.verticalAlignTop') }}</option>
-                <option value="center">{{ $tc('sw-cms.elements.general.config.label.verticalAlignCenter') }}</option>
-                <option value="flex-end">{{ $tc('sw-cms.elements.general.config.label.verticalAlignBottom') }}</option>
+                {% block sw_cms_element_product_box_config_settings_vertical_align_options %}
+                    <option
+                        v-for="(config, alignment) in verticalAlignments"
+                        :key="alignment"
+                        :value="alignment"
+                    >
+                        {{ $t(config.label) }}
+                    </option>
+                {% endblock %}
             </sw-select-field>
         {% endblock %}
     </div>

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/product-box/config/sw-cms-el-config-product-box.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/product-box/config/sw-cms-el-config-product-box.html.twig
@@ -39,7 +39,7 @@
                              v-model="element.config.displayMode.value">
                 {% block sw_cms_element_product_box_config_displaymode_select_options %}
                     <option
-                        v-for="(config, mode) in cmsPageState.fieldOptions.mediaDisplayMode"
+                        v-for="(config, mode) in imageDisplayModes"
                         :key="mode"
                         :value="mode"
                     >

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/product-box/config/sw-cms-el-config-product-box.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/product-box/config/sw-cms-el-config-product-box.html.twig
@@ -22,9 +22,15 @@
         {% block sw_cms_element_product_box_config_layout_select %}
             <sw-select-field :label="$tc('sw-cms.elements.productBox.config.label.layoutType')"
                              v-model="element.config.boxLayout.value">
-                <option value="standard">{{ $tc('sw-cms.elements.productBox.config.label.layoutTypeStandard') }}</option>
-                <option value="image">{{ $tc('sw-cms.elements.productBox.config.label.layoutTypeImage') }}</option>
-                <option value="minimal">{{ $tc('sw-cms.elements.productBox.config.label.layoutTypeMinimal') }}</option>
+                {% block sw_cms_element_product_box_config_layout_select_options %}
+                    <option
+                        v-for="(config, type) in cmsPageState.fieldOptions.productBoxLayoutType"
+                        :key="type"
+                        :value="type"
+                    >
+                        {{ $t(config.label) }}
+                    </option>
+                {% endblock %}
             </sw-select-field>
         {% endblock %}
 

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/product-listing/config/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/product-listing/config/index.js
@@ -7,6 +7,7 @@ Component.register('sw-cms-el-config-product-listing', {
     template,
 
     mixins: [
+        Mixin.getByName('cms-state'),
         Mixin.getByName('cms-element')
     ],
 

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/product-listing/config/sw-cms-el-config-product-listing.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/product-listing/config/sw-cms-el-config-product-listing.html.twig
@@ -4,9 +4,13 @@
         {% block sw_cms_element_product_listing_config_layout_select %}
             <sw-select-field :label="$tc('sw-cms.elements.productBox.config.label.layoutType')" v-model="element.config.boxLayout.value">
                 {% block sw_cms_element_product_listing_config_layout_select_options %}
-                    <option value="standard">{{ $tc('sw-cms.elements.productBox.config.label.layoutTypeStandard') }}</option>
-                    <option value="image">{{ $tc('sw-cms.elements.productBox.config.label.layoutTypeImage') }}</option>
-                    <option value="minimal">{{ $tc('sw-cms.elements.productBox.config.label.layoutTypeMinimal') }}</option>
+                    <option
+                        v-for="(config, type) in cmsPageState.fieldOptions.productBoxLayoutType"
+                        :key="type"
+                        :value="type"
+                    >
+                        {{ $t(config.label) }}
+                    </option>
                 {% endblock %}
             </sw-select-field>
         {% endblock %}

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/product-slider/config/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/product-slider/config/index.js
@@ -10,6 +10,7 @@ Component.register('sw-cms-el-config-product-slider', {
     inject: ['repositoryFactory'],
 
     mixins: [
+        Mixin.getByName('cms-state'),
         Mixin.getByName('cms-element')
     ],
 

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/product-slider/config/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/product-slider/config/index.js
@@ -1,7 +1,7 @@
 import template from './sw-cms-el-config-product-slider.html.twig';
 import './sw-cms-el-config-product-slider.scss';
 
-const { Component, Mixin } = Shopware;
+const { Component, Mixin, State } = Shopware;
 const { Criteria, EntityCollection } = Shopware.Data;
 
 Component.register('sw-cms-el-config-product-slider', {
@@ -45,6 +45,11 @@ Component.register('sw-cms-el-config-product-slider', {
             context.inheritance = true;
 
             return context;
+        },
+
+        imageDisplayModes() {
+            // can also be directly access in the template without computed getter
+            return State.getters['cmsPageState/imageDisplayModes'];
         }
     },
 

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/product-slider/config/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/product-slider/config/index.js
@@ -48,8 +48,11 @@ Component.register('sw-cms-el-config-product-slider', {
         },
 
         imageDisplayModes() {
-            // can also be directly access in the template without computed getter
             return State.getters['cmsPageState/imageDisplayModes'];
+        },
+
+        verticalAlignments() {
+            return State.getters['cmsPageState/verticalAlignments'];
         }
     },
 

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/product-slider/config/sw-cms-el-config-product-slider.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/product-slider/config/sw-cms-el-config-product-slider.html.twig
@@ -76,9 +76,15 @@
                             {% block sw_cms_element_product_slider_config_settings_box_layout %}
                                 <sw-select-field :label="$tc('sw-cms.elements.productBox.config.label.layoutType')"
                                                  v-model="element.config.boxLayout.value">
-                                    <option value="standard">{{ $tc('sw-cms.elements.productBox.config.label.layoutTypeStandard') }}</option>
-                                    <option value="image">{{ $tc('sw-cms.elements.productBox.config.label.layoutTypeImage') }}</option>
-                                    <option value="minimal">{{ $tc('sw-cms.elements.productBox.config.label.layoutTypeMinimal') }}</option>
+                                    {% block sw_cms_element_product_slider_config_settings_box_layout_options %}
+                                        <option
+                                            v-for="(config, type) in cmsPageState.fieldOptions.productBoxLayoutType"
+                                            :key="type"
+                                            :value="type"
+                                        >
+                                            {{ $t(config.label) }}
+                                        </option>
+                                    {% endblock %}
                                 </sw-select-field>
                             {% endblock %}
 

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/product-slider/config/sw-cms-el-config-product-slider.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/product-slider/config/sw-cms-el-config-product-slider.html.twig
@@ -57,9 +57,15 @@
                             {% block sw_cms_element_product_slider_config_settings_display_mode %}
                                 <sw-select-field :label="$tc('sw-cms.elements.general.config.label.displayMode')"
                                                  v-model="element.config.displayMode.value">
-                                    <option value="standard">{{ $tc('sw-cms.elements.general.config.label.displayModeStandard') }}</option>
-                                    <option value="cover">{{ $tc('sw-cms.elements.general.config.label.displayModeCover') }}</option>
-                                    <option value="contain">{{ $tc('sw-cms.elements.general.config.label.displayModeContain') }}</option>
+                                    {% block sw_cms_element_product_slider_config_settings_display_mode_options %}
+                                        <option
+                                            v-for="(config, mode) in cmsPageState.fieldOptions.mediaDisplayMode"
+                                            :key="mode"
+                                            :value="mode"
+                                        >
+                                            {{ $t(config.label) }}
+                                        </option>
+                                    {% endblock %}
                                 </sw-select-field>
                             {% endblock %}
 

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/product-slider/config/sw-cms-el-config-product-slider.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/product-slider/config/sw-cms-el-config-product-slider.html.twig
@@ -59,7 +59,7 @@
                                                  v-model="element.config.displayMode.value">
                                     {% block sw_cms_element_product_slider_config_settings_display_mode_options %}
                                         <option
-                                            v-for="(config, mode) in cmsPageState.fieldOptions.mediaDisplayMode"
+                                            v-for="(config, mode) in imageDisplayModes"
                                             :key="mode"
                                             :value="mode"
                                         >

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/product-slider/config/sw-cms-el-config-product-slider.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/product-slider/config/sw-cms-el-config-product-slider.html.twig
@@ -73,9 +73,15 @@
                                 <sw-select-field :label="$tc('sw-cms.elements.general.config.label.verticalAlign')"
                                                  v-model="element.config.verticalAlign.value"
                                                  :placeholder="$tc('sw-cms.elements.general.config.label.verticalAlign')">
-                                    <option value="flex-start">{{ $tc('sw-cms.elements.general.config.label.verticalAlignTop') }}</option>
-                                    <option value="center">{{ $tc('sw-cms.elements.general.config.label.verticalAlignCenter') }}</option>
-                                    <option value="flex-end">{{ $tc('sw-cms.elements.general.config.label.verticalAlignBottom') }}</option>
+                                    {% block sw_cms_element_product_slider_config_settings_vertical_align_options %}
+                                        <option
+                                            v-for="(config, alignment) in verticalAlignments"
+                                            :key="alignment"
+                                            :value="alignment"
+                                        >
+                                            {{ $t(config.label) }}
+                                        </option>
+                                    {% endblock %}
                                 </sw-select-field>
                             {% endblock %}
 

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/text/config/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/text/config/index.js
@@ -1,7 +1,7 @@
 import template from './sw-cms-el-config-text.html.twig';
 import './sw-cms-el-config-text.scss';
 
-const { Component, Mixin } = Shopware;
+const { Component, Mixin, State } = Shopware;
 
 Component.register('sw-cms-el-config-text', {
     template,
@@ -12,6 +12,12 @@ Component.register('sw-cms-el-config-text', {
 
     created() {
         this.createdComponent();
+    },
+
+    computed: {
+        verticalAlignments() {
+            return State.getters['cmsPageState/verticalAlignments'];
+        }
     },
 
     methods: {

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/text/config/sw-cms-el-config-text.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/text/config/sw-cms-el-config-text.html.twig
@@ -40,9 +40,15 @@
                         <sw-select-field :label="$tc('sw-cms.elements.general.config.label.verticalAlign')"
                                          v-model="element.config.verticalAlign.value"
                                          :placeholder="$tc('sw-cms.elements.general.config.label.verticalAlign')">
-                            <option value="flex-start">{{ $tc('sw-cms.elements.general.config.label.verticalAlignTop') }}</option>
-                            <option value="center">{{ $tc('sw-cms.elements.general.config.label.verticalAlignCenter') }}</option>
-                            <option value="flex-end">{{ $tc('sw-cms.elements.general.config.label.verticalAlignBottom') }}</option>
+                            {% block sw_cms_el_text_config_settings_vertical_align_options %}
+                                <option
+                                    v-for="(config, alignment) in verticalAlignments"
+                                    :key="alignment"
+                                    :value="alignment"
+                                >
+                                    {{ $t(config.label) }}
+                                </option>
+                            {% endblock %}
                         </sw-select-field>
                     {% endblock %}
                 </sw-container>

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/youtube-video/config/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/youtube-video/config/index.js
@@ -1,7 +1,7 @@
 import template from './sw-cms-el-config-youtube-video.html.twig';
 import './sw-cms-el-config-youtube-video.scss';
 
-const { Component, Mixin } = Shopware;
+const { Component, Mixin, State } = Shopware;
 
 Component.register('sw-cms-el-config-youtube-video', {
     template,
@@ -31,6 +31,10 @@ Component.register('sw-cms-el-config-youtube-video', {
             set(link) {
                 this.element.config.videoID.value = this.shortenLink(link);
             }
+        },
+
+        videoDisplayModes() {
+            return State.getters['cmsPageState/videoDisplayModes'];
         }
     },
 

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/youtube-video/config/sw-cms-el-config-youtube-video.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/youtube-video/config/sw-cms-el-config-youtube-video.html.twig
@@ -68,8 +68,15 @@
             <sw-select-field v-model="element.config.displayMode.value"
                                 :placeholder="$tc('sw-cms.elements.general.config.label.displayMode')"
                                 :label="$tc('sw-cms.elements.general.config.label.displayMode')">
-                <option value="standard">{{ $tc('sw-cms.elements.general.config.label.displayModeStandard') }}</option>
-                <option value="streched">{{ $tc('sw-cms.elements.general.config.label.displayModeStretch') }}</option>
+                {% block sw_cms_element_youtube_video_config_display_mode_options %}
+                    <option
+                        v-for="(config, mode) in videoDisplayModes"
+                        :key="mode"
+                        :value="mode"
+                    >
+                        {{ $t(config.label) }}
+                    </option>
+                {% endblock %}
             </sw-select-field>
         {% endblock %}
 

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/state/cms-page.state.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/state/cms-page.state.js
@@ -29,6 +29,14 @@ Shopware.State.registerModule('cmsPageState', {
                     vertical: true
                 }
             },
+            formType: {
+                contact: {
+                    label: 'sw-cms.elements.form.config.label.typeContact'
+                },
+                newsletter: {
+                    label: 'sw-cms.elements.form.config.label.typeNewsletter'
+                }
+            },
             mediaBackgroundMode: {
                 auto: {
                     label: 'sw-cms.detail.label.backgroundMediaModeAuto'
@@ -177,6 +185,21 @@ Shopware.State.registerModule('cmsPageState', {
 
             Vue.set(state.fieldOptions.alignment, name, {
                 ...(state.fieldOptions.alignment[name] || {}),
+                ...configuration
+            });
+        },
+
+        setFormType(state, configuration) {
+            if (!('name' in configuration)) {
+                return;
+            }
+
+            configuration = { ...configuration };
+            const name = configuration.name;
+            delete configuration.name;
+
+            Vue.set(state.fieldOptions.formType, name, {
+                ...(state.fieldOptions.formType[name] || {}),
                 ...configuration
             });
         },

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/state/cms-page.state.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/state/cms-page.state.js
@@ -15,6 +15,20 @@ Shopware.State.registerModule('cmsPageState', {
         selectedBlock: null,
         isSystemDefaultLanguage: true,
         fieldOptions: {
+            alignment: {
+                'flex-start': {
+                    label: 'sw-cms.elements.general.config.label.verticalAlignTop',
+                    vertical: true
+                },
+                center: {
+                    label: 'sw-cms.elements.general.config.label.verticalAlignCenter',
+                    vertical: true
+                },
+                'flex-end': {
+                    label: 'sw-cms.elements.general.config.label.verticalAlignBottom',
+                    vertical: true
+                }
+            },
             mediaDisplayMode: {
                 standard: {
                     label: 'sw-cms.elements.general.config.label.displayModeStandard',
@@ -125,6 +139,21 @@ Shopware.State.registerModule('cmsPageState', {
             state.isSystemDefaultLanguage = isSystemDefaultLanguage;
         },
 
+        setAlignment(state, configuration) {
+            if (!('name' in configuration)) {
+                return;
+            }
+
+            configuration = { ...configuration };
+            const name = configuration.name;
+            delete configuration.name;
+
+            Vue.set(state.fieldOptions.alignment, name, {
+                ...(state.fieldOptions.alignment[name] || {}),
+                ...configuration
+            });
+        },
+
         setMediaDisplayMode(state, configuration) {
             if (!('name' in configuration)) {
                 return;
@@ -176,6 +205,20 @@ Shopware.State.registerModule('cmsPageState', {
     },
 
     getters: {
+        verticalAlignments(state) {
+            return Object.fromEntries(
+                Object.entries(state.fieldOptions.alignment)
+                    .filter(config => config[1] && config[1].vertical)
+            );
+        },
+
+        horizontalAlignments(state) {
+            return Object.fromEntries(
+                Object.entries(state.fieldOptions.alignment)
+                    .filter(config => config[1] && config[1].horizontal)
+            );
+        },
+
         imageDisplayModes(state) {
             return Object.fromEntries(
                 Object.entries(state.fieldOptions.mediaDisplayMode)

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/state/cms-page.state.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/state/cms-page.state.js
@@ -29,6 +29,29 @@ Shopware.State.registerModule('cmsPageState', {
                     vertical: true
                 }
             },
+            blockCategory: {
+                text: {
+                    label: 'sw-cms.detail.label.blockCategoryText'
+                },
+                image: {
+                    label: 'sw-cms.detail.label.blockCategoryImage'
+                },
+                video: {
+                    label: 'sw-cms.detail.label.blockCategoryVideo'
+                },
+                'text-image': {
+                    label: 'sw-cms.detail.label.blockCategoryTextImage'
+                },
+                commerce: {
+                    label: 'sw-cms.detail.label.blockCategoryCommerce'
+                },
+                sidebar: {
+                    label: 'sw-cms.detail.label.blockCategorySidebar'
+                },
+                form: {
+                    label: 'sw-cms.detail.label.blockCategoryForm'
+                }
+            },
             formType: {
                 contact: {
                     label: 'sw-cms.elements.form.config.label.typeContact'
@@ -218,6 +241,21 @@ Shopware.State.registerModule('cmsPageState', {
 
             Vue.set(state.fieldOptions.alignment, name, {
                 ...(state.fieldOptions.alignment[name] || {}),
+                ...configuration
+            });
+        },
+
+        setBlockCategory(state, configuration) {
+            if (!('name' in configuration)) {
+                return;
+            }
+
+            configuration = { ...configuration };
+            const name = configuration.name;
+            delete configuration.name;
+
+            Vue.set(state.fieldOptions.blockCategory, name, {
+                ...(state.fieldOptions.blockCategory[name] || {}),
                 ...configuration
             });
         },

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/state/cms-page.state.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/state/cms-page.state.js
@@ -28,13 +28,16 @@ Shopware.State.registerModule('cmsPageState', {
             },
             productBoxLayoutType: {
                 standard: {
-                    label: 'sw-cms.elements.productBox.config.label.layoutTypeStandard'
+                    label: 'sw-cms.elements.productBox.config.label.layoutTypeStandard',
+                    image: true
                 },
                 image: {
-                    label: 'sw-cms.elements.productBox.config.label.layoutTypeImage'
+                    label: 'sw-cms.elements.productBox.config.label.layoutTypeImage',
+                    image: true
                 },
                 minimal: {
-                    label: 'sw-cms.elements.productBox.config.label.layoutTypeMinimal'
+                    label: 'sw-cms.elements.productBox.config.label.layoutTypeMinimal',
+                    image: true
                 }
             }
         }
@@ -164,6 +167,15 @@ Shopware.State.registerModule('cmsPageState', {
         setBlock({ commit }, block) {
             commit('removeSelectedSection');
             commit('setSelectedBlock', block);
+        }
+    },
+
+    getters: {
+        imageDisplayModes(state) {
+            return Object.fromEntries(
+                Object.entries(state.fieldOptions.mediaDisplayMode)
+                    .filter(config => config[1] && config[1].image)
+            );
         }
     }
 });

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/state/cms-page.state.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/state/cms-page.state.js
@@ -111,6 +111,14 @@ Shopware.State.registerModule('cmsPageState', {
                     label: 'sw-cms.elements.productBox.config.label.layoutTypeMinimal'
                 }
             },
+            sectionMobileBehaviour: {
+                hidden: {
+                    label: 'sw-cms.detail.sidebar.mobileOptionHidden'
+                },
+                wrap: {
+                    label: 'sw-cms.detail.sidebar.mobileOptionWrap'
+                }
+            },
             sectionSizingMode: {
                 boxed: {
                     label: 'sw-cms.detail.label.sizingOptionBoxed'
@@ -315,6 +323,21 @@ Shopware.State.registerModule('cmsPageState', {
 
             Vue.set(state.fieldOptions.productBoxLayoutType, name, {
                 ...(state.fieldOptions.productBoxLayoutType[name] || {}),
+                ...configuration
+            });
+        },
+
+        setSectionMobileBehaviour(state, configuration) {
+            if (!('name' in configuration)) {
+                return;
+            }
+
+            configuration = { ...configuration };
+            const name = configuration.name;
+            delete configuration.name;
+
+            Vue.set(state.fieldOptions.sectionMobileBehaviour, name, {
+                ...(state.fieldOptions.sectionMobileBehaviour[name] || {}),
                 ...configuration
             });
         },

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/state/cms-page.state.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/state/cms-page.state.js
@@ -83,6 +83,23 @@ Shopware.State.registerModule('cmsPageState', {
                     label: 'sw-cms.elements.imageSlider.config.label.navigationPositionOutside'
                 }
             },
+            pageType: {
+                page: {
+                    label: 'sw-cms.detail.label.pageTypeShopPage'
+                },
+                landingpage: {
+                    label: 'sw-cms.detail.label.pageTypeLandingpage'
+                },
+                product_list: {
+                    label: 'sw-cms.detail.label.pageTypeCategory'
+                }
+                /*
+                will be implemented in the future
+                product_detail: {
+                    label: 'sw-cms.detail.label.pageTypeProduct'
+                }
+                */
+            },
             productBoxLayoutType: {
                 standard: {
                     label: 'sw-cms.elements.productBox.config.label.layoutTypeStandard'
@@ -260,6 +277,21 @@ Shopware.State.registerModule('cmsPageState', {
 
             Vue.set(state.fieldOptions.mediaSliderNavigationPosition, name, {
                 ...(state.fieldOptions.mediaSliderNavigationPosition[name] || {}),
+                ...configuration
+            });
+        },
+
+        setPageType(state, configuration) {
+            if (!('name' in configuration)) {
+                return;
+            }
+
+            configuration = { ...configuration };
+            const name = configuration.name;
+            delete configuration.name;
+
+            Vue.set(state.fieldOptions.pageType, name, {
+                ...(state.fieldOptions.pageType[name] || {}),
                 ...configuration
             });
         },

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/state/cms-page.state.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/state/cms-page.state.js
@@ -48,6 +48,14 @@ Shopware.State.registerModule('cmsPageState', {
                     video: true
                 }
             },
+            mediaGalleryNavigationPreviewPosition: {
+                left: {
+                    label: 'sw-cms.elements.imageGallery.config.label.navigationPreviewPositionLeft'
+                },
+                underneath: {
+                    label: 'sw-cms.elements.imageGallery.config.label.navigationPreviewPositionUnderneath'
+                }
+            },
             mediaSliderNavigationPosition: {
                 inside: {
                     label: 'sw-cms.elements.imageSlider.config.label.navigationPositionInside'
@@ -173,6 +181,21 @@ Shopware.State.registerModule('cmsPageState', {
 
             Vue.set(state.fieldOptions.mediaDisplayMode, name, {
                 ...(state.fieldOptions.mediaDisplayMode[name] || {}),
+                ...configuration
+            });
+        },
+
+        setMediaGalleryNavigationPreviewPosition(state, configuration) {
+            if (!('name' in configuration)) {
+                return;
+            }
+
+            configuration = { ...configuration };
+            const name = configuration.name;
+            delete configuration.name;
+
+            Vue.set(state.fieldOptions.mediaGalleryNavigationPreviewPosition, name, {
+                ...(state.fieldOptions.mediaGalleryNavigationPreviewPosition[name] || {}),
                 ...configuration
             });
         },

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/state/cms-page.state.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/state/cms-page.state.js
@@ -110,6 +110,14 @@ Shopware.State.registerModule('cmsPageState', {
                 minimal: {
                     label: 'sw-cms.elements.productBox.config.label.layoutTypeMinimal'
                 }
+            },
+            sectionSizingMode: {
+                boxed: {
+                    label: 'sw-cms.detail.label.sizingOptionBoxed'
+                },
+                full_width: {
+                    label: 'sw-cms.detail.label.sizingOptionFull'
+                }
             }
         }
     },
@@ -307,6 +315,21 @@ Shopware.State.registerModule('cmsPageState', {
 
             Vue.set(state.fieldOptions.productBoxLayoutType, name, {
                 ...(state.fieldOptions.productBoxLayoutType[name] || {}),
+                ...configuration
+            });
+        },
+
+        setSectionSizingMode(state, configuration) {
+            if (!('name' in configuration)) {
+                return;
+            }
+
+            configuration = { ...configuration };
+            const name = configuration.name;
+            delete configuration.name;
+
+            Vue.set(state.fieldOptions.sectionSizingMode, name, {
+                ...(state.fieldOptions.sectionSizingMode[name] || {}),
                 ...configuration
             });
         }

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/state/cms-page.state.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/state/cms-page.state.js
@@ -17,27 +17,32 @@ Shopware.State.registerModule('cmsPageState', {
         fieldOptions: {
             mediaDisplayMode: {
                 standard: {
-                    label: 'sw-cms.elements.general.config.label.displayModeStandard'
+                    label: 'sw-cms.elements.general.config.label.displayModeStandard',
+                    image: true,
+                    video: true
                 },
                 cover: {
-                    label: 'sw-cms.elements.general.config.label.displayModeCover'
+                    label: 'sw-cms.elements.general.config.label.displayModeCover',
+                    image: true
                 },
                 contain: {
-                    label: 'sw-cms.elements.general.config.label.displayModeContain'
+                    label: 'sw-cms.elements.general.config.label.displayModeContain',
+                    image: true
+                },
+                stretched: {
+                    label: 'sw-cms.elements.general.config.label.displayModeStretch',
+                    video: true
                 }
             },
             productBoxLayoutType: {
                 standard: {
-                    label: 'sw-cms.elements.productBox.config.label.layoutTypeStandard',
-                    image: true
+                    label: 'sw-cms.elements.productBox.config.label.layoutTypeStandard'
                 },
                 image: {
-                    label: 'sw-cms.elements.productBox.config.label.layoutTypeImage',
-                    image: true
+                    label: 'sw-cms.elements.productBox.config.label.layoutTypeImage'
                 },
                 minimal: {
-                    label: 'sw-cms.elements.productBox.config.label.layoutTypeMinimal',
-                    image: true
+                    label: 'sw-cms.elements.productBox.config.label.layoutTypeMinimal'
                 }
             }
         }
@@ -175,6 +180,13 @@ Shopware.State.registerModule('cmsPageState', {
             return Object.fromEntries(
                 Object.entries(state.fieldOptions.mediaDisplayMode)
                     .filter(config => config[1] && config[1].image)
+            );
+        },
+
+        videoDisplayModes(state) {
+            return Object.fromEntries(
+                Object.entries(state.fieldOptions.mediaDisplayMode)
+                    .filter(config => config[1] && config[1].video)
             );
         }
     }

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/state/cms-page.state.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/state/cms-page.state.js
@@ -48,6 +48,14 @@ Shopware.State.registerModule('cmsPageState', {
                     video: true
                 }
             },
+            mediaSliderNavigationPosition: {
+                inside: {
+                    label: 'sw-cms.elements.imageSlider.config.label.navigationPositionInside'
+                },
+                outside: {
+                    label: 'sw-cms.elements.imageSlider.config.label.navigationPositionOutside'
+                }
+            },
             productBoxLayoutType: {
                 standard: {
                     label: 'sw-cms.elements.productBox.config.label.layoutTypeStandard'
@@ -165,6 +173,21 @@ Shopware.State.registerModule('cmsPageState', {
 
             Vue.set(state.fieldOptions.mediaDisplayMode, name, {
                 ...(state.fieldOptions.mediaDisplayMode[name] || {}),
+                ...configuration
+            });
+        },
+
+        setMediaSliderNavigationPosition(state, configuration) {
+            if (!('name' in configuration)) {
+                return;
+            }
+
+            configuration = { ...configuration };
+            const name = configuration.name;
+            delete configuration.name;
+
+            Vue.set(state.fieldOptions.mediaSliderNavigationPosition, name, {
+                ...(state.fieldOptions.mediaSliderNavigationPosition[name] || {}),
                 ...configuration
             });
         },

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/state/cms-page.state.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/state/cms-page.state.js
@@ -29,6 +29,17 @@ Shopware.State.registerModule('cmsPageState', {
                     vertical: true
                 }
             },
+            mediaBackgroundMode: {
+                auto: {
+                    label: 'sw-cms.detail.label.backgroundMediaModeAuto'
+                },
+                contain: {
+                    label: 'sw-cms.detail.label.backgroundMediaModeContain'
+                },
+                cover: {
+                    label: 'sw-cms.detail.label.backgroundMediaModeCover'
+                }
+            },
             mediaDisplayMode: {
                 standard: {
                     label: 'sw-cms.elements.general.config.label.displayModeStandard',
@@ -166,6 +177,21 @@ Shopware.State.registerModule('cmsPageState', {
 
             Vue.set(state.fieldOptions.alignment, name, {
                 ...(state.fieldOptions.alignment[name] || {}),
+                ...configuration
+            });
+        },
+
+        setMediaBackgroundMode(state, configuration) {
+            if (!('name' in configuration)) {
+                return;
+            }
+
+            configuration = { ...configuration };
+            const name = configuration.name;
+            delete configuration.name;
+
+            Vue.set(state.fieldOptions.mediaBackgroundMode, name, {
+                ...(state.fieldOptions.mediaBackgroundMode[name] || {}),
                 ...configuration
             });
         },

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/state/cms-page.state.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/state/cms-page.state.js
@@ -15,6 +15,17 @@ Shopware.State.registerModule('cmsPageState', {
         selectedBlock: null,
         isSystemDefaultLanguage: true,
         fieldOptions: {
+            mediaDisplayMode: {
+                standard: {
+                    label: 'sw-cms.elements.general.config.label.displayModeStandard'
+                },
+                cover: {
+                    label: 'sw-cms.elements.general.config.label.displayModeCover'
+                },
+                contain: {
+                    label: 'sw-cms.elements.general.config.label.displayModeContain'
+                }
+            },
             productBoxLayoutType: {
                 standard: {
                     label: 'sw-cms.elements.productBox.config.label.layoutTypeStandard'
@@ -104,6 +115,21 @@ Shopware.State.registerModule('cmsPageState', {
 
         setIsSystemDefaultLanguage(state, isSystemDefaultLanguage) {
             state.isSystemDefaultLanguage = isSystemDefaultLanguage;
+        },
+
+        setMediaDisplayMode(state, configuration) {
+            if (!('name' in configuration)) {
+                return;
+            }
+
+            configuration = { ...configuration };
+            const name = configuration.name;
+            delete configuration.name;
+
+            Vue.set(state.fieldOptions.mediaDisplayMode, name, {
+                ...(state.fieldOptions.mediaDisplayMode[name] || {}),
+                ...configuration
+            });
         },
 
         setProductBoxLayoutType(state, configuration) {

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/state/cms-page.state.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/state/cms-page.state.js
@@ -1,3 +1,5 @@
+import Vue from 'vue';
+
 Shopware.State.registerModule('cmsPageState', {
     namespaced: true,
 
@@ -11,7 +13,20 @@ Shopware.State.registerModule('cmsPageState', {
         currentCmsDeviceView: 'desktop',
         selectedSection: null,
         selectedBlock: null,
-        isSystemDefaultLanguage: true
+        isSystemDefaultLanguage: true,
+        fieldOptions: {
+            productBoxLayoutType: {
+                standard: {
+                    label: 'sw-cms.elements.productBox.config.label.layoutTypeStandard'
+                },
+                image: {
+                    label: 'sw-cms.elements.productBox.config.label.layoutTypeImage'
+                },
+                minimal: {
+                    label: 'sw-cms.elements.productBox.config.label.layoutTypeMinimal'
+                }
+            }
+        }
     },
 
     mutations: {
@@ -89,6 +104,21 @@ Shopware.State.registerModule('cmsPageState', {
 
         setIsSystemDefaultLanguage(state, isSystemDefaultLanguage) {
             state.isSystemDefaultLanguage = isSystemDefaultLanguage;
+        },
+
+        setProductBoxLayoutType(state, configuration) {
+            if (!('name' in configuration)) {
+                return;
+            }
+
+            configuration = { ...configuration };
+            const name = configuration.name;
+            delete configuration.name;
+
+            Vue.set(state.fieldOptions.productBoxLayoutType, name, {
+                ...(state.fieldOptions.productBoxLayoutType[name] || {}),
+                ...configuration
+            });
         }
     },
 

--- a/src/Docs/Resources/current/4-how-to/350-use-and-add-options-in-cms.md
+++ b/src/Docs/Resources/current/4-how-to/350-use-and-add-options-in-cms.md
@@ -10,7 +10,7 @@ Media display modes are used to determine how a media should behave in sizing (c
 In a case you want to read the display modes you can use the `cms-state` mixin in your component:
 
 ```js
-const { Component, Mixin } = Shopware;
+const { Component, Mixin, State } = Shopware;
 
 Component.register('foobar', {
     mixins: [
@@ -22,6 +22,11 @@ Component.register('foobar', {
         mediaDisplayModes() {
             // can also be directly access in the template without computed getter
             return this.cmsPageState.fieldOptions.mediaDisplayMode;
+        },
+
+        imageDisplayModes() {
+            // can also be directly access in the template without computed getter
+            return State.getters['cmsPageState/imageDisplayModes'];
         }
     }
 });
@@ -36,7 +41,9 @@ Shopware.State.commit(
         // technical name
         name: 'foobar',
         // snippet to display as label
-        label: 'sw-cms.elements.general.config.label.displayModeFoobar'
+        label: 'sw-cms.elements.general.config.label.displayModeFoobar',
+        // when media mode is available for images
+        image: true
     }
 );
 ```

--- a/src/Docs/Resources/current/4-how-to/350-use-and-add-options-in-cms.md
+++ b/src/Docs/Resources/current/4-how-to/350-use-and-add-options-in-cms.md
@@ -4,10 +4,75 @@
 
 This HowTo will teach you to access CMS options in the administration.
 
+## Alignments
+
+Alignments are used to determine how an element should be aligned within its parent either vertically or horizontally.
+In a case you want to read the alignments you can use the `cms-state` mixin or the global State to use customized getters in your component:
+
+```js
+const { Component, Mixin, State } = Shopware;
+
+Component.register('foobar', {
+    mixins: [
+        // provides this.cmsPageState
+        Mixin.getByName('cms-state')
+    ],
+
+    computed: {
+        alignments() {
+            // can also be directly access in the template without computed getter
+            return this.cmsPageState.fieldOptions.alignment;
+        },
+
+        horizontalAlignments() {
+            return State.getters['cmsPageState/horizontalAlignments'];
+        },
+
+        verticalAlignments() {
+            return State.getters['cmsPageState/verticalAlignments'];
+        }
+    }
+});
+```
+
+When you want to add a new alignment you can execute the following statement any time in your plugin:
+
+```js
+Shopware.State.commit(
+    'cmsPageState/setAlignment',
+    {
+        // technical name
+        name: 'foobar',
+        // snippet to display as label
+        label: 'sw-cms.elements.general.config.label.verticalAlignTop',
+        // when alignment is available for y-axis
+        vertical: true
+    }
+);
+```
+
+Therefore you also need add a corresponding snippet for it:
+
+```json
+{
+    "sw-cms": {
+        "elements": {
+            "general": {
+                "config": {
+                    "label": {
+                        "alignmentFoobar": "Foobar"
+                    }
+                }
+            }
+        }
+    }
+}
+```
+
 ## Media display mode
 
 Media display modes are used to determine how a media should behave in sizing (cover, contain).
-In a case you want to read the display modes you can use the `cms-state` mixin in your component:
+In a case you want to read the display modes you can use the `cms-state` mixin or the global State to use customized getters in your component:
 
 ```js
 const { Component, Mixin, State } = Shopware;

--- a/src/Docs/Resources/current/4-how-to/350-use-and-add-options-in-cms.md
+++ b/src/Docs/Resources/current/4-how-to/350-use-and-add-options-in-cms.md
@@ -4,6 +4,61 @@
 
 This HowTo will teach you to access CMS options in the administration.
 
+## Product box layout types
+
+Product box layout types are the choices of products boxes that are used in listings, sliders or single products.
+In a case you want to read the box types you can use the `cms-state` mixin in your component:
+
+```js
+const { Component, Mixin } = Shopware;
+
+Component.register('foobar', {
+    mixins: [
+        // provides this.cmsPageState
+        Mixin.getByName('cms-state')
+    ],
+
+    computed: {
+        productBoxLayoutTypes() {
+            // can also be directly access in the template without computed getter
+            return this.cmsPageState.fieldOptions.productBoxLayoutType;
+        }
+    }
+});
+```
+
+When you want to add a new box type you can execute the following statement any time in your plugin:
+
+```js
+Shopware.State.commit(
+    'cmsPageState/setProductBoxLayoutType',
+    {
+        // technical name
+        name: 'foobar',
+        // snippet to display as label
+        label: 'sw-cms.elements.productBox.config.label.layoutTypeFoobar'
+    }
+);
+```
+
+Therefore you also need add a corresponding snippet for it:
+
+```json
+{
+    "sw-cms": {
+        "elements": {
+            "productBox": {
+                "config": {
+                    "label": {
+                        "layoutTypeFoobar": "Foobar"
+                    }
+                }
+            }
+        }
+    }
+}
+```
+
 ## Implement a new CMS field option state
 
 In the imaginary case let us add an image mirror state that defines whether an image has to be either mirrored vertically, horizontally or not at all.

--- a/src/Docs/Resources/current/4-how-to/350-use-and-add-options-in-cms.md
+++ b/src/Docs/Resources/current/4-how-to/350-use-and-add-options-in-cms.md
@@ -69,6 +69,57 @@ Therefore you also need to add a corresponding snippet for it:
 }
 ```
 
+## Block categories
+
+Block categories are the groups the single elements are grouped into (text, image, ecommerce).
+In a case you want to read the categories you can use the `cms-state` mixin in your component:
+
+```js
+const { Component, Mixin } = Shopware;
+
+Component.register('foobar', {
+    mixins: [
+        // provides this.cmsPageState
+        Mixin.getByName('cms-state')
+    ],
+
+    computed: {
+        blockCategories() {
+            // can also be directly access in the template without computed getter
+            return this.cmsPageState.fieldOptions.blockCategory;
+        }
+    }
+});
+```
+
+When you want to add a new category you can execute the following statement any time in your plugin:
+
+```js
+Shopware.State.commit(
+    'cmsPageState/setBlockCategory',
+    {
+        // technical name
+        name: 'foobar',
+        // snippet to display as label
+        label: 'sw-cms.detail.label.blockCategoryFoobar'
+    }
+);
+```
+
+Therefore you also need to add a corresponding snippet for it:
+
+```json
+{
+    "sw-cms": {
+        "detail": {
+            "label": {
+                "blockCategoryFoobar": "Foobar"
+            }
+        }
+    }
+}
+```
+
 ## Form types
 
 Form types are used to determine which form should be embed into the page (contact, newsletter).

--- a/src/Docs/Resources/current/4-how-to/350-use-and-add-options-in-cms.md
+++ b/src/Docs/Resources/current/4-how-to/350-use-and-add-options-in-cms.md
@@ -25,8 +25,11 @@ Component.register('foobar', {
         },
 
         imageDisplayModes() {
-            // can also be directly access in the template without computed getter
             return State.getters['cmsPageState/imageDisplayModes'];
+        },
+
+        videoDisplayModes() {
+            return State.getters['cmsPageState/videoDisplayModes'];
         }
     }
 });

--- a/src/Docs/Resources/current/4-how-to/350-use-and-add-options-in-cms.md
+++ b/src/Docs/Resources/current/4-how-to/350-use-and-add-options-in-cms.md
@@ -1,0 +1,60 @@
+[titleEn]: <>(Use and add options in CMS)
+[metaDescriptionEn]: <>(This HowTo will teach you to access options in CMS blocks and elements.)
+[hash]: <>(article:use_and_add_options_in_cms)
+
+This HowTo will teach you to access CMS options in the administration.
+
+## Implement a new CMS field option state
+
+In the imaginary case let us add an image mirror state that defines whether an image has to be either mirrored vertically, horizontally or not at all.
+At first you choose a unique field option state e.g. `mediaMirrorMode`.
+Second the field option state has to be added:
+
+```js
+// src/Administration/Resources/app/administration/src/module/sw-cms/state/cms-page.state.js
+
+Shopware.State.registerModule('cmsPageState', {
+    // ...
+    state: {
+        // ...
+        fieldOptions: {
+            // add initial modes in state initialization
+            mediaMirrorMode: {
+                none: {
+                    label: 'sw-cms.detail.mediaMirrorMode.none'
+                },
+                horizontal: {
+                    label: 'sw-cms.detail.mediaMirrorMode.horizontal'
+                },
+                vertical: {
+                    label: 'sw-cms.detail.mediaMirrorMode.vertical'
+                }
+            }
+        }
+    },
+
+    mutations: {
+        // ...
+        // add mutation to make it easily accessible and extensible
+        setMediaMirrorMode(state, configuration) {
+            // check the existence of configuration.name as it is used as key for the modes
+            if (!('name' in configuration)) {
+                return;
+            }
+
+            // clone object to remove the name from its properties without altering the input value
+            configuration = { ...configuration };
+            const name = configuration.name;
+            delete configuration.name;
+
+            // use Vue.set to make the state change reactive
+            Vue.set(state.fieldOptions.mediaMirrorMode, name, {
+                ...(state.fieldOptions.mediaMirrorMode[name] || {}),
+                ...configuration
+            });
+        }
+    }
+});
+``` 
+
+Third add example code for usage and extensibility to this documentation page.

--- a/src/Docs/Resources/current/4-how-to/350-use-and-add-options-in-cms.md
+++ b/src/Docs/Resources/current/4-how-to/350-use-and-add-options-in-cms.md
@@ -69,6 +69,61 @@ Therefore you also need to add a corresponding snippet for it:
 }
 ```
 
+## Form types
+
+Form types are used to determine which form should be embed into the page (contact, newsletter).
+In a case you want to read the alignments you can use the `cms-state` mixin in your component:
+
+```js
+const { Component, Mixin } = Shopware;
+
+Component.register('foobar', {
+    mixins: [
+        // provides this.cmsPageState
+        Mixin.getByName('cms-state')
+    ],
+
+    computed: {
+        formTypes() {
+            // can also be directly access in the template without computed getter
+            return this.cmsPageState.fieldOptions.formType;
+        }
+    }
+});
+```
+
+When you want to add a new form type you can execute the following statement any time in your plugin:
+
+```js
+Shopware.State.commit(
+    'cmsPageState/setFormType',
+    {
+        // technical name
+        name: 'foobar',
+        // snippet to display as label
+        label: 'sw-cms.elements.form.config.label.typeFoobar'
+    }
+);
+```
+
+Therefore you also need to add a corresponding snippet for it:
+
+```json
+{
+    "sw-cms": {
+        "elements": {
+            "form": {
+                "config": {
+                    "label": {
+                        "typeFoobar": "Foobar"
+                    }
+                }
+            }
+        }
+    }
+}
+```
+
 ## Media background mode
 
 Media background modes are used to determine how a media should behave in sizing (cover, contain) when used as background.

--- a/src/Docs/Resources/current/4-how-to/350-use-and-add-options-in-cms.md
+++ b/src/Docs/Resources/current/4-how-to/350-use-and-add-options-in-cms.md
@@ -4,6 +4,61 @@
 
 This HowTo will teach you to access CMS options in the administration.
 
+## Media display mode
+
+Media display modes are used to determine how a media should behave in sizing (cover, contain).
+In a case you want to read the display modes you can use the `cms-state` mixin in your component:
+
+```js
+const { Component, Mixin } = Shopware;
+
+Component.register('foobar', {
+    mixins: [
+        // provides this.cmsPageState
+        Mixin.getByName('cms-state')
+    ],
+
+    computed: {
+        mediaDisplayModes() {
+            // can also be directly access in the template without computed getter
+            return this.cmsPageState.fieldOptions.mediaDisplayMode;
+        }
+    }
+});
+```
+
+When you want to add a new display mode you can execute the following statement any time in your plugin:
+
+```js
+Shopware.State.commit(
+    'cmsPageState/setMediaDisplayMode',
+    {
+        // technical name
+        name: 'foobar',
+        // snippet to display as label
+        label: 'sw-cms.elements.general.config.label.displayModeFoobar'
+    }
+);
+```
+
+Therefore you also need add a corresponding snippet for it:
+
+```json
+{
+    "sw-cms": {
+        "elements": {
+            "general": {
+                "config": {
+                    "label": {
+                        "displayModeFoobar": "Foobar"
+                    }
+                }
+            }
+        }
+    }
+}
+```
+
 ## Product box layout types
 
 Product box layout types are the choices of products boxes that are used in listings, sliders or single products.

--- a/src/Docs/Resources/current/4-how-to/350-use-and-add-options-in-cms.md
+++ b/src/Docs/Resources/current/4-how-to/350-use-and-add-options-in-cms.md
@@ -350,6 +350,57 @@ Therefore you also need to add a corresponding snippet for it:
 }
 ```
 
+## Page types
+
+Page types are the different types of CMS pages (listing, landing page, static page).
+In a case you want to read the page types you can use the `cms-state` mixin in your component:
+
+```js
+const { Component, Mixin } = Shopware;
+
+Component.register('foobar', {
+    mixins: [
+        // provides this.cmsPageState
+        Mixin.getByName('cms-state')
+    ],
+
+    computed: {
+        pageTypes() {
+            // can also be directly access in the template without computed getter
+            return this.cmsPageState.fieldOptions.pageType;
+        }
+    }
+});
+```
+
+When you want to add a new box type you can execute the following statement any time in your plugin:
+
+```js
+Shopware.State.commit(
+    'cmsPageState/setPageType',
+    {
+        // technical name
+        name: 'foobar',
+        // snippet to display as label
+        label: 'sw-cms.detail.label.pageTypeFoobar'
+    }
+);
+```
+
+Therefore you also need to add a corresponding snippet for it:
+
+```json
+{
+    "sw-cms": {
+        "detail": {
+            "label": {
+                "pageTypeFoobar": "Foobar"
+            }
+        }
+    }
+}
+```
+
 ## Product box layout types
 
 Product box layout types are the choices of products boxes that are used in listings, sliders or single products.

--- a/src/Docs/Resources/current/4-how-to/350-use-and-add-options-in-cms.md
+++ b/src/Docs/Resources/current/4-how-to/350-use-and-add-options-in-cms.md
@@ -134,6 +134,61 @@ Therefore you also need add a corresponding snippet for it:
 }
 ```
 
+## Media slider navigation position
+
+Media slider navigation position are the choices of navigation positions that are used in sliders.
+In a case you want to read the box types you can use the `cms-state` mixin in your component:
+
+```js
+const { Component, Mixin } = Shopware;
+
+Component.register('foobar', {
+    mixins: [
+        // provides this.cmsPageState
+        Mixin.getByName('cms-state')
+    ],
+
+    computed: {
+        mediaSliderNavigationPositions() {
+            // can also be directly access in the template without computed getter
+            return this.cmsPageState.fieldOptions.mediaSliderNavigationPosition;
+        }
+    }
+});
+```
+
+When you want to add a new navigation position you can execute the following statement any time in your plugin:
+
+```js
+Shopware.State.commit(
+    'cmsPageState/setMediaSliderNavigationPosition',
+    {
+        // technical name
+        name: 'foobar',
+        // snippet to display as label
+        label: 'sw-cms.elements.imageSlider.config.label.navigationPositionInside'
+    }
+);
+```
+
+Therefore you also need add a corresponding snippet for it:
+
+```json
+{
+    "sw-cms": {
+        "elements": {
+            "imageSlider": {
+                "config": {
+                    "label": {
+                        "navigationPositionFoobar": "Foobar"
+                    }
+                }
+            }
+        }
+    }
+}
+```
+
 ## Product box layout types
 
 Product box layout types are the choices of products boxes that are used in listings, sliders or single products.

--- a/src/Docs/Resources/current/4-how-to/350-use-and-add-options-in-cms.md
+++ b/src/Docs/Resources/current/4-how-to/350-use-and-add-options-in-cms.md
@@ -134,6 +134,61 @@ Therefore you also need add a corresponding snippet for it:
 }
 ```
 
+## Media gallery navigation preview position
+
+Media gallery navigation preview position are the choices for the location of preview images on a gallery.
+In a case you want to read the positions you can use the `cms-state` mixin in your component:
+
+```js
+const { Component, Mixin } = Shopware;
+
+Component.register('foobar', {
+    mixins: [
+        // provides this.cmsPageState
+        Mixin.getByName('cms-state')
+    ],
+
+    computed: {
+        mediaSliderNavigationPositions() {
+            // can also be directly access in the template without computed getter
+            return this.cmsPageState.fieldOptions.mediaGalleryNavigationPreviewPosition;
+        }
+    }
+});
+```
+
+When you want to add a new preview position you can execute the following statement any time in your plugin:
+
+```js
+Shopware.State.commit(
+    'cmsPageState/setMediaGalleryNavigationPreviewPosition',
+    {
+        // technical name
+        name: 'foobar',
+        // snippet to display as label
+        label: 'sw-cms.elements.imageGallery.config.label.navigationPreviewPositionFoobar'
+    }
+);
+```
+
+Therefore you also need add a corresponding snippet for it:
+
+```json
+{
+    "sw-cms": {
+        "elements": {
+            "imageGallery": {
+                "config": {
+                    "label": {
+                        "navigationPreviewPositionFoobar": "Foobar"
+                    }
+                }
+            }
+        }
+    }
+}
+```
+
 ## Media slider navigation position
 
 Media slider navigation position are the choices of navigation positions that are used in sliders.

--- a/src/Docs/Resources/current/4-how-to/350-use-and-add-options-in-cms.md
+++ b/src/Docs/Resources/current/4-how-to/350-use-and-add-options-in-cms.md
@@ -51,7 +51,7 @@ Shopware.State.commit(
 );
 ```
 
-Therefore you also need add a corresponding snippet for it:
+Therefore you also need to add a corresponding snippet for it:
 
 ```json
 {
@@ -63,6 +63,57 @@ Therefore you also need add a corresponding snippet for it:
                         "alignmentFoobar": "Foobar"
                     }
                 }
+            }
+        }
+    }
+}
+```
+
+## Media background mode
+
+Media background modes are used to determine how a media should behave in sizing (cover, contain) when used as background.
+In a case you want to read the background modes you can use the `cms-state` mixin in your component:
+
+```js
+const { Component, Mixin } = Shopware;
+
+Component.register('foobar', {
+    mixins: [
+        // provides this.cmsPageState
+        Mixin.getByName('cms-state')
+    ],
+
+    computed: {
+        mediaBackgroundModes() {
+            // can also be directly access in the template without computed getter
+            return this.cmsPageState.fieldOptions.mediaBackgroundMode;
+        }
+    }
+});
+```
+
+When you want to add a new background mode you can execute the following statement any time in your plugin:
+
+```js
+Shopware.State.commit(
+    'cmsPageState/setMediaBackgroundMode',
+    {
+        // technical name
+        name: 'foobar',
+        // snippet to display as label
+        label: 'sw-cms.detail.label.backgroundMediaModeFoobar'
+    }
+);
+```
+
+Therefore you also need to add a corresponding snippet for it:
+
+```json
+{
+    "sw-cms": {
+        "detail": {
+            "label": {
+                "backgroundMediaModeFoobar": "Foobar"
             }
         }
     }
@@ -116,7 +167,7 @@ Shopware.State.commit(
 );
 ```
 
-Therefore you also need add a corresponding snippet for it:
+Therefore you also need to add a corresponding snippet for it:
 
 ```json
 {
@@ -171,7 +222,7 @@ Shopware.State.commit(
 );
 ```
 
-Therefore you also need add a corresponding snippet for it:
+Therefore you also need to add a corresponding snippet for it:
 
 ```json
 {
@@ -226,7 +277,7 @@ Shopware.State.commit(
 );
 ```
 
-Therefore you also need add a corresponding snippet for it:
+Therefore you also need to add a corresponding snippet for it:
 
 ```json
 {
@@ -281,7 +332,7 @@ Shopware.State.commit(
 );
 ```
 
-Therefore you also need add a corresponding snippet for it:
+Therefore you also need to add a corresponding snippet for it:
 
 ```json
 {

--- a/src/Docs/Resources/current/4-how-to/350-use-and-add-options-in-cms.md
+++ b/src/Docs/Resources/current/4-how-to/350-use-and-add-options-in-cms.md
@@ -456,6 +456,57 @@ Therefore you also need to add a corresponding snippet for it:
 }
 ```
 
+## Section sizing modes
+
+Section sizing modes are the sizing behaviours or single sections (boxed, fullwidth).
+In a case you want to read the sizing modes you can use the `cms-state` mixin in your component:
+
+```js
+const { Component, Mixin } = Shopware;
+
+Component.register('foobar', {
+    mixins: [
+        // provides this.cmsPageState
+        Mixin.getByName('cms-state')
+    ],
+
+    computed: {
+        sectionSizingModes() {
+            // can also be directly access in the template without computed getter
+            return this.cmsPageState.fieldOptions.sectionSizingMode;
+        }
+    }
+});
+```
+
+When you want to add a new sizing mode you can execute the following statement any time in your plugin:
+
+```js
+Shopware.State.commit(
+    'cmsPageState/setSectionSizingMode',
+    {
+        // technical name
+        name: 'foobar',
+        // snippet to display as label
+        label: 'sw-cms.detail.label.sizingOptionFoobar'
+    }
+);
+```
+
+Therefore you also need to add a corresponding snippet for it:
+
+```json
+{
+    "sw-cms": {
+        "detail": {
+            "label": {
+                "sizingOptionFoobar": "Foobar"
+            }
+        }
+    }
+}
+```
+
 ## Implement a new CMS field option state
 
 In the imaginary case let us add an image mirror state that defines whether an image has to be either mirrored vertically, horizontally or not at all.

--- a/src/Docs/Resources/current/4-how-to/350-use-and-add-options-in-cms.md
+++ b/src/Docs/Resources/current/4-how-to/350-use-and-add-options-in-cms.md
@@ -456,6 +456,57 @@ Therefore you also need to add a corresponding snippet for it:
 }
 ```
 
+## Section mobile behaviour
+
+Section mobile behaviours are the ways a sidebar can react on a mobile viewport.
+In a case you want to read the behaviours you can use the `cms-state` mixin in your component:
+
+```js
+const { Component, Mixin } = Shopware;
+
+Component.register('foobar', {
+    mixins: [
+        // provides this.cmsPageState
+        Mixin.getByName('cms-state')
+    ],
+
+    computed: {
+        sectionMobileBehaviours() {
+            // can also be directly access in the template without computed getter
+            return this.cmsPageState.fieldOptions.sectionMobileBehaviour;
+        }
+    }
+});
+```
+
+When you want to add a new section mobile behaviour option you can execute the following statement any time in your plugin:
+
+```js
+Shopware.State.commit(
+    'cmsPageState/setSectionMobileBehaviour',
+    {
+        // technical name
+        name: 'foobar',
+        // snippet to display as label
+        label: 'sw-cms.detail.sidebar.mobileOptionFoobar'
+    }
+);
+```
+
+Therefore you also need add a corresponding snippet for it:
+
+```json
+{
+    "sw-cms": {
+        "detail": {
+            "sidebar": {
+                "mobileOptionFoobar": "Foobar"
+            }
+        }
+    }
+}
+```
+
 ## Section sizing modes
 
 Section sizing modes are the sizing behaviours or single sections (boxed, fullwidth).


### PR DESCRIPTION
### 1. Why is this change necessary?
Add services and blocks to manipulate selection fields more easily and centralized. E.g. when you add a new product box layout you have to change override three twig blocks to add an option. Two of these blocks surround the selections and not the options. So only one can override the selection successfully in a not update-safe way. If I add a new cms block that shall also support product box layouts I can add the standard entries but I won't be automatically be aware of new entries.

### 2. What does this change do, exactly?
Move every non-null hardcoded option in a selection into a cms service to provide these and possibly future values.

### 3. Describe each step to reproduce the issue or behaviour.
1. Add product box layout
2. Override multiple twig js blocks (non update-safe and competitive to other bundles)
3. Add new cms block with product box layout selection but without new product box layout from other plugin 🙄
4. 💢 

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
