### PR TITLE
use thumbnails for media in configurator option + add blocks

### DIFF
--- a/src/Storefront/Resources/views/storefront/page/product-detail/configurator.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/product-detail/configurator.html.twig
@@ -71,13 +71,25 @@
                                                                    for="{{ optionIdentifier }}">
 
                                                                 {% if displayType == 'media' and media %}
-                                                                    <img src="{{ media|sw_encode_media_url }}"
-                                                                         class="product-detail-configurator-option-image"
-                                                                         alt="{{ option.translated.name }}"/>
+                                                                    {% block page_product_detail_configurator_option_radio_label_media %}
+                                                                        {% sw_thumbnails 'configurator-option-img-thumbnails' with {
+                                                                            media: media,
+                                                                            sizes: {
+                                                                                'default': '52px'
+                                                                            },
+                                                                            attributes: {
+                                                                                'class': 'product-detail-configurator-option-image',
+                                                                                'alt': option.translated.name,
+                                                                                'title': option.translated.name
+                                                                            }
+                                                                        } %}
+                                                                    {% endblock %}
                                                                 {% elseif displayType == 'text' or
                                                                           (displayType == 'media' and not media) or
                                                                           (displayType == 'color' and not option.colorHexCode) %}
-                                                                    {{ option.translated.name }}
+                                                                    {% block page_product_detail_configurator_option_radio_label_text %}
+                                                                        {{ option.translated.name }}
+                                                                    {% endblock %}
                                                                 {% endif %}
                                                             </label>
                                                         {% endblock %}


### PR DESCRIPTION
### 1. Why is this change necessary?
In effect the small images loaded for configuration option are full-sized (1200px by default).
![image](https://user-images.githubusercontent.com/135993/83118755-12a99700-a0cf-11ea-9110-b80e08be9bf5.png)

### 2. What does this change do, exactly?

- Respect thumbnails for configuration options.
- Set default to 52px as it's the effect size on all devices.
- Added to new blocks related to the config options.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
