### PR TITLE
Fix customfields sorting

### DIFF
--- a/UPGRADE-6.2.md
+++ b/UPGRADE-6.2.md
@@ -189,7 +189,8 @@ Administration
             ]
         }
         ```
-
+* CustomFields are now sorted naturally when custom position is used with customFieldPosition (for example 1,9,10 instead of 1,10,9)
+ 
 Storefront
 ----------
 

--- a/src/Administration/Resources/app/administration/src/module/sw-category/page/sw-category-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-category/page/sw-category-detail/index.js
@@ -97,7 +97,7 @@ Component.register('sw-category-detail', {
             criteria.addFilter(Criteria.equals('relations.entityName', 'category'));
             criteria
                 .getAssociation('customFields')
-                .addSorting(Criteria.sort('config.customFieldPosition'));
+                .addSorting(Criteria.sort('config.customFieldPosition', 'ASC', true));
 
             return criteria;
         },

--- a/src/Administration/Resources/app/administration/src/module/sw-manufacturer/page/sw-manufacturer-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-manufacturer/page/sw-manufacturer-detail/index.js
@@ -91,7 +91,7 @@ Component.register('sw-manufacturer-detail', {
             );
 
             criteria.getAssociation('customFields')
-                .addSorting(Criteria.sort('config.customFieldPosition', 'ASC'))
+                .addSorting(Criteria.sort('config.customFieldPosition', 'ASC', true))
                 .setLimit(100);
 
             return criteria;

--- a/src/Administration/Resources/app/administration/src/module/sw-media/component/sidebar/sw-media-quickinfo/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-media/component/sidebar/sw-media-quickinfo/index.js
@@ -76,7 +76,7 @@ Component.register('sw-media-quickinfo', {
             const criteria = new Criteria(1, 100)
                 .addFilter(Criteria.equals('relations.entityName', 'media'))
                 .addAssociation('customFields')
-                .addSorting(Criteria.sort('config.customFieldPosition'))
+                .addSorting(Criteria.sort('config.customFieldPosition', 'ASC', true))
                 .setLimit(100);
 
             const searchResult = await this.customFieldSetRepository.search(criteria, Shopware.Context.api);

--- a/src/Administration/Resources/app/administration/src/module/sw-product/page/sw-product-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/page/sw-product-detail/index.js
@@ -143,7 +143,7 @@ Component.register('sw-product-detail', {
             criteria.addFilter(Criteria.equals('relations.entityName', 'product'));
             criteria
                 .getAssociation('customFields')
-                .addSorting(Criteria.sort('config.customFieldPosition'));
+                .addSorting(Criteria.sort('config.customFieldPosition', 'ASC', true));
 
             return criteria;
         },

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/page/sw-sales-channel-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/page/sw-sales-channel-detail/index.js
@@ -222,7 +222,7 @@ Component.register('sw-sales-channel-detail', {
 
             criteria.addFilter(Criteria.equals('relations.entityName', 'sales_channel'));
             criteria.getAssociation('customFields')
-                .addSorting(Criteria.sort('config.customFieldPosition'));
+                .addSorting(Criteria.sort('config.customFieldPosition', 'ASC', true));
 
             this.customFieldRepository
                 .search(criteria, Context.api)


### PR DESCRIPTION
### 1. Why is this change necessary?
Custom fields where not sorted naturally by customFieldPosition.
Before: 1,10,9
With this change: 1,9,10

### 2. What does this change do, exactly?
It sets the sort naturally flag on the custom fields.

### 3. Describe each step to reproduce the issue or behaviour.
Add product custom fields with customFieldPosition 1, 10 and 9

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
