### PR TITLE
Remove async from injectPlugin calls

### DIFF
--- a/src/Administration/Resources/app/administration/src/core/application.js
+++ b/src/Administration/Resources/app/administration/src/core/application.js
@@ -566,7 +566,6 @@ class ApplicationBootstrapper {
             // create script tag with src
             const script = document.createElement('script');
             script.src = scriptSrc;
-            script.async = true;
 
             // resolve when script was loaded succcessfully
             script.onload = () => {


### PR DESCRIPTION
### 1. Why is this change necessary?
Currently all scripts provided by plugins in the administration are loaded with `async=true` which means that there is no predictable order for plugins to be loaded. The problem is that this denies developers to build a set of base plugins which then can be used in a final theme plugin accessing those functionality while the theme is being loaded last. Alternatively if performance is a concern (yet i don't see the point since everything is loaded on first load always) you could use `defer` instead.

### 2. What does this change do, exactly?
Load all scripts synchronously or defer them.

### 3. Describe each step to reproduce the issue or behaviour.
Define a Mixin via a custom plugin and then try to use it in another plugin. The administration will fail on boot with a hard to read error.

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
