### PR TITLE
NTR: promotion shipping costs in offcanvas cart

### DIFF
--- a/src/Storefront/Resources/views/storefront/component/checkout/offcanvas-cart-summary.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/checkout/offcanvas-cart-summary.html.twig
@@ -21,19 +21,27 @@
             {% set activeShipping = page.cart.deliveries.elements[0] %}
 
             {% block component_offcanvas_summary_content_info %}
-                <div class="row offcanvas-shipping-info">
-                    <span class="col-7 shipping-label shipping-cost">
-                        <strong>{{ "checkout.summaryShipping"|trans|sw_sanitize }}</strong>
-
-                        <small {% if page.shippingMethods|length %}class="js-toggle-shipping-selection"{% endif %}>
-                            ({{ activeShipping.shippingMethod.translated.name }})
-                        </small>
-                    </span>
-
-                    <span class="col-5 shipping-value shipping-cost">
-                        + {{ activeShipping.shippingCosts.totalPrice|currency }}
-                    </span>
-                </div>
+                {% for shipping in page.cart.deliveries %}
+                    {% block component_offcanvas_summary_content_info_delivery %}
+                        <div class="row offcanvas-shipping-info">
+                            <span class="col-7 shipping-label shipping-cost">
+                                {% block component_offcanvas_summary_content_info_delivery_title %}
+                                    <strong>{{ "checkout.summaryShipping"|trans|sw_sanitize }}</strong>
+                                {% endblock %}
+                                {% block component_offcanvas_summary_content_info_delivery_method %}
+                                    <small {% if page.shippingMethods|length %}class="js-toggle-shipping-selection"{% endif %}>
+                                        ({{ shipping.shippingMethod.translated.name }})
+                                    </small>
+                                {% endblock %}
+                            </span>
+                            {% block component_offcanvas_summary_content_info_delivery_value %}
+                                <span class="col-5 shipping-value shipping-cost">
+                                    {{ shipping.shippingCosts.totalPrice|currency }}
+                                </span>
+                            {% endblock %}
+                        </div>
+                    {% endblock %}
+                {% endfor %}
             {% endblock %}
 
             {% block component_offcanvas_summary_content_shipping %}


### PR DESCRIPTION

### 1. Why is this change necessary?
at the moment only one delivery will be shown in the offcanvas cart
but promotion with shipping costs will create an additional delivery.
its shown in the cart, but not in the off canvas cart

### 2. What does this change do, exactly?
it will show multiple delivery entries in the off canvart.
please note i've removed the hardcoded +.
a minus comes from the float value, otherwise nothing is shown

### 3. Describe each step to reproduce the issue or behaviour.
create a promotion with shipping costs.
add it to a cart with shipping costs.
you'll see the correct cart sum in the off canvas, but it looks as if shipping costs will be added

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.

<img width="520" alt="Screenshot 2020-05-18 at 15 00 26" src="https://user-images.githubusercontent.com/5579326/82247784-448c6200-9947-11ea-84e3-a1129613316c.png">
