### PR TITLE
Add keep-cache option to warmup command

### DIFF
--- a/src/Storefront/Framework/Cache/CacheWarmer/CacheWarmer.php
+++ b/src/Storefront/Framework/Cache/CacheWarmer/CacheWarmer.php
@@ -85,8 +85,10 @@ class CacheWarmer extends AbstractMessageHandler
         return [WarmUpMessage::class];
     }
 
-    public function warmUp(string $cacheId): void
+    public function warmUp(?string $cacheId = null): void
     {
+        $cacheId = $cacheId ?? $this->cacheIdLoader->load();
+        
         $criteria = new Criteria();
         $domains = $this->domainRepository->search($criteria, Context::createDefaultContext());
 

--- a/src/Storefront/Framework/Command/HttpCacheWarmUpCommand.php
+++ b/src/Storefront/Framework/Command/HttpCacheWarmUpCommand.php
@@ -6,6 +6,7 @@ use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Storefront\Framework\Cache\CacheWarmer\CacheWarmer;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class HttpCacheWarmUpCommand extends Command
@@ -23,9 +24,18 @@ class HttpCacheWarmUpCommand extends Command
         $this->warmer = $warmer;
     }
 
+    protected function configure()
+    {
+        $this->addOption('keep-cache', null, InputOption::VALUE_NONE, 'Keeps the same cache id so no cache invalidation is triggered');
+    }
+
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $cacheId = Uuid::randomHex();
+        $cacheId = null;
+
+        if (!$input->getOption('keep-cache')) {
+            $cacheId = Uuid::randomHex();
+        }
 
         $this->warmer->warmUp($cacheId);
 


### PR DESCRIPTION
### 1. Why is this change necessary?
Imagine all the people… Are afraid of building a cache during webrequest. So they use a cache warmer. To keep the cache warm and cozy you just execute the cache warmer regularly and let a message consumer do its work.

Meanwhile on the storage.

![grafik](https://user-images.githubusercontent.com/1133593/83686949-634b5380-a5eb-11ea-8f8c-b2ae0543d616.png)

So by now the mysql server made a new scientific discovery after it was not possible to dump its memory to the storage. Just four days and an hourly warmup trigger to make it up to a terabyte of cache directories.

![43vosx](https://user-images.githubusercontent.com/1133593/83687144-a1e10e00-a5eb-11ea-9220-7a23ac7d54f7.jpg)

### 2. What does this change do, exactly?
Adds an option to keep the current cache as warmup target and make cache id optional for the cache warmup message dispatching service.

### 3. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
- [x] Request memes from @jkrzefski 
