### PR TITLE
Fix for missing account order product images

### DIFF
--- a/src/Storefront/Page/Account/Order/AccountOrderPageLoader.php
+++ b/src/Storefront/Page/Account/Order/AccountOrderPageLoader.php
@@ -119,6 +119,7 @@ class AccountOrderPageLoader
             ->addAssociation('deliveries.shippingMethod')
             ->addAssociation('orderCustomer.customer')
             ->addAssociation('lineItems')
+            ->addAssociation('lineItems.cover')
             ->setLimit($limit)
             ->setOffset(($page - 1) * $limit)
             ->setTotalCountMode(Criteria::TOTAL_COUNT_MODE_NEXT_PAGES);

--- a/src/Storefront/Page/Account/Overview/AccountOverviewPageLoader.php
+++ b/src/Storefront/Page/Account/Overview/AccountOverviewPageLoader.php
@@ -89,6 +89,7 @@ class AccountOverviewPageLoader
         $criteria = (new Criteria())
             ->addSorting(new FieldSorting('orderDateTime', FieldSorting::DESCENDING))
             ->addAssociation('lineItems')
+            ->addAssociation('lineItems.cover')
             ->addAssociation('transactions.paymentMethod')
             ->addAssociation('deliveries.shippingMethod')
             ->setLimit(1)


### PR DESCRIPTION
### 1. Why is this change necessary?
The orders are displayed on the customer account page without product images after update on 6.2. This changes fix it.

### 2. What does this change do, exactly?
I added only lineItems cover to populate images data.

### 3. Describe each step to reproduce the issue or behaviour.
1) log into your customer account
2) place an order if you didn't have one
3) on the ../account/order page click on "View" to see ordered products: you will see that product images missing
or on the ../account page in "Last order" click on "View" to see ordered products: you will see that product images missing

### 4. Please link to the relevant issues (if any).
No issues found

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
+ [ ] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.
=> contribution documentation is not available now