### PR TITLE
Support rules that depend on the cart context for shipping methods

### DIFF
--- a/src/Core/Checkout/DependencyInjection/cart.xml
+++ b/src/Core/Checkout/DependencyInjection/cart.xml
@@ -55,6 +55,7 @@
             <argument type="service" id="Shopware\Core\Checkout\Cart\CartPersister"/>
             <argument type="service" id="Shopware\Core\Checkout\Cart\CartCalculator"/>
             <argument type="service" id="Shopware\Core\Checkout\Cart\LineItemFactoryRegistry"/>
+            <argument type="service" id="Shopware\Core\Checkout\Cart\CartRuleLoader"/>
         </service>
 
         <service id="Shopware\Core\Checkout\Cart\SalesChannel\CartLoadRoute" public="true">
@@ -72,6 +73,7 @@
             <argument type="service" id="event_dispatcher"/>
             <argument type="service" id="Shopware\Core\Checkout\Cart\CartCalculator"/>
             <argument type="service" id="Shopware\Core\Checkout\Cart\CartPersister"/>
+            <argument type="service" id="Shopware\Core\Checkout\Cart\CartRuleLoader"/>
         </service>
 
         <service id="Shopware\Core\Checkout\Cart\SalesChannel\CartItemAddRoute" public="true">
@@ -79,6 +81,7 @@
             <argument type="service" id="Shopware\Core\Checkout\Cart\CartPersister"/>
             <argument type="service" id="event_dispatcher"/>
             <argument type="service" id="Shopware\Core\Checkout\Cart\LineItemFactoryRegistry"/>
+            <argument type="service" id="Shopware\Core\Checkout\Cart\CartRuleLoader"/>
         </service>
 
         <service id="Shopware\Core\Checkout\Cart\SalesChannel\CartOrderRoute" public="true">


### PR DESCRIPTION
### 1. Why is this change necessary?
You can't rely on rules used in shipping method activation or shipping method price matrix as they might be valid or invalid right after the item is added to the cart but that is after the calculation.

### 2. What does this change do, exactly?
After the cart has been changed the rules are reloaded and the cart is recalculated based on the new rules. So new shipping methods can apply.

### 3. Describe each step to reproduce the issue or behaviour.
The setup is as following: Have rule that is meant to be for shipping and is based on the a tag "foobar" in a line item. Create a shipping method pricing matrix based on rules. One rules is "always true" and the other the foobar rule.
You want to add a product with the foobar-tag into your cart by pushing the "add to basket" button. The request is coming in, the rules are loaded. The foobar rule is not valid as the cart is empty and therefore there is no line item with a product that has this tag. The only valid rule that is in the context is "always true". The shipping method and price is calcaluted based on that. You have the cart sidebar open and see a shipping price/method that is wrong as the foobar rule should trigger but it is not loaded so it can't trigger.

### 4. Checklist
- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

### 5. Known issues
Due to first miscalculation errors like ShippingMethodBlockedError can occur as the cart became invalid for a short time and this error is passed onto the second calculated cart. There is still a fix for this needed but maybe someone from @shopwareBot can comment on that.