### PR TITLE
Fix packUnit not displayed on product detail

### DIFF
--- a/src/Storefront/Resources/views/storefront/page/product-detail/buy-widget-form.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/product-detail/buy-widget-form.html.twig
@@ -26,7 +26,7 @@
                                         class="custom-select product-detail-quantity-select">
                                     {% for quantity in range(product.minPurchase, product.calculatedMaxPurchase, product.purchaseSteps) %}
                                         <option value="{{ quantity }}">
-                                            {{ quantity }}{% if product.packUnit %} {{ product.packUnit }}{% endif %}
+                                            {{ quantity }}{% if product.translated.packUnit %} {{ product.translated.packUnit }}{% endif %}
                                         </option>
                                     {% endfor %}
                                 </select>


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/community).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
The packUnit is not displayed on the product detail page. The variable is access by `product.packUnit` but this does not work, as it's in the translation table.

### 2. What does this change do, exactly?
`product.packUnit` -> `product.translated.packUnit`

### 3. Describe each step to reproduce the issue or behaviour.
Enter a package unit in the administration for a product. It's not display on the product's page.

### 4. Please link to the relevant issues (if any).
-

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.
