### PR TITLE
fix: padding changed to margin as intended in admin

### DIFF
--- a/src/Storefront/Resources/views/storefront/section/cms-section-block-container.html.twig
+++ b/src/Storefront/Resources/views/storefront/section/cms-section-block-container.html.twig
@@ -6,7 +6,7 @@
     {% set left = block.marginLeft ? block.marginLeft : 0 %}
 
     {% if top or right or bottom or left %}
-        {% set padding = top ~ " " ~ right ~ " " ~ bottom ~ " " ~ left %}
+        {% set margin = top ~ " " ~ right ~ " " ~ bottom ~ " " ~ left %}
     {% endif %}
 
     {% set blockBgColor = block.backgroundColor %}
@@ -35,7 +35,7 @@
 
         {% block section_content_block_container %}
             <div class="cms-block-container"
-                 style="{% if padding %}padding: {{ padding }};{% endif %}">
+                 style="{% if margin %}margin: {{ margin }};{% endif %}">
 
                 {% block section_content_block_row %}
                     <div class="cms-block-container-row row cms-row {{ sidebarClasses }}">


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/community).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
Because the mixup of padding/margin is confusing to the user, also i find it a better user experience to do margin instead of padding.

### 2. What does this change do, exactly?
Change Padding in Layouts to use Margin instead

### 3. Describe each step to reproduce the issue or behaviour.
1. Go to admin
2. Go to Shopping Experiences and choose a layout
3. Under "layout" settings for a block, you can change Margin

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
