### PR TITLE
NEXT-8065 - Change tmp filename of sitemap

### DIFF
--- a/CHANGELOG-6.3.md
+++ b/CHANGELOG-6.3.md
@@ -24,6 +24,7 @@ NEXT
 #### Core
 
 * Changed `keyword` fields in Elasticsearch to normalize to lower case
+* Changed temporary filename of sitemap to avoid conflicts with other installations
 
 #### Storefront
 

--- a/src/Core/Content/Sitemap/Service/SitemapHandle.php
+++ b/src/Core/Content/Sitemap/Service/SitemapHandle.php
@@ -43,7 +43,7 @@ class SitemapHandle implements SitemapHandleInterface
     {
         $this->filesystem = $filesystem;
 
-        $filePath = $this->getTmpFilePath();
+        $filePath = $this->getTmpFilePath($context);
         $this->handle = gzopen($filePath, 'ab');
         $this->printHeader();
 
@@ -68,7 +68,7 @@ class SitemapHandle implements SitemapHandleInterface
                 $this->printFooter();
                 gzclose($this->handle);
                 ++$this->index;
-                $path = $this->getTmpFilePath();
+                $path = $this->getTmpFilePath($this->context);
                 $this->handle = gzopen($path, 'ab');
                 $this->printHeader();
                 $this->tmpFiles[] = $path;
@@ -97,7 +97,7 @@ class SitemapHandle implements SitemapHandleInterface
 
     private function getFilePath(int $index, SalesChannelContext $salesChannelContext): string
     {
-        return $this->getPath($salesChannelContext) . $this->getFileName($index);
+        return $this->getPath($salesChannelContext) . $this->getFileName($salesChannelContext, $index);
     }
 
     private function getPath(SalesChannelContext $salesChannelContext): string
@@ -105,14 +105,14 @@ class SitemapHandle implements SitemapHandleInterface
         return 'sitemap/salesChannel-' . $salesChannelContext->getSalesChannel()->getId() . '-' . $salesChannelContext->getSalesChannel()->getLanguageId() . '/';
     }
 
-    private function getTmpFilePath(): string
+    private function getTmpFilePath(SalesChannelContext $salesChannelContext): string
     {
-        return rtrim(sys_get_temp_dir(), '/') . '/' . $this->getFileName();
+        return rtrim(sys_get_temp_dir(), '/') . '/' . $this->getFileName($salesChannelContext);
     }
 
-    private function getFileName(?int $index = null): string
+    private function getFileName(SalesChannelContext $salesChannelContext, ?int $index = null): string
     {
-        return sprintf(self::SITEMAP_NAME_PATTERN, $index ?? $this->index);
+        return sprintf($salesChannelContext->getSalesChannel()->getId() . '-' . self::SITEMAP_NAME_PATTERN, $index ?? $this->index);
     }
 
     private function printHeader(): void


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/community).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
Currently when the sitemap is generated, it writes a temporary file with the name sitemap-product-1.xml.gz to the temp location that is configured within php ( sys_get_temp_dir()). However in case of a shared server with multiple server users and Shopware installations the temporary file be owned by just one server user. Because the temporary filename is always the same, the other installations cannot generate the sitemap because they get a permission denied error when trying to write to the temporary file.

### 2. What does this change do, exactly?
The change adds the saleschannelid to the temporary filename and it is unlikely that there are installations with the same saleschannelid.

### 3. Describe each step to reproduce the issue or behaviour.
Install multiple shopware installations under different server users on the same server. Then try to generate the sitemap on each installation.

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/NEXT-8065

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
