### PR TITLE
integrated ip-anonymization for google analytics

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/snippet/de-DE.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/snippet/de-DE.json
@@ -231,6 +231,9 @@
           },
           "trackOrders": {
             "label": "Bestellungen tracken"
+          },
+          "anonymizeIp": {
+            "label": "Ip-Anonymisierung"
           }
         }
       },

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/snippet/en-GB.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/snippet/en-GB.json
@@ -221,6 +221,9 @@
           },
           "trackOrders": {
             "label": "Track orders"
+          },
+          "anonymizeIp": {
+            "label": "Anonymize Ip"
           }
         }
       },

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/view/sw-sales-channel-detail-analytics/sw-sales-channel-detail-analytics.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/view/sw-sales-channel-detail-analytics/sw-sales-channel-detail-analytics.html.twig
@@ -45,6 +45,16 @@
                         >
                         </sw-field>
                     {% endblock %}
+
+                    {% block sw_sales_channel_detail_analytics_fields_anonymize_ip %}
+                        <sw-field
+                            type="switch"
+                            :label="$tc('sw-sales-channel.detail.analytics.fields.anonymizeIp.label')"
+                            name="anonymizeIp"
+                            v-model="salesChannel.analytics.anonymizeIp"
+                        >
+                        </sw-field>
+                    {% endblock %}
                 </sw-container>
             {% endblock %}
         </template>

--- a/src/Core/Migration/Migration1591272594AddGoogleAnalyticsAnonymizeIpColumn.php
+++ b/src/Core/Migration/Migration1591272594AddGoogleAnalyticsAnonymizeIpColumn.php
@@ -1,0 +1,26 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Migration;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Framework\Migration\MigrationStep;
+
+class Migration1591272594AddGoogleAnalyticsAnonymizeIpColumn extends MigrationStep
+{
+    public function getCreationTimestamp(): int
+    {
+        return 1591272594;
+    }
+
+    public function update(Connection $connection): void
+    {
+        $connection->executeUpdate(
+            'ALTER TABLE sales_channel_analytics
+            ADD COLUMN anonymize_ip TINYINT(1) NOT NULL DEFAULT \'1\'
+        ');
+    }
+
+    public function updateDestructive(Connection $connection): void
+    {
+    }
+}

--- a/src/Core/Migration/Migration1591272594AddGoogleAnalyticsAnonymizeIpColumn.php
+++ b/src/Core/Migration/Migration1591272594AddGoogleAnalyticsAnonymizeIpColumn.php
@@ -16,8 +16,8 @@ class Migration1591272594AddGoogleAnalyticsAnonymizeIpColumn extends MigrationSt
     {
         $connection->executeUpdate(
             'ALTER TABLE sales_channel_analytics
-            ADD COLUMN anonymize_ip TINYINT(1) NOT NULL DEFAULT \'1\'
-        ');
+            ADD COLUMN anonymize_ip TINYINT(1) NOT NULL DEFAULT \'1\''
+        );
     }
 
     public function updateDestructive(Connection $connection): void

--- a/src/Core/System/SalesChannel/Aggregate/SalesChannelAnalytics/SalesChannelAnalyticsDefinition.php
+++ b/src/Core/System/SalesChannel/Aggregate/SalesChannelAnalytics/SalesChannelAnalyticsDefinition.php
@@ -38,6 +38,7 @@ class SalesChannelAnalyticsDefinition extends EntityDefinition
             new StringField('tracking_id', 'trackingId'),
             new BoolField('active', 'active'),
             new BoolField('track_orders', 'trackOrders'),
+            new BoolField('anonymize_ip', 'anonymizeIp'),
             (new OneToOneAssociationField('salesChannel', 'id', 'analytics_id', SalesChannelDefinition::class, false)),
         ]);
     }

--- a/src/Core/System/SalesChannel/Aggregate/SalesChannelAnalytics/SalesChannelAnalyticsEntity.php
+++ b/src/Core/System/SalesChannel/Aggregate/SalesChannelAnalytics/SalesChannelAnalyticsEntity.php
@@ -26,6 +26,11 @@ class SalesChannelAnalyticsEntity extends Entity
     protected $trackOrders;
 
     /**
+     * @var bool
+     */
+    protected $anonymizeIp;
+
+    /**
      * @var SalesChannelEntity
      */
     protected $salesChannel;
@@ -58,6 +63,16 @@ class SalesChannelAnalyticsEntity extends Entity
     public function setTrackOrders(bool $trackOrders): void
     {
         $this->trackOrders = $trackOrders;
+    }
+
+    public function isAnonymizeIp(): bool
+    {
+        return $this->anonymizeIp;
+    }
+
+    public function setAnonymizeIp(bool $anonymizeIp): void
+    {
+        $this->anonymizeIp = $anonymizeIp;
     }
 
     public function getSalesChannel(): SalesChannelEntity

--- a/src/Storefront/Resources/app/storefront/test/e2e/cypress/support/commands/commands.js
+++ b/src/Storefront/Resources/app/storefront/test/e2e/cypress/support/commands/commands.js
@@ -192,7 +192,8 @@ Cypress.Commands.add('addAnalyticsFixtureToSalesChannel', () => {
                 analytics: {
                     trackingId: 'UA-000000000-0',
                     active: true,
-                    trackOrders: true
+                    trackOrders: true,
+                    anonymizeIp: true
                 }
             }
         })

--- a/src/Storefront/Resources/views/storefront/component/analytics.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/analytics.html.twig
@@ -11,14 +11,17 @@
 
             function gtag() { dataLayer.push(arguments); }
 
-            window.gtagCallback = () => {
-                gtag('js', new Date());
+            {% block component_head_analytics_tag_config %}
+                window.gtagCallback = () => {
+                    gtag('js', new Date());
 
-                gtag('config', '{{ trackingId }}', {
-                    'cookie_domain': 'none',
-                    'cookie_prefix': '_swag_ga',
-                });
-            };
+                    gtag('config', '{{ trackingId }}', {
+                        'anonymize_ip': '{{ context.salesChannel.analytics.isAnonymizeIp() }}',
+                        'cookie_domain': 'none',
+                        'cookie_prefix': '_swag_ga',
+                    });
+                };
+            {% endblock %}
         </script>
     {% endif %}
 {% endblock %}


### PR DESCRIPTION
### 1. Why is this change necessary?
When integrating google analytics in Europe it is mandatory to enable ip-anonymisation. Right now there is no support build in for managing ip-anonymisation. There is some discussion in the forum with a bid to send in a PR -> https://forum.shopware.com/discussion/68503/google-analytics-anonymizeip-in-cookie-consent-manager

### 2. What does this change do, exactly?
It extends the configuration-page for google analytics (in the admin-ui under a specific sales channel) with a switch to enable or disable ip-anonymization for google analytics.

### 3. Describe each step to reproduce the issue or behaviour.
see above

### 4. Please link to the relevant issues (if any).
none found

### 5. Checklist
- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them -> the link in your pr-template leading to your contribution-guideline is dead
