### PR TITLE
Add reference price block to checkout-item

### DIFF
--- a/src/Storefront/Resources/views/storefront/page/checkout/checkout-item.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/checkout/checkout-item.html.twig
@@ -112,11 +112,20 @@
                                                     </div>
                                                 {% endblock %}
 
+                                                {% set price = lineItem.price %}
+
                                                 {% block page_checkout_item_info_features %}
                                                     {% if lineItem.type == 'product' and lineItem.payload.features is not null %}
                                                         {% sw_include '@Storefront/storefront/component/product/feature/list.html.twig' with {
                                                             'features': lineItem.payload.features
                                                         } %}
+                                                    {% elseif lineItem.type == 'product' and lineItem.price.referencePrice is not null %}
+                                                        {# TODO: This branch can be removed, once the FEATURE_NEXT_6997 flag is removed #}
+                                                        {{ "checkout.priceUnitName"|trans|sw_sanitize }}
+                                                        <span class="price-unit-reference">
+                                                            {{ price.referencePrice.purchaseUnit }} {{ price.referencePrice.unitName }}
+                                                            ({{ price.referencePrice.price|currency }}{{ "general.star"|trans|sw_sanitize }} / {{ price.referencePrice.referenceUnit }} {{ price.referencePrice.unitName }})
+                                                        </span>
                                                     {% endif %}
                                                 {% endblock %}
 


### PR DESCRIPTION
### 1. Why is this change necessary?
There is no easy way to hide the reference price. (CSS is not a solution when it is about hiding an information technically).

### 2. What does this change do, exactly?
Surround an if-stmt with a block.

### 3. Describe each step to reproduce the issue or behaviour.
Try to remove the reference price from the output with just one block.

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

### 5. Bypass

There are ~~two~~ three ways to still get rid of this.
1. Use the block above to unset the lineItem variable so the following condition does not evaluate truthy. You have to use the follow-up block to re-set the lineItem variable.
2. Capture the parent block, evaluate some twig copies to generate the content that needs to be removed, use that to search for it and replace it from the block.
3. And my future I will take the patch file to this pull request and patch it directly in the composer project to have the new block 😁 