### PR TITLE
NEXT-8603 Don't load multiple bundles from plugins

### DIFF
--- a/src/Core/Framework/Plugin/KernelPluginLoader/KernelPluginLoader.php
+++ b/src/Core/Framework/Plugin/KernelPluginLoader/KernelPluginLoader.php
@@ -73,26 +73,37 @@ abstract class KernelPluginLoader extends Bundle
         return $this->pluginInstances;
     }
 
-    final public function getBundles($kernelParameters = []): iterable
+    final public function getBundles($kernelParameters = [], array $loadedBundles = []): iterable
     {
         if (!$this->initialized) {
             return;
         }
 
         foreach ($this->pluginInstances->getActives() as $plugin) {
-            yield $plugin;
+            if (!in_array($plugin->getName(), $loadedBundles, true)) {
+                yield $plugin;
+                $loadedBundles[] = $plugin->getName();
+            }
 
             $copy = new KernelPluginCollection($this->getPluginInstances()->all());
             $additionalBundleParameters = new AdditionalBundleParameters($this->classLoader, $copy, $kernelParameters);
             $additionalBundles = $plugin->getAdditionalBundles($additionalBundleParameters);
+
             if (empty($additionalBundles)) {
-                yield from $plugin->getExtraBundles($this->classLoader);
-            } else {
-                yield from $additionalBundles;
+                $additionalBundles = $plugin->getExtraBundles($this->classLoader);
+            }
+
+            foreach ($additionalBundles as $bundle) {
+                if (!in_array($bundle->getName(), $loadedBundles, true)) {
+                    yield $bundle;
+                    $loadedBundles[] = $bundle->getName();
+                }
             }
         }
 
-        yield $this;
+        if (!in_array($this->getName(), $loadedBundles, true)) {
+            yield $this;
+        }
     }
 
     /**

--- a/src/Core/Framework/Test/Plugin/KernelPluginLoader/StaticKernelPluginLoaderTest.php
+++ b/src/Core/Framework/Test/Plugin/KernelPluginLoader/StaticKernelPluginLoaderTest.php
@@ -42,7 +42,7 @@ class StaticKernelPluginLoaderTest extends TestCase
 
         static::assertCount(1, $loader->getPluginInfos());
         $kernelPlugins = $loader->getPluginInstances();
-        static::assertCount(1, $kernelPlugins->all());
+        static::assertCount(2, $kernelPlugins->all());
         static::assertInstanceOf(Plugin::class, $kernelPlugins->get($activePluginData['baseClass']));
     }
 
@@ -55,7 +55,7 @@ class StaticKernelPluginLoaderTest extends TestCase
         $loader = new StaticKernelPluginLoader($this->classLoader, null, $plugins);
         $loader->initializePlugins(TEST_PROJECT_DIR);
 
-        static::assertCount(1, $loader->getPluginInfos());
+        static::assertCount(2, $loader->getPluginInfos());
         $kernelPlugins = $loader->getPluginInstances()->all();
         static::assertCount(0, $kernelPlugins);
     }
@@ -187,6 +187,23 @@ class StaticKernelPluginLoaderTest extends TestCase
         static::assertCount(2, $bundles);
         static::assertInstanceOf('SwagTest\SwagTest', $bundles[0]);
         static::assertSame($loader, $bundles[1]);
+    }
+
+    public function testGetBundlesWithAdditionalBundlesThatAreDuplicates(): void
+    {
+        $activePluginData = $this->getActivePlugin()->jsonSerialize();
+        $activePluginDataWithUnneededBundles = $this->getActivePluginWithBundle()->jsonSerialize();
+        $loader = new StaticKernelPluginLoader($this->classLoader, null, [
+            $activePluginData, $activePluginDataWithUnneededBundles
+        ]);
+        $loader->initializePlugins(TEST_PROJECT_DIR);
+
+        $bundles = iterator_to_array($loader->getBundles([], ['FrameworkBundle']));
+        static::assertCount(4, $bundles);
+        static::assertInstanceOf('SwagTest\SwagTest', $bundles[0]);
+        static::assertInstanceOf('Shopware\Core\Framework\Test\Plugin\Bundles\FooBarBundle', $bundles[1]);
+        static::assertInstanceOf('SwagTestWithBundle\SwagTestWithBundle', $bundles[2]);
+        static::assertSame($loader, $bundles[2]);
     }
 
     public function testGetBundlesNoActive(): void

--- a/src/Core/Framework/Test/Plugin/PluginIntegrationTestBehaviour.php
+++ b/src/Core/Framework/Test/Plugin/PluginIntegrationTestBehaviour.php
@@ -98,4 +98,25 @@ trait PluginIntegrationTestBehaviour
 
         return $active;
     }
+
+    protected function getActivePluginWithBundle(): PluginEntity
+    {
+        $plugin = new PluginEntity();
+        $plugin->assign([
+            'id' => Uuid::randomHex(),
+            'name' => 'SwagTestWithBundle',
+            'baseClass' => 'SwagTestWithBundle\\SwagTestWithBundle',
+            'version' => '1.0.0',
+            'active' => false,
+            'path' => __DIR__ . '/_fixture/plugins/SwagTestWithBundle',
+            'autoload' => ['psr-4' => ['SwagTestWithBundle\\' => 'src/']],
+            'createdAt' => new \DateTimeImmutable('2019-01-01'),
+            'managedByComposer' => false,
+        ]);
+
+        $plugin->setInstalledAt(new \DateTimeImmutable());
+        $plugin->setActive(true);
+
+        return $plugin;
+    }
 }

--- a/src/Core/Framework/Test/Plugin/_fixture/bundles/FooBarBundle.php
+++ b/src/Core/Framework/Test/Plugin/_fixture/bundles/FooBarBundle.php
@@ -1,0 +1,10 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\Test\Plugin\Bundles;
+
+use Symfony\Component\HttpKernel\Bundle\Bundle;
+
+class FooBarBundle extends Bundle
+{
+    protected $name = 'FancyBundleName';
+}

--- a/src/Core/Framework/Test/Plugin/_fixture/plugins/SwagTest/src/SwagTest.php
+++ b/src/Core/Framework/Test/Plugin/_fixture/plugins/SwagTest/src/SwagTest.php
@@ -3,10 +3,12 @@
 namespace SwagTest;
 
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepositoryInterface;
+use Shopware\Core\Framework\Parameter\AdditionalBundleParameters;
 use Shopware\Core\Framework\Plugin;
 use Shopware\Core\Framework\Plugin\Context\DeactivateContext;
 use Shopware\Core\Framework\Plugin\Context\UninstallContext;
 use Shopware\Core\Framework\Plugin\Context\UpdateContext;
+use Shopware\Core\Framework\Test\Plugin\Bundles\FooBarBundle;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
 
 class SwagTest extends Plugin
@@ -92,5 +94,14 @@ class SwagTest extends Plugin
     public function getMigrationNamespace(): string
     {
         return $_SERVER['FAKE_MIGRATION_NAMESPACE'] ?? parent::getMigrationNamespace();
+    }
+
+    public function getAdditionalBundles(AdditionalBundleParameters $parameters): array
+    {
+        require_once __DIR__ . '/../../../bundles/FooBarBundle.php';
+
+        return [
+            new FooBarBundle(),
+        ];
     }
 }

--- a/src/Core/Framework/Test/Plugin/_fixture/plugins/SwagTestWithBundle/CHANGELOG.md
+++ b/src/Core/Framework/Test/Plugin/_fixture/plugins/SwagTestWithBundle/CHANGELOG.md
@@ -1,0 +1,2 @@
+# 1.0.0
+- initialized SwagTestWithBundle

--- a/src/Core/Framework/Test/Plugin/_fixture/plugins/SwagTestWithBundle/composer.json
+++ b/src/Core/Framework/Test/Plugin/_fixture/plugins/SwagTestWithBundle/composer.json
@@ -1,0 +1,33 @@
+{
+    "name": "swag/test-with-bundle",
+    "description": "Test description for a plugin with bundles that should be loaded but are duplicates and therefore discarded",
+    "version": "v1.0.0",
+    "type": "shopware-platform-plugin",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "shopware AG",
+            "role": "Manufacturer"
+        }
+    ],
+    "require": {
+        "shopware/core": ">=6.0"
+    },
+    "extra": {
+        "shopware-plugin-class": "SwagTestWithBundle\\SwagTestWithBundle",
+        "copyright": "(c) by shopware AG",
+        "label": {
+            "de-DE": "Deutscher Pluginname",
+            "en-GB": "English plugin name"
+        },
+        "description": {
+            "de-DE": "Deutsche Beschreibung",
+            "en-GB": "English description"
+        }
+    },
+    "autoload": {
+        "psr-4": {
+           "SwagTestWithBundle\\": "src"
+        }
+    }
+}

--- a/src/Core/Framework/Test/Plugin/_fixture/plugins/SwagTestWithBundle/src/SwagTestWithBundle.php
+++ b/src/Core/Framework/Test/Plugin/_fixture/plugins/SwagTestWithBundle/src/SwagTestWithBundle.php
@@ -1,0 +1,23 @@
+<?php declare(strict_types=1);
+
+namespace SwagTestWithBundle;
+
+use Shopware\Core\Framework\Parameter\AdditionalBundleParameters;
+use Shopware\Core\Framework\Plugin;
+use Shopware\Core\Framework\Test\Plugin\Bundles\FooBarBundle;
+use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
+
+class SwagTestWithBundle extends Plugin
+{
+    public function getAdditionalBundles(AdditionalBundleParameters $parameters): array
+    {
+        require_once __DIR__ . '/../../../bundles/FooBarBundle.php';
+
+        return [
+            // is already provided externally and should not be loaded
+            new FrameworkBundle(),
+            // is already provided by SwagTest and should not be loaded twice
+            new FooBarBundle(),
+        ];
+    }
+}

--- a/src/Core/Kernel.php
+++ b/src/Core/Kernel.php
@@ -90,15 +90,20 @@ class Kernel extends HttpKernel
     {
         /** @var array $bundles */
         $bundles = require $this->getProjectDir() . '/config/bundles.php';
+        $instanciatedBundleNames = [];
 
-        /** @var string $class */
+        /** @var class-string<\Symfony\Component\HttpKernel\Bundle\Bundle> $class */
         foreach ($bundles as $class => $envs) {
             if (isset($envs['all']) || isset($envs[$this->environment])) {
-                yield new $class();
+                /** @var \Symfony\Component\HttpKernel\Bundle\Bundle $bundle */
+                $bundle = new $class();
+                $instanciatedBundleNames[] = $bundle->getName();
+
+                yield $bundle;
             }
         }
 
-        yield from $this->pluginLoader->getBundles($this->getKernelParameters());
+        yield from $this->pluginLoader->getBundles($this->getKernelParameters(), $instanciatedBundleNames);
     }
 
     public function getProjectDir()


### PR DESCRIPTION
### 1. Why is this change necessary?
In theory any plugin can load additional bundles but when someone else already adds this bundle the plugin can't be activated.

### 2. What does this change do, exactly?
The plugin loader keeps track of every bundle name it emits and prevents from emitting a bundle twice.

### 3. Describe each step to reproduce the issue or behaviour.
1. Have two plugins serving at least one same additional bundle that both share
2. Plugin activation not possible due to duplicate bundle loading within symfony

### 4. Please link to the relevant issues (if any).

https://issues.shopware.com/issues/NEXT-8603
#858

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
