### PR TITLE
Allow more headers in the CorsListener

### DIFF
--- a/src/Core/Framework/Api/EventListener/CorsListener.php
+++ b/src/Core/Framework/Api/EventListener/CorsListener.php
@@ -46,6 +46,8 @@ class CorsListener implements EventSubscriberInterface
             PlatformRequest::HEADER_ACCESS_KEY,
             PlatformRequest::HEADER_LANGUAGE_ID,
             PlatformRequest::HEADER_VERSION_ID,
+            PlatformRequest::HEADER_INHERITANCE,
+            PlatformRequest::HEADER_FAIL_ON_ERROR,
         ];
 
         $response = $event->getResponse();

--- a/src/Core/PlatformRequest.php
+++ b/src/Core/PlatformRequest.php
@@ -23,6 +23,11 @@ final class PlatformRequest
     public const HEADER_INCLUDE_SEO_URLS = 'sw-include-seo-urls';
 
     /**
+     * Entity repository headers
+     */
+    public const HEADER_FAIL_ON_ERROR = 'fail-on-error';
+
+    /**
      * This header is used in the administration to get all fields
      */
     public const HEADER_IGNORE_DEPRECATIONS = 'sw-api-compatibility';


### PR DESCRIPTION
### 1. Why is this change necessary?

As discussed with @OliverSkroblin, headers `sw-inheritance` and `fail-on-error` should also be whitelisted for cross-origin requests.

### 2. What does this change do, exactly?

Allows `sw-inheritance` and `fail-on-error` headers in the `CorsListener`.

### 3. Describe each step to reproduce the issue or behaviour.

### 4. Please link to the relevant issues (if any).

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
