### PR TITLE
Fix MissingOrderRelationException declaration

### DIFF
--- a/src/Core/Checkout/Cart/Order/OrderConverter.php
+++ b/src/Core/Checkout/Cart/Order/OrderConverter.php
@@ -210,7 +210,7 @@ class OrderConverter
     public function convertToCart(OrderEntity $order, Context $context): Cart
     {
         if ($order->getLineItems() === null) {
-            throw new MissingOrderRelationException('lineItem');
+            throw new MissingOrderRelationException('lineItems');
         }
 
         if ($order->getDeliveries() === null) {


### PR DESCRIPTION
Correctly name the missing association "lineItems" instead of "lineItem"

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/community).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?


### 2. What does this change do, exactly?


### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
