### PR TITLE
Add store commands

### DIFF
--- a/src/Core/Framework/DependencyInjection/store.xml
+++ b/src/Core/Framework/DependencyInjection/store.xml
@@ -51,5 +51,21 @@
                 <argument>%kernel.project_dir%/vendor/shopware/core/Framework/Store/public.key</argument>
             </argument>
         </service>
+
+        <service id="Shopware\Core\Framework\Store\Command\StoreDownloadCommand">
+            <argument type="service" id="Shopware\Core\Framework\Store\Services\StoreClient" />
+            <argument type="service" id="plugin.repository" />
+            <argument type="service" id="Shopware\Core\Framework\Plugin\PluginManagementService" />
+            <argument type="service" id="Shopware\Core\Framework\Plugin\PluginLifecycleService" />
+            <argument type="service" id="user.repository" />
+            <tag name="console.command"/>
+        </service>
+
+        <service id="Shopware\Core\Framework\Store\Command\StoreLoginCommand">
+            <argument type="service" id="Shopware\Core\Framework\Store\Services\StoreClient" />
+            <argument type="service" id="user.repository" />
+            <argument type="service" id="Shopware\Core\System\SystemConfig\SystemConfigService"/>
+            <tag name="console.command"/>
+        </service>
     </services>
 </container>

--- a/src/Core/Framework/Store/Command/StoreDownloadCommand.php
+++ b/src/Core/Framework/Store/Command/StoreDownloadCommand.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopware\Core\Framework\Store\Command;
+
+use GuzzleHttp\Exception\ClientException;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepositoryInterface;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\Plugin\PluginEntity;
+use Shopware\Core\Framework\Plugin\PluginLifecycleService;
+use Shopware\Core\Framework\Plugin\PluginManagementService;
+use Shopware\Core\Framework\Store\Exception\CanNotDownloadPluginManagedByComposerException;
+use Shopware\Core\Framework\Store\Exception\StoreApiException;
+use Shopware\Core\Framework\Store\Exception\StoreTokenMissingException;
+use Shopware\Core\Framework\Store\Services\StoreClient;
+use Shopware\Core\System\User\UserEntity;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\HttpFoundation\Response;
+
+class StoreDownloadCommand extends Command
+{
+    static public $defaultName = 'store:download';
+
+    /**
+     * @var StoreClient
+     */
+    private $storeClient;
+
+    /**
+     * @var EntityRepositoryInterface
+     */
+    private $pluginRepo;
+
+    /**
+     * @var PluginManagementService
+     */
+    private $pluginManagementService;
+
+    /**
+     * @var PluginLifecycleService
+     */
+    private $pluginLifecycleService;
+
+    /**
+     * @var EntityRepositoryInterface
+     */
+    private $userRepository;
+
+    public function __construct(
+        StoreClient $storeClient,
+        EntityRepositoryInterface $pluginRepo,
+        PluginManagementService $pluginManagementService,
+        PluginLifecycleService $pluginLifecycleService,
+        EntityRepositoryInterface $userRepository
+    ) {
+        $this->storeClient = $storeClient;
+        $this->pluginRepo = $pluginRepo;
+        $this->pluginManagementService = $pluginManagementService;
+        $this->pluginLifecycleService = $pluginLifecycleService;
+        $this->userRepository = $userRepository;
+
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this->addOption('pluginName', 'p', InputOption::VALUE_REQUIRED, 'Name of plugin')
+            ->addOption('language', 'l', InputOption::VALUE_OPTIONAL, 'Language', '')
+            ->addOption('user', 'u', InputOption::VALUE_OPTIONAL, 'User')
+        ;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $context = Context::createDefaultContext();
+
+        $pluginName = $input->getOption('pluginName');
+        $language = $input->getOption('language');
+
+        $criteria = new Criteria();
+        $criteria->addFilter(new EqualsFilter('plugin.name', $pluginName));
+
+        /** @var PluginEntity|null $plugin */
+        $plugin = $this->pluginRepo->search($criteria, $context)->first();
+
+        if ($plugin !== null && $plugin->getManagedByComposer()) {
+            throw new CanNotDownloadPluginManagedByComposerException('can not downloads plugins managed by composer from store api');
+        }
+
+        $unauthenticated = !$input->getOption('user');
+        if ($unauthenticated) {
+            $storeToken = '';
+        } else {
+            $storeToken = $this->getUserStoreToken($context, $input->getOption('user'));
+        }
+
+        try {
+            $data = $this->storeClient->getDownloadDataForPlugin($pluginName, $storeToken, $language, !$unauthenticated);
+        } catch (ClientException $exception) {
+            throw new StoreApiException($exception);
+        }
+
+        $statusCode = $this->pluginManagementService->downloadStorePlugin($data->getLocation(), $context);
+        if ($statusCode !== Response::HTTP_OK) {
+            return $statusCode;
+        }
+
+        /** @var PluginEntity|null $plugin */
+        $plugin = $this->pluginRepo->search($criteria, $context)->first();
+        if ($plugin && $plugin->getUpgradeVersion()) {
+            $this->pluginLifecycleService->updatePlugin($plugin, $context);
+        }
+
+        return 0;
+    }
+
+    private function getUserStoreToken(Context $context, string $user): string
+    {
+        $criteria = new Criteria();
+        $criteria->addFilter(new EqualsFilter('user.username', $user));
+
+        /** @var UserEntity|null $user */
+        $user = $this->userRepository->search($criteria, $context)->first();
+
+        if ($user->getStoreToken() === null) {
+            throw new StoreTokenMissingException();
+        }
+
+        return $user->getStoreToken();
+    }
+}

--- a/src/Core/Framework/Store/Command/StoreLoginCommand.php
+++ b/src/Core/Framework/Store/Command/StoreLoginCommand.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopware\Core\Framework\Store\Command;
+
+use GuzzleHttp\Exception\ClientException;
+use RuntimeException;
+use Shopware\Core\Framework\Api\Context\AdminApiSource;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepositoryInterface;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\Store\Exception\StoreApiException;
+use Shopware\Core\Framework\Store\Exception\StoreInvalidCredentialsException;
+use Shopware\Core\Framework\Store\Services\StoreClient;
+use Shopware\Core\System\SystemConfig\SystemConfigService;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class StoreLoginCommand extends Command
+{
+    static public $defaultName = 'store:login';
+
+    /**
+     * @var StoreClient
+     */
+    private $storeClient;
+
+    /**
+     * @var SystemConfigService
+     */
+    private $configService;
+
+    /**
+     * @var EntityRepositoryInterface
+     */
+    private $userRepository;
+
+
+    public function __construct(
+        StoreClient $storeClient,
+        EntityRepositoryInterface $userRepository,
+        SystemConfigService $configService
+    ) {
+        $this->storeClient = $storeClient;
+        $this->userRepository = $userRepository;
+        $this->configService = $configService;
+
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this->addOption('shopwareId', 'i', InputOption::VALUE_REQUIRED, 'Shopware ID')
+            ->addOption('password', 'p', InputOption::VALUE_REQUIRED, 'Password')
+            ->addOption('user', 'u', InputOption::VALUE_REQUIRED, 'User')
+            ->addOption('host', 'g', InputOption::VALUE_OPTIONAL, 'License host')
+            ->addOption('language', 'l', InputOption::VALUE_OPTIONAL, 'Language', '')
+        ;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $context = Context::createDefaultContext();
+
+        $host = $input->getOption('host');
+        if (!empty($host)) {
+            $this->configService->set('core.store.licenseHost', $host);
+        }
+
+        $shopwareId = $input->getOption('shopwareId');
+        $password = $input->getOption('password');
+        $user = $input->getOption('user');
+        $language = $input->getOption('language');
+
+        $criteria = new Criteria();
+        $criteria->addFilter(new EqualsFilter('user.username', $user));
+
+        $userId = $this->userRepository->searchIds($criteria, $context)->firstId();
+
+        if ($userId === null) {
+            throw new RuntimeException('User not found');
+        }
+
+        $userContext = new Context(new AdminApiSource($userId));
+
+        if ($shopwareId === null || $password === null) {
+            throw new StoreInvalidCredentialsException();
+        }
+
+        try {
+            $accessTokenStruct = $this->storeClient->loginWithShopwareId($shopwareId, $password, $language, $userContext);
+        } catch (ClientException $exception) {
+            throw new StoreApiException($exception);
+        }
+
+        $this->configService->set('core.store.shopSecret', $accessTokenStruct->getShopSecret());
+        $this->configService->set('core.store.shopwareId', $shopwareId);
+
+        $this->userRepository->update([
+            ['id' => $userId, 'storeToken' => $accessTokenStruct->getShopUserToken()->getToken()],
+        ], $context);
+
+        return 0;
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?

It's necessary for automatic deployment.

### 2. What does this change do, exactly?

It add store commands. One for login into account and one to download a plugin from store.
The credentials will be saved on the user.
And the LicenseDomain and accountId in the database from the shop.

### 3. Describe each step to reproduce the issue or behaviour.

````
bin/console store:login -iAccountId -pPassword -uAdminUser -gLicenseDomain
bin/console store:download -pPluginName -uAdminUser
````
### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
