### PR TITLE
compare IP addresses case insensitive

### DIFF
--- a/CHANGELOG-6.3.md
+++ b/CHANGELOG-6.3.md
@@ -277,6 +277,7 @@ NEXT
 * Added new flag `\Shopware\Core\Checkout\Cart\Error\Error::isPersistent` which defines if an errors should be persistent when processing the cart multiple times.
 * Deprecated `purchasePrice` in `Shopware\Core\Content\Product` use `purchasePrices` instead
 * Deprecated `payload.purchasePrice` in `Shopware\Core\Checkout\Cart\LineItem\LineItem` use `payload.purchasePrices` instead
+* Fixed a bug concering case insensetive IP comparsion in maintanence mode
 
 #### Storefront
 

--- a/src/Storefront/Framework/Routing/MaintenanceModeResolver.php
+++ b/src/Storefront/Framework/Routing/MaintenanceModeResolver.php
@@ -5,6 +5,7 @@ namespace Shopware\Storefront\Framework\Routing;
 use Shopware\Core\SalesChannelRequest;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpFoundation\IpUtils;
 
 class MaintenanceModeResolver
 {
@@ -75,10 +76,9 @@ class MaintenanceModeResolver
 
     private function isClientAllowed(Request $request): bool
     {
-        return in_array(
+        return IpUtils::checkIp(
             $request->getClientIp(),
-            $this->getMaintenanceWhitelist($this->requestStack->getMasterRequest()),
-            true
+            $this->getMaintenanceWhitelist($this->requestStack->getMasterRequest())
         );
     }
 

--- a/src/Storefront/Test/Framework/Routing/MaintenanceModeResolverTest.php
+++ b/src/Storefront/Test/Framework/Routing/MaintenanceModeResolverTest.php
@@ -104,9 +104,7 @@ class MaintenanceModeResolverTest extends TestCase
                 true,
             ],
             'maintenance mode is active, sales channel requested, proxy, whitelisted client ip - mixed case' => [
-                $this->getRequest(true, false, false, false, true, true,
-                ['2003:F0:3f08:Db00:6D4:c4Ff:Fe48:74F4'],
-                '2003:f0:3F08:dB00:6d4:C4fF:fE48:74f4'),
+                $this->getRequest(true, false, false, false, true, true, ['2003:F0:3f08:Db00:6D4:c4Ff:Fe48:74F4'], '2003:f0:3F08:dB00:6d4:C4fF:fE48:74f4'),
                 false,
             ],
         ];

--- a/src/Storefront/Test/Framework/Routing/MaintenanceModeResolverTest.php
+++ b/src/Storefront/Test/Framework/Routing/MaintenanceModeResolverTest.php
@@ -103,6 +103,12 @@ class MaintenanceModeResolverTest extends TestCase
                 $this->getRequest(true, false, false, false, true, true, ['127.0.0.1', '::1']),
                 true,
             ],
+            'maintenance mode is active, sales channel requested, proxy, whitelisted client ip - mixed case' => [
+                $this->getRequest(true, false, false, false, true, true,
+                ['2003:F0:3f08:Db00:6D4:c4Ff:Fe48:74F4'],
+                '2003:f0:3F08:dB00:6d4:C4fF:fE48:74f4'),
+                false,
+            ],
         ];
     }
 


### PR DESCRIPTION
### 1. Why is this change necessary?
IPv6 addresses are valid in both upper & lowercase. 

### 2. What does this change do, exactly?
It forces an case insensitive comparison.

### 3. Describe each step to reproduce the issue or behaviour.
1. Add your (uppercase) IPv6 Address to the whitelist of your sales channel. 
2. enable maintenance mode
3. You can not view your shop
4. Add the same IP but in lowercase -> now you are able to see your shop

### 4. Please link to the relevant issues (if any).
See #1275 

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
