### PR TITLE
add easy possibility to define senderEmail

### DIFF
--- a/src/Core/Content/MailTemplate/Service/MailService.php
+++ b/src/Core/Content/MailTemplate/Service/MailService.php
@@ -122,7 +122,11 @@ class MailService implements MailServiceInterface
             $templateData['salesChannel'] = $salesChannel;
         }
 
-        $senderEmail = $this->systemConfigService->get('core.basicInformation.email', $salesChannelId);
+        if(isset($data['senderEmail'])) {
+            $senderEmail = $data['senderEmail'];
+        }
+
+        $senderEmail = $senderEmail ?? $this->systemConfigService->get('core.basicInformation.email', $salesChannelId);
 
         $senderEmail = $senderEmail ?? $this->systemConfigService->get('core.mailerSettings.senderAddress');
 


### PR DESCRIPTION
### 1. Why is this change necessary?
We need to be able to make the senderEmail flexible because we are sending all mails named and addressed by customer agent. 

### 2. What does this change do, exactly?
Respect data senderEmail in MailService.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
