### PR TITLE
ensure all ids are returned in a search query

### DIFF
--- a/src/Elasticsearch/Framework/DataAbstractionLayer/ElasticsearchEntitySearcher.php
+++ b/src/Elasticsearch/Framework/DataAbstractionLayer/ElasticsearchEntitySearcher.php
@@ -112,10 +112,10 @@ class ElasticsearchEntitySearcher implements EntitySearcherInterface
         $this->helper->addSortings($definition, $criteria, $search, $context);
         $this->helper->addTerm($criteria, $search, $context, $definition);
 
-        if ($criteria->getLimit()) {
+        if ($criteria->getLimit() !== null) {
             $search->setSize($criteria->getLimit());
         }
-        if ($criteria->getOffset()) {
+        if ($criteria->getOffset() !== null) {
             $search->setFrom($criteria->getOffset());
         }
 

--- a/src/Elasticsearch/Framework/DataAbstractionLayer/ElasticsearchEntitySearcher.php
+++ b/src/Elasticsearch/Framework/DataAbstractionLayer/ElasticsearchEntitySearcher.php
@@ -112,8 +112,12 @@ class ElasticsearchEntitySearcher implements EntitySearcherInterface
         $this->helper->addSortings($definition, $criteria, $search, $context);
         $this->helper->addTerm($criteria, $search, $context, $definition);
 
-        $search->setSize($criteria->getLimit());
-        $search->setFrom($criteria->getOffset());
+        if ($criteria->getLimit()) {
+            $search->setSize($criteria->getLimit());
+        }
+        if ($criteria->getOffset()) {
+            $search->setFrom($criteria->getOffset());
+        }
 
         return $search;
     }

--- a/src/Elasticsearch/Framework/ElasticsearchHelper.php
+++ b/src/Elasticsearch/Framework/ElasticsearchHelper.php
@@ -156,6 +156,7 @@ class ElasticsearchHelper
         );
 
         $search->addQuery($query, BoolQuery::FILTER);
+        $search->setSize(count(array_values($ids)));
     }
 
     public function addFilters(EntityDefinition $definition, Criteria $criteria, Search $search, Context $context): void


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/community).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?

Shopware internally fires two requests to ES. One for the actual search with offset and size parameters set. This one is fine. The next one just passes the IDs, but without size parameter (which would make sense for a SQL database, as by default, all tuples are returned). However, ES has a default size of 10 for search results, if the size parameter is not set. Therefore, only 10 documents are returned which is wrong.

### 2. What does this change do, exactly?

Pass the "size" parameter to the request body of the ES request.

### 3. Describe each step to reproduce the issue or behaviour.

Paginated product listing in 6.2 only shows 10 products if ES is enabled.

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
