### PR TITLE
bundle:dump | _info/config like symfony assets:install

### DIFF
--- a/src/Core/Framework/Api/Controller/InfoController.php
+++ b/src/Core/Framework/Api/Controller/InfoController.php
@@ -139,7 +139,7 @@ class InfoController extends AbstractController
                 continue;
             }
 
-            $bundleName = mb_strtolower($bundle->getName());
+            $bundleName = preg_replace('/bundle$/', '', strtolower($bundle->getName()));
 
             $styles = array_map(static function (string $filename) use ($package, $bundleName) {
                 $url = 'bundles/' . $bundleName . '/' . $filename;
@@ -182,7 +182,9 @@ class InfoController extends AbstractController
 
     private function getAdministrationScripts(Bundle $bundle): array
     {
-        $path = 'administration/js/' . str_replace('_', '-', $bundle->getContainerPrefix()) . '.js';
+        $technicalName = str_replace('_', '-', preg_replace('/_?bundle$/', '', $bundle->getContainerPrefix()));
+
+        $path = 'administration/js/' . str_replace('_', '-', $technicalName) . '.js';
         $bundlePath = $bundle->getPath();
 
         if (!file_exists($bundlePath . '/Resources/public/' . $path)) {

--- a/src/Core/Framework/Plugin/BundleConfigGenerator.php
+++ b/src/Core/Framework/Plugin/BundleConfigGenerator.php
@@ -68,10 +68,13 @@ class BundleConfigGenerator implements BundleConfigGeneratorInterface
                 $path = ltrim(mb_substr($path, mb_strlen($projectDir)), '/');
             }
 
-            $bundles[$bundle->getName()] = [
+            $bundleName = preg_replace('/bundle$/', '', strtolower($bundle->getName()));
+            $technicalName = str_replace('_', '-', preg_replace('/_?bundle$/', '', $bundle->getContainerPrefix()));
+
+            $bundles[$bundleName] = [
                 'basePath' => $path . '/',
                 'views' => ['Resources/views'],
-                'technicalName' => str_replace('_', '-', $bundle->getContainerPrefix()),
+                'technicalName' => $technicalName,
                 'administration' => [
                     'path' => 'Resources/app/administration/src',
                     'entryFilePath' => $this->getEntryFile($bundle, 'Resources/app/administration/src'),


### PR DESCRIPTION
### 1. Why is this change necessary?
Shopware imitates symfony assets routines but fails at a very specific point.

### 2. What does this change do, exactly?
It removes the bundle suffix at some points that are related to the file path generation.

### 3. Describe each step to reproduce the issue or behaviour.
1. Have a bundle (or plugin) loaded that has a suffix "Bundle" (e.g. FoobarBundle)
2. Add changes in administration (probably also a problem storefront changes)
3. Run `psh.phar administration:watch` and see changes take effect
4. Run `psh.phar administration:build` and :shipit: 
5. Generated assets are not loaded
6. See 404 in administration to load `bundles/foobar/administration/js/foobar-bundle.js`
7. Looks goo... hey wait there is a `public/bundles/foobarbundle` directory instead of `public/bundles/foobar`
8. See symfony removing bundle suffix on `assets:install` ([here](https://github.com/symfony/symfony/blob/9ce1f025017fb2b2d4c4883af31b994c07e34326/src/Symfony/Bundle/FrameworkBundle/Command/AssetsInstallCommand.php#L140))
9. Run `bundle:dump` to update `plugins.json` and see wrong asset paths
10. Check `_info/config` request and see wrong asset paths

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
