### PR TITLE
Add event to access the criteria when loading addresses in the storefront

### DIFF
--- a/src/Storefront/Page/Address/Listing/AddressListingCriteriaEvent.php
+++ b/src/Storefront/Page/Address/Listing/AddressListingCriteriaEvent.php
@@ -1,0 +1,42 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Storefront\Page\Address\Listing;
+
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Event\NestedEvent;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
+
+class AddressListingCriteriaEvent extends NestedEvent
+{
+    /**
+     * @var Criteria
+     */
+    private $criteria;
+
+    /**
+     * @var SalesChannelContext
+     */
+    private $salesChannelContext;
+
+    public function __construct(Criteria $criteria, SalesChannelContext $salesChannelContext)
+    {
+        $this->criteria = $criteria;
+        $this->salesChannelContext = $salesChannelContext;
+    }
+
+    public function getCriteria(): Criteria
+    {
+        return $this->criteria;
+    }
+
+    public function getContext(): Context
+    {
+        return $this->salesChannelContext->getContext();
+    }
+
+    public function getSalesChannelContext(): SalesChannelContext
+    {
+        return $this->salesChannelContext;
+    }
+}

--- a/src/Storefront/Page/Address/Listing/AddressListingPageLoader.php
+++ b/src/Storefront/Page/Address/Listing/AddressListingPageLoader.php
@@ -147,6 +147,10 @@ class AddressListingPageLoader
             ->addAssociation('customer_address.country')
             ->addFilter(new EqualsFilter('customer_address.customerId', $context->getCustomer()->getId()));
 
+        $this->eventDispatcher->dispatch(
+            new AddressListingCriteriaEvent($criteria, $context)
+        );
+
         /** @var CustomerAddressCollection $collection */
         $collection = $this->addressRepository->search($criteria, $context->getContext())->getEntities();
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/community).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
Currently, all available addresses would be loaded for the customer (even if you have 100000 addresses) and this can be a huge performance issue.

With this change, we can limit the addresses that will be loaded by mutating the criteria object. We actually need this to build a storefront plugin.

### 2. What does this change do, exactly?
It adds an event to change the criteria when the customer's addresses are loaded in the storefront.

### 3. Describe each step to reproduce the issue or behaviour.
There is nothing to reproduce actually because this PR only adds an event.

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

Notes:
- If a test is required for this change, I do not know how to write it...
- I have not adjusted the documentation yet because there is no header like "Shopware 6.2.2" or similar and also I don't know on which version this change would be released
