### PR TITLE
increase the possible nested_objects for elasticsearch

### DIFF
--- a/src/Elasticsearch/Resources/config/services.xml
+++ b/src/Elasticsearch/Resources/config/services.xml
@@ -12,6 +12,7 @@
                     <parameter key="number_of_replicas">3</parameter>
                     <parameter key="mapping.total_fields.limit">5000</parameter>
                     <parameter key="mapping.nested_fields.limit">500</parameter>
+                    <parameter key="mapping.nested_objects.limit">1000000</parameter>
                 </parameter>
 
                 <parameter key="analysis" type="collection">


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/community).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
Description is in the related Issue

### 2. What does this change do, exactly?
It increases the default value for nested_object in the Elasticsearch

### 3. Describe each step to reproduce the issue or behaviour.
Steps:
- Add multiple products with a high amount of variants (>600) and a high amount of property-options (~
400)
- Start the `dal:refresh:index`

### 4. Please link to the relevant issues (if any).
https://github.com/shopware/platform/issues/1174

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
