### PR TITLE
NEXT-8616 - fixes https://github.com/shopware/platform/issues/885

### DIFF
--- a/CHANGELOG-6.2.md
+++ b/CHANGELOG-6.2.md
@@ -755,3 +755,4 @@ To get the diff between two versions, go to https://github.com/shopware/platform
     * Deprecated `window.accessKey` and `window.contextToken`, the variables contains now an empty string
     * Removed `HttpClient()` constructor parameters in `src/Storefront/Resources/app/storefront/src/service/http-client.service.js`
     * Fix timezone of `orderDate` in ordergrid
+    * Added image lazy loading capability to the `ZoomModalPlugin` which allows to load images only if the zoom modal was opened

--- a/src/Storefront/Resources/app/storefront/src/main.js
+++ b/src/Storefront/Resources/app/storefront/src/main.js
@@ -49,7 +49,6 @@ import GallerySliderPlugin from 'src/plugin/slider/gallery-slider.plugin';
 import ProductSliderPlugin from 'src/plugin/slider/product-slider.plugin';
 import ZoomModalPlugin from 'src/plugin/zoom-modal/zoom-modal.plugin';
 import MagnifierPlugin from 'src/plugin/magnifier/magnifier.plugin';
-import ImageZoomPlugin from 'src/plugin/image-zoom/image-zoom.plugin';
 import VariantSwitchPlugin from 'src/plugin/variant-switch/variant-switch.plugin';
 import CmsSlotReloadPlugin from 'src/plugin/cms-slot-reload/cms-slot-reload.plugin';
 import CmsSlotHistoryReloadPlugin from 'src/plugin/cms-slot-reload/cms-slot-history-reload.plugin';
@@ -116,7 +115,6 @@ PluginManager.register('GallerySlider', GallerySliderPlugin, '[data-gallery-slid
 PluginManager.register('ProductSlider', ProductSliderPlugin, '[data-product-slider]');
 PluginManager.register('ZoomModal', ZoomModalPlugin, '[data-zoom-modal]');
 PluginManager.register('Magnifier', MagnifierPlugin, '[data-magnifier]');
-PluginManager.register('ImageZoom', ImageZoomPlugin, '[data-image-zoom]');
 PluginManager.register('VariantSwitch', VariantSwitchPlugin, '[data-variant-switch]');
 PluginManager.register('CmsSlotReload', CmsSlotReloadPlugin, '[data-cms-slot-reload]');
 PluginManager.register('CmsSlotHistoryReload', CmsSlotHistoryReloadPlugin, document);

--- a/src/Storefront/Resources/views/storefront/element/cms-element-image-gallery.html.twig
+++ b/src/Storefront/Resources/views/storefront/element/cms-element-image-gallery.html.twig
@@ -357,10 +357,11 @@
                                                                                                         {% sw_thumbnails 'gallery-slider-image-thumbnails' with {
                                                                                                             media: image,
                                                                                                             attributes: {
-                                                                                                                'class': 'gallery-slider-image js-image-zoom-element',
+                                                                                                                'class': 'gallery-slider-image js-image-zoom-element js-load-img',
                                                                                                                 'alt': (image.translated.alt ?: fallbackImageTitle),
                                                                                                                 'title': (image.translated.title ?: fallbackImageTitle)
-                                                                                                            }
+                                                                                                            },
+                                                                                                            load: false
                                                                                                         } %}
                                                                                                     {% endblock %}
                                                                                                 </div>
@@ -432,10 +433,11 @@
                                                                                                                 'default': '200px'
                                                                                                             },
                                                                                                             attributes: {
-                                                                                                                'class': 'gallery-slider-thumbnails-image',
+                                                                                                                'class': 'gallery-slider-thumbnails-image js-load-img',
                                                                                                                 'alt': (image.translated.alt ?: fallbackImageTitle),
                                                                                                                 'title': (image.translated.title ?: fallbackImageTitle)
-                                                                                                            }
+                                                                                                            },
+                                                                                                            load: false
                                                                                                         } %}
                                                                                                     </div>
                                                                                                 {% endblock %}

--- a/src/Storefront/Resources/views/storefront/utilities/thumbnail.html.twig
+++ b/src/Storefront/Resources/views/storefront/utilities/thumbnail.html.twig
@@ -1,5 +1,10 @@
 {# uses cms block column count and all available thumbnails to determine the correct image size for the current viewport #}
 {% if media.thumbnails|length > 0 %}
+    {# activate load per default. If it is not activated only a data-src is set instead of the src tag. #}
+    {% if load is not defined %}
+        {% set load = true %}
+    {% endif %}
+
     {% if columns and sizes is not defined %}
         {# set image size for every viewport #}
         {% set sizes = {
@@ -42,9 +47,9 @@
         {% for key, value in shopware.theme.breakpoint|reverse %}{% if maxWidth %}(max-width: {{ maxWidth }}px) and {% endif %}(min-width: {{ value }}px) {{ sizes[key] }}{% set maxWidth = value-1 %}{% if not loop.last %}, {% endif %}{% endfor %}, {{ sizeFallback }}vw
     {% endapply %}{% endset %}
 {% endif %}
-<img src="{{ media|sw_encode_media_url }}"
+<img {% if load %}src="{{ media|sw_encode_media_url }}" {% else %}data-src="{{ media|sw_encode_media_url }}" {% endif %}
     {% if media.thumbnails|length > 0 %}
-        srcset="{{ srcsetValue }}"
+        {% if load %}srcset="{{ srcsetValue }}" {% else %}data-srcset="{{ srcsetValue }}" {% endif %}
         {% if sizes['default'] %}
         sizes="{{ sizes['default'] }}"
         {% elseif sizes|length > 0 %}


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/community).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
At the moment all zoom modal images are loaded on page load although the modal is never opened. This is a lot of data which needs to be loaded on page load and the user might never open the zoom modal.

### 2. What does this change do, exactly?
It replaces the image "src" with a "data-src" attribute and loads the images only if the user opens the zoom modal.
After all the images are loaded the ImageZoomPlugin is initialized and the user is able to zoom in. 

### 3. Describe each step to reproduce the issue or behaviour.
- go to the product detail page and open the network tab of your developer console
- you should notice that a lot of images are loaded, the last ones are the big images for the zoom modal


### 4. Please link to the relevant issues (if any).
fixes https://github.com/shopware/platform/issues/885

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
