### PR TITLE
Open product from administration in saleschannel

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/context-menu/sw-context-menu-item/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/context-menu/sw-context-menu-item/index.js
@@ -26,6 +26,12 @@ Component.register('sw-context-menu-item', {
             required: false
         },
 
+        href: {
+            type: String,
+            required: false,
+            default: null
+        },
+
         target: {
             type: String,
             required: false,

--- a/src/Administration/Resources/app/administration/src/app/component/context-menu/sw-context-menu-item/sw-context-menu-item.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/context-menu/sw-context-menu-item/sw-context-menu-item.html.twig
@@ -24,6 +24,29 @@
         </router-link>
     {% endblock %}
 
+    {% block sw_context_menu_item_link %}
+        <div v-else-if="href && href.length"
+             class="sw-context-menu-item"
+             :class="contextMenuItemStyles">
+            {% block sw_context_menu_item_icon %}
+                <slot name="icon">
+                    {% block sw_context_menu_item_slot_icon %}
+                        <sw-icon :name="icon" small v-if="icon"></sw-icon>
+                    {% endblock %}
+                </slot>
+            {% endblock %}
+
+            {% block sw_context_menu_item_text %}
+                <a class="sw-context-menu-item__text"
+                   :class="{ 'is--disabled': disabled }"
+                   :href="href"
+                   :target="target">
+                    <slot>{% block sw_context_menu_item_slot_default %}{% endblock %}</slot>
+                </a>
+            {% endblock %}
+        </div>
+    {% endblock %}
+
     {% block sw_context_menu_item_entry %}
         <div v-else
              class="sw-context-menu-item"

--- a/src/Administration/Resources/app/administration/src/app/component/structure/sw-page/sw-page.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/structure/sw-page/sw-page.scss
@@ -130,6 +130,18 @@ $sw-page-smart-bar-headline-font-weight: 600;
         .sw-context-button__menu-position {
             margin-right: 0;
         }
+
+        > .sw-context-button {
+            margin-right: 8px;
+
+            &:last-child {
+                margin-right: 0;
+            }
+
+            > .sw-button {
+                margin-right: 0;
+            }
+        }
     }
 
     .sw-page__smart-bar-amount {

--- a/src/Administration/Resources/app/administration/src/module/sw-product/helper/sw-products-link-loader.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/helper/sw-products-link-loader.js
@@ -1,0 +1,17 @@
+export default class ProductLinkLoader {
+    constructor() {
+        // set dependencies
+        this.syncService = Shopware.Service('syncService');
+        this.httpClient = this.syncService.httpClient;
+    }
+
+    loadLinks(id) {
+        // Return all existing variations from the server
+        return this.httpClient.get(
+            `/_action/product/${id}/links`,
+            { headers: this.syncService.getBasicHeaders() }
+        ).then((response) => {
+            return response.data;
+        });
+    }
+}

--- a/src/Administration/Resources/app/administration/src/module/sw-product/page/sw-product-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/page/sw-product-detail/index.js
@@ -1,5 +1,6 @@
 import { ifNext6997, next6997 } from 'src/flag/feature_next6997';
 
+import ProductLinkLoader from '../../helper/sw-products-link-loader';
 import template from './sw-product-detail.html.twig';
 import swProductDetailState from './state';
 import errorConfiguration from './error.cfg.json';
@@ -42,7 +43,8 @@ Component.register('sw-product-detail', {
         return {
             productNumberPreview: '',
             isSaveSuccessful: false,
-            cloning: false
+            cloning: false,
+            productLinks: null
         };
     },
 
@@ -279,12 +281,29 @@ Component.register('sw-product-detail', {
             return this.loadAll();
         },
 
+        loadProductLinks() {
+            this.productLinks = null;
+            let result = Promise.resolve([]);
+
+            if (this.productId && this.productId.length) {
+                result = (new ProductLinkLoader())
+                    .loadLinks(this.productId)
+                    .then(data => {
+                        this.productLinks = data;
+                        return data;
+                    });
+            }
+
+            return result;
+        },
+
         loadAll() {
             return Promise.all([
                 this.loadProduct(),
                 this.loadCurrencies(),
                 this.loadTaxes(),
-                this.loadAttributeSet()
+                this.loadAttributeSet(),
+                this.loadProductLinks()
             ]);
         },
 
@@ -637,6 +656,12 @@ Component.register('sw-product-detail', {
         onDuplicateFinish(duplicate) {
             this.cloning = false;
             this.$router.push({ name: 'sw.product.detail', params: { id: duplicate.id } });
+        },
+
+        onSaveAndOpen(publicUrl) {
+            this.onSave().then(() => {
+                window.open(publicUrl, '_blank');
+            });
         }
     }
 });

--- a/src/Administration/Resources/app/administration/src/module/sw-product/page/sw-product-detail/sw-product-detail.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/page/sw-product-detail/sw-product-detail.html.twig
@@ -39,7 +39,9 @@
                     {% endblock %}
 
                     {% block sw_product_detail_actions_save_context_menu %}
-                        <sw-context-button>
+                        <sw-context-button
+                            :menuWidth="450"
+                        >
                             <template slot="button">
                                 <sw-button
                                     class="sw-product-detail__button-context-menu"
@@ -62,6 +64,18 @@
                                     }"
                                     @click="onDuplicate">
                                     {{ $tc('sw-product.detail.buttonSaveDuplicate') }}
+                                </sw-context-menu-item>
+                            {% endblock %}
+
+                            {% block sw_product_detail_actions_open_storefront_links %}
+                                <sw-context-menu-item
+                                    v-for="productLink of productLinks"
+                                    icon="default-action-external"
+                                    target="_blank"
+                                    :key="productLink.salesChannelDomain + productLink.path"
+                                    @click.prevent="onSaveAndOpen(productLink.salesChannelDomain + productLink.path)"
+                                >
+                                    {{ $t('sw-product.detail.buttonSaveAndOpenStorefrontLink', productLink) }}
                                 </sw-context-menu-item>
                             {% endblock %}
                         {% endblock %}

--- a/src/Administration/Resources/app/administration/src/module/sw-product/snippet/de-DE.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/snippet/de-DE.json
@@ -187,6 +187,7 @@
       "buttonSave": "Speichern",
       "buttonSaveDuplicate": "Speichern und duplizieren",
       "buttonSaveAndNew": "Speichern und neues erstellen",
+      "buttonSaveAndOpenStorefrontLink": "Speichern und öffnen in {salesChannelName} ({salesChannelDomain})",
       "tabGeneral": "Allgemein",
       "tabAdvancedPrices": "Erweiterte Preise",
       "tabProperties": "Eigenschaften zuweisen",

--- a/src/Administration/Resources/app/administration/src/module/sw-product/snippet/en-GB.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/snippet/en-GB.json
@@ -187,6 +187,7 @@
       "buttonSave": "Save",
       "buttonSaveDuplicate": "Save and duplicate",
       "buttonSaveAndNew": "Save and create new",
+      "buttonSaveAndOpenStorefrontLink": "Save and open in {salesChannelName} ({salesChannelDomain})",
       "tabGeneral": "General",
       "tabAdvancedPrices": "Advanced pricing",
       "tabVariation": "Variants",

--- a/src/Core/Content/DependencyInjection/product.xml
+++ b/src/Core/Content/DependencyInjection/product.xml
@@ -122,6 +122,7 @@
 
         <service id="Shopware\Core\Content\Product\Api\ProductActionController" public="true">
             <argument type="service" id="Shopware\Core\Content\Product\Util\VariantCombinationLoader"/>
+            <argument type="service" id="Shopware\Core\Content\Product\Util\ProductLinkLoader"/>
             <call method="setContainer">
                 <argument type="service" id="service_container"/>
             </call>
@@ -133,6 +134,11 @@
 
         <service id="Shopware\Core\Content\Product\Util\VariantCombinationLoader">
             <argument type="service" id="Doctrine\DBAL\Connection"/>
+        </service>
+
+        <service id="Shopware\Core\Content\Product\Util\ProductLinkLoader">
+            <argument type="service" id="router.default"/>
+            <argument type="service" id="sales_channel_domain.repository"/>
         </service>
 
         <service id="Shopware\Core\System\DeliveryTime\DeliveryTimeDefinition">

--- a/src/Core/Content/Product/Api/ProductActionController.php
+++ b/src/Core/Content/Product/Api/ProductActionController.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Core\Content\Product\Api;
 
+use Shopware\Core\Content\Product\Util\ProductLinkLoader;
 use Shopware\Core\Content\Product\Util\VariantCombinationLoader;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Routing\Annotation\RouteScope;
@@ -19,9 +20,15 @@ class ProductActionController extends AbstractController
      */
     private $combinationLoader;
 
-    public function __construct(VariantCombinationLoader $combinationLoader)
+    /**
+     * @var ProductLinkLoader
+     */
+    private $productLinkLoader;
+
+    public function __construct(VariantCombinationLoader $combinationLoader, ProductLinkLoader $productLinkLoader)
     {
         $this->combinationLoader = $combinationLoader;
+        $this->productLinkLoader = $productLinkLoader;
     }
 
     /**
@@ -34,5 +41,15 @@ class ProductActionController extends AbstractController
         return new JsonResponse(
             $this->combinationLoader->load($productId, $context)
         );
+    }
+
+    /**
+     * @Route("/api/v{version}/_action/product/{productId}/links", name="api.action.product.links", methods={"GET"})
+     *
+     * @return JsonResponse
+     */
+    public function getLinks(string $productId, Context $context)
+    {
+        return new JsonResponse($this->productLinkLoader->load($productId, $context));
     }
 }

--- a/src/Core/Content/Product/Util/ProductLink.php
+++ b/src/Core/Content/Product/Util/ProductLink.php
@@ -1,0 +1,93 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Content\Product\Util;
+
+use Shopware\Core\Framework\Struct\Struct;
+
+class ProductLink extends Struct
+{
+    /**
+     * @var string
+     */
+    protected $salesChannelId;
+
+    /**
+     * @var string
+     */
+    protected $salesChannelName;
+
+    /**
+     * @var string
+     */
+    protected $salesChannelDomain;
+
+    /**
+     * @var string
+     */
+    protected $path;
+
+    /**
+     * @var string
+     */
+    protected $productId;
+
+    public function getSalesChannelId(): string
+    {
+        return $this->salesChannelId;
+    }
+
+    public function setSalesChannelId(string $salesChannelId): self
+    {
+        $this->salesChannelId = $salesChannelId;
+
+        return $this;
+    }
+
+    public function getSalesChannelName(): string
+    {
+        return $this->salesChannelName;
+    }
+
+    public function setSalesChannelName(string $salesChannelName): self
+    {
+        $this->salesChannelName = $salesChannelName;
+
+        return $this;
+    }
+
+    public function getSalesChannelDomain(): string
+    {
+        return $this->salesChannelDomain;
+    }
+
+    public function setSalesChannelDomain(string $salesChannelDomain): self
+    {
+        $this->salesChannelDomain = $salesChannelDomain;
+
+        return $this;
+    }
+
+    public function getPath(): string
+    {
+        return $this->path;
+    }
+
+    public function setPath(string $path): self
+    {
+        $this->path = $path;
+
+        return $this;
+    }
+
+    public function getProductId(): string
+    {
+        return $this->productId;
+    }
+
+    public function setProductId(string $productId): self
+    {
+        $this->productId = $productId;
+
+        return $this;
+    }
+}

--- a/src/Core/Content/Product/Util/ProductLinkCollection.php
+++ b/src/Core/Content/Product/Util/ProductLinkCollection.php
@@ -1,0 +1,22 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Content\Product\Util;
+
+use Shopware\Core\Framework\Struct\Collection;
+
+/**
+ * @method void             add(ProductLink $entity)
+ * @method void             set(string $key, ProductLink $entity)
+ * @method ProductLink[]    getIterator()
+ * @method ProductLink[]    getElements()
+ * @method ProductLink|null get(string $key)
+ * @method ProductLink|null first()
+ * @method ProductLink|null last()
+ */
+class ProductLinkCollection extends Collection
+{
+    protected function getExpectedClass(): string
+    {
+        return ProductLink::class;
+    }
+}

--- a/src/Core/Content/Product/Util/ProductLinkLoader.php
+++ b/src/Core/Content/Product/Util/ProductLinkLoader.php
@@ -1,0 +1,54 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Content\Product\Util;
+
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepositoryInterface;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\System\SalesChannel\Aggregate\SalesChannelDomain\SalesChannelDomainEntity;
+use Symfony\Component\Routing\RouterInterface;
+
+class ProductLinkLoader
+{
+    /**
+     * @var RouterInterface
+     */
+    private $router;
+
+    /**
+     * @var EntityRepositoryInterface
+     */
+    private $salesChannelDomainRepository;
+
+    public function __construct(RouterInterface $router, EntityRepositoryInterface $salesChannelDomainRepository)
+    {
+        $this->router = $router;
+        $this->salesChannelDomainRepository = $salesChannelDomainRepository;
+    }
+
+    public function load(string $productId, Context $context): ProductLinkCollection
+    {
+        $result = new ProductLinkCollection();
+        $path = $this->router->generate('frontend.detail.page', ['productId' => $productId]);
+
+        $criteria = (new Criteria())
+            ->addFilter(new EqualsFilter('salesChannel.navigationCategory.nestedProducts.id', $productId))
+            ->addAssociation('salesChannel');
+        $entitySearchResult = $this->salesChannelDomainRepository->search($criteria, $context);
+
+        /** @var SalesChannelDomainEntity $salesChannelDomain */
+        foreach ($entitySearchResult->getElements() as $salesChannelDomain) {
+            $result->add(
+                (new ProductLink())
+                ->setPath($path)
+                ->setProductId($productId)
+                ->setSalesChannelDomain($salesChannelDomain->getUrl())
+                ->setSalesChannelId($salesChannelDomain->getSalesChannelId())
+                ->setSalesChannelName($salesChannelDomain->getSalesChannel()->getName())
+            );
+        }
+
+        return $result;
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?
<img width="466" alt="grafik" src="https://user-images.githubusercontent.com/1133593/75116004-5e7a1980-5664-11ea-9aed-195a95100e7b.png">

### 2. What does this change do, exactly?
<img width="802" alt="grafik" src="https://user-images.githubusercontent.com/1133593/75115984-3ee2f100-5664-11ea-9040-2802674362f0.png">

* Add normal external links to sw-context-menu-item
* Add API action to load product links in any sales channel
* Add "Open in" button to admin product detail page

### 3. Describe each step to reproduce the issue or behaviour.
1. Know shopware 5
2. Miss features like opening the product in a saleschannel without navigating there first

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
