### PR TITLE
Fix: Promotion ActiveDateRange time

### DIFF
--- a/src/Core/Checkout/Promotion/Gateway/Template/ActiveDateRange.php
+++ b/src/Core/Checkout/Promotion/Gateway/Template/ActiveDateRange.php
@@ -18,9 +18,7 @@ class ActiveDateRange extends MultiFilter
     {
         $today = new \DateTime();
         $today = $today->setTimezone(new \DateTimeZone('UTC'));
-
-        $todayStart = $today->format('Y-m-d 0:0:0');
-        $todayEnd = $today->format('Y-m-d 23:59:59');
+        $today = $today->format('Y-m-d H:i:s');
 
         $filterNoDateRange = new MultiFilter(
             MultiFilter::CONNECTION_AND,
@@ -33,7 +31,7 @@ class ActiveDateRange extends MultiFilter
         $filterStartedNoEndDate = new MultiFilter(
             MultiFilter::CONNECTION_AND,
             [
-                new RangeFilter('validFrom', ['lte' => $todayStart]),
+                new RangeFilter('validFrom', ['lte' => $today]),
                 new EqualsFilter('validUntil', null),
             ]
         );
@@ -42,15 +40,15 @@ class ActiveDateRange extends MultiFilter
             MultiFilter::CONNECTION_AND,
             [
                 new EqualsFilter('validFrom', null),
-                new RangeFilter('validUntil', ['gte' => $todayEnd]),
+                new RangeFilter('validUntil', ['gte' => $today]),
             ]
         );
 
         $activeDateRangeFilter = new MultiFilter(
             MultiFilter::CONNECTION_AND,
             [
-                new RangeFilter('validFrom', ['lte' => $todayStart]),
-                new RangeFilter('validUntil', ['gte' => $todayEnd]),
+                new RangeFilter('validFrom', ['lte' => $today]),
+                new RangeFilter('validUntil', ['gte' => $today]),
             ]
         );
 


### PR DESCRIPTION
# 1. Why is this change necessary?
ActiveDateRange filter will exclude the last day of a promotion, cause $todayEnd is set to 23:59:59 and the user can only set Time to 23:59:00 in backend.
23:59:59 (Current time) > 23:59:00 (Promotion time) => Promotion is not active for the last day

### 2. What does this change do, exactly?
Use the actual current DateTime for the ActiveDateRange filter

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
