### PR TITLE
Fix src paths in extending js plugin documentation how to example

### DIFF
--- a/src/Docs/Resources/current/50-how-to/570-extend-core-js-storefront-plugin.md
+++ b/src/Docs/Resources/current/50-how-to/570-extend-core-js-storefront-plugin.md
@@ -11,11 +11,11 @@
 ## Extending an existing JavaScript plugin
 
 As JavaScript storefront plugins are vanilla JavaScript classes you can simply extend them.
-So in your case you create a `Resources/storefront/my-cookie-permission` folder and put an empty file `my-cookie-permission.plugin.js` in there.
+So in your case you create a `Resources/app/storefront/src/my-cookie-permission` folder and put an empty file `my-cookie-permission.plugin.js` in there.
 Next you create a JavaScript class that extends the original CookiePermission plugin:
 
 ```js
-import CookiePermissionPlugin from 'src/script/plugin/cookie-permission/cookie-permission.plugin';
+import CookiePermissionPlugin from 'src/plugin/cookie/cookie-permission.plugin';
 
 export default class MyCookiePermission extends CookiePermissionPlugin {
 }
@@ -26,8 +26,8 @@ For now you first override the `init()` function to set the cookie value that is
 After that you call the init method of the original plugin.
 
 ```js
-import CookiePermissionPlugin from 'src/script/plugin/cookie-permission/cookie-permission.plugin';
-import CookieStorage from 'src/script/helper/storage/cookie-storage.helper';
+import CookiePermissionPlugin from 'src/plugin/cookie/cookie-permission.plugin';
+import CookieStorage from 'src/helper/storage/cookie-storage.helper';
 
 export default class MyCookiePermission extends CookiePermissionPlugin {
     init() {
@@ -42,8 +42,8 @@ Therefore you override the `_hideCookieBar()` function to show the dialogue and 
 So your whole plugin now looks like this:
 
 ```js
-import CookiePermissionPlugin from 'src/script/plugin/cookie-permission/cookie-permission.plugin';
-import CookieStorage from 'src/script/helper/storage/cookie-storage.helper';
+import CookiePermissionPlugin from 'src/plugin/cookie/cookie-permission.plugin';
+import CookieStorage from 'src/helper/storage/cookie-storage.helper';
 
 export default class MyCookiePermission extends CookiePermissionPlugin {
     init() {


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
I had a problem with extending js plugin. I finded out that the documentation have old paths. It has taken me 2 hours to find out what is wrong. I think that litle change can help someone else don't spend so much time on this topic.

### 2. What does this change do, exactly?
It is fixing the example paths in documentation.
Correcting the example folder path and imports of helper.js and cookie-permission plugin to be exactly the same as in repository.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
https://docs.shopware.com/en/shopware-platform-dev-en/how-to/extend-core-js-storefront-plugin
Github code example: https://github.com/shopware/swag-docs-extend-js-plugin

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
