### PR TITLE
Exchange untranslated translation key in administration

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-slot/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-slot/index.js
@@ -54,7 +54,7 @@ Component.register('sw-cms-slot', {
                 };
             }
             return {
-                message: this.$tc('sw-cms.elements.configTabSettings'),
+                message: this.$tc('sw-cms.elements.general.config.tab.settings'),
                 disabled: true
             };
         }


### PR DESCRIPTION
### 1. Why is this change necessary?
The used translation key does not exist in a json file.
<img width="814" alt="grafik" src="https://user-images.githubusercontent.com/1133593/84603679-83eb9700-ae90-11ea-8fc5-736514e078a9.png">

### 2. What does this change do, exactly?
Exchange a translation key with one that looks similar in name so it should be in content as well.

### 3. Describe each step to reproduce the issue or behaviour.
I just stumbled upon it while working on an other pull request.

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
