### PR TITLE
NEXT-8285 - #820 JS Error in Admin Area Users & Rights (New User)

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-settings-user/page/sw-settings-user-detail/sw-settings-user-detail.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-user/page/sw-settings-user-detail/sw-settings-user-detail.html.twig
@@ -136,45 +136,6 @@
                                         {% endblock %}
                                     </div>
                                 {% endblock %}
-
-                                {% block sw_settings_user_detail_content_password_modal %}
-                                    <sw-modal v-if="changePasswordModal"
-                                              @modal-close="onClosePasswordModal"
-                                              :title="$tc('sw-settings-user.user-detail.labelNewPassword')"
-                                              variant="small">
-                                        {{ $tc('sw-settings-user.user-detail.textChangePassword') }}
-
-                                        {% block sw_settings_user_detail_content_password_modal_input %}
-                                            <sw-password-field
-                                                class="sw-settings-user-detail__new-password"
-                                                v-model="newPassword"
-                                                :passwordToggleAble="true"
-                                                :copyAble="false"
-                                                :placeholder="$tc('sw-settings-user.user-detail.placeholderNewPassword')">
-                                            </sw-password-field>
-                                        {% endblock %}
-
-                                        {% block sw_settings_user_detail_password_modal_footer %}
-                                            <template #modal-footer>
-                                                {% block sw_settings_user_detail_password_modal_actions_cancel %}
-                                                    <sw-button @click="onClosePasswordModal"
-                                                               size="small">
-                                                        {{ $tc('sw-settings-user.user-detail.labelButtonCancel') }}
-                                                    </sw-button>
-                                                {% endblock %}
-
-                                                {% block sw_settings_user_detail_password_modal_actions_change %}
-                                                    <sw-button @click="onSubmit"
-                                                               variant="primary"
-                                                               size="small"
-                                                               :disabled="disableConfirm">
-                                                        {{ $tc('sw-settings-user.user-detail.labelButtonChangePassword') }}
-                                                    </sw-button>
-                                                {% endblock %}
-                                            </template>
-                                        {% endblock %}
-                                    </sw-modal>
-                                {% endblock %}
                             </sw-card>
                         {% endblock %}
 
@@ -235,6 +196,45 @@
                         {% endblock %}
                     {% endblock %}
                 </sw-card-view>
+
+                {% block sw_settings_user_detail_content_password_modal %}
+                    <sw-modal v-if="changePasswordModal"
+                              @modal-close="onClosePasswordModal"
+                              :title="$tc('sw-settings-user.user-detail.labelNewPassword')"
+                              variant="small">
+                        {{ $tc('sw-settings-user.user-detail.textChangePassword') }}
+
+                        {% block sw_settings_user_detail_content_password_modal_input %}
+                        <sw-password-field
+                            class="sw-settings-user-detail__new-password"
+                            v-model="newPassword"
+                            :passwordToggleAble="true"
+                            :copyAble="false"
+                            :placeholder="$tc('sw-settings-user.user-detail.placeholderNewPassword')">
+                        </sw-password-field>
+                        {% endblock %}
+
+                        {% block sw_settings_user_detail_password_modal_footer %}
+                        <template #modal-footer>
+                            {% block sw_settings_user_detail_password_modal_actions_cancel %}
+                            <sw-button @click="onClosePasswordModal"
+                                       size="small">
+                                {{ $tc('sw-settings-user.user-detail.labelButtonCancel') }}
+                            </sw-button>
+                            {% endblock %}
+
+                            {% block sw_settings_user_detail_password_modal_actions_change %}
+                            <sw-button @click="onSubmit"
+                                       variant="primary"
+                                       size="small"
+                                       :disabled="disableConfirm">
+                                {{ $tc('sw-settings-user.user-detail.labelButtonChangePassword') }}
+                            </sw-button>
+                            {% endblock %}
+                        </template>
+                        {% endblock %}
+                    </sw-modal>
+                {% endblock %}
 
                 {% block sw_settings_user_detail_grid_inner_slot_delete_modal %}
                     <sw-modal v-if="showDeleteModal"


### PR DESCRIPTION
### 1. Why is this change necessary?
Fix the crash when changing admin passwords.

### 2. What does this change do, exactly?
The onSubmit function crashed because it changed the appearance of the modal (hiding it), but also triggered onSave. In onSave, this cards are all put in a loading state, which removes all child components. The modal was a child of a card, so Vue could not find the child anymore, and thus crashed.

Solution:
Move the code for the modal outside of the sw-card element. (Other modals were already there)

### 3. Describe each step to reproduce the issue or behaviour.
Steps to reproduction:

login admin area
navigation to the user & rights area
create a new user
fill in mandatory fields
click save
click change password
enter password
Expected result: Confirmation that the password has been changed.

Actual result: Crash of the Admin.

### 4. Please link to the relevant issues (if any).
https://github.com/shopware/platform/issues/820

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
