### PR TITLE
Fixes #1072 Add Sales Channel commands

### DIFF
--- a/CHANGELOG-6.2.md
+++ b/CHANGELOG-6.2.md
@@ -26,6 +26,10 @@ To get the diff between two versions, go to https://github.com/shopware/platform
     * Changed `\Shopware\Core\System\SalesChannel\Api\StructEncoder` to work correctly with aggregations
     * Changed `product.listing_prices` data structure. The new structure will be reindexed by `\Shopware\Core\Content\Product\DataAbstractionLayer\ProductIndexer` but may take same time to complete
     * Added `AddressListingCriteriaEvent`
+    * Added Sales Channel commands
+        * `sales-channel:list`
+        * `sales-channel:maintenance:enable`
+        * `sales-channel:maintenance:disable`
 
 * Storefront
     * Added block `component_offcanvas_cart_header_item_counter` to `src/Storefront/Resources/views/storefront/component/checkout/offcanvas-cart.html.twig`

--- a/src/Core/System/DependencyInjection/sales_channel.xml
+++ b/src/Core/System/DependencyInjection/sales_channel.xml
@@ -120,6 +120,24 @@
             <tag name="console.command"/>
         </service>
 
+        <service id="Shopware\Core\System\SalesChannel\Command\SalesChannelListCommand">
+            <argument type="service" id="sales_channel.repository"/>
+
+            <tag name="console.command"/>
+        </service>
+
+        <service id="Shopware\Core\System\SalesChannel\Command\SalesChannelMaintenanceEnableCommand">
+            <argument type="service" id="sales_channel.repository"/>
+
+            <tag name="console.command"/>
+        </service>
+
+        <service id="Shopware\Core\System\SalesChannel\Command\SalesChannelMaintenanceDisableCommand">
+            <argument type="service" id="sales_channel.repository"/>
+
+            <tag name="console.command"/>
+        </service>
+
         <service id="Shopware\Core\System\SalesChannel\Entity\SalesChannelDefinitionInstanceRegistry" public="true">
             <argument type="string"/>
             <argument type="service" id="service_container" />

--- a/src/Core/System/SalesChannel/Command/SalesChannelListCommand.php
+++ b/src/Core/System/SalesChannel/Command/SalesChannelListCommand.php
@@ -1,0 +1,128 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\System\SalesChannel\Command;
+
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepositoryInterface;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\System\Currency\CurrencyEntity;
+use Shopware\Core\System\Language\LanguageEntity;
+use Shopware\Core\System\SalesChannel\Aggregate\SalesChannelDomain\SalesChannelDomainEntity;
+use Shopware\Core\System\SalesChannel\SalesChannelCollection;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\Table;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class SalesChannelListCommand extends Command
+{
+    protected static $defaultName = 'sales-channel:list';
+
+    /**
+     * @var EntityRepositoryInterface
+     */
+    private $salesChannelRepository;
+
+    public function __construct(
+        EntityRepositoryInterface $salesChannelRepository
+    ) {
+        $this->salesChannelRepository = $salesChannelRepository;
+
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this->addOption(
+            'output',
+            '0',
+            InputOption::VALUE_OPTIONAL,
+            'Output mode',
+            'table'
+        );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $headers = [
+            'id',
+            'Name',
+            'Active',
+            'Maintenance',
+            'Default Language',
+            'Languages',
+            'Default Currency',
+            'Currencies',
+            'Domains',
+        ];
+
+        $criteria = new Criteria();
+        $criteria->addAssociations(['language', 'languages', 'currency', 'currencies', 'domains']);
+        /** @var SalesChannelCollection $salesChannels */
+        $salesChannels = $this->salesChannelRepository->search($criteria, Context::createDefaultContext());
+        foreach ($salesChannels as $salesChannel) {
+            $data[] = [
+                $salesChannel->getId(),
+                $salesChannel->getName(),
+                $salesChannel->getActive() ? 'active' : 'inactive',
+                $salesChannel->isMaintenance() ? 'on' : 'off',
+                $salesChannel->getLanguage()->getName(),
+                $salesChannel->getLanguages()->map(function (LanguageEntity $language) {
+                    return $language->getName();
+                }),
+                $salesChannel->getCurrency()->getName(),
+                $salesChannel->getCurrencies()->map(function (CurrencyEntity $currency) {
+                    return $currency->getName();
+                }),
+                $salesChannel->getDomains()->map(function (SalesChannelDomainEntity $domain) {
+                    return $domain->getUrl();
+                }),
+            ];
+        }
+
+        if ($input->getOption('output') === 'json') {
+            return $this->renderJson($output, $headers, $data);
+        }
+
+        return $this->renderTable($output, $headers, $data);
+    }
+
+    private function renderJson(OutputInterface $output, array $headers, array $data)
+    {
+        $json = [];
+
+        foreach ($data as $row) {
+            $jsonItem = [];
+            foreach ($row as $item => $value) {
+                $jsonItem[strtolower((string) ($headers[$item] ?? $item))] = $value;
+            }
+            $json[] = $jsonItem;
+        }
+
+        $output->write(json_encode($json));
+
+        return 0;
+    }
+
+    private function renderTable(OutputInterface $output, array $headers, array $data)
+    {
+        $table = new Table($output);
+        $table->setHeaders($headers);
+
+        // Normalize data
+        foreach ($data as $rowKey => $row) {
+            foreach ($row as $columnKey => $column) {
+                if (is_array($column)) {
+                    $data[$rowKey][$columnKey] = implode(', ', $column);
+                }
+            }
+        }
+
+        $table->addRows($data);
+
+        $table->render();
+
+        return 0;
+    }
+}

--- a/src/Core/System/SalesChannel/Command/SalesChannelMaintenanceDisableCommand.php
+++ b/src/Core/System/SalesChannel/Command/SalesChannelMaintenanceDisableCommand.php
@@ -1,0 +1,10 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\System\SalesChannel\Command;
+
+class SalesChannelMaintenanceDisableCommand extends SalesChannelMaintenanceEnableCommand
+{
+    protected static $defaultName = 'sales-channel:maintenance:disable';
+
+    protected $setMaintenanceMode = false;
+}

--- a/src/Core/System/SalesChannel/Command/SalesChannelMaintenanceEnableCommand.php
+++ b/src/Core/System/SalesChannel/Command/SalesChannelMaintenanceEnableCommand.php
@@ -1,0 +1,87 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\System\SalesChannel\Command;
+
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepositoryInterface;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class SalesChannelMaintenanceEnableCommand extends Command
+{
+    protected static $defaultName = 'sales-channel:maintenance:enable';
+
+    /**
+     * @var bool
+     */
+    protected $setMaintenanceMode = true;
+
+    /**
+     * @var EntityRepositoryInterface
+     */
+    private $salesChannelRepository;
+
+    public function __construct(
+        EntityRepositoryInterface $salesChannelRepository
+    ) {
+        $this->salesChannelRepository = $salesChannelRepository;
+
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this->addArgument(
+            'ids',
+            InputArgument::IS_ARRAY | InputArgument::OPTIONAL,
+            'Which Sales Channels do you want to update maintenance mode for? (Optional when --all flag is used)',
+            []
+        )->addOption(
+            'all',
+            'a',
+            InputOption::VALUE_NONE,
+            'Set maintenance mode for all sales channels'
+        );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $context = Context::createDefaultContext();
+        $criteria = new Criteria();
+
+        if (!$input->getOption('all')) {
+            $ids = $input->getArgument('ids');
+            if (empty($ids)) {
+                $output->write('No sales channels were updated. Provide id(s) or run with --all option.');
+
+                return 0;
+            }
+
+            $criteria->setIds($ids);
+        }
+        $salesChannelIds = $this->salesChannelRepository->searchIds($criteria, $context)->getIds();
+
+        if (empty($salesChannelIds)) {
+            $output->write(sprintf('No sales channels were updated'));
+
+            return 0;
+        }
+
+        $update = array_map(function (string $id) {
+            return [
+                'id' => $id,
+                'maintenance' => $this->setMaintenanceMode,
+            ];
+        }, $salesChannelIds);
+
+        $this->salesChannelRepository->update($update, $context);
+
+        $output->write(sprintf('Updated maintenance mode for %s sales channel(s)', count($salesChannelIds)));
+
+        return 0;
+    }
+}

--- a/src/Core/System/Test/SalesChannel/Command/SalesChannelListCommandTest.php
+++ b/src/Core/System/Test/SalesChannel/Command/SalesChannelListCommandTest.php
@@ -1,0 +1,25 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\System\Test\SalesChannel\Command;
+
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
+use Shopware\Core\System\SalesChannel\Command\SalesChannelListCommand;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class SalesChannelListCommandTest extends TestCase
+{
+    use IntegrationTestBehaviour;
+
+    public function testNoValidationErrors(): void
+    {
+        $commandTester = new CommandTester($this->getContainer()->get(SalesChannelListCommand::class));
+        $commandTester->execute([]);
+
+        static::assertEquals(
+            0,
+            $commandTester->getStatusCode(),
+            "\"bin/console sales-channel:list\" returned errors:\n" . $commandTester->getDisplay()
+        );
+    }
+}

--- a/src/Core/System/Test/SalesChannel/Command/SalesChannelMaintenanceDisableCommandTest.php
+++ b/src/Core/System/Test/SalesChannel/Command/SalesChannelMaintenanceDisableCommandTest.php
@@ -1,0 +1,70 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\System\Test\SalesChannel\Command;
+
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Defaults;
+use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
+use Shopware\Core\System\SalesChannel\Command\SalesChannelMaintenanceDisableCommand;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class SalesChannelMaintenanceDisableCommandTest extends TestCase
+{
+    use IntegrationTestBehaviour;
+
+    public function testNoValidationErrors(): void
+    {
+        $commandTester = new CommandTester($this->getContainer()->get(SalesChannelMaintenanceDisableCommand::class));
+        $commandTester->execute([]);
+
+        static::assertEquals(
+            0,
+            $commandTester->getStatusCode(),
+            "\"bin/console sales-channel:maintenance:disable\" returned errors:\n" . $commandTester->getDisplay()
+        );
+    }
+
+    public function testUnknownSalesChannelIds(): void
+    {
+        $commandTester = new CommandTester($this->getContainer()->get(SalesChannelMaintenanceDisableCommand::class));
+        $commandTester->execute(['ids' => [\Shopware\Core\Framework\Uuid\Uuid::randomHex()]]);
+
+        static::assertEquals(
+            'No sales channels were updated',
+            $commandTester->getDisplay()
+        );
+    }
+
+    public function testNoSalesChannelIds(): void
+    {
+        $commandTester = new CommandTester($this->getContainer()->get(SalesChannelMaintenanceDisableCommand::class));
+        $commandTester->execute([]);
+
+        static::assertEquals(
+            'No sales channels were updated. Provide id(s) or run with --all option.',
+            $commandTester->getDisplay()
+        );
+    }
+
+    public function testOneSalesChannelIds(): void
+    {
+        $commandTester = new CommandTester($this->getContainer()->get(SalesChannelMaintenanceDisableCommand::class));
+        $commandTester->execute(['ids' => [Defaults::SALES_CHANNEL]]);
+
+        static::assertEquals(
+            'Updated maintenance mode for 1 sales channel(s)',
+            $commandTester->getDisplay()
+        );
+    }
+
+    public function testAllSalesChannelIds(): void
+    {
+        $commandTester = new CommandTester($this->getContainer()->get(SalesChannelMaintenanceDisableCommand::class));
+        $commandTester->execute(['--all' => true]);
+
+        static::assertEquals(
+            'Updated maintenance mode for 2 sales channel(s)',
+            $commandTester->getDisplay()
+        );
+    }
+}

--- a/src/Core/System/Test/SalesChannel/Command/SalesChannelMaintenanceEnableCommandTest.php
+++ b/src/Core/System/Test/SalesChannel/Command/SalesChannelMaintenanceEnableCommandTest.php
@@ -1,0 +1,70 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\System\Test\SalesChannel\Command;
+
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Defaults;
+use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
+use Shopware\Core\System\SalesChannel\Command\SalesChannelMaintenanceEnableCommand;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class SalesChannelMaintenanceEnableCommandTest extends TestCase
+{
+    use IntegrationTestBehaviour;
+
+    public function testNoValidationErrors(): void
+    {
+        $commandTester = new CommandTester($this->getContainer()->get(SalesChannelMaintenanceEnableCommand::class));
+        $commandTester->execute([]);
+
+        static::assertEquals(
+            0,
+            $commandTester->getStatusCode(),
+            "\"bin/console sales-channel:maintenance:enable\" returned errors:\n" . $commandTester->getDisplay()
+        );
+    }
+
+    public function testUnknownSalesChannelIds(): void
+    {
+        $commandTester = new CommandTester($this->getContainer()->get(SalesChannelMaintenanceEnableCommand::class));
+        $commandTester->execute(['ids' => [\Shopware\Core\Framework\Uuid\Uuid::randomHex()]]);
+
+        static::assertEquals(
+            'No sales channels were updated',
+            $commandTester->getDisplay()
+        );
+    }
+
+    public function testNoSalesChannelIds(): void
+    {
+        $commandTester = new CommandTester($this->getContainer()->get(SalesChannelMaintenanceEnableCommand::class));
+        $commandTester->execute([]);
+
+        static::assertEquals(
+            'No sales channels were updated. Provide id(s) or run with --all option.',
+            $commandTester->getDisplay()
+        );
+    }
+
+    public function testOneSalesChannelIds(): void
+    {
+        $commandTester = new CommandTester($this->getContainer()->get(SalesChannelMaintenanceEnableCommand::class));
+        $commandTester->execute(['ids' => [Defaults::SALES_CHANNEL]]);
+
+        static::assertEquals(
+            'Updated maintenance mode for 1 sales channel(s)',
+            $commandTester->getDisplay()
+        );
+    }
+
+    public function testAllSalesChannelIds(): void
+    {
+        $commandTester = new CommandTester($this->getContainer()->get(SalesChannelMaintenanceEnableCommand::class));
+        $commandTester->execute(['--all' => true]);
+
+        static::assertEquals(
+            'Updated maintenance mode for 2 sales channel(s)',
+            $commandTester->getDisplay()
+        );
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?
Adds console commands to set maintenance mode on sales channels.

### 2. What does this change do, exactly?
    * Added Sales Channel commands
        * `sales-channel:list`
        * `sales-channel:maintenance:enable`
        * `sales-channel:maintenance:disable`

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
#1072 

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
