### PR TITLE
Add net and gross purchase prices

### DIFF
--- a/CHANGELOG-6.3.md
+++ b/CHANGELOG-6.3.md
@@ -952,6 +952,8 @@ Refactored `src/module/sw-plugin/snippet/en-GB.json`:
 * Allow specifying translations for languages that don't exist. These translations will now be silently skipped.
   This used to throw the exception `\Shopware\Core\Framework\Routing\Exception\LanguageNotFoundException`.
 * Added check to prevent mails being sent when `\Shopware\Core\Content\MailTemplate\Service\Event\MailBeforeSentEvent::stopPropagation` was called before
+* Deprecated `purchasePrice` in `Shopware\Core\Content\Product` use `purchasePrices` instead
+* Deprecated `payload.purchasePrice` in `Shopware\Core\Checkout\Cart\LineItem\LineItem` use `payload.purchasePrices` instead
 
 #### Storefront
 * Added plugin injection in hot mode

--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-price-field/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-price-field/index.js
@@ -95,18 +95,24 @@ Component.register('sw-price-field', {
             type: String,
             required: false,
             default: null
+        },
+
+        name: {
+            type: String,
+            required: false,
+            default: null
         }
     },
 
     watch: {
         'priceForCurrency.linked': function priceLinkedWatcher(value) {
-            if (value === true) {
+            if (value === true && this.priceForCurrency.gross !== null) {
                 this.convertGrossToNet(this.priceForCurrency.gross);
             }
         },
 
         'taxRate.id': function taxRateWatcher() {
-            if (this.priceForCurrency.linked === true) {
+            if (this.priceForCurrency.linked === true && this.priceForCurrency.gross !== null) {
                 this.convertGrossToNet(this.priceForCurrency.gross);
             }
         }
@@ -170,6 +176,14 @@ Component.register('sw-price-field', {
 
         netError() {
             return this.error ? this.error.net : null;
+        },
+
+        grossFieldName() {
+            return this.name ? `${this.name}-gross` : 'sw-price-field-gross';
+        },
+
+        netFieldName() {
+            return this.name ? `${this.name}-net` : 'sw-price-field-net';
         }
     },
 

--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-price-field/sw-price-field.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-price-field/sw-price-field.html.twig
@@ -16,7 +16,7 @@
                       :error="grossError"
                       @input-change="onPriceGrossChange"
                       :disabled="isDisabled"
-                      name="sw-price-field-gross"
+                      :name="grossFieldName"
                       v-bind="$attrs"
                       v-model="priceForCurrency.gross"
                       @keyup="keymonitor">
@@ -49,7 +49,7 @@
                       :digits="currency.decimalPrecision"
                       :error="netError"
                       :disabled="isInherited || disabled"
-                      name="sw-price-field-net"
+                      :name="netFieldName"
                       v-bind="$attrs"
                       v-model="priceForCurrency.net"
                       @keyup="keymonitor">

--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-purchase-price-field/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-purchase-price-field/index.js
@@ -1,0 +1,81 @@
+import template from './sw-purchase-price-field.html.twig';
+
+const { Component } = Shopware;
+
+Component.register('sw-purchase-price-field', {
+    template,
+
+    props: {
+        price: {
+            type: Array,
+            required: true
+        },
+
+        compact: {
+            type: Boolean,
+            required: false,
+            default: false
+        },
+
+        taxRate: {
+            type: Object,
+            required: true
+        },
+
+        error: {
+            type: Object,
+            required: false,
+            default: null
+        },
+
+        label: {
+            required: false,
+            default: true
+        },
+
+        disabled: {
+            required: false,
+            default: false
+        },
+
+        currency: {
+            type: Object,
+            required: true
+        }
+    },
+
+    computed: {
+        purchasePrice: {
+            get() {
+                const priceForCurrency = this.price.find((price) => price.currencyId === this.currency.id);
+                if (priceForCurrency) {
+                    return [priceForCurrency];
+                }
+
+                return [{
+                    gross: null,
+                    currencyId: this.currency.id,
+                    linked: true,
+                    net: null
+                }];
+            },
+
+            set(newPurchasePrice) {
+                let priceForCurrency = this.price.find((price) => price.currencyId === newPurchasePrice.currencyId);
+                if (priceForCurrency) {
+                    priceForCurrency = newPurchasePrice;
+                } else {
+                    this.price.push(newPurchasePrice);
+                }
+
+                this.$emit('input', this.price);
+            }
+        }
+    },
+
+    methods: {
+        purchasePriceChanged(value) {
+            this.purchasePrice = value;
+        }
+    }
+});

--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-purchase-price-field/sw-purchase-price-field.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-purchase-price-field/sw-purchase-price-field.html.twig
@@ -1,0 +1,14 @@
+{% block sw_purchase_price_field %}
+    <sw-price-field name="sw-purchase-price-field"
+                    :price="purchasePrice"
+                    :taxRate="taxRate"
+                    :disabled="disabled"
+                    :grossLabel="$tc('sw-product.priceForm.labelPurchasePriceGross')"
+                    :netLabel="$tc('sw-product.priceForm.labelPurchasePriceNet')"
+                    :compact="compact"
+                    :label="label"
+                    :error="error"
+                    :currency="currency"
+                    @change="purchasePriceChanged">
+    </sw-price-field>
+{% endblock %}

--- a/src/Administration/Resources/app/administration/src/app/component/rule/condition-type/sw-condition-line-item-purchase-price/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/rule/condition-type/sw-condition-line-item-purchase-price/index.js
@@ -1,4 +1,5 @@
 import template from './sw-condition-line-item-purchase-price.html.twig';
+import './sw-condition-line-item-purchase-price.scss';
 
 const { Component } = Shopware;
 const { mapPropertyErrors } = Component.getComponentHelper();
@@ -9,6 +10,10 @@ Component.extend('sw-condition-line-item-purchase-price', 'sw-condition-base', {
     computed: {
         operators() {
             return this.conditionDataProviderService.getOperatorSet('number');
+        },
+
+        isNetOperators() {
+            return this.conditionDataProviderService.getOperatorSet('isNet');
         },
 
         amount: {
@@ -25,7 +30,9 @@ Component.extend('sw-condition-line-item-purchase-price', 'sw-condition-base', {
         ...mapPropertyErrors('condition', ['value.operator', 'value.amount']),
 
         currentError() {
-            return this.conditionValueOperatorError || this.conditionValueAmountError;
+            return this.conditionValueIsNetError
+                || this.conditionValueOperatorError
+                || this.conditionValueAmountError;
         }
     }
 });

--- a/src/Administration/Resources/app/administration/src/app/component/rule/condition-type/sw-condition-line-item-purchase-price/sw-condition-line-item-purchase-price.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/rule/condition-type/sw-condition-line-item-purchase-price/sw-condition-line-item-purchase-price.html.twig
@@ -1,5 +1,9 @@
 {% block sw_condition_value_content %}
     <div class="sw-condition-line-item-purchase-price sw-condition__condition-value">
+        {% block sw_condition_line_item_purchase_price_field_gross_net %}
+            <sw-condition-is-net-select v-bind="{ operators: isNetOperators, condition }"></sw-condition-is-net-select>
+        {% endblock %}
+
         {% block sw_condition_line_item_purchase_price_field_operator %}
             <sw-condition-operator-select v-bind="{ operators, condition }"></sw-condition-operator-select>
         {% endblock %}

--- a/src/Administration/Resources/app/administration/src/app/component/rule/condition-type/sw-condition-line-item-purchase-price/sw-condition-line-item-purchase-price.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/rule/condition-type/sw-condition-line-item-purchase-price/sw-condition-line-item-purchase-price.scss
@@ -1,0 +1,6 @@
+@import "~scss/variables";
+
+.sw-condition .sw-condition-line-item-purchase-price.sw-condition__condition-value {
+    display: grid;
+    grid-template-columns: auto auto 1fr;
+}

--- a/src/Administration/Resources/app/administration/src/app/component/rule/sw-condition-is-net-select/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/rule/sw-condition-is-net-select/index.js
@@ -1,0 +1,20 @@
+const { Component } = Shopware;
+
+Component.extend('sw-condition-is-net-select', 'sw-condition-operator-select', {
+    computed: {
+        operator: {
+            get() {
+                if (!this.condition.value) {
+                    return null;
+                }
+                return this.condition.value.isNet;
+            },
+            set(isNet) {
+                if (!this.condition.value) {
+                    this.condition.value = {};
+                }
+                this.condition.value = { ...this.condition.value, isNet };
+            }
+        }
+    }
+});

--- a/src/Administration/Resources/app/administration/src/app/service/rule-condition.service.js
+++ b/src/Administration/Resources/app/administration/src/app/service/rule-condition.service.js
@@ -44,6 +44,14 @@ export default function createConditionService() {
         isNoneOf: {
             identifier: '!=',
             label: 'global.sw-condition.operator.isNoneOf'
+        },
+        gross: {
+            identifier: false,
+            label: 'global.sw-condition.operator.gross'
+        },
+        net: {
+            identifier: true,
+            label: 'global.sw-condition.operator.net'
         }
     };
     const operatorSets = {
@@ -83,6 +91,10 @@ export default function createConditionService() {
             operators.lowerThan,
             operators.lowerThanEquals,
             operators.notEquals
+        ],
+        isNet: [
+            operators.gross,
+            operators.net
         ]
     };
 

--- a/src/Administration/Resources/app/administration/src/app/snippet/de-DE.json
+++ b/src/Administration/Resources/app/administration/src/app/snippet/de-DE.json
@@ -485,7 +485,9 @@
         "greaterThan": "Größer",
         "notEquals": "Ungleich",
         "isOneOf": "Ist eine von",
-        "isNoneOf": "Ist keine von"
+        "isNoneOf": "Ist keine von",
+        "gross": "Brutto",
+        "net": "Netto"
       },
       "placeholderErrorMessage": "Platzhalter können nicht gespeichert werden.",
       "dataErrorMessage": "Es wurden nicht alle Pflichtfelder befüllt.",

--- a/src/Administration/Resources/app/administration/src/app/snippet/en-GB.json
+++ b/src/Administration/Resources/app/administration/src/app/snippet/en-GB.json
@@ -486,7 +486,9 @@
         "greaterThan": "Is greater than",
         "notEquals": "Is not equal to",
         "isOneOf": "Is one of",
-        "isNoneOf": "Is none of"
+        "isNoneOf": "Is none of",
+        "gross": "Gross",
+        "net": "Net"
       },
       "placeholderErrorMessage": "Placeholder cannot be saved.",
       "dataErrorMessage": "Required fields not filled.",

--- a/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-price-form/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-price-form/index.js
@@ -32,7 +32,7 @@ Component.register('sw-product-price-form', {
             'currencies'
         ]),
 
-        ...mapPropertyErrors('product', ['taxId', 'price', 'purchasePrice'])
+        ...mapPropertyErrors('product', ['taxId', 'price', 'purchasePrices'])
     },
 
     methods: {

--- a/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-price-form/sw-product-price-form.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-price-form/sw-product-price-form.html.twig
@@ -1,6 +1,6 @@
 {% block sw_product_price_form %}
     <div class="sw-product-price-form">
-        <sw-container columns="1fr 2fr" gap="0px 30px" class="sw-product-price-form__prices">
+        <sw-container columns="1fr 1fr" gap="0px 30px" class="sw-product-price-form__prices">
             <div>
                 {% block sw_product_price_form_tax_field %}
                     <sw-inherit-wrapper v-model="product.taxId"
@@ -32,25 +32,18 @@
                 {% endblock %}
 
                 {% block sw_product_price_form_purchase_price_field %}
-                    <sw-inherit-wrapper v-model="product.purchasePrice"
+                    <sw-inherit-wrapper v-if="!isLoading"
+                                        v-model="product.purchasePrices"
+                                        label=" "
                                         :hasParent="!!parentProduct.id"
-                                        :inheritedValue="parentProduct.purchasePrice"
-                                        :label="$tc('sw-product.priceForm.labelPurchasePriceGross')">
+                                        :inheritedValue="parentProduct.purchasePrices">
                         <template #content="{ currentValue, updateCurrentValue, isInherited }">
-
-                            <sw-field type="number"
-                                      :error="productPurchasePriceError"
-                                      :min="0"
-                                      :disabled="isInherited"
-                                      :placeholder="$tc('sw-product.priceForm.placeholderPurchasePriceGross')"
-                                      :value="currentValue"
-                                      @change="updateCurrentValue"
-                                      @keyup="keymonitor">
-                                <template #suffix>
-                                    <span class="sw-product-price-form__currency" v-if="defaultCurrency">{{ defaultCurrency.symbol }}</span>
-                                </template>
-                            </sw-field>
-
+                            <sw-purchase-price-field :price="currentValue"
+                                            :taxRate="productTaxRate"
+                                            :disabled="isInherited"
+                                            :error="productPurchasePricesError ? productPurchasePricesError[0] : null"
+                                            :currency="defaultCurrency">
+                            </sw-purchase-price-field>
                         </template>
                     </sw-inherit-wrapper>
                 {% endblock %}

--- a/src/Administration/Resources/app/administration/src/module/sw-product/page/sw-product-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/page/sw-product-detail/index.js
@@ -311,13 +311,14 @@ Component.register('sw-product-detail', {
                 this.loadAttributeSet(),
                 this.loadDefaultFeatureSet()
             ]).then(() => {
-                // set default product price
+                // set default product price and empty purchase price
                 this.product.price = [{
                     currencyId: this.defaultCurrency.id,
                     net: null,
                     linked: true,
                     gross: null
                 }];
+                this.product.purchasePrices = [];
 
                 this.product.featureSet = this.defaultFeatureSet;
 
@@ -334,6 +335,8 @@ Component.register('sw-product-detail', {
                 this.productCriteria
             ).then((res) => {
                 Shopware.State.commit('swProductDetail/setProduct', res);
+                // Initialize an empty price collection if the product has no purchase prices
+                this.product.purchasePrices = this.product.purchasePrices || [];
 
                 if (this.product.parentId) {
                     this.loadParentProduct();

--- a/src/Administration/Resources/app/administration/src/module/sw-product/snippet/de-DE.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/snippet/de-DE.json
@@ -40,7 +40,8 @@
     },
     "priceForm": {
       "labelTaxRate": "Steuersatz",
-      "labelPurchasePriceGross": "Einkaufspreis (Brutto)",
+      "labelPurchasePriceGross": "Einkaufspreis (brutto)",
+      "labelPurchasePriceNet": "Einkaufspreis (netto)",
       "labelUnit": "Maßeinheit",
       "labelPurchaseUnit": "Verkaufseinheit",
       "labelReferenceUnit": "Grundeinheit",

--- a/src/Administration/Resources/app/administration/src/module/sw-product/snippet/en-GB.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/snippet/en-GB.json
@@ -40,7 +40,8 @@
     },
     "priceForm": {
       "labelTaxRate": "Tax rate",
-      "labelPurchasePriceGross": "Purchasing price (gross)",
+      "labelPurchasePriceGross": "Purchase price (gross)",
+      "labelPurchasePriceNet": "Purchase price (net)",
       "labelUnit": "Unit of measurement",
       "labelPurchaseUnit": "Selling unit",
       "labelReferenceUnit": "Basic unit",

--- a/src/Administration/Resources/app/administration/test/e2e/cypress/integration/catalogue/sw-product/crud.spec.js
+++ b/src/Administration/Resources/app/administration/test/e2e/cypress/integration/catalogue/sw-product/crud.spec.js
@@ -36,9 +36,6 @@ describe('Product: Test crud operations', () => {
         cy.get('input[name=sw-field--product-name]').typeAndCheck('Product with file upload image');
         cy.get('.sw-select-product__select_manufacturer')
             .typeSingleSelectAndCheck('shopware AG', '.sw-select-product__select_manufacturer');
-        cy.get('select[name=sw-field--product-taxId]').select('Standard rate');
-        cy.get('#sw-price-field-gross').type('10');
-
 
         if (Cypress.isBrowser({ family: 'chromium' })) {
             // Add image to product
@@ -60,8 +57,15 @@ describe('Product: Test crud operations', () => {
         }
 
         // Check net price calculation
+        cy.get('select[name=sw-field--product-taxId]').select('Standard rate');
+        cy.get('#sw-price-field-gross').type('10');
         cy.wait('@calculatePrice').then(() => {
             cy.get('#sw-price-field-net').should('have.value', '8.4');
+        });
+
+        cy.get('#sw-purchase-price-field-gross').type('1');
+        cy.wait('@calculatePrice').then(() => {
+            cy.get('#sw-purchase-price-field-net').should('have.value', '0.84');
         });
 
         cy.get('input[name=sw-field--product-stock]').type('100');

--- a/src/Administration/Resources/app/administration/test/module/sw-import-export/service/mocks/entity-schema.mock.js
+++ b/src/Administration/Resources/app/administration/test/module/sw-import-export/service/mocks/entity-schema.mock.js
@@ -1199,8 +1199,8 @@ export default {
                     inherited: true
                 }
             },
-            purchasePrice: {
-                type: 'float',
+            purchasePrices: {
+                type: 'json',
                 flags: {
                     inherited: true
                 }

--- a/src/Core/Checkout/Cart/Rule/LineItemPurchasePriceRule.php
+++ b/src/Core/Checkout/Cart/Rule/LineItemPurchasePriceRule.php
@@ -10,6 +10,7 @@ use Shopware\Core\Framework\Rule\RuleScope;
 use Shopware\Core\Framework\Util\FloatComparator;
 use Symfony\Component\Validator\Constraints\Choice;
 use Symfony\Component\Validator\Constraints\NotBlank;
+use Symfony\Component\Validator\Constraints\NotNull;
 use Symfony\Component\Validator\Constraints\Type;
 
 class LineItemPurchasePriceRule extends Rule
@@ -24,10 +25,16 @@ class LineItemPurchasePriceRule extends Rule
      */
     protected $operator;
 
-    public function __construct(string $operator = self::OPERATOR_EQ, ?float $amount = null)
+    /**
+     * @var bool
+     */
+    protected $isNet;
+
+    public function __construct(bool $isNet = true, string $operator = self::OPERATOR_EQ, ?float $amount = null)
     {
         parent::__construct();
 
+        $this->isNet = $isNet;
         $this->operator = $operator;
         $this->amount = $amount;
     }
@@ -59,6 +66,7 @@ class LineItemPurchasePriceRule extends Rule
     public function getConstraints(): array
     {
         return [
+            'isNet' => [new NotNull(), new Type('bool')],
             'amount' => [new NotBlank(), new Type('numeric')],
             'operator' => [
                 new NotBlank(),
@@ -82,36 +90,58 @@ class LineItemPurchasePriceRule extends Rule
      */
     private function matchPurchasePriceCondition(LineItem $lineItem): bool
     {
-        $purchasePrice = $lineItem->getPayloadValue('purchasePrice');
-
-        if ($purchasePrice === null) {
+        $purchasePriceAmount = $this->getPurchasePriceAmount($lineItem);
+        if (!$purchasePriceAmount) {
             return false;
         }
 
         $this->amount = (float) $this->amount;
 
-        /* @var float $purchasePrice */
+        /* @var float $purchasePriceAmount */
         switch ($this->operator) {
             case self::OPERATOR_GTE:
-                return FloatComparator::greaterThanOrEquals($purchasePrice, $this->amount);
+                return FloatComparator::greaterThanOrEquals($purchasePriceAmount, $this->amount);
 
             case self::OPERATOR_LTE:
-                return FloatComparator::lessThanOrEquals($purchasePrice, $this->amount);
+                return FloatComparator::lessThanOrEquals($purchasePriceAmount, $this->amount);
 
             case self::OPERATOR_GT:
-                return FloatComparator::greaterThan($purchasePrice, $this->amount);
+                return FloatComparator::greaterThan($purchasePriceAmount, $this->amount);
 
             case self::OPERATOR_LT:
-                return FloatComparator::lessThan($purchasePrice, $this->amount);
+                return FloatComparator::lessThan($purchasePriceAmount, $this->amount);
 
             case self::OPERATOR_EQ:
-                return FloatComparator::equals($purchasePrice, $this->amount);
+                return FloatComparator::equals($purchasePriceAmount, $this->amount);
 
             case self::OPERATOR_NEQ:
-                return FloatComparator::notEquals($purchasePrice, $this->amount);
+                return FloatComparator::notEquals($purchasePriceAmount, $this->amount);
 
             default:
                 throw new UnsupportedOperatorException($this->operator, self::class);
         }
+    }
+
+    private function getPurchasePriceAmount(LineItem $lineItem): ?float
+    {
+        $purchasePricePayload = $lineItem->getPayloadValue('purchasePrices');
+        if (!$purchasePricePayload) {
+            return null;
+        }
+
+        $purchasePrice = json_decode($purchasePricePayload);
+        if (!$purchasePrice) {
+            return null;
+        }
+
+        if ($this->isNet && property_exists($purchasePrice, 'net')) {
+            return $purchasePrice->net;
+        }
+
+        if (property_exists($purchasePrice, 'gross')) {
+            return $purchasePrice->gross;
+        }
+
+        return null;
     }
 }

--- a/src/Core/Checkout/Test/Cart/Rule/LineItemPurchasePriceRuleTest.php
+++ b/src/Core/Checkout/Test/Cart/Rule/LineItemPurchasePriceRuleTest.php
@@ -9,6 +9,9 @@ use Shopware\Core\Checkout\Cart\LineItem\LineItemCollection;
 use Shopware\Core\Checkout\Cart\Rule\CartRuleScope;
 use Shopware\Core\Checkout\Cart\Rule\LineItemPurchasePriceRule;
 use Shopware\Core\Checkout\Cart\Rule\LineItemScope;
+use Shopware\Core\Defaults;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\Pricing\Price;
 use Shopware\Core\Framework\Rule\Rule;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
@@ -44,15 +47,35 @@ class LineItemPurchasePriceRuleTest extends TestCase
     /**
      * @dataProvider getMatchingRuleTestData
      */
-    public function testIfMatchesCorrectWithLineItem(string $operator, float $amount, float $lineItemAmount, bool $expected): void
+    public function testIfMatchesCorrectWithLineItemPurchasePriceGross(string $operator, float $amount, float $lineItemPurchasePriceGross, bool $expected): void
     {
         $this->rule->assign([
+            'isNet' => false,
             'amount' => $amount,
             'operator' => $operator,
         ]);
 
         $match = $this->rule->match(new LineItemScope(
-            $this->createLineItem($lineItemAmount),
+            $this->createLineItemWithPurchasePrice(0, $lineItemPurchasePriceGross),
+            $this->createMock(SalesChannelContext::class)
+        ));
+
+        static::assertEquals($expected, $match);
+    }
+
+    /**
+     * @dataProvider getMatchingRuleTestData
+     */
+    public function testIfMatchesCorrectWithLineItemPurchasePriceNet(string $operator, float $amount, float $lineItemPurchasePriceNet, bool $expected): void
+    {
+        $this->rule->assign([
+            'isNet' => true,
+            'amount' => $amount,
+            'operator' => $operator,
+        ]);
+
+        $match = $this->rule->match(new LineItemScope(
+            $this->createLineItemWithPurchasePrice($lineItemPurchasePriceNet, 0),
             $this->createMock(SalesChannelContext::class)
         ));
 
@@ -90,9 +113,10 @@ class LineItemPurchasePriceRuleTest extends TestCase
     /**
      * @dataProvider getCartRuleScopeTestData
      */
-    public function testIfMatchesCorrectWithCartRuleScope(string $operator, float $amount, float $lineItemAmount1, float $lineItemAmount2, bool $expected): void
+    public function testIfMatchesCorrectWithCartRuleScope(string $operator, float $amount, float $lineItemPurchasePrice1, float $lineItemPurchasePrice2, bool $expected): void
     {
         $this->rule->assign([
+            'isNet' => true,
             'amount' => $amount,
             'operator' => $operator,
         ]);
@@ -100,8 +124,8 @@ class LineItemPurchasePriceRuleTest extends TestCase
         $cart = new Cart('test', Uuid::randomHex());
 
         $lineItemCollection = new LineItemCollection();
-        $lineItemCollection->add($this->createLineItem($lineItemAmount1));
-        $lineItemCollection->add($this->createLineItem($lineItemAmount2));
+        $lineItemCollection->add($this->createLineItemWithPurchasePrice($lineItemPurchasePrice1));
+        $lineItemCollection->add($this->createLineItemWithPurchasePrice($lineItemPurchasePrice2));
 
         $cart->setLineItems($lineItemCollection);
 
@@ -154,9 +178,29 @@ class LineItemPurchasePriceRuleTest extends TestCase
         static::assertFalse($match);
     }
 
-    private function createLineItem(float $purchasePrice): LineItem
+    private function getContextMockWithDefaultCurrency(): Context
     {
-        return (new LineItem(Uuid::randomHex(), 'product', null, 3))
-            ->setPayloadValue('purchasePrice', $purchasePrice);
+        $baseContext = $this->createMock(Context::class);
+        $baseContext->method('getCurrencyId')->willReturn(Defaults::CURRENCY);
+
+        return $baseContext;
+    }
+
+    private function createLineItemWithPurchasePrice(
+        float $purchasePriceNet = 0,
+        float $purchasePriceGross = 0
+    ): LineItem {
+        $lineItemWithPurchasePrice = new LineItem(Uuid::randomHex(), 'product', null, 3);
+        $lineItemWithPurchasePrice->setPayloadValue(
+            'purchasePrices',
+            json_encode(new Price(
+                Defaults::CURRENCY,
+                $purchasePriceNet,
+                $purchasePriceGross,
+                false
+            ))
+        );
+
+        return $lineItemWithPurchasePrice;
     }
 }

--- a/src/Core/Content/DependencyInjection/product.xml
+++ b/src/Core/Content/DependencyInjection/product.xml
@@ -127,6 +127,10 @@
             </call>
         </service>
 
+        <service id="Shopware\Core\Content\Product\Api\ProductPurchasePriceApiConverter" public="true" >
+            <tag name="shopware.api.converter"/>
+        </service>
+
         <service id="Shopware\Core\Content\Product\Aggregate\ProductVisibility\ProductVisibilityDefinition">
             <tag name="shopware.entity.definition"/>
         </service>

--- a/src/Core/Content/Product/Api/ProductPurchasePriceApiConverter.php
+++ b/src/Core/Content/Product/Api/ProductPurchasePriceApiConverter.php
@@ -1,0 +1,50 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Content\Product\Api;
+
+use Shopware\Core\Framework\Api\Converter\ApiConverter;
+
+class ProductPurchasePriceApiConverter extends ApiConverter
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getApiVersion(): int
+    {
+        return 4;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getDeprecations(): array
+    {
+        return [
+            'product' => [
+                'purchasePrice',
+            ],
+        ];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getNewFields(): array
+    {
+        return [
+            'product' => [
+                'purchasePrices',
+            ],
+        ];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getConverterFunctions(): array
+    {
+        // No need to convert any values here, because the database trigger keep both fields in sync. See also
+        // Shopware\Core\Migration\Migration1582724349294AddNetAndGrossPurchasePrice
+        return [];
+    }
+}

--- a/src/Core/Content/Product/Cart/ProductCartProcessor.php
+++ b/src/Core/Content/Product/Cart/ProductCartProcessor.php
@@ -239,6 +239,11 @@ class ProductCartProcessor implements CartProcessorInterface, CartDataCollectorI
 
         $lineItem->setQuantityInformation($quantityInformation);
 
+        $purchasePrices = null;
+        if ($product->getPurchasePrices()) {
+            $purchasePrices = $product->getPurchasePrices()->getCurrencyPrice(Defaults::CURRENCY);
+        }
+
         $payload = [
             'isCloseout' => $product->getIsCloseout(),
             'customFields' => $product->getCustomFields(),
@@ -246,7 +251,8 @@ class ProductCartProcessor implements CartProcessorInterface, CartDataCollectorI
             'releaseDate' => $product->getReleaseDate() ? $product->getReleaseDate()->format(Defaults::STORAGE_DATE_TIME_FORMAT) : null,
             'isNew' => $product->isNew(),
             'markAsTopseller' => $product->getMarkAsTopseller(),
-            'purchasePrice' => $product->getPurchasePrice(),
+            'purchasePrice' => $purchasePrices ? $purchasePrices->getGross() : null,
+            'purchasePrices' => $purchasePrices ? json_encode($purchasePrices) : null,
             'productNumber' => $product->getProductNumber(),
             'manufacturerId' => $product->getManufacturerId(),
             'taxId' => $product->getTaxId(),

--- a/src/Core/Content/Product/ProductDefinition.php
+++ b/src/Core/Content/Product/ProductDefinition.php
@@ -33,6 +33,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\ChildrenAssociationField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\DateTimeField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\FkField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\CascadeDelete;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\Deprecated;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\Inherited;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\PrimaryKey;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\ReadProtected;
@@ -148,7 +149,8 @@ class ProductDefinition extends EntityDefinition
             (new FloatField('purchase_unit', 'purchaseUnit'))->addFlags(new Inherited()),
             (new FloatField('reference_unit', 'referenceUnit'))->addFlags(new Inherited()),
             (new BoolField('shipping_free', 'shippingFree'))->addFlags(new Inherited()),
-            (new FloatField('purchase_price', 'purchasePrice'))->addFlags(new Inherited()),
+            (new FloatField('purchase_price', 'purchasePrice'))->addFlags(new Inherited(), new Deprecated('v3', 'v4')),
+            (new PriceField('purchase_prices', 'purchasePrices'))->addFlags(new Inherited()),
             (new BoolField('mark_as_topseller', 'markAsTopseller'))->addFlags(new Inherited()),
             (new FloatField('weight', 'weight'))->addFlags(new Inherited()),
             (new FloatField('width', 'width'))->addFlags(new Inherited()),

--- a/src/Core/Content/Product/ProductEntity.php
+++ b/src/Core/Content/Product/ProductEntity.php
@@ -161,9 +161,16 @@ class ProductEntity extends Entity
     protected $shippingFree;
 
     /**
+     * @deprecated tag:v6.4.0 use $purchasePrices instead
+     *
      * @var float|null
      */
     protected $purchasePrice;
+
+    /**
+     * @var PriceCollection|null
+     */
+    protected $purchasePrices;
 
     /**
      * @var bool|null
@@ -624,14 +631,30 @@ class ProductEntity extends Entity
         $this->shippingFree = $shippingFree;
     }
 
+    /**
+     * @deprecated tag:v6.4.0 use getPurchasePrices() instead
+     */
     public function getPurchasePrice(): ?float
     {
         return $this->purchasePrice;
     }
 
+    /**
+     * @deprecated tag:v6.4.0 use setPurchasePrices() instead
+     */
     public function setPurchasePrice(?float $purchasePrice): void
     {
         $this->purchasePrice = $purchasePrice;
+    }
+
+    public function getPurchasePrices(): ?PriceCollection
+    {
+        return $this->purchasePrices;
+    }
+
+    public function setPurchasePrices(?PriceCollection $purchasePrices): void
+    {
+        $this->purchasePrices = $purchasePrices;
     }
 
     public function getMarkAsTopseller(): ?bool

--- a/src/Core/Content/Test/Product/Cart/ProductCartProcessorTest.php
+++ b/src/Core/Content/Test/Product/Cart/ProductCartProcessorTest.php
@@ -4,7 +4,9 @@ namespace Shopware\Core\Content\Test\Product\Cart;
 
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\Cart\Cart;
+use Shopware\Core\Checkout\Cart\CartBehavior;
 use Shopware\Core\Checkout\Cart\Delivery\Struct\DeliveryInformation;
+use Shopware\Core\Checkout\Cart\LineItem\CartDataCollection;
 use Shopware\Core\Checkout\Cart\SalesChannel\CartService;
 use Shopware\Core\Content\Product\Aggregate\ProductFeatureSet\ProductFeatureSetDefinition;
 use Shopware\Core\Content\Product\Aggregate\ProductVisibility\ProductVisibilityDefinition;
@@ -133,6 +135,38 @@ class ProductCartProcessorTest extends TestCase
 
         $actualProduct = $cart->get($product->getId());
         static::assertSame('test', $actualProduct->getLabel());
+    }
+
+    public function testLineItemPropertiesPurchasePrice(): void
+    {
+        $this->createProduct();
+
+        $token = $this->ids->create('token');
+        /** @var SalesChannelContextService $salesChannelContextService */
+        $salesChannelContextService = $this->getContainer()->get(SalesChannelContextService::class);
+        $context = $salesChannelContextService->get(Defaults::SALES_CHANNEL, $token);
+        /** @var CartService $cartService */
+        $cartService = $this->getContainer()->get(CartService::class);
+        $cart = $cartService->getCart($token, $context);
+        $product = $this->getContainer()->get(ProductLineItemFactory::class)->create($this->ids->get('product'));
+        $cartService->add($cart, $product, $context);
+
+        /** @var ProductCartProcessor $productCartProcessor */
+        $productCartProcessor = $this->getContainer()->get(ProductCartProcessor::class);
+        $productCartProcessor->collect(
+            new CartDataCollection(),
+            $cart,
+            $context,
+            new CartBehavior()
+        );
+
+        $payload = $cart->get($product->getId())->getPayload();
+        static::assertEquals(7.5, $payload['purchasePrice']);
+        $purchasePrices = json_decode($payload['purchasePrices']);
+        static::assertSame(Defaults::CURRENCY, $purchasePrices->currencyId);
+        static::assertSame(7.5, $purchasePrices->gross);
+        static::assertSame(5, $purchasePrices->net);
+        static::assertFalse($purchasePrices->linked);
     }
 
     public function testPayloadContainsFeatures(): void
@@ -410,6 +444,11 @@ class ProductCartProcessorTest extends TestCase
             'stock' => 10,
             'price' => [
                 ['currencyId' => Defaults::CURRENCY, 'gross' => 15, 'net' => 10, 'linked' => false],
+            ],
+            'purchasePrice' => 7.5,
+            'purchasePrices' => [
+                ['currencyId' => Defaults::CURRENCY, 'gross' => 7.5, 'net' => 5, 'linked' => false],
+                ['currencyId' => Uuid::randomHex(), 'gross' => 150, 'net' => 100, 'linked' => false],
             ],
             'active' => true,
             'tax' => ['name' => 'test', 'taxRate' => 15],

--- a/src/Core/Framework/Demodata/Generator/ProductGenerator.php
+++ b/src/Core/Framework/Demodata/Generator/ProductGenerator.php
@@ -125,6 +125,7 @@ class ProductGenerator implements DemodataGeneratorInterface
     private function createSimpleProduct(DemodataContext $context, EntitySearchResult $taxes): array
     {
         $price = $context->getFaker()->randomFloat(2, 1, 1000);
+        $purchasePrice = $context->getFaker()->randomFloat(2, 1, 100);
         $rules = $context->getIds('rule');
         $tax = $taxes->get(array_rand($taxes->getIds()));
         $reverseTaxrate = 1 + ($tax->getTaxRate() / 100);
@@ -134,6 +135,7 @@ class ProductGenerator implements DemodataGeneratorInterface
             'id' => Uuid::randomHex(),
             'productNumber' => Uuid::randomHex(),
             'price' => [['currencyId' => Defaults::CURRENCY, 'gross' => $price, 'net' => $price / $reverseTaxrate, 'linked' => true]],
+            'purchasePrices' => [['currencyId' => Defaults::CURRENCY, 'gross' => $purchasePrice, 'net' => $purchasePrice / $reverseTaxrate, 'linked' => true]],
             'name' => $faker->productName,
             'description' => $faker->text(),
             'descriptionLong' => $this->generateRandomHTML(

--- a/src/Core/Framework/Test/DataAbstractionLayer/Write/TranslationTest.php
+++ b/src/Core/Framework/Test/DataAbstractionLayer/Write/TranslationTest.php
@@ -481,7 +481,14 @@ class TranslationTest extends TestCase
                 'weight' => 0,
                 'minPurchase' => 1,
                 'shippingFree' => false,
-                'purchasePrice' => 0,
+                'purchasePrices' => [
+                    [
+                        'currencyId' => Defaults::CURRENCY,
+                        'gross' => 0,
+                        'net' => 0,
+                        'linked' => true,
+                    ],
+                ],
             ],
         ];
 
@@ -597,7 +604,14 @@ class TranslationTest extends TestCase
                 'weight' => 0,
                 'minPurchase' => 1,
                 'shippingFree' => false,
-                'purchasePrice' => 0,
+                'purchasePrices' => [
+                    [
+                        'currencyId' => Defaults::CURRENCY,
+                        'gross' => 0,
+                        'net' => 0,
+                        'linked' => true,
+                    ],
+                ],
             ],
         ];
         $productRepo = $this->getContainer()->get('product.repository');

--- a/src/Core/Migration/Migration1593698606AddNetAndGrossPurchasePrices.php
+++ b/src/Core/Migration/Migration1593698606AddNetAndGrossPurchasePrices.php
@@ -1,0 +1,112 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Migration;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Defaults;
+use Shopware\Core\Framework\Migration\MigrationStep;
+
+class Migration1593698606AddNetAndGrossPurchasePrices extends MigrationStep
+{
+    public function getCreationTimestamp(): int
+    {
+        return 1593698606;
+    }
+
+    public function update(Connection $connection): void
+    {
+        $this->migrateProductPurchasePriceField($connection);
+        $this->migrateCartLineItemPurchasePriceRuleCondition($connection);
+        $this->addSynchDatabaseTrigger($connection);
+    }
+
+    public function updateDestructive(Connection $connection): void
+    {
+    }
+
+    private function migrateCartLineItemPurchasePriceRuleCondition(Connection $connection): void
+    {
+        $rows = $connection->fetchAll('SELECT id, value FROM rule_condition WHERE type = "cartLineItemPurchasePrice"');
+        foreach ($rows as $row) {
+            $conditionValue = json_decode($row['value']);
+            if (property_exists($conditionValue, 'isNet')) {
+                continue;
+            }
+
+            $conditionValue->isNet = false;
+            $connection->executeUpdate(
+                'UPDATE rule_condition SET value = :conditionValue WHERE id = :id',
+                [
+                    'conditionValue' => json_encode($conditionValue),
+                    'id' => $row['id'],
+                ]
+            );
+        }
+    }
+
+    private function migrateProductPurchasePriceField(Connection $connection): void
+    {
+        // Add new 'purchase_prices' JSON field
+        $connection->executeUpdate('ALTER TABLE `product` ADD `purchase_prices` JSON NULL AFTER `purchase_price`;');
+
+        // Convert any existing purchase price values into the new 'purchase_prices' JSON field
+        $defaultCurrencyId = Defaults::CURRENCY;
+        $connection->executeUpdate(
+            'UPDATE `product`
+            LEFT JOIN tax ON product.tax_id = tax.id
+            SET purchase_prices = IF(
+                purchase_price IS NULL,
+                NULL,
+                JSON_OBJECT(
+                    :currencyKey, JSON_OBJECT(
+                        "net", `product`.`purchase_price` / (1 + (`tax`.`tax_rate` / 100)),
+                        "gross", `product`.`purchase_price`,
+                        "linked", "true",
+                        "currencyId", :currencyId
+                    )
+                )
+            );',
+            [
+                'currencyKey' => sprintf('c%s', $defaultCurrencyId),
+                'currencyId' => $defaultCurrencyId,
+            ]
+        );
+    }
+
+    /**
+     * Adds a database trigger that keeps the fields 'purchase_price' and 'purchase_prices' in sync. That means updating
+     * either value will update the other.
+     */
+    private function addSynchDatabaseTrigger(Connection $connection): void
+    {
+        $query = sprintf(
+            'CREATE TRIGGER product_purchase_prices_sync BEFORE UPDATE ON product
+                FOR EACH ROW
+                BEGIN
+                IF NEW.purchase_prices != OLD.purchase_prices THEN BEGIN
+
+                    SET NEW.purchase_price = JSON_EXTRACT(NEW.purchase_prices, \'$.c%1$s.gross\');
+
+                END; ELSE BEGIN
+
+                    IF NEW.purchase_price != OLD.purchase_price THEN BEGIN
+                        DECLARE taxRate DECIMAL(10,2);
+                        SET taxRate = (SELECT tax_rate FROM tax WHERE id = NEW.tax);
+
+                        SET NEW.purchase_prices = CONCAT(
+                            \'{"c%1$s": {"net": \',
+                            CONVERT((NEW.purchase_price / (1 + (taxRate/100))), CHAR(50)),
+                            \', "gross": \',
+                            CONVERT(NEW.purchase_price, CHAR(50)),
+                            \', "linked": true, "currencyId": "%1$s"}}\'
+                        );
+                    END; END IF;
+
+                END; END IF;
+                END',
+            Defaults::CURRENCY
+        );
+
+        $this->createTrigger($connection, $query);
+    }
+}

--- a/src/Docs/Resources/current/60-references-internals/10-core/10-erd/_puml/erd-all.puml
+++ b/src/Docs/Resources/current/60-references-internals/10-core/10-erd/_puml/erd-all.puml
@@ -785,6 +785,7 @@ Table(ShopwareCoreContentProductProductDefinition, "product\n(Product)") {
    referenceUnit float
    shippingFree bool
    purchasePrice float
+   purchasePrices json
    markAsTopseller bool
    weight float
    width float

--- a/src/Docs/Resources/current/60-references-internals/10-core/10-erd/_puml/erd-shopware-core-content-product.puml
+++ b/src/Docs/Resources/current/60-references-internals/10-core/10-erd/_puml/erd-shopware-core-content-product.puml
@@ -56,6 +56,7 @@ Table(ShopwareCoreContentProductProductDefinition, "product\n(Product)") {
    referenceUnit float
    shippingFree bool
    purchasePrice float
+   purchasePrices json
    markAsTopseller bool
    weight float
    width float

--- a/src/Elasticsearch/Test/Product/ElasticsearchProductTest.php
+++ b/src/Elasticsearch/Test/Product/ElasticsearchProductTest.php
@@ -1305,6 +1305,21 @@ class ElasticsearchProductTest extends TestCase
     /**
      * @depends testIndexing
      */
+    public function testFilterPurchasePricesPriceField(TestDataCollection $data): void
+    {
+        $searcher = $this->createEntitySearcher();
+
+        // Filter by the PriceField purchasePrices
+        $criteria = new Criteria();
+        $criteria->addFilter(new EqualsFilter('purchasePrices', 100));
+
+        $products = $searcher->search($this->productDefinition, $criteria, $data->getContext());
+        static::assertCount(3, $products->getIds());
+    }
+
+    /**
+     * @depends testIndexing
+     */
     public function testFilterCustomTextField(TestDataCollection $data): void
     {
         $criteria = new Criteria();
@@ -1527,6 +1542,9 @@ class ElasticsearchProductTest extends TestCase
             'name' => $name,
             'stock' => $stock,
             'purchasePrice' => $purchasePrice,
+            'purchasePrices' => [
+                ['currencyId' => Defaults::CURRENCY, 'gross' => $purchasePrice, 'net' => $purchasePrice / 115 * 100, 'linked' => false],
+            ],
             'price' => [
                 ['currencyId' => Defaults::CURRENCY, 'gross' => $price, 'net' => $price / 115 * 100, 'linked' => false],
             ],


### PR DESCRIPTION
_This is an updated and improved version of https://github.com/shopware/platform/pull/663 for the 6.3.1.0 release_

### 1. Why is this change necessary?

Currently the product and the payload of the order line items have a purchase price field of type `float`. Many users want to manage their purchase prices as _net_ prices. Some want to use different currencies when purchasing products.
Hence the more complex `PriceField` with gross and net prices as well as currencies would be more suitable.

### 2. What does this change do, exactly?

Adds a new purchase price field of the more complex type `PriceField` which supports purchases prices as net and gross prices as well as purchase prices in multiple currencies (even though the code right now only uses a single purchase price in the default currency).

- A field `purchase_prices` of type `PriceField` is added to the product definition as well as to the order line items (and some corresponding classes).
- The old `float` purchase price field (and some corresponding functions) is marked as deprecated.
- The existing `LineItemPurchasePriceRule` improved to handle gross _or_ net purchase prices. Existing rules are migrated.
- A migration is added to migrate the deprecated purchase price field to the new one.
- An ApiConverter is added to provide the old purchase price field for the api v2 and the new field for the api v3.
- A database trigger is added to keep the deprecated purchase price field in sync with the new one (updating either will update the other).
- The administration product view is updated to display the new purchase price field.
- Existing PHPUnit and Cypress e2e tests are updated and some new tests are added.

<img width="1010" alt="Screenshot 2020-07-06 at 09 08 10" src="https://user-images.githubusercontent.com/12038224/86566505-0f28eb80-bf6a-11ea-8ac3-f9fb8b2a6864.png">

### 3. Describe each step to reproduce the issue or behaviour.

### 4. Please link to the relevant issues (if any).

- https://issues.shopware.com/issues/NEXT-7666
- https://issues.shopware.com/issues/NEXT-5021

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
