### PR TITLE
Use min purchase as lower bound for listing price calculation

### DIFF
--- a/src/Core/Content/Product/SalesChannel/SalesChannelProductSubscriber.php
+++ b/src/Core/Content/Product/SalesChannel/SalesChannelProductSubscriber.php
@@ -61,7 +61,7 @@ class SalesChannelProductSubscriber implements EventSubscriberInterface
 
     private function calculatePrices(SalesChannelContext $context, SalesChannelProductEntity $product): void
     {
-        $prices = $this->priceDefinitionBuilder->build($product, $context);
+        $prices = $this->priceDefinitionBuilder->build($product, $context, $product->getMinPurchase() ?? 1);
 
         //calculate listing price
         $product->setCalculatedListingPrice(


### PR DESCRIPTION
### 1. Why is this change necessary?
When a product only has prices from starting at quantity 150 the listing price is generated for the hidden default parameter of quantity 1. As there is no price for below 150 it fails to load the listing.

### 2. What does this change do, exactly?
Use the min purchase information to define the lower bound of the listing price.

### 3. Describe each step to reproduce the issue or behaviour.
1. Create prices that do not start below 2
2. Load a listing

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
