### PR TITLE
Add behaviour struct to allow controlling listing loader behaviour

### DIFF
--- a/src/Core/Content/Product/SalesChannel/Listing/ProductListingBehaviour.php
+++ b/src/Core/Content/Product/SalesChannel/Listing/ProductListingBehaviour.php
@@ -1,0 +1,24 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Content\Product\SalesChannel\Listing;
+
+use Shopware\Core\Framework\Struct\Struct;
+
+class ProductListingBehaviour extends Struct
+{
+    public const EXTENSION_NAME = 'behaviour';
+
+    protected $preferMainVariant = true;
+
+    public function isPreferMainVariant(): bool
+    {
+        return $this->preferMainVariant;
+    }
+
+    public function setPreferMainVariant(bool $preferMainVariant): self
+    {
+        $this->preferMainVariant = $preferMainVariant;
+
+        return $this;
+    }
+}

--- a/src/Core/Content/Product/SalesChannel/Listing/ProductListingLoader.php
+++ b/src/Core/Content/Product/SalesChannel/Listing/ProductListingLoader.php
@@ -72,7 +72,12 @@ class ProductListingLoader
 
         $mapping = array_combine($ids->getIds(), $ids->getIds());
 
-        if (!$this->hasOptionFilter($criteria)) {
+        $behaviour = $criteria->getExtensionOfType(
+            ProductListingBehaviour::EXTENSION_NAME,
+            ProductListingBehaviour::class
+        ) ?? new ProductListingBehaviour();
+
+        if (!$this->hasOptionFilter($criteria) && $behaviour->isPreferMainVariant()) {
             list($variantIds, $mapping) = $this->resolvePreviews($ids->getIds(), $context);
         }
 


### PR DESCRIPTION
### 1. Why is this change necessary?
It is not possible to have a slightly customized listing without the main variant set as "preview" without having an option related filter when main variants are set.

### 2. What does this change do, exactly?
Add a struct used as criteria extension (in contrast to a new parameter) to disable the preview building.

### 3. Describe each step to reproduce the issue or behaviour.
In my case I tried to make a variant-only listing by removing the group by and adding some other filters but the main variant id was set (and used in other scenarios, so I couldn't null it).

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
