### PR TITLE
Add register event for guest customer

### DIFF
--- a/src/Core/Checkout/Customer/Event/GuestCustomerRegisterEvent.php
+++ b/src/Core/Checkout/Customer/Event/GuestCustomerRegisterEvent.php
@@ -1,0 +1,13 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Checkout\Customer\Event;
+
+class GuestCustomerRegisterEvent extends CustomerRegisterEvent
+{
+    public const EVENT_NAME = 'checkout.customer.guest_register';
+
+    public function getName(): string
+    {
+        return self::EVENT_NAME;
+    }
+}

--- a/src/Core/Checkout/Customer/SalesChannel/RegisterConfirmRoute.php
+++ b/src/Core/Checkout/Customer/SalesChannel/RegisterConfirmRoute.php
@@ -4,6 +4,7 @@ namespace Shopware\Core\Checkout\Customer\SalesChannel;
 
 use OpenApi\Annotations as OA;
 use Shopware\Core\Checkout\Customer\Event\CustomerRegisterEvent;
+use Shopware\Core\Checkout\Customer\Event\GuestCustomerRegisterEvent;
 use Shopware\Core\Checkout\Customer\Exception\CustomerAlreadyConfirmedException;
 use Shopware\Core\Checkout\Customer\Exception\CustomerNotFoundByHashException;
 use Shopware\Core\Checkout\Customer\Exception\NoHashProvidedException;
@@ -110,10 +111,10 @@ class RegisterConfirmRoute extends AbstractRegisterConfirmRoute
             $context->getContext()
         );
 
-        if (!$customer->getGuest()) {
-            $event = new CustomerRegisterEvent($context, $customer);
-
-            $this->eventDispatcher->dispatch($event);
+        if ($customer->getGuest()) {
+            $this->eventDispatcher->dispatch(new GuestCustomerRegisterEvent($context, $customer));
+        } else {
+            $this->eventDispatcher->dispatch(new CustomerRegisterEvent($context, $customer));
         }
 
         return new CustomerResponse($customer);

--- a/src/Core/Checkout/Customer/SalesChannel/RegisterRoute.php
+++ b/src/Core/Checkout/Customer/SalesChannel/RegisterRoute.php
@@ -8,6 +8,7 @@ use Shopware\Core\Checkout\Customer\CustomerEvents;
 use Shopware\Core\Checkout\Customer\Event\CustomerDoubleOptInRegistrationEvent;
 use Shopware\Core\Checkout\Customer\Event\CustomerRegisterEvent;
 use Shopware\Core\Checkout\Customer\Event\DoubleOptInGuestOrderEvent;
+use Shopware\Core\Checkout\Customer\Event\GuestCustomerRegisterEvent;
 use Shopware\Core\Checkout\Customer\Validation\Constraint\CustomerEmailUnique;
 use Shopware\Core\Checkout\Order\SalesChannel\OrderService;
 use Shopware\Core\Framework\Context;
@@ -175,6 +176,8 @@ class RegisterRoute extends AbstractRegisterRoute
             $this->eventDispatcher->dispatch($this->getDoubleOptInEvent($customerEntity, $context, $data->get('storefrontUrl')));
         } elseif (!$customerEntity->getGuest()) {
             $this->eventDispatcher->dispatch(new CustomerRegisterEvent($context, $customerEntity));
+        } else {
+            $this->eventDispatcher->dispatch(new GuestCustomerRegisterEvent($context, $customerEntity));
         }
 
         // We don't want to leak the hash in store-api


### PR DESCRIPTION
### 1. Why is this change necessary?
When you subscribe the CustomerRegisterEvent you don't get notified when it is a guest. The really good way to check if there is a guest registration you need to subscribe the DAL events for customer insertions. This sort of makes sense as a guest is not registered but in the end the person has a customer entry so they are still in the system and were entried via the registration form. You still miss it when you subscribe the normal event.

### 2. What does this change do, exactly?
As it would be a breaking change as the existing event CustomerRegisterEvent would be triggered more often and thus send more emails I add a new event that gets dispatched instead. It extends the existing event so the same event handler can be used and just have to be subscribed twice.

### 3. Describe each step to reproduce the issue or behaviour.
1. Subscribe CustomerRegisterEvent to transfer customer data to CRM
2. Order as guest
3. Look into CRM and don't have a new contact

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

![443zlw](https://user-images.githubusercontent.com/1133593/83904213-c0681600-a75f-11ea-9fcb-612f1d423e7a.jpg)

