### PR TITLE
Add raw twig filter in plain mail template fields

### DIFF
--- a/src/Core/Migration/Migration1597255720AddRawTwigFilterInPlainMailTemplateFields.php
+++ b/src/Core/Migration/Migration1597255720AddRawTwigFilterInPlainMailTemplateFields.php
@@ -1,0 +1,32 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Migration;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Framework\Migration\MigrationStep;
+
+class Migration1597255720AddRawTwigFilterInPlainMailTemplateFields extends MigrationStep
+{
+    public const UP = <<<'SQL'
+UPDATE mail_template_translation
+INNER JOIN mail_template ON mail_template_translation.mail_template_id = mail_template.id
+SET mail_template_translation.sender_name = REPLACE(mail_template_translation.sender_name, '}}', '|raw }}'),
+    mail_template_translation.subject = REPLACE(mail_template_translation.subject, '}}', '|raw }}'),
+    mail_template_translation.content_plain = REPLACE(mail_template_translation.content_plain, '}}', '|raw }}')
+WHERE mail_template.system_default = 1
+SQL;
+
+    public function getCreationTimestamp(): int
+    {
+        return 1597255720;
+    }
+
+    public function update(Connection $connection): void
+    {
+        $connection->executeUpdate(self::UP);
+    }
+
+    public function updateDestructive(Connection $connection): void
+    {
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?
When you have special characters in you sales channel name they will be escaped in the default mail templates.
Let's say you have a sales channel with the name `Cars & Racing`. When a user triggers an email to be send from the default mail templates, the subject will look like this `Cars &amp; Racing`.

### 2. What does this change do, exactly?
Adds raw twig flag to all unchanged fields in the mail_template_translation table that contain a twig placeholder and are used in plain text.

### 3. Describe each step to reproduce the issue or behaviour.
1. Setup and initialize a Shopware 6 instance with default data
2. Go to administration
3. Create a sales channel with a special character in the name (e.g. `Cars & Racing`)
4. Go to storefront
5. Trigger an email from the sales channel (e.g. via a user registration)

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
