### PR TITLE
Admin API doesn’t distinguish user and integration credentials and fails on some routes

### DIFF
--- a/src/Core/Framework/Api/Controller/Exception/ExpectedUserHttpException.php
+++ b/src/Core/Framework/Api/Controller/Exception/ExpectedUserHttpException.php
@@ -1,0 +1,24 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\Api\Controller\Exception;
+
+use Shopware\Core\Framework\ShopwareHttpException;
+use Symfony\Component\HttpFoundation\Response;
+
+class ExpectedUserHttpException extends ShopwareHttpException
+{
+    public function __construct()
+    {
+        parent::__construct('Expected user, got login from integration.');
+    }
+
+    public function getErrorCode(): string
+    {
+        return 'FRAMEWORK__EXPECTED_USER';
+    }
+
+    public function getStatusCode(): int
+    {
+        return Response::HTTP_FORBIDDEN;
+    }
+}

--- a/src/Core/Framework/Api/Controller/UserController.php
+++ b/src/Core/Framework/Api/Controller/UserController.php
@@ -15,6 +15,7 @@ use Shopware\Core\System\User\UserEntity;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Shopware\Core\Framework\Api\Controller\Exception\ExpectedUserHttpException;
 use Symfony\Component\Routing\Annotation\Route;
 
 /**
@@ -50,7 +51,9 @@ class UserController extends AbstractController
         }
 
         $userId = $context->getSource()->getUserId();
-
+        if (!$userId) {
+            throw new ExpectedUserHttpException();
+        }
         /** @var UserEntity|null $user */
         $user = $this->userRepository->search(new Criteria([$userId]), $context)->first();
         if (!$user) {
@@ -70,6 +73,9 @@ class UserController extends AbstractController
         }
 
         $userId = $context->getSource()->getUserId();
+        if (!$userId) {
+            throw new ExpectedUserHttpException();
+        }
         $result = $this->userRepository->searchIds(new Criteria([$userId]), $context);
 
         if ($result->getTotal() === 0) {


### PR DESCRIPTION
### 1. Why is this change necessary?
Currently, if you are trying to access `/api/v1/_info/me` or `/api/_info/ping` with an access token generated without a user relation (e.g client_credentials from an integration) you get an 500 internal error from the search method call on the clientRepository  because clientId is null.

### 2. What does this change do, exactly?
It returns a 403 HTTP error if a request is made with an access token generated via client credentials (Integration).

### 3. Describe each step to reproduce the issue or behaviour.
1. Generate client_id and client_secret via an integration
2. Get an oAuth access_token with those credentials
3. Make a get request with this token on `/api/v1/_info/me` or `/api/v1/_info/ping`
4. Get the following error
```json
{
    "errors": [
        {
            "status": "500",
            "code": "FRAMEWORK__INCONSISTENT_CRITERIA_IDS",
            "title": "Internal Server Error",
            "detail": "Inconsistent argument for Criteria. Please filter all invalid values first.",
            "meta": {
                "parameters": []
            }
        }
    ]
}
```
### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
