### PR TITLE
NEXT-8601 - Use theme technical name for theme prefix.

### DIFF
--- a/CHANGELOG-6.2.md
+++ b/CHANGELOG-6.2.md
@@ -570,6 +570,7 @@ To get the diff between two versions, go to https://github.com/shopware/platform
     * Deprecated `sort` parameter for product listing, search and suggest gateway, use `order` instead
     * Added block `document_line_item_table_iterator` to `@Framework\documents\base.html.twig` to override the lineItem iterator
     * Added `StoreApiClient` which allows to send requests to `store-api` and `sales-channel-api` routes.
+    * Use theme technical name for path resolving of compiled assets instead of the theme ID.
 
 **Removals**
 

--- a/src/Storefront/Theme/ThemeCompiler.php
+++ b/src/Storefront/Theme/ThemeCompiler.php
@@ -86,7 +86,7 @@ class ThemeCompiler implements ThemeCompilerInterface
         StorefrontPluginConfigurationCollection $configurationCollection,
         bool $withAssets = true
     ): void {
-        $themePrefix = self::getThemePrefix($salesChannelId, $themeId);
+        $themePrefix = self::getThemePrefix($salesChannelId, $themeConfig->getTechnicalName());
         $outputPath = 'theme' . DIRECTORY_SEPARATOR . $themePrefix;
 
         if ($withAssets && $this->publicFilesystem->has($outputPath)) {
@@ -129,9 +129,9 @@ class ThemeCompiler implements ThemeCompilerInterface
         }
     }
 
-    public static function getThemePrefix(string $salesChannelId, string $themeId): string
+    public static function getThemePrefix(string $salesChannelId, string $themeName): string
     {
-        return md5($themeId . $salesChannelId);
+        return md5($themeName . $salesChannelId);
     }
 
     private function copyAssets(


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/community).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
Different environments (e.g. staging or deployment environments) have different theme IDs. This currently results in different paths for compiled Storefront assets and prevents precompiling themes during deployments.

### 2. What does this change do, exactly?
This changes the theme ID for the path resolving to the theme technical name, which is consistent for the same theme. The resulting path is then the same between environments.

I have not added a dedicated video or any tests because this changes one string for another and has no functional changes.

### 3. Describe each step to reproduce the issue or behaviour.
* Have a deployment environment (e.g. container-based) and compile the themes before transferring your project to a server.
* Have missing theme assets because the deployment environment has a different theme ID on every run.

### 4. Please link to the relevant issues (if any).
#863 
https://issues.shopware.com/issues/NEXT-8601

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
