### PR TITLE
Add a short command for activate plugin on plugin:install command

### DIFF
--- a/src/Core/Framework/Plugin/Command/Lifecycle/PluginInstallCommand.php
+++ b/src/Core/Framework/Plugin/Command/Lifecycle/PluginInstallCommand.php
@@ -18,7 +18,7 @@ class PluginInstallCommand extends AbstractPluginLifecycleCommand
     protected function configure(): void
     {
         $this->configureCommand(self::LIFECYCLE_METHOD);
-        $this->addOption('activate', null, InputOption::VALUE_NONE, 'Activate plugins after installation.')
+        $this->addOption('activate', 'a', InputOption::VALUE_NONE, 'Activate plugins after installation.')
             ->addOption('reinstall', null, InputOption::VALUE_NONE, 'Reinstall the plugins');
     }
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
When installing a plugin, the `--refresh` and `--clearCache` commands can be abbreviated by passing `-r` and `-c`, respectively. However, `--activate` cannot be abbreviated now. 

### 2. What does this change do, exactly?
This PR is to make `-a` the shortcut command for `--activate`, allowing us to type;

`bin/console plugin:install MyPlugin -c -a -r` or even `bin/console plugin:install MyPlugin -car` (easier to remember)

### 3. Describe each step to reproduce the issue or behaviour.
Using the `-a` flag now gives;

```

                                   
  The "-a" option does not exist.  
                                   

plugin:install [-r|--refresh] [-c|--clearCache] [--activate] [--reinstall] [-h|--help] [-q|--quiet] [-v|vv|vvv|--verbose] [-V|--version] [--ansi] [--no-ansi] [-n|--no-interaction] [-e|--env ENV] [--no-debug] [--] <command> <plugins>...

```

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have written tests and verified that they fail without my change - there are no tests for this command
- [x] I have squashed any insignificant commits
- [x] I have written or adjusted the documentation according to my changes - not necessary, just a small extra feature
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
