### PR TITLE
NEXT-5263 - PDF Upload

### DIFF
--- a/CHANGELOG-6.2.md
+++ b/CHANGELOG-6.2.md
@@ -337,6 +337,12 @@ To get the diff between two versions, go to https://github.com/shopware/platform
     * If you edited one of these mail templates you need to add the `rawUrl` function manually like this: `{{ rawUrl('frontend.account.edit-order.page', { 'orderId': order.id }, salesChannel.domain|first.url) }}` 
     * Price input fields substitute commas with dots automatically in Add Product page.
     * Added a link to the customer name in the order overview. With this it is now possible to open the customer directly from the overview.
+    * Added property `fileAccept` to 
+        * `sw-media-upload-v2`
+        * `sw-media-compact-upload-v2`
+        * `sw-media-modal-v2`
+        * `sw-media-index`
+    * Change default value of `accept` in `sw-media-index` to `*/*` to allow all types of files in media management 
 
 * Core    
     * Added support of module favicons from plugins, set the `faviconSrc` prop of your module to the name of your bundle in the public bundles folder.

--- a/src/Administration/Resources/app/administration/src/app/component/media/sw-media-compact-upload-v2/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/media/sw-media-compact-upload-v2/index.js
@@ -31,6 +31,12 @@ Shopware.Component.extend('sw-media-compact-upload-v2', 'sw-media-upload-v2', {
             type: [String, Object],
             required: false,
             default: ''
+        },
+
+        fileAccept: {
+            type: String,
+            required: false,
+            default: 'image/*'
         }
     },
 

--- a/src/Administration/Resources/app/administration/src/app/component/media/sw-media-compact-upload-v2/sw-media-compact-upload-v2.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/media/sw-media-compact-upload-v2/sw-media-compact-upload-v2.html.twig
@@ -131,7 +131,7 @@
                        type="file"
                        id="files"
                        ref="fileInput"
-                       accept="image/*"
+                       :accept="fileAccept"
                        :multiple="multiSelect"
                        @change="onFileInputChange"/>
             </form>

--- a/src/Administration/Resources/app/administration/src/app/component/media/sw-media-upload-v2/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/media/sw-media-upload-v2/index.js
@@ -89,6 +89,12 @@ Component.register('sw-media-upload-v2', {
             type: Object,
             required: false,
             default: null
+        },
+
+        fileAccept: {
+            type: String,
+            required: false,
+            default: 'image/*'
         }
     },
 

--- a/src/Administration/Resources/app/administration/src/app/component/media/sw-media-upload-v2/sw-media-upload-v2.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/media/sw-media-upload-v2/sw-media-upload-v2.html.twig
@@ -170,7 +170,7 @@
                        type="file"
                        id="files"
                        ref="fileInput"
-                       accept="image/*"
+                       :accept="fileAccept"
                        :multiple="multiSelect"
                        @change="onFileInputChange"/>
             </form>

--- a/src/Administration/Resources/app/administration/src/module/sw-media/component/sw-media-modal-v2/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-media/component/sw-media-modal-v2/index.js
@@ -39,6 +39,12 @@ Component.register('sw-media-modal-v2', {
             type: Boolean,
             required: false,
             default: true
+        },
+
+        fileAccept: {
+            type: String,
+            required: false,
+            default: 'image/*'
         }
     },
 

--- a/src/Administration/Resources/app/administration/src/module/sw-media/component/sw-media-modal-v2/sw-media-modal-v2.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-media/component/sw-media-modal-v2/sw-media-modal-v2.html.twig
@@ -70,6 +70,7 @@
                                                 <sw-media-upload-v2
                                                     class="sw-media-modal-v2__upload-container"
                                                     variant="regular"
+                                                    :fileAccept="fileAccept"
                                                     :uploadTag="uploadTag"
                                                     :defaultFolder="entityContext"
                                                     :targetFolder="folderId"

--- a/src/Administration/Resources/app/administration/src/module/sw-media/page/sw-media-index/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-media/page/sw-media-index/index.js
@@ -12,6 +12,12 @@ Component.register('sw-media-index', {
         routeFolderId: {
             type: String,
             default: null
+        },
+
+        fileAccept: {
+            type: String,
+            required: false,
+            default: '*/*'
         }
     },
 

--- a/src/Administration/Resources/app/administration/src/module/sw-media/page/sw-media-index/sw-media-index.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-media/page/sw-media-index/sw-media-index.html.twig
@@ -51,6 +51,7 @@
                 {% block sw_media_index_smart_bar_media_upload %}
                     <sw-media-upload-v2
                         variant="compact"
+                        :fileAccept="fileAccept"
                         :targetFolderId="routeFolderId"
                         :uploadTag="uploadTag">
                     </sw-media-upload-v2>

--- a/src/Administration/Resources/app/administration/test/component/media/sw-media-compact-upload-v2.spec.js
+++ b/src/Administration/Resources/app/administration/test/component/media/sw-media-compact-upload-v2.spec.js
@@ -1,0 +1,52 @@
+import { createLocalVue, shallowMount } from '@vue/test-utils';
+import 'src/app/component/media/sw-media-upload-v2';
+import 'src/app/component/media/sw-media-compact-upload-v2';
+
+describe('src/app/component/media/sw-media-compact-upload-v2', () => {
+    let wrapper;
+
+    beforeEach(() => {
+        const localVue = createLocalVue();
+        localVue.directive('droppable', {});
+
+        wrapper = shallowMount(Shopware.Component.build('sw-media-compact-upload-v2'), {
+            localVue,
+            stubs: {
+                'sw-context-button': true,
+                'sw-context-menu-item': true,
+                'sw-icon': true,
+                'sw-button': true
+            },
+            mocks: {
+                $t: v => v,
+                $tc: v => v
+            },
+            provide: {
+                repositoryFactory: {},
+                mediaService: {}
+            },
+            propsData: {
+                uploadTag: 'my-upload'
+            }
+        });
+    });
+
+    it('should be a Vue.js component', () => {
+        expect(wrapper.isVueInstance()).toBeTruthy();
+    });
+
+    it('should contain the default accept value', () => {
+        const fileInput = wrapper.find('.sw-media-upload-v2__file-input');
+
+        expect(fileInput.attributes().accept).toBe('image/*');
+    });
+
+    it('should contain "application/pdf" value', () => {
+        wrapper.setProps({
+            fileAccept: 'application/pdf'
+        });
+        const fileInput = wrapper.find('.sw-media-upload-v2__file-input');
+
+        expect(fileInput.attributes().accept).toBe('application/pdf');
+    });
+});

--- a/src/Administration/Resources/app/administration/test/component/media/sw-media-upload-v2.spec.js
+++ b/src/Administration/Resources/app/administration/test/component/media/sw-media-upload-v2.spec.js
@@ -1,0 +1,78 @@
+import { createLocalVue, shallowMount } from '@vue/test-utils';
+import 'src/app/component/media/sw-media-upload-v2';
+
+describe('src/app/component/media/sw-media-upload-v2', () => {
+    let wrapper;
+
+    beforeEach(() => {
+        const localVue = createLocalVue();
+        localVue.directive('droppable', {});
+
+        wrapper = shallowMount(Shopware.Component.build('sw-media-upload-v2'), {
+            localVue,
+            stubs: {
+                'sw-context-button': true,
+                'sw-context-menu-item': true,
+                'sw-icon': true,
+                'sw-button': true
+            },
+            mocks: {
+                $t: v => v,
+                $tc: v => v
+            },
+            provide: {
+                repositoryFactory: {},
+                mediaService: {}
+            },
+            propsData: {
+                uploadTag: 'my-upload'
+            }
+        });
+    });
+
+    it('should be a Vue.js component', () => {
+        expect(wrapper.isVueInstance()).toBeTruthy();
+    });
+
+    it('should contain the default accept value', () => {
+        const fileInput = wrapper.find('.sw-media-upload-v2__file-input');
+
+        expect(fileInput.attributes().accept).toBe('image/*');
+    });
+
+    it('should contain "application/pdf" value', () => {
+        wrapper.setProps({
+            fileAccept: 'application/pdf'
+        });
+        const fileInput = wrapper.find('.sw-media-upload-v2__file-input');
+
+        expect(fileInput.attributes().accept).toBe('application/pdf');
+    });
+
+    it('should contain "image/jpeg","image/gif","image/png" values', () => {
+        wrapper.setProps({
+            fileAccept: 'image/jpeg,image/gif,image/png'
+        });
+        const fileInput = wrapper.find('.sw-media-upload-v2__file-input');
+
+        expect(fileInput.attributes().accept).toBe('image/jpeg,image/gif,image/png');
+    });
+
+    it('should contain mixed content-types value', () => {
+        wrapper.setProps({
+            fileAccept: 'image/jpeg,image/gif,image/png,application/pdf,image/x-eps'
+        });
+        const fileInput = wrapper.find('.sw-media-upload-v2__file-input');
+
+        expect(fileInput.attributes().accept).toBe('image/jpeg,image/gif,image/png,application/pdf,image/x-eps');
+    });
+
+    it('should contain all content-types value', () => {
+        wrapper.setProps({
+            fileAccept: '*/*'
+        });
+        const fileInput = wrapper.find('.sw-media-upload-v2__file-input');
+
+        expect(fileInput.attributes().accept).toBe('*/*');
+    });
+});

--- a/src/Administration/Resources/app/administration/test/module/sw-media/component/sw-media-modal-v2/sw-media-modal-v2.spec.js
+++ b/src/Administration/Resources/app/administration/test/module/sw-media/component/sw-media-modal-v2/sw-media-modal-v2.spec.js
@@ -1,0 +1,53 @@
+import { createLocalVue, shallowMount } from '@vue/test-utils';
+import 'src/module/sw-media/component/sw-media-modal-v2';
+
+describe('src/module/sw-media/component/sw-media-modal-v2', () => {
+    let wrapper;
+
+    beforeEach(() => {
+        const localVue = createLocalVue();
+        localVue.directive('droppable', {});
+
+        wrapper = shallowMount(Shopware.Component.build('sw-media-modal-v2'), {
+            localVue,
+            stubs: {
+                'sw-modal': true,
+                'sw-tabs': '<div><slot name="content" active="upload"></slot></div>',
+                'sw-media-sidebar': true,
+                'sw-button': true,
+                'sw-media-upload-v2': true,
+                'sw-upload-listener': true,
+                'sw-media-grid': true
+            },
+            mocks: {
+                $t: v => v,
+                $tc: v => v
+            },
+            provide: {
+                repositoryFactory: {},
+                mediaService: {}
+            },
+            propsData: {
+                uploadTag: 'my-upload'
+            }
+        });
+    });
+
+    it('should be a Vue.js component', () => {
+        expect(wrapper.isVueInstance()).toBeTruthy();
+    });
+
+
+    it('should contain the default accept value', () => {
+        const fileInput = wrapper.find('sw-media-upload-v2-stub');
+        expect(fileInput.attributes().fileaccept).toBe('image/*');
+    });
+
+    it('should contain "application/pdf" value', () => {
+        wrapper.setProps({
+            fileAccept: 'application/pdf'
+        });
+        const fileInput = wrapper.find('sw-media-upload-v2-stub');
+        expect(fileInput.attributes().fileaccept).toBe('application/pdf');
+    });
+});

--- a/src/Administration/Resources/app/administration/test/module/sw-media/page/sw-media-index.spec.js
+++ b/src/Administration/Resources/app/administration/test/module/sw-media/page/sw-media-index.spec.js
@@ -1,0 +1,57 @@
+import { createLocalVue, shallowMount } from '@vue/test-utils';
+import 'src/module/sw-media/page/sw-media-index';
+
+describe('src/module/sw-media/page/sw-media-index', () => {
+    let wrapper;
+
+    beforeEach(() => {
+        const localVue = createLocalVue();
+        localVue.directive('droppable', { });
+
+        wrapper = shallowMount(Shopware.Component.build('sw-media-index'), {
+            localVue,
+            stubs: {
+                'sw-context-button': true,
+                'sw-context-menu-item': true,
+                'sw-icon': true,
+                'sw-button': true,
+                'sw-page': '<div><slot name="smart-bar-actions"></slot></div>',
+                'sw-search-bar': true,
+                'sw-media-sidebar': true,
+                'sw-media-library': true,
+                'sw-upload-listener': true,
+                'sw-language-switch': true,
+                'router-link': true,
+                'sw-media-upload-v2': true
+            },
+            mocks: {
+                $t: v => v,
+                $tc: v => v,
+                $route: {
+                    query: ''
+                }
+            },
+            provide: {
+                repositoryFactory: { },
+                mediaService: { }
+            }
+        });
+    });
+
+    it('should be a Vue.js component', () => {
+        expect(wrapper.isVueInstance()).toBeTruthy();
+    });
+
+    it('should contain the default accept value', () => {
+        const fileInput = wrapper.find('sw-media-upload-v2-stub');
+        expect(fileInput.attributes().fileaccept).toBe('*/*');
+    });
+
+    it('should contain "application/pdf" value', () => {
+        wrapper.setProps({
+            fileAccept: 'application/pdf'
+        });
+        const fileInput = wrapper.find('sw-media-upload-v2-stub');
+        expect(fileInput.attributes().fileaccept).toBe('application/pdf');
+    });
+});


### PR DESCRIPTION
### 1. Why is this change necessary?

Fix for issue #806

### 2. What does this change do, exactly?

* Added property `fileAccept` to 
  * `sw-media-upload-v2`
  * `sw-media-compact-upload-v2`
  * `sw-media-modal-v2`
  * `sw-media-index`
* Change default value of `accept` in `sw-media-index` to `*/*` to allow all types of files in the 

### 3. Describe each step to reproduce the issue or behaviour.

1. go to the mediamanager
2. select an folder and upload a file that is **not** an image
3. after that you will see this file in the folder

### 4. Please link to the relevant issues (if any).

#806

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
