### PR TITLE
NEXT-7083 correct blur handling

### DIFF
--- a/CHANGELOG-6.2.md
+++ b/CHANGELOG-6.2.md
@@ -301,6 +301,7 @@ To get the diff between two versions, go to https://github.com/shopware/platform
         * Added new condition `cartLineItemCustomField` in `condition-type-data-provider.decorator.js`
     * Added support of module favicons from plugins, set the `faviconSrc` prop of your module to the name of your bundle in the public bundles folder.   
     * Added `media-upload-cancel` to `media.api.service`
+    * Fixed a bug in `sw-confirm-field` when using firefox where the cancel and submit action was without function
     * Fixed a bug in `sw-duplicated-media-v2` to reload media list when user clicked to cancel
     * Fixed a bug in `sw-sales-channel-detail-base` for IP whitelist on maintenance mode on new sales channel 
     * Added mapping validation for import/export profiles

--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-confirm-field/sw-confirm-field.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-confirm-field/sw-confirm-field.html.twig
@@ -21,6 +21,7 @@
                         square
                         size="x-small"
                         @click="onCancelSubmit"
+                        @mousedown.prevent
                         tabindex="-1">
 
                         {% block sw_field_inline_cancel_submit_button_icon %}
@@ -37,6 +38,7 @@
                         size="x-small"
                         variant="primary"
                         @click="onSubmitValue"
+                        @mousedown.prevent
                         tabindex="-1">
 
                         {% block sw_field_inline_submit_button_icon %}


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/community).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
The original problem could not be reproduced. But during my investigation the media alt, title and name field when using firefox were not working. The cause is that the sw-confirm-field confirm and cancel buttons dont work, as the blur event is called before the click event and the current changes are lost.

### 2. What does this change do, exactly?
prevents the blur event when confirm or cancel is clicked

### 3. Describe each step to reproduce the issue or behaviour.
use firefox and add change the media name, title or alt  text.

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [X] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.
