### PR TITLE
NEXT-8437 - correct demo data product stream filters

### DIFF
--- a/src/Core/Framework/Demodata/Generator/ProductStreamGenerator.php
+++ b/src/Core/Framework/Demodata/Generator/ProductStreamGenerator.php
@@ -37,42 +37,40 @@ class ProductStreamGenerator implements DemodataGeneratorInterface
     {
         $context->getConsole()->progressStart($numberOfItems);
 
-        $categories = $context->getIds('category');
-        $manufacturer = $context->getIds('product_manufacturer');
-        $products = $context->getIds('product');
+        $faker = $context->getFaker();
 
         $pool = [
-            ['field' => 'height', 'type' => 'range', 'parameters' => [RangeFilter::GTE => random_int(1, 1000)]],
-            ['field' => 'width', 'type' => 'range', 'parameters' => [RangeFilter::GTE => random_int(1, 1000)]],
-            ['field' => 'weight', 'type' => 'range', 'parameters' => [RangeFilter::GTE => random_int(1, 1000)]],
-            ['field' => 'height', 'type' => 'range', 'parameters' => [RangeFilter::LTE => random_int(1, 1000)]],
-            ['field' => 'width', 'type' => 'range', 'parameters' => [RangeFilter::LTE => random_int(1, 1000)]],
-            ['field' => 'weight', 'type' => 'range', 'parameters' => [RangeFilter::LTE => random_int(1, 1000)]],
-            ['field' => 'height', 'type' => 'range', 'parameters' => [RangeFilter::GT => random_int(1, 500), RangeFilter::LT => random_int(500, 1000)]],
-            ['field' => 'width', 'type' => 'range', 'parameters' => [RangeFilter::GT => random_int(1, 500), RangeFilter::LT => random_int(500, 1000)]],
-            ['field' => 'weight', 'type' => 'range', 'parameters' => [RangeFilter::GT => random_int(1, 500), RangeFilter::LT => random_int(500, 1000)]],
+            ['field' => 'height', 'type' => 'range', 'parameters' => [RangeFilter::GTE => $faker->numberBetween(1, 1000)]],
+            ['field' => 'width', 'type' => 'range', 'parameters' => [RangeFilter::GTE => $faker->numberBetween(1, 1000)]],
+            ['field' => 'weight', 'type' => 'range', 'parameters' => [RangeFilter::GTE => $faker->numberBetween(1, 1000)]],
+            ['field' => 'height', 'type' => 'range', 'parameters' => [RangeFilter::LTE => $faker->numberBetween(1, 1000)]],
+            ['field' => 'width', 'type' => 'range', 'parameters' => [RangeFilter::LTE => $faker->numberBetween(1, 1000)]],
+            ['field' => 'weight', 'type' => 'range', 'parameters' => [RangeFilter::LTE => $faker->numberBetween(1, 1000)]],
+            ['field' => 'height', 'type' => 'range', 'parameters' => [RangeFilter::GT => $faker->numberBetween(1, 500), RangeFilter::LT => $faker->numberBetween(500, 1000)]],
+            ['field' => 'width', 'type' => 'range', 'parameters' => [RangeFilter::GT => $faker->numberBetween(1, 500), RangeFilter::LT => $faker->numberBetween(500, 1000)]],
+            ['field' => 'weight', 'type' => 'range', 'parameters' => [RangeFilter::GT => $faker->numberBetween(1, 500), RangeFilter::LT => $faker->numberBetween(500, 1000)]],
             ['field' => 'stock', 'type' => 'equals', 'value' => '1000'],
             ['field' => 'name', 'type' => 'contains', 'value' => 'Awesome'],
-            ['field' => 'categories.id', 'type' => 'equalsAny', 'value' => implode('|', [$categories[random_int(0, \count($categories) - 1)], $categories[random_int(0, \count($categories) - 1)]])],
-            ['field' => 'id', 'type' => 'equalsAny', 'value' => implode('|', [$products[random_int(0, \count($products) - 1)], $products[random_int(0, \count($products) - 1)]])],
-            ['field' => 'manufacturerId', 'type' => 'equals', 'value' => $manufacturer[random_int(0, \count($manufacturer) - 1)]],
+            ['field' => 'categories.id', 'type' => 'equalsAny', 'value' => implode('|', [$context->getRandomId('category'), $context->getRandomId('category')])],
+            ['field' => 'id', 'type' => 'equalsAny', 'value' => implode('|', [$context->getRandomId('product'), $context->getRandomId('product')])],
+            ['field' => 'manufacturer.id', 'type' => 'equals', 'value' => $context->getRandomId('product_manufacturer')],
         ];
 
-        $pool[] = ['type' => 'multi', 'queries' => [$pool[random_int(0, \count($pool) - 1)], $pool[random_int(0, \count($pool) - 1)]]];
-        $pool[] = ['type' => 'multi', 'operator' => 'OR', 'queries' => [$pool[random_int(0, \count($pool) - 1)], $pool[random_int(0, \count($pool) - 1)]]];
+        $pool[] = ['type' => 'multi', 'operator' => 'AND', 'queries' => [$faker->randomElement($pool), $faker->randomElement($pool)]];
+        $pool[] = ['type' => 'multi', 'operator' => 'OR', 'queries' => [$faker->randomElement($pool), $faker->randomElement($pool)]];
 
         $payload = [];
         for ($i = 0; $i < $numberOfItems; ++$i) {
             $filters = [];
 
-            for ($j = 0, $jMax = random_int(1, 5); $j < $jMax; ++$j) {
-                $filters[] = array_merge($pool[random_int(0, \count($pool) - 1)], ['position' => $j]);
+            for ($j = 0, $jMax = $faker->numberBetween(1, 5); $j < $jMax; ++$j) {
+                $filters[] = array_merge($faker->randomElement($pool), ['position' => $j]);
             }
 
             $payload[] = [
                 'id' => Uuid::randomHex(),
-                'name' => $context->getFaker()->productName,
-                'description' => $context->getFaker()->text(),
+                'name' => $faker->productName,
+                'description' => $faker->text(),
                 'filters' => [['type' => 'multi', 'operator' => 'OR', 'queries' => $filters]],
             ];
         }

--- a/src/Core/Framework/DependencyInjection/demodata.xml
+++ b/src/Core/Framework/DependencyInjection/demodata.xml
@@ -71,13 +71,11 @@
         </service>
 
         <service id="Shopware\Core\Framework\Demodata\Generator\ProductGenerator">
-            <argument type="service" id="Shopware\Core\Framework\DataAbstractionLayer\Write\EntityWriter" />
             <argument type="service" id="tax.repository" />
             <argument type="service" id="Doctrine\DBAL\Connection" />
-            <argument type="service" id="Shopware\Core\Content\Product\ProductDefinition"/>
+            <argument type="service" id="product.repository"/>
 
             <tag name="shopware.demodata_generator"/>
-            <argument type="service" id="product.repository"/>
         </service>
 
         <service id="Shopware\Core\Framework\Demodata\Generator\MediaGenerator">


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/community).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
Corrects the product stream filter for product manufacturers and the and multi filter which are generated with the generate demo data command. Also cleans the product generator and adds the height and width field required for the product streams.

### 2. What does this change do, exactly?
Changes some filters.

### 3. Describe each step to reproduce the issue or behaviour.
Open the administration and look for product streams with a "and" multi filter and assigned product manufacturers. See this Video what was changed exaxctly:

https://vimeo.com/418368659/a86cf565da

### 4. Please link to the relevant issues (if any).
#672 

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.
