### PR TITLE
Allow customer password to be nullable like the definition states

### DIFF
--- a/src/Core/Checkout/Customer/CustomerEntity.php
+++ b/src/Core/Checkout/Customer/CustomerEntity.php
@@ -85,7 +85,7 @@ class CustomerEntity extends Entity
     protected $company;
 
     /**
-     * @var string
+     * @var string|null
      */
     protected $password;
 
@@ -409,12 +409,12 @@ class CustomerEntity extends Entity
         $this->company = $company;
     }
 
-    public function getPassword(): string
+    public function getPassword(): ?string
     {
         return $this->password;
     }
 
-    public function setPassword(string $password): void
+    public function setPassword(?string $password): void
     {
         $this->password = $password;
     }


### PR DESCRIPTION
### 1. Why is this change necessary?
Guest customers have no password. The customer definition does not require the password to be set. The customer entity instead does.

### 2. What does this change do, exactly?
Make the property and its getters and setters nullable.

### 3. Describe each step to reproduce the issue or behaviour.
1. Have plugins installed that process customer logins
2. ![grafik](https://user-images.githubusercontent.com/1133593/83903610-be518780-a75e-11ea-8052-a697b028935d.png)

### 4. Checklist
- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
