### PR TITLE
Add own (and other well known) IP address to maintenance mode

### DIFF
--- a/src/Administration/Controller/AdministrationController.php
+++ b/src/Administration/Controller/AdministrationController.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Administration\Controller;
 
+use Shopware\Administration\KnownIps\KnownIpsCollector;
 use Shopware\Administration\Snippet\SnippetFinderInterface;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Adapter\Twig\TemplateFinder;
@@ -34,16 +35,23 @@ class AdministrationController extends AbstractController
 
     private $supportedApiVersions;
 
+    /**
+     * @var KnownIpsCollector
+     */
+    private $knownIpsCollector;
+
     public function __construct(
         TemplateFinder $finder,
         FirstRunWizardClient $firstRunWizardClient,
         SnippetFinderInterface $snippetFinder,
-        $supportedApiVersions
+        $supportedApiVersions,
+        KnownIpsCollector $knownIpsCollector
     ) {
         $this->finder = $finder;
         $this->firstRunWizardClient = $firstRunWizardClient;
         $this->snippetFinder = $snippetFinder;
         $this->supportedApiVersions = $supportedApiVersions;
+        $this->knownIpsCollector = $knownIpsCollector;
     }
 
     /**
@@ -80,6 +88,24 @@ class AdministrationController extends AbstractController
         }
 
         return new JsonResponse($snippets);
+    }
+
+    /**
+     * @RouteScope(scopes={"administration"})
+     * @Route("/api/v{version}/_admin/known-ips", name="api.admin.known-ips", methods={"GET"})
+     */
+    public function knownIps(Request $request): Response
+    {
+        $ips = [];
+
+        foreach ($this->knownIpsCollector->collectIps($request) as $ip => $name) {
+            $ips[] = [
+                'name' => $name,
+                'value' => $ip,
+            ];
+        }
+
+        return new JsonResponse(['ips' => $ips]);
     }
 
     private function getLatestApiVersion(): int

--- a/src/Administration/DependencyInjection/services.xml
+++ b/src/Administration/DependencyInjection/services.xml
@@ -16,6 +16,7 @@
             <argument type="service" id="Shopware\Core\Framework\Store\Services\FirstRunWizardClient"/>
             <argument type="service" id="Shopware\Administration\Snippet\SnippetFinder"/>
             <argument>%kernel.supported_api_versions%</argument>
+            <argument type="service" id="Shopware\Administration\KnownIps\KnownIpsCollector"/>
             <call method="setContainer">
                 <argument type="service" id="service_container"/>
             </call>
@@ -33,5 +34,7 @@
             <argument type="service" id="Shopware\Administration\Snippet\CachedSnippetFinder.inner" />
             <argument type="service" id="cache.object" />
         </service>
+
+        <service id="Shopware\Administration\KnownIps\KnownIpsCollector"/>
     </services>
 </container>

--- a/src/Administration/KnownIps/KnownIpsCollector.php
+++ b/src/Administration/KnownIps/KnownIpsCollector.php
@@ -1,0 +1,31 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Administration\KnownIps;
+
+use Shopware\Core\System\Annotation\Concept\ExtensionPattern\Decoratable;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * @Decoratable()
+ */
+class KnownIpsCollector
+{
+    /**
+     * The result is mapped as ip => name|snippet-key. So by default it will look like this:
+     * <code>
+     *     [
+     *         '127.0.0.1' => 'global.sw-multi-tag-ip-select.knownIps.you'
+     *     ]
+     * </code>
+     */
+    public function collectIps(Request $request): array
+    {
+        $result = [];
+
+        if ($request->getClientIp()) {
+            $result[$request->getClientIp()] = 'global.sw-multi-tag-ip-select.knownIps.you';
+        }
+
+        return $result;
+    }
+}

--- a/src/Administration/Resources/app/administration/src/app/component/form/select/base/sw-multi-tag-ip-select/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/form/select/base/sw-multi-tag-ip-select/index.js
@@ -22,6 +22,12 @@ Component.extend('sw-multi-tag-ip-select', 'sw-multi-tag-select', {
             type: Function,
             required: false,
             default: searchTerm => string.isValidIp(searchTerm)
+        },
+
+        knownIps: {
+            type: Array,
+            required: false,
+            default: []
         }
     },
 
@@ -30,6 +36,31 @@ Component.extend('sw-multi-tag-ip-select', 'sw-multi-tag-select', {
             const err = !this.inputIsValid && this.searchTerm.length > 0;
 
             return err ? { code: 'SHOPWARE_INVALID_IP' } : null;
+        },
+
+        validKnownIps() {
+            return this.knownIps.filter(ip => string.isValidIp(ip.value));
+        },
+
+        validUnselectedKnownIps() {
+            return this.validKnownIps.filter(ip => this.value.indexOf(ip.value) === -1);
+        }
+    },
+
+    methods: {
+        addSpecific(value) {
+            this.searchTerm = value;
+            this.addItem();
+        },
+
+        getKnownIp(ip) {
+            const index = this.validKnownIps.findIndex(knownIp => knownIp.value === ip.value);
+
+            if (index === -1) {
+                return null;
+            }
+
+            return this.validKnownIps[index];
         }
     }
 });

--- a/src/Administration/Resources/app/administration/src/app/component/form/select/base/sw-multi-tag-ip-select/sw-multi-tag-ip-select.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/form/select/base/sw-multi-tag-ip-select/sw-multi-tag-ip-select.html.twig
@@ -5,3 +5,28 @@
 {% block sw_multi_tag_select_validation_invalid_message %}
     {{ $tc('global.sw-multi-tag-ip-select.enterValidIp') }}
 {% endblock %}
+
+{% block sw_multi_tag_select_validation_invalid %}
+    {% parent %}
+
+    <div
+        @click="addSpecific(knownIp.value)"
+        v-for="knownIp of validUnselectedKnownIps"
+        class="sw-multi-tag-select-valid"
+    >
+        <span>
+            {{ knownIp.value }} ({{ $te(knownIp.name) ? $tc(knownIp.name) : knownIp.name }})
+        </span>
+    </div>
+{% endblock %}
+
+{% block sw_multi_tag_select_base_selection_list_label_inner %}
+    <template v-if="getKnownIp(item)">
+        <slot name="selection-label-property" v-bind="{ item, index, labelProperty, valueProperty}">
+            {{ getKey(item, labelProperty) }} ({{ $te(getKnownIp(item).name) ? $tc(getKnownIp(item).name) : getKnownIp(item).name }})
+        </slot>
+    </template>
+    <template v-else>
+        {% parent %}
+    </template>
+{% endblock %}

--- a/src/Administration/Resources/app/administration/src/app/snippet/de-DE.json
+++ b/src/Administration/Resources/app/administration/src/app/snippet/de-DE.json
@@ -445,7 +445,10 @@
     },
     "sw-multi-tag-ip-select": {
       "enterValidIp": "Bitte gib eine valide IPv4- oder IPv6-Adresse ein",
-      "addIpAdress": "IP-Adresse hinzufügen"
+      "addIpAdress": "IP-Adresse hinzufügen",
+      "knownIps": {
+        "you": "Du"
+      }
     },
     "sw-multi-ip-select": {
       "enterValidIp": "Bitte gib eine valide IPv4- oder IPv6-Adresse ein",

--- a/src/Administration/Resources/app/administration/src/app/snippet/en-GB.json
+++ b/src/Administration/Resources/app/administration/src/app/snippet/en-GB.json
@@ -446,7 +446,10 @@
     },
     "sw-multi-tag-ip-select": {
       "enterValidIp": "Please enter a valid IPv4 or IPv6 address",
-      "addIpAdress": "Add IP address"
+      "addIpAdress": "Add IP address",
+      "knownIps": {
+        "you": "You"
+      }
     },
     "sw-multi-ip-select": {
       "enterValidIp": "Please enter a valid IPv4 or IPv6 address",

--- a/src/Administration/Resources/app/administration/src/core/service/api/known-ips.api.service.js
+++ b/src/Administration/Resources/app/administration/src/core/service/api/known-ips.api.service.js
@@ -1,0 +1,30 @@
+import ApiService from '../api.service';
+
+/**
+ * @class
+ * @extends ApiService
+ */
+class KnownIpsApiService extends ApiService {
+    constructor(httpClient, loginService, apiEndpoint = 'known-ips') {
+        super(httpClient, loginService, apiEndpoint);
+        this.name = 'knownIpsService';
+    }
+
+    /**
+     * Get snippets
+     *
+     * @returns {Promise<Array<{name: String, value: String}>>}
+     */
+    getKnownIps() {
+        const headers = this.getBasicHeaders();
+
+        return this.httpClient
+            .get('/_admin/known-ips', {
+                headers
+            }).then(response => {
+                return response.data.ips;
+            });
+    }
+}
+
+export default KnownIpsApiService;

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/view/sw-sales-channel-detail-base/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/view/sw-sales-channel-detail-base/index.js
@@ -20,7 +20,8 @@ Component.register('sw-sales-channel-detail-base', {
     inject: [
         'salesChannelService',
         'productExportService',
-        'repositoryFactory'
+        'repositoryFactory',
+        'knownIpsService'
     ],
 
     props: {
@@ -86,8 +87,15 @@ Component.register('sw-sales-channel-detail-base', {
             selectedStorefrontSalesChannel: null,
             invalidFileName: false,
             isFileNameChecking: false,
-            disableGenerateByCronjob: false
+            disableGenerateByCronjob: false,
+            knownIps: []
         };
+    },
+
+    created() {
+        this.knownIpsService.getKnownIps().then(ips => {
+            this.knownIps = ips;
+        });
     },
 
     computed: {

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/view/sw-sales-channel-detail-base/sw-sales-channel-detail-base.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/view/sw-sales-channel-detail-base/sw-sales-channel-detail-base.html.twig
@@ -483,6 +483,7 @@
                         class="sw-order-user-card__tag-select"
                         :label="$tc('sw-sales-channel.detail.ipAddressWhitleList')"
                         :helpText="$tc('sw-sales-channel.detail.ipAddressWhitleListHelpText')"
+                        :knownIps="knownIps"
                         v-model="maintenanceIpWhitelist">
                     </sw-multi-tag-ip-select>
                 {% endblock %}


### PR DESCRIPTION
### 1. Why is this change necessary?
This way you can simply add your own IP to the maintenance mode without looking it up.
![known-ip-address](https://user-images.githubusercontent.com/1133593/89110075-4a261e00-d447-11ea-95c0-b26999349f3e.gif)

### 2. What does this change do, exactly?
Adds a route with page loader with an event as entrypoint to add custom known IPs by other plugins.
One known IP that is implemented by default is the same IP address source that is checked in the maintenance mode for the whitelisting.

### 3. Describe each step to reproduce the issue or behaviour.
1. Start maintenance mode
2. Go to pages like [myip.is](https://myip.is) to look for my own IP
3. Enter it into the whitelisted IP addresses
4. Load shop and be not whitelisted
5. Realize I am in a VPN to that shop and have a different IP address to it
6. Lookup OpenVPN for my IP address
7. Enter my VPN IP address into the whitelisted IP addresses

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
