### PR TITLE
Implement additional blocks in sw-cms-el-config-product-box module

### DIFF
--- a/UPGRADE-6.2.md
+++ b/UPGRADE-6.2.md
@@ -241,6 +241,11 @@ Administration
 This was an important change, because every checkbox and switch field has the same id. This causes problems when you click
 on the corresponding label.
 
+* Implemented blocks for the different options in the `sw-cms-el-config-product-box` modules `sw-select-field`s. 
+This allows to append additional options to the `sw-select-field`s.
+    * Added `{% block sw_cms_element_product_box_config_layout_select_options %}`
+    * Added `{% block sw_cms_element_product_box_config_displaymode_select_options %}`
+    * Added `{% block sw_cms_element_product_box_config_settings_vertical_align_options %}`
 
 Storefront
 ----------

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/product-box/config/sw-cms-el-config-product-box.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/product-box/config/sw-cms-el-config-product-box.html.twig
@@ -22,18 +22,22 @@
         {% block sw_cms_element_product_box_config_layout_select %}
             <sw-select-field :label="$tc('sw-cms.elements.productBox.config.label.layoutType')"
                              v-model="element.config.boxLayout.value">
-                <option value="standard">{{ $tc('sw-cms.elements.productBox.config.label.layoutTypeStandard') }}</option>
-                <option value="image">{{ $tc('sw-cms.elements.productBox.config.label.layoutTypeImage') }}</option>
-                <option value="minimal">{{ $tc('sw-cms.elements.productBox.config.label.layoutTypeMinimal') }}</option>
+                {% block sw_cms_element_product_box_config_layout_select_options %}
+                    <option value="standard">{{ $tc('sw-cms.elements.productBox.config.label.layoutTypeStandard') }}</option>
+                    <option value="image">{{ $tc('sw-cms.elements.productBox.config.label.layoutTypeImage') }}</option>
+                    <option value="minimal">{{ $tc('sw-cms.elements.productBox.config.label.layoutTypeMinimal') }}</option>
+                {% endblock %}
             </sw-select-field>
         {% endblock %}
 
         {% block sw_cms_element_product_box_config_displaymode_select %}
             <sw-select-field :label="$tc('sw-cms.elements.general.config.label.displayMode')"
                              v-model="element.config.displayMode.value">
-                <option value="standard">{{ $tc('sw-cms.elements.general.config.label.displayModeStandard') }}</option>
-                <option value="cover">{{ $tc('sw-cms.elements.general.config.label.displayModeCover') }}</option>
-                <option value="contain">{{ $tc('sw-cms.elements.general.config.label.displayModeContain') }}</option>
+                {% block sw_cms_element_product_box_config_displaymode_select_options %}
+                    <option value="standard">{{ $tc('sw-cms.elements.general.config.label.displayModeStandard') }}</option>
+                    <option value="cover">{{ $tc('sw-cms.elements.general.config.label.displayModeCover') }}</option>
+                    <option value="contain">{{ $tc('sw-cms.elements.general.config.label.displayModeContain') }}</option>
+                {% endblock %}
             </sw-select-field>
         {% endblock %}
 
@@ -41,9 +45,11 @@
             <sw-select-field :label="$tc('sw-cms.elements.general.config.label.verticalAlign')"
                              v-model="element.config.verticalAlign.value"
                              :placeholder="$tc('sw-cms.elements.general.config.label.verticalAlign')">
-                <option value="flex-start">{{ $tc('sw-cms.elements.general.config.label.verticalAlignTop') }}</option>
-                <option value="center">{{ $tc('sw-cms.elements.general.config.label.verticalAlignCenter') }}</option>
-                <option value="flex-end">{{ $tc('sw-cms.elements.general.config.label.verticalAlignBottom') }}</option>
+                {% block sw_cms_element_product_box_config_settings_vertical_align_options %}
+                    <option value="flex-start">{{ $tc('sw-cms.elements.general.config.label.verticalAlignTop') }}</option>
+                    <option value="center">{{ $tc('sw-cms.elements.general.config.label.verticalAlignCenter') }}</option>
+                    <option value="flex-end">{{ $tc('sw-cms.elements.general.config.label.verticalAlignBottom') }}</option>
+                {% endblock %}
             </sw-select-field>
         {% endblock %}
     </div>


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/community).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
If one tries to add additional options to one of the sw-select-fields in the sw-cms-el-config-product-box module, e.g., custom product box layouts, plugin developers have to override the whole block around the sw-select-field (or they perform dirty JS stuff). In the case another third party developers wants to add further options this will crash and options added before will be removed.

### 2. What does this change do, exactly?
The change implements additional blocks around the option tags itself so that the block can be extended with further options.

### 3. Describe each step to reproduce the issue or behaviour.
see point 1.

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
