### PR TITLE
Update 050-filter-search-limit.md

### DIFF
--- a/src/Docs/Resources/current/3-api/050-filter-search-limit.md
+++ b/src/Docs/Resources/current/3-api/050-filter-search-limit.md
@@ -558,9 +558,9 @@ The `sort` parameter controls the sorting of the result. Several sorts can be pa
 ```json
 {
     "sort": [
-        { "field": "stock", "direction": "DESC" },
-        { "field": "price", "direction": "ASC" },
-        { "field": "productNumber", "direction": "asc", "naturalSorting":  true}
+        { "field": "stock", "order": "DESC" },
+        { "field": "price", "order": "ASC" },
+        { "field": "productNumber", "order": "asc", "naturalSorting":  true}
     ]
 }
 ```


### PR DESCRIPTION
### 1. Why is this change necessary?
Fix an error in the docs.

### 2. What does this change do, exactly?
Fixes an invalid key for performing sorting with the sales channel api.

### 3. Describe each step to reproduce the issue or behaviour.
The key "direction" does nothing, it is actually "order"

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.
