### PR TITLE
Add hint to set APP_ENV to dev for accessing the swagger documentation

### DIFF
--- a/src/Docs/Resources/current/3-api/030-admin-api-usage.md
+++ b/src/Docs/Resources/current/3-api/030-admin-api-usage.md
@@ -719,3 +719,4 @@ List of products with their media associations limited to one.
 ## Full schema
 
 The full schema can be explored with swagger: `/api/v1/_info/swagger.html`
+To access the full schema, you have to make sure, that the `APP_ENV` is set to `dev`.


### PR DESCRIPTION
### 1. Why is this change necessary?
I was trying to access the swagger documentation but just got an error all the time. To protect other users from this, I have adapted the documentation.

### 2. What does this change do, exactly?
It enhances the 030-admin-api-usage.md file.

### 3. Describe each step to reproduce the issue or behaviour.
:heavy_minus_sign: 

### 4. Please link to the relevant issues (if any).
:heavy_minus_sign: 

### 5. Checklist

- [X] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [X] I have written or adjusted the documentation according to my changes
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.
