### PR TITLE
fix sorting

### DIFF
--- a/src/Storefront/Page/Product/Configurator/ProductPageConfiguratorLoader.php
+++ b/src/Storefront/Page/Product/Configurator/ProductPageConfiguratorLoader.php
@@ -167,7 +167,7 @@ class ProductPageConfiguratorLoader
                         return $a->getTranslation('name') <=> $b->getTranslation('name');
                     }
 
-                    return $a->getPosition() <=> $b->getPosition();
+                    return $a->getTranslation('position') <=> $b->getTranslation('position');
                 }
             );
         }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/community).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?

The property `position` of `PropertyGroupOptionEntity` is null if the context is in another language and there is no specific translation for the property group option. This results in an error, as `getPosition()` has to either return `int` or `null`. Therefore, custom sorting is only possible if all property group options have a translation (which is not desirable).

### 2. What does this change do, exactly?

It uses the `getTranslation` method to access the property `position`.

### 3. Describe each step to reproduce the issue or behaviour.

- Make sure your shop has at least two languages
- Add a property group with custom sorting
- Add a property option only in the primary language
- Add a product with a variant that uses the added property group as a dimension
- Access the product in the storefront

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
