### PR TITLE
Add manufacturer keywords

### DIFF
--- a/src/Core/Content/Product/DataAbstractionLayer/SearchKeywordUpdater.php
+++ b/src/Core/Content/Product/DataAbstractionLayer/SearchKeywordUpdater.php
@@ -77,7 +77,7 @@ class SearchKeywordUpdater
     {
         $products = $context->disableCache(function (Context $context) use ($ids) {
             return $context->enableInheritance(function (Context $context) use ($ids) {
-                return $this->productRepository->search(new Criteria($ids), $context);
+                return $this->productRepository->search((new Criteria($ids))->addAssociation('manufacturer'), $context);
             });
         });
 

--- a/src/Core/Content/Product/SearchKeyword/ProductSearchKeywordAnalyzer.php
+++ b/src/Core/Content/Product/SearchKeyword/ProductSearchKeywordAnalyzer.php
@@ -32,7 +32,7 @@ class ProductSearchKeywordAnalyzer implements ProductSearchKeywordAnalyzerInterf
             }
         }
 
-        if ($product->getManufacturer()) {
+        if ($product->getManufacturer() && $product->getManufacturer()->getTranslation('name') !== null) {
             $keywords->add(new AnalyzedKeyword((string) $product->getManufacturer()->getTranslation('name'), 500));
         }
         if ($product->getManufacturerNumber()) {


### PR DESCRIPTION
### 1. Why is this change necessary?
It's not possible to search products by manufacturers.

### 2. What does this change do, exactly?
Sets the association to product manufacturer before searching, so the field won't be empty and we can update search keywords by manufacturer translations.

### 3. Describe each step to reproduce the issue or behaviour.
Go to storefront.
Try searching by product manufacturer.
Doesn't work.

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
