### PR TITLE
* fix reportValidity polyfill missing

### DIFF
--- a/src/Storefront/Resources/app/storefront/package-lock.json
+++ b/src/Storefront/Resources/app/storefront/package-lock.json
@@ -11749,6 +11749,11 @@
       "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs=",
       "dev": true
     },
+    "report-validity": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/report-validity/-/report-validity-1.0.1.tgz",
+      "integrity": "sha512-ZL50ObXnB86fMvIeVkSwLXGkV9ojyJj7T1czLG5EtC7jZzKeZXIoHvhlGqMPwuq5LTJhRKPgmq0obTRaR+grCQ=="
+    },
     "request": {
       "version": "2.88.0",
       "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",

--- a/src/Storefront/Resources/app/storefront/package.json
+++ b/src/Storefront/Resources/app/storefront/package.json
@@ -46,6 +46,7 @@
     "optimize-css-assets-webpack-plugin": "5.0.3",
     "popper.js": "1.15.0",
     "query-string": "6.8.2",
+    "report-validity": "^1.0.1",
     "sass-resources-loader": "2.0.1",
     "stylelint-webpack-plugin": "0.10.5",
     "terser-webpack-plugin": "2.2.3",

--- a/src/Storefront/Resources/app/storefront/src/helper/polyfill-loader.helper.js
+++ b/src/Storefront/Resources/app/storefront/src/helper/polyfill-loader.helper.js
@@ -10,6 +10,7 @@ import ElementClosestPolyfill from 'element-closest';
 import 'formdata-polyfill';
 import 'object-fit-polyfill';
 import 'intersection-observer';
+import 'report-validity';
 
 ElementClosestPolyfill(window);
 objectFitImages();


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/community).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
HTMLFormElement.reportValidity() is used `this._firstInvalidElement.reportValidity(false); in form-scroll-to-invalid-field-plugin.js` without being polyfilled, which breaks IE 11.

### 2. What does this change do, exactly?
Adds polyfill to use the function in older browsers

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
