### PR TITLE
NEXT-9311: show asterisk if telephone number field is required

### DIFF
--- a/CHANGELOG-6.2.md
+++ b/CHANGELOG-6.2.md
@@ -22,6 +22,7 @@ To get the diff between two versions, go to https://github.com/shopware/platform
 * Storefront
     * Added block `component_offcanvas_cart_header_item_counter` to `src/Storefront/Resources/views/storefront/component/checkout/offcanvas-cart.html.twig`
     * Added the `--keep-cache` option to the `http:cache:warm:up` to keep the current cache as warmup target
+    * Show required asterisk on telephone number field if the field is required in registration form.
 
 **Removals**
 

--- a/src/Storefront/Resources/views/storefront/component/address/address-form.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/address/address-form.html.twig
@@ -375,7 +375,7 @@
                         {% block component_address_form_phone_number_label %}
                             <label class="form-label"
                                    for="{{ prefix }}AddressPhoneNumber">
-                                {{ "address.phoneNumberLabel"|trans|sw_sanitize }}
+                                {{ "address.phoneNumberLabel"|trans|sw_sanitize }}{{ shopware.config.core.loginRegistration.phoneNumberFieldRequired ? "general.required"|trans|sw_sanitize }}
                             </label>
                         {% endblock %}
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/community).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
The telephone number form field in the registration form is missing the asterisk if the field is configured to be required in the backend.

### 2. What does this change do, exactly?
If the field is required an asterisk is shown next to the label like already implemented for other fields.

### 3. Describe each step to reproduce the issue or behaviour.
In Settings -> Login/Registration in the backend set the telephone number to required. Go /checkout/register. The phone field is missing the asterisk that marks the field as required.

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/NEXT-9311

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.