### PR TITLE
Check headerLogos not be equal to desktop logo

### DIFF
--- a/src/Storefront/Resources/views/storefront/layout/header/logo.html.twig
+++ b/src/Storefront/Resources/views/storefront/layout/header/logo.html.twig
@@ -7,14 +7,14 @@
                 {% block layout_header_logo_image %}
                     <picture>
                         {% block layout_header_logo_image_tablet %}
-                            {% if shopware.theme['sw-logo-tablet'] %}
+                            {% if shopware.theme['sw-logo-tablet'] and shopware.theme['sw-logo-tablet'] != shopware.theme['sw-logo-desktop'] %}
                                 <source srcset="{{ shopware.theme['sw-logo-tablet'] |sw_encode_url }}"
                                         media="(min-width: {{ shopware.theme.breakpoint.md }}px) and (max-width: {{ shopware.theme.breakpoint.lg - 1 }}px)">
                             {% endif %}
                         {% endblock %}
 
                         {% block layout_header_logo_image_mobile %}
-                            {% if shopware.theme['sw-logo-mobile'] %}
+                            {% if shopware.theme['sw-logo-mobile'] and shopware.theme['sw-logo-mobile'] != shopware.theme['sw-logo-desktop'] %}
                                 <source srcset="{{ shopware.theme['sw-logo-mobile'] |sw_encode_url }}"
                                         media="(max-width: {{ shopware.theme.breakpoint.md - 1 }}px)">
                             {% endif %}


### PR DESCRIPTION
### 1. Why is this change necessary?
When user defined the same files for the specific headerLogos, all will be printed. This could be caught.

### 2. What does this change do, exactly?
Add a check for `sw-logo-mobile` and `sw-logo-tablet` not be equal to `sw-logo-desktop` to prevent their output.

### 3. Describe each step to reproduce the issue or behaviour.
- open demoshop where all logos are set the same - or set it on your own
- see source for mobile and tablet are printed into storefront, but having same src as `img` which is for desktop

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
