### PR TITLE
Fixed list spacing within theme-guide/configuration documentation

### DIFF
--- a/src/Docs/Resources/current/30-theme-guide/20-configuration.md
+++ b/src/Docs/Resources/current/30-theme-guide/20-configuration.md
@@ -159,6 +159,7 @@ The following parameters can be defined for a config field item:
 You can use different field types in your theme manager:
 
 * A text field example:
+
 ```json
 "modal-padding": {
     "label": {
@@ -172,6 +173,7 @@ You can use different field types in your theme manager:
 ```
 
 * A number field example: 
+
 ```json
 "visible-slides": {
     "label": {
@@ -190,6 +192,7 @@ You can use different field types in your theme manager:
 ```
 
 * Two boolean field examples:
+
 ```json
 "navigation-fixed": {
     "label": {


### PR DESCRIPTION
Fixed spacing between list and code block to prevent wrong formatting.

<img width="715" alt="Bildschirmfoto 2020-05-28 um 15 11 59" src="https://user-images.githubusercontent.com/8193345/83140624-089b8e80-a0f7-11ea-9c13-7aeb949a3c8b.png">
