### PR TITLE
Fix _score sorting via API

### DIFF
--- a/src/Core/Framework/DataAbstractionLayer/Dbal/CriteriaQueryHelper.php
+++ b/src/Core/Framework/DataAbstractionLayer/Dbal/CriteriaQueryHelper.php
@@ -226,6 +226,13 @@ trait CriteriaQueryHelper
             $this->validateSortingDirection($sorting->getDirection());
 
             if ($sorting->getField() === '_score') {
+                if (!$this->hasQueriesOrTerm($criteria)) {
+                    continue;
+                }
+
+                // Only add manual _score sorting if the query contains a _score calculation and selection (i.e. the
+                // criteria has a term or queries). Otherwise the SQL selection would fail because no _score field
+                // exists in any entity.
                 $query->addOrderBy('_score', $sorting->getDirection());
                 $query->addState('_score');
 
@@ -301,6 +308,11 @@ trait CriteriaQueryHelper
         }
 
         return false;
+    }
+
+    private function hasQueriesOrTerm(Criteria $criteria): bool
+    {
+        return !empty($criteria->getQueries()) || $criteria->getTerm();
     }
 
     /**

--- a/src/Core/Framework/DataAbstractionLayer/Search/RequestCriteriaBuilder.php
+++ b/src/Core/Framework/DataAbstractionLayer/Search/RequestCriteriaBuilder.php
@@ -445,6 +445,12 @@ class RequestCriteriaBuilder
 
     private function buildFieldName(EntityDefinition $definition, string $fieldName): string
     {
+        if ($fieldName === '_score') {
+            // Do not prefix _score fields because they are not actual entity properties but a calculated field in the
+            // SQL selection.
+            return $fieldName;
+        }
+
         $prefix = $definition->getEntityName() . '.';
 
         if (mb_strpos($fieldName, $prefix) === false) {

--- a/src/Core/Framework/Test/DataAbstractionLayer/Dbal/CriteriaQueryHelperTest.php
+++ b/src/Core/Framework/Test/DataAbstractionLayer/Dbal/CriteriaQueryHelperTest.php
@@ -39,7 +39,7 @@ class CriteriaQueryHelperTest extends TestCase
         $taxRepository->search($criteria, $context);
     }
 
-    public function testDoNotSortByScoreIfNoScoreQueryOrSearchTermIsSet(): void
+    public function testDoNotSortByScoreAutomaticallyIfNoScoreQueryOrSearchTermIsSet(): void
     {
         $productDefinition = $this->getContainer()->get(ProductDefinition::class);
         $queryMock = $this->createMock(QueryBuilder::class);
@@ -48,6 +48,19 @@ class CriteriaQueryHelperTest extends TestCase
             ->method('addOrderBy');
 
         $this->buildQueryByCriteria($queryMock, $productDefinition, new Criteria(), Context::createDefaultContext());
+    }
+
+    public function testDoNotSortByScoreManuallyIfNoScoreQueryOrSearchTermIsSet(): void
+    {
+        $criteria = new Criteria();
+        $criteria->addSorting(new FieldSorting('_score'));
+        $productDefinition = $this->getContainer()->get(ProductDefinition::class);
+        $queryMock = $this->createMock(QueryBuilder::class);
+        $queryMock
+            ->expects(static::never())
+            ->method('addOrderBy');
+
+        $this->buildQueryByCriteria($queryMock, $productDefinition, $criteria, Context::createDefaultContext());
     }
 
     public function testSortByScoreIfScoreQueryIsSet(): void

--- a/src/Core/Framework/Test/DataAbstractionLayer/Search/RequestCriteriaBuilderTest.php
+++ b/src/Core/Framework/Test/DataAbstractionLayer/Search/RequestCriteriaBuilderTest.php
@@ -122,4 +122,28 @@ class RequestCriteriaBuilderTest extends TestCase
 
         static::assertEquals($testArray, $criteriaArray);
     }
+
+    public function testManualScoreSorting(): void
+    {
+        $body = [
+            'sort' => [
+                [
+                    'field' => '_score',
+                ],
+            ],
+        ];
+        $request = new Request([], $body, [], [], []);
+        $request->setMethod(Request::METHOD_POST);
+
+        $criteria = $this->requestCriteriaBuilder->handleRequest(
+            $request,
+            new Criteria(),
+            $this->getContainer()->get(ProductDefinition::class),
+            Context::createDefaultContext()
+        );
+
+        $sorting = $criteria->getSorting();
+        static::assertCount(1, $sorting);
+        static::assertEquals('_score', $sorting[0]->getField());
+    }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?

As discussed with @OliverSkroblin when you want to fetch entities via API and sort them by a search term (`_score`) _and_ a secondary sorting you need to add both sortings (by `_score` and any other field) manually to the request.
But is not possible to sort by `_score` via api because no entity has a `_score` field.

```
criteria.addSorting(Criteria.sort('_score', 'DESC'));
````
```
status: "400"
title: "Bad Request
code: "FRAMEWORK__UNMAPPED_FIELD"
detail: "Field "_score" in entity "product" was not found."
```

### 2. What does this change do, exactly?

This PR fixes this by doing two things:
1. Supports sorting by `_score` by not prefixing this sort field with the entity name (e.g. it is not changed to `product._score`)
2. Only adds the sorting by `_score` if a `_score` is actually added to the DBAL query (i.e. the query has a search term or otherwise scoreable query)

Old: no sorting by search term (`_score`)
<img width="402" alt="Screenshot 2020-08-27 at 15 42 52" src="https://user-images.githubusercontent.com/12038224/91459377-e09f0100-e886-11ea-82b5-87e67b63fd23.png">

New: sorting by search term (`_score`) and alphanumerically
<img width="385" alt="Screenshot 2020-08-27 at 15 40 03" src="https://user-images.githubusercontent.com/12038224/91459394-e694e200-e886-11ea-988b-106c737aa9de.png">

### 3. Describe each step to reproduce the issue or behaviour.

Create a search POST request of any entity with a sorting by `_score`. The request will fail with the response shown in **1.**


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
