### PR TITLE
Add support for files that have an EXIF orientation.

### DIFF
--- a/src/Core/Content/Media/Thumbnail/ThumbnailService.php
+++ b/src/Core/Content/Media/Thumbnail/ThumbnailService.php
@@ -242,12 +242,12 @@ class ThumbnailService
         try {
             $exif = exif_read_data($filePath);
 
-            if(!empty($exif['Orientation']) && $exif['Orientation'] == 8) {
-                $image = imagerotate($image,90,0);
-            } elseif(!empty($exif['Orientation']) && $exif['Orientation'] == 3) {
-                $image = imagerotate($image,180,0);
-            } elseif(!empty($exif['Orientation']) && $exif['Orientation'] == 6) {
-                $image = imagerotate($image,-90,0);
+            if (!empty($exif['Orientation']) && $exif['Orientation'] === 8) {
+                $image = imagerotate($image, 90, 0);
+            } elseif (!empty($exif['Orientation']) && $exif['Orientation'] === 3) {
+                $image = imagerotate($image, 180, 0);
+            } elseif (!empty($exif['Orientation']) && $exif['Orientation'] === 6) {
+                $image = imagerotate($image, -90, 0);
             }
         } catch (\Exception $e) {
             // Ignore.

--- a/src/Core/Content/Media/Thumbnail/ThumbnailService.php
+++ b/src/Core/Content/Media/Thumbnail/ThumbnailService.php
@@ -239,18 +239,20 @@ class ThumbnailService
             throw new FileTypeNotSupportedException($media->getId());
         }
 
-        try {
-            $exif = exif_read_data($filePath);
+        if (extension_loaded('exif')) {
+            try {
+                $exif = exif_read_data($filePath);
 
-            if (!empty($exif['Orientation']) && $exif['Orientation'] === 8) {
-                $image = imagerotate($image, 90, 0);
-            } elseif (!empty($exif['Orientation']) && $exif['Orientation'] === 3) {
-                $image = imagerotate($image, 180, 0);
-            } elseif (!empty($exif['Orientation']) && $exif['Orientation'] === 6) {
-                $image = imagerotate($image, -90, 0);
+                if (!empty($exif['Orientation']) && $exif['Orientation'] === 8) {
+                    $image = imagerotate($image, 90, 0);
+                } elseif (!empty($exif['Orientation']) && $exif['Orientation'] === 3) {
+                    $image = imagerotate($image, 180, 0);
+                } elseif (!empty($exif['Orientation']) && $exif['Orientation'] === 6) {
+                    $image = imagerotate($image, -90, 0);
+                }
+            } catch (\Exception $e) {
+                // Ignore.
             }
-        } catch (\Exception $e) {
-            // Ignore.
         }
 
         return $image;

--- a/src/Core/Content/Media/Thumbnail/ThumbnailService.php
+++ b/src/Core/Content/Media/Thumbnail/ThumbnailService.php
@@ -238,6 +238,20 @@ class ThumbnailService
         if (!$image) {
             throw new FileTypeNotSupportedException($media->getId());
         }
+        
+        try {
+            $exif = exif_read_data($filePath);
+
+            if(!empty($exif['Orientation']) && $exif['Orientation'] == 8) {
+                $image = imagerotate($image,90,0);
+            } elseif(!empty($exif['Orientation']) && $exif['Orientation'] == 3) {
+                $image = imagerotate($image,180,0);
+            } elseif(!empty($exif['Orientation']) && $exif['Orientation'] == 6) {
+                $image = imagerotate($image,-90,0);
+            }
+        } catch (\Exception $e) {
+            // Ignore.
+        }
 
         return $image;
     }

--- a/src/Core/Content/Media/Thumbnail/ThumbnailService.php
+++ b/src/Core/Content/Media/Thumbnail/ThumbnailService.php
@@ -239,7 +239,7 @@ class ThumbnailService
             throw new FileTypeNotSupportedException($media->getId());
         }
 
-        if (extension_loaded('exif')) {
+        if (function_exists('exif_read_data')) {
             try {
                 $exif = exif_read_data($filePath);
 

--- a/src/Core/Content/Media/Thumbnail/ThumbnailService.php
+++ b/src/Core/Content/Media/Thumbnail/ThumbnailService.php
@@ -238,7 +238,7 @@ class ThumbnailService
         if (!$image) {
             throw new FileTypeNotSupportedException($media->getId());
         }
-        
+
         try {
             $exif = exif_read_data($filePath);
 


### PR DESCRIPTION
### 1. Why is this change necessary?
Without this change, thumbnails of images that have an exif-orientation are not displayed correctly. 

### 2. What does this change do, exactly?
We change the orientation to the correct one, before raw image ressource is used to create thumbnails.

### 3. Describe each step to reproduce the issue or behaviour.
Upload a file with exif property "Orientation" = 3 or 6 or 8.

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.
