### PR TITLE
add new event for adding categories to the validate function of NavigationLoader

### DIFF
--- a/src/Core/Content/Category/Event/NavigationValidationCategoryIdsLoadedEvent.php
+++ b/src/Core/Content/Category/Event/NavigationValidationCategoryIdsLoadedEvent.php
@@ -1,0 +1,46 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Content\Category\Event;
+
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Event\NestedEvent;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
+
+class NavigationValidationCategoryIdsLoadedEvent extends NestedEvent
+{
+    /**
+     * @var array
+     */
+    protected $ids;
+
+    /**
+     * @var SalesChannelContext
+     */
+    protected $salesChannelContext;
+
+    public function __construct(array $ids, SalesChannelContext $salesChannelContext)
+    {
+        $this->ids = $ids;
+        $this->salesChannelContext = $salesChannelContext;
+    }
+
+    public function getContext(): Context
+    {
+        return $this->salesChannelContext->getContext();
+    }
+
+    public function getCategoryIds(): array
+    {
+        return $this->ids;
+    }
+
+    public function addCategoryId($id): void
+    {
+        array_push($this->ids, $id);
+    }
+
+    public function getSalesChannelContext(): SalesChannelContext
+    {
+        return $this->salesChannelContext;
+    }
+}

--- a/src/Core/Content/Category/Service/NavigationLoader.php
+++ b/src/Core/Content/Category/Service/NavigationLoader.php
@@ -6,6 +6,7 @@ use Doctrine\DBAL\Connection;
 use Shopware\Core\Content\Category\CategoryCollection;
 use Shopware\Core\Content\Category\CategoryEntity;
 use Shopware\Core\Content\Category\Event\NavigationLoadedEvent;
+use Shopware\Core\Content\Category\Event\NavigationValidationCategoryIdsLoadedEvent;
 use Shopware\Core\Content\Category\Exception\CategoryNotFoundException;
 use Shopware\Core\Content\Category\SalesChannel\NavigationRouteInterface;
 use Shopware\Core\Content\Category\Tree\Tree;
@@ -257,7 +258,11 @@ class NavigationLoader implements NavigationLoaderInterface
             $context->getSalesChannel()->getNavigationCategoryId(),
         ]);
 
-        foreach ($ids as $id) {
+        $event = new NavigationValidationCategoryIdsLoadedEvent($ids, $context);
+
+        $this->eventDispatcher->dispatch($event);
+
+        foreach ($event->getCategoryIds() as $id) {
             if ($this->isChildCategory($activeId, $path, $id)) {
                 return;
             }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/community).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
I created a new navigation entry point, that is added to the saleschannel definition. I could display the new navigation, but the links to the category pages were broken, because of a CategoryNotFoundException. I needed to add a new category id the the validate function of the NavigationLoader. But this function is private and so I could not extend the array of category ids.

### 2. What does this change do, exactly?
To solve this I created a new Event, which stores to array of categoryIds and provides a function to add a new categoryId.

### 3. Describe each step to reproduce the issue or behaviour.
--

### 4. Please link to the relevant issues (if any).
--

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
