### PR TITLE
Get settings from translated

### DIFF
--- a/src/Core/Content/ContactForm/SalesChannel/ContactFormRoute.php
+++ b/src/Core/Content/ContactForm/SalesChannel/ContactFormRoute.php
@@ -98,8 +98,8 @@ class ContactFormRoute extends AbstractContactFormRoute
             if ($slotId) {
                 $criteria = new Criteria([$slotId]);
                 $slot = $this->cmsSlotRepository->search($criteria, $context->getContext());
-                $receivers = $slot->getEntities()->first()->get('config')['mailReceiver']['value'];
-                $message = $slot->getEntities()->first()->get('config')['confirmationText']['value'];
+                $receivers = $slot->getEntities()->first()->get('translated')['config']['mailReceiver']['value'];
+                $message = $slot->getEntities()->first()->get('translated')['config']['confirmationText']['value'];
             }
         }
 


### PR DESCRIPTION
### 1. Why is this change necessary?
At this moment the contact form gives error 500

### 2. What does this change do, exactly?
Change the data get from config to translated config

### 3. Describe each step to reproduce the issue or behaviour.
Open Shopping experience;
add page
Lading page
Add form block
Settings: Contact
Change Reciever to other mail

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
