### PR TITLE
Forbid deleting fallback customer group

### DIFF
--- a/changelog/_unreleased/2020-07-28-forbid-deletion-of-default-customer-grouop.md
+++ b/changelog/_unreleased/2020-07-28-forbid-deletion-of-default-customer-grouop.md
@@ -1,0 +1,8 @@
+---
+title: Forbid deletion of default customer group
+author: Joshua Behrens
+author_email: code@joshua-behrens.de
+author_github: @JoshuaBehrens
+---
+# Core
+* Added check and validation exception on customer group deletion to prevent deletion of the default customer group

--- a/src/Core/Checkout/Customer/Aggregate/CustomerGroup/CustomerGroupValidator.php
+++ b/src/Core/Checkout/Customer/Aggregate/CustomerGroup/CustomerGroupValidator.php
@@ -1,0 +1,75 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Checkout\Customer\Aggregate\CustomerGroup;
+
+use Shopware\Core\Defaults;
+use Shopware\Core\Framework\DataAbstractionLayer\Write\Command\CascadeDeleteCommand;
+use Shopware\Core\Framework\DataAbstractionLayer\Write\Command\DeleteCommand;
+use Shopware\Core\Framework\DataAbstractionLayer\Write\Validation\PreWriteValidationEvent;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\Framework\Validation\WriteConstraintViolationException;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Validator\ConstraintViolation;
+use Symfony\Component\Validator\ConstraintViolationInterface;
+use Symfony\Component\Validator\ConstraintViolationList;
+
+class CustomerGroupValidator implements EventSubscriberInterface
+{
+    public const VIOLATION_DELETE_DEFAULT_CUSTOMER_GROUP = 'delete_default_customer_group_violation';
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            PreWriteValidationEvent::class => 'preValidate',
+        ];
+    }
+
+    public function preValidate(PreWriteValidationEvent $event): void
+    {
+        $commands = $event->getCommands();
+
+        foreach ($commands as $command) {
+            if ($command instanceof CascadeDeleteCommand || $command->getDefinition()->getClass() !== CustomerGroupDefinition::class) {
+                continue;
+            }
+
+            $pk = $command->getPrimaryKey();
+            $id = \mb_strtolower(Uuid::fromBytesToHex($pk['id']));
+
+            if (!$command instanceof DeleteCommand || $id !== Defaults::FALLBACK_CUSTOMER_GROUP) {
+                continue;
+            }
+
+            $violations = new ConstraintViolationList();
+            $violations->add($this->buildViolation(
+                'The default customer group {{ id }} cannot be deleted.',
+                ['{{ id }}' => $id],
+                null,
+                '/' . $id,
+                $id,
+                self::VIOLATION_DELETE_DEFAULT_CUSTOMER_GROUP
+            ));
+            $event->getExceptions()->add(new WriteConstraintViolationException($violations, $command->getPath()));
+        }
+    }
+
+    private function buildViolation(
+        string $messageTemplate,
+        array $parameters,
+        $root = null,
+        ?string $propertyPath = null,
+        ?string $invalidValue = null,
+        ?string $code = null
+    ): ConstraintViolationInterface {
+        return new ConstraintViolation(
+            str_replace(array_keys($parameters), array_values($parameters), $messageTemplate),
+            $messageTemplate,
+            $parameters,
+            $root,
+            $propertyPath,
+            $invalidValue,
+            null,
+            $code
+        );
+    }
+}

--- a/src/Core/Checkout/DependencyInjection/customer.xml
+++ b/src/Core/Checkout/DependencyInjection/customer.xml
@@ -34,6 +34,10 @@
             <tag name="shopware.entity.definition"/>
         </service>
 
+        <service id="Shopware\Core\Checkout\Customer\Aggregate\CustomerGroup\CustomerGroupValidator">
+            <tag name="kernel.event_subscriber"/>
+        </service>
+
         <service id="Shopware\Core\Checkout\Customer\SalesChannel\AccountService">
             <argument type="service" id="customer.repository"/>
             <argument type="service" id="Shopware\Core\System\SalesChannel\Context\SalesChannelContextPersister"/>

--- a/src/Core/Checkout/Test/Customer/Repository/CustomerGroupValidatorTest.php
+++ b/src/Core/Checkout/Test/Customer/Repository/CustomerGroupValidatorTest.php
@@ -1,0 +1,74 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Checkout\Test\Customer\Repository;
+
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Defaults;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepositoryInterface;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Write\WriteException;
+use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
+use Shopware\Core\Framework\Uuid\Uuid;
+
+class CustomerGroupValidatorTest extends TestCase
+{
+    use IntegrationTestBehaviour;
+
+    /**
+     * @var EntityRepositoryInterface
+     */
+    private $customerGroupRepository;
+
+    /**
+     * @var EntityRepositoryInterface
+     */
+    private $customerRepository;
+
+    /**
+     * @var EntityRepositoryInterface
+     */
+    private $salesChannelRepository;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->customerGroupRepository = $this->getContainer()->get('customer_group.repository');
+        $this->customerRepository = $this->getContainer()->get('customer.repository');
+        $this->salesChannelRepository = $this->getContainer()->get('sales_channel.repository');
+    }
+
+    public function testDeletionOfDefaultGroup(): void
+    {
+        $customerGroupId = Uuid::randomHex();
+        $context = Context::createDefaultContext();
+
+        $this->customerGroupRepository->create([[
+            'id' => $customerGroupId,
+            'name' => 'Exchange for default',
+            'registrationTitle' => 'Exchange for default',
+            'registrationIntroduction' => 'Exchange for default',
+            'registrationOnlyCompanyRegistration' => false,
+            'registrationSeoMetaDescription' => '',
+        ]], $context);
+
+        // make default customer group unused elsewhere
+        $this->salesChannelRepository->update(array_map(static function (string $id) use ($customerGroupId): array {
+            return [
+                'id' => $id,
+                'customerGroupId' => $customerGroupId,
+            ];
+        }, $this->salesChannelRepository->searchIds(new Criteria(), $context)->getIds()), $context);
+        $this->customerRepository->update(array_map(static function (string $id) use ($customerGroupId): array {
+            return [
+                'id' => $id,
+                'customerGroupId' => $customerGroupId,
+            ];
+        }, $this->customerRepository->searchIds(new Criteria(), $context)->getIds()), $context);
+
+        $this->expectException(WriteException::class);
+        $this->expectExceptionMessageMatches('/The default customer group ' . Defaults::FALLBACK_CUSTOMER_GROUP . ' cannot be deleted/');
+        $this->customerGroupRepository->delete([['id' => Defaults::FALLBACK_CUSTOMER_GROUP]], $context);
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?
Some code expects the fallback customer group to exist. But no one is stopped to delete it.

Shopware 5 is calling:
https://github.com/shopware/platform/blob/4b9c799ff56c1141326e18a998f6573f972ae988/src/Core/System/SalesChannel/Context/SalesChannelContextFactory.php#L188-L191

### 2. What does this change do, exactly?
Add deletion restriction for the fallback customer group.

### 3. Describe each step to reproduce the issue or behaviour.
1. Delete all customers that are assigned to the fallback customer group
2. Remove all assignments in sales channels to this customer group
3. Delete the customer group in the admin
4. Storefront goes
![grafik](https://user-images.githubusercontent.com/1133593/88606251-7bd06b00-d07c-11ea-8aa2-68b25f3afc73.png)

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
