### PR TITLE
Fix filter for getting product exports

### DIFF
--- a/src/Core/Content/ProductExport/ScheduledTask/ProductExportGenerateTaskHandler.php
+++ b/src/Core/Content/ProductExport/ScheduledTask/ProductExportGenerateTaskHandler.php
@@ -73,7 +73,7 @@ class ProductExportGenerateTaskHandler extends ScheduledTaskHandler
                     new MultiFilter(
                         'OR',
                         [
-                            new EqualsFilter('salesChannelId', $salesChannelContext->getSalesChannel()->getId()),
+                            new EqualsFilter('storefrontSalesChannelId', $salesChannelContext->getSalesChannel()->getId()),
                             new EqualsFilter('salesChannelDomain.salesChannel.id', $salesChannelContext->getSalesChannel()->getId()),
                         ]
                     )


### PR DESCRIPTION
### 1. Why is this change necessary?
Comparing the sales channel id for product export should be point on the selected storefront sales channel id instead.

### 2. What does this change do, exactly?
The current filter on the salesChannelId is not useful.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
