### PR TITLE
NEXT-8288 Newsletter GDPR

### DIFF
--- a/CHANGELOG-6.2.md
+++ b/CHANGELOG-6.2.md
@@ -588,6 +588,8 @@ To get the diff between two versions, go to https://github.com/shopware/platform
         * page_checkout_confirm_form_submit
     * Added JS plugins `FormCsrfHandler` and `FormPreserver` to the `<form>` element in `src/Storefront/Resources/views/storefront/page/account/order/index.html.twig`
     * Removed alphanumeric filter product numbers in the quick add action
+    * Removed `required` status for `firstName` and `lastName`on `newsletter-form.html.twig`
+    * Added fallback for missing `getFirstName` and `getLastName` on `NewsletterRegisterEvent.php`
 
 **Removals**
 

--- a/src/Core/Content/Newsletter/Event/NewsletterRegisterEvent.php
+++ b/src/Core/Content/Newsletter/Event/NewsletterRegisterEvent.php
@@ -83,9 +83,15 @@ class NewsletterRegisterEvent extends Event implements MailActionInterface
             return $this->mailRecipientStruct;
         }
 
+        $recipientName = $this->newsletterRecipient->getEmail();
+
+        if ($this->newsletterRecipient->getFirstName() && $this->newsletterRecipient->getLastName()) {
+            $recipientName =  $this->newsletterRecipient->getFirstName() . ' ' . $this->newsletterRecipient->getLastName();
+        }
+
         return new MailRecipientStruct(
             [
-                $this->newsletterRecipient->getEmail() => $this->newsletterRecipient->getFirstName() . ' ' . $this->newsletterRecipient->getLastName(),
+                $this->newsletterRecipient->getEmail() => $recipientName
             ]
         );
     }

--- a/src/Storefront/Resources/views/storefront/element/cms-element-form/form-types/newsletter-form.html.twig
+++ b/src/Storefront/Resources/views/storefront/element/cms-element-form/form-types/newsletter-form.html.twig
@@ -59,7 +59,6 @@
                     {% sw_include '@Storefront/storefront/element/cms-element-form/form-components/cms-element-form-input.html.twig'
                         with {
                         fieldName: 'firstName',
-                        required: true,
                         additionalClass: 'col-md-4',
                         label: 'newsletter.labelFirstName',
                         placeholder: 'newsletter.placeholderFirstName'
@@ -71,7 +70,6 @@
                     {% sw_include '@Storefront/storefront/element/cms-element-form/form-components/cms-element-form-input.html.twig'
                         with {
                         fieldName: 'lastName',
-                        required: true,
                         additionalClass: 'col-md-4',
                         label: 'newsletter.labelLastName',
                         placeholder: 'newsletter.placeholderLastName'


### PR DESCRIPTION
### 1. Why is this change necessary?
GDPR Compliance

### 2. What does this change do, exactly?
* Removed `required` status for `firstName` and `lastName`on `newsletter-form.html.twig`
* Added fallback for missing `getFirstName` and `getLastName` on `NewsletterRegisterEvent.php`

