### PR TITLE
Added a fix for tracking the purchase price for a discount for Google…

### DIFF
--- a/src/Storefront/Resources/views/storefront/component/checkout/hidden-line-items-information.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/checkout/hidden-line-items-information.html.twig
@@ -1,12 +1,17 @@
 {% block component_hidden_line_items_information %}
     <div class="d-none hidden-line-items-information">
         {% for lineItem in lineItems  %}
+            {% if lineItem.priceDefinition.price %}
+              {% set gaPrice = lineItem.priceDefinition.price %}
+            {% else %}
+              {% set gaPrice = lineItem.price.totalPrice %}
+            {% endif %}
             {% block component_hidden_line_item_information %}
                 <span class="hidden-line-item"
                       data-id="{{ lineItem.id }}"
                       data-name="{{ lineItem.label }}"
                       data-quantity="{{ lineItem.quantity }}"
-                      data-price="{{ lineItem.priceDefinition.price }}">
+                      data-price="{{ gaPrice }}">
                 </span>
             {% endblock %}
         {% endfor %}


### PR DESCRIPTION
… Analtytics

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/community).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?

When a discount is applied to the cart the purchase price is null for "lineItem.priceDefinition.price ". I have added a conditional to fix this.


### 2. What does this change do, exactly?

Fixes tracking for orders with promotions.

### 3. Describe each step to reproduce the issue or behaviour.

Setup a test Google Analytics account and promotion. Make a test order and check that the purchase price is correct in Google Analytics. You should also see the discount/promotion under products in Google Analtyics.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.
