### PR TITLE
Invalidate translator snippet set id cache on request change

### DIFF
--- a/src/Core/Framework/Adapter/Translation/RequestStackCacheInvalidate.php
+++ b/src/Core/Framework/Adapter/Translation/RequestStackCacheInvalidate.php
@@ -1,0 +1,66 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\Adapter\Translation;
+
+use Shopware\Core\SalesChannelRequest;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+class RequestStackCacheInvalidate extends RequestStack
+{
+    /**
+     * @var RequestStack
+     */
+    private $decorated;
+
+    /**
+     * @var TranslatorRequestCache
+     */
+    private $translatorRequestCache;
+
+    public function __construct(RequestStack $decorated, TranslatorRequestCache $translatorRequestCache)
+    {
+        $this->decorated = $decorated;
+        $this->translatorRequestCache = $translatorRequestCache;
+    }
+
+    public function push(Request $request)
+    {
+        $this->translatorRequestCache->reset();
+        $this->decorated->push($this->setSnippetSetIdByRequest($request));
+    }
+
+    public function pop()
+    {
+        $this->translatorRequestCache->reset();
+
+        return $this->setSnippetSetIdByRequest($this->decorated->pop());
+    }
+
+    public function getCurrentRequest()
+    {
+        return $this->decorated->getCurrentRequest();
+    }
+
+    public function getMasterRequest()
+    {
+        return $this->decorated->getMasterRequest();
+    }
+
+    public function getParentRequest()
+    {
+        return $this->decorated->getParentRequest();
+    }
+
+    private function setSnippetSetIdByRequest(?Request $request): ?Request
+    {
+        if (!$request) {
+            $this->translatorRequestCache->setSnippetSetId(null);
+            return null;
+        }
+
+        $this->translatorRequestCache->setSnippetSetId($request->attributes->get(SalesChannelRequest::ATTRIBUTE_DOMAIN_SNIPPET_SET_ID));
+
+        return $request;
+    }
+}

--- a/src/Core/Framework/Adapter/Translation/TranslatorRequestCache.php
+++ b/src/Core/Framework/Adapter/Translation/TranslatorRequestCache.php
@@ -1,0 +1,55 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\Adapter\Translation;
+
+class TranslatorRequestCache
+{
+    /**
+     * @var string|null
+     */
+    private $snippetSetId;
+
+    private $isCustomized = [];
+
+    /**
+     * @var string|null
+     */
+    private $fallbackLocale;
+
+    public function reset(): void
+    {
+        $this->snippetSetId = null;
+        $this->isCustomized = [];
+        $this->fallbackLocale = null;
+    }
+
+    public function getSnippetSetId(): ?string
+    {
+        return $this->snippetSetId;
+    }
+
+    public function setSnippetSetId(?string $snippetSetId): void
+    {
+        $this->snippetSetId = $snippetSetId;
+    }
+
+    public function getIsCustomized(): array
+    {
+        return $this->isCustomized;
+    }
+
+    public function setIsCustomized(array $isCustomized): void
+    {
+        $this->isCustomized = $isCustomized;
+    }
+
+    public function getFallbackLocale(): ?string
+    {
+        return $this->fallbackLocale;
+    }
+
+    public function setFallbackLocale(?string $fallbackLocale): void
+    {
+        $this->fallbackLocale = $fallbackLocale;
+    }
+}

--- a/src/Core/Framework/DependencyInjection/services.xml
+++ b/src/Core/Framework/DependencyInjection/services.xml
@@ -193,12 +193,12 @@ base-uri 'self';
         <service id="Shopware\Core\Framework\Adapter\Translation\Translator"
                  decorates="translator">
             <argument type="service" id="Shopware\Core\Framework\Adapter\Translation\Translator.inner"/>
-            <argument type="service" id="request_stack"/>
             <argument type="service" id="cache.object"/>
             <argument type="service" id="translator.formatter"/>
             <argument type="service" id="Shopware\Core\System\Snippet\SnippetService"/>
             <argument type="service" id="language.repository"/>
             <argument>%kernel.environment%</argument>
+            <argument type="service" id="Shopware\Core\Framework\Adapter\Translation\TranslatorRequestCache"/>
 
             <tag name="monolog.logger"/>
         </service>
@@ -209,6 +209,14 @@ base-uri 'self';
 
             <tag name="kernel.event_subscriber"/>
         </service>
+
+        <service id="Shopware\Core\Framework\Adapter\Translation\RequestStackCacheInvalidate"
+                 decorates="request_stack">
+            <argument type="service" id="Shopware\Core\Framework\Adapter\Translation\RequestStackCacheInvalidate.inner"/>
+            <argument type="service" id="Shopware\Core\Framework\Adapter\Translation\TranslatorRequestCache"/>
+        </service>
+
+        <service id="Shopware\Core\Framework\Adapter\Translation\TranslatorRequestCache"/>
 
         <!-- Snippets -->
         <service id="Shopware\Core\System\Snippet\SnippetService">


### PR DESCRIPTION
### 1. Why is this change necessary?
When you need to use translations in the storefront in a headless environment you fake requests as the translator adapter fetches the snippet set id from the request and is stored forever. So changing requests does not reset this cache.

### 2. What does this change do, exactly?
It adds a decorator to request_stack to automatically reset the translator cache when the stack changes.

### 3. Describe each step to reproduce the issue or behaviour.
1. Generate request with snippet set attribute
2. Push request onto stack
3. Use translations
4. Pop stack
5. Generate request with other snippet set attribute (other language)
6. Push request onto stack
7. Use translations
8. Get translations in the language of the snippet set from step 1

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
