### PR TITLE
fix cursor on field copyable

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-field-copyable/sw-field-copyable.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-field-copyable/sw-field-copyable.scss
@@ -1,5 +1,5 @@
 .sw-field-copyable {
-    .sw-icon {
+    &.sw-icon {
         cursor: pointer;
     }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?
There is no pointer-cursor on field copyable because sw-icon isn't a child. So, the declaration is wrong.

### 2. What does this change do, exactly?
Fix scss for sw-field-copyable

### 3. Describe each step to reproduce the issue or behaviour.
- add Integration-Access
- move mouse over "copy-icon"
- see cursor not changing

![image](https://user-images.githubusercontent.com/135993/82210236-f2c7e580-990e-11ea-99dc-28ab56737c18.png)


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
