### PR TITLE
add missing block the cancel order modal

### DIFF
--- a/src/Storefront/Resources/views/storefront/page/account/order-history/order-item.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/account/order-history/order-item.html.twig
@@ -156,18 +156,20 @@
                                                     {% block page_account_order_item_context_menu_reorder_form_button %}
                                                         <button class="order-table-header-context-menu-content-link" type="submit">{{ "account.orderContextMenuReorder"|trans|sw_sanitize }}</button>
                                                     {% endblock %}
-                                                     </form>
-                                                {% endblock %}
+                                                 </form>
                                             {% endblock %}
+                                        {% endblock %}
 
-                                        {% if orderState != 'cancelled' and shopware.config.core.cart.enableOrderRefunds %}
-                                            <button type="button"
-                                                    class="order-table-header-context-menu-content-link"
-                                                    data-toggle="modal"
-                                                    data-target="#order-{{ order.id }}">
-                                                {{ "account.editOrderCancelOrderButton"|trans|sw_sanitize }}
-                                            </button>
-                                        {% endif %}
+                                        {% block page_account_order_item_context_menu_cancel_order %}
+                                            {% if orderState != 'cancelled' and shopware.config.core.cart.enableOrderRefunds %}
+                                                <button type="button"
+                                                        class="order-table-header-context-menu-content-link"
+                                                        data-toggle="modal"
+                                                        data-target="#order-{{ order.id }}">
+                                                    {{ "account.editOrderCancelOrderButton"|trans|sw_sanitize }}
+                                                </button>
+                                            {% endif %}
+                                        {% endblock %}
                                     {% endblock %}
                                </div>
                             {% endblock %}


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/community).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
The cancel account button is introduced in two locations. One is missing a block to enable plugins the possibility to override the block.

### 2. What does this change do, exactly?


### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.
