### PR TITLE
NEXT-8010 - Fix Product detail page images are downloaded anew each t…

### DIFF
--- a/src/Storefront/Resources/app/storefront/src/plugin/magnifier/magnifier.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/magnifier/magnifier.plugin.js
@@ -439,6 +439,7 @@ export default class MagnifierPlugin extends Plugin {
         this._zoomImage = this._zoomImageContainer.querySelector(`.${this.options.zoomImageClass}`);
 
         if (this._zoomImage) {
+            this._zoomImage.style.display = 'unset';
             return this._zoomImage;
         }
 
@@ -458,7 +459,7 @@ export default class MagnifierPlugin extends Plugin {
      */
     _removeZoomImage() {
         const zoomImages = document.querySelectorAll(`.${this.options.zoomImageClass}`);
-        Iterator.iterate(zoomImages, zoomImage => zoomImage.remove());
+        Iterator.iterate(zoomImages, zoomImage => zoomImage.style.display = 'none');
 
         this.$emitter.publish('removeZoomImage');
     }


### PR DESCRIPTION
…ime the magnifying glass function is used #847


### 1. Why is this change necessary?
When magnifying the product image the product image is loaded every time the mouse leaves the product image and enters it again.

### 2. What does this change do, exactly?
If the mouse leaves the product image the created magnified image is not deleted but hidden. If the mouse reenters the product image the magnified image is shown again.

### 3. Describe each step to reproduce the issue or behaviour.
Open the PDP open the development tools and check the network. The images are loaded every time the magnifier hits the image after not being on the image.

### 4. Please link to the relevant issues (if any).
https://github.com/shopware/platform/issues/847

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
