### PR TITLE
Fix block name typo and mark old one deprecated

### DIFF
--- a/src/Storefront/Resources/views/storefront/page/product-detail/buy-widget-price.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/product-detail/buy-widget-price.html.twig
@@ -124,10 +124,15 @@
                     {% endblock %}
 
                     {% if price.referencePrice is not null %}
+                        {% block page_product_detail_price_unit_reference_content %}
+                        
+                        {# @deprecated tag:v6.3.0 #}
                         {% block page_product_detail_price_unit_refrence_content %}
                             <span class="price-unit-reference-content">
                                 ({{ price.referencePrice.price|currency }}{{ "general.star"|trans|sw_sanitize }} / {{ price.referencePrice.referenceUnit }} {{ price.referencePrice.unitName }})
                             </span>
+                        {% endblock %}
+                        
                         {% endblock %}
                     {% endif %}
                 </div>


### PR DESCRIPTION
### 1. Why is this change necessary?
It is just a typo.

### 2. What does this change do, exactly?
Fix a typo but provide both blocks to ensure compatibility.

### 3. Describe each step to reproduce the issue or behaviour.
Override this block but write the name by hand and type `reference` correctly.

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
