### PR TITLE
fix subscribe to newsletter for unsubscribed customers

### DIFF
--- a/src/Core/Content/Newsletter/NewsletterSubscriptionService.php
+++ b/src/Core/Content/Newsletter/NewsletterSubscriptionService.php
@@ -117,7 +117,7 @@ class NewsletterSubscriptionService implements NewsletterSubscriptionServiceInte
 
         $data = $this->completeData($data, $context);
 
-        $this->newsletterRecipientRepository->create([$data], $context->getContext());
+        $this->newsletterRecipientRepository->upsert([$data], $context->getContext());
 
         $recipient = $this->getNewsletterRecipient('email', $data['email'], $context->getContext());
 


### PR DESCRIPTION
### 1. Why is this change necessary?
if you want to subscribe to the newsletter but you have been subscribed before, an error will occur.
It doesn't matter if you are subscribed already or are unsubscribed again. As soon as your email is stored in `newsletter_recipient` the subscribe action will fail.

### 2. What does this change do, exactly?
changes the subscribe query from `create` to `upsert`

### 3. Describe each step to reproduce the issue or behaviour.
subscribe to newsletter -> subscribe again
or
subscribe to newsletter -> unsubscribe -> subscribe again

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
