### PR TITLE
NEXT-8546

### DIFF
--- a/CHANGELOG-6.2.md
+++ b/CHANGELOG-6.2.md
@@ -509,6 +509,7 @@ To get the diff between two versions, go to https://github.com/shopware/platform
     * Added `definition` parameter in `\Shopware\Elasticsearch\Framework\ElasticsearchHelper::addTerm`
     * Deprecated `\Shopware\Storefront\Controller\SearchController::pagelet`, use `\Shopware\Storefront\Controller\SearchController::ajax` instead
     * Deprecated `widgets.search.pagelet` route, use `widgets.search.pagelet.v2` instead
+    * `SystemConfigService::get` will now return the value that was set with `SystemConfigService::set`. Now when a `0` is set, a `0` will be the returned with `get` instead of `null`.
 
 * Storefront
     * Deprecated `$connection->executeQuery()` for write operations

--- a/src/Core/System/SystemConfig/SystemConfigService.php
+++ b/src/Core/System/SystemConfig/SystemConfigService.php
@@ -271,10 +271,6 @@ class SystemConfigService
         $key = array_shift($keys);
 
         if (empty($keys)) {
-            if ($value !== false && empty($value)) {
-                return $configValues;
-            }
-
             $configValues[$key] = $value;
         } else {
             if (!\array_key_exists($key, $configValues)) {

--- a/src/Core/System/Test/SystemConfig/SystemConfigServiceTest.php
+++ b/src/Core/System/Test/SystemConfig/SystemConfigServiceTest.php
@@ -41,7 +41,6 @@ class SystemConfigServiceTest extends TestCase
             [null],
             [0],
             [1234],
-            [0.0],
             [1243.42314],
             [''],
             ['test'],
@@ -57,7 +56,17 @@ class SystemConfigServiceTest extends TestCase
     {
         $this->systemConfigService->set('foo.bar', $expected);
         $actual = $this->systemConfigService->get('foo.bar');
-        static::assertEquals($expected, $actual);
+        static::assertSame($expected, $actual);
+    }
+
+    /**
+     * mysql 5.7.30 casts 0.0 to 0
+     */
+    public function testFloatZero(): void
+    {
+        $this->systemConfigService->set('foo.bar', 0.0);
+        $actual = $this->systemConfigService->get('foo.bar');
+        static::assertEquals(0.0, $actual);
     }
 
     public function testSetGetSalesChannel(): void
@@ -72,7 +81,7 @@ class SystemConfigServiceTest extends TestCase
 
         $this->systemConfigService->set('foo.bar', '', Defaults::SALES_CHANNEL);
         $actual = $this->systemConfigService->get('foo.bar', Defaults::SALES_CHANNEL);
-        static::assertEquals('test', $actual);
+        static::assertEquals('', $actual);
     }
 
     public function testSetGetSalesChannelBool(): void
@@ -84,10 +93,6 @@ class SystemConfigServiceTest extends TestCase
         $this->systemConfigService->set('foo.bar', true, Defaults::SALES_CHANNEL);
         $actual = $this->systemConfigService->get('foo.bar', Defaults::SALES_CHANNEL);
         static::assertTrue($actual);
-
-        $this->systemConfigService->set('foo.bar', '', Defaults::SALES_CHANNEL);
-        $actual = $this->systemConfigService->get('foo.bar', Defaults::SALES_CHANNEL);
-        static::assertFalse($actual);
     }
 
     public function testGetDomainNoData(): void


### PR DESCRIPTION
### 1. Why is this change necessary?
The `SystemConfigService` would not return the values that were written to it. This inconsistency meant that values of e.g. `0` were not possible.

### 2. What does this change do, exactly?
Remove a faulty early return in the resolution of config arrays.

### 3. Describe each step to reproduce the issue or behaviour.
1. Set a config key's value to `0`.
2. Get said config keys value. It is now `null`.

### 4. Please link to the relevant issues (if any).
https://github.com/shopware/platform/issues/861

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
