### PR TITLE
NEXT-7788 - Add config for disabling reviews

### DIFF
--- a/CHANGELOG-6.2.md
+++ b/CHANGELOG-6.2.md
@@ -343,6 +343,7 @@ To get the diff between two versions, go to https://github.com/shopware/platform
         * `sw-media-modal-v2`
         * `sw-media-index`
     * Change default value of `accept` in `sw-media-index` to `*/*` to allow all types of files in media management 
+    * Added config option for disabling reviews in the storefront
 
 * Core    
     * Added support of module favicons from plugins, set the `faviconSrc` prop of your module to the name of your bundle in the public bundles folder.
@@ -518,6 +519,8 @@ To get the diff between two versions, go to https://github.com/shopware/platform
     * Deprecated `\Shopware\Storefront\Controller\SearchController::pagelet`, use `\Shopware\Storefront\Controller\SearchController::ajax` instead
     * Deprecated `widgets.search.pagelet` route, use `widgets.search.pagelet.v2` instead
     * Added possibility to delete orders without documents on `sw-order-list`
+    * Added `\Shopware\Core\Content\Product\Exception\ReviewNotActiveException` exception
+        * This exception is thrown if the review routes are called if reviews are disabled
 
 * Storefront
     * Deprecated `$connection->executeQuery()` for write operations

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-listing/snippet/de-DE.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-listing/snippet/de-DE.json
@@ -1,9 +1,9 @@
 {
   "sw-settings-listing": {
     "general": {
-      "mainMenuItemGeneral": "Produktliste",
-      "textHeadline": "Produktliste",
-      "description": "Verwaltung von Einstellungen für die Produktliste.",
+      "mainMenuItemGeneral": "Produkte",
+      "textHeadline": "Produkte",
+      "description": "Verwaltung von Einstellungen für Produkte.",
       "buttonSave": "Speichern",
       "titleSaveSuccess": "Erfolg",
       "messageSaveSuccess": "Die Konfiguration wurde erfolgreich gespeichert.",

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-listing/snippet/en-GB.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-listing/snippet/en-GB.json
@@ -1,9 +1,9 @@
 {
   "sw-settings-listing": {
     "general": {
-      "mainMenuItemGeneral": "Product listings",
-      "textHeadline": "Product listings",
-      "description": "Manage the display of product listings here.",
+      "mainMenuItemGeneral": "Products",
+      "textHeadline": "Products",
+      "description": "Manage the display of products here.",
       "buttonSave": "Save",
       "titleSaveSuccess": "Success",
       "messageSaveSuccess": "The configuration has been saved.",

--- a/src/Core/Content/Product/Exception/ReviewNotActiveExeption.php
+++ b/src/Core/Content/Product/Exception/ReviewNotActiveExeption.php
@@ -1,0 +1,24 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Content\Product\Exception;
+
+use Shopware\Core\Framework\ShopwareHttpException;
+use Symfony\Component\HttpFoundation\Response;
+
+class ReviewNotActiveExeption extends ShopwareHttpException
+{
+    public function __construct()
+    {
+        parent::__construct('Reviews not activated');
+    }
+
+    public function getErrorCode(): string
+    {
+        return 'PRODUCT__REVIEW_NOT_ACTIVE';
+    }
+
+    public function getStatusCode(): int
+    {
+        return Response::HTTP_FORBIDDEN;
+    }
+}

--- a/src/Core/Migration/Migration1589458026SetDefaultReviewConfig.php
+++ b/src/Core/Migration/Migration1589458026SetDefaultReviewConfig.php
@@ -1,0 +1,30 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Migration;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Defaults;
+use Shopware\Core\Framework\Migration\MigrationStep;
+use Shopware\Core\Framework\Uuid\Uuid;
+
+class Migration1589458026SetDefaultReviewConfig extends MigrationStep
+{
+    public function getCreationTimestamp(): int
+    {
+        return 1589458026;
+    }
+
+    public function update(Connection $connection): void
+    {
+        $connection->insert('system_config', [
+            'id' => Uuid::randomBytes(),
+            'configuration_key' => 'core.listing.showReview',
+            'configuration_value' => '{"_value": true}',
+            'created_at' => (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT),
+        ]);
+    }
+
+    public function updateDestructive(Connection $connection): void
+    {
+    }
+}

--- a/src/Core/System/Resources/config/listing.xml
+++ b/src/Core/System/Resources/config/listing.xml
@@ -2,8 +2,8 @@
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/shopware/platform/master/src/Core/System/SystemConfig/Schema/config.xsd">
     <card>
-        <title>Product listings</title>
-        <title lang="de-DE">Produktlisten</title>
+        <title>Product</title>
+        <title lang="de-DE">Produkt</title>
 
         <input-field type="bool">
             <name>allowBuyInListing</name>
@@ -19,6 +19,14 @@
             <label lang="de-DE">Produkte nach Abverkaufende ausblenden</label>
             <helpText>Products marked as on "clearance sale" are hidden, as soon as their stock depletes back to 0.</helpText>
             <helpText lang="de-DE">Produkte die mit "Abverkauf" markiert sind, werden nicht mehr angezeigt, sobald ihr Lagerbestand 0 erreicht.</helpText>
+        </input-field>
+
+        <input-field type="bool">
+            <name>showReview</name>
+            <label>Show reviews</label>
+            <label lang="de-DE">Bewertungen anzeigen</label>
+            <helpText>Activate to show reviews</helpText>
+            <helpText lang="de-DE">Aktivieren um Bewertungen anzuzeigen</helpText>
         </input-field>
 
         <input-field type="int">

--- a/src/Storefront/Controller/ProductController.php
+++ b/src/Storefront/Controller/ProductController.php
@@ -2,12 +2,14 @@
 
 namespace Shopware\Storefront\Controller;
 
+use Shopware\Core\Content\Product\Exception\ReviewNotActiveExeption;
 use Shopware\Core\Content\Product\SalesChannel\ProductReviewService;
 use Shopware\Core\Content\Seo\SeoUrlPlaceholderHandlerInterface;
 use Shopware\Core\Framework\Routing\Annotation\RouteScope;
 use Shopware\Core\Framework\Validation\DataBag\RequestDataBag;
 use Shopware\Core\Framework\Validation\Exception\ConstraintViolationException;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Shopware\Core\System\SystemConfig\SystemConfigService;
 use Shopware\Storefront\Framework\Cache\Annotation\HttpCache;
 use Shopware\Storefront\Framework\Routing\RequestTransformer;
 use Shopware\Storefront\Page\Product\Configurator\ProductCombinationFinder;
@@ -54,20 +56,28 @@ class ProductController extends StorefrontController
      */
     private $productReviewLoader;
 
+    /**
+     * @var SystemConfigService
+     */
+    private $systemConfigService;
+
     public function __construct(
         ProductPageLoader $productPageLoader,
         ProductCombinationFinder $combinationFinder,
         MinimalQuickViewPageLoader $minimalQuickViewPageLoader,
         ProductReviewService $productReviewService,
         SeoUrlPlaceholderHandlerInterface $seoUrlPlaceholderHandler,
-        ProductReviewLoader $productReviewLoader
-    ) {
+        ProductReviewLoader $productReviewLoader,
+        SystemConfigService $systemConfigService
+    )
+    {
         $this->productPageLoader = $productPageLoader;
         $this->combinationFinder = $combinationFinder;
         $this->minimalQuickViewPageLoader = $minimalQuickViewPageLoader;
         $this->productReviewService = $productReviewService;
         $this->seoUrlPlaceholderHandler = $seoUrlPlaceholderHandler;
         $this->productReviewLoader = $productReviewLoader;
+        $this->systemConfigService = $systemConfigService;
     }
 
     /**
@@ -125,6 +135,8 @@ class ProductController extends StorefrontController
      */
     public function saveReview(string $productId, RequestDataBag $data, SalesChannelContext $context): Response
     {
+        $this->checkReviewsActive($context);
+
         $this->denyAccessUnlessLoggedIn();
 
         try {
@@ -157,11 +169,25 @@ class ProductController extends StorefrontController
      */
     public function loadReviews(Request $request, RequestDataBag $data, SalesChannelContext $context): Response
     {
+        $this->checkReviewsActive($context);
+
         $reviews = $this->productReviewLoader->load($request, $context);
 
         return $this->renderStorefront('storefront/page/product-detail/review/review.html.twig', [
             'reviews' => $reviews,
             'ratingSuccess' => $request->get('success'),
         ]);
+    }
+
+    /**
+     * @throws ReviewNotActiveExeption
+     */
+    private function checkReviewsActive(SalesChannelContext $context): void
+    {
+        $showReview = $this->systemConfigService->get('core.listing.showReview', $context->getSalesChannel()->getId());
+
+        if (!$showReview) {
+            throw new ReviewNotActiveExeption();
+        }
     }
 }

--- a/src/Storefront/DependencyInjection/controller.xml
+++ b/src/Storefront/DependencyInjection/controller.xml
@@ -156,7 +156,7 @@
             <argument type="service" id="Shopware\Core\Content\Product\SalesChannel\ProductReviewService"/>
             <argument type="service" id="Shopware\Core\Content\Seo\SeoUrlPlaceholderHandlerInterface"/>
             <argument type="service" id="Shopware\Storefront\Page\Product\Review\ProductReviewLoader"/>
-
+            <argument type="service" id="Shopware\Core\System\SystemConfig\SystemConfigService" />
             <call method="setContainer">
                 <argument type="service" id="service_container"/>
             </call>

--- a/src/Storefront/Framework/Twig/TemplateDataExtension.php
+++ b/src/Storefront/Framework/Twig/TemplateDataExtension.php
@@ -76,10 +76,7 @@ class TemplateDataExtension extends AbstractExtension implements GlobalsInterfac
 
         return [
             'shopware' => [
-                'config' => array_merge(
-                    $this->getDefaultConfiguration(),
-                    $this->systemConfigService->all($context->getSalesChannel()->getId())
-                ),
+                'config' => $this->getConfig($context),
                 'theme' => $this->getThemeConfig($context->getSalesChannel()->getId(), $themeId),
                 'dateFormat' => DATE_ATOM,
                 'csrfEnabled' => $this->csrfEnabled,
@@ -143,9 +140,6 @@ class TemplateDataExtension extends AbstractExtension implements GlobalsInterfac
             'confirm' => [
                 'revocationNotice' => true,
             ],
-            'detail' => [
-                'showReviews' => true,
-            ],
         ];
     }
 
@@ -167,5 +161,18 @@ class TemplateDataExtension extends AbstractExtension implements GlobalsInterfac
         }
 
         return $controllerInfo;
+    }
+
+    private function getConfig(SalesChannelContext $context): array
+    {
+        $config = array_merge(
+            $this->getDefaultConfiguration(),
+            $this->systemConfigService->all($context->getSalesChannel()->getId())
+        );
+
+        /** @deprecated tag:v6.3.0 - core.listing.showReview instead */
+        $config['detail']['showReviews'] = $config['core']['listing']['showReview'];
+
+        return $config;
     }
 }

--- a/src/Storefront/Resources/views/storefront/component/listing/filter/filter-rating.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/listing/filter/filter-rating.html.twig
@@ -22,70 +22,72 @@
 } %}
 
 {% block component_filter_rating %}
-    <div class="filter-rating filter-panel-item{% if not sidebar %} dropdown{% endif %}"
-         data-filter-rating="true"
-         data-filter-rating-options='{{ filterRatingOptions|json_encode }}'>
+    {% if shopware.config.core.listing.showReview %}
+        <div class="filter-rating filter-panel-item{% if not sidebar %} dropdown{% endif %}"
+             data-filter-rating="true"
+             data-filter-rating-options='{{ filterRatingOptions|json_encode }}'>
 
-        {% block component_filter_rating_toggle %}
-            <button class="filter-panel-item-toggle btn{% if sidebar %} btn-block{% endif %}"
-                    aria-expanded="false"
-                    {% if sidebar %}
-                    data-toggle="collapse"
-                    data-target="#{{ filterItemId }}"
-                    {% else %}
-                    data-toggle="dropdown"
-                    data-offset="0,8"
-                    aria-haspopup="true"
-                    {% endif %}>
+            {% block component_filter_rating_toggle %}
+                <button class="filter-panel-item-toggle btn{% if sidebar %} btn-block{% endif %}"
+                        aria-expanded="false"
+                        {% if sidebar %}
+                        data-toggle="collapse"
+                        data-target="#{{ filterItemId }}"
+                        {% else %}
+                        data-toggle="dropdown"
+                        data-offset="0,8"
+                        aria-haspopup="true"
+                        {% endif %}>
 
-                {% block component_filter_rating_display_name %}
-                    {{ displayName }}
-                {% endblock %}
+                    {% block component_filter_rating_display_name %}
+                        {{ displayName }}
+                    {% endblock %}
 
-                {% block component_filter_rating_count %}
-                    <span class="filter-rating-count"></span>
-                {% endblock %}
+                    {% block component_filter_rating_count %}
+                        <span class="filter-rating-count"></span>
+                    {% endblock %}
 
-                {% block component_filter_rating_toggle_icon %}
-                    {% sw_icon 'arrow-medium-down' style {'pack': 'solid', 'size': 'xs', 'class': 'filter-panel-item-toggle'} %}
-                {% endblock %}
-            </button>
-        {% endblock %}
+                    {% block component_filter_rating_toggle_icon %}
+                        {% sw_icon 'arrow-medium-down' style {'pack': 'solid', 'size': 'xs', 'class': 'filter-panel-item-toggle'} %}
+                    {% endblock %}
+                </button>
+            {% endblock %}
 
-        {% block component_filter_rating_dropdown %}
-            <div class="filter-rating-dropdown filter-panel-item-dropdown{% if sidebar %} collapse{% else %} dropdown-menu{% endif %}"
-                 id="{{ filterItemId }}">
+            {% block component_filter_rating_dropdown %}
+                <div class="filter-rating-dropdown filter-panel-item-dropdown{% if sidebar %} collapse{% else %} dropdown-menu{% endif %}"
+                     id="{{ filterItemId }}">
 
-                {% block component_filter_rating_container %}
-                    <div class="filter-rating-container" data-rating-system="true">
-                        {% for point in 1..maxPoints %}
+                    {% block component_filter_rating_container %}
+                        <div class="filter-rating-container" data-rating-system="true">
+                            {% for point in 1..maxPoints %}
 
-                            {% block component_filter_rating_point_label %}
-                                <label data-review-form-point="{{ point }}"
-                                       class="filter-rating-star {% if currentPoints >= point %} is-active{% endif %}">
+                                {% block component_filter_rating_point_label %}
+                                    <label data-review-form-point="{{ point }}"
+                                           class="filter-rating-star {% if currentPoints >= point %} is-active{% endif %}">
 
-                                    {% block component_filter_rating_point_radio %}
-                                        <input class="product-detail-review-form-radio"
-                                               type="radio"
-                                               name="points"
-                                               value="{{ point }}">
-                                    {% endblock %}
+                                        {% block component_filter_rating_point_radio %}
+                                            <input class="product-detail-review-form-radio"
+                                                   type="radio"
+                                                   name="points"
+                                                   value="{{ point }}">
+                                        {% endblock %}
 
-                                    {% block component_filter_rating_point_radio_element %}
-                                        {% sw_include '@Storefront/storefront/component/review/point.html.twig' with {
-                                            type: 'blank'
-                                        } %}
-                                    {% endblock %}
-                                </label>
+                                        {% block component_filter_rating_point_radio_element %}
+                                            {% sw_include '@Storefront/storefront/component/review/point.html.twig' with {
+                                                type: 'blank'
+                                            } %}
+                                        {% endblock %}
+                                    </label>
+                                {% endblock %}
+                            {% endfor %}
+
+                            {% block component_filter_rating_text_placeholder %}
+                                <div data-rating-text="true"></div>
                             {% endblock %}
-                        {% endfor %}
-
-                        {% block component_filter_rating_text_placeholder %}
-                            <div data-rating-text="true"></div>
-                        {% endblock %}
-                    </div>
-                {% endblock %}
-            </div>
-        {% endblock %}
-    </div>
+                        </div>
+                    {% endblock %}
+                </div>
+            {% endblock %}
+        </div>
+    {% endif %}
 {% endblock %}

--- a/src/Storefront/Resources/views/storefront/component/product/card/box-standard.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/product/card/box-standard.html.twig
@@ -63,7 +63,7 @@
                     {% block component_product_box_info %}
                         <div class="product-info">
                             {% block component_product_box_rating %}
-                                {% if shopware.config.detail.showReviews %}
+                                {% if shopware.config.core.listing.showReview %}
                                     <div class="product-rating">
                                         {% if product.ratingAverage %}
                                             {% sw_include '@Storefront/storefront/component/review/rating.html.twig' with {

--- a/src/Storefront/Resources/views/storefront/page/product-detail/buy-widget.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/product-detail/buy-widget.html.twig
@@ -127,7 +127,7 @@
                     } %}
 
                     {% block page_product_detail_reviews %}
-                        {% if page.product.ratingAverage > 0 and shopware.config.detail.showReviews %}
+                        {% if page.product.ratingAverage > 0 and shopware.config.core.listing.showReview %}
                             <p class="product-detail-reviews">
                                 {% sw_include '@Storefront/storefront/component/review/rating.html.twig' with {
                                     points: page.product.ratingAverage,

--- a/src/Storefront/Resources/views/storefront/page/product-detail/tabs.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/product-detail/tabs.html.twig
@@ -37,7 +37,7 @@
                             </li>
                         {% endblock %}
                         {% block page_product_detail_tabs_navigation_review %}
-                            {% if shopware.config.detail.showReviews %}
+                            {% if shopware.config.core.listing.showReview %}
                                 <li class="nav-item">
                                     <a class="nav-link {% if (ratingSuccess == 1) or (ratingSuccess == -1) %}active{% endif %} product-detail-tab-navigation-link"
                                        id="review-tab"
@@ -74,7 +74,7 @@
                         {% endblock %}
 
                         {% block page_product_detail_tabs_content_review %}
-                            {% if shopware.config.detail.showReviews %}
+                            {% if shopware.config.core.listing.showReview %}
                                 <div class="tab-pane fade show {% if (ratingSuccess == 1) or (ratingSuccess == -1) %}active{% endif %}"
                                      id="review-tab-pane"
                                      role="tabpanel"


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/community).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
Currently there is no way to disable reviews in the storefront except editing the templates.

### 2. What does this change do, exactly?
This change adds a config option. If this option is set, reviews are shown in the storefront. If not set, reviews are disabled.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
https://github.com/shopware/platform/issues/852

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.
