### PR TITLE
* fix thumbnails being created larger than the original

### DIFF
--- a/src/Core/Content/Media/Thumbnail/ThumbnailService.php
+++ b/src/Core/Content/Media/Thumbnail/ThumbnailService.php
@@ -281,17 +281,33 @@ class ThumbnailService
         if ($imageSize['width'] >= $imageSize['height']) {
             $aspectRatio = $imageSize['height'] / $imageSize['width'];
 
-            return [
-                'width' => $preferredThumbnailSize->getWidth(),
-                'height' => (int) ceil($preferredThumbnailSize->getHeight() * $aspectRatio),
+            $calculatedWidth = $preferredThumbnailSize->getWidth();
+            $calculatedHeight = (int) ceil($preferredThumbnailSize->getHeight() * $aspectRatio);
+
+            $useOriginalSizeInThumbnails = $imageSize['width'] < $calculatedWidth || $imageSize['height'] < $calculatedHeight;
+
+            return $useOriginalSizeInThumbnails ? [
+                'width' => $imageSize['width'],
+                'height' => $imageSize['height'],
+            ] : [
+                'width' => $calculatedWidth,
+                'height' => $calculatedHeight,
             ];
         }
 
         $aspectRatio = $imageSize['width'] / $imageSize['height'];
 
-        return [
-            'width' => (int) ceil($preferredThumbnailSize->getWidth() * $aspectRatio),
-            'height' => $preferredThumbnailSize->getHeight(),
+        $calculatedWidth = (int) ceil($preferredThumbnailSize->getWidth() * $aspectRatio);
+        $calculatedHeight = $preferredThumbnailSize->getHeight();
+
+        $useOriginalSizeInThumbnails = $imageSize['width'] < $calculatedWidth || $imageSize['height'] < $calculatedHeight;
+
+        return $useOriginalSizeInThumbnails ? [
+            'width' => $imageSize['width'],
+            'height' => $imageSize['height'],
+        ] : [
+            'width' => $calculatedWidth,
+            'height' => $calculatedHeight,
         ];
     }
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/community).

Do your changes need to be mentioned in the documentation?
No
-->

### 1. Why is this change necessary?
This fixes the thumbnail creation creating thumbnails which larger than the original. Take an image of 300x300 for instance and a setting of a 1920x1920 thumbnail size. The result is a 1920x1920 pixelated upscaled image with a filesize thats even bigger than the original.

### 2. What does this change do, exactly?
This PR will write the thumbnails in the same manner but preserve original dimensions if the source width/ height is smaller than the original.

### 3. Describe each step to reproduce the issue or behaviour.
* Upload an image of 300x300
* Generate thumbnails via cli for instance (1920x1920)
* See the result which is larger in size and pixelated

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
