### PR TITLE
Hellip metaDescription and tab-preview

### DIFF
--- a/src/Storefront/Resources/views/storefront/layout/meta.html.twig
+++ b/src/Storefront/Resources/views/storefront/layout/meta.html.twig
@@ -1,7 +1,7 @@
 {% block layout_head_inner %}
     {% set metaInformation = page.metaInformation %}
     {% set basicConfig = shopware.config.core.basicInformation %}
-    {% set metaDescription = metaInformation.metaDescription|striptags|trim|u.truncate(shopware.config.seo.descriptionMaxLength ?? 160) %}
+    {% set metaDescription = metaInformation.metaDescription|striptags|trim|u.truncate(shopware.config.seo.descriptionMaxLength ?? 160, '…') %}
     {% set metaTitle = metaInformation.metaTitle|striptags|trim %}
     {% set metaKeywords = metaInformation.metaKeywords|striptags|trim %}
 

--- a/src/Storefront/Resources/views/storefront/page/product-detail/tabs.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/product-detail/tabs.html.twig
@@ -22,7 +22,7 @@
                                     </span>
                                     {% if page.product.translated.description|length > 0 %}
                                         <span class="product-detail-tab-preview">
-                                            {{ page.product.translated.description|raw|striptags|u.truncate(125) }}
+                                            {{ page.product.translated.description|raw|striptags|u.truncate(125, '…') }}
 
                                             {# truncate always cuts down the length to 125 characters.
                                                So it will only shorten the string if it exceeds 125 chars.


### PR DESCRIPTION
### 1. Why is this change necessary?
Hellips should be used while truncating.  The hellips where default in abandoned TwigExtensions, which has been replaced by [u-Filter](https://twig.symfony.com/doc/3.x/filters/u.html)

### 2. What does this change do, exactly?
Add hellips for truncated metaDescription and preview of detail-tab.
There are some other occurrences for truncate. But I wasn't able to find out in what way they are important.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
