### PR TITLE
NEXT-8195 Fix timezone of order time in ordergrid

### DIFF
--- a/CHANGELOG-6.2.md
+++ b/CHANGELOG-6.2.md
@@ -712,3 +712,4 @@ To get the diff between two versions, go to https://github.com/shopware/platform
     * Deprecated `page_checkout_confirm_payment_cancel` in `src/Storefront/Resources/views/storefront/page/checkout/confirm/confirm-payment.html.twig`
     * Deprecated `window.accessKey` and `window.contextToken`, the variables contains now an empty string
     * Removed `HttpClient()` constructor parameters in `src/Storefront/Resources/app/storefront/src/service/http-client.service.js`
+    * Fix timezone of `orderDate` in ordergrid

--- a/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-list/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-list/index.js
@@ -167,7 +167,7 @@ Component.register('sw-order-list', {
                 label: 'sw-order.list.columnDeliveryState',
                 allowResize: true
             }, {
-                property: 'orderDateTime',
+                property: 'orderDate',
                 label: 'sw-order.list.orderDate',
                 allowResize: true
             }, {


### PR DESCRIPTION
### 1. Why is this change necessary?
The current order is always formatted with the UTC timezone instead of the configured timezone.

### 2. What does this change do, exactly?
The correct orderdate is shown in the ordergrid with the timezone taking into consideration.

### 3. Describe each step to reproduce the issue or behaviour.
### 4. Please link to the relevant issues (if any).
#830 

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.