### PR TITLE
Prevent unintended endless loop in RepositoryIterator

### DIFF
--- a/src/Core/Framework/DataAbstractionLayer/Dbal/Common/RepositoryIterator.php
+++ b/src/Core/Framework/DataAbstractionLayer/Dbal/Common/RepositoryIterator.php
@@ -29,6 +29,9 @@ class RepositoryIterator
         if ($criteria === null) {
             $criteria = new Criteria();
             $criteria->setOffset(0);
+        }
+        
+        if ($criteria->getLimit() === null || $criteria->getLimit() < 1) {
             $criteria->setLimit(50);
         }
 


### PR DESCRIPTION
### 1. Why is this change necessary?
When you pass a criteria to add association you can miss setting the limit and this will end in an endless loop as no steps forward will be done.

### 2. What does this change do, exactly?
Applies the fallback limit to existing criterias as well.

### 3. Describe each step to reproduce the issue or behaviour.
```
$iterator = new RepositoryIterator($productRepository, $context, (new Criteria())->addAssociation('manufacturer'));
while ($iterator->fetchIds() !== null);
```

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
