### PR TITLE
NEXT-7413 Single select reset option Fixes #588

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/form/select/entity/sw-entity-single-select/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/form/select/entity/sw-entity-single-select/index.js
@@ -33,6 +33,11 @@ Component.register('sw-entity-single-select', {
             required: false,
             default: ''
         },
+        resetOption: {
+            type: String,
+            required: false,
+            default: ''
+        },
         labelProperty: {
             type: String,
             required: false,
@@ -160,6 +165,13 @@ Component.register('sw-entity-single-select', {
          */
         loadSelected() {
             if (this.value === '' || this.value === null) {
+                if (this.resetOption) {
+                    this.singleSelection = {
+                        id: null,
+                        name: this.resetOption
+                    };
+                }
+
                 return Promise.resolve();
             }
 
@@ -236,6 +248,15 @@ Component.register('sw-entity-single-select', {
                         this.resultCollection.push(item);
                     }
                 });
+            }
+
+            if (this.resetOption) {
+                if (!this.resultCollection.has(null)) {
+                    this.resultCollection.unshift({
+                        id: null,
+                        name: this.resetOption
+                    });
+                }
             }
         },
 

--- a/src/Administration/Resources/app/administration/src/app/component/structure/sw-sales-channel-switch/sw-sales-channel-switch.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/structure/sw-sales-channel-switch/sw-sales-channel-switch.html.twig
@@ -43,6 +43,7 @@
                     :placeholder="$tc('sw-sales-channel-switch.labelDefaultOption')"
                     :label="label"
                     :searchPlaceholder="$tc('sw-sales-channel-switch.placeholderSelect')"
+                    :resetOption="$tc('sw-sales-channel-switch.labelDefaultOption')"
                     @change="onChange"
                     :value="salesChannelId"
                     entity="sales_channel">


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/community).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
Fix for issue #588 

### 2. What does this change do, exactly?
- Add a resetOption property to sw-entity-single-select
-  If this property is set, the select has no placeholder anymore and this options is selected per default(as replacement for the placeholder)
- This options gets also added to the normal results list
- If the user clears the select and clicks outside, this option is selected again, as this is the default option
- Added the resetOption to sw-sales-channel-switch

### 3. Describe each step to reproduce the issue or behaviour.
In configuration pages where the sw-sales-channel-switch is used, a new option All Sales Channels will be added to the list.

### 4. Please link to the relevant issues (if any).
https://github.com/shopware/platform/issues/588

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
