### PR TITLE
Move schema folder for generated .sql files to the root directory

### DIFF
--- a/src/Core/Framework/DataAbstractionLayer/Command/CreateSchemaCommand.php
+++ b/src/Core/Framework/DataAbstractionLayer/Command/CreateSchemaCommand.php
@@ -36,7 +36,7 @@ class CreateSchemaCommand extends Command
         parent::__construct();
         $this->schemaGenerator = $generator;
         $this->registry = $registry;
-        $this->dir = $rootDir . '/../schema/';
+        $this->dir = $rootDir . '/schema/';
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int

--- a/src/Core/Framework/DependencyInjection/data-abstraction-layer.xml
+++ b/src/Core/Framework/DependencyInjection/data-abstraction-layer.xml
@@ -11,7 +11,7 @@
         <service id="Shopware\Core\Framework\DataAbstractionLayer\Command\CreateSchemaCommand">
             <argument type="service" id="Shopware\Core\Framework\DataAbstractionLayer\SchemaGenerator"/>
             <argument type="service" id="Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry"/>
-            <argument>%kernel.root_dir%</argument>
+            <argument>%kernel.project_dir%</argument>
 
             <tag name="console.command"/>
         </service>

--- a/src/Docs/Resources/current/4-how-to/170-plugin-migrations.md
+++ b/src/Docs/Resources/current/4-how-to/170-plugin-migrations.md
@@ -75,13 +75,16 @@ First you should create the migration class with `bin/console database:create-mi
 This command will create a class with a unique timestamp and the two update methods.
 
 ### SQL schema
-After that you could execute the following command: `bin/console dal:create:schema`
-This command selects all active entity definitions known to Shopware and tries to create SQL queries on base of the fields.
+After that you could execute the following command: `bin/console dal:create:schema`.
+
+This command selects **all active entity definitions** known to Shopware and tries to create SQL queries on base of the fields.
 *Note: Your plugin has to be activated, otherwise your custom entity definition will not be considered.*
-The queries are outputted into `/schema`.
+
+The `*.sql` files with the SQL queries are saved into the `/schema` folder within your project root directory where your `composer.json` lives.
 Search for the correct SQL file and copy the query to your migration file. 
+
 *Note: This command is in beta state and should not be used blindly*
-Double check if the generated SQL query really fits your needs.
+Double check if the generated SQL query really fits your needs. Keep in mind that you should delete the generated folder after you copied your necessary files.
 
 ## Source
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/community).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
Generated files should not live within the `vendor` directory. Instead place the files into the project root directory

### 2. What does this change do, exactly?
Change the location of the `schema` folder for generated .sql files.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
