### PR TITLE
Fix TLS mailing

### DIFF
--- a/src/Core/Content/MailTemplate/Service/MailerFactory.php
+++ b/src/Core/Content/MailTemplate/Service/MailerFactory.php
@@ -56,8 +56,8 @@ class MailerFactory
         switch ($encryption) {
             case 'ssl':
                 return 'ssl';
-            case 'tsl':
-                return 'tsl';
+            case 'tls':
+                return 'tls';
             default:
                 return null;
         }

--- a/src/Core/Content/MailTemplate/Service/MailerTransportFactory.php
+++ b/src/Core/Content/MailTemplate/Service/MailerTransportFactory.php
@@ -42,8 +42,8 @@ class MailerTransportFactory implements MailerTransportFactoryInterface
         switch ($encryption) {
             case 'ssl':
                 return 'ssl';
-            case 'tsl':
-                return 'tsl';
+            case 'tls':
+                return 'tls';
             default:
                 return null;
         }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/community).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?

Mail servers requiring TLS are not working because of a typo.

### 2. What does this change do, exactly?

Swap `tsl` with `tls`.

### 3. Describe each step to reproduce the issue or behaviour.

Try to send mails through an SMTP that requires TLS encrypted connections (eg smtp.office365.com)

### 4. Please link to the relevant issues (if any).

Probably many, eg https://forum.shopware.com/discussion/65384/e-mail-versand-office365

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
