### PR TITLE
Fixed active state in flyout navigation

### DIFF
--- a/CHANGELOG-6.2.md
+++ b/CHANGELOG-6.2.md
@@ -30,6 +30,7 @@ To get the diff between two versions, go to https://github.com/shopware/platform
     * Added request attribute with key `\Shopware\Storefront\Framework\Routing\RequestTransformer::STOREFRONT_URL` for the base url of the storefront. It contains scheme, host, port, sub directory of the web root and the virtual path. Example: http://localhost:8000/subdir/de
     * Fixed urls in emails for shops with virtual paths like /de
     * Added `GenericPageLoaderInterface` to `CheckoutConfirmPageLoader`
+    * Fixed active state in the flyout navigation
 
 **Removals**
 

--- a/src/Storefront/Resources/views/storefront/layout/navigation/categories.html.twig
+++ b/src/Storefront/Resources/views/storefront/layout/navigation/categories.html.twig
@@ -34,7 +34,8 @@
                         {% if level < navigationMaxDepth %}
                             {% sw_include '@Storefront/storefront/layout/navigation/categories.html.twig' with {
                                 navigationTree: treeItem.children,
-                                level: level + 1
+                                level: level + 1,
+                                page: page
                             } only %}
                         {% endif %}
                     {% endblock %}

--- a/src/Storefront/Resources/views/storefront/layout/navigation/flyout.html.twig
+++ b/src/Storefront/Resources/views/storefront/layout/navigation/flyout.html.twig
@@ -48,7 +48,8 @@
                         {% block layout_navigation_flyout_categories_recoursion %}
                             {% sw_include '@Storefront/storefront/layout/navigation/categories.html.twig' with {
                                 navigationTree: navigationTree.children,
-                                navigationMedia: category.media
+                                navigationMedia: category.media,
+                                page: page
                             } only %}
                         {% endblock %}
                     </div>

--- a/src/Storefront/Resources/views/storefront/layout/navigation/navigation.html.twig
+++ b/src/Storefront/Resources/views/storefront/layout/navigation/navigation.html.twig
@@ -77,7 +77,7 @@
                                              data-flyout-menu-id="{{ treeItem.category.id }}">
                                             <div class="container">
                                                 {% block layout_main_navigation_menu_flyout_include %}
-                                                    {% sw_include '@Storefront/storefront/layout/navigation/flyout.html.twig' with {navigationTree: treeItem, level: level+1} only %}
+                                                    {% sw_include '@Storefront/storefront/layout/navigation/flyout.html.twig' with {navigationTree: treeItem, level: level+1, page: page} only %}
                                                 {% endblock %}
                                             </div>
                                         </div>


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/community).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
Because page was not passed to the underlying blocks, the active state was never set on the navigation items.

### 2. What does this change do, exactly?
It passes the page along so the activeId can be accessed.

### 3. Describe each step to reproduce the issue or behaviour.
Create an environment with demodata. Use the navigation and click a navigation item. It won't have the class 'active'.

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.
