### PR TITLE
Add custom line item block for documents

### DIFF
--- a/src/Core/Framework/Resources/views/documents/base.html.twig
+++ b/src/Core/Framework/Resources/views/documents/base.html.twig
@@ -273,6 +273,8 @@
                                         {% endblock %}
                                     </tr>
                                 {% endfor %}
+                                {% block document_line_item_table_rows_custom %}
+                                {% endblock %}
                             </table>
                         {% endblock %}
                     </div>


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/community).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
It is not possible to add a custom row inside the table without overwriting the whole table

### 2. What does this change do, exactly?
adds a block to add a custom row inside the table

### 3. Describe each step to reproduce the issue or behaviour.
I just wanted to add the shipping costs to the table itself, but it won't work without overwriting the whole table. Now the following is possible:

```
{% sw_extends '@Framework/documents/base.html.twig' %}

    {% block document_line_item_table_rows_custom %}
        {% if loop.last == true %}
            <tr class="line-item">
                    <td>Versand</td>
                    <td class="line-item-breakable">{{ order.deliveries.first.shippingMethod.name }}</td>
                    <td class="align-right">1</td>
                    <td class="align-right">{% for tax in order.deliveries.first.shippingCosts.calculatedTaxes %}{{ tax.taxRate }}%{% if loop.last %}{% else %}<br>{% endif %}{% endfor %}</td>
                    <td class="align-right">{{ order.deliveries.first.shippingCosts.unitPrice|currency(currencyIsoCode) }}</td>
                    <td class="align-right">{{ order.deliveries.first.shippingCosts.totalPrice|currency(currencyIsoCode) }}</td>
            </tr>
        {% endif %}
    {% endblock %}
            
```

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
