### PR TITLE
[FIX] Replaced PaymentMethodRoute class with AbstractPaymentMethodRoute

### DIFF
--- a/CHANGELOG-6.3.md
+++ b/CHANGELOG-6.3.md
@@ -91,6 +91,7 @@ NEXT
 * Added generation of order delivery positions when editing an order in the administration
 * Changed the way `senderEmail` is resolved in `\Shopware\Core\Content\MailTemplate\Service\MailService`. It's now possible to override it with `$data['senderEmail']`. 
 * Thumbnails are no longer being upscaled when the original image is smaller than the desired thumbnail size
+* Replaced `PaymentMethodRoute` class with `AbstractPaymentMethodRoute` in `Shopware\Core\Checkout\Order\SalesChannel\SetPaymentOrderRoute` to ensure the extendability of the `PaymentMethodRoute`
 
 #### Storefront
 

--- a/src/Core/Checkout/Order/SalesChannel/SetPaymentOrderRoute.php
+++ b/src/Core/Checkout/Order/SalesChannel/SetPaymentOrderRoute.php
@@ -8,7 +8,7 @@ use Shopware\Core\Checkout\Cart\Price\Struct\CalculatedPrice;
 use Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionStates;
 use Shopware\Core\Checkout\Order\OrderEntity;
 use Shopware\Core\Checkout\Payment\Exception\UnknownPaymentMethodException;
-use Shopware\Core\Checkout\Payment\SalesChannel\PaymentMethodRoute;
+use Shopware\Core\Checkout\Payment\SalesChannel\AbstractPaymentMethodRoute;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepositoryInterface;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
@@ -33,7 +33,7 @@ class SetPaymentOrderRoute extends AbstractSetPaymentOrderRoute
     private $orderRepository;
 
     /**
-     * @var PaymentMethodRoute
+     * @var AbstractPaymentMethodRoute
      */
     private $paymentRoute;
 
@@ -50,7 +50,7 @@ class SetPaymentOrderRoute extends AbstractSetPaymentOrderRoute
     public function __construct(
         OrderService $orderService,
         EntityRepositoryInterface $orderRepository,
-        PaymentMethodRoute $paymentRoute,
+        AbstractPaymentMethodRoute $paymentRoute,
         StateMachineRegistry $stateMachineRegistry
     ) {
         $this->orderService = $orderService;


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?

If you extend the `Shopware\Core\Checkout\Payment\SalesChannel\PaymentMethodRoute` with your own class, you will get an error if you open e.g. the order history in the customer area in the storefront. Thats because in `Shopware\Core\Checkout\Order\SalesChannel\SetPaymentOrderRoute` there was the `PaymentMethodRoute` class as parameter of the constructor. So any other class was not working as parameter there.

### 2. What does this change do, exactly?

The change replaces the `PaymentMethodRoute` parameter with the `AbstractPaymentMethodRoute` class. So any class extending the `AbstractPaymentMethodRoute` will work as parameter now. 

### 3. Describe each step to reproduce the issue or behaviour.

- Create an own class which decorates the `PaymentMethodRoute`
- Open the order history in the storefront (maybe you need an order first)

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
