### PR TITLE
Addresses association in AccountOverviewPageLoader search criteria

### DIFF
--- a/src/Storefront/Page/Account/Overview/AccountOverviewPageLoader.php
+++ b/src/Storefront/Page/Account/Overview/AccountOverviewPageLoader.php
@@ -83,6 +83,7 @@ class AccountOverviewPageLoader
             ->addAssociation('lineItems')
             ->addAssociation('transactions.paymentMethod')
             ->addAssociation('deliveries.shippingMethod')
+            ->addAssociation('addresses')
             ->setLimit(1)
             ->addAssociation('orderCustomer');
 


### PR DESCRIPTION
### 1. Why is this change necessary?
`addresses` property of a `OrderrEntity` is null under the `/account` routing(account overview).
As a result displaying addresses in the last order overview is not possible.
This PR corresponds to https://github.com/shopware/platform/pull/866 the difference is that it has to do with a `newestOrder` field of `AccountOverviewPage` class object.

![obraz](https://user-images.githubusercontent.com/14996446/82798916-80f51c00-9e79-11ea-851f-622cf202f86d.png)

### 2. What does this change do, exactly?
addresses property of a OrderrEntity is **not** null.

### 3. Describe each step to reproduce the issue or behaviour.
Visit `Mein Konto/Übersicht`

### 4. Please link to the relevant issues (if any).


### 5. Checklist
- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
