### PR TITLE
Add info about cms element overrides by categories

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-slot/sw-cms-slot.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-slot/sw-cms-slot.html.twig
@@ -13,6 +13,16 @@
             <div class="sw-cms-slot__overlay" v-if="active">
                 {% block sw_cms_slot_overlay_content %}
                     <div class="sw-cms-slot__actions">
+                        {% block sw_cms_slot_overlay_action_override %}
+                            <div
+                                v-if="categorySlotConfigOverrides.length > 0"
+                                class="sw-cms-slot__settings-override"
+                                @click="onOverrideButtonClick"
+                            >
+                                <sw-icon name="default-object-lightbulb" size="16" color="#f39c12"></sw-icon>
+                            </div>
+                        {% endblock %}
+
                         {% block sw_cms_slot_overlay_action_settings %}
                             <div
                                 class="sw-cms-slot__settings-action"
@@ -47,6 +57,44 @@
                         {% block sw_cms_slot_settings_modal_action_confirm %}
                             <sw-button variant="primary" @click="onCloseSettingsModal">
                                 {{ $tc('sw-cms.detail.label.buttonElementSettingsConfirm') }}
+                            </sw-button>
+                        {% endblock %}
+                    </template>
+                {% endblock %}
+            </sw-modal>
+        {% endblock %}
+
+        {% block sw_cms_slot_overrides_modal %}
+            <sw-modal
+                class="sw-cms-slot__overrides-modal"
+                v-if="showOverrides"
+                :title="$tc('sw-cms.detail.title.elementOverridesModal')"
+                @modal-close="onCloseOverrideModal"
+            >
+                {% block sw_cms_slot_overrides_modal_overrides %}
+                    {% block sw_cms_slot_overrides_modal_overrides_category %}
+                        <div>
+                            {% block sw_cms_slot_overrides_modal_overrides_category_items %}
+                                <div
+                                    class="sw-cms-slot__overrides-modal-category"
+                                    v-for="category of categorySlotConfigOverrides"
+                                    :key="category.id"
+                                    @click="gotoCategory(category.id)"
+                                >
+                                    {% block sw_cms_slot_overrides_modal_overrides_category_item %}
+                                        {{ category.name || category.translated.name }}
+                                    {% endblock %}
+                                </div>
+                            {% endblock %}
+                        </div>
+                    {% endblock %}
+                {% endblock %}
+
+                {% block sw_cms_slot_overrides_modal_footer %}
+                    <template slot="modal-footer">
+                        {% block sw_cms_slot_overrides_modal_action_confirm %}
+                            <sw-button variant="primary" @click="onCloseOverrideModal">
+                                {{ $tc('sw-cms.detail.label.buttonElementOverridesClose') }}
                             </sw-button>
                         {% endblock %}
                     </template>

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-slot/sw-cms-slot.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-slot/sw-cms-slot.scss
@@ -35,7 +35,7 @@
 
     .sw-cms-slot__actions {
         display: grid;
-        grid-template-columns: 1fr 1fr;
+        grid-template-columns: 1fr 1fr 1fr;
         justify-content: right;
         justify-items: right;
         align-content: center;
@@ -49,6 +49,7 @@
         border-bottom-left-radius: 4px;
     }
 
+    .sw-cms-slot__settings-override,
     .sw-cms-slot__settings-action,
     .sw-cms-slot__element-action {
         padding: 10px;
@@ -68,6 +69,13 @@
         &:hover {
             color: $color-shopware-blue;
         }
+    }
+}
+
+.sw-cms-slot__overrides-modal {
+    .sw-cms-slot__overrides-modal-category {
+        color: #189EFF;
+        cursor: pointer;
     }
 }
 

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/snippet/de-DE.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/snippet/de-DE.json
@@ -86,6 +86,7 @@
         "blockCategoryForm": "Formular",
         "buttonElementSettingsConfirm": "Fertig",
         "buttonElementChangeAbort": "Abbrechen",
+        "buttonElementOverridesClose": "Schließen",
         "blockNameField": "Block-Name",
         "blockNameFieldPlaceholder": "Gib einen Namen ein ...",
         "blockSizingField": "Größenmodus",
@@ -150,7 +151,8 @@
       },
       "title": {
         "elementSettingsModal": "Element-Einstellungen",
-        "elementChangeModal": "Element austauschen"
+        "elementChangeModal": "Element austauschen",
+        "elementOverridesModal": "Element Überschreibungen"
       },
       "tooltip": {
         "blockNameField": "Benenne jeden Block individuell und eindeutig, um einen guten Überblick über Deine Arbeit zu behalten.",

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/snippet/en-GB.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/snippet/en-GB.json
@@ -86,6 +86,7 @@
         "blockCategoryForm": "Form",
         "buttonElementSettingsConfirm": "Done",
         "buttonElementChangeAbort": "Cancel",
+        "buttonElementOverridesClose": "Close",
         "blockNameField": "Block name",
         "blockNameFieldPlaceholder": "Enter name...",
         "blockSizingField": "Sizing mode",
@@ -150,7 +151,8 @@
       },
       "title": {
         "elementSettingsModal": "Element settings",
-        "elementChangeModal": "Replace element"
+        "elementChangeModal": "Replace element",
+        "elementOverridesModal": "Element overrides"
       },
       "tooltip": {
         "blockNameField": "Name each block individually to keep track of your work.",


### PR DESCRIPTION
### 1. Why is this change necessary?
It is unclear to other content editors that a category overrides content of a cms page without the usage of data binding. This should be noticably communicated to every content editors.

### 2. What does this change do, exactly?
Add an icon to show an info screen which other entity is overriding a block.

![grafik](https://user-images.githubusercontent.com/1133593/84607232-69271b80-aeac-11ea-9860-426e5514635d.png)
![grafik](https://user-images.githubusercontent.com/1133593/84607270-a8ee0300-aeac-11ea-899c-1f8ece55cbaf.png)
![grafik](https://user-images.githubusercontent.com/1133593/84607369-2e71b300-aead-11ea-9510-6e44251e390a.png)
![grafik](https://user-images.githubusercontent.com/1133593/84607413-6bd64080-aead-11ea-9e20-8e174ea5cf1a.png)
![grafik](https://user-images.githubusercontent.com/1133593/84607489-e43d0180-aead-11ea-9c73-53354dcacef9.png)

### 3. Describe each step to reproduce the issue or behaviour.
1. Setup static cms page
2. Assign cms page to category
3. Go to content tab in category amend content of block
4. Come back later or be other persona
5. See text on category page storefront
6. Go to shopping experiences
7. Edit cms page
8. Don't find the text you look for
9. Be confused as it is a static page without data binding

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
