### PR TITLE
NEXT-7413 #588 Add reset button to entity-single-select

### DIFF
--- a/CHANGELOG-6.2.md
+++ b/CHANGELOG-6.2.md
@@ -217,6 +217,8 @@ To get the diff between two versions, go to https://github.com/shopware/platform
       * `sw-property-option-detail
         * Added injection of `repositoryFactory`
         * Method `successfulUpload` is now async  
+      * `sw-entity-single-select`
+        * Added `enableResetButton` and `resetButtonTooltip` properties
       * sw-upload-store-listener  is deprecated and replaced by sw-upload-listener
       * sw-cms/elements/image-gallery/config/index.js
         * Method `createdComponent` is now async

--- a/src/Administration/Resources/app/administration/src/app/component/form/select/base/sw-select-base/sw-select-base.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/form/select/base/sw-select-base/sw-select-base.html.twig
@@ -10,7 +10,9 @@
                 <slot name="sw-select-selection" v-bind="{ identification, error, disabled, size, expand, collapse }"></slot>
                 <div class="sw-select__selection-indicators">
                     <sw-loader v-if="isLoading" class="sw-select__select-indicator" size="16px"></sw-loader>
+                    <slot name="sw-select-before-indicators" v-bind="{ identification, error, disabled, size, expand, collapse }"></slot>
                     <sw-icon class="sw-select__select-indicator" name="small-arrow-medium-down" small></sw-icon>
+                    <slot name="sw-select-after-indicators" v-bind="{ identification, error, disabled, size, expand, collapse }"></slot>
                 </div>
             </div>
 

--- a/src/Administration/Resources/app/administration/src/app/component/form/select/base/sw-select-base/sw-select-base.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/form/select/base/sw-select-base/sw-select-base.scss
@@ -45,6 +45,11 @@ $sw-select-focus-transition: all ease-in-out 0.2s;
         }
     }
 
+    .sw-select__selection-indicators .sw-button--x-small {
+        margin-top: -4px;
+        margin-right: 4px;
+    }
+
     .sw-select__select-indicator {
         flex-shrink: 0;
         cursor: pointer;

--- a/src/Administration/Resources/app/administration/src/app/component/form/select/entity/sw-entity-single-select/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/form/select/entity/sw-entity-single-select/index.js
@@ -76,6 +76,17 @@ Component.register('sw-entity-single-select', {
             type: Boolean,
             required: false,
             default: false
+        },
+
+        enableResetButton: {
+            type: Boolean,
+            required: false,
+            default: false
+        },
+        resetButtonTooltip: {
+            type: String,
+            required: false,
+            default: ''
         }
     },
 
@@ -282,6 +293,17 @@ Component.register('sw-entity-single-select', {
 
         closeResultList() {
             this.$refs.selectBase.collapse();
+        },
+
+        resetValue() {
+            this.searchTerm = '';
+            this.itemRecentlySelected = false;
+
+            if (!this.disableAutoClose) {
+                this.closeResultList();
+            }
+
+            this.clearSelection();
         },
 
         setValue(item) {

--- a/src/Administration/Resources/app/administration/src/app/component/form/select/entity/sw-entity-single-select/sw-entity-single-select.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/form/select/entity/sw-entity-single-select/sw-entity-single-select.html.twig
@@ -42,6 +42,22 @@
                 </template>
             {% endblock %}
 
+            {% block sw_entity_single_select_base_reset_button %}
+                <template #sw-select-before-indicators>
+                    <sw-button v-if="enableResetButton && value"
+                               @click.stop="resetValue"
+                               size="x-small"
+                               v-tooltip="{
+                                    message: resetButtonTooltip
+                                  }"
+                               :square="true">
+                        <sw-icon class="sw-entity-single-select__selection-reset"
+                                 name="small-default-x-line-medium"
+                                 small></sw-icon>
+                    </sw-button>
+                </template>
+            {% endblock %}
+
             {% block sw_entity_single_select_base_results %}
                 <template #results-list>
                     {% block sw_entity_single_select_base_results_slot %}

--- a/src/Administration/Resources/app/administration/src/app/component/structure/sw-sales-channel-switch/sw-sales-channel-switch.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/structure/sw-sales-channel-switch/sw-sales-channel-switch.html.twig
@@ -43,6 +43,8 @@
                     :placeholder="$tc('sw-sales-channel-switch.labelDefaultOption')"
                     :label="label"
                     :searchPlaceholder="$tc('sw-sales-channel-switch.placeholderSelect')"
+                    :enableResetButton="true"
+                    :resetButtonTooltip="$tc('sw-sales-channel-switch.labelDefaultOption')"
                     @change="onChange"
                     :value="salesChannelId"
                     entity="sales_channel">


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/community).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
Fix for issue https://github.com/shopware/platform/issues/588

### 2. What does this change do, exactly?
Add the possibility of adding content to indicators in sw-select-base.
This is used in sw-entity-single-select to add a Reset button. (optional, of course)
This reset button functionality is then implemented in the sw-sales-channel-switch which is used on the config pages.

### 3. Describe each step to reproduce the issue or behaviour.
https://shopwarecommunity.slack.com/files/U0137QDTD0B/F0136N3DELX/screen_recording_2020-05-14_at_11.02.29.mov

### 4. Please link to the relevant issues (if any).
https://github.com/shopware/platform/issues/588

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
