### PR TITLE
NEXT-8631 - Add ability to change default currency

### DIFF
--- a/CHANGELOG-6.2.md
+++ b/CHANGELOG-6.2.md
@@ -7,6 +7,14 @@ in 6.2 minor versions.
 To get the diff for a specific change, go to https://github.com/shopware/platform/commit/XXX where XXX is the change hash
 To get the diff between two versions, go to https://github.com/shopware/platform/compare/v6.1.0...6.2
 
+### 6.2.X - Boostday
+
+**Addition / Changes**
+
+* Core
+    * Added new controller `\Shopware\Core\System\Currency\Api\ChangeCurrencyController` to handle default currency switches
+
+
 ### 6.2.0
 
 **Addition / Changes**

--- a/src/Administration/Resources/app/administration/src/app/init-post/worker.init.js
+++ b/src/Administration/Resources/app/administration/src/app/init-post/worker.init.js
@@ -241,6 +241,19 @@ function registerThumbnailMiddleware(factory) {
         }
     });
 
+    factory.register('RecalculatePricesForCurrencyMessage', {
+        name: 'Shopware\\Core\\System\\Currency\\Message\\RecalculatePricesForCurrencyMessage',
+        fn: function middleware(next, { entry, $root, notification }) {
+            messageQueueNotification('currencyRecalculatePrices', ids, next, entry, $root, notification, {
+                title: 'global.default.success',
+                message: 'global.notification-center.worker-listener.recalculateCurrencyPrices.message',
+                success: 'global.notification-center.worker-listener.recalculateCurrencyPrices.messageSuccess',
+                foregroundSuccessMessage: 'global.notification-center.worker-listener.recalculateCurrencyPrices.foregroundSuccessMessage'
+            }, 50);
+        }
+    });
+
+
 
     return true;
 }

--- a/src/Administration/Resources/app/administration/src/app/snippet/de-DE.json
+++ b/src/Administration/Resources/app/administration/src/app/snippet/de-DE.json
@@ -85,6 +85,12 @@
           "title": "Indexierung der Rabattaktionen",
           "message": "Rabattaktion indexiert. | Noch eine Rabattaktion verbleibend ... | Circa {n} Rabattaktionen verbleibend ...",
           "messageSuccess": "Rabattaktionen indexiert."
+        },
+        "recalculateCurrencyPrices": {
+          "title": "Währungspreise werden neuindexiert",
+          "message": "Währungspreise indexiert. | Circa {n} Währungspreise verbleibend...",
+          "messageSuccess": "Währungspreise wurden neuindexiert.",
+          "foregroundSuccessMessage": "Währungspreise wurden neuindexiert. Bitte lösche den Cache um den Prozess zu beenden."
         }
       },
       "plugin-updates-listener": {

--- a/src/Administration/Resources/app/administration/src/app/snippet/en-GB.json
+++ b/src/Administration/Resources/app/administration/src/app/snippet/en-GB.json
@@ -85,6 +85,12 @@
           "title": "Indexing promotions",
           "message": "Promotion indexed. | One promotion remaining... | {n} promotions remaining...",
           "messageSuccess": "Promotions have been indexed."
+        },
+        "recalculateCurrencyPrices": {
+          "title": "Reindexing currency prices",
+          "message": "Currency prices indexed. | Currency prices remaining... | {n} currency prices remaining...",
+          "messageSuccess": "Currency prices have been indexed.",
+          "foregroundSuccessMessage": "Currency prices have been indexed. Please delete the cache to finish the process."
         }
       },
       "plugin-updates-listener": {

--- a/src/Administration/Resources/app/administration/src/core/service/api/language.api.service.js
+++ b/src/Administration/Resources/app/administration/src/core/service/api/language.api.service.js
@@ -1,0 +1,26 @@
+import ApiService from '../api.service';
+
+/**
+ * @class
+ * @extends ApiService
+ */
+class LanguageApiService extends ApiService {
+    constructor(httpClient, loginService, apiEndpoint = 'language') {
+        super(httpClient, loginService, apiEndpoint);
+        this.name = 'languageApiService';
+    }
+
+    changeDefaultCurrency(currencyId, additionalParams = {}, additionalHeaders = {}) {
+        const route = `_action/currency/change-default-currency/${currencyId}`;
+
+        const headers = this.getBasicHeaders(additionalHeaders);
+
+        return this.httpClient
+            .post(route, {}, {
+                additionalParams,
+                headers
+            });
+    }
+}
+
+export default LanguageApiService;

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-currency/page/sw-settings-currency-detail/sw-settings-currency-detail.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-currency/page/sw-settings-currency-detail/sw-settings-currency-detail.html.twig
@@ -115,6 +115,45 @@
                             {% endblock %}
                         </sw-container>
                     </sw-card>
+
+                    {% block sw_settings_currency_detail_card_change_default_currency %}
+                        <sw-card :title="$tc('sw-settings-currency.detail.changeDefaultCurrencyTitle')">
+                            {% block sw_settings_currency_detail_card_change_default_currency_content %}
+                                <sw-button variant="primary" @click="showChangeDefaultCurrencyModal = true" :disabled="currency.isSystemDefault">
+                                    {{ $tc('sw-settings-currency.detail.changeDefaultCurrencyButton') }}
+                                </sw-button>
+                            {% endblock %}
+                        </sw-card>
+                    {% endblock %}
+                {% endblock %}
+
+                {% block sw_settings_currency_detail_change_default_currency_modal %}
+                    <sw-modal v-if="showChangeDefaultCurrencyModal"
+                              @modal-close="showChangeDefaultCurrencyModal = false"
+                              :title="$tc('sw-settings-currency.detail.changeDefaultCurrencyTitle')"
+                              variant="small">
+                        {% block sw_settings_currency_detail_change_default_currency_modal_content %}
+                            <p class="sw-data-grid__confirm-bulk-delete-text">
+                                {{ $tc('sw-settings-currency.detail.changeDefaultCurrencyModalText') }}
+                            </p>
+                        {% endblock %}
+
+                        <template #modal-footer>
+                            {% block sw_settings_currency_detail_change_default_currency_modal_actions %}
+                                <slot name="bulk-modal-cancel">
+                                    <sw-button @click="showChangeDefaultCurrencyModal = false" size="small">
+                                        {{ $tc('global.default.cancel') }}
+                                    </sw-button>
+                                </slot>
+
+                                <slot name="bulk-modal-delete-items">
+                                    <sw-button @click="changeToDefaultCurrency" variant="primary" size="small">
+                                        {{ $tc('global.default.yes') }}
+                                    </sw-button>
+                                </slot>
+                            {% endblock %}
+                        </template>
+                    </sw-modal>
                 {% endblock %}
             </sw-card-view>
         {% endblock %}

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-currency/page/sw-settings-currency-list/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-currency/page/sw-settings-currency-list/index.js
@@ -1,4 +1,5 @@
 import template from './sw-settings-currency-list.html.twig';
+import './sw-settings-currency-list.html.scss';
 
 const { Component, Mixin } = Shopware;
 const { Criteria } = Shopware.Data;

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-currency/page/sw-settings-currency-list/sw-settings-currency-list.html.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-currency/page/sw-settings-currency-list/sw-settings-currency-list.html.scss
@@ -1,0 +1,3 @@
+.sw-settings-currency-list__column_text {
+    margin-right: 12px;
+}

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-currency/page/sw-settings-currency-list/sw-settings-currency-list.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-currency/page/sw-settings-currency-list/sw-settings-currency-list.html.twig
@@ -59,6 +59,18 @@
                                        :isLoading="isLoading"
                                        @inline-edit-save="onInlineEditSave">
 
+                        {% block sw_settings_currency_list_grid_columns_name %}
+                            <template #column-name="{ item }">
+                                <router-link class="sw-settings-currency-list__column_text"
+                                             :to="{ name: 'sw.settings.currency.detail', params: { id: item.id } }">
+                                    {{ item.name }}
+                                </router-link>
+                                <sw-label size="medium" appearance="pill" :ghost="false" :caps="false" v-if="item.isSystemDefault">
+                                    {{ $tc('sw-settings-currency.list.default') }}
+                                </sw-label>
+                            </template>
+                        {% endblock %}
+
                         {% block sw_settings_currency_list_grid_columns_actions %}
                             <template #actions="{ item }">
                                 {% block sw_settings_currency_list_grid_columns_actions_edit %}

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-currency/snippet/de-DE.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-currency/snippet/de-DE.json
@@ -20,7 +20,8 @@
       "titleDeleteSuccess": "Erfolg",
       "messageDeleteSuccess": "Die Währung \"{name}\" wurde erfolgreich gelöscht.",
       "buttonCancel": "Abbrechen",
-      "buttonDelete": "Löschen"
+      "buttonDelete": "Löschen",
+      "default": "Systemstandard"
     },
     "detail": {
       "textHeadline": "Neue Währung",
@@ -42,7 +43,11 @@
       "buttonCancel": "Abbrechen",
       "buttonSave": "Speichern",
       "notificationErrorTitle": "Fehler",
-      "notificationErrorMessage": "Fehler beim Speichern der Währung."
+      "notificationErrorMessage": "Fehler beim Speichern der Währung.",
+      "changeDefaultCurrencyTitle": "Standard Währung",
+      "changeDefaultCurrencyButton": "Diese Währung zur Standard Währung umwandeln.",
+      "changeDefaultCurrencyModalText": "Möchtest du wirklich die Standardwährung ändern? Im Anschluss werden im Hintergrund alle Preise umgerechnet",
+      "changeDefaultCurrencySuccess": "Die Währung wurde erfolgreich umgestellt. Im Hintergrund werden die Preise nun aktualisiert."
     }
   }
 }

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-currency/snippet/en-GB.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-currency/snippet/en-GB.json
@@ -20,7 +20,8 @@
       "titleDeleteSuccess": "Currency",
       "messageDeleteSuccess": "Currency \"{name}\" has been deleted.",
       "buttonCancel": "Cancel",
-      "buttonDelete": "Delete"
+      "buttonDelete": "Delete",
+      "default": "System default"
     },
     "detail": {
       "textHeadline": "New currency",
@@ -42,7 +43,11 @@
       "buttonCancel": "Cancel",
       "buttonSave": "Save",
       "notificationErrorTitle": "Error",
-      "notificationErrorMessage": "An error occured while saving your currency."
+      "notificationErrorMessage": "An error occured while saving your currency.",
+      "changeDefaultCurrencyTitle": "Default currency",
+      "changeDefaultCurrencyButton": "Set as default currency",
+      "changeDefaultCurrencyModalText": "Do you want to process?",
+      "changeDefaultCurrencySuccess": "Currency was successfully made default. The prices will be now updated in the background."
     }
   }
 }

--- a/src/Core/System/Currency/Api/ChangeCurrencyController.php
+++ b/src/Core/System/Currency/Api/ChangeCurrencyController.php
@@ -1,0 +1,143 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\System\Currency\Api;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Defaults;
+use Shopware\Core\Framework\Adapter\Cache\CacheClearer;
+use Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\PriceField;
+use Shopware\Core\Framework\Routing\Annotation\RouteScope;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\System\Currency\Message\RecalculatePricesForCurrencyMessage;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Routing\Annotation\Route;
+
+/**
+ * @RouteScope(scopes={"api"})
+ */
+class ChangeCurrencyController
+{
+    /**
+     * @var Connection
+     */
+    private $connection;
+
+    /**
+     * @var DefinitionInstanceRegistry
+     */
+    private $definitionInstanceRegistry;
+
+    /**
+     * @var MessageBusInterface
+     */
+    private $messageBus;
+
+    /**
+     * @var CacheClearer
+     */
+    private $cacheClearer;
+
+    public function __construct(
+        Connection $connection,
+        DefinitionInstanceRegistry $definitionInstanceRegistry,
+        MessageBusInterface $messageBus,
+        CacheClearer $cacheClearer
+    ) {
+        $this->connection = $connection;
+        $this->definitionInstanceRegistry = $definitionInstanceRegistry;
+        $this->messageBus = $messageBus;
+        $this->cacheClearer = $cacheClearer;
+    }
+
+    /**
+     * @Route(path="/api/v{version}/_action/currency/change-default-currency/{currencyId}", methods={"POST"}, name="api.custom.currency.change-default")
+     */
+    public function change(string $currencyId): JsonResponse
+    {
+        $currencyId = strtolower($currencyId);
+        $this->checkIsValidCurrencyId($currencyId);
+
+        $defaultCurrencyId = Uuid::fromHexToBytes(Defaults::CURRENCY);
+
+        $swapId = Uuid::randomBytes();
+
+        $stmt = $this->connection->prepare('UPDATE currency SET id = :newId WHERE id = :oldId');
+
+        $stmt->execute([
+            'newId' => $swapId,
+            'oldId' => $defaultCurrencyId,
+        ]);
+
+        $stmt->execute([
+            'newId' => $defaultCurrencyId,
+            'oldId' => Uuid::fromHexToBytes($currencyId),
+        ]);
+
+        $factor = (float) $this->connection->fetchColumn('SELECT factor FROM currency WHERE id = :id', ['id' => $defaultCurrencyId]);
+        $this->connection->executeQuery(
+            'UPDATE currency SET factor = IF(id = :id, 1, factor * :fixFactor);',
+            [
+                'id' => $defaultCurrencyId,
+                'fixFactor' => 1 / $factor,
+            ]
+        );
+
+        $this->schedulePriceUpdates($factor);
+
+        $this->cacheClearer->invalidateTags([
+            'entity_currency', // Invalidate entity reader
+            'currency.id', // Invalidate entity searcher
+        ]);
+
+        return new JsonResponse(['id' => Defaults::CURRENCY]);
+    }
+
+    private function checkIsValidCurrencyId(string $currencyId): void
+    {
+        if ($currencyId === Defaults::CURRENCY) {
+            throw new \RuntimeException('The given currencyId is already the default');
+        }
+
+        $exists = (bool) $this->connection->fetchColumn('SELECT 1 FROM currency WHERE id = UNHEX(?) LIMIT 1', [
+            $currencyId,
+        ]);
+
+        if (!$exists) {
+            throw new \RuntimeException('The given currencyId does not exists');
+        }
+    }
+
+    private function schedulePriceUpdates(float $fixFactor): void
+    {
+        $tables = $this->getTablesAndFields();
+
+        foreach ($tables as $table => $fields) {
+            $ids = $this->connection->executeQuery('SELECT LOWER(HEX(id)) FROM ' . $table)->fetchAll(\PDO::FETCH_COLUMN);
+
+            $chunks = array_chunk($ids, 50);
+
+            foreach ($chunks as $chunk) {
+                $msg = new RecalculatePricesForCurrencyMessage($table, $fields, $chunk, $fixFactor);
+                $this->messageBus->dispatch($msg);
+            }
+        }
+    }
+
+    private function getTablesAndFields(): array
+    {
+        $updateTables = [];
+
+        foreach ($this->definitionInstanceRegistry->getDefinitions() as $definition) {
+            $fields = $definition->getFields()->filterInstance(PriceField::class);
+            if ($fields->count()) {
+                $updateTables[$definition->getEntityName()] = array_values($fields->fmap(static function (PriceField $field) {
+                    return $field->getStorageName();
+                }));
+            }
+        }
+
+        return $updateTables;
+    }
+}

--- a/src/Core/System/Currency/Message/RecalculatePricesForCurrencyMessage.php
+++ b/src/Core/System/Currency/Message/RecalculatePricesForCurrencyMessage.php
@@ -1,0 +1,54 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\System\Currency\Message;
+
+class RecalculatePricesForCurrencyMessage
+{
+    /**
+     * @var string
+     */
+    private $table;
+
+    /**
+     * @var array
+     */
+    private $fields;
+
+    /**
+     * @var array
+     */
+    private $ids;
+
+    /**
+     * @var float
+     */
+    private $multiplyWith;
+
+    public function __construct(string $table, array $fields, array $ids, float $multiplyWith)
+    {
+        $this->table = $table;
+        $this->fields = $fields;
+        $this->ids = $ids;
+        $this->multiplyWith = $multiplyWith;
+    }
+
+    public function getTable(): string
+    {
+        return $this->table;
+    }
+
+    public function getFields(): array
+    {
+        return $this->fields;
+    }
+
+    public function getIds(): array
+    {
+        return $this->ids;
+    }
+
+    public function getMultiplyWith(): float
+    {
+        return $this->multiplyWith;
+    }
+}

--- a/src/Core/System/Currency/Message/RecalculatePricesForCurrencyMessageHandler.php
+++ b/src/Core/System/Currency/Message/RecalculatePricesForCurrencyMessageHandler.php
@@ -1,0 +1,64 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\System\Currency\Message;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Framework\Adapter\Cache\CacheClearer;
+use Shopware\Core\Framework\MessageQueue\Handler\AbstractMessageHandler;
+use Shopware\Core\Framework\Uuid\Uuid;
+
+class RecalculatePricesForCurrencyMessageHandler extends AbstractMessageHandler
+{
+    /**
+     * @var Connection
+     */
+    private $connection;
+
+    /**
+     * @var CacheClearer
+     */
+    private $cacheClearer;
+
+    public function __construct(Connection $connection, CacheClearer $cacheClearer)
+    {
+        $this->connection = $connection;
+        $this->cacheClearer = $cacheClearer;
+    }
+
+    /**
+     * @param RecalculatePricesForCurrencyMessage $message
+     */
+    public function handle($message): void
+    {
+        $updateQuery = <<<SQL
+UPDATE #table#
+SET #field# = JSON_SET(
+    #field#,
+    '$.cb7d2554b0ce847cd82f3ac9bd1c0dfca.net', JSON_EXTRACT(#field#, '$.cb7d2554b0ce847cd82f3ac9bd1c0dfca.net') * :factor,
+    '$.cb7d2554b0ce847cd82f3ac9bd1c0dfca.gross', JSON_EXTRACT(#field#, '$.cb7d2554b0ce847cd82f3ac9bd1c0dfca.gross') * :factor
+)
+WHERE id IN (:ids)
+SQL;
+        foreach ($message->getFields() as $field) {
+            $execQuery = str_replace(['#table#', '#field#'], [$message->getTable(), $field], $updateQuery);
+
+            $this->connection->executeQuery(
+                $execQuery,
+                [
+                    'ids' => Uuid::fromHexToBytesList($message->getIds()),
+                    'factor' => $message->getMultiplyWith(),
+                ],
+                [
+                    'ids' => Connection::PARAM_STR_ARRAY,
+                ]
+            );
+        }
+    }
+
+    public static function getHandledMessages(): iterable
+    {
+        return [
+            RecalculatePricesForCurrencyMessage::class,
+        ];
+    }
+}

--- a/src/Core/System/DependencyInjection/currency.xml
+++ b/src/Core/System/DependencyInjection/currency.xml
@@ -39,5 +39,18 @@
             <argument type="service" id="Shopware\Core\Framework\DataAbstractionLayer\Search\RequestCriteriaBuilder"/>
             <argument type="service" id="Shopware\Core\System\Currency\SalesChannel\SalesChannelCurrencyDefinition"/>
         </service>
+
+        <service id="Shopware\Core\System\Currency\Api\ChangeCurrencyController" public="true">
+            <argument type="service" id="Doctrine\DBAL\Connection"/>
+            <argument type="service" id="Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry"/>
+            <argument type="service" id="messenger.bus.shopware"/>
+            <argument type="service" id="Shopware\Core\Framework\Adapter\Cache\CacheClearer"/>
+        </service>
+
+        <service id="Shopware\Core\System\Currency\Message\RecalculatePricesForCurrencyMessageHandler">
+            <argument type="service" id="Doctrine\DBAL\Connection"/>
+            <argument type="service" id="Shopware\Core\Framework\Adapter\Cache\CacheClearer"/>
+            <tag name="messenger.message_handler"/>
+        </service>
     </services>
 </container>

--- a/src/Core/System/Resources/config/routes.xml
+++ b/src/Core/System/Resources/config/routes.xml
@@ -13,6 +13,7 @@
     <import resource="../../SalesChannel/SalesChannel/**/*Route.php" type="annotation" />
     <import resource="../../StateMachine/Api/*Controller.php" type="annotation" />
     <import resource="../../Currency/SalesChannel/**/*Route.php" type="annotation" />
+    <import resource="../../Currency/Api/**/*Controller.php" type="annotation" />
     <import resource="../../Language/SalesChannel/**/*Route.php" type="annotation" />
     <import resource="../../Salutation/SalesChannel/**/*Route.php" type="annotation" />
 </routes>


### PR DESCRIPTION
### 1. Why is this change necessary?

Ability to change default currency

### 2. What does this change do, exactly?

Button in administration to change to a new currency as system default

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.

### 6. Whats missing?

Cause of using plain SQL. Cache Invaldation does not work correctly. Also if deleted the right cache tags are deleted the entire storefront is broken. Even the invalidation from administration does not work anymore.
Looks like system currency changing breaks handling of invalidation. Needs to be debugged.
