### PR TITLE
Add missing page loading entrypoints

### DIFF
--- a/src/Storefront/DependencyInjection/services.xml
+++ b/src/Storefront/DependencyInjection/services.xml
@@ -192,6 +192,7 @@
             <argument type="service" id="Shopware\Core\System\SystemConfig\SystemConfigService"/>
             <argument type="service" id="Shopware\Core\Checkout\Payment\SalesChannel\PaymentMethodRoute"/>
             <argument type="service" id="Shopware\Core\Checkout\Shipping\SalesChannel\ShippingMethodRoute"/>
+            <argument type="service" id="event_dispatcher"/>
         </service>
 
         <service id="Shopware\Storefront\Page\Search\SearchPageLoader" public="true">

--- a/src/Storefront/DependencyInjection/services.xml
+++ b/src/Storefront/DependencyInjection/services.xml
@@ -253,6 +253,7 @@
             <argument type="service" id="Shopware\Core\Checkout\Cart\SalesChannel\CartService"/>
             <argument type="service" id="Shopware\Core\Checkout\Shipping\SalesChannel\ShippingMethodRoute"/>
             <argument type="service" id="Shopware\Core\Checkout\Payment\SalesChannel\PaymentMethodRoute"/>
+            <argument type="service" id="Shopware\Storefront\Page\GenericPageLoader"/>
         </service>
 
         <service id="Shopware\Storefront\Page\Checkout\Cart\CheckoutCartPageLoader">

--- a/src/Storefront/Page/Checkout/Confirm/CheckoutConfirmPage.php
+++ b/src/Storefront/Page/Checkout/Confirm/CheckoutConfirmPage.php
@@ -24,6 +24,9 @@ class CheckoutConfirmPage extends Page
      */
     protected $shippingMethods;
 
+    /**
+     * @deprecated tag:v6.3.0 use CheckoutConfirmPage::createFrom instead
+     */
     public function __construct(PaymentMethodCollection $paymentMethods, ShippingMethodCollection $shippingMethods)
     {
         $this->paymentMethods = $paymentMethods;

--- a/src/Storefront/Page/Checkout/Confirm/CheckoutConfirmPageLoader.php
+++ b/src/Storefront/Page/Checkout/Confirm/CheckoutConfirmPageLoader.php
@@ -9,6 +9,7 @@ use Shopware\Core\Checkout\Shipping\SalesChannel\AbstractShippingMethodRoute;
 use Shopware\Core\Checkout\Shipping\ShippingMethodCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\Exception\InconsistentCriteriaIdsException;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Shopware\Storefront\Page\GenericPageLoaderInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -34,16 +35,23 @@ class CheckoutConfirmPageLoader
      */
     private $paymentMethodRoute;
 
+    /**
+     * @var GenericPageLoaderInterface
+     */
+    private $genericPageLoader;
+
     public function __construct(
         EventDispatcherInterface $eventDispatcher,
         CartService $cartService,
         AbstractShippingMethodRoute $shippingMethodRoute,
-        AbstractPaymentMethodRoute $paymentMethodRoute
+        AbstractPaymentMethodRoute $paymentMethodRoute,
+        GenericPageLoaderInterface $genericPageLoader
     ) {
         $this->eventDispatcher = $eventDispatcher;
         $this->cartService = $cartService;
         $this->shippingMethodRoute = $shippingMethodRoute;
         $this->paymentMethodRoute = $paymentMethodRoute;
+        $this->genericPageLoader = $genericPageLoader;
     }
 
     /**
@@ -51,11 +59,11 @@ class CheckoutConfirmPageLoader
      */
     public function load(Request $request, SalesChannelContext $salesChannelContext): CheckoutConfirmPage
     {
-        $page = new CheckoutConfirmPage(
-            $this->getPaymentMethods($salesChannelContext),
-            $this->getShippingMethods($salesChannelContext)
-        );
+        $page = $this->genericPageLoader->load($request, $salesChannelContext);
+        $page = CheckoutConfirmPage::createFrom($page);
 
+        $page->setPaymentMethods($this->getPaymentMethods($salesChannelContext));
+        $page->setShippingMethods($this->getShippingMethods($salesChannelContext));
         $page->setCart($this->cartService->getCart($salesChannelContext->getToken(), $salesChannelContext));
 
         $this->eventDispatcher->dispatch(

--- a/src/Storefront/Page/GenericPageLoadedEvent.php
+++ b/src/Storefront/Page/GenericPageLoadedEvent.php
@@ -1,0 +1,25 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Storefront\Page;
+
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Symfony\Component\HttpFoundation\Request;
+
+class GenericPageLoadedEvent extends PageLoadedEvent
+{
+    /**
+     * @var Page
+     */
+    protected $page;
+
+    public function __construct(Page $page, SalesChannelContext $salesChannelContext, Request $request)
+    {
+        $this->page = $page;
+        parent::__construct($salesChannelContext, $request);
+    }
+
+    public function getPage(): Page
+    {
+        return $this->page;
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?
The confirm page loading flow is the only one that differs to other flows which led to missing generic page data like menus or meta information.
When you want to edit meta information on any page you want had to subscribe to all the events for every page.
![subscribe all the events](https://i.imgflip.com/3vtoud.jpg)

### 2. What does this change do, exactly?
Change the way the `CheckoutConfirmPage` is created by not using the constructor but using the createFrom trait. The constructor is marked deprecated by now. The `CheckoutConfirmPageLoader` now uses the `GenericPageLoader` to load additional page data.
The `GenericPageLoader` now triggers an event when a page is loaded.

### 3. Describe each step to reproduce the issue or behaviour.
* Open up the confirm page and try to display a footer menu
* Try to edit meta information on every page without to register to all the events.

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

### 5. Hotfixes

You can fix the missing generic page data on a `CheckoutConfirmPage` with this subscriber:

```php
<?php declare(strict_types=1);

namespace Foobar\Subscriber;

use Shopware\Storefront\Page\Checkout\Confirm\CheckoutConfirmPage;
use Shopware\Storefront\Page\Checkout\Confirm\CheckoutConfirmPageLoadedEvent;
use Shopware\Storefront\Page\GenericPageLoader;
use Shopware\Storefront\Page\PageLoadedEvent;
use Symfony\Component\EventDispatcher\EventSubscriberInterface;

class CheckoutConfirmGenericLoaderPatch implements EventSubscriberInterface
{
    /**
     * @var GenericPageLoader
     */
    private $genericPageLoader;

    public function __construct(GenericPageLoader $genericPageLoader)
    {
        $this->genericPageLoader = $genericPageLoader;
    }

    public static function getSubscribedEvents()
    {
        return [
            CheckoutConfirmPageLoadedEvent::class => 'loadGenericPage',
        ];
    }

    public function loadGenericPage(PageLoadedEvent $event): void
    {
        /** @var CheckoutConfirmPage $page */
        $page = $event->getPage();
        $genericPage = $this->genericPageLoader->load($event->getRequest(), $event->getSalesChannelContext());

        $page->setFooter($genericPage->getFooter());
        $page->setHeader($genericPage->getHeader());
        $page->setMetaInformation($genericPage->getMetaInformation());
        $page->setSalesChannelPaymentMethods($genericPage->getSalesChannelPaymentMethods());
        $page->setSalesChannelShippingMethods($genericPage->getSalesChannelShippingMethods());
        $page->setExtensions($genericPage->getExtensions());
    }
}

```