### PR TITLE
Output password minimum length value instead of key to configuration

### DIFF
--- a/src/Storefront/Resources/views/storefront/component/account/register.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/account/register.html.twig
@@ -133,7 +133,7 @@
                                                        id="personalPassword"
                                                        placeholder="{{ "account.personalPasswordPlaceholder"|trans|striptags }}{{ "general.required"|trans|striptags }}"
                                                        name="password"
-                                                       minlength="shopware.config.core.loginRegistration.passwordMinLength"
+                                                       minlength="{{ shopware.config.core.loginRegistration.passwordMinLength }}"
                                                        {% if shopware.config.core.loginRegistration.requirePasswordConfirmation %}
                                                        data-form-validation-equal="newPassword"
                                                        {% endif %}


### PR DESCRIPTION
### 1. Why is this change necessary?
This is the html in the register form:
```
<input
    type="password"
    class="form-control"
    autocomplete="new-password"
    id="personalPassword"
    placeholder="Passwort eingeben ...*"
    name="password"
    minlength="shopware.config.core.loginRegistration.passwordMinLength"
    data-form-validation-length="8"
    data-form-validation-length-message="Das Passwort muss mindestens 8 Zeichen lang sein."
    required="required">
```
Zoom in
```
    placeholder="Passwort eingeben ...*"
    name="password"
    minlength="shopware.config.core.loginRegistration.passwordMinLength"
    data-form-validation-length="8"
    data-form-validation-length-message="Das Passwort muss mindestens 8 Zeichen lang sein."
```
More zoom
```
    name="password"
    minlength="shopware.config.core.loginRegistration.passwordMinLength"
    data-form-validation-length="8"
```
Aaah
```
    minlength="shopware.config.core.loginRegistration.passwordMinLength"
```

### 2. What does this change do, exactly?
Twig changes:
```
    minlength="{{ shopware.config.core.loginRegistration.passwordMinLength }}"
```

### 3. Describe each step to reproduce the issue or behaviour.
1. Install shopware

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
