### PR TITLE
fix message in plugin list

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-plugin/view/sw-plugin-list/sw-plugin-list.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-plugin/view/sw-plugin-list/sw-plugin-list.html.twig
@@ -65,7 +65,7 @@
                                         :label="item.active ? $tc('sw-plugin.list.activated') : $tc('sw-plugin.list.deactivated')"
                                         :disabled="!item.installedAt"
                                         @change="changeActiveState(item, $event)"
-                                        v-tooltip="{ disable: !item.installedAt, message: $tc('sw-plugin.list.tooltipActivationDisabled') }">
+                                        v-tooltip="{ disabled: item.installedAt, message: $tc('sw-plugin.list.tooltipActivationDisabled') }">
                                     </sw-switch-field>
                                 {% endblock %}
                             </template>


### PR DESCRIPTION
### 1. Why is this change necessary?
![image](https://user-images.githubusercontent.com/135993/77886074-80b91580-7268-11ea-89d2-e399e9766e4a.png)
The tooltip should only be shown on plugins which aren't installed.

### 2. What does this change do, exactly?
Use correct property in tooltip component.
![image](https://user-images.githubusercontent.com/135993/77886159-a47c5b80-7268-11ea-8bbb-a2692530948b.png)
![image](https://user-images.githubusercontent.com/135993/77886186-ae9e5a00-7268-11ea-944f-628b8af8b92f.png)


### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
