### PR TITLE
Update SyncController.php

### DIFF
--- a/src/Core/Framework/Api/Controller/SyncController.php
+++ b/src/Core/Framework/Api/Controller/SyncController.php
@@ -4,7 +4,7 @@ namespace Shopware\Core\Framework\Api\Controller;
 
 use Shopware\Core\Framework\Api\Sync\SyncBehavior;
 use Shopware\Core\Framework\Api\Sync\SyncOperation;
-use Shopware\Core\Framework\Api\Sync\SyncService;
+use Shopware\Core\Framework\Api\Sync\SyncServiceInterface;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Routing\Annotation\RouteScope;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
@@ -27,11 +27,11 @@ class SyncController extends AbstractController
     private $serializer;
 
     /**
-     * @var SyncService
+     * @var SyncServiceInterface
      */
     private $syncService;
 
-    public function __construct(SyncService $syncService, Serializer $serializer)
+    public function __construct(SyncServiceInterface $syncService, Serializer $serializer)
     {
         $this->serializer = $serializer;
         $this->syncService = $syncService;


### PR DESCRIPTION
Require SyncServiceInterface instead of SyncService at the SyncController

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/community).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
We extend / override the SyncService and then when we make an api call to the SyncController it causes an error because the Controller requires the SyncService instead of the SyncServiceInterrface.

### 2. What does this change do, exactly?
Change the requirement of the SyncService to the SyncServiceInterface at the SyncController.

### 3. Describe each step to reproduce the issue or behaviour.
When you extend / override the SyncService an you make an api call, it causes an error because the SyncController needs the original SyncService of Shopware.

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes -> not needed
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
