### PR TITLE
NEXT-8598 - Add plural to packaging unit - Fixes #868

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-product-stream/snippet/de-DE.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-product-stream/snippet/de-DE.json
@@ -66,6 +66,7 @@
         "net": "Netto",
         "option": "Option",
         "packUnit": "Verpackungseinheit",
+        "packUnitPlural": "Verpackungseinheit Mehrzahl",
         "price": "Preis",
         "product": "Produkt",
         "productNumber": "Produktnummer",

--- a/src/Administration/Resources/app/administration/src/module/sw-product-stream/snippet/en-GB.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-product-stream/snippet/en-GB.json
@@ -66,6 +66,7 @@
         "net": "Net",
         "option": "Option",
         "packUnit": "Pack unit",
+        "packUnitPlural": "Pack unit plural",
         "price": "Price",
         "product": "Product",
         "productNumber": "Product number",

--- a/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-packaging-form/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-packaging-form/index.js
@@ -24,6 +24,7 @@ Component.register('sw-product-packaging-form', {
             'purchaseUnit',
             'referenceUnit',
             'packUnit',
+            'PackUnitPlural',
             'width',
             'height',
             'length',

--- a/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-packaging-form/sw-product-packaging-form.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-packaging-form/sw-product-packaging-form.html.twig
@@ -1,109 +1,103 @@
 {% block sw_product_packaging_form %}
     <div class="sw-product-packaging-form">
+        <sw-container columns="1fr 1fr 1fr" gap="0px 30px">
+            {% block sw_product_packaging_form_width_field %}
+                <sw-inherit-wrapper v-model="product.width"
+                                    :hasParent="!!parentProduct.id"
+                                    :inheritedValue="parentProduct.width">
+                    <template #content="props">
 
-        <sw-container columns="repeat(auto-fit, minmax(250px, 1fr)" gap="0px 30px">
-            <sw-container columns="1fr 1fr" gap="0px 30px">
-                {% block sw_product_packaging_form_width_field %}
-                    <sw-inherit-wrapper v-model="product.width"
-                                        :hasParent="!!parentProduct.id"
-                                        :inheritedValue="parentProduct.width">
-                        <template #content="props">
+                        <sw-field type="number"
+                                  :mapInheritance="props"
+                                  :label="$tc('sw-product.settingsForm.labelWidth')"
+                                  :placeholder="$tc('sw-product.settingsForm.placeholderWidth')"
+                                  :min="0"
+                                  :error="productWidthError"
+                                  :disabled="props.isInherited"
+                                  :value="props.currentValue"
+                                  @change="props.updateCurrentValue">
+                            <template #suffix>
+                                <span>mm</span>
+                            </template>
+                        </sw-field>
 
-                            <sw-field type="number"
-                                      :mapInheritance="props"
-                                      :label="$tc('sw-product.settingsForm.labelWidth')"
-                                      :placeholder="$tc('sw-product.settingsForm.placeholderWidth')"
-                                      :min="0"
-                                      :error="productWidthError"
-                                      :disabled="props.isInherited"
-                                      :value="props.currentValue"
-                                      @change="props.updateCurrentValue">
-                                <template #suffix>
-                                    <span>mm</span>
-                                </template>
-                            </sw-field>
+                    </template>
+                </sw-inherit-wrapper>
+            {% endblock %}
 
-                        </template>
-                    </sw-inherit-wrapper>
-                {% endblock %}
+            {% block sw_product_packaging_form_height_field %}
+                <sw-inherit-wrapper v-model="product.height"
+                                    :hasParent="!!parentProduct.id"
+                                    :inheritedValue="parentProduct.height">
+                    <template #content="props">
 
-                {% block sw_product_packaging_form_height_field %}
-                    <sw-inherit-wrapper v-model="product.height"
-                                        :hasParent="!!parentProduct.id"
-                                        :inheritedValue="parentProduct.height">
-                        <template #content="props">
+                        <sw-field type="number"
+                                  :mapInheritance="props"
+                                  :label="$tc('sw-product.settingsForm.labelHeight')"
+                                  :placeholder="$tc('sw-product.settingsForm.placeholderHeight')"
+                                  :min="0"
+                                  :error="productHeightError"
+                                  :disabled="props.isInherited"
+                                  :value="props.currentValue"
+                                  @change="props.updateCurrentValue">
+                            <template #suffix>
+                                <span>mm</span>
+                            </template>
+                        </sw-field>
 
-                            <sw-field type="number"
-                                      :mapInheritance="props"
-                                      :label="$tc('sw-product.settingsForm.labelHeight')"
-                                      :placeholder="$tc('sw-product.settingsForm.placeholderHeight')"
-                                      :min="0"
-                                      :error="productHeightError"
-                                      :disabled="props.isInherited"
-                                      :value="props.currentValue"
-                                      @change="props.updateCurrentValue">
-                                <template #suffix>
-                                    <span>mm</span>
-                                </template>
-                            </sw-field>
+                    </template>
+                </sw-inherit-wrapper>
+            {% endblock %}
 
-                        </template>
-                    </sw-inherit-wrapper>
-                {% endblock %}
-            </sw-container>
+            {% block sw_product_settings_form_length_field %}
+                <sw-inherit-wrapper v-model="product.length"
+                                    :hasParent="!!parentProduct.id"
+                                    :inheritedValue="parentProduct.length">
+                    <template #content="props">
 
-            <sw-container columns="1fr 1fr" gap="0px 30px">
-                {% block sw_product_settings_form_length_field %}
-                    <sw-inherit-wrapper v-model="product.length"
-                                        :hasParent="!!parentProduct.id"
-                                        :inheritedValue="parentProduct.length">
-                        <template #content="props">
+                        <sw-field type="number"
+                                  :mapInheritance="props"
+                                  :label="$tc('sw-product.settingsForm.labelLength')"
+                                  :placeholder="$tc('sw-product.settingsForm.placeholderLength')"
+                                  :min="0"
+                                  :error="productLengthError"
+                                  :disabled="props.isInherited"
+                                  :value="props.currentValue"
+                                  @change="props.updateCurrentValue">
+                            <template #suffix>
+                                <span>mm</span>
+                            </template>
+                        </sw-field>
 
-                            <sw-field type="number"
-                                      :mapInheritance="props"
-                                      :label="$tc('sw-product.settingsForm.labelLength')"
-                                      :placeholder="$tc('sw-product.settingsForm.placeholderLength')"
-                                      :min="0"
-                                      :error="productLengthError"
-                                      :disabled="props.isInherited"
-                                      :value="props.currentValue"
-                                      @change="props.updateCurrentValue">
-                                <template #suffix>
-                                    <span>mm</span>
-                                </template>
-                            </sw-field>
-
-                        </template>
-                    </sw-inherit-wrapper>
-                {% endblock %}
-
-                {% block sw_product_settings_form_weight_field %}
-                    <sw-inherit-wrapper v-model="product.weight"
-                                        :hasParent="!!parentProduct.id"
-                                        :inheritedValue="parentProduct.weight">
-                        <template #content="props">
-
-                            <sw-field type="number"
-                                      :mapInheritance="props"
-                                      :label="$tc('sw-product.settingsForm.labelWeight')"
-                                      :placeholder="$tc('sw-product.settingsForm.placeholderWeight')"
-                                      :min="0"
-                                      :error="productWeightError"
-                                      :disabled="props.isInherited"
-                                      :value="props.currentValue"
-                                      @change="props.updateCurrentValue">
-                                <template #suffix>
-                                    <span>kg</span>
-                                </template>
-                            </sw-field>
-
-                        </template>
-                    </sw-inherit-wrapper>
-                {% endblock %}
-            </sw-container>
+                    </template>
+                </sw-inherit-wrapper>
+            {% endblock %}
         </sw-container>
+        <sw-container columns="1fr 1fr 1fr" gap="0px 30px">
+            {% block sw_product_settings_form_weight_field %}
+                <sw-inherit-wrapper v-model="product.weight"
+                                    :hasParent="!!parentProduct.id"
+                                    :inheritedValue="parentProduct.weight">
+                    <template #content="props">
 
-        <sw-container columns="repeat(4, 1fr)" gap="0px 30px">
+                        <sw-field type="number"
+                                  :mapInheritance="props"
+                                  :label="$tc('sw-product.settingsForm.labelWeight')"
+                                  :placeholder="$tc('sw-product.settingsForm.placeholderWeight')"
+                                  :min="0"
+                                  :error="productWeightError"
+                                  :disabled="props.isInherited"
+                                  :value="props.currentValue"
+                                  @change="props.updateCurrentValue">
+                            <template #suffix>
+                                <span>kg</span>
+                            </template>
+                        </sw-field>
+
+                    </template>
+                </sw-inherit-wrapper>
+            {% endblock %}
+
             {% block sw_product_price_form_purchase_unit_field %}
                 <sw-inherit-wrapper v-model="product.purchaseUnit"
                                     :hasParent="!!parentProduct.id"
@@ -147,7 +141,8 @@
                     </template>
                 </sw-inherit-wrapper>
             {% endblock %}
-
+        </sw-container>
+        <sw-container columns="1fr 1fr 1fr" gap="0px 30px">
             {% block sw_product_price_form_pack_unit_field %}
                 <sw-inherit-wrapper v-model="product.packUnit"
                                     :hasParent="!!parentProduct.id"
@@ -161,6 +156,27 @@
                                   :placeholder="placeholder(product, 'packUnit', $tc('sw-product.priceForm.placeholderPackUnit'))"
                                   :disabled="props.isInherited"
                                   :helpText="$tc('sw-product.packagingForm.packUnitHelpText')"
+                                  :value="props.currentValue"
+                                  @input="props.updateCurrentValue">
+                        </sw-field>
+
+                    </template>
+                </sw-inherit-wrapper>
+            {% endblock %}
+
+            {% block sw_product_price_form_pack_unit_plural_field %}
+                <sw-inherit-wrapper v-model="product.packUnitPlural"
+                                    :hasParent="!!parentProduct.id"
+                                    :inheritedValue="parentProduct.packUnitPlural">
+                    <template #content="props">
+
+                        <sw-field type="text"
+                                  :mapInheritance="props"
+                                  :error="productPackUnitPluralError"
+                                  :label="$tc('sw-product.priceForm.labelPackUnitPlural')"
+                                  :placeholder="placeholder(product, 'packUnitPlural', $tc('sw-product.priceForm.placeholderPackUnitPlural'))"
+                                  :disabled="props.isInherited"
+                                  :helpText="$tc('sw-product.packagingForm.packUnitPluralHelpText')"
                                   :value="props.currentValue"
                                   @input="props.updateCurrentValue">
                         </sw-field>

--- a/src/Administration/Resources/app/administration/src/module/sw-product/snippet/de-DE.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/snippet/de-DE.json
@@ -44,6 +44,7 @@
       "labelPurchaseUnit": "Verkaufseinheit",
       "labelReferenceUnit": "Grundeinheit",
       "labelPackUnit": "Verpackungseinheit",
+      "labelPackUnitPlural": "Verpackungseinheit Mehrzahl",
       "placeholderTaxRate": "Wähle einen Steuersatz aus ...",
       "placeholderPurchasePriceGross": "Einkaufspreis eingeben ...",
       "placeholderPriceGross": "Bruttopreis eingeben ...",
@@ -51,6 +52,7 @@
       "placeholderPurchaseUnit": "Verkaufseinheit eingeben ...",
       "placeholderReferenceUnit": "Grundeinheit eingeben ...",
       "placeholderPackUnit": "Verpackungseinheit eingeben ...",
+      "placeholderPackUnitPlural": "Verpackungseinheit Mehrzahl eingeben ...",
       "optionLitre": "Liter",
       "optionKilogram": "Kilogramm",
       "optionMetre": "Meter"
@@ -104,6 +106,7 @@
       "placeholderUnit": "Wähle aus ...",
       "referenceUnitHelpText": "Der Wert, mit dem der Grundpreis eines Produkts berechnet wird. Abhängig von der verwendeten Maßeinheit trägst du hier wahrscheinlich eine '1' ein. Wenn z.B. die Verkaufseinheit in Litern gemessen wird, dann berechnest Du mit der '1' den Grundreis für 1 Liter. Soll der Grundpreis für 100 Milliliter berechnet werden, füge '0,1' ein.",
       "packUnitHelpText": "Art der Verpackung: z.B. Flasche, Kiste, Tiegel ...",
+      "packUnitPluralHelpText": "Art der Verpackung Mehrzahl: z.B. Flaschen, Kisten ...",
       "purchaseUnitHelpText": "Gib die Gesamtmenge des Produktes in einer Verkaufseinheit an. Für einen Sechserpack Getränkedosen (6 x 0,33 l = 2 l), füge hier z.B. '2' ein. Nicht vergessen: 'Sechserpack' bei Verpackungseinheit eintragen und die passende Maßeinheit 'Liter' in 'Einstellungen > Shop' anlegen."
     },
     "detailBase": {

--- a/src/Administration/Resources/app/administration/src/module/sw-product/snippet/en-GB.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/snippet/en-GB.json
@@ -43,13 +43,14 @@
       "labelPurchaseUnit": "Selling unit",
       "labelReferenceUnit": "Basic unit",
       "labelPackUnit": "Packaging unit",
+      "labelPackUnitPlural": "Packaging unit plural",
       "placeholderTaxRate": "Select tax rate...",
       "placeholderPurchasePriceGross": "Enter purchasing price...",
       "placeholderPriceGross": "Enter gross price...",
       "placeholderPriceNet": "Enter net price...",
       "placeholderPurchaseUnit": "Enter selling unit...",
       "placeholderReferenceUnit": "Enter basic unit...",
-      "placeholderPackUnit": "Enter packaging unit...",
+      "placeholderPackUnitPlural": "Enter packaging unit in plural...",
       "optionLitre": "Litre",
       "optionKilogram": "Kilogram",
       "optionMetre": "Metre"
@@ -103,6 +104,7 @@
       "labelUnit": "Scale unit",
       "referenceUnitHelpText": "Value used to calculate a base price for a given product. Depending on the chosen scale unit, you will most likely want to put a '1' here. E.g. if the selling unit is measured in 'litres' a '1' will calculate the base price for 1 liter of product. '0.1' would calculate the base price for 100 milliliters and so on.",
       "packUnitHelpText": "Type of packing: e.g. bottle, crate, tin...",
+      "packUnitPluralHelpText": "Type of packing in plural: e.g. bottles, crates ...",
       "purchaseUnitHelpText": "State the aggregate contents of a selling unit. For a sixpack of cans (6 x 0.33 l = 2 l), put '2'. Don't forget to put 'sixpack' as the packaging unit and add the scale unit 'litres' in 'Settings > Shop' accordingly."
     },
     "detailBase": {

--- a/src/Administration/Resources/app/administration/test/module/sw-import-export/service/mocks/entity-schema.mock.js
+++ b/src/Administration/Resources/app/administration/test/module/sw-import-export/service/mocks/entity-schema.mock.js
@@ -1374,6 +1374,13 @@ export default {
                     translatable: true
                 }
             },
+            packUnitPlural: {
+                type: 'string',
+                flags: {
+                    inherited: true,
+                    translatable: true
+                }
+            },
             customFields: {
                 type: 'json_object',
                 properties: [],
@@ -3222,6 +3229,10 @@ export default {
                 flags: []
             },
             packUnit: {
+                type: 'string',
+                flags: []
+            },
+            packUnitPlural: {
                 type: 'string',
                 flags: []
             },

--- a/src/Core/Content/Product/Aggregate/ProductTranslation/ProductTranslationDefinition.php
+++ b/src/Core/Content/Product/Aggregate/ProductTranslation/ProductTranslationDefinition.php
@@ -49,6 +49,7 @@ class ProductTranslationDefinition extends EntityTranslationDefinition
             (new LongTextField('description', 'description'))->addFlags(new AllowHtml()),
             new StringField('meta_title', 'metaTitle'),
             new StringField('pack_unit', 'packUnit'),
+            new StringField('pack_unit_plural', 'packUnitPlural'),
 
             new CustomFields(),
         ]);

--- a/src/Core/Content/Product/Aggregate/ProductTranslation/ProductTranslationEntity.php
+++ b/src/Core/Content/Product/Aggregate/ProductTranslation/ProductTranslationEntity.php
@@ -43,6 +43,11 @@ class ProductTranslationEntity extends TranslationEntity
     protected $packUnit;
 
     /**
+     * @var string|null
+     */
+    protected $packUnitPlural;
+
+    /**
      * @var ProductEntity|null
      */
     protected $product;
@@ -110,6 +115,16 @@ class ProductTranslationEntity extends TranslationEntity
     public function setPackUnit(?string $packUnit): void
     {
         $this->packUnit = $packUnit;
+    }
+
+    public function getPackUnitPlural(): ?string
+    {
+        return $this->packUnitPlural;
+    }
+
+    public function setPackUnitPlural(?string $packUnitPlural): void
+    {
+        $this->packUnitPlural = $packUnitPlural;
     }
 
     public function getProduct(): ?ProductEntity

--- a/src/Core/Content/Product/ProductDefinition.php
+++ b/src/Core/Content/Product/ProductDefinition.php
@@ -188,6 +188,7 @@ class ProductDefinition extends EntityDefinition
             (new TranslatedField('description'))->addFlags(new Inherited()),
             (new TranslatedField('metaTitle'))->addFlags(new Inherited()),
             (new TranslatedField('packUnit'))->addFlags(new Inherited()),
+            (new TranslatedField('packUnitPlural'))->addFlags(new Inherited()),
             new TranslatedField('customFields'),
 
             //parent - child inheritance

--- a/src/Core/Content/Product/ProductEntity.php
+++ b/src/Core/Content/Product/ProductEntity.php
@@ -239,6 +239,11 @@ class ProductEntity extends Entity
     protected $packUnit;
 
     /**
+     * @var string|null
+     */
+    protected $packUnitPlural;
+
+    /**
      * @var array|null
      */
     protected $variantRestrictions;
@@ -720,6 +725,16 @@ class ProductEntity extends Entity
     public function setPackUnit(?string $packUnit): void
     {
         $this->packUnit = $packUnit;
+    }
+
+    public function getPackUnitPlural(): ?string
+    {
+        return $this->packUnitPlural;
+    }
+
+    public function setPackUnitPlural(?string $packUnitPlural): void
+    {
+        $this->packUnitPlural = $packUnitPlural;
     }
 
     public function getTax(): ?TaxEntity

--- a/src/Core/Migration/Migration1536233120Product.php
+++ b/src/Core/Migration/Migration1536233120Product.php
@@ -70,7 +70,7 @@ class Migration1536233120Product extends MigrationStep
               `tags` BINARY(16) NULL,
               `variant_restrictions` JSON NULL,
               `configurator_group_sorting` JSON NULL,
-              # TODO Camel case naming is currenc intended. See NEXT-3085 
+              # TODO Camel case naming is currenc intended. See NEXT-3085
               `searchKeywords` BINARY(16) NULL,
               `created_at` DATETIME(3) NULL,
               `updated_at` DATETIME(3) NULL,
@@ -109,6 +109,7 @@ class Migration1536233120Product extends MigrationStep
               `description` MEDIUMTEXT COLLATE utf8mb4_unicode_ci NULL,
               `meta_title` VARCHAR(255) COLLATE utf8mb4_unicode_ci NULL,
               `pack_unit` VARCHAR(255) COLLATE utf8mb4_unicode_ci NULL,
+              `pack_unit_plural` VARCHAR(255) COLLATE utf8mb4_unicode_ci NULL,
               `custom_fields` JSON NULL,
               `created_at` DATETIME(3) NOT NULL,
               `updated_at` DATETIME(3) NULL,

--- a/src/Storefront/Resources/views/storefront/page/product-detail/buy-widget-form.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/product-detail/buy-widget-form.html.twig
@@ -26,7 +26,16 @@
                                         class="custom-select product-detail-quantity-select">
                                     {% for quantity in range(product.minPurchase, product.calculatedMaxPurchase, product.purchaseSteps) %}
                                         <option value="{{ quantity }}">
-                                            {{ quantity }}{% if product.packUnit %} {{ product.packUnit }}{% endif %}
+                                            {{ quantity }}
+                                            {% if quantity == 1 %}
+                                                {% if product.packUnit %} {{ product.packUnit }}{% endif %}
+                                            {% else %}
+                                                {% if product.packUnitPlural %}
+                                                    {{ product.packUnitPlural }}
+                                                {% elseif product.packUnit %}
+                                                    {{ product.packUnit }}
+                                                {% endif %}
+                                            {% endif %}
                                         </option>
                                     {% endfor %}
                                 </select>


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/community).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?

To have the correct plural or singular name for the package unit of one product.

### 2. What does this change do, exactly?

It adds another text input to the sw-product-packaging-form so the user can add the correct (singular or plural) package unit one product.

### 3. Describe each step to reproduce the issue or behaviour.

Steps of the issue old behavior:
1- The user adds one package unit.
2- There is no way of setting the singular/plural form of a packaging unit because there is only one input field.
3- In the frontend the quantity select on the product detail page will have a wrong value for either singular or plural quantities.

Example of old output:
1 Bottle
2 Bottle
...
Or:
1 Bottles
2 Bottles
...

### 4. Please link to the relevant issues (if any).

/issues/868

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.