### PR TITLE
Warning: count(): Parameter must be an array or an object that implements Countable

### DIFF
--- a/src/Core/Content/Product/SalesChannel/Listing/ProductListingFeaturesSubscriber.php
+++ b/src/Core/Content/Product/SalesChannel/Listing/ProductListingFeaturesSubscriber.php
@@ -371,7 +371,7 @@ class ProductListingFeaturesSubscriber implements EventSubscriberInterface
         $groups = array_column($groups, 'id');
 
         // expanded group count matches option count? All variants are displayed
-        if (count($groups) === count($product->getOptionIds())) {
+        if (is_array($product->getOptionIds()) && count($groups) === count($product->getOptionIds())) {
             return false;
         }
 


### PR DESCRIPTION
### 1. Why is this change necessary?

This change will fix the error :

Uncaught PHP Exception ErrorException: "Warning: count(): Parameter must be an array or an object that implements Countable" at 

/vendor/shopware/core/Content/Product/SalesChannel/Listing/ProductListingFeaturesSubscriber.php line 374

### 2. What does this change do, exactly?

This change will check if $product->getOptionIds() is array before do the count() .  

if (is_array($product->getOptionIds()) && count($groups) === count($product->getOptionIds())) {
     return false;
}

### 3. Describe each step to reproduce the issue or behavior.

- Install Shopware Enterprise Search and index data.
- Type text in the search box and click on any Proposals text-link in the search Pop-up.

![image](https://user-images.githubusercontent.com/1167168/87127987-14af6a00-c2b9-11ea-876a-784234c890f8.png)

- After click on the Proposal text link, you will see the error

![image](https://user-images.githubusercontent.com/1167168/87128104-43c5db80-c2b9-11ea-88a8-a40f35e66bb4.png)

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
