### PR TITLE
NEXT-6651 asset urls via CDN, publish commands

### DIFF
--- a/CHANGELOG-6.2.md
+++ b/CHANGELOG-6.2.md
@@ -512,6 +512,7 @@ To get the diff between two versions, go to https://github.com/shopware/platform
     * Deprecated `\Shopware\Storefront\Controller\SearchController::pagelet`, use `\Shopware\Storefront\Controller\SearchController::ajax` instead
     * Deprecated `widgets.search.pagelet` route, use `widgets.search.pagelet.v2` instead
     * Added possibility to delete orders without documents on `sw-order-list`
+    * Added possibility to have assets on a remote filesystem like S3
 
 * Storefront
     * Deprecated `$connection->executeQuery()` for write operations

--- a/src/Core/Framework/Adapter/Asset/AssetPackageService.php
+++ b/src/Core/Framework/Adapter/Asset/AssetPackageService.php
@@ -4,6 +4,7 @@ namespace Shopware\Core\Framework\Adapter\Asset;
 
 use Symfony\Component\Asset\Packages;
 use Symfony\Component\Asset\PathPackage;
+use Symfony\Component\Asset\UrlPackage;
 
 class AssetPackageService
 {
@@ -12,16 +13,27 @@ class AssetPackageService
      */
     private $packages;
 
-    public function __construct(Packages $packages)
+    /**
+     * @var string
+     */
+    private $cdnUrl;
+
+    public function __construct(Packages $packages, ?string $cdnUrl)
     {
         $this->packages = $packages;
+        $this->cdnUrl = $cdnUrl;
     }
 
     public function addAssetPackage(string $bundleName, string $bundlePath): void
     {
+        if ($this->cdnUrl) {
+            $package = new UrlPackage($this->cdnUrl . '/bundles/' . mb_strtolower($bundleName), new LastModifiedVersionStrategy($bundlePath));
+        } else {
+            $package = new PathPackage('/bundles/' . mb_strtolower($bundleName), new LastModifiedVersionStrategy($bundlePath));
+        }
         $this->packages->addPackage(
             '@' . $bundleName,
-            new PathPackage('/bundles/' . mb_strtolower($bundleName), new LastModifiedVersionStrategy($bundlePath))
+            $package
         );
     }
 }

--- a/src/Core/Framework/Adapter/Command/AssetsPublishCommand.php
+++ b/src/Core/Framework/Adapter/Command/AssetsPublishCommand.php
@@ -1,0 +1,53 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\Adapter\Command;
+
+use Shopware\Core\Framework\Plugin\Util\AssetService;
+use Shopware\Core\Kernel;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\ProgressBar;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class AssetsPublishCommand extends Command
+{
+    protected static $defaultName = 'assets:publish';
+
+    /**
+     * @var AssetService
+     */
+    private $assetService;
+
+    /**
+     * @var Kernel
+     */
+    private $kernel;
+
+    public function __construct(AssetService $assetService, Kernel $kernel)
+    {
+        parent::__construct();
+        $this->assetService = $assetService;
+        $this->kernel = $kernel;
+    }
+
+    protected function configure(): void
+    {
+        parent::configure();
+        $this->setDescription('Upload local assets to remote filesystem');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $kernelBundles = $this->kernel->getBundles();
+        $output->writeln('Uploading assets of bundles');
+        $progressBar = new ProgressBar($output, count($kernelBundles));
+        foreach ($kernelBundles as $bundle) {
+            $this->assetService->copyAssetsFromBundle($bundle->getName());
+            $progressBar->advance();
+        }
+        $progressBar->finish();
+        $output->writeln('');
+
+        return 0;
+    }
+}

--- a/src/Core/Framework/Adapter/Command/MediaPublishCommand.php
+++ b/src/Core/Framework/Adapter/Command/MediaPublishCommand.php
@@ -1,0 +1,69 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\Adapter\Command;
+
+use League\Flysystem\FilesystemInterface;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\ProgressBar;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Finder\Finder;
+
+class MediaPublishCommand extends Command
+{
+    protected static $defaultName = 'media:publish';
+
+    /**
+     * @var string
+     */
+    private $localPublicDirectory;
+
+    /**
+     * @var FilesystemInterface
+     */
+    private $publicFilesystem;
+
+    public function __construct(FilesystemInterface $publicFilesystem, string $localPublicDirectory)
+    {
+        parent::__construct();
+        $this->localPublicDirectory = $localPublicDirectory;
+        $this->publicFilesystem = $publicFilesystem;
+    }
+
+    protected function configure(): void
+    {
+        parent::configure();
+        $this->setDescription('Upload all local media to remote filesystem');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $directoriesToUpload = ['media', 'thumbnail'];
+
+        foreach ($directoriesToUpload as $directory) {
+            $files = $this->getFilesIteratorForFolder($directory);
+
+            $output->writeln('Uploading files from ' . $directory);
+            $progressBar = new ProgressBar($output);
+
+            foreach ($progressBar->iterate($files) as $file) {
+                $fs = fopen($file->getPathname(), 'rb');
+                $this->publicFilesystem->putStream($directory . '/' . $file->getRelativePathname(), $fs);
+                fclose($fs);
+            }
+            $progressBar->finish();
+            $output->writeln('');
+        }
+
+        return 0;
+    }
+
+    private function getFilesIteratorForFolder(string $folderName): \Iterator
+    {
+        return Finder::create()
+            ->ignoreDotFiles(false)
+            ->files()
+            ->in($this->localPublicDirectory . '/' . $folderName)
+            ->getIterator();
+    }
+}

--- a/src/Core/Framework/DependencyInjection/filesystem.xml
+++ b/src/Core/Framework/DependencyInjection/filesystem.xml
@@ -46,5 +46,19 @@
         <service id="Shopware\Core\Framework\Adapter\Filesystem\Plugin\CopyBatch">
             <tag name="shopware.filesystem.plugin" />
         </service>
+
+        <service id="Shopware\Core\Framework\Adapter\Command\AssetsPublishCommand">
+            <argument type="service" id="Shopware\Core\Framework\Plugin\Util\AssetService" />
+            <argument type="service" id="kernel" />
+
+            <tag name="console.command"/>
+        </service>
+
+        <service id="Shopware\Core\Framework\Adapter\Command\MediaPublishCommand">
+            <argument type="service" id="shopware.filesystem.public" />
+            <argument>%kernel.project_dir%/public</argument>
+
+            <tag name="console.command"/>
+        </service>
     </services>
 </container>

--- a/src/Core/Framework/DependencyInjection/services.xml
+++ b/src/Core/Framework/DependencyInjection/services.xml
@@ -47,6 +47,7 @@
         <!-- Asset -->
         <service id="Shopware\Core\Framework\Adapter\Asset\AssetPackageService" public="true">
             <argument type="service" id="assets.packages"/>
+            <argument>%shopware.cdn.url%</argument>
         </service>
 
         <!-- Database / Doctrine -->

--- a/src/Docs/Resources/deprecated/4-how-to/310-use-s3-datastorage.md
+++ b/src/Docs/Resources/deprecated/4-how-to/310-use-s3-datastorage.md
@@ -63,6 +63,27 @@ shopware:
     strategy: "md5"
 ```
 
+After you changed your configuration you can use the command `bin/console media:publish` to upload all local media
+and thumbnails to your remote filesystem.
+
+## Assets
+
+As you want your JS and CSS files as well as other static assets to be also served from your CDN and remote filesystem,
+you have to set the following in your `config/packages/symfony.yml`:
+
+```yaml
+framework:
+  assets:
+    base_urls:
+      - "https://s3.{your-bucket-region}.amazonaws.com/{your-private-bucket-name}"
+```
+
+as well.
+
+Plugin assets are uploaded automatically if you install a plugin. 
+
+But to ensure that all files are present, you can use the `bin/console assets:remote:publish` command.
+
 ## AWS access
 
 Accessing the buckets is controlled through IAM, this means that your Shopware 6 instance needs 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/community).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?

Because if you try to use a remote filesystem atm, the static assets are upload to the remote filesystem `shopware.filesystem.public` but the `asset()` function in twig is not aware of that.

### 2. What does this change do, exactly?

Just like the Symfony framework bundle `\Symfony\Bundle\FrameworkBundle\DependencyInjection\FrameworkExtension::createPackageDefinition` they either create a `PathPackage` or an `UrlPackage` depending on the presence of a `base_url`.

Until now the `\Shopware\Core\Framework\Adapter\Asset\AssetPackageService` always created `PathPackage` instances. We now respect the CDN configuration.

**Notice**: I use the `shopware.cdn.url` instead of the Symfony `framework.assets.base_urls` as Symfony has fallbacks and much more that Shopware isn't capable of and as the filesystem is codewise strictly the same, I think it's better to tie that to the shopware configuration. Maybe it would even be better to create a CompilerPass to set the framework base_url configuration automatically as this is hardly coupled to the Shopware application (feedback wanted).

I also document and introduce 2 new commands that help you migrate your currently local filesystem to a remote filesystem.

### 3. Describe each step to reproduce the issue or behaviour.

Add this to your `docker-compose.yml`:

```yaml
  minio:
    image: minio/minio
    ports:
      - "9001:9000"
    environment:
      MINIO_ACCESS_KEY: minio
      MINIO_SECRET_KEY: minio123
    command: server /data
```

Add this to `config/packages/shopware.yml`:

```yaml
shopware:
  filesystem:
    public:
      type: 'amazon-s3'
      config:
        bucket: "shopware"
        region: "us-east-1"
        endpoint: "http://minio:9000"
        use_path_style_endpoint: true
        protocol: "http"
        credentials:
          key: "minio"
          secret: "minio123"
        options:
          visibility: "public"
  cdn:
    url: 'http://localhost:9001/shopware/'
    strategy: 'id'
```

_Patch notice_: The option `protocol` is currently not supported by the S3 adapter, you have to modify `\Shopware\Core\Framework\Adapter\Filesystem\Adapter\AwsS3v3Factory::resolveS3Options` to allow that option.

And this to `config/packages/symfony.yml`:

```yaml
framework:
  assets:
    base_urls:
      - "http://localhost:9001/shopware/"
```

Then run:

```
bin/console theme:compile
bin/console media:publish
bin/console assets:publish
```

You should now have a working admin and storefront that use all resources from the simulated CDN `http://localhost:9001/shopware`.

### 4. Please link to the relevant issues (if any).

#466

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
