### PR TITLE
[FIX] Fix variable names according to event name

### DIFF
--- a/src/Core/Content/MailTemplate/Service/MailService.php
+++ b/src/Core/Content/MailTemplate/Service/MailService.php
@@ -107,8 +107,8 @@ class MailService implements MailServiceInterface
 
     public function send(array $data, Context $context, array $templateData = []): ?\Swift_Message
     {
-        $mailSentEvent = new MailBeforeValidateEvent($data, $context, $templateData);
-        $this->eventDispatcher->dispatch($mailSentEvent);
+        $mailBeforeValidateEvent = new MailBeforeValidateEvent($data, $context, $templateData);
+        $this->eventDispatcher->dispatch($mailBeforeValidateEvent);
 
         $definition = $this->getValidationDefinition($context);
         $this->dataValidator->validate($data, $definition);
@@ -182,10 +182,10 @@ class MailService implements MailServiceInterface
             $binAttachments
         );
 
-        $mailSentEvent = new MailBeforeSentEvent($data, $message, $context);
-        $this->eventDispatcher->dispatch($mailSentEvent);
+        $mailBeforeSentEvent = new MailBeforeSentEvent($data, $message, $context);
+        $this->eventDispatcher->dispatch($mailBeforeSentEvent);
 
-        if ($mailSentEvent->isPropagationStopped()) {
+        if ($mailBeforeSentEvent->isPropagationStopped()) {
             return null;
         }
 


### PR DESCRIPTION
### 1. Why is this change necessary?
All variables were called `$mailSentEvent`

### 2. What does this change do, exactly?
Rename variables according to the event name

### 3. Describe each step to reproduce the issue or behaviour.
Take a look at the file

### 4. Please link to the relevant issues (if any).
///

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
  - No need to
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
  - No need to
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
  - No need to
- [x] I have read the contribution requirements and fulfil them.
