### PR TITLE
Added pagination to entity single select component

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/form/select/entity/sw-entity-single-select-pagination/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/form/select/entity/sw-entity-single-select-pagination/index.js
@@ -4,5 +4,14 @@ import './sw-entity-single-select-pagination.scss';
 const { Component } = Shopware;
 
 Component.extend('sw-entity-single-select-pagination', 'sw-pagination', {
-    template
+    template,
+
+    computed: {
+        isFirstPage() {
+            return this.currentPage === 1;
+        },
+        isLastPage() {
+            return this.currentPage === this.maxPage;
+        }
+    }
 });

--- a/src/Administration/Resources/app/administration/src/app/component/form/select/entity/sw-entity-single-select-pagination/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/form/select/entity/sw-entity-single-select-pagination/index.js
@@ -1,0 +1,8 @@
+import template from './sw-entity-single-select-pagination.html.twig';
+import './sw-entity-single-select-pagination.scss';
+
+const { Component } = Shopware;
+
+Component.extend('sw-entity-single-select-pagination', 'sw-pagination', {
+    template
+});

--- a/src/Administration/Resources/app/administration/src/app/component/form/select/entity/sw-entity-single-select-pagination/sw-entity-single-select-pagination.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/form/select/entity/sw-entity-single-select-pagination/sw-entity-single-select-pagination.html.twig
@@ -2,12 +2,12 @@
     {% block sw_pagination %}
         <div class="sw-pagination sw-entity-single-select__pagination" v-if="shouldBeVisible">
             {% block sw_pagination_page_first %}
-                <button :disabled="currentPage === 1" @click.stop="firstPage" class="sw-pagination__page-button">
+                <button :disabled="isFirstPage" @click.stop="firstPage" class="sw-pagination__page-button">
                     <sw-icon name="small-arrow-medium-double-left" small/>
                 </button>
             {% endblock %}
             {% block sw_pagination_page_prev %}
-                <button :disabled="currentPage === 1" @click.stop="prevPage" class="sw-pagination__page-button">
+                <button :disabled="isFirstPage" @click.stop="prevPage" class="sw-pagination__page-button">
                     <sw-icon name="small-arrow-medium-left" small/>
                 </button>
             {% endblock %}
@@ -15,12 +15,12 @@
             {% block sw_pagination_page_list %}<span>{{ currentPage }}/{{ maxPage }}</span>{% endblock %}
 
             {% block sw_pagination_page_next %}
-                <button :disabled="currentPage === maxPage" @click.stop="nextPage" class="sw-pagination__page-button">
+                <button :disabled="isLastPage" @click.stop="nextPage" class="sw-pagination__page-button">
                     <sw-icon name="small-arrow-medium-right" small/>
                 </button>
             {% endblock %}
             {% block sw_pagination_page_last %}
-                <button :disabled="currentPage === maxPage" @click.stop="lastPage" class="sw-pagination__page-button">
+                <button :disabled="isLastPage" @click.stop="lastPage" class="sw-pagination__page-button">
                     <sw-icon name="small-arrow-medium-double-right" small/>
                 </button>
             {% endblock %}

--- a/src/Administration/Resources/app/administration/src/app/component/form/select/entity/sw-entity-single-select-pagination/sw-entity-single-select-pagination.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/form/select/entity/sw-entity-single-select-pagination/sw-entity-single-select-pagination.html.twig
@@ -1,0 +1,29 @@
+{% block sw_entity_single_select_pagination %}
+    {% block sw_pagination %}
+        <div class="sw-pagination sw-entity-single-select__pagination" v-if="shouldBeVisible">
+            {% block sw_pagination_page_first %}
+                <button :disabled="currentPage === 1" @click.stop="firstPage" class="sw-pagination__page-button">
+                    <sw-icon name="small-arrow-medium-double-left" small/>
+                </button>
+            {% endblock %}
+            {% block sw_pagination_page_prev %}
+                <button :disabled="currentPage === 1" @click.stop="prevPage" class="sw-pagination__page-button">
+                    <sw-icon name="small-arrow-medium-left" small/>
+                </button>
+            {% endblock %}
+
+            {% block sw_pagination_page_list %}<span>{{ currentPage }}/{{ maxPage }}</span>{% endblock %}
+
+            {% block sw_pagination_page_next %}
+                <button :disabled="currentPage === maxPage" @click.stop="nextPage" class="sw-pagination__page-button">
+                    <sw-icon name="small-arrow-medium-right" small/>
+                </button>
+            {% endblock %}
+            {% block sw_pagination_page_last %}
+                <button :disabled="currentPage === maxPage" @click.stop="lastPage" class="sw-pagination__page-button">
+                    <sw-icon name="small-arrow-medium-double-right" small/>
+                </button>
+            {% endblock %}
+        </div>
+    {% endblock %}
+{% endblock %}

--- a/src/Administration/Resources/app/administration/src/app/component/form/select/entity/sw-entity-single-select-pagination/sw-entity-single-select-pagination.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/form/select/entity/sw-entity-single-select-pagination/sw-entity-single-select-pagination.scss
@@ -1,0 +1,10 @@
+.sw-entity-single-select__pagination {
+    &.sw-pagination {
+        padding: 12px 15px;
+        min-height: unset;
+
+        .sw-pagination__page-button {
+            padding: 2px;
+        }
+    }
+}

--- a/src/Administration/Resources/app/administration/src/app/component/form/select/entity/sw-entity-single-select/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/form/select/entity/sw-entity-single-select/index.js
@@ -88,7 +88,8 @@ Component.register('sw-entity-single-select', {
             isLoading: false,
             // used to track if an item was selected before closing the result list
             itemRecentlySelected: false,
-            lastSelection: null
+            lastSelection: null,
+            totalItems: 0
         };
     },
 
@@ -113,17 +114,6 @@ Component.register('sw-entity-single-select', {
          * @returns {EntityCollection}
          */
         results() {
-            if (this.singleSelection && this.resultCollection) {
-                const collection = this.createCollection(this.resultCollection);
-                collection.push(this.singleSelection);
-                this.resultCollection.forEach((item) => {
-                    if (item.id !== this.singleSelection.id) {
-                        collection.add(item);
-                    }
-                });
-                return collection;
-            }
-
             return this.resultCollection;
         }
     },
@@ -220,23 +210,25 @@ Component.register('sw-entity-single-select', {
             return this.repository.search(this.criteria, this.context).then((result) => {
                 this.displaySearch(result);
 
+                this.totalItems = result.total;
+
                 this.isLoading = false;
 
                 return result;
             });
         },
 
-        displaySearch(result) {
-            if (!this.resultCollection) {
+        changePage(item) {
+            this.isLoading = true;
+            this.criteria.setPage(item.page);
+            this.repository.search(this.criteria, this.context).then((result) => {
                 this.resultCollection = result;
-            } else {
-                result.forEach(item => {
-                    // Prevent duplicate entries
-                    if (!this.resultCollection.has(item.id)) {
-                        this.resultCollection.push(item);
-                    }
-                });
-            }
+                this.isLoading = false;
+            });
+        },
+
+        displaySearch(result) {
+            this.resultCollection = result;
         },
 
         onSelectExpanded() {

--- a/src/Administration/Resources/app/administration/src/app/component/form/select/entity/sw-entity-single-select/sw-entity-single-select.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/form/select/entity/sw-entity-single-select/sw-entity-single-select.html.twig
@@ -80,15 +80,20 @@
                                     </template>
                                 {% endblock %}
 
-                                {% block sw_entity_single_select_base_results_list_after %}
+                                {% block sw_entity_single_select_base_results_list_pagination %}
                                     <template #after-item-list>
-                                        <slot name="after-item-list"></slot>
+                                        <sw-entity-single-select-pagination @page-change="changePage"
+                                                                            :total="totalItems"
+                                                                            :limit="resultLimit"
+                                                                            :page="criteria.page">
+                                        </sw-entity-single-select-pagination>
                                     </template>
                                 {% endblock %}
                             {% endblock %}
                         </sw-select-result-list>
                     {% endblock %}
                 </template>
+        <div>asdf</div>
             {% endblock %}
         {% endblock %}
     </sw-select-base>

--- a/src/Administration/Resources/app/administration/src/app/component/form/select/entity/sw-entity-single-select/sw-entity-single-select.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/form/select/entity/sw-entity-single-select/sw-entity-single-select.html.twig
@@ -80,13 +80,16 @@
                                     </template>
                                 {% endblock %}
 
-                                {% block sw_entity_single_select_base_results_list_pagination %}
+                                {% block sw_entity_single_select_base_results_list_after %}
                                     <template #after-item-list>
-                                        <sw-entity-single-select-pagination @page-change="changePage"
-                                                                            :total="totalItems"
-                                                                            :limit="resultLimit"
-                                                                            :page="criteria.page">
-                                        </sw-entity-single-select-pagination>
+                                        <slot name="after-item-list"></slot>
+                                        {% block sw_entity_single_select_base_results_list_pagination %}
+                                            <sw-entity-single-select-pagination @page-change="changePage"
+                                                                                :total="totalItems"
+                                                                                :limit="resultLimit"
+                                                                                :page="criteria.page">
+                                            </sw-entity-single-select-pagination>
+                                        {% endblock %}
                                     </template>
                                 {% endblock %}
                             {% endblock %}

--- a/src/Administration/Resources/app/administration/src/app/component/form/select/entity/sw-entity-single-select/sw-entity-single-select.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/form/select/entity/sw-entity-single-select/sw-entity-single-select.html.twig
@@ -93,7 +93,6 @@
                         </sw-select-result-list>
                     {% endblock %}
                 </template>
-        <div>asdf</div>
             {% endblock %}
         {% endblock %}
     </sw-select-base>


### PR DESCRIPTION
### 1. Why is this change necessary?
This is related to https://github.com/shopware/platform/issues/835. It is actually possible to display more then 25 entries, but it is quite tricky to reach them with the search or keyboard.

### 2. What does this change do, exactly?
It extends the sw-entity-single-select component with a version of the sw-pagination, enabling browsing through select fields with pagination if there are too many entries for one 'page'.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
