### PR TITLE
Fix change shipping address on confirm page

### DIFF
--- a/src/Storefront/Resources/views/storefront/page/checkout/confirm/confirm-address.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/checkout/confirm/confirm-address.html.twig
@@ -75,7 +75,7 @@
                             {% block page_checkout_confirm_address_shipping_actions %}
                                 <div class="card-actions">
                                     {% set addressEditorOptions = {
-                                        changeBilling: true,
+                                        changeShipping: true,
                                         addressId: shippingAddress.id,
                                         csrfToken: sw_csrf("frontend.account.addressbook", {"mode": "token"})
                                     } %}


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/community).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
Change shipping button on confirm page should change the shipping address.

### 2. What does this change do, exactly?
Fix the data attribute to change the shipping address instead of the billing address in the modal window.

### 3. Describe each step to reproduce the issue or behaviour.
Go on confirm page and try to change your inidvidual shipping address.

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/NEXT-8586

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
