### PR TITLE
Allow override frame options

### DIFF
--- a/src/Core/Framework/Api/EventListener/ResponseHeaderListener.php
+++ b/src/Core/Framework/Api/EventListener/ResponseHeaderListener.php
@@ -24,17 +24,20 @@ class ResponseHeaderListener implements EventSubscriberInterface
 
     public function onResponse(ResponseEvent $event): void
     {
+        $headersBag = $event->getResponse()->headers;
         foreach (self::HEADERS as $header) {
-            $event->getResponse()->headers->set(
+            $headersBag->set(
                 $header,
                 $event->getRequest()->headers->get($header),
                 false
             );
         }
-        $event->getResponse()->headers->set(
-            PlatformRequest::HEADER_FRAME_OPTIONS,
-            'deny',
-            false
-        );
+        if (!$headersBag->has(PlatformRequest::HEADER_FRAME_OPTIONS)) {
+            $headersBag->set(
+                PlatformRequest::HEADER_FRAME_OPTIONS,
+                'deny',
+                false
+            );
+        }
     }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?

https://forum.shopware.com/discussion/66699/keine-einbindung-ueber-iframe-oder-object-data-moeglich#latest

### 2. What does this change do, exactly?

It checks if the header are already set.

### 3. Describe each step to reproduce the issue or behaviour.

Try to include a shop page in a iframe.
Try to override the request.
2 headers will be set and it not work.

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.
