### PR TITLE
correct change detection and automatic reloading with webpack

### DIFF
--- a/src/Administration/Resources/app/administration/build/dev-server.js
+++ b/src/Administration/Resources/app/administration/build/dev-server.js
@@ -9,14 +9,15 @@ const proxy = require('http-proxy-middleware');
 const WebpackPluginInjector = require('@shopware-ag/webpack-plugin-injector');
 const config = require('../config');
 
-const injector = new WebpackPluginInjector('var/plugins.json', {}, 'administration');
-
 if (!process.env.NODE_ENV) {
     process.env.NODE_ENV = JSON.parse(config.dev.env.NODE_ENV);
 }
+
 const webpackConfig = process.env.NODE_ENV === 'testing'
     ? require('./webpack.prod.conf')
     : require('./webpack.dev.conf');
+
+const injector = new WebpackPluginInjector('var/plugins.json', webpackConfig, 'administration');
 
 // default host + port where dev server listens for incoming traffic
 const port = process.env.PORT || config.dev.port;


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/community).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
When using the ./psh.phar administration:watch command with installed plugins, the plugin files are compiled successfully. But changes to the plugin administration js files are ignored and do not lead to a recompile and browser reload automatically.

### 2. What does this change do, exactly?
Enables hot reloading and compiling for plugin administration.js changes

### 3. Describe each step to reproduce the issue or behaviour.
- install SwagPaypal into a development installation shopware/development
- administration:watch
- change the main.js of SwagPaypal (app/administration/something)
- no automatic recompile 🤦 

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.
