### PR TITLE
Remove unused DI dependency from database:migrate(-destructive) command

### DIFF
--- a/src/Core/Framework/DependencyInjection/services.xml
+++ b/src/Core/Framework/DependencyInjection/services.xml
@@ -126,7 +126,6 @@ base-uri 'self';
 
         <service id="Shopware\Core\Framework\Migration\Command\MigrationCommand">
             <argument type="service" id="Shopware\Core\Framework\Migration\MigrationCollectionLoader"/>
-            <argument type="service" id="Shopware\Core\Framework\Migration\MigrationRuntime"/>
             <argument type="service" id="cache.object"/>
 
             <tag name="console.command"/>
@@ -141,7 +140,6 @@ base-uri 'self';
 
         <service id="Shopware\Core\Framework\Migration\Command\MigrationDestructiveCommand">
             <argument type="service" id="Shopware\Core\Framework\Migration\MigrationCollectionLoader"/>
-            <argument type="service" id="Shopware\Core\Framework\Migration\MigrationRuntime"/>
             <argument type="service" id="cache.object"/>
 
             <tag name="console.command"/>

--- a/src/Core/Framework/Migration/Command/MigrationCommand.php
+++ b/src/Core/Framework/Migration/Command/MigrationCommand.php
@@ -6,7 +6,6 @@ use Shopware\Core\Framework\Adapter\Console\ShopwareStyle;
 use Shopware\Core\Framework\Migration\Exception\MigrateException;
 use Shopware\Core\Framework\Migration\MigrationCollection;
 use Shopware\Core\Framework\Migration\MigrationCollectionLoader;
-use Shopware\Core\Framework\Migration\MigrationRuntime;
 use Symfony\Component\Cache\Adapter\TagAwareAdapterInterface;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
@@ -25,11 +24,6 @@ class MigrationCommand extends Command
     protected $loader;
 
     /**
-     * @var MigrationRuntime
-     */
-    protected $runner;
-
-    /**
      * @var SymfonyStyle
      */
     protected $io;
@@ -39,15 +33,11 @@ class MigrationCommand extends Command
      */
     private $cache;
 
-    public function __construct(
-        MigrationCollectionLoader $loader,
-        MigrationRuntime $runner,
-        TagAwareAdapterInterface $cache
-    ) {
+    public function __construct(MigrationCollectionLoader $loader, TagAwareAdapterInterface $cache)
+    {
         parent::__construct();
 
         $this->loader = $loader;
-        $this->runner = $runner;
         $this->cache = $cache;
     }
 


### PR DESCRIPTION
### 1. Why is this change necessary?
Well, it is just not needed.

### 2. What does this change do, exactly?
Remove an unused dependency in two commands.

### 3. Describe each step to reproduce the issue or behaviour.
1. Copy parts of this command
2. Be confused why things are required but not used

### 4. Checklist
- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
