### PR TITLE
Fixes #1105 Fixes pagination on custom field set fields

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-settings-custom-field/component/sw-custom-field-list/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-custom-field/component/sw-custom-field-list/index.js
@@ -69,6 +69,7 @@ Component.register('sw-custom-field-list', {
             this.isLoading = true;
             const params = this.getListingParams();
             params.sortBy = 'config.customFieldPosition';
+            params['total-count-mode'] = 1;
 
             if (params.term) {
                 params.criteria = CriteriaFactory.multi(


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/community).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
No more than 10 custom fields can be handled in the Custom Field Set administration view.

### 2. What does this change do, exactly?
Add the total-count-mode param.

### 3. Describe each step to reproduce the issue or behaviour.
If you are on the detail page of a customfieldset you only get 10 customfields displayed, because there's a parameter limit: 10 when calling the API.

As there's no pagination, that makes it impossible to get the other custom fields.

### 4. Please link to the relevant issues (if any).
#1105 

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
