### PR TITLE
Add missing search extension to product listing loader

### DIFF
--- a/src/Core/Content/Product/SalesChannel/Listing/ProductListingLoader.php
+++ b/src/Core/Content/Product/SalesChannel/Listing/ProductListingLoader.php
@@ -74,6 +74,23 @@ class ProductListingLoader
         $read = $criteria->cloneForRead($variantIds);
 
         $entities = $this->repository->search($read, $context);
+        
+        $search = $ids->getData();
+        /** @var Entity $element */
+        foreach ($entities as $element) {
+            if (!\array_key_exists($element->getUniqueIdentifier(), $search)) {
+                continue;
+            }
+
+            $data = $search[$element->getUniqueIdentifier()];
+            unset($data['id']);
+
+            if (empty($data)) {
+                continue;
+            }
+
+            $element->addExtension('search', new ArrayEntity($data));
+        }
 
         return new EntitySearchResult(
             $ids->getTotal(),


### PR DESCRIPTION
By Shopware 6.2.0-RC1 the search extension is no longer available for products in the product listing.
Inside the search extension the _score is stored which is needed for the Shopware Enterprise Search.


### 1. Why is this change necessary?
The search extension and the _score is missing for the product search result. Shopware Enterprise Search needs the _score for the search preview.
For the change of Shopware 6.2.0-RC1 this missing.

### 2. What does this change do, exactly?
It adds the search extension with the _score to the search result.

### 3. Describe each step to reproduce the issue or behaviour.
Try the search preview of the Shopware Enterprise Search at 6.2.0-RC1.

### 4. Please link to the relevant issues (if any).
No issue was created yet.

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
