### PR TITLE
Use valid type for Twitter Cards

### DIFF
--- a/src/Storefront/Resources/views/storefront/layout/meta.html.twig
+++ b/src/Storefront/Resources/views/storefront/layout/meta.html.twig
@@ -42,7 +42,7 @@
                       content="{{ shopware.theme['sw-logo-desktop'] }}"/>
 
                 <meta name="twitter:card"
-                      content="website"/>
+                      content="summary"/>
                 <meta name="twitter:site"
                       content="{{ basicConfig.shopName }}"/>
                 <meta name="twitter:title"


### PR DESCRIPTION
### 1. Why is this change necessary?
Right now the used type »website« for Twitter Cards does not exist. Because of that Shopware 6 URLs cannot be shown correctly when sharing on Twitter. This must be changed to a valid type. I think »summary« fits best.

Checkout Twitter Cards documentation:
https://developer.twitter.com/en/docs/tweets/optimize-with-cards/overview/abouts-cards

### 2. What does this change do, exactly?
It just changes the Twitter Cards type to »summary«.

### 3. Describe each step to reproduce the issue or behaviour.
1. Go to https://twitter.com and login.
2. Create a tweet with a Shopware 6 URL.
3. Have a look at the tweet. The Twitter Cards information from meta tags are not shown. Example: https://twitter.com/vv_agentur/status/1244905546395856898


### 4. Please link to the relevant issues (if any).
I did not find any.

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
