### PR TITLE
NEXT-8627 - fixes wrong redirect to broken offcanvas if user clicks o…

### DIFF
--- a/CHANGELOG-6.2.md
+++ b/CHANGELOG-6.2.md
@@ -756,3 +756,4 @@ To get the diff between two versions, go to https://github.com/shopware/platform
     * Removed `HttpClient()` constructor parameters in `src/Storefront/Resources/app/storefront/src/service/http-client.service.js`
     * Fix timezone of `orderDate` in ordergrid
     * Added image lazy loading capability to the `ZoomModalPlugin` which allows to load images only if the zoom modal was opened
+    * Fix wrong behavior in `AddToCartPlugin` if user clicks on add to cart button before the js plugin is completely loaded

--- a/src/Storefront/Resources/app/storefront/src/plugin/add-to-cart/add-to-cart.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/add-to-cart/add-to-cart.plugin.js
@@ -6,6 +6,12 @@ import FormSerializeUtil from 'src/utility/form/form-serialize.util';
 
 export default class AddToCartPlugin extends Plugin {
 
+    static options = {
+        redirectOffcanvasSelector: '[data-redirect-to="offcanvas"]',
+        redirectDetailSelector: '[data-redirect-to="detail"]',
+        redirectDetailParamSelector: '[data-redirect-parameters="true"]'
+    };
+
     init() {
         this._getForm();
 
@@ -13,7 +19,30 @@ export default class AddToCartPlugin extends Plugin {
             throw new Error(`No form found for the plugin: ${this.constructor.name}`);
         }
 
+        this._prepareFormRedirect();
+
         this._registerEvents();
+    }
+
+    /**
+     * prepares the redirect values
+     * fallback redirect back to detail page is deactivated
+     * offcanvas redirect is activated
+     *
+     * @private
+     */
+    _prepareFormRedirect() {
+        try {
+            const redirectOffcanvasInput = DomAccess.querySelector(this._form, this.options.redirectOffcanvasSelector);
+            const redirectDetailInput = DomAccess.querySelector(this._form, this.options.redirectDetailSelector);
+            const redirectDetailParamInput = DomAccess.querySelector(this._form, this.options.redirectDetailParamSelector);
+
+            redirectOffcanvasInput.disabled = false;
+            redirectDetailInput.disabled = true;
+            redirectDetailParamInput.disabled = true;
+        } catch (e) {
+            // preparations are not needed if fields are not available
+        }
     }
 
     /**

--- a/src/Storefront/Resources/views/storefront/component/product/card/action.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/product/card/action.html.twig
@@ -23,9 +23,22 @@
                             {% block component_product_box_action_form %}
 
                                 {% block component_product_box_action_buy_redirect_input %}
+                                    {# fallback redirect back to detail page is deactivated via js #}
                                     <input type="hidden"
                                            name="redirectTo"
-                                           value="frontend.cart.offcanvas"/>
+                                           data-redirect-to="detail"
+                                           value="frontend.detail.page">
+
+                                    <input type="hidden"
+                                           name="redirectParameters"
+                                           data-redirect-parameters="true"
+                                           value='{"productId": "{{ product.id }}"}'>
+
+                                    {# offcanvas redirect is activated via js #}
+                                    <input type="hidden"
+                                           name="redirectTo"
+                                           data-redirect-to="offcanvas"
+                                           value="frontend.cart.offcanvas" disabled/>
                                 {% endblock %}
 
                                 {% block page_product_detail_buy_product_buy_info %}

--- a/src/Storefront/Resources/views/storefront/page/product-detail/buy-widget-form.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/product-detail/buy-widget-form.html.twig
@@ -50,21 +50,22 @@
                     {% endblock %}
 
                     {% block page_product_detail_buy_product_buy_info %}
+                        {# fallback redirect back to detail page is deactivated via js #}
                         <input type="hidden"
-                               name="lineItems[{{ product.id }}][id]"
-                               value="{{ product.id }}">
+                               name="redirectTo"
+                               data-redirect-to="detail"
+                               value="frontend.detail.page">
+
                         <input type="hidden"
-                               name="lineItems[{{ product.id }}][type]"
-                               value="product">
+                               name="redirectParameters"
+                               data-redirect-parameters="true"
+                               value='{"productId": "{{ product.id }}"}'>
+
+                        {# offcanvas redirect is activated via js #}
                         <input type="hidden"
-                               name="lineItems[{{ product.id }}][referencedId]"
-                               value="{{ product.id }}">
-                        <input type="hidden"
-                               name="lineItems[{{ product.id }}][stackable]"
-                               value="1">
-                        <input type="hidden"
-                               name="lineItems[{{ product.id }}][removable]"
-                               value="1">
+                               name="redirectTo"
+                               data-redirect-to="offcanvas"
+                               value="frontend.cart.offcanvas" disabled/>
                     {% endblock %}
 
                     {% block page_product_detail_product_buy_meta %}


### PR DESCRIPTION
…n add to cart before js is ready - fixes https://github.com/shopware/platform/issues/906

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/community).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
If you add a product to the cart (e.g. on product detail page) and the JS Plugin is not ready you are redirected to a offcanvas widget with no styling.

### 2. What does this change do, exactly?
I changed the hidden input "redirectTo" value in the form from "frontend.cart.offcanvas" to "frontend.detail.page".
It is changed back via js in the AddToCartPlugin.
This way the product is added to the cart and the page refreshes if the JS Plugin was not ready.
If the plugin was already initialized and the user clicks on the button the offcanvas opens like it did before.

### 3. Describe each step to reproduce the issue or behaviour.
Click on the "add to cart" button before the page is completely loaded or e.g if you have a slow connection (you can try it with the developer console if you enable "Slow 3G") it also happens


### 4. Please link to the relevant issues (if any).
https://github.com/shopware/platform/issues/906

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
