### PR TITLE
Fix icon form plugin added settings icons are not used

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-settings/page/sw-settings-index/sw-settings-index.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings/page/sw-settings-index/sw-settings-index.html.twig
@@ -86,9 +86,9 @@
                                                                       :label="$tc(pluginSettingsItem.label)"
                                                                       :to="{ name: pluginSettingsItem.to }"
                                                                       :id="pluginSettingsItem.id">
-                                                        <component v-if="pluginSettingsItem.iconComponent" :is="pluginSettingsItem.iconComponent"></component>
-                                                        <template v-else #icon>
-                                                            <sw-icon :name="pluginSettingsItem.icon"></sw-icon>
+                                                        <template #icon>
+                                                            <component v-if="pluginSettingsItem.iconComponent" :is="pluginSettingsItem.iconComponent"></component>
+                                                            <sw-icon v-else :name="pluginSettingsItem.icon"></sw-icon>
                                                         </template>
                                                     </sw-settings-item>
 


### PR DESCRIPTION
### 1. Why is this change necessary?
Icons of plugin added settings items don't work

### 2. What does this change do, exactly?
Fix issue on calling if and in else the template slot

### 3. Describe each step to reproduce the issue or behaviour.
Add an settings item like this in your plugin module:

settingsItem: [
        {
            name:   'acris-shop-switch-rule',
            to:     'acris.shop.switch.rule.index',
            label:  'acris-shop-switch-rule.general.mainMenuItemGeneral',
            group:  'plugins',
            icon:   'default-arrow-switch'
        }
    ]

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
