### PR TITLE
respect 3 digits for productWeight in admin

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-packaging-form/sw-product-packaging-form.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-packaging-form/sw-product-packaging-form.html.twig
@@ -85,6 +85,7 @@
                                   :label="$tc('sw-product.settingsForm.labelWeight')"
                                   :placeholder="$tc('sw-product.settingsForm.placeholderWeight')"
                                   :min="0"
+                                  :digits="3"
                                   :error="productWeightError"
                                   :disabled="props.isInherited"
                                   :value="props.currentValue"


### PR DESCRIPTION
### 1. Why is this change necessary?
While productWeight is in kg, gram should be respected in administration, too.

### 2. What does this change do, exactly?
Set digits to 3.

### 3. Describe each step to reproduce the issue or behaviour.
Try setting 3 digits after comma. This will be rounded to 2 digits.

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/NEXT-9049

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
