### PR TITLE
Fix group by and caching for compound primary key entities

### DIFF
--- a/src/Core/Framework/DataAbstractionLayer/Dbal/EntitySearcher.php
+++ b/src/Core/Framework/DataAbstractionLayer/Dbal/EntitySearcher.php
@@ -171,9 +171,18 @@ class EntitySearcher implements EntitySearcherInterface
         }
 
         if ($query->hasState(EntityDefinitionQueryHelper::HAS_TO_MANY_JOIN)) {
-            $query->addGroupBy(
-                EntityDefinitionQueryHelper::escape($table) . '.' . EntityDefinitionQueryHelper::escape('id')
-            );
+            if ($definition->getFields()->getByStorageName('id') !== null) {
+                $query->addGroupBy(
+                    EntityDefinitionQueryHelper::escape($table) . '.' . EntityDefinitionQueryHelper::escape('id')
+                );
+            } else {
+                /** @var Field&StorageAware $field */
+                foreach ($definition->getPrimaryKeys()->filterInstance(StorageAware::class) as $field) {
+                    $query->addGroupBy(
+                        EntityDefinitionQueryHelper::escape($table) . '.' . EntityDefinitionQueryHelper::escape($field->getStorageName())
+                    );
+                }
+            }
         }
     }
 


### PR DESCRIPTION
### 1. Why is this change necessary?
It is currently impossible to query translation and I assume other relation tables that have a compound primary key.

### 2. What does this change do, exactly?
It improves cache handling and searching to work with compound keys.

### 3. Describe each step to reproduce the issue or behaviour.
```
/** @var EntityRepositoryInterface $product_translation */
$criteria = new Criteria();
$criteria->addFilter(new EqualsFilter('product.productNumber', 'foobar')); // Has to exist
$product_translation->search($criteria, Context::createDefaultContext()); // 💣 without group by fix
$product_translation->search($criteria, Context::createDefaultContext()); // 💣 without cache fix
```

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
