### PR TITLE
Store combinations that are available into the AvailableCombinationResult

### DIFF
--- a/src/Core/Content/Product/SalesChannel/Detail/AvailableCombinationResult.php
+++ b/src/Core/Content/Product/SalesChannel/Detail/AvailableCombinationResult.php
@@ -16,24 +16,21 @@ class AvailableCombinationResult extends Struct
      */
     protected $optionIds = [];
 
+    /**
+     * @var array
+     */
+    protected $combinations = [];
+
     public function hasCombination(array $optionIds): bool
     {
-        $optionIds = array_values($optionIds);
-        sort($optionIds);
-
-        $hash = md5(json_encode($optionIds));
-
-        return isset($this->hashes[$hash]);
+        return isset($this->hashes[$this->calculateHash($optionIds)]);
     }
 
     public function addCombination(array $optionIds): void
     {
-        $optionIds = array_values($optionIds);
-        sort($optionIds);
-
-        $hash = md5(json_encode($optionIds));
-
+        $hash = $this->calculateHash($optionIds);
         $this->hashes[$hash] = true;
+        $this->combinations[$hash] = $optionIds;
 
         foreach ($optionIds as $id) {
             $this->optionIds[$id] = true;
@@ -48,5 +45,18 @@ class AvailableCombinationResult extends Struct
     public function getHashes(): array
     {
         return $this->hashes;
+    }
+
+    public function getCombinations(): array
+    {
+        return $this->combinations;
+    }
+
+    private function calculateHash(array $optionIds): string
+    {
+        $optionIds = array_values($optionIds);
+        sort($optionIds);
+
+        return md5(json_encode($optionIds));
     }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?
When you use the combination loader you might want to have the combinations that are available -- like the name lets you expect -- you can get them out of there.

### 2. What does this change do, exactly?
Store every possible options set that is added as well as the original value to read via a getter.

### 3. Describe each step to reproduce the issue or behaviour.
Try to read the possible combinations without questioning every option set and check whether the hash is in the result.

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
