### PR TITLE
Fix node version info for HRM

### DIFF
--- a/src/Docs/Resources/current/1-getting-started/10-requirements/__categoryInfo.md
+++ b/src/Docs/Resources/current/1-getting-started/10-requirements/__categoryInfo.md
@@ -14,7 +14,7 @@ PHP
 *  7.2 or higher
 * `memory_limit` 512M minimum
 * `max_execution_time` 30 seconds minimum
-* Extensions: 
+* Extensions:
     * ext-curl
     * ext-dom  
     * ext-fileinfo  
@@ -38,13 +38,13 @@ PHP
 SQL
 * MySQL 5.7.21 or higher
 * MariaDB 10.3 or higher
-    
+
 JavaScript
-* Node.js 8.10.0 or higher
+* Node.js 8.10.0 or higher (10.x if you want to use ./psh.phar storefront:hot)
 * NPM 6.5.0 or higher
 
 Various
-* Apache 2.4 or higher with mod-rewrite enabled 
+* Apache 2.4 or higher with mod-rewrite enabled
 * Bash
 * Git
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/community).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
It is not possbile to run the HRM with Node 8.x

### 2. What does this change do, exactly?
Add info for devs

### 3. Describe each step to reproduce the issue or behaviour.
Try to run HRM with recommended Node Version

### 4. Please link to the relevant issues (if any).
https://forum.shopware.com/discussion/66496/undefined-tld-bei-storefront-hot?new=1

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
