### PR TITLE
Extract AccountOrderDetailPage from AccountOrderController

### DIFF
--- a/src/Storefront/DependencyInjection/controller.xml
+++ b/src/Storefront/DependencyInjection/controller.xml
@@ -9,13 +9,13 @@
 
         <service id="Shopware\Storefront\Controller\AccountOrderController">
             <argument type="service" id="Shopware\Storefront\Page\Account\Order\AccountOrderPageLoader"/>
-            <argument type="service" id="Shopware\Core\Checkout\Order\SalesChannel\OrderRoute"/>
             <argument type="service" id="Shopware\Storefront\Page\Account\Order\AccountEditOrderPageLoader"/>
             <argument type="service" id="Shopware\Core\System\SalesChannel\SalesChannel\ContextSwitchRoute"/>
             <argument type="service" id="Shopware\Core\Checkout\Order\SalesChannel\CancelOrderRoute"/>
             <argument type="service" id="Shopware\Core\Checkout\Order\SalesChannel\SetPaymentOrderRoute"/>
             <argument type="service" id="Shopware\Core\Checkout\Payment\SalesChannel\HandlePaymentMethodRoute"/>
             <argument type="service" id="event_dispatcher"/>
+            <argument type="service" id="Shopware\Storefront\Page\Account\Order\AccountOrderDetailPageLoader"/>
             <call method="setContainer">
                 <argument type="service" id="service_container"/>
             </call>

--- a/src/Storefront/DependencyInjection/services.xml
+++ b/src/Storefront/DependencyInjection/services.xml
@@ -298,6 +298,12 @@
             <argument type="service" id="Shopware\Core\Checkout\Customer\SalesChannel\AccountService"/>
         </service>
 
+        <service id="Shopware\Storefront\Page\Account\Order\AccountOrderDetailPageLoader">
+            <argument type="service" id="Shopware\Storefront\Page\GenericPageLoader"/>
+            <argument type="service" id="event_dispatcher"/>
+            <argument type="service" id="Shopware\Core\Checkout\Order\SalesChannel\OrderRoute"/>
+        </service>
+
         <service id="Shopware\Storefront\Page\Account\Order\AccountEditOrderPageLoader">
             <argument type="service" id="Shopware\Storefront\Page\GenericPageLoader"/>
             <argument type="service" id="event_dispatcher"/>

--- a/src/Storefront/Page/Account/Order/AccountOrderDetailPage.php
+++ b/src/Storefront/Page/Account/Order/AccountOrderDetailPage.php
@@ -1,0 +1,44 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Storefront\Page\Account\Order;
+
+use Shopware\Core\Checkout\Order\Aggregate\OrderLineItem\OrderLineItemCollection;
+use Shopware\Core\Checkout\Order\OrderEntity;
+use Shopware\Storefront\Page\Page;
+
+class AccountOrderDetailPage extends Page
+{
+    /**
+     * @var OrderEntity
+     */
+    protected $order;
+
+    /**
+     * @var OrderLineItemCollection|null
+     */
+    protected $lineItems;
+
+    public function getOrder(): OrderEntity
+    {
+        return $this->order;
+    }
+
+    public function setOrder(OrderEntity $order): self
+    {
+        $this->order = $order;
+
+        return $this;
+    }
+
+    public function getLineItems(): ?OrderLineItemCollection
+    {
+        return $this->lineItems;
+    }
+
+    public function setLineItems(?OrderLineItemCollection $lineItems): self
+    {
+        $this->lineItems = $lineItems;
+
+        return $this;
+    }
+}

--- a/src/Storefront/Page/Account/Order/AccountOrderDetailPageLoadedEvent.php
+++ b/src/Storefront/Page/Account/Order/AccountOrderDetailPageLoadedEvent.php
@@ -1,0 +1,26 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Storefront\Page\Account\Order;
+
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Shopware\Storefront\Page\PageLoadedEvent;
+use Symfony\Component\HttpFoundation\Request;
+
+class AccountOrderDetailPageLoadedEvent extends PageLoadedEvent
+{
+    /**
+     * @var AccountOrderDetailPage
+     */
+    protected $page;
+
+    public function __construct(AccountOrderDetailPage $page, SalesChannelContext $salesChannelContext, Request $request)
+    {
+        $this->page = $page;
+        parent::__construct($salesChannelContext, $request);
+    }
+
+    public function getPage(): AccountOrderDetailPage
+    {
+        return $this->page;
+    }
+}

--- a/src/Storefront/Page/Account/Order/AccountOrderDetailPageLoader.php
+++ b/src/Storefront/Page/Account/Order/AccountOrderDetailPageLoader.php
@@ -1,0 +1,103 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Storefront\Page\Account\Order;
+
+use Shopware\Core\Checkout\Cart\Exception\CustomerNotLoggedInException;
+use Shopware\Core\Checkout\Order\OrderEntity;
+use Shopware\Core\Checkout\Order\SalesChannel\AbstractOrderRoute;
+use Shopware\Core\Checkout\Order\SalesChannel\OrderRouteResponseStruct;
+use Shopware\Core\Content\Category\Exception\CategoryNotFoundException;
+use Shopware\Core\Framework\DataAbstractionLayer\Exception\InconsistentCriteriaIdsException;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Sorting\FieldSorting;
+use Shopware\Core\Framework\Routing\Exception\MissingRequestParameterException;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Shopware\Storefront\Event\RouteRequest\OrderRouteRequestEvent;
+use Shopware\Storefront\Page\GenericPageLoaderInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+class AccountOrderDetailPageLoader
+{
+    /**
+     * @var GenericPageLoaderInterface
+     */
+    private $genericLoader;
+
+    /**
+     * @var EventDispatcherInterface
+     */
+    private $eventDispatcher;
+
+    /**
+     * @var AbstractOrderRoute
+     */
+    private $orderRoute;
+
+    public function __construct(
+        GenericPageLoaderInterface $genericLoader,
+        EventDispatcherInterface $eventDispatcher,
+        AbstractOrderRoute $orderRoute
+    ) {
+        $this->genericLoader = $genericLoader;
+        $this->eventDispatcher = $eventDispatcher;
+        $this->orderRoute = $orderRoute;
+    }
+
+    /**
+     * @throws CategoryNotFoundException
+     * @throws CustomerNotLoggedInException
+     * @throws InconsistentCriteriaIdsException
+     * @throws MissingRequestParameterException
+     */
+    public function load(Request $request, SalesChannelContext $salesChannelContext): AccountOrderDetailPage
+    {
+        if (!$salesChannelContext->getCustomer()) {
+            throw new CustomerNotLoggedInException();
+        }
+
+        $orderId = (string) $request->get('id');
+
+        if ($orderId === '') {
+            throw new MissingRequestParameterException('id');
+        }
+
+        $criteria = new Criteria([$orderId]);
+        $criteria
+            ->addAssociation('lineItems')
+            ->addAssociation('orderCustomer')
+            ->addAssociation('transactions.paymentMethod')
+            ->addAssociation('deliveries.shippingMethod')
+            ->addAssociation('lineItems.cover');
+
+        $criteria->getAssociation('transactions')
+            ->addSorting(new FieldSorting('createdAt'));
+
+        $apiRequest = new Request();
+
+        $event = new OrderRouteRequestEvent($request, $apiRequest, $salesChannelContext, $criteria);
+        $this->eventDispatcher->dispatch($event);
+
+        /** @var OrderRouteResponseStruct $result */
+        $result = $this->orderRoute
+            ->load($event->getStoreApiRequest(), $salesChannelContext)
+            ->getObject();
+
+        $order = $result->getOrders()->first();
+
+        if (!$order instanceof OrderEntity) {
+            throw new NotFoundHttpException();
+        }
+
+        $page = AccountOrderDetailPage::createFrom($this->genericLoader->load($request, $salesChannelContext));
+        $page->setLineItems($order->getNestedLineItems());
+        $page->setOrder($order);
+
+        $this->eventDispatcher->dispatch(
+            new AccountOrderDetailPageLoadedEvent($page, $salesChannelContext, $request)
+        );
+
+        return $page;
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?
It is difficult to add additional order info to the order detail widgets without this page loader.

### 2. What does this change do, exactly?
Extracts the ajax loaded order detail widget into a dedicated page loader.

### 3. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
