### PR TITLE
NEXT-4890 - Adds media association in loadLevel

### DIFF
--- a/src/Core/Content/Category/Service/NavigationLoader.php
+++ b/src/Core/Content/Category/Service/NavigationLoader.php
@@ -106,6 +106,7 @@ class NavigationLoader implements NavigationLoaderInterface
 
         $criteria = new Criteria();
         $criteria->addFilter(new EqualsFilter('category.parentId', $categoryId));
+        $criteria->addAssociation('media');
 
         /** @var CategoryCollection $categories */
         $categories = $this->categoryRepository->search($criteria, $context)->getEntities();


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/community).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
The media data is missing in the offcanvas menu when loading a new category level via ajax (/widgets/menu/offcanvas).

### 2. What does this change do, exactly?
`$criteria->addAssociation('media');`

### 3. Describe each step to reproduce the issue or behaviour.
Try to access `item.category.media` in `@Storefront/storefront/layout/navigation/offcanvas/item-link.html.twig` while changing the category in the offcanvas menu (works for the initial load of the current level).

### 4. Please link to the relevant issues (if any).
Seems related: https://issues.shopware.com/issues/NEXT-4890

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
