### PR TITLE
Move validation below sanitization in StringFieldSerializer

### DIFF
--- a/src/Core/Framework/DataAbstractionLayer/FieldSerializer/StringFieldSerializer.php
+++ b/src/Core/Framework/DataAbstractionLayer/FieldSerializer/StringFieldSerializer.php
@@ -30,16 +30,14 @@ class StringFieldSerializer extends AbstractFieldSerializer
             $data->setValue(null);
         }
 
+        if ($data->getValue() !== null && !$field->is(AllowHtml::class)) {
+            $data->setValue(strip_tags((string) $data->getValue()));
+        }
+        
         $this->validateIfNeeded($field, $existence, $data, $parameters);
 
-        $value = $data->getValue();
-
-        if ($value !== null && !$field->is(AllowHtml::class)) {
-            $value = strip_tags((string) $value);
-        }
-
         /* @var StringField $field */
-        yield $field->getStorageName() => $value !== null ? (string) $value : null;
+        yield $field->getStorageName() => $data->getValue() !== null ? (string) $data->getValue() : null;
     }
 
     public function decode(Field $field, $value): ?string


### PR DESCRIPTION
### 1. Why is this change necessary?
With the current state it is possible to bypass a required-flag by providing input that only consists of html-tags.

### 2. What does this change do, exactly?
Move the validation below the sanitization.

### 3. Describe each step to reproduce the issue or behaviour.
1. Use the DAL to insert e.g. a customer with a last name of `<test>`.
2. The customer has now been inserted with an empty string for last name.

### 4. Please link to the relevant issues (if any).
None.

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
