### PR TITLE
Use GenericPageLoaderInterface in AccountEditOrderpageLoader

### DIFF
--- a/CHANGELOG-6.2.md
+++ b/CHANGELOG-6.2.md
@@ -549,6 +549,7 @@ To get the diff between two versions, go to https://github.com/shopware/platform
         * `storefront.htmlPurifier.enableCache`: Boolean to turn `HTMLPurifier`s cache cache on or off (defaults to `true`)
     * Deprecated `sort` parameter for product listing, search and suggest gateway, use `order` instead
     * Added block `document_line_item_table_iterator` to `@Framework\documents\base.html.twig` to override the lineItem iterator
+    * Changed type of `GenericPageLoader` to `GenericPageLoaderInterface` in `AccountEditOrderPageLoader`
     
 **Removals**
 

--- a/src/Storefront/Page/Account/Order/AccountEditOrderPageLoader.php
+++ b/src/Storefront/Page/Account/Order/AccountEditOrderPageLoader.php
@@ -14,14 +14,14 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Sorting\FieldSorting;
 use Shopware\Core\Framework\Routing\Exception\MissingRequestParameterException;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
-use Shopware\Storefront\Page\GenericPageLoader;
+use Shopware\Storefront\Page\GenericPageLoaderInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\Request;
 
 class AccountEditOrderPageLoader
 {
     /**
-     * @var GenericPageLoader
+     * @var GenericPageLoaderInterface
      */
     private $genericLoader;
 
@@ -41,7 +41,7 @@ class AccountEditOrderPageLoader
     private $paymentMethodRoute;
 
     public function __construct(
-        GenericPageLoader $genericLoader,
+        GenericPageLoaderInterface $genericLoader,
         EventDispatcherInterface $eventDispatcher,
         AbstractOrderRoute $orderRoute,
         AbstractPaymentMethodRoute $paymentMethodRoute


### PR DESCRIPTION
### 1. Why is this change necessary?
The use of GenericPageLoader instead of the Interface breaks the account order page if the generic page loader was decorated by a plugin.

### 2. What does this change do, exactly?
Change the type of the generic page loader to use the interface instead of a concrete implementation

### 3. Describe each step to reproduce the issue or behaviour.
Decorate the GenericLoader the usual Symfony way the decoration will be of type GenericPageLoaderInterface which will break the AccountEditOrderPageLoader because it expects a type of GenericPageLoader 

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
