### PR TITLE
Fixes #1071 Add namespace variable to sw_icon

### DIFF
--- a/src/Storefront/Resources/app/storefront/src/scss/page/checkout/_cart-item.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/page/checkout/_cart-item.scss
@@ -25,6 +25,7 @@
 
     .icon {
         height: 100%;
+
         > svg {
             top: 0;
         }

--- a/src/Storefront/Resources/views/storefront/utilities/icon.html.twig
+++ b/src/Storefront/Resources/views/storefront/utilities/icon.html.twig
@@ -5,8 +5,12 @@
         {% set pack = 'default' %}
     {% endif %}
 
+    {% if namespace is not defined %}
+        {% set namespace = 'Storefront' %}
+    {% endif %}
+
     <span
         class="icon icon-{{ name }}{% for entry in styles %}{% if entry != "" %} icon-{{ entry }}{% endif %}{% endfor %}">
-            {{ source('@Storefront/../app/storefront/dist/assets/icon/'~ pack ~'/'~ name ~'.svg', ignore_missing = true) }}
+            {{ source('@' ~ namespace ~ '/../app/storefront/dist/assets/icon/'~ pack ~'/'~ name ~'.svg', ignore_missing = true) }}
     </span>
 {% endblock %}


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/community).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
Allow themes to add their own icons without fully overriding the icon.html.twig.

### 2. What does this change do, exactly?
Make it possible to pass a namespace variable to the sw_icon extension. Defaults to Storefront.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
#1071 

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
