### PR TITLE
Consider nullable values

### DIFF
--- a/CHANGELOG-6.2.md
+++ b/CHANGELOG-6.2.md
@@ -68,6 +68,7 @@ To get the diff between two versions, go to https://github.com/shopware/platform
     * Added methods `isProductGroup` `setIsProductGroup` `isVariantProduct` in `\Shopware\Core\Content\Product\ProductEntity` 
     * DB level write operation (e.g. cascade deletes) are not validated against the write prtoection anymore
     * Changed exit code from command `es:index` to 0
+    * Added support for nullable values for MultiInsertQueryQueue
  
 * Storefront
     * Added `pack_unit_plural` to `buy-widget-form.html.twig`

--- a/src/Core/Framework/DataAbstractionLayer/Doctrine/MultiInsertQueryQueue.php
+++ b/src/Core/Framework/DataAbstractionLayer/Doctrine/MultiInsertQueryQueue.php
@@ -61,7 +61,11 @@ class MultiInsertQueryQueue
                 $type = $types[$key];
             }
 
-            $value = $this->connection->quote($value, $type);
+            if ($value === null) {
+                $value = 'NULL';
+            } else {
+                $value = $this->connection->quote($value, $type);
+            }
         }
 
         $this->inserts[$table][] = [


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/community).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
It fixes a bug when trying to "null" a date field of an associated entity.

### 2. What does this change do, exactly?
It simply adds a check if the given value is null and sets the value to "NULL"

### 3. Describe each step to reproduce the issue or behaviour.
1. Create a new entity which has a one to one relation to e.g. a product
2. The entity must have a DateField which is nullable (non required)
3. Create the corresponding row in the database
4. Try to "null" the DateField using the DAL
5. ???
6. Profit! You get an exception which says that `''` is not a valid date.

### 4. Please link to the relevant issues (if any).
-

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [x] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
