### PR TITLE
Extend filter entries to allow 4 digits to compare against weights

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/rule/condition-type/sw-condition-line-item-dimension-weight/sw-condition-line-item-dimension-weight.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/rule/condition-type/sw-condition-line-item-dimension-weight/sw-condition-line-item-dimension-weight.html.twig
@@ -9,6 +9,7 @@
                 numberType="float"
                 size="medium"
                 :step="0.01"
+                :digits="4"
                 :placeholder="$tc('sw-product.settingsForm.placeholderWidth')"
                 :min="0"
                 v-model="amount">

--- a/src/Administration/Resources/app/administration/src/app/component/rule/condition-type/sw-condition-weight-of-cart/sw-condition-weight-of-cart.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/rule/condition-type/sw-condition-weight-of-cart/sw-condition-weight-of-cart.html.twig
@@ -5,7 +5,7 @@
         {% endblock %}
 
         {% block sw_condition_weight_of_cart_field_weight %}
-            <sw-number-field size="medium" :step="0.01" v-model="weight"></sw-number-field>
+            <sw-number-field size="medium" :step="0.01" :digits="4" v-model="weight"></sw-number-field>
         {% endblock %}
     </div>
 {% endblock %}


### PR DESCRIPTION
### 1. Why is this change necessary?
Make sure you can compare to the same digit amount you can store the product weights.

### 2. What does this change do, exactly?
Set digits property to number-fields that are used for weights as the default falls back to 2.

### 3. Describe each step to reproduce the issue or behaviour.
1. Setup a weight rule when the cart is at least 1.234 kg heavy
2. Input field rounds to 1.23 kg

### 4. Please link to the relevant issues (if any).
Follow up to @tinect s #997 

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
