### PR TITLE
Added missing step

### DIFF
--- a/src/Docs/Resources/current/2-internals/4-plugins/010-plugin-quick-start.md
+++ b/src/Docs/Resources/current/2-internals/4-plugins/010-plugin-quick-start.md
@@ -123,7 +123,7 @@ Read [here](./050-plugin-information.md) for more information about the content 
 Now, that you've created the two necessary plugin files, you're able to install the plugin.
 This is done using one of the [plugin commands](./030-plugin-commands.md).
 
-Starting in your **project root** directory, run the command `bin/console plugin:install --activate --clearCache PluginQuickStart` to install and activate the plugin.
+Starting in your **project root** directory, check if your plugin is detected run `bin/console plugin:list`. When your new plugin is missing, execute the command `bin/console plugin:refresh`. Then run the command `bin/console plugin:install --activate --clearCache PluginQuickStart` to install and activate the plugin.
 
 ## Plugin configuration
 

--- a/src/Docs/Resources/current/2-internals/4-plugins/010-plugin-quick-start.md
+++ b/src/Docs/Resources/current/2-internals/4-plugins/010-plugin-quick-start.md
@@ -123,7 +123,7 @@ Read [here](./050-plugin-information.md) for more information about the content 
 Now, that you've created the two necessary plugin files, you're able to install the plugin.
 This is done using one of the [plugin commands](./030-plugin-commands.md).
 
-Starting in your **project root** directory, check if your plugin is detected run `bin/console plugin:list`. When your new plugin is missing, execute the command `bin/console plugin:refresh`. Then run the command `bin/console plugin:install --activate --clearCache PluginQuickStart` to install and activate the plugin.
+Starting in your **project root** directory, check if your plugin is already known to Shopware by running the command `bin/console plugin:list`. If your new plugin is missing, execute the command `bin/console plugin:refresh`. Afterwards run the command `bin/console plugin:install --activate --clearCache PluginQuickStart` to install and activate the plugin.
 
 ## Plugin configuration
 


### PR DESCRIPTION
For me it was not enough to execute the `bin/console plugin:install` command. 
Before that I had to update the list of plugins, with the `bin/console plugin:refresh` command. This step was missing in the documentation

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/community).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
A Step was missing to follow the guide.

### 2. What does this change do, exactly?
Clarifies the process to create a plugin

### 3. Describe each step to reproduce the issue or behaviour.
Follow the process to create a Plugin. Without the `refresh` Command the plugin cannot activated.

### 4. Please link to the relevant issues (if any).
-

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ x ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.
