### PR TITLE
Product list filters NEXT-8591 #880

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/sidebar/sw-filter-sidebar-item/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/sidebar/sw-filter-sidebar-item/index.js
@@ -169,6 +169,7 @@ Component.register('sw-filter-sidebar-item', {
                 }
 
                 if ((typeof value === 'undefined') || value === null || value.length === 0) return;
+                if (filterOption.inputType === filterInputTypeOptions.switch && !value) return;
 
                 try {
                     criteriaArray.push(Criteria[filterOption.criteriaType](field, value));

--- a/src/Administration/Resources/app/administration/src/app/component/sidebar/sw-filter-sidebar-item/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/sidebar/sw-filter-sidebar-item/index.js
@@ -1,0 +1,218 @@
+import template from './sw-filter-sidebar-item.html.twig';
+import './sw-filter-sidebar-item.scss';
+
+const { Component } = Shopware;
+const { Criteria } = Shopware.Data;
+
+const filterInputTypeOptions = {
+    switch: 'switch',
+    range: 'range',
+    input: 'input',
+    number: 'number',
+    singleSelect: 'singleSelect',
+    multiSelect: 'multiSelect'
+};
+
+Component.register('sw-filter-sidebar-item', {
+    template,
+
+    inject: ['repositoryFactory'],
+
+    data() {
+        return {
+            isLoading: false,
+            filter: {},
+            selectedOptions: {},
+            repository: {}
+        };
+    },
+
+    props: {
+        filterOptions: {
+            type: Array,
+            required: false,
+            default: [
+                {
+                    name: 'activeInactive',
+                    label: 'activeInactive',
+                    placeholder: 'activeInactive',
+                    field: 'product.active',
+                    inputType: 'singleSelect',
+                    criteriaType: 'equals',
+                    options: [
+                        {
+                            name: 'Active',
+                            value: true
+                        },
+                        {
+                            name: 'Inactive',
+                            value: false
+                        }
+                    ]
+                }
+            ],
+            schema: [{
+                name: 'camelCase, unique',
+                label: 'label for input',
+                placeholder: 'placeholder for input',
+                field: 'field for query e.g. product.active',
+                inputType: 'one of filterInputTypeOptions',
+                criteriaType: 'Criteria operator e.g. equals',
+                options: [
+                    {
+                        name: 'option name',
+                        value: 'unique id'
+                    },
+                    {
+                        name: 'option name',
+                        value: 'unique id'
+                    }
+                ],
+                repository: 'repository reference used to with repositoryFactory.create - this is used to populate options'
+            }]
+        }
+    },
+
+    watch: {
+        filter: {
+            handler() {
+                this.$emit('update-criteria-array', this.getCriteriaArray());
+            },
+            deep: true
+        }
+    },
+
+    async created() {
+        this.setRepositoriesAndNestedVariables();
+
+        await this.setOptionsOnFilters();
+    },
+
+    methods: {
+        inputTrigger(event, filterOptionName) {
+            this.$set(this.filter, filterOptionName, event);
+        },
+
+        setRepositoriesAndNestedVariables() {
+            const neededRepositories = [];
+            this.filterOptions.forEach((filterOption) => {
+                if (filterOption.repository) {
+                    neededRepositories.push(filterOption.repository);
+                }
+
+                if (filterOption.inputType === 'range') {
+                    this.$set(this.filter, filterOption.name, { from: null, to: null });
+                }
+            });
+
+            neededRepositories.forEach((neededRepository) => {
+                this.repository[neededRepository] = this.repositoryFactory.create(neededRepository);
+            });
+        },
+
+        rangeInputTrigger(event, filterOptionName, criteria) {
+            const value = this.filter[filterOptionName];
+            value[criteria] = event;
+
+            this.$set(this.filter, filterOptionName, value);
+        },
+
+        setOptionsOnFilters() {
+            this.loading = true;
+            const promises = [];
+            this.filterOptions.forEach((filterOption) => {
+                if (filterOption.repository) {
+                    promises.push(this.repository[filterOption.repository].search(
+                        new Criteria(),
+                        Shopware.Context.api
+                    ).then((response) => {
+                        response = response.map((object) => {
+                            return {
+                                name: object.name || object.title,
+                                value: object.id
+                            };
+                        });
+
+                        filterOption.options = response;
+                    }));
+                }
+            });
+            return Promise.all(promises).then(() => {
+                this.loading = false;
+                this.$forceUpdate();
+            });
+        },
+
+        getCriteriaArray() {
+            const criteriaArray = [];
+
+            this.filterOptions.forEach((filterOption) => {
+                if (!filterInputTypeOptions[filterOption.inputType]) {
+                    console.error(`Unknown type ${filterOption.inputType} for ${JSON.parse(filterOption)}`);
+                    return;
+                }
+
+                const { field } = filterOption;
+
+                let value;
+                if (filterOption.criteriaType === filterInputTypeOptions.range) {
+                    value = {};
+                    if (this.filter[filterOption.name].from || this.filter[filterOption.name].from === 0) {
+                        value.gte = this.filter[filterOption.name].from;
+                    }
+                    if (this.filter[filterOption.name].to || this.filter[filterOption.name].to === 0) {
+                        value.lte = this.filter[filterOption.name].to;
+                    }
+                    if (!value.gte && value.gte !== 0 && !value.lte && value.lte !== 0) return;
+                } else {
+                    value = this.filter[filterOption.name];
+                }
+
+                if ((typeof value === 'undefined') || value === null || value.length === 0) return;
+
+                try {
+                    criteriaArray.push(Criteria[filterOption.criteriaType](field, value));
+                } catch (e) {
+                    console.error(`Unknown criteriaType ${filterOption.criteriaType} for ${filterOption}`);
+                    console.error(e);
+                }
+            });
+
+            return criteriaArray;
+        },
+
+        getManufacturerList() {
+            const criteria = new Criteria();
+            criteria.setLimit(500);
+            this.manufacturerRepository.search(criteria, Shopware.Context.api).then(response => {
+                let manufacturers = response;
+
+                manufacturers = manufacturers.map((manufacturer) => {
+                    return {
+                        id: manufacturer.id,
+                        name: manufacturer.name
+                    };
+                });
+
+                this.manufacturers = manufacturers;
+            });
+        },
+
+        getSalesChannelList() {
+            const criteria = new Criteria();
+            criteria.setLimit(500);
+            this.salesChannelRepository.search(criteria, Shopware.Context.api).then(response => {
+                let salesChannels = response;
+
+                salesChannels = salesChannels.map((salesChannel) => {
+                    return {
+                        id: salesChannel.id,
+                        name: salesChannel.name
+                    };
+                });
+
+                this.salesChannels = salesChannels;
+            });
+        }
+    }
+});

--- a/src/Administration/Resources/app/administration/src/app/component/sidebar/sw-filter-sidebar-item/sw-filter-sidebar-item.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/sidebar/sw-filter-sidebar-item/sw-filter-sidebar-item.html.twig
@@ -1,0 +1,78 @@
+{% block sw_product_list_sidebar_filter %}
+<sw-sidebar-item
+        icon="default-action-filter"
+        title="Filter"
+        ref="filter">
+
+    <sw-container v-for="filterOption in filterOptions" :key="filterOption.name" columns="1fr " gap="6px"
+                  class="sidebar--filter-container">
+        <sw-switch-field
+                v-if="filterOption.inputType === 'switch'"
+                size="small"
+                :label="filterOption.label"
+                :placeholder="filterOption.placeholder"
+                v-model="filter[filterOption.name]">
+        </sw-switch-field>
+
+        <sw-text-field
+                v-else-if="filterOption.inputType === 'input'"
+                :label="filterOption.label"
+                :placeholder="filterOption.placeholder"
+                :value="filter.productNumber"
+                @input="inputTrigger($event, filterOption.name)">
+        </sw-text-field>
+
+        <sw-number-field
+                v-else-if="filterOption.inputType === 'number'"
+                numberType="float"
+                :label="filterOption.label"
+                :placeholder="filterOption.placeholder"
+                :value="filter[filterOption.name]"
+                @change="inputTrigger($event, filterOption.name)">
+        </sw-number-field>
+
+        <sw-single-select
+                v-else-if="filterOption.inputType === 'singleSelect'"
+                v-model="filter[filterOption.name]"
+                :label="filterOption.label"
+                :placeholder="filterOption.placeholder"
+                :options="filterOption.options"
+                valueProperty="value"
+                labelProperty="name"
+                :value="filter[filterOption.name]">
+        </sw-single-select>
+
+        <sw-multi-select
+                v-else-if="filterOption.inputType === 'multiSelect'"
+                v-model="filter[filterOption.name]"
+                :label="filterOption.label"
+                :placeholder="filterOption.placeholder"
+                :options="filterOption.options"
+                valueProperty="value"
+                labelProperty="name"
+                :value="filter[filterOption.name]">
+        </sw-multi-select>
+
+
+        <span v-else-if="filterOption.inputType === 'range'">
+            <h3>{{ filterOption.label }}</h3>
+            <sw-container columns="1fr 1fr" gap="12px">
+                <sw-number-field numberType="float"
+                                 :label="$tc('sw-product.list.filter.range.from.placeholder')"
+                                 :placeholder="$tc('sw-product.list.filter.range.from.placeholder')"
+                                 :value="filter[filterOption.name].from"
+                                 @change="rangeInputTrigger($event, filterOption.name, 'from')">
+                </sw-number-field>
+
+                <sw-number-field numberType="float"
+                                 :label="$tc('sw-product.list.filter.range.to.placeholder')"
+                                 :placeholder="$tc('sw-product.list.filter.range.to.placeholder')"
+                                 :value="filter[filterOption.name].to"
+                                 @change="rangeInputTrigger($event, filterOption.name, 'to')">
+                </sw-number-field>
+            </sw-container>
+        </span>
+    </sw-container>
+
+</sw-sidebar-item>
+{% endblock %}

--- a/src/Administration/Resources/app/administration/src/app/component/sidebar/sw-filter-sidebar-item/sw-filter-sidebar-item.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/sidebar/sw-filter-sidebar-item/sw-filter-sidebar-item.scss
@@ -1,0 +1,6 @@
+.sidebar--filter-container {
+    padding: 15px;
+    .sw-field--switch {
+        margin: 0;
+    }
+}

--- a/src/Administration/Resources/app/administration/src/module/sw-customer/page/sw-customer-list/sw-customer-list.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-customer/page/sw-customer-list/sw-customer-list.html.twig
@@ -196,8 +196,9 @@
                     {% endblock %}
 
                     {% block sw_customer_list_sidebar_filter %}
-                        <sw-sidebar-item icon="default-action-filter"
-                                         :title="$tc('sw-customer.list.titleSidebarItemFilter')">
+                        <sw-sidebar-item
+                                icon="default-action-filter"
+                                :title="$tc('sw-customer.list.titleSidebarItemFilter')">
 
                             {% block sw_customer_list_sidebar_filter_affiliate_code %}
                                 <sw-multi-select

--- a/src/Administration/Resources/app/administration/src/module/sw-product/page/sw-product-list/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/page/sw-product-list/index.js
@@ -24,7 +24,75 @@ Component.register('sw-product-list', {
             naturalSorting: true,
             isLoading: false,
             isBulkLoading: false,
-            total: 0
+            total: 0,
+            criteriaArray: [],
+            filterOptions: [
+                {
+                    name: 'onClearance',
+                    label: this.$tc('sw-product.list.filter.clearanceSale.label'),
+                    field: 'product.isCloseout',
+                    inputType: 'switch',
+                    criteriaType: 'equals'
+                },
+                {
+                    name: 'activeInactive',
+                    label: this.$tc('sw-product.list.filter.activeInactive.label'),
+                    placeholder: this.$tc('sw-product.list.filter.activeInactive.placeholder'),
+                    field: 'product.active',
+                    inputType: 'singleSelect',
+                    criteriaType: 'equals',
+                    options: [
+                        {
+                            name: 'Active',
+                            value: true
+                        },
+                        {
+                            name: 'Inactive',
+                            value: false
+                        }
+                    ]
+                },
+                {
+                    name: 'manufacturer',
+                    label: this.$tc('sw-product.list.filter.manufacturer.label'),
+                    placeholder: this.$tc('sw-product.list.filter.manufacturer.placeholder'),
+                    field: 'product.manufacturerId',
+                    inputType: 'multiSelect',
+                    criteriaType: 'equalsAny',
+                    repository: 'product_manufacturer'
+                },
+                {
+                    name: 'salesChannel',
+                    label: this.$tc('sw-product.list.filter.salesChannel.label'),
+                    placeholder: this.$tc('sw-product.list.filter.salesChannel.placeholder'),
+                    field: 'product.visibilities.salesChannelId',
+                    inputType: 'multiSelect',
+                    criteriaType: 'equalsAny',
+                    repository: 'sales_channel'
+                },
+                {
+                    name: 'productNumber',
+                    label: this.$tc('sw-product.list.filter.productNumber.label'),
+                    placeholder: this.$tc('sw-product.list.filter.productNumber.placeholder'),
+                    field: 'product.productNumber',
+                    inputType: 'input',
+                    criteriaType: 'contains'
+                },
+                {
+                    name: 'price',
+                    label: this.$tc('sw-product.list.filter.price.label'),
+                    field: 'product.price',
+                    inputType: 'range',
+                    criteriaType: 'range'
+                },
+                {
+                    name: 'stock',
+                    label: this.$tc('sw-product.list.filter.stock.label'),
+                    field: 'product.stock',
+                    inputType: 'range',
+                    criteriaType: 'range'
+                }
+            ]
         };
     },
 
@@ -78,6 +146,11 @@ Component.register('sw-product-list', {
     },
 
     methods: {
+        updateCriteria(criteriaArray) {
+            this.criteriaArray = criteriaArray;
+            this.getList();
+        },
+
         getList() {
             this.isLoading = true;
 
@@ -89,6 +162,10 @@ Component.register('sw-product-list', {
             productCriteria.addSorting(Criteria.sort(this.sortBy, this.sortDirection, this.naturalSorting));
             productCriteria.addAssociation('cover');
             productCriteria.addAssociation('manufacturer');
+
+            this.criteriaArray.forEach((filter) => {
+                productCriteria = productCriteria.addFilter(filter);
+            });
 
             const currencyCriteria = new Criteria(1, 500);
 

--- a/src/Administration/Resources/app/administration/src/module/sw-product/page/sw-product-list/sw-product-list.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/page/sw-product-list/sw-product-list.twig
@@ -148,6 +148,13 @@
                             @click="onRefresh">
                         </sw-sidebar-item>
                     {% endblock %}
+
+                    {% block sw_product_list_sidebar_filter %}
+                        <sw-filter-sidebar-item
+                                @update-criteria-array="updateCriteria"
+                                :filterOptions="filterOptions">
+                        </sw-filter-sidebar-item>
+                    {% endblock %}
                 </sw-sidebar>
             </template>
         {% endblock %}

--- a/src/Administration/Resources/app/administration/src/module/sw-product/snippet/de-DE.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/snippet/de-DE.json
@@ -180,7 +180,47 @@
       "textDeleteConfirm": "Möchtest Du das Produkt \"{name}\" wirklich löschen? | Möchtest Du diese {count} Produkte wirklich löschen?",
       "titleSidebarItemRefresh": "Aktualisieren",
       "titleSaveSuccess": "Erfolg",
-      "messageSaveSuccess": "Das Produkt \"{name}\" wurde erfolgreich gespeichert."
+      "messageSaveSuccess": "Das Produkt \"{name}\" wurde erfolgreich gespeichert.",
+      "filter": {
+        "manufacturer" : {
+          "label": "Manufacturer",
+          "placeholder": "Manufacturer"
+        },
+        "activeInactive": {
+          "label": "Only show Active / Inactive products",
+          "placeholder": "Active / Inactive"
+        },
+        "clearanceSale": {
+          "label": "Show only on clearance"
+        },
+        "productNumber": {
+          "label": "Product Number",
+          "placeholder": "Product Number..."
+        },
+        "price": {
+          "label": "Price"
+        },
+        "range" : {
+          "from": {
+            "label": "From",
+            "placeholder": "From..."
+          },
+          "to": {
+            "label": "To",
+            "placeholder": "To..."
+          }
+        },
+        "stock": {
+          "label": "Stock"
+        },
+        "missingCover": {
+          "label": "Missing cover image"
+        },
+        "salesChannel": {
+          "label": "Sales Channel",
+          "placeholder": "Sales Channel"
+        }
+      }
     },
     "detail": {
       "textHeadline": "Neues Produkt",

--- a/src/Administration/Resources/app/administration/src/module/sw-product/snippet/en-GB.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/snippet/en-GB.json
@@ -179,7 +179,47 @@
       "textDeleteConfirm": "Are you sure you really want to delete the product \"{name}\"? | Are you sure you really want to delete these {count} products?",
       "titleSidebarItemRefresh": "Refresh",
       "titleSaveSuccess": "Success",
-      "messageSaveSuccess": "Product \"{name}\" has been saved."
+      "messageSaveSuccess": "Product \"{name}\" has been saved.",
+      "filter": {
+        "manufacturer" : {
+          "label": "Manufacturer",
+          "placeholder": "Manufacturer"
+        },
+        "activeInactive": {
+          "label": "Only show Active / Inactive products",
+          "placeholder": "Active / Inactive"
+        },
+        "clearanceSale": {
+          "label": "Show only on clearance"
+        },
+        "productNumber": {
+          "label": "Product Number",
+          "placeholder": "Product Number..."
+        },
+        "price": {
+          "label": "Price"
+        },
+        "range" : {
+          "from": {
+            "label": "From",
+            "placeholder": "From..."
+          },
+          "to": {
+            "label": "To",
+            "placeholder": "To..."
+          }
+        },
+        "stock": {
+          "label": "Stock"
+        },
+        "missingCover": {
+          "label": "Missing cover image"
+        },
+        "salesChannel": {
+          "label": "Sales Channel",
+          "placeholder": "Sales Channel"
+        }
+      }
     },
     "detail": {
       "textHeadline": "New product",


### PR DESCRIPTION
### 1. Why is this change necessary?
Fix for issue #880 

### 2. What does this change do, exactly?
Allows the filtering of products on the product list page in the admin panel.

The filter sidebar item is created as its own component and can be used on any list page with by simply passing an array of what filter options is wanted.

### 3. Describe each step to reproduce the issue or behaviour.
Go to product listing page in the administration panel, before change is was not possible to filter in the result, after change it is.

### 4. Please link to the relevant issues (if any).
#880 

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
