### PR TITLE
Reduce strictness in changelog format

### DIFF
--- a/src/Core/Framework/Plugin/Changelog/ChangelogParser.php
+++ b/src/Core/Framework/Plugin/Changelog/ChangelogParser.php
@@ -16,7 +16,7 @@ class ChangelogParser
         $currentRelease = null;
 
         foreach ($this->parse($path) as $line) {
-            switch ($line[0]) {
+            switch (mb_substr($line, 0, 1)) {
                 case '#':
                     $currentRelease = $this->parseTitle($line);
 
@@ -44,7 +44,7 @@ class ChangelogParser
         }
 
         while ($line = fgets($file)) {
-            yield $line;
+            yield ltrim($line);
         }
 
         fclose($file);
@@ -52,11 +52,11 @@ class ChangelogParser
 
     private function parseTitle($line): string
     {
-        return mb_strtolower(trim(mb_substr($line, 1)));
+        return mb_strtolower(rtrim(ltrim($line, '# \t')));
     }
 
     private function parseItem($line): string
     {
-        return trim(mb_substr($line, 1));
+        return rtrim(ltrim($line, '-* \t'));
     }
 }

--- a/src/Core/Framework/Test/Plugin/_fixture/plugins/SwagTest/CHANGELOG_de-DE.md
+++ b/src/Core/Framework/Test/Plugin/_fixture/plugins/SwagTest/CHANGELOG_de-DE.md
@@ -1,7 +1,7 @@
 # 1.0.0
-- SwagTest initialisiert
-* composer.json angepasst
+ - SwagTest initialisiert
+ * composer.json angepasst
 
-# 1.0.1
-- Migrationen hinzugefügt
-* nichts gemacht
+## 1.0.1
+-- Migrationen hinzugefügt
+** nichts gemacht


### PR DESCRIPTION
### 1. Why is this change necessary?
This allows less strict changelog files as those should be readable in other markdown renderers e.g. on code hosting services as well as in shopware.

```
# Changelog

## 1.0.0
- Initial setup

### 1.1.0

 * This is a very great feature
 ** Part of this feature is an additional indention
```

### 2. What does this change do, exactly?
Change substrings against trims to allow similar effect (removing symbols on the left side of a line).

### 3. Describe each step to reproduce the issue or behaviour.
1. Use an open source plugin with a similar changelog like in point 1
2. Publish it on github
3. Improve rendering for github markdown renderer
4. Prepare it for community store release
5. Get a hint that there is a built-in changelog reader that is not able parse the changelog file

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
