### PR TITLE
Add system config reloading

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-settings/component/sw-system-config/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings/component/sw-system-config/index.js
@@ -93,6 +93,11 @@ Component.register('sw-system-config', {
                 return Promise.resolve();
             }
 
+            return this.loadCurrentSalesChannelConfig();
+        },
+        loadCurrentSalesChannelConfig() {
+            this.isLoading = true;
+
             return this.systemConfigApiService.getValues(this.domain, this.currentSalesChannelId)
                 .then(values => {
                     this.$set(this.actualConfigData, this.currentSalesChannelId, values);


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/community).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?

Currently the `sw-system-config` component caches the config values and just returns them when calling `readAll()`.
Due to this it is currently not possible to reload the config values for the currently selected sales channel without directly modifying the `actualConfigData` property.

### 2. What does this change do, exactly?

This change adds a `loadCurrentSalesChannelConfig` function which loads the current sales channel config without using the cached value. Thus it is possible to discard the changes of the config for the currently selected sales channel and reload it from the server.

### 3. Describe each step to reproduce the issue or behaviour.

- Create a custom config page using the `sw-system-config` component in its template.
- Try reloading the config via `readAll()`

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
