### PR TITLE
Change displaying not installed plugins

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-plugin/snippet/de-DE.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-plugin/snippet/de-DE.json
@@ -101,7 +101,7 @@
             "activated": "Aktiviert",
             "config": "Konfiguration",
             "description": "Beschreibung",
-            "tooltipActivationDisabled": "Du kannst nur installierte Plugins aktivieren."
+            "notInstalled": "Nicht installiert"
         },
         "license-list": {
             "textMyPurchases": "Eingekaufte Lizenzen",

--- a/src/Administration/Resources/app/administration/src/module/sw-plugin/snippet/en-GB.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-plugin/snippet/en-GB.json
@@ -101,7 +101,7 @@
       "activated": "Activated",
       "config": "Config",
       "description": "Description",
-      "tooltipActivationDisabled": "You can only activate installed plugins."
+      "notInstalled": "Not installed"
     },
     "license-list": {
       "textMyPurchases": "Purchased licenses",

--- a/src/Administration/Resources/app/administration/src/module/sw-plugin/view/sw-plugin-list/sw-plugin-list.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-plugin/view/sw-plugin-list/sw-plugin-list.html.twig
@@ -59,14 +59,16 @@
                             <template #column-active="{ item, compact }">
                                 {% block sw_plugin_list_grid_columns_activated_label %}
                                     <sw-switch-field
+                                        v-if="item.installedAt"
                                         class="sw-plugin-list__switch-active"
                                         v-model="item.active"
                                         :value="item.active"
                                         :label="item.active ? $tc('sw-plugin.list.activated') : $tc('sw-plugin.list.deactivated')"
-                                        :disabled="!item.installedAt"
-                                        @change="changeActiveState(item, $event)"
-                                        v-tooltip="{ disabled: item.installedAt, message: $tc('sw-plugin.list.tooltipActivationDisabled') }">
+                                        @change="changeActiveState(item, $event)">
                                     </sw-switch-field>
+                                    <sw-label v-else variant="info">
+                                        {{ $tc('sw-plugin.list.notInstalled') }}
+                                    </sw-label>
                                 {% endblock %}
                             </template>
 


### PR DESCRIPTION
### 1. Why is this change necessary?
We should display info without any mouseover.
![image](https://user-images.githubusercontent.com/135993/91459669-2e1b6e00-e887-11ea-8c1e-114faf1d3712.png)


### 2. What does this change do, exactly?
Replaced tooltip with a label.
![image](https://user-images.githubusercontent.com/135993/91459413-ea286900-e886-11ea-8a8a-fc97dd14b262.png)


### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
