### PR TITLE
Fix custom entity repository definitions

### DIFF
--- a/src/Core/Framework/DependencyInjection/CompilerPass/EntityCompilerPass.php
+++ b/src/Core/Framework/DependencyInjection/CompilerPass/EntityCompilerPass.php
@@ -56,7 +56,7 @@ class EntityCompilerPass implements CompilerPassInterface
             /*
              * @deprecated tag:v6.3.0 use getEntityName instead
              */
-            if ($entity !== null && $entity !== $fallBackEntity) {
+            if ($fallBackEntity !== null && $entity !== $fallBackEntity) {
                 $entityNameMap[$fallBackEntity] = $serviceId;
                 $fallBackRepositoryId = $fallBackEntity . '.repository';
             }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/community).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
Shopware 6.2 deprecated the usage of `entity` on `shopware.entity.definition` tags, but omitting that attribute causes custom entity repository definitions to break.

### 2. What does this change do, exactly?

### 3. Describe each step to reproduce the issue or behaviour.
https://github.com/shopware/platform/blob/a2db8ae5c53228b872bcbf72d41a9ef52db7a919/src/Core/Framework/DependencyInjection/CompilerPass/EntityCompilerPass.php#L51-L70

Without this change `$fallBackRepositoryId` will always be `".repository"` for entity definitions that omit the `entity` attribute. This leads to a `ServiceNotFoundException` in line 68 and therefore the custom repository definition will be overwritten with the default `EntityRepository`.

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
