### PR TITLE
NEXT-8428: Add customer link to customer overview

### DIFF
--- a/CHANGELOG-6.2.md
+++ b/CHANGELOG-6.2.md
@@ -336,6 +336,7 @@ To get the diff between two versions, go to https://github.com/shopware/platform
         * `order_transaction.state.paid_partially`
     * If you edited one of these mail templates you need to add the `rawUrl` function manually like this: `{{ rawUrl('frontend.account.edit-order.page', { 'orderId': order.id }, salesChannel.domain|first.url) }}` 
     * Price input fields substitute commas with dots automatically in Add Product page.
+    * Added a link to the customer name in the order overview. With this it is now possible to open the customer directly from the overview.
 
 * Core    
     * Added support of module favicons from plugins, set the `faviconSrc` prop of your module to the name of your bundle in the public bundles folder.

--- a/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-list/sw-order-list.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-list/sw-order-list.html.twig
@@ -69,7 +69,9 @@
                                 {% block sw_order_list_grid_columns %}
                                     {% block sw_order_list_grid_columns_customer_name %}
                                         <template #column-orderCustomer.firstName="{ item }">
-                                            {{ item.orderCustomer.firstName }} {{ item.orderCustomer.lastName }}
+                                            <router-link :to="{ name: 'sw.customer.detail', params: { id: item.orderCustomer.customerId } }">
+                                                {{ item.orderCustomer.firstName }} {{ item.orderCustomer.lastName }}
+                                            </router-link>
                                         </template>
                                     {% endblock %}
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/community).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
To make it easier for admin user to find/edit the user of an order

### 2. What does this change do, exactly?
It adds a router link wrapped around the name of the customer in the order overview

### 3. Describe each step to reproduce the issue or behaviour.
Open order overview and click on the customer name
See: 
https://vimeo.com/418368609/a556913058


### 4. Please link to the relevant issues (if any).
https://github.com/shopware/platform/issues/802

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
