### PR TITLE
NEXT-8629: Enable submit button in buy widget only after add to cart plugin is executed

### DIFF
--- a/src/Storefront/Resources/app/storefront/src/plugin/add-to-cart/add-to-cart.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/add-to-cart/add-to-cart.plugin.js
@@ -14,6 +14,7 @@ export default class AddToCartPlugin extends Plugin {
         }
 
         this._registerEvents();
+        this._enableSubmitButton();
     }
 
     /**
@@ -32,6 +33,26 @@ export default class AddToCartPlugin extends Plugin {
 
     _registerEvents() {
         this.el.addEventListener('submit', this._formSubmit.bind(this));
+    }
+
+    /**
+     * Enables the submit button of the form, once the script is executed.
+     * This is used, to circumvent submitting the form with its default
+     * behavior, which would redirect to an unstyled page.
+     * @private
+     */
+    _enableSubmitButton() {
+        this._submitButton = DomAccess.querySelector(
+            this._form,
+            'button[type="submit"]',
+            false,
+        );
+
+        if (!this._submitButton) {
+            return;
+        }
+
+        this._submitButton.disabled = false;
     }
 
     /**

--- a/src/Storefront/Resources/views/storefront/page/product-detail/buy-widget-form.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/product-detail/buy-widget-form.html.twig
@@ -70,9 +70,11 @@
                     {% block page_product_detail_buy_button_container %}
                         <div class="col-8">
                             {% block page_product_detail_buy_button %}
-                                <button class="btn btn-primary btn-block btn-buy"
+                                <button type="submit"
+                                        class="btn btn-primary btn-block btn-buy"
                                         title="{{ "detail.addProduct"|trans|striptags }}"
-                                        aria-label="{{ "detail.addProduct"|trans|striptags }}">
+                                        aria-label="{{ "detail.addProduct"|trans|striptags }}"
+                                        disabled="disabled">
                                     {{ "detail.addProduct"|trans|sw_sanitize }}
                                 </button>
                             {% endblock %}


### PR DESCRIPTION
### 1. Why is this change necessary?
Whenever a user clicks on the add to cart button on a product detail page when the JavaScript is not fully executed, the result is a redirect to the line-item-add route, which is unstyled. This is due to the add-to-cart plugin being responsible of handling the form submit via AJAX request, thus not redirecting to the aforementioned route. This problem frequently occurs with slower connections, such as mobile networks.

### 2. What does this change do, exactly?
This fix prevents the button from being clicked, when the script is not yet executed and thus enforces the intended add-to-cart plugin behavior. This is achieved by disabling the submit button by default and re-enabling it, once the add-to-cart plugin code executes.

### 3. Describe each step to reproduce the issue or behaviour.
1. Visit a product detail page
2. While the page is still loading, click the add to cart button (you might need to throttle your connection via browser dev-tools, if the page happens to be too fast otherwise)

**Expected result**
The off-canvas cart appears and the product is added to it.

**Actual result**
The user is redirected to the line-item-add route, which is unstyled.

### 4. Please link to the relevant issues (if any).
none

### 5. Checklist

- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
