### PR TITLE
Normalize timezone of DateTime objects during serialization

### DIFF
--- a/src/Core/Framework/DataAbstractionLayer/FieldSerializer/DateFieldSerializer.php
+++ b/src/Core/Framework/DataAbstractionLayer/FieldSerializer/DateFieldSerializer.php
@@ -42,6 +42,8 @@ class DateFieldSerializer extends AbstractFieldSerializer
 
             return;
         }
+        
+        $value = $value->setTimezone(new \DateTimeZone('UTC'));
 
         yield $field->getStorageName() => $value->format(Defaults::STORAGE_DATE_FORMAT);
     }


### PR DESCRIPTION
### 1. Why is this change necessary?
The timezone is purposefully omitted in the format of `datetime` columns. (See https://github.com/shopware/platform/blob/6.2/src/Core/Defaults.php#L40)
When a `DateTime` object with timezone `+02:00` is written by the DAL and read again, the result will have a timezone of `+00:00` without having the time actually converted. So important information of this object is lost during serialization.

### 2. What does this change do, exactly?
With my change, the `DateTime` is converted 
to `UTC` a.k.a. `+00:00` during serialization, so the time actually stays the same.

### 3. Describe each step to reproduce the issue or behaviour.
1. Have a `DateTime` object like this: `2020-05-15 10:00:00+02:00`
2. Write it using the DAL and read it again.
3. Your result is `2020-05-15 10:00:00+00:00`. Timezone information is lost.

With my change in place, the read should give you `2020-05-15 08:00:00+00:00`.

### 4. Please link to the relevant issues (if any).
None (I think).

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
