### PR TITLE
Clone plugin configurations before altering their contents to remove side effects on plugin config reading

### DIFF
--- a/src/Storefront/Test/Theme/ThemeTest.php
+++ b/src/Storefront/Test/Theme/ThemeTest.php
@@ -2,6 +2,8 @@
 
 namespace Shopware\Storefront\Test\Theme;
 
+use PHPUnit\Framework\Constraint\Callback;
+use PHPUnit\Framework\Constraint\IsEqual;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
@@ -11,10 +13,16 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Storefront\Test\Theme\fixtures\ThemeFixtures;
+use Shopware\Storefront\Theme\StorefrontPluginConfiguration\StorefrontPluginConfiguration;
+use Shopware\Storefront\Theme\StorefrontPluginConfiguration\StorefrontPluginConfigurationFactory;
 use Shopware\Storefront\Theme\StorefrontPluginRegistry;
+use Shopware\Storefront\Theme\ThemeCompiler;
 use Shopware\Storefront\Theme\ThemeEntity;
 use Shopware\Storefront\Theme\ThemeLifecycleService;
 use Shopware\Storefront\Theme\ThemeService;
+use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\KernelInterface;
 
 class ThemeTest extends TestCase
 {
@@ -251,6 +259,176 @@ class ThemeTest extends TestCase
         static::assertTrue($themeCompiled);
     }
 
+    public function testCompileNonStorefrontThemesWithSameTechnicalNameNotLeakingConfigurationFromPreviousCompilations(): void
+    {
+        $this->createParentlessSimpleTheme();
+        $criteria = new Criteria();
+        $criteria->addFilter(new EqualsFilter('technicalName', 'SimpleTheme'));
+        /** @var ThemeEntity $baseTheme */
+        $baseTheme = $this->themeRepository->search($criteria, $this->context)->first();
+
+        $criteria = new Criteria();
+        $criteria->addFilter(new EqualsFilter('name', $this->createTheme($baseTheme)));
+        /** @var ThemeEntity $childTheme */
+        $childTheme = $this->themeRepository->search($criteria, $this->context)->first();
+        $this->themeRepository->update([[
+            'id' => $childTheme->getId(),
+            'technicalName' => null,
+        ]], $this->context);
+
+        $expectedColor = '';
+        $expectedTheme = '';
+        $themeCompilerMock = $this->createMock(ThemeCompiler::class);
+        $themeCompilerMock->expects(static::exactly(2))
+            ->method('compileTheme')
+            ->with(
+                new IsEqual(Defaults::SALES_CHANNEL),
+                new Callback(static function (string $value) use (&$expectedTheme): bool {
+                    return $value === $expectedTheme;
+                }),
+                new Callback(static function (StorefrontPluginConfiguration $value) use (&$expectedColor): bool {
+                    return $value->getThemeConfig()['fields']['sw-color-brand-primary']['value'] === $expectedColor;
+                })
+            );
+
+        $themeService = new ThemeService(
+            new StorefrontPluginRegistry(
+                new class ($this->getContainer()->get('kernel')) implements KernelInterface {
+                    /**
+                     * @var KernelInterface
+                     */
+                    private $kernel;
+
+                    /**
+                     * @var fixtures\SimpleTheme\SimpleTheme
+                     */
+                    private $simpleTheme;
+
+                    public function __construct(KernelInterface $kernel)
+                    {
+                        $this->kernel = $kernel;
+                        $this->simpleTheme = new fixtures\SimpleTheme\SimpleTheme();
+                    }
+
+                    public function getBundles()
+                    {
+                        $bundles = $this->kernel->getBundles();
+                        $bundles[$this->simpleTheme->getName()] = $this->simpleTheme;
+
+                        return $bundles;
+                    }
+
+                    public function getBundle($name)
+                    {
+                        return $name === $this->simpleTheme->getName() ? $this->simpleTheme : $this->kernel->getBundle($name);
+                    }
+
+                    public function handle(Request $request, $type = self::MASTER_REQUEST, $catch = true)
+                    {
+                        return $this->kernel->{__FUNCTION__}(...func_get_args());
+                    }
+
+                    public function registerBundles()
+                    {
+                        return $this->kernel->{__FUNCTION__}(...func_get_args());
+                    }
+
+                    public function registerContainerConfiguration(LoaderInterface $loader)
+                    {
+                        return $this->kernel->{__FUNCTION__}(...func_get_args());
+                    }
+
+                    public function boot()
+                    {
+                        return $this->kernel->{__FUNCTION__}(...func_get_args());
+                    }
+
+                    public function shutdown()
+                    {
+                        return $this->kernel->{__FUNCTION__}(...func_get_args());
+                    }
+
+                    public function locateResource($name)
+                    {
+                        return $this->kernel->{__FUNCTION__}(...func_get_args());
+                    }
+
+                    public function getName()
+                    {
+                        return $this->kernel->{__FUNCTION__}(...func_get_args());
+                    }
+
+                    public function getEnvironment()
+                    {
+                        return $this->kernel->{__FUNCTION__}(...func_get_args());
+                    }
+
+                    public function isDebug()
+                    {
+                        return $this->kernel->{__FUNCTION__}(...func_get_args());
+                    }
+
+                    public function getRootDir()
+                    {
+                        return $this->kernel->{__FUNCTION__}(...func_get_args());
+                    }
+
+                    public function getContainer()
+                    {
+                        return $this->kernel->{__FUNCTION__}(...func_get_args());
+                    }
+
+                    public function getStartTime()
+                    {
+                        return $this->kernel->{__FUNCTION__}(...func_get_args());
+                    }
+
+                    public function getCacheDir()
+                    {
+                        return $this->kernel->{__FUNCTION__}(...func_get_args());
+                    }
+
+                    public function getLogDir()
+                    {
+                        return $this->kernel->{__FUNCTION__}(...func_get_args());
+                    }
+
+                    public function getCharset()
+                    {
+                        return $this->kernel->{__FUNCTION__}(...func_get_args());
+                    }
+
+                    public function __call($name, $arguments)
+                    {
+                        return $this->kernel->{__FUNCTION__}(...func_get_args());
+                    }
+                },
+                $this->getContainer()->get(StorefrontPluginConfigurationFactory::class)
+            ),
+            $this->getContainer()->get('theme.repository'),
+            $this->getContainer()->get('theme_sales_channel.repository'),
+            $this->getContainer()->get('media.repository'),
+            $themeCompilerMock
+        );
+        $themeService->updateTheme(
+            $childTheme->getId(),
+            [
+                'sw-color-brand-primary' => [
+                    'value' => '#b1900f',
+                ],
+            ],
+            null,
+            $this->context
+        );
+
+        $expectedColor = '#b1900f';
+        $expectedTheme = $childTheme->getId();
+        $themeService->compileTheme(Defaults::SALES_CHANNEL, $childTheme->getId(), $this->context);
+        $expectedColor = '#008490';
+        $expectedTheme = $baseTheme->getId();
+        $themeService->compileTheme(Defaults::SALES_CHANNEL, $baseTheme->getId(), $this->context);
+    }
+
     public function testRefreshPlugin(): void
     {
         $themeLifecycleService = $this->getContainer()->get(ThemeLifecycleService::class);
@@ -317,6 +495,38 @@ class ThemeTest extends TestCase
                     'labels' => $parentTheme->getLabels(),
                     'customFields' => $parentTheme->getCustomFields(),
                     'previewMediaId' => $parentTheme->getPreviewMediaId(),
+                    'active' => true,
+                ],
+            ],
+            $this->context
+        );
+
+        return $name;
+    }
+
+    /**
+     * @throws \Exception
+     */
+    private function createParentlessSimpleTheme(): string
+    {
+        $name = 'test' . Uuid::randomHex();
+
+        $id = Uuid::randomHex();
+        $this->themeRepository->create(
+            [
+                [
+                    'id' => $id,
+                    'parentThemeId' => null,
+                    'name' => $name,
+                    'technicalName' => 'SimpleTheme',
+                    'createdAt' => (new \DateTimeImmutable())->format(Defaults::STORAGE_DATE_TIME_FORMAT),
+                    'configValues' => null,
+                    'baseConfig' => [],
+                    'description' => 'This is a theme',
+                    'author' => 'Shopware AG',
+                    'labels' => [],
+                    'customFields' => [],
+                    'previewMediaId' => null,
                     'active' => true,
                 ],
             ],

--- a/src/Storefront/Theme/ThemeService.php
+++ b/src/Storefront/Theme/ThemeService.php
@@ -364,7 +364,7 @@ class ThemeService
                 throw new InvalidThemeException(StorefrontPluginRegistry::BASE_THEME_NAME);
             }
 
-            return $pluginConfig;
+            return clone $pluginConfig;
         }
         $pluginConfig = null;
         if ($theme->getTechnicalName() !== null) {
@@ -382,11 +382,13 @@ class ThemeService
                 $parentTheme = false;
                 $pluginConfig = $this->pluginRegistry->getConfigurations()->getByTechnicalName(StorefrontPluginRegistry::BASE_THEME_NAME);
             }
+
             if (!$pluginConfig) {
                 throw new InvalidThemeException($parentTheme ? $parentTheme->getTechnicalName() : StorefrontPluginRegistry::BASE_THEME_NAME);
             }
         }
 
+        $pluginConfig = clone $pluginConfig;
         $pluginConfig->setThemeConfig($this->getThemeConfiguration($theme->getId(), $translate, $context));
 
         return $pluginConfig;


### PR DESCRIPTION
### 0. Preface
This is a re-open of #1081 with tests added.

### 1. Why is this change necessary?
This affects at least theme compilation. The order of the themes to be compiled can affect following compilations in the same runtime when they compile the technically same source files but a different theme instance.
![grafik](https://user-images.githubusercontent.com/1133593/85932709-afc63e00-b8ce-11ea-99ad-338151daf10f.png)
See more about my debugging notes in point 5.

### 2. What does this change do, exactly?
Adds a clone before changing a plugin configuration from the plugin configuration collection. As the plugin configuration object is stored as reference every change to it is also present in the runtime-cached collection. So assigning the merged configuration back into the object and therefore indirectly into the collection as well overrides future reads on the plugin configuration.

### 3. Describe each step to reproduce the issue or behaviour.
* Create a theme plugin
* Assign it to a storefront saleschannel
* Duplicate the theme in the administration
* Assign "child" theme to an other storefront saleschannel so two instance of the technical theme are assigned to a storefront saleschannel
* Configure the child
* Compile the theme using `bin/console theme:compile` and pray for the parent to not look like the child

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

### 5. Manual test cases and debug notes

**TLDR**
I examined theme compilation and DAL seems to be weird but might not be the problem.

**Prelude**
You have a multi-saleschannel setup. Every saleschannel has a different style but they technically share the same source code for twig, js and scss. Now you create a new sales channel Foobar, copy a configured theme of an existing sales channel like Party and assign the copy to the new sales channel Foobar. To match the new style one can change some variables for Foobar. `bin/console theme:compile`. WAIT why does Party partially have the same color scheme like the new Foobar? Compile Party again via administration. Looks good again. Whew ok. Maybe a hiccup in the CD or a cache. FF to the next run of `bin/console theme:compile` Party looks like Foobar again. There is something wrong here.

**Preparations**
To test it I alter the `ThemeCompileCommand` to partially compile some sales channel. I added some debugging dump into the ThemeCompiler and look out for one of the configured variables that are getting mixed up. The theme compiler is called with correctly themeIds and salesChannel each time but with different variable configurations. For this I replace the ids with their resembling terms Foobar and Party.

**Research**
Test cases for changes in `ThemeCompileCommand::getSalesChannels`


**Case 1 (no changes):**

```
private function getSalesChannels(Context $context): SalesChannelCollection
{
    $criteria = new Criteria();
    $criteria->addAssociation('themes');

    /** @var SalesChannelCollection $result */
    $result = $this->salesChannelRepository->search($criteria, $context)->getEntities();

    return $result;
}
```

**Case 2a/b (Ask for the themes specifically)**
```
private function getSalesChannels(Context $context): SalesChannelCollection
{
    $criteria = new Criteria(['Party']);
    $criteria->addAssociation('themes');

    /** @var SalesChannelCollection $result */
    $result = $this->salesChannelRepository->search($criteria, $context)->getEntities();

    return $result;
}
```
```
private function getSalesChannels(Context $context): SalesChannelCollection
{
    $criteria = new Criteria(['Foobar']);
    $criteria->addAssociation('themes');

    /** @var SalesChannelCollection $result */
    $result = $this->salesChannelRepository->search($criteria, $context)->getEntities();

    return $result;
}
```

**Case 3 (Ask for both themes at the same time)**

```
private function getSalesChannels(Context $context): SalesChannelCollection
{
    $criteria = new Criteria(['Party', 'Foobar']);
    $criteria->addAssociation('themes');

    /** @var SalesChannelCollection $result */
    $result = $this->salesChannelRepository->search($criteria, $context)->getEntities();

    return $result;
}
```

**Case 4 (Ask for both themes at the same time but different)**

```
private function getSalesChannels(Context $context): SalesChannelCollection
{
    $criteria = new Criteria();
    $criteria->addAssociation('themes');
    $criteria->addFilter(new EqualsAnyFilter('id', ['Party', 'Foobar']));

    /** @var SalesChannelCollection $result */
    $result = $this->salesChannelRepository->search($criteria, $context)->getEntities();

    return $result;
}
```

**Research results**

The configuration for Party is #bcc1c7 and for Foobar #ff00ff

**Case 1 (wrong):**
```
{
    "salesChannelId": "Foobar",
    "variable": "#ff00ff"
}
{
    "salesChannelId": "Party",
    "variable": "#ff00ff"
}

```

**Case 2 (correct):**
```
{
    "salesChannelId": "Foobar",
    "variable": "#ff00ff"
}
{
    "salesChannelId": "Party",
    "variable": "#bcc1c7"
}
```

**Case 3 (correct):**
```
{
    "salesChannelId": "Party",
    "variable": "#bcc1c7"
}
{
    "salesChannelId": "Foobar",
    "variable": "#ff00ff"
}
```

**Case 4(incorrect):**
```
{
    "salesChannelId": "Foobar",
    "variable": "#ff00ff"
}
{
    "salesChannelId": "Party",
    "variable": "#ff00ff"
}
```

**Result analysis**

Every time we ask the salesChannel by id in the criteria object the themes of the salesChannel are compiled correctly. But the change from case 3 and case 4 should be the same. I get the feeling by looking at the code from 3 and 4 is not expressing the same intention.

![grafik](https://user-images.githubusercontent.com/1133593/85932293-03368d00-b8cb-11ea-9167-1db626dc6ee9.png)
