### PR TITLE
Resolve media urls during SCSS variable compilation

### DIFF
--- a/CHANGELOG-6.2.md
+++ b/CHANGELOG-6.2.md
@@ -656,6 +656,7 @@ To get the diff between two versions, go to https://github.com/shopware/platform
     * Added block `document_line_item_table_iterator` to `@Framework\documents\base.html.twig` to override the lineItem iterator
     * Added `StoreApiClient` which allows to send requests to `store-api` and `sales-channel-api` routes.
     * Theme configuration now allows zero as a value when overriding
+    * Added resolving of media ids to `Shopware\Storefront\Theme\ThemeCompiler`
     
 **Removals**
 

--- a/src/Storefront/DependencyInjection/theme.xml
+++ b/src/Storefront/DependencyInjection/theme.xml
@@ -21,6 +21,7 @@
             <argument>%kernel.debug%</argument>
             <argument type="service" id="Symfony\Component\EventDispatcher\EventDispatcherInterface" />
             <argument type="service" id="Shopware\Storefront\Theme\ThemeFileImporter"/>
+            <argument type="service" id="media.repository"/>
         </service>
 
         <service id="Shopware\Storefront\Theme\ThemeFileImporter"/>

--- a/src/Storefront/Test/Theme/ThemeCompilerTest.php
+++ b/src/Storefront/Test/Theme/ThemeCompilerTest.php
@@ -291,6 +291,7 @@ PHP_EOL;
 
         $actual = $dumpVariables->invoke($this->themeCompiler, $mockConfig, $this->mockSalesChannelId);
 
-        static::assertStringContainsString('testImage.png', $actual);
+        $re = '/\$sw-logo-desktop:\s*\'.*\/testImage\.png\'\s*;/m';
+        static::assertRegExp($re, $actual);
     }
 }

--- a/src/Storefront/Theme/ThemeCompiler.php
+++ b/src/Storefront/Theme/ThemeCompiler.php
@@ -7,7 +7,12 @@ use Padaliyajay\PHPAutoprefixer\Autoprefixer;
 use ScssPhp\ScssPhp\Compiler;
 use ScssPhp\ScssPhp\Formatter\Crunched;
 use ScssPhp\ScssPhp\Formatter\Expanded;
+use Shopware\Core\Content\Media\MediaEntity;
 use Shopware\Core\Framework\Adapter\Filesystem\Plugin\CopyBatchInput;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepositoryInterface;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Storefront\Event\ThemeCompilerEnrichScssVariablesEvent;
 use Shopware\Storefront\Theme\Exception\InvalidThemeException;
 use Shopware\Storefront\Theme\Exception\ThemeCompileException;
@@ -55,6 +60,11 @@ class ThemeCompiler implements ThemeCompilerInterface
     private $tempFilesystem;
 
     /**
+     * @var EntityRepositoryInterface
+     */
+    private $mediaRepository;
+
+    /**
      * @param ThemeFileImporterInterface|null $themeFileImporter will be required in v6.3.0
      */
     public function __construct(
@@ -64,7 +74,8 @@ class ThemeCompiler implements ThemeCompilerInterface
         string $cacheDir,
         bool $debug,
         EventDispatcherInterface $eventDispatcher,
-        ?ThemeFileImporterInterface $themeFileImporter = null
+        ?ThemeFileImporterInterface $themeFileImporter = null,
+        EntityRepositoryInterface $mediaRepository
     ) {
         $this->publicFilesystem = $publicFilesystem;
         $this->tempFilesystem = $tempFilesystem;
@@ -77,6 +88,7 @@ class ThemeCompiler implements ThemeCompilerInterface
 
         $this->scssCompiler->setFormatter($debug ? Expanded::class : Crunched::class);
         $this->eventDispatcher = $eventDispatcher;
+        $this->mediaRepository = $mediaRepository;
     }
 
     public function compileTheme(
@@ -240,6 +252,22 @@ class ThemeCompiler implements ThemeCompilerInterface
             }
 
             if ($data['type'] === 'media') {
+                // Resolve path if media id is given
+                if (Uuid::isValid($data['value'])) {
+                    /** @var MediaEntity|null $media */
+                    $media = $this->mediaRepository
+                        ->search(
+                            new Criteria([$data['value']]),
+                            Context::createDefaultContext()
+                        )
+                        ->getEntities()
+                        ->first();
+
+                    if ($media) {
+                        $data['value'] = $media->getUrl();
+                    }
+                }
+
                 $variables[$key] = '\'' . $data['value'] . '\'';
             } else {
                 $variables[$key] = $data['value'];

--- a/src/Storefront/Theme/ThemeCompiler.php
+++ b/src/Storefront/Theme/ThemeCompiler.php
@@ -270,14 +270,14 @@ class ThemeCompiler implements ThemeCompilerInterface
             /** @var MediaCollection $medias */
             $medias = $this->mediaRepository
             ->search(
-                new Criteria($mediaIds),
+                new Criteria(array_values($mediaIds)),
                 Context::createDefaultContext()
             )
             ->getEntities();
 
-            foreach ($medias as $key => $media) {
+            foreach ($mediaIds as $key => $mediaId) {
                 /* @var MediaEntity $media */
-                $variables[$key] = '\'' . $media->getUrl() . '\'';
+                $variables[$key] = '\'' . $medias->get($mediaId)->getUrl() . '\'';
             }
         }
 


### PR DESCRIPTION
### 1. Why is this change necessary?
When using `media` fields in a `theme.json`, the corresponding scss variables only contain the media id which makes it unusable in css. In order to use it as e.g. a background image we need the media url.

### 2. What does this change do, exactly?
This change checks in the `ThemeCompiler` if the value of a `media` field is a valid `Uuid`. If that's the case, it uses a simple search in the media repository to find the associated media. If one is found, the old field value is replaced by the media url as provided by `$media->getUrl()`.

### 3. Describe each step to reproduce the issue or behaviour.
Add a media field to the theme.json config and try to access the corresponding variable in SCSS.
Instead of a path we only get an id.

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
