### PR TITLE
Update box-standard.html.twig with lazyloading

### DIFF
--- a/src/Storefront/Resources/views/storefront/component/product/card/box-standard.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/product/card/box-standard.html.twig
@@ -33,6 +33,7 @@
                                         'class': 'product-image is-'~displayMode,
                                         'alt': (cover.translated.alt ?: name),
                                         'title': (cover.translated.title ?: name)
+                                        ,'loading': 'lazy'
                                     } %}
 
                                     {% if displayMode == 'cover' or displayMode == 'contain' %}


### PR DESCRIPTION
By simply adding 'loading': 'lazy' to the image attribute, the image is lazyloading in Chrome and in the future in all other browsers.

### 1. Why is this change necessary?
Better page speed, therefor better SEO

### 2. What does this change do, exactly?
Adds the attribute 'loading': 'lazy' to the image element

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ x] I have read the contribution requirements and fulfil them.
