### PR TITLE
Encourage usage of constants in RangeFilter example

### DIFF
--- a/src/Core/Framework/DataAbstractionLayer/Search/Filter/RangeFilter.php
+++ b/src/Core/Framework/DataAbstractionLayer/Search/Filter/RangeFilter.php
@@ -26,12 +26,12 @@ class RangeFilter extends Filter
      * @example
      *
      * new RangeFilter('price', [
-     *      'gte' => 5.99,
-     *      'lte' => 21.99
+     *      RangeFilter::GTE => 5.99,
+     *      RangeFilter::LTE => 21.99
      * ])
      *
      * new RangeFilter('price', [
-     *      'gt' => 5.99
+     *      RangeFilter::GT => 5.99
      * ])
      */
     public function __construct(string $field, array $parameters = [])


### PR DESCRIPTION
### 1. Why is this change necessary?
It is just a not so good example when the consts are right above it.

### 2. What does this change do, exactly?
Others can copy the example, constants change, 💣  Things are not working anymore.

### 3. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
