### PR TITLE
Mark active navigation

### DIFF
--- a/changelog/_unreleased/2020-11-08-mark-active-navigation-path.md
+++ b/changelog/_unreleased/2020-11-08-mark-active-navigation-path.md
@@ -1,0 +1,13 @@
+---
+title: Mark active navigation path
+issue: NEXT-11958
+author: Sebastian König
+author_email: s.koenig@tinect.de
+author_github: @tinect
+---
+# Storefront
+*  Add style to mark active navigation `.navigation-flyout-link.active` in `skin/shopware/layout/_navigation-flyout.scss`
+*  Add variable `activePath` in `layout/navigation/categories.html.twig` in block `layout_navigation_categories`
+*  Add variable `activePath` in `layout/navigation/navigation.html.twig` in block `layout_main_navigation_menu_items`
+*  Add check for activePath for every `navigation-flyout-link` in block `layout_navigation_categories_item_link` in `layout/navigation/categories.html.twig` to mark complete active path
+*  Add check for activePath for every `main-navigation-link` in block `layout_main_navigation_menu_item` in `layout/navigation/navigation.html.twig` to mark complete active path

--- a/src/Storefront/Resources/app/storefront/src/scss/skin/shopware/layout/_navigation-flyout.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/skin/shopware/layout/_navigation-flyout.scss
@@ -51,6 +51,11 @@ Custom skin styling for navigation flyout which opens on hover over the main nav
         color: $primary;
         padding-left: 5px;
     }
+
+    &.active {
+        color: $primary;
+        font-weight: $font-weight-bold;
+    }
 }
 
 .navigation-flyout-bar {

--- a/src/Storefront/Resources/views/storefront/layout/navigation/categories.html.twig
+++ b/src/Storefront/Resources/views/storefront/layout/navigation/categories.html.twig
@@ -6,6 +6,12 @@
     {% endif %}
     {% set activeId = page.header.navigation.active.id %}
 
+    {% if page.product is defined %}
+        {% set activePath = page.product.categoryTree %}
+    {% else %}
+        {% set activePath = page.header.navigation.active.path %}
+    {% endif %}
+
     <div class="{% if level == 0 %}row {% endif %}navigation-flyout-categories is-level-{{ level }}">
         {% for treeItem in navigationTree %}
             {% set id = treeItem.category.id %}
@@ -21,7 +27,7 @@
                                 <span itemprop="name">{{ name }}</span>
                             </div>
                         {% else %}
-                            <a class="nav-item nav-link navigation-flyout-link is-level-{{ level }}{% if id is same as(activeId) %} active{% endif %}"
+                            <a class="nav-item nav-link navigation-flyout-link is-level-{{ level }}{% if id == activeId or id in activePath %} active{% endif %}"
                                href="{% if treeItem.category.type == 'link' %}{{ link }}{% else %}{{ seoUrl('frontend.navigation.page', { navigationId: id }) }}{% endif %}"
                                itemprop="url"
                                title="{{ name }}">

--- a/src/Storefront/Resources/views/storefront/layout/navigation/navigation.html.twig
+++ b/src/Storefront/Resources/views/storefront/layout/navigation/navigation.html.twig
@@ -21,6 +21,12 @@
                         {% endblock %}
 
                         {% block layout_main_navigation_menu_items %}
+                            {% if page.product is defined %}
+                                {% set activePath = page.product.categoryTree %}
+                            {% else %}
+                                {% set activePath = page.header.navigation.active.path %}
+                            {% endif %}
+
                             {% for treeItem in page.header.navigation.tree %}
                                 {% set category = treeItem.category %}
                                 {% set name = category.translated.name %}
@@ -38,7 +44,7 @@
                                             </div>
                                         </div>
                                     {% else %}
-                                        <a class="nav-link main-navigation-link{% if categorId is same as(page.header.navigation.active.id) %} active{% endif %}"
+                                        <a class="nav-link main-navigation-link{% if categorId == page.header.navigation.active.id or categorId in activePath %} active{% endif %}"
                                            href="{% if category.translated.externalLink %}{{ category.translated.externalLink }}{% else %}{{ seoUrl('frontend.navigation.page', { navigationId: categorId }) }}{% endif %}"
                                            itemprop="url"
                                             {% if treeItem.children|length > 0 %}


### PR DESCRIPTION
### 1. Why is this change necessary?
There is no marking of active category in navigation.
The complete path should be marked as active in navigation - fixes #1278 

### 2. What does this change do, exactly?
Add style to active navigation.
Check active path for navigation to mark them active
![after](https://user-images.githubusercontent.com/135993/91362481-de8f6080-e7fa-11ea-91be-ae0b90758dec.JPG)


### 3. Describe each step to reproduce the issue or behaviour.
Visit navigation, fly out the navigation, see it isn't marked.

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
