### PR TITLE
Deharcoded thumbnail sizes

### DIFF
--- a/src/Storefront/Resources/views/storefront/component/product/card/box-standard.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/product/card/box-standard.html.twig
@@ -4,6 +4,13 @@
         {% set id = product.id %}
         {% set cover = product.cover.media %}
         {% set variation = product.variation %}
+        {% set thumbnailSizes = {
+            'xs': '501px',
+            'sm': '315px',
+            'md': '427px',
+            'lg': '333px',
+            'xl': '284px'
+        } %}
 
         <div class="card product-box box-{{ layout }}">
             {% block component_product_box_content %}
@@ -42,13 +49,7 @@
 
                                     {% sw_thumbnails 'product-image-thumbnails' with {
                                         media: cover,
-                                        sizes: {
-                                            'xs': '501px',
-                                            'sm': '315px',
-                                            'md': '427px',
-                                            'lg': '333px',
-                                            'xl': '284px'
-                                        }
+                                        sizes: thumbnailSizes
                                     } %}
                                 {% else %}
                                     <div class="product-image-placeholder">


### PR DESCRIPTION
### 1. Why is this change necessary?
Because we want just customize image sizes without overwriting whole twig block

### 2. What does this change do, exactly?
Makes thumbnail sizes more customizable 

### 3. Describe each step to reproduce the issue or behaviour.

### 4. Please link to the relevant issues (if any).

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
