### PR TITLE
Add sales channel route and configuration for sw-domain-hash

### DIFF
--- a/src/Core/Framework/Routing/ApiRouteScope.php
+++ b/src/Core/Framework/Routing/ApiRouteScope.php
@@ -15,7 +15,7 @@ class ApiRouteScope extends AbstractRouteScope implements ApiContextRouteScopeDe
     /**
      * @var string[]
      */
-    protected $allowedPaths = ['api'];
+    protected $allowedPaths = ['api', 'sw-domain-hash.html'];
 
     public function isAllowed(Request $request): bool
     {

--- a/src/Core/SalesChannelRequest.php
+++ b/src/Core/SalesChannelRequest.php
@@ -6,6 +6,8 @@ final class SalesChannelRequest
 {
     public const ATTRIBUTE_IS_SALES_CHANNEL_REQUEST = '_is_sales_channel';
 
+    public const ATTRIBUTE_IS_ALLOWED_IN_MAINTENANCE = 'allow_maintenance';
+
     public const ATTRIBUTE_THEME_ID = 'theme-id';
     public const ATTRIBUTE_THEME_NAME = 'theme-name';
     public const ATTRIBUTE_THEME_BASE_NAME = 'theme-base-name';

--- a/src/Core/System/Resources/config/store.xml
+++ b/src/Core/System/Resources/config/store.xml
@@ -12,5 +12,15 @@
             <placeholder>Enter license domain...</placeholder>
             <placeholder lang="de-DE">Gib eine Lizenzdomain ein ...</placeholder>
         </input-field>
+
+        <input-field>
+            <name>verificationHash</name>
+            <label>Verification hash</label>
+            <label lang="de-DE">Verifikationsprüfsumme</label>
+            <helpText>This setting is part of the Shopware shop verification process to verify this installation to be in your ownership. When a sw-domain-hash.html file is present it will probably override this setting.</helpText>
+            <helpText lang="de-DE">Diese Einstellung wird benötigt im Shopware Shop Verifikationsprozess um diese Installation deiner Zugehörigkeit zu indentifizieren. Wenn eine sw-domain-hash.html Datei vorliegt, wird diese wahrscheinlich dieser Einstellung vorgezogen.</helpText>
+            <placeholder>Enter verification code ...</placeholder>
+            <placeholder lang="de-DE">Gib den Verifikationscode ein ...</placeholder>
+        </input-field>
     </card>
 </config>

--- a/src/Docs/Resources/current/50-how-to/770-storefront-controller-available-in-maintenance-mode.md
+++ b/src/Docs/Resources/current/50-how-to/770-storefront-controller-available-in-maintenance-mode.md
@@ -1,0 +1,46 @@
+[titleEn]: <>(Make storefront controller available in maintenance mode)
+[metaDescriptionEn]: <>(This HowTo will show you how to make a storefront controller available in maintenance mode)
+[hash]: <>(article:how_to_add_enable_controller_maintenance)
+
+## Overview
+
+This guide will show you how to make controller routes available in a maintenance mode situation.
+
+## Route attributes
+
+```php
+<?php
+
+use Shopware\Core\SalesChannelRequest;
+use Symfony\Component\HttpFoundation\Request;
+
+/** @var Request $request */
+$request->attributes->set(
+    SalesChannelRequest::ATTRIBUTE_IS_ALLOWED_IN_MAINTENANCE,
+    true
+);
+```
+
+## Route annotation defaults
+
+```php
+<?php
+
+use Shopware\Core\Framework\Routing\Annotation\RouteScope;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+
+/**
+ * @RouteScope(scopes={"storefront"})
+ */
+class Controller
+{
+    /**
+     * @Route("my-page", defaults={"allow_maintenance"=true})
+     */
+    public function routeAction(): Response
+    {
+        return new Response();
+    }
+}
+```

--- a/src/Storefront/Controller/MaintenanceController.php
+++ b/src/Storefront/Controller/MaintenanceController.php
@@ -38,7 +38,7 @@ class MaintenanceController extends StorefrontController
 
     /**
      * @HttpCache()
-     * @Route("/maintenance", name="frontend.maintenance.page", methods={"GET"})
+     * @Route("/maintenance", name="frontend.maintenance.page", methods={"GET"}, defaults={"allow_maintenance"=true})
      */
     public function renderMaintenancePage(Request $request, SalesChannelContext $context): ?Response
     {
@@ -73,7 +73,7 @@ class MaintenanceController extends StorefrontController
      * Route for stand alone cms pages during maintenance
      *
      * @HttpCache()
-     * @Route("/maintenance/singlepage/{id}", name="frontend.maintenance.singlepage", methods={"GET"})
+     * @Route("/maintenance/singlepage/{id}", name="frontend.maintenance.singlepage", methods={"GET"}, defaults={"allow_maintenance"=true})
      *
      * @throws MissingRequestParameterException
      * @throws PageNotFoundException

--- a/src/Storefront/Controller/VerificationHashController.php
+++ b/src/Storefront/Controller/VerificationHashController.php
@@ -1,0 +1,47 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Storefront\Controller;
+
+use Shopware\Core\Framework\Routing\Annotation\RouteScope;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Shopware\Core\System\SystemConfig\SystemConfigService;
+use Shopware\Storefront\Exception\VerificationHashNotConfiguredException;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+
+/**
+ * @RouteScope(scopes={"api"})
+ */
+class VerificationHashController extends AbstractController
+{
+    /**
+     * @var SystemConfigService
+     */
+    private $systemConfigService;
+
+    public function __construct(SystemConfigService $systemConfigService)
+    {
+        $this->systemConfigService = $systemConfigService;
+    }
+
+    /**
+     * @Route("/sw-domain-hash.html", name="api.verification-hash.load", methods={"GET"}, defaults={"auth_required"=false})
+     *
+     * @throws VerificationHashNotConfiguredException
+     */
+    public function load(): Response
+    {
+        $verificationHash = $this->systemConfigService->get('core.store.verificationHash');
+
+        if (empty($verificationHash)) {
+            throw new VerificationHashNotConfiguredException();
+        }
+
+        return Response::create(
+            $verificationHash,
+            Response::HTTP_OK,
+            ['Content-Type' => 'text/plain']
+        );
+    }
+}

--- a/src/Storefront/DependencyInjection/controller.xml
+++ b/src/Storefront/DependencyInjection/controller.xml
@@ -226,5 +226,12 @@
                 <argument type="service" id="service_container"/>
             </call>
         </service>
+
+        <service id="Shopware\Storefront\Controller\VerificationHashController" public="true">
+            <argument type="service" id="Shopware\Core\System\SystemConfig\SystemConfigService"/>
+            <call method="setContainer">
+                <argument type="service" id="service_container"/>
+            </call>
+        </service>
     </services>
 </container>

--- a/src/Storefront/Exception/VerificationHashNotConfiguredException.php
+++ b/src/Storefront/Exception/VerificationHashNotConfiguredException.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Storefront\Exception;
+
+use Shopware\Core\Framework\ShopwareHttpException;
+use Symfony\Component\HttpFoundation\Response;
+
+class VerificationHashNotConfiguredException extends ShopwareHttpException
+{
+    public function __construct(?\Throwable $e = null)
+    {
+        parent::__construct(
+            'No verification hash configured.',
+            [],
+            $e
+        );
+    }
+
+    public function getErrorCode(): string
+    {
+        return 'SYSTEM__VERIFICATION_HASH_NOT_CONFIGURED';
+    }
+
+    public function getStatusCode(): int
+    {
+        return Response::HTTP_NOT_FOUND;
+    }
+}

--- a/src/Storefront/Framework/Routing/MaintenanceModeResolver.php
+++ b/src/Storefront/Framework/Routing/MaintenanceModeResolver.php
@@ -44,12 +44,17 @@ class MaintenanceModeResolver
 
     private function isMaintenancePageRequest(Request $request): bool
     {
+        if ($request->attributes->getBoolean(SalesChannelRequest::ATTRIBUTE_IS_ALLOWED_IN_MAINTENANCE)) {
+            return true;
+        }
+
         $route = $request->attributes->get('_route');
 
         if (!$route) {
             return false;
         }
 
+        // @deprecated tag:v6.4.0 - Use defaults={"allow_maintenance"=true} in Route definition instead
         return mb_strpos($route, 'frontend.maintenance') !== false;
     }
 

--- a/src/Storefront/Test/Framework/Routing/MaintenanceModeResolverTest.php
+++ b/src/Storefront/Test/Framework/Routing/MaintenanceModeResolverTest.php
@@ -190,6 +190,7 @@ class MaintenanceModeResolverTest extends TestCase
 
         if ($isMaintenancePageRoute) {
             $request->attributes->set('_route', 'frontend.maintenance');
+            $request->attributes->set(SalesChannelRequest::ATTRIBUTE_IS_ALLOWED_IN_MAINTENANCE, true);
         }
 
         if ($useProxy) {


### PR DESCRIPTION
### 1. Why is this change necessary?
File upload/DNS settings are less common to be easily available for persons that setup shops and handle shopware accounts.

### 2. What does this change do, exactly?
Add a configuration field for sales channels that are served under /sw-domain-hash.html

### 3. Describe each step to reproduce the issue or behaviour.
1. Have a coworker setting up shops
2. Coworkers request me to upload a file
3. Me being annoyed as everything is pipeline controlled
4. Rather choose the DNS way
5. Change a DNS setting that might need some time to be populated across servers
6. 🙄

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

### 5. Additionals

This should be added as well to the account.shopware.com verification process so people are aware that this option is available without this high technical obstacle.