### PR TITLE
Rely on cmsPage object instead of page.cmsPage

### DIFF
--- a/src/Storefront/Resources/views/storefront/element/cms-element-product-listing.html.twig
+++ b/src/Storefront/Resources/views/storefront/element/cms-element-product-listing.html.twig
@@ -7,7 +7,7 @@
         {% set listingColumns = 'col-sm-6 col-lg-6 col-xl-4' %}
     {% endif %}
 
-    {% set slot = page.cmsPage.firstElementOfType('product-listing') %}
+    {% set slot = cmsPage.firstElementOfType('product-listing') %}
 
     {% set filterUrl = null %}
     {% set dataUrl = null %}

--- a/src/Storefront/Resources/views/storefront/element/cms-element-sidebar-filter.html.twig
+++ b/src/Storefront/Resources/views/storefront/element/cms-element-sidebar-filter.html.twig
@@ -1,6 +1,6 @@
 {% block element_sidebar_filter %}
     {% set config = element.fieldConfig.elements %}
-    {% set slot = page.cmsPage.firstElementOfType('product-listing') %}
+    {% set slot = cmsPage.firstElementOfType('product-listing') %}
 
     <div class="cms-element-sidebar-filter">
         {% block element_product_listing_filter_button %}


### PR DESCRIPTION
### 1. Why is this change necessary?
The `page` object is `null` in the route `/widgets/cms/navigation/{navigationId}`
Besides a `product-listing` we display `sidebar-filter` block in this routing so that we have filters refreshed every filter option change. Due to `page` object is `null` we have empty filters.

### 2. What does this change do, exactly?
Makes filters in `/widgets/cms/navigation/{navigationId}` route not empty.

### 3. Describe each step to reproduce the issue or behaviour.

### 4. Please link to the relevant issues (if any).

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
