### PR TITLE
NEXT-8142 Remove inner blocks utilities_thumbnail

### DIFF
--- a/src/Storefront/Resources/views/storefront/utilities/thumbnail.html.twig
+++ b/src/Storefront/Resources/views/storefront/utilities/thumbnail.html.twig
@@ -1,61 +1,58 @@
 {% block utilities_thumbnail %}
-    {% block utilities_thumbnail_logic %}
-        {# uses cms block column count and all available thumbnails to determine the correct image size for the current viewport #}
-        {% if media.thumbnails|length > 0 %}
-            {% if columns and sizes is not defined %}
-                {# set image size for every viewport #}
-                {% set sizes = {
-                    'xs': (shopware.theme.breakpoint.sm - 1) ~'px',
-                    'sm': (shopware.theme.breakpoint.md - 1) ~'px',
-                    'md': ((shopware.theme.breakpoint.lg - 1) / columns)|round(0, 'ceil') ~'px',
-                    'lg': ((shopware.theme.breakpoint.xl - 1) / columns)|round(0, 'ceil') ~'px'
-                } %}
+    {# uses cms block column count and all available thumbnails to determine the correct image size for the current viewport #}
+    {% if media.thumbnails|length > 0 %}
+        {% if columns and sizes is not defined %}
+            {# set image size for every viewport #}
+            {% set sizes = {
+                'xs': (shopware.theme.breakpoint.sm - 1) ~'px',
+                'sm': (shopware.theme.breakpoint.md - 1) ~'px',
+                'md': ((shopware.theme.breakpoint.lg - 1) / columns)|round(0, 'ceil') ~'px',
+                'lg': ((shopware.theme.breakpoint.xl - 1) / columns)|round(0, 'ceil') ~'px'
+            } %}
 
-                {# set image size for largest viewport depending on the cms block sizing mode (boxed or full-width) #}
-                {% if layout == 'full-width' %}
-                    {% set container = 100 %}
-                    {% set sizes = sizes|merge({ 'xl': (container / columns)|round(0, 'ceil') ~'vw'}) %}
-                {% else %}
-                    {% set container = 1360 %}
-                    {% set sizes = sizes|merge({ 'xl': (container / columns)|round(0, 'ceil') ~'px'}) %}
-                {% endif %}
+            {# set image size for largest viewport depending on the cms block sizing mode (boxed or full-width) #}
+            {% if layout == 'full-width' %}
+                {% set container = 100 %}
+                {% set sizes = sizes|merge({ 'xl': (container / columns)|round(0, 'ceil') ~'vw'}) %}
+            {% else %}
+                {% set container = 1360 %}
+                {% set sizes = sizes|merge({ 'xl': (container / columns)|round(0, 'ceil') ~'px'}) %}
             {% endif %}
-
-            {% set thumbnails = media.thumbnails|sort|reverse %}
-
-            {# generate srcset with all available thumbnails #}
-            {% set srcsetValue %}{% apply spaceless %}
-                {{ media|sw_encode_media_url }} {{ thumbnails|first.width + 1 }}w, {% for thumbnail in thumbnails %}{{ thumbnail.url | sw_encode_url }} {{ thumbnail.width }}w{% if not loop.last %}, {% endif %}{% endfor %}
-            {% endapply %}{% endset %}
-
-            {# generate sizes #}
-            {% set sizesValue %}{% apply spaceless %}
-                {% set sizeFallback = 100 %}
-
-                {# set largest size depending on column count of cms block #}
-                {% if columns %}
-                    {% set sizeFallback = (sizeFallback / columns)|round(0, 'ceil') %}
-                {% endif %}
-
-                {% if thumbnails|first.width > shopware.theme.breakpoint|reverse|first %}
-                    {% set maxWidth = thumbnails|first.width %}
-                {% endif %}
-
-                {% for key, value in shopware.theme.breakpoint|reverse %}{% if maxWidth %}(max-width: {{ maxWidth }}px) and {% endif %}(min-width: {{ value }}px) {{ sizes[key] }}{% set maxWidth = value-1 %}{% if not loop.last %}, {% endif %}{% endfor %}, {{ sizeFallback }}vw
-            {% endapply %}{% endset %}
         {% endif %}
-    {% endblock %}
-    {% block utilities_thumbnail_image %}
-        <img src="{{ media|sw_encode_media_url }}"
-            {% if media.thumbnails|length > 0 %}
-                srcset="{{ srcsetValue }}"
-                {% if sizes['default'] %}
-                sizes="{{ sizes['default'] }}"
-                {% elseif sizes|length > 0 %}
-                sizes="{{ sizesValue }}"
-                {% endif %}
+
+        {% set thumbnails = media.thumbnails|sort|reverse %}
+
+        {# generate srcset with all available thumbnails #}
+        {% set srcsetValue %}{% apply spaceless %}
+            {{ media|sw_encode_media_url }} {{ thumbnails|first.width + 1 }}w, {% for thumbnail in thumbnails %}{{ thumbnail.url | sw_encode_url }} {{ thumbnail.width }}w{% if not loop.last %}, {% endif %}{% endfor %}
+        {% endapply %}{% endset %}
+
+        {# generate sizes #}
+        {% set sizesValue %}{% apply spaceless %}
+            {% set sizeFallback = 100 %}
+
+            {# set largest size depending on column count of cms block #}
+            {% if columns %}
+                {% set sizeFallback = (sizeFallback / columns)|round(0, 'ceil') %}
             {% endif %}
-            {% for key, value in attributes %}{% if value != '' %} {{ key }}="{{ value }}"{% endif %}{% endfor %}
-        />
-    {% endblock %}
+
+            {% if thumbnails|first.width > shopware.theme.breakpoint|reverse|first %}
+                {% set maxWidth = thumbnails|first.width %}
+            {% endif %}
+
+            {% for key, value in shopware.theme.breakpoint|reverse %}{% if maxWidth %}(max-width: {{ maxWidth }}px) and {% endif %}(min-width: {{ value }}px) {{ sizes[key] }}{% set maxWidth = value-1 %}{% if not loop.last %}, {% endif %}{% endfor %}, {{ sizeFallback }}vw
+        {% endapply %}{% endset %}
+    {% endif %}
+
+    <img src="{{ media|sw_encode_media_url }}"
+        {% if media.thumbnails|length > 0 %}
+            srcset="{{ srcsetValue }}"
+            {% if sizes['default'] %}
+            sizes="{{ sizes['default'] }}"
+            {% elseif sizes|length > 0 %}
+            sizes="{{ sizesValue }}"
+            {% endif %}
+        {% endif %}
+        {% for key, value in attributes %}{% if value != '' %} {{ key }}="{{ value }}"{% endif %}{% endfor %}
+    />
 {% endblock %}

--- a/src/Storefront/Resources/views/storefront/utilities/thumbnail.html.twig
+++ b/src/Storefront/Resources/views/storefront/utilities/thumbnail.html.twig
@@ -44,15 +44,17 @@
         {% endapply %}{% endset %}
     {% endif %}
 
-    <img src="{{ media|sw_encode_media_url }}"
-        {% if media.thumbnails|length > 0 %}
-            srcset="{{ srcsetValue }}"
-            {% if sizes['default'] %}
-            sizes="{{ sizes['default'] }}"
-            {% elseif sizes|length > 0 %}
-            sizes="{{ sizesValue }}"
+    {% block utilities_thumbnail_image %}
+        <img src="{{ media|sw_encode_media_url }}"
+            {% if media.thumbnails|length > 0 %}
+                srcset="{{ srcsetValue }}"
+                {% if sizes['default'] %}
+                sizes="{{ sizes['default'] }}"
+                {% elseif sizes|length > 0 %}
+                sizes="{{ sizesValue }}"
+                {% endif %}
             {% endif %}
-        {% endif %}
-        {% for key, value in attributes %}{% if value != '' %} {{ key }}="{{ value }}"{% endif %}{% endfor %}
-    />
+            {% for key, value in attributes %}{% if value != '' %} {{ key }}="{{ value }}"{% endif %}{% endfor %}
+        />
+    {% endblock %}
 {% endblock %}


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/community).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
All thumbnails using the sw_thumbnails function are broken and don't actually use smaller versions.

### 2. What does this change do, exactly?
Remove two inner twig blocks in @Storefront/storefront/utilities/thumbnail.html.twig as this works against the scope of Twig variables. Setting variables in twig using 'set' is scoped within the block. The variables set in the 'utilities_thumbnail_logic' block could never get to the utilities_thumbnail_image because the scope of the variable would not allow it.

### 3. Describe each step to reproduce the issue or behaviour.
Check the source code of any thumbnail image. It always has an empty source set.

### 4. Please link to the relevant issues (if any).
https://github.com/shopware/platform/issues/837

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
