### PR TITLE
Replaced "declare(strict_types = 1)" to "declare(strict_types=1)" on the documentation

### DIFF
--- a/src/Docs/Resources/current/20-developer-guide/110-content-translations.md
+++ b/src/Docs/Resources/current/20-developer-guide/110-content-translations.md
@@ -145,7 +145,7 @@ Everything else is already handled by the `EntityTranslationDefinition`, for exa
 and a `languageId` field.
 
 ```php
-<?php declare(strict_types = 1);
+<?php declare(strict_types=1);
 
 namespace Swag\CustomEntityTranslations\Custom\Aggregate\CustomTranslation;
 
@@ -195,7 +195,7 @@ Additional to that you to add your custom translated field(s), `label` in this e
 parent's id, `customEntityId` in this case, as well as a property for the actual `CustomEntity` object.
 
 ```php
-<?php declare(strict_types = 1);
+<?php declare(strict_types=1);
 
 namespace Swag\CustomEntityTranslations\Custom\Aggregate\CustomTranslation;
 
@@ -274,7 +274,7 @@ class CustomTranslationEntity extends TranslationEntity
 Your custom translation entity also has to come with a respective collection class, which also extends from `EntityCollection`.
 
 ```php
-<?php declare(strict_types = 1);
+<?php declare(strict_types=1);
 
 namespace Swag\CustomEntityTranslations\Custom\Aggregate\CustomTranslation;
 

--- a/src/Docs/Resources/current/20-developer-guide/80-console-commands.md
+++ b/src/Docs/Resources/current/20-developer-guide/80-console-commands.md
@@ -85,7 +85,7 @@ Your command's class should extend from the
 ```php
 // SwagExamplePlugin/src/Command/ExampleCommand.php
 
-<?php declare(strict_types = 1);
+<?php declare(strict_types=1);
 
 namespace Swag\ExamplePlugin\Command;
 

--- a/src/Docs/Resources/current/50-how-to/010-indepth-guide-bundle/060-entity-translation.md
+++ b/src/Docs/Resources/current/50-how-to/010-indepth-guide-bundle/060-entity-translation.md
@@ -217,7 +217,7 @@ All of those properties need a getter and a setter again, so add those too.
 
 Here's the example `BundleTranslationEntity`:
 ```php
-<?php declare(strict_types = 1);
+<?php declare(strict_types=1);
 
 namespace Swag\BundleExample\Core\Content\Bundle\Aggregate\BundleTranslation;
 
@@ -286,7 +286,7 @@ any field related stuff, there's no `TranslatedEntityCollection` or something al
 Just like in the `BundleCollection`, override the method `getExpectedClass` and return the FQCN for your `BundleTranslationEntity` here.
 
 ```php
-<?php declare(strict_types = 1);
+<?php declare(strict_types=1);
 
 namespace Swag\BundleExample\Core\Content\Bundle\Aggregate\BundleTranslation;
 

--- a/src/Docs/Resources/current/50-how-to/060-custom-entity-translations.md
+++ b/src/Docs/Resources/current/50-how-to/060-custom-entity-translations.md
@@ -142,7 +142,7 @@ In this example, the directory structure would look like this:
 Since creating an `EntityCollection` was already explained in the [previous HowTo](./050-custom-entity.md), only the differences are going to be explained here.
 
 ```php
-<?php declare(strict_types = 1);
+<?php declare(strict_types=1);
 
 namespace Swag\CustomEntityTranslations\Custom\Aggregate\CustomTranslation;
 
@@ -200,7 +200,7 @@ Additional to that you to add your custom translated field(s), `label` in this e
 parent's id, `customEntityId` in this case, as well as a property for the actual `CustomEntity` object.
 
 ```php
-<?php declare(strict_types = 1);
+<?php declare(strict_types=1);
 
 namespace Swag\CustomEntityTranslations\Custom\Aggregate\CustomTranslation;
 
@@ -279,7 +279,7 @@ class CustomTranslationEntity extends TranslationEntity
 Your custom translation entity also has to come with a respective collection class, which also extends from `EntityCollection`.
 
 ```php
-<?php declare(strict_types = 1);
+<?php declare(strict_types=1);
 
 namespace Swag\CustomEntityTranslations\Custom\Aggregate\CustomTranslation;
 

--- a/src/Docs/Resources/current/50-how-to/070-add-service.md
+++ b/src/Docs/Resources/current/50-how-to/070-add-service.md
@@ -32,7 +32,7 @@ Here's an example `services.xml`:
 
 And the related example service:
 ```php
-<?php declare(strict_types = 1);
+<?php declare(strict_types=1);
 
 namespace Swag\CustomService\Service;
 

--- a/src/Docs/Resources/current/50-how-to/080-decorating-a-service.md
+++ b/src/Docs/Resources/current/50-how-to/080-decorating-a-service.md
@@ -36,7 +36,7 @@ Here's an example `services.xml`:
 
 And the related example services:
 ```php
-<?php declare(strict_types = 1);
+<?php declare(strict_types=1);
 
 namespace Swag\ServiceDecoration\Service;
 

--- a/src/Docs/Resources/current/50-how-to/090-plugin-commands.md
+++ b/src/Docs/Resources/current/50-how-to/090-plugin-commands.md
@@ -34,7 +34,7 @@ Here's an example `services.xml` which registers your custom command:
 
 And the related example command:
 ```php
-<?php declare(strict_types = 1);
+<?php declare(strict_types=1);
 
 namespace Swag\PluginCommands\Command;
 

--- a/src/Docs/Resources/deprecated/1-getting-started/35-indepth-guide-bundle/060-entity-translation.md
+++ b/src/Docs/Resources/deprecated/1-getting-started/35-indepth-guide-bundle/060-entity-translation.md
@@ -217,7 +217,7 @@ All of those properties need a getter and a setter again, so add those too.
 
 Here's the example `BundleTranslationEntity`:
 ```php
-<?php declare(strict_types = 1);
+<?php declare(strict_types=1);
 
 namespace Swag\BundleExample\Core\Content\Bundle\Aggregate\BundleTranslation;
 
@@ -286,7 +286,7 @@ any field related stuff, there's no `TranslatedEntityCollection` or something al
 Just like in the `BundleCollection`, override the method `getExpectedClass` and return the FQCN for your `BundleTranslationEntity` here.
 
 ```php
-<?php declare(strict_types = 1);
+<?php declare(strict_types=1);
 
 namespace Swag\BundleExample\Core\Content\Bundle\Aggregate\BundleTranslation;
 

--- a/src/Docs/Resources/deprecated/2-internals/4-plugins/010-plugin-quick-start.md
+++ b/src/Docs/Resources/deprecated/2-internals/4-plugins/010-plugin-quick-start.md
@@ -340,7 +340,7 @@ into services. Earlier in this tutorial you already created a `services.xml` fil
 Sticking to the previous examples, you could just name it `MyService` and place it into a `src/Service` directory.
 
 ```php
-<?php declare(strict_types = 1);
+<?php declare(strict_types=1);
 
 namespace Swag\PluginQuickStart\Service;
 

--- a/src/Docs/Resources/deprecated/4-how-to/060-custom-entity-translations.md
+++ b/src/Docs/Resources/deprecated/4-how-to/060-custom-entity-translations.md
@@ -142,7 +142,7 @@ In this example, the directory structure would look like this:
 Since creating an `EntityCollection` was already explained in the [previous HowTo](./050-custom-entity.md), only the differences are going to be explained here.
 
 ```php
-<?php declare(strict_types = 1);
+<?php declare(strict_types=1);
 
 namespace Swag\CustomEntityTranslations\Custom\Aggregate\CustomTranslation;
 
@@ -200,7 +200,7 @@ Additional to that you to add your custom translated field(s), `label` in this e
 parent's id, `customEntityId` in this case, as well as a property for the actual `CustomEntity` object.
 
 ```php
-<?php declare(strict_types = 1);
+<?php declare(strict_types=1);
 
 namespace Swag\CustomEntityTranslations\Custom\Aggregate\CustomTranslation;
 
@@ -279,7 +279,7 @@ class CustomTranslationEntity extends TranslationEntity
 Your custom translation entity also has to come with a respective collection class, which also extends from `EntityCollection`.
 
 ```php
-<?php declare(strict_types = 1);
+<?php declare(strict_types=1);
 
 namespace Swag\CustomEntityTranslations\Custom\Aggregate\CustomTranslation;
 

--- a/src/Docs/Resources/deprecated/4-how-to/070-add-service.md
+++ b/src/Docs/Resources/deprecated/4-how-to/070-add-service.md
@@ -32,7 +32,7 @@ Here's an example `services.xml`:
 
 And the related example service:
 ```php
-<?php declare(strict_types = 1);
+<?php declare(strict_types=1);
 
 namespace Swag\CustomService\Service;
 

--- a/src/Docs/Resources/deprecated/4-how-to/080-decorating-a-service.md
+++ b/src/Docs/Resources/deprecated/4-how-to/080-decorating-a-service.md
@@ -36,7 +36,7 @@ Here's an example `services.xml`:
 
 And the related example services:
 ```php
-<?php declare(strict_types = 1);
+<?php declare(strict_types=1);
 
 namespace Swag\ServiceDecoration\Service;
 

--- a/src/Docs/Resources/deprecated/4-how-to/090-plugin-commands.md
+++ b/src/Docs/Resources/deprecated/4-how-to/090-plugin-commands.md
@@ -34,7 +34,7 @@ Here's an example `services.xml` which registers your custom command:
 
 And the related example command:
 ```php
-<?php declare(strict_types = 1);
+<?php declare(strict_types=1);
 
 namespace Swag\PluginCommands\Command;
 


### PR DESCRIPTION
Simple adjustments on the documentation.

From:
```
<?php declare(strict_types = 1);
```

To:
```
<?php declare(strict_types=1);
```

Trying to keep consistency, as the other sample codes.


My very first contribution 😊 (from *hopefully* many)!