### PR TITLE
Fix CMS slot config for translated content

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-category/page/sw-category-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-category/page/sw-category-detail/index.js
@@ -227,6 +227,9 @@ Component.register('sw-category-detail', {
                         section.blocks.forEach((block) => {
                             block.slots.forEach((slot) => {
                                 if (this.category.slotConfig[slot.id]) {
+                                    if (slot.config === null) {
+                                        slot.config = {};
+                                    }
                                     merge(slot.config, cloneDeep(this.category.slotConfig[slot.id]));
                                 }
                             });


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/community).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?

When editting the contents of a category through the content tab on the category detail page, it works fine for the default language. For all other languages, it always shows the placeholder content if the underlying shopping experience does not have a config for the slots in that language. Changing the content and saving works, but after saving (and even after reloading), the default placeholder content is shown again.

### 2. What does this change do, exactly?

Shopware tries to merge the config of each slot of the shopping experience with the config of the corresponding slot on the category. In some cases in a multi-locale setup, the config for the slot of the shopping experience is NULL for all languages but the one it was created in. Then, the merge of the configs fails. This change ensures that the config is never null before merging, but an empty object instead. This way, if there is no config on the shopping experience, the config of the category is used.

### 3. Describe each step to reproduce the issue or behaviour.

- Prepare shopware setup with multiple locales
- Create shopping experience with text slots while using default locale
- Create new category, assign to shopping experience created above, save
- Switch to different language
- Try to edit & save the text slots

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.
