### PR TITLE
Remove hover from non links

### DIFF
--- a/src/Storefront/Resources/app/storefront/src/scss/skin/shopware/page/checkout/_cart-item.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/skin/shopware/page/checkout/_cart-item.scss
@@ -35,7 +35,7 @@
     color: $body-color;
     font-weight: $font-weight-bold;
 
-    &:hover {
+    a&:hover {
         color: $primary;
         text-decoration: none;
     }


### PR DESCRIPTION
### 1. Why is this change necessary?
Hovering on non-links in card shouldn't change its colour.

### 2. What does this change do, exactly?
Change hover to its a-tag

### 3. Describe each step to reproduce the issue or behaviour.
Add a not product type to cart, hover over name.

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
