### PR TITLE
Add isMerged flag to LineItemAddedEvent

### DIFF
--- a/src/Core/Checkout/Cart/Event/LineItemAddedEvent.php
+++ b/src/Core/Checkout/Cart/Event/LineItemAddedEvent.php
@@ -24,11 +24,17 @@ class LineItemAddedEvent extends Event
      */
     protected $context;
 
-    public function __construct(LineItem $lineItem, Cart $cart, SalesChannelContext $context)
+    /**
+     * @var bool
+     */
+    protected $merged;
+
+    public function __construct(LineItem $lineItem, Cart $cart, SalesChannelContext $context, bool $merged = false)
     {
         $this->lineItem = $lineItem;
         $this->cart = $cart;
         $this->context = $context;
+        $this->merged = $merged;
     }
 
     public function getLineItem(): LineItem
@@ -44,5 +50,10 @@ class LineItemAddedEvent extends Event
     public function getContext(): SalesChannelContext
     {
         return $this->context;
+    }
+
+    public function isMerged(): bool
+    {
+        return $this->merged;
     }
 }

--- a/src/Core/Checkout/Cart/SalesChannel/CartItemAddRoute.php
+++ b/src/Core/Checkout/Cart/SalesChannel/CartItemAddRoute.php
@@ -83,8 +83,9 @@ class CartItemAddRoute extends AbstractCartItemAddRoute
         }
 
         foreach ($items as $item) {
+            $alreadyExists = $cart->has($item->getId());
             $cart->add($item);
-            $this->eventDispatcher->dispatch(new LineItemAddedEvent($item, $cart, $context));
+            $this->eventDispatcher->dispatch(new LineItemAddedEvent($item, $cart, $context, $alreadyExists));
         }
 
         $cart->markModified();


### PR DESCRIPTION
### 1. Why is this change necessary?
When a product is added to the cart and it is already present in the cart just the quantity of the lineitem in the cart is changed. Any changes towards the item instance in the event data does not get merged into the cart as it is not the item instance in the cart when merge happened. To be aware of this situation we need this flag so we can check manually merge e.g. the payload manually and get the other item from the cart using `$event->getCart()->get($event->getLineItem()->getId())`.

This adds some code smell as this expects the LineItemCollection to behave like it does right now but IMHO this smell depends on the fact that the LineItemCollection has business logic inside™️.

This change has been done with shopware 6.2.2 in mind. The new LineItemFactory makes it easier for me now the create the lineitems like I'd like to but my custom payload data is still not merged so the event is needed for the merge. But do I need to merge or just set it? This is a tricky problem without this flag.

### 2. What does this change do, exactly?
Adds an optional flag to the event that can be used to check whether the item was "merged" into the cart instead of being added.

### 3. Describe each step to reproduce the issue or behaviour.
* Add a subscriber to the LineItemAddedEvent
* Change payload in subscriber
* Add product twice to cart
* Now the payload has not been updated when you use the lineItem from the event data

### 4. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.