### PR TITLE
NEXT-8594 - Add possibility to delete orders on sw-order-list

### DIFF
--- a/CHANGELOG-6.2.md
+++ b/CHANGELOG-6.2.md
@@ -509,6 +509,7 @@ To get the diff between two versions, go to https://github.com/shopware/platform
     * Added `definition` parameter in `\Shopware\Elasticsearch\Framework\ElasticsearchHelper::addTerm`
     * Deprecated `\Shopware\Storefront\Controller\SearchController::pagelet`, use `\Shopware\Storefront\Controller\SearchController::ajax` instead
     * Deprecated `widgets.search.pagelet` route, use `widgets.search.pagelet.v2` instead
+    * Added possibility to delete orders without documents on `sw-order-list`
 
 * Storefront
     * Deprecated `$connection->executeQuery()` for write operations

--- a/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-list/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-list/index.js
@@ -23,6 +23,7 @@ Component.register('sw-order-list', {
             sortDirection: 'DESC',
             isLoading: false,
             filterLoading: false,
+            showDeleteModal: false,
             availableAffiliateCodes: [],
             affiliateCodeFilter: [],
             availableCampaignCodes: [],
@@ -62,6 +63,7 @@ Component.register('sw-order-list', {
             criteria.addAssociation('salesChannel');
             criteria.addAssociation('orderCustomer');
             criteria.addAssociation('currency');
+            criteria.addAssociation('documents');
             criteria.addAssociation('transactions');
             criteria.addAssociation('deliveries');
             criteria.getAssociation('transactions').addSorting(Criteria.sort('createdAt'));
@@ -123,10 +125,15 @@ Component.register('sw-order-list', {
                 this.isLoading = false;
             });
         },
+
         getBillingAddress(order) {
             return order.addresses.find((address) => {
                 return address.id === order.billingAddressId;
             });
+        },
+
+        disableDeletion(order) {
+            return order.documents.length > 0;
         },
 
         getOrderColumns() {
@@ -231,6 +238,22 @@ Component.register('sw-order-list', {
         onChangeCampaignCodeFilter(value) {
             this.campaignCodeFilter = value;
             this.getList();
+        },
+
+        onDelete(id) {
+            this.showDeleteModal = id;
+        },
+
+        onCloseDeleteModal() {
+            this.showDeleteModal = false;
+        },
+
+        onConfirmDelete(id) {
+            this.showDeleteModal = false;
+
+            return this.orderRepository.delete(id, Shopware.Context.api).then(() => {
+                this.getList();
+            });
         }
     }
 });

--- a/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-list/sw-order-list.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-list/sw-order-list.html.twig
@@ -132,6 +132,12 @@
                                                     {{ $tc('sw-order.list.contextMenuView') }}
                                                 </sw-context-menu-item>
                                             {% endblock %}
+
+                                            {% block sw_order_list_grid_columns_actions_delete %}
+                                            <sw-context-menu-item variant="danger" :disabled="disableDeletion(item)" @click="onDelete(item.id)">
+                                                {{ $tc('sw-order.list.contextMenuDelete') }}
+                                            </sw-context-menu-item>
+                                            {% endblock %}
                                         {% endblock %}
 
                                         {# @deprecated tag:v6.4.0 use `sw_order_list_grid_columns_actions_view` with parent instead #}
@@ -142,6 +148,39 @@
                                         {% block sw_customer_list_grid_columns_actions_delete %}
                                         {% endblock %}
                                     </template>
+                                {% endblock %}
+
+                                {% block sw_order_list_grid_action_modals %}
+                                <template #action-modals="{ item }">
+                                    {% block sw_order_list_delete_modal %}
+                                    <sw-modal v-if="showDeleteModal === item.id"
+                                              @modal-close="onCloseDeleteModal"
+                                              :title="$tc('sw-order.list.modalTitleDelete')"
+                                              variant="small">
+                                        {% block sw_order_list_delete_modal_confirm_delete_text %}
+                                        <p class="sw-order-list__confirm-delete-text">
+                                            {{ $tc('sw-order.list.textDeleteConfirm', 0, { orderNumber: `${item.orderNumber}` }) }}
+                                        </p>
+                                        {% endblock %}
+
+                                        {% block sw_order_list_delete_modal_footer %}
+                                        <template #modal-footer>
+                                            {% block sw_order_list_delete_modal_cancel %}
+                                            <sw-button @click="onCloseDeleteModal" size="small">
+                                                {{ $tc('sw-order.list.buttonCancel') }}
+                                            </sw-button>
+                                            {% endblock %}
+
+                                            {% block sw_order_list_delete_modal_confirm %}
+                                            <sw-button @click="onConfirmDelete(item.id)" variant="primary" size="small">
+                                                {{ $tc('sw-order.list.buttonDelete') }}
+                                            </sw-button>
+                                            {% endblock %}
+                                        </template>
+                                        {% endblock %}
+                                    </sw-modal>
+                                    {% endblock %}
+                                </template>
                                 {% endblock %}
 
                                 <template #pagination>

--- a/src/Administration/Resources/app/administration/src/module/sw-order/snippet/de-DE.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/snippet/de-DE.json
@@ -28,7 +28,11 @@
       "titleSidebarItemRefresh": "Aktualisieren",
       "titleSidebarItemFilter": "Filter",
       "titleSidebarItemFilterAffiliateCode": "Affiliate-Code",
-      "titleSidebarItemFilterCampaignCode": "Kampagnen-Code"
+      "titleSidebarItemFilterCampaignCode": "Kampagnen-Code",
+      "buttonDelete": "Löschen",
+      "buttonCancel": "Abbrechen",
+      "modalTitleDelete": "Bestellung löschen",
+      "textDeleteConfirm": "Möchten Sie diese Bestellung ({orderNumber}) wirklich löschen?"
     },
     "detail": {
       "buttonCancel": "Änderungen verwerfen",

--- a/src/Administration/Resources/app/administration/src/module/sw-order/snippet/en-GB.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/snippet/en-GB.json
@@ -28,7 +28,11 @@
       "titleSidebarItemRefresh": "Refresh",
       "titleSidebarItemFilter": "Filter",
       "titleSidebarItemFilterAffiliateCode": "Affiliate code",
-      "titleSidebarItemFilterCampaignCode": "Campaign code"
+      "titleSidebarItemFilterCampaignCode": "Campaign code",
+      "buttonDelete": "Delete",
+      "buttonCancel": "Cancel",
+      "modalTitleDelete": "Delete order",
+      "textDeleteConfirm": "Do you really want to delete this order ({orderNumber})?"
     },
     "detail": {
       "buttonCancel": "Discard changes",


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/community).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->
Fixes #872

### 1. Why is this change necessary?
To provide a possibility for deleting orders in sw-order-list

### 2. What does this change do, exactly?
It adds a context menu item for deletion in sw-order-list. The item will only be active if there are no documents available for this order. On click a modal to confirm the action appears.

### 3. Describe each step to reproduce the issue or behaviour.
Go to sw-order-list and try to delete an order.

### 4. Please link to the relevant issues (if any).
Video: https://vimeo.com/user87685972/review/418417816/7381333452
Issue: #872

### 5. Checklist

- [x] I have squashed any insignificant commits
- [x] I have read the contribution requirements and fulfil them.
