### PR TITLE
Add twig blocks to the `sw-product-detail` template for the sidebar and sidebar-items

### DIFF
--- a/CHANGELOG-6.2.md
+++ b/CHANGELOG-6.2.md
@@ -335,6 +335,9 @@ To get the diff between two versions, go to https://github.com/shopware/platform
         * `order_transaction.state.refunded`
         * `order_transaction.state.paid_partially`
     * If you edited one of these mail templates you need to add the `rawUrl` function manually like this: `{{ rawUrl('frontend.account.edit-order.page', { 'orderId': order.id }, salesChannel.domain|first.url) }}` 
+    * Added twig blocks to the `sw-product-detail` template for the sidebar and sidebar-items
+        * `sw_product_detail_sidebar`
+        * `sw_product_detail_sidebar_additional_items`
 
 * Core    
     * Added support of module favicons from plugins, set the `faviconSrc` prop of your module to the name of your bundle in the public bundles folder.

--- a/src/Administration/Resources/app/administration/src/module/sw-product/page/sw-product-detail/sw-product-detail.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/page/sw-product-detail/sw-product-detail.html.twig
@@ -151,6 +151,7 @@
         {% endblock %}
 
         <template slot="sidebar">
+            {% block sw_product_detail_sidebar %}
             <sw-sidebar :propagateWidth="true">
                 <sw-sidebar-media-item ref="mediaSidebarItem">
                     <template slot="context-menu-items" slot-scope="media">
@@ -159,7 +160,11 @@
                         </sw-context-menu-item>
                     </template>
                 </sw-sidebar-media-item>
+
+                {% block sw_product_detail_sidebar_additional_items %}
+                {% endblock %}
             </sw-sidebar>
+            {% endblock %}
         </template>
     </sw-page>
 {% endblock %}


### PR DESCRIPTION
### 1. Why is this change necessary?

As discussed with @mitelg, in the product detail page, the sidebar and its sidebar items are not wrapped in a twig block. Hence the current sidebar item (media sidebar) is shown in all tabs of the detail page. This prevents plugins from modifying or extending the sidebar with additional sidebar-items.

### 2. What does this change do, exactly?

This PR adds twig blocks to the sidebar and sidebar-items.

### 3. Describe each step to reproduce the issue or behaviour.

### 4. Please link to the relevant issues (if any).

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
