### PR TITLE
NEXT-7703 - Accept all cookies flag

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/component/sw-sales-channel-detail-cookie/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/component/sw-sales-channel-detail-cookie/index.js
@@ -1,0 +1,23 @@
+import template from './sw-sales-channel-detail-cookie.html.twig';
+
+const { Component } = Shopware;
+const { Criteria } = Shopware.Data;
+
+Component.register('sw-sales-channel-detail-cookie', {
+    template,
+
+    props: {
+        salesChannel: {
+            required: true
+        }
+    },
+
+    computed: {
+        domainCriteria() {
+            const criteria = new Criteria();
+            criteria.addFilter(Criteria.equals('salesChannelId', this.salesChannel.id));
+
+            return criteria;
+        }
+    }
+});

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/component/sw-sales-channel-detail-cookie/sw-sales-channel-detail-cookie.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/component/sw-sales-channel-detail-cookie/sw-sales-channel-detail-cookie.html.twig
@@ -1,0 +1,26 @@
+{% block sw_sales_channel_detail_cookie %}
+    <sw-card :title="$tc('sw-sales-channel.detail.cookie.title')"
+             class="sw-sales-channel-detail-cookie">
+        {% block sw_sales_channel_detail_cookie_title %}
+        <h4>
+            <span class="sw-sales-channel-detail-domains__headline-text sw-sales-channel-detail-base__headline-text">{{ $tc('sw-sales-channel.detail.cookie.titleCard') }}</span>
+        </h4>
+        {% endblock %}
+
+        {% block sw_sales_channel_detail_cookie_content %}
+            {% block sw_sales_channel_detail_cookie_description %}
+            <div class="sw-sales-channel-detail-base__description-text">
+                {{ $tc('sw-sales-channel.detail.cookie.titleDescription') }}
+            </div>
+            {% endblock %}
+
+            {% block sw_sales_channel_detail_cookie_content_enable %}
+                <sw-switch-field
+                    v-model="salesChannel.cookieAcceptAllActive"
+                    :label="$tc('sw-sales-channel.detail.cookie.enableCheckbox')"
+                ></sw-switch-field>
+            {% endblock %}
+
+        {% endblock %}
+    </sw-card>
+{% endblock %}

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/index.js
@@ -8,6 +8,8 @@ import './component/sw-sales-channel-modal-detail';
 import './component/sw-sales-channel-detail-domains';
 import './component/sw-sales-channel-detail-hreflang';
 
+import './component/sw-sales-channel-detail-cookie';
+
 import './component/sw-sales-channel-detail-protect-link';
 import './component/sw-sales-channel-detail-account-connect';
 import './component/sw-sales-channel-detail-account-disconnect';

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/snippet/de-DE.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/snippet/de-DE.json
@@ -202,6 +202,11 @@
           "csv": "CSV"
         }
       },
+      "cookie": {
+        "title": "Cookie",
+        "titleCard": "Accept All Cookies",
+        "titleDescription": "The check is used to accept all cookies with one button without the need of configuration"
+      },
       "hreflang": {
         "title": "Hreflang",
         "titleCard": "Hreflang-Integration",

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/snippet/de-DE.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/snippet/de-DE.json
@@ -204,9 +204,9 @@
       },
       "cookie": {
         "title": "Cookie",
-        "titleCard": "Accept All Cookies",
-        "titleDescription": "The check is used to accept all cookies with one button without the need of configuration",
-        "enableCheckbox": "Active"
+        "titleCard": "Alle Cookies akzeptieren",
+        "titleDescription": "Dieser Schalter wird dazu verwendet um einen \"Alle akzeptieren\" Knopf im Cookie Banner anzuzeigen",
+        "enableCheckbox": "Aktiv"
       },
       "hreflang": {
         "title": "Hreflang",

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/snippet/de-DE.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/snippet/de-DE.json
@@ -205,7 +205,8 @@
       "cookie": {
         "title": "Cookie",
         "titleCard": "Accept All Cookies",
-        "titleDescription": "The check is used to accept all cookies with one button without the need of configuration"
+        "titleDescription": "The check is used to accept all cookies with one button without the need of configuration",
+        "enableCheckbox": "Active"
       },
       "hreflang": {
         "title": "Hreflang",

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/snippet/en-GB.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/snippet/en-GB.json
@@ -192,6 +192,11 @@
           }
         }
       },
+      "cookie": {
+        "title": "Cookie",
+        "titleCard": "Accept All Cookies",
+        "titleDescription": "The check is used to accept all cookies with one button without the need of configuration"
+      },
       "hreflang": {
         "title": "Hreflang",
         "titleCard": "Hreflang integration",

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/snippet/en-GB.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/snippet/en-GB.json
@@ -195,7 +195,8 @@
       "cookie": {
         "title": "Cookie",
         "titleCard": "Accept All Cookies",
-        "titleDescription": "The check is used to accept all cookies with one button without the need of configuration"
+        "titleDescription": "The check is used to accept all cookies with one button without the need of configuration",
+        "enableCheckbox": "Active"
       },
       "hreflang": {
         "title": "Hreflang",

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/snippet/en-GB.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/snippet/en-GB.json
@@ -194,8 +194,8 @@
       },
       "cookie": {
         "title": "Cookie",
-        "titleCard": "Accept All Cookies",
-        "titleDescription": "The check is used to accept all cookies with one button without the need of configuration",
+        "titleCard": "Accept all cookies",
+        "titleDescription": "This switch is used to display a \"Accept all cookies\" button in the cookie banner",
         "enableCheckbox": "Active"
       },
       "hreflang": {

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/view/sw-sales-channel-detail-base/sw-sales-channel-detail-base.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/view/sw-sales-channel-detail-base/sw-sales-channel-detail-base.html.twig
@@ -213,7 +213,7 @@
             </sw-card>
         {% endblock %}
 
-        {% block sw_sales_channel_detail_base_options_hreflang %}
+        {% block sw_sales_channel_detail_base_options_cookie %}
             <sw-sales-channel-detail-cookie
                 v-if="salesChannel && isStoreFront"
                 :salesChannel="salesChannel"

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/view/sw-sales-channel-detail-base/sw-sales-channel-detail-base.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/view/sw-sales-channel-detail-base/sw-sales-channel-detail-base.html.twig
@@ -214,6 +214,14 @@
         {% endblock %}
 
         {% block sw_sales_channel_detail_base_options_hreflang %}
+            <sw-sales-channel-detail-cookie
+                v-if="salesChannel && isStoreFront"
+                :salesChannel="salesChannel"
+                :isLoading="isLoading">
+            </sw-sales-channel-detail-cookie>
+        {% endblock %}
+
+        {% block sw_sales_channel_detail_base_options_hreflang %}
             <sw-sales-channel-detail-hreflang
                 v-if="salesChannel && isStoreFront"
                 :salesChannel="salesChannel"

--- a/src/Core/Migration/Migration1589446209AddAcceptAllCookieFlag.php
+++ b/src/Core/Migration/Migration1589446209AddAcceptAllCookieFlag.php
@@ -1,0 +1,31 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Migration;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Framework\Migration\MigrationStep;
+
+class Migration1589446209AddAcceptAllCookieFlag extends MigrationStep
+{
+    public function getCreationTimestamp(): int
+    {
+        return 1589446209;
+    }
+
+    public function update(Connection $connection): void
+    {
+        $connection->executeUpdate(
+            'ALTER TABLE sales_channel
+            ADD COLUMN `cookie_accept_all_active` TINYINT(1) NOT NULL DEFAULT 0 AFTER `analytics_id`'
+        );
+    }
+
+    public function updateDestructive(Connection $connection): void
+    {
+        // implement update destructive
+        $connection->executeUpdate(
+            'ALTER TABLE sales_channel
+            DROP COLUMN `cookie_accept_all_active`'
+        );
+    }
+}

--- a/src/Core/System/SalesChannel/SalesChannelDefinition.php
+++ b/src/Core/System/SalesChannel/SalesChannelDefinition.php
@@ -118,6 +118,7 @@ class SalesChannelDefinition extends EntityDefinition
             new BoolField('hreflang_active', 'hreflangActive'),
             new BoolField('maintenance', 'maintenance'),
             new ListField('maintenance_ip_whitelist', 'maintenanceIpWhitelist'),
+            new BoolField('cookie_accept_all_active', 'cookieAcceptAllActive'),
             new TranslatedField('customFields'),
             (new TranslationsAssociationField(SalesChannelTranslationDefinition::class, 'sales_channel_id'))->addFlags(new Required()),
             new ManyToManyAssociationField('currencies', CurrencyDefinition::class, SalesChannelCurrencyDefinition::class, 'sales_channel_id', 'currency_id'),

--- a/src/Core/System/SalesChannel/SalesChannelEntity.php
+++ b/src/Core/System/SalesChannel/SalesChannelEntity.php
@@ -333,6 +333,11 @@ class SalesChannelEntity extends Entity
     protected $analytics;
 
     /**
+     * @var bool
+     */
+    protected $cookieAcceptAllActive;
+
+    /**
      * @var GoogleShoppingAccountEntity|null
      */
     protected $googleShoppingAccount;
@@ -921,6 +926,16 @@ class SalesChannelEntity extends Entity
     public function setAnalytics(?SalesChannelAnalyticsEntity $analytics): void
     {
         $this->analytics = $analytics;
+    }
+
+    public function isCookieAcceptAllActive(): bool
+    {
+        return $this->cookieAcceptAllActive;
+    }
+
+    public function setCookieAcceptAllActive(bool $cookieAcceptAllActive): void
+    {
+        $this->cookieAcceptAllActive = $cookieAcceptAllActive;
     }
 
     public function getGoogleShoppingAccount(): ?GoogleShoppingAccountEntity

--- a/src/Storefront/DependencyInjection/services.xml
+++ b/src/Storefront/DependencyInjection/services.xml
@@ -43,6 +43,7 @@
             <argument type="service" id="request_stack"/>
             <argument type="service" id="Shopware\Core\System\SystemConfig\SystemConfigService"/>
             <argument type="service" id="Shopware\Storefront\Theme\ThemeService"/>
+            <argument type="service" id="Shopware\Storefront\Framework\Cookie\CookieService"/>
             <argument>%storefront.csrf.enabled%</argument>
             <argument>%storefront.csrf.mode%</argument>
 
@@ -439,6 +440,10 @@
         </service>
 
         <service id="Shopware\Storefront\Framework\Cookie\CookieProviderInterface" class="Shopware\Storefront\Framework\Cookie\CookieProvider" />
+
+        <service id="Shopware\Storefront\Framework\Cookie\CookieService">
+            <argument type="service" id="Shopware\Storefront\Framework\Cookie\CookieProviderInterface"/>
+        </service>
 
         <service id="Shopware\Storefront\Framework\Captcha\CaptchaRouteListener">
             <argument type="tagged" tag="shopware.storefront.captcha"/>

--- a/src/Storefront/Framework/Cookie/CookieService.php
+++ b/src/Storefront/Framework/Cookie/CookieService.php
@@ -1,0 +1,51 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Storefront\Framework\Cookie;
+
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
+
+class CookieService
+{
+    /**
+     * @var CookieProvider
+     */
+    private $cookieProvider;
+
+    public function __construct(CookieProvider $cookieProvider)
+    {
+        $this->cookieProvider = $cookieProvider;
+    }
+
+    public function getCookieGroups(SalesChannelContext $context)
+    {
+        $cookieGroups = $this->cookieProvider->getCookieGroups();
+
+        return $this->filterGoogleAnalyticsCookie($context, $cookieGroups);
+    }
+
+    private function filterGoogleAnalyticsCookie(SalesChannelContext $context, array $cookieGroups): array
+    {
+        if ($context->getSalesChannel()->getAnalytics() && $context->getSalesChannel()->getAnalytics()->isActive()) {
+            return $cookieGroups;
+        }
+
+        $filteredGroups = [];
+
+        foreach ($cookieGroups as $cookieGroup) {
+            if ($cookieGroup['snippet_name'] === 'cookie.groupStatistical') {
+                $cookieGroup['entries'] = array_filter($cookieGroup['entries'], function ($item) {
+                    return $item['snippet_name'] !== 'cookie.groupStatisticalGoogleAnalytics';
+                });
+                // Only add statistics cookie group if it has entries
+                if (count($cookieGroup['entries']) > 0) {
+                    $filteredGroups[] = $cookieGroup;
+                }
+
+                continue;
+            }
+            $filteredGroups[] = $cookieGroup;
+        }
+
+        return $filteredGroups;
+    }
+}

--- a/src/Storefront/Framework/Cookie/CookieService.php
+++ b/src/Storefront/Framework/Cookie/CookieService.php
@@ -7,11 +7,11 @@ use Shopware\Core\System\SalesChannel\SalesChannelContext;
 class CookieService
 {
     /**
-     * @var CookieProvider
+     * @var CookieProviderInterface
      */
     private $cookieProvider;
 
-    public function __construct(CookieProvider $cookieProvider)
+    public function __construct(CookieProviderInterface $cookieProvider)
     {
         $this->cookieProvider = $cookieProvider;
     }

--- a/src/Storefront/Framework/Twig/TemplateDataExtension.php
+++ b/src/Storefront/Framework/Twig/TemplateDataExtension.php
@@ -7,6 +7,7 @@ use Shopware\Core\PlatformRequest;
 use Shopware\Core\SalesChannelRequest;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
+use Shopware\Storefront\Framework\Cookie\CookieService;
 use Shopware\Storefront\Theme\ThemeCompiler;
 use Shopware\Storefront\Theme\ThemeService;
 use Symfony\Component\HttpFoundation\Request;
@@ -32,6 +33,11 @@ class TemplateDataExtension extends AbstractExtension implements GlobalsInterfac
     private $themeService;
 
     /**
+     * @var CookieService
+     */
+    private $cookieService;
+
+    /**
      * @var bool
      */
     private $csrfEnabled;
@@ -45,6 +51,7 @@ class TemplateDataExtension extends AbstractExtension implements GlobalsInterfac
         RequestStack $requestStack,
         SystemConfigService $systemConfigService,
         ThemeService $themeService,
+        CookieService $cookieService,
         bool $csrfEnabled,
         string $csrfMode
     ) {
@@ -53,6 +60,7 @@ class TemplateDataExtension extends AbstractExtension implements GlobalsInterfac
         $this->themeService = $themeService;
         $this->csrfEnabled = $csrfEnabled;
         $this->csrfMode = $csrfMode;
+        $this->cookieService = $cookieService;
     }
 
     public function getGlobals(): array
@@ -90,6 +98,7 @@ class TemplateDataExtension extends AbstractExtension implements GlobalsInterfac
             'context' => $context,
             'activeRoute' => $request->attributes->get('_route'),
             'formViolations' => $request->attributes->get('formViolations'),
+            'cookieGroups' => $this->cookieService->getCookieGroups($context),
         ];
     }
 

--- a/src/Storefront/Resources/app/storefront/src/main.js
+++ b/src/Storefront/Resources/app/storefront/src/main.js
@@ -32,6 +32,7 @@ import OffCanvasCartPlugin from 'src/plugin/offcanvas-cart/offcanvas-cart.plugin
 import AddToCartPlugin from 'src/plugin/add-to-cart/add-to-cart.plugin';
 import CookiePermissionPlugin from 'src/plugin/cookie/cookie-permission.plugin';
 import CookieConfigurationPlugin from 'src/plugin/cookie/cookie-configuration.plugin';
+import CookieAcceptAllPlugin from 'src/plugin/cookie/cookie-accept-all.plugin';
 import ScrollUpPlugin from 'src/plugin/scroll-up/scroll-up.plugin';
 import CollapseFooterColumnsPlugin from 'src/plugin/collapse/collapse-footer-columns.plugin';
 import FlyoutMenuPlugin from 'src/plugin/main-menu/flyout-menu.plugin';
@@ -94,6 +95,7 @@ register plugins
 PluginManager.register('DateFormat', DateFormat, '[data-date-format]');
 PluginManager.register('CookiePermission', CookiePermissionPlugin, '[data-cookie-permission]');
 PluginManager.register('CookieConfiguration', CookieConfigurationPlugin, '[data-cookie-permission]');
+PluginManager.register('CookieAcceptAll', CookieAcceptAllPlugin, '[data-cookie-permission]');
 PluginManager.register('ScrollUp', ScrollUpPlugin, '[data-scroll-up]');
 PluginManager.register('SearchWidget', SearchWidgetPlugin, '[data-search-form]');
 PluginManager.register('CartWidget', CartWidgetPlugin, '[data-cart-widget]');

--- a/src/Storefront/Resources/app/storefront/src/plugin/cookie/cookie-accept-all.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/cookie/cookie-accept-all.plugin.js
@@ -1,0 +1,66 @@
+import Plugin from 'src/plugin-system/plugin.class';
+import DeviceDetection from 'src/helper/device-detection.helper';
+
+export default class CookieAcceptAllPlugin extends Plugin {
+
+    static options = {
+        buttonAcceptAllSelector: '.js-cookie-accept-all'
+    };
+
+    init() {
+
+        this._button = this.el.querySelector(this.options.buttonAcceptAllSelector);
+
+        this._registerEvents();
+    }
+
+    /**
+     * Registers the events for the accept all cookies button
+     * @private
+     */
+    _registerEvents() {
+
+        if (this._button) {
+            const submitEvent = (DeviceDetection.isTouchDevice()) ? 'touchstart' : 'click';
+            this._button.addEventListener(submitEvent, this._handleAcceptAll.bind(this));
+        }
+    }
+
+    /**
+     * Handle accept all
+     * @private
+     */
+    _handleAcceptAll() {
+        const activeCookies = this._getCookies('active');
+        const inactiveCookies = this._getCookies('inactive');
+        const { cookiePreference } = this.options;
+
+        const activeCookieNames = [];
+        const inactiveCookieNames = [];
+
+        inactiveCookies.forEach(({ cookie }) => {
+            inactiveCookieNames.push(cookie);
+
+            if (CookieStorage.getItem(cookie)) {
+                CookieStorage.removeItem(cookie);
+            }
+        });
+
+        /**
+         * Cookies without value are passed to the updateListener
+         * ( see "_handleUpdateListener" method )
+         */
+        activeCookies.forEach(({ cookie, value, expiration }) => {
+            activeCookieNames.push(cookie);
+
+            if (cookie && value) {
+                CookieStorage.setItem(cookie, value, expiration);
+            }
+        });
+
+        CookieStorage.setItem(cookiePreference, '1', '30');
+
+        this._handleUpdateListener(activeCookieNames, inactiveCookieNames);
+        this.closeOffCanvas();
+    }
+}

--- a/src/Storefront/Resources/app/storefront/src/plugin/cookie/cookie-accept-all.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/cookie/cookie-accept-all.plugin.js
@@ -1,16 +1,19 @@
 import Plugin from 'src/plugin-system/plugin.class';
 import DeviceDetection from 'src/helper/device-detection.helper';
+import CookieStorage from 'src/helper/storage/cookie-storage.helper';
 
 export default class CookieAcceptAllPlugin extends Plugin {
 
     static options = {
-        buttonAcceptAllSelector: '.js-cookie-accept-all'
+        buttonAcceptAllSelector: '.js-cookie-accept-all',
+        cookieGroups: 'cookieGroups'
     };
 
     init() {
 
         this._button = this.el.querySelector(this.options.buttonAcceptAllSelector);
-
+        this.options
+        console.log(this.options.cookieGroups);
         this._registerEvents();
     }
 

--- a/src/Storefront/Resources/app/storefront/src/plugin/cookie/cookie-accept-all.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/cookie/cookie-accept-all.plugin.js
@@ -14,7 +14,6 @@ export default class CookieAcceptAllPlugin extends Plugin {
     init() {
 
         this._button = this.el.querySelector(this.options.buttonAcceptAllSelector);
-        this.options
         console.log(this.options.cookieGroups);
         this._registerEvents();
     }
@@ -51,7 +50,7 @@ export default class CookieAcceptAllPlugin extends Plugin {
      */
     _handleAcceptAll() {
 
-        const allCookies = JSON.parse(this.options.cookieGroups)
+        const allCookies = JSON.parse(this.options.cookieGroups);
         const {cookiePreference} = this.options;
 
         const cookieGroupNames = [];
@@ -60,11 +59,14 @@ export default class CookieAcceptAllPlugin extends Plugin {
          * Cookies without value are passed to the updateListener
          * ( see "_handleUpdateListener" method )
          */
-        allCookies.forEach(({cookie, value, expiration}) => {
-            cookieGroupNames.push(cookie);
+        allCookies.forEach(({cookie, value, expiration, entries}) => {
 
-            if (cookie && value) {
-                CookieStorage.setItem(cookie, value, expiration);
+            if (entries) {
+                entries.forEach(({cookie, value, expiration}) => {
+                    this._setCookie(cookie, value, expiration, cookieGroupNames);
+                });
+            } else {
+                this._setCookie(cookie, value, expiration, cookieGroupNames);
             }
         });
 
@@ -72,5 +74,13 @@ export default class CookieAcceptAllPlugin extends Plugin {
 
         this._handleUpdateListener(cookieGroupNames);
         this._hideCookieBar();
+    }
+
+    _setCookie(cookie, value, expiration, cookieGroupNames) {
+        cookieGroupNames.push(cookie);
+
+        if (cookie && value) {
+            CookieStorage.setItem(cookie, value, expiration);
+        }
     }
 }

--- a/src/Storefront/Resources/app/storefront/src/plugin/cookie/cookie-accept-all.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/cookie/cookie-accept-all.plugin.js
@@ -14,7 +14,6 @@ export default class CookieAcceptAllPlugin extends Plugin {
     init() {
 
         this._button = this.el.querySelector(this.options.buttonAcceptAllSelector);
-        console.log(this.options.cookieGroups);
         this._registerEvents();
     }
 

--- a/src/Storefront/Resources/snippet/de_DE/storefront.de-DE.json
+++ b/src/Storefront/Resources/snippet/de_DE/storefront.de-DE.json
@@ -511,7 +511,8 @@
     "groupRequiredTimezone": "Zeitzone",
     "groupStatistical": "Statistik",
     "groupStatisticalDescription": "Diese Cookies werden für Statistiken und Shop Performance Metriken genutzt.",
-    "groupStatisticalGoogleAnalytics": "Google Analytics"
+    "groupStatisticalGoogleAnalytics": "Google Analytics",
+    "acceptAll": "Alle akzeptieren"
   },
   "ellipsis": {
     "expandLabel": "mehr anzeigen",

--- a/src/Storefront/Resources/snippet/en_GB/storefront.en-GB.json
+++ b/src/Storefront/Resources/snippet/en_GB/storefront.en-GB.json
@@ -511,7 +511,8 @@
     "groupRequiredTimezone": "Timezone",
     "groupStatistical": "Statistic",
     "groupStatisticalDescription": "These cookies are used for statistics and shop performance metrics.",
-    "groupStatisticalGoogleAnalytics": "Google Analytics"
+    "groupStatisticalGoogleAnalytics": "Google Analytics",
+    "acceptAll": "Accept all"
   },
   "ellipsis": {
     "expandLabel": "show more",

--- a/src/Storefront/Resources/views/storefront/layout/cookie/cookie-permission.html.twig
+++ b/src/Storefront/Resources/views/storefront/layout/cookie/cookie-permission.html.twig
@@ -1,13 +1,16 @@
 {% block layout_cookie_permission_inner %}
 
-    {% set cookieAcceptAllOptions = {
-        cookieGroups: cookieGroups|json_encode
-    } %}
+    {% if context.salesChannel.cookieAcceptAllActive %}
+        {% set cookieAcceptAllOptions = {
+            cookieGroups: cookieGroups|json_encode
+        } %}
+    {% endif %}
 
     <div
         class="cookie-permission-container"
         data-cookie-permission="true"
-        data-cookie-accept-all-options="{{ cookieAcceptAllOptions|json_encode }}">
+        {% if context.salesChannel.cookieAcceptAllActive %}
+        data-cookie-accept-all-options="{{ cookieAcceptAllOptions|json_encode }}{% endif %}">
         <div class="container">
             <div class="row align-items-center">
 
@@ -42,13 +45,15 @@
                         {% endblock %}
 
                         {% block layout_cookie_permission_inner_button_accept_all %}
-                            <span class="js-cookie-accept-all">
-                                <button
-                                    type="submit"
-                                    class="btn btn-primary">
-                                    {{ "cookie.save"|trans|sw_sanitize }}
-                                </button>
-                            </span>
+                            {% if context.salesChannel.cookieAcceptAllActive %}
+                                <span class="js-cookie-accept-all">
+                                        <button
+                                            type="submit"
+                                            class="btn btn-primary">
+                                            {{ "cookie.acceptAll"|trans|sw_sanitize }}
+                                        </button>
+                                    </span>
+                            {% endif %}
                         {% endblock %}
                     </div>
                 {% endblock %}

--- a/src/Storefront/Resources/views/storefront/layout/cookie/cookie-permission.html.twig
+++ b/src/Storefront/Resources/views/storefront/layout/cookie/cookie-permission.html.twig
@@ -1,7 +1,8 @@
 {% block layout_cookie_permission_inner %}
     <div
         class="cookie-permission-container"
-        data-cookie-permission="true">
+        data-cookie-permission="true"
+        data-cookie-accept-all-options="{ 'cookieGroups': '{{ cookieGroups|json_encode }}' }">
         <div class="container">
             <div class="row align-items-center">
 

--- a/src/Storefront/Resources/views/storefront/layout/cookie/cookie-permission.html.twig
+++ b/src/Storefront/Resources/views/storefront/layout/cookie/cookie-permission.html.twig
@@ -1,8 +1,13 @@
 {% block layout_cookie_permission_inner %}
+
+    {% set cookieAcceptAllOptions = {
+        cookieGroups: cookieGroups|json_encode
+    } %}
+
     <div
         class="cookie-permission-container"
         data-cookie-permission="true"
-        data-cookie-accept-all-options="{ 'cookieGroups': '{{ cookieGroups|json_encode }}' }">
+        data-cookie-accept-all-options="{{ cookieAcceptAllOptions|json_encode }}">
         <div class="container">
             <div class="row align-items-center">
 

--- a/src/Storefront/Resources/views/storefront/layout/cookie/cookie-permission.html.twig
+++ b/src/Storefront/Resources/views/storefront/layout/cookie/cookie-permission.html.twig
@@ -34,6 +34,16 @@
                                 </button>
                             </span>
                         {% endblock %}
+
+                        {% block layout_cookie_permission_inner_button_accept_all %}
+                            <span class="js-cookie-accept-all">
+                                <button
+                                    type="submit"
+                                    class="btn btn-primary">
+                                    {{ "cookie.save"|trans|sw_sanitize }}
+                                </button>
+                            </span>
+                        {% endblock %}
                     </div>
                 {% endblock %}
             </div>


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/community).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
Currently there is no way to accept all cookies without configuring them. This feature is necessary as it will allow the users to accept all cookies as well as keep the option to configure or deny them.

### 2. What does this change do, exactly?

This pull requests adds a flag to the Sales Channel wether or not to accept all cookies with just one button in frontend. The check works per SalesChannel so it can be activated per setting.

### 3. Describe each step to reproduce the issue or behaviour.
1. Open shopware administration
2. Go to Sales Channel
3. Activate the function under Cookie container
4. Go to frontend of the shop, delete your cookies if they weren't deleted
5. You now see a 3rd button option at the bottom of your screen with the text "Accept All"

### 4. Please link to the relevant issues (if any).

#838 

https://github.com/shopware/platform/issues/838

### 5. Checklist
- cs fix
- static-analyze
- unit

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
