### PR TITLE
NEXT-8436 - Remove alpha numerical filter from quick add. Fixes #680

### DIFF
--- a/CHANGELOG-6.2.md
+++ b/CHANGELOG-6.2.md
@@ -579,7 +579,8 @@ To get the diff between two versions, go to https://github.com/shopware/platform
         * page_checkout_aside_actions_payment_method_id
         * page_checkout_confirm_form_submit
     * Added JS plugins `FormCsrfHandler` and `FormPreserver` to the `<form>` element in `src/Storefront/Resources/views/storefront/page/account/order/index.html.twig`
-    
+    * Removed alphanumeric filter product numbers in the quick add action
+
 **Removals**
 
 * Administration

--- a/src/Storefront/Controller/CartLineItemController.php
+++ b/src/Storefront/Controller/CartLineItemController.php
@@ -179,7 +179,8 @@ class CartLineItemController extends StorefrontController
      */
     public function addProductByNumber(Request $request, SalesChannelContext $salesChannelContext): Response
     {
-        $number = $request->request->getAlnum('number');
+        $number = $request->request->get('number');
+
         if (!$number) {
             throw new MissingRequestParameterException('number');
         }

--- a/src/Storefront/Test/Controller/CartLineItemControllerTest.php
+++ b/src/Storefront/Test/Controller/CartLineItemControllerTest.php
@@ -3,8 +3,17 @@
 namespace Shopware\Storefront\Test\Controller;
 
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Checkout\Cart\SalesChannel\CartService;
+use Shopware\Core\Content\Product\Aggregate\ProductVisibility\ProductVisibilityDefinition;
+use Shopware\Core\Defaults;
+use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\System\SalesChannel\Context\SalesChannelContextFactory;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Shopware\Storefront\Controller\CartLineItemController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Session\Flash\FlashBagInterface;
 
 class CartLineItemControllerTest extends TestCase
@@ -40,6 +49,41 @@ class CartLineItemControllerTest extends TestCase
         static::assertTrue($response->isRedirect(), $response->getContent());
     }
 
+    /**
+     * @dataProvider productNumbers
+     */
+    public function testAddProductByNumber(string $productId, string $productNumber): void
+    {
+        $contextToken = Uuid::randomHex();
+
+        /** @var CartService $cartService */
+        $cartService = $this->getContainer()->get(CartService::class);
+        $this->createProduct($productId, $productNumber);
+        $request = $this->createRequest(['number' => $productNumber]);
+
+        $salesChannelContext = $this->createSalesChannelContext($contextToken);
+        /** @var Response $response */
+        $response = $this->getContainer()->get(CartLineItemController::class)->addProductByNumber($request, $salesChannelContext);
+
+        $cartLineItem = $cartService->getCart($contextToken, $salesChannelContext)->getLineItems()->get($productId);
+
+        static::assertArrayHasKey('success', $this->getFlashBag()->all());
+        static::assertNotNull($cartLineItem);
+        static::assertSame(200, $response->getStatusCode());
+    }
+
+    public function productNumbers(): array
+    {
+        return [
+            [Uuid::randomHex(), 'test.123'],
+            [Uuid::randomHex(), 'test 123'],
+            [Uuid::randomHex(), 'test-123'],
+            [Uuid::randomHex(), 'test_123'],
+            [Uuid::randomHex(), 'testäüö123'],
+            [Uuid::randomHex(), 'test/123'],
+        ];
+    }
+
     private function getLineItemAddPayload(string $productId): array
     {
         return [
@@ -60,5 +104,49 @@ class CartLineItemControllerTest extends TestCase
     private function getFlashBag(): FlashBagInterface
     {
         return $this->getContainer()->get('session')->getFlashBag();
+    }
+
+    private function createProduct(string $productId, string $productNumber): void
+    {
+        $taxId = Uuid::randomHex();
+        $context = Context::createDefaultContext();
+
+        $product = [
+            'id' => $productId,
+            'name' => 'Test product',
+            'productNumber' => $productNumber,
+            'stock' => 1,
+            'price' => [
+                ['currencyId' => Defaults::CURRENCY, 'gross' => 15.99, 'net' => 10, 'linked' => false],
+            ],
+            'tax' => ['id' => $taxId, 'name' => 'testTaxRate', 'taxRate' => 15],
+            'categories' => [
+                ['id' => $productId, 'name' => 'Test category'],
+            ],
+            'visibilities' => [
+                [
+                    'id' => $productId,
+                    'salesChannelId' => Defaults::SALES_CHANNEL,
+                    'visibility' => ProductVisibilityDefinition::VISIBILITY_ALL,
+                ],
+            ],
+        ];
+        $this->getContainer()->get('product.repository')->create([$product], $context);
+    }
+
+    private function createSalesChannelContext(string $contextToken): SalesChannelContext
+    {
+        return $this->getContainer()->get(SalesChannelContextFactory::class)->create(
+            $contextToken,
+            Defaults::SALES_CHANNEL
+        );
+    }
+
+    private function createRequest(array $request = []): Request
+    {
+        $request = new Request([], $request);
+        $request->setSession($this->getContainer()->get('session'));
+
+        return $request;
     }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/community).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
It was not possible to add products with non alpha numerical chars in their product numbers via quick add. Like whitespace or dots (e.g. for generated variants)

### 2. What does this change do, exactly?
Remove the alpha numerical filter

### 3. Describe each step to reproduce the issue or behaviour.
Create a product with a dot or a whitespace in the product number.
See: https://vimeo.com/418478329/9f1eb39223

### 4. Please link to the relevant issues (if any).
https://github.com/shopware/platform/issues/680

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
