### PR TITLE
fix: <service> tags must be nested inside of a single <services> tag

### DIFF
--- a/src/Docs/Resources/current/30-theme-guide/40-snippets.md
+++ b/src/Docs/Resources/current/30-theme-guide/40-snippets.md
@@ -124,9 +124,6 @@ Example:
         <service id="MyTheme\Resources\snippet\en_GB\SnippetFile_en_GB" public="true">
             <tag name="shopware.snippet.file"/>
         </service>
-    </services>
-
-    <services>
         <service id="MyTheme\Resources\snippet\de_DE\SnippetFile_de_DE" public="true">
             <tag name="shopware.snippet.file"/>
         </service>


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/community).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
Documentation is a little off.
`<service>` tags must be nested inside of a single `<services> `tag

### 2. What does this change do, exactly?
The services.xml file doesn't work without this change

### 3. Describe each step to reproduce the issue or behaviour.
Just replace 
```
<services>
       <service></service>
</services>
<services>
       <service></service>
</services>
```
With
```
<services>
       <service></service>
       <service></service>
</services>
```

### 4. Please link to the relevant issues (if any).
https://github.com/shopware/platform/blob/6.2/src/Docs/Resources/current/30-theme-guide/40-snippets.md

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.