### PR TITLE
Allow setting displayType on element-level

### DIFF
--- a/src/Storefront/Resources/views/storefront/component/listing/filter/filter-property-select.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/listing/filter/filter-property-select.html.twig
@@ -2,6 +2,9 @@
 
 {% block component_filter_multi_select_list_item %}
     <li class="filter-multi-select-list-item filter-property-select-list-item">
+        {% if element.displayType %}
+            {% set displayType = element.displayType %}
+        {% endif %}
         {% if displayType == 'color' or displayType == 'media' %}
             {% set color = element.colorHexCode %}
             {% set media = element.media.url %}


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/community).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
It is a feature to allow user to set `displayType` of property filter to be on an element-level. Right now if a color filter also have an image, we cannot show a color for another element in the filter items if an image for that filter item is not found.

### 2. What does this change do, exactly?
This change checks if a `displayType` is set on a filter item (element) then it replaces the displayType of the filter in the template. That way for e.g if a `color` filter element is an image and that image is not found, they displayType can be changed to `color` on an element level instead of showing blank media.

### 3. Describe each step to reproduce the issue or behaviour.

### 4. Please link to the relevant issues (if any).

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
