### PR TITLE
Add new property constant

### DIFF
--- a/src/Core/Content/Property/PropertyGroupDefinition.php
+++ b/src/Core/Content/Property/PropertyGroupDefinition.php
@@ -25,6 +25,8 @@ class PropertyGroupDefinition extends EntityDefinition
 
     public const DISPLAY_TYPE_IMAGE = 'image';
 
+    public const DISPLAY_TYPE_MEDIA = 'media';
+
     public const DISPLAY_TYPE_COLOR = 'color';
 
     public const SORTING_TYPE_NUMERIC = 'numeric';


### PR DESCRIPTION
### 1. Why is this change necessary?
When creating properties the media type is missing

### 2. What does this change do, exactly?
You have a constant to create properties correctly

### 3. Describe each step to reproduce the issue or behaviour.
We have trusted the constants for the import of properties. The constant `DISPLAY_TYPE_IMAGE` was good for images. The administration does not know the value `image`.

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
