### PR TITLE
Save MailRecipientStruct in property to allow external modification

### DIFF
--- a/src/Core/Checkout/Cart/Event/CheckoutOrderPlacedEvent.php
+++ b/src/Core/Checkout/Cart/Event/CheckoutOrderPlacedEvent.php
@@ -66,15 +66,13 @@ class CheckoutOrderPlacedEvent extends Event implements MailActionInterface
 
     public function getMailStruct(): MailRecipientStruct
     {
-        if ($this->mailRecipientStruct) {
-            return $this->mailRecipientStruct;
+        if (!$this->mailRecipientStruct instanceof MailRecipientStruct) {
+            $this->mailRecipientStruct = new MailRecipientStruct([
+                $this->order->getOrderCustomer()->getEmail() => $this->order->getOrderCustomer()->getFirstName() . ' ' . $this->order->getOrderCustomer()->getLastName(),
+            ]);
         }
 
-        return new MailRecipientStruct(
-            [
-                $this->order->getOrderCustomer()->getEmail() => $this->order->getOrderCustomer()->getFirstName() . ' ' . $this->order->getOrderCustomer()->getLastName(),
-            ]
-        );
+        return $this->mailRecipientStruct;
     }
 
     public function getSalesChannelId(): ?string

--- a/src/Core/Checkout/Customer/Event/CustomerAccountRecoverRequestEvent.php
+++ b/src/Core/Checkout/Customer/Event/CustomerAccountRecoverRequestEvent.php
@@ -37,6 +37,11 @@ class CustomerAccountRecoverRequestEvent extends Event implements MailActionInte
      */
     private $shopName;
 
+    /**
+     * @var MailRecipientStruct
+     */
+    private $mailRecipientStruct;
+
     public function __construct(SalesChannelContext $salesChannelContext, CustomerRecoveryEntity $customerRecovery, string $resetUrl)
     {
         $this->salesChannelContext = $salesChannelContext;
@@ -75,11 +80,15 @@ class CustomerAccountRecoverRequestEvent extends Event implements MailActionInte
 
     public function getMailStruct(): MailRecipientStruct
     {
-        $customer = $this->customerRecovery->getCustomer();
+        if (!$this->mailRecipientStruct instanceof MailRecipientStruct) {
+            $customer = $this->customerRecovery->getCustomer();
 
-        return new MailRecipientStruct([
-            $customer->getEmail() => $customer->getFirstName() . ' ' . $customer->getLastName(),
-        ]);
+            $this->mailRecipientStruct = new MailRecipientStruct([
+                $customer->getEmail() => $customer->getFirstName() . ' ' . $customer->getLastName(),
+            ]);
+        }
+
+        return $this->mailRecipientStruct;
     }
 
     public function getSalesChannelId(): ?string

--- a/src/Core/Checkout/Customer/Event/CustomerDoubleOptInRegistrationEvent.php
+++ b/src/Core/Checkout/Customer/Event/CustomerDoubleOptInRegistrationEvent.php
@@ -32,6 +32,11 @@ class CustomerDoubleOptInRegistrationEvent extends Event implements MailActionIn
      */
     private $confirmUrl;
 
+    /**
+     * @var MailRecipientStruct
+     */
+    private $mailRecipientStruct;
+
     public function __construct(
         CustomerEntity $customer,
         SalesChannelContext $salesChannelContext,
@@ -56,11 +61,13 @@ class CustomerDoubleOptInRegistrationEvent extends Event implements MailActionIn
 
     public function getMailStruct(): MailRecipientStruct
     {
-        return new MailRecipientStruct(
-            [
+        if (!$this->mailRecipientStruct instanceof MailRecipientStruct) {
+            $this->mailRecipientStruct = new MailRecipientStruct([
                 $this->customer->getEmail() => $this->customer->getFirstName() . ' ' . $this->customer->getLastName(),
-            ]
-        );
+            ]);
+        }
+
+        return $this->mailRecipientStruct;
     }
 
     public function getCustomer(): CustomerEntity

--- a/src/Core/Checkout/Customer/Event/CustomerRegisterEvent.php
+++ b/src/Core/Checkout/Customer/Event/CustomerRegisterEvent.php
@@ -65,15 +65,13 @@ class CustomerRegisterEvent extends Event implements MailActionInterface
 
     public function getMailStruct(): MailRecipientStruct
     {
-        if ($this->mailRecipientStruct) {
-            return $this->mailRecipientStruct;
+        if (!$this->mailRecipientStruct instanceof MailRecipientStruct) {
+            $this->mailRecipientStruct = new MailRecipientStruct([
+                $this->customer->getEmail() => $this->customer->getFirstName() . ' ' . $this->customer->getLastName(),
+            ]);
         }
 
-        return new MailRecipientStruct(
-            [
-                $this->customer->getEmail() => $this->customer->getFirstName() . ' ' . $this->customer->getLastName(),
-            ]
-        );
+        return $this->mailRecipientStruct;
     }
 
     public function getSalesChannelId(): ?string

--- a/src/Core/Checkout/Customer/Event/DoubleOptInGuestOrderEvent.php
+++ b/src/Core/Checkout/Customer/Event/DoubleOptInGuestOrderEvent.php
@@ -32,6 +32,11 @@ class DoubleOptInGuestOrderEvent extends Event implements MailActionInterface
      */
     private $confirmUrl;
 
+    /**
+     * @var MailRecipientStruct
+     */
+    private $mailRecipientStruct;
+
     public function __construct(
         CustomerEntity $customer,
         SalesChannelContext $salesChannelContext,
@@ -56,11 +61,13 @@ class DoubleOptInGuestOrderEvent extends Event implements MailActionInterface
 
     public function getMailStruct(): MailRecipientStruct
     {
-        return new MailRecipientStruct(
-            [
-                $this->customer->getEmail() => $this->customer->getFirstName() . ' ' . $this->customer->getLastName(),
-            ]
-        );
+        if (!$this->mailRecipientStruct instanceof MailRecipientStruct) {
+        $this->mailRecipientStruct = new MailRecipientStruct([
+            $this->customer->getEmail() => $this->customer->getFirstName() . ' ' . $this->customer->getLastName(),
+        ]);
+    }
+
+        return $this->mailRecipientStruct;
     }
 
     public function getCustomer(): CustomerEntity

--- a/src/Core/Checkout/Order/Event/OrderStateMachineStateChangeEvent.php
+++ b/src/Core/Checkout/Order/Event/OrderStateMachineStateChangeEvent.php
@@ -34,6 +34,11 @@ class OrderStateMachineStateChangeEvent extends Event implements MailActionInter
      */
     private $name;
 
+    /**
+     * @var MailRecipientStruct
+     */
+    private $mailRecipientStruct;
+
     public function __construct(string $eventName, OrderEntity $order, ?string $salesChannelId, Context $context)
     {
         $this->order = $order;
@@ -55,15 +60,17 @@ class OrderStateMachineStateChangeEvent extends Event implements MailActionInter
 
     public function getMailStruct(): MailRecipientStruct
     {
-        if ($this->order->getOrderCustomer() === null) {
-            throw new MailEventConfigurationException('Data for mailRecipientStruct not available.', self::class);
+        if (!$this->mailRecipientStruct instanceof MailRecipientStruct) {
+            if ($this->order->getOrderCustomer() === null) {
+                throw new MailEventConfigurationException('Data for mailRecipientStruct not available.', self::class);
+            }
+
+            $this->mailRecipientStruct = new MailRecipientStruct([
+                $this->order->getOrderCustomer()->getEmail() => $this->order->getOrderCustomer()->getFirstName() . ' ' . $this->order->getOrderCustomer()->getLastName(),
+            ]);
         }
 
-        return new MailRecipientStruct(
-            [
-                $this->order->getOrderCustomer()->getEmail() => $this->order->getOrderCustomer()->getFirstName() . ' ' . $this->order->getOrderCustomer()->getLastName(),
-            ]
-        );
+        return $this->mailRecipientStruct;
     }
 
     public function getSalesChannelId(): ?string

--- a/src/Core/Content/Newsletter/Event/NewsletterConfirmEvent.php
+++ b/src/Core/Content/Newsletter/Event/NewsletterConfirmEvent.php
@@ -69,15 +69,13 @@ class NewsletterConfirmEvent extends Event implements MailActionInterface
 
     public function getMailStruct(): MailRecipientStruct
     {
-        if ($this->mailRecipientStruct) {
-            return $this->mailRecipientStruct;
+        if (!$this->mailRecipientStruct instanceof MailRecipientStruct) {
+            $this->mailRecipientStruct = new MailRecipientStruct([
+                $this->newsletterRecipient->getEmail() => $this->newsletterRecipient->getFirstName() . ' ' . $this->newsletterRecipient->getLastName(),
+            ]);
         }
 
-        return new MailRecipientStruct(
-            [
-                $this->newsletterRecipient->getEmail() => $this->newsletterRecipient->getFirstName() . ' ' . $this->newsletterRecipient->getLastName(),
-            ]
-        );
+        return $this->mailRecipientStruct;
     }
 
     public function getSalesChannelId(): ?string

--- a/src/Core/Content/Newsletter/Event/NewsletterRegisterEvent.php
+++ b/src/Core/Content/Newsletter/Event/NewsletterRegisterEvent.php
@@ -79,15 +79,13 @@ class NewsletterRegisterEvent extends Event implements MailActionInterface
 
     public function getMailStruct(): MailRecipientStruct
     {
-        if ($this->mailRecipientStruct) {
-            return $this->mailRecipientStruct;
+        if (!$this->mailRecipientStruct instanceof MailRecipientStruct) {
+            $this->mailRecipientStruct = new MailRecipientStruct([
+                $this->newsletterRecipient->getEmail() => $this->newsletterRecipient->getFirstName() . ' ' . $this->newsletterRecipient->getLastName(),
+            ]);
         }
 
-        return new MailRecipientStruct(
-            [
-                $this->newsletterRecipient->getEmail() => $this->newsletterRecipient->getFirstName() . ' ' . $this->newsletterRecipient->getLastName(),
-            ]
-        );
+        return $this->mailRecipientStruct;
     }
 
     public function getSalesChannelId(): ?string

--- a/src/Core/Content/Newsletter/Event/NewsletterUpdateEvent.php
+++ b/src/Core/Content/Newsletter/Event/NewsletterUpdateEvent.php
@@ -76,15 +76,13 @@ class NewsletterUpdateEvent extends Event implements MailActionInterface
 
     public function getMailStruct(): MailRecipientStruct
     {
-        if ($this->mailRecipientStruct) {
-            return $this->mailRecipientStruct;
+        if (!$this->mailRecipientStruct instanceof MailRecipientStruct) {
+            $this->mailRecipientStruct = new MailRecipientStruct([
+                $this->newsletterRecipient->getEmail() => $this->newsletterRecipient->getFirstName() . ' ' . $this->newsletterRecipient->getLastName(),
+            ]);
         }
 
-        return new MailRecipientStruct(
-            [
-                $this->newsletterRecipient->getEmail() => $this->newsletterRecipient->getFirstName() . ' ' . $this->newsletterRecipient->getLastName(),
-            ]
-        );
+        return $this->mailRecipientStruct;
     }
 
     public function getSalesChannelId(): ?string

--- a/src/Core/System/User/Recovery/UserRecoveryRequestEvent.php
+++ b/src/Core/System/User/Recovery/UserRecoveryRequestEvent.php
@@ -32,6 +32,11 @@ class UserRecoveryRequestEvent extends Event implements BusinessEventInterface, 
      */
     private $resetUrl;
 
+    /**
+     * @var MailRecipientStruct
+     */
+    private $mailRecipientStruct;
+
     public function __construct(UserRecoveryEntity $userRecovery, string $resetUrl, Context $context)
     {
         $this->userRecovery = $userRecovery;
@@ -64,11 +69,15 @@ class UserRecoveryRequestEvent extends Event implements BusinessEventInterface, 
 
     public function getMailStruct(): MailRecipientStruct
     {
-        $user = $this->userRecovery->getUser();
+        if (!$this->mailRecipientStruct instanceof MailRecipientStruct) {
+            $user = $this->userRecovery->getUser();
 
-        return new MailRecipientStruct([
-            $user->getEmail() => $user->getFirstName() . ' ' . $user->getLastName(),
-        ]);
+            $this->mailRecipientStruct = new MailRecipientStruct([
+                $user->getEmail() => $user->getFirstName() . ' ' . $user->getLastName(),
+            ]);
+        }
+
+        return $this->mailRecipientStruct;
     }
 
     public function getSalesChannelId(): ?string


### PR DESCRIPTION
### 1. Why is this change necessary?
Most of the events that implement `MailActionInterface` do not allow an external modification of the `MailRecipientStruct`. Let's say I wanted to add a recipient to the mail of the `CheckoutOrderPlacedEvent`. There are two possible situations: Either the `MailRecipientStruct` was set by the constructor or not. If it has been set, I can add recipients like so:

```php
$event->getMailStruct()->setRecipients(...);
```

If it has not been set, I have no way to modify the recipients externally.

### 2. What does this change do, exactly?
It changes the `getMailStruct` method of almost every event that implements `MailActionInterface` to be more similar to each other and to always save the `MailRecipientStruct` in a private property. This way, it is now always possible to modify the recipients externally. Regardless of whether or not it has been set in the constructor.

### 3. Describe each step to reproduce the issue or behaviour.
1. Subscribe to `CheckoutOrderPlacedEvent`.
2. `$event->getMailStruct()->setRecipients(...);`
3. See your overwrite to have no effect.

### 4. Please link to the relevant issues (if any).
None.

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
