### PR TITLE
Fix composer install of the production template

### DIFF
--- a/src/Core/Framework/Adapter/Asset/FallbackUrlPackage.php
+++ b/src/Core/Framework/Adapter/Asset/FallbackUrlPackage.php
@@ -20,7 +20,7 @@ class FallbackUrlPackage extends UrlPackage
         $basePath = $request->getSchemeAndHttpHost() . $request->getBasePath();
         $requestUrl = rtrim($basePath, '/') . '/';
 
-        if ($request->getHost() === '') {
+        if ($request->getHost() === '' && isset($_SERVER['APP_URL'])) {
             $requestUrl = $_SERVER['APP_URL'];
         }
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/community).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
Otherwise a `composer install` without having a `.env` file (or even with a `.env` file, I have not checked) fails with the error:
``` 
$ composer install
> [ ! -f vendor/autoload.php ] || bin/console system:update:prepare
PHP Notice:  Undefined index: APP_URL in /srv/http/sw/6/3/0/0/vendor/shopware/core/Framework/Adapter/Asset/FallbackUrlPackage.php on line 24
PHP Stack trace:
PHP   1. {main}() /srv/http/sw/6/3/0/0/bin/console:0
PHP   2. Symfony\Bundle\FrameworkBundle\Console\Application->run() /srv/http/sw/6/3/0/0/bin/console:68
PHP   3. Symfony\Bundle\FrameworkBundle\Console\Application->doRun() /srv/http/sw/6/3/0/0/vendor/symfony/console/Application.php:148
PHP   4. Symfony\Bundle\FrameworkBundle\Console\Application->registerCommands() /srv/http/sw/6/3/0/0/vendor/symfony/framework-bundle/Console/Application.php:75
PHP   5. Shopware\Production\Kernel->boot() /srv/http/sw/6/3/0/0/vendor/symfony/framework-bundle/Console/Application.php:169
PHP   6. Shopware\Core\Framework\Framework->boot() /srv/http/sw/6/3/0/0/vendor/shopware/core/Kernel.php:147
PHP   7. Shopware\Core\Framework\Framework->boot() /srv/http/sw/6/3/0/0/vendor/shopware/core/Framework/Framework.php:89
PHP   8. ContainerXPx9Prm\srcShopware_Production_KernelProdContainer->get() /srv/http/sw/6/3/0/0/vendor/shopware/core/Framework/Bundle.php:39
PHP   9. ContainerXPx9Prm\srcShopware_Production_KernelProdContainer->make() /srv/http/sw/6/3/0/0/vendor/symfony/dependency-injection/Container.php:225
PHP  10. ContainerXPx9Prm\srcShopware_Production_KernelProdContainer->getAssetPackageServiceService() /srv/http/sw/6/3/0/0/vendor/symfony/dependency-injection/Container.php:251
PHP  11. ContainerXPx9Prm\srcShopware_Production_KernelProdContainer->getAssets_PackagesService() /srv/http/sw/6/3/0/0/var/cache/prod_h673ef96c4816990aea050b1d28ca1b2f/ContainerXPx9Prm/srcShopware_Production_KernelProdContainer.php:4184
PHP  12. ContainerXPx9Prm\srcShopware_Production_KernelProdContainer->getShopware_Asset_AssetService() /srv/http/sw/6/3/0/0/var/cache/prod_h673ef96c4816990aea050b1d28ca1b2f/ContainerXPx9Prm/srcShopware_Production_KernelProdContainer.php:17774

PHP  13. Shopware\Core\Framework\Adapter\Asset\FallbackUrlPackage->__construct() /srv/http/sw/6/3/0/0/var/cache/prod_h673ef96c4816990aea050b1d28ca1b2f/ContainerXPx9Prm/srcShopware_Production_KernelProdContainer.php:19471
PHP  14. iterator_to_array() /srv/http/sw/6/3/0/0/vendor/shopware/core/Framework/Adapter/Asset/FallbackUrlPackage.php:13
PHP  15. Shopware\Core\Framework\Adapter\Asset\FallbackUrlPackage->applyFallback() /srv/http/sw/6/3/0/0/vendor/shopware/core/Framework/Adapter/Asset/FallbackUrlPackage.php:13

In UrlPackage.php line 131:
                         
  "" is not a valid URL  
                         

Script [ ! -f vendor/autoload.php ] || bin/console system:update:prepare handling the pre-install-cmd event returned with error code 1
```
### 2. What does this change do, exactly?
Checks if the value which is tried to be accessed is set.

### 3. Describe each step to reproduce the issue or behaviour.
```
git clone -b "v6.3.0.0" --depth 1 https://github.com/shopware/production
cd production && composer install
```

### 4. Please link to the relevant issues (if any).
-

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
