### PR TITLE
Fixed z-index issue from editor inline toolbar within a modal

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-text-editor/sw-text-editor-toolbar/sw-text-editor-toolbar.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-text-editor/sw-text-editor-toolbar/sw-text-editor-toolbar.scss
@@ -14,7 +14,7 @@ $sw-text-editor-toolbar-item-color-boxed: #9aa8b5;
     justify-items: center;
     position: absolute;
     user-select: none;
-    z-index: 1000;
+    z-index: 2000;
 
     &::before {
         content: '';

--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-text-editor/sw-text-editor-toolbar/sw-text-editor-toolbar.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-text-editor/sw-text-editor-toolbar/sw-text-editor-toolbar.scss
@@ -14,7 +14,7 @@ $sw-text-editor-toolbar-item-color-boxed: #9aa8b5;
     justify-items: center;
     position: absolute;
     user-select: none;
-    z-index: 250;
+    z-index: 1000;
 
     &::before {
         content: '';


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/8193345/76384736-704c0400-6368-11ea-9100-aee006e3784c.png)


<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/community).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
If you have the inline-editor within a modal the toolbar is behind the modal.
`.sw-modal` contains `$z-index-modal` where the value is 1000. So the toolbar needs at least a `z-index: 1001`. To have an even number and enough space to the modal z-index i set the z-index to `2000` of `.sw-text-editor-toolbar.scss `.


### 2. What does this change do, exactly?
Change z-index of the inline text-editor toolbar

### 3. Describe each step to reproduce the issue or behaviour.
Open the CMS element settings which are having the inline text-editor and try to change the text.

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
