### PR TITLE
Feature/add saleschannel context to cart created event

### DIFF
--- a/src/Core/Checkout/Cart/Event/CartCreatedEvent.php
+++ b/src/Core/Checkout/Cart/Event/CartCreatedEvent.php
@@ -3,22 +3,41 @@
 namespace Shopware\Core\Checkout\Cart\Event;
 
 use Shopware\Core\Checkout\Cart\Cart;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Event\ShopwareEvent;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Contracts\EventDispatcher\Event;
 
-class CartCreatedEvent extends Event
+class CartCreatedEvent extends Event implements ShopwareEvent
 {
     /**
      * @var Cart
      */
     protected $cart;
 
-    public function __construct(Cart $cart)
+    /**
+     * @var SalesChannelContext
+     */
+    protected $salesChannelContext;
+
+    public function __construct(Cart $cart, SalesChannelContext $salesChannelContext)
     {
         $this->cart = $cart;
+        $this->salesChannelContext = $salesChannelContext;
     }
 
     public function getCart(): Cart
     {
         return $this->cart;
+    }
+
+    public function getContext(): Context
+    {
+        return $this->salesChannelContext->getContext();
+    }
+
+    public function getSalesChannelContext(): SalesChannelContext
+    {
+        return $this->salesChannelContext;
     }
 }

--- a/src/Core/Checkout/Cart/SalesChannel/CartLoadRoute.php
+++ b/src/Core/Checkout/Cart/SalesChannel/CartLoadRoute.php
@@ -69,17 +69,17 @@ class CartLoadRoute extends AbstractCartLoadRoute
         try {
             $cart = $this->persister->load($token, $context);
         } catch (CartTokenNotFoundException $e) {
-            $cart = $this->createNew($token, $name);
+            $cart = $this->createNew($token, $context, $name);
         }
 
         return new CartResponse($this->cartCalculator->calculate($cart, $context));
     }
 
-    private function createNew($token, $name): Cart
+    private function createNew($token, SalesChannelContext $context, $name): Cart
     {
         $cart = new Cart($name, $token);
 
-        $this->eventDispatcher->dispatch(new CartCreatedEvent($cart));
+        $this->eventDispatcher->dispatch(new CartCreatedEvent($cart, $context));
 
         return $cart;
     }

--- a/src/Core/Checkout/Cart/SalesChannel/CartService.php
+++ b/src/Core/Checkout/Cart/SalesChannel/CartService.php
@@ -99,11 +99,11 @@ class CartService
         $this->cart[$cart->getToken()] = $cart;
     }
 
-    public function createNew(string $token, string $name = self::SALES_CHANNEL): Cart
+    public function createNew(string $token, SalesChannelContext $context, string $name = self::SALES_CHANNEL): Cart
     {
         $cart = new Cart($name, $token);
 
-        $this->eventDispatcher->dispatch(new CartCreatedEvent($cart));
+        $this->eventDispatcher->dispatch(new CartCreatedEvent($cart, $context));
 
         return $this->cart[$cart->getToken()] = $cart;
     }

--- a/src/Core/Checkout/Cart/SalesChannel/SalesChannelCartController.php
+++ b/src/Core/Checkout/Cart/SalesChannel/SalesChannelCartController.php
@@ -152,7 +152,7 @@ class SalesChannelCartController extends AbstractController
         $token = $request->request->getAlnum('token', $context->getToken());
         $name = $request->request->getAlnum('name', CartService::SALES_CHANNEL);
 
-        $this->cartService->createNew($token, $name);
+        $this->cartService->createNew($token, $context, $name);
 
         return new JsonResponse(
             [PlatformRequest::HEADER_CONTEXT_TOKEN => $context->getToken()],

--- a/src/Core/Checkout/Test/Cart/CartServiceTest.php
+++ b/src/Core/Checkout/Test/Cart/CartServiceTest.php
@@ -97,12 +97,12 @@ class CartServiceTest extends TestCase
         $cartService = $this->getContainer()->get(CartService::class);
 
         $token = Uuid::randomHex();
-        $newCart = $cartService->createNew($token, __METHOD__);
+        $newCart = $cartService->createNew($token, $this->getSalesChannelContext(), __METHOD__);
 
         static::assertInstanceOf(CartCreatedEvent::class, $caughtEvent);
         static::assertSame($newCart, $caughtEvent->getCart());
         static::assertSame($newCart, $cartService->getCart($token, $this->getSalesChannelContext()));
-        static::assertNotSame($newCart, $cartService->createNew($token, __METHOD__));
+        static::assertNotSame($newCart, $cartService->createNew($token, $this->getSalesChannelContext(), __METHOD__));
     }
 
     public function testLineItemAddedEventFired(): void

--- a/src/Core/Checkout/Test/Cart/Promotion/Integration/PromotionDiscountCompositionTest.php
+++ b/src/Core/Checkout/Test/Cart/Promotion/Integration/PromotionDiscountCompositionTest.php
@@ -345,7 +345,7 @@ class PromotionDiscountCompositionTest extends TestCase
 
     private function orderWithPromotion(string $code, array $productIds, SalesChannelContext $context): string
     {
-        $cart = $this->cartService->createNew($context->getToken());
+        $cart = $this->cartService->createNew($context->getToken(), $context);
 
         foreach ($productIds as $productId) {
             $cart = $this->addProduct($productId, 3, $cart, $this->cartService, $context);

--- a/src/Core/Checkout/Test/Cart/Promotion/Integration/PromotionExtensionCodesTest.php
+++ b/src/Core/Checkout/Test/Cart/Promotion/Integration/PromotionExtensionCodesTest.php
@@ -57,7 +57,7 @@ class PromotionExtensionCodesTest extends TestCase
         $this->context = $this->getContainer()->get(SalesChannelContextFactory::class)->create(Uuid::randomHex(), Defaults::SALES_CHANNEL);
 
         // make sure we always start with a fresh cart
-        $this->cartService->createNew($this->context->getToken());
+        $this->cartService->createNew($this->context->getToken(), $this->context);
     }
 
     /**

--- a/src/Core/Checkout/Test/Order/SalesChannel/OrderServiceTest.php
+++ b/src/Core/Checkout/Test/Order/SalesChannel/OrderServiceTest.php
@@ -364,7 +364,7 @@ class OrderServiceTest extends TestCase
     public function testCreateOrder(): void
     {
         $data = new RequestDataBag(['tos' => true]);
-        $this->fillCart($this->salesChannelContext->getToken());
+        $this->fillCart($this->salesChannelContext->getToken(), $this->salesChannelContext);
 
         $orderId = $this->orderService->createOrder($data, $this->salesChannelContext);
 
@@ -380,7 +380,7 @@ class OrderServiceTest extends TestCase
     public function testCreateOrderSendsMail(): void
     {
         $data = new RequestDataBag(['tos' => true]);
-        $this->fillCart($this->salesChannelContext->getToken());
+        $this->fillCart($this->salesChannelContext->getToken(), $this->salesChannelContext);
 
         $domain = 'http://shopware.' . Uuid::randomHex();
         $this->setDomainForSalesChannel($domain, Defaults::LANGUAGE_SYSTEM);
@@ -455,7 +455,7 @@ class OrderServiceTest extends TestCase
     public function testMailTemplateHasCorrectDomain(): void
     {
         $data = new RequestDataBag(['tos' => true]);
-        $this->fillCart($this->salesChannelContext->getToken());
+        $this->fillCart($this->salesChannelContext->getToken(), $this->salesChannelContext);
 
         $firstDomain = 'http://shopware.first-domain';
         $this->setDomainForSalesChannel($firstDomain, Defaults::LANGUAGE_SYSTEM);
@@ -503,7 +503,7 @@ class OrderServiceTest extends TestCase
     public function testMailTemplateHandlesVirtualDomains(): void
     {
         $data = new RequestDataBag(['tos' => true]);
-        $this->fillCart($this->salesChannelContext->getToken());
+        $this->fillCart($this->salesChannelContext->getToken(), $this->salesChannelContext);
 
         $domain = 'http://shopware.test/virtual-domain';
         $this->setDomainForSalesChannel($domain, Defaults::LANGUAGE_SYSTEM);
@@ -533,7 +533,7 @@ class OrderServiceTest extends TestCase
     private function performOrder(): string
     {
         $data = new RequestDataBag(['tos' => true]);
-        $this->fillCart($this->salesChannelContext->getToken());
+        $this->fillCart($this->salesChannelContext->getToken(), $this->salesChannelContext);
 
         return $this->orderService->createOrder($data, $this->salesChannelContext);
     }
@@ -575,9 +575,9 @@ class OrderServiceTest extends TestCase
         return $customerId;
     }
 
-    private function fillCart(string $contextToken): void
+    private function fillCart(string $contextToken, SalesChannelContext $context): void
     {
-        $cart = $this->getContainer()->get(CartService::class)->createNew($contextToken);
+        $cart = $this->getContainer()->get(CartService::class)->createNew($contextToken, $context);
 
         $productId = $this->createProduct();
         $cart->add(new LineItem('lineItem1', LineItem::PRODUCT_LINE_ITEM_TYPE, $productId));

--- a/src/Core/Framework/Demodata/Generator/OrderGenerator.php
+++ b/src/Core/Framework/Demodata/Generator/OrderGenerator.php
@@ -128,7 +128,7 @@ SQL;
 
             $new = $lineItems->slice($offset, $itemCount);
 
-            $cart = $this->cartService->createNew($token, 'demo-data');
+            $cart = $this->cartService->createNew($token, $salesChannelContext, 'demo-data');
             $cart->addLineItems($new);
 
             $cart = $this->cartService->recalculate($cart, $salesChannelContext);

--- a/src/Docs/Resources/current/60-references-internals/10-core/50-checkout-process/_examples/10-cart-example.php
+++ b/src/Docs/Resources/current/60-references-internals/10-core/50-checkout-process/_examples/10-cart-example.php
@@ -2,6 +2,7 @@
 
 namespace ExampleCreateNew {
     use Shopware\Core\Checkout\Cart\SalesChannel\CartService;
+    use Shopware\Core\System\SalesChannel\SalesChannelContext;
     use Symfony\Component\Routing\Annotation\Route;
 
     class NewCartController
@@ -12,11 +13,11 @@ namespace ExampleCreateNew {
         /**
          * @Route("/", name="cart.test")
          */
-        public function createNewCart(): void
+        public function createNewCart(SalesChannelContext $salesChannelContext): void
         {
             // Load the token through the request or from other sources
             $token = '596a70b408014230a140fd5d94d3402b';
-            $cart = $this->cartService->createNew($token);
+            $cart = $this->cartService->createNew($token, $salesChannelContext);
         }
     }
 } // code-example-end
@@ -217,7 +218,7 @@ namespace DocsTest {
             $controller = new NewCartController();
 
             $this->setUpController($controller);
-            $controller->createNewCart();
+            $controller->createNewCart($this->getSalesChannelContext());
 
             static::assertTrue(true); //indicate all went well
         }

--- a/src/Docs/Resources/deprecated/2-internals/1-core/50-checkout-process/_examples/10-cart-example.php
+++ b/src/Docs/Resources/deprecated/2-internals/1-core/50-checkout-process/_examples/10-cart-example.php
@@ -2,6 +2,7 @@
 
 namespace ExampleCreateNew {
     use Shopware\Core\Checkout\Cart\SalesChannel\CartService;
+    use Shopware\Core\System\SalesChannel\SalesChannelContext;
     use Symfony\Component\Routing\Annotation\Route;
 
     class NewCartController
@@ -12,11 +13,11 @@ namespace ExampleCreateNew {
         /**
          * @Route("/", name="cart.test")
          */
-        public function createNewCart(): void
+        public function createNewCart(SalesChannelContext $salesChannelContext): void
         {
             // Load the token through the request or from other sources
             $token = '596a70b408014230a140fd5d94d3402b';
-            $cart = $this->cartService->createNew($token);
+            $cart = $this->cartService->createNew($token, $salesChannelContext);
         }
     }
 } // code-example-end
@@ -213,7 +214,7 @@ namespace DocsTest {
             $controller = new NewCartController();
 
             $this->setUpController($controller);
-            $controller->createNewCart();
+            $controller->createNewCart($this->getSalesChannelContext());
 
             static::assertTrue(true); //indicate all went well
         }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/community).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?

- With this change, the SalesChannel is available in the CartCreatedEvent

### 2. What does this change do, exactly?

- add SalesChannel Property to CartCreatedEvent and updates all places where the event is created explicitly or implicitly

### 3. Describe each step to reproduce the issue or behaviour.

- add an Subscriber for the CartCreatedEvent an you will get the SalesChannel from the event

### 4. Please link to the relevant issues (if any).

- NO ISSUE

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
