### PR TITLE
Added an additional class to cart offcanvas

### DIFF
--- a/CHANGELOG-6.2.md
+++ b/CHANGELOG-6.2.md
@@ -18,6 +18,9 @@ To get the diff between two versions, go to https://github.com/shopware/platform
 
 * Core
     * Added `ProductCartProcessor::ALLOW_PRODUCT_LABEL_OVERWRITES`
+    
+* Storefront
+    * Added an additional class to the cart offcanvas called `cart-offcanvas`
 
 ### 6.2.3
 

--- a/src/Storefront/Resources/app/storefront/src/plugin/offcanvas-cart/offcanvas-cart.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/offcanvas-cart/offcanvas-cart.plugin.js
@@ -19,7 +19,8 @@ export default class OffCanvasCartPlugin extends Plugin {
         cartPromotionSelector: '.js-offcanvas-cart-promotion',
         offcanvasPosition: 'right',
         shippingContainerSelector: '.offcanvas-shipping-preference',
-        shippingToggleSelector: '.js-toggle-shipping-selection'
+        shippingToggleSelector: '.js-toggle-shipping-selection',
+        additionalOffcanvasClass: 'cart-offcanvas'
     };
 
     init() {
@@ -36,6 +37,7 @@ export default class OffCanvasCartPlugin extends Plugin {
      */
     openOffCanvas(url, data, callback) {
         AjaxOffCanvas.open(url, data, this._onOffCanvasOpened.bind(this, callback), this.options.offcanvasPosition);
+        AjaxOffCanvas.setAdditionalClassName(this.options.additionalOffcanvasClass);
     }
 
     /**


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/community).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
Right now there is no way to uniquely style the 'offcanvas' of a cart.

### 2. What does this change do, exactly?
This change add's an additional identifier class to the offcanvas of the cart.

### 3. Describe each step to reproduce the issue or behaviour.

1. Open the offcanvas cart.
2. There is only a class 'offcanvas'.

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [X] I have written or adjusted the documentation according to my changes
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.
