### PR TITLE
[TASK] Correct parameter naming - database storageName vs. object pro…

### DIFF
--- a/src/Core/Framework/Migration/InheritanceUpdaterTrait.php
+++ b/src/Core/Framework/Migration/InheritanceUpdaterTrait.php
@@ -6,11 +6,11 @@ use Doctrine\DBAL\Connection;
 
 trait InheritanceUpdaterTrait
 {
-    protected function updateInheritance(Connection $connection, string $entity, string $propertyName): void
+    protected function updateInheritance(Connection $connection, string $entity, string $storageName): void
     {
         $sql = str_replace(
             ['#table#', '#column#'],
-            [$entity, $propertyName],
+            [$entity, $storageName],
             'ALTER TABLE `#table#` ADD COLUMN `#column#` binary(16) NULL'
         );
 


### PR DESCRIPTION
### 1. Why is this change necessary?
 
Especially for beginners it should clearly be differentiated, where an object of a class and its properties come into play or if the fields of a database table are subject of the interest. 

### 2. What does this change do, exactly?

It changes the misleading naming of a method parameter. 

 ### 3. Describe each step to reproduce the issue or behaviour.
 ### 4. Please link to the relevant issues (if any).
 ### 5. Checklist
 
     * [ ]  I have written tests and verified that they fail without my change
 
     * [x]  I have squashed any insignificant commits
 
     * [x]  I have written or adjusted the documentation according to my changes
 
     * [ ]  This change has comments for package types, values, functions, and non-obvious lines of code
 
     * [x]  I have read the contribution requirements and fulfil them.
