### PR TITLE
Add position to CustomFieldSets

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-custom-field-set-renderer/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-custom-field-set-renderer/index.js
@@ -27,6 +27,12 @@ Component.register('sw-custom-field-set-renderer', {
         };
     },
 
+    computed: {
+        sortedSets() {
+            return this.sets.sort((a, b) => a.position - b.position);
+        }
+    },
+
     props: {
         sets: {
             type: Array,

--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-custom-field-set-renderer/sw-custom-field-set-renderer.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-custom-field-set-renderer/sw-custom-field-set-renderer.html.twig
@@ -5,11 +5,11 @@
                 <sw-tabs v-if="variant === 'tabs'"
                          class="sw-custom-field-set-renderer__card-tabs"
                          variant="minimal"
-                         :defaultItem="sets[0].name">
+                         :defaultItem="sortedSets[0].name">
                     {% block sw_custom_field_set_renderer_card_tabs %}
                         <template slot-scope="{ active }">
                             <sw-tabs-item
-                                    v-for="set in sets"
+                                    v-for="set in sortedSets"
                                     v-if="set.customFields"
                                     :key="`sw-tab--${set.id}`"
                                     variant="minimal"
@@ -22,7 +22,7 @@
 
                     {% block sw_custom_field_set_renderer_card_tabs_content %}
                         <template slot="content" slot-scope="{ active }">
-                            <div v-for="set in sets"
+                            <div v-for="set in sortedSets"
                                  v-if="set.customFields"
                                  v-show="active === set.name">
                                 <template v-for="customField in set.customFields">
@@ -43,7 +43,7 @@
             {% block sw_custom_field_set_renderer_media %}
                 <template v-else-if="variant === 'media-collapse'">
                     <sw-media-collapse
-                            v-for="set in sets"
+                            v-for="set in sortedSets"
                             v-if="set.customFields.length > 0"
                             :key="`sw-media-collapse--${set.id}`"
                             :expandOnLoading="false"

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-custom-field/component/sw-custom-field-set-detail-base/sw-custom-field-detail-base.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-custom-field/component/sw-custom-field-set-detail-base/sw-custom-field-detail-base.html.twig
@@ -12,6 +12,14 @@
             </sw-field>
         {% endblock %}
 
+        {% block sw_settings_custom_field_set_detail_base_position %}
+            <sw-field
+                type="number"
+                :label="$tc(`sw-settings-custom-field.set.detail.labelPosition`)"
+                v-model="set.position">
+            </sw-field>
+        {% endblock %}
+
         {% block sw_settings_custom_field_set_detail_base_translated %}
             <sw-field
                     type="switch"

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-custom-field/snippet/de-DE.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-custom-field/snippet/de-DE.json
@@ -22,6 +22,7 @@
       },
       "detail": {
         "labelTechnicalName": "Technischer Name",
+        "labelPosition": "Position",
         "textHeadline": "Zusatzfeld-Set",
         "buttonCancel": "Abbrechen",
         "buttonSave": "Speichern",

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-custom-field/snippet/en-GB.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-custom-field/snippet/en-GB.json
@@ -22,6 +22,7 @@
       },
       "detail": {
         "labelTechnicalName": "Technical name",
+        "labelPosition": "Position",
         "textHeadline": "Custom field set",
         "buttonCancel": "Cancel",
         "buttonSave": "Save",

--- a/src/Core/Migration/Migration1595160327AddPositionToCustomFieldSet.php
+++ b/src/Core/Migration/Migration1595160327AddPositionToCustomFieldSet.php
@@ -1,0 +1,26 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Migration;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Framework\Migration\MigrationStep;
+
+class Migration1595160327AddPositionToCustomFieldSet extends MigrationStep
+{
+    public function getCreationTimestamp(): int
+    {
+        return 1595160327;
+    }
+
+    public function update(Connection $connection): void
+    {
+        $connection->executeUpdate('
+            ALTER TABLE `custom_field_set`
+            ADD COLUMN `position` INT(11) NOT NULL DEFAULT 1 AFTER `active`;
+        ');
+    }
+
+    public function updateDestructive(Connection $connection): void
+    {
+    }
+}

--- a/src/Core/System/CustomField/Aggregate/CustomFieldSet/CustomFieldSetDefinition.php
+++ b/src/Core/System/CustomField/Aggregate/CustomFieldSet/CustomFieldSetDefinition.php
@@ -8,6 +8,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\CascadeDelete;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\PrimaryKey;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\Required;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\IdField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\IntField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\JsonField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\OneToManyAssociationField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\StringField;
@@ -42,6 +43,7 @@ class CustomFieldSetDefinition extends EntityDefinition
             new JsonField('config', 'config', [], []),
 
             new BoolField('active', 'active'),
+            (new IntField('position', 'position'))->addFlags(new Required()),
 
             (new OneToManyAssociationField('customFields', CustomFieldDefinition::class, 'set_id'))->addFlags(new CascadeDelete()),
             (new OneToManyAssociationField('relations', CustomFieldSetRelationDefinition::class, 'set_id'))->addFlags(new CascadeDelete()),

--- a/src/Core/System/CustomField/Aggregate/CustomFieldSet/CustomFieldSetDefinition.php
+++ b/src/Core/System/CustomField/Aggregate/CustomFieldSet/CustomFieldSetDefinition.php
@@ -35,6 +35,13 @@ class CustomFieldSetDefinition extends EntityDefinition
         return CustomFieldSetEntity::class;
     }
 
+    public function getDefaults(): array
+    {
+        return [
+            'position' => 1,
+        ];
+    }
+
     protected function defineFields(): FieldCollection
     {
         return new FieldCollection([
@@ -43,7 +50,7 @@ class CustomFieldSetDefinition extends EntityDefinition
             new JsonField('config', 'config', [], []),
 
             new BoolField('active', 'active'),
-            (new IntField('position', 'position'))->addFlags(new Required()),
+            (new IntField('position', 'position')),
 
             (new OneToManyAssociationField('customFields', CustomFieldDefinition::class, 'set_id'))->addFlags(new CascadeDelete()),
             (new OneToManyAssociationField('relations', CustomFieldSetRelationDefinition::class, 'set_id'))->addFlags(new CascadeDelete()),

--- a/src/Core/System/CustomField/Aggregate/CustomFieldSet/CustomFieldSetEntity.php
+++ b/src/Core/System/CustomField/Aggregate/CustomFieldSet/CustomFieldSetEntity.php
@@ -27,6 +27,11 @@ class CustomFieldSetEntity extends Entity
     protected $active;
 
     /**
+     * @var int
+     */
+    protected $position;
+
+    /**
      * @var CustomFieldCollection|null
      */
     protected $customFields;
@@ -64,6 +69,16 @@ class CustomFieldSetEntity extends Entity
     public function setActive(bool $active): void
     {
         $this->active = $active;
+    }
+
+    public function getPosition(): int
+    {
+        return $this->position;
+    }
+
+    public function setPosition(int $position): void
+    {
+        $this->position = $position;
     }
 
     public function getCustomFields(): ?CustomFieldCollection


### PR DESCRIPTION
### 1. Why is this change necessary?
Allows a custom order of tabs of custom field sets on the product detail edit page.

### 2. What does this change do, exactly?
- Add a position field to CustomFieldSet entity
- Sort Custom Fields tabs in product detail page

### 3. Describe each step to reproduce the issue or behaviour.
Set positions (default is 1 for all so unsorted/no change in behaviour) and check out the order of the tabs on the product detail edit page.

### 4. Please link to the relevant issues (if any).
#1125

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
