### PR TITLE
Align head cells of right-aligned columns to the right

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/data-grid/sw-data-grid/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/data-grid/sw-data-grid/index.js
@@ -329,11 +329,13 @@ Component.register('sw-data-grid', {
         },
 
         getHeaderCellClasses(column, index) {
-            return [{
-                'sw-data-grid__cell--sortable': column.dataIndex,
-                'sw-data-grid__cell--icon-label': column.iconLabel
-            },
-            `sw-data-grid__cell--${index}`
+            return [
+                {
+                    'sw-data-grid__cell--sortable': column.dataIndex,
+                    'sw-data-grid__cell--icon-label': column.iconLabel
+                },
+                `sw-data-grid__cell--${index}`,
+                `sw-data-grid__cell--align-${column.align}`
             ];
         },
 

--- a/src/Administration/Resources/app/administration/src/app/component/data-grid/sw-data-grid/sw-data-grid.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/data-grid/sw-data-grid/sw-data-grid.scss
@@ -115,6 +115,13 @@
         }
     }
 
+    .sw-data-grid__cell--align-right.sw-data-grid__cell--header {
+        .sw-data-grid__cell-content {
+            flex-flow: row-reverse;
+            justify-content: flex-start;
+        }
+    }
+
     .sw-data-grid__cell--align-left {
         .sw-data-grid__cell-content {
             justify-content: flex-start;


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?

As briefly discussed with Dennis Mader in Slack: In the `sw-data-grid` component you can set the `align` property of columns to left/right/center. But this `align` property is not used in the styling of the head cell. Hence the head cell is always aligned to the left regardless of the column specification.

Old (head cell aligned to the left, column aligned to the right/center)
<img width="867" alt="Screenshot 2020-08-28 at 16 06 10" src="https://user-images.githubusercontent.com/12038224/91578356-54561200-e94a-11ea-88d1-5e7a4d1635e8.png">

### 2. What does this change do, exactly?

Updates the head cell CSS class to use the column `align` property (works with left/right/center).
Updates the CSS styling to move the head cell context menu to the left if the head cell is aligned to the right. The menu stays on the right side (as before) if the column is aligned to the left or center.

New (head cell and column aligned to the right/center)
<img width="858" alt="Screenshot 2020-08-28 at 16 05 28" src="https://user-images.githubusercontent.com/12038224/91578409-6afc6900-e94a-11ea-9daf-3347aff00a31.png">

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
