### PR TITLE
added ip-anonymisation-tag to analytics

### DIFF
--- a/src/Storefront/Resources/views/storefront/component/analytics.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/analytics.html.twig
@@ -11,14 +11,17 @@
 
             function gtag() { dataLayer.push(arguments); }
 
-            window.gtagCallback = () => {
-                gtag('js', new Date());
+            {% block component_head_analytics_tag_config %}
+                window.gtagCallback = () => {
+                    gtag('js', new Date());
 
-                gtag('config', '{{ trackingId }}', {
-                    'cookie_domain': 'none',
-                    'cookie_prefix': '_swag_ga',
-                });
-            };
+                    gtag('config', '{{ trackingId }}', {
+                        'anonymize_ip': true,
+                        'cookie_domain': 'none',
+                        'cookie_prefix': '_swag_ga',
+                    });
+                };
+            {% endblock %}
         </script>
     {% endif %}
 {% endblock %}


### PR DESCRIPTION
### 1. Why is this change necessary?

When integrating google analytics in Europe it is mandatory to integrate ip-anonymisation. It is not explicitly enabled in the current codebase and the default is (of course - it's google) false. 
There is some kind of a discussion in the forum with a bid to send in a PR -> https://forum.shopware.com/discussion/68503/google-analytics-anonymizeip-in-cookie-consent-manager

### 2. What does this change do, exactly?
It enables ip-anonymisation in google analytics and adds a new fancy twig-block around the tag-configuration to better handle twig-overrides of the affected file.

### 3. Describe each step to reproduce the issue or behaviour.
see above

### 4. Please link to the relevant issues (if any).
none found

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [(x)] I have read the contribution requirements and fulfil them. -> the link in your pr-template leading to your contribution-guideline is dead
