### PR TITLE
respect more given mailData

### DIFF
--- a/src/Core/Content/MailTemplate/Service/MailService.php
+++ b/src/Core/Content/MailTemplate/Service/MailService.php
@@ -185,6 +185,22 @@ class MailService implements MailServiceInterface
             $binAttachments
         );
 
+        if (isset($data['recipientsCc'])) {
+            $message->setCc($data['recipientsCc']);
+        }
+
+        if (isset($data['recipientsBcc'])) {
+            $message->setBcc($data['recipientsBcc']);
+        }
+
+        if (isset($data['replyTo'])) {
+            $message->setReplyTo($data['replyTo']);
+        }
+
+        if (isset($data['returnPath'])) {
+            $message->setReturnPath($data['returnPath']);
+        }
+
         $mailBeforeSentEvent = new MailBeforeSentEvent($data, $message, $context);
         $this->eventDispatcher->dispatch($mailBeforeSentEvent);
 


### PR DESCRIPTION
### 1. Why is this change necessary?
When using the MailService of MailTemplate in plugin, it'll be great, if there is a possibility to specify some more mailData with parameter.

### 2. What does this change do, exactly?
This PR introduced using `recipientsCc`, `recipientsBcc`, `replyTo`, `returnPath` in given parameters.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
