### PR TITLE
* fix ansi quotes in mysql statement by using simple single quotes

### DIFF
--- a/.github/setup-db.sh
+++ b/.github/setup-db.sh
@@ -5,7 +5,7 @@ STARTPARAMS=""
 DB=$1
 
 if [[ $DB == "mysql:8.0.19" ]]; then
-    STARTPARAMS="mysqld --default-authentication-plugin=mysql_native_password"
+    STARTPARAMS="mysqld --default-authentication-plugin=mysql_native_password --ansi"
 fi
 
 docker run -it --mount type=tmpfs,destination=/var/lib/mysql --name=mysqld -d -e MYSQL_ROOT_PASSWORD=shopware -e MYSQL_DATABASE=shopware -p3306:3306 ${DB} ${STARTPARAMS}

--- a/src/Storefront/Framework/Routing/RequestTransformer.php
+++ b/src/Storefront/Framework/Routing/RequestTransformer.php
@@ -381,8 +381,8 @@ class RequestTransformer implements RequestTransformerInterface
         $statement = $this->connection->createQueryBuilder()
             ->select(
                 [
-                    'CONCAT(TRIM(TRAILING "/" FROM domain.url), "/") `key`',
-                    'CONCAT(TRIM(TRAILING "/" FROM domain.url), "/") url',
+                    'CONCAT(TRIM(TRAILING \'/\' FROM domain.url), \'/\') `key`',
+                    'CONCAT(TRIM(TRAILING \'/\' FROM domain.url), \'/\') url',
                     'LOWER(HEX(domain.id)) id',
                     'LOWER(HEX(sales_channel.id)) salesChannelId',
                     'LOWER(HEX(sales_channel.type_id)) typeId',


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/community).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
Fixes ansi quotes in this mysql statement in order to support for instance managed Digital Ocean databases by using escaped single quotes.

https://www.digitalocean.com/community/questions/sql-requests-with-double-quotes-not-working-with-managed-database

### 2. What does this change do, exactly?
Fixes an error in stricter managed databases where you don't have access to change the sqlmode

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/NEXT-9920

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
