### PR TITLE
Use prefixed version_id column in version aware many to one relations

### DIFF
--- a/changelog/_unreleased/2020-07-06-fix-fetching-version-aware-many-to-one-relations.md
+++ b/changelog/_unreleased/2020-07-06-fix-fetching-version-aware-many-to-one-relations.md
@@ -1,0 +1,9 @@
+---
+title: Fix fetching version-aware ManyToOne relations
+issue: NEXT-12749
+author: Joshua Behrens
+author_email: behrens@heptacom.de
+author_github: @JoshuaBehrens
+---
+# Core
+* Fixed bug on SQL generation in `Shopware\Core\Framework\DataAbstractionLayer\Dbal\JoinBuilder\ManyToOneJoinBuilder` when fetching version-aware ManyToOne relations like `product_translation.product`

--- a/src/Core/Framework/DataAbstractionLayer/Dbal/JoinBuilder/ManyToOneJoinBuilder.php
+++ b/src/Core/Framework/DataAbstractionLayer/Dbal/JoinBuilder/ManyToOneJoinBuilder.php
@@ -98,11 +98,19 @@ class ManyToOneJoinBuilder implements JoinBuilderInterface
         }
 
         if ($versionAware) {
+            $sourceVersionColumn = $field->getReferenceDefinition()->getEntityName() . '_version_id';
+
+            if ($definition->getFields()->getByStorageName($sourceVersionColumn) === null) {
+                $sourceVersionColumn = 'version_id';
+            }
+
+            $sourceVersion = EntityDefinitionQueryHelper::escape($on) . '.' . EntityDefinitionQueryHelper::escape($sourceVersionColumn);
+
             $parameters = [
                 '#source#' => $source,
-                '#root#' => EntityDefinitionQueryHelper::escape($on),
                 '#alias#' => EntityDefinitionQueryHelper::escape($alias),
                 '#reference_column#' => EntityDefinitionQueryHelper::escape($field->getReferenceField()),
+                '#source_version#' => $sourceVersion,
             ];
 
             $queryBuilder->leftJoin(
@@ -112,7 +120,7 @@ class ManyToOneJoinBuilder implements JoinBuilderInterface
                 str_replace(
                     array_keys($parameters),
                     array_values($parameters),
-                    '#source# = #alias#.#reference_column# AND #root#.`version_id` = #alias#.`version_id`'
+                    '#source# = #alias#.#reference_column# AND #source_version# = #alias#.`version_id`'
                 )
             );
 


### PR DESCRIPTION
### 1. Why is this change necessary?
It is possible to query `product.translations` but not `product_translation.product` as the other way round generates an invalid join condition:

>  SQLSTATE[42S22]: Column not found: 1054 Unknown column 'product_translation.version_id' in 'on clause'

### 2. What does this change do, exactly?
It generates the version_id name similar to the `OneToManyJoinBuilder` or `ReferenceVersionField`.

### 3. Describe each step to reproduce the issue or behaviour.
```
/** @var EntityRepositoryInterface $product_translation */
$criteria = new Criteria();
$criteria->addFilter(new EqualsFilter('product.productNumber', 'foobar'));
$product_translation->searchIds($criteria, Context::createDefaultContext());
```

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
