### PR TITLE
Added "blocks" to thumbnail.html.twig to extend it

### DIFF
--- a/CHANGELOG-6.2.md
+++ b/CHANGELOG-6.2.md
@@ -541,6 +541,8 @@ To get the diff between two versions, go to https://github.com/shopware/platform
         * `storefront.htmlPurifier.cacheDir`: Directory to write `HTMLPurifier` cache (defaults to `kernel.cache_dir`)
         * `storefront.htmlPurifier.enableCache`: Boolean to turn `HTMLPurifier`s cache cache on or off (defaults to `true`)
     * Deprecated `sort` parameter for product listing, search and suggest gateway, use `order` instead
+    * Added `utilities_thumbnail`, `utilities_thumbnail_logic`, `utilities_thumbnail_image` twig blocks to thumbnail.html.twig
+
 **Removals**
 
 * Administration

--- a/src/Storefront/Resources/views/storefront/utilities/thumbnail.html.twig
+++ b/src/Storefront/Resources/views/storefront/utilities/thumbnail.html.twig
@@ -1,56 +1,62 @@
-{# uses cms block column count and all available thumbnails to determine the correct image size for the current viewport #}
-{% if media.thumbnails|length > 0 %}
-    {% if columns and sizes is not defined %}
-        {# set image size for every viewport #}
-        {% set sizes = {
-            'xs': (shopware.theme.breakpoint.sm - 1) ~'px',
-            'sm': (shopware.theme.breakpoint.md - 1) ~'px',
-            'md': ((shopware.theme.breakpoint.lg - 1) / columns)|round(0, 'ceil') ~'px',
-            'lg': ((shopware.theme.breakpoint.xl - 1) / columns)|round(0, 'ceil') ~'px'
-        } %}
+{% block utilities_thumbnail %}
+    {% block utilities_thumbnail_logic %}
+        {# uses cms block column count and all available thumbnails to determine the correct image size for the current viewport #}
+        {% if media.thumbnails|length > 0 %}
+            {% if columns and sizes is not defined %}
+                {# set image size for every viewport #}
+                {% set sizes = {
+                    'xs': (shopware.theme.breakpoint.sm - 1) ~'px',
+                    'sm': (shopware.theme.breakpoint.md - 1) ~'px',
+                    'md': ((shopware.theme.breakpoint.lg - 1) / columns)|round(0, 'ceil') ~'px',
+                    'lg': ((shopware.theme.breakpoint.xl - 1) / columns)|round(0, 'ceil') ~'px'
+                } %}
 
-        {# set image size for largest viewport depending on the cms block sizing mode (boxed or full-width) #}
-        {% if layout == 'full-width' %}
-            {% set container = 100 %}
-            {% set sizes = sizes|merge({ 'xl': (container / columns)|round(0, 'ceil') ~'vw'}) %}
-        {% else %}
-            {% set container = 1360 %}
-            {% set sizes = sizes|merge({ 'xl': (container / columns)|round(0, 'ceil') ~'px'}) %}
+                {# set image size for largest viewport depending on the cms block sizing mode (boxed or full-width) #}
+                {% if layout == 'full-width' %}
+                    {% set container = 100 %}
+                    {% set sizes = sizes|merge({ 'xl': (container / columns)|round(0, 'ceil') ~'vw'}) %}
+                {% else %}
+                    {% set container = 1360 %}
+                    {% set sizes = sizes|merge({ 'xl': (container / columns)|round(0, 'ceil') ~'px'}) %}
+                {% endif %}
+            {% endif %}
+
+            {% set thumbnails = media.thumbnails|sort|reverse %}
+
+            {# generate srcset with all available thumbnails #}
+            {% set srcsetValue %}{% apply spaceless %}
+                {{ media|sw_encode_media_url }} {{ thumbnails|first.width + 1 }}w, {% for thumbnail in thumbnails %}{{ thumbnail.url | sw_encode_url }} {{ thumbnail.width }}w{% if not loop.last %}, {% endif %}{% endfor %}
+            {% endapply %}{% endset %}
+
+            {# generate sizes #}
+            {% set sizesValue %}{% apply spaceless %}
+                {% set sizeFallback = 100 %}
+
+                {# set largest size depending on column count of cms block #}
+                {% if columns %}
+                    {% set sizeFallback = (sizeFallback / columns)|round(0, 'ceil') %}
+                {% endif %}
+
+                {% if thumbnails|first.width > shopware.theme.breakpoint|reverse|first %}
+                    {% set maxWidth = thumbnails|first.width %}
+                {% endif %}
+
+                {% for key, value in shopware.theme.breakpoint|reverse %}{% if maxWidth %}(max-width: {{ maxWidth }}px) and {% endif %}(min-width: {{ value }}px) {{ sizes[key] }}{% set maxWidth = value-1 %}{% if not loop.last %}, {% endif %}{% endfor %}, {{ sizeFallback }}vw
+            {% endapply %}{% endset %}
         {% endif %}
-    {% endif %}
-
-    {% set thumbnails = media.thumbnails|sort|reverse %}
-
-    {# generate srcset with all available thumbnails #}
-    {% set srcsetValue %}{% apply spaceless %}
-        {{ media|sw_encode_media_url }} {{ thumbnails|first.width + 1 }}w, {% for thumbnail in thumbnails %}{{ thumbnail.url | sw_encode_url }} {{ thumbnail.width }}w{% if not loop.last %}, {% endif %}{% endfor %}
-    {% endapply %}{% endset %}
-
-    {# generate sizes #}
-    {% set sizesValue %}{% apply spaceless %}
-        {% set sizeFallback = 100 %}
-
-        {# set largest size depending on column count of cms block #}
-        {% if columns %}
-            {% set sizeFallback = (sizeFallback / columns)|round(0, 'ceil') %}
-        {% endif %}
-
-        {% if thumbnails|first.width > shopware.theme.breakpoint|reverse|first %}
-            {% set maxWidth = thumbnails|first.width %}
-        {% endif %}
-
-        {% for key, value in shopware.theme.breakpoint|reverse %}{% if maxWidth %}(max-width: {{ maxWidth }}px) and {% endif %}(min-width: {{ value }}px) {{ sizes[key] }}{% set maxWidth = value-1 %}{% if not loop.last %}, {% endif %}{% endfor %}, {{ sizeFallback }}vw
-    {% endapply %}{% endset %}
-{% endif %}
-<img src="{{ media|sw_encode_media_url }}"
-    {% if media.thumbnails|length > 0 %}
-        srcset="{{ srcsetValue }}"
-        {% if sizes['default'] %}
-        sizes="{{ sizes['default'] }}"
-        {% elseif sizes|length > 0 %}
-        sizes="{{ sizesValue }}"
-        {% endif %}
-    {% endif %}
-    {% for key, value in attributes %}{% if value != '' %} {{ key }}="{{ value }}"{% endif %}{% endfor %}
-/>
+    {% endblock %}
+    {% block utilities_thumbnail_image %}
+        <img src="{{ media|sw_encode_media_url }}"
+            {% if media.thumbnails|length > 0 %}
+                srcset="{{ srcsetValue }}"
+                {% if sizes['default'] %}
+                sizes="{{ sizes['default'] }}"
+                {% elseif sizes|length > 0 %}
+                sizes="{{ sizesValue }}"
+                {% endif %}
+            {% endif %}
+            {% for key, value in attributes %}{% if value != '' %} {{ key }}="{{ value }}"{% endif %}{% endfor %}
+        />
+    {% endblock %}
+{% endblock %}
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/community).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
to extend the thumbnail function

### 2. What does this change do, exactly?
adding blocks to the template

### 3. Describe each step to reproduce the issue or behaviour.
with missing blocks you can't extend the thumbnail.html.twig

### 4. Please link to the relevant issues (if any).
SWAG-133736

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
