### PR TITLE
Fixes #1079 Added new user:change-password command

### DIFF
--- a/CHANGELOG-6.2.md
+++ b/CHANGELOG-6.2.md
@@ -26,6 +26,7 @@ To get the diff between two versions, go to https://github.com/shopware/platform
     * Changed `\Shopware\Core\System\SalesChannel\Api\StructEncoder` to work correctly with aggregations
     * Changed `product.listing_prices` data structure. The new structure will be reindexed by `\Shopware\Core\Content\Product\DataAbstractionLayer\ProductIndexer` but may take same time to complete
     * Added `AddressListingCriteriaEvent`
+    * Added `UserChangePasswordCommand`
 
 * Storefront
     * Added block `component_offcanvas_cart_header_item_counter` to `src/Storefront/Resources/views/storefront/component/checkout/offcanvas-cart.html.twig`

--- a/src/Core/System/DependencyInjection/user.xml
+++ b/src/Core/System/DependencyInjection/user.xml
@@ -11,7 +11,11 @@
 
         <service id="Shopware\Core\System\User\Command\UserCreateCommand">
             <argument type="service" id="Shopware\Core\System\User\Service\UserProvisioner"/>
+            <tag name="console.command"/>
+        </service>
 
+        <service id="Shopware\Core\System\User\Command\UserChangePasswordCommand">
+            <argument type="service" id="user.repository"/>
             <tag name="console.command"/>
         </service>
 

--- a/src/Core/System/Test/User/Command/UserChangePasswordCommandTest.php
+++ b/src/Core/System/Test/User/Command/UserChangePasswordCommandTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopware\Core\System\Test\User\Command;
+
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepositoryInterface;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\System\User\Command\UserChangePasswordCommand;
+use Shopware\Core\System\User\UserEntity;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class UserChangePasswordCommandTest extends TestCase
+{
+    use IntegrationTestBehaviour;
+
+    /**
+     * @var EntityRepositoryInterface
+     */
+    private $userRepository;
+
+    /**
+     * @var Context
+     */
+    private $context;
+
+    protected function setUp(): void
+    {
+        $this->userRepository = $this->getContainer()->get('user.repository');
+        $this->context = Context::createDefaultContext();
+    }
+
+    public function testUnknownUser(): void
+    {
+        $commandTester = new CommandTester($this->getContainer()->get(UserChangePasswordCommand::class));
+        $commandTester->execute(['username' => 'shopware']);
+
+        static::assertIsInt(mb_strpos($commandTester->getDisplay(), 'The user "shopware" does not exist.'));
+        static::assertEquals(1, $commandTester->getStatusCode());
+    }
+
+    public function testKnownUser(): void
+    {
+        $this->createUser('shopware', 'shopwarePassword');
+
+        $commandTester = new CommandTester($this->getContainer()->get(UserChangePasswordCommand::class));
+        $commandTester->execute([
+            'username' => 'shopware',
+            '--password' => 'newPassword',
+        ]);
+
+        static::assertIsInt(mb_strpos(
+            $commandTester->getDisplay(),
+            'The password of user "shopware" has been changed succesfully.'
+        ));
+        static::assertEquals(0, $commandTester->getStatusCode());
+    }
+
+    public function testItChangesThePassword(): void
+    {
+        $uuid = $this->createUser('shopware', 'shopwarePassword');
+
+        $newPassword = Uuid::randomHex();
+        $commandTester = new CommandTester($this->getContainer()->get(UserChangePasswordCommand::class));
+        $commandTester->execute([
+            'username' => 'shopware',
+            '--password' => $newPassword,
+        ]);
+
+        /** @var UserEntity $user */
+        $user = $this->userRepository->search(new Criteria([$uuid]), $this->context)->first();
+
+        $passwordVerify = password_verify($newPassword, $user->getPassword());
+        static::assertTrue($passwordVerify);
+    }
+
+    private function createUser(string $username, string $password): string
+    {
+        $uuid = Uuid::randomHex();
+
+        $this->userRepository->create([
+            [
+                'id' => $uuid,
+                'localeId' => $this->getLocaleIdOfSystemLanguage(),
+                'username' => $username,
+                'password' => $password,
+                'firstName' => sprintf('Foo%s', Uuid::randomHex()),
+                'lastName' => sprintf('Bar%s', Uuid::randomHex()),
+                'email' => sprintf('%s@foo.bar', $uuid),
+            ],
+        ], $this->context);
+
+        return $uuid;
+    }
+}

--- a/src/Core/System/User/Command/UserChangePasswordCommand.php
+++ b/src/Core/System/User/Command/UserChangePasswordCommand.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopware\Core\System\User\Command;
+
+use Shopware\Core\Framework\Adapter\Console\ShopwareStyle;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\Question;
+
+class UserChangePasswordCommand extends Command
+{
+    protected static $defaultName = 'user:change-password';
+
+    /**
+     * @var EntityRepository
+     */
+    private $userRepository;
+
+    public function __construct(EntityRepository $userRepository)
+    {
+        $this->userRepository = $userRepository;
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addArgument('username', InputArgument::REQUIRED, 'Username of the user')
+            ->addOption('password', 'p', InputOption::VALUE_REQUIRED, 'New password for the user');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new ShopwareStyle($input, $output);
+        $context = Context::createDefaultContext();
+
+        $username = $input->getArgument('username');
+        $password = $input->getOption('password');
+
+        $userId = $this->getUserId($username, $context);
+        if (!$userId) {
+            $io->error(sprintf('The user "%s" does not exist.', $username));
+
+            return 1;
+        }
+
+        if (empty($password)) {
+            $passwordQuestion = new Question('New password for the user');
+            $passwordQuestion->setHidden(true);
+            $passwordQuestion->setMaxAttempts(3);
+
+            $password = $io->askQuestion($passwordQuestion);
+        }
+
+        $this->userRepository->update([
+            [
+                'id' => $userId,
+                'password' => $password,
+            ],
+        ], $context);
+
+        $io->success(sprintf('The password of user "%s" has been changed succesfully.', $username));
+
+        return 0;
+    }
+
+    private function getUserId(string $username, Context $context): ?string
+    {
+        $criteria = (new Criteria())
+            ->addFilter(new EqualsFilter('username', $username));
+
+        return $this->userRepository->searchIds($criteria, $context)->firstId();
+    }
+}


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/community).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
This adds a new user:change-password command to change an admin users password.


### 2. What does this change do, exactly?
It adds the command.

### 3. Describe each step to reproduce the issue or behaviour.
A password can be changed using bin/console user:change-password username.


### 4. Please link to the relevant issues (if any).
#1079 

### 5. Checklist

- [X] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.
