### PR TITLE
fix: add missing custom fields to order AddressTransformer

### DIFF
--- a/src/Core/Checkout/Cart/Order/Transformer/AddressTransformer.php
+++ b/src/Core/Checkout/Cart/Order/Transformer/AddressTransformer.php
@@ -44,6 +44,7 @@ class AddressTransformer
             'additionalAddressLine2' => $address->getAdditionalAddressLine2(),
             'countryId' => $address->getCountryId(),
             'countryStateId' => $address->getCountryStateId(),
+            'customFields' => $address->getCustomFields(),
         ]);
     }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/community).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
Since the order address is a snapshot of the customer address, all custom fields that may be added to the respective customer address, should be cloned too.
With this change it's also possible to access the custom fields of the customer address when querying the order or one of its addresses via api.

### 2. What does this change do, exactly?
Add the customFields attribute of the customer address to the list of attributes to clone to create a order address.

### 3. Describe each step to reproduce the issue or behaviour.
-

### 4. Please link to the relevant issues (if any).
-

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
