### PR TITLE
Add products per page selection in listing

### DIFF
--- a/changelog/_unreleased/2020-08-03-add-products-per-page-selection-in-listing.md
+++ b/changelog/_unreleased/2020-08-03-add-products-per-page-selection-in-listing.md
@@ -1,0 +1,12 @@
+---
+title: Add products per page selection in listing
+author: Joshua Behrens
+author_email: code@joshua-behrens.de
+author_github: @JoshuaBehrens
+---
+# Admin
+* Added setting to set the allowed product count steps that are selectable in the storefront
+___
+# Storefront
+* Added a dropdown with different product counts for user choice to change
+___

--- a/src/Core/System/Resources/config/listing.xml
+++ b/src/Core/System/Resources/config/listing.xml
@@ -53,5 +53,14 @@
             <helpText lang="de-DE">Die Anzahl der Produkte die auf einer Suchseite oder in einer Produktliste je Seite in der Storefront angezeigt werden.</helpText>
             <min>1</min>
         </input-field>
+
+        <input-field>
+            <name>productCountSteps</name>
+            <label>Products/page</label>
+            <label lang="de-DE">Produkte/Seite</label>
+            <helpText>Integers starting from 1, separated by commas.</helpText>
+            <helpText lang="de-DE">Ganzzahlen ab 1, getrennt mit Kommas.</helpText>
+            <defaultValue>24,36,48</defaultValue>
+        </input-field>
     </card>
 </config>

--- a/src/Storefront/Resources/app/storefront/src/plugin/listing/listing-pagination.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/listing/listing-pagination.plugin.js
@@ -5,12 +5,15 @@ import deepmerge from 'deepmerge';
 export default class ListingPaginationPlugin extends FilterBasePlugin {
 
     static options = deepmerge(FilterBasePlugin.options, {
-        page: 1
+        page: 1,
+        limit: 24
     });
 
     init() {
         this._initButtons();
-        this.tempValue = null;
+        this._initLimitSelection();
+        this.tempPage = null;
+        this.tempLimit = null;
     }
 
     _initButtons() {
@@ -18,6 +21,14 @@ export default class ListingPaginationPlugin extends FilterBasePlugin {
 
         if (this.buttons) {
             this._registerButtonEvents();
+        }
+    }
+
+    _initLimitSelection() {
+        this.limitSelections = DomAccess.querySelectorAll(this.el,  '.product-count select', false);
+
+        if (this.limitSelections) {
+            this._registerLimitSelectionEvents();
         }
     }
 
@@ -30,10 +41,25 @@ export default class ListingPaginationPlugin extends FilterBasePlugin {
         });
     }
 
+    /**
+     * @private
+     */
+    _registerLimitSelectionEvents() {
+        this.limitSelections.forEach(select => {
+            select.addEventListener('change', this.onChangeProductCount.bind(this));
+        });
+    }
+
     onChangePage(event) {
-        this.tempValue = event.target.value;
+        this.tempPage = event.target.value;
         this.listing.changeListing();
-        this.tempValue = null;
+        this.tempPage = null;
+    }
+
+    onChangeProductCount(event) {
+        this.tempLimit = event.target.value;
+        this.listing.changeListing();
+        this.tempLimit = null;
     }
 
     /**
@@ -53,14 +79,22 @@ export default class ListingPaginationPlugin extends FilterBasePlugin {
      * @public
      */
     getValues() {
-        if (this.tempValue !== null) {
-            return { p: this.tempValue };
+        const result = {};
+
+        if (this.tempPage !== null) {
+            result.p = this.tempPage;
         }
-        return { p: 1 };
+
+        if (this.tempLimit !== null) {
+            result.limit = this.tempLimit;
+        }
+
+        return result;
     }
 
     afterContentChange() {
         this._initButtons();
+        this._initLimitSelection();
     }
 
     /**

--- a/src/Storefront/Resources/snippet/de_DE/storefront.de-DE.json
+++ b/src/Storefront/Resources/snippet/de_DE/storefront.de-DE.json
@@ -34,6 +34,7 @@
     "maintenanceModeHeader": "Wartungsmodus",
     "maintenanceModeDescription": "Wir aktualisieren derzeit die Inhalte dieser Seite. Bitte schauen Sie später wieder vorbei.",
     "sortingLabel": "Sortierung",
+    "productCountLabel": "Produkte/Seite",
     "next": "Nächstes",
     "previous": "Vorheriges",
     "formSubmit": "Absenden"

--- a/src/Storefront/Resources/snippet/en_GB/storefront.en-GB.json
+++ b/src/Storefront/Resources/snippet/en_GB/storefront.en-GB.json
@@ -34,6 +34,7 @@
     "maintenanceModeHeader": "Maintenance mode",
     "maintenanceModeDescription": "We are currently updating this site. Please check back later.",
     "sortingLabel": "Sorting",
+    "productCountLabel": "Products/page",
     "next": "Next",
     "previous": "Previous",
     "formSubmit": "Submit"

--- a/src/Storefront/Resources/views/storefront/component/pagination.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/pagination.html.twig
@@ -1,156 +1,188 @@
 {% block component_pagination_nav %}
+    {# @var criteria \Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria #}
     {% set currentPage = ((criteria.offset + 1) / criteria.limit )|round(0, 'ceil') %}
     {% set totalPages = (entities.total / criteria.limit)|round(0, 'ceil') %}
 
     {% if totalPages > 1 %}
         <nav aria-label="pagination" class="pagination-nav">
             {% block component_pagination %}
-            <ul class="pagination">
-                {% block component_pagination_first %}
-                    <li class="page-item page-first{% if currentPage == 1 %} disabled{% endif %}">
-                        {% block component_pagination_first_input %}
-                            <input type="radio"
-                                   {% if currentPage == 1 %}disabled="disabled"{% endif %}
-                                   name="p"
-                                   id="p-first"
-                                   value="1"
-                                   class="d-none"
-                                   title="pagination">
-                        {% endblock %}
+                <ul class="pagination">
+                    {% block component_pagination_first %}
+                        <li class="page-item page-first{% if currentPage == 1 %} disabled{% endif %}">
+                            {% block component_pagination_first_input %}
+                                <input type="radio"
+                                       {% if currentPage == 1 %}disabled="disabled"{% endif %}
+                                       name="p"
+                                       id="p-first"
+                                       value="1"
+                                       class="d-none"
+                                       title="pagination">
+                            {% endblock %}
 
-                        {% block component_pagination_first_label %}
-                            <label class="page-link" for="p-first">
-                                {% block component_pagination_first_link %}
-                                    {% sw_icon 'arrow-medium-double-left' style { 'size': 'fluid', 'pack': 'solid'} %}
-                                {% endblock %}
-                            </label>
-                        {% endblock %}
-                    </li>
-                {% endblock %}
-
-                {% block component_pagination_prev %}
-                    <li class="page-item page-prev{% if currentPage == 1 %} disabled{% endif %}">
-                        {% block component_pagination_prev_input %}
-                            <input type="radio"
-                                   {% if currentPage == 1 %}disabled="disabled"{% endif %}
-                                   name="p"
-                                   id="p-prev"
-                                   value="{{ currentPage - 1 }}"
-                                   class="d-none"
-                                   title="pagination">
-                        {% endblock %}
-
-                        {% block component_pagination_prev_label %}
-                            <label class="page-link" for="p-prev">
-                                {% block component_pagination_prev_link %}
-                                    {% block component_pagination_prev_icon %}
-                                        {% sw_icon 'arrow-medium-left' style {'size': 'fluid', 'pack': 'solid'} %}
+                            {% block component_pagination_first_label %}
+                                <label class="page-link" for="p-first">
+                                    {% block component_pagination_first_link %}
+                                        {% sw_icon 'arrow-medium-double-left' style { 'size': 'fluid', 'pack': 'solid'} %}
                                     {% endblock %}
-                                {% endblock %}
-                            </label>
-                        {% endblock %}
-                    </li>
-                {% endblock %}
+                                </label>
+                            {% endblock %}
+                        </li>
+                    {% endblock %}
 
-                {% block component_pagination_loop %}
-                    {% set start = currentPage - 2 %}
-                    {% if start <= 0 %}
-                        {% set start = currentPage - 1 %}
-                        {% if start <= 0 %}
-                            {% set start = currentPage %}
-                        {% endif %}
-                    {% endif %}
+                    {% block component_pagination_prev %}
+                        <li class="page-item page-prev{% if currentPage == 1 %} disabled{% endif %}">
+                            {% block component_pagination_prev_input %}
+                                <input type="radio"
+                                       {% if currentPage == 1 %}disabled="disabled"{% endif %}
+                                       name="p"
+                                       id="p-prev"
+                                       value="{{ currentPage - 1 }}"
+                                       class="d-none"
+                                       title="pagination">
+                            {% endblock %}
 
-                    {% set end = start + 4 %}
-
-                    {% if end > totalPages %}
-                        {% set end = totalPages %}
-                    {% endif %}
-
-                    {% for page in start..end %}
-
-                        {% set isActive = (currentPage == page) %}
-
-                        {% block component_pagination_item %}
-                            <li class="page-item{% if isActive %} active{% endif %}">
-                                {% block component_pagination_item_input %}
-                                    <input type="radio"
-                                           name="p"
-                                           id="p{{ page }}"
-                                           value="{{ page }}"
-                                           class="d-none"
-                                           title="pagination"
-                                           {% if isActive %}checked="checked"{% endif %}>
-                                {% endblock %}
-
-                                {% block component_pagination_item_label %}
-                                    <label class="page-link"
-                                           for="p{{ page }}">
-                                        {% block component_pagination_item_link %}
-                                            {% block component_pagination_item_text %}
-                                                {{ page }}
-                                            {% endblock %}
+                            {% block component_pagination_prev_label %}
+                                <label class="page-link" for="p-prev">
+                                    {% block component_pagination_prev_link %}
+                                        {% block component_pagination_prev_icon %}
+                                            {% sw_icon 'arrow-medium-left' style {'size': 'fluid', 'pack': 'solid'} %}
                                         {% endblock %}
-                                    </label>
-                                {% endblock %}
-                            </li>
-                        {% endblock %}
-
-                    {% endfor %}
-                {% endblock %}
-
-                {% block component_pagination_next %}
-                    <li class="page-item page-next{% if currentPage == totalPages %} disabled{% endif %}">
-                        {% block component_pagination_next_input %}
-                            <input type="radio"
-                                   {% if currentPage == totalPages %}disabled="disabled"{% endif %}
-                                   name="p"
-                                   id="p-next"
-                                   value="{{ currentPage + 1 }}"
-                                   class="d-none"
-                                   title="pagination">
-                        {% endblock %}
-
-                        {% block component_pagination_next_label %}
-                            <label class="page-link" for="p-next">
-                                {% block component_pagination_next_link %}
-                                    {% block component_pagination_next_icon %}
-                                        {% sw_icon 'arrow-medium-right' style { 'size': 'fluid', 'pack': 'solid'} %}
                                     {% endblock %}
-                                {% endblock %}
+                                </label>
+                            {% endblock %}
+                        </li>
+                    {% endblock %}
+
+                    {% block component_pagination_loop %}
+                        {% set start = currentPage - 2 %}
+                        {% if start <= 0 %}
+                            {% set start = currentPage - 1 %}
+                            {% if start <= 0 %}
+                                {% set start = currentPage %}
+                            {% endif %}
+                        {% endif %}
+
+                        {% set end = start + 4 %}
+
+                        {% if end > totalPages %}
+                            {% set end = totalPages %}
+                        {% endif %}
+
+                        {% for page in start..end %}
+
+                            {% set isActive = (currentPage == page) %}
+
+                            {% block component_pagination_item %}
+                                <li class="page-item{% if isActive %} active{% endif %}">
+                                    {% block component_pagination_item_input %}
+                                        <input type="radio"
+                                               name="p"
+                                               id="p{{ page }}"
+                                               value="{{ page }}"
+                                               class="d-none"
+                                               title="pagination"
+                                               {% if isActive %}checked="checked"{% endif %}>
+                                    {% endblock %}
+
+                                    {% block component_pagination_item_label %}
+                                        <label class="page-link"
+                                               for="p{{ page }}">
+                                            {% block component_pagination_item_link %}
+                                                {% block component_pagination_item_text %}
+                                                    {{ page }}
+                                                {% endblock %}
+                                            {% endblock %}
+                                        </label>
+                                    {% endblock %}
+                                </li>
+                            {% endblock %}
+
+                        {% endfor %}
+                    {% endblock %}
+
+                    {% block component_pagination_next %}
+                        <li class="page-item page-next{% if currentPage == totalPages %} disabled{% endif %}">
+                            {% block component_pagination_next_input %}
+                                <input type="radio"
+                                       {% if currentPage == totalPages %}disabled="disabled"{% endif %}
+                                       name="p"
+                                       id="p-next"
+                                       value="{{ currentPage + 1 }}"
+                                       class="d-none"
+                                       title="pagination">
+                            {% endblock %}
+
+                            {% block component_pagination_next_label %}
+                                <label class="page-link" for="p-next">
+                                    {% block component_pagination_next_link %}
+                                        {% block component_pagination_next_icon %}
+                                            {% sw_icon 'arrow-medium-right' style { 'size': 'fluid', 'pack': 'solid'} %}
+                                        {% endblock %}
+                                    {% endblock %}
+                                </label>
+                            {% endblock %}
+                        </li>
+                    {% endblock %}
+
+                    {% block component_pagination_last %}
+                        <li class="page-item page-last{% if currentPage == totalPages %} disabled{% endif %}">
+                            {% block component_pagination_last_input %}
+                                <input type="radio"
+                                       {% if currentPage == totalPages %}disabled="disabled"{% endif %}
+                                       name="p"
+                                       id="p-last"
+                                       value="{{ totalPages }}"
+                                       class="d-none"
+                                       title="pagination">
+                            {% endblock %}
+
+                            {% block component_pagination_last_label %}
+                                <label class="page-link" for="p-last">
+                                    {% block component_pagination_last_link %}
+                                        {% block component_pagination_last_icon %}
+                                            {% sw_icon 'arrow-medium-double-right' style {
+                                                'size': 'fluid',
+                                                'pack': 'solid'
+                                            } %}
+                                        {% endblock %}
+                                    {% endblock %}
+                                </label>
+                            {% endblock %}
+                        </li>
+                    {% endblock %}
+                </ul>
+            {% endblock %}
+
+            {% set productCountSteps = shopware.config.core.listing.productCountSteps|split(',') %}
+
+            {% if productCountSteps is not empty %}
+                {% block component_product_count %}
+                    <div class="product-count d-flex">
+                        {% block component_product_count_label %}
+                            <label for="limit" class="d-flex align-items-center mx-2">
+                                {{ 'general.productCountLabel'|trans }}
                             </label>
                         {% endblock %}
-                    </li>
-                {% endblock %}
 
-                {% block component_pagination_last %}
-                    <li class="page-item page-last{% if currentPage == totalPages %} disabled{% endif %}">
-                        {% block component_pagination_last_input %}
-                            <input type="radio"
-                                   {% if currentPage == totalPages %}disabled="disabled"{% endif %}
-                                   name="p"
-                                   id="p-last"
-                                   value="{{ totalPages }}"
-                                   class="d-none"
-                                   title="pagination">
-                        {% endblock %}
-
-                        {% block component_pagination_last_label %}
-                            <label class="page-link" for="p-last">
-                                {% block component_pagination_last_link %}
-                                    {% block component_pagination_last_icon %}
-                                        {% sw_icon 'arrow-medium-double-right' style {
-                                            'size': 'fluid',
-                                            'pack': 'solid'
-                                        } %}
+                        {% block component_product_count_input %}
+                            <select id="limit" class="custom-select" name="limit" aria-label="{{ 'general.productCountLabel'|trans|striptags }}">
+                                {% for step in productCountSteps %}
+                                    {% block component_product_count_input_option %}
+                                        <option
+                                            value="{{ step }}"
+                                            {% if criteria.limit == step %}selected="selected"{% endif %}
+                                        >
+                                            {% block component_product_count_input_option_text %}
+                                                {{ step }}
+                                            {% endblock %}
+                                        </option>
                                     {% endblock %}
-                                {% endblock %}
-                            </label>
+                                {% endfor %}
+                            </select>
                         {% endblock %}
-                    </li>
+                    </div>
                 {% endblock %}
-            </ul>
-        {% endblock %}
+            {% endif %}
         </nav>
     {% endif %}
 {% endblock %}

--- a/src/Storefront/Test/Controller/SearchControllerTest.php
+++ b/src/Storefront/Test/Controller/SearchControllerTest.php
@@ -3,8 +3,13 @@
 namespace Shopware\Storefront\Test\Controller;
 
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Product\Aggregate\ProductVisibility\ProductVisibilityDefinition;
+use Shopware\Core\Defaults;
+use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\System\SystemConfig\SystemConfigService;
 
 class SearchControllerTest extends TestCase
 {
@@ -24,6 +29,22 @@ class SearchControllerTest extends TestCase
         static::assertStringContainsString(htmlentities($term), $html);
     }
 
+    public function testProductCountSelection(): void
+    {
+        /** @var SystemConfigService $configService */
+        $configService = $this->getContainer()->get(SystemConfigService::class);
+        $configService->set('core.listing.productCountSteps', '12,24,36,48');
+        $this->createProductOnDatabase();
+        $browser = KernelLifecycleManager::createBrowser($this->getKernel());
+        $browser->request('GET', $_SERVER['APP_URL'] . '/search?search=count');
+        $html = $browser->getResponse()->getContent();
+
+        static::assertRegExp('#<select id="limit".*<option\s*value="12".*>\s*12\s*</option>.*</select>#sx', $html);
+        static::assertRegExp('#<select id="limit".*<option\s*value="24".*>\s*24\s*</option>.*</select>#sx', $html);
+        static::assertRegExp('#<select id="limit".*<option\s*value="36".*>\s*36\s*</option>.*</select>#sx', $html);
+        static::assertRegExp('#<select id="limit".*<option\s*value="48".*>\s*48\s*</option>.*</select>#sx', $html);
+    }
+
     public function getProviderInvalidTerms(): iterable
     {
         yield ['<h1 style="color:red">Test</h1>'];
@@ -36,5 +57,49 @@ class SearchControllerTest extends TestCase
         yield ['<script src=1 href=1 onerror="javascript:alert(1)"></script>'];
         yield ['<svg onResize svg onResize="javascript:javascript:alert(1)"></svg onResize>'];
         yield ['"/><img/onerror=\x0Ajavascript:alert(1)\x0Asrc=xxx:x />'];
+    }
+
+    private function createProductOnDatabase(): void
+    {
+        $taxId = Uuid::randomHex();
+        $context = Context::createDefaultContext();
+;
+        $this->getContainer()->get('product.repository')
+            ->create(\array_map(static function (int $counter) use ($taxId): array {
+                $productId = Uuid::randomHex();
+
+                return [
+                    'id' => $productId,
+                    'name' => 'Test count product ' . $counter,
+                    'productNumber' => $productId,
+                    'stock' => 1,
+                    'price' => [
+                        [
+                            'currencyId' => Defaults::CURRENCY,
+                            'gross' => 15.99,
+                            'net' => 10,
+                            'linked' => false,
+                        ],
+                    ],
+                    'tax' => [
+                        'id' => $taxId,
+                        'name' => 'testTaxRate',
+                        'taxRate' => 15,
+                    ],
+                    'categories' => [
+                        [
+                            'id' => $productId,
+                            'name' => 'Test category'
+                        ],
+                    ],
+                    'visibilities' => [
+                        [
+                            'id' => $productId,
+                            'salesChannelId' => Defaults::SALES_CHANNEL,
+                            'visibility' => ProductVisibilityDefinition::VISIBILITY_ALL,
+                        ],
+                    ],
+                ];
+            }, range(0, 100)), $context);
     }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?
There is already an interpretation of the limit parameter in the URL in the ProductListingFeaturesSubscriber but without any input selection.
https://github.com/shopware/platform/blob/7704106f4627996de0689b4ea91db58b1687f9ff/src/Core/Content/Product/SalesChannel/Listing/ProductListingFeaturesSubscriber.php#L496-L505

Now we have an input. (CSS help needed 😅 and a bigger upload limitations)
![change-limit-in-storefront](https://user-images.githubusercontent.com/1133593/89136040-e0367300-d531-11ea-8a6c-984ae4deda5f.gif)

### 2. What does this change do, exactly?
* Add a configuration for the steps
* Add selection input field
* Add javascript to react on field changes

### 3. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
