### PR TITLE
revert level of taxRuleCard

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-settings-tax/snippet/de-DE.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-tax/snippet/de-DE.json
@@ -30,25 +30,25 @@
       "buttonSave": "Speichern",
       "notificationErrorTitle": "Fehler",
       "notificationErrorMessage": "Fehler beim Speichern des Steuersatzes."
+    },
+    "taxRuleCard": {
+      "tooltipCountries": "Falls nicht alle verfügbaren Länder angezeigt werden, gib einen konkreten Namen ein, um dieses Land auswählen zu können. Länder können über Einstellungen/Länder bearbeitet und neu angelegt werden.",
+      "labelTaxRate": "Steuersatz",
+      "labelAppliesOn": "Gilt für",
+      "labelCountryName": "Land",
+      "cardTitle": "Länder-Steuersätze",
+      "searchBarPlaceholder": "Suche Länder",
+      "labelCreateNew": "Land hinzufügen",
+      "labelCancel": "Abbrechen",
+      "labelStates": "Staaten",
+      "labelZipCode": "Postleitzahl",
+      "labelFromZipCode": "Bis ...",
+      "labelToZipCode": "Von ...",
+      "emptyStateDescription": "Füge weitere Steuerraten für verschiedene Länder hinzu.",
+      "createStateDescription": "Speichere zuerst den Steuersatz, um weitere Länder hinzufügen zu können.",
+      "modalTitleDelete": "Land löschen",
+      "textDeleteConfirm": "Bist Du Dir sicher, dass Du das Land \"{name}\" löschen möchtest?",
+      "placeholderStates": "Staaten hinzufügen"
     }
-  },
-  "taxRuleCard": {
-    "tooltipCountries": "Falls nicht alle verfügbaren Länder angezeigt werden, gib einen konkreten Namen ein, um dieses Land auswählen zu können. Länder können über Einstellungen/Länder bearbeitet und neu angelegt werden.",
-    "labelTaxRate": "Steuersatz",
-    "labelAppliesOn": "Gilt für",
-    "labelCountryName": "Land",
-    "cardTitle": "Länder-Steuersätze",
-    "searchBarPlaceholder": "Suche Länder",
-    "labelCreateNew": "Land hinzufügen",
-    "labelCancel": "Abbrechen",
-    "labelStates": "Staaten",
-    "labelZipCode": "Postleitzahl",
-    "labelFromZipCode": "Bis ...",
-    "labelToZipCode": "Von ...",
-    "emptyStateDescription": "Füge weitere Steuerraten für verschiedene Länder hinzu.",
-    "createStateDescription": "Speichere zuerst den Steuersatz, um weitere Länder hinzufügen zu können.",
-    "modalTitleDelete": "Land löschen",
-    "textDeleteConfirm": "Bist Du Dir sicher, dass Du das Land \"{name}\" löschen möchtest?",
-    "placeholderStates": "Staaten hinzufügen"
   }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?
The current level of german translations for taxRuleCard is wrong.

### 2. What does this change do, exactly?
Fix level to get them translated.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
