### PR TITLE
custome fields should also available for category type link

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-category/view/sw-category-detail-base/sw-category-detail-base.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-category/view/sw-category-detail-base/sw-category-detail-base.html.twig
@@ -121,17 +121,17 @@
                             :urls="category.seoUrls">
                 </sw-seo-url>
             {% endblock %}
-
-            {% block sw_category_detail_attribute_sets %}
-                <sw-card :title="$tc('sw-settings-custom-field.general.mainMenuItemGeneral')"
-                         v-if="customFieldSetsArray.length > 0"
-                         :isLoading="isLoading">
-                    <sw-custom-field-set-renderer
-                            :entity="category"
-                            :sets="customFieldSetsArray">
-                    </sw-custom-field-set-renderer>
-                </sw-card>
-            {% endblock %}
         </template>
+
+        {% block sw_category_detail_attribute_sets %}
+            <sw-card :title="$tc('sw-settings-custom-field.general.mainMenuItemGeneral')"
+                     v-if="customFieldSetsArray.length > 0"
+                     :isLoading="isLoading">
+                <sw-custom-field-set-renderer
+                        :entity="category"
+                        :sets="customFieldSetsArray">
+                </sw-custom-field-set-renderer>
+            </sw-card>
+        {% endblock %}
     </div>
 {% endblock %}


### PR DESCRIPTION
### 1. Why is this change necessary?
custome fields should also available for category type link

### 2. What does this change do, exactly?
move the custome field block outside the template if

### 3. Describe each step to reproduce the issue or behaviour.
if you change category to type link, the custome field block not shown

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
