### PR TITLE
Fix import command

### DIFF
--- a/src/Core/Content/ImportExport/Command/ImportEntityCommand.php
+++ b/src/Core/Content/ImportExport/Command/ImportEntityCommand.php
@@ -89,7 +89,7 @@ class ImportEntityCommand extends Command
 
         $progress = new Progress($log->getId(), Progress::STATE_PROGRESS, 0);
         do {
-            $progress = $importExport->export(Context::createDefaultContext(), new Criteria(), $progress->getOffset());
+            $progress = $importExport->import(Context::createDefaultContext(), new Criteria(), $progress->getOffset());
             $progressBar->setProgress($progress->getOffset());
             $records += $progress->getProcessedRecords();
         } while (!$progress->isFinished());

--- a/src/Core/Content/ImportExport/Command/ImportEntityCommand.php
+++ b/src/Core/Content/ImportExport/Command/ImportEntityCommand.php
@@ -89,7 +89,7 @@ class ImportEntityCommand extends Command
 
         $progress = new Progress($log->getId(), Progress::STATE_PROGRESS, 0);
         do {
-            $progress = $importExport->import(Context::createDefaultContext(), new Criteria(), $progress->getOffset());
+            $progress = $importExport->import(Context::createDefaultContext(), $progress->getOffset());
             $progressBar->setProgress($progress->getOffset());
             $records += $progress->getProcessedRecords();
         } while (!$progress->isFinished());


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/community).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
The import command currently uses the export method of the ImportExportService instead of the import method.

### 2. What does this change do, exactly?
It uses import() instead of export().

### 3. Describe each step to reproduce the issue or behaviour.
Use the command to import a csv file.

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [X] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.
