### PR TITLE
NEXT-8617: Rework offcanvas and disable body scroll on iOS

### DIFF
--- a/CHANGELOG-6.2.md
+++ b/CHANGELOG-6.2.md
@@ -712,3 +712,21 @@ To get the diff between two versions, go to https://github.com/shopware/platform
     * Deprecated `page_checkout_confirm_payment_cancel` in `src/Storefront/Resources/views/storefront/page/checkout/confirm/confirm-payment.html.twig`
     * Deprecated `window.accessKey` and `window.contextToken`, the variables contains now an empty string
     * Removed `HttpClient()` constructor parameters in `src/Storefront/Resources/app/storefront/src/service/http-client.service.js`
+    * Added `body-scroll-lock@3.0.2` as a storefront npm dependency
+    * Added `ScrollLockPlugin` in `src/Storefront/Resources/app/storefront/src/plugin/scroll-lock/scroll-lock.plugin.js` to prevent body scrolling on iOS
+    * Refactored `OffcanvasPlugin` in `src/Storefront/Resources/app/storefront/src/plugin/offcanvas/offcanvas.plugin.js` to be a plugin rather than a singleton
+    * Refactored `AjaxOffcanvasPlugin` in `src/Storefront/Resources/app/storefront/src/plugin/offcanvas/ajax-offcanvas.plugin.js` to use the new offcanvas plugin
+    * Refactored `HtmlOffcanvasPlugin` in `src/Storefront/Resources/app/storefront/src/plugin/offcanvas/html-offcanvas.plugin.js` to use the new offcanvas plugin
+    * Refactored `OffcanvasCartPlugin` in `src/Storefront/Resources/app/storefront/src/plugin/offcanvas-cart/offcanvas-cart.plugin.js` to use the new offcanvas plugin
+    * Refactored `OffcanvasFilterPlugin` in `src/Storefront/Resources/app/storefront/src/plugin/offcanvas-filter/offcanvas-filter.plugin.js` to use the new offcanvas plugin
+    * Refactored `OffcanvasTabsPlugin` in `src/Storefront/Resources/app/storefront/src/plugin/offcanvas-tabs/offcanvas-tabs.plugin.js` to use the new offcanvas plugin
+    * Refactored `OffcanvasMenuPlugin` in `src/Storefront/Resources/app/storefront/src/plugin/main-menu/offcanvas-menu.plugin.js` to use the new offcanvas plugin
+    * Refactored `AccountMenuPlugin` in `src/Storefront/Resources/app/storefront/src/plugin/header/account-menu.plugin.js` to use the new offcanvas plugin
+    * Renamed `SwagBlockLinkPlugin` to `PreventLinkClickPlugin` in `src/Storefront/Resources/app/storefront/src/plugin/prevent-link-click/prevent-link-click.plugin.js`
+    * Fixed missing DomAccess required check in `src/Storefront/Resources/app/storefront/src/plugin/cross-selling/cross-selling.plugin.js`
+
+
+
+
+    
+

--- a/src/Storefront/Resources/app/storefront/package-lock.json
+++ b/src/Storefront/Resources/app/storefront/package-lock.json
@@ -3038,6 +3038,11 @@
         }
       }
     },
+    "body-scroll-lock": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/body-scroll-lock/-/body-scroll-lock-3.0.2.tgz",
+      "integrity": "sha512-PtItUun94iIupKry8J/h6SfRCLWZnly77KbPsTSKALmxfR282L8R0Ujkv7bydSZvLxAJS4sBJ3y/E6X8gYkGrQ=="
+    },
     "bonjour": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/bonjour/-/bonjour-3.5.0.tgz",

--- a/src/Storefront/Resources/app/storefront/package.json
+++ b/src/Storefront/Resources/app/storefront/package.json
@@ -25,6 +25,7 @@
   "dependencies": {
     "@shopware-ag/webpack-plugin-injector": "1.0.3",
     "are-you-es5": "1.3.3",
+    "body-scroll-lock": "3.0.2",
     "bootstrap": "4.3.1",
     "copy-webpack-plugin": "5.1.1",
     "deepmerge": "4.0.0",

--- a/src/Storefront/Resources/app/storefront/src/main.js
+++ b/src/Storefront/Resources/app/storefront/src/main.js
@@ -74,7 +74,8 @@ import CrossSellingPlugin from 'src/plugin/cross-selling/cross-selling.plugin';
 import CountryStateSelectPlugin from 'src/plugin/forms/form-country-state-select.plugin';
 import EllipsisPlugin from 'src/plugin/ellipsis/ellipsis.plugin';
 import GoogleAnalyticsPlugin from 'src/plugin/google-analytics/google-analytics.plugin';
-import SwagBlockLink from 'src/helper/block-link.helper';
+import PreventLinkClickPlugin from 'src/plugin/prevent-link-click/prevent-link-click.plugin';
+import ScrollLockPlugin from 'src/plugin/scroll-lock/scroll-lock.plugin.js';
 
 window.eventEmitter = new NativeEventEmitter();
 
@@ -138,7 +139,8 @@ PluginManager.register('DatePicker', DatePickerPlugin, '[data-date-picker]');
 PluginManager.register('FormCmsHandler', FormCmsHandlerPlugin, '.cms-element-form form');
 PluginManager.register('CountryStateSelect', CountryStateSelectPlugin, '[data-country-state-select]');
 PluginManager.register('Ellipsis', EllipsisPlugin, '[data-ellipsis]');
-PluginManager.register('SwagBlockLink', SwagBlockLink, '[href="#not-found"]');
+PluginManager.register('PreventLinkClick', PreventLinkClickPlugin, '[href="#not-found"]');
+PluginManager.register('ScrollLock', ScrollLockPlugin, 'html');
 
 if (window.csrf.enabled && window.csrf.mode === 'ajax') {
     PluginManager.register('FormCsrfHandler', FormCsrfHandlerPlugin, '[data-form-csrf-handler]');

--- a/src/Storefront/Resources/app/storefront/src/plugin/cross-selling/cross-selling.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/cross-selling/cross-selling.plugin.js
@@ -21,9 +21,12 @@ export default class CrossSellingPlugin extends Plugin {
         const id = event.target.id;
         const correspondingContent = DomAccess.querySelector(document, `#${id}-pane`);
 
-        const slider = DomAccess.querySelector(correspondingContent, this.options.productSliderSelector);
-        const sliderInstance = window.PluginManager.getPluginInstanceFromElement(slider, 'ProductSlider');
-
-        sliderInstance.rebuild(ViewportDetection.getCurrentViewport(), true);
+        const slider = DomAccess.querySelector(correspondingContent, this.options.productSliderSelector, false);
+        if (slider) {
+            const sliderInstance = window.PluginManager.getPluginInstanceFromElement(slider, 'ProductSlider');
+            if (sliderInstance) {
+                sliderInstance.rebuild(ViewportDetection.getCurrentViewport(), true);
+            }
+        }
     }
 }

--- a/src/Storefront/Resources/app/storefront/src/plugin/header/account-menu.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/header/account-menu.plugin.js
@@ -1,10 +1,9 @@
-import Plugin from 'src/plugin-system/plugin.class';
 import DomAccess from 'src/helper/dom-access.helper';
-import OffCanvas from 'src/plugin/offcanvas/offcanvas.plugin';
 import DeviceDetection from 'src/helper/device-detection.helper';
 import ViewportDetection from 'src/helper/viewport-detection.helper';
+import OffcanvasPlugin from '../offcanvas/offcanvas.plugin';
 
-export default class OffCanvasAccountMenu extends Plugin {
+export default class OffCanvasAccountMenu extends OffcanvasPlugin {
 
     static options = {
         /**
@@ -26,7 +25,7 @@ export default class OffCanvasAccountMenu extends Plugin {
          * from which direction the
          * offcanvas opens
          */
-        offcanvasPostion: 'left'
+        offcanvasPostion: 'right'
     };
 
     init() {
@@ -60,8 +59,8 @@ export default class OffCanvasAccountMenu extends Plugin {
 
         this._dropdown.classList.add(this.options.hiddenClass);
 
-        OffCanvas.open(this._dropdown.innerHTML, null, this.options.offcanvasPostion, true, OffCanvas.REMOVE_OFF_CANVAS_DELAY());
-        OffCanvas.setAdditionalClassName(this.options.additionalClass);
+        this.open(this._dropdown.innerHTML, null, this.options.offcanvasPostion, true);
+        this.setAdditionalClassName(this.options.additionalClass);
 
         this.$emitter.publish('onClickAccountMenuTrigger');
     }
@@ -72,8 +71,8 @@ export default class OffCanvasAccountMenu extends Plugin {
      * @private
      */
     _onViewportHasChanged() {
-        if (this._isInAllowedViewports() === false && OffCanvas.exists()) {
-            OffCanvas.close();
+        if (this._isInAllowedViewports() === false && this.exists()) {
+            this.close();
         }
 
         if (this._dropdown) {

--- a/src/Storefront/Resources/app/storefront/src/plugin/main-menu/offcanvas-menu.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/main-menu/offcanvas-menu.plugin.js
@@ -1,11 +1,10 @@
-import Plugin from 'src/plugin-system/plugin.class';
-import OffCanvas from 'src/plugin/offcanvas/offcanvas.plugin';
+import OffCanvasPlugin from 'src/plugin/offcanvas/offcanvas.plugin';
 import LoadingIndicator from 'src/utility/loading-indicator/loading-indicator.util';
 import HttpClient from 'src/service/http-client.service';
 import DomAccess from 'src/helper/dom-access.helper';
 import Iterator from 'src/helper/iterator.helper';
 
-export default class OffcanvasMenuPlugin extends Plugin {
+export default class OffcanvasMenuPlugin extends OffCanvasPlugin {
 
     static options = {
         navigationUrl: window.router['frontend.menu.offcanvas'],
@@ -44,16 +43,17 @@ export default class OffcanvasMenuPlugin extends Plugin {
      * @private
      */
     _registerEvents() {
+        super._registerEvents(true);
         this.el.removeEventListener(this.options.tiggerEvent, this._getLinkEventHandler.bind(this));
         this.el.addEventListener(this.options.tiggerEvent, this._getLinkEventHandler.bind(this));
 
-        if (OffCanvas.exists()) {
-            const offCanvasElements = OffCanvas.getOffCanvas();
+        if (this.exists()) {
+            const offCanvasElements = this.getOffCanvas();
 
             Iterator.iterate(offCanvasElements, offcanvas => {
                 const links = offcanvas.querySelectorAll(this.options.linkSelector);
                 Iterator.iterate(links, link => {
-                    OffcanvasMenuPlugin._resetLoader(link);
+                    this._resetLoader(link);
                     link.addEventListener('click', (event) => {
                         this._getLinkEventHandler(event, link);
                     });
@@ -69,9 +69,9 @@ export default class OffcanvasMenuPlugin extends Plugin {
      * @private
      */
     _openMenu(event) {
-        OffcanvasMenuPlugin._stopEvent(event);
-        OffCanvas.open(this._content, this._registerEvents.bind(this), this.options.position);
-        OffCanvas.setAdditionalClassName(this.options.additionalOffcanvasClass);
+        this._stopEvent(event);
+        this.open(this._content, this._registerEvents.bind(this), this.options.position);
+        this.setAdditionalClassName(this.options.additionalOffcanvasClass);
 
         this.$emitter.publish('openMenu');
     }
@@ -93,12 +93,12 @@ export default class OffcanvasMenuPlugin extends Plugin {
             return this._openMenu(event);
         }
 
-        OffcanvasMenuPlugin._stopEvent(event);
+        this._stopEvent(event);
         if (link.classList.contains(this.options.linkLoadingClass)) {
             return;
         }
 
-        OffcanvasMenuPlugin._setLoader(link);
+        this._setLoader(link);
 
         const url = DomAccess.getAttribute(link, 'data-href', false) || DomAccess.getAttribute(link, 'href', false);
 
@@ -122,7 +122,7 @@ export default class OffcanvasMenuPlugin extends Plugin {
      * @param link
      * @private
      */
-    static _setLoader(link) {
+    _setLoader(link) {
         link.classList.add(this.options.linkLoadingClass);
         const icon = link.querySelector(this.options.loadingIconSelector);
 
@@ -138,7 +138,7 @@ export default class OffcanvasMenuPlugin extends Plugin {
      * @param link
      * @private
      */
-    static _resetLoader(link) {
+    _resetLoader(link) {
         link.classList.remove(this.options.linkLoadingClass);
         const icon = link.querySelector(this.options.loadingIconSelector);
         if (icon && icon._linkIcon) {
@@ -157,8 +157,8 @@ export default class OffcanvasMenuPlugin extends Plugin {
     _updateOverlay(animationType, content) {
         this._content = content;
 
-        if (OffCanvas.exists()) {
-            const offcanvasMenu = OffcanvasMenuPlugin._getOffcanvasMenu();
+        if (this.exists()) {
+            const offcanvasMenu = this._getOffcanvasMenu();
 
             // if there is no content present
             // insert the whole response into the offcanvas
@@ -167,8 +167,8 @@ export default class OffcanvasMenuPlugin extends Plugin {
             }
 
             this._createOverlayElements();
-            const currentContent = OffcanvasMenuPlugin._getOverlayContent(offcanvasMenu);
-            const menuContent = OffcanvasMenuPlugin._getMenuContentFromResponse(content);
+            const currentContent = this._getOverlayContent(offcanvasMenu);
+            const menuContent = this._getMenuContentFromResponse(content);
 
             this._replaceOffcanvasMenuContent(animationType, menuContent, currentContent);
             this._registerEvents();
@@ -270,9 +270,9 @@ export default class OffcanvasMenuPlugin extends Plugin {
      * @returns {string}
      * @private
      */
-    static _getMenuContentFromResponse(content) {
+    _getMenuContentFromResponse(content) {
         const html = new DOMParser().parseFromString(content, 'text/html');
-        return OffcanvasMenuPlugin._getOverlayContent(html);
+        return this._getOverlayContent(html);
     }
 
     /**
@@ -283,7 +283,7 @@ export default class OffcanvasMenuPlugin extends Plugin {
      * @returns {string}
      * @private
      */
-    static _getOverlayContent(element) {
+    _getOverlayContent(element) {
         if (!element) {
             return '';
         }
@@ -303,11 +303,11 @@ export default class OffcanvasMenuPlugin extends Plugin {
      * @private
      */
     _createOverlayElements() {
-        const offcanvasMenu = OffcanvasMenuPlugin._getOffcanvasMenu();
+        const offcanvasMenu = this._getOffcanvasMenu();
 
         if (offcanvasMenu) {
-            this._placeholder = OffcanvasMenuPlugin._createPlaceholder(offcanvasMenu);
-            this._overlay = OffcanvasMenuPlugin._createNavigationOverlay(offcanvasMenu);
+            this._placeholder = this._createPlaceholder(offcanvasMenu);
+            this._overlay = this._createNavigationOverlay(offcanvasMenu);
         }
 
         this.$emitter.publish('createOverlayElements');
@@ -319,8 +319,8 @@ export default class OffcanvasMenuPlugin extends Plugin {
      * @returns {HTMLElement}
      * @private
      */
-    static _createNavigationOverlay(container) {
-        const offcanvas = OffcanvasMenuPlugin._getOffcanvas();
+    _createNavigationOverlay(container) {
+        const offcanvas = this._getOffcanvas();
         const currentOverlay = offcanvas.querySelector(this.options.overlayClass);
         if (currentOverlay) {
             return currentOverlay;
@@ -340,8 +340,8 @@ export default class OffcanvasMenuPlugin extends Plugin {
      * @returns {HTMLElement}
      * @private
      */
-    static _createPlaceholder(container) {
-        const offcanvas = OffcanvasMenuPlugin._getOffcanvas();
+    _createPlaceholder(container) {
+        const offcanvas = this._getOffcanvas();
         const currentPlaceholder = offcanvas.querySelector(this.options.placeholderClass);
         if (currentPlaceholder) {
             return currentPlaceholder;
@@ -392,19 +392,10 @@ export default class OffcanvasMenuPlugin extends Plugin {
      */
     _replaceOffcanvasContent(content) {
         this._content = content;
-        OffCanvas.setContent(this._content);
+        this.setContent(this._content);
         this._registerEvents();
 
         this.$emitter.publish('replaceOffcanvasContent');
-    }
-
-    /**
-     * @param {Event} event
-     * @private
-     */
-    static _stopEvent(event) {
-        event.preventDefault();
-        event.stopImmediatePropagation();
     }
 
     /**
@@ -413,8 +404,8 @@ export default class OffcanvasMenuPlugin extends Plugin {
      * @returns {Node}
      * @private
      */
-    static _getOffcanvas() {
-        return OffCanvas.getOffCanvas()[0];
+    _getOffcanvas() {
+        return this.getOffCanvas()[0];
     }
 
     /**
@@ -423,9 +414,18 @@ export default class OffcanvasMenuPlugin extends Plugin {
      * @returns {Element|any}
      * @private
      */
-    static _getOffcanvasMenu() {
-        const offcanvas = OffcanvasMenuPlugin._getOffcanvas();
+    _getOffcanvasMenu() {
+        const offcanvas = this._getOffcanvas();
 
         return offcanvas.querySelector(this.options.menuSelector);
+    }
+
+    /**
+     * @param {Event} event
+     * @private
+     */
+    _stopEvent(event) {
+        event.preventDefault();
+        event.stopImmediatePropagation();
     }
 }

--- a/src/Storefront/Resources/app/storefront/src/plugin/offcanvas-filter/offcanvas-filter.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/offcanvas-filter/offcanvas-filter.plugin.js
@@ -1,8 +1,7 @@
-import OffCanvas from 'src/plugin/offcanvas/offcanvas.plugin';
-import Plugin from 'src/plugin-system/plugin.class';
+import OffCanvasPlugin from 'src/plugin/offcanvas/offcanvas.plugin';
 import DomAccess from 'src/helper/dom-access.helper';
 
-export default class OffCanvasFilter extends Plugin {
+export default class OffCanvasFilterPlugin extends OffCanvasPlugin {
 
     init() {
         this._registerEventListeners();
@@ -24,7 +23,7 @@ export default class OffCanvasFilter extends Plugin {
         // move filter back to original place
         filterContent.innerHTML = oldChildNode.innerHTML;
 
-        document.$emitter.unsubscribe('onCloseOffcanvas', this._onCloseOffCanvas.bind(this));
+        this.$emitter.unsubscribe('onCloseOffcanvas', this._onCloseOffCanvas.bind(this));
         window.PluginManager.getPluginInstances('Listing')[0].refreshRegistry();
     }
 
@@ -36,29 +35,15 @@ export default class OffCanvasFilter extends Plugin {
      */
     _onClickOffCanvasFilter(event) {
         event.preventDefault();
-        const filterContent = document.querySelector('[data-offcanvas-filter-content="true"]');
+        const filterContent = DomAccess.querySelector(document, '[data-offcanvas-filter-content="true"]');
 
-        if (!filterContent) {
-            throw Error('There was no DOM element with the data attribute "data-offcanvas-filter-content".')
-        }
-
-        OffCanvas.open(
-            filterContent.innerHTML,
-            () => {},
-            'bottom',
-            true,
-            0,
-            true,
-            'offcanvas-filter'
-        );
+        this.open(filterContent.innerHTML, () => {}, 'bottom', true, true, 'offcanvas-filter');
 
         const filterPanel = DomAccess.querySelector(filterContent, '.filter-panel');
-
-        // move filter from original place to offcanvas
-        filterPanel.remove();
+        if (filterPanel) filterPanel.remove();
 
         window.PluginManager.getPluginInstances('Listing')[0].refreshRegistry();
-        document.$emitter.subscribe('onCloseOffcanvas', this._onCloseOffCanvas.bind(this));
+        this.$emitter.subscribe('onCloseOffcanvas', this._onCloseOffCanvas.bind(this));
 
         this.$emitter.publish('onClickOffCanvasFilter');
     }

--- a/src/Storefront/Resources/app/storefront/src/plugin/offcanvas-tabs/offcanvas-tabs.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/offcanvas-tabs/offcanvas-tabs.plugin.js
@@ -1,9 +1,8 @@
 import DomAccess from 'src/helper/dom-access.helper';
-import OffCanvas from 'src/plugin/offcanvas/offcanvas.plugin';
+import OffCanvasPlugin from 'src/plugin/offcanvas/offcanvas.plugin';
 import ViewportDetection from 'src/helper/viewport-detection.helper';
-import Plugin from 'src/plugin-system/plugin.class';
 
-export default class OffCanvasTabs extends Plugin {
+export default class OffCanvasTabsPlugin extends OffCanvasPlugin {
 
     static options = {
 
@@ -44,12 +43,11 @@ export default class OffCanvasTabs extends Plugin {
         if (DomAccess.hasAttribute(tab, 'href')) {
             const tabTarget = DomAccess.getAttribute(tab, 'href');
             const pane = DomAccess.querySelector(document, tabTarget);
-            OffCanvas.open(
+            this.open(
                 pane.innerHTML,
                 () => { window.PluginManager.initializePlugins() },
                 this.options.offcanvasPostion,
                 true,
-                OffCanvas.REMOVE_OFF_CANVAS_DELAY(),
                 true
             );
         }

--- a/src/Storefront/Resources/app/storefront/src/plugin/offcanvas/html-offcanvas.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/offcanvas/html-offcanvas.plugin.js
@@ -1,19 +1,18 @@
-import OffCanvas from 'src/plugin/offcanvas/offcanvas.plugin';
+import OffCanvasPlugin from 'src/plugin/offcanvas/offcanvas.plugin';
 
-export default class HtmlOffCanvas extends OffCanvas {
+export default class HtmlOffCanvasPlugin extends OffCanvasPlugin {
 
     /**
      * Open an offcanvas with HTML content from any given selector
      * @param {string} selector
      * @param {'left'|'right'} position
      * @param {boolean} closable
-     * @param {number} delay
      * @param {boolean} fullwidth
      * @param {array|string} cssClass
      */
 
-    static open(selector, position = 'left', closable = true, delay = OffCanvas.REMOVE_OFF_CANVAS_DELAY, fullwidth = false, cssClass = '') {
-        super.open(HtmlOffCanvas._getContent(selector), position, closable, delay, fullwidth, cssClass);
+    open(selector, position = 'left', closable = true, fullwidth = false, cssClass = '') {
+        super.open(this._getContent(selector), position, closable, fullwidth, cssClass);
     }
 
     /**
@@ -23,10 +22,10 @@ export default class HtmlOffCanvas extends OffCanvas {
      * @returns {string}
      * @private
      */
-    static _getContent(selector) {
+    _getContent(selector) {
         const parent = document.querySelector(selector);
 
-        if (parent instanceof Element === false) {
+        if (!(parent instanceof Element)) {
             throw Error('Parent element does not exist!');
         }
 

--- a/src/Storefront/Resources/app/storefront/src/plugin/prevent-link-click/prevent-link-click.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/prevent-link-click/prevent-link-click.plugin.js
@@ -1,6 +1,6 @@
 import Plugin from 'src/plugin-system/plugin.class';
 
-export default class SwagBlockLink extends Plugin {
+export default class PreventLinkClickPlugin extends Plugin {
     init() {
         this.el.addEventListener('click', (event) => {
             event.preventDefault();

--- a/src/Storefront/Resources/app/storefront/src/plugin/scroll-lock/scroll-lock.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/scroll-lock/scroll-lock.plugin.js
@@ -1,0 +1,84 @@
+import Plugin from 'src/plugin-system/plugin.class';
+import Iterator from 'src/helper/iterator.helper';
+import { clearAllBodyScrollLocks, disableBodyScroll } from 'body-scroll-lock';
+
+const NO_SCROLL_CLS = 'no-scroll';
+
+export default class ScrollLockPlugin extends Plugin {
+
+    static options = {
+        scrollable: [
+            '.offcanvas',
+            '.modal'
+        ]
+    };
+
+    init() {
+        this._registerEvents();
+    }
+
+    _registerEvents() {
+        this.mutationObserver = new MutationObserver(this._onMutate.bind(this));
+        this.mutationObserver.observe(this.el, {
+            attributes: true,
+            characterData: true,
+            childList: false,
+            subtree: false,
+            attributeOldValue: false,
+            characterDataOldValue: false
+        });
+        $(document).on('show.bs.modal', () => document.documentElement.classList.add(NO_SCROLL_CLS));
+        $(document).on('hide.bs.modal', () => document.documentElement.classList.remove(NO_SCROLL_CLS));
+    }
+
+    /**
+     * listen to the class changes of the provided element
+     * if no-scroll is present body scroll is disabled
+     *
+     * @param records
+     * @private
+     */
+    _onMutate(records) {
+        Iterator.iterate(records, record => {
+            if (record.type === 'attributes' && record.attributeName === 'class') {
+                if (record.target.classList.contains(NO_SCROLL_CLS)) {
+                    this._disableScroll();
+                } else {
+                    this._enableScroll();
+                }
+            }
+        })
+    }
+
+    /**
+     * disables scroll expect on the elements listed in options.scrollable
+     *
+     * @private
+     */
+    _disableScroll() {
+        Iterator.iterate(this.options.scrollable, scrollableSelector => {
+            const scrollables = document.querySelectorAll(scrollableSelector);
+            Iterator.iterate(scrollables, scrollable => {
+                scrollable.style['-webkit-overflow-scrolling'] = 'touch';
+                scrollable.style['scroll-behavior'] = 'smooth';
+                disableBodyScroll(scrollable);
+            });
+        });
+    }
+
+    /**
+     * enables the scroll again
+     *
+     * @private
+     */
+    _enableScroll() {
+        clearAllBodyScrollLocks();
+        Iterator.iterate(this.options.scrollable, scrollableSelector => {
+            const scrollables = document.querySelectorAll(scrollableSelector);
+            Iterator.iterate(scrollables, scrollable => {
+                scrollable.style['-webkit-overflow-scrolling'] = 'initial';
+                scrollable.style['scroll-behavior'] = 'initial';
+            });
+        });
+    }
+}


### PR DESCRIPTION
The iOS body was scrollable when an offcanvas or modal was open. This is now fixed via the body-lock-scroll vendor.
Also the offcanvas component was not extendable, it’s now a full fletched plugin.

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/community).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
Because the offcanvas was not extendable.
And the background scrolled when an offcanvas or modal was open

### 2. What does this change do, exactly?
- Listen to class changes (.no-scroll) on the HTML element, to prevent scrolling except modal/offcanvas elements
- turn the offcanvas singleton into an extendable plugin


### 3. Describe each step to reproduce the issue or behaviour.
- Take and iOS device
- open the offcanvas menu via the burger icon
- open a category, so the offcanvas height exceeds the device height
- scroll down and up
- the body in the background should NOT scroll anymore after this change

### 4. Please link to the relevant issues (if any).
https://github.com/shopware/platform/issues/886

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
