### PR TITLE
sets preserve_keys parameter

### DIFF
--- a/src/Core/Content/Product/SearchKeyword/ProductSearchTermInterpreter.php
+++ b/src/Core/Content/Product/SearchKeyword/ProductSearchTermInterpreter.php
@@ -55,7 +55,7 @@ class ProductSearchTermInterpreter implements ProductSearchTermInterpreterInterf
 
         $scoring = $this->score($tokens, $matches);
 
-        $scoring = \array_slice($scoring, 0, 8);
+        $scoring = \array_slice($scoring, 0, 8, true);
 
         foreach ($scoring as $keyword => $score) {
             $this->logger->info('Search match: ' . $keyword . ' with score ' . (float) $score);


### PR DESCRIPTION
### 1. Why is this change necessary?
When searching products by product numbers the yielded search results will be incorrect. 

### 2. What does this change do, exactly?
Sets the preserve_keys parameter for the array_slice method to true so integer array indices won't be reseted.

### 3. Describe each step to reproduce the issue or behaviour.
1. Go to Storefront
2. Search for a product by product number
3. Get unwanted and too few results

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
