### PR TITLE
NEXT-8438: Fixes #769 | add event listener to close flyout when cursor leaves window, also repair flyout flickering

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/structure/sw-admin-menu/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/structure/sw-admin-menu/index.js
@@ -103,6 +103,11 @@ Component.register('sw-admin-menu', {
 
     mounted() {
         this.mountedComponent();
+        document.addEventListener('mouseleave', this.closeFlyout);
+    },
+    
+    beforeDestroy() {
+        document.removeEventListener('mouseleave', this.closeFlyout);
     },
 
     methods: {
@@ -222,8 +227,12 @@ Component.register('sw-admin-menu', {
 
             return true;
         },
-
-        closeFlyout() {
+        closeFlyout(event) {
+            if (event.toElement && event.toElement.closest('.sw-admin-menu__navigation-list-item')) {
+                if (event.toElement.closest('.sw-admin-menu__navigation-list-item').classList.contains(this.flyoutEntries[0].parent)) {
+                    return;
+                }
+            }
             this.lastFlyoutEntries = this.flyoutEntries;
             this.flyoutEntries = [];
         },

--- a/src/Administration/Resources/app/administration/src/app/component/structure/sw-admin-menu/sw-admin-menu.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/structure/sw-admin-menu/sw-admin-menu.html.twig
@@ -155,7 +155,7 @@
                     <div v-if="flyoutEntries.length"
                          class="sw-admin-menu__flyout"
                          :style="flyoutStyle"
-                         @mouseleave="closeFlyout">
+                         @mouseleave="closeFlyout($event)">
 
                         {% block sw_admin_menu_flyout_label %}
                             <div v-if="!isExpanded" class="sw-admin-menu__flyout-label" :style="{'border-color': flyoutColor}">


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/community).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
Necessary since the flyout would stay open even after the cursor left the browser window.

Also fixed issue of flickering of the flyout which came to be because of the closeFlyout event getting triggered when moving the mouse slowly from the flyout to the parent navigation element (the issue got worse because of the css transition of the flyout).

### 2. What does this change do, exactly?
Improves usability of admin-menu by not firing the flyout close event if the cursor moves from the flyout to the parent navigation element. Also adds an event listener which closes the flyout if the cursor leaves the browser window.

### 3. Describe each step to reproduce the issue or behaviour.

First issue (navigation flyouts not closing if the cursor leaves the browser window):
1.) Have the browser window not full screen
2.) Hover over a navigation element and then leave the browser window with your cursor (to the left)

Second issue (flyout flickering)
1.) Hover over any menu-item that opens the flyout
2.) Hover into the flyout
3.) Slowly move over the edge from flyout back to active menu item (glitch should trigger within a couple of pixels)

### 4. Please link to the relevant issues (if any).
[#769](https://github.com/shopware/platform/issues/769)

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

### 6. Video footage
[send.firefox (download works only one time!)](https://send.firefox.com/download/92dcbcfab27d4059/#Z4D5500c_j2LtqrUNFZgnA)

### 7. Contributors
@cfege
@MDSLKTR 
@thomasfranz94