### PR TITLE
Send mails to CC and BCC

### DIFF
--- a/src/Core/Content/MailTemplate/Subscriber/MailSendSubscriber.php
+++ b/src/Core/Content/MailTemplate/Subscriber/MailSendSubscriber.php
@@ -105,6 +105,8 @@ class MailSendSubscriber implements EventSubscriberInterface
 
         $data = new DataBag();
         $data->set('recipients', $mailEvent->getMailStruct()->getRecipients());
+        $data->set('recipientsCc', $mailEvent->getMailStruct()->getCcRecipients());
+        $data->set('recipientsBcc', $mailEvent->getMailStruct()->getBccRecipients());
         $data->set('senderName', $mailTemplate->getTranslation('senderName'));
         $data->set('salesChannelId', $mailEvent->getSalesChannelId());
 

--- a/src/Core/Framework/Event/EventData/MailRecipientStruct.php
+++ b/src/Core/Framework/Event/EventData/MailRecipientStruct.php
@@ -11,20 +11,38 @@ class MailRecipientStruct
 
     /**
      * @var string|null
+     *
+     * @deprecated tag:v6.3.0 use $bccRecipients instead
      */
     private $bcc;
 
     /**
+     * @var array|null
+     */
+    private $bccRecipients;
+
+    /**
      * @var string|null
+     *
+     * @deprecated tag:v6.3.0 use $ccRecipients instead
      */
     private $cc;
 
     /**
-     * @param array $recipients ['email' => 'firstName lastName']
+     * @var array|null
      */
-    public function __construct(array $recipients)
+    private $ccRecipients;
+
+    /**
+     * @param array $recipients ['email' => 'firstName lastName']
+     * @param array|null $ccRecipients ['email' => 'firstName lastName']
+     * @param array|null $bccRecipients ['email' => 'firstName lastName']
+     */
+    public function __construct(array $recipients, ?array $ccRecipients = null, ?array $bccRecipients = null)
     {
         $this->recipients = $recipients;
+        $this->ccRecipients = $ccRecipients;
+        $this->bccRecipients = $bccRecipients;
     }
 
     public function getRecipients(): array
@@ -37,23 +55,73 @@ class MailRecipientStruct
         $this->recipients = $recipients;
     }
 
+    /**
+     * @deprecated tag:v6.3.0 use $getBccRecipients instead
+     */
     public function getBcc(): ?string
     {
-        return $this->bcc;
+        return $this->bcc ?? $this->convertRecipientArrayToString($this->bccRecipients);
     }
 
+    /**
+     * @deprecated tag:v6.3.0 use $setBccRecipients instead
+     */
     public function setBcc(?string $bcc): void
     {
-        $this->bcc = $bcc;
+        $this->bcc = $bcc ?? $this->convertRecipientArrayToString($this->bccRecipients);
     }
 
+    public function getBccRecipients(): ?array
+    {
+        return $this->bccRecipients;
+    }
+
+    public function setBccRecipients(?array $bccRecipients): void
+    {
+        $this->bccRecipients = $bccRecipients;
+    }
+
+    /**
+     * @deprecated tag:v6.3.0 use $getCcRecipients instead
+     */
     public function getCc(): ?string
     {
-        return $this->cc;
+        return $this->cc ?? $this->convertRecipientArrayToString($this->ccRecipients);
     }
 
+    /**
+     * @deprecated tag:v6.3.0 use $setCcRecipients instead
+     */
     public function setCc(?string $cc): void
     {
-        $this->cc = $cc;
+        $this->cc = $cc ?? $this->convertRecipientArrayToString($this->ccRecipients);
+    }
+
+    public function getCcRecipients(): ?array
+    {
+        return $this->ccRecipients;
+    }
+
+    public function setCcRecipients(?array $ccRecipients): void
+    {
+        $this->ccRecipients = $ccRecipients;
+    }
+
+    /**
+     * @deprecated tag:v6.3.0 Don't use strings for the recipients
+     */
+    private function convertRecipientArrayToString(?array $recipients): ?string
+    {
+        if (is_null($recipients) || $recipients === []) {
+            return null;
+        }
+
+        $items = [];
+
+        foreach ($recipients as $email => $name) {
+            $items[] = sprintf('%s <%s>', trim($name), $email);
+        }
+
+        return implode(', ', $items);
     }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?
CC and BCC are not handled yet when sending a mail without additional subscribers. CC and BCC are handled differently to TO recipients.

### 2. What does this change do, exactly?
Make CC and BCC an array like TO recipients. Pass on CC and BCC so the MailSender can add them to the Swift_Message

### 3. Describe each step to reproduce the issue or behaviour.
Add CCs to a MailRecipientStruct

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
