### PR TITLE
Exclude plugin vendor directories from openapi search paths

### DIFF
--- a/src/Core/Framework/Api/ApiDefinition/Generator/OpenApi/OpenApiLoader.php
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/OpenApi/OpenApiLoader.php
@@ -5,6 +5,7 @@ namespace Shopware\Core\Framework\Api\ApiDefinition\Generator\OpenApi;
 use OpenApi\Annotations\OpenApi;
 use OpenApi\Annotations\Operation;
 use OpenApi\Annotations\UNDEFINED;
+use Symfony\Component\Finder\Finder;
 use const OpenApi\Annotations\UNDEFINED;
 use function OpenApi\scan;
 
@@ -38,7 +39,8 @@ class OpenApiLoader
             // plugins
             $this->rootDir . '/custom/plugins',
         ];
-        $openApi = scan($pathsToScan, ['analysis' => new DeactivateValidationAnalysis()]);
+        $pathsToExclude = $this->pluginVendorDirectories();
+        $openApi = scan($pathsToScan, ['analysis' => new DeactivateValidationAnalysis(), 'exclude' => $pathsToExclude]);
 
         $allUndefined = true;
         $calculatedPaths = [];
@@ -59,6 +61,13 @@ class OpenApiLoader
         $openApi->paths = $calculatedPaths;
 
         return $openApi;
+    }
+
+    private function pluginVendorDirectories(): array
+    {
+        $finder = (new Finder())->directories()->in($this->rootDir . '/custom/plugins')->depth(1)->name('vendor');
+
+        return array_keys(iterator_to_array($finder));
     }
 
     private function getTagForApi(bool $forSalesChannel): string

--- a/src/Core/Framework/Test/Api/ApiDefinition/Generator/FlysystemReadOnlyStreamWrapper.php
+++ b/src/Core/Framework/Test/Api/ApiDefinition/Generator/FlysystemReadOnlyStreamWrapper.php
@@ -1,0 +1,245 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\Test\Api\ApiDefinition\Generator;
+
+use League\Flysystem\FileNotFoundException;
+use League\Flysystem\Filesystem;
+use Shopware\Core\Framework\Test\TestCaseBase\FilesystemBehaviour;
+use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
+
+/**
+ * Incomplete adapter to make Flysystem usable via stream wrapper.
+ *
+ * It allows using the test Flysystem instance with file system related code expecting string paths.
+ * This class only implements the methods for reading files and directories, writes have to be
+ * done using the Flysystem instance directly.
+ */
+class FlysystemReadOnlyStreamWrapper
+{
+    use KernelTestBehaviour;
+    use FilesystemBehaviour;
+
+    private const MODES = [
+        'file' => 0100644, // rw-r--r--
+        'dir' => 0040755,  // rwxr-xr-x
+    ];
+
+    /**
+     * @var string
+     */
+    private $filePath;
+
+    /**
+     * @var int
+     */
+    private $fileOffset = 0;
+
+    /**
+     * @var mixed[]
+     */
+    private $dirListing = [];
+
+    public function stream_open(string $path, string $mode, int $options, ?string &$openedPath): bool
+    {
+        $filePath = $this->parseWrapperFilename($path);
+
+        if (!$this->isFile($filePath)) {
+            return false;
+        }
+
+        $this->filePath = $filePath;
+        $this->fileOffset = 0;
+
+        return true;
+    }
+
+    public function stream_read(int $count): string
+    {
+        $buffer = mb_substr($this->getFileContents(), $this->fileOffset, $count);
+        $this->fileOffset = min($this->fileOffset + $count, $this->getSize());
+
+        return $buffer;
+    }
+
+    public function stream_tell(): int
+    {
+        return $this->fileOffset;
+    }
+
+    public function stream_eof(): bool
+    {
+        return $this->getSize() === $this->fileOffset;
+    }
+
+    public function stream_seek(int $offset, int $whence = SEEK_SET): bool
+    {
+        $setters = [
+            SEEK_SET => 'setAbsoluteOffset',
+            SEEK_CUR => 'setRelativeOffset',
+            SEEK_END => 'setOffsetFromEnd',
+        ];
+
+        return isset($setters[$whence])
+            ? $this->{$setters[$whence]}($offset)
+            : false;
+    }
+
+    /**
+     * @return array|bool
+     */
+    public function stream_stat()
+    {
+        return $this->url_stat($this->filePath, 0);
+    }
+
+    /**
+     * @return array|bool
+     */
+    public function url_stat(string $path, int $flags)
+    {
+        $filePath = $this->parseWrapperFilename($path);
+        $type = $this->getItemType($filePath);
+        if (!isset(self::MODES[$type])) {
+            return false;
+        }
+        $size = $this->isFile($filePath) ? $this->getMetadata($filePath)['size'] : 0;
+        $timestamp = $this->getMetadata($filePath)['timestamp'] ?? 0;
+
+        return [
+            1 => 0,
+            'ino' => 0,
+            2 => self::MODES[$type],
+            'mode' => self::MODES[$type],
+            3 => 0,
+            'nlink' => 0,
+            4 => 0,
+            'uid' => 0,
+            5 => 0,
+            'gid' => 0,
+            6 => 0,
+            'rdev' => 0,
+            7 => $size,
+            'size' => $size,
+            8 => $timestamp,
+            'atime' => $timestamp,
+            9 => $timestamp,
+            'mtime' => $timestamp,
+            10 => $timestamp,
+            'ctime' => $timestamp,
+            11 => 0,
+            'blksize' => 0,
+            12 => 0,
+            'blocks' => 0,
+        ];
+    }
+
+    public function dir_opendir(string $path, int $options): bool
+    {
+        $filename = $this->parseWrapperFilename($path);
+
+        if ($this->isDir($filename)) {
+            $this->dirListing = $this->getFilesystemInstance()->listContents($filename);
+
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * @return string|bool
+     */
+    public function dir_readdir()
+    {
+        $item = current($this->dirListing);
+        next($this->dirListing);
+
+        return $item['basename'] ?? false;
+    }
+
+    public function dir_rewinddir(): bool
+    {
+        reset($this->dirListing);
+
+        return true;
+    }
+
+    private function getFilesystemInstance(): Filesystem
+    {
+        return $this->getFilesystem('shopware.filesystem.private');
+    }
+
+    private function parseWrapperFilename(string $path): string
+    {
+        $parts = parse_url(str_replace(':///', '://', $path));
+
+        return ($parts['host'] ?? '') . ($parts['path'] ?? '');
+    }
+
+    private function getMetadata(string $filename): array
+    {
+        try {
+            return $this->getFilesystemInstance()->getMetadata($filename);
+        } catch (FileNotFoundException $exception) {
+            return [];
+        }
+    }
+
+    private function getSize(): int
+    {
+        return $this->getMetadata($this->filePath)['size'];
+    }
+
+    private function getFileContents(): string
+    {
+        return $this->getFilesystemInstance()->read($this->filePath);
+    }
+
+    private function setAbsoluteOffset(int $offset): bool
+    {
+        if ($offset < $this->getSize() && $offset >= 0) {
+            $this->fileOffset = $offset;
+
+            return true;
+        }
+
+        return false;
+    }
+
+    private function setRelativeOffset(int $offset): bool
+    {
+        return $offset >= 0
+            ? $this->setAbsoluteOffset($this->fileOffset + $offset)
+            : false;
+    }
+
+    private function setOffsetFromEnd(int $offset): bool
+    {
+        $size = $this->getSize();
+
+        return strlen($size) + $offset >= 0
+            ? $this->setAbsoluteOffset(strlen($size) + $offset)
+            : false;
+    }
+
+    private function getItemType(string $filePath): string
+    {
+        try {
+            $data = $this->getMetadata($filePath);
+
+            return $data['type'] ?? '';
+        } catch (FileNotFoundException $exception) {
+            return '';
+        }
+    }
+
+    private function isDir(string $filePath): bool
+    {
+        return $this->getItemType($filePath) === 'dir';
+    }
+
+    private function isFile(string $filePath): bool
+    {
+        return $this->getItemType($filePath) === 'file';
+    }
+}

--- a/src/Core/Framework/Test/Api/ApiDefinition/Generator/OpenApiLoaderTest.php
+++ b/src/Core/Framework/Test/Api/ApiDefinition/Generator/OpenApiLoaderTest.php
@@ -1,0 +1,73 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\Test\Api\ApiDefinition\Generator;
+
+use League\Flysystem\Filesystem;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Api\ApiDefinition\Generator\OpenApi\OpenApiLoader;
+use Shopware\Core\Framework\Api\Controller\ApiController;
+use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
+
+class OpenApiLoaderTest extends TestCase
+{
+    use IntegrationTestBehaviour;
+
+    private const TESTFS = 'testfs';
+
+    /**
+     * @before
+     */
+    public function registerTestFileStreamWrapper(): void
+    {
+        stream_wrapper_register(self::TESTFS, FlysystemReadOnlyStreamWrapper::class);
+    }
+
+    /**
+     * @after
+     */
+    public function unregisterTestFileStreamWrapper(): void
+    {
+        stream_wrapper_unregister(self::TESTFS);
+    }
+
+    /**
+     * @OA\Get(
+     *      path="/_testDummyDeclarationFromPluginVendorDir",
+     *      description="Dummy API declaration for testing purposes",
+     *      operationId="testDummy",
+     *      tags={},
+     *      @OA\Response(
+     *          response="400",
+     *          ref="#/components/responses/400"
+     *      )
+     * )
+     */
+    public function testOpenApiLoaderExcludesFilesInPluginVendorDirectories(): void
+    {
+        $sourceFileWithApiDeclarations = (new \ReflectionClass(ApiController::class))->getFileName();
+
+        $pluginFile = '/custom/plugins/TestPlugin/Core/Controller/ApiController.php';
+        $pluginVendorFile = '/custom/plugins/TestPlugin/vendor/some/library/src/Core/ApiController.php';
+
+        $fileSystem = $this->getFilesystem('shopware.filesystem.private');
+        $this->createOpenApiLoaderSearchPathDirectories($fileSystem);
+        $fileSystem->put($pluginFile, file_get_contents($sourceFileWithApiDeclarations));
+        $fileSystem->put($pluginVendorFile, file_get_contents(__FILE__));
+
+        $openApi = (new OpenApiLoader(self::TESTFS . '://'))->load(false);
+        $apiDeclarations = json_decode($openApi->toJson(), true);
+
+        $message1 = 'Expected API declaration from file in plugin folder was not loaded.';
+        static::assertArrayHasKey('/_search', $apiDeclarations['paths'], $message1);
+
+        $message2 = 'API declaration from file in plugin vendor folder was not expected to be loaded.';
+        static::assertArrayNotHasKey('/_testDummyDeclarationFromPluginVendorDir', $apiDeclarations['paths'], $message2);
+    }
+
+    private function createOpenApiLoaderSearchPathDirectories(Filesystem $fileSystem): void
+    {
+        $fileSystem->createDir('/src');
+        $fileSystem->createDir('/vendor/shopware');
+        $fileSystem->createDir('/custom/plugins');
+    }
+}


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/community).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?

When installing dependencies in plugins in order to execute unit tests in isolation from the shopware development system, the OpenApiLoader used up all available memory (tested with 16G memory_limit).

I agree this is an edge case, but it cost me 4-5 hours to figure out why the swagger UI wasn't loading. I hope this will save someone else the trouble.

### 2. What does this change do, exactly?

This commit excludes vendor directories within custom/plugins/* from the OpenApiLoader search path.

### 3. Describe each step to reproduce the issue or behaviour.

1. Create a plugin that requires `"shopware/platform": "6.1.x@dev"` in its `composer.json.
2. Run `composer install` in the plugin directory
3. Try to open the swagger UI at /api/v1/_info/swagger.html

### 4. Please link to the relevant issues (if any).

No issue.

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes <-- none are required
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
