### PR TITLE
Admin node-sass version from 4.13.1 to 4.14.1

### DIFF
--- a/src/Administration/Resources/app/administration/package-lock.json
+++ b/src/Administration/Resources/app/administration/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "administration",
-    "version": "6.2.1",
+    "version": "1.0.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/src/Administration/Resources/app/administration/package-lock.json
+++ b/src/Administration/Resources/app/administration/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "administration",
-    "version": "1.0.0",
+    "version": "6.2.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -7075,13 +7075,13 @@
             "dev": true
         },
         "globule": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/globule/-/globule-1.3.1.tgz",
-            "integrity": "sha512-OVyWOHgw29yosRHCHo7NncwR1hW5ew0W/UrvtwvjefVJeQ26q4/8r8FmPsSF1hJ93IgWkyv16pCTz6WblMzm/g==",
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/globule/-/globule-1.3.2.tgz",
+            "integrity": "sha512-7IDTQTIu2xzXkT+6mlluidnWo+BypnbSoEVVQCGfzqnl5Ik8d3e1d4wycb8Rj9tWW+Z39uPWsdlquqiqPCd/pA==",
             "dev": true,
             "requires": {
                 "glob": "~7.1.1",
-                "lodash": "~4.17.12",
+                "lodash": "~4.17.10",
                 "minimatch": "~3.0.2"
             }
         },
@@ -7829,12 +7829,6 @@
             "requires": {
                 "loose-envify": "^1.0.0"
             }
-        },
-        "invert-kv": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-            "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
-            "dev": true
         },
         "ip": {
             "version": "1.1.5",
@@ -8752,9 +8746,9 @@
             "integrity": "sha1-o6vicYryQaKykE+EpiWXDzia4yo="
         },
         "js-base64": {
-            "version": "2.5.2",
-            "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.5.2.tgz",
-            "integrity": "sha512-Vg8czh0Q7sFBSUMWWArX/miJeBWYBPpdU/3M/DKSaekLMqrqVPaedp+5mZhie/r0lgrcaYBfwXatEew6gwgiQQ==",
+            "version": "2.6.1",
+            "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.6.1.tgz",
+            "integrity": "sha512-G5x2saUTupU9D/xBY9snJs3TxvwX8EkpLFiYlPpDt/VmMHOXprnSU1nxiTmFbijCX4BLF/cMRIfAcC5BiMYgFQ==",
             "dev": true
         },
         "js-levenshtein": {
@@ -9016,15 +9010,6 @@
             "dev": true,
             "requires": {
                 "launch-editor": "^2.2.1"
-            }
-        },
-        "lcid": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-            "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
-            "dev": true,
-            "requires": {
-                "invert-kv": "^1.0.0"
             }
         },
         "left-pad": {
@@ -10116,9 +10101,9 @@
             }
         },
         "node-sass": {
-            "version": "4.13.1",
-            "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.13.1.tgz",
-            "integrity": "sha512-TTWFx+ZhyDx1Biiez2nB0L3YrCZ/8oHagaDalbuBSlqXgUPsdkUSzJsVxeDO9LtPB49+Fh3WQl3slABo6AotNw==",
+            "version": "4.14.1",
+            "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.14.1.tgz",
+            "integrity": "sha512-sjCuOlvGyCJS40R8BscF5vhVlQjNN069NtQ1gSxyK1u9iqvn6tf7O1R4GNowVZfiZUCRt5MmMs1xd+4V/7Yr0g==",
             "dev": true,
             "requires": {
                 "async-foreach": "^0.1.3",
@@ -10135,7 +10120,7 @@
                 "node-gyp": "^3.8.0",
                 "npmlog": "^4.0.0",
                 "request": "^2.88.0",
-                "sass-graph": "^2.2.4",
+                "sass-graph": "2.2.5",
                 "stdout-stream": "^1.4.0",
                 "true-case-path": "^1.0.2"
             },
@@ -10659,15 +10644,6 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
             "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
-        },
-        "os-locale": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
-            "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
-            "dev": true,
-            "requires": {
-                "lcid": "^1.0.0"
-            }
         },
         "os-tmpdir": {
             "version": "1.0.2",
@@ -12725,206 +12701,15 @@
             }
         },
         "sass-graph": {
-            "version": "2.2.4",
-            "resolved": "https://registry.npmjs.org/sass-graph/-/sass-graph-2.2.4.tgz",
-            "integrity": "sha1-E/vWPNHK8JCLn9k0dq1DpR0eC0k=",
+            "version": "2.2.5",
+            "resolved": "https://registry.npmjs.org/sass-graph/-/sass-graph-2.2.5.tgz",
+            "integrity": "sha512-VFWDAHOe6mRuT4mZRd4eKE+d8Uedrk6Xnh7Sh9b4NGufQLQjOrvf/MQoOdx+0s92L89FeyUUNfU597j/3uNpag==",
             "dev": true,
             "requires": {
                 "glob": "^7.0.0",
                 "lodash": "^4.0.0",
                 "scss-tokenizer": "^0.2.3",
-                "yargs": "^7.0.0"
-            },
-            "dependencies": {
-                "ansi-regex": {
-                    "version": "2.1.1",
-                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-                    "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-                    "dev": true
-                },
-                "camelcase": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-                    "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
-                    "dev": true
-                },
-                "cliui": {
-                    "version": "3.2.0",
-                    "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-                    "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-                    "dev": true,
-                    "requires": {
-                        "string-width": "^1.0.1",
-                        "strip-ansi": "^3.0.1",
-                        "wrap-ansi": "^2.0.0"
-                    }
-                },
-                "find-up": {
-                    "version": "1.1.2",
-                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-                    "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-                    "dev": true,
-                    "requires": {
-                        "path-exists": "^2.0.0",
-                        "pinkie-promise": "^2.0.0"
-                    }
-                },
-                "get-caller-file": {
-                    "version": "1.0.3",
-                    "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
-                    "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
-                    "dev": true
-                },
-                "is-fullwidth-code-point": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-                    "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-                    "dev": true,
-                    "requires": {
-                        "number-is-nan": "^1.0.0"
-                    }
-                },
-                "load-json-file": {
-                    "version": "1.1.0",
-                    "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-                    "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-                    "dev": true,
-                    "requires": {
-                        "graceful-fs": "^4.1.2",
-                        "parse-json": "^2.2.0",
-                        "pify": "^2.0.0",
-                        "pinkie-promise": "^2.0.0",
-                        "strip-bom": "^2.0.0"
-                    }
-                },
-                "path-exists": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-                    "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-                    "dev": true,
-                    "requires": {
-                        "pinkie-promise": "^2.0.0"
-                    }
-                },
-                "path-type": {
-                    "version": "1.1.0",
-                    "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-                    "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-                    "dev": true,
-                    "requires": {
-                        "graceful-fs": "^4.1.2",
-                        "pify": "^2.0.0",
-                        "pinkie-promise": "^2.0.0"
-                    }
-                },
-                "read-pkg": {
-                    "version": "1.1.0",
-                    "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-                    "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-                    "dev": true,
-                    "requires": {
-                        "load-json-file": "^1.0.0",
-                        "normalize-package-data": "^2.3.2",
-                        "path-type": "^1.0.0"
-                    }
-                },
-                "read-pkg-up": {
-                    "version": "1.0.1",
-                    "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-                    "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-                    "dev": true,
-                    "requires": {
-                        "find-up": "^1.0.0",
-                        "read-pkg": "^1.0.0"
-                    }
-                },
-                "require-main-filename": {
-                    "version": "1.0.1",
-                    "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-                    "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
-                    "dev": true
-                },
-                "string-width": {
-                    "version": "1.0.2",
-                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-                    "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-                    "dev": true,
-                    "requires": {
-                        "code-point-at": "^1.0.0",
-                        "is-fullwidth-code-point": "^1.0.0",
-                        "strip-ansi": "^3.0.0"
-                    }
-                },
-                "strip-ansi": {
-                    "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                    "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-                    "dev": true,
-                    "requires": {
-                        "ansi-regex": "^2.0.0"
-                    }
-                },
-                "strip-bom": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-                    "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-                    "dev": true,
-                    "requires": {
-                        "is-utf8": "^0.2.0"
-                    }
-                },
-                "which-module": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
-                    "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=",
-                    "dev": true
-                },
-                "wrap-ansi": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
-                    "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
-                    "dev": true,
-                    "requires": {
-                        "string-width": "^1.0.1",
-                        "strip-ansi": "^3.0.1"
-                    }
-                },
-                "y18n": {
-                    "version": "3.2.1",
-                    "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-                    "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
-                    "dev": true
-                },
-                "yargs": {
-                    "version": "7.1.0",
-                    "resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz",
-                    "integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
-                    "dev": true,
-                    "requires": {
-                        "camelcase": "^3.0.0",
-                        "cliui": "^3.2.0",
-                        "decamelize": "^1.1.1",
-                        "get-caller-file": "^1.0.1",
-                        "os-locale": "^1.4.0",
-                        "read-pkg-up": "^1.0.1",
-                        "require-directory": "^2.1.1",
-                        "require-main-filename": "^1.0.1",
-                        "set-blocking": "^2.0.0",
-                        "string-width": "^1.0.2",
-                        "which-module": "^1.0.0",
-                        "y18n": "^3.2.1",
-                        "yargs-parser": "^5.0.0"
-                    }
-                },
-                "yargs-parser": {
-                    "version": "5.0.0",
-                    "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz",
-                    "integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
-                    "dev": true,
-                    "requires": {
-                        "camelcase": "^3.0.0"
-                    }
-                }
+                "yargs": "^13.3.2"
             }
         },
         "sass-loader": {

--- a/src/Administration/Resources/app/administration/package-lock.json
+++ b/src/Administration/Resources/app/administration/package-lock.json
@@ -7075,13 +7075,13 @@
             "dev": true
         },
         "globule": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/globule/-/globule-1.3.1.tgz",
-            "integrity": "sha512-OVyWOHgw29yosRHCHo7NncwR1hW5ew0W/UrvtwvjefVJeQ26q4/8r8FmPsSF1hJ93IgWkyv16pCTz6WblMzm/g==",
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/globule/-/globule-1.3.2.tgz",
+            "integrity": "sha512-7IDTQTIu2xzXkT+6mlluidnWo+BypnbSoEVVQCGfzqnl5Ik8d3e1d4wycb8Rj9tWW+Z39uPWsdlquqiqPCd/pA==",
             "dev": true,
             "requires": {
                 "glob": "~7.1.1",
-                "lodash": "~4.17.12",
+                "lodash": "~4.17.10",
                 "minimatch": "~3.0.2"
             }
         },
@@ -7829,12 +7829,6 @@
             "requires": {
                 "loose-envify": "^1.0.0"
             }
-        },
-        "invert-kv": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-            "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
-            "dev": true
         },
         "ip": {
             "version": "1.1.5",
@@ -8752,9 +8746,9 @@
             "integrity": "sha1-o6vicYryQaKykE+EpiWXDzia4yo="
         },
         "js-base64": {
-            "version": "2.5.2",
-            "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.5.2.tgz",
-            "integrity": "sha512-Vg8czh0Q7sFBSUMWWArX/miJeBWYBPpdU/3M/DKSaekLMqrqVPaedp+5mZhie/r0lgrcaYBfwXatEew6gwgiQQ==",
+            "version": "2.6.1",
+            "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.6.1.tgz",
+            "integrity": "sha512-G5x2saUTupU9D/xBY9snJs3TxvwX8EkpLFiYlPpDt/VmMHOXprnSU1nxiTmFbijCX4BLF/cMRIfAcC5BiMYgFQ==",
             "dev": true
         },
         "js-levenshtein": {
@@ -9016,15 +9010,6 @@
             "dev": true,
             "requires": {
                 "launch-editor": "^2.2.1"
-            }
-        },
-        "lcid": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-            "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
-            "dev": true,
-            "requires": {
-                "invert-kv": "^1.0.0"
             }
         },
         "left-pad": {
@@ -10116,9 +10101,9 @@
             }
         },
         "node-sass": {
-            "version": "4.13.1",
-            "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.13.1.tgz",
-            "integrity": "sha512-TTWFx+ZhyDx1Biiez2nB0L3YrCZ/8oHagaDalbuBSlqXgUPsdkUSzJsVxeDO9LtPB49+Fh3WQl3slABo6AotNw==",
+            "version": "4.14.1",
+            "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.14.1.tgz",
+            "integrity": "sha512-sjCuOlvGyCJS40R8BscF5vhVlQjNN069NtQ1gSxyK1u9iqvn6tf7O1R4GNowVZfiZUCRt5MmMs1xd+4V/7Yr0g==",
             "dev": true,
             "requires": {
                 "async-foreach": "^0.1.3",
@@ -10135,7 +10120,7 @@
                 "node-gyp": "^3.8.0",
                 "npmlog": "^4.0.0",
                 "request": "^2.88.0",
-                "sass-graph": "^2.2.4",
+                "sass-graph": "2.2.5",
                 "stdout-stream": "^1.4.0",
                 "true-case-path": "^1.0.2"
             },
@@ -10659,15 +10644,6 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
             "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
-        },
-        "os-locale": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
-            "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
-            "dev": true,
-            "requires": {
-                "lcid": "^1.0.0"
-            }
         },
         "os-tmpdir": {
             "version": "1.0.2",
@@ -12725,206 +12701,15 @@
             }
         },
         "sass-graph": {
-            "version": "2.2.4",
-            "resolved": "https://registry.npmjs.org/sass-graph/-/sass-graph-2.2.4.tgz",
-            "integrity": "sha1-E/vWPNHK8JCLn9k0dq1DpR0eC0k=",
+            "version": "2.2.5",
+            "resolved": "https://registry.npmjs.org/sass-graph/-/sass-graph-2.2.5.tgz",
+            "integrity": "sha512-VFWDAHOe6mRuT4mZRd4eKE+d8Uedrk6Xnh7Sh9b4NGufQLQjOrvf/MQoOdx+0s92L89FeyUUNfU597j/3uNpag==",
             "dev": true,
             "requires": {
                 "glob": "^7.0.0",
                 "lodash": "^4.0.0",
                 "scss-tokenizer": "^0.2.3",
-                "yargs": "^7.0.0"
-            },
-            "dependencies": {
-                "ansi-regex": {
-                    "version": "2.1.1",
-                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-                    "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-                    "dev": true
-                },
-                "camelcase": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-                    "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
-                    "dev": true
-                },
-                "cliui": {
-                    "version": "3.2.0",
-                    "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-                    "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-                    "dev": true,
-                    "requires": {
-                        "string-width": "^1.0.1",
-                        "strip-ansi": "^3.0.1",
-                        "wrap-ansi": "^2.0.0"
-                    }
-                },
-                "find-up": {
-                    "version": "1.1.2",
-                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-                    "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-                    "dev": true,
-                    "requires": {
-                        "path-exists": "^2.0.0",
-                        "pinkie-promise": "^2.0.0"
-                    }
-                },
-                "get-caller-file": {
-                    "version": "1.0.3",
-                    "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
-                    "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
-                    "dev": true
-                },
-                "is-fullwidth-code-point": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-                    "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-                    "dev": true,
-                    "requires": {
-                        "number-is-nan": "^1.0.0"
-                    }
-                },
-                "load-json-file": {
-                    "version": "1.1.0",
-                    "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-                    "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-                    "dev": true,
-                    "requires": {
-                        "graceful-fs": "^4.1.2",
-                        "parse-json": "^2.2.0",
-                        "pify": "^2.0.0",
-                        "pinkie-promise": "^2.0.0",
-                        "strip-bom": "^2.0.0"
-                    }
-                },
-                "path-exists": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-                    "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-                    "dev": true,
-                    "requires": {
-                        "pinkie-promise": "^2.0.0"
-                    }
-                },
-                "path-type": {
-                    "version": "1.1.0",
-                    "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-                    "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-                    "dev": true,
-                    "requires": {
-                        "graceful-fs": "^4.1.2",
-                        "pify": "^2.0.0",
-                        "pinkie-promise": "^2.0.0"
-                    }
-                },
-                "read-pkg": {
-                    "version": "1.1.0",
-                    "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-                    "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-                    "dev": true,
-                    "requires": {
-                        "load-json-file": "^1.0.0",
-                        "normalize-package-data": "^2.3.2",
-                        "path-type": "^1.0.0"
-                    }
-                },
-                "read-pkg-up": {
-                    "version": "1.0.1",
-                    "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-                    "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-                    "dev": true,
-                    "requires": {
-                        "find-up": "^1.0.0",
-                        "read-pkg": "^1.0.0"
-                    }
-                },
-                "require-main-filename": {
-                    "version": "1.0.1",
-                    "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-                    "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
-                    "dev": true
-                },
-                "string-width": {
-                    "version": "1.0.2",
-                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-                    "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-                    "dev": true,
-                    "requires": {
-                        "code-point-at": "^1.0.0",
-                        "is-fullwidth-code-point": "^1.0.0",
-                        "strip-ansi": "^3.0.0"
-                    }
-                },
-                "strip-ansi": {
-                    "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                    "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-                    "dev": true,
-                    "requires": {
-                        "ansi-regex": "^2.0.0"
-                    }
-                },
-                "strip-bom": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-                    "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-                    "dev": true,
-                    "requires": {
-                        "is-utf8": "^0.2.0"
-                    }
-                },
-                "which-module": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
-                    "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=",
-                    "dev": true
-                },
-                "wrap-ansi": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
-                    "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
-                    "dev": true,
-                    "requires": {
-                        "string-width": "^1.0.1",
-                        "strip-ansi": "^3.0.1"
-                    }
-                },
-                "y18n": {
-                    "version": "3.2.1",
-                    "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-                    "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
-                    "dev": true
-                },
-                "yargs": {
-                    "version": "7.1.0",
-                    "resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz",
-                    "integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
-                    "dev": true,
-                    "requires": {
-                        "camelcase": "^3.0.0",
-                        "cliui": "^3.2.0",
-                        "decamelize": "^1.1.1",
-                        "get-caller-file": "^1.0.1",
-                        "os-locale": "^1.4.0",
-                        "read-pkg-up": "^1.0.1",
-                        "require-directory": "^2.1.1",
-                        "require-main-filename": "^1.0.1",
-                        "set-blocking": "^2.0.0",
-                        "string-width": "^1.0.2",
-                        "which-module": "^1.0.0",
-                        "y18n": "^3.2.1",
-                        "yargs-parser": "^5.0.0"
-                    }
-                },
-                "yargs-parser": {
-                    "version": "5.0.0",
-                    "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz",
-                    "integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
-                    "dev": true,
-                    "requires": {
-                        "camelcase": "^3.0.0"
-                    }
-                }
+                "yargs": "^13.3.2"
             }
         },
         "sass-loader": {

--- a/src/Administration/Resources/app/administration/package.json
+++ b/src/Administration/Resources/app/administration/package.json
@@ -122,7 +122,7 @@
         "launch-editor-middleware": "2.2.1",
         "less": "3.9.0",
         "less-loader": "5.0.0",
-        "node-sass": "4.13.1",
+        "node-sass": "4.14.1",
         "opn": "6.0.0",
         "prismjs": "1.17.1",
         "sass-loader": "7.1.0",


### PR DESCRIPTION
Update packages.json due to errors encountered on Ubuntu: "Error: Node Sass does not yet support your current environment: Linux 64-bit with Unsuported Runtime (83)"

Updating the node-sass fixed the issue.


<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/community).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
 Because it is failing to build administration via bin/build-administration.sh

### 2. What does this change do, exactly?
Updates npm package node-sass version from 4.13.1 to 4.14.1

### 3. Describe each step to reproduce the issue or behaviour.
Ubuntu 18.04 x86_64 GNU/Linux
run bin/build-administration.sh and you will get following error:
![image](https://user-images.githubusercontent.com/16402164/85272443-77f96980-b47c-11ea-996a-378e301d683a.png)

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
