### PR TITLE
Fix en-GB sw-condition snippets

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/snippet/en-GB.json
+++ b/src/Administration/Resources/app/administration/src/app/snippet/en-GB.json
@@ -496,8 +496,8 @@
                 "notEquals": "Is not equal to",
                 "isOneOf": "Is one of",
                 "isNoneOf": "Is none of",
-                "gross": "Brutto",
-                "net": "Netto"
+                "gross": "Gross",
+                "net": "Net"
             },
             "placeholderErrorMessage": "Placeholder cannot be saved.",
             "dataErrorMessage": "Required fields not filled.",


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?

Some `sw-condition` snippet values in the `en-GB` JSON are in German.


### 2. What does this change do, exactly?

Changes the snippets to the english values.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
