### PR TITLE
* fix checkbox (toggle group) event propagation on mobile devices

### DIFF
--- a/src/Storefront/Resources/app/storefront/src/plugin/cookie/cookie-configuration.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/cookie/cookie-configuration.plugin.js
@@ -21,7 +21,6 @@
 
 import Plugin from 'src/plugin-system/plugin.class';
 import CookieStorage from 'src/helper/storage/cookie-storage.helper';
-import DeviceDetection from 'src/helper/device-detection.helper';
 import AjaxOffCanvas from 'src/plugin/offcanvas/ajax-offcanvas.plugin';
 import OffCanvas from 'src/plugin/offcanvas/offcanvas.plugin';
 import AjaxModalExtension from 'src/utility/modal-extension/ajax-modal-extension.util';
@@ -33,7 +32,7 @@ export default class CookieConfiguration extends Plugin {
 
     static options = {
         offCanvasPosition: 'left',
-        submitEvent: (DeviceDetection.isTouchDevice()) ? 'touchstart' : 'click',
+        submitEvent: 'click',
         cookiePreference: 'cookie-preference',
         cookieSelector: '[data-cookie]',
         buttonOpenSelector: '.js-cookie-configuration-button button',


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/community).

Do your changes need to be mentioned in the documentation?
No
-->

### 1. Why is this change necessary?
This fixes the cookie configuration checkboxes on mobile devices when selecting a cookie group (e.g statistics) which will then toggle all checkboxes in that subgroup.

### 2. What does this change do, exactly?
This event doesn't propagate when using `touchstart` but will when using `click`. I don't see the reason for device detection here as `touchstart` is included in the `click` event chain (without the trouble).

### 3. Describe each step to reproduce the issue or behaviour.
* Add statistics cookies
* Switch to a mobile device (or emulate)
* Click on statistics
* See that the checkboxes for the individual cookies are not checked by pressing the arrow icon
* Repeat on desktop and see that it works

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
