### PR TITLE
NEXT-8644 - Fix sidebar on orderlist page in administration

### DIFF
--- a/CHANGELOG-6.3.md
+++ b/CHANGELOG-6.3.md
@@ -762,7 +762,8 @@ Refactored `src/module/sw-plugin/snippet/en-GB.json`:
 * Added block `sw_product_detail_properties_empty_state__inherit_switch` to component `sw-product-detail-properties`
 * Added block `sw_product_detail_properties_assginment` to component `sw-product-detail-properties`
 * Added block `sw_product_detail_properties_empty` to component `sw-product-detail-properties`
-
+* Fixed the sidebar with filters that wasn't displayed in the orderlist
+ 
 #### Core
 * Deprecated `\Shopware\Core\Checkout\Cart\Tax\TaxRuleCalculator`, use `\Shopware\Core\Checkout\Cart\Tax\TaxCalculator` instead
 * Added `Criteria $criteria` parameter in store api routes. The parameter will be required in 6.4. At the moment the parameter is commented out in the `*AbstractRoute`, but it is already passed:

--- a/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-list/sw-order-list.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-list/sw-order-list.html.twig
@@ -206,7 +206,8 @@
             </template>
 
             {% block sw_order_list_sidebar %}
-                <sw-sidebar #sidebar class="sw-order-list__sidebar">
+                <template #sidebar>
+                <sw-sidebar class="sw-order-list__sidebar">
 
                     {% block sw_order_list_sidebar_refresh %}
                         <sw-sidebar-item
@@ -250,6 +251,7 @@
                         </sw-sidebar-item>
                     {% endblock %}
                 </sw-sidebar>
+                </template>
             {% endblock %}
         {% endblock %}
     </sw-page>


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/community).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
On the orderlist paga in the administration the sidebar isn't showed although it contains a  refresh button and some filters.

### 2. What does this change do, exactly?
It shows the sidebar again as it supposed to be.

### 3. Describe each step to reproduce the issue or behaviour.
Go to the administration and go to the orderlist. It should show a sidebar with filters on the right side but it isn't showed.

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/NEXT-8644

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
