### PR TITLE
Check if resource after filesystem::putStream still exists, before closing

### DIFF
--- a/src/Core/Content/ImportExport/ImportExport.php
+++ b/src/Core/Content/ImportExport/ImportExport.php
@@ -294,7 +294,9 @@ class ImportExport
         // copy final file into filesystem
         $this->filesystem->putStream($target, $tmp);
 
-        fclose($tmp);
+        if (is_resource($tmp)) {
+            fclose($tmp);
+        }
         unlink($tmpFile);
 
         foreach ($partFiles as $p) {

--- a/src/Core/Framework/Plugin/Util/AssetService.php
+++ b/src/Core/Framework/Plugin/Util/AssetService.php
@@ -96,7 +96,9 @@ class AssetService
         foreach ($files as $file) {
             $fs = fopen($file->getPathname(), 'rb');
             $this->filesystem->putStream($targetDir . '/' . $file->getRelativePathname(), $fs);
-            fclose($fs);
+            if (is_resource($fs)) {
+                fclose($fs);
+            }
         }
     }
 


### PR DESCRIPTION
### 1. Why is this change necessary?
See https://github.com/shopware/platform/issues/1223

### 2. What does this change do, exactly?
Add checks after each putStream.

### 3. Describe each step to reproduce the issue or behaviour.
See https://github.com/shopware/platform/issues/1223

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
