### PR TITLE
Hide BackgroundImageMode when BackgroundImage not set

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-block/sw-cms-block-config/sw-cms-block-config.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-block/sw-cms-block-config/sw-cms-block-config.html.twig
@@ -54,9 +54,9 @@
                     </sw-upload-listener>
 
                     {% block sw_cms_block_config_background_image_position_field %}
-                        <sw-select-field :label="$tc('sw-cms.detail.label.backgroundMediaMode')"
-                                         v-model="block.backgroundMediaMode"
-                                         :disabled="!block.backgroundMediaId">
+                        <sw-select-field v-if="block.backgroundMediaId"
+                                         :label="$tc('sw-cms.detail.label.backgroundMediaMode')"
+                                         v-model="block.backgroundMediaMode">
                             <option value="auto">{{ $tc('sw-cms.detail.label.backgroundMediaModeAuto') }}</option>
                             <option value="contain">{{ $tc('sw-cms.detail.label.backgroundMediaModeContain') }}</option>
                             <option value="cover">{{ $tc('sw-cms.detail.label.backgroundMediaModeCover') }}</option>

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-section/sw-cms-section-config/sw-cms-section-config.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-section/sw-cms-section-config/sw-cms-section-config.html.twig
@@ -77,9 +77,9 @@
                     </sw-upload-listener>
 
                     {% block sw_cms_section_config_background_image_position_field %}
-                        <sw-select-field :label="$tc('sw-cms.detail.label.backgroundMediaMode')"
-                                         v-model="section.backgroundMediaMode"
-                                         :disabled="!section.backgroundMediaId">
+                        <sw-select-field v-if="section.backgroundMediaId"
+                                         :label="$tc('sw-cms.detail.label.backgroundMediaMode')"
+                                         v-model="section.backgroundMediaMode">
                             <option value="auto">{{ $tc('sw-cms.detail.label.backgroundMediaModeAuto') }}</option>
                             <option value="contain">{{ $tc('sw-cms.detail.label.backgroundMediaModeContain') }}</option>
                             <option value="cover">{{ $tc('sw-cms.detail.label.backgroundMediaModeCover') }}</option>


### PR DESCRIPTION
### 1. Why is this change necessary?
Instead of disabling backgroundImageMode, we should hide it when BackgroundImage is not set. Showing disabled and inherited options will only confuse users.

### 2. What does this change do, exactly?
Hide backgroundImageMode when BackgroundImage is not set.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
