### PR TITLE
The taxes have to be detected based on the shipping addresses and not based on the billing addresses.

### DIFF
--- a/src/Core/System/Tax/TaxRuleType/EntireCountryRuleTypeFilter.php
+++ b/src/Core/System/Tax/TaxRuleType/EntireCountryRuleTypeFilter.php
@@ -23,8 +23,8 @@ class EntireCountryRuleTypeFilter implements TaxRuleTypeFilterInterface
 
     private function metPreconditions(TaxRuleEntity $taxRuleEntity, ?CustomerEntity $customer, ShippingLocation $shippingLocation): bool
     {
-        if ($customer !== null && $customer->getActiveBillingAddress() !== null) {
-            return $customer->getActiveBillingAddress()->getCountryId() === $taxRuleEntity->getCountryId();
+        if ($customer !== null && $customer->getActiveShippingAddress() !== null) {
+            return $customer->getActiveShippingAddress()->getCountryId() === $taxRuleEntity->getCountryId();
         }
 
         return $shippingLocation->getCountry()->getId() === $taxRuleEntity->getCountryId();

--- a/src/Core/System/Tax/TaxRuleType/IndividualStatesRuleTypeFilter.php
+++ b/src/Core/System/Tax/TaxRuleType/IndividualStatesRuleTypeFilter.php
@@ -34,8 +34,8 @@ class IndividualStatesRuleTypeFilter implements TaxRuleTypeFilterInterface
             return false;
         }
 
-        if ($customer !== null && $customer->getActiveBillingAddress()) {
-            return $customer->getActiveBillingAddress()->getCountryId() === $taxRuleEntity->getCountryId();
+        if ($customer !== null && $customer->getActiveShippingAddress()) {
+            return $customer->getActiveShippingAddress()->getCountryId() === $taxRuleEntity->getCountryId();
         }
 
         return $shippingLocation->getCountry()->getId() === $taxRuleEntity->getCountryId();
@@ -43,8 +43,8 @@ class IndividualStatesRuleTypeFilter implements TaxRuleTypeFilterInterface
 
     private function getStateId(?CustomerEntity $customer, ShippingLocation $shippingLocation): ?string
     {
-        if ($customer !== null && $customer->getActiveBillingAddress() !== null) {
-            return $customer->getActiveBillingAddress()->getCountryStateId();
+        if ($customer !== null && $customer->getActiveShippingAddress() !== null) {
+            return $customer->getActiveShippingAddress()->getCountryStateId();
         }
 
         return $shippingLocation->getState() !== null ? $shippingLocation->getState()->getId() : null;

--- a/src/Core/System/Tax/TaxRuleType/ZipCodeRangeRuleTypeFilter.php
+++ b/src/Core/System/Tax/TaxRuleType/ZipCodeRangeRuleTypeFilter.php
@@ -36,8 +36,8 @@ class ZipCodeRangeRuleTypeFilter implements TaxRuleTypeFilterInterface
             return false;
         }
 
-        if ($customer !== null && $customer->getActiveBillingAddress()) {
-            return $customer->getActiveBillingAddress()->getCountryId() === $taxRuleEntity->getCountryId();
+        if ($customer !== null && $customer->getActiveShippingAddress()) {
+            return $customer->getActiveShippingAddress()->getCountryId() === $taxRuleEntity->getCountryId();
         }
 
         return $shippingLocation->getCountry()->getId() === $taxRuleEntity->getCountryId();
@@ -45,8 +45,8 @@ class ZipCodeRangeRuleTypeFilter implements TaxRuleTypeFilterInterface
 
     private function getZipCode(?CustomerEntity $customer, ShippingLocation $shippingLocation): ?string
     {
-        if ($customer !== null && $customer->getActiveBillingAddress() !== null) {
-            return $customer->getActiveBillingAddress()->getZipcode();
+        if ($customer !== null && $customer->getActiveShippingAddress() !== null) {
+            return $customer->getActiveShippingAddress()->getZipcode();
         }
 
         $address = $shippingLocation->getAddress();

--- a/src/Core/System/Tax/TaxRuleType/ZipCodeRuleTypeFilter.php
+++ b/src/Core/System/Tax/TaxRuleType/ZipCodeRuleTypeFilter.php
@@ -34,8 +34,8 @@ class ZipCodeRuleTypeFilter implements TaxRuleTypeFilterInterface
             return false;
         }
 
-        if ($customer !== null && $customer->getActiveBillingAddress()) {
-            return $customer->getActiveBillingAddress()->getCountryId() === $taxRuleEntity->getCountryId();
+        if ($customer !== null && $customer->getActiveShippingAddress()) {
+            return $customer->getActiveShippingAddress()->getCountryId() === $taxRuleEntity->getCountryId();
         }
 
         return $shippingLocation->getCountry()->getId() === $taxRuleEntity->getCountryId();
@@ -43,8 +43,8 @@ class ZipCodeRuleTypeFilter implements TaxRuleTypeFilterInterface
 
     private function getZipCode(?CustomerEntity $customer, ShippingLocation $shippingLocation): ?string
     {
-        if ($customer !== null && $customer->getActiveBillingAddress() !== null) {
-            return $customer->getActiveBillingAddress()->getZipcode();
+        if ($customer !== null && $customer->getActiveShippingAddress() !== null) {
+            return $customer->getActiveShippingAddress()->getZipcode();
         }
 
         $address = $shippingLocation->getAddress();


### PR DESCRIPTION
### 1. Why is this change necessary?
The taxes have to be detected based on the shipping addresses and not based on the billing addresses.

### 2. What does this change do, exactly?
Change the tax detection rules to use the shipping and not the billing addresses.

### 3. Describe each step to reproduce the issue or behaviour.
When you have a billing and a shipping address as a customer inside different countries, the tax will be detected based on the billing address. This is false - it must be detected based on the shipping address.

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
