### PR TITLE
use shipping address in delivery_note template instead of billing address

### DIFF
--- a/src/Core/Framework/Resources/views/documents/delivery_note.html.twig
+++ b/src/Core/Framework/Resources/views/documents/delivery_note.html.twig
@@ -8,6 +8,24 @@
     <h1>{% trans with {'%deliveryNoteNumber%': config.custom.deliveryNoteNumber, '%orderNumber%': order.orderNumber} %}document.deliveryNoteHeadline{% endtrans %}</h1>
 {% endblock %}
 
+{% block document_recipient %}
+    {% set firstDelivery = order.deliveries|first %}
+    {% set deliveryAddressId = firstDelivery.shippingOrderAddressId %}
+    {% set deliveryAddress = order.addresses.get(deliveryAddressId) %}
+    <span class="sender-address-small">
+        {% block document_recipient_sender %}
+            {{ config.companyAddress }}<br><br>
+        {% endblock %}
+    </span>
+    {% if deliveryAddress.company %}
+        {{ deliveryAddress.company }}<br>
+    {% endif %}
+    {{ deliveryAddress.firstName }} {{ deliveryAddress.lastName }}<br>
+    {{ deliveryAddress.street }}<br>
+    {{ deliveryAddress.zipcode }} {{ deliveryAddress.city }}<br>
+    {{ deliveryAddress.country.name }}<br>
+{% endblock %}
+
 {% block document_side_info_contents %}
     {{ parent() }}
     <tr><td>{% trans with {'%deliveryDate%': config.custom.deliveryDate|format_date('medium', locale=order.saleschannel.language.locale.code)} %}document.deliveryDate{% endtrans %}</td></tr>


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/community).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
Normally (and in Shopware 5) the shipping-address is used in the delivery note.

### 2. What does this change do, exactly?
Now the delivery_note template alters the document_recipient block to output the shipping address instead of the billing address, wich is used in the base document template

### 3. Describe each step to reproduce the issue or behaviour.
Generate a delivery note in the backend.

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
