### PR TITLE
Lookup technical name by theme inheritance in theme:dump

### DIFF
--- a/src/Storefront/Theme/Command/ThemeDumpCommand.php
+++ b/src/Storefront/Theme/Command/ThemeDumpCommand.php
@@ -80,7 +80,7 @@ class ThemeDumpCommand extends Command
 
         /** @var ThemeEntity $themeEntity */
         $themeEntity = $themes->first();
-        $themeConfig = $this->pluginRegistry->getConfigurations()->getByTechnicalName($themeEntity->getTechnicalName());
+        $themeConfig = $this->pluginRegistry->getConfigurations()->getByTechnicalName($this->getTechnicalName($themeEntity->getId()));
 
         $dump = $this->themeFileResolver->resolveFiles(
             $themeConfig,
@@ -96,5 +96,24 @@ class ThemeDumpCommand extends Command
         );
 
         return 0;
+    }
+
+    private function getTechnicalName(string $themeId): ?string
+    {
+        $technicalName = null;
+
+        do {
+            /** @var ThemeEntity|null $theme */
+            $theme = $this->themeRepository->search(new Criteria([$themeId]), $this->context)->first();
+
+            if (!$theme instanceof ThemeEntity) {
+                break;
+            }
+
+            $technicalName = $theme->getTechnicalName();
+            $themeId = $theme->getParentThemeId();
+        } while (is_null($technicalName) && !is_null($themeId));
+
+        return $technicalName;
     }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?
`theme:dump` does not work when a theme has no technical name (which is not required).

### 2. What does this change do, exactly?
Look up the technical name in the theme inheritance.

### 3. Describe each step to reproduce the issue or behaviour.
1. Copy theme in administration
2. Run `theme:dump` or anything related like storefront watching

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
