### PR TITLE
do not autoplay videos in admin

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/vimeo-video/component/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/vimeo-video/component/index.js
@@ -19,6 +19,7 @@ Component.register('sw-cms-el-vimeo-video', {
             return this.element.config.videoID.value;
         },
 
+        /** @deprecated:v6.4.0 */
         autoplay() {
             if (!this.element.config.autoplay.value) {
                 return '';
@@ -94,7 +95,6 @@ Component.register('sw-cms-el-vimeo-video', {
         videoUrl() {
             return `https://player.vimeo.com/video/
             ${this.videoID}?\
-            ${this.autoplay}\
             ${this.byLine}\
             ${this.color}\
             ${this.doNotTrack}\

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/youtube-video/component/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/youtube-video/component/index.js
@@ -19,6 +19,7 @@ Component.register('sw-cms-el-youtube-video', {
             return 'rel=0&';
         },
 
+        /** @deprecated:v6.4.0 */
         autoPlay() {
             if (!this.element.config.autoPlay.value) {
                 return '';
@@ -67,7 +68,6 @@ Component.register('sw-cms-el-youtube-video', {
             const url = `https://www.youtube-nocookie.com/embed/\
             ${this.videoID}?\
             ${this.relatedVideos}\
-            ${this.autoPlay}\
             ${this.loop}\
             ${this.showControls}\
             ${this.start}\


### PR DESCRIPTION
### 1. Why is this change necessary?
Oh, yeah! Some people are embedding youtube or vimeo in their shops. I don't like to discuss its detriment ... but ...

Activating autoplay should not start video in administration because it's very annoying.

### 2. What does this change do, exactly?
Remove managing `autoPlay`-config in administration.

### 3. Describe each step to reproduce the issue or behaviour.
Add valid youtube-video to cms. Activate `autoPlay`, see and hear video(s) starting in administration. 

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
