### PR TITLE
add placeholder for pluginIcon

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-plugin/component/sw-plugin-table-entry/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-plugin/component/sw-plugin-table-entry/index.js
@@ -36,6 +36,20 @@ Component.register('sw-plugin-table-entry', {
         }
     },
 
+    computed: {
+        iconSrc() {
+            if (this.icon) {
+                return `data:image/png;base64,${this.icon}`;
+            }
+
+            if (this.iconPath) {
+                return this.iconPath;
+            }
+
+            return 'data:image/gif;base64,R0lGODlhKAAoAIAAAAAAAAAAACH5BAEAAAAALAAAAAAoACgAAAInhI+py+0Po5y02ouz3rz7D4biSJbmiabqyrbuC8fyTNf2jef6ziMFADs=';
+        }
+    },
+
     methods: {
         labelVariant(licenseInfo) {
             if (licenseInfo.level === 'violation') {

--- a/src/Administration/Resources/app/administration/src/module/sw-plugin/component/sw-plugin-table-entry/sw-plugin-table-entry.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-plugin/component/sw-plugin-table-entry/sw-plugin-table-entry.html.twig
@@ -1,8 +1,7 @@
 {% block sw_plugin_table_entry %}
     <div class="sw-plugin-table-entry">
         {% block sw_plugin_table_entry_icon %}
-            <img v-if="icon" :src="'data:image/png;base64, ' + icon"/>
-            <img v-if="iconPath" :src="iconPath"/>
+            <img :src="iconSrc"/>
         {% endblock %}
 
         {% block sw_plugin_table_entry_icon_container %}


### PR DESCRIPTION
### 1. Why is this change necessary?
For some lazy people there may be an ugly view in listing of plugin manager, due to missing plugin.png in Resources/config. There should be a placeholder.

### 2. What does this change do, exactly?
I refrained from adjusting the style. So, I introduced a transparent 1x1 GIF as placeholder, with width and height of 40px.

### 3. Describe each step to reproduce the issue or behaviour.
Add one plugin with icon and one plugin without any icon. See texts not being on a line.

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
