### PR TITLE
Fix long texts in offcanvas

### DIFF
--- a/changelog/_unreleased/2021-02-02-fix-long-texts-in-offcanvas.md
+++ b/changelog/_unreleased/2021-02-02-fix-long-texts-in-offcanvas.md
@@ -1,0 +1,10 @@
+---
+title: Fix long texts in offcanvas
+issue: NEXT-12273
+author: Sebastian König
+author_email: s.koenig@tinect.de 
+author_github: @tinect
+---
+# Storefront
+* Changed block `component_offcanvas_product_details` of `component/checkout/offcanvas-item.html.twig` to have a static `col-7` container
+* Changed style for `cart-item-details` to break words in `layout/_offcanvas-cart.scss`

--- a/src/Storefront/Resources/app/storefront/src/scss/layout/_offcanvas-cart.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/layout/_offcanvas-cart.scss
@@ -59,6 +59,7 @@ Extends the basic offcanvas component with additional cart styles.
 
     .cart-item-details {
         margin-bottom: $spacer;
+        word-break: break-word;
     }
 
     .cart-item-details-container {

--- a/src/Storefront/Resources/views/storefront/component/checkout/offcanvas-item.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/checkout/offcanvas-item.html.twig
@@ -56,7 +56,7 @@
                 {% endblock %}
 
                 {% block component_offcanvas_product_details %}
-                    <div class="col cart-item-details">
+                    <div class="col-7 cart-item-details">
                         {% block component_offcanvas_product_details_inner %}
                             <div class="cart-item-details-container">
                                 {% block component_offcanvas_product_label %}


### PR DESCRIPTION
### 1. Why is this change necessary?
Too long texts for one line are overflowing. You know, we are not in a position to dictate what the names should be.

![before](https://user-images.githubusercontent.com/135993/89908317-0624dd00-dbee-11ea-99fa-f31bfde5ab09.JPG)


### 2. What does this change do, exactly?
- Specify static cols of 7 onto offcanvas' cart-item-details to get space for the actions (f.e. remove) always saves.
- add break-word onto offcanvas' cart-item-details
![after](https://user-images.githubusercontent.com/135993/89908339-0e7d1800-dbee-11ea-9369-a614ca929ca5.JPG)



### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
