### PR TITLE
Admin node-sass version from 4.13.1 to 4.14.1

### DIFF
--- a/src/Administration/Resources/app/administration/package.json
+++ b/src/Administration/Resources/app/administration/package.json
@@ -122,7 +122,7 @@
         "launch-editor-middleware": "2.2.1",
         "less": "3.9.0",
         "less-loader": "5.0.0",
-        "node-sass": "4.13.1",
+        "node-sass": "4.14.1",
         "opn": "6.0.0",
         "prismjs": "1.17.1",
         "sass-loader": "7.1.0",


### PR DESCRIPTION
Update packages.json due to errors encountered on Ubuntu: "Error: Node Sass does not yet support your current environment: Linux 64-bit with Unsuported Runtime (83)"

Updating the node-sass fixed the issue.

![image](https://user-images.githubusercontent.com/16402164/85272443-77f96980-b47c-11ea-996a-378e301d683a.png)


<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/community).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?


### 2. What does this change do, exactly?


### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.
