### PR TITLE
Change default logger rotation by configuration

### DIFF
--- a/src/Core/Framework/DependencyInjection/Configuration.php
+++ b/src/Core/Framework/DependencyInjection/Configuration.php
@@ -25,6 +25,7 @@ class Configuration implements ConfigurationInterface
                 ->append($this->createSitemapSection())
                 ->append($this->createDeploymentSection())
                 ->append($this->createMediaSection())
+                ->append($this->createLoggerSection())
             ->end();
 
         return $treeBuilder;
@@ -234,6 +235,20 @@ class Configuration implements ConfigurationInterface
             ->children()
                 ->booleanNode('enable_url_upload_feature')->end()
                 ->booleanNode('enable_url_validation')->end()
+            ->end();
+
+        return $rootNode;
+    }
+
+    private function createLoggerSection(): ArrayNodeDefinition
+    {
+        /** @var ArrayNodeDefinition $rootNode */
+        $rootNode = (new TreeBuilder('logger'))->getRootNode();
+        $rootNode
+            ->children()
+                ->integerNode('file_rotation_count')
+                    ->defaultValue(14)
+                ->end()
             ->end();
 
         return $rootNode;

--- a/src/Core/Framework/DependencyInjection/services.xml
+++ b/src/Core/Framework/DependencyInjection/services.xml
@@ -440,6 +440,7 @@ base-uri 'self';
         <!-- Util -->
         <service id="Shopware\Core\Framework\Log\LoggerFactory">
             <argument type="string">%kernel.logs_dir%/%%s_%kernel.environment%.log</argument>
+            <argument>%shopware.logger.file_rotation_count%</argument>
         </service>
 
         <service id="Shopware\Core\Framework\Routing\Annotation\CriteriaValueResolver">

--- a/src/Core/Framework/Log/LoggerFactory.php
+++ b/src/Core/Framework/Log/LoggerFactory.php
@@ -11,9 +11,12 @@ class LoggerFactory
 {
     private $rotatingFilePathPattern = '';
 
-    public function __construct(string $rotatingFilePathPattern)
+    private $defaultFileRotationCount;
+
+    public function __construct(string $rotatingFilePathPattern, int $defaultFileRotationCount = 14)
     {
         $this->rotatingFilePathPattern = $rotatingFilePathPattern;
+        $this->defaultFileRotationCount = $defaultFileRotationCount;
     }
 
     public function createRotating(string $filePrefix, ?int $fileRotationCount = null): LoggerInterface
@@ -21,7 +24,7 @@ class LoggerFactory
         $filepath = sprintf($this->rotatingFilePathPattern, $filePrefix);
 
         $result = new Logger($filePrefix);
-        $result->pushHandler(new RotatingFileHandler($filepath, $fileRotationCount ?? 14));
+        $result->pushHandler(new RotatingFileHandler($filepath, $fileRotationCount ?? $this->defaultFileRotationCount));
         $result->pushProcessor(new PsrLogMessageProcessor());
 
         return $result;

--- a/src/Core/Framework/Resources/config/packages/shopware.yaml
+++ b/src/Core/Framework/Resources/config/packages/shopware.yaml
@@ -51,3 +51,6 @@ shopware:
     media:
         enable_url_upload_feature: true
         enable_url_validation: true
+
+    logger:
+        file_rotation_count: 14

--- a/src/Docs/Resources/current/50-how-to/350-how-to-log.md
+++ b/src/Docs/Resources/current/50-how-to/350-how-to-log.md
@@ -1,0 +1,64 @@
+[titleEn]: <>(How to log)
+[metaDescriptionEn]: <>(This article shows you how to configure default logger settings and create logger instances)
+[hash]: <>(article:how_to_log)
+
+## Overview
+
+Shopware 6 uses Monolog loggers and provide a central factory for the most common logging cases.
+
+## Setup a logger
+
+You can use the LoggerFactory class to generate a logger service within your service definition:
+
+<div class="tabs">
+    <nav>
+        <a href="#">XML</a>
+        <a href="#">YML</a>
+    </nav>
+    <div class="tabs-container">
+        <section>
+            <pre><code><service id="acme_powerful_plugin.foobar.logger" class="Psr\Log\LoggerInterface">
+    <factory service="Shopware\Core\Framework\Log\LoggerFactory" method="createRotating"/>
+    <argument type="string">acme_powerful_plugin_foobar</argument>
+    <argument>90</argument>
+</service>
+</code></pre>
+        </section>
+        <section>
+            <pre><code>acme_powerful_plugin.foobar.logger:
+    class: Psr\Log\LoggerInterface
+    factory:
+        - '@Shopware\Core\Framework\Log\LoggerFactory'
+        - createRotating
+    arguments:
+        - acme_powerful_plugin_foobar
+        - 90
+</code></pre>
+        </section>
+    </div>
+</div>
+
+This provides a logger that has a file rotation of 90 days.
+So every file older than 90 days will be deleted.
+When you omit the limit the configuration key `shopware.logger.file_rotation_count` is read for the default file rotation.
+Using the value `0` will stop the rotation at all.
+
+## Configuration
+
+The configuration for Shopware 6 resides in the general bundle configuration:
+
+```
+<development root>
+└── config
+   └── packages
+      └── shopware.yml
+```
+
+To change default logging behaviour for your shop you need to add the `logger:` map to 
+the `shopware.yml`:
+
+```yaml
+shopware:
+    logger:
+        file_rotation_count: 90 # defaults to 14
+```


### PR DESCRIPTION
### 1. Why is this change necessary?
14 is a nice limit but when you have to look something up you might want to change the default of 14. This is easy. You just pass in an other value on creation but this just counts for your own service definition. You can use a compiler pass and adjust settings for other service definitions but they don't have to be a service definition in the first place, so maybe use a decorator for the factory? Possible but hacky all in all. What about a simple configuration?

**Sidenote** I [contributed the factory ~1200 PRs ago](https://github.com/shopware/platform/pull/50) in the first place so the jokes are on me 😁 

I add a common how-to for logging due to the docs refactoring my original log documentation got removed and therefore can't be looked up anymore.

### 2. What does this change do, exactly?
Log files get deleted after 14 days when no other limit is given. Now the limit is passed in via service definition of the factory which is read from the configuration which still has the 14 as default.

### 3. Describe each step to reproduce the issue or behaviour.
1. Log something
2. Wait 15 days
3. Lookup logs
4. No backups, no pity

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
