### PR TITLE
Implemented completion aware interface for stecman symfony console completion

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -118,7 +118,8 @@
         "twig/intl-extra": "2.12.3",
         "twig/string-extra": "2.12.3",
         "twig/twig": "2.12.3",
-        "zircote/swagger-php": "3.0.3"
+        "zircote/swagger-php": "3.0.3",
+        "stecman/symfony-console-completion": "^0.11.0"
     },
     "require-dev": {
         "ext-tokenizer": "*",

--- a/composer.json
+++ b/composer.json
@@ -71,6 +71,7 @@
         "scssphp/scssphp": "1.0.6",
         "sensio/framework-extra-bundle": "5.5.3",
         "sroze/messenger-enqueue-transport": "0.4.0",
+        "stecman/symfony-console-completion": "^0.11.0",
         "superbalist/flysystem-google-storage": "7.2.2",
         "swiftmailer/swiftmailer": "6.2.3",
         "symfony/asset": "4.4.4",
@@ -118,8 +119,7 @@
         "twig/intl-extra": "2.12.3",
         "twig/string-extra": "2.12.3",
         "twig/twig": "2.12.3",
-        "zircote/swagger-php": "3.0.3",
-        "stecman/symfony-console-completion": "^0.11.0"
+        "zircote/swagger-php": "3.0.3"
     },
     "require-dev": {
         "ext-tokenizer": "*",

--- a/src/Core/Framework/Api/Command/DumpSchemaCommand.php
+++ b/src/Core/Framework/Api/Command/DumpSchemaCommand.php
@@ -3,13 +3,16 @@
 namespace Shopware\Core\Framework\Api\Command;
 
 use Shopware\Core\Framework\Api\ApiDefinition\DefinitionService;
+use Stecman\Component\Symfony\Console\BashCompletion\Completion\CompletionAwareInterface;
+use Stecman\Component\Symfony\Console\BashCompletion\Completion\ShellPathCompletion;
+use Stecman\Component\Symfony\Console\BashCompletion\CompletionContext;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class DumpSchemaCommand extends Command
+class DumpSchemaCommand extends Command implements CompletionAwareInterface
 {
     protected static $defaultName = 'framework:schema';
 
@@ -23,6 +26,27 @@ class DumpSchemaCommand extends Command
         parent::__construct();
 
         $this->definitionService = $definitionService;
+    }
+
+    public function completeOptionValues($optionName, CompletionContext $context)
+    {
+        if ($optionName === 'schema-format') {
+            return [
+                'simple',
+                'openapi3',
+            ];
+        }
+
+        return [];
+    }
+
+    public function completeArgumentValues($argumentName, CompletionContext $context)
+    {
+        if ($argumentName === 'outfile') {
+            exit(ShellPathCompletion::PATH_COMPLETION_EXIT_CODE);
+        }
+
+        return [];
     }
 
     protected function configure(): void

--- a/src/Core/Framework/DependencyInjection/services.xml
+++ b/src/Core/Framework/DependencyInjection/services.xml
@@ -98,11 +98,10 @@
         </service>
 
         <service id="Shopware\Core\Framework\Migration\Command\CreateMigrationCommand">
-            <argument type="service" id="Shopware\Core\Framework\Plugin\KernelPluginCollection"/>
-            <argument type="service" id="Shopware\Core\Framework\Plugin\PluginService"/>
-            <argument>%kernel.project_dir%</argument>
-
             <tag name="console.command"/>
+            <argument type="service" id="Shopware\Core\Framework\Plugin\KernelPluginCollection"/>
+            <argument>%kernel.project_dir%</argument>
+            <argument type="service" id="plugin.repository"/>
         </service>
 
         <service id="Shopware\Core\Framework\Migration\Command\RefreshMigrationCommand">
@@ -411,6 +410,10 @@
         <!-- Util -->
         <service id="Shopware\Core\Framework\Log\LoggerFactory">
             <argument type="string">%kernel.logs_dir%/%%s_%kernel.environment%.log</argument>
+        </service>
+
+        <service id="Stecman\Component\Symfony\Console\BashCompletion\CompletionCommand">
+            <tag name="console.command"/>
         </service>
 
         <!--SnippetFiles-->

--- a/src/Core/Framework/Migration/Command/RefreshMigrationCommand.php
+++ b/src/Core/Framework/Migration/Command/RefreshMigrationCommand.php
@@ -2,14 +2,40 @@
 
 namespace Shopware\Core\Framework\Migration\Command;
 
+use Stecman\Component\Symfony\Console\BashCompletion\Completion\CompletionAwareInterface;
+use Stecman\Component\Symfony\Console\BashCompletion\CompletionContext;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Finder\Finder;
 
-class RefreshMigrationCommand extends Command
+class RefreshMigrationCommand extends Command implements CompletionAwareInterface
 {
     protected static $defaultName = 'database:refresh-migration';
+
+    public function completeOptionValues($optionName, CompletionContext $context)
+    {
+        return [];
+    }
+
+    public function completeArgumentValues($argumentName, CompletionContext $context)
+    {
+        $finder = new Finder();
+        $finder->in(getcwd())
+            ->name('Migration*.php')
+            ->exclude('vendor')
+            ->exclude(['dev-ops', 'test*', 'Test*'])
+        ;
+
+        $result = [];
+
+        foreach ($finder as $migrationFile) {
+            $result[] = $migrationFile->getRelativePathname();
+        }
+
+        return $result;
+    }
 
     protected function configure(): void
     {

--- a/src/Core/Framework/Plugin/Command/Lifecycle/AbstractPluginLifecycleCommand.php
+++ b/src/Core/Framework/Plugin/Command/Lifecycle/AbstractPluginLifecycleCommand.php
@@ -13,6 +13,8 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\MultiFilter;
 use Shopware\Core\Framework\Plugin\PluginCollection;
 use Shopware\Core\Framework\Plugin\PluginEntity;
 use Shopware\Core\Framework\Plugin\PluginLifecycleService;
+use Stecman\Component\Symfony\Console\BashCompletion\Completion\CompletionAwareInterface;
+use Stecman\Component\Symfony\Console\BashCompletion\CompletionContext;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
@@ -23,7 +25,7 @@ use Symfony\Component\Console\Output\NullOutput;
 use Symfony\Component\Console\Question\ChoiceQuestion;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
-abstract class AbstractPluginLifecycleCommand extends Command
+abstract class AbstractPluginLifecycleCommand extends Command implements CompletionAwareInterface
 {
     /**
      * @var PluginLifecycleService
@@ -50,6 +52,28 @@ abstract class AbstractPluginLifecycleCommand extends Command
         $this->pluginLifecycleService = $pluginLifecycleService;
         $this->pluginRepo = $pluginRepo;
         $this->cacheClearer = $cacheClearer;
+    }
+
+    public function completeOptionValues($optionName, CompletionContext $context)
+    {
+        return [];
+    }
+
+    public function completeArgumentValues($argumentName, CompletionContext $context)
+    {
+        if ($argumentName === 'plugins') {
+            $plugins = $this->pluginRepo->search(new Criteria(), Context::createDefaultContext())->getEntities();
+            $result = [];
+
+            foreach ($plugins as $plugin) {
+                $cleanName = preg_replace('/\\W/', ' ', $plugin->getName());
+                $result[] = explode(' ', $cleanName);
+            }
+
+            return array_merge([], ...$result);
+        }
+
+        return [];
     }
 
     protected function configureCommand(string $lifecycleMethod): void

--- a/src/Core/Framework/Plugin/Command/PluginListCommand.php
+++ b/src/Core/Framework/Plugin/Command/PluginListCommand.php
@@ -9,12 +9,14 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\ContainsFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\MultiFilter;
 use Shopware\Core\Framework\Plugin\PluginCollection;
+use Stecman\Component\Symfony\Console\BashCompletion\Completion\CompletionAwareInterface;
+use Stecman\Component\Symfony\Console\BashCompletion\CompletionContext;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class PluginListCommand extends Command
+class PluginListCommand extends Command implements CompletionAwareInterface
 {
     protected static $defaultName = 'plugin:list';
 
@@ -27,6 +29,41 @@ class PluginListCommand extends Command
     {
         parent::__construct();
         $this->pluginRepo = $pluginRepo;
+    }
+
+    public function completeOptionValues($optionName, CompletionContext $context)
+    {
+        if ($optionName === 'filter') {
+            $criteria = new Criteria();
+
+            if (!empty($context->getCurrentWord())) {
+                $criteria->addFilter(new MultiFilter(
+                    MultiFilter::CONNECTION_OR,
+                    [
+                        new ContainsFilter('name', $context->getCurrentWord()),
+                        new ContainsFilter('label', $context->getCurrentWord()),
+                    ]
+                ));
+            }
+
+            /** @var PluginCollection $plugins */
+            $plugins = $this->pluginRepo->search($criteria, Context::createDefaultContext())->getEntities();
+            $result = [];
+
+            foreach ($plugins as $plugin) {
+                $result[] = self::getTextParts($plugin->getName());
+                $result[] = self::getTextParts($plugin->getLabel());
+            }
+
+            return array_unique(array_merge([], ...$result));
+        }
+
+        return [];
+    }
+
+    public function completeArgumentValues($argumentName, CompletionContext $context)
+    {
+        return [];
     }
 
     /**
@@ -111,5 +148,13 @@ class PluginListCommand extends Command
         );
 
         return 0;
+    }
+
+    protected static function getTextParts(string $text): array
+    {
+        $text = preg_replace('/[A-Z]/', ' $0', $text);
+        $text = preg_replace('/\\W/', ' ', $text);
+
+        return explode(' ', $text);
     }
 }

--- a/src/Core/System/DependencyInjection/sales_channel.xml
+++ b/src/Core/System/DependencyInjection/sales_channel.xml
@@ -116,6 +116,8 @@
             <argument type="service" id="country.repository"/>
             <argument type="service" id="snippet_set.repository"/>
             <argument type="service" id="category.repository"/>
+            <argument type="service" id="customer_group.repository"/>
+            <argument type="service" id="currency.repository"/>
 
             <tag name="console.command"/>
         </service>

--- a/src/Core/System/DependencyInjection/state_machine.xml
+++ b/src/Core/System/DependencyInjection/state_machine.xml
@@ -27,7 +27,7 @@
 
         <service id="Shopware\Core\System\StateMachine\Command\WorkflowDumpCommand">
             <argument type="service" id="Shopware\Core\System\StateMachine\StateMachineRegistry"/>
-
+            <argument type="service" id="state_machine.repository"/>
             <tag name="console.command"/>
         </service>
         <service id="Shopware\Core\System\StateMachine\StateMachineDefinition">

--- a/src/Core/composer.json
+++ b/src/Core/composer.json
@@ -116,7 +116,8 @@
         "twig/intl-extra": "2.12.3",
         "twig/string-extra": "2.12.3",
         "twig/twig": "2.12.3",
-        "zircote/swagger-php": "3.0.3"
+        "zircote/swagger-php": "3.0.3",
+        "stecman/symfony-console-completion": "^0.11.0"
     },
     "require-dev": {
         "ext-tokenizer": "*",

--- a/src/Docs/Command/ConvertMarkdownDocsCommand.php
+++ b/src/Docs/Command/ConvertMarkdownDocsCommand.php
@@ -7,6 +7,8 @@ use Shopware\Docs\Convert\Document;
 use Shopware\Docs\Convert\DocumentTree;
 use Shopware\Docs\Convert\DuplicateHashException;
 use Shopware\Docs\Convert\WikiApiService;
+use Stecman\Component\Symfony\Console\BashCompletion\Completion\CompletionAwareInterface;
+use Stecman\Component\Symfony\Console\BashCompletion\CompletionContext;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -15,7 +17,7 @@ use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Finder\SplFileInfo;
 
-class ConvertMarkdownDocsCommand extends Command
+class ConvertMarkdownDocsCommand extends Command implements CompletionAwareInterface
 {
     private const CATEGORY_SITE_FILENAME = '__categoryInfo.md';
 
@@ -32,6 +34,36 @@ class ConvertMarkdownDocsCommand extends Command
     {
         parent::__construct($name);
         $this->environment = getenv('APP_ENV');
+    }
+
+    public function completeOptionValues($optionName, CompletionContext $context)
+    {
+        if ($optionName === 'input' || $optionName === 'output') {
+            $result = [];
+            $finder = (new Finder())
+                ->in(getcwd())
+                ->directories()
+                ->exclude([
+                    'vendor',
+                    'dev-ops',
+                    'Test*',
+                    'test*',
+                ])
+            ;
+
+            foreach ($finder as $directory) {
+                $result[] = $directory->getRelativePathname();
+            }
+
+            return $result;
+        }
+
+        return [];
+    }
+
+    public function completeArgumentValues($argumentName, CompletionContext $context)
+    {
+        return [];
     }
 
     protected function configure(): void

--- a/src/Docs/Resources/current/50-how-to/090-plugin-commands.md
+++ b/src/Docs/Resources/current/50-how-to/090-plugin-commands.md
@@ -54,7 +54,9 @@ class ExampleCommand extends Command
 ```
 
 In this example, it would be located in the directory `<plugin root>/src/Command`.
-After installing, you can now execute your command by running this command: `bin/console plugin-commands:example`
+After installing, you can now execute your command by running this command: `bin/console plugin-commands:example`.
+The auto completion is done automatically for command names and option names.
+If you have a defined set of values for an argument or option you can implement the [CompletionAwareInterface](https://github.com/stecman/symfony-console-completion#implementing-completionawareinterface).
 
 Make sure to read the full guide about [Symfony commands](https://symfony.com/doc/current/console.html) to understand, how to deal with commands and how they can be configured.
 

--- a/src/Docs/Resources/deprecated/4-how-to/090-plugin-commands.md
+++ b/src/Docs/Resources/deprecated/4-how-to/090-plugin-commands.md
@@ -54,7 +54,9 @@ class ExampleCommand extends Command
 ```
 
 In this example, it would be located in the directory `<plugin root>/src/Command`.
-After installing, you can now execute your command by running this command: `bin/console plugin-commands:example`
+After installing, you can now execute your command by running this command: `bin/console plugin-commands:example`.
+The auto completion is done automatically for command names and option names.
+If you have a defined set of values for an argument or option you can implement the [CompletionAwareInterface](https://github.com/stecman/symfony-console-completion#implementing-completionawareinterface).
 
 Make sure to read the full guide about [Symfony commands](https://symfony.com/doc/current/console.html) to understand, how to deal with commands and how they can be configured.
 

--- a/src/Docs/composer.json
+++ b/src/Docs/composer.json
@@ -32,6 +32,7 @@
         "symfony/dependency-injection": "4.4.4",
         "symfony/filesystem": "4.4.4",
         "symfony/finder": "4.4.4",
-        "symfony/http-kernel": "4.4.4"
+        "symfony/http-kernel": "4.4.4",
+        "stecman/symfony-console-completion": "^0.11.0"
     }
 }

--- a/src/Storefront/DependencyInjection/services.xml
+++ b/src/Storefront/DependencyInjection/services.xml
@@ -142,6 +142,8 @@
             <argument type="service" id="country.repository"/>
             <argument type="service" id="snippet_set.repository"/>
             <argument type="service" id="category.repository"/>
+            <argument type="service" id="customer_group.repository"/>
+            <argument type="service" id="currency.repository"/>
 
             <tag name="console.command"/>
         </service>

--- a/src/Storefront/Framework/Command/SalesChannelCreateStorefrontCommand.php
+++ b/src/Storefront/Framework/Command/SalesChannelCreateStorefrontCommand.php
@@ -30,7 +30,9 @@ class SalesChannelCreateStorefrontCommand extends SalesChannelCreateCommand
         EntityRepositoryInterface $shippingMethodRepository,
         EntityRepositoryInterface $countryRepository,
         EntityRepositoryInterface $snippetSetRepository,
-        EntityRepositoryInterface $categoryRepository
+        EntityRepositoryInterface $categoryRepository,
+        EntityRepositoryInterface $customerGroupRepository,
+        EntityRepositoryInterface $currencyRepository
     ) {
         parent::__construct(
             $definitionRegistry,
@@ -39,7 +41,9 @@ class SalesChannelCreateStorefrontCommand extends SalesChannelCreateCommand
             $shippingMethodRepository,
             $countryRepository,
             $snippetSetRepository,
-            $categoryRepository
+            $categoryRepository,
+            $customerGroupRepository,
+            $currencyRepository
         );
         $this->categoryRepository = $categoryRepository;
     }

--- a/src/Storefront/Theme/Command/ThemeChangeCommand.php
+++ b/src/Storefront/Theme/Command/ThemeChangeCommand.php
@@ -11,6 +11,8 @@ use Shopware\Core\System\SalesChannel\SalesChannelEntity;
 use Shopware\Storefront\Theme\StorefrontPluginRegistryInterface;
 use Shopware\Storefront\Theme\ThemeEntity;
 use Shopware\Storefront\Theme\ThemeService;
+use Stecman\Component\Symfony\Console\BashCompletion\Completion\CompletionAwareInterface;
+use Stecman\Component\Symfony\Console\BashCompletion\CompletionContext;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -19,7 +21,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\ChoiceQuestion;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
-class ThemeChangeCommand extends Command
+class ThemeChangeCommand extends Command implements CompletionAwareInterface
 {
     protected static $defaultName = 'theme:change';
 
@@ -73,6 +75,20 @@ class ThemeChangeCommand extends Command
         $this->themeRepository = $themeRepository;
         $this->themeSalesChannelRepository = $themeSalesChannelRepository;
         $this->context = Context::createDefaultContext();
+    }
+
+    public function completeOptionValues($optionName, CompletionContext $context)
+    {
+        return [];
+    }
+
+    public function completeArgumentValues($argumentName, CompletionContext $context)
+    {
+        if ($argumentName === 'theme-name') {
+            return $this->getThemeChoices();
+        }
+
+        return [];
     }
 
     protected function configure(): void

--- a/src/Storefront/composer.json
+++ b/src/Storefront/composer.json
@@ -47,7 +47,8 @@
         "true/punycode": "2.1.1",
         "twig/intl-extra": "2.12.3",
         "twig/string-extra": "2.12.3",
-        "twig/twig": "2.12.3"
+        "twig/twig": "2.12.3",
+        "stecman/symfony-console-completion": "^0.11.0"
     },
     "require-dev": {
         "phpunit/phpunit": "8.5.2"


### PR DESCRIPTION
### 1. Why is this change necessary?
For easier usability of console commands. This is a rebased follow up to #33 

Did you ever recognized a whole uuid? Do you know by heart what the plugin was spelled?

Examples in usage were already shown in the [pull request for shopware 5](https://github.com/shopware/shopware/pull/1488).

### 2. What does this change do, exactly?
Implements for all core/shipped commands the CompletionAwareInterface
Adds hints in the documentation

### 3. Describe each step to reproduce the issue or behaviour.
Press tab to complete your shopware console commands. It just does not work.

### 4. Which documentation changes (if any) need to be made because of this PR?
https://docs.shopware.com should get a hint on the setup and pros.
There is a complementary pull request to https://github.com/shopware/development/pull/20 to ensure this features is ready in the default docker container.

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
