### PR TITLE
support not stackable lineItems in splitter

### DIFF
--- a/src/Core/Checkout/Cart/LineItem/LineItemQuantitySplitter.php
+++ b/src/Core/Checkout/Cart/LineItem/LineItemQuantitySplitter.php
@@ -35,8 +35,14 @@ class LineItemQuantitySplitter
 
         $taxRules = $tmpItem->getPrice()->getTaxRules();
 
-        // change the quantity to 1 single item
+        /*
+         * change the quantity to 1 single item.
+         * we force setting temporarily stackable to true.
+         */
+        $isStackable = $tmpItem->isStackable();
+        $tmpItem->setStackable(true);
         $tmpItem->setQuantity($quantity);
+        $tmpItem->setStackable($isStackable);
 
         $quantityDefinition = new QuantityPriceDefinition(
             $unitPrice,


### PR DESCRIPTION
### 1. Why is this change necessary?
When having a non-stackable lineItem, the promotion fails.

### 2. What does this change do, exactly?


### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
