### PR TITLE
Add product criteria events to CrossSellingLoader

### DIFF
--- a/src/Storefront/Page/Product/CrossSelling/CrossSellingLoader.php
+++ b/src/Storefront/Page/Product/CrossSelling/CrossSellingLoader.php
@@ -118,6 +118,10 @@ class CrossSellingLoader
 
         $criteria = $this->handleAvailableStock($criteria, $context);
 
+        $this->eventDispatcher->dispatch(
+            new CrossSellingProductStreamCriteriaEvent($crossSelling, $criteria, $context)
+        );
+
         $searchResult = $this->productRepository->search($criteria, $context);
 
         /** @var ProductCollection $products */
@@ -165,6 +169,10 @@ class CrossSellingLoader
         }
 
         $criteria = $this->handleAvailableStock($criteria, $context);
+
+        $this->eventDispatcher->dispatch(
+            new CrossSellingProductListCriteriaEvent($crossSelling, $criteria, $context)
+        );
 
         $searchResult = $this->productRepository->search($criteria, $context);
 

--- a/src/Storefront/Page/Product/CrossSelling/CrossSellingProductCriteriaEvent.php
+++ b/src/Storefront/Page/Product/CrossSelling/CrossSellingProductCriteriaEvent.php
@@ -1,0 +1,58 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Storefront\Page\Product\CrossSelling;
+
+use Shopware\Core\Content\Product\Aggregate\ProductCrossSelling\ProductCrossSellingEntity;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Event\ShopwareEvent;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Symfony\Contracts\EventDispatcher\Event;
+
+abstract class CrossSellingProductCriteriaEvent extends Event implements ShopwareEvent
+{
+    /**
+     * @var ProductCrossSellingEntity
+     */
+    private $crossSelling;
+
+    /**
+     * @var Criteria
+     */
+    private $criteria;
+
+    /**
+     * @var SalesChannelContext
+     */
+    private $salesChannelContext;
+
+    public function __construct(
+        ProductCrossSellingEntity $crossSelling,
+        Criteria $criteria,
+        SalesChannelContext $salesChannelContext
+    ) {
+        $this->crossSelling = $crossSelling;
+        $this->criteria = $criteria;
+        $this->salesChannelContext = $salesChannelContext;
+    }
+
+    public function getCrossSelling(): ProductCrossSellingEntity
+    {
+        return $this->crossSelling;
+    }
+
+    public function getCriteria(): Criteria
+    {
+        return $this->criteria;
+    }
+
+    public function getContext(): Context
+    {
+        return $this->salesChannelContext->getContext();
+    }
+
+    public function getSalesChannelContext(): SalesChannelContext
+    {
+        return $this->salesChannelContext;
+    }
+}

--- a/src/Storefront/Page/Product/CrossSelling/CrossSellingProductListCriteriaEvent.php
+++ b/src/Storefront/Page/Product/CrossSelling/CrossSellingProductListCriteriaEvent.php
@@ -1,0 +1,7 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Storefront\Page\Product\CrossSelling;
+
+class CrossSellingProductListCriteriaEvent extends CrossSellingProductCriteriaEvent
+{
+}

--- a/src/Storefront/Page/Product/CrossSelling/CrossSellingProductStreamCriteriaEvent.php
+++ b/src/Storefront/Page/Product/CrossSelling/CrossSellingProductStreamCriteriaEvent.php
@@ -1,0 +1,7 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Storefront\Page\Product\CrossSelling;
+
+class CrossSellingProductStreamCriteriaEvent extends CrossSellingProductCriteriaEvent
+{
+}


### PR DESCRIPTION
### 1. Why is this change necessary?
There's currently no convenient way for a plugin to modify the criteria that are used to load cross selling products.

### 2. What does this change do, exactly?
Add two new events that give access to the `Criteria` objects from the `CrossSellingLoader`.

### 3. Describe each step to reproduce the issue or behaviour.
\-

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.