### PR TITLE
Add config for storefront hot-proxy assets port

### DIFF
--- a/CHANGELOG-6.2.md
+++ b/CHANGELOG-6.2.md
@@ -28,6 +28,11 @@ To get the diff between two versions, go to https://github.com/shopware/platform
     * Fixed property sorting for multi language shops
     * Added an additional class to the cart offcanvas called `cart-offcanvas`
     * Added all language flags according to language packs
+    * We extended setup of the `storefront:hot-proxy`
+          * The proxy's assets port is now configurable.
+            * Using psh: just override the `STOREFRONT_ASSETS_PORT` constant (this will also map the port for docker setup)
+            * Using npm: run `APP_URL="<your url>" STOREFRONT_ASSETS_PORT=<some port> PROJECT_ROOT=<path to your root folder>/ npm run hot-proxy` from the storefronts js directory.
+          * The default port is still port 9999.
 
 ### 6.2.3
 

--- a/src/Storefront/Resources/app/storefront/build/proxy-server-hot/index.js
+++ b/src/Storefront/Resources/app/storefront/build/proxy-server-hot/index.js
@@ -22,6 +22,7 @@ module.exports = function createProxyServer({ appPort, originalHost, proxyHost, 
                 ...client_req.headers,
                 host: originalUrl,
                 'hot-reload-mode': true,
+                'hot-reload-port': process.env.STOREFRONT_ASSETS_PORT || 9999,
                 'accept-encoding': 'identity',
             },
         };

--- a/src/Storefront/Resources/app/storefront/build/utils.js
+++ b/src/Storefront/Resources/app/storefront/build/utils.js
@@ -44,7 +44,7 @@ function getProjectRootPath() {
  * @return {String}
  */
 function getPublicPath() {
-    return `${getHostname()}${(isHotModuleReplacementMode()) ? ':9999' : ''}/`;
+    return `${getHostname()}${(isHotModuleReplacementMode()) ? ':' + (process.env.STOREFRONT_ASSETS_PORT || 9999) : ''}/`;
 }
 
 /**

--- a/src/Storefront/Resources/app/storefront/build/webpack.hot.config.js
+++ b/src/Storefront/Resources/app/storefront/build/webpack.hot.config.js
@@ -102,7 +102,7 @@ const devServer = {
     hot: true,
     compress: false,
     disableHostCheck: true,
-    port: 9999,
+    port: process.env.STOREFRONT_ASSETS_PORT || 9999,
     host: '0.0.0.0',
     clientLogLevel: 'warning',
     headers: {

--- a/src/Storefront/Resources/views/storefront/base.html.twig
+++ b/src/Storefront/Resources/views/storefront/base.html.twig
@@ -155,12 +155,13 @@
         {% block base_script_hmr_mode %}
             {% if isHMRMode %}
                 {% set baseUrl = app.request.getScheme() ~ '://' ~ app.request.getHost() %}
-                <script type="text/javascript" src="{{ baseUrl }}:9999/js/vendor-node.js"></script>
-                <script type="text/javascript" src="{{ baseUrl }}:9999/js/vendor-shared.js"></script>
-                <script type="text/javascript" src="{{ baseUrl }}:9999/js/runtime.js"></script>
-                <script type="text/javascript" src="{{ baseUrl }}:9999/js/app.js"></script>
+                {% set port = app.request.headers.get('hot-reload-port') %}
+                <script type="text/javascript" src="{{ baseUrl }}:{{ port }}/js/vendor-node.js"></script>
+                <script type="text/javascript" src="{{ baseUrl }}:{{ port }}/js/vendor-shared.js"></script>
+                <script type="text/javascript" src="{{ baseUrl }}:{{ port }}/js/runtime.js"></script>
+                <script type="text/javascript" src="{{ baseUrl }}:{{ port }}/js/app.js"></script>
                 {# The storefront entry is a combined entry point which contains all plugins & themes #}
-                <script type="text/javascript" src="{{ baseUrl }}:9999/js/storefront.js"></script>
+                <script type="text/javascript" src="{{ baseUrl }}:{{ port }}/js/storefront.js"></script>
             {% else %}
                 {% for file in shopware.theme.assets.js %}
                     <script type="text/javascript" src="{{ asset(file) }}" async></script>


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/community).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
It improves usability while developing for Shopware. Yet it is not possible to configure the assets port `9999` because it is hard-coded.

### 2. What does this change do, exactly?
It adds an env variable `STOREFRONT_ASSETS_PORT` where you can define a custom port. 

### 3. Describe each step to reproduce the issue or behaviour.
Simply run
```bash
export STOREFRONT_ASSETS_PORT=1337
./psh storefront:hot-proxy
```

The storefront (under port 9998) should run as before, but with port 1337 instead of 9999, for example.

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [x] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
