### PR TITLE
fix use noOfReplicas as configured when settings index alias

### DIFF
--- a/src/Elasticsearch/Framework/Indexing/CreateAliasTaskHandler.php
+++ b/src/Elasticsearch/Framework/Indexing/CreateAliasTaskHandler.php
@@ -25,17 +25,24 @@ class CreateAliasTaskHandler extends ScheduledTaskHandler
      */
     private $elasticsearchHelper;
 
+    /**
+     * @var array
+     */
+    private $config;
+
     public function __construct(
         EntityRepositoryInterface $scheduledTaskRepository,
         Client $client,
         Connection $connection,
-        ElasticsearchHelper $elasticsearchHelper
+        ElasticsearchHelper $elasticsearchHelper,
+        array $config
     ) {
         parent::__construct($scheduledTaskRepository);
         $this->client = $client;
         $this->connection = $connection;
         $this->scheduledTaskRepository = $scheduledTaskRepository;
         $this->elasticsearchHelper = $elasticsearchHelper;
+        $this->config = $config;
     }
 
     public static function getHandledMessages(): iterable
@@ -113,7 +120,7 @@ class CreateAliasTaskHandler extends ScheduledTaskHandler
             $this->client->indices()->putSettings([
                 'index' => $index,
                 'body' => [
-                    'number_of_replicas' => 3,
+                    'number_of_replicas' => $this->config['settings']['index']['number_of_replicas'],
                     'refresh_interval' => null,
                 ],
             ]);

--- a/src/Elasticsearch/Resources/config/services.xml
+++ b/src/Elasticsearch/Resources/config/services.xml
@@ -138,6 +138,7 @@
             <argument type="service" id="Elasticsearch\Client"/>
             <argument type="service" id="Doctrine\DBAL\Connection"/>
             <argument type="service" id="Shopware\Elasticsearch\Framework\ElasticsearchHelper"/>
+            <argument>%elasticsearch.index.config%</argument>
 
             <tag name="messenger.message_handler"/>
         </service>


### PR DESCRIPTION
### 1. Why is this change necessary?

Because you have a parameter `%elasticsearch.index.config%` which contains the settings that you want to have for your elasticsearch indices. This settings are used on index creation.

But when the indexing process is finished and the aliases are created, the setting `number_of_replicas` was hardcoded to `3` instead of using the previous settings.

### 2. What does this change do, exactly?

Respect the parameter containing the replicas setting.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
