### PR TITLE
NEXT-8260 Fix Sorting the properties in the filter has wrong order #827

### DIFF
--- a/src/Core/Content/Product/SalesChannel/Listing/ProductListingFeaturesSubscriber.php
+++ b/src/Core/Content/Product/SalesChannel/Listing/ProductListingFeaturesSubscriber.php
@@ -363,6 +363,7 @@ class ProductListingFeaturesSubscriber implements EventSubscriberInterface
         // group options by their property-group
         $grouped = $options->groupByPropertyGroups();
         $grouped->sortByPositions();
+        $grouped->sortByConfig();
 
         // remove id results to prevent wrong usages
         $event->getResult()->getAggregations()->remove('properties');

--- a/src/Core/Content/Property/PropertyGroupCollection.php
+++ b/src/Core/Content/Property/PropertyGroupCollection.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Core\Content\Property;
 
+use Shopware\Core\Content\Property\Aggregate\PropertyGroupOption\PropertyGroupOptionEntity;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
 
 /**
@@ -43,6 +44,28 @@ class PropertyGroupCollection extends EntityCollection
 
             return $posA <=> $posB;
         });
+    }
+
+    public function sortByConfig(): void
+    {
+        /** @var PropertyGroupEntity $group */
+        foreach ($this->elements as $group) {
+            if (!$group->getOptions()) {
+                continue;
+            }
+
+            $group->getOptions()->sort(static function (PropertyGroupOptionEntity $a, PropertyGroupOptionEntity $b) use ($group) {
+                if ($group->getSortingType() === PropertyGroupDefinition::SORTING_TYPE_ALPHANUMERIC) {
+                    return strnatcmp($a->getTranslation('name'), $b->getTranslation('name'));
+                }
+
+                if ($group->getSortingType() === PropertyGroupDefinition::SORTING_TYPE_NUMERIC) {
+                    return $a->getTranslation('name') <=> $b->getTranslation('name');
+                }
+
+                return ($a->getTranslation('position') ?? $a->getPosition()) <=> ($b->getTranslation('position') ?? $b->getPosition());
+            });
+        }
     }
 
     public function getApiAlias(): string

--- a/src/Storefront/Page/Product/ProductLoader.php
+++ b/src/Storefront/Page/Product/ProductLoader.php
@@ -7,10 +7,7 @@ use Shopware\Core\Content\Product\Exception\ProductNotFoundException;
 use Shopware\Core\Content\Product\SalesChannel\ProductAvailableFilter;
 use Shopware\Core\Content\Product\SalesChannel\SalesChannelProductEntity;
 use Shopware\Core\Content\Property\Aggregate\PropertyGroupOption\PropertyGroupOptionCollection;
-use Shopware\Core\Content\Property\Aggregate\PropertyGroupOption\PropertyGroupOptionEntity;
 use Shopware\Core\Content\Property\PropertyGroupCollection;
-use Shopware\Core\Content\Property\PropertyGroupDefinition;
-use Shopware\Core\Content\Property\PropertyGroupEntity;
 use Shopware\Core\Framework\DataAbstractionLayer\Exception\InconsistentCriteriaIdsException;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
@@ -124,29 +121,10 @@ class ProductLoader
             $sorted[$group->getId()] = $group;
         }
 
-        usort(
-            $sorted,
-            static function (PropertyGroupEntity $a, PropertyGroupEntity $b) {
-                return strnatcmp($a->getTranslation('name'), $b->getTranslation('name'));
-            }
-        );
+        $propertyGroupCollection = new PropertyGroupCollection($sorted);
+        $propertyGroupCollection->sortByPositions();
+        $propertyGroupCollection->sortByConfig();
 
-        foreach ($sorted as $group) {
-            $group->getOptions()->sort(
-                static function (PropertyGroupOptionEntity $a, PropertyGroupOptionEntity $b) use ($group) {
-                    if ($group->getSortingType() === PropertyGroupDefinition::SORTING_TYPE_ALPHANUMERIC) {
-                        return strnatcmp($a->getTranslation('name'), $b->getTranslation('name'));
-                    }
-
-                    if ($group->getSortingType() === PropertyGroupDefinition::SORTING_TYPE_ALPHANUMERIC) {
-                        return $a->getTranslation('name') <=> $b->getTranslation('name');
-                    }
-
-                    return $a->getPosition() <=> $b->getPosition();
-                }
-            );
-        }
-
-        return new PropertyGroupCollection($sorted);
+        return $propertyGroupCollection;
     }
 }


### PR DESCRIPTION
NEXT-8260 Fix Sorting the properties in the filter has wrong order #827

### 1. Why is this change necessary?
The sorting of property group options isn't correct in the storefront. Only the propery groups are sorted.

### 2. What does this change do, exactly?
The options in the property groups are now filter either numerically, alphanummerically, or in a custom fashion based on the position of the option. The custom sorting can be different depending on the translation.
The product groups and product group options are also sorted as configured in the admin.

### 3. Describe each step to reproduce the issue or behaviour.
Load a product list with group option filters or open the product detail page. Check if the configured sorting from the admin equals the sorting in the storefront

### 4. Please link to the relevant issues (if any).
https://github.com/shopware/platform/issues/827

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
