### PR TITLE
Show one to one extension errors

### DIFF
--- a/src/Administration/Resources/app/administration/src/core/data/error-resolver.data.js
+++ b/src/Administration/Resources/app/administration/src/core/data/error-resolver.data.js
@@ -132,6 +132,14 @@ export default class ErrorResolver {
             return;
         }
 
+        if (definition.isToOneAssociation(field)) {
+            this.resolveOneToOneFieldError(
+                `${entity.getEntityName()}.${entity.id}.${fieldName}`,
+                error,
+            );
+            return;
+        }
+
         if (definition.isJsonField(field)) {
             this.resolveJsonFieldError(
                 `${entity.getEntityName()}.${entity.id}.${fieldName}`,
@@ -169,6 +177,19 @@ export default class ErrorResolver {
             }
 
             this.resolveJsonFieldError(path, error[fieldName]);
+        });
+    }
+
+    resolveOneToOneFieldError(basePath, error) {
+        Object.keys(error).forEach((fieldName) => {
+            const path = `${basePath}.${fieldName}`;
+
+            if (error[fieldName] instanceof this.ShopwareError) {
+                Shopware.State.dispatch('error/addApiError', {
+                    expression: path,
+                    error: error[fieldName]
+                });
+            }
         });
     }
 


### PR DESCRIPTION
### 1. Why is this change necessary?
Error messages for OneToOneAssociation are currently not shown in the administration. In my case, I added a "OneToOne" association to "Product". The fields in the administration were not highlighted if the validation failed.
Input with error before my changes
![error-before](https://user-images.githubusercontent.com/36924392/84824253-e7f09580-b01f-11ea-9c67-26bc771d810f.png)
After my changes
![after-error](https://user-images.githubusercontent.com/36924392/84824272-ef17a380-b01f-11ea-9239-1b2956a7abc3.png)

### 2. What does this change do, exactly?
The change means that now errors from OneToOne associations in the 'error-resolver' are pushed into the store.

### 3. Describe each step to reproduce the issue or behaviour.
Create a Plugin that extends "Product" with a "OneToOneAssociationField".

> ProductExtension.php
```
...
 public function extendFields(FieldCollection $collection): void
    {
        $collection->add(
            (new OneToOneAssociationField(
                'myPlugin',
                'id',
                'product_id',
                MyPluginDefinition::class
            ))->addFlags(new CascadeDelete())
        );
    }
...
```
> sw-product-detail-my-plugin-tab/index.js
```
...
...mapPropertyErrors(
    'product',
    [
        'myPlugin.textField'
    ]
),
...
```
> sw-product-detail-my-plugin-tab.html.twig
```
...
<sw-field required
          :value="product.extensions.myPlugin.textField"
          :error="productMyPluginTextFieldError">
</sw-field>
...
```
### 4. Please link to the relevant issues (if any).
_

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
