### PR TITLE
Add entrypoint to change checkout item counter

### DIFF
--- a/src/Storefront/Resources/views/storefront/component/checkout/offcanvas-cart.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/checkout/offcanvas-cart.html.twig
@@ -18,14 +18,18 @@
                     <div class="col">
                         {{ "checkout.cartHeader"|trans|sw_sanitize }}
                     </div>
+                    
+                    {% set checkoutItemCounter = page.cart.lineItems|length %}
 
-                    {% if isCartNotEmpty %}
-                        <div class="col-auto">
-                            <small class="offcanvas-cart-header-count">
-                                {{ "checkout.itemCounter"|trans({'%count%': page.cart.lineItems|length})|sw_sanitize }}
-                            </small>
-                        </div>
-                    {% endif %}
+                    {% block component_offcanvas_cart_header_item_counter %}
+                        {% if isCartNotEmpty %}
+                            <div class="col-auto">
+                                <small class="offcanvas-cart-header-count">
+                                    {{ "checkout.itemCounter"|trans({'%count%': checkoutItemCounter})|sw_sanitize }}
+                                </small>
+                            </div>
+                        {% endif %}
+                    {% endblock %}
                 </div>
             {% endblock %}
 


### PR DESCRIPTION
### 1. Why is this change necessary?
Not every lineitem is a product. The snippet states there are x products in the cart. I'd like to reduce the checkout item count by custom line items that are no products or similar to products. 

In my case these lineitems custom surcharges and fees.

### 2. What does this change do, exactly?
Adds a block as entrypoint for other developers and extracted the lineitem count as variable that can be changed with that new entrypoint.

### 3. Describe each step to reproduce the issue or behaviour.
1. Add cart processor to add surcharges for every product in the cart
2. Have displayed twice as much products in the cart as product lineitems in the cart

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
