### PR TITLE
Fix boolean field generation in EntityGenerator

### DIFF
--- a/src/Core/Framework/DataAbstractionLayer/EntityGenerator.php
+++ b/src/Core/Framework/DataAbstractionLayer/EntityGenerator.php
@@ -258,7 +258,7 @@ EOF;
 
                 break;
             case $field instanceof BoolField:
-                $type = 'boolean';
+                $type = 'bool';
 
                 break;
             case $field instanceof DateTimeField:


### PR DESCRIPTION
### 1. Why is this change necessary?
Return types of getter methods and argument types in setter methods are broken in generated entities for boolean fields. It will look like this:

```php
public function getActive(): ?boolean
{
    return $this->active;
}
```

### 2. What does this change do, exactly?
With this change the type will be `bool` instead of `boolean`.

### 3. Describe each step to reproduce the issue or behaviour.
1. Have an entity definition with at least one boolean field in it.
2. Run `dal:create:entities`.

### 4. Please link to the relevant issues (if any).
None.

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
