### PR TITLE
Sort component overrides on usage instead on insertion

### DIFF
--- a/src/Administration/Resources/app/administration/src/core/factory/component.factory.js
+++ b/src/Administration/Resources/app/administration/src/core/factory/component.factory.js
@@ -35,7 +35,7 @@ const componentRegistry = new Map();
 /**
  * Registry which holds all component overrides
  *
- * @type {Map<any, any>}
+ * @type {Map<String, Array<{name: String, _overrideIndex: Number}>>}
  */
 const overrideRegistry = new Map();
 
@@ -57,7 +57,7 @@ function getComponentRegistry() {
 /**
  * Returns the map with all registered component overrides.
  *
- * @returns {Map}
+ * @returns {Map<String, Array<{name: String, _overrideIndex: Number}>>}
  */
 function getOverrideRegistry() {
     return overrideRegistry;
@@ -210,12 +210,8 @@ function override(componentName, componentConfiguration, overrideIndex = null) {
     }
 
     const overrides = overrideRegistry.get(componentName) || [];
-
-    if (overrideIndex !== null && overrideIndex >= 0 && overrides.length > 0) {
-        overrides.splice(overrideIndex, 0, config);
-    } else {
-        overrides.push(config);
-    }
+    config._overrideIndex = overrideIndex || overrides.length;
+    overrides.push(config);
 
     overrideRegistry.set(componentName, overrides);
 
@@ -313,11 +309,12 @@ function build(componentName, skipTemplate = false) {
 
 /**
  * Reorganizes the structure of the given overrides.
- * @param {Object} overrides
+ * @param {Array<{name: String, _overrideIndex: Number}>} overrides
  * @returns {Object}
  */
 function convertOverrides(overrides) {
     return overrides
+        .sort((a, b) => Math.sign(a._overrideIndex - b._overrideIndex))
         .reduceRight((acc, overrideComp) => {
             if (acc.length === 0) {
                 return [overrideComp];

--- a/src/Administration/Resources/app/administration/test/core/factory/component.factory.spec.js
+++ b/src/Administration/Resources/app/administration/test/core/factory/component.factory.spec.js
@@ -200,6 +200,56 @@ describe('core/factory/component.factory.js', () => {
     );
 
     it(
+        'should register two overrides of an existing component in the override registry (with index) and the indexed override can be registered first as well',
+        () => {
+            ComponentFactory.register('test-component', {
+                created() {},
+                methods: {
+                    testMethod() {
+                        return 'This is a test method.';
+                    }
+                },
+                template: '<div>This is a test template.</div>'
+            });
+
+            const overrideTwo = ComponentFactory.override('test-component', {
+                methods: {
+                    testMethod() {
+                        return 'This is the second override.';
+                    }
+                }
+            }, 0);
+
+            const overrideOne = ComponentFactory.override('test-component', {
+                methods: {
+                    testMethod() {
+                        return 'This is the first override.';
+                    }
+                }
+            });
+
+            const registry = ComponentFactory.getComponentRegistry();
+            const overrideRegistry = ComponentFactory.getOverrideRegistry();
+
+            expect(typeof overrideOne.methods.testMethod).toBe('function');
+            expect(typeof overrideTwo.methods.testMethod).toBe('function');
+            expect(overrideOne.template).toBe(undefined);
+            expect(overrideTwo.template).toBe(undefined);
+            expect(registry.has('test-component')).toBe(true);
+            expect(registry.get('test-component')).toBeInstanceOf(Object);
+            expect(overrideRegistry.has('test-component')).toBe(true);
+            expect(overrideRegistry.get('test-component')).toBeInstanceOf(Array);
+            expect(overrideRegistry.get('test-component').length).toBe(2);
+            expect(overrideRegistry.get('test-component')[0]).toBeInstanceOf(Object);
+            expect(overrideRegistry.get('test-component')[1]).toBeInstanceOf(Object);
+            expect(typeof overrideRegistry.get('test-component')[0].methods.testMethod).toBe('function');
+            expect(typeof overrideRegistry.get('test-component')[1].methods.testMethod).toBe('function');
+            expect(overrideRegistry.get('test-component')[0].methods.testMethod()).toBe('This is the second override.');
+            expect(overrideRegistry.get('test-component')[1].methods.testMethod()).toBe('This is the first override.');
+        }
+    );
+
+    it(
         'should provide the rendered template of a component including overrides',
         () => {
             ComponentFactory.register('test-component', {


### PR DESCRIPTION
### 1. Why is this change necessary?
When two plugins override a core component they are fooled into the option to control the override order.

### 2. What does this change do, exactly?
Postpone override sorting to overriden object building to manage the order more reliable.

### 3. Describe each step to reproduce the issue or behaviour.
1. Have a plugin that overrides a core component and adds more twig blocks
2. Have a second plugin that overrides the same core component to change content of the newly added twig blocks
3. To ensure the twig inheritance order add a high index as third parameter to `Shopware.Component.override`
4. Still be first in twig inheritance order as the index is ignored

So we have two `Shopware.Component.override` calls which I alias as `thirdParty` and `me`. `me` wants to extend `thirdParty`. As the order of plugins being injected into the administration and the way the browser loads the injected files is sort-of random the order of these calls is random as well. Lets iterate the possible orders and their outcome.

```js
thirdParty(); // triggers push as no index is given
me(100); // triggers splice as an index is given which is similar to a push
```

This results in `me` being last but not by the fact that `me` passed in an index. Any index > 0 would have the same outcome. So this ok as outcome but not reliable.

```js
me(100); // triggers push as no other overridees are registered
thirdParty(); // triggers push as no index is given
```

This results in `me` being first so `me` can't extend the block that is created by `thirdParty`. Any index `me` passes in won't help `me` when `me` is the first registered overridee. This is not working out and not reliable at all.

### 4. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
