### PR TITLE
add properties to productstream field selection

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/service/product-stream-condition.service.js
+++ b/src/Administration/Resources/app/administration/src/app/service/product-stream-condition.service.js
@@ -202,7 +202,6 @@ export default function conditionService() {
             'metaTitle',
             'prices',
             'services',
-            'properties',
             'searchKeywords',
             'categories',
             'canonicalUrl',

--- a/src/Administration/Resources/app/administration/src/module/sw-product-stream/snippet/de-DE.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-product-stream/snippet/de-DE.json
@@ -75,6 +75,7 @@
         "price": "Preis",
         "product": "Produkt",
         "productNumber": "Produktnummer",
+        "properties": "Eigenschaft",
         "purchasePrice": "Verkaufspreis",
         "purchaseUnit": "Verkaufseinheit",
         "referenceUnit": "Grundeinheit",

--- a/src/Administration/Resources/app/administration/src/module/sw-product-stream/snippet/en-GB.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-product-stream/snippet/en-GB.json
@@ -75,6 +75,7 @@
         "price": "Price",
         "product": "Product",
         "productNumber": "Product number",
+        "properties": "Property",
         "purchasePrice": "Purchase price",
         "purchaseUnit": "Purchase unit",
         "referenceUnit": "Reference unit",


### PR DESCRIPTION
### 1. Why is this change necessary?
This small change has the effect that the item properties are also available in the Selection field for the configuration of dynamic product groups.
This is particularly useful if the dynamic product groups are based on properties such as e.g. the color or size to be filtered.

### 2. What does this change do, exactly?
removes the product properties from the blacklist

### 3. Describe each step to reproduce the issue or behaviour.
create an dynamic productgroup an choose 'properties'

### 4. Please link to the relevant issues (if any).

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
