### PR TITLE
NEXT-6182 Fix calculation of shipping costs

### DIFF
--- a/CHANGELOG-6.2.md
+++ b/CHANGELOG-6.2.md
@@ -17,6 +17,8 @@ To get the diff between two versions, go to https://github.com/shopware/platform
 * Administration
     * Custom fields assigned to a category entity can now also be configured in categories of type "link"
 
+* Core
+    * Fixed `DeliveryCalculator` to only set shipping costs to zero if all items in cart have free shipping set
 
 ### 6.2.3
 

--- a/src/Core/Checkout/Cart/Delivery/DeliveryCalculator.php
+++ b/src/Core/Checkout/Cart/Delivery/DeliveryCalculator.php
@@ -85,7 +85,7 @@ class DeliveryCalculator
             return;
         }
 
-        if ($this->hasDeliveryShippingFreeItems($delivery)) {
+        if ($this->hasDeliveryWithOnlyShippingFreeItems($delivery)) {
             $costs = $this->calculateShippingCosts(
                 new PriceCollection([new Price(Defaults::CURRENCY, 0, 0, false)]),
                 $delivery->getPositions()->getLineItems(),
@@ -134,15 +134,15 @@ class DeliveryCalculator
         $delivery->setShippingCosts($costs);
     }
 
-    private function hasDeliveryShippingFreeItems(Delivery $delivery): bool
+    private function hasDeliveryWithOnlyShippingFreeItems(Delivery $delivery): bool
     {
         foreach ($delivery->getPositions()->getLineItems()->getIterator() as $lineItem) {
-            if ($lineItem->getDeliveryInformation() && $lineItem->getDeliveryInformation()->getFreeDelivery()) {
-                return true;
+            if ($lineItem->getDeliveryInformation() && !$lineItem->getDeliveryInformation()->getFreeDelivery()) {
+                return false;
             }
         }
 
-        return false;
+        return true;
     }
 
     private function matches(Delivery $delivery, ShippingMethodPriceEntity $shippingMethodPrice, SalesChannelContext $context): bool


### PR DESCRIPTION
### 1. Why is this change necessary?

Shipping cost calculation currently returns a shipping cost of zero whenever an item with free shipping is in the cart, even if there are others where shipping is not free. 


### 2. What does this change do, exactly?

It changes the calculation of shipping costs to only return zero if there are only free shipping items in the cart, otherwise the normal rules apply.


### 3. Describe each step to reproduce the issue or behaviour.

- Configure shipping costs to be a non-zero value
- Configure an item with free shipping
- Add any (non-free-shipping) item to the cart --> shipping costs apply
- Add free shipping item to cart --> shipping costs are zero (even though the other items are still there)


### 4. Please link to the relevant issues (if any).

https://issues.shopware.com/issues/NEXT-6182


### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes 
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
