### PR TITLE
Internal change of criteria objects leak outside

### DIFF
--- a/src/Core/Framework/DataAbstractionLayer/Dbal/CriteriaQueryHelper.php
+++ b/src/Core/Framework/DataAbstractionLayer/Dbal/CriteriaQueryHelper.php
@@ -49,15 +49,10 @@ trait CriteriaQueryHelper
             $criteria->addQuery(...$queries);
         }
 
+        $filters = array_merge($criteria->getFilters(), $criteria->getPostFilters());
         $filter = $this->antiJoinTransform(
             $definition,
-            new MultiFilter(
-                'AND',
-                array_merge(
-                    $criteria->getFilters(),
-                    $criteria->getPostFilters()
-                )
-            )
+            count($filters) === 1 ? $filters[0] : new MultiFilter('AND', $filters)
         );
 
         $criteria->resetFilters();

--- a/src/Core/Framework/DataAbstractionLayer/EntityRepository.php
+++ b/src/Core/Framework/DataAbstractionLayer/EntityRepository.php
@@ -77,6 +77,8 @@ class EntityRepository implements EntityRepositoryInterface
 
     public function search(Criteria $criteria, Context $context): EntitySearchResult
     {
+        $criteria = clone $criteria;
+
         $aggregations = null;
         if ($criteria->getAggregations()) {
             $aggregations = $this->aggregate($criteria, $context);
@@ -125,7 +127,7 @@ class EntityRepository implements EntityRepositoryInterface
 
     public function aggregate(Criteria $criteria, Context $context): AggregationResultCollection
     {
-        $result = $this->aggregator->aggregate($this->definition, $criteria, $context);
+        $result = $this->aggregator->aggregate($this->definition, clone $criteria, $context);
 
         $event = new EntityAggregationResultLoadedEvent($this->definition, $result, $context);
         $this->eventDispatcher->dispatch($event, $event->getName());
@@ -135,6 +137,8 @@ class EntityRepository implements EntityRepositoryInterface
 
     public function searchIds(Criteria $criteria, Context $context): IdSearchResult
     {
+        $criteria = clone $criteria;
+
         $this->eventDispatcher->dispatch(
             new EntitySearchedEvent($criteria, $this->definition, $context)
         );

--- a/src/Core/Framework/Test/DataAbstractionLayer/EntityRepositoryTest.php
+++ b/src/Core/Framework/Test/DataAbstractionLayer/EntityRepositoryTest.php
@@ -28,6 +28,8 @@ use Shopware\Core\Framework\DataAbstractionLayer\Read\EntityReaderInterface;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\EntityAggregatorInterface;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearcherInterface;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\MultiFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\VersionManager;
 use Shopware\Core\Framework\Rule\Container\AndRule;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
@@ -105,7 +107,18 @@ class EntityRepositoryTest extends TestCase
             $context
         );
 
-        $locale = $repository->search(new Criteria([$id]), $context);
+        $criteria = new Criteria([$id]);
+        $locale = $repository->search($criteria, $context);
+
+        static::assertEquals([$id], $criteria->getIds());
+        static::assertEmpty($criteria->getSorting());
+        static::assertEmpty($criteria->getSource());
+        static::assertEmpty($criteria->getFilters());
+        static::assertEmpty($criteria->getPostFilters());
+        static::assertEmpty($criteria->getAggregations());
+        static::assertEmpty($criteria->getAssociations());
+        static::assertNull($criteria->getLimit());
+        static::assertNull($criteria->getOffset());
 
         static::assertInstanceOf(EntityCollection::class, $locale);
         static::assertCount(1, $locale);
@@ -137,7 +150,17 @@ class EntityRepositoryTest extends TestCase
         $listener->expects(static::once())->method('__invoke');
         $dispatcher->addListener('locale.loaded', $listener);
 
-        $locale = $repository->search(new Criteria([$id]), $context);
+        $criteria = new Criteria([$id]);
+        $locale = $repository->search($criteria, $context);
+        static::assertEquals([$id], $criteria->getIds());
+        static::assertEmpty($criteria->getSorting());
+        static::assertEmpty($criteria->getSource());
+        static::assertEmpty($criteria->getFilters());
+        static::assertEmpty($criteria->getPostFilters());
+        static::assertEmpty($criteria->getAggregations());
+        static::assertEmpty($criteria->getAssociations());
+        static::assertNull($criteria->getLimit());
+        static::assertNull($criteria->getOffset());
 
         static::assertInstanceOf(EntityCollection::class, $locale);
         static::assertCount(1, $locale);
@@ -199,6 +222,25 @@ class EntityRepositoryTest extends TestCase
         $criteria->addAssociation('manufacturer');
 
         $locale = $repository->search($criteria, $context);
+
+        static::assertEquals([$id, $id2], $criteria->getIds());
+        static::assertEmpty($criteria->getSorting());
+        static::assertEmpty($criteria->getSource());
+        static::assertEmpty($criteria->getFilters());
+        static::assertEmpty($criteria->getPostFilters());
+        static::assertEmpty($criteria->getAggregations());
+        static::assertNull($criteria->getLimit());
+        static::assertNull($criteria->getOffset());
+        static::assertCount(1, $criteria->getAssociations());
+        static::assertNotNull($criteria->getAssociation('manufacturer'));
+        static::assertEmpty($criteria->getAssociation('manufacturer')->getSorting());
+        static::assertEmpty($criteria->getAssociation('manufacturer')->getSource());
+        static::assertEmpty($criteria->getAssociation('manufacturer')->getFilters());
+        static::assertEmpty($criteria->getAssociation('manufacturer')->getPostFilters());
+        static::assertEmpty($criteria->getAssociation('manufacturer')->getAggregations());
+        static::assertEmpty($criteria->getAssociation('manufacturer')->getAssociations());
+        static::assertNull($criteria->getAssociation('manufacturer')->getLimit());
+        static::assertNull($criteria->getAssociation('manufacturer')->getOffset());
 
         static::assertInstanceOf(EntityCollection::class, $locale);
         static::assertCount(2, $locale);
@@ -323,6 +365,33 @@ class EntityRepositoryTest extends TestCase
         $criteria->addAssociation('manufacturer');
 
         $locale = $repository->search($criteria, $context);
+        static::assertEquals([$id, $id2], $criteria->getIds());
+        static::assertEmpty($criteria->getSorting());
+        static::assertEmpty($criteria->getSource());
+        static::assertEmpty($criteria->getFilters());
+        static::assertEmpty($criteria->getPostFilters());
+        static::assertEmpty($criteria->getAggregations());
+        static::assertNull($criteria->getLimit());
+        static::assertNull($criteria->getOffset());
+        static::assertCount(2, $criteria->getAssociations());
+        static::assertNotNull($criteria->getAssociation('prices'));
+        static::assertEmpty($criteria->getAssociation('prices')->getSorting());
+        static::assertEmpty($criteria->getAssociation('prices')->getSource());
+        static::assertEmpty($criteria->getAssociation('prices')->getFilters());
+        static::assertEmpty($criteria->getAssociation('prices')->getPostFilters());
+        static::assertEmpty($criteria->getAssociation('prices')->getAggregations());
+        static::assertEmpty($criteria->getAssociation('prices')->getAssociations());
+        static::assertNull($criteria->getAssociation('prices')->getLimit());
+        static::assertNull($criteria->getAssociation('prices')->getOffset());
+        static::assertNotNull($criteria->getAssociation('manufacturer'));
+        static::assertEmpty($criteria->getAssociation('manufacturer')->getSorting());
+        static::assertEmpty($criteria->getAssociation('manufacturer')->getSource());
+        static::assertEmpty($criteria->getAssociation('manufacturer')->getFilters());
+        static::assertEmpty($criteria->getAssociation('manufacturer')->getPostFilters());
+        static::assertEmpty($criteria->getAssociation('manufacturer')->getAggregations());
+        static::assertEmpty($criteria->getAssociation('manufacturer')->getAssociations());
+        static::assertNull($criteria->getAssociation('manufacturer')->getLimit());
+        static::assertNull($criteria->getAssociation('manufacturer')->getOffset());
 
         static::assertInstanceOf(EntityCollection::class, $locale);
         static::assertCount(2, $locale);
@@ -358,7 +427,17 @@ class EntityRepositoryTest extends TestCase
         static::assertCount(3, $written->getIds());
         static::assertContains($newId, $written->getIds());
 
-        $entities = $repository->search(new Criteria([$id, $newId]), $context);
+        $criteria = new Criteria([$id, $newId]);
+        $entities = $repository->search($criteria, $context);
+        static::assertEquals([$id, $newId], $criteria->getIds());
+        static::assertEmpty($criteria->getSorting());
+        static::assertEmpty($criteria->getSource());
+        static::assertEmpty($criteria->getFilters());
+        static::assertEmpty($criteria->getPostFilters());
+        static::assertEmpty($criteria->getAggregations());
+        static::assertEmpty($criteria->getAssociations());
+        static::assertNull($criteria->getLimit());
+        static::assertNull($criteria->getOffset());
 
         static::assertCount(2, $entities);
         static::assertTrue($entities->has($id));
@@ -407,6 +486,24 @@ class EntityRepositoryTest extends TestCase
         $criteria = new Criteria([$id, $newId]);
         $criteria->addAssociation('children');
         $entities = $repository->search($criteria, $context);
+        static::assertEquals([$id, $newId], $criteria->getIds());
+        static::assertEmpty($criteria->getSorting());
+        static::assertEmpty($criteria->getSource());
+        static::assertEmpty($criteria->getFilters());
+        static::assertEmpty($criteria->getPostFilters());
+        static::assertEmpty($criteria->getAggregations());
+        static::assertNull($criteria->getLimit());
+        static::assertNull($criteria->getOffset());
+        static::assertCount(1, $criteria->getAssociations());
+        static::assertNotNull($criteria->getAssociation('children'));
+        static::assertEmpty($criteria->getAssociation('children')->getSorting());
+        static::assertEmpty($criteria->getAssociation('children')->getSource());
+        static::assertEmpty($criteria->getAssociation('children')->getFilters());
+        static::assertEmpty($criteria->getAssociation('children')->getPostFilters());
+        static::assertEmpty($criteria->getAssociation('children')->getAggregations());
+        static::assertEmpty($criteria->getAssociation('children')->getAssociations());
+        static::assertNull($criteria->getAssociation('children')->getLimit());
+        static::assertNull($criteria->getAssociation('children')->getOffset());
 
         static::assertCount(2, $entities);
         static::assertTrue($entities->has($id));
@@ -484,6 +581,23 @@ class EntityRepositoryTest extends TestCase
         $criteria->addAssociation('addresses');
 
         $entities = $repository->search($criteria, $context);
+        static::assertEquals([$recordA, $newId], $criteria->getIds());
+        static::assertEmpty($criteria->getSorting());
+        static::assertEmpty($criteria->getSource());
+        static::assertEmpty($criteria->getFilters());
+        static::assertEmpty($criteria->getPostFilters());
+        static::assertNull($criteria->getLimit());
+        static::assertNull($criteria->getOffset());
+        static::assertCount(1, $criteria->getAggregations());
+        static::assertNotNull($criteria->getAssociation('addresses'));
+        static::assertEmpty($criteria->getAssociation('addresses')->getSorting());
+        static::assertEmpty($criteria->getAssociation('addresses')->getSource());
+        static::assertEmpty($criteria->getAssociation('addresses')->getFilters());
+        static::assertEmpty($criteria->getAssociation('addresses')->getPostFilters());
+        static::assertEmpty($criteria->getAssociation('addresses')->getAggregations());
+        static::assertEmpty($criteria->getAssociation('addresses')->getAssociations());
+        static::assertNull($criteria->getAssociation('addresses')->getLimit());
+        static::assertNull($criteria->getAssociation('addresses')->getOffset());
 
         static::assertCount(2, $entities);
         static::assertTrue($entities->has($recordA));
@@ -560,6 +674,24 @@ class EntityRepositoryTest extends TestCase
         $criteria = new Criteria([$recordA, $newId]);
         $criteria->addAssociation('tags');
         $entities = $repository->search($criteria, $context);
+        static::assertEquals([$recordA, $newId], $criteria->getIds());
+        static::assertEmpty($criteria->getSorting());
+        static::assertEmpty($criteria->getSource());
+        static::assertEmpty($criteria->getFilters());
+        static::assertEmpty($criteria->getPostFilters());
+        static::assertEmpty($criteria->getAggregations());
+        static::assertNull($criteria->getLimit());
+        static::assertNull($criteria->getOffset());
+        static::assertCount(1, $criteria->getAssociations());
+        static::assertNotNull($criteria->getAssociation('tags'));
+        static::assertEmpty($criteria->getAssociation('tags')->getSorting());
+        static::assertEmpty($criteria->getAssociation('tags')->getSource());
+        static::assertEmpty($criteria->getAssociation('tags')->getFilters());
+        static::assertEmpty($criteria->getAssociation('tags')->getPostFilters());
+        static::assertEmpty($criteria->getAssociation('tags')->getAggregations());
+        static::assertEmpty($criteria->getAssociation('tags')->getAssociations());
+        static::assertNull($criteria->getAssociation('tags')->getLimit());
+        static::assertNull($criteria->getAssociation('tags')->getOffset());
 
         static::assertCount(2, $entities);
         static::assertTrue($entities->has($recordA));
@@ -616,6 +748,24 @@ class EntityRepositoryTest extends TestCase
         $Criteria->addAssociation('children');
         /** @var CategoryEntity $category */
         $category = $repo->search($Criteria, $context)->get($newId);
+        static::assertEquals([$id], $Criteria->getIds());
+        static::assertEmpty($Criteria->getSorting());
+        static::assertEmpty($Criteria->getSource());
+        static::assertEmpty($Criteria->getFilters());
+        static::assertEmpty($Criteria->getPostFilters());
+        static::assertEmpty($Criteria->getAggregations());
+        static::assertNull($Criteria->getLimit());
+        static::assertNull($Criteria->getOffset());
+        static::assertCount(1, $Criteria->getAssociations());
+        static::assertNotNull($Criteria->getAssociation('children'));
+        static::assertEmpty($Criteria->getAssociation('children')->getSorting());
+        static::assertEmpty($Criteria->getAssociation('children')->getSource());
+        static::assertEmpty($Criteria->getAssociation('children')->getFilters());
+        static::assertEmpty($Criteria->getAssociation('children')->getPostFilters());
+        static::assertEmpty($Criteria->getAssociation('children')->getAggregations());
+        static::assertEmpty($Criteria->getAssociation('children')->getAssociations());
+        static::assertNull($Criteria->getAssociation('children')->getLimit());
+        static::assertNull($Criteria->getAssociation('children')->getOffset());
 
         static::assertCount(2, $category->getChildren());
     }
@@ -776,6 +926,24 @@ class EntityRepositoryTest extends TestCase
 
         /** @var MediaFolderEntity $folder */
         $folder = $repository->search($criteria, $context)->get($id);
+        static::assertEquals([$id], $criteria->getIds());
+        static::assertEmpty($criteria->getSorting());
+        static::assertEmpty($criteria->getSource());
+        static::assertEmpty($criteria->getFilters());
+        static::assertEmpty($criteria->getPostFilters());
+        static::assertEmpty($criteria->getAggregations());
+        static::assertNull($criteria->getLimit());
+        static::assertNull($criteria->getOffset());
+        static::assertCount(1, $criteria->getAssociations());
+        static::assertNotNull($criteria->getAssociation('children'));
+        static::assertEmpty($criteria->getAssociation('children')->getSorting());
+        static::assertEmpty($criteria->getAssociation('children')->getSource());
+        static::assertEmpty($criteria->getAssociation('children')->getFilters());
+        static::assertEmpty($criteria->getAssociation('children')->getPostFilters());
+        static::assertEmpty($criteria->getAssociation('children')->getAggregations());
+        static::assertEmpty($criteria->getAssociation('children')->getAssociations());
+        static::assertEquals(2, $criteria->getAssociation('children')->getLimit());
+        static::assertEquals(0, $criteria->getAssociation('children')->getOffset());
 
         static::assertInstanceOf(MediaFolderEntity::class, $folder);
         static::assertInstanceOf(MediaFolderCollection::class, $folder->getChildren());
@@ -788,6 +956,24 @@ class EntityRepositoryTest extends TestCase
 
         /** @var MediaFolderEntity $folder */
         $folder = $repository->search($criteria, $context)->get($id);
+        static::assertEquals([$id], $criteria->getIds());
+        static::assertEmpty($criteria->getSorting());
+        static::assertEmpty($criteria->getSource());
+        static::assertEmpty($criteria->getFilters());
+        static::assertEmpty($criteria->getPostFilters());
+        static::assertEmpty($criteria->getAggregations());
+        static::assertNull($criteria->getLimit());
+        static::assertNull($criteria->getOffset());
+        static::assertCount(1, $criteria->getAssociations());
+        static::assertNotNull($criteria->getAssociation('children'));
+        static::assertEmpty($criteria->getAssociation('children')->getSorting());
+        static::assertEmpty($criteria->getAssociation('children')->getSource());
+        static::assertEmpty($criteria->getAssociation('children')->getFilters());
+        static::assertEmpty($criteria->getAssociation('children')->getPostFilters());
+        static::assertEmpty($criteria->getAssociation('children')->getAggregations());
+        static::assertEmpty($criteria->getAssociation('children')->getAssociations());
+        static::assertEquals(3, $criteria->getAssociation('children')->getLimit());
+        static::assertEquals(2, $criteria->getAssociation('children')->getOffset());
 
         static::assertInstanceOf(MediaFolderEntity::class, $folder);
         static::assertInstanceOf(MediaFolderCollection::class, $folder->getChildren());
@@ -797,6 +983,53 @@ class EntityRepositoryTest extends TestCase
         foreach ($firstIds as $id) {
             static::assertNotContains($id, $secondIds);
         }
+    }
+
+    public function testFilterConsistencyOnCriteriaObject(): void
+    {
+        $id = Uuid::randomHex();
+        $data = [
+            'id' => $id,
+            'name' => 'Main',
+            'children' => [
+                ['id' => Uuid::randomHex(), 'name' => 'Child1'],
+                ['id' => Uuid::randomHex(), 'name' => 'Child2'],
+            ],
+        ];
+
+        $repository = $this->createRepository(CategoryDefinition::class);
+        $context = Context::createDefaultContext();
+
+        $repository->create([$data], $context);
+        $newId = Uuid::randomHex();
+
+        $result = $repository->clone($id, $context, $newId);
+        static::assertInstanceOf(EntityWrittenContainerEvent::class, $result);
+
+        $written = $result->getEventByEntityName(CategoryDefinition::ENTITY_NAME);
+        static::assertCount(3, $written->getIds());
+        static::assertContains($newId, $written->getIds());
+
+        $criteria = new Criteria();
+        $criteria->addFilter(new MultiFilter(MultiFilter::CONNECTION_OR, [
+            new EqualsFilter('name', 'Child1'),
+            new EqualsFilter('name', 'Child2'),
+        ]));
+        $repository->search($criteria, $context);
+        static::assertEquals([], $criteria->getIds());
+        static::assertEmpty($criteria->getSorting());
+        static::assertEmpty($criteria->getSource());
+        static::assertCount(1, $criteria->getFilters());
+        static::assertEmpty($criteria->getPostFilters());
+        static::assertEmpty($criteria->getAggregations());
+        static::assertEmpty($criteria->getAssociations());
+        static::assertNull($criteria->getLimit());
+        static::assertNull($criteria->getOffset());
+        static::assertInstanceOf(MultiFilter::class, $criteria->getFilters()[0]);
+        /** @var MultiFilter $multiFilter */
+        $multiFilter = $criteria->getFilters()[0];
+        static::assertEquals(MultiFilter::CONNECTION_OR, $multiFilter->getOperator());
+        static::assertCount(2, $multiFilter->getQueries());
     }
 
     protected function createRepository(string $definition): EntityRepository


### PR DESCRIPTION
### 1. Why is this change necessary?
I have a pagination utility:

```php
<?php declare(strict_types=1);

namespace Heptacom\FooBar\Utility;

use Shopware\Core\Framework\Context;
use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
use Shopware\Core\Framework\DataAbstractionLayer\EntityRepositoryInterface;
use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;

abstract class Repository
{
    /**
     * @return \Traversable|EntityCollection[]
     */
    public static function page(EntityRepositoryInterface $repo, Criteria $criteria, Context $context): \Traversable
    {
        $criteria->setOffset(0);

        do {
            $result = $repo->search($criteria, $context);
            $entities = $result->getEntities();
            $resultCount = $result->count();
            yield $entities;
            unset($entities, $result);

            $criteria->setOffset($criteria->getOffset() + $resultCount);
        } while ($resultCount > 0);
    }
}
```
This makes it easy to paginate over a repository. Easy schmeezy. I let a long running process iterate over a googolplex entries an bump into an exception:
```
In EntityDefinitionQueryHelper.php line 43:
                                                              
  [Error]                                                     
  Maximum function nesting level of '256' reached, aborting!  
                                                              

Exception trace:
  at /platform/src/Core/Framework/DataAbstractionLayer/Dbal/EntityDefinitionQueryHelper.php:43
 mb_strpos() at /platform/src/Core/Framework/DataAbstractionLayer/Dbal/EntityDefinitionQueryHelper.php:43
 Shopware\Core\Framework\DataAbstractionLayer\Dbal\EntityDefinitionQueryHelper::escape() at /platform/src/Core/Framework/DataAbstractionLayer/Dbal/FieldAccessorBuilder/DefaultFieldAccessorBuilder.php:19
 Shopware\Core\Framework\DataAbstractionLayer\Dbal\FieldAccessorBuilder\DefaultFieldAccessorBuilder->buildAccessor() at /platform/src/Core/Framework/DataAbstractionLayer/Dbal/EntityDefinitionQueryHelper.php:701
 Shopware\Core\Framework\DataAbstractionLayer\Dbal\EntityDefinitionQueryHelper->buildFieldSelector() at /platform/src/Core/Framework/DataAbstractionLayer/Dbal/EntityDefinitionQueryHelper.php:688
 Shopware\Core\Framework\DataAbstractionLayer\Dbal\EntityDefinitionQueryHelper->buildInheritedAccessor() at /platform/src/Core/Framework/DataAbstractionLayer/Dbal/EntityDefinitionQueryHelper.php:183
 Shopware\Core\Framework\DataAbstractionLayer\Dbal\EntityDefinitionQueryHelper->getFieldAccessor() at /platform/src/Core/Framework/DataAbstractionLayer/Dbal/EntityDefinitionQueryHelper.php:217
 Shopware\Core\Framework\DataAbstractionLayer\Dbal\EntityDefinitionQueryHelper->getFieldAccessor() at /platform/src/Core/Framework/DataAbstractionLayer/Dbal/EntityDefinitionQueryHelper.php:217
 Shopware\Core\Framework\DataAbstractionLayer\Dbal\EntityDefinitionQueryHelper->getFieldAccessor() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:209
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parseEqualsFilter() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:94
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parse() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:276
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->iterateNested() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:240
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parseMultiFilter() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:106
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parse() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:276
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->iterateNested() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:240
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parseMultiFilter() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:106
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parse() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:276
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->iterateNested() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:240
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parseMultiFilter() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:106
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parse() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:276
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->iterateNested() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:240
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parseMultiFilter() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:106
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parse() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:276
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->iterateNested() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:240
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parseMultiFilter() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:106
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parse() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:276
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->iterateNested() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:240
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parseMultiFilter() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:106
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parse() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:276
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->iterateNested() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:240
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parseMultiFilter() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:106
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parse() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:276
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->iterateNested() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:240
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parseMultiFilter() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:106
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parse() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:276
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->iterateNested() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:240
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parseMultiFilter() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:106
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parse() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:276
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->iterateNested() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:240
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parseMultiFilter() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:106
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parse() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:276
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->iterateNested() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:240
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parseMultiFilter() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:106
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parse() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:276
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->iterateNested() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:240
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parseMultiFilter() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:106
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parse() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:276
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->iterateNested() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:240
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parseMultiFilter() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:106
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parse() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:276
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->iterateNested() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:240
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parseMultiFilter() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:106
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parse() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:276
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->iterateNested() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:240
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parseMultiFilter() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:106
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parse() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:276
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->iterateNested() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:240
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parseMultiFilter() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:106
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parse() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:276
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->iterateNested() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:240
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parseMultiFilter() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:106
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parse() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:276
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->iterateNested() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:240
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parseMultiFilter() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:106
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parse() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:276
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->iterateNested() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:240
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parseMultiFilter() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:106
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parse() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:276
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->iterateNested() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:240
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parseMultiFilter() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:106
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parse() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:276
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->iterateNested() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:240
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parseMultiFilter() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:106
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parse() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:276
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->iterateNested() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:240
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parseMultiFilter() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:106
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parse() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:276
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->iterateNested() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:240
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parseMultiFilter() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:106
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parse() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:276
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->iterateNested() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:240
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parseMultiFilter() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:106
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parse() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:276
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->iterateNested() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:240
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parseMultiFilter() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:106
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parse() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:276
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->iterateNested() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:240
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parseMultiFilter() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:106
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parse() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:276
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->iterateNested() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:240
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parseMultiFilter() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:106
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parse() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:276
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->iterateNested() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:240
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parseMultiFilter() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:106
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parse() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:276
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->iterateNested() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:240
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parseMultiFilter() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:106
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parse() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:276
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->iterateNested() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:240
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parseMultiFilter() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:106
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parse() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:276
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->iterateNested() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:240
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parseMultiFilter() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:106
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parse() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:276
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->iterateNested() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:240
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parseMultiFilter() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:106
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parse() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:276
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->iterateNested() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:240
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parseMultiFilter() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:106
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parse() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:276
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->iterateNested() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:240
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parseMultiFilter() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:106
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parse() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:276
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->iterateNested() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:240
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parseMultiFilter() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:106
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parse() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:276
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->iterateNested() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:240
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parseMultiFilter() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:106
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parse() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:276
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->iterateNested() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:240
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parseMultiFilter() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:106
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parse() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:276
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->iterateNested() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:240
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parseMultiFilter() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:106
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parse() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:276
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->iterateNested() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:240
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parseMultiFilter() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:106
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parse() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:276
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->iterateNested() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:240
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parseMultiFilter() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:106
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parse() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:276
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->iterateNested() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:240
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parseMultiFilter() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:106
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parse() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:276
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->iterateNested() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:240
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parseMultiFilter() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:106
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parse() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:276
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->iterateNested() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:240
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parseMultiFilter() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:106
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parse() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:276
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->iterateNested() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:240
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parseMultiFilter() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:106
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parse() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:276
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->iterateNested() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:240
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parseMultiFilter() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:106
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parse() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:276
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->iterateNested() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:240
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parseMultiFilter() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:106
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parse() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:276
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->iterateNested() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:240
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parseMultiFilter() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:106
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parse() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:276
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->iterateNested() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:240
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parseMultiFilter() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:106
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parse() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:276
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->iterateNested() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:240
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parseMultiFilter() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:106
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parse() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:276
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->iterateNested() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:240
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parseMultiFilter() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:106
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parse() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:276
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->iterateNested() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:240
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parseMultiFilter() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:106
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parse() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:276
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->iterateNested() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:240
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parseMultiFilter() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:106
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parse() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:276
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->iterateNested() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:240
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parseMultiFilter() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:106
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parse() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:276
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->iterateNested() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:240
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parseMultiFilter() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:106
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parse() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:276
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->iterateNested() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:240
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parseMultiFilter() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:106
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parse() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:276
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->iterateNested() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:240
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parseMultiFilter() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:106
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parse() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:276
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->iterateNested() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:240
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parseMultiFilter() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:106
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parse() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:276
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->iterateNested() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:240
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parseMultiFilter() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:106
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parse() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:276
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->iterateNested() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:240
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parseMultiFilter() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:106
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parse() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:276
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->iterateNested() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:240
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parseMultiFilter() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:106
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parse() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:276
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->iterateNested() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:240
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parseMultiFilter() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:106
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parse() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:276
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->iterateNested() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:240
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parseMultiFilter() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:106
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parse() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:276
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->iterateNested() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:240
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parseMultiFilter() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:106
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parse() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:276
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->iterateNested() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:240
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parseMultiFilter() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:106
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parse() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:276
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->iterateNested() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:240
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parseMultiFilter() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:106
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parse() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:276
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->iterateNested() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:240
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parseMultiFilter() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:106
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parse() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:276
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->iterateNested() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:240
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parseMultiFilter() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:106
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parse() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:276
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->iterateNested() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:240
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parseMultiFilter() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:106
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parse() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:276
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->iterateNested() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:240
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parseMultiFilter() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:106
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parse() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:276
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->iterateNested() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:240
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parseMultiFilter() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:106
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parse() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:276
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->iterateNested() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:240
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parseMultiFilter() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:106
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parse() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:276
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->iterateNested() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:240
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parseMultiFilter() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:106
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parse() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:276
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->iterateNested() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:240
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parseMultiFilter() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:106
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parse() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:276
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->iterateNested() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:240
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parseMultiFilter() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:106
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parse() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:276
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->iterateNested() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:240
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parseMultiFilter() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:106
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parse() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:276
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->iterateNested() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:240
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parseMultiFilter() at /platform/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php:106
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parse() at /platform/src/Core/Framework/DataAbstractionLayer/Dbal/CriteriaQueryHelper.php:143
 Shopware\Core\Framework\DataAbstractionLayer\Dbal\EntitySearcher->addFilter() at /platform/src/Core/Framework/DataAbstractionLayer/Dbal/CriteriaQueryHelper.php:88
 Shopware\Core\Framework\DataAbstractionLayer\Dbal\EntitySearcher->buildQueryByCriteria() at /platform/src/Core/Framework/DataAbstractionLayer/Dbal/EntitySearcher.php:85
 Shopware\Core\Framework\DataAbstractionLayer\Dbal\EntitySearcher->search() at /platform/src/Elasticsearch/Framework/DataAbstractionLayer/ElasticsearchEntitySearcher.php:53
 Shopware\Elasticsearch\Framework\DataAbstractionLayer\ElasticsearchEntitySearcher->search() at /platform/src/Core/Framework/DataAbstractionLayer/Cache/CachedEntitySearcher.php:74
 Shopware\Core\Framework\DataAbstractionLayer\Cache\CachedEntitySearcher->search() at /platform/src/Core/Profiling/Entity/EntitySearcherProfiler.php:34
 Shopware\Core\Profiling\Entity\EntitySearcherProfiler->search() at /platform/src/Core/Framework/DataAbstractionLayer/EntityRepository.php:134
 Shopware\Core\Framework\DataAbstractionLayer\EntityRepository->searchIds() at /platform/src/Core/Framework/DataAbstractionLayer/EntityRepository.php:90
 Shopware\Core\Framework\DataAbstractionLayer\EntityRepository->search() at /custom/plugins/heptacom-foobar/src/Utility/Repository.php:20
 Heptacom\FooBar\Utility\Repository::page() at /custom/plugins/heptacom-foobar/src/FooBar/Baz.php:51
 // ...
 Symfony\Component\Console\Command\Command->run() at /vendor/symfony/console/Application.php:1030
 Symfony\Component\Console\Application->doRunCommand() at /vendor/symfony/framework-bundle/Console/Application.php:97
 Symfony\Bundle\FrameworkBundle\Console\Application->doRunCommand() at /vendor/symfony/console/Application.php:272
 Symfony\Component\Console\Application->doRun() at /vendor/symfony/framework-bundle/Console/Application.php:83
 Symfony\Bundle\FrameworkBundle\Console\Application->doRun() at /vendor/symfony/console/Application.php:148
 Symfony\Component\Console\Application->run() at /bin/console:46
```

One might see the three level recursion of 
```
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parse() at SqlQueryParser.php:276
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->iterateNested() at SqlQueryParser.php:240
 Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser->parseMultiFilter() at SqlQueryParser.php:106
```
This is totally fine. Although one might be able to optimize `iterateNested` to stop this recursion by iterating the inner elements already and queuing them up but it is technically a correct way to work a nested filter. But wait? Why the fuck is there such a deep nesting? And why is this not crashing right away but after running some minutes. After some debugging I found a hell of multi filters with 1 1️⃣ in letters ONE child. The deepest tree leaves are my original filters. When do they stack you might ask?
![criteria-tree](https://user-images.githubusercontent.com/1133593/75435564-8367d880-5953-11ea-8643-c52b60948f8e.gif)

Well anytime I use an `EntityRepositoyInterface::search(Ids)?` call. The internal way of processing this criteria objects leak out of the process. Yikes!

### 2. What does this change do, exactly?
Stop leaking internal criteria changes by cloning the criteria first. Stop wrapping a single filter in a multi filter. The latter one is not really fixing it but stops this exact case from getting worse.

### 3. Describe each step to reproduce the issue or behaviour.
1. Choose a criteria object to re-use over multiple `EntityRepositoyInterface::search(Ids)?` call
2. A lot

### 4. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

### 5. Additionals

You still want to use such a pagination wrapper like I did without this PR merged? Just pass the criteria object as clone into it:
```php
<?php declare(strict_types=1);

namespace Heptacom\FooBar\Utility;

use Shopware\Core\Framework\Context;
use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
use Shopware\Core\Framework\DataAbstractionLayer\EntityRepositoryInterface;
use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;

abstract class Repository
{
    /**
     * @return \Traversable|EntityCollection[]
     */
    public static function page(EntityRepositoryInterface $repo, Criteria $criteria, Context $context): \Traversable
    {
        $criteria->setOffset(0);

        do {
            //                      vvvvv
            $result = $repo->search(clone $criteria, $context);
            $entities = $result->getEntities();
            $resultCount = $result->count();
            yield $entities;
            unset($entities, $result);

            $criteria->setOffset($criteria->getOffset() + $resultCount);
        } while ($resultCount > 0);
    }
}
```