### PR TITLE
Fix: LineItemTagRule do not work correctly for CartRuleScopes

### DIFF
--- a/src/Core/Checkout/Cart/Rule/LineItemTagRule.php
+++ b/src/Core/Checkout/Cart/Rule/LineItemTagRule.php
@@ -45,13 +45,13 @@ class LineItemTagRule extends Rule
             return false;
         }
 
+        $identifiers = [];
+
         foreach ($scope->getCart()->getLineItems() as $lineItem) {
-            if ($this->lineItemMatches($lineItem)) {
-                return true;
-            }
+            $identifiers = array_merge($identifiers, $this->extractTagIds($lineItem));
         }
 
-        return false;
+        return $this->tagsMatches($identifiers);
     }
 
     public function getConstraints(): array
@@ -66,11 +66,16 @@ class LineItemTagRule extends Rule
     {
         $identifiers = $this->extractTagIds($lineItem);
 
+        return $this->tagsMatches($identifiers);
+    }
+
+    private function tagsMatches(array $tags): bool
+    {
         switch ($this->operator) {
             case self::OPERATOR_EQ:
-                return !empty(array_intersect($identifiers, $this->identifiers));
+                return !empty(array_intersect($tags, $this->identifiers));
             case self::OPERATOR_NEQ:
-                return empty(array_intersect($identifiers, $this->identifiers));
+                return empty(array_intersect($tags, $this->identifiers));
             default:
                 throw new UnsupportedOperatorException($this->operator, self::class);
         }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/community).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
My Problem was, that I wanted to use tags on products, to define the shipping type for this product. I have shipping by parcel and shipping by forwarding agent. If theres a product with tag "forwarding agent", the cart cannot be shipped by parcel. And if theres no product with this tag, it cannot be shipped by forwarding agent. Before my change only the second condition worked, but if there is a product in cart, which has the tag "forwarding agent" along with other products, which do not have this tag, the user can choose the shipping by parcel. 
This happened, because the LineItemTagRule did not work correctly, when it was called with scope CartRuleScope. The expected behaviour is that the rule watches all tags of line items in the cart, not to iterate over all line items and if one fits, the rule matches.

### 2. What does this change do, exactly?
Instead of iterating over the line items and return true, when the rule matches for one of them, I merge all tags of line items in the cart, before executing the matching logic.

### 3. Describe each step to reproduce the issue or behaviour.
1. Create new tag "forwarding agent" and assign it to a product
2. Create two new rules:
2.1. Rule "parcel": Line Item Tag Is none of "forwarding agent"
2.2. Rule "forwarding agent": Line Item Tag is one of "forwarding agent"
3. Create two shipping methods (e.g. "parcel" and "forwarding agent") and assign the according rules to them
4. Put the product, which has the tag "forwarding agent" in the cart -> Until here it's correct and you can only choose "forwarding agent" as shipping method.
5. Put another product in the cart, that do not has this tag -> Now you can also choose "parcel" as shipping method.

### 4. Please link to the relevant issues (if any).
---

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
