### PR TITLE
NEXT-8427 - Rename EAN to GTIN

### DIFF
--- a/CHANGELOG-6.2.md
+++ b/CHANGELOG-6.2.md
@@ -335,7 +335,8 @@ To get the diff between two versions, go to https://github.com/shopware/platform
         * `order_transaction.state.refunded`
         * `order_transaction.state.paid_partially`
     * If you edited one of these mail templates you need to add the `rawUrl` function manually like this: `{{ rawUrl('frontend.account.edit-order.page', { 'orderId': order.id }, salesChannel.domain|first.url) }}` 
-
+    * Rename snippet `EAN` to `GTIN`
+    
 * Core    
     * Added support of module favicons from plugins, set the `faviconSrc` prop of your module to the name of your bundle in the public bundles folder.
     * Set `crossSellingAssignedProducts` and `tags` to `CascadeDelete` in `ProductDefinition`
@@ -570,7 +571,8 @@ To get the diff between two versions, go to https://github.com/shopware/platform
     * Deprecated `sort` parameter for product listing, search and suggest gateway, use `order` instead
     * Added block `document_line_item_table_iterator` to `@Framework\documents\base.html.twig` to override the lineItem iterator
     * Added `StoreApiClient` which allows to send requests to `store-api` and `sales-channel-api` routes.
-
+    * Added `GTIN` label to the product detail page
+    
 **Removals**
 
 * Administration

--- a/src/Administration/Resources/app/administration/src/module/sw-product-stream/snippet/de-DE.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-product-stream/snippet/de-DE.json
@@ -45,7 +45,7 @@
         "choose": "Auswahl",
         "description": "Beschreibung",
         "descriptionLong": "Langbeschreibung",
-        "ean": "EAN",
+        "ean": "GTIN",
         "gross": "Brutto",
         "group": "Gruppe",
         "height": "Höhe",

--- a/src/Administration/Resources/app/administration/src/module/sw-product-stream/snippet/en-GB.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-product-stream/snippet/en-GB.json
@@ -45,7 +45,7 @@
         "choose": "Choose",
         "description": "Description",
         "descriptionLong": "Description long",
-        "ean": "EAN",
+        "ean": "GTIN",
         "gross": "Gross",
         "group": "Group",
         "height": "Height",

--- a/src/Administration/Resources/app/administration/src/module/sw-product/snippet/de-DE.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/snippet/de-DE.json
@@ -72,7 +72,7 @@
       "labelWeight": "Gewicht",
       "labelMinPurchase": "Mindestabnahme",
       "labelMaxPurchase": "Maximalabnahme",
-      "labelEan": "EAN",
+      "labelEan": "GTIN",
       "labelManufacturerNumber": "Herstellernummer",
       "labelStock": "Lagerbestand",
       "labelActive": "Aktiv",
@@ -94,7 +94,7 @@
       "placeholderMaxPurchase": "Maximalabnahme ...",
       "placeholderPurchaseSteps": "Verkaufsintervall (Stückzahl) ...",
       "placeholderRestockTime": "Wiederauffüllintervall ...",
-      "placeholderEan": "Gib die EAN-Nummer ein ...",
+      "placeholderEan": "Gib die GTIN ein ...",
       "placeholderManufacturerNumber": "Gib die Herstellernummer ein ...",
       "labelAvailableStock": "Verfügbarer Bestand",
       "labelPurchaseSteps": "Staffelung"

--- a/src/Administration/Resources/app/administration/src/module/sw-product/snippet/en-GB.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/snippet/en-GB.json
@@ -71,7 +71,7 @@
       "labelWeight": "Weight",
       "labelMinPurchase": "Min. order quantity",
       "labelMaxPurchase": "Max. order quantity",
-      "labelEan": "EAN",
+      "labelEan": "GTIN",
       "labelManufacturerNumber": "Manufacturer product number",
       "labelStock": "Stock",
       "labelActive": "Active",
@@ -93,7 +93,7 @@
       "placeholderMaxPurchase": "Max. amount purchaseable...",
       "placeholderPurchaseSteps": "Enter purchase steps...",
       "placeholderRestockTime": "Enter restock time in days...",
-      "placeholderEan": "Enter EAN number...",
+      "placeholderEan": "Enter GTIN...",
       "placeholderManufacturerNumber": "Enter product number...",
       "labelAvailableStock": "Available stock",
       "labelPurchaseSteps": "Purchase steps"

--- a/src/Storefront/Resources/app/storefront/src/scss/page/product-detail/_product-detail.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/page/product-detail/_product-detail.scss
@@ -35,3 +35,7 @@
 .product-detail-ordernumber-container {
     margin-bottom: $spacer;
 }
+
+.product-detail-gtin-container {
+    margin-bottom: $spacer;
+}

--- a/src/Storefront/Resources/app/storefront/src/scss/skin/shopware/page/product-detail/_product-detail.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/skin/shopware/page/product-detail/_product-detail.scss
@@ -61,3 +61,7 @@
 .product-detail-quantity-select {
     height: 100%;
 }
+
+.product-detail-gtin-label {
+    font-weight: $font-weight-bold;
+}

--- a/src/Storefront/Resources/snippet/de_DE/storefront.de-DE.json
+++ b/src/Storefront/Resources/snippet/de_DE/storefront.de-DE.json
@@ -483,7 +483,8 @@
     "reviewLoginSignupLink": "Klicken Sie hier, um sich anzumelden.",
     "reviewLoginCancelButton": "Abbrechen",
     "reviewAvgRate": "von",
-    "reviewAvgRateElements": "Sternen"
+    "reviewAvgRateElements": "Sternen",
+    "gtin": "GTIN:"
   },
   "footer": {
     "serviceHotlineHeadline": "Service-Hotline",

--- a/src/Storefront/Resources/snippet/en_GB/storefront.en-GB.json
+++ b/src/Storefront/Resources/snippet/en_GB/storefront.en-GB.json
@@ -483,7 +483,8 @@
     "reviewLoginSignupLink": "Click here to sign up.",
     "reviewLoginCancelButton": "Cancel",
     "reviewAvgRate": "out of",
-    "reviewAvgRateElements": "stars"
+    "reviewAvgRateElements": "stars",
+    "gtin": "GTIN:"
   },
   "footer": {
     "serviceHotlineHeadline": "Service hotline",

--- a/src/Storefront/Resources/views/storefront/page/product-detail/buy-widget.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/product-detail/buy-widget.html.twig
@@ -189,7 +189,27 @@
                             {{ page.product.productNumber }}
                         </span>
                     {% endblock %}
-                </div>
+            {% endif %}
+        {% endblock %}
+
+        {% block page_product_detail_ean_container %}
+            {% if page.product.ean %}
+                <div class="product-detail-gtin-container">
+                    {% block page_product_detail_ean_label %}
+                        <span class="product-detail-gtin-label">
+                            {{ "detail.gtin"|trans|sw_sanitize }}
+                        </span>
+                    {% endblock %}
+
+                    {% block page_product_detail_gtin %}
+                        <meta itemprop="productGtin"
+                              content="{{ page.product.ean }}"/>
+                        <span class="product-detail-gtin"
+                              itemprop="gtin">
+                            {{ page.product.ean }}
+                        </span>
+                    {% endblock %}
+               </div>
             {% endif %}
         {% endblock %}
     </div>


### PR DESCRIPTION
fixed #803 

### 1. Why is this change necessary?
For the EAN, the obsolete designation is used ("European Article Number") which has been replaced by GTIN ("Global Trade Item Number") since 2005. We should adapt this at least in the English language.

### 2. What does this change do, exactly?
This changes `EAN` to `GTIN` in the administration and adds a new label `GTIN` to the product detail page (if a GTIN is available for this product).

This PR does not change the field names inside the database or product definition to decrease the risk of bugs.

Since none of the actual logic was touched, a test is not required.

### 3. Describe each step to reproduce the issue or behaviour.
Set the GTIN of any product in the administration and go to the detail page. You should now be able to see a new Label "GTIN" below the product order number label. 

### 4. Please link to the relevant issues (if any).
https://github.com/shopware/platform/issues/803

### 5. Checklist

- [X] I have written tests and verified that they fail without my change
No tests required
- [X] I have squashed any insignificant commits
- [X] I have written or adjusted the documentation according to my changes
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.
