### PR TITLE
fix Thumbnail in listing and product-gallery

### DIFF
--- a/src/Storefront/Resources/views/storefront/component/product/card/box-standard.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/product/card/box-standard.html.twig
@@ -42,13 +42,7 @@
 
                                     {% sw_thumbnails 'product-image-thumbnails' with {
                                         media: cover,
-                                        sizes: {
-                                            'xs': '501px',
-                                            'sm': '315px',
-                                            'md': '427px',
-                                            'lg': '333px',
-                                            'xl': '284px'
-                                        }
+                                        sizes: sizes
                                     } %}
                                 {% else %}
                                     <div class="product-image-placeholder">

--- a/src/Storefront/Resources/views/storefront/component/product/card/box.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/product/card/box.html.twig
@@ -6,5 +6,21 @@
         {% set layout = 'standard' %}
     {% endif %}
 
+    {# Default is 200px #}
+    {% set sizes = {
+        'default': '200px'
+    } %}
+
+    {# We overwrite definition for layout image #}
+    {% if layout == 'image' %}
+        {% set sizes = {
+            'xs': '332px',
+            'sm': '295px',
+            'md': '332px',
+            'lg': '319px',
+            'xl': '274px',
+        } %}
+    {% endif %}
+
     {% sw_include "@Storefront/storefront/component/product/card/box-" ~ layout ~ ".html.twig" ignore missing %}
 {% endblock %}

--- a/src/Storefront/Resources/views/storefront/element/cms-element-image-gallery.html.twig
+++ b/src/Storefront/Resources/views/storefront/element/cms-element-image-gallery.html.twig
@@ -139,7 +139,13 @@
                                                                             {% endif %}
 
                                                                             {% sw_thumbnails 'gallery-slider-image-thumbnails' with {
-                                                                                media: image
+                                                                                media: image,
+                                                                                sizes: {
+                                                                                    'xs': '225px',
+                                                                                    'sm': '430px',
+                                                                                    'md': '430px',
+                                                                                    'lg': '430px'
+                                                                                }
                                                                             } %}
                                                                         </div>
                                                                     </div>

--- a/src/Storefront/Resources/views/storefront/utilities/thumbnail.html.twig
+++ b/src/Storefront/Resources/views/storefront/utilities/thumbnail.html.twig
@@ -39,11 +39,7 @@
             {% set sizeFallback = (sizeFallback / columns)|round(0, 'ceil') %}
         {% endif %}
 
-        {% if thumbnails|first.width > shopware.theme.breakpoint|reverse|first %}
-            {% set maxWidth = thumbnails|first.width %}
-        {% endif %}
-
-        {% for key, value in shopware.theme.breakpoint|reverse %}{% if maxWidth %}(max-width: {{ maxWidth }}px) and {% endif %}(min-width: {{ value }}px) {{ sizes[key] }}{% set maxWidth = value-1 %}{% if not loop.last %}, {% endif %}{% endfor %}, {{ sizeFallback }}vw
+        {% for key, value in shopware.theme.breakpoint|reverse %}(min-width: {{ value }}px) {{ sizes[key] }}{% if not loop.last %}, {% endif %}{% endfor %}, {{ sizeFallback }}vw
     {% endapply %}{% endset %}
 {% endif %}
 <img {% if load %}src="{{ media|sw_encode_media_url }}" {% else %}data-src="{{ media|sw_encode_media_url }}" {% endif %}


### PR DESCRIPTION
### 1. Why is this change necessary?
The thumbnails in listing and detail page aren't defined correct.
Main-problem: on desktops >1920px the original image is loaded - which is superfluous.
On other breakpoints, the thumbnail of size 800px has been loaded, while it's just displayed in size of 200px

### 2. What does this change do, exactly?
I checked the image sizes in box-image in every breakpoint and defined a value for it. 

It looks like, there is no need for max-width, so I removed it :-)

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
