### PR TITLE
Make additional information optional for CustomerCanceledAsyncPaymentException

### DIFF
--- a/src/Core/Checkout/Payment/Exception/CustomerCanceledAsyncPaymentException.php
+++ b/src/Core/Checkout/Payment/Exception/CustomerCanceledAsyncPaymentException.php
@@ -4,11 +4,11 @@ namespace Shopware\Core\Checkout\Payment\Exception;
 
 class CustomerCanceledAsyncPaymentException extends PaymentProcessException
 {
-    public function __construct(string $orderTransactionId, string $additionalInformation)
+    public function __construct(string $orderTransactionId, string $additionalInformation = '')
     {
         parent::__construct(
             $orderTransactionId,
-            'The customer canceled the external payment process. Additional information:' . PHP_EOL . '{{ additionalInformation }}',
+            'The customer canceled the external payment process. {{ additionalInformation }}',
             ['additionalInformation' => $additionalInformation]
         );
     }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/community).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
I think and I actually have the case that additional information for this exception isn't always necessary.

Effectively I can only think of one additional information for the customer which could be "Retry again or use another payment method." for which the prefixed string "Additional information:" would be unnecessary.

### 2. What does this change do, exactly?
Set the parameter for additional information as optional and remove the "Additional information" string from the exceptions' message.

### 3. Describe each step to reproduce the issue or behavior.
none

### 4. Please link to the relevant issues (if any).
none

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
