### PR TITLE
Allow empty input in EntityWriter

### DIFF
--- a/src/Core/Framework/DataAbstractionLayer/Write/EntityWriter.php
+++ b/src/Core/Framework/DataAbstractionLayer/Write/EntityWriter.php
@@ -280,10 +280,10 @@ class EntityWriter implements EntityWriterInterface
      */
     private function validateWriteInput(array $data): void
     {
-        $valid = array_keys($data) === range(0, \count($data) - 1);
+        $valid = array_keys($data) === range(0, \count($data) - 1) || $data === [];
 
         if (!$valid) {
-            throw new \InvalidArgumentException('Expected input to be non empty non associative array.');
+            throw new \InvalidArgumentException('Expected input to be non associative array.');
         }
     }
 


### PR DESCRIPTION
### 1. Why is this change necessary?
The DAL works great on collections. And a very nice thing about collections is that you don't have to worry about the amount of content inside it. Executing write operations with no contents would not harm anyone. Now you don't have to check your arrays to be non-empty before passing them to the DAL and still have the same result.

### 2. What does this change do, exactly?
Allow empty input in write operations. A write operation with no contents will simply do nothing.

### 3. Describe each step to reproduce the issue or behaviour.
```php
$ids = [];
$productRepository->delete($ids, $context);
```

### 4. Please link to the relevant issues (if any).
None.

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
