### PR TITLE
Make customerId field in ProductReview nullable

### DIFF
--- a/src/Core/Content/Product/Aggregate/ProductReview/ProductReviewEntity.php
+++ b/src/Core/Content/Product/Aggregate/ProductReview/ProductReviewEntity.php
@@ -19,7 +19,7 @@ class ProductReviewEntity extends Entity
     protected $productId;
 
     /**
-     * @var string
+     * @var string|null
      */
     protected $customerId;
 
@@ -98,12 +98,12 @@ class ProductReviewEntity extends Entity
         $this->productId = $productId;
     }
 
-    public function getCustomerId(): string
+    public function getCustomerId(): ?string
     {
         return $this->customerId;
     }
 
-    public function setCustomerId(string $customerId): void
+    public function setCustomerId(?string $customerId): void
     {
         $this->customerId = $customerId;
     }


### PR DESCRIPTION
### 1. Why is this change necessary?
Once upon a time. The DDL said `product_review.customer_id` is nullable but the definition said it is required. Then @htkassner / @King-of-Babylon joined the server b6ab8ef661913ba4d32987729ba3b7cda627a6f3 and made it non-required to match the DLL.
Now a fellow wanderer is happy to see the definition matching the DDL. But a shiver crawls through his spine. The rubber duck squeaks. A thunder strikes a tree. He can see it cristal clear: The entity still doesn't match the definition. A spit onto his index finger gives him the power only his grandmother had once in his childhood. He smears it along the code lines and give it a final cleaning swipe.

![grafik](https://user-images.githubusercontent.com/1133593/91363040-ff0bea80-e7fb-11ea-98b6-a4ae29dfa37b.png)

### 2. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
