### PR TITLE
Update address-personal.html.twig

### DIFF
--- a/src/Storefront/Resources/views/storefront/component/address/address-personal.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/address/address-personal.html.twig
@@ -15,7 +15,7 @@
                         <select name="{% if prefix %}{{ prefix }}[accountType]{% else %}accountType{% endif %}"
                                 id="{{ prefix }}accountType"
                                 required="required"
-                                class="custom-select contact-select{% if formViolations.getViolations('/typeId') %} is-invalid{% endif %}"
+                                class="custom-select contact-select{% if formViolations.getViolations('/typeId').count > 0 %} is-invalid{% endif %}"
                                 data-form-field-toggle="true"
                                 data-form-field-toggle-target=".js-field-toggle-contact-type-company"
                                 data-form-field-toggle-value="{{ constant('Shopware\\Core\\Checkout\\Customer\\CustomerEntity::ACCOUNT_TYPE_BUSINESS') }}">
@@ -41,12 +41,13 @@
                                         value="">
                                     {{ "account.personalTypeLabel"|trans|sw_sanitize }}{{ "general.required"|trans|sw_sanitize }}
                                 </option>
-                                <option value="{{ constant('Shopware\\Core\\Checkout\\Customer\\CustomerEntity::ACCOUNT_TYPE_PRIVATE') }}">
+                                <option value="{{ constant('Shopware\\Core\\Checkout\\Customer\\CustomerEntity::ACCOUNT_TYPE_PRIVATE') }}"{% if data.get('acountType') == constant('Shopware\\Core\\Checkout\\Customer\\CustomerEntity::ACCOUNT_TYPE_PRIVATE') %} selected{% endif %}>
                                     {{ "account.personalTypePrivate"|trans|sw_sanitize }}
                                 </option>
-                                <option value="{{ constant('Shopware\\Core\\Checkout\\Customer\\CustomerEntity::ACCOUNT_TYPE_BUSINESS') }}">
+                                <option value="{{ constant('Shopware\\Core\\Checkout\\Customer\\CustomerEntity::ACCOUNT_TYPE_BUSINESS') }}"{% if data.get('accountType') == constant('Shopware\\Core\\Checkout\\Customer\\CustomerEntity::ACCOUNT_TYPE_BUSINESS') %} selected{% endif %}>
                                     {{ "account.personalTypeBusiness"|trans|sw_sanitize }}
                                 </option>
+                                <option>test</option>
                             {% endif %}
                         </select>
                     {% endblock %}

--- a/src/Storefront/Resources/views/storefront/component/address/address-personal.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/address/address-personal.html.twig
@@ -47,7 +47,6 @@
                                 <option value="{{ constant('Shopware\\Core\\Checkout\\Customer\\CustomerEntity::ACCOUNT_TYPE_BUSINESS') }}"{% if data.get('accountType') == constant('Shopware\\Core\\Checkout\\Customer\\CustomerEntity::ACCOUNT_TYPE_BUSINESS') %} selected{% endif %}>
                                     {{ "account.personalTypeBusiness"|trans|sw_sanitize }}
                                 </option>
-                                <option>test</option>
                             {% endif %}
                         </select>
                     {% endblock %}


### PR DESCRIPTION
BUGFIX for validation errors.


### 1. Why is this change necessary?
Without these changes the "I am" field is not preselected after error on vat id validation error.
 
### 2. What does this change do, exactly?
Fix the error.

### 3. Describe each step to reproduce the issue or behaviour.
Currently i could only reproduce this with our plugin in versions < 1.0.1
https://store.shopware.com/lenz698198643790/umsatzsteuer-ustid-validierung-pro-sw6.html

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.
