### PR TITLE
Allow additional sorting after ‘_score’ sorting

### DIFF
--- a/CHANGELOG-6.2.md
+++ b/CHANGELOG-6.2.md
@@ -482,6 +482,8 @@ To get the diff between two versions, go to https://github.com/shopware/platform
     * Deprecated `\Shopware\Core\Framework\DataAbstractionLayer\Search\RequestCriteriaBuilder::getAllowedLimits`
     * Deprecated `shopware.api.allowed_limits` configuration
     * Added `definition` parameter in `\Shopware\Elasticsearch\Framework\ElasticsearchHelper::addTerm` 
+    * Allow additional sorting after the `_score` sorting when using a search term or score query in `\Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria`
+
 * Storefront
     * Deprecated `$connection->executeQuery()` for write operations
     * Added `\Shopware\Core\Framework\Api\Controller\CaptchaController` which provides a list of all available captchas to the administration

--- a/src/Core/Framework/DataAbstractionLayer/Dbal/CriteriaQueryHelper.php
+++ b/src/Core/Framework/DataAbstractionLayer/Dbal/CriteriaQueryHelper.php
@@ -205,9 +205,8 @@ trait CriteriaQueryHelper
         $select = 'SUM(' . implode(' + ', $queries->getWheres()) . ')';
         $query->addSelect($select . ' as _score');
 
-        if (empty($criteria->getSorting())) {
-            $query->addOrderBy('_score', 'DESC');
-        }
+        // Sort by _score primarily if the criteria has a score query or search term
+        $this->addSortings($definition, [new FieldSorting('_score', FieldSorting::DESCENDING)], $query, $context);
 
         $minScore = array_map(function (ScoreQuery $query) {
             return $query->getScore();

--- a/src/Core/Framework/Test/DataAbstractionLayer/Dbal/CriteriaQueryHelperTest.php
+++ b/src/Core/Framework/Test/DataAbstractionLayer/Dbal/CriteriaQueryHelperTest.php
@@ -3,16 +3,25 @@
 namespace Shopware\Core\Framework\Test\DataAbstractionLayer\Dbal;
 
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Product\ProductDefinition;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\Dbal\CriteriaQueryHelper;
+use Shopware\Core\Framework\DataAbstractionLayer\Dbal\EntityDefinitionQueryHelper;
 use Shopware\Core\Framework\DataAbstractionLayer\Dbal\Exception\InvalidSortingDirectionException;
+use Shopware\Core\Framework\DataAbstractionLayer\Dbal\QueryBuilder;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepositoryInterface;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\ContainsFilter;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Query\ScoreQuery;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Sorting\FieldSorting;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Term\EntityScoreQueryBuilder;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Term\SearchTermInterpreter;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 
 class CriteriaQueryHelperTest extends TestCase
 {
-    use IntegrationTestBehaviour;
+    use CriteriaQueryHelper, IntegrationTestBehaviour;
 
     public function testInvalidSortingDirection(): void
     {
@@ -26,5 +35,79 @@ class CriteriaQueryHelperTest extends TestCase
 
         static::expectException(InvalidSortingDirectionException::class);
         $taxRepository->search($criteria, $context);
+    }
+
+    public function testDoNotSortByScoreIfNoScoreQueryOrSearchTermIsSet(): void
+    {
+        $productDefinition = $this->getContainer()->get(ProductDefinition::class);
+        $queryMock = $this->createMock(QueryBuilder::class);
+        $queryMock
+            ->expects($this->never())
+            ->method('addOrderBy');
+
+        $this->buildQueryByCriteria($queryMock, $productDefinition, new Criteria(), Context::createDefaultContext());
+    }
+
+    public function testSortByScoreIfScoreQueryIsSet(): void
+    {
+        $productDefinition = $this->getContainer()->get(ProductDefinition::class);
+        $criteria = new Criteria();
+        $criteria->addQuery(new ScoreQuery(new ContainsFilter('name', 'test matching'), 1000));
+        $queryMock = $this->createMock(QueryBuilder::class);
+        $queryMock
+            ->expects($this->once())
+            ->method('addOrderBy')
+            ->with('_score', 'DESC');
+
+        $this->buildQueryByCriteria($queryMock, $productDefinition, $criteria, Context::createDefaultContext());
+    }
+
+    public function testSortByScoreIfSearchTermIsSet(): void
+    {
+        $productDefinition = $this->getContainer()->get(ProductDefinition::class);
+        $criteria = new Criteria();
+        $criteria->setTerm('searchTerm');
+        $queryMock = $this->createMock(QueryBuilder::class);
+        $queryMock
+            ->expects($this->once())
+            ->method('addOrderBy')
+            ->with('_score', 'DESC');
+
+        $this->buildQueryByCriteria($queryMock, $productDefinition, $criteria, Context::createDefaultContext());
+    }
+
+    public function testSortByScoreAndAdditionalSorting(): void
+    {
+        $productDefinition = $this->getContainer()->get(ProductDefinition::class);
+        $criteria = new Criteria();
+        $criteria->setTerm('searchTerm');
+        $criteria->addSorting(new FieldSorting('createdAt', FieldSorting::ASCENDING));
+        $queryMock = $this->createMock(QueryBuilder::class);
+        $queryMock
+            ->expects($this->exactly(2))
+            ->method('addOrderBy')
+            ->withConsecutive(['_score', 'DESC'], ['`product`.`created_at`', 'ASC']);
+
+        $this->buildQueryByCriteria($queryMock, $productDefinition, $criteria, Context::createDefaultContext());
+    }
+
+    protected function getParser(): SqlQueryParser
+    {
+        return $this->getContainer()->get(SqlQueryParser::class);
+    }
+
+    protected function getDefinitionHelper(): EntityDefinitionQueryHelper
+    {
+        return $this->getContainer()->get(EntityDefinitionQueryHelper::class);
+    }
+
+    protected function getInterpreter(): SearchTermInterpreter
+    {
+        return $this->getContainer()->get(SearchTermInterpreter::class);
+    }
+
+    protected function getScoreBuilder(): EntityScoreQueryBuilder
+    {
+        return $this->getContainer()->get(EntityScoreQueryBuilder::class);
     }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?

As discussed with @OliverSkroblin, when using a `Criteria` with a score query or search term the result of the query will be sorted by `_score` (e.g. search rank) iff no other sorting was set in the criteria.
Hence it is not possible to use a `_score` sorting with any additional sorting to further sort result entries with the same score:
<img width="181" alt="Screenshot 2020-05-04 at 18 24 43" src="https://user-images.githubusercontent.com/12038224/81268150-dd69d600-9047-11ea-9db7-b8e87285d4d3.png">

### 2. What does this change do, exactly?
With this PR it is possible to add sortings in addition to an existing `_score` sorting.
<img width="155" alt="Screenshot 2020-05-04 at 18 44 06" src="https://user-images.githubusercontent.com/12038224/81268459-3df91300-9048-11ea-8455-9b848599929a.png">

### 3. Describe each step to reproduce the issue or behaviour.
In the administration, take an entity search field and search for entities with the same prefix in the name. Since the prefix is matched for all of them and the have the same `_score`, they are listed with no specific sorting (see the first screenshot).

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
