### PR TITLE
Allow or, oR and Or as multifilter connection

### DIFF
--- a/src/Core/Framework/DataAbstractionLayer/Search/Parser/QueryStringParser.php
+++ b/src/Core/Framework/DataAbstractionLayer/Search/Parser/QueryStringParser.php
@@ -36,7 +36,7 @@ class QueryStringParser
                 $queries = [];
                 $operator = MultiFilter::CONNECTION_AND;
 
-                if (isset($query['operator']) && $query['operator'] === MultiFilter::CONNECTION_OR) {
+                if (isset($query['operator']) && mb_strtoupper($query['operator']) === MultiFilter::CONNECTION_OR) {
                     $operator = MultiFilter::CONNECTION_OR;
                 }
 


### PR DESCRIPTION
### 1. Why is this change necessary?
It is confusing in the administration to build up a criteria:
```
criteria.addFilter(Criteria.multi('or', [
    Criteria.contains('key', params.term),
    Criteria.contains('name', params.term)
]));
```
which looks like an or ut behaves like an and.

### 2. What does this change do, exactly?
Just uppercases the incoming value.

### 3. Describe each step to reproduce the issue or behaviour.
Use the API with a lower case or as multi filter.

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
