### PR TITLE
NEXT-8340 - Fix the media file name direction in media library Fixes …

### DIFF
--- a/CHANGELOG-6.2.md
+++ b/CHANGELOG-6.2.md
@@ -344,6 +344,7 @@ To get the diff between two versions, go to https://github.com/shopware/platform
         * `sw-media-index`
     * Change default value of `accept` in `sw-media-index` to `*/*` to allow all types of files in media management 
 
+    * Fixed the displaying of the media filename in Media Library grid in case it only contains digits
 * Core    
     * Added support of module favicons from plugins, set the `faviconSrc` prop of your module to the name of your bundle in the public bundles folder.
     * Set `crossSellingAssignedProducts` and `tags` to `CascadeDelete` in `ProductDefinition`

--- a/src/Administration/Resources/app/administration/src/app/component/media/sw-media-base-item/sw-media-base-item.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/media/sw-media-base-item/sw-media-base-item.scss
@@ -122,7 +122,6 @@ $sw-media-base-item-preview-background:      $color-white;
 
             border: 1px solid transparent;
             line-height: 27px;
-            direction: rtl;
         }
 
         .sw-media-base-item__name-field {


### PR DESCRIPTION
…#810

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/community).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
In case a media file contains only digits the name of the file was displayed with the wrong direction in media library grid

### 2. What does this change do, exactly?
The directorion of the title was set in the CSS to rtl instead of ltr

### 3. Describe each step to reproduce the issue or behaviour.
Upload an image file into the media library that contains only digits, for instance 12345.jpg. After uploading it displays the title in grid as jpg.12345

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/NEXT-8340

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
