### PR TITLE
Hide passwords if overridden value is used as placeholder

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-password-field/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-password-field/index.js
@@ -21,6 +21,12 @@ Component.extend('sw-password-field', 'sw-text-field', {
             default: true
         },
 
+        placeholderIsPassword: {
+            type: Boolean,
+            required: false,
+            default: false
+        },
+        
         autocomplete: {
             type: String,
             required: false

--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-password-field/sw-password-field.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-password-field/sw-password-field.html.twig
@@ -6,7 +6,7 @@
                     <input :type="showPassword ? 'text' : 'password'"
                            :id="identification"
                            :name="identification"
-                           :placeholder="placeholder"
+                           :placeholder="showPassword || !placeholderIsPassword ? placeholder : '*'.repeat(placeholder.length ?? 6)"
                            :disabled="disabled"
                            :value="currentValue"
                            :autocomplete="autocomplete"

--- a/src/Administration/Resources/app/administration/src/module/sw-settings/component/sw-system-config/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings/component/sw-system-config/index.js
@@ -144,6 +144,10 @@ Component.register('sw-system-config', {
                 } else if (bind.type === 'bool') {
                     // Add inheritedValue for checkbox fields to restore the inherited state
                     bind.config.inheritedValue = this.actualConfigData.null[bind.name] || false;
+                } else if (bind.type === 'password') {
+                    // Add inherited placeholder and mark placeholder as password so the rendering element can choose to hide it
+                    bind.placeholderIsPassword = true;
+                    bind.placeholder = `${this.actualConfigData.null[bind.name]}`;
                 } else if (bind.type !== 'multi-select' && !types.isUndefined(this.actualConfigData.null[bind.name])) {
                     // Add inherited placeholder
                     bind.placeholder = `${this.actualConfigData.null[bind.name]}`;


### PR DESCRIPTION
### 1. Why is this change necessary?
A password can be exposed without the intention when specifying the sales channel to configure  a password for.

### 2. What does this change do, exactly?
Add a property for password fields to expect placeholders be passwords as well and thus can be made visible like the value itself.
![pr-hide-password](https://user-images.githubusercontent.com/1133593/84599098-d49ec800-ae6f-11ea-917d-8308752a96f6.gif)

### 3. Describe each step to reproduce the issue or behaviour.
![pr-not-so-hidy-password](https://user-images.githubusercontent.com/1133593/84599059-8b4e7880-ae6f-11ea-9ad1-05a42dd3176a.gif)

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
