### PR TITLE
Fix link to product from order line item

### DIFF
--- a/CHANGELOG-6.3.md
+++ b/CHANGELOG-6.3.md
@@ -21,6 +21,8 @@ NEXT
 
 #### Administration
 
+* Fixed the link from an order detail page to the product corresponding to an order line item, which could be incorrect for order line items not originating from ordinary cart line items.
+
 #### Core
 
 * Changed `keyword` fields in Elasticsearch to normalize to lower case

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-line-items-grid/sw-order-line-items-grid.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-line-items-grid/sw-order-line-items-grid.html.twig
@@ -88,7 +88,7 @@
                             {% block sw_order_line_items_grid_grid_columns_label_link %}
                                 <router-link v-else-if="!isInlineEdit && isProductItem(item)"
                                              :title="$tc('sw-order.detailBase.contextMenuShowProduct')"
-                                             :to="{ name: 'sw.product.detail', params: { id: item.identifier } }">
+                                             :to="{ name: 'sw.product.detail', params: { id: item.productId } }">
 
                                     {% block sw_order_line_items_grid_column_payload_options %}
                                         <div v-if="item.payload && item.payload.options"


### PR DESCRIPTION
### 1. Why is this change necessary?

The administration's client-side route "sw.product.detail" expects a supplied parameter to be a product id.

The product id is already properly used to generate the link in the context menu (instead of using the order line item "identifier").

While the previously used "identifier" from the order line item may match the product id, it may also be different.

Order line items created by the LineItemTransformer, given cart line items originally created by the CartLineItemController using the ProductLineItemFactory, will have such an "identifier" matching the product id.

However, that does not necessarily apply to "identifiers" of order line items created elsewhere. The OrderConverter from the SwagMigrationAssistant plugin is such a counterexample, as it sets the "identifier" to the order line item's id (not the product's id).



### 2. What does this change do, exactly?

This patch adjusts the link generation to use the known product id from
the order line item record.


### 3. Describe each step to reproduce the issue or behaviour.

1. Create an order with an order line item with an `identifier` that does not match its product id. Such an order line item can, for example, be created by using SwagMigrationAssistant to migrate a Shopware 5 shop to Shopware 6 (where the order line item's `id` will be used for the `identifier`), see: <https://github.com/shopware/SwagMigrationAssistant/blob/a32f19de2e1c5039d42250e64c8246bc90280d3f/Profile/Shopware/Converter/OrderConverter.php#L805>.
2. Open the orders overview in the administration. Open the order with the created order line item. Try to access the corresponding product by clicking the order line item's name in the order line items grid.
3. That clicked link on the order line item's name will lead to an empty products detail page in the administration and errors appear on the browser console, as there is no corresponding product with the id of the order line item's `identifier` value.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.**
