### PR TITLE
stringify theme text and textarea values (not only media)

### DIFF
--- a/src/Storefront/Theme/ThemeCompiler.php
+++ b/src/Storefront/Theme/ThemeCompiler.php
@@ -231,7 +231,7 @@ class ThemeCompiler
                     continue;
                 }
 
-                if ($data['type'] === 'media') {
+                if (in_array($data['type'], ['media','text','textarea']) {
                     $variables[$key] = '\'' . $data['value'] . '\'';
                 } else {
                     $variables[$key] = $data['value'];

--- a/src/Storefront/Theme/ThemeCompiler.php
+++ b/src/Storefront/Theme/ThemeCompiler.php
@@ -231,7 +231,7 @@ class ThemeCompiler
                     continue;
                 }
 
-                if (in_array($data['type'], ['media','text','textarea']) {
+                if (in_array($data['type'], ['media','text','textarea'])) {
                     $variables[$key] = '\'' . $data['value'] . '\'';
                 } else {
                     $variables[$key] = $data['value'];


### PR DESCRIPTION
### 1. Why is this change necessary?
When adding new text or textarea values to the a custom theme config, the theme compiler fails since these values are not stringified and therefore not valid json.


### 2. What does this change do, exactly?
the same way as config variables of type 'media', the type 'text' and 'textrea' is also stringified.

### 3. Describe each step to reproduce the issue or behaviour.
create a custom theme. 
add a config variable to theme.json with type 'text' or 'textarea'
go to the backend, select storefront and edit theme.
fill more than one word and also numbers or even a url in the text or textarea config element.
save.
use bin/console theme:compile --> it fails.
