### PR TITLE
Make name pattern match twig pattern a bit more

### DIFF
--- a/UPGRADE-6.4.md
+++ b/UPGRADE-6.4.md
@@ -13,6 +13,7 @@ Core
 ----
 
 * Implementations of `\Shopware\Core\Framework\Api\Sync\SyncServiceInterface::sync` need to change the type of the first argument `$operations` to `iterable`.
+* System and plugin configurations made with `config.xml` can now have less than 4 characters as configuration key but are not allowed anymore to start with a number.
 
 Administration
 --------------

--- a/src/Core/System/SystemConfig/Schema/config.xsd
+++ b/src/Core/System/SystemConfig/Schema/config.xsd
@@ -85,7 +85,7 @@
     </xs:complexType>
     <xs:simpleType name="name">
         <xs:restriction base="xs:string">
-            <xs:pattern value="[a-zA-Z0-9]{4,}"/>
+            <xs:pattern value="[a-zA-Z][a-zA-Z0-9]*"/>
         </xs:restriction>
     </xs:simpleType>
 </xs:schema>


### PR DESCRIPTION
### 1. Why is this change necessary?
When you have a name like key or url you have to add more to it to make it match that pattern although it is perfectly fine. When your name begins with a number it is more hassle to use it in twig as a leading number -- like in most of the other programming languages -- results in a parsing of an expression where the number is not part of the string anymore. Likely to fail.

### 2. What does this change do, exactly?
Change a regex so it is less hassle by changing the length limit from 4 to 1 and forbid numbers as first character.

### 3. Describe each step to reproduce the issue or behaviour.
1. Have a key that starts with a number
2. Read the configuration in a twig template
3. https://twigfiddle.com/p66dqm

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
