### PR TITLE
Fix mixed up german snippets.

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-cms/snippet/de-DE.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/snippet/de-DE.json
@@ -417,7 +417,7 @@
           "label": "Bild-Slider"
         },
         "imageThreeColumn": {
-          "label": "Zwei Spalten, zentriert"
+          "label": "Drei Spalten, zentriert"
         },
         "imageThreeCover": {
           "label": "Drei Spalten, gestreckt"
@@ -453,10 +453,10 @@
           "label": "Zwei Spalten, Teaser-Text"
         },
         "textThreeColumn": {
-          "label": "Zwei Spalten, Text"
+          "label": "Drei Spalten, Text"
         },
         "textTwoColumn": {
-          "label": "Drei Spalten, Text"
+          "label": "Zwei Spalten, Text"
         }
       },
       "textImage": {


### PR DESCRIPTION
### 1. Why is this change necessary?
Some of the german snippets for CMS block names were mixed up. Namely the numbers two and three.

### 2. What does this change do, exactly?
It fixes these mixed up snippets.

### 3. Describe each step to reproduce the issue or behaviour.
Set the admin language to german and edit a shopping experience. The blocks for two/three columns of text have their names mixed up. The three column image block also has a wrong name.

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
