### PR TITLE
Add check to see if primary key already exists

### DIFF
--- a/src/Core/Migration/Migration1572264837AddCacheId.php
+++ b/src/Core/Migration/Migration1572264837AddCacheId.php
@@ -21,7 +21,6 @@ class Migration1572264837AddCacheId extends MigrationStep
         } catch (DBALException $e) {
             // PK already exists
         }
-        
         $connection->executeUpdate(
             '
             INSERT IGNORE INTO app_config (`key`, `value`)

--- a/src/Core/Migration/Migration1572264837AddCacheId.php
+++ b/src/Core/Migration/Migration1572264837AddCacheId.php
@@ -16,8 +16,12 @@ class Migration1572264837AddCacheId extends MigrationStep
     public function update(Connection $connection): void
     {
         $connection->executeUpdate('DELETE FROM app_config');
-        $connection->exec('ALTER TABLE app_config ADD PRIMARY KEY (`key`)');
-
+        try {
+                 $connection->exec('ALTER TABLE app_config ADD PRIMARY KEY (`key`)');
+        } catch (DBALException $e) {
+            // PK already exists
+        }
+        
         $connection->executeUpdate(
             '
             INSERT IGNORE INTO app_config (`key`, `value`)

--- a/src/Core/Migration/Migration1572264837AddCacheId.php
+++ b/src/Core/Migration/Migration1572264837AddCacheId.php
@@ -17,7 +17,7 @@ class Migration1572264837AddCacheId extends MigrationStep
     {
         $connection->executeUpdate('DELETE FROM app_config');
         try {
-                 $connection->exec('ALTER TABLE app_config ADD PRIMARY KEY (`key`)');
+            $connection->exec('ALTER TABLE app_config ADD PRIMARY KEY (`key`)');
         } catch (DBALException $e) {
             // PK already exists
         }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/community).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
Because Digital Ocean, for example, requires a primary key in existing databases to avoid replication issues.

https://www.digitalocean.com/docs/databases/mysql/

"MySQL databases containing tables without a primary key and which contain more than 5000 rows may experience replication issues. To prevent this, DigitalOcean now requires you to add a primary key for each new table you create in any managed MySQL database created after 8 April 2020. We strongly recommend that you also add primary keys in existing databases to avoid replication issues.

"

### 2. What does this change do, exactly?
Adds a primary key to the table 

### 3. Describe each step to reproduce the issue or behaviour.
I encoutered the bug during the process in the installation wizard. When the database was being filled

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
