### PR TITLE
Use constants instead of raw string in SyncService

### DIFF
--- a/src/Core/Framework/Api/Sync/SyncService.php
+++ b/src/Core/Framework/Api/Sync/SyncService.php
@@ -135,10 +135,10 @@ class SyncService implements SyncServiceInterface
         $repository = $this->definitionRegistry->getRepository($operation->getEntity());
 
         switch (mb_strtolower($operation->getAction())) {
-            case 'upsert':
+            case SyncOperation::ACTION_UPSERT:
                 return $this->upsertRecords($operation, $context, $repository);
 
-            case 'delete':
+            case SyncOperation::ACTION_DELETE:
                 return $this->deleteRecords($operation, $context, $repository);
 
             default:


### PR DESCRIPTION
### 1. Why is this change necessary?
There are constants which are meant to be used for creators of SyncOperations. The service should use them as well.

### 2. What does this change do, exactly?
Replace bare strings with constants that are used in the same context and have the same evaluated value.

### 3. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
