### PR TITLE
Plugin name question

### DIFF
--- a/src/Core/Framework/Plugin/Command/PluginCreateCommand.php
+++ b/src/Core/Framework/Plugin/Command/PluginCreateCommand.php
@@ -7,6 +7,7 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\Question;
 
 class PluginCreateCommand extends Command
 {
@@ -93,7 +94,7 @@ EOL;
     protected function configure(): void
     {
         $this
-            ->addArgument('name', InputArgument::REQUIRED)
+            ->addArgument('name', InputArgument::OPTIONAL)
             ->addOption('create-config', 'c', InputOption::VALUE_NONE, 'Create config.xml')
             ->setDescription('Creates a plugin skeleton');
     }
@@ -104,6 +105,12 @@ EOL;
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $name = $input->getArgument('name');
+
+        if (!$name) {
+            $question = new Question('Please enter a plugin name: ');
+            $name = $this->getHelper('question')->ask($input, $output, $question);
+        }
+
         $name = ucfirst($name);
 
         $directory = $this->projectDir . '/custom/plugins/' . $name;

--- a/src/Storefront/Theme/Command/ThemeCreateCommand.php
+++ b/src/Storefront/Theme/Command/ThemeCreateCommand.php
@@ -35,13 +35,11 @@ class ThemeCreateCommand extends Command
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $io = new SymfonyStyle($input, $output);
-        $helper = $this->getHelper('question');
-
         $themeName = $input->getArgument('theme-name');
 
         if (!$themeName) {
-            $question = new Question('Please enter a theme name:');
-            $themeName = $helper->ask($input, $output, $question);
+            $question = new Question('Please enter a theme name: ');
+            $themeName = $this->getHelper('question')->ask($input, $output, $question);
         }
 
         if (preg_match('/^[A-Za-z]\w{3,}$/', $themeName) !== 1) {


### PR DESCRIPTION
### 1. Why is this change necessary?
1. It provides a consistent behaviour.
2. My change only calls getHelper() if it's actually required 

### 2. What does this change do, exactly?
The change makes the plugin creation command ask for a plugin name if not provided.
(Basically copied from template:create)

### 3. Describe each step to reproduce the issue or behaviour.
`bin/console plugin:create`

### 4. Please link to the relevant issues (if any).
I didn't find one

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.
