### PR TITLE
Replace AjaxModalExtensionUtil with UrlModalPlugin

### DIFF
--- a/src/Docs/Resources/current/50-how-to/760-open-widget-pages-in-modal.md
+++ b/src/Docs/Resources/current/50-how-to/760-open-widget-pages-in-modal.md
@@ -1,0 +1,50 @@
+[titleEn]: <>(Open widget pages in modal)
+[metaDescriptionEn]: <>(This HowTo will show you how to open a widget page)
+[hash]: <>(article:how_to_widget_pages_in_modal)
+
+## Overview
+
+This guide will show you how to open any page in a modal.
+
+## UrlModalPlugin
+
+This javascript plugin is automatically registered onto any element matching the selector `[data-toggle="modal"][data-url]`.
+It extends the already existing [Bootstrap feature](https://getbootstrap.com/docs/4.3/components/modal/#live-demo) how to work with modals by loading their content asynchronously and embed them later into a modal element.
+All you need to open up e.g. the info widget page about checkout information in a modal is:
+
+```html
+<a class="btn btn-info"
+   data-toggle="modal"
+   data-url="{{ path('frontend.cms.page', { id: shopware.config.core.basicInformation.shippingPaymentInfoPage }) }}"
+>
+    Open checkout notes
+</a>
+```
+
+The content of the loaded html does not need to ship styling or additional javascript as the storefront PluginManager is invoked and the HTML in the response is directly added to the DOM of the current page.
+This way you can take advantage of the already loaded stylesheets and javascript and furthermore reduce the response to the content to be displayed.
+
+## Additional configuration
+
+When you want to apply further styles or scripts to the modal you can let it automatically get a class added to its main element.
+This can be changed with either a plugin option or a data attribute:
+
+```html
+<a class="btn btn-info"
+   data-toggle="modal"
+   data-url="{{ path('frontend.cms.page', { id: shopware.config.core.basicInformation.shippingPaymentInfoPage }) }}"
+   data-modal-class="fancy-class" 
+>
+    Open checkout notes
+</a>
+```
+or
+```html
+<a class="btn btn-info"
+   data-toggle="modal"
+   data-url="{{ path('frontend.cms.page', { id: shopware.config.core.basicInformation.shippingPaymentInfoPage }) }}"
+   data-url-modal-plugin-options='{{ { modalClass: "fancy-class" }|json_encode }}'
+>
+    Open checkout notes
+</a>
+```

--- a/src/Storefront/Resources/app/storefront/src/main.js
+++ b/src/Storefront/Resources/app/storefront/src/main.js
@@ -83,6 +83,7 @@ import WishlistWidgetPlugin from 'src/plugin/header/wishlist-widget.plugin';
 import WishlistLocalStoragePlugin from 'src/plugin/wishlist/local-wishlist.plugin';
 import WishlistPersistStoragePlugin from 'src/plugin/wishlist/persist-wishlist.plugin';
 import AddToWishlistPlugin from 'src/plugin/wishlist/add-to-wishlist.plugin';
+import UrlModalPlugin from 'src/plugin/url-modal/url-modal.plugin';
 
 window.eventEmitter = new NativeEventEmitter();
 
@@ -161,6 +162,8 @@ PluginManager.register('Ellipsis', EllipsisPlugin, '[data-ellipsis]');
 PluginManager.register('SwagBlockLink', SwagBlockLink, '[href="#not-found"]');
 PluginManager.register('ClearInput', ClearInputPlugin, '[data-clear-input]');
 PluginManager.register('CmsGdprVideoElement', CmsGdprVideoElement, '[data-cms-gdpr-video-element]');
+PluginManager.register('ClearInput', ClearInputPlugin, '[data-clear-input]')
+PluginManager.register('UrlModal', UrlModalPlugin, '[data-toggle="modal"][data-url]');
 
 if (window.csrf.enabled && window.csrf.mode === 'ajax') {
     PluginManager.register('FormCsrfHandler', FormCsrfHandlerPlugin, '[data-form-csrf-handler]');
@@ -187,8 +190,6 @@ document.addEventListener('readystatechange', (event) => {
 /*
 run utils
 */
-new AjaxModalExtensionUtil();
-
 new TimezoneUtil();
 
 new TooltipUtil();

--- a/src/Storefront/Resources/app/storefront/src/plugin/cookie/cookie-configuration.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/cookie/cookie-configuration.plugin.js
@@ -23,7 +23,6 @@ import Plugin from 'src/plugin-system/plugin.class';
 import CookieStorage from 'src/helper/storage/cookie-storage.helper';
 import AjaxOffCanvas from 'src/plugin/offcanvas/ajax-offcanvas.plugin';
 import OffCanvas from 'src/plugin/offcanvas/offcanvas.plugin';
-import AjaxModalExtension from 'src/utility/modal-extension/ajax-modal-extension.util';
 
 // this event will be published via a global (document) EventEmitter
 export const COOKIE_CONFIGURATION_UPDATE = 'CookieConfiguration_Update';
@@ -53,8 +52,6 @@ export default class CookieConfiguration extends Plugin {
             active: [],
             inactive: []
         };
-
-        this.ajaxModalExtension = null;
 
         this._registerEvents();
     }
@@ -180,8 +177,6 @@ export default class CookieConfiguration extends Plugin {
     closeOffCanvas(callback) {
         AjaxOffCanvas.close();
 
-        this.ajaxModalExtension = null;
-
         if (typeof callback === 'function') {
             callback();
         }
@@ -195,10 +190,8 @@ export default class CookieConfiguration extends Plugin {
      */
     _onOffCanvasOpened(callback) {
         this._registerOffCanvasEvents();
-
-        this.ajaxModalExtension = new AjaxModalExtension(false);
-
         this._setInitialState();
+        PluginManager.initializePlugins();
 
         if (typeof callback === 'function') {
             callback();

--- a/src/Storefront/Resources/app/storefront/src/plugin/url-modal/url-modal.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/url-modal/url-modal.plugin.js
@@ -1,0 +1,84 @@
+import HttpClient from 'src/service/http-client.service';
+import Plugin from 'src/plugin-system/plugin.class';
+import PluginManager from 'src/plugin-system/plugin.manager';
+import PageLoadingIndicatorUtil from 'src/utility/loading-indicator/page-loading-indicator.util';
+import DeviceDetection from 'src/helper/device-detection.helper';
+import DomAccess from 'src/helper/dom-access.helper';
+import PseudoModalUtil from 'src/utility/modal-extension/pseudo-modal.util';
+
+/**
+ * This class extends the Bootstrap modal functionality by
+ * adding an event listener to modal triggers that contain
+ * a special "data-url" attribute which is needed to load
+ * the modal content by AJAX
+ *
+ * Notice: The response template needs to have the markup as defined in the Bootstrap docs
+ * https://getbootstrap.com/docs/4.3/components/modal/#live-demo
+ */
+export default class UrlModalPlugin extends Plugin {
+
+    static options = {
+        modalBackdrop: true,
+
+        urlAttribute: 'data-url',
+
+        modalClassAttribute: 'data-modal-class',
+
+        modalClass: null
+    };
+
+    init() {
+        this._registerEvents();
+    }
+
+    /**
+     * Register events
+     * @private
+     */
+    _registerEvents() {
+        const eventType = (DeviceDetection.isTouchDevice()) ? 'touchend' : 'click';
+
+        this.el.removeEventListener('click', this._onClickHandleAjaxModal.bind(this));
+        this.el.removeEventListener('touchend', this._onClickHandleAjaxModal.bind(this));
+        this.el.addEventListener(eventType, this._onClickHandleAjaxModal.bind(this));
+    }
+
+    /**
+     * When clicking/touching the modal trigger the button shall
+     * show a loading indicator and an AJAX request needs to be triggered.
+     * The response then has to be placed inside the modal which will show up.
+     * @param {Event} event
+     * @private
+     */
+    _onClickHandleAjaxModal(event) {
+        event.preventDefault();
+        event.stopPropagation();
+        PageLoadingIndicatorUtil.create(this.options.modalBackdrop);
+
+        const client = new HttpClient();
+        const url = DomAccess.getAttribute(this.el, this.options.urlAttribute);
+        const modalClasses = [DomAccess.getAttribute(this.el, this.options.modalClassAttribute), this.options.modalClass];
+
+        client.get(url, response => this._openModal(response, modalClasses));
+    }
+
+    /**
+     * Opens the ajax modal
+     * If called from within a offcanvas, the existing backdrop should not be removed by the PageLoadingIndicatorUtils
+     *
+     * @param response
+     * @param {Array<String>} classes
+     * @private
+     */
+    _openModal(response, classes) {
+        PageLoadingIndicatorUtil.remove(this.options.modalBackdrop);
+        const pseudoModal = new PseudoModalUtil(response, this.options.modalBackdrop);
+
+        pseudoModal.open(() => {
+            const modal = pseudoModal.getModal();
+            modal.classList.add(...classes);
+            PluginManager.initializePlugins();
+            this.$emitter.publish('urlModalShow', { modal });
+        });
+    }
+}

--- a/src/Storefront/Resources/app/storefront/src/utility/modal-extension/ajax-modal-extension.util.js
+++ b/src/Storefront/Resources/app/storefront/src/utility/modal-extension/ajax-modal-extension.util.js
@@ -15,6 +15,8 @@ const URL_DATA_ATTRIBUTE = 'data-url';
  *
  * Notice: The response template needs to have the markup as defined in the Bootstrap docs
  * https://getbootstrap.com/docs/4.3/components/modal/#live-demo
+ *
+ * @deprecated tag:v6.4.0 - Use UrlModalPlugin instead
  */
 export default class AjaxModalExtensionUtil {
 
@@ -22,6 +24,7 @@ export default class AjaxModalExtensionUtil {
      * Constructor.
      */
     constructor(modalBackdrop = true) {
+        console.warn('Using the AjaxModalExtensionUtil is deprecated and will be removed in 6.4.0. Use UrlModalPlugin instead');
         this._client = new HttpClient();
         this.useModalBackdrop = modalBackdrop;
 


### PR DESCRIPTION
### 1. Why is this change necessary?
The AjaxModalExtensionUtil is added event handlers to everything its selector matches globally everytime it is instantiated. This leads to some bugs when using the CookieManager or custom invokes of the AjaxModalExtensionUtil.

### 2. What does this change do, exactly?
1. Deprecate AjaxModalExtensionUtil and stops using it
2. Use the UrlModalPlugin instead
3. Add docs how to do modals properly

### 3. Describe each step to reproduce the issue or behaviour.
1. Visit [shopwaredemo.store](https://shopwaredemo.store)
2. Open the cookie configuration
3. Close the cookie configuration
4. Open a modal like the contact form (misconfigured on shopwaredemo.store)
5. See it open twice
![duplicate-open-modal-handler-low-fps](https://user-images.githubusercontent.com/1133593/89073765-652b5c00-d37b-11ea-979d-8b6d88a82fd5.gif)


### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
