### PR TITLE
Add tests for EntityForeignKeyResolver

### DIFF
--- a/src/Core/Framework/Test/DataAbstractionLayer/Dbal/EntityForeignKeyResolverTest.php
+++ b/src/Core/Framework/Test/DataAbstractionLayer/Dbal/EntityForeignKeyResolverTest.php
@@ -1,0 +1,278 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\Test\DataAbstractionLayer\Dbal;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\Dbal\EntityForeignKeyResolver;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Test\DataAbstractionLayer\Dbal\Fixtures\CascadeDeleteChild;
+use Shopware\Core\Framework\Test\DataAbstractionLayer\Dbal\Fixtures\GrandParentDefinition;
+use Shopware\Core\Framework\Test\DataAbstractionLayer\Dbal\Fixtures\ParentDefinition;
+use Shopware\Core\Framework\Test\DataAbstractionLayer\Dbal\Fixtures\RestrictDeleteChild;
+use Shopware\Core\Framework\Test\DataAbstractionLayer\Dbal\Fixtures\SetNullChild;
+use Shopware\Core\Framework\Test\DataAbstractionLayer\Field\DataAbstractionLayerFieldTestBehaviour;
+use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
+use Shopware\Core\Framework\Uuid\Uuid;
+
+class EntityForeignKeyResolverTest extends TestCase
+{
+    use IntegrationTestBehaviour;
+    use DataAbstractionLayerFieldTestBehaviour;
+
+    /**
+     * @var Connection
+     */
+    private $connection;
+
+    /**
+     * @var string
+     */
+    private $parentId;
+
+    /**
+     * @var string
+     */
+    private $grandParentId;
+
+    /**
+     * @var EntityForeignKeyResolver
+     */
+    private $entityForeignKeyResolver;
+
+    /**
+     * @var GrandParentDefinition
+     */
+    private $grandParentDefinition;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->connection = $this->getContainer()->get(Connection::class);
+
+        $this->deleteTestTables();
+
+        $this->registerDefinition(
+            GrandParentDefinition::class,
+            ParentDefinition::class,
+            RestrictDeleteChild::class,
+            CascadeDeleteChild::class,
+            SetNullChild::class
+        );
+
+        $this->connection->executeUpdate('CREATE TABLE `EntityForeignKeyResolverTest_grand_parent` (
+                `id` BINARY(16) NOT NULL,
+                `created_at` DATETIME(3) NOT NULL,
+                `updated_at` DATETIME(3) NULL,
+                PRIMARY KEY (`id`)
+            )
+        ');
+        $this->connection->executeUpdate('
+            CREATE TABLE `EntityForeignKeyResolverTest_parent` (
+                `id` BINARY(16) NOT NULL,
+                `grand_parent_id` BINARY(16) NOT NULL,
+                `created_at` DATETIME(3) NOT NULL,
+                `updated_at` DATETIME(3) NULL,
+                PRIMARY KEY (`id`),
+                FOREIGN KEY (`grand_parent_id`)
+                    REFERENCES `EntityForeignKeyResolverTest_grand_parent` (`id`)
+                    ON DELETE CASCADE ON UPDATE CASCADE
+            )
+        ');
+        $this->connection->executeUpdate('CREATE TABLE `EntityForeignKeyResolverTest_child_cascadeDelete` (
+                `id` BINARY(16) NOT NULL,
+                `parent_id` BINARY(16) NOT NULL,
+                `created_at` DATETIME(3) NOT NULL,
+                `updated_at` DATETIME(3) NULL,
+                PRIMARY KEY (`id`),
+                FOREIGN KEY (`parent_id`)
+                    REFERENCES `EntityForeignKeyResolverTest_parent` (`id`)
+                    ON DELETE CASCADE ON UPDATE CASCADE
+            )
+        ');
+        $this->connection->executeUpdate('
+            CREATE TABLE `EntityForeignKeyResolverTest_child_restrictDelete` (
+                `id` BINARY(16) NOT NULL,
+                `parent_id` BINARY(16) NOT NULL,
+                `created_at` DATETIME(3) NOT NULL,
+                `updated_at` DATETIME(3) NULL,
+                PRIMARY KEY (`id`),
+                FOREIGN KEY (`parent_id`)
+                    REFERENCES `EntityForeignKeyResolverTest_parent` (`id`)
+                    ON DELETE RESTRICT ON UPDATE CASCADE
+            )
+        ');
+        $this->connection->executeUpdate('
+            CREATE TABLE `EntityForeignKeyResolverTest_child_setNull` (
+                `id` BINARY(16) NOT NULL,
+                `parent_id` BINARY(16) NULL,
+                `created_at` DATETIME(3) NOT NULL,
+                `updated_at` DATETIME(3) NULL,
+                PRIMARY KEY (`id`),
+                FOREIGN KEY (`parent_id`)
+                    REFERENCES `EntityForeignKeyResolverTest_parent` (`id`)
+                    ON DELETE RESTRICT ON UPDATE CASCADE
+            )
+        ');
+
+        $this->parentId = Uuid::randomHex();
+        $this->grandParentId = Uuid::randomHex();
+
+        $this->connection->executeUpdate(
+            'INSERT INTO `EntityForeignKeyResolverTest_grand_parent` (
+                `id`,
+                 `created_at`
+            ) VALUES (
+                UNHEX(:id),
+                NOW(3)
+            )',
+            ['id' => $this->grandParentId]
+        );
+        $this->connection->executeUpdate(
+            'INSERT INTO `EntityForeignKeyResolverTest_parent` (
+                `id`,
+                `grand_parent_id`,
+                 `created_at`
+            ) VALUES (
+                UNHEX(:id),
+                UNHEX(:grandParentId),
+                NOW(3)
+            )',
+            [
+                'id' => $this->parentId,
+                'grandParentId' => $this->grandParentId,
+            ]
+        );
+
+
+        $this->grandParentDefinition = $this->getContainer()->get(GrandParentDefinition::class);
+        $this->entityForeignKeyResolver = $this->getContainer()->get(EntityForeignKeyResolver::class);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->deleteTestTables();
+
+        parent::tearDown();
+    }
+
+    private function deleteTestTables(): void
+    {
+        $this->connection->executeUpdate('DROP TABLE IF EXISTS `EntityForeignKeyResolverTest_child_cascadeDelete`');
+        $this->connection->executeUpdate('DROP TABLE IF EXISTS `EntityForeignKeyResolverTest_child_restrictDelete`');
+        $this->connection->executeUpdate('DROP TABLE IF EXISTS `EntityForeignKeyResolverTest_child_setNull`');
+        $this->connection->executeUpdate('DROP TABLE IF EXISTS `EntityForeignKeyResolverTest_parent`');
+        $this->connection->executeUpdate('DROP TABLE IF EXISTS `EntityForeignKeyResolverTest_grand_parent`');
+    }
+
+    public function testRespectsNestedRestrictDelete(): void
+    {
+        $childId = Uuid::randomHex();
+        $this->connection->executeUpdate(
+            'INSERT INTO `EntityForeignKeyResolverTest_child_restrictDelete` (
+                `id`,
+                `parent_id`,
+                 `created_at`
+            ) VALUES (
+                UNHEX(:id),
+                UNHEX(:parentId),
+                NOW(3)
+            )',
+            [
+                'parentId' => $this->parentId,
+                'id' => $childId,
+            ]
+        );
+
+        $deleteRestrictions = $this->entityForeignKeyResolver->getAffectedDeleteRestrictions(
+            $this->grandParentDefinition,
+            [
+                ['id' => $this->grandParentId],
+            ],
+            Context::createDefaultContext()
+        );
+
+        $deleteRestrictionsForDeletedEntity = $this->getRestrictionsForEntity(
+            $deleteRestrictions,
+            $this->grandParentId
+        );
+        self::assertEquals(
+            [$childId],
+            $deleteRestrictionsForDeletedEntity['EntityForeignKeyResolverTest_child_restrictDelete']
+        );
+    }
+
+    public function testRespectsNestedCascadeDelete(): void
+    {
+        $childId = Uuid::randomHex();
+        $this->connection->executeUpdate(
+            'INSERT INTO `EntityForeignKeyResolverTest_child_cascadeDelete` (
+                `id`,
+                `parent_id`,
+                 `created_at`
+            ) VALUES (
+                UNHEX(:id),
+                UNHEX(:parentId),
+                NOW(3)
+            )',
+            [
+                'parentId' => $this->parentId,
+                'id' => $childId,
+            ]
+        );
+
+        $deletes = $this->entityForeignKeyResolver->getAffectedDeletes(
+            $this->grandParentDefinition,
+            [
+                ['id' => $this->grandParentId],
+            ],
+            Context::createDefaultContext()
+        );
+
+        $deletesForDeletedEntity = $this->getRestrictionsForEntity($deletes, $this->grandParentId);
+        self::assertEquals([$childId], $deletesForDeletedEntity['EntityForeignKeyResolverTest_child_cascadeDelete']);
+    }
+
+    public function testRespectsNestedSetNullOnDelete(): void
+    {
+        $childId = Uuid::randomHex();
+        $this->connection->executeUpdate(
+            'INSERT INTO `EntityForeignKeyResolverTest_child_setNull` (
+                `id`,
+                `parent_id`,
+                 `created_at`
+            ) VALUES (
+                UNHEX(:id),
+                UNHEX(:parentId),
+                NOW(3)
+            )',
+            [
+                'parentId' => $this->parentId,
+                'id' => $childId,
+            ]
+        );
+
+        $setNulls = $this->entityForeignKeyResolver->getAffectedSetNulls(
+            $this->grandParentDefinition,
+            [
+                ['id' => $this->grandParentId],
+            ],
+            Context::createDefaultContext()
+        );
+
+        $setNullsForDeletedEntity = $this->getRestrictionsForEntity($setNulls, $this->grandParentId);
+        self::assertEquals([$childId], $setNullsForDeletedEntity['EntityForeignKeyResolverTest_child_setNull']);
+    }
+
+    private function getRestrictionsForEntity(array $restrictions, string $entityId)
+    {
+        foreach ($restrictions as $restriction) {
+            if ($restriction['pk'] === $entityId) {
+                return $restriction['restrictions'];
+            }
+        }
+
+        return [];
+    }
+}

--- a/src/Core/Framework/Test/DataAbstractionLayer/Dbal/Fixtures/CascadeDeleteChild.php
+++ b/src/Core/Framework/Test/DataAbstractionLayer/Dbal/Fixtures/CascadeDeleteChild.php
@@ -1,0 +1,30 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\Test\DataAbstractionLayer\Dbal\Fixtures;
+
+use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\FkField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\PrimaryKey;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\Required;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\IdField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\ManyToOneAssociationField;
+use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
+
+class CascadeDeleteChild extends EntityDefinition
+{
+    public const ENTITY_NAME = 'EntityForeignKeyResolverTest_child_cascadeDelete';
+
+    public function getEntityName(): string
+    {
+        return self::ENTITY_NAME;
+    }
+
+    protected function defineFields(): FieldCollection
+    {
+        return new FieldCollection([
+            (new IdField('id', 'id'))->addFlags(new PrimaryKey()),
+            (new FkField('parent_id', 'parentId', ParentDefinition::class))->addFlags(new Required()),
+            new ManyToOneAssociationField('parent', 'parent_id', ParentDefinition::class, 'id'),
+        ]);
+    }
+}

--- a/src/Core/Framework/Test/DataAbstractionLayer/Dbal/Fixtures/GrandParentDefinition.php
+++ b/src/Core/Framework/Test/DataAbstractionLayer/Dbal/Fixtures/GrandParentDefinition.php
@@ -1,0 +1,33 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\Test\DataAbstractionLayer\Dbal\Fixtures;
+
+use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\CascadeDelete;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\PrimaryKey;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\IdField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\OneToManyAssociationField;
+use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
+
+class GrandParentDefinition extends EntityDefinition
+{
+    public const ENTITY_NAME = 'EntityForeignKeyResolverTest_grand_parent';
+
+    public function getEntityName(): string
+    {
+        return self::ENTITY_NAME;
+    }
+
+    protected function defineFields(): FieldCollection
+    {
+        return new FieldCollection([
+            (new IdField('id', 'id'))->addFlags(new PrimaryKey()),
+            (new OneToManyAssociationField(
+                'parents',
+                ParentDefinition::class,
+                'grand_parent_id',
+                'id'
+            ))->addFlags(new CascadeDelete())
+        ]);
+    }
+}

--- a/src/Core/Framework/Test/DataAbstractionLayer/Dbal/Fixtures/ParentDefinition.php
+++ b/src/Core/Framework/Test/DataAbstractionLayer/Dbal/Fixtures/ParentDefinition.php
@@ -1,0 +1,57 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\Test\DataAbstractionLayer\Dbal\Fixtures;
+
+use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\FkField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\CascadeDelete;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\PrimaryKey;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\Required;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\RestrictDelete;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\SetNullOnDelete;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\IdField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\ManyToOneAssociationField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\OneToManyAssociationField;
+use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
+
+class ParentDefinition extends EntityDefinition
+{
+    public const ENTITY_NAME = 'EntityForeignKeyResolverTest_parent';
+
+    public function getEntityName(): string
+    {
+        return self::ENTITY_NAME;
+    }
+
+    protected function defineFields(): FieldCollection
+    {
+        return new FieldCollection([
+            (new IdField('id', 'id'))->addFlags(new PrimaryKey()),
+            (new FkField(
+                'grand_parent_id',
+                'grandParentId',
+                GrandParentDefinition::class,
+                'id')
+            )->addFlags(new Required()),
+            new ManyToOneAssociationField('grandParent', 'grand_parent_id', GrandParentDefinition::class, 'id'),
+            (new OneToManyAssociationField(
+                'cascade_delete_children',
+                CascadeDeleteChild::class,
+                'parent_id',
+                'id'
+            ))->addFlags(new CascadeDelete()),
+            (new OneToManyAssociationField(
+                'restrict_delete_children',
+                CascadeDeleteChild::class,
+                'parent_id',
+                'id'
+            ))->addFlags(new RestrictDelete()),
+            (new OneToManyAssociationField(
+                'set_null_children',
+                CascadeDeleteChild::class,
+                'parent_id',
+                'id'
+            ))->addFlags(new SetNullOnDelete()),
+        ]);
+    }
+}

--- a/src/Core/Framework/Test/DataAbstractionLayer/Dbal/Fixtures/RestrictDeleteChild.php
+++ b/src/Core/Framework/Test/DataAbstractionLayer/Dbal/Fixtures/RestrictDeleteChild.php
@@ -1,0 +1,30 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\Test\DataAbstractionLayer\Dbal\Fixtures;
+
+use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\FkField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\PrimaryKey;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\Required;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\IdField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\ManyToOneAssociationField;
+use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
+
+class RestrictDeleteChild extends EntityDefinition
+{
+    public const ENTITY_NAME = 'EntityForeignKeyResolverTest_child_restrictDelete';
+
+    public function getEntityName(): string
+    {
+        return self::ENTITY_NAME;
+    }
+
+    protected function defineFields(): FieldCollection
+    {
+        return new FieldCollection([
+            (new IdField('id', 'id'))->addFlags(new PrimaryKey()),
+            (new FkField('parent_id', 'parentId', ParentDefinition::class))->addFlags(new Required()),
+            new ManyToOneAssociationField('parent', 'parent_id', ParentDefinition::class, 'id'),
+        ]);
+    }
+}

--- a/src/Core/Framework/Test/DataAbstractionLayer/Dbal/Fixtures/SetNullChild.php
+++ b/src/Core/Framework/Test/DataAbstractionLayer/Dbal/Fixtures/SetNullChild.php
@@ -1,0 +1,30 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\Test\DataAbstractionLayer\Dbal\Fixtures;
+
+use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\FkField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\PrimaryKey;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\Required;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\IdField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\ManyToOneAssociationField;
+use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
+
+class SetNullChild extends EntityDefinition
+{
+    public const ENTITY_NAME = 'EntityForeignKeyResolverTest_child_setNull';
+
+    public function getEntityName(): string
+    {
+        return self::ENTITY_NAME;
+    }
+
+    protected function defineFields(): FieldCollection
+    {
+        return new FieldCollection([
+            (new IdField('id', 'id'))->addFlags(new PrimaryKey()),
+            (new FkField('parent_id', 'parentId', ParentDefinition::class))->addFlags(new Required()),
+            new ManyToOneAssociationField('parent', 'parent_id', ParentDefinition::class, 'id'),
+        ]);
+    }
+}


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/community).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well.
-->

### 1. Why is this change necessary?

`Shopware\Core\Framework\DataAbstractionLayer\Dbal\EntityForeignKeyResolver` resolves whether (among other things) the deletion of an entity is blocked by a `RestrictDelete`. However, restrictions are not resolved recursively at present. This causes problems when a `CascadeDelete` is blocked by another `RestrictDelete`. For example:

* Assume the following entities: `GrandParent`, `Parent`, `Child` with the following FK constraints:
`GrandParent` -- _CascaseDelete_ --> `Parent` -- _RestrictDelete_ --> `Child`
If you now want to delete a `GrandParent` that still has a `Parent` with a `Child`, the database will throw an error, as expected.
* The DAL should actually return a 409 conflict in the case you try to do the same via the API.
* Unfortunately, when checking the associations, the DAL only scans the direct associations of the entity to be deleted. So it recognizes that `Parent` will be removed when `GrandParent` is removed (it also determines which ones), but it does not recognize that `Parent` cannot be removed because there is still a _RestrictDelete_ on `Child`.
* This is because the DAL does not scan the entities' associations recursively for delete restrictions

=> EntityForeignKeyResolver needs to resolve the restrictions recursively.

### 2. What does this change do, exactly?

It add test that fail as long as the issue with the `EntityForeignKeyResolver` is not resolved. It does not fix the issue.

### 3. Describe each step to reproduce the issue or behaviour.

See test.

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.