### PR TITLE
Missing FR key configuration_sconfig_country

### DIFF
--- a/src/Recovery/Install/data/lang/fr.php
+++ b/src/Recovery/Install/data/lang/fr.php
@@ -100,7 +100,7 @@ return [
     'configuration_sconfig_domain' => 'Shop-Domain :',
     'configuration_sconfig_language' => 'Langue système standard :',
     'configuration_sconfig_currency' => 'Devise par défaut :',
-     'configuration_sconfig_country' => 'Pays par défaut :',
+    'configuration_sconfig_country' => 'Pays par défaut :',
     'configuration_sconfig_currency_info' => 'Cette devise est utilisée par défaut pour le prix des produits.',
     'configuration_admin_currency_eur' => 'Euro',
     'configuration_admin_currency_usd' => 'Dollar (US)',

--- a/src/Recovery/Install/data/lang/fr.php
+++ b/src/Recovery/Install/data/lang/fr.php
@@ -100,6 +100,7 @@ return [
     'configuration_sconfig_domain' => 'Shop-Domain :',
     'configuration_sconfig_language' => 'Langue système standard :',
     'configuration_sconfig_currency' => 'Devise par défaut :',
+     'configuration_sconfig_country' => 'Pays par défaut :',
     'configuration_sconfig_currency_info' => 'Cette devise est utilisée par défaut pour le prix des produits.',
     'configuration_admin_currency_eur' => 'Euro',
     'configuration_admin_currency_usd' => 'Dollar (US)',


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/community).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
In order to show the good label instead of "configuration_sconfig_country" 

### 2. What does this change do, exactly?
add the translation + the key

### 3. Describe each step to reproduce the issue or behaviour.
use the install wizard in French
https://files.slack.com/files-pri/T011TTK0DMK-F017KN0MEDP/bug.png
### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
