### PR TITLE
updated documentation howto 540 (compatibility)

### DIFF
--- a/src/Docs/Resources/current/4-how-to/540-add-data-to-a-storefront-page.md
+++ b/src/Docs/Resources/current/4-how-to/540-add-data-to-a-storefront-page.md
@@ -66,14 +66,13 @@ Now that we have registered our Subscriber to the right event we first need to f
     {
         $criteria = new Criteria();
         $criteria->addFilter(new EqualsFilter('product.active', true));
-        $criteria->addAggregation(new CountAggregation('product.id', 'productCount'));
+        $criteria->addAggregation(new CountAggregation('productCount', 'product.id'));
 
         /** @var CountResult $productCountResult */
         $productCountResult = $this->productRepository
-            ->aggregate($criteria, $event->getContext())
+            ->search($criteria, $event->getContext())
             ->getAggregations()
-            ->get('productCount')
-            ->getResult()[0];
+            ->get('productCount');
 
         $event->getPagelet()->addExtension('product_count', $productCountResult);
     }
@@ -127,14 +126,13 @@ class FooterSubscriber implements EventSubscriberInterface
     {
         $criteria = new Criteria();
         $criteria->addFilter(new EqualsFilter('product.active', true));
-        $criteria->addAggregation(new CountAggregation('product.id', 'productCount'));
+        $criteria->addAggregation(new CountAggregation('productCount', 'product.id'));
 
         /** @var CountResult $productCountResult */
         $productCountResult = $this->productRepository
-            ->aggregate($criteria, $event->getContext())
+            ->search($criteria, $event->getContext())
             ->getAggregations()
-            ->get('productCount')
-            ->getResult()[0];
+            ->get('productCount');
 
         $event->getPagelet()->addExtension('product_count', $productCountResult);
     }


### PR DESCRIPTION
### 1. Why is this change necessary?
The documentation's howto (540) does not work with the latest codebase. (https://docs.shopware.com/en/shopware-platform-dev-en/how-to/add-data-to-a-storefront-page)
I already created a PR for changing the example plugin. (https://github.com/shopware/swag-docs-extend-page/pull/1)

### 2. What does this change do, exactly?
Make the howto compatible with the latest code base.

### 3. Describe each step to reproduce the issue or behaviour.
/

### 4. Please link to the relevant issues (if any).
/

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [X] I have written or adjusted the documentation according to my changes
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.
