### PR TITLE
NEXT-8267 Makes all variants visible under price markups

### DIFF
--- a/CHANGELOG-6.2.md
+++ b/CHANGELOG-6.2.md
@@ -337,6 +337,7 @@ To get the diff between two versions, go to https://github.com/shopware/platform
     * If you edited one of these mail templates you need to add the `rawUrl` function manually like this: `{{ rawUrl('frontend.account.edit-order.page', { 'orderId': order.id }, salesChannel.domain|first.url) }}` 
     * Price input fields substitute commas with dots automatically in Add Product page.
     * Added a link to the customer name in the order overview. With this it is now possible to open the customer directly from the overview.
+    * Made all variants visible under price markups
 
 * Core    
     * Added support of module favicons from plugins, set the `faviconSrc` prop of your module to the name of your bundle in the public bundles folder.

--- a/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-variants/sw-product-variants-configurator/sw-product-variants-configurator-prices/sw-product-variants-configurator-prices.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-variants/sw-product-variants-configurator/sw-product-variants-configurator-prices/sw-product-variants-configurator-prices.scss
@@ -5,6 +5,8 @@ $sw-product-variants-configurator-prices-search-border: $color-steam-cloud;
 
 .sw-product-variants-configurator-prices {
     height: 100%;
+    display: flex;
+    flex-direction: column;
 
     .sw-product-variants-configurator-prices__alert {
         margin-right: 8px;


### PR DESCRIPTION
### 1. Why is this change necessary?
Footer was blocking variants under markups and markdowns

### 2. What does this change do, exactly?
Made all variants visible

### 3. Describe each step to reproduce the issue or behaviour.
Create more than 7 variants and and go to markups

### 4. Please link to the relevant issues (if any).
#824 

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
