### PR TITLE
fix incrementing recursion variable

### DIFF
--- a/src/Storefront/Theme/ThemeFileResolver.php
+++ b/src/Storefront/Theme/ThemeFileResolver.php
@@ -112,7 +112,7 @@ class ThemeFileResolver
                 $considerPlugins = false;
 
                 foreach ($configurationCollection->getNoneThemes() as $plugin) {
-                    foreach ($this->resolve($plugin, $configurationCollection, $onlySourceFiles, $considerPlugins, $configFileResolver, ++$recursionLevel) as $item) {
+                    foreach ($this->resolve($plugin, $configurationCollection, $onlySourceFiles, $considerPlugins, $configFileResolver, $recursionLevel + 1) as $item) {
                         $resolvedFiles->add($item);
                     }
                 }
@@ -137,7 +137,7 @@ class ThemeFileResolver
                 throw new InvalidThemeException($name);
             }
 
-            foreach ($this->resolve($configuration, $configurationCollection, $onlySourceFiles, $considerPlugins, $configFileResolver, ++$recursionLevel) as $item) {
+            foreach ($this->resolve($configuration, $configurationCollection, $onlySourceFiles, $considerPlugins, $configFileResolver, $recursionLevel + 1) as $item) {
                 $resolvedFiles->add($item);
             }
         }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/community).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?

The code `++$recursionLevel` increases the variable directly inside the loop, which is not the desired behaviour. Because of the bug, plugin SCSS files get not compiled to all.css.

### 2. What does this change do, exactly?

It corrects the recursion.

### 3. Describe each step to reproduce the issue or behaviour.

Correctly increase the counter.

### 4. Please link to the relevant issues (if any).

https://issues.shopware.com/issues/NEXT-9214

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
