### PR TITLE
fixed line break issue on form labels and texts for iOS

### DIFF
--- a/CHANGELOG-6.3.md
+++ b/CHANGELOG-6.3.md
@@ -216,3 +216,4 @@ Table of contents
 * Removed `HttpClient()` constructor parameters in `src/Storefront/Resources/app/storefront/src/service/http-client.service.js`
 * Fix timezone of `orderDate` in ordergrid
 * Added image lazy loading capability to the `ZoomModalPlugin` which allows to load images only if the zoom modal was opened
+* fixed line break issue on form labels for iOS

--- a/src/Storefront/Resources/views/storefront/element/cms-element-form/form-components/cms-element-form-input.html.twig
+++ b/src/Storefront/Resources/views/storefront/element/cms-element-form/form-components/cms-element-form-input.html.twig
@@ -1,9 +1,8 @@
 {% block cms_element_form_input %}
     <div class="form-group {{ additionalClass }}">
         {% block cms_element_form_input_label %}
-            <label class="form-label" for="form-{{ fieldName }}">
-                {{ label|trans }}{% if required %} {{ "general.required"|trans }}{% endif %}
-            </label>
+            <label class="form-label"
+                   for="form-{{ fieldName }}">{{ label|trans }}{% if required %} {{ "general.required"|trans }}{% endif %}</label>
         {% endblock %}
 
         {% block cms_element_form_input_input %}
@@ -12,7 +11,7 @@
                    id="form-{{ fieldName }}"
                    value="{{ data.get( fieldName ) }}"
                    placeholder="{{ placeholder|trans }}"
-                   {% if required %}required="required"{% endif %}
+                {% if required %}required="required"{% endif %}
                    class="form-control{% if formViolations.getViolations( '/' ~ fieldName ) %} is-invalid{% endif %}"/>
 
             {% if formViolations.getViolations( '/' ~ fieldName ) is not empty %}

--- a/src/Storefront/Resources/views/storefront/page/product-detail/tabs.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/product-detail/tabs.html.twig
@@ -46,11 +46,8 @@
                                        href="#review-tab-pane"
                                        role="tab"
                                        aria-controls="review-tab-pane"
-                                       aria-selected="true">
-                                        {{ "detail.tabsReview"|trans|sw_sanitize }}
-                                        <span class="product-detail-tab-navigation-icon">
-                                            {% sw_icon 'arrow-medium-right' style {'pack':'solid'} %}
-                                        </span>
+                                       aria-selected="true">{{ "detail.tabsReview"|trans|sw_sanitize }}<span
+                                            class="product-detail-tab-navigation-icon">{% sw_icon 'arrow-medium-right' style {'pack':'solid'} %}</span>
                                     </a>
                                 </li>
                             {% endif %}


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/community).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->


### 1. Why is this change necessary?
- fixes a linebreak bug on iOS 

### 2. What does this change do, exactly?
- prevents line break after label

### 3. Describe each step to reproduce the issue or behaviour.
- Just adapted the twig file

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
![detail_page](https://user-images.githubusercontent.com/4333324/83248306-2aebe580-a1a5-11ea-88b0-9567e1674f72.png)
![form](https://user-images.githubusercontent.com/4333324/83248307-2cb5a900-a1a5-11ea-8aab-8447d9b51e5b.png)


