### PR TITLE
Remove shopware storefront dependency in core

### DIFF
--- a/src/Core/Migration/Migration1585490020ActivateHoneypotCaptcha.php
+++ b/src/Core/Migration/Migration1585490020ActivateHoneypotCaptcha.php
@@ -6,11 +6,12 @@ use Doctrine\DBAL\Connection;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Migration\MigrationStep;
 use Shopware\Core\Framework\Uuid\Uuid;
-use Shopware\Storefront\Framework\Captcha\HoneypotCaptcha;
 
 class Migration1585490020ActivateHoneypotCaptcha extends MigrationStep
 {
     private const CONFIG_KEY = 'core.basicInformation.activeCaptchas';
+    
+    private const CAPTCHA_NAME = 'honeypot';
 
     public function getCreationTimestamp(): int
     {
@@ -29,7 +30,7 @@ class Migration1585490020ActivateHoneypotCaptcha extends MigrationStep
         $connection->insert('system_config', [
             'id' => Uuid::randomBytes(),
             'configuration_key' => self::CONFIG_KEY,
-            'configuration_value' => sprintf('{"_value": ["%s"]}', HoneypotCaptcha::CAPTCHA_NAME),
+            'configuration_value' => sprintf('{"_value": ["%s"]}', self::CAPTCHA_NAME),
             'created_at' => (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT),
         ]);
     }


### PR DESCRIPTION
### 1. Why is this change necessary?
You can't run migrations from shopware/core without depending on `shopware/storefront` as well. I never thought that there was a dependency in `core` towards `storefront`... but there is. And it hurts me deeply. I mean the migration which is part of every deployment now breaks when shopware/storefront is missing. And the migration has dynamic content. It is never a good idea when a migration has dynamic content. It should have the same result anytime it gets executed without any outside dependencies. Not even within the project it comes from as it would simply get refactored by any refactoring tools.

### 2. What does this change do, exactly?
It removes a hidden dependency by copying a value from the constant over to the migration.

### 3. Describe each step to reproduce the issue or behaviour.
1. `composer require shopware/core:6.2`
2. `(new Application(/* ... */))->run(new StringInput('database:migrate --all'));`

### 4. Issue

https://issues.shopware.com/issues/NEXT-8572

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
