### PR TITLE
Not call actions of business event when its propagation was stopped

### DIFF
--- a/src/Core/Framework/Event/BusinessEventDispatcher.php
+++ b/src/Core/Framework/Event/BusinessEventDispatcher.php
@@ -42,7 +42,7 @@ class BusinessEventDispatcher implements EventDispatcherInterface
     {
         $event = $this->dispatcher->dispatch($event, $eventName);
 
-        if ($event instanceof BusinessEventInterface) {
+        if ($event instanceof BusinessEventInterface && !$event->isPropagationStopped()) {
             $this->callActions($event);
         }
 


### PR DESCRIPTION
### 1. Why is this change necessary?
When a business event is stopped, it would only seem logical that no consequential actions are called. However, this is not the case as the registered actions are called regardless. E.g. when I stop `checkout.order.placed`, I do not expect the consequential action `action.mail.send` to be called.

### 2. What does this change do, exactly?
It checks, if the events propagation was stopped before calling its actions.

### 3. Describe each step to reproduce the issue or behaviour.
1. Subscribe to `checkout.order.placed` and stop the propagation.
2. Place an order.
3. See that mails are still sent.

### 4. Please link to the relevant issues (if any).
None.

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
