### PR TITLE
Hide properties on product detail page

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-property/component/sw-property-detail-base/sw-property-detail-base.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-property/component/sw-property-detail-base/sw-property-detail-base.html.twig
@@ -18,13 +18,26 @@
                       :placeholder="placeholder(propertyGroup, 'description', $tc('sw-property.detail.placeholderDescription'))" />
         {% endblock %}
 
-        {% block sw_property_detail_base_filterable %}
-            <sw-switch-field
-                    name="propertyGroupFilterable"
-                    class="sw-property-detail__filterable"
-                    :label="$tc('sw-property.detail.labelFilterable')"
-                    v-model="propertyGroup.filterable">
-            </sw-switch-field>
+        {% block sw_property_detail_filter_visible_container %}
+            <sw-container columns="repeat(2, 1fr)" gap="0px 30px">
+                {% block sw_property_detail_base_filterable %}
+                    <sw-switch-field
+                            name="propertyGroupFilterable"
+                            class="sw-property-detail__filterable"
+                            :label="$tc('sw-property.detail.labelFilterable')"
+                            v-model="propertyGroup.filterable">
+                    </sw-switch-field>
+                {% endblock %}
+
+                {% block sw_property_detail_base_visible_on_detail %}
+                    <sw-switch-field
+                            name="propertyGroupVisibleOnDetail"
+                            class="sw-property-detail__visible-on-detail"
+                            :label="$tc('sw-property.detail.labelVisibleOnDetail')"
+                            v-model="propertyGroup.visibleOnDetail">
+                    </sw-switch-field>
+                {% endblock %}
+            </sw-container>
         {% endblock %}
 
         {% block sw_property_detail_sorting_display_container %}

--- a/src/Administration/Resources/app/administration/src/module/sw-property/snippet/de-DE.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-property/snippet/de-DE.json
@@ -32,6 +32,7 @@
       "labelName": "Name",
       "placeholderName": "Namen eingeben ...",
       "labelFilterable": "Im Produktfilter von Produktlisten anzeigen",
+      "labelVisibleOnDetail": "Anzeige auf der Produktdetailseite",
       "labelDisplayType": "Darstellung der Ausprägungsauswahl",
       "labelSortingType": "Sortierung",
       "labelOptionName": "Name",

--- a/src/Administration/Resources/app/administration/src/module/sw-property/snippet/en-GB.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-property/snippet/en-GB.json
@@ -32,6 +32,7 @@
       "labelName": "Name",
       "placeholderName": "Enter name...",
       "labelFilterable": "Display in product filters",
+      "labelVisibleOnDetail": "Display on product detail page",
       "labelDisplayType": "Value display type",
       "labelSortingType": "Sorting",
       "labelOptionName": "Name",

--- a/src/Core/Content/Property/Aggregate/PropertyGroupTranslation/PropertyGroupTranslationDefinition.php
+++ b/src/Core/Content/Property/Aggregate/PropertyGroupTranslation/PropertyGroupTranslationDefinition.php
@@ -4,6 +4,7 @@ namespace Shopware\Core\Content\Property\Aggregate\PropertyGroupTranslation;
 
 use Shopware\Core\Content\Property\PropertyGroupDefinition;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityTranslationDefinition;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\BoolField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\CustomFields;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\Required;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\IntField;
@@ -48,6 +49,7 @@ class PropertyGroupTranslationDefinition extends EntityTranslationDefinition
             (new StringField('name', 'name'))->addFlags(new Required()),
             new LongTextField('description', 'description'),
             new IntField('position', 'position'),
+            new BoolField('visible_on_detail', 'visibleOnDetail'),
             new CustomFields(),
         ]);
     }

--- a/src/Core/Content/Property/Aggregate/PropertyGroupTranslation/PropertyGroupTranslationEntity.php
+++ b/src/Core/Content/Property/Aggregate/PropertyGroupTranslation/PropertyGroupTranslationEntity.php
@@ -28,6 +28,11 @@ class PropertyGroupTranslationEntity extends TranslationEntity
     protected $position;
 
     /**
+     * @var bool|null
+     */
+    protected $visibleOnDetail;
+
+    /**
      * @var PropertyGroupEntity|null
      */
     protected $propertyGroup;
@@ -85,6 +90,16 @@ class PropertyGroupTranslationEntity extends TranslationEntity
     public function setPosition(?int $position): void
     {
         $this->position = $position;
+    }
+
+    public function getVisibleOnDetail(): ?bool
+    {
+        return $this->visibleOnDetail;
+    }
+
+    public function setVisibleOnDetail(bool $visibleOnDetail): void
+    {
+        $this->visibleOnDetail = $visibleOnDetail;
     }
 
     public function getCustomFields(): ?array

--- a/src/Core/Content/Property/PropertyGroupDefinition.php
+++ b/src/Core/Content/Property/PropertyGroupDefinition.php
@@ -35,6 +35,8 @@ class PropertyGroupDefinition extends EntityDefinition
 
     public const FILTERABLE = true;
 
+    public const VISIBLE_ON_DETAIL = true;
+
     public function getEntityName(): string
     {
         return self::ENTITY_NAME;
@@ -56,6 +58,7 @@ class PropertyGroupDefinition extends EntityDefinition
             'displayType' => self::DISPLAY_TYPE_TEXT,
             'sortingType' => self::SORTING_TYPE_ALPHANUMERIC,
             'filterable' => self::FILTERABLE,
+            'visibleOnDetail' => self::VISIBLE_ON_DETAIL,
         ];
     }
 
@@ -68,6 +71,7 @@ class PropertyGroupDefinition extends EntityDefinition
             (new StringField('display_type', 'displayType'))->setFlags(new Required()),
             (new StringField('sorting_type', 'sortingType'))->setFlags(new Required()),
             new BoolField('filterable', 'filterable'),
+            new TranslatedField('visibleOnDetail'),
             new TranslatedField('position'),
             new TranslatedField('customFields'),
             (new OneToManyAssociationField('options', PropertyGroupOptionDefinition::class, 'property_group_id', 'id'))->addFlags(new CascadeDelete(), new SearchRanking(SearchRanking::ASSOCIATION_SEARCH_RANKING)),

--- a/src/Core/Content/Property/PropertyGroupEntity.php
+++ b/src/Core/Content/Property/PropertyGroupEntity.php
@@ -81,7 +81,7 @@ class PropertyGroupEntity extends Entity
         $this->filterable = $filterable;
     }
 
-    public function getVisibleOnDetail(): bool
+    public function isVisibleOnDetail(): bool
     {
         return $this->visibleOnDetail;
     }

--- a/src/Core/Content/Property/PropertyGroupEntity.php
+++ b/src/Core/Content/Property/PropertyGroupEntity.php
@@ -42,6 +42,11 @@ class PropertyGroupEntity extends Entity
     protected $filterable;
 
     /**
+     * @var bool
+     */
+    protected $visibleOnDetail;
+
+    /**
      * @var PropertyGroupOptionCollection|null
      */
     protected $options;
@@ -74,6 +79,16 @@ class PropertyGroupEntity extends Entity
     public function setFilterable(bool $filterable): void
     {
         $this->filterable = $filterable;
+    }
+
+    public function getVisibleOnDetail(): bool
+    {
+        return $this->visibleOnDetail;
+    }
+
+    public function setVisibleOnDetail(bool $visibleOnDetail): void
+    {
+        $this->visibleOnDetail = $visibleOnDetail;
     }
 
     public function getOptions(): ?PropertyGroupOptionCollection

--- a/src/Core/Migration/Migration1595149625AddVisibleOnDetailToPropertyGroupTranslation.php
+++ b/src/Core/Migration/Migration1595149625AddVisibleOnDetailToPropertyGroupTranslation.php
@@ -1,0 +1,27 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Migration;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Framework\Migration\MigrationStep;
+
+class Migration1595149625AddVisibleOnDetailToPropertyGroupTranslation extends MigrationStep
+{
+    public function getCreationTimestamp(): int
+    {
+        return 1595149625;
+    }
+
+    public function update(Connection $connection): void
+    {
+        $connection->executeUpdate('
+            ALTER TABLE `property_group_translation`
+            ADD COLUMN `visible_on_detail` TINYINT(1) NOT NULL DEFAULT 1
+        ');
+    }
+
+    public function updateDestructive(Connection $connection): void
+    {
+        // TODO: Implement updateDestructive() method.
+    }
+}

--- a/src/Storefront/Page/Product/ProductLoader.php
+++ b/src/Storefront/Page/Product/ProductLoader.php
@@ -108,7 +108,7 @@ class ProductLoader
         foreach ($properties as $option) {
             $group = $option->getGroup();
 
-            if (!$group) {
+            if (!$group || !$group->getVisibleOnDetail()) {
                 continue;
             }
 


### PR DESCRIPTION
### 1. Why is this change necessary?
Allows the admin to hide certain properties from product detail pages.

### 2. What does this change do, exactly?
Adds a checkbox to the Property Group administration view, adds a field to the PropertyGroupTranslation, filters the 'disabled' proeprty groups out of the sortedProperties in the ProductLoader.

### 3. Describe each step to reproduce the issue or behaviour.
![Screenshot 2020-07-19 at 11 25 39](https://user-images.githubusercontent.com/3930922/87871675-a0f51780-c9b2-11ea-88a9-7faedef11882.png)

### 4. Please link to the relevant issues (if any).
#1122 

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change (no tests available for properties)
- [x] I have squashed any insignificant commits
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
