### PR TITLE
Use disabled cache to look up data to link to sales channel

### DIFF
--- a/src/Core/System/SalesChannel/Command/SalesChannelCreateCommand.php
+++ b/src/Core/System/SalesChannel/Command/SalesChannelCreateCommand.php
@@ -10,6 +10,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepositoryInterface;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\IdSearchResult;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Sorting\FieldSorting;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\WriteException;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -234,11 +235,16 @@ class SalesChannelCreateCommand extends Command
     {
         $repository = $this->definitionRegistry->getRepository($entity);
 
+        /** @var IdSearchResult $ids */
+        $ids = $context->disableCache(function (Context $context) use ($repository): IdSearchResult {
+            return $repository->searchIds(new Criteria(), $context);
+        });
+
         return array_map(
             function (string $id) {
                 return ['id' => $id];
             },
-            $repository->searchIds(new Criteria(), $context)->getIds()
+            $ids->getIds()
         );
     }
 


### PR DESCRIPTION
### 1. Why is this change necessary?
When the cache is not up to date it tries to link non-existant languages to the sales channel. That is forbidden by database constraints.

### 2. What does this change do, exactly?
Wraps a search ids in a disableCache callback. 

### 3. Describe each step to reproduce the issue or behaviour.
1. Use https://github.com/shopware/production/pull/24
2. Run the added command
3. Add new sales channel with changed locales without deleting cache first

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
