### PR TITLE
Compare option position stored in the translation

### DIFF
--- a/src/Core/Content/Property/Aggregate/PropertyGroupOption/PropertyGroupOptionEntity.php
+++ b/src/Core/Content/Property/Aggregate/PropertyGroupOption/PropertyGroupOptionEntity.php
@@ -26,7 +26,7 @@ class PropertyGroupOptionEntity extends Entity
     protected $name;
 
     /**
-     * @var int
+     * @var int|null
      */
     protected $position;
 
@@ -189,12 +189,12 @@ class PropertyGroupOptionEntity extends Entity
         $this->media = $media;
     }
 
-    public function getPosition(): int
+    public function getPosition(): ?int
     {
         return $this->position;
     }
 
-    public function setPosition(int $position): void
+    public function setPosition(?int $position): void
     {
         $this->position = $position;
     }

--- a/src/Storefront/Page/Product/Configurator/ProductPageConfiguratorLoader.php
+++ b/src/Storefront/Page/Product/Configurator/ProductPageConfiguratorLoader.php
@@ -167,7 +167,7 @@ class ProductPageConfiguratorLoader
                         return $a->getTranslation('name') <=> $b->getTranslation('name');
                     }
 
-                    return $a->getPosition() <=> $b->getPosition();
+                    return ($a->getTranslation('position') ?? 0) <=> ($b->getTranslation('position') ?? 0);
                 }
             );
         }

--- a/src/Storefront/Page/Product/ProductLoader.php
+++ b/src/Storefront/Page/Product/ProductLoader.php
@@ -143,7 +143,7 @@ class ProductLoader
                         return $a->getTranslation('name') <=> $b->getTranslation('name');
                     }
 
-                    return $a->getPosition() <=> $b->getPosition();
+                    return ($a->getTranslation('position') ?? 0) <=> ($b->getTranslation('position') ?? 0);
                 }
             );
         }


### PR DESCRIPTION
### 1. Why is this change necessary?
The option position is stored as translation. So this should also be read from the translation. I assume there might be a deeper problem why the position property is not set of the main entity but this is not for me to decide.

This is the error:
![grafik](https://user-images.githubusercontent.com/1133593/78779351-1a856e80-799d-11ea-837c-87b29c21a47c.png)

### 2. What does this change do, exactly?
Compare a different field that represents the same value: the position of the option to display at.

### 3. Describe each step to reproduce the issue or behaviour.
1. Have a shop in English
2. Upsert data in English
3. Open product in a German storefront

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
