### PR TITLE
Clone plugin configurations before altering their contents to remove side effects on plugin config reading

### DIFF
--- a/src/Storefront/Theme/ThemeService.php
+++ b/src/Storefront/Theme/ThemeService.php
@@ -364,7 +364,7 @@ class ThemeService
                 throw new InvalidThemeException(StorefrontPluginRegistry::BASE_THEME_NAME);
             }
 
-            return $pluginConfig;
+            return clone $pluginConfig;
         }
         $pluginConfig = null;
         if ($theme->getTechnicalName() !== null) {
@@ -382,11 +382,13 @@ class ThemeService
                 $parentTheme = false;
                 $pluginConfig = $this->pluginRegistry->getConfigurations()->getByTechnicalName(StorefrontPluginRegistry::BASE_THEME_NAME);
             }
+
             if (!$pluginConfig) {
                 throw new InvalidThemeException($parentTheme ? $parentTheme->getTechnicalName() : StorefrontPluginRegistry::BASE_THEME_NAME);
             }
         }
 
+        $pluginConfig = clone $pluginConfig;
         $pluginConfig->setThemeConfig($this->getThemeConfiguration($theme->getId(), $translate, $context));
 
         return $pluginConfig;


### PR DESCRIPTION
### 1. Why is this change necessary?
This affects at least theme compilation. The order of the themes to be compiled can affect following compilations in the same runtime when they compile the technically same source files but a different theme instance.
![grafik](https://user-images.githubusercontent.com/1133593/85932709-afc63e00-b8ce-11ea-99ad-338151daf10f.png)
See more about my debugging notes in point 5.

### 2. What does this change do, exactly?
Adds a clone before changing a plugin configuration from the plugin configuration collection. As the plugin configuration object is stored as reference every change to it is also present in the runtime-cached collection. So assigning the merged configuration back into the object and therefore indirectly into the collection as well overrides future reads on the plugin configuration.

### 3. Describe each step to reproduce the issue or behaviour.
* Create a theme plugin
* Assign it to a storefront saleschannel
* Duplicate the theme in the administration
* Assign "child" theme to an other storefront saleschannel so two instance of the technical theme are assigned to a storefront saleschannel
* Configure the child
* Compile the theme using `bin/console theme:compile` and pray for the parent to not look like the child

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

### 5. Manual test cases and debug notes

**TLDR**
I examined theme compilation and DAL seems to be weird but might not be the problem.

**Prelude**
You have a multi-saleschannel setup. Every saleschannel has a different style but they technically share the same source code for twig, js and scss. Now you create a new sales channel Foobar, copy a configured theme of an existing sales channel like Party and assign the copy to the new sales channel Foobar. To match the new style one can change some variables for Foobar. `bin/console theme:compile`. WAIT why does Party partially have the same color scheme like the new Foobar? Compile Party again via administration. Looks good again. Whew ok. Maybe a hiccup in the CD or a cache. FF to the next run of `bin/console theme:compile` Party looks like Foobar again. There is something wrong here.

**Preparations**
To test it I alter the `ThemeCompileCommand` to partially compile some sales channel. I added some debugging dump into the ThemeCompiler and look out for one of the configured variables that are getting mixed up. The theme compiler is called with correctly themeIds and salesChannel each time but with different variable configurations. For this I replace the ids with their resembling terms Foobar and Party.

**Research**
Test cases for changes in `ThemeCompileCommand::getSalesChannels`


**Case 1 (no changes):**

```
private function getSalesChannels(Context $context): SalesChannelCollection
{
    $criteria = new Criteria();
    $criteria->addAssociation('themes');

    /** @var SalesChannelCollection $result */
    $result = $this->salesChannelRepository->search($criteria, $context)->getEntities();

    return $result;
}
```

**Case 2a/b (Ask for the themes specifically)**
```
private function getSalesChannels(Context $context): SalesChannelCollection
{
    $criteria = new Criteria(['Party']);
    $criteria->addAssociation('themes');

    /** @var SalesChannelCollection $result */
    $result = $this->salesChannelRepository->search($criteria, $context)->getEntities();

    return $result;
}
```
```
private function getSalesChannels(Context $context): SalesChannelCollection
{
    $criteria = new Criteria(['Foobar']);
    $criteria->addAssociation('themes');

    /** @var SalesChannelCollection $result */
    $result = $this->salesChannelRepository->search($criteria, $context)->getEntities();

    return $result;
}
```

**Case 3 (Ask for both themes at the same time)**

```
private function getSalesChannels(Context $context): SalesChannelCollection
{
    $criteria = new Criteria(['Party', 'Foobar']);
    $criteria->addAssociation('themes');

    /** @var SalesChannelCollection $result */
    $result = $this->salesChannelRepository->search($criteria, $context)->getEntities();

    return $result;
}
```

**Case 4 (Ask for both themes at the same time but different)**

```
private function getSalesChannels(Context $context): SalesChannelCollection
{
    $criteria = new Criteria();
    $criteria->addAssociation('themes');
    $criteria->addFilter(new EqualsAnyFilter('id', ['Party', 'Foobar']));

    /** @var SalesChannelCollection $result */
    $result = $this->salesChannelRepository->search($criteria, $context)->getEntities();

    return $result;
}
```

**Research results**

The configuration for Party is #bcc1c7 and for Foobar #ff00ff

**Case 1 (wrong):**
```
{
    "salesChannelId": "Foobar",
    "variable": "#ff00ff"
}
{
    "salesChannelId": "Party",
    "variable": "#ff00ff"
}

```

**Case 2 (correct):**
```
{
    "salesChannelId": "Foobar",
    "variable": "#ff00ff"
}
{
    "salesChannelId": "Party",
    "variable": "#bcc1c7"
}
```

**Case 3 (correct):**
```
{
    "salesChannelId": "Party",
    "variable": "#bcc1c7"
}
{
    "salesChannelId": "Foobar",
    "variable": "#ff00ff"
}
```

**Case 4(incorrect):**
```
{
    "salesChannelId": "Foobar",
    "variable": "#ff00ff"
}
{
    "salesChannelId": "Party",
    "variable": "#ff00ff"
}
```

**Result analysis**

Every time we ask the salesChannel by id in the criteria object the themes of the salesChannel are compiled correctly. But the change from case 3 and case 4 should be the same. I get the feeling by looking at the code from 3 and 4 is not expressing the same intention.

![grafik](https://user-images.githubusercontent.com/1133593/85932293-03368d00-b8cb-11ea-9167-1db626dc6ee9.png)
