### PR TITLE
Fix doubled cart quantity #1008

### DIFF
--- a/src/Core/Checkout/Cart/CartRuleLoader.php
+++ b/src/Core/Checkout/Cart/CartRuleLoader.php
@@ -4,6 +4,7 @@ namespace Shopware\Core\Checkout\Cart;
 
 use Psr\Log\LoggerInterface;
 use Shopware\Core\Checkout\Cart\Exception\CartTokenNotFoundException;
+use Shopware\Core\Checkout\Promotion\Cart\PromotionCartAddedInformationError;
 use Shopware\Core\Content\Rule\RuleCollection;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepositoryInterface;
@@ -117,9 +118,7 @@ class CartRuleLoader
         $context->setRuleIds($rules->getIds());
 
         // save the cart if errors exist, so the errors get persisted
-        if ($cart->getErrors()->count() > 0) {
-            $this->cartPersister->save($cart, $context);
-        }
+        $this->checkAndHandleErrors($cart, $context);
 
         return new RuleLoaderResult($cart, $rules);
     }
@@ -168,5 +167,15 @@ class CartRuleLoader
             || $previousLineItems->getKeys() !== $currentLineItems->getKeys()
             || $previousLineItems->getTypes() !== $currentLineItems->getTypes()
         ;
+    }
+
+    private function checkAndHandleErrors(Cart $cart, SalesChannelContext $context): void
+    {
+        foreach ($cart->getErrors() as $error) {
+            if (!$error instanceof PromotionCartAddedInformationError) {
+                $this->cartPersister->save($cart, $context);
+                return;
+            }
+        }
     }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/community).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well.
-->

### 1. Why is this change necessary?
Because adding items to empty cart, when any promotion item is active, doubles the quantity of added items.

### 2. What does this change do, exactly?
It changes the way that errors in CartRuleLoader are handled - the error of type "PromotionCartAddedInformationError" is omitted, because it's logically not an error, so the cart is not saved "for persisting errors", which prevents preloading already filled cart, when it should be empty.

### 3. Describe each step to reproduce the issue or behaviour.
1. Create an promotion in Admin Panel -> Marketing -> Promotions, which is applicable in your current state
2. Try to add a item to the cart
3. Quantity should be doubled (you should see that two items was added in default)
Another way:
1. Make an successful order
2. Create an promotion in Admin Panel -> Marketing -> Promotions, which is applicable in your current state
3. Go to order history page and try to add to cart the order which you have made earlier
4. The added quantity should be doubled

Didn't tested with more than one item in cart, but it seems that the issue is independent of quantity for any product/item.

### 4. Please link to the relevant issues (if any).
https://github.com/shopware/platform/issues/1008

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
