### PR TITLE
Fix division by zero error in pagination

### DIFF
--- a/src/Storefront/Resources/views/storefront/component/product/listing.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/product/listing.html.twig
@@ -1,4 +1,9 @@
-{% set currentPage = ((searchResult.criteria.offset + 1) / searchResult.criteria.limit )|round(0, 'ceil') %}
+{% if searchResult.criteria.limit == 0 %}
+    {% set limit = 1 %}
+{% else %}
+    {% set limit = searchResult.criteria.limit %}
+{% endif %}
+{% set currentPage = ((searchResult.criteria.offset + 1) / limit )|round(0, 'ceil') %}
 {% set paginationConfig = { page: currentPage }|json_encode %}
 
 {% set listingPagination = {


### PR DESCRIPTION
### 1. Why is this change necessary?

This is a fix for pagination when there are no products, it can give the following error:
```
An exception has been thrown during the rendering of a template ("Warning: Division by zero").
```

### 2. What does this change do, exactly?

It fixes the bug

### 3. Describe each step to reproduce the issue or behaviour.

Select any filter which would make the `searchResult.criteria.limit` to be zero and reload the page. 

### 4. Please link to the relevant issues (if any).

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
