### PR TITLE
add promotion support for cart collections

### DIFF
--- a/src/Core/Checkout/Cart/LineItem/LineItemCollection.php
+++ b/src/Core/Checkout/Cart/LineItem/LineItemCollection.php
@@ -199,7 +199,7 @@ class LineItemCollection extends Collection
     {
         $flat = [];
         foreach ($lineItems as $lineItem) {
-            $flat[] = $lineItem;
+            $flat[$lineItem->getId()] = $lineItem;
             if (!$lineItem->getChildren()) {
                 continue;
             }
@@ -207,7 +207,7 @@ class LineItemCollection extends Collection
             $nested = $this->buildFlat($lineItem->getChildren());
 
             foreach ($nested as $nest) {
-                $flat[] = $nest;
+                $flat[$nest->getId()] = $nest;
             }
         }
 

--- a/src/Core/Checkout/Promotion/Cart/Discount/ScopePackager/CartScopeDiscountPackager.php
+++ b/src/Core/Checkout/Promotion/Cart/Discount/ScopePackager/CartScopeDiscountPackager.php
@@ -47,7 +47,7 @@ class CartScopeDiscountPackager extends DiscountPackager
      */
     public function getMatchingItems(DiscountLineItem $discount, Cart $cart, SalesChannelContext $context): DiscountPackageCollection
     {
-        $allItems = $cart->getLineItems()->filterType(LineItem::PRODUCT_LINE_ITEM_TYPE);
+        $allItems = new LineItemCollection($cart->getLineItems()->filterFlatByType(LineItem::PRODUCT_LINE_ITEM_TYPE));
 
         $singleItems = $this->splitQuantities($allItems, $context);
 

--- a/src/Core/Checkout/Promotion/Cart/PromotionCalculator.php
+++ b/src/Core/Checkout/Promotion/Cart/PromotionCalculator.php
@@ -457,13 +457,14 @@ class PromotionCalculator
      */
     private function enrichPackagesWithCartData(DiscountPackageCollection $result, Cart $cart, SalesChannelContext $context): DiscountPackageCollection
     {
+        $flattenLineItems = $cart->getLineItems()->getFlat();
+
         // set the line item from the cart for each unit
         foreach ($result as $package) {
             $cartItemsForUnit = new LineItemFlatCollection();
 
             foreach ($package->getMetaData() as $item) {
-                /** @var LineItem $cartItem */
-                $cartItem = $cart->get($item->getLineItemId());
+                $cartItem = $flattenLineItems[$item->getLineItemId()];
 
                 // create a new item with only a quantity of x
                 // including calculated price for our original cart item

--- a/src/Core/Checkout/Test/Cart/Promotion/Integration/Calculation/PromotionMixedCalculationTest.php
+++ b/src/Core/Checkout/Test/Cart/Promotion/Integration/Calculation/PromotionMixedCalculationTest.php
@@ -3,7 +3,7 @@
 namespace Shopware\Core\Checkout\Test\Cart\Promotion\Integration\Calculation;
 
 use PHPUnit\Framework\TestCase;
-use Shopware\Core\Checkout\Cart\Cart;
+use Shopware\Core\Checkout\Cart\LineItem\LineItem;
 use Shopware\Core\Checkout\Cart\Price\Struct\CalculatedPrice;
 use Shopware\Core\Checkout\Cart\SalesChannel\CartService;
 use Shopware\Core\Checkout\Cart\Tax\Struct\CalculatedTax;
@@ -178,7 +178,7 @@ class PromotionMixedCalculationTest extends TestCase
         $cart = $this->addPromotionCode($code, $cart, $this->cartService, $this->context);
 
         /** @var CalculatedPrice $discountPrice */
-        $discountPrice = $cart->getLineItems()->getFlat()[2]->getPrice();
+        $discountPrice = $cart->getLineItems()->filterFlatByType(LineItem::PROMOTION_LINE_ITEM_TYPE)[0]->getPrice();
 
         /** @var CalculatedTax $tax1 */
         $tax1 = $discountPrice->getCalculatedTaxes()->getElements()[19]->getTax();

--- a/src/Core/Checkout/Test/Cart/Promotion/Integration/PromotionDiscountCompositionTest.php
+++ b/src/Core/Checkout/Test/Cart/Promotion/Integration/PromotionDiscountCompositionTest.php
@@ -3,7 +3,7 @@
 namespace Shopware\Core\Checkout\Test\Cart\Promotion\Integration;
 
 use PHPUnit\Framework\TestCase;
-use Shopware\Core\Checkout\Cart\Cart;
+use Shopware\Core\Checkout\Cart\LineItem\LineItem;
 use Shopware\Core\Checkout\Cart\SalesChannel\CartService;
 use Shopware\Core\Checkout\Promotion\Aggregate\PromotionDiscount\PromotionDiscountEntity;
 use Shopware\Core\Checkout\Promotion\PromotionEntity;
@@ -93,7 +93,7 @@ class PromotionDiscountCompositionTest extends TestCase
         $cart = $this->addPromotionCode($code, $cart, $this->cartService, $this->context);
 
         // get discount line item
-        $discountItem = $cart->getLineItems()->getFlat()[2];
+        $discountItem = $cart->getLineItems()->filterFlatByType(LineItem::PROMOTION_LINE_ITEM_TYPE)[0];
 
         static::assertTrue($discountItem->hasPayloadValue('composition'), 'composition node is missing');
 
@@ -141,7 +141,7 @@ class PromotionDiscountCompositionTest extends TestCase
         $cart = $this->addPromotionCode($code, $cart, $this->cartService, $this->context);
 
         // get discount line item
-        $discountItem = $cart->getLineItems()->getFlat()[2];
+        $discountItem = $cart->getLineItems()->filterFlatByType(LineItem::PROMOTION_LINE_ITEM_TYPE)[0];
 
         static::assertTrue($discountItem->hasPayloadValue('composition'), 'composition node is missing');
 
@@ -269,7 +269,7 @@ class PromotionDiscountCompositionTest extends TestCase
         $cart = $this->addPromotionCode($code, $cart, $this->cartService, $this->context);
 
         // get discount line item
-        $discountItem = $cart->getLineItems()->getFlat()[2];
+        $discountItem = $cart->getLineItems()->filterFlatByType(LineItem::PROMOTION_LINE_ITEM_TYPE)[0];
 
         static::assertTrue($discountItem->hasPayloadValue('composition'), 'composition node is missing');
 
@@ -320,7 +320,7 @@ class PromotionDiscountCompositionTest extends TestCase
         $cart = $this->addPromotionCode($code, $cart, $this->cartService, $this->context);
 
         // get discount line item
-        $discountItem = $cart->getLineItems()->getFlat()[2];
+        $discountItem = $cart->getLineItems()->filterFlatByType(LineItem::PROMOTION_LINE_ITEM_TYPE)[0];
 
         static::assertTrue($discountItem->hasPayloadValue('composition'), 'composition node is missing');
 
@@ -346,7 +346,7 @@ class PromotionDiscountCompositionTest extends TestCase
 
         $cart = $this->addPromotionCode($code, $cart, $this->cartService, $context);
 
-        $promotions = $cart->getLineItems()->filterType('promotion');
+        $promotions = $cart->getLineItems()->filterType(LineItem::PROMOTION_LINE_ITEM_TYPE);
         static::assertCount(1, $promotions);
 
         return $this->cartService->order($cart, $context);


### PR DESCRIPTION
### 1. Why is this change necessary?
We need to be able to respect all lineItems for promotions. Currently, the promotion doesn't flatten the item.

### 2. What does this change do, exactly?
- flatten items in getMatchingItems of CartScopeDiscountPackager.php
- buildFlat of LineItemCollection uses id of lineItem for key
Maybe you find a better solution... :-)
![image](https://user-images.githubusercontent.com/135993/88847543-73e10a00-d1e7-11ea-8106-9ef8f397500d.png)

### 3. Describe each step to reproduce the issue or behaviour.
Add cart-discount to promotion (f.e. 2%). Add lineitem with children. Check the cart-discount hasn't been added or updated.
![image](https://user-images.githubusercontent.com/135993/88847361-39776d00-d1e7-11ea-9719-fbea6e211095.png)

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
