### PR TITLE
lower and rise position value argument field fix

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/data-grid/sw-data-grid-column-position/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/data-grid/sw-data-grid-column-position/index.js
@@ -64,13 +64,13 @@ Component.register('sw-data-grid-column-position', {
 
     methods: {
         onLowerPositionValue() {
-            this.lowerPositionValue(this.value, this.item);
+            this.lowerPositionValue(this.value, this.item, this.field);
             this.$emit('lower-position-value', this.value);
             this.$emit('position-changed', this.value);
         },
 
         onRaisePositionValue() {
-            this.raisePositionValue(this.value, this.item);
+            this.raisePositionValue(this.value, this.item, this.field);
             this.$emit('raise-position-value', this.value);
             this.$emit('position-changed', this.value);
         }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/community).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
Currently, you cannot use the sw-data-grid-column-position component to sort by a value other than 'position'

### 2. What does this change do, exactly?
Change add the missing argument "filed" to the function lowerPositionValue and raisePositionValue call.

### 3. Describe each step to reproduce the issue or behaviour.
Use the sw-data-grid-column-position component in the sw-entity-listing component by passing 'field' argument other than the default (other than 'position')

### 4. Please link to the relevant issues (if any).
none

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.
