### PR TITLE
Add check for missing custom field

### DIFF
--- a/src/Core/Checkout/Cart/Rule/LineItemCustomFieldRule.php
+++ b/src/Core/Checkout/Cart/Rule/LineItemCustomFieldRule.php
@@ -78,6 +78,12 @@ class LineItemCustomFieldRule extends Rule
     {
         try {
             $customFields = $lineItem->getPayloadValue('customFields');
+
+            if (empty($customFields)
+                || !\array_key_exists($this->renderedField['name'], $customFields)) {
+                return false;
+            }
+
             $expected = $this->renderedFieldValue;
             $actual = $customFields[$this->renderedField['name']];
         } catch (PayloadKeyNotFoundException $e) {


### PR DESCRIPTION
### 1. Why is this change necessary?
Using the `LineItemCustomFieldRule` currently is risky because it crashes the cart when a lineitem without that custom field is added to the cart.

### 2. What does this change do, exactly?
It checks that the custom field that the rule is supposed to check actually exists before accessing it.

### 3. Describe each step to reproduce the issue or behaviour.
Create a rule using the `LineItemCustomFieldRule`, checking for some custom field. Add a product to the basket, without adding any custom field, or without that specific custom field.

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
