### PR TITLE
Check for PK in temp_import_export_profile_translation

### DIFF
--- a/src/Core/Migration/Migration1594887171TempImportExportProfileTranslationPK.php
+++ b/src/Core/Migration/Migration1594887171TempImportExportProfileTranslationPK.php
@@ -1,0 +1,32 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Migration;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\DBALException;
+use Shopware\Core\Framework\Migration\MigrationStep;
+
+class Migration1594887171TempImportExportProfileTranslationPK extends MigrationStep
+{
+    public function getCreationTimestamp(): int
+    {
+        return 1594887171;
+    }
+
+    public function update(Connection $connection): void
+    {
+        try {
+            $connection->executeUpdate('
+                ALTER TABLE `temp_import_export_profile_translation`
+                ADD PRIMARY KEY (`id`);
+            ');
+        } catch (DBALException $e) {
+            // PK already exists
+        }
+    }
+
+    public function updateDestructive(Connection $connection): void
+    {
+        // nothing
+    }
+}


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/community).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
The reason is for all shops that are already installed the migrations with the CREATE TABLE won't run with the newly added PKs

### 2. What does this change do, exactly?
check the presence of the PK

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
