### PR TITLE
do not _display_ thumbnails higher than the original, alternative to #1236

### DIFF
--- a/src/Storefront/Resources/views/storefront/utilities/thumbnail.html.twig
+++ b/src/Storefront/Resources/views/storefront/utilities/thumbnail.html.twig
@@ -23,7 +23,7 @@
         {% endif %}
     {% endif %}
 
-    {% set thumbnails = media.thumbnails|sort|reverse %}
+    {% set thumbnails = media.thumbnails|filter((v) => v.width <= media.metaData.width and v.height <= media.metaData.height)|sort|reverse %}
 
     {# generate srcset with all available thumbnails #}
     {% set srcsetValue %}{% apply spaceless %}


### PR DESCRIPTION
### 1. Why is this change necessary?
We do not need thumbnails in storefront which are higher than the original. 

This is an ALTERNATIVE to #1236 because it will make API inconsistent.

### 2. What does this change do, exactly?
- Result, if the image is lower than 1920px, 1920px thumbnail won't be created and displayed:
`<img src="http://domääähn/media/82/76/78/1588756920/10001-1573520404.jpg"
srcset="http://domääähn/media/82/76/78/1588756920/10001-1573520404.jpg 801w,
http://domääähn/thumbnail/82/76/78/1588756920/10001-1573520404_800x800.jpg 800w,
http://domääähn/thumbnail/82/76/78/1588756920/10001-1573520404_400x400.jpg 400w,
http://domääähn/thumbnail/82/76/78/1588756920/10001-1573520404_100x100.jpg 100w,
http://domääähn/thumbnail/82/76/78/1588756920/10001-1573520404_50x50.jpg 50w"
sizes="(min-width: 1200px) 284px, (max-width: 1199px) and (min-width: 992px) 333px, (max-width: 991px) and (min-width: 768px) 427px, (max-width: 767px) and (min-width: 576px) 315px, (max-width: 575px) and (min-width: 0px) 501px, 100vw" class="product-image is-standard" alt="Drahtseil Schlüsselanhänger rund" title="Drahtseil Schlüsselanhänger rund">`

### 3. Describe each step to reproduce the issue or behaviour.
- upload product media with size of <1920px
- run thumbnail-generation
- 1920px thumbnail has been listed in storefront

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
