### PR TITLE
Change priority of sender email

### DIFF
--- a/src/Core/Content/MailTemplate/Service/MailService.php
+++ b/src/Core/Content/MailTemplate/Service/MailService.php
@@ -130,9 +130,9 @@ class MailService implements MailServiceInterface
             $templateData['salesChannel'] = $salesChannel;
         }
 
-        $senderEmail = $this->systemConfigService->get('core.basicInformation.email', $salesChannelId);
+        $senderEmail = $this->systemConfigService->get('core.mailerSettings.senderAddress');
 
-        $senderEmail = $senderEmail ?? $this->systemConfigService->get('core.mailerSettings.senderAddress');
+        $senderEmail = $senderEmail ?? $this->systemConfigService->get('core.basicInformation.email', $salesChannelId);
 
         if ($senderEmail === null) {
             $this->logger->error('senderMail not configured for salesChannel: ' . $salesChannelId . '. Please check system_config \'core.basicInformation.email\'');


### PR DESCRIPTION
### 1. Why is this change necessary?
Prioritizing the shop owner email address over the sender email is not comprehensible when the mailing settings call this field sender mail but is effectively not.

### 2. What does this change do, exactly?
It prefers to send an email as mail sender instead of shop owner.

### 3. Describe each step to reproduce the issue or behaviour.
1. Setup dev system
2. Setup SMTP settings
3. Test order email by ordering
4. ![grafik](https://user-images.githubusercontent.com/1133593/77338685-f84be980-6d2a-11ea-90b2-252e61ccf05e.png)
5. Anonymous?
6. Google the error
7. Dang it. Sure it is a problem with commercial outlook again
8. Use other SMTP endpoint
9. Still issues about wrong credential
10. Colleague: hey, did you check it might be an issue on shopware side
11. Shop... ware 💭 ?
12. Debug a lot
13. See `doNotReply@localhost` as sender
14. \> le_wut.png
15. Debug the source to track it down to my current change

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
