### PR TITLE
NEXT-9696 | Listing fiter cut off during overflow hidden

### DIFF
--- a/src/Storefront/Resources/app/storefront/src/scss/component/_cms-sections.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/component/_cms-sections.scss
@@ -5,8 +5,6 @@ General styling for cms sections
 */
 
 .cms-section {
-    overflow: hidden;
-
     &.bg-image {
         background-repeat: no-repeat;
         background-position: 50%;


### PR DESCRIPTION
If you have a CMS Section that doesn't have enough space at the bottom - e.g. only the filter element in it, the filters will be cut off when you open them due to `overflow: hidden;`

I'm not quite sure what the `overflow: hidden;` is for since it is basically superfluous according to my tests.

**Ticket:** 
https://issues.shopware.com/issues/NEXT-9696

**Bug:**
<img width="1709" alt="Bildschirmfoto 2020-07-14 um 13 44 22" src="https://user-images.githubusercontent.com/8193345/87420950-dd093080-c5de-11ea-998e-ab039181b1a7.png">

**Solution:**
<img width="1728" alt="Bildschirmfoto 2020-07-14 um 14 34 01" src="https://user-images.githubusercontent.com/8193345/87421144-25285300-c5df-11ea-83dd-db02fa09290f.png">

