### PR TITLE
NEXT-6803 - Fix weight calculation for shippingcosts Fixes #945

### DIFF
--- a/src/Core/Checkout/Cart/Delivery/Struct/DeliveryPositionCollection.php
+++ b/src/Core/Checkout/Cart/Delivery/Struct/DeliveryPositionCollection.php
@@ -67,7 +67,7 @@ class DeliveryPositionCollection extends Collection
     {
         $weights = $this->getLineItems()->map(function (LineItem $deliverable) {
             if ($deliverable->getDeliveryInformation()) {
-                return $deliverable->getDeliveryInformation()->getWeight();
+                return $deliverable->getDeliveryInformation()->getWeight() * $deliverable->getQuantity();
             }
 
             return 0;


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/community).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
There is a bug in shipping costs calculation in case multiple items of same product are sold.

### 2. What does this change do, exactly?
It multiplies the product weight in the line item with the quantity in the lineitem.

### 3. Describe each step to reproduce the issue or behaviour.
Set product the product weight of a product to 5Kg.
Set shippingcosts with a price matrix for 1 - 9 Kg = 1 euro and 10 - 100 Kg = 2 euro.
So in case you order 1 item, it should be 1 euro because the weight is 5 Kg.
In case you order two items of the same product the weight becomes 10 Kg so shippingcosts should be 2 euro, however it always uses the weight of 1 item so it stays 1 euro.

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/NEXT-6803

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
