### PR TITLE
fix sorting countries

### DIFF
--- a/src/Core/System/Country/CountryCollection.php
+++ b/src/Core/System/Country/CountryCollection.php
@@ -33,8 +33,8 @@ class CountryCollection extends EntityCollection
                 return $a->getPosition() <=> $b->getPosition();
             }
 
-            if ($a->getName() !== $b->getName()) {
-                return strnatcasecmp($a->getName(), $b->getName());
+            if ($a->getTranslation('name') !== $b->getTranslation('name')) {
+                return strnatcasecmp($a->getTranslation('name'), $b->getTranslation('name'));
             }
 
             return 0;


### PR DESCRIPTION
### 1. Why is this change necessary?
Currently...:
- the sorting of countries is failing, when the current saleschannel language should use inherited translation
- the sorting doesn't respect current translation

### 2. What does this change do, exactly?
Respect translated value

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
