### PR TITLE
NEXT-6407 - Upload media on manufacturer detail

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-manufacturer/page/sw-manufacturer-detail/sw-manufacturer-detail.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-manufacturer/page/sw-manufacturer-detail/sw-manufacturer-detail.html.twig
@@ -98,6 +98,7 @@
                                     :defaultFolder="manufacturerRepository.entityName"
                                     @sw-media-upload-v2-media-upload-success="setMediaItem"
                                     @media-drop="onDropMedia"
+                                    @media-upload-sidebar-open="openMediaSidebar"
                                     @media-upload-remove-image="onUnlinkLogo">
                                 </sw-media-upload-v2>
                             {% endblock %}


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/community).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
Currently there is no option to open Media in manufacturer detail page in the administration

### 2. What does this change do, exactly?
This change adds the button option to open the fly-cart sidebar with already uploaded media 

### 3. Describe each step to reproduce the issue or behaviour.

1. Go to the admin
2. Manufacturer
3. Click on one of the manufacturers
4. Now you should see button called "Open media" under "Upload media"

### 4. Please link to the relevant issues (if any).

#815 

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
