### PR TITLE
Convert version in openapi schema to string

### DIFF
--- a/src/Core/Framework/Api/ApiDefinition/Generator/OpenApi/OpenApiSchemaBuilder.php
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/OpenApi/OpenApiSchemaBuilder.php
@@ -67,7 +67,7 @@ class OpenApiSchemaBuilder
     {
         return new Info([
             'title' => 'Shopware ' . self::API[$api]['name'],
-            'version' => $version,
+            'version' => (string) $version,
         ]);
     }
 


### PR DESCRIPTION
### 1. Why is this change necessary?
Because current openapi specification is invalid.
The version key must be a string.
Check it on https://editor.swagger.io/

### 2. What does this change do, exactly?
It casts the version to string.

### 3. Describe each step to reproduce the issue or behaviour.

1. Get openapi schema `/api/v1/_info/openapi3.json`
2. Paste into https://editor.swagger.io/
3. Get following error

```
Structural error at info.version
should be string
```

### 4. Please link to the relevant issues (if any).
None

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
