### PR TITLE
NEXT-7417 - Fix replace comma automatically by dot in price fields

### DIFF
--- a/CHANGELOG-6.2.md
+++ b/CHANGELOG-6.2.md
@@ -335,6 +335,7 @@ To get the diff between two versions, go to https://github.com/shopware/platform
         * `order_transaction.state.refunded`
         * `order_transaction.state.paid_partially`
     * If you edited one of these mail templates you need to add the `rawUrl` function manually like this: `{{ rawUrl('frontend.account.edit-order.page', { 'orderId': order.id }, salesChannel.domain|first.url) }}` 
+    * Price input fields substitute commas with dots automatically in Add Product page.
 
 * Core    
     * Added support of module favicons from plugins, set the `faviconSrc` prop of your module to the name of your bundle in the public bundles folder.

--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-price-field/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-price-field/index.js
@@ -282,6 +282,13 @@ Component.register('sw-price-field', {
             const calculatedPrice = value * this.currency.factor;
             const priceRounded = calculatedPrice.toFixed(this.currency.decimalPrecision);
             return Number(priceRounded);
+        },
+
+        keymonitor(event) {
+            if (event.key === ',') {
+                const value = event.currentTarget.value;
+                event.currentTarget.value = value.replace(/.$/, '.');
+            }
         }
     }
 });

--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-price-field/sw-price-field.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-price-field/sw-price-field.html.twig
@@ -18,7 +18,8 @@
                       :disabled="isDisabled"
                       name="sw-price-field-gross"
                       v-bind="$attrs"
-                      v-model="priceForCurrency.gross">
+                      v-model="priceForCurrency.gross"
+                      @keyup="keymonitor">
                 <template #suffix v-if="!disableSuffix">
                     {{ currency.symbol }}
                 </template>
@@ -50,7 +51,8 @@
                       :disabled="isInherited || disabled"
                       name="sw-price-field-net"
                       v-bind="$attrs"
-                      v-model="priceForCurrency.net">
+                      v-model="priceForCurrency.net"
+                      @keyup="keymonitor">
                 <template #suffix v-if="!disableSuffix">
                     {{ currency.symbol }}
                 </template>

--- a/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-price-form/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-price-form/index.js
@@ -51,6 +51,13 @@ Component.register('sw-product-price-form', {
             this.product.price = prices;
 
             this.displayMaintainCurrencies = false;
+        },
+
+        keymonitor(event) {
+            if (event.key === ',') {
+                const value = event.currentTarget.value;
+                event.currentTarget.value = value.replace(/.$/, '.');
+            }
         }
     }
 });

--- a/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-price-form/sw-product-price-form.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-price-form/sw-product-price-form.html.twig
@@ -44,7 +44,8 @@
                                       :disabled="isInherited"
                                       :placeholder="$tc('sw-product.priceForm.placeholderPurchasePriceGross')"
                                       :value="currentValue"
-                                      @change="updateCurrentValue">
+                                      @change="updateCurrentValue"
+                                      @keyup="keymonitor">
                                 <template #suffix>
                                     <span class="sw-product-price-form__currency" v-if="defaultCurrency">{{ defaultCurrency.symbol }}</span>
                                 </template>


### PR DESCRIPTION
### 1. Why is this change necessary?
Fix for issue #823 

### 2. What does this change do, exactly?
When you type in a comma in any of the price fields, it is automatically replaced by a dot. 

### 3. Describe each step to reproduce the issue or behaviour.
In the administration side, navigate to the page for adding a new product. In the price section, type in a comma instead of a decimal point and it should be automatically replaced by a dot.

### 4. Please link to the relevant issues (if any).
#823 

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
