### PR TITLE
Fix 404 and typo on Contributing Code link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ Shopware is available under MIT license. If you want to contribute code (feature
 If you want more details about available licensing or the contribution agreements we offer, you can contact us at <contact@shopware.com>.
 
 ## Contributing to the Shopware code base
-If you want to learn how to contribute code to Shopware, please refer to [Contribution Code](https://docs.shopware.com/en/shopware-platform-dev-en/community/contributing-code?category=shopware-platform-dev-en/community).  
+If you want to learn how to contribute code to Shopware, please refer to [Contributing Code](https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contributing-code?category=shopware-platform-dev-en/contribution).  
 
 ## Documentation
 


### PR DESCRIPTION
Just noticed that the "Contributing Code" link  in the CONTRIBUTING.md leads to a 404 and is misspelled. This PR updates the link to correctly point to the current documentation page and fixes the spelling according to the title on the documentation page.