### PR TITLE
Add new commands system:config:get and system:config:set

### DIFF
--- a/src/Core/System/DependencyInjection/configuration.xml
+++ b/src/Core/System/DependencyInjection/configuration.xml
@@ -30,5 +30,17 @@
             <argument type="service" id="system_config.repository"/>
             <argument type="service" id="Shopware\Core\System\SystemConfig\Util\ConfigReader" />
         </service>
+
+        <service id="Shopware\Core\System\SystemConfig\Command\ConfigGet">
+            <argument type="service" id="Shopware\Core\System\SystemConfig\SystemConfigService"/>
+
+            <tag name="console.command"/>
+        </service>
+
+        <service id="Shopware\Core\System\SystemConfig\Command\ConfigSet">
+            <argument type="service" id="Shopware\Core\System\SystemConfig\SystemConfigService"/>
+
+            <tag name="console.command"/>
+        </service>
     </services>
 </container>

--- a/src/Core/System/SystemConfig/Command/ConfigGet.php
+++ b/src/Core/System/SystemConfig/Command/ConfigGet.php
@@ -1,0 +1,46 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\System\SystemConfig\Command;
+
+use Shopware\Core\System\SystemConfig\SystemConfigService;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class ConfigGet extends Command
+{
+    protected static $defaultName = 'system:config:get';
+
+    /**
+     * @var SystemConfigService
+     */
+    private $systemConfigService;
+
+    public function __construct(SystemConfigService $systemConfigService)
+    {
+        parent::__construct();
+        $this->systemConfigService = $systemConfigService;
+    }
+
+    protected function configure()
+    {
+        $this
+            ->addArgument('key', InputArgument::REQUIRED)
+            ->addOption('salesChannelId', 's', InputOption::VALUE_OPTIONAL)
+        ;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $value = $this->systemConfigService->get(
+            $input->getArgument('key'),
+            $input->getOption('salesChannelId')
+        );
+
+        $output->writeln($value);
+
+        return 0;
+    }
+}

--- a/src/Core/System/SystemConfig/Command/ConfigSet.php
+++ b/src/Core/System/SystemConfig/Command/ConfigSet.php
@@ -1,0 +1,46 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\System\SystemConfig\Command;
+
+use Shopware\Core\System\SystemConfig\SystemConfigService;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class ConfigSet extends Command
+{
+    protected static $defaultName = 'system:config:set';
+
+    /**
+     * @var SystemConfigService
+     */
+    private $systemConfigService;
+
+    public function __construct(SystemConfigService $systemConfigService)
+    {
+        parent::__construct();
+        $this->systemConfigService = $systemConfigService;
+    }
+
+    protected function configure()
+    {
+        $this
+            ->addArgument('key', InputArgument::REQUIRED)
+            ->addArgument('value', InputArgument::REQUIRED)
+            ->addOption('salesChannelId', 's', InputOption::VALUE_OPTIONAL)
+        ;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $this->systemConfigService->set(
+            $input->getArgument('key'),
+            $input->getArgument('value'),
+            $input->getOption('salesChannelId')
+        );
+
+        return 0;
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?
It enables easier provisioning of systems via cli.

### 2. What does this change do, exactly?
Add two new commands `system:config:get` and `system:config:set`.

### 3. Describe each step to reproduce the issue or behaviour.
1. Run the new commands.

### 4. Please link to the relevant issues (if any).
None.

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
