### PR TITLE
do not create thumbnails higher than the original

### DIFF
--- a/src/Core/Content/Media/Thumbnail/ThumbnailService.php
+++ b/src/Core/Content/Media/Thumbnail/ThumbnailService.php
@@ -121,7 +121,29 @@ class ThumbnailService
         $tobBeCreatedSizes = new MediaThumbnailSizeCollection($config->getMediaThumbnailSizes()->getElements());
         $toBeDeletedThumbnails = new MediaThumbnailCollection($media->getThumbnails()->getElements());
 
+        $maxWidth = 0;
+        $maxHeight = 0;
+        $metaData = $media->getMetaData();
+        if (is_array($metaData) && isset($metaData['width'], $metaData['height'])) {
+            $maxWidth = $metaData['width'];
+            $maxHeight = $metaData['height'];
+        }
+
         foreach ($tobBeCreatedSizes as $thumbnailSize) {
+            if ($maxWidth > 0 && $maxWidth < $thumbnailSize->getWidth()) {
+                // We don't want to create this thumbnail, because it would be bigger than the original
+                $tobBeCreatedSizes->remove($thumbnailSize->getId());
+
+                continue;
+            }
+
+            if ($maxHeight > 0 && $maxHeight < $thumbnailSize->getHeight()) {
+                // We don't want to create this thumbnail, because it would be bigger than the original
+                $tobBeCreatedSizes->remove($thumbnailSize->getId());
+
+                continue;
+            }
+
             foreach ($toBeDeletedThumbnails as $thumbnail) {
                 if ($thumbnail->getWidth() === $thumbnailSize->getWidth()
                     && $thumbnail->getHeight() === $thumbnailSize->getHeight()


### PR DESCRIPTION
### 1. Why is this change necessary?
We do not need thumbnails which are higher than the original. `sw-thumbnails` will catch sizes for us.

### 2. What does this change do, exactly?
- replaces #1118, so it could and should be reverted
- Result, if the image is lower than 1920px, 1920px thumbnail won't be created and displayed:
`<img src="http://domääähn/media/82/76/78/1588756920/10001-1573520404.jpg"
srcset="http://domääähn/media/82/76/78/1588756920/10001-1573520404.jpg 801w,
http://domääähn/thumbnail/82/76/78/1588756920/10001-1573520404_800x800.jpg 800w,
http://domääähn/thumbnail/82/76/78/1588756920/10001-1573520404_400x400.jpg 400w,
http://domääähn/thumbnail/82/76/78/1588756920/10001-1573520404_100x100.jpg 100w,
http://domääähn/thumbnail/82/76/78/1588756920/10001-1573520404_50x50.jpg 50w"
sizes="(min-width: 1200px) 284px, (max-width: 1199px) and (min-width: 992px) 333px, (max-width: 991px) and (min-width: 768px) 427px, (max-width: 767px) and (min-width: 576px) 315px, (max-width: 575px) and (min-width: 0px) 501px, 100vw" class="product-image is-standard" alt="Drahtseil Schlüsselanhänger rund" title="Drahtseil Schlüsselanhänger rund">`

  #### Pros
  - save Requests
  - save Bandwidth
  - save Storage
  - save Processcosts

  #### Cons
  - you could not expect all configured thumbnailSizes of mediaFolder being created and reported in any api

### 3. Describe each step to reproduce the issue or behaviour.
- upload product media with size of <1920px. See 1920px
- run thumbnail-generation
- 1920px thumbnail has been created

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
