### PR TITLE
Add new kernel-parameter "kernel.vendor_dir" pointing to the composer vendor directory

### DIFF
--- a/src/Core/Framework/Bundle.php
+++ b/src/Core/Framework/Bundle.php
@@ -11,6 +11,7 @@ use Symfony\Component\Cache\DependencyInjection\CacheCollectorPass;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\Config\Loader\DelegatingLoader;
 use Symfony\Component\Config\Loader\LoaderResolver;
+use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
@@ -33,6 +34,7 @@ abstract class Bundle extends SymfonyBundle
         $this->registerFilesystem($container, 'private');
         $this->registerFilesystem($container, 'public');
         $this->registerEvents($container);
+        $this->registerBundleDirectory($container);
 
         // Can be removed when 4.4.14 is released and required in composer.json
         $removingPasses = $container->getCompilerPassConfig()->getBeforeRemovingPasses();
@@ -165,5 +167,10 @@ abstract class Bundle extends SymfonyBundle
         foreach (glob($this->getPath() . '/Resources/config/services.*') as $path) {
             $delegatingLoader->load($path);
         }
+    }
+
+    private function registerBundleDirectory(ContainerBuilder $container): void
+    {
+        $container->setParameter(Container::underscore($this->getName()) . '.bundle_dir', $this->getPath());
     }
 }

--- a/src/Core/Framework/DependencyInjection/services.xml
+++ b/src/Core/Framework/DependencyInjection/services.xml
@@ -114,7 +114,7 @@ base-uri 'self';
 
         <service id="Shopware\Core\Framework\Migration\Command\CreateMigrationCommand">
             <argument type="service" id="Shopware\Core\Framework\Plugin\KernelPluginCollection"/>
-            <argument>%kernel.project_dir%</argument>
+            <argument type="service" id="Shopware\Core\Framework\Migration\MigrationSource.core"/>
 
             <tag name="console.command"/>
         </service>

--- a/src/Core/Framework/DependencyInjection/store.xml
+++ b/src/Core/Framework/DependencyInjection/store.xml
@@ -47,8 +47,7 @@
 
         <service id="Shopware\Core\Framework\Store\Services\OpenSSLVerifier">
             <argument type="collection">
-                <argument>%kernel.project_dir%/vendor/shopware/platform/src/Core/Framework/Store/public.key</argument>
-                <argument>%kernel.project_dir%/vendor/shopware/core/Framework/Store/public.key</argument>
+                <argument>%framework.bundle_dir%/Store/public.key</argument>
             </argument>
         </service>
 

--- a/src/Core/Framework/Migration/Command/CreateMigrationCommand.php
+++ b/src/Core/Framework/Migration/Command/CreateMigrationCommand.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Core\Framework\Migration\Command;
 
+use Shopware\Core\Framework\Migration\MigrationSource;
 use Shopware\Core\Framework\Plugin;
 use Shopware\Core\Framework\Plugin\KernelPluginCollection;
 use Symfony\Component\Console\Command\Command;
@@ -15,20 +16,20 @@ class CreateMigrationCommand extends Command
     protected static $defaultName = 'database:create-migration';
 
     /**
-     * @var string
-     */
-    private $projectDir;
-
-    /**
      * @var KernelPluginCollection
      */
     private $kernelPluginCollection;
 
-    public function __construct(KernelPluginCollection $kernelPluginCollection, string $projectDir)
+    /**
+     * @var MigrationSource
+     */
+    private $coreMigrationSource;
+
+    public function __construct(KernelPluginCollection $kernelPluginCollection, MigrationSource $coreMigrationSource)
     {
         parent::__construct();
-        $this->projectDir = $projectDir;
         $this->kernelPluginCollection = $kernelPluginCollection;
+        $this->coreMigrationSource = $coreMigrationSource;
     }
 
     protected function configure(): void
@@ -96,8 +97,9 @@ class CreateMigrationCommand extends Command
             $output->writeln(sprintf('Creating plugin-migration with namespace %s in path %s...', $namespace, $directory));
         } else {
             // We create a core-migration in case no plugin was given
-            $directory = $this->projectDir . '/vendor/shopware/platform/src/Core/Migration/';
+            $sourceDirectories = $this->coreMigrationSource->getSourceDirectories();
             $namespace = 'Shopware\\Core\\Migration';
+            $directory = array_search($namespace, $sourceDirectories, true);
 
             $output->writeln('Creating core-migration ...');
         }


### PR DESCRIPTION
### 1. Why is this change necessary?

I tried running a modified version of the [production template](https://github.com/shopware/production) as a library instead of a project. As it turns out, that is not actually difficult with a few minor changes to have a dynamic location of the vendor directory.

### 2. What does this change do, exactly?

This adds a new kernel parameter called `kernel.vendor_dir` that holds the absolute path to the vendor directory. Also some usages of `kernel.project_dir` followed by `/vendor/...` have been replaced with usages of `kernel.vendor_dir` followed by `/...`.

The way to determine the location of the vendor directory has been taken from [this answer on Stack Overflow.](https://stackoverflow.com/a/45364136/5210292)

### 3. Describe each step to reproduce the issue or behaviour.

1. Make a new composer project.
2. Require `shopware/production` via composer.
3. Try running `vendor/shopware/production/bin/console`.

You will run into errors saying that some files could not be found. This makes sense, because in this case the vendor directory is not located in the project directory.

### 4. Please link to the relevant issues (if any).

None.

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
