### PR TITLE
Fix FKFields not being converted from hex to binary when used as the PK.

### DIFF
--- a/src/Core/Framework/DataAbstractionLayer/Dbal/CriteriaQueryHelper.php
+++ b/src/Core/Framework/DataAbstractionLayer/Dbal/CriteriaQueryHelper.php
@@ -107,7 +107,7 @@ trait CriteriaQueryHelper
 
         if (!\is_array($primaryKeys[0]) || \count($primaryKeys[0]) === 1) {
             $primaryKeyField = $definition->getPrimaryKeys()->first();
-            if ($primaryKeyField instanceof IdField) {
+            if ($primaryKeyField instanceof IdField || $primaryKeyField instanceof FkField) {
                 $primaryKeys = array_map(function ($id) {
                     if (is_array($id)) {
                         return Uuid::fromHexToBytes($id[0]);


### PR DESCRIPTION
### 1. Why is this change necessary?
When the primary key of an entity is a single FKField, using the constructor argument of Criteria won't work, because the hex representation of the ID is not converted to binary, causing the SQL query to find no results.

### 2. What does this change do, exactly?
It converts hex to binary for FKFields when previously this would only happen with IDFields. 

### 3. Describe each step to reproduce the issue or behaviour.
Try searchIds on the 'theme_sales_channel' entity.
`$criteria = new Criteria([Defaults::SALES_CHANNEL]);
$themeSalesChannelRepository->searchIds($criteria, $context);`

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.
