### PR TITLE
* fix translated fields not being extendable

### DIFF
--- a/src/Core/Framework/DataAbstractionLayer/EntityDefinition.php
+++ b/src/Core/Framework/DataAbstractionLayer/EntityDefinition.php
@@ -19,6 +19,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\OneToManyAssociationField
 use Shopware\Core\Framework\DataAbstractionLayer\Field\OneToOneAssociationField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\ParentAssociationField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\ReferenceVersionField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\TranslatedField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\TranslationsAssociationField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\UpdatedAtField;
 use Shopware\Core\Framework\Struct\ArrayEntity;
@@ -145,8 +146,14 @@ abstract class EntityDefinition
                     continue;
                 }
 
+                if ($field instanceof TranslatedField) {
+                    $fields->add($field);
+
+                    continue;
+                }
+
                 if (!$field instanceof FkField) {
-                    throw new \Exception('Only AssociationFields, FkFields/ReferenceVersionFields for a ManyToOneAssociationField or fields flagged as Runtime can be added as Extension.');
+                    throw new \Exception('Only AssociationFields, FkFields/ReferenceVersionFields, TranslatedFields for a ManyToOneAssociationField or fields flagged as Runtime can be added as Extension.');
                 }
 
                 if (!$this->hasAssociationWithStorageName($field->getStorageName(), $new)) {


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/community).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
For product translations it is currently not possible to add another media field as an extension.

### 2. What does this change do, exactly?
Adds translatedField to be allowed fields for extensions and adapt the error message.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
