### PR TITLE
Fix datepicker date and time handling

### DIFF
--- a/src/Administration/Resources/app/administration/package-lock.json
+++ b/src/Administration/Resources/app/administration/package-lock.json
@@ -4648,6 +4648,11 @@
         }
       }
     },
+    "dayjs": {
+      "version": "1.8.32",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.8.32.tgz",
+      "integrity": "sha512-V91aTRu5btP+uzGHaaOfodckEfBWhmi9foRP7cauAO1PTB8+tZ9o0Jec7q6TIIRY1N4q1IfiKsZunkB/AEWqMQ=="
+    },
     "de-indent": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/de-indent/-/de-indent-1.0.2.tgz",

--- a/src/Administration/Resources/app/administration/package.json
+++ b/src/Administration/Resources/app/administration/package.json
@@ -43,6 +43,7 @@
     "bottlejs": "1.7.2",
     "cookie-storage": "^6.0.0",
     "copy-webpack-plugin": "5.1.1",
+    "dayjs": "^1.8.32",
     "dompurify": "2.0.7",
     "eslint-friendly-formatter": "4.0.1",
     "flatpickr": "4.6.3",

--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-datepicker/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-datepicker/index.js
@@ -1,8 +1,12 @@
 import Flatpickr from 'flatpickr';
 import 'flatpickr/dist/l10n';
+import dayjs from 'dayjs';
+import customParseFormat from 'dayjs/plugin/customParseFormat';
 import template from './sw-datepicker.html.twig';
 import 'flatpickr/dist/flatpickr.css';
 import './sw-datepicker.scss';
+
+dayjs.extend(customParseFormat);
 
 const { Component, Mixin } = Shopware;
 
@@ -390,16 +394,16 @@ Component.register('sw-datepicker', {
         },
 
         createConfig() {
-            let dateFormat = 'Y-m-dTH:i:S+00:00';
-            let altFormat = 'Y-m-d H:i';
+            let dateFormat = 'YYYY-MM-DDTHH:mm:ssZ';
+            let altFormat = 'YYYY-MM-DD HH:mm';
 
             if (this.dateType === 'time') {
-                dateFormat = 'H:i:S+00:00';
-                altFormat = 'H:i';
+                dateFormat = 'HH:mm:ssZ';
+                altFormat = 'HH:mm';
             }
 
             if (this.dateType === 'date') {
-                altFormat = 'Y-m-d';
+                altFormat = 'YYYY-MM-DD';
             }
 
             this.defaultConfig = {
@@ -408,7 +412,13 @@ Component.register('sw-datepicker', {
                 dateFormat,
                 altInput: true,
                 altFormat,
-                allowInput: true
+                allowInput: true,
+                parseDate: (datestr, format) => {
+                    return dayjs(datestr, format).toDate();
+                },
+                formatDate: (date, format) => {
+                    return dayjs(date).format(format);
+                }
             };
         }
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?

Currently the datepicker stores dates and times without any timezone information and just uses `+00:00` to indicate UTC, while in reality the timezone of the browser could be different.


### 2. What does this change do, exactly?
This PR adds the correct timezone offset to the stored date/time string and parses such a string correctly.
Unfortunately Flatpickr itself is not able to include timezone offsets. Hence the library [dayjs](https://day.js.org/) was used to achieve this because of its very similar interface to moment, but much smaller size (2KB gzipped).

The following bundle size changes were observed due to this change:
```
static/js/app.js +175 Bytes
static/js/vendors-node.js +9309 Bytes
```


### 3. Describe each step to reproduce the issue or behaviour.
- Create a plugin configuration xml file (`config.xml`) with a input field of type `time`, `date` or `datetime`. Eg:
```
<input-field type="time">
    <name>myNotificationTime</name>
    <label>Time of the day when the noticiation should be sent</label>
    <label lang="de-DE">Zeitpunkt zu dem die Benachrichtigung täglich versendet werden soll</label>
</input-field>
```
- Open the plugin configuration in the Administration and input a time and/or date and save the configuration
- Observe the persisted value in the database: If you entered 16:00 the database will show 16:00:00+00:00

### 4. Please link to the relevant issues (if any).

- https://issues.shopware.com/issues/NEXT-8205

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
