### PR TITLE
Allow plugin developers to use custom label property.

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-settings/component/sw-system-config/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings/component/sw-system-config/index.js
@@ -154,6 +154,10 @@ Component.register('sw-system-config', {
             if (['single-select', 'multi-select'].includes(bind.type)) {
                 bind.config.labelProperty = 'name';
                 bind.config.valueProperty = 'id';
+                
+                if(bind.config.labelProperty !== undefined) {
+                    bind.config.labelProperty = bind.config.labelProperty;
+                }
             }
 
             return bind;


### PR DESCRIPTION
Without this fix it is not possible to use a custom labelProperty for config.xml values. With this fix you can use e.g.: <labelProperty>displayName</labelProperty> in config.xml for entity salutation.

example value for <component> in config.xml

<component name="sw-entity-single-select">
    <name>salutation</name>
    <entity>salutation</entity>
    <labelProperty>displayName</labelProperty>
    <label>Salutation</label>
    <label lang="de-DE">Anrede</label>
</component>

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/community).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?


### 2. What does this change do, exactly?


### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.
