### PR TITLE
sw-data-grid bulk panel is still shortened when action column is hidden

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/data-grid/sw-data-grid/sw-data-grid.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/data-grid/sw-data-grid/sw-data-grid.scss
@@ -250,11 +250,17 @@
         background: $color-white;
         font-size: 14px;
         left: 0;
-        right: 88px;
+        right: 0;
         height: 64px;
         z-index: 7;
         border-bottom: 1px inset $color-steam-cloud;
         padding: 20px 12px 20px 100px;
+    }
+
+    &.sw-data-grid--actions {
+        .sw-data-grid__bulk {
+            right: 88px;
+        }
     }
 
     .sw-data-grid__bulk-selected {


### PR DESCRIPTION
### 1. Why is this change necessary?
When using the `sw-data-grid` component and use selection but not the row action feature the bulk panel still thinks it has to have the action column width from its own width subtracted.
![grafik](https://user-images.githubusercontent.com/1133593/75471902-15430600-5993-11ea-8b5c-9525c31469fb.png)

### 2. What does this change do, exactly?
Make the width of the bulk panel depending on the fact whether row actions are used.
![grafik](https://user-images.githubusercontent.com/1133593/75471783-f3498380-5992-11ea-8392-a95b4a0182f4.png)

### 3. Describe each step to reproduce the issue or behaviour.
```
<sw-page>
    <template #content>
        <sw-data-grid :showActions="false"><!-- add some width-taking data --></sw-data-grid>
    </template>
</sw-page>
```

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
