### PR TITLE
use variables of font-weight

### DIFF
--- a/src/Storefront/Resources/app/storefront/src/scss/component/_category-navigation.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/component/_category-navigation.scss
@@ -38,7 +38,7 @@ Styling for category navigation component.
 .category-navigation-link {
     display: block;
     padding: 8px 20px;
-    font-weight: normal;
+    font-weight: $font-weight-normal;
     color: $sw-text-color;
 
     &:hover {
@@ -47,10 +47,10 @@ Styling for category navigation component.
 
     &.is-active {
         color: $sw-color-brand-primary;
-        font-weight: bold;
+        font-weight: $font-weight-bold;
     }
 
     &.in-path {
-        font-weight: bold;
+        font-weight: $font-weight-bold;
     }
 }

--- a/src/Storefront/Resources/app/storefront/src/scss/component/_cms-element.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/component/_cms-element.scss
@@ -122,7 +122,7 @@ General styling for cms elements
 .cms-element-product-slider {
     .cms-element-title {
         font-size: $font-size-lg;
-        font-weight: bold;
+        font-weight: $font-weight-bold;
         color: $headings-color;
     }
 

--- a/src/Storefront/Resources/app/storefront/src/scss/component/_cms-form-confirmation.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/component/_cms-form-confirmation.scss
@@ -2,7 +2,7 @@
     padding: 10% 20%;
     text-align: center;
     font-size: 18px;
-    font-weight: 600;
+    font-weight: $font-weight-semibold;
 
     div.alert {
         margin-top: 1em;

--- a/src/Storefront/Resources/app/storefront/src/scss/component/_filter-panel.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/component/_filter-panel.scss
@@ -97,7 +97,7 @@ This file contains the generic styling for all filter items.
     margin: 0;
     line-height: 1;
     border: 0 none;
-    font-weight: bold;
+    font-weight: $font-weight-bold;
     color: $dark;
     font-size: 16px;
     background-color: transparent;
@@ -125,7 +125,7 @@ This file contains the generic styling for all filter items.
     border-radius: 50px;
     height: 32px;
     line-height: 26px;
-    font-weight: normal;
+    font-weight: $font-weight-normal;
     vertical-align: top;
     margin-right: 8px;
 }

--- a/src/Storefront/Resources/app/storefront/src/scss/component/_filter-range.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/component/_filter-range.scss
@@ -61,5 +61,5 @@ This filter item should only be used inside a filter panel.
     height: 28px;
     line-height: 28px;
     text-align: center;
-    font-weight: bold;
+    font-weight: $font-weight-bold;
 }

--- a/src/Storefront/Resources/app/storefront/src/scss/component/_offcanvas.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/component/_offcanvas.scss
@@ -61,7 +61,7 @@ The sliding direction can be left or right.
 
         .offcanvas-title {
             font-size: 24px;
-            font-weight: bold;
+            font-weight: $font-weight-bold;
         }
     }
 

--- a/src/Storefront/Resources/app/storefront/src/scss/skin/shopware/layout/_top-bar.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/skin/shopware/layout/_top-bar.scss
@@ -7,7 +7,7 @@ The top bar contains e.g. the language switcher, the currency switcher and the s
 
 .top-bar-nav-btn.btn {
     color: $body-color;
-    font-weight: normal;
+    font-weight: $font-weight-normal;
     padding: 0;
 
     &:hover {

--- a/src/Storefront/Resources/app/storefront/src/scss/skin/shopware/page/account/_order-detail.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/skin/shopware/page/account/_order-detail.scss
@@ -17,7 +17,7 @@ $order-grid-gutter-width: 20px;
 }
 
 .order-table-header {
-    font-weight: bold;
+    font-weight: $font-weight-bold;
 }
 
 .order-item-name {
@@ -26,7 +26,7 @@ $order-grid-gutter-width: 20px;
 
 .order-detail-content-header {
     margin-top: $spacer-md;
-    font-weight: bold;
+    font-weight: $font-weight-bold;
 }
 
 .order-item-product-name {
@@ -79,5 +79,5 @@ $order-grid-gutter-width: 20px;
 }
 
 .order-item-variants-properties-name {
-    font-weight: bold;
+    font-weight: $font-weight-bold;
 }

--- a/src/Storefront/Resources/app/storefront/src/scss/skin/shopware/page/checkout/_cart-item.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/skin/shopware/page/checkout/_cart-item.scss
@@ -28,7 +28,7 @@
 }
 
 .cart-item-variants-properties-name {
-    font-weight: bold;
+    font-weight: $font-weight-bold;
 }
 
 .cart-item-label {


### PR DESCRIPTION
### 1. Why is this change necessary?
There are hardcoded font-weight in Storefront. We should use its variables.

### 2. What does this change do, exactly?
Change hardcoded font-weight to its variables

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
