### PR TITLE
Fix time_format in documents based on the order locale

### DIFF
--- a/src/Core/Framework/Resources/views/documents/base.html.twig
+++ b/src/Core/Framework/Resources/views/documents/base.html.twig
@@ -13,7 +13,7 @@
 
     {% set currencyIsoCode = order.currency.isoCode %}
 
-    {% set locale = customer.customer.language.locale.code %}
+    {% set locale = order.language.locale.code %}
 
     {% if config.itemsPerPage <= 0 %}
         {% set itemsPerPage = 10 %}


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/community).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
The time_format in the documents was broken.

### 2. What does this change do, exactly?
The time_format is now based on the locale, the previous variable was not existent.

### 3. Describe each step to reproduce the issue or behaviour.
Create a document and have a look at the right. The time_format won't be applied since customer.customer.language.locale.code does not exist

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
