### PR TITLE
Output list of refreshed themes in theme:refresh command

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,8117 @@
+parameters:
+	ignoreErrors:
+		-
+			message: "#^Cannot call method getCountry\\(\\) on Shopware\\\\Core\\\\Checkout\\\\Customer\\\\Aggregate\\\\CustomerAddress\\\\CustomerAddressEntity\\|null\\.$#"
+			count: 2
+			path: src/Core/Checkout/Cart/Address/AddressValidator.php
+
+		-
+			message: "#^Cannot call method getShippingAvailable\\(\\) on Shopware\\\\Core\\\\System\\\\Country\\\\CountryEntity\\|null\\.$#"
+			count: 1
+			path: src/Core/Checkout/Cart/Address/AddressValidator.php
+
+		-
+			message: "#^Cannot call method getTranslation\\(\\) on Shopware\\\\Core\\\\System\\\\Country\\\\CountryEntity\\|null\\.$#"
+			count: 1
+			path: src/Core/Checkout/Cart/Address/AddressValidator.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Checkout\\\\Cart\\\\Cart\\:\\:get\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Checkout/Cart/Cart.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Checkout\\\\Cart\\\\CartBehavior\\:\\:hasPermission\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Checkout/Cart/CartBehavior.php
+
+		-
+			message: "#^Cannot call method getId\\(\\) on Shopware\\\\Core\\\\Checkout\\\\Customer\\\\CustomerEntity\\|null\\.$#"
+			count: 1
+			path: src/Core/Checkout/Cart/CartPersister.php
+
+		-
+			message: "#^Parameter \\#1 \\$entity of static method Shopware\\\\Core\\\\Checkout\\\\Cart\\\\Delivery\\\\Struct\\\\DeliveryTime\\:\\:createFromEntity\\(\\) expects Shopware\\\\Core\\\\System\\\\DeliveryTime\\\\DeliveryTimeEntity, Shopware\\\\Core\\\\System\\\\DeliveryTime\\\\DeliveryTimeEntity\\|null given\\.$#"
+			count: 1
+			path: src/Core/Checkout/Cart/Delivery/DeliveryBuilder.php
+
+		-
+			message: "#^Cannot call method getDeliveryDate\\(\\) on Shopware\\\\Core\\\\Checkout\\\\Cart\\\\Delivery\\\\Struct\\\\DeliveryPosition\\|null\\.$#"
+			count: 1
+			path: src/Core/Checkout/Cart/Delivery/DeliveryBuilder.php
+
+		-
+			message: "#^Cannot call method getFreeDelivery\\(\\) on Shopware\\\\Core\\\\Checkout\\\\Cart\\\\Delivery\\\\Struct\\\\DeliveryInformation\\|null\\.$#"
+			count: 1
+			path: src/Core/Checkout/Cart/Delivery/DeliveryCalculator.php
+
+		-
+			message: "#^Parameter \\#1 \\$price of method Shopware\\\\Core\\\\Checkout\\\\Cart\\\\Delivery\\\\DeliveryCalculator\\:\\:getPriceForTaxState\\(\\) expects Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Pricing\\\\Price, Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Pricing\\\\Price\\|null given\\.$#"
+			count: 1
+			path: src/Core/Checkout/Cart/Delivery/DeliveryCalculator.php
+
+		-
+			message: "#^Cannot call method getCurrencyId\\(\\) on Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Pricing\\\\Price\\|null\\.$#"
+			count: 1
+			path: src/Core/Checkout/Cart/Delivery/DeliveryCalculator.php
+
+		-
+			message: "#^Parameter \\#1 \\$priceCollection of method Shopware\\\\Core\\\\Checkout\\\\Cart\\\\Delivery\\\\DeliveryCalculator\\:\\:getCurrencyPrice\\(\\) expects Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Pricing\\\\PriceCollection, Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Pricing\\\\PriceCollection\\|null given\\.$#"
+			count: 2
+			path: src/Core/Checkout/Cart/Delivery/DeliveryCalculator.php
+
+		-
+			message: "#^Cannot call method getShippingMethod\\(\\) on Shopware\\\\Core\\\\Checkout\\\\Cart\\\\Delivery\\\\Struct\\\\Delivery\\|null\\.$#"
+			count: 1
+			path: src/Core/Checkout/Cart/Delivery/DeliveryProcessor.php
+
+		-
+			message: "#^Cannot call method setShippingMethod\\(\\) on Shopware\\\\Core\\\\Checkout\\\\Cart\\\\Delivery\\\\Struct\\\\Delivery\\|null\\.$#"
+			count: 1
+			path: src/Core/Checkout/Cart/Delivery/DeliveryProcessor.php
+
+		-
+			message: "#^Parameter \\#1 \\$entity of method Shopware\\\\Core\\\\Checkout\\\\Customer\\\\Aggregate\\\\CustomerAddress\\\\CustomerAddressCollection\\:\\:add\\(\\) expects Shopware\\\\Core\\\\Checkout\\\\Customer\\\\Aggregate\\\\CustomerAddress\\\\CustomerAddressEntity, Shopware\\\\Core\\\\Checkout\\\\Customer\\\\Aggregate\\\\CustomerAddress\\\\CustomerAddressEntity\\|null given\\.$#"
+			count: 1
+			path: src/Core/Checkout/Cart/Delivery/Struct/DeliveryCollection.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Checkout\\\\Cart\\\\Delivery\\\\Struct\\\\DeliveryPositionCollection\\:\\:set\\(\\) has parameter \\$deliveryPosition with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Checkout/Cart/Delivery/Struct/DeliveryPositionCollection.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Checkout\\\\Cart\\\\Delivery\\\\Struct\\\\DeliveryPositionCollection\\:\\:set\\(\\) has parameter \\$key with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Checkout/Cart/Delivery/Struct/DeliveryPositionCollection.php
+
+		-
+			message: "#^Cannot call method getWeight\\(\\) on Shopware\\\\Core\\\\Checkout\\\\Cart\\\\Delivery\\\\Struct\\\\DeliveryInformation\\|null\\.$#"
+			count: 1
+			path: src/Core/Checkout/Cart/Delivery/Struct/DeliveryPositionCollection.php
+
+		-
+			message: "#^Parameter \\#1 \\$country of class Shopware\\\\Core\\\\Checkout\\\\Cart\\\\Delivery\\\\Struct\\\\ShippingLocation constructor expects Shopware\\\\Core\\\\System\\\\Country\\\\CountryEntity, Shopware\\\\Core\\\\System\\\\Country\\\\CountryEntity\\|null given\\.$#"
+			count: 1
+			path: src/Core/Checkout/Cart/Delivery/Struct/ShippingLocation.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Checkout\\\\Cart\\\\Delivery\\\\Struct\\\\ShippingLocation\\:\\:getCountry\\(\\) should return Shopware\\\\Core\\\\System\\\\Country\\\\CountryEntity but returns Shopware\\\\Core\\\\System\\\\Country\\\\CountryEntity\\|null\\.$#"
+			count: 1
+			path: src/Core/Checkout/Cart/Delivery/Struct/ShippingLocation.php
+
+		-
+			message: "#^Cannot call method getEmail\\(\\) on Shopware\\\\Core\\\\Checkout\\\\Order\\\\Aggregate\\\\OrderCustomer\\\\OrderCustomerEntity\\|null\\.$#"
+			count: 1
+			path: src/Core/Checkout/Cart/Event/CheckoutOrderPlacedEvent.php
+
+		-
+			message: "#^Cannot call method getFirstName\\(\\) on Shopware\\\\Core\\\\Checkout\\\\Order\\\\Aggregate\\\\OrderCustomer\\\\OrderCustomerEntity\\|null\\.$#"
+			count: 1
+			path: src/Core/Checkout/Cart/Event/CheckoutOrderPlacedEvent.php
+
+		-
+			message: "#^Cannot call method getLastName\\(\\) on Shopware\\\\Core\\\\Checkout\\\\Order\\\\Aggregate\\\\OrderCustomer\\\\OrderCustomerEntity\\|null\\.$#"
+			count: 1
+			path: src/Core/Checkout/Cart/Event/CheckoutOrderPlacedEvent.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Checkout\\\\Cart\\\\LineItem\\\\Group\\\\LineItemQuantityCollection\\:\\:has\\(\\) has parameter \\$key with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Checkout/Cart/LineItem/Group/LineItemQuantityCollection.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Checkout\\\\Cart\\\\LineItem\\\\LineItem\\:\\:getPayloadValue\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Checkout/Cart/LineItem/LineItem.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Checkout\\\\Cart\\\\LineItem\\\\LineItemCollection\\:\\:set\\(\\) has parameter \\$key with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Checkout/Cart/LineItem/LineItemCollection.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Checkout\\\\Cart\\\\LineItem\\\\LineItemCollection\\:\\:set\\(\\) has parameter \\$lineItem with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Checkout/Cart/LineItem/LineItemCollection.php
+
+		-
+			message: "#^Cannot call method getPriority\\(\\) on Shopware\\\\Core\\\\Checkout\\\\Cart\\\\Price\\\\Struct\\\\PriceDefinitionInterface\\|null\\.$#"
+			count: 1
+			path: src/Core/Checkout/Cart/LineItem/LineItemCollection.php
+
+		-
+			message: "#^Cannot call method getUnitPrice\\(\\) on Shopware\\\\Core\\\\Checkout\\\\Cart\\\\Price\\\\Struct\\\\CalculatedPrice\\|null\\.$#"
+			count: 1
+			path: src/Core/Checkout/Cart/LineItem/LineItemQuantitySplitter.php
+
+		-
+			message: "#^Cannot call method getTaxRules\\(\\) on Shopware\\\\Core\\\\Checkout\\\\Cart\\\\Price\\\\Struct\\\\CalculatedPrice\\|null\\.$#"
+			count: 1
+			path: src/Core/Checkout/Cart/LineItem/LineItemQuantitySplitter.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\Checkout\\\\Cart\\\\LineItemFactoryRegistry\\:\\:\\$handlers \\(array\\<Shopware\\\\Core\\\\Checkout\\\\Cart\\\\LineItemFactoryHandler\\\\LineItemFactoryInterface\\>\\) does not accept iterable\\.$#"
+			count: 1
+			path: src/Core/Checkout/Cart/LineItemFactoryRegistry.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Checkout\\\\Cart\\\\Order\\\\Api\\\\OrderRecalculationController\\:\\:addCreditItemToOrder\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Checkout/Cart/Order/Api/OrderRecalculationController.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\Checkout\\\\Cart\\\\Order\\\\IdStruct\\:\\:\\$id has no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Checkout/Cart/Order/IdStruct.php
+
+		-
+			message: "#^Parameter \\#1 \\$customer of static method Shopware\\\\Core\\\\Checkout\\\\Cart\\\\Order\\\\Transformer\\\\CustomerTransformer\\:\\:transform\\(\\) expects Shopware\\\\Core\\\\Checkout\\\\Customer\\\\CustomerEntity, Shopware\\\\Core\\\\Checkout\\\\Customer\\\\CustomerEntity\\|null given\\.$#"
+			count: 1
+			path: src/Core/Checkout/Cart/Order/OrderConverter.php
+
+		-
+			message: "#^Cannot call method getActiveBillingAddress\\(\\) on Shopware\\\\Core\\\\Checkout\\\\Customer\\\\CustomerEntity\\|null\\.$#"
+			count: 2
+			path: src/Core/Checkout/Cart/Order/OrderConverter.php
+
+		-
+			message: "#^Cannot call method getId\\(\\) on Shopware\\\\Core\\\\Checkout\\\\Customer\\\\Aggregate\\\\CustomerAddress\\\\CustomerAddressEntity\\|null\\.$#"
+			count: 1
+			path: src/Core/Checkout/Cart/Order/OrderConverter.php
+
+		-
+			message: "#^Parameter \\#1 \\$address of static method Shopware\\\\Core\\\\Checkout\\\\Cart\\\\Order\\\\Transformer\\\\AddressTransformer\\:\\:transform\\(\\) expects Shopware\\\\Core\\\\Checkout\\\\Customer\\\\Aggregate\\\\CustomerAddress\\\\CustomerAddressEntity, Shopware\\\\Core\\\\Checkout\\\\Customer\\\\Aggregate\\\\CustomerAddress\\\\CustomerAddressEntity\\|null given\\.$#"
+			count: 1
+			path: src/Core/Checkout/Cart/Order/OrderConverter.php
+
+		-
+			message: "#^Cannot call method getCustomerId\\(\\) on Shopware\\\\Core\\\\Checkout\\\\Order\\\\Aggregate\\\\OrderCustomer\\\\OrderCustomerEntity\\|null\\.$#"
+			count: 1
+			path: src/Core/Checkout/Cart/Order/OrderConverter.php
+
+		-
+			message: "#^Cannot call method getGroupId\\(\\) on Shopware\\\\Core\\\\Checkout\\\\Customer\\\\CustomerEntity\\|null\\.$#"
+			count: 1
+			path: src/Core/Checkout/Cart/Order/OrderConverter.php
+
+		-
+			message: "#^Cannot call method getCountryStateId\\(\\) on Shopware\\\\Core\\\\Checkout\\\\Order\\\\Aggregate\\\\OrderAddress\\\\OrderAddressEntity\\|null\\.$#"
+			count: 1
+			path: src/Core/Checkout/Cart/Order/OrderConverter.php
+
+		-
+			message: "#^Argument of an invalid type Shopware\\\\Core\\\\Checkout\\\\Order\\\\Aggregate\\\\OrderTransaction\\\\OrderTransactionCollection\\|null supplied for foreach, only iterables are supported\\.$#"
+			count: 1
+			path: src/Core/Checkout/Cart/Order/OrderConverter.php
+
+		-
+			message: "#^Parameter \\#4 \\$price of class Shopware\\\\Core\\\\Checkout\\\\Cart\\\\Delivery\\\\Struct\\\\DeliveryPosition constructor expects Shopware\\\\Core\\\\Checkout\\\\Cart\\\\Price\\\\Struct\\\\CalculatedPrice, Shopware\\\\Core\\\\Checkout\\\\Cart\\\\Price\\\\Struct\\\\CalculatedPrice\\|null given\\.$#"
+			count: 1
+			path: src/Core/Checkout/Cart/Order/RecalculationService.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Checkout\\\\Cart\\\\Order\\\\RecalculationService\\:\\:fetchOrder\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Checkout/Cart/Order/RecalculationService.php
+
+		-
+			message: "#^Cannot call method getId\\(\\) on Shopware\\\\Core\\\\Checkout\\\\Customer\\\\Aggregate\\\\CustomerAddress\\\\CustomerAddressEntity\\|null\\.$#"
+			count: 1
+			path: src/Core/Checkout/Cart/Order/Transformer/DeliveryTransformer.php
+
+		-
+			message: "#^Cannot call method getId\\(\\) on Shopware\\\\Core\\\\Content\\\\Media\\\\MediaEntity\\|null\\.$#"
+			count: 1
+			path: src/Core/Checkout/Cart/Order/Transformer/LineItemTransformer.php
+
+		-
+			message: "#^Parameter \\#1 \\$type of method Shopware\\\\Core\\\\Checkout\\\\Cart\\\\LineItem\\\\LineItem\\:\\:setType\\(\\) expects string, string\\|null given\\.$#"
+			count: 1
+			path: src/Core/Checkout/Cart/Order/Transformer/LineItemTransformer.php
+
+		-
+			message: "#^Parameter \\#1 \\$netPrice of method Shopware\\\\Core\\\\Checkout\\\\Cart\\\\Tax\\\\TaxCalculator\\:\\:calculateGross\\(\\) expects float, float\\|null given\\.$#"
+			count: 1
+			path: src/Core/Checkout/Cart/Price/GrossPriceCalculator.php
+
+		-
+			message: "#^Parameter \\#1 \\$price of method Shopware\\\\Core\\\\Checkout\\\\Cart\\\\Price\\\\PriceRoundingInterface\\:\\:round\\(\\) expects float, float\\|null given\\.$#"
+			count: 1
+			path: src/Core/Checkout/Cart/Price/GrossPriceCalculator.php
+
+		-
+			message: "#^Parameter \\#1 \\$price of method Shopware\\\\Core\\\\Checkout\\\\Cart\\\\Price\\\\PriceRoundingInterface\\:\\:round\\(\\) expects float, float\\|null given\\.$#"
+			count: 1
+			path: src/Core/Checkout/Cart/Price/NetPriceCalculator.php
+
+		-
+			message: "#^Parameter \\#2 \\$listPrice of static method Shopware\\\\Core\\\\Checkout\\\\Cart\\\\Price\\\\Struct\\\\ListPrice\\:\\:createFromUnitPrice\\(\\) expects float, float\\|null given\\.$#"
+			count: 1
+			path: src/Core/Checkout/Cart/Price/NetPriceCalculator.php
+
+		-
+			message: "#^Cannot call method getPurchaseUnit\\(\\) on Shopware\\\\Core\\\\Checkout\\\\Cart\\\\Price\\\\Struct\\\\ReferencePriceDefinition\\|null\\.$#"
+			count: 2
+			path: src/Core/Checkout/Cart/Price/ReferencePriceCalculator.php
+
+		-
+			message: "#^Cannot call method getReferenceUnit\\(\\) on Shopware\\\\Core\\\\Checkout\\\\Cart\\\\Price\\\\Struct\\\\ReferencePriceDefinition\\|null\\.$#"
+			count: 2
+			path: src/Core/Checkout/Cart/Price/ReferencePriceCalculator.php
+
+		-
+			message: "#^Cannot call method getUnitName\\(\\) on Shopware\\\\Core\\\\Checkout\\\\Cart\\\\Price\\\\Struct\\\\ReferencePriceDefinition\\|null\\.$#"
+			count: 1
+			path: src/Core/Checkout/Cart/Price/ReferencePriceCalculator.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\Checkout\\\\Cart\\\\Price\\\\Struct\\\\CalculatedPrice\\:\\:\\$referencePrice \\(Shopware\\\\Core\\\\Checkout\\\\Cart\\\\Price\\\\Struct\\\\ReferencePrice\\) does not accept Shopware\\\\Core\\\\Checkout\\\\Cart\\\\Price\\\\Struct\\\\ReferencePrice\\|null\\.$#"
+			count: 1
+			path: src/Core/Checkout/Cart/Price/Struct/CalculatedPrice.php
+
+		-
+			message: "#^Parameter \\#1 \\$json of function json_decode expects string, string\\|false given\\.$#"
+			count: 1
+			path: src/Core/Checkout/Cart/PriceActionController.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\Checkout\\\\Cart\\\\Processor\\:\\:\\$processors \\(array\\<Shopware\\\\Core\\\\Checkout\\\\Cart\\\\CartProcessorInterface\\>\\) does not accept iterable\\.$#"
+			count: 1
+			path: src/Core/Checkout/Cart/Processor.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\Checkout\\\\Cart\\\\Processor\\:\\:\\$collectors \\(array\\<Shopware\\\\Core\\\\Checkout\\\\Cart\\\\CartDataCollectorInterface\\>\\) does not accept iterable\\.$#"
+			count: 1
+			path: src/Core/Checkout/Cart/Processor.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\Checkout\\\\Cart\\\\Rule\\\\CartAmountRule\\:\\:\\$amount \\(float\\) does not accept float\\|null\\.$#"
+			count: 1
+			path: src/Core/Checkout/Cart/Rule/CartAmountRule.php
+
+		-
+			message: "#^Cannot call method getFreeDelivery\\(\\) on Shopware\\\\Core\\\\Checkout\\\\Cart\\\\Delivery\\\\Struct\\\\DeliveryInformation\\|null\\.$#"
+			count: 1
+			path: src/Core/Checkout/Cart/Rule/CartHasDeliveryFreeItemRule.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\Checkout\\\\Cart\\\\Rule\\\\CartWeightRule\\:\\:\\$weight \\(float\\) does not accept float\\|null\\.$#"
+			count: 1
+			path: src/Core/Checkout/Cart/Rule/CartWeightRule.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\Checkout\\\\Cart\\\\Rule\\\\GoodsCountRule\\:\\:\\$count \\(int\\) does not accept int\\|null\\.$#"
+			count: 1
+			path: src/Core/Checkout/Cart/Rule/GoodsCountRule.php
+
+		-
+			message: "#^Cannot call method match\\(\\) on Shopware\\\\Core\\\\Framework\\\\Rule\\\\Container\\\\Container\\|null\\.$#"
+			count: 1
+			path: src/Core/Checkout/Cart/Rule/GoodsCountRule.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\Checkout\\\\Cart\\\\Rule\\\\GoodsPriceRule\\:\\:\\$amount \\(float\\) does not accept float\\|null\\.$#"
+			count: 1
+			path: src/Core/Checkout/Cart/Rule/GoodsPriceRule.php
+
+		-
+			message: "#^Cannot call method match\\(\\) on Shopware\\\\Core\\\\Framework\\\\Rule\\\\Container\\\\Container\\|null\\.$#"
+			count: 1
+			path: src/Core/Checkout/Cart/Rule/GoodsPriceRule.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\Checkout\\\\Cart\\\\Rule\\\\LineItemDimensionHeightRule\\:\\:\\$amount \\(float\\) does not accept float\\|null\\.$#"
+			count: 1
+			path: src/Core/Checkout/Cart/Rule/LineItemDimensionHeightRule.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\Checkout\\\\Cart\\\\Rule\\\\LineItemDimensionLengthRule\\:\\:\\$amount \\(float\\) does not accept float\\|null\\.$#"
+			count: 1
+			path: src/Core/Checkout/Cart/Rule/LineItemDimensionLengthRule.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\Checkout\\\\Cart\\\\Rule\\\\LineItemDimensionWeightRule\\:\\:\\$amount \\(float\\) does not accept float\\|null\\.$#"
+			count: 1
+			path: src/Core/Checkout/Cart/Rule/LineItemDimensionWeightRule.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\Checkout\\\\Cart\\\\Rule\\\\LineItemDimensionWidthRule\\:\\:\\$amount \\(float\\) does not accept float\\|null\\.$#"
+			count: 1
+			path: src/Core/Checkout/Cart/Rule/LineItemDimensionWidthRule.php
+
+		-
+			message: "#^Parameter \\#5 \\$rules of class Shopware\\\\Core\\\\Checkout\\\\Cart\\\\LineItem\\\\Group\\\\LineItemGroupDefinition constructor expects Shopware\\\\Core\\\\Content\\\\Rule\\\\RuleCollection, Shopware\\\\Core\\\\Content\\\\Rule\\\\RuleCollection\\|null given\\.$#"
+			count: 1
+			path: src/Core/Checkout/Cart/Rule/LineItemGroupRule.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\Checkout\\\\Cart\\\\Rule\\\\LineItemListPriceRule\\:\\:\\$amount \\(float\\) does not accept float\\|null\\.$#"
+			count: 1
+			path: src/Core/Checkout/Cart/Rule/LineItemListPriceRule.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\Checkout\\\\Cart\\\\Rule\\\\LineItemOfTypeRule\\:\\:\\$lineItemType \\(string\\) does not accept string\\|null\\.$#"
+			count: 1
+			path: src/Core/Checkout/Cart/Rule/LineItemOfTypeRule.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\Checkout\\\\Cart\\\\Rule\\\\LineItemPurchasePriceRule\\:\\:\\$amount \\(float\\) does not accept float\\|null\\.$#"
+			count: 1
+			path: src/Core/Checkout/Cart/Rule/LineItemPurchasePriceRule.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\Checkout\\\\Cart\\\\Rule\\\\LineItemRule\\:\\:\\$identifiers \\(array\\<string\\>\\) does not accept array\\|null\\.$#"
+			count: 1
+			path: src/Core/Checkout/Cart/Rule/LineItemRule.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\Checkout\\\\Cart\\\\Rule\\\\LineItemTagRule\\:\\:\\$identifiers \\(array\\<string\\>\\) does not accept array\\|null\\.$#"
+			count: 1
+			path: src/Core/Checkout/Cart/Rule/LineItemTagRule.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\Checkout\\\\Cart\\\\Rule\\\\LineItemTotalPriceRule\\:\\:\\$amount \\(float\\) does not accept float\\|null\\.$#"
+			count: 1
+			path: src/Core/Checkout/Cart/Rule/LineItemTotalPriceRule.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\Checkout\\\\Cart\\\\Rule\\\\LineItemUnitPriceRule\\:\\:\\$amount \\(float\\) does not accept float\\|null\\.$#"
+			count: 1
+			path: src/Core/Checkout/Cart/Rule/LineItemUnitPriceRule.php
+
+		-
+			message: "#^Cannot call method getUnitPrice\\(\\) on Shopware\\\\Core\\\\Checkout\\\\Cart\\\\Price\\\\Struct\\\\CalculatedPrice\\|null\\.$#"
+			count: 1
+			path: src/Core/Checkout/Cart/Rule/LineItemUnitPriceRule.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\Checkout\\\\Cart\\\\Rule\\\\LineItemWithQuantityRule\\:\\:\\$id \\(string\\) does not accept string\\|null\\.$#"
+			count: 1
+			path: src/Core/Checkout/Cart/Rule/LineItemWithQuantityRule.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\Checkout\\\\Cart\\\\Rule\\\\LineItemWithQuantityRule\\:\\:\\$quantity \\(int\\) does not accept int\\|null\\.$#"
+			count: 1
+			path: src/Core/Checkout/Cart/Rule/LineItemWithQuantityRule.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\Checkout\\\\Cart\\\\Rule\\\\LineItemsInCartRule\\:\\:\\$identifiers \\(array\\<string\\>\\) does not accept array\\|null\\.$#"
+			count: 1
+			path: src/Core/Checkout/Cart/Rule/LineItemsInCartRule.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Checkout\\\\Cart\\\\SalesChannel\\\\CartLoadRoute\\:\\:createNew\\(\\) has parameter \\$name with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Checkout/Cart/SalesChannel/CartLoadRoute.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Checkout\\\\Cart\\\\SalesChannel\\\\CartLoadRoute\\:\\:createNew\\(\\) has parameter \\$token with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Checkout/Cart/SalesChannel/CartLoadRoute.php
+
+		-
+			message: "#^Parameter \\#1 \\$lineItem of method Shopware\\\\Core\\\\Checkout\\\\Cart\\\\SalesChannel\\\\SalesChannelCartController\\:\\:updateLineItemByRequest\\(\\) expects Shopware\\\\Core\\\\Checkout\\\\Cart\\\\LineItem\\\\LineItem, Shopware\\\\Core\\\\Checkout\\\\Cart\\\\LineItem\\\\LineItem\\|null given\\.$#"
+			count: 1
+			path: src/Core/Checkout/Cart/SalesChannel/SalesChannelCartController.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Checkout\\\\Cart\\\\SalesChannel\\\\SalesChannelCartController\\:\\:initPriceDefinition\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Checkout/Cart/SalesChannel/SalesChannelCartController.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\Checkout\\\\Cart\\\\Validator\\:\\:\\$validators \\(array\\<Shopware\\\\Core\\\\Checkout\\\\Cart\\\\CartValidatorInterface\\>\\) does not accept iterable\\.$#"
+			count: 1
+			path: src/Core/Checkout/Cart/Validator.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\Checkout\\\\Checkout\\:\\:\\$name has no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Checkout/Checkout.php
+
+		-
+			message: "#^Parameter \\#2 \\$customerGroup of class Shopware\\\\Core\\\\Checkout\\\\Customer\\\\Event\\\\CustomerGroupRegistrationAccepted constructor expects Shopware\\\\Core\\\\Checkout\\\\Customer\\\\Aggregate\\\\CustomerGroup\\\\CustomerGroupEntity, Shopware\\\\Core\\\\Checkout\\\\Customer\\\\Aggregate\\\\CustomerGroup\\\\CustomerGroupEntity\\|null given\\.$#"
+			count: 1
+			path: src/Core/Checkout/Customer/Api/CustomerGroupRegistrationActionController.php
+
+		-
+			message: "#^Parameter \\#2 \\$customerGroup of class Shopware\\\\Core\\\\Checkout\\\\Customer\\\\Event\\\\CustomerGroupRegistrationDeclined constructor expects Shopware\\\\Core\\\\Checkout\\\\Customer\\\\Aggregate\\\\CustomerGroup\\\\CustomerGroupEntity, Shopware\\\\Core\\\\Checkout\\\\Customer\\\\Aggregate\\\\CustomerGroup\\\\CustomerGroupEntity\\|null given\\.$#"
+			count: 1
+			path: src/Core/Checkout/Customer/Api/CustomerGroupRegistrationActionController.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Checkout\\\\Customer\\\\DataAbstractionLayer\\\\CustomerIndexer\\:\\:iterate\\(\\) has parameter \\$offset with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Checkout/Customer/DataAbstractionLayer/CustomerIndexer.php
+
+		-
+			message: "#^Cannot call method getEmail\\(\\) on Shopware\\\\Core\\\\Checkout\\\\Customer\\\\CustomerEntity\\|null\\.$#"
+			count: 1
+			path: src/Core/Checkout/Customer/Event/CustomerAccountRecoverRequestEvent.php
+
+		-
+			message: "#^Cannot call method getFirstName\\(\\) on Shopware\\\\Core\\\\Checkout\\\\Customer\\\\CustomerEntity\\|null\\.$#"
+			count: 1
+			path: src/Core/Checkout/Customer/Event/CustomerAccountRecoverRequestEvent.php
+
+		-
+			message: "#^Cannot call method getLastName\\(\\) on Shopware\\\\Core\\\\Checkout\\\\Customer\\\\CustomerEntity\\|null\\.$#"
+			count: 1
+			path: src/Core/Checkout/Customer/Event/CustomerAccountRecoverRequestEvent.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\Checkout\\\\Customer\\\\Password\\\\LegacyPasswordVerifier\\:\\:\\$encoder \\(array\\<Shopware\\\\Core\\\\Checkout\\\\Customer\\\\Password\\\\LegacyEncoder\\\\LegacyEncoderInterface\\>\\) does not accept iterable\\.$#"
+			count: 1
+			path: src/Core/Checkout/Customer/Password/LegacyPasswordVerifier.php
+
+		-
+			message: "#^Parameter \\#2 \\$hash of method Shopware\\\\Core\\\\Checkout\\\\Customer\\\\Password\\\\LegacyEncoder\\\\LegacyEncoderInterface\\:\\:isPasswordValid\\(\\) expects string, string\\|null given\\.$#"
+			count: 1
+			path: src/Core/Checkout/Customer/Password/LegacyPasswordVerifier.php
+
+		-
+			message: "#^Parameter \\#1 \\$encoder of class Shopware\\\\Core\\\\Checkout\\\\Customer\\\\Exception\\\\LegacyPasswordEncoderNotFoundException constructor expects string, string\\|null given\\.$#"
+			count: 1
+			path: src/Core/Checkout/Customer/Password/LegacyPasswordVerifier.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\Checkout\\\\Customer\\\\Rule\\\\BillingCountryRule\\:\\:\\$countryIds \\(array\\<string\\>\\) does not accept array\\|null\\.$#"
+			count: 1
+			path: src/Core/Checkout/Customer/Rule/BillingCountryRule.php
+
+		-
+			message: "#^Cannot call method getCountry\\(\\) on Shopware\\\\Core\\\\Checkout\\\\Customer\\\\Aggregate\\\\CustomerAddress\\\\CustomerAddressEntity\\|null\\.$#"
+			count: 1
+			path: src/Core/Checkout/Customer/Rule/BillingCountryRule.php
+
+		-
+			message: "#^Cannot call method getId\\(\\) on Shopware\\\\Core\\\\System\\\\Country\\\\CountryEntity\\|null\\.$#"
+			count: 1
+			path: src/Core/Checkout/Customer/Rule/BillingCountryRule.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\Checkout\\\\Customer\\\\Rule\\\\BillingStreetRule\\:\\:\\$streetName \\(string\\) does not accept string\\|null\\.$#"
+			count: 1
+			path: src/Core/Checkout/Customer/Rule/BillingStreetRule.php
+
+		-
+			message: "#^Cannot call method getStreet\\(\\) on Shopware\\\\Core\\\\Checkout\\\\Customer\\\\Aggregate\\\\CustomerAddress\\\\CustomerAddressEntity\\|null\\.$#"
+			count: 1
+			path: src/Core/Checkout/Customer/Rule/BillingStreetRule.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\Checkout\\\\Customer\\\\Rule\\\\BillingZipCodeRule\\:\\:\\$zipCodes \\(array\\<string\\>\\) does not accept array\\|null\\.$#"
+			count: 1
+			path: src/Core/Checkout/Customer/Rule/BillingZipCodeRule.php
+
+		-
+			message: "#^Cannot call method getZipcode\\(\\) on Shopware\\\\Core\\\\Checkout\\\\Customer\\\\Aggregate\\\\CustomerAddress\\\\CustomerAddressEntity\\|null\\.$#"
+			count: 1
+			path: src/Core/Checkout/Customer/Rule/BillingZipCodeRule.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\Checkout\\\\Customer\\\\Rule\\\\CustomerGroupRule\\:\\:\\$customerGroupIds \\(array\\<string\\>\\) does not accept array\\|null\\.$#"
+			count: 1
+			path: src/Core/Checkout/Customer/Rule/CustomerGroupRule.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\Checkout\\\\Customer\\\\Rule\\\\CustomerNumberRule\\:\\:\\$numbers \\(array\\<string\\>\\) does not accept array\\|null\\.$#"
+			count: 1
+			path: src/Core/Checkout/Customer/Rule/CustomerNumberRule.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\Checkout\\\\Customer\\\\Rule\\\\CustomerTagRule\\:\\:\\$identifiers \\(array\\<string\\>\\) does not accept array\\|null\\.$#"
+			count: 1
+			path: src/Core/Checkout/Customer/Rule/CustomerTagRule.php
+
+		-
+			message: "#^Cannot call method getId\\(\\) on Shopware\\\\Core\\\\Checkout\\\\Customer\\\\Aggregate\\\\CustomerAddress\\\\CustomerAddressEntity\\|null\\.$#"
+			count: 4
+			path: src/Core/Checkout/Customer/Rule/DifferentAddressesRule.php
+
+		-
+			message: "#^Cannot call method format\\(\\) on DateTimeInterface\\|null\\.$#"
+			count: 2
+			path: src/Core/Checkout/Customer/Rule/IsNewCustomerRule.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\Checkout\\\\Customer\\\\Rule\\\\LastNameRule\\:\\:\\$lastName \\(string\\) does not accept string\\|null\\.$#"
+			count: 1
+			path: src/Core/Checkout/Customer/Rule/LastNameRule.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\Checkout\\\\Customer\\\\Rule\\\\ShippingCountryRule\\:\\:\\$countryIds \\(array\\<string\\>\\) does not accept array\\|null\\.$#"
+			count: 1
+			path: src/Core/Checkout/Customer/Rule/ShippingCountryRule.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\Checkout\\\\Customer\\\\Rule\\\\ShippingStreetRule\\:\\:\\$streetName \\(string\\) does not accept string\\|null\\.$#"
+			count: 1
+			path: src/Core/Checkout/Customer/Rule/ShippingStreetRule.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\Checkout\\\\Customer\\\\Rule\\\\ShippingZipCodeRule\\:\\:\\$zipCodes \\(array\\<string\\>\\) does not accept array\\|null\\.$#"
+			count: 1
+			path: src/Core/Checkout/Customer/Rule/ShippingZipCodeRule.php
+
+		-
+			message: "#^Parameter \\#2 \\$hash of function password_verify expects string, string\\|null given\\.$#"
+			count: 1
+			path: src/Core/Checkout/Customer/SalesChannel/AccountService.php
+
+		-
+			message: "#^Cannot call method getId\\(\\) on Shopware\\\\Core\\\\Checkout\\\\Customer\\\\CustomerEntity\\|null\\.$#"
+			count: 2
+			path: src/Core/Checkout/Customer/SalesChannel/AddressService.php
+
+		-
+			message: "#^Parameter \\#1 \\$customer of method Shopware\\\\Core\\\\Checkout\\\\Customer\\\\Aggregate\\\\CustomerAddress\\\\CustomerAddressCollection\\:\\:sortByDefaultAddress\\(\\) expects Shopware\\\\Core\\\\Checkout\\\\Customer\\\\CustomerEntity, Shopware\\\\Core\\\\Checkout\\\\Customer\\\\CustomerEntity\\|null given\\.$#"
+			count: 1
+			path: src/Core/Checkout/Customer/SalesChannel/AddressService.php
+
+		-
+			message: "#^Cannot call method getId\\(\\) on Shopware\\\\Core\\\\Checkout\\\\Customer\\\\CustomerEntity\\|null\\.$#"
+			count: 1
+			path: src/Core/Checkout/Customer/SalesChannel/ChangeCustomerProfileRoute.php
+
+		-
+			message: "#^Cannot call method getId\\(\\) on Shopware\\\\Core\\\\Checkout\\\\Customer\\\\CustomerEntity\\|null\\.$#"
+			count: 1
+			path: src/Core/Checkout/Customer/SalesChannel/ChangeEmailRoute.php
+
+		-
+			message: "#^Cannot call method getId\\(\\) on Shopware\\\\Core\\\\Checkout\\\\Customer\\\\CustomerEntity\\|null\\.$#"
+			count: 1
+			path: src/Core/Checkout/Customer/SalesChannel/ChangePasswordRoute.php
+
+		-
+			message: "#^Cannot call method getId\\(\\) on Shopware\\\\Core\\\\Checkout\\\\Customer\\\\CustomerEntity\\|null\\.$#"
+			count: 1
+			path: src/Core/Checkout/Customer/SalesChannel/ChangePaymentMethodRoute.php
+
+		-
+			message: "#^Parameter \\#2 \\$customer of class Shopware\\\\Core\\\\Checkout\\\\Customer\\\\Event\\\\CustomerChangedPaymentMethodEvent constructor expects Shopware\\\\Core\\\\Checkout\\\\Customer\\\\CustomerEntity, Shopware\\\\Core\\\\Checkout\\\\Customer\\\\CustomerEntity\\|null given\\.$#"
+			count: 1
+			path: src/Core/Checkout/Customer/SalesChannel/ChangePaymentMethodRoute.php
+
+		-
+			message: "#^Cannot call method getId\\(\\) on Shopware\\\\Core\\\\Checkout\\\\Customer\\\\CustomerEntity\\|null\\.$#"
+			count: 1
+			path: src/Core/Checkout/Customer/SalesChannel/DeleteAddressRoute.php
+
+		-
+			message: "#^Cannot call method getId\\(\\) on Shopware\\\\Core\\\\Checkout\\\\Customer\\\\CustomerEntity\\|null\\.$#"
+			count: 3
+			path: src/Core/Checkout/Customer/SalesChannel/SwitchDefaultAddressRoute.php
+
+		-
+			message: "#^Cannot call method getId\\(\\) on Shopware\\\\Core\\\\Checkout\\\\Customer\\\\CustomerEntity\\|null\\.$#"
+			count: 2
+			path: src/Core/Checkout/Customer/SalesChannel/UpsertAddressRoute.php
+
+		-
+			message: "#^Cannot call method getId\\(\\) on Shopware\\\\Core\\\\Checkout\\\\Customer\\\\CustomerEntity\\|null\\.$#"
+			count: 1
+			path: src/Core/Checkout/Customer/SalesChannel/CustomerRoute.php
+
+		-
+			message: "#^Cannot call method getId\\(\\) on Shopware\\\\Core\\\\Checkout\\\\Customer\\\\CustomerEntity\\|null\\.$#"
+			count: 1
+			path: src/Core/Checkout/Customer/SalesChannel/ListAddressRoute.php
+
+		-
+			message: "#^Parameter \\#2 \\$hash of function password_verify expects string, string\\|null given\\.$#"
+			count: 1
+			path: src/Core/Checkout/Customer/SalesChannel/LoginRoute.php
+
+		-
+			message: "#^Parameter \\#2 \\$customer of class Shopware\\\\Core\\\\Checkout\\\\Customer\\\\Event\\\\CustomerLogoutEvent constructor expects Shopware\\\\Core\\\\Checkout\\\\Customer\\\\CustomerEntity, Shopware\\\\Core\\\\Checkout\\\\Customer\\\\CustomerEntity\\|null given\\.$#"
+			count: 1
+			path: src/Core/Checkout/Customer/SalesChannel/LogoutRoute.php
+
+		-
+			message: "#^Cannot call method getElements\\(\\) on Shopware\\\\Core\\\\System\\\\SalesChannel\\\\Aggregate\\\\SalesChannelDomain\\\\SalesChannelDomainCollection\\|null\\.$#"
+			count: 1
+			path: src/Core/Checkout/Customer/SalesChannel/RegisterRoute.php
+
+		-
+			message: "#^Cannot call method getId\\(\\) on Shopware\\\\Core\\\\Checkout\\\\Customer\\\\CustomerEntity\\|null\\.$#"
+			count: 1
+			path: src/Core/Checkout/Customer/SalesChannel/SalesChannelCustomerController.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Checkout\\\\Customer\\\\SalesChannel\\\\SalesChannelCustomerController\\:\\:serialize\\(\\) has parameter \\$data with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Checkout/Customer/SalesChannel/SalesChannelCustomerController.php
+
+		-
+			message: "#^Cannot call method getElements\\(\\) on Shopware\\\\Core\\\\System\\\\SalesChannel\\\\Aggregate\\\\SalesChannelDomain\\\\SalesChannelDomainCollection\\|null\\.$#"
+			count: 1
+			path: src/Core/Checkout/Customer/SalesChannel/SendPasswordRecoveryMailRoute.php
+
+		-
+			message: "#^Offset 'customerGroupId' does not exist on array\\|string\\.$#"
+			count: 3
+			path: src/Core/Checkout/Customer/Subscriber/CustomerGroupSubscriber.php
+
+		-
+			message: "#^Cannot call method getCustomerId\\(\\) on Shopware\\\\Core\\\\Checkout\\\\Order\\\\Aggregate\\\\OrderCustomer\\\\OrderCustomerEntity\\|null\\.$#"
+			count: 1
+			path: src/Core/Checkout/Customer/Subscriber/CustomerMetaFieldSubscriber.php
+
+		-
+			message: "#^Cannot call method count\\(\\) on Shopware\\\\Core\\\\Checkout\\\\Order\\\\Aggregate\\\\OrderCustomer\\\\OrderCustomerCollection\\|null\\.$#"
+			count: 1
+			path: src/Core/Checkout/Customer/Subscriber/CustomerMetaFieldSubscriber.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\Checkout\\\\Customer\\\\Validation\\\\Constraint\\\\CustomerEmailUnique\\:\\:\\$message has no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Checkout/Customer/Validation/Constraint/CustomerEmailUnique.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\Checkout\\\\Customer\\\\Validation\\\\Constraint\\\\CustomerEmailUnique\\:\\:\\$errorNames has no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Checkout/Customer/Validation/Constraint/CustomerEmailUnique.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\Checkout\\\\Customer\\\\Validation\\\\Constraint\\\\CustomerPasswordMatches\\:\\:\\$message has no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Checkout/Customer/Validation/Constraint/CustomerPasswordMatches.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\Checkout\\\\Customer\\\\Validation\\\\Constraint\\\\CustomerPasswordMatches\\:\\:\\$context has no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Checkout/Customer/Validation/Constraint/CustomerPasswordMatches.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\Checkout\\\\Customer\\\\Validation\\\\Constraint\\\\CustomerPasswordMatches\\:\\:\\$errorNames has no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Checkout/Customer/Validation/Constraint/CustomerPasswordMatches.php
+
+		-
+			message: "#^Cannot call method getEmail\\(\\) on Shopware\\\\Core\\\\Checkout\\\\Customer\\\\CustomerEntity\\|null\\.$#"
+			count: 1
+			path: src/Core/Checkout/Customer/Validation/Constraint/CustomerPasswordMatchesValidator.php
+
+		-
+			message: "#^Parameter \\#3 \\$filenameFallback of static method Symfony\\\\Component\\\\HttpFoundation\\\\HeaderUtils\\:\\:makeDisposition\\(\\) expects string, string\\|null given\\.$#"
+			count: 1
+			path: src/Core/Checkout/Document/Controller/DocumentController.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Checkout\\\\Document\\\\DocumentConfiguration\\:\\:__set\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Checkout/Document/DocumentConfiguration.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Checkout\\\\Document\\\\DocumentConfiguration\\:\\:__set\\(\\) has parameter \\$name with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Checkout/Document/DocumentConfiguration.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Checkout\\\\Document\\\\DocumentConfiguration\\:\\:__set\\(\\) has parameter \\$value with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Checkout/Document/DocumentConfiguration.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Checkout\\\\Document\\\\DocumentConfiguration\\:\\:__get\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Checkout/Document/DocumentConfiguration.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Checkout\\\\Document\\\\DocumentConfiguration\\:\\:__get\\(\\) has parameter \\$name with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Checkout/Document/DocumentConfiguration.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Checkout\\\\Document\\\\DocumentConfiguration\\:\\:__isset\\(\\) has parameter \\$name with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Checkout/Document/DocumentConfiguration.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\Checkout\\\\Document\\\\DocumentConfiguration\\:\\:\\$pageOrientation \\(string\\) does not accept string\\|null\\.$#"
+			count: 1
+			path: src/Core/Checkout/Document/DocumentConfiguration.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\Checkout\\\\Document\\\\DocumentConfiguration\\:\\:\\$pageSize \\(string\\) does not accept string\\|null\\.$#"
+			count: 1
+			path: src/Core/Checkout/Document/DocumentConfiguration.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\Checkout\\\\Document\\\\DocumentEntity\\:\\:\\$documentMediaFile \\(Shopware\\\\Core\\\\Content\\\\Media\\\\MediaEntity\\) does not accept Shopware\\\\Core\\\\Content\\\\Media\\\\MediaEntity\\|null\\.$#"
+			count: 1
+			path: src/Core/Checkout/Document/DocumentEntity.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\Checkout\\\\Document\\\\DocumentEntity\\:\\:\\$documentMediaFileId \\(string\\) does not accept string\\|null\\.$#"
+			count: 1
+			path: src/Core/Checkout/Document/DocumentEntity.php
+
+		-
+			message: "#^Cannot call method getCode\\(\\) on Shopware\\\\Core\\\\System\\\\Locale\\\\LocaleEntity\\|null\\.$#"
+			count: 1
+			path: src/Core/Checkout/Document/DocumentGenerator/CreditNoteGenerator.php
+
+		-
+			message: "#^Cannot call method first\\(\\) on Shopware\\\\Core\\\\Checkout\\\\Order\\\\Aggregate\\\\OrderDelivery\\\\OrderDeliveryCollection\\|null\\.$#"
+			count: 1
+			path: src/Core/Checkout/Document/DocumentGenerator/DeliveryNoteGenerator.php
+
+		-
+			message: "#^Cannot call method getCode\\(\\) on Shopware\\\\Core\\\\System\\\\Locale\\\\LocaleEntity\\|null\\.$#"
+			count: 1
+			path: src/Core/Checkout/Document/DocumentGenerator/DeliveryNoteGenerator.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\Checkout\\\\Document\\\\DocumentGenerator\\\\DocumentGeneratorRegistry\\:\\:\\$documentGenerators \\(array\\<Shopware\\\\Core\\\\Checkout\\\\Document\\\\DocumentGenerator\\\\DocumentGeneratorInterface\\>\\) does not accept iterable\\.$#"
+			count: 1
+			path: src/Core/Checkout/Document/DocumentGenerator/DocumentGeneratorRegistry.php
+
+		-
+			message: "#^Cannot call method getCode\\(\\) on Shopware\\\\Core\\\\System\\\\Locale\\\\LocaleEntity\\|null\\.$#"
+			count: 1
+			path: src/Core/Checkout/Document/DocumentGenerator/InvoiceGenerator.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Checkout\\\\Document\\\\DocumentGenerator\\\\StornoGenerator\\:\\:handlePrices\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Checkout/Document/DocumentGenerator/StornoGenerator.php
+
+		-
+			message: "#^Argument of an invalid type Shopware\\\\Core\\\\Checkout\\\\Order\\\\Aggregate\\\\OrderLineItem\\\\OrderLineItemCollection\\|null supplied for foreach, only iterables are supported\\.$#"
+			count: 1
+			path: src/Core/Checkout/Document/DocumentGenerator/StornoGenerator.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\Checkout\\\\Document\\\\DocumentIdStruct\\:\\:\\$id has no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Checkout/Document/DocumentIdStruct.php
+
+		-
+			message: "#^Cannot call method getFileExtension\\(\\) on Shopware\\\\Core\\\\Content\\\\Media\\\\MediaEntity\\|null\\.$#"
+			count: 1
+			path: src/Core/Checkout/Document/DocumentService.php
+
+		-
+			message: "#^Cannot call method getFileName\\(\\) on Shopware\\\\Core\\\\Content\\\\Media\\\\MediaEntity\\|null\\.$#"
+			count: 1
+			path: src/Core/Checkout/Document/DocumentService.php
+
+		-
+			message: "#^Cannot call method getMimeType\\(\\) on Shopware\\\\Core\\\\Content\\\\Media\\\\MediaEntity\\|null\\.$#"
+			count: 1
+			path: src/Core/Checkout/Document/DocumentService.php
+
+		-
+			message: "#^Parameter \\#1 \\$contentType of method Shopware\\\\Core\\\\Checkout\\\\Document\\\\GeneratedDocument\\:\\:setContentType\\(\\) expects string, string\\|null given\\.$#"
+			count: 1
+			path: src/Core/Checkout/Document/DocumentService.php
+
+		-
+			message: "#^Parameter \\#1 \\$mediaId of method Shopware\\\\Core\\\\Content\\\\Media\\\\MediaService\\:\\:loadFile\\(\\) expects string, string\\|null given\\.$#"
+			count: 1
+			path: src/Core/Checkout/Document/DocumentService.php
+
+		-
+			message: "#^Parameter \\#1 \\$specificConfig of static method Shopware\\\\Core\\\\Checkout\\\\Document\\\\DocumentConfigurationFactory\\:\\:createConfiguration\\(\\) expects array, array\\|null given\\.$#"
+			count: 1
+			path: src/Core/Checkout/Document/DocumentService.php
+
+		-
+			message: "#^Cannot call method getTechnicalName\\(\\) on Shopware\\\\Core\\\\Checkout\\\\Document\\\\Aggregate\\\\DocumentType\\\\DocumentTypeEntity\\|null\\.$#"
+			count: 1
+			path: src/Core/Checkout/Document/DocumentService.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\Checkout\\\\Document\\\\FileGenerator\\\\FileGeneratorRegistry\\:\\:\\$fileGenerators \\(array\\<Shopware\\\\Core\\\\Checkout\\\\Document\\\\FileGenerator\\\\FileGeneratorInterface\\>\\) does not accept iterable\\.$#"
+			count: 1
+			path: src/Core/Checkout/Document/FileGenerator/FileGeneratorRegistry.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Checkout\\\\Document\\\\FileGenerator\\\\PdfGenerator\\:\\:generate\\(\\) should return string but returns string\\|null\\.$#"
+			count: 1
+			path: src/Core/Checkout/Document/FileGenerator/PdfGenerator.php
+
+		-
+			message: "#^Parameter \\#2 \\$search of function array_key_exists expects array, array\\|null given\\.$#"
+			count: 1
+			path: src/Core/Checkout/Order/Aggregate/OrderLineItem/OrderLineItemCollection.php
+
+		-
+			message: "#^Cannot call method getTechnicalName\\(\\) on Shopware\\\\Core\\\\System\\\\StateMachine\\\\Aggregation\\\\StateMachineState\\\\StateMachineStateEntity\\|null\\.$#"
+			count: 1
+			path: src/Core/Checkout/Order/Aggregate/OrderTransaction/OrderTransactionCollection.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\Checkout\\\\Order\\\\Aggregate\\\\OrderTransaction\\\\OrderTransactionEntity\\:\\:\\$stateMachineState has no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Checkout/Order/Aggregate/OrderTransaction/OrderTransactionEntity.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Checkout\\\\Order\\\\Exception\\\\LanguageOfOrderDeleteException\\:\\:__construct\\(\\) has parameter \\$e with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Checkout/Order/Exception/LanguageOfOrderDeleteException.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Checkout\\\\Order\\\\OrderEntity\\:\\:getAmountNet\\(\\) should return float but returns float\\|null\\.$#"
+			count: 1
+			path: src/Core/Checkout/Order/OrderEntity.php
+
+		-
+			message: "#^Cannot call method getId\\(\\) on Shopware\\\\Core\\\\Checkout\\\\Customer\\\\CustomerEntity\\|null\\.$#"
+			count: 1
+			path: src/Core/Checkout/Order/SalesChannel/OrderRoute.php
+
+		-
+			message: "#^Argument of an invalid type Shopware\\\\Core\\\\Content\\\\Rule\\\\RuleCollection\\|null supplied for foreach, only iterables are supported\\.$#"
+			count: 1
+			path: src/Core/Checkout/Order/SalesChannel/OrderRoute.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Checkout\\\\Order\\\\SalesChannel\\\\OrderRouteResponseStruct\\:\\:__construct\\(\\) has parameter \\$paymentChangeable with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Checkout/Order/SalesChannel/OrderRouteResponseStruct.php
+
+		-
+			message: "#^Cannot call method getId\\(\\) on Shopware\\\\Core\\\\System\\\\SalesChannel\\\\SalesChannelEntity\\|null\\.$#"
+			count: 1
+			path: src/Core/Checkout/Order/SalesChannel/OrderService.php
+
+		-
+			message: "#^Cannot call method getDecimalPrecision\\(\\) on Shopware\\\\Core\\\\System\\\\Currency\\\\CurrencyEntity\\|null\\.$#"
+			count: 1
+			path: src/Core/Checkout/Order/SalesChannel/OrderService.php
+
+		-
+			message: "#^Parameter \\#1 \\$orderId of class Shopware\\\\Core\\\\Checkout\\\\Cart\\\\Exception\\\\OrderNotFoundException constructor expects string, string\\|false given\\.$#"
+			count: 1
+			path: src/Core/Checkout/Order/SalesChannel/OrderService.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Checkout\\\\Order\\\\SalesChannel\\\\OrderService\\:\\:getOrder\\(\\) should return Shopware\\\\Core\\\\Checkout\\\\Order\\\\OrderEntity but returns Shopware\\\\Core\\\\Checkout\\\\Order\\\\OrderEntity\\|null\\.$#"
+			count: 1
+			path: src/Core/Checkout/Order/SalesChannel/OrderService.php
+
+		-
+			message: "#^Cannot access offset \\(int\\|string\\) on array\\<Shopware\\\\Core\\\\Checkout\\\\Payment\\\\Cart\\\\PaymentHandler\\\\AsynchronousPaymentHandlerInterface\\>\\|Shopware\\\\Core\\\\Checkout\\\\Payment\\\\Cart\\\\PaymentHandler\\\\SynchronousPaymentHandlerInterface\\.$#"
+			count: 2
+			path: src/Core/Checkout/Payment/Cart/PaymentHandler/PaymentHandlerRegistry.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Checkout\\\\Payment\\\\Cart\\\\PaymentHandler\\\\PaymentHandlerRegistry\\:\\:getHandler\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Checkout/Payment/Cart/PaymentHandler/PaymentHandlerRegistry.php
+
+		-
+			message: "#^Parameter \\#2 \\$search of function array_key_exists expects array, array\\<Shopware\\\\Core\\\\Checkout\\\\Payment\\\\Cart\\\\PaymentHandler\\\\AsynchronousPaymentHandlerInterface\\>\\|Shopware\\\\Core\\\\Checkout\\\\Payment\\\\Cart\\\\PaymentHandler\\\\SynchronousPaymentHandlerInterface given\\.$#"
+			count: 1
+			path: src/Core/Checkout/Payment/Cart/PaymentHandler/PaymentHandlerRegistry.php
+
+		-
+			message: "#^Parameter \\#1 \\$keyPath of class League\\\\OAuth2\\\\Server\\\\CryptKey constructor expects string, Lcobucci\\\\JWT\\\\Signer\\\\Key\\|string given\\.$#"
+			count: 1
+			path: src/Core/Checkout/Payment/Cart/Token/JWTFactoryV2.php
+
+		-
+			message: "#^Parameter \\#1 \\$subject of method Lcobucci\\\\JWT\\\\Builder\\:\\:setSubject\\(\\) expects string, string\\|null given\\.$#"
+			count: 1
+			path: src/Core/Checkout/Payment/Cart/Token/JWTFactoryV2.php
+
+		-
+			message: "#^Parameter \\#1 \\$str of function mb_strtolower expects string, string\\|null given\\.$#"
+			count: 2
+			path: src/Core/Checkout/Payment/DataAbstractionLayer/PaymentHandlerIdentifierSubscriber.php
+
+		-
+			message: "#^Parameter \\#1 \\$orderTransactionId of method Shopware\\\\Core\\\\Checkout\\\\Payment\\\\PaymentService\\:\\:getPaymentTransactionStruct\\(\\) expects string, string\\|null given\\.$#"
+			count: 1
+			path: src/Core/Checkout/Payment/PaymentService.php
+
+		-
+			message: "#^Parameter \\#1 \\$paymentMethodId of method Shopware\\\\Core\\\\Checkout\\\\Payment\\\\PaymentService\\:\\:getPaymentHandlerById\\(\\) expects string, string\\|null given\\.$#"
+			count: 1
+			path: src/Core/Checkout/Payment/PaymentService.php
+
+		-
+			message: "#^Parameter \\#1 \\$paymentMethodId of class Shopware\\\\Core\\\\Checkout\\\\Payment\\\\Exception\\\\UnknownPaymentMethodException constructor expects string, string\\|null given\\.$#"
+			count: 1
+			path: src/Core/Checkout/Payment/PaymentService.php
+
+		-
+			message: "#^Parameter \\#1 \\$token of class Shopware\\\\Core\\\\Checkout\\\\Payment\\\\Exception\\\\TokenExpiredException constructor expects string, string\\|null given\\.$#"
+			count: 1
+			path: src/Core/Checkout/Payment/PaymentService.php
+
+		-
+			message: "#^Parameter \\#1 \\$tokenId of method Shopware\\\\Core\\\\Checkout\\\\Payment\\\\Cart\\\\Token\\\\TokenFactoryInterfaceV2\\:\\:invalidateToken\\(\\) expects string, string\\|null given\\.$#"
+			count: 1
+			path: src/Core/Checkout/Payment/PaymentService.php
+
+		-
+			message: "#^Parameter \\#2 \\$order of class Shopware\\\\Core\\\\Checkout\\\\Payment\\\\Cart\\\\AsyncPaymentTransactionStruct constructor expects Shopware\\\\Core\\\\Checkout\\\\Order\\\\OrderEntity, Shopware\\\\Core\\\\Checkout\\\\Order\\\\OrderEntity\\|null given\\.$#"
+			count: 1
+			path: src/Core/Checkout/Payment/PaymentService.php
+
+		-
+			message: "#^Cannot call method getTargetUrl\\(\\) on Symfony\\\\Component\\\\HttpFoundation\\\\RedirectResponse\\|null\\.$#"
+			count: 1
+			path: src/Core/Checkout/Payment/SalesChannel/HandlePaymentMethodRouteResponse.php
+
+		-
+			message: "#^Cannot cast array\\|string to float\\.$#"
+			count: 1
+			path: src/Core/Checkout/Promotion/Cart/Discount/Calculator/DiscountPercentageCalculator.php
+
+		-
+			message: "#^Parameter \\#1 \\$str of function trim expects string, array\\|string given\\.$#"
+			count: 1
+			path: src/Core/Checkout/Promotion/Cart/Discount/Calculator/DiscountPercentageCalculator.php
+
+		-
+			message: "#^Parameter \\#1 \\$label of class Shopware\\\\Core\\\\Checkout\\\\Promotion\\\\Cart\\\\Discount\\\\DiscountLineItem constructor expects string, string\\|null given\\.$#"
+			count: 1
+			path: src/Core/Checkout/Promotion/Cart/PromotionCalculator.php
+
+		-
+			message: "#^Parameter \\#2 \\$priceDefinition of class Shopware\\\\Core\\\\Checkout\\\\Promotion\\\\Cart\\\\Discount\\\\DiscountLineItem constructor expects Shopware\\\\Core\\\\Checkout\\\\Cart\\\\Price\\\\Struct\\\\PriceDefinitionInterface, Shopware\\\\Core\\\\Checkout\\\\Cart\\\\Price\\\\Struct\\\\PriceDefinitionInterface\\|null given\\.$#"
+			count: 1
+			path: src/Core/Checkout/Promotion/Cart/PromotionCalculator.php
+
+		-
+			message: "#^Cannot call method match\\(\\) on Shopware\\\\Core\\\\Framework\\\\Rule\\\\Rule\\|null\\.$#"
+			count: 1
+			path: src/Core/Checkout/Promotion/Cart/PromotionCalculator.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\Checkout\\\\Promotion\\\\Cart\\\\PromotionCartAddedInformationError\\:\\:\\$name \\(string\\) does not accept string\\|null\\.$#"
+			count: 1
+			path: src/Core/Checkout/Promotion/Cart/PromotionCartAddedInformationError.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\Checkout\\\\Promotion\\\\Cart\\\\PromotionCartDeletedInformationError\\:\\:\\$name \\(string\\) does not accept string\\|null\\.$#"
+			count: 1
+			path: src/Core/Checkout/Promotion/Cart/PromotionCartDeletedInformationError.php
+
+		-
+			message: "#^Parameter \\#1 \\$label of class Shopware\\\\Core\\\\Checkout\\\\Promotion\\\\Exception\\\\InvalidPriceDefinitionException constructor expects string, string\\|null given\\.$#"
+			count: 5
+			path: src/Core/Checkout/Promotion/Cart/PromotionDeliveryCalculator.php
+
+		-
+			message: "#^Cannot call method match\\(\\) on Shopware\\\\Core\\\\Framework\\\\Rule\\\\Rule\\|null\\.$#"
+			count: 1
+			path: src/Core/Checkout/Promotion/Cart/PromotionDeliveryCalculator.php
+
+		-
+			message: "#^Cannot call method fetchAll\\(\\) on Doctrine\\\\DBAL\\\\Driver\\\\Statement\\|int\\.$#"
+			count: 1
+			path: src/Core/Checkout/Promotion/DataAbstractionLayer/PromotionExclusionUpdater.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Checkout\\\\Promotion\\\\DataAbstractionLayer\\\\PromotionIndexer\\:\\:iterate\\(\\) has parameter \\$offset with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Checkout/Promotion/DataAbstractionLayer/PromotionIndexer.php
+
+		-
+			message: "#^Argument of an invalid type Shopware\\\\Core\\\\Checkout\\\\Order\\\\Aggregate\\\\OrderLineItem\\\\OrderLineItemCollection\\|null supplied for foreach, only iterables are supported\\.$#"
+			count: 1
+			path: src/Core/Checkout/Promotion/Subscriber/PromotionIndividualCodeRedeemer.php
+
+		-
+			message: "#^Parameter \\#2 \\$customerId of method Shopware\\\\Core\\\\Checkout\\\\Promotion\\\\Aggregate\\\\PromotionIndividualCode\\\\PromotionIndividualCodeEntity\\:\\:setRedeemed\\(\\) expects string, string\\|null given\\.$#"
+			count: 1
+			path: src/Core/Checkout/Promotion/Subscriber/PromotionIndividualCodeRedeemer.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Checkout\\\\Promotion\\\\Subscriber\\\\PromotionIndividualCodeRedeemer\\:\\:getIndividualCode\\(\\) should return Shopware\\\\Core\\\\Checkout\\\\Promotion\\\\Aggregate\\\\PromotionIndividualCode\\\\PromotionIndividualCodeEntity but returns Shopware\\\\Core\\\\Checkout\\\\Promotion\\\\Aggregate\\\\PromotionIndividualCode\\\\PromotionIndividualCodeEntity\\|null\\.$#"
+			count: 1
+			path: src/Core/Checkout/Promotion/Subscriber/PromotionIndividualCodeRedeemer.php
+
+		-
+			message: "#^Cannot call method fetchAll\\(\\) on Doctrine\\\\DBAL\\\\Driver\\\\Statement\\|int\\.$#"
+			count: 1
+			path: src/Core/Checkout/Promotion/Util/PromotionCodesLoader.php
+
+		-
+			message: "#^Cannot call method fetchAll\\(\\) on Doctrine\\\\DBAL\\\\Driver\\\\Statement\\|int\\.$#"
+			count: 3
+			path: src/Core/Checkout/Promotion/Validator/PromotionValidator.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Checkout\\\\Shipping\\\\DataAbstractionLayer\\\\ShippingMethodIndexer\\:\\:iterate\\(\\) has parameter \\$offset with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Checkout/Shipping/DataAbstractionLayer/ShippingMethodIndexer.php
+
+		-
+			message: "#^Parameter \\#1 \\$arr1 of function array_merge expects array, array\\|Shopware\\\\Core\\\\Checkout\\\\Shipping\\\\Aggregate\\\\ShippingMethodPrice\\\\ShippingMethodPriceCollection given\\.$#"
+			count: 1
+			path: src/Core/Checkout/Shipping/ShippingMethodCollection.php
+
+		-
+			message: "#^Class Shopware\\\\Core\\\\Checkout\\\\Test\\\\Cart\\\\Promotion\\\\Helpers\\\\Fakes\\\\FakeResultStatement implements generic interface IteratorAggregate but does not specify its types\\: TKey, TValue$#"
+			count: 1
+			path: src/Core/Checkout/Test/Cart/Promotion/Helpers/Fakes/FakeResultStatement.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Checkout\\\\Test\\\\Cart\\\\TestError\\:\\:unknown\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Checkout/Test/Cart/TestError.php
+
+		-
+			message: "#^Cannot call method getCustomer\\(\\) on Shopware\\\\Core\\\\Checkout\\\\Order\\\\Aggregate\\\\OrderCustomer\\\\OrderCustomerEntity\\|null\\.$#"
+			count: 1
+			path: src/Core/Checkout/Test/Payment/Handler/V630/SyncTestPaymentHandler.php
+
+		-
+			message: "#^Cannot call method fetchAll\\(\\) on Doctrine\\\\DBAL\\\\Driver\\\\Statement\\|int\\.$#"
+			count: 1
+			path: src/Core/Content/Category/DataAbstractionLayer/CategoryBreadcrumbUpdater.php
+
+		-
+			message: "#^Parameter \\#1 \\$id of method Shopware\\\\Core\\\\Content\\\\Category\\\\DataAbstractionLayer\\\\CategoryBreadcrumbUpdater\\:\\:buildBreadcrumb\\(\\) expects string, string\\|null given\\.$#"
+			count: 1
+			path: src/Core/Content/Category/DataAbstractionLayer/CategoryBreadcrumbUpdater.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Content\\\\Category\\\\DataAbstractionLayer\\\\CategoryIndexer\\:\\:iterate\\(\\) has parameter \\$offset with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Content/Category/DataAbstractionLayer/CategoryIndexer.php
+
+		-
+			message: "#^Cannot call method getState\\(\\) on Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Write\\\\EntityExistence\\|null\\.$#"
+			count: 1
+			path: src/Core/Content/Category/DataAbstractionLayer/CategoryIndexer.php
+
+		-
+			message: "#^Cannot call method fetchAll\\(\\) on Doctrine\\\\DBAL\\\\Driver\\\\Statement\\|int\\.$#"
+			count: 1
+			path: src/Core/Content/Category/DataAbstractionLayer/CategoryIndexer.php
+
+		-
+			message: "#^Cannot call method getId\\(\\) on Shopware\\\\Core\\\\Content\\\\Category\\\\CategoryEntity\\|null\\.$#"
+			count: 1
+			path: src/Core/Content/Category/Tree/Tree.php
+
+		-
+			message: "#^Cannot call method getPath\\(\\) on Shopware\\\\Core\\\\Content\\\\Category\\\\CategoryEntity\\|null\\.$#"
+			count: 1
+			path: src/Core/Content/Category/Tree/Tree.php
+
+		-
+			message: "#^Parameter \\#2 \\$str of function explode expects string, string\\|null given\\.$#"
+			count: 1
+			path: src/Core/Content/Category/Tree/Tree.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\Content\\\\Category\\\\Tree\\\\TreeItem\\:\\:\\$category \\(Shopware\\\\Core\\\\Content\\\\Category\\\\CategoryEntity\\) does not accept Shopware\\\\Core\\\\Content\\\\Category\\\\CategoryEntity\\|null\\.$#"
+			count: 1
+			path: src/Core/Content/Category/Tree/TreeItem.php
+
+		-
+			message: "#^Parameter \\#1 \\$collection of method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\EntityCollection\\:\\:merge\\(\\) expects Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\EntityCollection, Shopware\\\\Core\\\\Content\\\\Cms\\\\Aggregate\\\\CmsSlot\\\\CmsSlotCollection\\|null given\\.$#"
+			count: 1
+			path: src/Core/Content/Cms/Aggregate/CmsBlock/CmsBlockCollection.php
+
+		-
+			message: "#^Parameter \\#2 \\$entity of method Shopware\\\\Core\\\\Content\\\\Cms\\\\Aggregate\\\\CmsSlot\\\\CmsSlotCollection\\:\\:set\\(\\) expects Shopware\\\\Core\\\\Content\\\\Cms\\\\Aggregate\\\\CmsSlot\\\\CmsSlotEntity, Shopware\\\\Core\\\\Content\\\\Cms\\\\Aggregate\\\\CmsSlot\\\\CmsSlotEntity\\|null given\\.$#"
+			count: 1
+			path: src/Core/Content/Cms/Aggregate/CmsBlock/CmsBlockCollection.php
+
+		-
+			message: "#^Parameter \\#1 \\$collection of method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\EntityCollection\\:\\:merge\\(\\) expects Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\EntityCollection, Shopware\\\\Core\\\\Content\\\\Cms\\\\Aggregate\\\\CmsBlock\\\\CmsBlockCollection\\|null given\\.$#"
+			count: 1
+			path: src/Core/Content/Cms/Aggregate/CmsSection/CmsSectionCollection.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Content\\\\Cms\\\\CmsPageEntity\\:\\:getName\\(\\) should return string but returns string\\|null\\.$#"
+			count: 1
+			path: src/Core/Content/Cms/CmsPageEntity.php
+
+		-
+			message: "#^Cannot call method getBlocks\\(\\) on Shopware\\\\Core\\\\Content\\\\Cms\\\\Aggregate\\\\CmsSection\\\\CmsSectionCollection\\|null\\.$#"
+			count: 1
+			path: src/Core/Content/Cms/CmsPageEntity.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\Content\\\\Cms\\\\Command\\\\CreatePageCommand\\:\\:\\$products \\(array\\<string\\>\\) does not accept array\\<array\\|string\\>\\.$#"
+			count: 1
+			path: src/Core/Content/Cms/Command/CreatePageCommand.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Content\\\\Cms\\\\Command\\\\CreatePageCommand\\:\\:getRandomProductId\\(\\) should return string but returns array\\|string\\.$#"
+			count: 1
+			path: src/Core/Content/Cms/Command/CreatePageCommand.php
+
+		-
+			message: "#^Possibly invalid array key type array\\<int, int\\|string\\>\\|int\\|string\\.$#"
+			count: 3
+			path: src/Core/Content/Cms/Command/CreatePageCommand.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\Content\\\\Cms\\\\Command\\\\CreatePageCommand\\:\\:\\$categories \\(array\\<string\\>\\) does not accept array\\<array\\|string\\>\\.$#"
+			count: 1
+			path: src/Core/Content/Cms/Command/CreatePageCommand.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Content\\\\Cms\\\\Command\\\\CreatePageCommand\\:\\:getRandomCategoryId\\(\\) should return string but returns array\\|string\\.$#"
+			count: 1
+			path: src/Core/Content/Cms/Command/CreatePageCommand.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\Content\\\\Cms\\\\Command\\\\CreatePageCommand\\:\\:\\$media \\(array\\<string\\>\\) does not accept array\\<array\\|string\\>\\.$#"
+			count: 1
+			path: src/Core/Content/Cms/Command/CreatePageCommand.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Content\\\\Cms\\\\Command\\\\CreatePageCommand\\:\\:getRandomMediaId\\(\\) should return string but returns array\\|string\\.$#"
+			count: 1
+			path: src/Core/Content/Cms/Command/CreatePageCommand.php
+
+		-
+			message: "#^Class Shopware\\\\Core\\\\Content\\\\Cms\\\\DataResolver\\\\CriteriaCollection implements generic interface IteratorAggregate but does not specify its types\\: TKey, TValue$#"
+			count: 1
+			path: src/Core/Content/Cms/DataResolver/CriteriaCollection.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Content\\\\Cms\\\\DataResolver\\\\Element\\\\AbstractCmsElementResolver\\:\\:resolveEntityValue\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Content/Cms/DataResolver/Element/AbstractCmsElementResolver.php
+
+		-
+			message: "#^Parameter \\#1 \\$field of method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Entity\\:\\:getTranslation\\(\\) expects string, string\\|null given\\.$#"
+			count: 1
+			path: src/Core/Content/Cms/DataResolver/Element/AbstractCmsElementResolver.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\Content\\\\Cms\\\\DataResolver\\\\Element\\\\ElementDataCollection\\:\\:\\$searchResults has no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Content/Cms/DataResolver/Element/ElementDataCollection.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\Content\\\\Cms\\\\DataResolver\\\\FieldConfig\\:\\:\\$value has no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Content/Cms/DataResolver/FieldConfig.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Content\\\\Cms\\\\DataResolver\\\\FieldConfig\\:\\:__construct\\(\\) has parameter \\$value with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Content/Cms/DataResolver/FieldConfig.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Content\\\\Cms\\\\DataResolver\\\\FieldConfig\\:\\:getValue\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Content/Cms/DataResolver/FieldConfig.php
+
+		-
+			message: "#^Cannot call method sort\\(\\) on Shopware\\\\Core\\\\Content\\\\Cms\\\\Aggregate\\\\CmsSection\\\\CmsSectionCollection\\|null\\.$#"
+			count: 1
+			path: src/Core/Content/Cms/SalesChannel/SalesChannelCmsPageLoader.php
+
+		-
+			message: "#^Argument of an invalid type Shopware\\\\Core\\\\Content\\\\Cms\\\\Aggregate\\\\CmsSection\\\\CmsSectionCollection\\|null supplied for foreach, only iterables are supported\\.$#"
+			count: 1
+			path: src/Core/Content/Cms/SalesChannel/SalesChannelCmsPageLoader.php
+
+		-
+			message: "#^Cannot call method getBlocks\\(\\) on Shopware\\\\Core\\\\Content\\\\Cms\\\\Aggregate\\\\CmsSection\\\\CmsSectionCollection\\|null\\.$#"
+			count: 3
+			path: src/Core/Content/Cms/SalesChannel/SalesChannelCmsPageLoader.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\Content\\\\Content\\:\\:\\$name has no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Content/Content.php
+
+		-
+			message: "#^Parameter \\#1 \\$time of class DateTimeImmutable constructor expects string, array\\<string\\>\\|string\\|null given\\.$#"
+			count: 1
+			path: src/Core/Content/ImportExport/Command/ImportEntityCommand.php
+
+		-
+			message: "#^Parameter \\#2 \\.\\.\\.\\$args of function sprintf expects bool\\|float\\|int\\|string\\|null, array\\<string\\>\\|string\\|null given\\.$#"
+			count: 1
+			path: src/Core/Content/ImportExport/Command/ImportEntityCommand.php
+
+		-
+			message: "#^Parameter \\#1 \\$path of class Symfony\\\\Component\\\\HttpFoundation\\\\File\\\\UploadedFile constructor expects string, array\\<string\\>\\|string\\|null given\\.$#"
+			count: 1
+			path: src/Core/Content/ImportExport/Command/ImportEntityCommand.php
+
+		-
+			message: "#^Parameter \\#1 \\$path of function basename expects string, array\\<string\\>\\|string\\|null given\\.$#"
+			count: 1
+			path: src/Core/Content/ImportExport/Command/ImportEntityCommand.php
+
+		-
+			message: "#^Parameter \\#1 \\$filename of function filesize expects string, array\\<string\\>\\|string\\|null given\\.$#"
+			count: 1
+			path: src/Core/Content/ImportExport/Command/ImportEntityCommand.php
+
+		-
+			message: "#^Parameter \\#1 \\$max of method Symfony\\\\Component\\\\Console\\\\Style\\\\SymfonyStyle\\:\\:createProgressBar\\(\\) expects int, int\\|false given\\.$#"
+			count: 1
+			path: src/Core/Content/ImportExport/Command/ImportEntityCommand.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Content\\\\ImportExport\\\\DataAbstractionLayer\\\\Serializer\\\\Entity\\\\AbstractEntitySerializer\\:\\:serialize\\(\\) has parameter \\$entity with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Entity/AbstractEntitySerializer.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Content\\\\ImportExport\\\\DataAbstractionLayer\\\\Serializer\\\\Entity\\\\AbstractEntitySerializer\\:\\:deserialize\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Entity/AbstractEntitySerializer.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Content\\\\ImportExport\\\\DataAbstractionLayer\\\\Serializer\\\\Entity\\\\AbstractEntitySerializer\\:\\:deserialize\\(\\) has parameter \\$entity with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Entity/AbstractEntitySerializer.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Content\\\\ImportExport\\\\DataAbstractionLayer\\\\Serializer\\\\Entity\\\\EntitySerializer\\:\\:serialize\\(\\) has parameter \\$entity with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Entity/EntitySerializer.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Content\\\\ImportExport\\\\DataAbstractionLayer\\\\Serializer\\\\Entity\\\\EntitySerializer\\:\\:deserialize\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Entity/EntitySerializer.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Content\\\\ImportExport\\\\DataAbstractionLayer\\\\Serializer\\\\Entity\\\\EntitySerializer\\:\\:deserialize\\(\\) has parameter \\$record with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Entity/EntitySerializer.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Content\\\\ImportExport\\\\DataAbstractionLayer\\\\Serializer\\\\Entity\\\\MediaSerializer\\:\\:serialize\\(\\) has parameter \\$value with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Entity/MediaSerializer.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Content\\\\ImportExport\\\\DataAbstractionLayer\\\\Serializer\\\\Entity\\\\MediaSerializer\\:\\:deserialize\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Entity/MediaSerializer.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Content\\\\ImportExport\\\\DataAbstractionLayer\\\\Serializer\\\\Entity\\\\MediaSerializer\\:\\:deserialize\\(\\) has parameter \\$value with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Entity/MediaSerializer.php
+
+		-
+			message: "#^Parameter \\#1 \\$it of function iterator_to_array expects Traversable, iterable given\\.$#"
+			count: 1
+			path: src/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Entity/MediaSerializer.php
+
+		-
+			message: "#^Cannot access offset 'path' on array\\(\\?'scheme' \\=\\> string, \\?'host' \\=\\> string, \\?'port' \\=\\> int, \\?'user' \\=\\> string, \\?'pass' \\=\\> string, \\?'path' \\=\\> string, \\?'query' \\=\\> string, \\?'fragment' \\=\\> string\\)\\|false\\.$#"
+			count: 1
+			path: src/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Entity/MediaSerializer.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Content\\\\ImportExport\\\\DataAbstractionLayer\\\\Serializer\\\\Entity\\\\MediaSerializer\\:\\:getMediaFolderId\\(\\) has parameter \\$entity with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Entity/MediaSerializer.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Content\\\\ImportExport\\\\DataAbstractionLayer\\\\Serializer\\\\Entity\\\\ProductSerializer\\:\\:serialize\\(\\) has parameter \\$value with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Entity/ProductSerializer.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Content\\\\ImportExport\\\\DataAbstractionLayer\\\\Serializer\\\\Entity\\\\ProductSerializer\\:\\:deserialize\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Entity/ProductSerializer.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Content\\\\ImportExport\\\\DataAbstractionLayer\\\\Serializer\\\\Entity\\\\ProductSerializer\\:\\:deserialize\\(\\) has parameter \\$value with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Entity/ProductSerializer.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Content\\\\ImportExport\\\\DataAbstractionLayer\\\\Serializer\\\\Entity\\\\SalutationSerializer\\:\\:deserialize\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Entity/SalutationSerializer.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Content\\\\ImportExport\\\\DataAbstractionLayer\\\\Serializer\\\\Entity\\\\SalutationSerializer\\:\\:deserialize\\(\\) has parameter \\$record with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Entity/SalutationSerializer.php
+
+		-
+			message: "#^Parameter \\#1 \\$it of function iterator_to_array expects Traversable, iterable given\\.$#"
+			count: 1
+			path: src/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Entity/SalutationSerializer.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Content\\\\ImportExport\\\\DataAbstractionLayer\\\\Serializer\\\\Field\\\\AbstractFieldSerializer\\:\\:serialize\\(\\) has parameter \\$value with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Field/AbstractFieldSerializer.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Content\\\\ImportExport\\\\DataAbstractionLayer\\\\Serializer\\\\Field\\\\AbstractFieldSerializer\\:\\:deserialize\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Field/AbstractFieldSerializer.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Content\\\\ImportExport\\\\DataAbstractionLayer\\\\Serializer\\\\Field\\\\AbstractFieldSerializer\\:\\:deserialize\\(\\) has parameter \\$value with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Field/AbstractFieldSerializer.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Content\\\\ImportExport\\\\DataAbstractionLayer\\\\Serializer\\\\Field\\\\FieldSerializer\\:\\:serialize\\(\\) has parameter \\$value with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Field/FieldSerializer.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Content\\\\ImportExport\\\\DataAbstractionLayer\\\\Serializer\\\\Field\\\\FieldSerializer\\:\\:deserialize\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Field/FieldSerializer.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Content\\\\ImportExport\\\\DataAbstractionLayer\\\\Serializer\\\\Field\\\\FieldSerializer\\:\\:deserialize\\(\\) has parameter \\$value with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Field/FieldSerializer.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Content\\\\ImportExport\\\\DataAbstractionLayer\\\\Serializer\\\\Field\\\\PriceSerializer\\:\\:serialize\\(\\) has parameter \\$prices with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Field/PriceSerializer.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Content\\\\ImportExport\\\\DataAbstractionLayer\\\\Serializer\\\\Field\\\\PriceSerializer\\:\\:deserialize\\(\\) has parameter \\$record with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Field/PriceSerializer.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Content\\\\ImportExport\\\\DataAbstractionLayer\\\\Serializer\\\\Field\\\\ToOneSerializer\\:\\:serialize\\(\\) has parameter \\$record with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Field/ToOneSerializer.php
+
+		-
+			message: "#^Parameter \\#1 \\$it of function iterator_to_array expects Traversable, iterable given\\.$#"
+			count: 1
+			path: src/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Field/ToOneSerializer.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Content\\\\ImportExport\\\\DataAbstractionLayer\\\\Serializer\\\\Field\\\\ToOneSerializer\\:\\:deserialize\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Field/ToOneSerializer.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Content\\\\ImportExport\\\\DataAbstractionLayer\\\\Serializer\\\\Field\\\\ToOneSerializer\\:\\:deserialize\\(\\) has parameter \\$records with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Field/ToOneSerializer.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Content\\\\ImportExport\\\\DataAbstractionLayer\\\\Serializer\\\\Field\\\\TranslationsSerializer\\:\\:serialize\\(\\) has parameter \\$translations with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Field/TranslationsSerializer.php
+
+		-
+			message: "#^Parameter \\#1 \\$it of function iterator_to_array expects Traversable, iterable given\\.$#"
+			count: 1
+			path: src/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Field/TranslationsSerializer.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Content\\\\ImportExport\\\\DataAbstractionLayer\\\\Serializer\\\\Field\\\\TranslationsSerializer\\:\\:deserialize\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Field/TranslationsSerializer.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Content\\\\ImportExport\\\\DataAbstractionLayer\\\\Serializer\\\\Field\\\\TranslationsSerializer\\:\\:deserialize\\(\\) has parameter \\$translations with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Field/TranslationsSerializer.php
+
+		-
+			message: "#^Cannot call method getCode\\(\\) on Shopware\\\\Core\\\\System\\\\Locale\\\\LocaleEntity\\|null\\.$#"
+			count: 1
+			path: src/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Field/TranslationsSerializer.php
+
+		-
+			message: "#^Cannot call method getSourceEntity\\(\\) on Shopware\\\\Core\\\\Content\\\\ImportExport\\\\ImportExportProfileEntity\\|null\\.$#"
+			count: 1
+			path: src/Core/Content/ImportExport/Event/Subscriber/CategoryCriteriaSubscriber.php
+
+		-
+			message: "#^Cannot call method getSourceEntity\\(\\) on Shopware\\\\Core\\\\Content\\\\ImportExport\\\\ImportExportProfileEntity\\|null\\.$#"
+			count: 1
+			path: src/Core/Content/ImportExport/Event/Subscriber/ProductCriteriaSubscriber.php
+
+		-
+			message: "#^Cannot call method getSize\\(\\) on Shopware\\\\Core\\\\Content\\\\ImportExport\\\\Aggregate\\\\ImportExportFile\\\\ImportExportFileEntity\\|null\\.$#"
+			count: 1
+			path: src/Core/Content/ImportExport/ImportExport.php
+
+		-
+			message: "#^Cannot call method getPath\\(\\) on Shopware\\\\Core\\\\Content\\\\ImportExport\\\\Aggregate\\\\ImportExportFile\\\\ImportExportFileEntity\\|null\\.$#"
+			count: 5
+			path: src/Core/Content/ImportExport/ImportExport.php
+
+		-
+			message: "#^Parameter \\#1 \\$total of method Shopware\\\\Core\\\\Content\\\\ImportExport\\\\Struct\\\\Progress\\:\\:setTotal\\(\\) expects int\\|null, int\\|false given\\.$#"
+			count: 1
+			path: src/Core/Content/ImportExport/ImportExport.php
+
+		-
+			message: "#^Parameter \\#2 \\$resource of method Shopware\\\\Core\\\\Content\\\\ImportExport\\\\Processing\\\\Reader\\\\AbstractReader\\:\\:read\\(\\) expects resource, resource\\|false given\\.$#"
+			count: 1
+			path: src/Core/Content/ImportExport/ImportExport.php
+
+		-
+			message: "#^Parameter \\#1 \\$filename of function fopen expects string, string\\|false given\\.$#"
+			count: 1
+			path: src/Core/Content/ImportExport/ImportExport.php
+
+		-
+			message: "#^Parameter \\#1 \\$source of function stream_copy_to_stream expects resource, resource\\|false given\\.$#"
+			count: 1
+			path: src/Core/Content/ImportExport/ImportExport.php
+
+		-
+			message: "#^Parameter \\#2 \\$dest of function stream_copy_to_stream expects resource, resource\\|false given\\.$#"
+			count: 1
+			path: src/Core/Content/ImportExport/ImportExport.php
+
+		-
+			message: "#^Parameter \\#2 \\$resource of method League\\\\Flysystem\\\\FilesystemInterface\\:\\:putStream\\(\\) expects resource, resource\\|false given\\.$#"
+			count: 1
+			path: src/Core/Content/ImportExport/ImportExport.php
+
+		-
+			message: "#^Parameter \\#1 \\$filename of function unlink expects string, string\\|false given\\.$#"
+			count: 1
+			path: src/Core/Content/ImportExport/ImportExport.php
+
+		-
+			message: "#^Parameter \\#2 \\$fileId of method Shopware\\\\Core\\\\Content\\\\ImportExport\\\\Service\\\\ImportExportService\\:\\:updateFile\\(\\) expects string, string\\|null given\\.$#"
+			count: 1
+			path: src/Core/Content/ImportExport/ImportExport.php
+
+		-
+			message: "#^Cannot call method getOriginalName\\(\\) on Shopware\\\\Core\\\\Content\\\\ImportExport\\\\Aggregate\\\\ImportExportFile\\\\ImportExportFileEntity\\|null\\.$#"
+			count: 1
+			path: src/Core/Content/ImportExport/ImportExport.php
+
+		-
+			message: "#^Offset 'extension' does not exist on array\\('dirname' \\=\\> string, 'basename' \\=\\> string, 'filename' \\=\\> string, \\?'extension' \\=\\> string\\)\\.$#"
+			count: 1
+			path: src/Core/Content/ImportExport/ImportExport.php
+
+		-
+			message: "#^Parameter \\#2 \\$profileId of method Shopware\\\\Core\\\\Content\\\\ImportExport\\\\Service\\\\ImportExportService\\:\\:prepareExport\\(\\) expects string, string\\|null given\\.$#"
+			count: 1
+			path: src/Core/Content/ImportExport/ImportExport.php
+
+		-
+			message: "#^Cannot call method getExpireDate\\(\\) on Shopware\\\\Core\\\\Content\\\\ImportExport\\\\Aggregate\\\\ImportExportFile\\\\ImportExportFileEntity\\|null\\.$#"
+			count: 1
+			path: src/Core/Content/ImportExport/ImportExport.php
+
+		-
+			message: "#^Parameter \\#1 \\$log of static method Shopware\\\\Core\\\\Content\\\\ImportExport\\\\Struct\\\\Config\\:\\:fromLog\\(\\) expects Shopware\\\\Core\\\\Content\\\\ImportExport\\\\Aggregate\\\\ImportExportLog\\\\ImportExportLogEntity, Shopware\\\\Core\\\\Content\\\\ImportExport\\\\Aggregate\\\\ImportExportLog\\\\ImportExportLogEntity\\|null given\\.$#"
+			count: 1
+			path: src/Core/Content/ImportExport/ImportExport.php
+
+		-
+			message: "#^Cannot call method getRecords\\(\\) on Shopware\\\\Core\\\\Content\\\\ImportExport\\\\Aggregate\\\\ImportExportLog\\\\ImportExportLogEntity\\|null\\.$#"
+			count: 1
+			path: src/Core/Content/ImportExport/ImportExport.php
+
+		-
+			message: "#^Cannot call method getFile\\(\\) on Shopware\\\\Core\\\\Content\\\\ImportExport\\\\Aggregate\\\\ImportExportLog\\\\ImportExportLogEntity\\|null\\.$#"
+			count: 1
+			path: src/Core/Content/ImportExport/ImportExport.php
+
+		-
+			message: "#^Cannot call method getId\\(\\) on Shopware\\\\Core\\\\Content\\\\ImportExport\\\\Aggregate\\\\ImportExportLog\\\\ImportExportLogEntity\\|null\\.$#"
+			count: 1
+			path: src/Core/Content/ImportExport/ImportExport.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Content\\\\ImportExport\\\\ImportExportFactory\\:\\:__construct\\(\\) has parameter \\$pipeFactories with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Content/ImportExport/ImportExportFactory.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Content\\\\ImportExport\\\\ImportExportFactory\\:\\:__construct\\(\\) has parameter \\$readerFactories with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Content/ImportExport/ImportExportFactory.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Content\\\\ImportExport\\\\ImportExportFactory\\:\\:__construct\\(\\) has parameter \\$writerFactories with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Content/ImportExport/ImportExportFactory.php
+
+		-
+			message: "#^Cannot call method getSourceEntity\\(\\) on Shopware\\\\Core\\\\Content\\\\ImportExport\\\\ImportExportProfileEntity\\|null\\.$#"
+			count: 1
+			path: src/Core/Content/ImportExport/ImportExportFactory.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Content\\\\ImportExport\\\\Processing\\\\Mapping\\\\Mapping\\:\\:__construct\\(\\) has parameter \\$default with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Content/ImportExport/Processing/Mapping/Mapping.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Content\\\\ImportExport\\\\Processing\\\\Mapping\\\\Mapping\\:\\:__construct\\(\\) has parameter \\$mappedDefault with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Content/ImportExport/Processing/Mapping/Mapping.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Content\\\\ImportExport\\\\Processing\\\\Mapping\\\\Mapping\\:\\:getDefault\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Content/ImportExport/Processing/Mapping/Mapping.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Content\\\\ImportExport\\\\Processing\\\\Mapping\\\\Mapping\\:\\:getMappedDefault\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Content/ImportExport/Processing/Mapping/Mapping.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Content\\\\ImportExport\\\\Processing\\\\Pipe\\\\EntityPipe\\:\\:in\\(\\) has parameter \\$entity with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Content/ImportExport/Processing/Pipe/EntityPipe.php
+
+		-
+			message: "#^Cannot call method serialize\\(\\) on Shopware\\\\Core\\\\Content\\\\ImportExport\\\\DataAbstractionLayer\\\\Serializer\\\\Entity\\\\AbstractEntitySerializer\\|null\\.$#"
+			count: 1
+			path: src/Core/Content/ImportExport/Processing/Pipe/EntityPipe.php
+
+		-
+			message: "#^Cannot call method deserialize\\(\\) on Shopware\\\\Core\\\\Content\\\\ImportExport\\\\DataAbstractionLayer\\\\Serializer\\\\Entity\\\\AbstractEntitySerializer\\|null\\.$#"
+			count: 1
+			path: src/Core/Content/ImportExport/Processing/Pipe/EntityPipe.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Content\\\\ImportExport\\\\Processing\\\\Pipe\\\\KeyMappingPipe\\:\\:mapKey\\(\\) has parameter \\$key with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Content/ImportExport/Processing/Pipe/KeyMappingPipe.php
+
+		-
+			message: "#^Parameter \\#1 \\$offset of method Shopware\\\\Core\\\\Content\\\\ImportExport\\\\Processing\\\\Reader\\\\CsvReader\\:\\:setOffset\\(\\) expects int, int\\|false given\\.$#"
+			count: 1
+			path: src/Core/Content/ImportExport/Processing/Reader/CsvReader.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Content\\\\ImportExport\\\\Processing\\\\Reader\\\\CsvReader\\:\\:handleBom\\(\\) has parameter \\$resource with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Content/ImportExport/Processing/Reader/CsvReader.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Content\\\\ImportExport\\\\Processing\\\\Reader\\\\CsvReader\\:\\:seek\\(\\) has parameter \\$resource with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Content/ImportExport/Processing/Reader/CsvReader.php
+
+		-
+			message: "#^Cannot call method getFileType\\(\\) on Shopware\\\\Core\\\\Content\\\\ImportExport\\\\ImportExportProfileEntity\\|null\\.$#"
+			count: 1
+			path: src/Core/Content/ImportExport/Processing/Reader/CsvReaderFactory.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\Content\\\\ImportExport\\\\Processing\\\\Writer\\\\AbstractFileWriter\\:\\:\\$tempPath \\(string\\) does not accept string\\|false\\.$#"
+			count: 1
+			path: src/Core/Content/ImportExport/Processing/Writer/AbstractFileWriter.php
+
+		-
+			message: "#^Parameter \\#1 \\$filename of function fopen expects string, string\\|false given\\.$#"
+			count: 1
+			path: src/Core/Content/ImportExport/Processing/Writer/AbstractFileWriter.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\Content\\\\ImportExport\\\\Processing\\\\Writer\\\\AbstractFileWriter\\:\\:\\$tempFile \\(resource\\) does not accept resource\\|false\\.$#"
+			count: 1
+			path: src/Core/Content/ImportExport/Processing/Writer/AbstractFileWriter.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\Content\\\\ImportExport\\\\Processing\\\\Writer\\\\AbstractFileWriter\\:\\:\\$buffer \\(resource\\) does not accept resource\\|false\\.$#"
+			count: 1
+			path: src/Core/Content/ImportExport/Processing/Writer/AbstractFileWriter.php
+
+		-
+			message: "#^Cannot call method getFileType\\(\\) on Shopware\\\\Core\\\\Content\\\\ImportExport\\\\ImportExportProfileEntity\\|null\\.$#"
+			count: 1
+			path: src/Core/Content/ImportExport/Processing/Writer/CsvFileWriterFactory.php
+
+		-
+			message: "#^Parameter \\#1 \\$haystack of function mb_strstr expects string, string\\|false given\\.$#"
+			count: 1
+			path: src/Core/Content/ImportExport/Processing/Writer/XmlFileWriter.php
+
+		-
+			message: "#^Parameter \\#2 \\$str of function fwrite expects string, string\\|false given\\.$#"
+			count: 1
+			path: src/Core/Content/ImportExport/Processing/Writer/XmlFileWriter.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Content\\\\ImportExport\\\\Processing\\\\Writer\\\\XmlFileWriter\\:\\:finish\\(\\) has parameter \\$targetPath with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Content/ImportExport/Processing/Writer/XmlFileWriter.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Content\\\\ImportExport\\\\Processing\\\\Writer\\\\XmlFileWriter\\:\\:toString\\(\\) has parameter \\$scalar with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Content/ImportExport/Processing/Writer/XmlFileWriter.php
+
+		-
+			message: "#^Cannot call method getFileType\\(\\) on Shopware\\\\Core\\\\Content\\\\ImportExport\\\\ImportExportProfileEntity\\|null\\.$#"
+			count: 1
+			path: src/Core/Content/ImportExport/Processing/Writer/XmlFileWriterFactory.php
+
+		-
+			message: "#^Parameter \\#3 \\$filenameFallback of static method Symfony\\\\Component\\\\HttpFoundation\\\\HeaderUtils\\:\\:makeDisposition\\(\\) expects string, string\\|null given\\.$#"
+			count: 1
+			path: src/Core/Content/ImportExport/Service/DownloadService.php
+
+		-
+			message: "#^Parameter \\#4 \\$originalFileName of method Shopware\\\\Core\\\\Content\\\\ImportExport\\\\Service\\\\ImportExportService\\:\\:storeFile\\(\\) expects string, string\\|null given\\.$#"
+			count: 1
+			path: src/Core/Content/ImportExport/Service/ImportExportService.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Content\\\\ImportExport\\\\Service\\\\ImportExportService\\:\\:detectType\\(\\) should return string but returns string\\|null\\.$#"
+			count: 1
+			path: src/Core/Content/ImportExport/Service/ImportExportService.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Content\\\\ImportExport\\\\Service\\\\ImportExportService\\:\\:getConfig\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Content/ImportExport/Service/ImportExportService.php
+
+		-
+			message: "#^Parameter \\#1 \\$value of static method Shopware\\\\Core\\\\Content\\\\ImportExport\\\\Service\\\\SupportedFeaturesService\\:\\:toBytes\\(\\) expects string, string\\|false given\\.$#"
+			count: 2
+			path: src/Core/Content/ImportExport/Service/SupportedFeaturesService.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Content\\\\ImportExport\\\\Struct\\\\Config\\:\\:get\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Content/ImportExport/Struct/Config.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Content\\\\ImportExport\\\\Struct\\\\Progress\\:\\:__construct\\(\\) has parameter \\$offset with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Content/ImportExport/Struct/Progress.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Content\\\\ImportExport\\\\Struct\\\\Progress\\:\\:__construct\\(\\) has parameter \\$total with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Content/ImportExport/Struct/Progress.php
+
+		-
+			message: "#^Argument of an invalid type Shopware\\\\Core\\\\Content\\\\MailTemplate\\\\Aggregate\\\\MailTemplateSalesChannel\\\\MailTemplateSalesChannelCollection\\|null supplied for foreach, only iterables are supported\\.$#"
+			count: 1
+			path: src/Core/Content/MailTemplate/Commands/AssignAllTemplatesToAllSalesChannelsCommand.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Content\\\\MailTemplate\\\\Service\\\\MailService\\:\\:getSender\\(\\) has parameter \\$data with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Content/MailTemplate/Service/MailService.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Content\\\\MailTemplate\\\\Service\\\\MailService\\:\\:enrichMessage\\(\\) has parameter \\$data with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Content/MailTemplate/Service/MailService.php
+
+		-
+			message: "#^Argument of an invalid type Shopware\\\\Core\\\\Content\\\\Media\\\\MediaCollection\\|null supplied for foreach, only iterables are supported\\.$#"
+			count: 1
+			path: src/Core/Content/MailTemplate/Service/MailService.php
+
+		-
+			message: "#^Parameter \\#1 \\$data of class Swift_Attachment constructor expects string\\|Swift_OutputByteStream\\|null, string\\|false given\\.$#"
+			count: 1
+			path: src/Core/Content/MailTemplate/Service/MessageFactory.php
+
+		-
+			message: "#^Parameter \\#3 \\$contentType of class Swift_Attachment constructor expects string\\|null, string\\|false given\\.$#"
+			count: 1
+			path: src/Core/Content/MailTemplate/Service/MessageFactory.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Content\\\\Media\\\\Aggregate\\\\MediaThumbnailSize\\\\MediaThumbnailSizeEntity\\:\\:getMediaFolderConfigurations\\(\\) should return Shopware\\\\Core\\\\Content\\\\Media\\\\Aggregate\\\\MediaFolderConfiguration\\\\MediaFolderConfigurationCollection but returns Shopware\\\\Core\\\\Content\\\\Media\\\\Aggregate\\\\MediaFolderConfiguration\\\\MediaFolderConfigurationCollection\\|null\\.$#"
+			count: 1
+			path: src/Core/Content/Media/Aggregate/MediaThumbnailSize/MediaThumbnailSizeEntity.php
+
+		-
+			message: "#^Parameter \\#2 \\$tempFile of method Shopware\\\\Core\\\\Content\\\\Media\\\\MediaService\\:\\:fetchFile\\(\\) expects string\\|null, string\\|false given\\.$#"
+			count: 1
+			path: src/Core/Content/Media/Api/MediaUploadController.php
+
+		-
+			message: "#^Parameter \\#1 \\$filename of function unlink expects string, string\\|false given\\.$#"
+			count: 1
+			path: src/Core/Content/Media/Api/MediaUploadController.php
+
+		-
+			message: "#^Cannot cast \\(array\\<string\\>\\)\\|string\\|true to int\\.$#"
+			count: 1
+			path: src/Core/Content/Media/Commands/GenerateMediaTypesCommand.php
+
+		-
+			message: "#^Parameter \\#2 \\$mimeType of class Shopware\\\\Core\\\\Content\\\\Media\\\\File\\\\MediaFile constructor expects string, string\\|null given\\.$#"
+			count: 1
+			path: src/Core/Content/Media/Commands/GenerateMediaTypesCommand.php
+
+		-
+			message: "#^Parameter \\#3 \\$fileExtension of class Shopware\\\\Core\\\\Content\\\\Media\\\\File\\\\MediaFile constructor expects string, string\\|null given\\.$#"
+			count: 1
+			path: src/Core/Content/Media/Commands/GenerateMediaTypesCommand.php
+
+		-
+			message: "#^Parameter \\#4 \\$fileSize of class Shopware\\\\Core\\\\Content\\\\Media\\\\File\\\\MediaFile constructor expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Core/Content/Media/Commands/GenerateMediaTypesCommand.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\Content\\\\Media\\\\Commands\\\\GenerateThumbnailsCommand\\:\\:\\$isAsync \\(bool\\) does not accept array\\<string\\>\\|bool\\|string\\|null\\.$#"
+			count: 1
+			path: src/Core/Content/Media/Commands/GenerateThumbnailsCommand.php
+
+		-
+			message: "#^Cannot cast array\\<string\\>\\|bool\\|string\\|null to int\\.$#"
+			count: 1
+			path: src/Core/Content/Media/Commands/GenerateThumbnailsCommand.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Content\\\\Media\\\\Commands\\\\GenerateThumbnailsCommand\\:\\:getFolderFilterFromInput\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Content/Media/Commands/GenerateThumbnailsCommand.php
+
+		-
+			message: "#^Parameter \\#2 \\.\\.\\.\\$args of function sprintf expects bool\\|float\\|int\\|string\\|null, \\(array\\<string\\>\\)\\|string\\|true given\\.$#"
+			count: 1
+			path: src/Core/Content/Media/Commands/GenerateThumbnailsCommand.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Content\\\\Media\\\\DataAbstractionLayer\\\\MediaFolderConfigurationIndexer\\:\\:iterate\\(\\) has parameter \\$offset with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Content/Media/DataAbstractionLayer/MediaFolderConfigurationIndexer.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Content\\\\Media\\\\DataAbstractionLayer\\\\MediaFolderIndexer\\:\\:iterate\\(\\) has parameter \\$offset with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Content/Media/DataAbstractionLayer/MediaFolderIndexer.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Content\\\\Media\\\\DataAbstractionLayer\\\\MediaFolderRepositoryDecorator\\:\\:getRawIds\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Content/Media/DataAbstractionLayer/MediaFolderRepositoryDecorator.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Content\\\\Media\\\\DataAbstractionLayer\\\\MediaIndexer\\:\\:iterate\\(\\) has parameter \\$offset with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Content/Media/DataAbstractionLayer/MediaIndexer.php
+
+		-
+			message: "#^Cannot call method getIds\\(\\) on Shopware\\\\Core\\\\Content\\\\Media\\\\Aggregate\\\\MediaThumbnail\\\\MediaThumbnailCollection\\|null\\.$#"
+			count: 1
+			path: src/Core/Content/Media/DataAbstractionLayer/MediaRepositoryDecorator.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Content\\\\Media\\\\DataAbstractionLayer\\\\MediaRepositoryDecorator\\:\\:getRawIds\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Content/Media/DataAbstractionLayer/MediaRepositoryDecorator.php
+
+		-
+			message: "#^Cannot call method getConfiguration\\(\\) on Shopware\\\\Core\\\\Content\\\\Media\\\\Aggregate\\\\MediaFolder\\\\MediaFolderEntity\\|null\\.$#"
+			count: 1
+			path: src/Core/Content/Media/DeleteNotUsedMediaService.php
+
+		-
+			message: "#^Cannot call method isNoAssociation\\(\\) on Shopware\\\\Core\\\\Content\\\\Media\\\\Aggregate\\\\MediaFolderConfiguration\\\\MediaFolderConfigurationEntity\\|null\\.$#"
+			count: 1
+			path: src/Core/Content/Media/DeleteNotUsedMediaService.php
+
+		-
+			message: "#^Cannot call method getId\\(\\) on Shopware\\\\Core\\\\Content\\\\Media\\\\Aggregate\\\\MediaFolder\\\\MediaFolderEntity\\|null\\.$#"
+			count: 1
+			path: src/Core/Content/Media/DeleteNotUsedMediaService.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Content\\\\Media\\\\Event\\\\MediaFileExtensionWhitelistEvent\\:\\:getWhitelist\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Content/Media/Event/MediaFileExtensionWhitelistEvent.php
+
+		-
+			message: "#^Parameter \\#2 \\$mimeType of class Shopware\\\\Core\\\\Content\\\\Media\\\\File\\\\MediaFile constructor expects string, string\\|false given\\.$#"
+			count: 2
+			path: src/Core/Content/Media/File/FileFetcher.php
+
+		-
+			message: "#^Parameter \\#1 \\$filename of function fopen expects string, string\\|false given\\.$#"
+			count: 1
+			path: src/Core/Content/Media/File/FileFetcher.php
+
+		-
+			message: "#^Parameter \\#1 \\$fp of function fwrite expects resource, resource\\|false given\\.$#"
+			count: 1
+			path: src/Core/Content/Media/File/FileFetcher.php
+
+		-
+			message: "#^Parameter \\#1 \\$fileName of class Shopware\\\\Core\\\\Content\\\\Media\\\\File\\\\MediaFile constructor expects string, string\\|false given\\.$#"
+			count: 1
+			path: src/Core/Content/Media/File/FileFetcher.php
+
+		-
+			message: "#^Parameter \\#4 \\$fileSize of class Shopware\\\\Core\\\\Content\\\\Media\\\\File\\\\MediaFile constructor expects int, int\\|false given\\.$#"
+			count: 1
+			path: src/Core/Content/Media/File/FileFetcher.php
+
+		-
+			message: "#^Parameter \\#1 \\$source of function stream_copy_to_stream expects resource, resource\\|string given\\.$#"
+			count: 1
+			path: src/Core/Content/Media/File/FileFetcher.php
+
+		-
+			message: "#^Parameter \\#1 \\$fileName of method Shopware\\\\Core\\\\Content\\\\Media\\\\File\\\\FileNameValidator\\:\\:validateFileName\\(\\) expects string, string\\|null given\\.$#"
+			count: 1
+			path: src/Core/Content/Media/File/FileLoader.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Content\\\\Media\\\\File\\\\FileLoader\\:\\:loadMediaFile\\(\\) should return string but returns string\\|false\\.$#"
+			count: 1
+			path: src/Core/Content/Media/File/FileLoader.php
+
+		-
+			message: "#^Parameter \\#3 \\$fileExtension of method Shopware\\\\Core\\\\Content\\\\Media\\\\File\\\\FileSaver\\:\\:ensureFileNameIsUnique\\(\\) expects string, string\\|null given\\.$#"
+			count: 1
+			path: src/Core/Content/Media/File/FileSaver.php
+
+		-
+			message: "#^Parameter \\#2 \\$oldFileName of class Shopware\\\\Core\\\\Content\\\\Media\\\\Exception\\\\CouldNotRenameFileException constructor expects string, string\\|null given\\.$#"
+			count: 2
+			path: src/Core/Content/Media/File/FileSaver.php
+
+		-
+			message: "#^Argument of an invalid type Shopware\\\\Core\\\\Content\\\\Media\\\\Aggregate\\\\MediaThumbnail\\\\MediaThumbnailCollection\\|null supplied for foreach, only iterables are supported\\.$#"
+			count: 1
+			path: src/Core/Content/Media/File/FileSaver.php
+
+		-
+			message: "#^Parameter \\#2 \\$resource of method League\\\\Flysystem\\\\FilesystemInterface\\:\\:putStream\\(\\) expects resource, resource\\|false given\\.$#"
+			count: 1
+			path: src/Core/Content/Media/File/FileSaver.php
+
+		-
+			message: "#^Parameter \\#1 \\$hostname of function gethostbyname expects string, string\\|false\\|null given\\.$#"
+			count: 1
+			path: src/Core/Content/Media/File/FileUrlValidator.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Content\\\\Media\\\\MediaEntity\\:\\:get\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Content/Media/MediaEntity.php
+
+		-
+			message: "#^Cannot call method getId\\(\\) on Shopware\\\\Core\\\\Content\\\\Media\\\\Aggregate\\\\MediaFolderConfiguration\\\\MediaFolderConfigurationEntity\\|null\\.$#"
+			count: 1
+			path: src/Core/Content/Media/MediaFolderService.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Content\\\\Media\\\\MediaFolderService\\:\\:fetchFolder\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Content/Media/MediaFolderService.php
+
+		-
+			message: "#^Parameter \\#1 \\$folder of method Shopware\\\\Core\\\\Content\\\\Media\\\\MediaService\\:\\:createMediaInFolder\\(\\) expects string, string\\|null given\\.$#"
+			count: 2
+			path: src/Core/Content/Media/MediaService.php
+
+		-
+			message: "#^Parameter \\#2 \\$fileName of method Shopware\\\\Core\\\\Content\\\\Media\\\\File\\\\FileFetcher\\:\\:fetchFileFromURL\\(\\) expects string, string\\|false given\\.$#"
+			count: 1
+			path: src/Core/Content/Media/MediaService.php
+
+		-
+			message: "#^Parameter \\#2 \\$fileName of method Shopware\\\\Core\\\\Content\\\\Media\\\\File\\\\FileFetcher\\:\\:fetchRequestData\\(\\) expects string, string\\|false given\\.$#"
+			count: 1
+			path: src/Core/Content/Media/MediaService.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\Content\\\\Media\\\\Metadata\\\\MetadataLoader\\:\\:\\$metadataLoader \\(array\\<Shopware\\\\Core\\\\Content\\\\Media\\\\Metadata\\\\MetadataLoader\\\\MetadataLoaderInterface\\>\\) does not accept iterable\\.$#"
+			count: 1
+			path: src/Core/Content/Media/Metadata/MetadataLoader.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Content\\\\Media\\\\Metadata\\\\MetadataLoader\\\\ImageMetadataLoader\\:\\:extractMetadata\\(\\) should return array\\|null but returns \\(array\\)\\|true\\.$#"
+			count: 1
+			path: src/Core/Content/Media/Metadata/MetadataLoader/ImageMetadataLoader.php
+
+		-
+			message: "#^Parameter \\#1 \\$fromValue of method Shopware\\\\Core\\\\Content\\\\Media\\\\Pathname\\\\PathnameStrategy\\\\AbstractPathNameStrategy\\:\\:generateMd5Path\\(\\) expects string, string\\|null given\\.$#"
+			count: 1
+			path: src/Core/Content/Media/Pathname/PathnameStrategy/FilenamePathnameStrategy.php
+
+		-
+			message: "#^Cannot call method getTimestamp\\(\\) on DateTimeInterface\\|null\\.$#"
+			count: 1
+			path: src/Core/Content/Media/Pathname/PathnameStrategy/PhysicalFilenamePathnameStrategy.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\Content\\\\Media\\\\Pathname\\\\PathnameStrategy\\\\StrategyFactory\\:\\:\\$strategies \\(array\\<Shopware\\\\Core\\\\Content\\\\Media\\\\Pathname\\\\PathnameStrategy\\\\PathnameStrategyInterface\\>\\) does not accept iterable\\.$#"
+			count: 1
+			path: src/Core/Content/Media/Pathname/PathnameStrategy/StrategyFactory.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\Content\\\\Media\\\\Pathname\\\\UrlGenerator\\:\\:\\$baseUrl \\(string\\) does not accept string\\|null\\.$#"
+			count: 1
+			path: src/Core/Content/Media/Pathname/UrlGenerator.php
+
+		-
+			message: "#^Parameter \\#1 \\$variable_representation of function unserialize expects string, string\\|null given\\.$#"
+			count: 1
+			path: src/Core/Content/Media/Subscriber/MediaFolderConfigLoadedSubscriber.php
+
+		-
+			message: "#^Argument of an invalid type Shopware\\\\Core\\\\Content\\\\Media\\\\Aggregate\\\\MediaThumbnail\\\\MediaThumbnailCollection\\|null supplied for foreach, only iterables are supported\\.$#"
+			count: 1
+			path: src/Core/Content/Media/Subscriber/MediaLoadedSubscriber.php
+
+		-
+			message: "#^Parameter \\#1 \\$variable_representation of function unserialize expects string, string\\|null given\\.$#"
+			count: 2
+			path: src/Core/Content/Media/Subscriber/MediaLoadedSubscriber.php
+
+		-
+			message: "#^Parameter \\#3 \\$thumbnailSizes of method Shopware\\\\Core\\\\Content\\\\Media\\\\Thumbnail\\\\ThumbnailService\\:\\:createThumbnailsForSizes\\(\\) expects Shopware\\\\Core\\\\Content\\\\Media\\\\Aggregate\\\\MediaThumbnailSize\\\\MediaThumbnailSizeCollection, Shopware\\\\Core\\\\Content\\\\Media\\\\Aggregate\\\\MediaThumbnailSize\\\\MediaThumbnailSizeCollection\\|null given\\.$#"
+			count: 1
+			path: src/Core/Content/Media/Thumbnail/ThumbnailService.php
+
+		-
+			message: "#^Cannot call method getElements\\(\\) on Shopware\\\\Core\\\\Content\\\\Media\\\\Aggregate\\\\MediaThumbnailSize\\\\MediaThumbnailSizeCollection\\|null\\.$#"
+			count: 1
+			path: src/Core/Content/Media/Thumbnail/ThumbnailService.php
+
+		-
+			message: "#^Cannot call method getElements\\(\\) on Shopware\\\\Core\\\\Content\\\\Media\\\\Aggregate\\\\MediaThumbnail\\\\MediaThumbnailCollection\\|null\\.$#"
+			count: 1
+			path: src/Core/Content/Media/Thumbnail/ThumbnailService.php
+
+		-
+			message: "#^Parameter \\#2 \\$type of method Shopware\\\\Core\\\\Content\\\\Media\\\\Thumbnail\\\\ThumbnailService\\:\\:createNewImage\\(\\) expects Shopware\\\\Core\\\\Content\\\\Media\\\\MediaType\\\\MediaType, Shopware\\\\Core\\\\Content\\\\Media\\\\MediaType\\\\MediaType\\|null given\\.$#"
+			count: 1
+			path: src/Core/Content/Media/Thumbnail/ThumbnailService.php
+
+		-
+			message: "#^Parameter \\#2 \\$contents of method League\\\\Flysystem\\\\FilesystemInterface\\:\\:update\\(\\) expects string, string\\|false given\\.$#"
+			count: 1
+			path: src/Core/Content/Media/Thumbnail/ThumbnailService.php
+
+		-
+			message: "#^Parameter \\#1 \\$image of function imagecreatefromstring expects string, string\\|false given\\.$#"
+			count: 1
+			path: src/Core/Content/Media/Thumbnail/ThumbnailService.php
+
+		-
+			message: "#^Cannot access offset 'Orientation' on array\\|false\\.$#"
+			count: 3
+			path: src/Core/Content/Media/Thumbnail/ThumbnailService.php
+
+		-
+			message: "#^Parameter \\#1 \\$im of function imagecolorallocate expects resource, resource\\|false given\\.$#"
+			count: 1
+			path: src/Core/Content/Media/Thumbnail/ThumbnailService.php
+
+		-
+			message: "#^Parameter \\#1 \\$im of function imagefill expects resource, resource\\|false given\\.$#"
+			count: 1
+			path: src/Core/Content/Media/Thumbnail/ThumbnailService.php
+
+		-
+			message: "#^Parameter \\#1 \\$im of function imagealphablending expects resource, resource\\|false given\\.$#"
+			count: 1
+			path: src/Core/Content/Media/Thumbnail/ThumbnailService.php
+
+		-
+			message: "#^Parameter \\#1 \\$im of function imagesavealpha expects resource, resource\\|false given\\.$#"
+			count: 1
+			path: src/Core/Content/Media/Thumbnail/ThumbnailService.php
+
+		-
+			message: "#^Parameter \\#1 \\$dst_im of function imagecopyresampled expects resource, resource\\|false given\\.$#"
+			count: 1
+			path: src/Core/Content/Media/Thumbnail/ThumbnailService.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Content\\\\Media\\\\Thumbnail\\\\ThumbnailService\\:\\:createNewImage\\(\\) should return resource but returns resource\\|false\\.$#"
+			count: 1
+			path: src/Core/Content/Media/Thumbnail/ThumbnailService.php
+
+		-
+			message: "#^Parameter \\#2 \\$contents of method League\\\\Flysystem\\\\FilesystemInterface\\:\\:put\\(\\) expects string, string\\|false given\\.$#"
+			count: 1
+			path: src/Core/Content/Media/Thumbnail/ThumbnailService.php
+
+		-
+			message: "#^Cannot call method getIds\\(\\) on Shopware\\\\Core\\\\Content\\\\Media\\\\Aggregate\\\\MediaThumbnail\\\\MediaThumbnailCollection\\|null\\.$#"
+			count: 1
+			path: src/Core/Content/Media/Thumbnail/ThumbnailService.php
+
+		-
+			message: "#^Parameter \\#2 \\$subject of function preg_match_all expects string, string\\|false given\\.$#"
+			count: 1
+			path: src/Core/Content/Media/TypeDetector/ImageTypeDetector.php
+
+		-
+			message: "#^Parameter \\#1 \\$fp of function fread expects resource, resource\\|false given\\.$#"
+			count: 3
+			path: src/Core/Content/Media/TypeDetector/ImageTypeDetector.php
+
+		-
+			message: "#^Parameter \\#1 \\$character of function ord expects string, string\\|false given\\.$#"
+			count: 1
+			path: src/Core/Content/Media/TypeDetector/ImageTypeDetector.php
+
+		-
+			message: "#^Parameter \\#1 \\$fp of function fclose expects resource, resource\\|false given\\.$#"
+			count: 1
+			path: src/Core/Content/Media/TypeDetector/ImageTypeDetector.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\Content\\\\Media\\\\TypeDetector\\\\TypeDetector\\:\\:\\$typeDetector \\(array\\<Shopware\\\\Core\\\\Content\\\\Media\\\\TypeDetector\\\\TypeDetectorInterface\\>\\) does not accept iterable\\.$#"
+			count: 1
+			path: src/Core/Content/Media/TypeDetector/TypeDetector.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Content\\\\Media\\\\TypeDetector\\\\TypeDetector\\:\\:detect\\(\\) should return Shopware\\\\Core\\\\Content\\\\Media\\\\MediaType\\\\MediaType but returns Shopware\\\\Core\\\\Content\\\\Media\\\\MediaType\\\\MediaType\\|null\\.$#"
+			count: 1
+			path: src/Core/Content/Media/TypeDetector/TypeDetector.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Content\\\\Newsletter\\\\Exception\\\\LanguageOfNewsletterDeleteException\\:\\:__construct\\(\\) has parameter \\$e with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Content/Newsletter/Exception/LanguageOfNewsletterDeleteException.php
+
+		-
+			message: "#^Cannot call method getElements\\(\\) on Shopware\\\\Core\\\\System\\\\SalesChannel\\\\Aggregate\\\\SalesChannelDomain\\\\SalesChannelDomainCollection\\|null\\.$#"
+			count: 1
+			path: src/Core/Content/Newsletter/SalesChannel/NewsletterSubscribeRoute.php
+
+		-
+			message: "#^Cannot call method getGroupId\\(\\) on Shopware\\\\Core\\\\Content\\\\Property\\\\Aggregate\\\\PropertyGroupOption\\\\PropertyGroupOptionEntity\\|null\\.$#"
+			count: 2
+			path: src/Core/Content/Product/Aggregate/ProductConfiguratorSetting/ProductConfiguratorSettingCollection.php
+
+		-
+			message: "#^Parameter \\#1 \\$object of static method Shopware\\\\Core\\\\Framework\\\\Struct\\\\Struct\\:\\:createFrom\\(\\) expects Shopware\\\\Core\\\\Framework\\\\Struct\\\\Struct, Shopware\\\\Core\\\\Content\\\\Property\\\\PropertyGroupEntity\\|null given\\.$#"
+			count: 1
+			path: src/Core/Content/Product/Aggregate/ProductConfiguratorSetting/ProductConfiguratorSettingCollection.php
+
+		-
+			message: "#^Cannot call method getGroup\\(\\) on Shopware\\\\Core\\\\Content\\\\Property\\\\Aggregate\\\\PropertyGroupOption\\\\PropertyGroupOptionEntity\\|null\\.$#"
+			count: 1
+			path: src/Core/Content/Product/Aggregate/ProductConfiguratorSetting/ProductConfiguratorSettingCollection.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\Content\\\\Product\\\\Aggregate\\\\ProductReview\\\\ProductReviewEntity\\:\\:\\$status \\(bool\\) does not accept bool\\|null\\.$#"
+			count: 1
+			path: src/Core/Content/Product/Aggregate/ProductReview/ProductReviewEntity.php
+
+		-
+			message: "#^Parameter \\#1 \\$quantity of method Shopware\\\\Core\\\\Checkout\\\\Cart\\\\Price\\\\Struct\\\\QuantityPriceDefinition\\:\\:setQuantity\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Core/Content/Product/Cart/ProductCartProcessor.php
+
+		-
+			message: "#^Cannot call method getMedia\\(\\) on Shopware\\\\Core\\\\Content\\\\Product\\\\Aggregate\\\\ProductMedia\\\\ProductMediaEntity\\|null\\.$#"
+			count: 1
+			path: src/Core/Content/Product/Cart/ProductCartProcessor.php
+
+		-
+			message: "#^Parameter \\#3 \\$freeDelivery of class Shopware\\\\Core\\\\Checkout\\\\Cart\\\\Delivery\\\\Struct\\\\DeliveryInformation constructor expects bool, bool\\|null given\\.$#"
+			count: 1
+			path: src/Core/Content/Product/Cart/ProductCartProcessor.php
+
+		-
+			message: "#^Cannot call method format\\(\\) on DateTimeInterface\\|null\\.$#"
+			count: 2
+			path: src/Core/Content/Product/Cart/ProductCartProcessor.php
+
+		-
+			message: "#^Argument of an invalid type Shopware\\\\Core\\\\Content\\\\Property\\\\Aggregate\\\\PropertyGroupOption\\\\PropertyGroupOptionCollection\\|null supplied for foreach, only iterables are supported\\.$#"
+			count: 1
+			path: src/Core/Content/Product/Cart/ProductCartProcessor.php
+
+		-
+			message: "#^Parameter \\#1 \\$name of method Shopware\\\\Core\\\\Content\\\\Product\\\\Cart\\\\ProductFeatureBuilder\\:\\:isRequiredCustomField\\(\\) expects string, int\\|string given\\.$#"
+			count: 1
+			path: src/Core/Content/Product/Cart/ProductFeatureBuilder.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Content\\\\Product\\\\Cart\\\\ProductLineItemCommandValidator\\:\\:findProducts\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Content/Product/Cart/ProductLineItemCommandValidator.php
+
+		-
+			message: "#^Cannot call method getEntities\\(\\) on Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Search\\\\EntitySearchResult\\|null\\.$#"
+			count: 1
+			path: src/Core/Content/Product/Cms/ProductSliderCmsElementResolver.php
+
+		-
+			message: "#^Cannot call method addAssociation\\(\\) on Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Search\\\\Criteria\\|null\\.$#"
+			count: 2
+			path: src/Core/Content/Product/Cms/ProductSliderCmsElementResolver.php
+
+		-
+			message: "#^Cannot call method fetchAll\\(\\) on Doctrine\\\\DBAL\\\\Driver\\\\Statement\\|int\\.$#"
+			count: 2
+			path: src/Core/Content/Product/DataAbstractionLayer/Indexing/ListingPriceUpdater.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Content\\\\Product\\\\DataAbstractionLayer\\\\Indexing\\\\ListingPriceUpdater\\:\\:getDefaultPrice\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Content/Product/DataAbstractionLayer/Indexing/ListingPriceUpdater.php
+
+		-
+			message: "#^Cannot call method fetchAll\\(\\) on Doctrine\\\\DBAL\\\\Driver\\\\Statement\\|int\\.$#"
+			count: 1
+			path: src/Core/Content/Product/DataAbstractionLayer/ProductCategoryDenormalizer.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Content\\\\Product\\\\DataAbstractionLayer\\\\ProductIndexer\\:\\:iterate\\(\\) has parameter \\$offset with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Content/Product/DataAbstractionLayer/ProductIndexer.php
+
+		-
+			message: "#^Cannot call method fetchAll\\(\\) on Doctrine\\\\DBAL\\\\Driver\\\\Statement\\|int\\.$#"
+			count: 1
+			path: src/Core/Content/Product/DataAbstractionLayer/RatingAverageUpdater.php
+
+		-
+			message: "#^Call to an undefined method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Write\\\\Command\\\\ChangeSetAware\\|Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Write\\\\Command\\\\InsertCommand\\:\\:getDefinition\\(\\)\\.$#"
+			count: 1
+			path: src/Core/Content/Product/DataAbstractionLayer/StockUpdater.php
+
+		-
+			message: "#^Call to an undefined method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Write\\\\Command\\\\ChangeSetAware\\|Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Write\\\\Command\\\\InsertCommand\\:\\:hasField\\(\\)\\.$#"
+			count: 3
+			path: src/Core/Content/Product/DataAbstractionLayer/StockUpdater.php
+
+		-
+			message: "#^Call to an undefined method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Write\\\\Command\\\\ChangeSetAware\\|Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Write\\\\Command\\\\InsertCommand\\:\\:requestChangeSet\\(\\)\\.$#"
+			count: 1
+			path: src/Core/Content/Product/DataAbstractionLayer/StockUpdater.php
+
+		-
+			message: "#^Argument of an invalid type Shopware\\\\Core\\\\Checkout\\\\Order\\\\Aggregate\\\\OrderLineItem\\\\OrderLineItemCollection\\|null supplied for foreach, only iterables are supported\\.$#"
+			count: 1
+			path: src/Core/Content/Product/DataAbstractionLayer/StockUpdater.php
+
+		-
+			message: "#^Cannot call method fetchAll\\(\\) on Doctrine\\\\DBAL\\\\Driver\\\\Statement\\|int\\.$#"
+			count: 1
+			path: src/Core/Content/Product/DataAbstractionLayer/StockUpdater.php
+
+		-
+			message: "#^Cannot call method fetchAll\\(\\) on Doctrine\\\\DBAL\\\\Driver\\\\Statement\\|int\\.$#"
+			count: 1
+			path: src/Core/Content/Product/DataAbstractionLayer/VariantListingUpdater.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Content\\\\Product\\\\Exception\\\\DuplicateProductNumberException\\:\\:__construct\\(\\) has parameter \\$e with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Content/Product/Exception/DuplicateProductNumberException.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Content\\\\Product\\\\Exception\\\\LanguageOfProductReviewDeleteException\\:\\:__construct\\(\\) has parameter \\$e with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Content/Product/Exception/LanguageOfProductReviewDeleteException.php
+
+		-
+			message: "#^Cannot call method getIds\\(\\) on Shopware\\\\Core\\\\Content\\\\Product\\\\Aggregate\\\\ProductPrice\\\\ProductPriceCollection\\|null\\.$#"
+			count: 1
+			path: src/Core/Content/Product/ProductCollection.php
+
+		-
+			message: "#^Parameter \\#1 \\$arr1 of function array_merge expects array, array\\|Shopware\\\\Core\\\\Content\\\\Product\\\\Aggregate\\\\ProductPrice\\\\ProductPriceCollection\\|null given\\.$#"
+			count: 1
+			path: src/Core/Content/Product/ProductCollection.php
+
+		-
+			message: "#^Parameter \\#1 \\$arr1 of function array_intersect expects array, array\\|null given\\.$#"
+			count: 1
+			path: src/Core/Content/Product/ProductCollection.php
+
+		-
+			message: "#^Parameter \\#1 \\$productStreamId of method Shopware\\\\Core\\\\Content\\\\ProductStream\\\\Service\\\\ProductStreamBuilderInterface\\:\\:buildFilters\\(\\) expects string, string\\|null given\\.$#"
+			count: 1
+			path: src/Core/Content/Product/SalesChannel/CrossSelling/ProductCrossSellingRoute.php
+
+		-
+			message: "#^Cannot call method sortByPosition\\(\\) on Shopware\\\\Core\\\\Content\\\\Product\\\\Aggregate\\\\ProductCrossSellingAssignedProducts\\\\ProductCrossSellingAssignedProductsCollection\\|null\\.$#"
+			count: 1
+			path: src/Core/Content/Product/SalesChannel/CrossSelling/ProductCrossSellingRoute.php
+
+		-
+			message: "#^Cannot call method getProductIds\\(\\) on Shopware\\\\Core\\\\Content\\\\Product\\\\Aggregate\\\\ProductCrossSellingAssignedProducts\\\\ProductCrossSellingAssignedProductsCollection\\|null\\.$#"
+			count: 1
+			path: src/Core/Content/Product/SalesChannel/CrossSelling/ProductCrossSellingRoute.php
+
+		-
+			message: "#^Cannot call method count\\(\\) on Shopware\\\\Core\\\\Content\\\\Product\\\\Aggregate\\\\ProductCrossSellingAssignedProducts\\\\ProductCrossSellingAssignedProductsCollection\\|null\\.$#"
+			count: 1
+			path: src/Core/Content/Product/SalesChannel/CrossSelling/ProductCrossSellingRoute.php
+
+		-
+			message: "#^Parameter \\#1 \\$productStreamId of method Shopware\\\\Core\\\\Content\\\\ProductStream\\\\Service\\\\ProductStreamBuilderInterface\\:\\:buildFilters\\(\\) expects string, string\\|null given\\.$#"
+			count: 1
+			path: src/Core/Content/Product/SalesChannel/CrossSelling/SalesChannelCrossSellingController.php
+
+		-
+			message: "#^Cannot call method fetchAll\\(\\) on Doctrine\\\\DBAL\\\\Driver\\\\Statement\\|int\\.$#"
+			count: 1
+			path: src/Core/Content/Product/SalesChannel/Detail/AvailableCombinationLoader.php
+
+		-
+			message: "#^Parameter \\#1 \\$str of function md5 expects string, string\\|false given\\.$#"
+			count: 2
+			path: src/Core/Content/Product/SalesChannel/Detail/AvailableCombinationResult.php
+
+		-
+			message: "#^Parameter \\#1 \\$productId of method Shopware\\\\Core\\\\Content\\\\Product\\\\SalesChannel\\\\Detail\\\\AvailableCombinationLoader\\:\\:load\\(\\) expects string, string\\|null given\\.$#"
+			count: 1
+			path: src/Core/Content/Product/SalesChannel/Detail/ProductConfiguratorLoader.php
+
+		-
+			message: "#^Cannot call method add\\(\\) on Shopware\\\\Core\\\\Content\\\\Property\\\\Aggregate\\\\PropertyGroupOption\\\\PropertyGroupOptionCollection\\|null\\.$#"
+			count: 1
+			path: src/Core/Content/Product/SalesChannel/Detail/ProductConfiguratorLoader.php
+
+		-
+			message: "#^Cannot call method sort\\(\\) on Shopware\\\\Core\\\\Content\\\\Property\\\\Aggregate\\\\PropertyGroupOption\\\\PropertyGroupOptionCollection\\|null\\.$#"
+			count: 1
+			path: src/Core/Content/Product/SalesChannel/Detail/ProductConfiguratorLoader.php
+
+		-
+			message: "#^Cannot call method getPosition\\(\\) on Shopware\\\\Core\\\\Content\\\\Product\\\\Aggregate\\\\ProductConfiguratorSetting\\\\ProductConfiguratorSettingEntity\\|null\\.$#"
+			count: 4
+			path: src/Core/Content/Product/SalesChannel/Detail/ProductConfiguratorLoader.php
+
+		-
+			message: "#^Argument of an invalid type array\\|null supplied for foreach, only iterables are supported\\.$#"
+			count: 1
+			path: src/Core/Content/Product/SalesChannel/Detail/ProductConfiguratorLoader.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Content\\\\Product\\\\SalesChannel\\\\Detail\\\\ProductDetailRoute\\:\\:findBestVariant\\(\\) should return string but returns array\\|string\\.$#"
+			count: 1
+			path: src/Core/Content/Product/SalesChannel/Detail/ProductDetailRoute.php
+
+		-
+			message: "#^Parameter \\#1 \\$var of function count expects array\\|Countable, array\\|null given\\.$#"
+			count: 1
+			path: src/Core/Content/Product/SalesChannel/Listing/ProductListingFeaturesSubscriber.php
+
+		-
+			message: "#^Parameter \\#1 \\$input of function array_values expects array, array\\|false given\\.$#"
+			count: 1
+			path: src/Core/Content/Product/SalesChannel/Listing/ProductListingLoader.php
+
+		-
+			message: "#^Parameter \\#1 \\$keys of function array_combine expects array, array\\|false given\\.$#"
+			count: 1
+			path: src/Core/Content/Product/SalesChannel/Listing/ProductListingLoader.php
+
+		-
+			message: "#^Parameter \\#2 \\$values of function array_combine expects array, array\\|false given\\.$#"
+			count: 1
+			path: src/Core/Content/Product/SalesChannel/Listing/ProductListingLoader.php
+
+		-
+			message: "#^Argument of an invalid type array\\|false supplied for foreach, only iterables are supported\\.$#"
+			count: 1
+			path: src/Core/Content/Product/SalesChannel/Listing/ProductListingLoader.php
+
+		-
+			message: "#^Possibly invalid array key type array\\|string\\.$#"
+			count: 3
+			path: src/Core/Content/Product/SalesChannel/Listing/ProductListingLoader.php
+
+		-
+			message: "#^Parameter \\#1 \\$id of method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Search\\\\IdSearchResult\\:\\:getDataOfId\\(\\) expects string, array\\|string given\\.$#"
+			count: 1
+			path: src/Core/Content/Product/SalesChannel/Listing/ProductListingLoader.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Content\\\\Product\\\\SalesChannel\\\\Listing\\\\ProductListingResult\\:\\:addCurrentFilter\\(\\) has parameter \\$value with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Content/Product/SalesChannel/Listing/ProductListingResult.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Content\\\\Product\\\\SalesChannel\\\\Listing\\\\ProductListingResult\\:\\:getCurrentFilter\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Content/Product/SalesChannel/Listing/ProductListingResult.php
+
+		-
+			message: "#^Parameter \\#1 \\$productStreamId of method Shopware\\\\Core\\\\Content\\\\ProductStream\\\\Service\\\\ProductStreamBuilderInterface\\:\\:buildFilters\\(\\) expects string, string\\|null given\\.$#"
+			count: 1
+			path: src/Core/Content/Product/SalesChannel/Listing/ProductListingRoute.php
+
+		-
+			message: "#^Parameter \\#1 \\$taxId of method Shopware\\\\Core\\\\System\\\\SalesChannel\\\\SalesChannelContext\\:\\:buildTaxRules\\(\\) expects string, string\\|null given\\.$#"
+			count: 4
+			path: src/Core/Content/Product/SalesChannel/Price/ProductPriceDefinitionBuilder.php
+
+		-
+			message: "#^Parameter \\#1 \\$rules of method Shopware\\\\Core\\\\Content\\\\Product\\\\SalesChannel\\\\Price\\\\ProductPriceDefinitionBuilder\\:\\:getFirstMatchingPriceRule\\(\\) expects Shopware\\\\Core\\\\Content\\\\Product\\\\Aggregate\\\\ProductPrice\\\\ProductPriceCollection, Shopware\\\\Core\\\\Content\\\\Product\\\\Aggregate\\\\ProductPrice\\\\ProductPriceCollection\\|null given\\.$#"
+			count: 3
+			path: src/Core/Content/Product/SalesChannel/Price/ProductPriceDefinitionBuilder.php
+
+		-
+			message: "#^Cannot call method getContextPrice\\(\\) on Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Pricing\\\\ListingPriceCollection\\|null\\.$#"
+			count: 1
+			path: src/Core/Content/Product/SalesChannel/Price/ProductPriceDefinitionBuilder.php
+
+		-
+			message: "#^Parameter \\#1 \\$price of method Shopware\\\\Core\\\\Content\\\\Product\\\\SalesChannel\\\\Price\\\\ProductPriceDefinitionBuilder\\:\\:getPriceForTaxState\\(\\) expects Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Pricing\\\\Price, Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Pricing\\\\Price\\|null given\\.$#"
+			count: 1
+			path: src/Core/Content/Product/SalesChannel/Price/ProductPriceDefinitionBuilder.php
+
+		-
+			message: "#^Cannot call method getCurrencyId\\(\\) on Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Pricing\\\\Price\\|null\\.$#"
+			count: 1
+			path: src/Core/Content/Product/SalesChannel/Price/ProductPriceDefinitionBuilder.php
+
+		-
+			message: "#^Parameter \\#1 \\$purchaseUnit of class Shopware\\\\Core\\\\Checkout\\\\Cart\\\\Price\\\\Struct\\\\ReferencePriceDefinition constructor expects float, float\\|null given\\.$#"
+			count: 1
+			path: src/Core/Content/Product/SalesChannel/Price/ProductPriceDefinitionBuilder.php
+
+		-
+			message: "#^Parameter \\#2 \\$referenceUnit of class Shopware\\\\Core\\\\Checkout\\\\Cart\\\\Price\\\\Struct\\\\ReferencePriceDefinition constructor expects float, float\\|null given\\.$#"
+			count: 1
+			path: src/Core/Content/Product/SalesChannel/Price/ProductPriceDefinitionBuilder.php
+
+		-
+			message: "#^Cannot call method getCurrencyPrice\\(\\) on Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Pricing\\\\PriceCollection\\|null\\.$#"
+			count: 2
+			path: src/Core/Content/Product/SalesChannel/Price/ProductPriceDefinitionBuilder.php
+
+		-
+			message: "#^Cannot call method getGross\\(\\) on Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Pricing\\\\Price\\|null\\.$#"
+			count: 1
+			path: src/Core/Content/Product/SalesChannel/Price/ProductPriceDefinitionBuilder.php
+
+		-
+			message: "#^Cannot call method getNet\\(\\) on Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Pricing\\\\Price\\|null\\.$#"
+			count: 1
+			path: src/Core/Content/Product/SalesChannel/Price/ProductPriceDefinitionBuilder.php
+
+		-
+			message: "#^Cannot call method getTranslation\\(\\) on Shopware\\\\Core\\\\Content\\\\Product\\\\Aggregate\\\\ProductManufacturer\\\\ProductManufacturerEntity\\|null\\.$#"
+			count: 2
+			path: src/Core/Content/Product/SearchKeyword/ProductSearchKeywordAnalyzer.php
+
+		-
+			message: "#^Parameter \\#1 \\$keyword of class Shopware\\\\Core\\\\Content\\\\Product\\\\SearchKeyword\\\\AnalyzedKeyword constructor expects string, string\\|null given\\.$#"
+			count: 2
+			path: src/Core/Content/Product/SearchKeyword/ProductSearchKeywordAnalyzer.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Content\\\\Product\\\\SearchKeyword\\\\ProductSearchTermInterpreter\\:\\:permute\\(\\) has parameter \\$arg with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Content/Product/SearchKeyword/ProductSearchTermInterpreter.php
+
+		-
+			message: "#^Cannot call method fetchAll\\(\\) on Doctrine\\\\DBAL\\\\Driver\\\\Statement\\|int\\.$#"
+			count: 1
+			path: src/Core/Content/Product/SearchKeyword/ProductSearchTermInterpreter.php
+
+		-
+			message: "#^Cannot call method map\\(\\) on Shopware\\\\Core\\\\Content\\\\Property\\\\Aggregate\\\\PropertyGroupOption\\\\PropertyGroupOptionCollection\\|null\\.$#"
+			count: 1
+			path: src/Core/Content/Product/Subscriber/ProductSubscriber.php
+
+		-
+			message: "#^Cannot call method getTranslation\\(\\) on Shopware\\\\Core\\\\Content\\\\Property\\\\PropertyGroupEntity\\|null\\.$#"
+			count: 2
+			path: src/Core/Content/Product/Subscriber/ProductSubscriber.php
+
+		-
+			message: "#^Argument of an invalid type array\\|null supplied for foreach, only iterables are supported\\.$#"
+			count: 1
+			path: src/Core/Content/Product/Subscriber/ProductSubscriber.php
+
+		-
+			message: "#^Cannot call method filterByGroupId\\(\\) on Shopware\\\\Core\\\\Content\\\\Property\\\\Aggregate\\\\PropertyGroupOption\\\\PropertyGroupOptionCollection\\|null\\.$#"
+			count: 1
+			path: src/Core/Content/Product/Subscriber/ProductSubscriber.php
+
+		-
+			message: "#^Cannot call method fetchAll\\(\\) on Doctrine\\\\DBAL\\\\Driver\\\\Statement\\|int\\.$#"
+			count: 1
+			path: src/Core/Content/Product/Util/VariantCombinationLoader.php
+
+		-
+			message: "#^Parameter \\#1 \\$salesChannel of method Shopware\\\\Core\\\\Content\\\\ProductExport\\\\ProductExportEntity\\:\\:setSalesChannel\\(\\) expects Shopware\\\\Core\\\\System\\\\SalesChannel\\\\SalesChannelEntity, Shopware\\\\Core\\\\System\\\\SalesChannel\\\\SalesChannelEntity\\|null given\\.$#"
+			count: 1
+			path: src/Core/Content/ProductExport/Api/ProductExportController.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Content\\\\ProductExport\\\\Api\\\\ProductExportController\\:\\:generateExportPreview\\(\\) should return Shopware\\\\Core\\\\Content\\\\ProductExport\\\\Struct\\\\ProductExportResult but returns Shopware\\\\Core\\\\Content\\\\ProductExport\\\\Struct\\\\ProductExportResult\\|null\\.$#"
+			count: 1
+			path: src/Core/Content/ProductExport/Api/ProductExportController.php
+
+		-
+			message: "#^Parameter \\#2 \\$salesChannelId of method Shopware\\\\Core\\\\System\\\\SalesChannel\\\\Context\\\\SalesChannelContextFactory\\:\\:create\\(\\) expects string, array\\<string\\>\\|string\\|null given\\.$#"
+			count: 1
+			path: src/Core/Content/ProductExport/Command/ProductExportGenerateCommand.php
+
+		-
+			message: "#^Parameter \\#3 \\$productExportId of method Shopware\\\\Core\\\\Content\\\\ProductExport\\\\Service\\\\ProductExporterInterface\\:\\:export\\(\\) expects string\\|null, array\\<string\\>\\|string\\|null given\\.$#"
+			count: 1
+			path: src/Core/Content/ProductExport/Command/ProductExportGenerateCommand.php
+
+		-
+			message: "#^Parameter \\#1 \\$ignoreCache of class Shopware\\\\Core\\\\Content\\\\ProductExport\\\\Struct\\\\ExportBehavior constructor expects bool, array\\<string\\>\\|bool\\|string\\|null given\\.$#"
+			count: 1
+			path: src/Core/Content/ProductExport/Command/ProductExportGenerateCommand.php
+
+		-
+			message: "#^Parameter \\#2 \\$includeInactive of class Shopware\\\\Core\\\\Content\\\\ProductExport\\\\Struct\\\\ExportBehavior constructor expects bool, array\\<string\\>\\|bool\\|string\\|null given\\.$#"
+			count: 1
+			path: src/Core/Content/ProductExport/Command/ProductExportGenerateCommand.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\Content\\\\ProductExport\\\\Event\\\\ProductExportLoggingEvent\\:\\:\\$name \\(string\\) does not accept string\\|null\\.$#"
+			count: 1
+			path: src/Core/Content/ProductExport/Event/ProductExportLoggingEvent.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\Content\\\\ProductExport\\\\Event\\\\ProductExportLoggingEvent\\:\\:\\$logLevel \\(int\\) does not accept int\\|null\\.$#"
+			count: 1
+			path: src/Core/Content/ProductExport/Event/ProductExportLoggingEvent.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\Content\\\\ProductExport\\\\Event\\\\ProductExportLoggingEvent\\:\\:\\$throwable \\(Throwable\\) does not accept Throwable\\|null\\.$#"
+			count: 1
+			path: src/Core/Content/ProductExport/Event/ProductExportLoggingEvent.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Content\\\\ProductExport\\\\Exception\\\\DuplicateFileNameException\\:\\:__construct\\(\\) has parameter \\$e with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Content/ProductExport/Exception/DuplicateFileNameException.php
+
+		-
+			message: "#^Parameter \\#2 \\$salesChannelId of method Shopware\\\\Core\\\\System\\\\SalesChannel\\\\Context\\\\SalesChannelContextFactory\\:\\:create\\(\\) expects string, array\\|string given\\.$#"
+			count: 1
+			path: src/Core/Content/ProductExport/ScheduledTask/ProductExportGenerateTaskHandler.php
+
+		-
+			message: "#^Parameter \\#2 \\$salesChannelId of class Shopware\\\\Core\\\\Content\\\\ProductExport\\\\ScheduledTask\\\\ProductExportPartialGeneration constructor expects string, array\\|string given\\.$#"
+			count: 1
+			path: src/Core/Content/ProductExport/ScheduledTask/ProductExportGenerateTaskHandler.php
+
+		-
+			message: "#^Cannot call method getLocaleId\\(\\) on Shopware\\\\Core\\\\System\\\\Language\\\\LanguageEntity\\|null\\.$#"
+			count: 1
+			path: src/Core/Content/ProductExport/ScheduledTask/ProductExportPartialGenerationHandler.php
+
+		-
+			message: "#^Cannot call method getLocaleId\\(\\) on Shopware\\\\Core\\\\System\\\\Language\\\\LanguageEntity\\|null\\.$#"
+			count: 1
+			path: src/Core/Content/ProductExport/Service/ProductExportGenerator.php
+
+		-
+			message: "#^Call to an undefined method object\\:\\:getContext\\(\\)\\.$#"
+			count: 1
+			path: src/Core/Content/ProductExport/Service/ProductExportGenerator.php
+
+		-
+			message: "#^Call to an undefined method object\\:\\:getContext\\(\\)\\.$#"
+			count: 2
+			path: src/Core/Content/ProductExport/Service/ProductExportRenderer.php
+
+		-
+			message: "#^Parameter \\#1 \\$templateSource of method Shopware\\\\Core\\\\Framework\\\\Adapter\\\\Twig\\\\StringTemplateRenderer\\:\\:render\\(\\) expects string, string\\|null given\\.$#"
+			count: 1
+			path: src/Core/Content/ProductExport/Service/ProductExportRenderer.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\Content\\\\ProductExport\\\\Service\\\\ProductExportValidator\\:\\:\\$validators \\(array\\<Shopware\\\\Core\\\\Content\\\\ProductExport\\\\Validator\\\\ValidatorInterface\\>\\) does not accept iterable\\.$#"
+			count: 1
+			path: src/Core/Content/ProductExport/Service/ProductExportValidator.php
+
+		-
+			message: "#^Cannot call method hasErrors\\(\\) on Shopware\\\\Core\\\\Content\\\\ProductExport\\\\Struct\\\\ProductExportResult\\|null\\.$#"
+			count: 1
+			path: src/Core/Content/ProductExport/Service/ProductExporter.php
+
+		-
+			message: "#^Cannot call method getErrors\\(\\) on Shopware\\\\Core\\\\Content\\\\ProductExport\\\\Struct\\\\ProductExportResult\\|null\\.$#"
+			count: 1
+			path: src/Core/Content/ProductExport/Service/ProductExporter.php
+
+		-
+			message: "#^Cannot call method getContent\\(\\) on Shopware\\\\Core\\\\Content\\\\ProductExport\\\\Struct\\\\ProductExportResult\\|null\\.$#"
+			count: 1
+			path: src/Core/Content/ProductExport/Service/ProductExporter.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Content\\\\ProductStream\\\\DataAbstractionLayer\\\\ProductStreamIndexer\\:\\:iterate\\(\\) has parameter \\$offset with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Content/ProductStream/DataAbstractionLayer/ProductStreamIndexer.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Content\\\\ProductStream\\\\DataAbstractionLayer\\\\ProductStreamIndexer\\:\\:buildPayload\\(\\) has parameter \\$filter with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Content/ProductStream/DataAbstractionLayer/ProductStreamIndexer.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Content\\\\ProductStream\\\\Exception\\\\FilterNotFoundException\\:\\:__construct\\(\\) has parameter \\$type with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Content/ProductStream/Exception/FilterNotFoundException.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Content\\\\ProductStream\\\\Exception\\\\NoFilterException\\:\\:__construct\\(\\) has parameter \\$id with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Content/ProductStream/Exception/NoFilterException.php
+
+		-
+			message: "#^Argument of an invalid type Shopware\\\\Core\\\\Content\\\\ProductStream\\\\Aggregate\\\\ProductStreamFilter\\\\ProductStreamFilterCollection\\|null supplied for foreach, only iterables are supported\\.$#"
+			count: 3
+			path: src/Core/Content/ProductStream/Service/ProductStreamBuilder.php
+
+		-
+			message: "#^Parameter \\#1 \\$operator of class Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Search\\\\Filter\\\\MultiFilter constructor expects string, string\\|null given\\.$#"
+			count: 1
+			path: src/Core/Content/ProductStream/Service/ProductStreamBuilder.php
+
+		-
+			message: "#^Parameter \\#1 \\$field of class Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Search\\\\Filter\\\\EqualsAnyFilter constructor expects string, string\\|null given\\.$#"
+			count: 1
+			path: src/Core/Content/ProductStream/Service/ProductStreamBuilder.php
+
+		-
+			message: "#^Parameter \\#2 \\$str of function explode expects string, string\\|null given\\.$#"
+			count: 1
+			path: src/Core/Content/ProductStream/Service/ProductStreamBuilder.php
+
+		-
+			message: "#^Parameter \\#1 \\$filter of method Shopware\\\\Core\\\\Content\\\\ProductStream\\\\Service\\\\ProductStreamBuilder\\:\\:ensureQueries\\(\\) expects Shopware\\\\Core\\\\Content\\\\ProductStream\\\\Aggregate\\\\ProductStreamFilter\\\\ProductStreamFilterEntity, Shopware\\\\Core\\\\Content\\\\ProductStream\\\\Aggregate\\\\ProductStreamFilter\\\\ProductStreamFilterEntity\\|null given\\.$#"
+			count: 1
+			path: src/Core/Content/ProductStream/Service/ProductStreamBuilder.php
+
+		-
+			message: "#^Parameter \\#1 \\$filterEntity of method Shopware\\\\Core\\\\Content\\\\ProductStream\\\\Service\\\\ProductStreamBuilder\\:\\:createFilter\\(\\) expects Shopware\\\\Core\\\\Content\\\\ProductStream\\\\Aggregate\\\\ProductStreamFilter\\\\ProductStreamFilterEntity, Shopware\\\\Core\\\\Content\\\\ProductStream\\\\Aggregate\\\\ProductStreamFilter\\\\ProductStreamFilterEntity\\|null given\\.$#"
+			count: 1
+			path: src/Core/Content/ProductStream/Service/ProductStreamBuilder.php
+
+		-
+			message: "#^Cannot call method getPosition\\(\\) on Shopware\\\\Core\\\\Content\\\\ProductStream\\\\Aggregate\\\\ProductStreamFilter\\\\ProductStreamFilterEntity\\|null\\.$#"
+			count: 1
+			path: src/Core/Content/ProductStream/Service/ProductStreamBuilder.php
+
+		-
+			message: "#^Cannot call method getQueries\\(\\) on Shopware\\\\Core\\\\Content\\\\ProductStream\\\\Aggregate\\\\ProductStreamFilter\\\\ProductStreamFilterEntity\\|null\\.$#"
+			count: 1
+			path: src/Core/Content/ProductStream/Service/ProductStreamBuilder.php
+
+		-
+			message: "#^Parameter \\#1 \\$entity of method Shopware\\\\Core\\\\Content\\\\ProductStream\\\\Aggregate\\\\ProductStreamFilter\\\\ProductStreamFilterCollection\\:\\:add\\(\\) expects Shopware\\\\Core\\\\Content\\\\ProductStream\\\\Aggregate\\\\ProductStreamFilter\\\\ProductStreamFilterEntity, Shopware\\\\Core\\\\Content\\\\ProductStream\\\\Aggregate\\\\ProductStreamFilter\\\\ProductStreamFilterEntity\\|null given\\.$#"
+			count: 1
+			path: src/Core/Content/ProductStream/Service/ProductStreamBuilder.php
+
+		-
+			message: "#^Parameter \\#1 \\$object of static method Shopware\\\\Core\\\\Framework\\\\Struct\\\\Struct\\:\\:createFrom\\(\\) expects Shopware\\\\Core\\\\Framework\\\\Struct\\\\Struct, Shopware\\\\Core\\\\Content\\\\Property\\\\PropertyGroupEntity\\|null given\\.$#"
+			count: 1
+			path: src/Core/Content/Property/Aggregate/PropertyGroupOption/PropertyGroupOptionCollection.php
+
+		-
+			message: "#^Argument of an invalid type Shopware\\\\Core\\\\Content\\\\Property\\\\Aggregate\\\\PropertyGroupOption\\\\PropertyGroupOptionCollection\\|null supplied for foreach, only iterables are supported\\.$#"
+			count: 1
+			path: src/Core/Content/Property/PropertyGroupCollection.php
+
+		-
+			message: "#^Cannot call method sort\\(\\) on Shopware\\\\Core\\\\Content\\\\Property\\\\Aggregate\\\\PropertyGroupOption\\\\PropertyGroupOptionCollection\\|null\\.$#"
+			count: 1
+			path: src/Core/Content/Property/PropertyGroupCollection.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Content\\\\Rule\\\\DataAbstractionLayer\\\\RuleIndexer\\:\\:iterate\\(\\) has parameter \\$offset with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Content/Rule/DataAbstractionLayer/RuleIndexer.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Content\\\\Rule\\\\RuleCollection\\:\\:filterMatchingRules\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Content/Rule/RuleCollection.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Content\\\\Rule\\\\RuleEntity\\:\\:getPayload\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Content/Rule/RuleEntity.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Content\\\\Rule\\\\RuleEntity\\:\\:setPayload\\(\\) has parameter \\$payload with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Content/Rule/RuleEntity.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Content\\\\Rule\\\\RuleValidator\\:\\:buildViolation\\(\\) has parameter \\$invalidValue with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Content/Rule/RuleValidator.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Content\\\\Rule\\\\RuleValidator\\:\\:buildViolation\\(\\) has parameter \\$root with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Content/Rule/RuleValidator.php
+
+		-
+			message: "#^Parameter \\#3 \\$definition of method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Search\\\\RequestCriteriaBuilder\\:\\:handleRequest\\(\\) expects Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\EntityDefinition, Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\EntityDefinition\\|Shopware\\\\Core\\\\System\\\\SalesChannel\\\\Entity\\\\SalesChannelDefinitionInterface given\\.$#"
+			count: 1
+			path: src/Core/Content/Seo/Api/SeoActionController.php
+
+		-
+			message: "#^Cannot call method getConfig\\(\\) on Shopware\\\\Core\\\\Content\\\\Seo\\\\SeoUrlRoute\\\\SeoUrlRouteInterface\\|null\\.$#"
+			count: 1
+			path: src/Core/Content/Seo/Api/SeoActionController.php
+
+		-
+			message: "#^Parameter \\#1 \\$it of function iterator_to_array expects Traversable, iterable given\\.$#"
+			count: 1
+			path: src/Core/Content/Seo/Api/SeoActionController.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Content\\\\Seo\\\\Entity\\\\Dbal\\\\SeoUrlJoinBuilder\\:\\:join\\(\\) has parameter \\$field with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Content/Seo/Entity/Dbal/SeoUrlJoinBuilder.php
+
+		-
+			message: "#^Argument of an invalid type Shopware\\\\Core\\\\System\\\\SalesChannel\\\\Aggregate\\\\SalesChannelDomain\\\\SalesChannelDomainCollection\\|null supplied for foreach, only iterables are supported\\.$#"
+			count: 1
+			path: src/Core/Content/Seo/HreflangLoader.php
+
+		-
+			message: "#^Cannot call method getCode\\(\\) on Shopware\\\\Core\\\\System\\\\Locale\\\\LocaleEntity\\|null\\.$#"
+			count: 2
+			path: src/Core/Content/Seo/HreflangLoader.php
+
+		-
+			message: "#^Cannot call method getLocale\\(\\) on Shopware\\\\Core\\\\System\\\\Language\\\\LanguageEntity\\|null\\.$#"
+			count: 2
+			path: src/Core/Content/Seo/HreflangLoader.php
+
+		-
+			message: "#^Cannot call method add\\(\\) on Shopware\\\\Core\\\\Content\\\\Seo\\\\SeoUrl\\\\SeoUrlCollection\\|null\\.$#"
+			count: 1
+			path: src/Core/Content/Seo/SalesChannel/StoreApiSeoResolver.php
+
+		-
+			message: "#^Cannot call method fetch\\(\\) on Doctrine\\\\DBAL\\\\Driver\\\\Statement\\|int\\.$#"
+			count: 2
+			path: src/Core/Content/Seo/SeoResolver.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\Content\\\\Seo\\\\SeoUrl\\\\SeoUrlEntity\\:\\:\\$isCanonical \\(bool\\) does not accept bool\\|null\\.$#"
+			count: 1
+			path: src/Core/Content/Seo/SeoUrl/SeoUrlEntity.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Content\\\\Seo\\\\SeoUrlPersister\\:\\:skipUpdate\\(\\) has parameter \\$existing with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Content/Seo/SeoUrlPersister.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Content\\\\Seo\\\\SeoUrlPersister\\:\\:skipUpdate\\(\\) has parameter \\$seoUrl with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Content/Seo/SeoUrlPersister.php
+
+		-
+			message: "#^Cannot call method fetchAll\\(\\) on Doctrine\\\\DBAL\\\\Driver\\\\Statement\\|int\\.$#"
+			count: 1
+			path: src/Core/Content/Seo/SeoUrlPersister.php
+
+		-
+			message: "#^Cannot access an offset on Shopware\\\\Core\\\\Content\\\\Seo\\\\SeoUrlRoute\\\\SeoUrlRouteInterface\\.$#"
+			count: 1
+			path: src/Core/Content/Seo/SeoUrlRoute/SeoUrlRouteRegistry.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Content\\\\Seo\\\\SeoUrlRoute\\\\SeoUrlRouteRegistry\\:\\:findByDefinition\\(\\) should return array\\<Shopware\\\\Core\\\\Content\\\\Seo\\\\SeoUrlRoute\\\\SeoUrlRouteInterface\\> but returns array\\|Shopware\\\\Core\\\\Content\\\\Seo\\\\SeoUrlRoute\\\\SeoUrlRouteInterface\\.$#"
+			count: 1
+			path: src/Core/Content/Seo/SeoUrlRoute/SeoUrlRouteRegistry.php
+
+		-
+			message: "#^Parameter \\#2 \\.\\.\\.\\$args of function sprintf expects bool\\|float\\|int\\|string\\|null, \\(array\\<string\\>\\)\\|string\\|true given\\.$#"
+			count: 1
+			path: src/Core/Content/Sitemap/Commands/SitemapGenerateCommand.php
+
+		-
+			message: "#^Cannot call method getId\\(\\) on Shopware\\\\Core\\\\System\\\\SalesChannel\\\\Aggregate\\\\SalesChannelType\\\\SalesChannelTypeEntity\\|null\\.$#"
+			count: 1
+			path: src/Core/Content/Sitemap/Commands/SitemapGenerateCommand.php
+
+		-
+			message: "#^Parameter \\#1 \\$var of function count expects array\\|Countable, Shopware\\\\Core\\\\System\\\\SalesChannel\\\\Aggregate\\\\SalesChannelDomain\\\\SalesChannelDomainCollection\\|null given\\.$#"
+			count: 1
+			path: src/Core/Content/Sitemap/Commands/SitemapGenerateCommand.php
+
+		-
+			message: "#^Cannot call method map\\(\\) on Shopware\\\\Core\\\\System\\\\SalesChannel\\\\Aggregate\\\\SalesChannelDomain\\\\SalesChannelDomainCollection\\|null\\.$#"
+			count: 1
+			path: src/Core/Content/Sitemap/Commands/SitemapGenerateCommand.php
+
+		-
+			message: "#^Parameter \\#2 \\$force of method Shopware\\\\Core\\\\Content\\\\Sitemap\\\\Commands\\\\SitemapGenerateCommand\\:\\:generateSitemap\\(\\) expects bool, array\\<string\\>\\|bool\\|string\\|null given\\.$#"
+			count: 1
+			path: src/Core/Content/Sitemap/Commands/SitemapGenerateCommand.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Content\\\\Sitemap\\\\ConfigHandler\\\\File\\:\\:__construct\\(\\) has parameter \\$sitemapConfig with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Content/Sitemap/ConfigHandler/File.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Content\\\\Sitemap\\\\ScheduledTask\\\\SitemapGenerateTaskHandler\\:\\:getSalesChannelContext\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Content/Sitemap/ScheduledTask/SitemapGenerateTaskHandler.php
+
+		-
+			message: "#^Cannot call method getId\\(\\) on Shopware\\\\Core\\\\System\\\\SalesChannel\\\\SalesChannelEntity\\|null\\.$#"
+			count: 1
+			path: src/Core/Content/Sitemap/ScheduledTask/SitemapGenerateTaskHandler.php
+
+		-
+			message: "#^Cannot call method getLanguageId\\(\\) on Shopware\\\\Core\\\\System\\\\SalesChannel\\\\SalesChannelEntity\\|null\\.$#"
+			count: 1
+			path: src/Core/Content/Sitemap/ScheduledTask/SitemapGenerateTaskHandler.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\Content\\\\Sitemap\\\\ScheduledTask\\\\SitemapMessage\\:\\:\\$lastSalesChannelId \\(string\\) does not accept string\\|null\\.$#"
+			count: 1
+			path: src/Core/Content/Sitemap/ScheduledTask/SitemapMessage.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\Content\\\\Sitemap\\\\ScheduledTask\\\\SitemapMessage\\:\\:\\$lastLanguageId \\(string\\) does not accept string\\|null\\.$#"
+			count: 1
+			path: src/Core/Content/Sitemap/ScheduledTask/SitemapMessage.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\Content\\\\Sitemap\\\\ScheduledTask\\\\SitemapMessage\\:\\:\\$lastProvider \\(string\\) does not accept string\\|null\\.$#"
+			count: 1
+			path: src/Core/Content/Sitemap/ScheduledTask/SitemapMessage.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\Content\\\\Sitemap\\\\Service\\\\ConfigHandler\\:\\:\\$configHandlers \\(array\\<Shopware\\\\Core\\\\Content\\\\Sitemap\\\\ConfigHandler\\\\ConfigHandlerInterface\\>\\) does not accept iterable\\.$#"
+			count: 1
+			path: src/Core/Content/Sitemap/Service/ConfigHandler.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\Content\\\\Sitemap\\\\Service\\\\SitemapExporter\\:\\:\\$urlProvider \\(array\\<Shopware\\\\Core\\\\Content\\\\Sitemap\\\\Provider\\\\UrlProviderInterface\\>\\) does not accept iterable\\.$#"
+			count: 1
+			path: src/Core/Content/Sitemap/Service/SitemapExporter.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\Content\\\\Sitemap\\\\Service\\\\SitemapHandle\\:\\:\\$tmpFiles has no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Content/Sitemap/Service/SitemapHandle.php
+
+		-
+			message: "#^Parameter \\#1 \\$zp of function gzwrite expects resource, resource\\|false given\\.$#"
+			count: 3
+			path: src/Core/Content/Sitemap/Service/SitemapHandle.php
+
+		-
+			message: "#^Parameter \\#1 \\$zp of function gzclose expects resource, resource\\|false given\\.$#"
+			count: 2
+			path: src/Core/Content/Sitemap/Service/SitemapHandle.php
+
+		-
+			message: "#^Parameter \\#2 \\$contents of method League\\\\Flysystem\\\\FilesystemInterface\\:\\:write\\(\\) expects string, string\\|false given\\.$#"
+			count: 1
+			path: src/Core/Content/Sitemap/Service/SitemapHandle.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Content\\\\Test\\\\Product\\\\SalesChannel\\\\Fixture\\\\ListingTestData\\:\\:getId\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Content/Test/Product/SalesChannel/Fixture/ListingTestData.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Content\\\\Test\\\\Product\\\\SalesChannel\\\\Fixture\\\\ListingTestData\\:\\:getKey\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Content/Test/Product/SalesChannel/Fixture/ListingTestData.php
+
+		-
+			message: "#^Parameter \\#1 \\$baseUrls of method Shopware\\\\Core\\\\Framework\\\\Adapter\\\\Asset\\\\FallbackUrlPackage\\:\\:applyFallback\\(\\) expects array, array\\<string\\>\\|string given\\.$#"
+			count: 1
+			path: src/Core/Framework/Adapter/Asset/FallbackUrlPackage.php
+
+		-
+			message: "#^Parameter \\#1 \\$it of function iterator_to_array expects Traversable, iterable given\\.$#"
+			count: 1
+			path: src/Core/Framework/Adapter/Asset/FallbackUrlPackage.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Adapter\\\\Cache\\\\CacheClearer\\:\\:handle\\(\\) has parameter \\$message with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/Adapter/Cache/CacheClearer.php
+
+		-
+			message: "#^Cannot access offset 'path' on array\\|false\\.$#"
+			count: 2
+			path: src/Core/Framework/Adapter/Filesystem/AbstractFilesystem.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\Framework\\\\Adapter\\\\Filesystem\\\\Filesystem\\:\\:\\$name has no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/Adapter/Filesystem/Filesystem.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\Framework\\\\Adapter\\\\Filesystem\\\\FilesystemFactory\\:\\:\\$adapterFactories \\(array\\<Shopware\\\\Core\\\\Framework\\\\Adapter\\\\Filesystem\\\\Adapter\\\\AdapterFactoryInterface\\>\\) does not accept iterable\\<Shopware\\\\Core\\\\Framework\\\\Adapter\\\\Filesystem\\\\Adapter\\\\AdapterFactoryInterface\\>\\.$#"
+			count: 1
+			path: src/Core/Framework/Adapter/Filesystem/FilesystemFactory.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\Framework\\\\Adapter\\\\Filesystem\\\\FilesystemFactory\\:\\:\\$filesystemPlugins \\(array\\<League\\\\Flysystem\\\\PluginInterface\\>\\) does not accept iterable\\<League\\\\Flysystem\\\\PluginInterface\\>\\.$#"
+			count: 1
+			path: src/Core/Framework/Adapter/Filesystem/FilesystemFactory.php
+
+		-
+			message: "#^Parameter \\#2 \\$resource of method League\\\\Flysystem\\\\FilesystemInterface\\:\\:putStream\\(\\) expects resource, resource\\|false given\\.$#"
+			count: 1
+			path: src/Core/Framework/Adapter/Filesystem/Plugin/CopyBatch.php
+
+		-
+			message: "#^Parameter \\#1 \\$str of function ltrim expects string, string\\|null given\\.$#"
+			count: 1
+			path: src/Core/Framework/Adapter/Filesystem/PrefixFilesystem.php
+
+		-
+			message: "#^Call to an undefined method Symfony\\\\Component\\\\Translation\\\\TranslatorBagInterface\\|Symfony\\\\Component\\\\Translation\\\\TranslatorInterface\\|Symfony\\\\Contracts\\\\Translation\\\\TranslatorInterface\\:\\:getCatalogue\\(\\)\\.$#"
+			count: 2
+			path: src/Core/Framework/Adapter/Translation/Translator.php
+
+		-
+			message: "#^Parameter \\#2 \\$locale of method Symfony\\\\Component\\\\Translation\\\\Formatter\\\\MessageFormatterInterface\\:\\:format\\(\\) expects string, string\\|null given\\.$#"
+			count: 1
+			path: src/Core/Framework/Adapter/Translation/Translator.php
+
+		-
+			message: "#^Call to an undefined method Symfony\\\\Component\\\\Translation\\\\TranslatorBagInterface\\|Symfony\\\\Component\\\\Translation\\\\TranslatorInterface\\|Symfony\\\\Contracts\\\\Translation\\\\TranslatorInterface\\:\\:setLocale\\(\\)\\.$#"
+			count: 1
+			path: src/Core/Framework/Adapter/Translation/Translator.php
+
+		-
+			message: "#^Call to an undefined method Symfony\\\\Component\\\\Translation\\\\TranslatorBagInterface\\|Symfony\\\\Component\\\\Translation\\\\TranslatorInterface\\|Symfony\\\\Contracts\\\\Translation\\\\TranslatorInterface\\:\\:getLocale\\(\\)\\.$#"
+			count: 1
+			path: src/Core/Framework/Adapter/Translation/Translator.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Adapter\\\\Translation\\\\Translator\\:\\:warmUp\\(\\) has parameter \\$cacheDir with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/Adapter/Translation/Translator.php
+
+		-
+			message: "#^Parameter \\#1 \\$locale of method Shopware\\\\Core\\\\Framework\\\\Adapter\\\\Translation\\\\Translator\\:\\:setLocale\\(\\) expects string, string\\|null given\\.$#"
+			count: 1
+			path: src/Core/Framework/Adapter/Translation/Translator.php
+
+		-
+			message: "#^Class Shopware\\\\Core\\\\Framework\\\\Adapter\\\\Twig\\\\AppTemplateIterator implements generic interface IteratorAggregate but does not specify its types\\: TKey, TValue$#"
+			count: 1
+			path: src/Core/Framework/Adapter/Twig/AppTemplateIterator.php
+
+		-
+			message: "#^Cannot call method getName\\(\\) on Shopware\\\\Core\\\\Framework\\\\App\\\\AppEntity\\|null\\.$#"
+			count: 1
+			path: src/Core/Framework/Adapter/Twig/EntityTemplateLoader.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Adapter\\\\Twig\\\\Filter\\\\CurrencyFilter\\:\\:formatCurrency\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/Adapter/Twig/Filter/CurrencyFilter.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Adapter\\\\Twig\\\\Filter\\\\CurrencyFilter\\:\\:formatCurrency\\(\\) has parameter \\$currencyIsoCode with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/Adapter/Twig/Filter/CurrencyFilter.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Adapter\\\\Twig\\\\Filter\\\\CurrencyFilter\\:\\:formatCurrency\\(\\) has parameter \\$languageId with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/Adapter/Twig/Filter/CurrencyFilter.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Adapter\\\\Twig\\\\Filter\\\\CurrencyFilter\\:\\:formatCurrency\\(\\) has parameter \\$price with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/Adapter/Twig/Filter/CurrencyFilter.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Adapter\\\\Twig\\\\Filter\\\\CurrencyFilter\\:\\:formatCurrency\\(\\) has parameter \\$twigContext with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/Adapter/Twig/Filter/CurrencyFilter.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Adapter\\\\Twig\\\\InstanceOfExtension\\:\\:isInstanceOf\\(\\) has parameter \\$class with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/Adapter/Twig/InstanceOfExtension.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Adapter\\\\Twig\\\\InstanceOfExtension\\:\\:isInstanceOf\\(\\) has parameter \\$var with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/Adapter/Twig/InstanceOfExtension.php
+
+		-
+			message: "#^Cannot call method aggregate\\(\\) on Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\EntityRepositoryInterface\\|null\\.$#"
+			count: 1
+			path: src/Core/Framework/Adapter/Twig/NamespaceHierarchy/BundleHierarchyBuilder.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\Framework\\\\Adapter\\\\Twig\\\\NamespaceHierarchy\\\\NamespaceHierarchyBuilder\\:\\:\\$namespaceHierarchyBuilders \\(array\\<Shopware\\\\Core\\\\Framework\\\\Adapter\\\\Twig\\\\NamespaceHierarchy\\\\TemplateNamespaceHierarchyBuilderInterface\\>\\) does not accept iterable\\.$#"
+			count: 1
+			path: src/Core/Framework/Adapter/Twig/NamespaceHierarchy/NamespaceHierarchyBuilder.php
+
+		-
+			message: "#^Binary operation \"\\+\" between int\\|string\\|false and 1 results in an error\\.$#"
+			count: 2
+			path: src/Core/Framework/Adapter/Twig/TemplateFinder.php
+
+		-
+			message: "#^Parameter \\#1 \\$name of method Twig\\\\Loader\\\\LoaderInterface\\:\\:exists\\(\\) expects string, string\\|null given\\.$#"
+			count: 1
+			path: src/Core/Framework/Adapter/Twig/TemplateFinder.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Adapter\\\\Twig\\\\TemplateFinder\\:\\:find\\(\\) should return string but returns string\\|null\\.$#"
+			count: 1
+			path: src/Core/Framework/Adapter/Twig/TemplateFinder.php
+
+		-
+			message: "#^Class Shopware\\\\Core\\\\Framework\\\\Adapter\\\\Twig\\\\TemplateIterator implements generic interface IteratorAggregate but does not specify its types\\: TKey, TValue$#"
+			count: 1
+			path: src/Core/Framework/Adapter/Twig/TemplateIterator.php
+
+		-
+			message: "#^Parameter \\#1 \\$str of function ltrim expects string, string\\|null given\\.$#"
+			count: 1
+			path: src/Core/Framework/Adapter/Twig/TokenParser/ExtendsTokenParser.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Api\\\\Acl\\\\AclWriteValidator\\:\\:buildViolation\\(\\) has parameter \\$invalidValue with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/Api/Acl/AclWriteValidator.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Api\\\\Acl\\\\AclWriteValidator\\:\\:buildViolation\\(\\) has parameter \\$root with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/Api/Acl/AclWriteValidator.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Api\\\\Acl\\\\AclWriteValidator\\:\\:getPrivilegeForParentWriteOperation\\(\\) should return string but returns string\\|null\\.$#"
+			count: 1
+			path: src/Core/Framework/Api/Acl/AclWriteValidator.php
+
+		-
+			message: "#^Call to an undefined method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\EntityDefinition\\|Shopware\\\\Core\\\\System\\\\SalesChannel\\\\Entity\\\\SalesChannelDefinitionInterface\\:\\:getEntityName\\(\\)\\.$#"
+			count: 1
+			path: src/Core/Framework/Api/ApiDefinition/Generator/EntitySchemaGenerator.php
+
+		-
+			message: "#^Parameter \\#1 \\$definition of method Shopware\\\\Core\\\\Framework\\\\Api\\\\ApiDefinition\\\\Generator\\\\EntitySchemaGenerator\\:\\:getEntitySchema\\(\\) expects Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\EntityDefinition, Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\EntityDefinition\\|Shopware\\\\Core\\\\System\\\\SalesChannel\\\\Entity\\\\SalesChannelDefinitionInterface given\\.$#"
+			count: 1
+			path: src/Core/Framework/Api/ApiDefinition/Generator/EntitySchemaGenerator.php
+
+		-
+			message: "#^Cannot call method getFields\\(\\) on Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\EntityDefinition\\|null\\.$#"
+			count: 2
+			path: src/Core/Framework/Api/ApiDefinition/Generator/OpenApi/OpenApiDefinitionSchemaBuilder.php
+
+		-
+			message: "#^Cannot call method getPropertyName\\(\\) on Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Field\\\\Field\\|null\\.$#"
+			count: 2
+			path: src/Core/Framework/Api/ApiDefinition/Generator/OpenApi/OpenApiDefinitionSchemaBuilder.php
+
+		-
+			message: "#^Parameter \\#1 \\$fieldClass of method Shopware\\\\Core\\\\Framework\\\\Api\\\\ApiDefinition\\\\Generator\\\\OpenApi\\\\OpenApiDefinitionSchemaBuilder\\:\\:getPropertyByField\\(\\) expects string, class\\-string\\<Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Field\\\\Field\\>\\|false given\\.$#"
+			count: 1
+			path: src/Core/Framework/Api/ApiDefinition/Generator/OpenApi/OpenApiDefinitionSchemaBuilder.php
+
+		-
+			message: "#^Parameter \\#1 \\$object of function get_class expects object, Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Field\\\\Field\\|null given\\.$#"
+			count: 1
+			path: src/Core/Framework/Api/ApiDefinition/Generator/OpenApi/OpenApiDefinitionSchemaBuilder.php
+
+		-
+			message: "#^Parameter \\#1 \\$field of method Shopware\\\\Core\\\\Framework\\\\Api\\\\ApiDefinition\\\\Generator\\\\OpenApi\\\\OpenApiDefinitionSchemaBuilder\\:\\:isWriteProtected\\(\\) expects Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Field\\\\Field, Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Field\\\\Field\\|null given\\.$#"
+			count: 1
+			path: src/Core/Framework/Api/ApiDefinition/Generator/OpenApi/OpenApiDefinitionSchemaBuilder.php
+
+		-
+			message: "#^Parameter \\#1 \\$field of method Shopware\\\\Core\\\\Framework\\\\Api\\\\ApiDefinition\\\\Generator\\\\OpenApi\\\\OpenApiDefinitionSchemaBuilder\\:\\:isDeprecated\\(\\) expects Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Field\\\\Field, Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Field\\\\Field\\|null given\\.$#"
+			count: 1
+			path: src/Core/Framework/Api/ApiDefinition/Generator/OpenApi/OpenApiDefinitionSchemaBuilder.php
+
+		-
+			message: "#^Parameter \\#1 \\$argument of class ReflectionClass constructor expects class\\-string\\<T of object\\>\\|T of object, string\\|false given\\.$#"
+			count: 1
+			path: src/Core/Framework/Api/ApiDefinition/Generator/OpenApi/OpenApiLoader.php
+
+		-
+			message: "#^Parameter \\#1 \\$definition of method Shopware\\\\Core\\\\Framework\\\\Api\\\\ApiDefinition\\\\Generator\\\\OpenApi3Generator\\:\\:shouldDefinitionBeIncluded\\(\\) expects Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\EntityDefinition, Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\EntityDefinition\\|Shopware\\\\Core\\\\System\\\\SalesChannel\\\\Entity\\\\SalesChannelDefinitionInterface given\\.$#"
+			count: 1
+			path: src/Core/Framework/Api/ApiDefinition/Generator/OpenApi3Generator.php
+
+		-
+			message: "#^Parameter \\#1 \\$definition of method Shopware\\\\Core\\\\Framework\\\\Api\\\\ApiDefinition\\\\Generator\\\\OpenApi3Generator\\:\\:shouldIncludeReferenceOnly\\(\\) expects Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\EntityDefinition, Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\EntityDefinition\\|Shopware\\\\Core\\\\System\\\\SalesChannel\\\\Entity\\\\SalesChannelDefinitionInterface given\\.$#"
+			count: 1
+			path: src/Core/Framework/Api/ApiDefinition/Generator/OpenApi3Generator.php
+
+		-
+			message: "#^Parameter \\#1 \\$definition of method Shopware\\\\Core\\\\Framework\\\\Api\\\\ApiDefinition\\\\Generator\\\\OpenApi3Generator\\:\\:getResourceUri\\(\\) expects Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\EntityDefinition, Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\EntityDefinition\\|Shopware\\\\Core\\\\System\\\\SalesChannel\\\\Entity\\\\SalesChannelDefinitionInterface given\\.$#"
+			count: 3
+			path: src/Core/Framework/Api/ApiDefinition/Generator/OpenApi3Generator.php
+
+		-
+			message: "#^Parameter \\#1 \\$definition of method Shopware\\\\Core\\\\Framework\\\\Api\\\\ApiDefinition\\\\Generator\\\\OpenApi\\\\OpenApiDefinitionSchemaBuilder\\:\\:getSchemaByDefinition\\(\\) expects Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\EntityDefinition, Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\EntityDefinition\\|Shopware\\\\Core\\\\System\\\\SalesChannel\\\\Entity\\\\SalesChannelDefinitionInterface given\\.$#"
+			count: 2
+			path: src/Core/Framework/Api/ApiDefinition/Generator/OpenApi3Generator.php
+
+		-
+			message: "#^Parameter \\#1 \\$definition of method Shopware\\\\Core\\\\Framework\\\\Api\\\\ApiDefinition\\\\Generator\\\\OpenApi\\\\OpenApiPathBuilder\\:\\:getPathActions\\(\\) expects Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\EntityDefinition, Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\EntityDefinition\\|Shopware\\\\Core\\\\System\\\\SalesChannel\\\\Entity\\\\SalesChannelDefinitionInterface given\\.$#"
+			count: 1
+			path: src/Core/Framework/Api/ApiDefinition/Generator/OpenApi3Generator.php
+
+		-
+			message: "#^Parameter \\#1 \\$definition of method Shopware\\\\Core\\\\Framework\\\\Api\\\\ApiDefinition\\\\Generator\\\\OpenApi\\\\OpenApiPathBuilder\\:\\:getTag\\(\\) expects Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\EntityDefinition, Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\EntityDefinition\\|Shopware\\\\Core\\\\System\\\\SalesChannel\\\\Entity\\\\SalesChannelDefinitionInterface given\\.$#"
+			count: 1
+			path: src/Core/Framework/Api/ApiDefinition/Generator/OpenApi3Generator.php
+
+		-
+			message: "#^Call to an undefined method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\EntityDefinition\\|Shopware\\\\Core\\\\System\\\\SalesChannel\\\\Entity\\\\SalesChannelDefinitionInterface\\:\\:getEntityName\\(\\)\\.$#"
+			count: 3
+			path: src/Core/Framework/Api/ApiDefinition/Generator/OpenApi3Generator.php
+
+		-
+			message: "#^Cannot call method toJson\\(\\) on OpenApi\\\\Annotations\\\\Schema\\|null\\.$#"
+			count: 1
+			path: src/Core/Framework/Api/ApiDefinition/Generator/OpenApi3Generator.php
+
+		-
+			message: "#^Call to an undefined method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\EntityDefinition\\|Shopware\\\\Core\\\\System\\\\SalesChannel\\\\Entity\\\\SalesChannelDefinitionInterface\\:\\:getFields\\(\\)\\.$#"
+			count: 2
+			path: src/Core/Framework/Api/ApiDefinition/Generator/OpenApi3Generator.php
+
+		-
+			message: "#^Parameter \\#1 \\$definition of method Shopware\\\\Core\\\\Framework\\\\Api\\\\ApiDefinition\\\\Generator\\\\StoreApiGenerator\\:\\:shouldDefinitionBeIncluded\\(\\) expects Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\EntityDefinition, Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\EntityDefinition\\|Shopware\\\\Core\\\\System\\\\SalesChannel\\\\Entity\\\\SalesChannelDefinitionInterface given\\.$#"
+			count: 1
+			path: src/Core/Framework/Api/ApiDefinition/Generator/StoreApiGenerator.php
+
+		-
+			message: "#^Parameter \\#1 \\$definition of method Shopware\\\\Core\\\\Framework\\\\Api\\\\ApiDefinition\\\\Generator\\\\StoreApiGenerator\\:\\:shouldIncludeReferenceOnly\\(\\) expects Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\EntityDefinition, Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\EntityDefinition\\|Shopware\\\\Core\\\\System\\\\SalesChannel\\\\Entity\\\\SalesChannelDefinitionInterface given\\.$#"
+			count: 1
+			path: src/Core/Framework/Api/ApiDefinition/Generator/StoreApiGenerator.php
+
+		-
+			message: "#^Parameter \\#1 \\$definition of method Shopware\\\\Core\\\\Framework\\\\Api\\\\ApiDefinition\\\\Generator\\\\OpenApi\\\\OpenApiDefinitionSchemaBuilder\\:\\:getSchemaByDefinition\\(\\) expects Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\EntityDefinition, Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\EntityDefinition\\|Shopware\\\\Core\\\\System\\\\SalesChannel\\\\Entity\\\\SalesChannelDefinitionInterface given\\.$#"
+			count: 1
+			path: src/Core/Framework/Api/ApiDefinition/Generator/StoreApiGenerator.php
+
+		-
+			message: "#^Parameter \\#1 \\$definition of method Shopware\\\\Core\\\\Framework\\\\Api\\\\ApiDefinition\\\\Generator\\\\StoreApiGenerator\\:\\:getResourceUri\\(\\) expects Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\EntityDefinition, Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\EntityDefinition\\|Shopware\\\\Core\\\\System\\\\SalesChannel\\\\Entity\\\\SalesChannelDefinitionInterface given\\.$#"
+			count: 1
+			path: src/Core/Framework/Api/ApiDefinition/Generator/StoreApiGenerator.php
+
+		-
+			message: "#^Parameter \\#1 \\$json of function json_decode expects string, string\\|false given\\.$#"
+			count: 1
+			path: src/Core/Framework/Api/ApiDefinition/Generator/StoreApiGenerator.php
+
+		-
+			message: "#^Parameter \\#1 \\$className of method Shopware\\\\Core\\\\Framework\\\\Api\\\\Command\\\\DumpClassSchemaCommand\\:\\:getCollectionEntity\\(\\) expects string, array\\<string\\>\\|string\\|null given\\.$#"
+			count: 1
+			path: src/Core/Framework/Api/Command/DumpClassSchemaCommand.php
+
+		-
+			message: "#^Parameter \\#1 \\$className of method Shopware\\\\Core\\\\Framework\\\\Api\\\\Command\\\\DumpClassSchemaCommand\\:\\:getFilePath\\(\\) expects string, array\\<string\\>\\|string\\|null given\\.$#"
+			count: 2
+			path: src/Core/Framework/Api/Command/DumpClassSchemaCommand.php
+
+		-
+			message: "#^Parameter \\#1 \\$entityClass of method Shopware\\\\Core\\\\Framework\\\\Api\\\\Command\\\\DumpClassSchemaCommand\\:\\:dumpProperties\\(\\) expects string, array\\<string\\>\\|string\\|null given\\.$#"
+			count: 1
+			path: src/Core/Framework/Api/Command/DumpClassSchemaCommand.php
+
+		-
+			message: "#^Parameter \\#1 \\$argument of class ReflectionClass constructor expects class\\-string\\<T of object\\>\\|T of object, string given\\.$#"
+			count: 2
+			path: src/Core/Framework/Api/Command/DumpClassSchemaCommand.php
+
+		-
+			message: "#^Parameter \\#1 \\$filePath of method Shopware\\\\Core\\\\Framework\\\\Api\\\\Command\\\\DumpClassSchemaCommand\\:\\:parseFile\\(\\) expects string, string\\|false given\\.$#"
+			count: 2
+			path: src/Core/Framework/Api/Command/DumpClassSchemaCommand.php
+
+		-
+			message: "#^Offset 0 does not exist on array\\<PhpParser\\\\Node\\\\Stmt\\>\\|null\\.$#"
+			count: 1
+			path: src/Core/Framework/Api/Command/DumpClassSchemaCommand.php
+
+		-
+			message: "#^Cannot cast PhpParser\\\\Node\\\\Expr\\|PhpParser\\\\Node\\\\Name to string\\.$#"
+			count: 1
+			path: src/Core/Framework/Api/Command/DumpClassSchemaCommand.php
+
+		-
+			message: "#^Parameter \\#1 \\$code of method PhpParser\\\\Parser\\:\\:parse\\(\\) expects string, string\\|false given\\.$#"
+			count: 1
+			path: src/Core/Framework/Api/Command/DumpClassSchemaCommand.php
+
+		-
+			message: "#^Parameter \\#1 \\$stmts of method Shopware\\\\Core\\\\Framework\\\\Api\\\\Command\\\\DumpClassSchemaCommand\\:\\:resolveNames\\(\\) expects array, array\\<PhpParser\\\\Node\\\\Stmt\\>\\|null given\\.$#"
+			count: 1
+			path: src/Core/Framework/Api/Command/DumpClassSchemaCommand.php
+
+		-
+			message: "#^Cannot cast PhpParser\\\\Node\\\\Identifier\\|PhpParser\\\\Node\\\\Name\\|PhpParser\\\\Node\\\\UnionType\\|null to string\\.$#"
+			count: 1
+			path: src/Core/Framework/Api/Command/DumpClassSchemaCommand.php
+
+		-
+			message: "#^Parameter \\#1 \\$file of function file_put_contents expects string, array\\<string\\>\\|string\\|null given\\.$#"
+			count: 1
+			path: src/Core/Framework/Api/Command/DumpSchemaCommand.php
+
+		-
+			message: "#^Cannot call method getPropertyName\\(\\) on Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Field\\\\Field\\|null\\.$#"
+			count: 3
+			path: src/Core/Framework/Api/Controller/ApiController.php
+
+		-
+			message: "#^Cannot call method getEntityName\\(\\) on Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\EntityDefinition\\|string\\.$#"
+			count: 4
+			path: src/Core/Framework/Api/Controller/ApiController.php
+
+		-
+			message: "#^Parameter \\#3 \\$definition of method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Search\\\\RequestCriteriaBuilder\\:\\:handleRequest\\(\\) expects Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\EntityDefinition, Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\EntityDefinition\\|string given\\.$#"
+			count: 1
+			path: src/Core/Framework/Api/Controller/ApiController.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Api\\\\Controller\\\\ApiController\\:\\:getDefinitionOfPath\\(\\) should return Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\EntityDefinition but returns Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\EntityDefinition\\|string\\.$#"
+			count: 1
+			path: src/Core/Framework/Api/Controller/ApiController.php
+
+		-
+			message: "#^Cannot call method getIds\\(\\) on Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Event\\\\EntityWrittenEvent\\|null\\.$#"
+			count: 6
+			path: src/Core/Framework/Api/Controller/ApiController.php
+
+		-
+			message: "#^Parameter \\#1 \\$entity of method Shopware\\\\Core\\\\Framework\\\\Api\\\\Controller\\\\ApiController\\:\\:executeWriteOperation\\(\\) expects Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\EntityDefinition, Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\EntityDefinition\\|string given\\.$#"
+			count: 1
+			path: src/Core/Framework/Api/Controller/ApiController.php
+
+		-
+			message: "#^Parameter \\#1 \\$definition of method Shopware\\\\Core\\\\Framework\\\\Api\\\\Response\\\\ResponseFactoryInterface\\:\\:createRedirectResponse\\(\\) expects Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\EntityDefinition, Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\EntityDefinition\\|string given\\.$#"
+			count: 1
+			path: src/Core/Framework/Api/Controller/ApiController.php
+
+		-
+			message: "#^Offset 'entity' does not exist on array\\('entity' \\=\\> string, 'value' \\=\\> string\\|null\\)\\|null\\.$#"
+			count: 2
+			path: src/Core/Framework/Api/Controller/ApiController.php
+
+		-
+			message: "#^Offset 'value' does not exist on array\\('entity' \\=\\> string, 'value' \\=\\> string\\|null\\)\\|null\\.$#"
+			count: 1
+			path: src/Core/Framework/Api/Controller/ApiController.php
+
+		-
+			message: "#^Parameter \\#3 \\$subject of function str_replace expects array\\|string, string\\|false given\\.$#"
+			count: 1
+			path: src/Core/Framework/Api/Controller/CacheController.php
+
+		-
+			message: "#^Cannot call method getId\\(\\) on Shopware\\\\Core\\\\Checkout\\\\Customer\\\\CustomerEntity\\|null\\.$#"
+			count: 1
+			path: src/Core/Framework/Api/Controller/SalesChannelProxyController.php
+
+		-
+			message: "#^Parameter \\#1 \\$field of class Shopware\\\\Core\\\\Framework\\\\Api\\\\Converter\\\\Exceptions\\\\QueryFutureFieldException constructor expects string, string\\|null given\\.$#"
+			count: 1
+			path: src/Core/Framework/Api/Converter/ApiVersionConverter.php
+
+		-
+			message: "#^Parameter \\#1 \\$field of class Shopware\\\\Core\\\\Framework\\\\Api\\\\Converter\\\\Exceptions\\\\QueryRemovedFieldException constructor expects string, string\\|null given\\.$#"
+			count: 1
+			path: src/Core/Framework/Api/Converter/ApiVersionConverter.php
+
+		-
+			message: "#^Parameter \\#1 \\$propertyName of method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\EntityDefinition\\:\\:getField\\(\\) expects string, string\\|null given\\.$#"
+			count: 1
+			path: src/Core/Framework/Api/Converter/ApiVersionConverter.php
+
+		-
+			message: "#^Parameter \\#1 \\$accessKey of static method Shopware\\\\Core\\\\Framework\\\\Api\\\\Util\\\\AccessKeyHelper\\:\\:getOrigin\\(\\) expects string, string\\|null given\\.$#"
+			count: 1
+			path: src/Core/Framework/Api/EventListener/Authentication/SalesChannelAuthenticationListener.php
+
+		-
+			message: "#^Parameter \\#1 \\$accessKey of method Shopware\\\\Core\\\\Framework\\\\Api\\\\EventListener\\\\Authentication\\\\SalesChannelAuthenticationListener\\:\\:getSalesChannelId\\(\\) expects string, string\\|null given\\.$#"
+			count: 1
+			path: src/Core/Framework/Api/EventListener/Authentication/SalesChannelAuthenticationListener.php
+
+		-
+			message: "#^Cannot call method fetchColumn\\(\\) on Doctrine\\\\DBAL\\\\Driver\\\\Statement\\|int\\.$#"
+			count: 1
+			path: src/Core/Framework/Api/EventListener/Authentication/SalesChannelAuthenticationListener.php
+
+		-
+			message: "#^Parameter \\#1 \\$exception of method Shopware\\\\Core\\\\Framework\\\\Api\\\\EventListener\\\\ErrorResponseFactory\\:\\:convertExceptionToError\\(\\) expects Throwable, Throwable\\|null given\\.$#"
+			count: 1
+			path: src/Core/Framework/Api/EventListener/ErrorResponseFactory.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Api\\\\EventListener\\\\ResponseExceptionListener\\:\\:__construct\\(\\) has parameter \\$debug with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/Api/EventListener/ResponseExceptionListener.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Api\\\\EventListener\\\\ResponseExceptionListener\\:\\:onKernelException\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/Api/EventListener/ResponseExceptionListener.php
+
+		-
+			message: "#^Parameter \\#2 \\$values of method Symfony\\\\Component\\\\HttpFoundation\\\\ResponseHeaderBag\\:\\:set\\(\\) expects array\\<string\\>\\|string, string\\|null given\\.$#"
+			count: 1
+			path: src/Core/Framework/Api/EventListener/ResponseHeaderListener.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Api\\\\OAuth\\\\AccessToken\\:\\:__construct\\(\\) has parameter \\$userIdentifier with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/Api/OAuth/AccessToken.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\Framework\\\\Api\\\\OAuth\\\\AccessToken\\:\\:\\$userIdentifier \\(string\\) does not accept int\\|string\\|null\\.$#"
+			count: 1
+			path: src/Core/Framework/Api/OAuth/AccessToken.php
+
+		-
+			message: "#^Parameter \\#2 \\$clientSecret of method Shopware\\\\Core\\\\Framework\\\\Api\\\\OAuth\\\\ClientRepository\\:\\:getByAccessKey\\(\\) expects string, string\\|null given\\.$#"
+			count: 1
+			path: src/Core/Framework/Api/OAuth/ClientRepository.php
+
+		-
+			message: "#^Cannot call method fetch\\(\\) on Doctrine\\\\DBAL\\\\Driver\\\\Statement\\|int\\.$#"
+			count: 2
+			path: src/Core/Framework/Api/OAuth/ClientRepository.php
+
+		-
+			message: "#^Parameter \\#1 \\$uuid of static method Shopware\\\\Core\\\\Framework\\\\Uuid\\\\Uuid\\:\\:fromHexToBytes\\(\\) expects string, int\\|string\\|null given\\.$#"
+			count: 1
+			path: src/Core/Framework/Api/OAuth/RefreshTokenRepository.php
+
+		-
+			message: "#^Cannot call method fetch\\(\\) on Doctrine\\\\DBAL\\\\Driver\\\\Statement\\|int\\.$#"
+			count: 1
+			path: src/Core/Framework/Api/OAuth/RefreshTokenRepository.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Api\\\\OAuth\\\\ScopeRepository\\:\\:getScopeEntityByIdentifier\\(\\) should return League\\\\OAuth2\\\\Server\\\\Entities\\\\ScopeEntityInterface but returns League\\\\OAuth2\\\\Server\\\\Entities\\\\ScopeEntityInterface\\|null\\.$#"
+			count: 1
+			path: src/Core/Framework/Api/OAuth/ScopeRepository.php
+
+		-
+			message: "#^Cannot call method fetchColumn\\(\\) on Doctrine\\\\DBAL\\\\Driver\\\\Statement\\|int\\.$#"
+			count: 1
+			path: src/Core/Framework/Api/OAuth/ScopeRepository.php
+
+		-
+			message: "#^Cannot call method fetch\\(\\) on Doctrine\\\\DBAL\\\\Driver\\\\Statement\\|int\\.$#"
+			count: 1
+			path: src/Core/Framework/Api/OAuth/UserRepository.php
+
+		-
+			message: "#^Parameter \\#1 \\$str of function mb_strtolower expects string, string\\|null given\\.$#"
+			count: 1
+			path: src/Core/Framework/Api/Response/Type/JsonFactoryBase.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\Framework\\\\Api\\\\Route\\\\ApiRouteLoader\\:\\:\\$isLoaded has no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/Api/Route/ApiRouteLoader.php
+
+		-
+			message: "#^Parameter \\#1 \\$str of function md5 expects string, string\\|false given\\.$#"
+			count: 2
+			path: src/Core/Framework/Api/Serializer/JsonApiDecoder.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Api\\\\Serializer\\\\JsonApiDecoder\\:\\:validateResourceIdentifier\\(\\) has parameter \\$resource with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/Api/Serializer/JsonApiDecoder.php
+
+		-
+			message: "#^Parameter \\#1 \\$str of function mb_strtolower expects string, string\\|null given\\.$#"
+			count: 1
+			path: src/Core/Framework/Api/Serializer/JsonApiEncoder.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Api\\\\Serializer\\\\JsonApiEncoder\\:\\:formatToJson\\(\\) should return string but returns string\\|false\\.$#"
+			count: 1
+			path: src/Core/Framework/Api/Serializer/JsonApiEncoder.php
+
+		-
+			message: "#^Parameter \\#2 \\$decoded of method Shopware\\\\Core\\\\Framework\\\\Api\\\\Serializer\\\\JsonEntityEncoder\\:\\:filterIncludes\\(\\) expects array, array\\|ArrayObject\\|bool\\|float\\|int\\|string\\|null given\\.$#"
+			count: 1
+			path: src/Core/Framework/Api/Serializer/JsonEntityEncoder.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Api\\\\Serializer\\\\Record\\:\\:setAttribute\\(\\) has parameter \\$value with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/Api/Serializer/Record.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Api\\\\Serializer\\\\Record\\:\\:addMeta\\(\\) has parameter \\$data with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/Api/Serializer/Record.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Api\\\\Serializer\\\\Record\\:\\:addExtension\\(\\) has parameter \\$value with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/Api/Serializer/Record.php
+
+		-
+			message: "#^Cannot call method jsonSerialize\\(\\) on Shopware\\\\Core\\\\Framework\\\\Struct\\\\Struct\\|null\\.$#"
+			count: 1
+			path: src/Core/Framework/Api/Serializer/Record.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Api\\\\Sync\\\\SyncOperationResult\\:\\:get\\(\\) has parameter \\$key with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/Api/Sync/SyncOperationResult.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Api\\\\Sync\\\\SyncOperationResult\\:\\:has\\(\\) has parameter \\$key with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/Api/Sync/SyncOperationResult.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Api\\\\Sync\\\\SyncService\\:\\:convertToApiVersion\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/Api/Sync/SyncService.php
+
+		-
+			message: "#^Parameter \\#1 \\$path of method Shopware\\\\Core\\\\Framework\\\\Validation\\\\WriteConstraintViolationException\\:\\:setPath\\(\\) expects string, string\\|null given\\.$#"
+			count: 1
+			path: src/Core/Framework/Api/Sync/SyncService.php
+
+		-
+			message: "#^Argument of an invalid type Shopware\\\\Core\\\\Framework\\\\Event\\\\NestedEventCollection\\|null supplied for foreach, only iterables are supported\\.$#"
+			count: 1
+			path: src/Core/Framework/Api/Sync/SyncService.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\Framework\\\\Api\\\\Util\\\\AccessKeyHelper\\:\\:\\$mapping has no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/Api/Util/AccessKeyHelper.php
+
+		-
+			message: "#^Cannot call method getName\\(\\) on Shopware\\\\Core\\\\Framework\\\\App\\\\AppEntity\\|null\\.$#"
+			count: 1
+			path: src/Core/Framework/App/ActionButton/ActionButtonLoader.php
+
+		-
+			message: "#^Cannot call method getIcon\\(\\) on Shopware\\\\Core\\\\Framework\\\\App\\\\AppEntity\\|null\\.$#"
+			count: 1
+			path: src/Core/Framework/App/ActionButton/ActionButtonLoader.php
+
+		-
+			message: "#^Argument of an invalid type Shopware\\\\Core\\\\Framework\\\\App\\\\Aggregate\\\\ActionButtonTranslation\\\\ActionButtonTranslationCollection\\|null supplied for foreach, only iterables are supported\\.$#"
+			count: 1
+			path: src/Core/Framework/App/ActionButton/ActionButtonLoader.php
+
+		-
+			message: "#^Cannot call method getCode\\(\\) on Shopware\\\\Core\\\\System\\\\Locale\\\\LocaleEntity\\|null\\.$#"
+			count: 1
+			path: src/Core/Framework/App/ActionButton/ActionButtonLoader.php
+
+		-
+			message: "#^Cannot call method getLocale\\(\\) on Shopware\\\\Core\\\\System\\\\Language\\\\LanguageEntity\\|null\\.$#"
+			count: 1
+			path: src/Core/Framework/App/ActionButton/ActionButtonLoader.php
+
+		-
+			message: "#^Cannot call method getAppSecret\\(\\) on Shopware\\\\Core\\\\Framework\\\\App\\\\AppEntity\\|null\\.$#"
+			count: 1
+			path: src/Core/Framework/App/ActionButton/AppActionLoader.php
+
+		-
+			message: "#^Cannot call method getVersion\\(\\) on Shopware\\\\Core\\\\Framework\\\\App\\\\AppEntity\\|null\\.$#"
+			count: 1
+			path: src/Core/Framework/App/ActionButton/AppActionLoader.php
+
+		-
+			message: "#^Cannot call method getStatusCode\\(\\) on Psr\\\\Http\\\\Message\\\\ResponseInterface\\|null\\.$#"
+			count: 1
+			path: src/Core/Framework/App/ActionButton/Executor.php
+
+		-
+			message: "#^Cannot call method getBody\\(\\) on Psr\\\\Http\\\\Message\\\\ResponseInterface\\|null\\.$#"
+			count: 1
+			path: src/Core/Framework/App/ActionButton/Executor.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\App\\\\AppEntity\\:\\:getLabel\\(\\) should return string but returns string\\|null\\.$#"
+			count: 1
+			path: src/Core/Framework/App/AppEntity.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\App\\\\AppEntity\\:\\:getUpdatedAt\\(\\) should return DateTimeInterface but returns DateTimeInterface\\|null\\.$#"
+			count: 1
+			path: src/Core/Framework/App/AppEntity.php
+
+		-
+			message: "#^Cannot call method getPermissions\\(\\) on Shopware\\\\Core\\\\Framework\\\\App\\\\Manifest\\\\Xml\\\\Permissions\\|null\\.$#"
+			count: 1
+			path: src/Core/Framework/App/Command/AppPrinter.php
+
+		-
+			message: "#^Cannot call method getModules\\(\\) on Shopware\\\\Core\\\\Framework\\\\App\\\\Manifest\\\\Xml\\\\Admin\\|null\\.$#"
+			count: 1
+			path: src/Core/Framework/App/Lifecycle/AppLifecycle.php
+
+		-
+			message: "#^Cannot call method getActionButtons\\(\\) on Shopware\\\\Core\\\\Framework\\\\App\\\\Manifest\\\\Xml\\\\Admin\\|null\\.$#"
+			count: 1
+			path: src/Core/Framework/App/Lifecycle/Persister/ActionButtonPersister.php
+
+		-
+			message: "#^Cannot call method getWebhooks\\(\\) on Shopware\\\\Core\\\\Framework\\\\App\\\\Manifest\\\\Xml\\\\Webhooks\\|null\\.$#"
+			count: 1
+			path: src/Core/Framework/App/Lifecycle/Persister/WebhookPersister.php
+
+		-
+			message: "#^Cannot call method getAccessKey\\(\\) on Shopware\\\\Core\\\\System\\\\Integration\\\\IntegrationEntity\\|null\\.$#"
+			count: 1
+			path: src/Core/Framework/App/Lifecycle/Registration/AppRegistrationService.php
+
+		-
+			message: "#^Cannot call method getSecret\\(\\) on Shopware\\\\Core\\\\Framework\\\\App\\\\Manifest\\\\Xml\\\\Setup\\|null\\.$#"
+			count: 1
+			path: src/Core/Framework/App/Lifecycle/Registration/HandshakeFactory.php
+
+		-
+			message: "#^Cannot call method getRegistrationUrl\\(\\) on Shopware\\\\Core\\\\Framework\\\\App\\\\Manifest\\\\Xml\\\\Setup\\|null\\.$#"
+			count: 1
+			path: src/Core/Framework/App/Lifecycle/Registration/HandshakeFactory.php
+
+		-
+			message: "#^Argument of an invalid type Shopware\\\\Core\\\\Framework\\\\App\\\\Aggregate\\\\AppTranslation\\\\AppTranslationCollection\\|null supplied for foreach, only iterables are supported\\.$#"
+			count: 1
+			path: src/Core/Framework/App/Manifest/ModuleLoader.php
+
+		-
+			message: "#^Argument of an invalid type DOMNamedNodeMap\\|null supplied for foreach, only iterables are supported\\.$#"
+			count: 1
+			path: src/Core/Framework/App/Manifest/Xml/ActionButton.php
+
+		-
+			message: "#^Argument of an invalid type DOMNamedNodeMap\\|null supplied for foreach, only iterables are supported\\.$#"
+			count: 1
+			path: src/Core/Framework/App/Manifest/Xml/CustomFieldTypes/CustomFieldType.php
+
+		-
+			message: "#^Argument of an invalid type DOMNamedNodeMap\\|null supplied for foreach, only iterables are supported\\.$#"
+			count: 1
+			path: src/Core/Framework/App/Manifest/Xml/CustomFieldTypes/SingleSelectField.php
+
+		-
+			message: "#^Argument of an invalid type DOMNamedNodeMap\\|null supplied for foreach, only iterables are supported\\.$#"
+			count: 1
+			path: src/Core/Framework/App/Manifest/Xml/Module.php
+
+		-
+			message: "#^Argument of an invalid type DOMNamedNodeMap\\|null supplied for foreach, only iterables are supported\\.$#"
+			count: 1
+			path: src/Core/Framework/App/Manifest/Xml/Webhook.php
+
+		-
+			message: "#^Argument of an invalid type array\\<int, string\\>\\|false supplied for foreach, only iterables are supported\\.$#"
+			count: 1
+			path: src/Core/Framework/Bundle.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Context\\:\\:disableCache\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/Context.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Context\\:\\:enableCache\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/Context.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Context\\:\\:enableInheritance\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/Context.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Context\\:\\:disableInheritance\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/Context.php
+
+		-
+			message: "#^Parameter \\#1 \\$aggregation of method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Cache\\\\CachedEntityAggregator\\:\\:getAggregationResult\\(\\) expects Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Search\\\\Aggregation\\\\Aggregation, Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Search\\\\Aggregation\\\\Aggregation\\|null given\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Cache/CachedEntityAggregator.php
+
+		-
+			message: "#^Parameter \\#1 \\$aggregation of method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Cache\\\\CachedEntityAggregator\\:\\:removeFilterAggregation\\(\\) expects Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Search\\\\Aggregation\\\\Aggregation, Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Search\\\\Aggregation\\\\Aggregation\\|null given\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Cache/CachedEntityAggregator.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Cache\\\\CachedEntityAggregator\\:\\:getAggregation\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Cache/CachedEntityAggregator.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Cache\\\\CachedEntityReader\\:\\:loadFilterResult\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Cache/CachedEntityReader.php
+
+		-
+			message: "#^Parameter \\#1 \\$str of function md5 expects string, string\\|false given\\.$#"
+			count: 6
+			path: src/Core/Framework/DataAbstractionLayer/Cache/EntityCacheKeyGenerator.php
+
+		-
+			message: "#^Cannot call method getFields\\(\\) on Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\EntityDefinition\\|null\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Cache/EntityCacheKeyGenerator.php
+
+		-
+			message: "#^Parameter \\#1 \\$definition of method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Cache\\\\EntityCacheKeyGenerator\\:\\:getFieldTag\\(\\) expects Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\EntityDefinition, Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\EntityDefinition\\|null given\\.$#"
+			count: 2
+			path: src/Core/Framework/DataAbstractionLayer/Cache/EntityCacheKeyGenerator.php
+
+		-
+			message: "#^Cannot call method newLine\\(\\) on Symfony\\\\Component\\\\Console\\\\Style\\\\SymfonyStyle\\|null\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Command/RefreshIndexCommand.php
+
+		-
+			message: "#^Cannot call method newLine\\(\\) on Symfony\\\\Component\\\\Console\\\\Style\\\\SymfonyStyle\\|null\\.$#"
+			count: 1
+			path: src/Elasticsearch/Framework/Command/ElasticsearchIndexingCommand.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\CompiledFieldCollection\\:\\:getMappedByStorageName\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/CompiledFieldCollection.php
+
+		-
+			message: "#^Cannot call method fetchAll\\(\\) on Doctrine\\\\DBAL\\\\Driver\\\\Statement\\|int\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Dbal/Common/LastIdQuery.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Dbal\\\\Common\\\\LastIdQuery\\:\\:\\$lastId \\(string\\|null\\) does not accept int\\|string\\|null\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Dbal/Common/LastIdQuery.php
+
+		-
+			message: "#^Cannot call method fetchColumn\\(\\) on Doctrine\\\\DBAL\\\\Driver\\\\Statement\\|int\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Dbal/Common/LastIdQuery.php
+
+		-
+			message: "#^Cannot call method fetchAll\\(\\) on Doctrine\\\\DBAL\\\\Driver\\\\Statement\\|int\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Dbal/Common/OffsetQuery.php
+
+		-
+			message: "#^Cannot call method fetchColumn\\(\\) on Doctrine\\\\DBAL\\\\Driver\\\\Statement\\|int\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Dbal/Common/OffsetQuery.php
+
+		-
+			message: "#^Parameter \\#1 \\$field of method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Dbal\\\\EntityDefinitionQueryHelper\\:\\:resolveField\\(\\) expects Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Field\\\\Field, Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Field\\\\Field\\|null given\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Dbal/EntityAggregator.php
+
+		-
+			message: "#^Parameter \\#1 \\$term of method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Search\\\\Term\\\\SearchTermInterpreter\\:\\:interpret\\(\\) expects string, string\\|null given\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Dbal/EntityAggregator.php
+
+		-
+			message: "#^Parameter \\#1 \\$fieldName of method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Dbal\\\\EntityDefinitionQueryHelper\\:\\:resolveAntiJoinAccessors\\(\\) expects string, int\\|string given\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Dbal/EntityAggregator.php
+
+		-
+			message: "#^Cannot call method fetchAll\\(\\) on Doctrine\\\\DBAL\\\\Driver\\\\Statement\\|int\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Dbal/EntityAggregator.php
+
+		-
+			message: "#^Parameter \\#1 \\$aggregation of method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Dbal\\\\EntityAggregator\\:\\:extendQuery\\(\\) expects Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Search\\\\Aggregation\\\\Aggregation, Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Search\\\\Aggregation\\\\Aggregation\\|null given\\.$#"
+			count: 3
+			path: src/Core/Framework/DataAbstractionLayer/Dbal/EntityAggregator.php
+
+		-
+			message: "#^Parameter \\#1 \\$sorting of method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Dbal\\\\EntityAggregator\\:\\:addSorting\\(\\) expects Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Search\\\\Sorting\\\\FieldSorting, Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Search\\\\Sorting\\\\FieldSorting\\|null given\\.$#"
+			count: 2
+			path: src/Core/Framework/DataAbstractionLayer/Dbal/EntityAggregator.php
+
+		-
+			message: "#^Parameter \\#1 \\$maxResults of method Doctrine\\\\DBAL\\\\Query\\\\QueryBuilder\\:\\:setMaxResults\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Dbal/EntityAggregator.php
+
+		-
+			message: "#^Parameter \\#1 \\$aggregation of method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Dbal\\\\EntityAggregator\\:\\:hydrateResult\\(\\) expects Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Search\\\\Aggregation\\\\Aggregation, Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Search\\\\Aggregation\\\\Aggregation\\|null given\\.$#"
+			count: 3
+			path: src/Core/Framework/DataAbstractionLayer/Dbal/EntityAggregator.php
+
+		-
+			message: "#^Parameter \\#1 \\$format of method DateTime\\:\\:format\\(\\) expects string, string\\|null given\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Dbal/EntityAggregator.php
+
+		-
+			message: "#^Parameter \\#1 \\$field of method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Dbal\\\\EntityDefinitionQueryHelper\\:\\:resolveField\\(\\) expects Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Field\\\\Field, Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Field\\\\Field\\|null given\\.$#"
+			count: 2
+			path: src/Core/Framework/DataAbstractionLayer/Dbal/EntityReader.php
+
+		-
+			message: "#^Parameter \\#1 \\$term of method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Search\\\\Term\\\\SearchTermInterpreter\\:\\:interpret\\(\\) expects string, string\\|null given\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Dbal/EntityReader.php
+
+		-
+			message: "#^Parameter \\#1 \\$fieldName of method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Dbal\\\\EntityDefinitionQueryHelper\\:\\:resolveAntiJoinAccessors\\(\\) expects string, int\\|string given\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Dbal/EntityReader.php
+
+		-
+			message: "#^Cannot call method fetchAll\\(\\) on Doctrine\\\\DBAL\\\\Driver\\\\Statement\\|int\\.$#"
+			count: 3
+			path: src/Core/Framework/DataAbstractionLayer/Dbal/EntityReader.php
+
+		-
+			message: "#^Cannot call method getPropertyName\\(\\) on Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Field\\\\Field\\|null\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Dbal/EntityReader.php
+
+		-
+			message: "#^Parameter \\#1 \\$haystack of function mb_strpos expects string, string\\|null given\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Dbal/EntityReader.php
+
+		-
+			message: "#^Parameter \\#1 \\$str of function mb_substr expects string, string\\|null given\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Dbal/EntityReader.php
+
+		-
+			message: "#^Parameter \\#1 \\$field of method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Dbal\\\\EntityDefinitionQueryHelper\\:\\:resolveField\\(\\) expects Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Field\\\\Field, Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Field\\\\Field\\|null given\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Dbal/EntitySearcher.php
+
+		-
+			message: "#^Parameter \\#1 \\$term of method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Search\\\\Term\\\\SearchTermInterpreter\\:\\:interpret\\(\\) expects string, string\\|null given\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Dbal/EntitySearcher.php
+
+		-
+			message: "#^Parameter \\#1 \\$fieldName of method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Dbal\\\\EntityDefinitionQueryHelper\\:\\:resolveAntiJoinAccessors\\(\\) expects string, int\\|string given\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Dbal/EntitySearcher.php
+
+		-
+			message: "#^Cannot call method fetchAll\\(\\) on Doctrine\\\\DBAL\\\\Driver\\\\Statement\\|int\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Dbal/EntitySearcher.php
+
+		-
+			message: "#^Cannot call method getFields\\(\\) on Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\EntityDefinition\\|null\\.$#"
+			count: 3
+			path: src/Core/Framework/DataAbstractionLayer/Dbal/EntityDefinitionQueryHelper.php
+
+		-
+			message: "#^Cannot call method getTranslationDefinition\\(\\) on Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\EntityDefinition\\|null\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Dbal/EntityDefinitionQueryHelper.php
+
+		-
+			message: "#^Parameter \\#1 \\$field of method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Dbal\\\\EntityDefinitionQueryHelper\\:\\:buildInheritedAccessor\\(\\) expects Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Field\\\\Field, Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Field\\\\Field\\|null given\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Dbal/EntityDefinitionQueryHelper.php
+
+		-
+			message: "#^Cannot call method getStorageName\\(\\) on Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Field\\\\FkField\\|null\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Dbal/EntityDefinitionQueryHelper.php
+
+		-
+			message: "#^Cannot call method getClass\\(\\) on Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\EntityDefinition\\|null\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Dbal/EntityDefinitionQueryHelper.php
+
+		-
+			message: "#^Parameter \\#2 \\$field of method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Dbal\\\\EntityDefinitionQueryHelper\\:\\:isInherited\\(\\) expects Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Field\\\\Field, Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Field\\\\Field\\|null given\\.$#"
+			count: 3
+			path: src/Core/Framework/DataAbstractionLayer/Dbal/EntityDefinitionQueryHelper.php
+
+		-
+			message: "#^Parameter \\#1 \\$field of method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Dbal\\\\EntityDefinitionQueryHelper\\:\\:getTranslationFieldAccessor\\(\\) expects Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Field\\\\Field, Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Field\\\\Field\\|Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Field\\\\StorageAware given\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Dbal/EntityDefinitionQueryHelper.php
+
+		-
+			message: "#^Cannot call method buildAccessor\\(\\) on Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Dbal\\\\FieldAccessorBuilder\\\\FieldAccessorBuilderInterface\\|null\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Dbal/EntityDefinitionQueryHelper.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Dbal\\\\EntityDefinitionQueryHelper\\:\\:buildFieldSelector\\(\\) should return string but returns string\\|null\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Dbal/EntityDefinitionQueryHelper.php
+
+		-
+			message: "#^Cannot call method fetchAll\\(\\) on Doctrine\\\\DBAL\\\\Driver\\\\Statement\\|int\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Dbal/EntityForeignKeyResolver.php
+
+		-
+			message: "#^Argument of an invalid type array\\<int, int\\|string\\>\\|null supplied for foreach, only iterables are supported\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Dbal/EntityForeignKeyResolver.php
+
+		-
+			message: "#^Cannot call method getPropertyName\\(\\) on Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Field\\\\Field\\|null\\.$#"
+			count: 3
+			path: src/Core/Framework/DataAbstractionLayer/Dbal/EntityForeignKeyResolver.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Dbal\\\\EntityHydrator\\:\\:createClass\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Dbal/EntityHydrator.php
+
+		-
+			message: "#^Cannot call method getPropertyName\\(\\) on Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Field\\\\Field\\|null\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Dbal/EntityHydrator.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Dbal\\\\EntityHydrator\\:\\:mergeJson\\(\\) should return string but returns string\\|false\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Dbal/EntityHydrator.php
+
+		-
+			message: "#^Call to an undefined method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Field\\\\Field\\|Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Field\\\\StorageAware\\:\\:getStorageName\\(\\)\\.$#"
+			count: 4
+			path: src/Core/Framework/DataAbstractionLayer/Dbal/EntityWriteGateway.php
+
+		-
+			message: "#^Call to an undefined method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Field\\\\Field\\|Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Field\\\\StorageAware\\:\\:getPropertyName\\(\\)\\.$#"
+			count: 3
+			path: src/Core/Framework/DataAbstractionLayer/Dbal/EntityWriteGateway.php
+
+		-
+			message: "#^Parameter \\#2 \\$field of class Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Exception\\\\PrimaryKeyNotProvidedException constructor expects Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Field\\\\Field, Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Field\\\\Field\\|Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Field\\\\StorageAware given\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Dbal/EntityWriteGateway.php
+
+		-
+			message: "#^Cannot call method getStorageName\\(\\) on Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Field\\\\FkField\\|null\\.$#"
+			count: 3
+			path: src/Core/Framework/DataAbstractionLayer/Dbal/EntityWriteGateway.php
+
+		-
+			message: "#^Cannot call method fetch\\(\\) on Doctrine\\\\DBAL\\\\Driver\\\\Statement\\|int\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Dbal/EntityWriteGateway.php
+
+		-
+			message: "#^Cannot call method getPropertyName\\(\\) on Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Field\\\\FkField\\|null\\.$#"
+			count: 2
+			path: src/Core/Framework/DataAbstractionLayer/Dbal/EntityWriteGateway.php
+
+		-
+			message: "#^Cannot call method getPropertyName\\(\\) on Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Field\\\\Field\\|null\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Dbal/EntityWriteGateway.php
+
+		-
+			message: "#^Cannot call method fetchAll\\(\\) on Doctrine\\\\DBAL\\\\Driver\\\\Statement\\|int\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Dbal/EntityWriteGateway.php
+
+		-
+			message: "#^Parameter \\#1 \\$attributeName of method Shopware\\\\Core\\\\System\\\\CustomField\\\\CustomFieldService\\:\\:getCustomField\\(\\) expects string, string\\|null given\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Dbal/FieldAccessorBuilder/CustomFieldsAccessorBuilder.php
+
+		-
+			message: "#^Parameter \\#1 \\$storageName of class Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Field\\\\JsonField constructor expects string, string\\|null given\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Dbal/FieldAccessorBuilder/CustomFieldsAccessorBuilder.php
+
+		-
+			message: "#^Parameter \\#2 \\$propertyName of class Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Field\\\\JsonField constructor expects string, string\\|null given\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Dbal/FieldAccessorBuilder/CustomFieldsAccessorBuilder.php
+
+		-
+			message: "#^Parameter \\#1 \\$str of function mb_strlen expects string, string\\|null given\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Dbal/FieldAccessorBuilder/JsonFieldAccessorBuilder.php
+
+		-
+			message: "#^Parameter \\#1 \\$field of method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Dbal\\\\EntityDefinitionQueryHelper\\:\\:resolveField\\(\\) expects Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Field\\\\Field, Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Field\\\\Field\\|null given\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Dbal/FieldResolver/OneToManyAssociationFieldResolver.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Dbal\\\\JoinBuilder\\\\JoinBuilderInterface\\:\\:join\\(\\) has parameter \\$field with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Dbal/JoinBuilder/JoinBuilderInterface.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Dbal\\\\JoinBuilder\\\\ManyToManyJoinBuilder\\:\\:join\\(\\) has parameter \\$field with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Dbal/JoinBuilder/ManyToManyJoinBuilder.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Dbal\\\\JoinBuilder\\\\ManyToOneJoinBuilder\\:\\:join\\(\\) has parameter \\$field with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Dbal/JoinBuilder/ManyToOneJoinBuilder.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Dbal\\\\JoinBuilder\\\\OneToManyJoinBuilder\\:\\:join\\(\\) has parameter \\$field with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Dbal/JoinBuilder/OneToManyJoinBuilder.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Dbal\\\\JoinBuilder\\\\TranslatedJoinBuilder\\:\\:join\\(\\) has parameter \\$field with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Dbal/JoinBuilder/TranslatedJoinBuilder.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Dbal\\\\JoinBuilder\\\\TranslatedJoinBuilder\\:\\:getSelectTemplate\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Dbal/JoinBuilder/TranslatedJoinBuilder.php
+
+		-
+			message: "#^Parameter \\#1 \\$definition of method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Dbal\\\\JoinBuilder\\\\TranslatedJoinBuilder\\:\\:getSelectTemplate\\(\\) expects Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\EntityDefinition, Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\EntityDefinition\\|null given\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Dbal/JoinBuilder/TranslatedJoinBuilder.php
+
+		-
+			message: "#^Call to an undefined method object\\:\\:getEntityClass\\(\\)\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/DefinitionInstanceRegistry.php
+
+		-
+			message: "#^Parameter \\#1 \\$argument of class ReflectionClass constructor expects class\\-string\\<T of object\\>\\|T of object, string given\\.$#"
+			count: 4
+			path: src/Core/Framework/DataAbstractionLayer/DefinitionValidator.php
+
+		-
+			message: "#^Cannot call method getName\\(\\) on ReflectionClass\\|false\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/DefinitionValidator.php
+
+		-
+			message: "#^Parameter \\#1 \\$haystack of function mb_strpos expects string, string\\|false given\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/DefinitionValidator.php
+
+		-
+			message: "#^Cannot call method getPropertyName\\(\\) on Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Field\\\\Field\\|null\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/DefinitionValidator.php
+
+		-
+			message: "#^Parameter \\#1 \\$str of function lcfirst expects string, string\\|null given\\.$#"
+			count: 2
+			path: src/Core/Framework/DataAbstractionLayer/DefinitionValidator.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Doctrine\\\\FetchModeHelper\\:\\:keyPair\\(\\) should return array but returns array\\|false\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Doctrine/FetchModeHelper.php
+
+		-
+			message: "#^Parameter \\#2 \\$pieces of function implode expects array, array\\|false given\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Doctrine/MultiInsertQueryQueue.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Doctrine\\\\RetryableQuery\\:\\:retryable\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Doctrine/RetryableQuery.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Doctrine\\\\RetryableQuery\\:\\:retry\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Doctrine/RetryableQuery.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Entity\\:\\:get\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Entity.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Entity\\:\\:getTranslation\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Entity.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Entity\\:\\:addTranslated\\(\\) has parameter \\$value with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Entity.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Entity\\:\\:getApiAlias\\(\\) should return string but returns string\\|null\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Entity.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\EntityCollection\\:\\:filterByProperty\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/EntityCollection.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\EntityCollection\\:\\:filterByProperty\\(\\) has parameter \\$value with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/EntityCollection.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\EntityCollection\\:\\:filterAndReduceByProperty\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/EntityCollection.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\EntityCollection\\:\\:filterAndReduceByProperty\\(\\) has parameter \\$value with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/EntityCollection.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\EntityCollection\\:\\:getList\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/EntityCollection.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\EntityGenerator\\:\\:\\$classTemplate has no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/EntityGenerator.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\EntityGenerator\\:\\:\\$propertyTemplate has no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/EntityGenerator.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\EntityGenerator\\:\\:\\$propertyFunctions has no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/EntityGenerator.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\EntityGenerator\\:\\:\\$collectionTemplate has no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/EntityGenerator.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\EntityGenerator\\:\\:generateEntity\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/EntityGenerator.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\EntityGenerator\\:\\:generateCollection\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/EntityGenerator.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\EntityGenerator\\:\\:getUsage\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/EntityGenerator.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\EntityGenerator\\:\\:getClassTypeHint\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/EntityGenerator.php
+
+		-
+			message: "#^Only iterables can be unpacked, Shopware\\\\Core\\\\Framework\\\\Event\\\\NestedEventCollection\\|null given in argument \\#1\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/EntityRepository.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\EntityTranslationDefinition\\:\\:getParentDefinition\\(\\) should return Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\EntityDefinition but returns Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\EntityDefinition\\|null\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/EntityTranslationDefinition.php
+
+		-
+			message: "#^Array \\(array\\<Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Write\\\\EntityExistence\\>\\) does not accept Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Write\\\\EntityExistence\\|null\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Event/EntityWrittenEvent.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Event\\\\EntityWrittenEvent\\:\\:getExistences\\(\\) should return array\\<Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Write\\\\EntityExistence\\> but returns array\\<Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Write\\\\EntityExistence\\|null\\>\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Event/EntityWrittenEvent.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Exception\\\\InvalidLimitQueryException\\:\\:__construct\\(\\) has parameter \\$limit with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Exception/InvalidLimitQueryException.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Exception\\\\InvalidPageQueryException\\:\\:__construct\\(\\) has parameter \\$page with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Exception/InvalidPageQueryException.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Exception\\\\QueryLimitExceededException\\:\\:__construct\\(\\) has parameter \\$limit with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Exception/QueryLimitExceededException.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Exception\\\\QueryLimitExceededException\\:\\:__construct\\(\\) has parameter \\$maxLimit with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Exception/QueryLimitExceededException.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\ExtensionRegistry\\:\\:\\$extensions \\(array\\<Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\EntityExtension\\>\\) does not accept iterable\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/ExtensionRegistry.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Field\\\\CustomFields\\:\\:__construct\\(\\) has parameter \\$propertyName with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Field/CustomFields.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Field\\\\CustomFields\\:\\:__construct\\(\\) has parameter \\$storageName with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Field/CustomFields.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Field\\\\FkField\\:\\:\\$storageName \\(string\\) does not accept string\\|null\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Field/ReferenceVersionField.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\FieldSerializer\\\\AbstractFieldSerializer\\:\\:requiresValidation\\(\\) has parameter \\$value with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/FieldSerializer/AbstractFieldSerializer.php
+
+		-
+			message: "#^Parameter \\#1 \\$entityName of method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\DefinitionInstanceRegistry\\:\\:getByEntityName\\(\\) expects string, string\\|null given\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/FieldSerializer/AbstractFieldSerializer.php
+
+		-
+			message: "#^Cannot call method is\\(\\) on Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Field\\\\Field\\|null\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/FieldSerializer/AbstractFieldSerializer.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\FieldSerializer\\\\BlobFieldSerializer\\:\\:decode\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/FieldSerializer/BlobFieldSerializer.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\FieldSerializer\\\\BlobFieldSerializer\\:\\:decode\\(\\) has parameter \\$value with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/FieldSerializer/BlobFieldSerializer.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\FieldSerializer\\\\BoolFieldSerializer\\:\\:decode\\(\\) has parameter \\$value with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/FieldSerializer/BoolFieldSerializer.php
+
+		-
+			message: "#^Parameter \\#1 \\$json of function json_decode expects string, string\\|false given\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/FieldSerializer/CalculatedPriceFieldSerializer.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\FieldSerializer\\\\CalculatedPriceFieldSerializer\\:\\:decode\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/FieldSerializer/CalculatedPriceFieldSerializer.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\FieldSerializer\\\\CalculatedPriceFieldSerializer\\:\\:decode\\(\\) has parameter \\$value with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/FieldSerializer/CalculatedPriceFieldSerializer.php
+
+		-
+			message: "#^Parameter \\#1 \\$json of function json_decode expects string, string\\|false given\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/FieldSerializer/CartPriceFieldSerializer.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\FieldSerializer\\\\CartPriceFieldSerializer\\:\\:decode\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/FieldSerializer/CartPriceFieldSerializer.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\FieldSerializer\\\\CartPriceFieldSerializer\\:\\:decode\\(\\) has parameter \\$value with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/FieldSerializer/CartPriceFieldSerializer.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\FieldSerializer\\\\ConfigJsonFieldSerializer\\:\\:decode\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/FieldSerializer/ConfigJsonFieldSerializer.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\FieldSerializer\\\\ConfigJsonFieldSerializer\\:\\:decode\\(\\) has parameter \\$value with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/FieldSerializer/ConfigJsonFieldSerializer.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\FieldSerializer\\\\CustomFieldsSerializer\\:\\:decode\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/FieldSerializer/CustomFieldsSerializer.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\FieldSerializer\\\\CustomFieldsSerializer\\:\\:decode\\(\\) has parameter \\$value with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/FieldSerializer/CustomFieldsSerializer.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\FieldSerializer\\\\DateFieldSerializer\\:\\:decode\\(\\) has parameter \\$value with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/FieldSerializer/DateFieldSerializer.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\FieldSerializer\\\\DateTimeFieldSerializer\\:\\:decode\\(\\) has parameter \\$value with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/FieldSerializer/DateTimeFieldSerializer.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\FieldSerializer\\\\EmailFieldSerializer\\:\\:decode\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/FieldSerializer/EmailFieldSerializer.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\FieldSerializer\\\\EmailFieldSerializer\\:\\:decode\\(\\) has parameter \\$value with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/FieldSerializer/EmailFieldSerializer.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\FieldSerializer\\\\FieldSerializerInterface\\:\\:decode\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/FieldSerializer/FieldSerializerInterface.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\FieldSerializer\\\\FieldSerializerInterface\\:\\:decode\\(\\) has parameter \\$value with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/FieldSerializer/FieldSerializerInterface.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\FieldSerializer\\\\FkFieldSerializer\\:\\:decode\\(\\) has parameter \\$value with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/FieldSerializer/FkFieldSerializer.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\FieldSerializer\\\\FloatFieldSerializer\\:\\:decode\\(\\) has parameter \\$value with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/FieldSerializer/FloatFieldSerializer.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\FieldSerializer\\\\IdFieldSerializer\\:\\:decode\\(\\) has parameter \\$value with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/FieldSerializer/IdFieldSerializer.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\FieldSerializer\\\\IntFieldSerializer\\:\\:decode\\(\\) has parameter \\$value with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/FieldSerializer/IntFieldSerializer.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\FieldSerializer\\\\JsonFieldSerializer\\:\\:encodeJson\\(\\) has parameter \\$value with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/FieldSerializer/JsonFieldSerializer.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\FieldSerializer\\\\JsonFieldSerializer\\:\\:encodeJson\\(\\) should return string but returns string\\|false\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/FieldSerializer/JsonFieldSerializer.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\FieldSerializer\\\\JsonFieldSerializer\\:\\:decode\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/FieldSerializer/JsonFieldSerializer.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\FieldSerializer\\\\JsonFieldSerializer\\:\\:decode\\(\\) has parameter \\$value with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/FieldSerializer/JsonFieldSerializer.php
+
+		-
+			message: "#^Parameter \\#2 \\$fieldName of class Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Write\\\\FieldException\\\\UnexpectedFieldException constructor expects string, int\\|string given\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/FieldSerializer/JsonFieldSerializer.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\FieldSerializer\\\\ListFieldSerializer\\:\\:decode\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/FieldSerializer/ListFieldSerializer.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\FieldSerializer\\\\ListFieldSerializer\\:\\:decode\\(\\) has parameter \\$value with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/FieldSerializer/ListFieldSerializer.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\FieldSerializer\\\\ListingPriceFieldSerializer\\:\\:decode\\(\\) has parameter \\$value with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/FieldSerializer/ListingPriceFieldSerializer.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\FieldSerializer\\\\LongTextFieldSerializer\\:\\:decode\\(\\) has parameter \\$value with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/FieldSerializer/LongTextFieldSerializer.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\FieldSerializer\\\\ManyToManyAssociationFieldSerializer\\:\\:decode\\(\\) has parameter \\$value with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/FieldSerializer/ManyToManyAssociationFieldSerializer.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\FieldSerializer\\\\ManyToManyAssociationFieldSerializer\\:\\:map\\(\\) has parameter \\$data with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/FieldSerializer/ManyToManyAssociationFieldSerializer.php
+
+		-
+			message: "#^Cannot call method getPropertyName\\(\\) on Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Field\\\\Field\\|null\\.$#"
+			count: 5
+			path: src/Core/Framework/DataAbstractionLayer/FieldSerializer/ManyToOneAssociationFieldSerializer.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\FieldSerializer\\\\ManyToOneAssociationFieldSerializer\\:\\:decode\\(\\) has parameter \\$value with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/FieldSerializer/ManyToOneAssociationFieldSerializer.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\FieldSerializer\\\\OneToManyAssociationFieldSerializer\\:\\:decode\\(\\) has parameter \\$value with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/FieldSerializer/OneToManyAssociationFieldSerializer.php
+
+		-
+			message: "#^Cannot call method getPropertyName\\(\\) on Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Field\\\\Field\\|null\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/FieldSerializer/OneToManyAssociationFieldSerializer.php
+
+		-
+			message: "#^Cannot call method getPropertyName\\(\\) on Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Field\\\\Field\\|null\\.$#"
+			count: 4
+			path: src/Core/Framework/DataAbstractionLayer/FieldSerializer/OneToOneAssociationFieldSerializer.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\FieldSerializer\\\\OneToOneAssociationFieldSerializer\\:\\:decode\\(\\) has parameter \\$value with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/FieldSerializer/OneToOneAssociationFieldSerializer.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\FieldSerializer\\\\OneToOneAssociationFieldSerializer\\:\\:mapOwningSide\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/FieldSerializer/OneToOneAssociationFieldSerializer.php
+
+		-
+			message: "#^Parameter \\#2 \\$algo of function password_hash expects int, int\\|string\\|null given\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/FieldSerializer/PasswordFieldSerializer.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\FieldSerializer\\\\PasswordFieldSerializer\\:\\:decode\\(\\) has parameter \\$value with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/FieldSerializer/PasswordFieldSerializer.php
+
+		-
+			message: "#^Parameter \\#1 \\$json of function json_decode expects string, string\\|false given\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/FieldSerializer/PriceDefinitionFieldSerializer.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\FieldSerializer\\\\PriceDefinitionFieldSerializer\\:\\:decode\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/FieldSerializer/PriceDefinitionFieldSerializer.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\FieldSerializer\\\\PriceDefinitionFieldSerializer\\:\\:decode\\(\\) has parameter \\$value with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/FieldSerializer/PriceDefinitionFieldSerializer.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\FieldSerializer\\\\PriceDefinitionFieldSerializer\\:\\:buildViolation\\(\\) has parameter \\$code with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/FieldSerializer/PriceDefinitionFieldSerializer.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\FieldSerializer\\\\PriceDefinitionFieldSerializer\\:\\:buildViolation\\(\\) has parameter \\$invalidValue with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/FieldSerializer/PriceDefinitionFieldSerializer.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\FieldSerializer\\\\PriceDefinitionFieldSerializer\\:\\:buildViolation\\(\\) has parameter \\$root with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/FieldSerializer/PriceDefinitionFieldSerializer.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\FieldSerializer\\\\PriceFieldSerializer\\:\\:decode\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/FieldSerializer/PriceFieldSerializer.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\FieldSerializer\\\\PriceFieldSerializer\\:\\:decode\\(\\) has parameter \\$value with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/FieldSerializer/PriceFieldSerializer.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\FieldSerializer\\\\ReferenceVersionFieldSerializer\\:\\:decode\\(\\) has parameter \\$value with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/FieldSerializer/ReferenceVersionFieldSerializer.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\FieldSerializer\\\\RemoteAddressFieldSerializer\\:\\:decode\\(\\) has parameter \\$value with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/FieldSerializer/RemoteAddressFieldSerializer.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\FieldSerializer\\\\StringFieldSerializer\\:\\:decode\\(\\) has parameter \\$value with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/FieldSerializer/StringFieldSerializer.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\FieldSerializer\\\\TranslatedFieldSerializer\\:\\:decode\\(\\) has parameter \\$value with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/FieldSerializer/TranslatedFieldSerializer.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\FieldSerializer\\\\TranslationsAssociationFieldSerializer\\:\\:decode\\(\\) has parameter \\$value with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/FieldSerializer/TranslationsAssociationFieldSerializer.php
+
+		-
+			message: "#^Cannot call method getPropertyName\\(\\) on Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Field\\\\Field\\|null\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/FieldSerializer/TranslationsAssociationFieldSerializer.php
+
+		-
+			message: "#^Parameter \\#1 \\$languageId of method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Write\\\\WriteParameterBag\\:\\:setCurrentWriteLanguageId\\(\\) expects string, int\\|string given\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/FieldSerializer/TranslationsAssociationFieldSerializer.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\FieldSerializer\\\\VersionDataPayloadFieldSerializer\\:\\:decode\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/FieldSerializer/VersionDataPayloadFieldSerializer.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\FieldSerializer\\\\VersionDataPayloadFieldSerializer\\:\\:decode\\(\\) has parameter \\$value with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/FieldSerializer/VersionDataPayloadFieldSerializer.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\FieldSerializer\\\\VersionFieldSerializer\\:\\:decode\\(\\) has parameter \\$value with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/FieldSerializer/VersionFieldSerializer.php
+
+		-
+			message: "#^Cannot call method fetchAll\\(\\) on Doctrine\\\\DBAL\\\\Driver\\\\Statement\\|int\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Indexing/ChildCountUpdater.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Indexing\\\\EntityIndexer\\:\\:iterate\\(\\) has parameter \\$offset with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Indexing/EntityIndexer.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Indexing\\\\EntityIndexerRegistry\\:\\:\\$indexer \\(array\\<Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Indexing\\\\EntityIndexer\\>\\) does not accept iterable\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Indexing/EntityIndexerRegistry.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Indexing\\\\EntityIndexerRegistry\\:\\:handle\\(\\) has parameter \\$message with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Indexing/EntityIndexerRegistry.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Indexing\\\\EntityIndexerRegistry\\:\\:iterateIndexer\\(\\) has parameter \\$offset with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Indexing/EntityIndexerRegistry.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Indexing\\\\EntityIndexingMessage\\:\\:\\$data has no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Indexing/EntityIndexingMessage.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Indexing\\\\EntityIndexingMessage\\:\\:\\$offset has no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Indexing/EntityIndexingMessage.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Indexing\\\\EntityIndexingMessage\\:\\:__construct\\(\\) has parameter \\$data with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Indexing/EntityIndexingMessage.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Indexing\\\\EntityIndexingMessage\\:\\:__construct\\(\\) has parameter \\$offset with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Indexing/EntityIndexingMessage.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Indexing\\\\EntityIndexingMessage\\:\\:getData\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Indexing/EntityIndexingMessage.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Indexing\\\\EntityIndexingMessage\\:\\:getOffset\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Indexing/EntityIndexingMessage.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Indexing\\\\MessageQueue\\\\IterateEntityIndexerMessage\\:\\:__construct\\(\\) has parameter \\$offset with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Indexing/MessageQueue/IterateEntityIndexerMessage.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Indexing\\\\MessageQueue\\\\IterateEntityIndexerMessage\\:\\:getOffset\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Indexing/MessageQueue/IterateEntityIndexerMessage.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Indexing\\\\MessageQueue\\\\IterateEntityIndexerMessage\\:\\:setOffset\\(\\) has parameter \\$offset with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Indexing/MessageQueue/IterateEntityIndexerMessage.php
+
+		-
+			message: "#^Cannot call method fetchAll\\(\\) on Doctrine\\\\DBAL\\\\Driver\\\\Statement\\|int\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Indexing/TreeUpdater.php
+
+		-
+			message: "#^Cannot call method fetch\\(\\) on Doctrine\\\\DBAL\\\\Driver\\\\Statement\\|int\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Indexing/TreeUpdater.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Pricing\\\\PriceCollection\\:\\:add\\(\\) has parameter \\$element with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Pricing/PriceCollection.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Pricing\\\\PriceCollection\\:\\:set\\(\\) has parameter \\$element with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Pricing/PriceCollection.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Pricing\\\\PriceCollection\\:\\:set\\(\\) has parameter \\$key with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Pricing/PriceCollection.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\SchemaGenerator\\:\\:\\$tableTemplate has no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/SchemaGenerator.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\SchemaGenerator\\:\\:\\$columnTemplate has no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/SchemaGenerator.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\SchemaGenerator\\:\\:generate\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/SchemaGenerator.php
+
+		-
+			message: "#^Cannot call method getStorageName\\(\\) on Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Field\\\\ReferenceVersionField\\|null\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/SchemaGenerator.php
+
+		-
+			message: "#^Cannot call method getFields\\(\\) on Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Search\\\\Aggregation\\\\Aggregation\\|null\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Search/Aggregation/Bucket/FilterAggregation.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Search\\\\AggregationResult\\\\Bucket\\\\Bucket\\:\\:\\$key \\(string\\) does not accept string\\|null\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Search/AggregationResult/Bucket/Bucket.php
+
+		-
+			message: "#^Cannot call method getName\\(\\) on Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Search\\\\AggregationResult\\\\AggregationResult\\|null\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Search/AggregationResult/Bucket/Bucket.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Search\\\\AggregationResult\\\\Metric\\\\MaxResult\\:\\:\\$max has no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Search/AggregationResult/Metric/MaxResult.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Search\\\\AggregationResult\\\\Metric\\\\MaxResult\\:\\:__construct\\(\\) has parameter \\$max with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Search/AggregationResult/Metric/MaxResult.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Search\\\\AggregationResult\\\\Metric\\\\MaxResult\\:\\:getMax\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Search/AggregationResult/Metric/MaxResult.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Search\\\\AggregationResult\\\\Metric\\\\MinResult\\:\\:\\$min has no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Search/AggregationResult/Metric/MinResult.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Search\\\\AggregationResult\\\\Metric\\\\MinResult\\:\\:__construct\\(\\) has parameter \\$min with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Search/AggregationResult/Metric/MinResult.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Search\\\\AggregationResult\\\\Metric\\\\MinResult\\:\\:getMin\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Search/AggregationResult/Metric/MinResult.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Search\\\\AggregationResult\\\\Metric\\\\StatsResult\\:\\:__construct\\(\\) has parameter \\$max with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Search/AggregationResult/Metric/StatsResult.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Search\\\\AggregationResult\\\\Metric\\\\StatsResult\\:\\:__construct\\(\\) has parameter \\$min with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Search/AggregationResult/Metric/StatsResult.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Search\\\\AggregationResult\\\\Metric\\\\StatsResult\\:\\:getMin\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Search/AggregationResult/Metric/StatsResult.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Search\\\\AggregationResult\\\\Metric\\\\StatsResult\\:\\:getMax\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Search/AggregationResult/Metric/StatsResult.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Search\\\\CompositeEntitySearcher\\:\\:\\$definitions \\(array\\<Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\EntityDefinition\\>\\) does not accept iterable\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Search/CompositeEntitySearcher.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Search\\\\Criteria\\:\\:hasEqualsFilter\\(\\) has parameter \\$field with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Search/Criteria.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Search\\\\Criteria\\:\\:getIncludes\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Search/Criteria.php
+
+		-
+			message: "#^Parameter \\#2 \\$entities of class Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Search\\\\EntitySearchResult constructor expects Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\EntityCollection, iterable given\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Search/EntitySearchResult.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Search\\\\Filter\\\\ContainsFilter\\:\\:__construct\\(\\) has parameter \\$value with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Search/Filter/ContainsFilter.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Search\\\\Filter\\\\ContainsFilter\\:\\:getValue\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Search/Filter/ContainsFilter.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Search\\\\Filter\\\\EqualsAnyFilter\\:\\:getValue\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Search/Filter/EqualsAnyFilter.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Search\\\\Filter\\\\EqualsFilter\\:\\:__construct\\(\\) has parameter \\$value with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Search/Filter/EqualsFilter.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Search\\\\Filter\\\\EqualsFilter\\:\\:getValue\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Search/Filter/EqualsFilter.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Search\\\\Filter\\\\RangeFilter\\:\\:hasParameter\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Search/Filter/RangeFilter.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Search\\\\Filter\\\\RangeFilter\\:\\:getParameter\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Search/Filter/RangeFilter.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Search\\\\IdSearchResult\\:\\:getDataFieldOfId\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Search/IdSearchResult.php
+
+		-
+			message: "#^Parameter \\#1 \\$aggregation of method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Search\\\\Parser\\\\AggregationParser\\:\\:aggregationToArray\\(\\) expects Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Search\\\\Aggregation\\\\Aggregation, Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Search\\\\Aggregation\\\\Aggregation\\|null given\\.$#"
+			count: 3
+			path: src/Core/Framework/DataAbstractionLayer/Search/Parser/AggregationParser.php
+
+		-
+			message: "#^Cannot call method getDirection\\(\\) on Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Search\\\\Sorting\\\\FieldSorting\\|null\\.$#"
+			count: 2
+			path: src/Core/Framework/DataAbstractionLayer/Search/Parser/AggregationParser.php
+
+		-
+			message: "#^Cannot call method getNaturalSorting\\(\\) on Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Search\\\\Sorting\\\\FieldSorting\\|null\\.$#"
+			count: 2
+			path: src/Core/Framework/DataAbstractionLayer/Search/Parser/AggregationParser.php
+
+		-
+			message: "#^Cannot call method getField\\(\\) on Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Search\\\\Sorting\\\\FieldSorting\\|null\\.$#"
+			count: 2
+			path: src/Core/Framework/DataAbstractionLayer/Search/Parser/AggregationParser.php
+
+		-
+			message: "#^Parameter \\#2 \\$field of class Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Search\\\\Aggregation\\\\Metric\\\\AvgAggregation constructor expects string, string\\|null given\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Search/Parser/AggregationParser.php
+
+		-
+			message: "#^Parameter \\#2 \\$field of class Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Search\\\\Aggregation\\\\Metric\\\\MaxAggregation constructor expects string, string\\|null given\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Search/Parser/AggregationParser.php
+
+		-
+			message: "#^Parameter \\#2 \\$field of class Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Search\\\\Aggregation\\\\Metric\\\\MinAggregation constructor expects string, string\\|null given\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Search/Parser/AggregationParser.php
+
+		-
+			message: "#^Parameter \\#2 \\$field of class Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Search\\\\Aggregation\\\\Metric\\\\StatsAggregation constructor expects string, string\\|null given\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Search/Parser/AggregationParser.php
+
+		-
+			message: "#^Parameter \\#2 \\$field of class Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Search\\\\Aggregation\\\\Metric\\\\SumAggregation constructor expects string, string\\|null given\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Search/Parser/AggregationParser.php
+
+		-
+			message: "#^Parameter \\#2 \\$field of class Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Search\\\\Aggregation\\\\Metric\\\\CountAggregation constructor expects string, string\\|null given\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Search/Parser/AggregationParser.php
+
+		-
+			message: "#^Parameter \\#2 \\$field of class Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Search\\\\Aggregation\\\\Metric\\\\EntityAggregation constructor expects string, string\\|null given\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Search/Parser/AggregationParser.php
+
+		-
+			message: "#^Parameter \\#2 \\$aggregation of class Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Search\\\\Aggregation\\\\Bucket\\\\FilterAggregation constructor expects Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Search\\\\Aggregation\\\\Aggregation, Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Search\\\\Aggregation\\\\Aggregation\\|null given\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Search/Parser/AggregationParser.php
+
+		-
+			message: "#^Parameter \\#2 \\$field of class Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Search\\\\Aggregation\\\\Bucket\\\\DateHistogramAggregation constructor expects string, string\\|null given\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Search/Parser/AggregationParser.php
+
+		-
+			message: "#^Parameter \\#2 \\$field of class Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Search\\\\Aggregation\\\\Bucket\\\\TermsAggregation constructor expects string, string\\|null given\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Search/Parser/AggregationParser.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Search\\\\Parser\\\\ParseResult\\:\\:\\$wheres has no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Search/Parser/ParseResult.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Search\\\\Parser\\\\ParseResult\\:\\:\\$parameters has no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Search/Parser/ParseResult.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Search\\\\Parser\\\\ParseResult\\:\\:\\$types has no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Search/Parser/ParseResult.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Search\\\\Parser\\\\ParseResult\\:\\:addParameter\\(\\) has parameter \\$type with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Search/Parser/ParseResult.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Search\\\\Parser\\\\ParseResult\\:\\:addParameter\\(\\) has parameter \\$value with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Search/Parser/ParseResult.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Search\\\\Parser\\\\ParseResult\\:\\:getType\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Search/Parser/ParseResult.php
+
+		-
+			message: "#^Parameter \\#1 \\$fieldName of method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Dbal\\\\EntityDefinitionQueryHelper\\:\\:getFieldAccessor\\(\\) expects string, string\\|null given\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Search\\\\Parser\\\\SqlQueryParser\\:\\:parseAntiJoin\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php
+
+		-
+			message: "#^Parameter \\#1 \\$json of function json_decode expects string, string\\|false given\\.$#"
+			count: 2
+			path: src/Core/Framework/DataAbstractionLayer/Search/RequestCriteriaBuilder.php
+
+		-
+			message: "#^Parameter \\#2 \\$fieldName of method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Search\\\\RequestCriteriaBuilder\\:\\:buildFieldName\\(\\) expects string, int\\|string given\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Search/RequestCriteriaBuilder.php
+
+		-
+			message: "#^Parameter \\#1 \\$str of function trim expects string, string\\|null given\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Search/Term/Tokenizer.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Validation\\\\EntityExists\\:\\:\\$message has no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Validation/EntityExists.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Validation\\\\EntityExists\\:\\:\\$errorNames has no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Validation/EntityExists.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Validation\\\\EntityNotExists\\:\\:\\$message has no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Validation/EntityNotExists.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Validation\\\\EntityNotExists\\:\\:\\$errorNames has no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Validation/EntityNotExists.php
+
+		-
+			message: "#^Parameter \\#1 \\$payload of method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\VersionManager\\:\\:addVersionToPayload\\(\\) expects array, array\\|null given\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/VersionManager.php
+
+		-
+			message: "#^Parameter \\#2 \\$definition of method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\VersionManager\\:\\:addVersionToPayload\\(\\) expects Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\EntityDefinition, Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\EntityDefinition\\|string given\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/VersionManager.php
+
+		-
+			message: "#^Parameter \\#1 \\$definition of method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Write\\\\EntityWriterInterface\\:\\:delete\\(\\) expects Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\EntityDefinition, Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\EntityDefinition\\|string given\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/VersionManager.php
+
+		-
+			message: "#^Parameter \\#1 \\$uuid of static method Shopware\\\\Core\\\\Framework\\\\Uuid\\\\Uuid\\:\\:fromHexToBytes\\(\\) expects string, string\\|null given\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/VersionManager.php
+
+		-
+			message: "#^Call to an undefined method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Field\\\\Field\\|Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Field\\\\StorageAware\\:\\:getStorageName\\(\\)\\.$#"
+			count: 2
+			path: src/Core/Framework/DataAbstractionLayer/VersionManager.php
+
+		-
+			message: "#^Call to an undefined method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Field\\\\Field\\|Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Field\\\\StorageAware\\:\\:getPropertyName\\(\\)\\.$#"
+			count: 5
+			path: src/Core/Framework/DataAbstractionLayer/VersionManager.php
+
+		-
+			message: "#^Cannot call method fetchColumn\\(\\) on Doctrine\\\\DBAL\\\\Driver\\\\Statement\\|int\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/VersionManager.php
+
+		-
+			message: "#^Cannot call method getEntityName\\(\\) on Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\EntityDefinition\\|null\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/VersionManager.php
+
+		-
+			message: "#^Offset string does not exist on array\\|null\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/VersionManager.php
+
+		-
+			message: "#^Parameter \\#1 \\$str of function md5 expects string, string\\|false given\\.$#"
+			count: 2
+			path: src/Core/Framework/DataAbstractionLayer/Write/Command/WriteCommandQueue.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Write\\\\DataStack\\\\DataStack\\:\\:update\\(\\) has parameter \\$value with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Write/DataStack/DataStack.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Write\\\\DataStack\\\\KeyValuePair\\:\\:\\$value has no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Write/DataStack/KeyValuePair.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Write\\\\DataStack\\\\KeyValuePair\\:\\:__construct\\(\\) has parameter \\$value with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Write/DataStack/KeyValuePair.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Write\\\\DataStack\\\\KeyValuePair\\:\\:getValue\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Write/DataStack/KeyValuePair.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Write\\\\DataStack\\\\KeyValuePair\\:\\:setValue\\(\\) has parameter \\$value with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Write/DataStack/KeyValuePair.php
+
+		-
+			message: "#^Cannot call method getSerializer\\(\\) on Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Field\\\\Field\\|null\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Write/EntityWriter.php
+
+		-
+			message: "#^Parameter \\#1 \\$field of method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\FieldSerializer\\\\FieldSerializerInterface\\:\\:decode\\(\\) expects Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Field\\\\Field, Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Field\\\\Field\\|null given\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Write/EntityWriter.php
+
+		-
+			message: "#^Cannot call method getPropertyName\\(\\) on Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Field\\\\Field\\|null\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Write/EntityWriter.php
+
+		-
+			message: "#^Call to an undefined method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Field\\\\Field\\|Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Field\\\\StorageAware\\:\\:getStorageName\\(\\)\\.$#"
+			count: 4
+			path: src/Core/Framework/DataAbstractionLayer/Write/EntityWriter.php
+
+		-
+			message: "#^Call to an undefined method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Field\\\\Field\\|Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Field\\\\StorageAware\\:\\:getPropertyName\\(\\)\\.$#"
+			count: 2
+			path: src/Core/Framework/DataAbstractionLayer/Write/EntityWriter.php
+
+		-
+			message: "#^Possibly invalid array key type \\(array\\|string\\)\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Write/EntityWriter.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Write\\\\EntityWriterInterface\\:\\:insert\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Write/EntityWriterInterface.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Write\\\\EntityWriterInterface\\:\\:update\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Write/EntityWriterInterface.php
+
+		-
+			message: "#^Cannot call method rowCount\\(\\) on Doctrine\\\\DBAL\\\\Driver\\\\Statement\\|int\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Write/Validation/LockValidator.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Write\\\\Validation\\\\Validator\\:\\:addConstraint\\(\\) has parameter \\$propertyValue with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Write/Validation/Validator.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Write\\\\WriteCommandExtractor\\:\\:extractJsonUpdate\\(\\) has parameter \\$data with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Write/WriteCommandExtractor.php
+
+		-
+			message: "#^Parameter \\#1 \\$entityName of method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\DefinitionInstanceRegistry\\:\\:getByEntityName\\(\\) expects string, string\\|null given\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Write/WriteCommandExtractor.php
+
+		-
+			message: "#^Call to an undefined method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Field\\\\Field\\|Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Field\\\\StorageAware\\:\\:getStorageName\\(\\)\\.$#"
+			count: 3
+			path: src/Core/Framework/DataAbstractionLayer/Write/WriteCommandExtractor.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Write\\\\WriteContext\\:\\:get\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Write/WriteContext.php
+
+		-
+			message: "#^Cannot cast array\\<string\\>\\|bool\\|string\\|null to int\\.$#"
+			count: 12
+			path: src/Core/Framework/Demodata/Command/DemodataCommand.php
+
+		-
+			message: "#^Cannot cast array\\<string\\>\\|bool\\|float\\|string to int\\.$#"
+			count: 5
+			path: src/Core/Framework/Demodata/Command/DemodataCommand.php
+
+		-
+			message: "#^Array \\(array\\<array\\<string\\>\\>\\) does not accept array\\<array\\|string\\>\\.$#"
+			count: 1
+			path: src/Core/Framework/Demodata/DemodataContext.php
+
+		-
+			message: "#^Parameter \\#1 \\$class of method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\DefinitionInstanceRegistry\\:\\:get\\(\\) expects string, Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\EntityDefinition\\|string given\\.$#"
+			count: 1
+			path: src/Core/Framework/Demodata/DemodataService.php
+
+		-
+			message: "#^Parameter \\#2 \\.\\.\\.\\$args of function sprintf expects bool\\|float\\|int\\|string\\|null, Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\EntityDefinition\\|string given\\.$#"
+			count: 1
+			path: src/Core/Framework/Demodata/DemodataService.php
+
+		-
+			message: "#^Parameter \\#1 \\$definition of method Shopware\\\\Core\\\\Framework\\\\Demodata\\\\DemodataRequest\\:\\:getOptions\\(\\) expects string, Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\EntityDefinition\\|string given\\.$#"
+			count: 1
+			path: src/Core/Framework/Demodata/DemodataService.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\Framework\\\\Demodata\\\\Faker\\\\Commerce\\:\\:\\$productName has no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/Demodata/Faker/Commerce.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Demodata\\\\Generator\\\\CategoryGenerator\\:\\:randomDepartment\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/Demodata/Generator/CategoryGenerator.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Demodata\\\\Generator\\\\CategoryGenerator\\:\\:getRootCategoryId\\(\\) should return string but returns array\\|string\\|null\\.$#"
+			count: 1
+			path: src/Core/Framework/Demodata/Generator/CategoryGenerator.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\Framework\\\\Demodata\\\\Generator\\\\CustomFieldGenerator\\:\\:\\$attributeSets has no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/Demodata/Generator/CustomFieldGenerator.php
+
+		-
+			message: "#^Parameter \\#1 \\$max of method Symfony\\\\Component\\\\Console\\\\Style\\\\SymfonyStyle\\:\\:progressStart\\(\\) expects int, float\\|int\\<1, max\\> given\\.$#"
+			count: 1
+			path: src/Core/Framework/Demodata/Generator/CustomFieldGenerator.php
+
+		-
+			message: "#^Offset 'attributes' does not exist on array\\|null\\.$#"
+			count: 1
+			path: src/Core/Framework/Demodata/Generator/CustomFieldGenerator.php
+
+		-
+			message: "#^Binary operation \"\\.\" between string and array\\|string results in an error\\.$#"
+			count: 1
+			path: src/Core/Framework/Demodata/Generator/CustomFieldGenerator.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Demodata\\\\Generator\\\\CustomFieldGenerator\\:\\:generateCustomFields\\(\\) has parameter \\$count with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/Demodata/Generator/CustomFieldGenerator.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Demodata\\\\Generator\\\\CustomFieldGenerator\\:\\:generateCustomFields\\(\\) has parameter \\$entityName with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/Demodata/Generator/CustomFieldGenerator.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Demodata\\\\Generator\\\\CustomFieldGenerator\\:\\:randomCustomFieldValue\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/Demodata/Generator/CustomFieldGenerator.php
+
+		-
+			message: "#^Parameter \\#3 \\.\\.\\.\\$args of function sprintf expects bool\\|float\\|int\\|string\\|null, array\\|string given\\.$#"
+			count: 1
+			path: src/Core/Framework/Demodata/Generator/MailHeaderFooterGenerator.php
+
+		-
+			message: "#^Parameter \\#3 \\.\\.\\.\\$args of function sprintf expects bool\\|float\\|int\\|string\\|null, array\\|string given\\.$#"
+			count: 1
+			path: src/Core/Framework/Demodata/Generator/MailTemplateGenerator.php
+
+		-
+			message: "#^Parameter \\#2 \\$mimeType of class Shopware\\\\Core\\\\Content\\\\Media\\\\File\\\\MediaFile constructor expects string, string\\|false given\\.$#"
+			count: 1
+			path: src/Core/Framework/Demodata/Generator/MediaGenerator.php
+
+		-
+			message: "#^Parameter \\#4 \\$fileSize of class Shopware\\\\Core\\\\Content\\\\Media\\\\File\\\\MediaFile constructor expects int, int\\|false given\\.$#"
+			count: 1
+			path: src/Core/Framework/Demodata/Generator/MediaGenerator.php
+
+		-
+			message: "#^Cannot call method getId\\(\\) on Shopware\\\\Core\\\\Content\\\\Media\\\\Aggregate\\\\MediaFolder\\\\MediaFolderEntity\\|null\\.$#"
+			count: 1
+			path: src/Core/Framework/Demodata/Generator/MediaGenerator.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Demodata\\\\Generator\\\\ProductGenerator\\:\\:getTaxes\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/Demodata/Generator/ProductGenerator.php
+
+		-
+			message: "#^Parameter \\#3 \\.\\.\\.\\$args of function sprintf expects bool\\|float\\|int\\|string\\|null, array\\|string given\\.$#"
+			count: 1
+			path: src/Core/Framework/Demodata/Generator/ProductGenerator.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Demodata\\\\Generator\\\\ProductGenerator\\:\\:getProperties\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/Demodata/Generator/ProductGenerator.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Demodata\\\\Generator\\\\ProductGenerator\\:\\:buildVisibilities\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/Demodata/Generator/ProductGenerator.php
+
+		-
+			message: "#^Parameter \\#1 \\$name of method Symfony\\\\Component\\\\Console\\\\Command\\\\Command\\:\\:setName\\(\\) expects string, string\\|null given\\.$#"
+			count: 1
+			path: src/Core/Framework/Demodata/PersonalData/CleanPersonalDataCommand.php
+
+		-
+			message: "#^Cannot cast array\\<string\\>\\|bool\\|string\\|null to int\\.$#"
+			count: 1
+			path: src/Core/Framework/Demodata/PersonalData/CleanPersonalDataCommand.php
+
+		-
+			message: "#^Binary operation \"\\.\" between 'Personal data for ' and array\\<string\\>\\|string\\|null results in an error\\.$#"
+			count: 1
+			path: src/Core/Framework/Demodata/PersonalData/CleanPersonalDataCommand.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DependencyInjection\\\\CompilerPass\\\\ActionEventCompilerPass\\:\\:getReflectionClass\\(\\) return type with generic class ReflectionClass does not specify its types\\: T$#"
+			count: 1
+			path: src/Core/Framework/DependencyInjection/CompilerPass/ActionEventCompilerPass.php
+
+		-
+			message: "#^Parameter \\#1 \\$input of method Doctrine\\\\Common\\\\Annotations\\\\DocParser\\:\\:parse\\(\\) expects string, string\\|false given\\.$#"
+			count: 1
+			path: src/Core/Framework/DependencyInjection/CompilerPass/ActionEventCompilerPass.php
+
+		-
+			message: "#^Cannot call method variableNode\\(\\) on Symfony\\\\Component\\\\Config\\\\Definition\\\\Builder\\\\NodeParentInterface\\|null\\.$#"
+			count: 1
+			path: src/Core/Framework/DependencyInjection/Configuration.php
+
+		-
+			message: "#^Cannot call method scalarNode\\(\\) on Symfony\\\\Component\\\\Config\\\\Definition\\\\Builder\\\\NodeParentInterface\\|null\\.$#"
+			count: 2
+			path: src/Core/Framework/DependencyInjection/Configuration.php
+
+		-
+			message: "#^Cannot call method integerNode\\(\\) on Symfony\\\\Component\\\\Config\\\\Definition\\\\Builder\\\\NodeParentInterface\\|null\\.$#"
+			count: 1
+			path: src/Core/Framework/DependencyInjection/Configuration.php
+
+		-
+			message: "#^Cannot call method end\\(\\) on Symfony\\\\Component\\\\Config\\\\Definition\\\\Builder\\\\NodeParentInterface\\|null\\.$#"
+			count: 5
+			path: src/Core/Framework/DependencyInjection/Configuration.php
+
+		-
+			message: "#^Cannot call method booleanNode\\(\\) on Symfony\\\\Component\\\\Config\\\\Definition\\\\Builder\\\\NodeParentInterface\\|null\\.$#"
+			count: 1
+			path: src/Core/Framework/DependencyInjection/Configuration.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\Framework\\\\Event\\\\BusinessEventRegistry\\:\\:\\$rawEventData has no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/Event/BusinessEventRegistry.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Feature\\:\\:ifActiveCall\\(\\) has parameter \\$arguments with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/Feature.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Feature\\:\\:ifActiveCall\\(\\) has parameter \\$object with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/Feature.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Framework\\:\\:buildConfig\\(\\) has parameter \\$environment with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/Framework.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\MessageQueue\\\\EncryptedBus\\:\\:__construct\\(\\) has parameter \\$publicKey with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/MessageQueue/EncryptedBus.php
+
+		-
+			message: "#^Parameter \\#3 \\$key of function openssl_public_encrypt expects resource\\|string, resource\\|false given\\.$#"
+			count: 1
+			path: src/Core/Framework/MessageQueue/EncryptedBus.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\MessageQueue\\\\Handler\\\\AbstractMessageHandler\\:\\:__invoke\\(\\) has parameter \\$message with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/MessageQueue/Handler/AbstractMessageHandler.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\MessageQueue\\\\Handler\\\\AbstractMessageHandler\\:\\:handle\\(\\) has parameter \\$message with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/MessageQueue/Handler/AbstractMessageHandler.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\MessageQueue\\\\Handler\\\\EncryptedMessageHandler\\:\\:__construct\\(\\) has parameter \\$privateKey with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/MessageQueue/Handler/EncryptedMessageHandler.php
+
+		-
+			message: "#^Parameter \\#2 \\$passphrase of function openssl_pkey_get_private expects string, string\\|null given\\.$#"
+			count: 1
+			path: src/Core/Framework/MessageQueue/Handler/EncryptedMessageHandler.php
+
+		-
+			message: "#^Parameter \\#3 \\$key of function openssl_private_decrypt expects array\\|resource\\|string, resource\\|false given\\.$#"
+			count: 1
+			path: src/Core/Framework/MessageQueue/Handler/EncryptedMessageHandler.php
+
+		-
+			message: "#^Parameter \\#1 \\$memoryLimit of method Shopware\\\\Core\\\\Framework\\\\MessageQueue\\\\ScheduledTask\\\\Command\\\\ScheduledTaskRunner\\:\\:convertToBytes\\(\\) expects string, \\(array\\<string\\>\\)\\|string\\|true given\\.$#"
+			count: 1
+			path: src/Core/Framework/MessageQueue/ScheduledTask/Command/ScheduledTaskRunner.php
+
+		-
+			message: "#^Parameter \\#2 \\.\\.\\.\\$args of function sprintf expects bool\\|float\\|int\\|string\\|null, array\\<string\\>\\|bool\\|string\\|null given\\.$#"
+			count: 2
+			path: src/Core/Framework/MessageQueue/ScheduledTask/Command/ScheduledTaskRunner.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\MessageQueue\\\\ScheduledTask\\\\MessageQueue\\\\RegisterScheduledTaskHandler\\:\\:handle\\(\\) has parameter \\$message with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/MessageQueue/ScheduledTask/MessageQueue/RegisterScheduledTaskHandler.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\Framework\\\\MessageQueue\\\\Subscriber\\\\CountHandledMessagesListener\\:\\:\\$handledMessages has no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/MessageQueue/Subscriber/CountHandledMessagesListener.php
+
+		-
+			message: "#^Cannot cast array\\<string\\>\\|string\\|null to string\\.$#"
+			count: 2
+			path: src/Core/Framework/Migration/Command/CreateMigrationCommand.php
+
+		-
+			message: "#^Parameter \\#2 \\$subject of function preg_match expects string, array\\<string\\>\\|bool\\|string given\\.$#"
+			count: 1
+			path: src/Core/Framework/Migration/Command/CreateMigrationCommand.php
+
+		-
+			message: "#^Parameter \\#1 \\$name of method Shopware\\\\Core\\\\Framework\\\\Migration\\\\Command\\\\CreateMigrationCommand\\:\\:createMigrationFile\\(\\) expects string, array\\<string\\>\\|bool\\|string given\\.$#"
+			count: 2
+			path: src/Core/Framework/Migration/Command/CreateMigrationCommand.php
+
+		-
+			message: "#^Parameter \\#3 \\$directory of method Shopware\\\\Core\\\\Framework\\\\Migration\\\\Command\\\\CreateMigrationCommand\\:\\:createMigrationFile\\(\\) expects string, string\\|false given\\.$#"
+			count: 1
+			path: src/Core/Framework/Migration/Command/CreateMigrationCommand.php
+
+		-
+			message: "#^Parameter \\#2 \\$needle of function mb_strpos expects string, \\(array\\<string\\>\\)\\|string\\|true given\\.$#"
+			count: 1
+			path: src/Core/Framework/Migration/Command/CreateMigrationCommand.php
+
+		-
+			message: "#^Parameter \\#2 \\.\\.\\.\\$args of function sprintf expects bool\\|float\\|int\\|string\\|null, \\(array\\<string\\>\\)\\|string\\|true given\\.$#"
+			count: 2
+			path: src/Core/Framework/Migration/Command/CreateMigrationCommand.php
+
+		-
+			message: "#^Parameter \\#1 \\$fp of function fwrite expects resource, resource\\|false given\\.$#"
+			count: 1
+			path: src/Core/Framework/Migration/Command/CreateMigrationCommand.php
+
+		-
+			message: "#^Parameter \\#3 \\$subject of function str_replace expects array\\|string, string\\|false given\\.$#"
+			count: 1
+			path: src/Core/Framework/Migration/Command/CreateMigrationCommand.php
+
+		-
+			message: "#^Parameter \\#1 \\$fp of function fclose expects resource, resource\\|false given\\.$#"
+			count: 1
+			path: src/Core/Framework/Migration/Command/CreateMigrationCommand.php
+
+		-
+			message: "#^Cannot cast array\\<string\\>\\|bool\\|string\\|null to int\\.$#"
+			count: 2
+			path: src/Core/Framework/Migration/Command/MigrationCommand.php
+
+		-
+			message: "#^Parameter \\#1 \\$identifier of method Shopware\\\\Core\\\\Framework\\\\Migration\\\\Command\\\\MigrationCommand\\:\\:runMigrationForIdentifier\\(\\) expects string, string\\|null given\\.$#"
+			count: 1
+			path: src/Core/Framework/Migration/Command/MigrationCommand.php
+
+		-
+			message: "#^Parameter \\#1 \\$path of function basename expects string, array\\<string\\>\\|string\\|null given\\.$#"
+			count: 1
+			path: src/Core/Framework/Migration/Command/RefreshMigrationCommand.php
+
+		-
+			message: "#^Parameter \\#1 \\$filename of function file_exists expects string, array\\<string\\>\\|string\\|null given\\.$#"
+			count: 1
+			path: src/Core/Framework/Migration/Command/RefreshMigrationCommand.php
+
+		-
+			message: "#^Parameter \\#3 \\$subject of function str_replace expects array\\|string, array\\<string\\>\\|string\\|null given\\.$#"
+			count: 1
+			path: src/Core/Framework/Migration/Command/RefreshMigrationCommand.php
+
+		-
+			message: "#^Parameter \\#1 \\$path of method Shopware\\\\Core\\\\Framework\\\\Migration\\\\Command\\\\RefreshMigrationCommand\\:\\:updateMigrationFile\\(\\) expects string, array\\<string\\>\\|string\\|null given\\.$#"
+			count: 1
+			path: src/Core/Framework/Migration/Command/RefreshMigrationCommand.php
+
+		-
+			message: "#^Parameter \\#1 \\$old_name of function rename expects string, array\\<string\\>\\|string\\|null given\\.$#"
+			count: 1
+			path: src/Core/Framework/Migration/Command/RefreshMigrationCommand.php
+
+		-
+			message: "#^Parameter \\#2 \\$new_name of function rename expects string, array\\|string given\\.$#"
+			count: 1
+			path: src/Core/Framework/Migration/Command/RefreshMigrationCommand.php
+
+		-
+			message: "#^Parameter \\#3 \\$subject of function str_replace expects array\\|string, string\\|false given\\.$#"
+			count: 1
+			path: src/Core/Framework/Migration/Command/RefreshMigrationCommand.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Migration\\\\MigrationCollection\\:\\:getMigrationSteps\\(\\) should return array\\<Shopware\\\\Core\\\\Framework\\\\Migration\\\\MigrationStep\\> but returns array\\<Shopware\\\\Core\\\\Framework\\\\Migration\\\\MigrationStep\\>\\|null\\.$#"
+			count: 1
+			path: src/Core/Framework/Migration/MigrationCollection.php
+
+		-
+			message: "#^Argument of an invalid type array\\<int, string\\>\\|false supplied for foreach, only iterables are supported\\.$#"
+			count: 1
+			path: src/Core/Framework/Migration/MigrationCollection.php
+
+		-
+			message: "#^Cannot call method fetchAll\\(\\) on Doctrine\\\\DBAL\\\\Driver\\\\Statement\\|int\\.$#"
+			count: 2
+			path: src/Core/Framework/Migration/MigrationRuntime.php
+
+		-
+			message: "#^Parameter \\#1 \\$maxResults of method Doctrine\\\\DBAL\\\\Query\\\\QueryBuilder\\:\\:setMaxResults\\(\\) expects int, int\\<1, max\\>\\|null given\\.$#"
+			count: 1
+			path: src/Core/Framework/Migration/MigrationRuntime.php
+
+		-
+			message: "#^Parameter \\#1 \\$mimeType of class Shopware\\\\Core\\\\Framework\\\\Plugin\\\\Exception\\\\PluginNotAZipFileException constructor expects string, string\\|null given\\.$#"
+			count: 1
+			path: src/Core/Framework/Plugin/Api/PluginController.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Plugin\\\\Changelog\\\\ChangelogParser\\:\\:parseTitle\\(\\) has parameter \\$line with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/Plugin/Changelog/ChangelogParser.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Plugin\\\\Changelog\\\\ChangelogParser\\:\\:parseItem\\(\\) has parameter \\$line with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/Plugin/Changelog/ChangelogParser.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Plugin\\\\Changelog\\\\ChangelogService\\:\\:getLocaleFromChangelogFile\\(\\) has parameter \\$file with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/Plugin/Changelog/ChangelogService.php
+
+		-
+			message: "#^Parameter \\#1 \\$arguments of method Shopware\\\\Core\\\\Framework\\\\Plugin\\\\Command\\\\Lifecycle\\\\AbstractPluginLifecycleCommand\\:\\:parsePluginArgument\\(\\) expects array, array\\<string\\>\\|string\\|null given\\.$#"
+			count: 1
+			path: src/Core/Framework/Plugin/Command/Lifecycle/AbstractPluginLifecycleCommand.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\Framework\\\\Plugin\\\\Command\\\\PluginCreateCommand\\:\\:\\$composerTemplate has no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/Plugin/Command/PluginCreateCommand.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\Framework\\\\Plugin\\\\Command\\\\PluginCreateCommand\\:\\:\\$bootstrapTemplate has no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/Plugin/Command/PluginCreateCommand.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\Framework\\\\Plugin\\\\Command\\\\PluginCreateCommand\\:\\:\\$servicesXmlTemplate has no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/Plugin/Command/PluginCreateCommand.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\Framework\\\\Plugin\\\\Command\\\\PluginCreateCommand\\:\\:\\$configXmlTemplate has no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/Plugin/Command/PluginCreateCommand.php
+
+		-
+			message: "#^Parameter \\#2 \\.\\.\\.\\$args of function sprintf expects bool\\|float\\|int\\|string\\|null, \\(array\\<string\\>\\)\\|string\\|true given\\.$#"
+			count: 1
+			path: src/Core/Framework/Plugin/Command/PluginListCommand.php
+
+		-
+			message: "#^Parameter \\#1 \\$file of method Shopware\\\\Core\\\\Framework\\\\Plugin\\\\PluginManagementService\\:\\:extractPluginZip\\(\\) expects string, array\\<string\\>\\|string\\|null given\\.$#"
+			count: 1
+			path: src/Core/Framework/Plugin/Command/PluginZipImportCommand.php
+
+		-
+			message: "#^Parameter \\#1 \\$path of function basename expects string, array\\<string\\>\\|string\\|null given\\.$#"
+			count: 1
+			path: src/Core/Framework/Plugin/Command/PluginZipImportCommand.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\Framework\\\\Plugin\\\\Context\\\\InstallContext\\:\\:\\$autoMigrate has no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/Plugin/Context/InstallContext.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Plugin\\\\KernelPluginLoader\\\\KernelPluginLoader\\:\\:getBundles\\(\\) has parameter \\$kernelParameters with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/Plugin/KernelPluginLoader/KernelPluginLoader.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Plugin\\\\KernelPluginLoader\\\\KernelPluginLoader\\:\\:getPluginInstance\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/Plugin/KernelPluginLoader/KernelPluginLoader.php
+
+		-
+			message: "#^Cannot access offset 'name' on array\\|false\\.$#"
+			count: 3
+			path: src/Core/Framework/Plugin/PluginExtractor.php
+
+		-
+			message: "#^Parameter \\#1 \\$pluginComposerName of method Shopware\\\\Core\\\\Framework\\\\Plugin\\\\Composer\\\\CommandExecutor\\:\\:require\\(\\) expects string, string\\|null given\\.$#"
+			count: 2
+			path: src/Core/Framework/Plugin/PluginLifecycleService.php
+
+		-
+			message: "#^Parameter \\#2 \\$prefix of function tempnam expects string, string\\|null given\\.$#"
+			count: 1
+			path: src/Core/Framework/Plugin/PluginManagementService.php
+
+		-
+			message: "#^Parameter \\#1 \\$path of function dirname expects string, string\\|false given\\.$#"
+			count: 1
+			path: src/Core/Framework/Plugin/PluginManagementService.php
+
+		-
+			message: "#^Parameter \\#1 \\$path of function realpath expects string, string\\|false given\\.$#"
+			count: 1
+			path: src/Core/Framework/Plugin/PluginManagementService.php
+
+		-
+			message: "#^Parameter \\#2 \\$name of method Symfony\\\\Component\\\\HttpFoundation\\\\File\\\\UploadedFile\\:\\:move\\(\\) expects string\\|null, string\\|false given\\.$#"
+			count: 1
+			path: src/Core/Framework/Plugin/PluginManagementService.php
+
+		-
+			message: "#^Parameter \\#1 \\$file of method Shopware\\\\Core\\\\Framework\\\\Plugin\\\\PluginManagementService\\:\\:extractPluginZip\\(\\) expects string, string\\|false given\\.$#"
+			count: 1
+			path: src/Core/Framework/Plugin/PluginManagementService.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Plugin\\\\PluginService\\:\\:getPluginIconRaw\\(\\) should return string\\|null but returns string\\|false\\.$#"
+			count: 1
+			path: src/Core/Framework/Plugin/PluginService.php
+
+		-
+			message: "#^Cannot access offset 'name' on array\\|false\\.$#"
+			count: 1
+			path: src/Core/Framework/Plugin/PluginZipDetector.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\Framework\\\\Plugin\\\\Requirement\\\\RequirementExceptionStack\\:\\:\\$exceptions has no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/Plugin/Requirement/RequirementExceptionStack.php
+
+		-
+			message: "#^Parameter \\#1 \\$str of function base64_encode expects string, string\\|null given\\.$#"
+			count: 1
+			path: src/Core/Framework/Plugin/Subscriber/PluginLoadedSubscriber.php
+
+		-
+			message: "#^Parameter \\#2 \\$resource of method League\\\\Flysystem\\\\FilesystemInterface\\:\\:putStream\\(\\) expects resource, resource\\|false given\\.$#"
+			count: 1
+			path: src/Core/Framework/Plugin/Util/AssetService.php
+
+		-
+			message: "#^Parameter \\#1 \\$pluginPath of method Shopware\\\\Core\\\\Framework\\\\Plugin\\\\Composer\\\\PackageProvider\\:\\:getPluginComposerPackage\\(\\) expects string, string\\|false given\\.$#"
+			count: 1
+			path: src/Core/Framework/Plugin/Util/PluginFinder.php
+
+		-
+			message: "#^Parameter \\#1 \\$pluginPath of method Shopware\\\\Core\\\\Framework\\\\Plugin\\\\Util\\\\PluginFinder\\:\\:addError\\(\\) expects string, string\\|false given\\.$#"
+			count: 1
+			path: src/Core/Framework/Plugin/Util/PluginFinder.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Plugin\\\\Util\\\\PluginIdProvider\\:\\:getPluginIdByBaseClass\\(\\) should return string but returns array\\|string\\|null\\.$#"
+			count: 1
+			path: src/Core/Framework/Plugin/Util/PluginIdProvider.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Plugin\\\\Util\\\\VersionSanitizer\\:\\:sanitizePluginVersion\\(\\) should return string but returns string\\|null\\.$#"
+			count: 1
+			path: src/Core/Framework/Plugin/Util/VersionSanitizer.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Routing\\\\ApiRequestContextResolver\\:\\:getContextParameters\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/Routing/ApiRequestContextResolver.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Routing\\\\ApiRequestContextResolver\\:\\:getParentLanguageId\\(\\) has parameter \\$languageId with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/Routing/ApiRequestContextResolver.php
+
+		-
+			message: "#^Cannot call method fetchAll\\(\\) on Doctrine\\\\DBAL\\\\Driver\\\\Statement\\|int\\.$#"
+			count: 2
+			path: src/Core/Framework/Routing/ApiRequestContextResolver.php
+
+		-
+			message: "#^Cannot call method fetchColumn\\(\\) on Doctrine\\\\DBAL\\\\Driver\\\\Statement\\|int\\.$#"
+			count: 3
+			path: src/Core/Framework/Routing/ApiRequestContextResolver.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Routing\\\\CoreSubscriber\\:\\:__construct\\(\\) has parameter \\$cspTemplates with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/Routing/CoreSubscriber.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Routing\\\\Exception\\\\LanguageNotFoundException\\:\\:__construct\\(\\) has parameter \\$languageId with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/Routing/Exception/LanguageNotFoundException.php
+
+		-
+			message: "#^Yield can be used only with these return types\\: Generator, Iterator, Traversable, iterable\\.$#"
+			count: 1
+			path: src/Core/Framework/Routing/QueryDataBagResolver.php
+
+		-
+			message: "#^Yield can be used only with these return types\\: Generator, Iterator, Traversable, iterable\\.$#"
+			count: 1
+			path: src/Core/Framework/Routing/RequestDataBagResolver.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\Framework\\\\Routing\\\\RouteScopeListener\\:\\:\\$whitelists \\(array\\<Shopware\\\\Core\\\\Framework\\\\Routing\\\\RouteScopeWhitelistInterface\\>\\) does not accept iterable\\.$#"
+			count: 1
+			path: src/Core/Framework/Routing/RouteScopeListener.php
+
+		-
+			message: "#^Parameter \\#1 \\$object of function get_class expects object, object\\|null given\\.$#"
+			count: 1
+			path: src/Core/Framework/Routing/RouteScopeListener.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Routing\\\\RouteScopeListener\\:\\:extractControllerClass\\(\\) should return string but returns class\\-string\\|false\\.$#"
+			count: 1
+			path: src/Core/Framework/Routing/RouteScopeListener.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\Framework\\\\Routing\\\\RouteScopeRegistry\\:\\:\\$routeScopes \\(array\\<Shopware\\\\Core\\\\Framework\\\\Routing\\\\AbstractRouteScope\\>\\) does not accept iterable\\.$#"
+			count: 1
+			path: src/Core/Framework/Routing/RouteScopeRegistry.php
+
+		-
+			message: "#^Parameter \\#2 \\$token of method Shopware\\\\Core\\\\System\\\\SalesChannel\\\\Context\\\\SalesChannelContextServiceInterface\\:\\:get\\(\\) expects string, string\\|null given\\.$#"
+			count: 1
+			path: src/Core/Framework/Routing/SalesChannelRequestContextResolver.php
+
+		-
+			message: "#^Cannot call method match\\(\\) on Shopware\\\\Core\\\\Framework\\\\Rule\\\\Rule\\|null\\.$#"
+			count: 1
+			path: src/Core/Framework/Rule/Container/NotRule.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Rule\\\\RuleCollection\\:\\:set\\(\\) has parameter \\$key with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/Rule/RuleCollection.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Rule\\\\RuleCollection\\:\\:set\\(\\) has parameter \\$rule with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/Rule/RuleCollection.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Rule\\\\RuleCollection\\:\\:has\\(\\) has parameter \\$class with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/Rule/RuleCollection.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\Framework\\\\Rule\\\\SalesChannelRule\\:\\:\\$salesChannelIds \\(array\\<string\\>\\) does not accept array\\|null\\.$#"
+			count: 1
+			path: src/Core/Framework/Rule/SalesChannelRule.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\Framework\\\\Rule\\\\WeekdayRule\\:\\:\\$dayOfWeek \\(int\\) does not accept int\\|null\\.$#"
+			count: 1
+			path: src/Core/Framework/Rule/WeekdayRule.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\ShopwareHttpException\\:\\:parse\\(\\) should return string but returns string\\|null\\.$#"
+			count: 1
+			path: src/Core/Framework/ShopwareHttpException.php
+
+		-
+			message: "#^Parameter \\#4 \\$userId of method Shopware\\\\Core\\\\Framework\\\\Store\\\\Services\\\\FirstRunWizardClient\\:\\:frwLogin\\(\\) expects string, string\\|null given\\.$#"
+			count: 1
+			path: src/Core/Framework/Store/Api/FirstRunWizardController.php
+
+		-
+			message: "#^Cannot call method getShopUserToken\\(\\) on Shopware\\\\Core\\\\Framework\\\\Store\\\\Struct\\\\AccessTokenStruct\\|null\\.$#"
+			count: 1
+			path: src/Core/Framework/Store/Api/FirstRunWizardController.php
+
+		-
+			message: "#^Cannot call method getStoreToken\\(\\) on Shopware\\\\Core\\\\System\\\\User\\\\UserEntity\\|null\\.$#"
+			count: 2
+			path: src/Core/Framework/Store/Api/FirstRunWizardController.php
+
+		-
+			message: "#^Cannot call method getStoreToken\\(\\) on Shopware\\\\Core\\\\System\\\\User\\\\UserEntity\\|null\\.$#"
+			count: 2
+			path: src/Core/Framework/Store/Api/StoreController.php
+
+		-
+			message: "#^Parameter \\#2 \\$user of method Shopware\\\\Core\\\\Framework\\\\Store\\\\Command\\\\StoreDownloadCommand\\:\\:getUserStoreToken\\(\\) expects string, array\\<string\\>\\|bool\\|string\\|null given\\.$#"
+			count: 1
+			path: src/Core/Framework/Store/Command/StoreDownloadCommand.php
+
+		-
+			message: "#^Parameter \\#1 \\$pluginName of method Shopware\\\\Core\\\\Framework\\\\Store\\\\Services\\\\StoreClient\\:\\:getDownloadDataForPlugin\\(\\) expects string, array\\<string\\>\\|bool\\|string\\|null given\\.$#"
+			count: 1
+			path: src/Core/Framework/Store/Command/StoreDownloadCommand.php
+
+		-
+			message: "#^Parameter \\#3 \\$language of method Shopware\\\\Core\\\\Framework\\\\Store\\\\Services\\\\StoreClient\\:\\:getDownloadDataForPlugin\\(\\) expects string, array\\<string\\>\\|bool\\|string\\|null given\\.$#"
+			count: 1
+			path: src/Core/Framework/Store/Command/StoreDownloadCommand.php
+
+		-
+			message: "#^Cannot call method getStoreToken\\(\\) on Shopware\\\\Core\\\\System\\\\User\\\\UserEntity\\|null\\.$#"
+			count: 2
+			path: src/Core/Framework/Store/Command/StoreDownloadCommand.php
+
+		-
+			message: "#^Parameter \\#1 \\$shopwareId of method Shopware\\\\Core\\\\Framework\\\\Store\\\\Services\\\\StoreClient\\:\\:loginWithShopwareId\\(\\) expects string, array\\<string\\>\\|bool\\|string given\\.$#"
+			count: 1
+			path: src/Core/Framework/Store/Command/StoreLoginCommand.php
+
+		-
+			message: "#^Parameter \\#2 \\$password of method Shopware\\\\Core\\\\Framework\\\\Store\\\\Services\\\\StoreClient\\:\\:loginWithShopwareId\\(\\) expects string, array\\<string\\>\\|bool\\|string given\\.$#"
+			count: 1
+			path: src/Core/Framework/Store/Command/StoreLoginCommand.php
+
+		-
+			message: "#^Parameter \\#3 \\$language of method Shopware\\\\Core\\\\Framework\\\\Store\\\\Services\\\\StoreClient\\:\\:loginWithShopwareId\\(\\) expects string, array\\<string\\>\\|bool\\|string\\|null given\\.$#"
+			count: 1
+			path: src/Core/Framework/Store/Command/StoreLoginCommand.php
+
+		-
+			message: "#^Cannot call method getBody\\(\\) on Psr\\\\Http\\\\Message\\\\ResponseInterface\\|null\\.$#"
+			count: 1
+			path: src/Core/Framework/Store/Exception/StoreApiException.php
+
+		-
+			message: "#^Cannot call method format\\(\\) on DateTimeImmutable\\|null\\.$#"
+			count: 2
+			path: src/Core/Framework/Store/Services/FirstRunWizardClient.php
+
+		-
+			message: "#^Parameter \\#2 \\$signature of function openssl_verify expects string, string\\|false given\\.$#"
+			count: 1
+			path: src/Core/Framework/Store/Services/OpenSSLVerifier.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Store\\\\Services\\\\OpenSSLVerifier\\:\\:getKeyResource\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/Store/Services/OpenSSLVerifier.php
+
+		-
+			message: "#^Parameter \\#1 \\$str of function trim expects string, string\\|false given\\.$#"
+			count: 1
+			path: src/Core/Framework/Store/Services/OpenSSLVerifier.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\Framework\\\\Store\\\\Services\\\\OpenSSLVerifier\\:\\:\\$keyResource \\(resource\\) does not accept resource\\|false\\.$#"
+			count: 1
+			path: src/Core/Framework/Store/Services/OpenSSLVerifier.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Store\\\\Struct\\\\LicenseDomainCollection\\:\\:add\\(\\) has parameter \\$element with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/Store/Struct/LicenseDomainCollection.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Store\\\\Struct\\\\LicenseDomainCollection\\:\\:set\\(\\) has parameter \\$element with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/Store/Struct/LicenseDomainCollection.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Store\\\\Struct\\\\LicenseDomainCollection\\:\\:set\\(\\) has parameter \\$key with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/Store/Struct/LicenseDomainCollection.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Store\\\\Struct\\\\PluginRecommendationCollection\\:\\:add\\(\\) has parameter \\$element with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/Store/Struct/PluginRecommendationCollection.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Store\\\\Struct\\\\PluginRecommendationCollection\\:\\:set\\(\\) has parameter \\$element with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/Store/Struct/PluginRecommendationCollection.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Store\\\\Struct\\\\PluginRecommendationCollection\\:\\:set\\(\\) has parameter \\$key with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/Store/Struct/PluginRecommendationCollection.php
+
+		-
+			message: "#^Class Shopware\\\\Core\\\\Framework\\\\Struct\\\\ArrayEntity implements generic interface ArrayAccess but does not specify its types\\: TKey, TValue$#"
+			count: 1
+			path: src/Core/Framework/Struct/ArrayEntity.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Struct\\\\ArrayEntity\\:\\:offsetExists\\(\\) has parameter \\$offset with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/Struct/ArrayEntity.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Struct\\\\ArrayEntity\\:\\:offsetGet\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/Struct/ArrayEntity.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Struct\\\\ArrayEntity\\:\\:offsetGet\\(\\) has parameter \\$offset with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/Struct/ArrayEntity.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Struct\\\\ArrayEntity\\:\\:offsetSet\\(\\) has parameter \\$offset with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/Struct/ArrayEntity.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Struct\\\\ArrayEntity\\:\\:offsetSet\\(\\) has parameter \\$value with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/Struct/ArrayEntity.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Struct\\\\ArrayEntity\\:\\:offsetUnset\\(\\) has parameter \\$offset with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/Struct/ArrayEntity.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Struct\\\\ArrayEntity\\:\\:get\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/Struct/ArrayEntity.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Struct\\\\ArrayEntity\\:\\:set\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/Struct/ArrayEntity.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Struct\\\\ArrayEntity\\:\\:set\\(\\) has parameter \\$key with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/Struct/ArrayEntity.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Struct\\\\ArrayEntity\\:\\:set\\(\\) has parameter \\$value with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/Struct/ArrayEntity.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Struct\\\\ArrayEntity\\:\\:all\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/Struct/ArrayEntity.php
+
+		-
+			message: "#^Class Shopware\\\\Core\\\\Framework\\\\Struct\\\\ArrayStruct implements generic interface ArrayAccess but does not specify its types\\: TKey, TValue$#"
+			count: 1
+			path: src/Core/Framework/Struct/ArrayStruct.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Struct\\\\ArrayStruct\\:\\:offsetExists\\(\\) has parameter \\$offset with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/Struct/ArrayStruct.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Struct\\\\ArrayStruct\\:\\:offsetGet\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/Struct/ArrayStruct.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Struct\\\\ArrayStruct\\:\\:offsetGet\\(\\) has parameter \\$offset with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/Struct/ArrayStruct.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Struct\\\\ArrayStruct\\:\\:offsetSet\\(\\) has parameter \\$offset with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/Struct/ArrayStruct.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Struct\\\\ArrayStruct\\:\\:offsetSet\\(\\) has parameter \\$value with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/Struct/ArrayStruct.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Struct\\\\ArrayStruct\\:\\:offsetUnset\\(\\) has parameter \\$offset with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/Struct/ArrayStruct.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Struct\\\\ArrayStruct\\:\\:get\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/Struct/ArrayStruct.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Struct\\\\ArrayStruct\\:\\:all\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/Struct/ArrayStruct.php
+
+		-
+			message: "#^Class Shopware\\\\Core\\\\Framework\\\\Struct\\\\Collection implements generic interface IteratorAggregate but does not specify its types\\: TKey, TValue$#"
+			count: 1
+			path: src/Core/Framework/Struct/Collection.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Struct\\\\Collection\\:\\:add\\(\\) has parameter \\$element with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/Struct/Collection.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Struct\\\\Collection\\:\\:set\\(\\) has parameter \\$element with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/Struct/Collection.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Struct\\\\Collection\\:\\:set\\(\\) has parameter \\$key with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/Struct/Collection.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Struct\\\\Collection\\:\\:has\\(\\) has parameter \\$key with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/Struct/Collection.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Struct\\\\Collection\\:\\:reduce\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/Struct/Collection.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Struct\\\\Collection\\:\\:reduce\\(\\) has parameter \\$initial with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/Struct/Collection.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Struct\\\\Collection\\:\\:first\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/Struct/Collection.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Struct\\\\Collection\\:\\:last\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/Struct/Collection.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Struct\\\\Collection\\:\\:validateType\\(\\) has parameter \\$element with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/Struct/Collection.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Checkout\\\\Cart\\\\Error\\\\Error\\:\\:createFrom\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Checkout/Cart/Error/Error.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Content\\\\ProductExport\\\\Error\\\\Error\\:\\:createFrom\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Content/ProductExport/Error/Error.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Struct\\\\Struct\\:\\:createFrom\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/Struct/Struct.php
+
+		-
+			message: "#^Array \\(array\\<Shopware\\\\Core\\\\Framework\\\\Struct\\\\Struct\\>\\) does not accept Shopware\\\\Core\\\\Framework\\\\Struct\\\\Struct\\|null\\.$#"
+			count: 1
+			path: src/Core/Framework/Struct/Struct.php
+
+		-
+			message: "#^Parameter \\#1 \\$object of function get_class expects object, Shopware\\\\Core\\\\Framework\\\\Struct\\\\Struct\\|null given\\.$#"
+			count: 1
+			path: src/Core/Framework/Struct/Struct.php
+
+		-
+			message: "#^Parameter \\#1 \\$str of function mb_strtolower expects string, string\\|null given\\.$#"
+			count: 1
+			path: src/Core/Framework/Struct/Struct.php
+
+		-
+			message: "#^Array \\(array\\<Shopware\\\\Core\\\\Framework\\\\Struct\\\\Struct\\>\\) does not accept Shopware\\\\Core\\\\Framework\\\\Struct\\\\Struct\\|null\\.$#"
+			count: 1
+			path: src/Core/Checkout/Document/Event/DocumentTemplateRendererParameterEvent.php
+
+		-
+			message: "#^Parameter \\#1 \\$object of function get_class expects object, Shopware\\\\Core\\\\Framework\\\\Struct\\\\Struct\\|null given\\.$#"
+			count: 1
+			path: src/Core/Checkout/Document/Event/DocumentTemplateRendererParameterEvent.php
+
+		-
+			message: "#^Array \\(array\\<Shopware\\\\Core\\\\Framework\\\\Struct\\\\Struct\\>\\) does not accept Shopware\\\\Core\\\\Framework\\\\Struct\\\\Struct\\|null\\.$#"
+			count: 1
+			path: src/Core/Checkout/Payment/Cart/SyncPaymentTransactionStruct.php
+
+		-
+			message: "#^Parameter \\#1 \\$object of function get_class expects object, Shopware\\\\Core\\\\Framework\\\\Struct\\\\Struct\\|null given\\.$#"
+			count: 1
+			path: src/Core/Checkout/Payment/Cart/SyncPaymentTransactionStruct.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Struct\\\\Serializer\\\\StructDecoder\\:\\:format\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/Struct/Serializer/StructDecoder.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Struct\\\\Serializer\\\\StructDecoder\\:\\:format\\(\\) has parameter \\$decoded with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/Struct/Serializer/StructDecoder.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\Framework\\\\Struct\\\\Serializer\\\\StructNormalizer\\:\\:\\$classes with generic class ReflectionClass does not specify its types\\: T$#"
+			count: 1
+			path: src/Core/Framework/Struct/Serializer/StructNormalizer.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Struct\\\\Serializer\\\\StructNormalizer\\:\\:normalize\\(\\) return type with generic class ArrayObject does not specify its types\\: TKey, TValue$#"
+			count: 1
+			path: src/Core/Framework/Struct/Serializer/StructNormalizer.php
+
+		-
+			message: "#^Parameter \\#1 \\$data of method Symfony\\\\Component\\\\Serializer\\\\Encoder\\\\JsonDecode\\:\\:decode\\(\\) expects string, bool\\|float\\|int\\|string given\\.$#"
+			count: 1
+			path: src/Core/Framework/Struct/Serializer/StructNormalizer.php
+
+		-
+			message: "#^Cannot call method getParameters\\(\\) on ReflectionMethod\\|null\\.$#"
+			count: 1
+			path: src/Core/Framework/Struct/Serializer/StructNormalizer.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Struct\\\\Serializer\\\\StructNormalizer\\:\\:getReflectionClass\\(\\) return type with generic class ReflectionClass does not specify its types\\: T$#"
+			count: 1
+			path: src/Core/Framework/Struct/Serializer/StructNormalizer.php
+
+		-
+			message: "#^Parameter \\#1 \\$argument of class ReflectionClass constructor expects class\\-string\\<T of object\\>\\|T of object, string given\\.$#"
+			count: 1
+			path: src/Core/Framework/Struct/Serializer/StructNormalizer.php
+
+		-
+			message: "#^Cannot call method getCode\\(\\) on Shopware\\\\Core\\\\System\\\\Locale\\\\LocaleEntity\\|null\\.$#"
+			count: 1
+			path: src/Core/Framework/Update/Api/UpdateController.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Update\\\\Api\\\\UpdateController\\:\\:createRecursiveFileIterator\\(\\) return type with generic class RecursiveIteratorIterator does not specify its types\\: T$#"
+			count: 1
+			path: src/Core/Framework/Update/Api/UpdateController.php
+
+		-
+			message: "#^Parameter \\#2 \\$version2 of function version_compare expects string, array\\|int\\|string given\\.$#"
+			count: 1
+			path: src/Core/Framework/Update/Checkers/MysqlVersionCheck.php
+
+		-
+			message: "#^Parameter \\#2 \\$version2 of function version_compare expects string, array\\|int\\|string given\\.$#"
+			count: 1
+			path: src/Core/Framework/Update/Checkers/PhpVersionCheck.php
+
+		-
+			message: "#^Argument of an invalid type array\\|int\\|string supplied for foreach, only iterables are supported\\.$#"
+			count: 1
+			path: src/Core/Framework/Update/Checkers/WriteableCheck.php
+
+		-
+			message: "#^Parameter \\#1 \\$str of function md5 expects string, string\\|false given\\.$#"
+			count: 1
+			path: src/Core/Framework/Update/Services/ApiClient.php
+
+		-
+			message: "#^Class Shopware\\\\Core\\\\Framework\\\\Update\\\\Services\\\\Archive\\\\Adapter implements generic interface SeekableIterator but does not specify its types\\: TKey, TValue$#"
+			count: 1
+			path: src/Core/Framework/Update/Services/Archive/Adapter.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\Framework\\\\Update\\\\Services\\\\Archive\\\\Entry\\\\Zip\\:\\:\\$name \\(string\\) does not accept string\\|false\\.$#"
+			count: 1
+			path: src/Core/Framework/Update/Services/Archive/Entry/Zip.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Update\\\\Services\\\\Archive\\\\Entry\\\\Zip\\:\\:getStream\\(\\) should return resource but returns resource\\|false\\.$#"
+			count: 1
+			path: src/Core/Framework/Update/Services/Archive/Entry/Zip.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Update\\\\Services\\\\Archive\\\\Entry\\\\Zip\\:\\:getContents\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/Update/Services/Archive/Entry/Zip.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Update\\\\Services\\\\Archive\\\\Zip\\:\\:getStream\\(\\) should return resource but returns resource\\|false\\.$#"
+			count: 1
+			path: src/Core/Framework/Update/Services/Archive/Zip.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Update\\\\Services\\\\Archive\\\\Zip\\:\\:getContents\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/Update/Services/Archive/Zip.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Update\\\\Services\\\\Archive\\\\Zip\\:\\:getEntry\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/Update/Services/Archive/Zip.php
+
+		-
+			message: "#^Cannot access property \\$query on Symfony\\\\Component\\\\HttpFoundation\\\\Request\\|null\\.$#"
+			count: 1
+			path: src/Core/Framework/Update/Services/PluginCompatibility.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\Framework\\\\Update\\\\Services\\\\RequirementsValidator\\:\\:\\$checkers \\(array\\<Shopware\\\\Core\\\\Framework\\\\Update\\\\Checkers\\\\CheckerInterface\\>\\) does not accept iterable\\.$#"
+			count: 1
+			path: src/Core/Framework/Update/Services/RequirementsValidator.php
+
+		-
+			message: "#^Parameter \\#1 \\$haystack of function strpos expects string, string\\|false given\\.$#"
+			count: 2
+			path: src/Core/Framework/Update/Services/UpdateHtaccess.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Update\\\\Steps\\\\UnpackStep\\:\\:__construct\\(\\) has parameter \\$destinationDir with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/Update/Steps/UnpackStep.php
+
+		-
+			message: "#^Parameter \\#1 \\$str of function mb_substr expects string, string\\|false given\\.$#"
+			count: 2
+			path: src/Core/Framework/Util/ArrayNormalizer.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Util\\\\Random\\:\\:getRandomArrayElement\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/Util/Random.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Util\\\\XmlReader\\:\\:parseOptionsNodeList\\(\\) has parameter \\$optionsList with generic class DOMNodeList but does not specify its types\\: TNode$#"
+			count: 1
+			path: src/Core/Framework/Util/XmlReader.php
+
+		-
+			message: "#^Cannot access property \\$childNodes on DOMNode\\|null\\.$#"
+			count: 1
+			path: src/Core/Framework/Util/XmlReader.php
+
+		-
+			message: "#^Cannot access property \\$nodeValue on DOMElement\\|null\\.$#"
+			count: 1
+			path: src/Core/Framework/Util/XmlReader.php
+
+		-
+			message: "#^Parameter \\#1 \\$clockSeqHi of static method Shopware\\\\Core\\\\Framework\\\\Uuid\\\\Uuid\\:\\:applyVariant\\(\\) expects int, float\\|int given\\.$#"
+			count: 1
+			path: src/Core/Framework/Uuid/Uuid.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Uuid\\\\Uuid\\:\\:randomBytes\\(\\) should return string but returns string\\|false\\.$#"
+			count: 1
+			path: src/Core/Framework/Uuid/Uuid.php
+
+		-
+			message: "#^Trying to invoke string but it might not be a callable\\.$#"
+			count: 2
+			path: src/Core/Framework/Validation/Constraint/ArrayOfTypeValidator.php
+
+		-
+			message: "#^Parameter \\#1 \\$errorCode of static method Symfony\\\\Component\\\\Validator\\\\Constraint\\:\\:getErrorName\\(\\) expects string, string\\|null given\\.$#"
+			count: 1
+			path: src/Core/Framework/Validation/Exception/ConstraintViolationException.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Webhook\\\\BusinessEventEncoder\\:\\:encodeProperty\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/Webhook/BusinessEventEncoder.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Webhook\\\\BusinessEventEncoder\\:\\:encodeProperty\\(\\) has parameter \\$property with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/Webhook/BusinessEventEncoder.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Webhook\\\\BusinessEventEncoder\\:\\:getProperty\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/Webhook/BusinessEventEncoder.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Webhook\\\\Hookable\\\\HookableEventFactory\\:\\:createHookablesFor\\(\\) has parameter \\$event with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/Webhook/Hookable/HookableEventFactory.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Webhook\\\\WebhookCollection\\:\\:filterForEvent\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Framework/Webhook/WebhookCollection.php
+
+		-
+			message: "#^Cannot call method getAclRoleId\\(\\) on Shopware\\\\Core\\\\Framework\\\\App\\\\AppEntity\\|null\\.$#"
+			count: 1
+			path: src/Core/Framework/Webhook/WebhookCollection.php
+
+		-
+			message: "#^Cannot call method getAclRoleId\\(\\) on Shopware\\\\Core\\\\Framework\\\\App\\\\AppEntity\\|null\\.$#"
+			count: 1
+			path: src/Core/Framework/Webhook/WebhookDispatcher.php
+
+		-
+			message: "#^Parameter \\#1 \\$appId of method Shopware\\\\Core\\\\Framework\\\\Webhook\\\\Hookable\\:\\:isAllowed\\(\\) expects string, string\\|null given\\.$#"
+			count: 1
+			path: src/Core/Framework/Webhook/WebhookDispatcher.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\HttpKernel\\:\\:handle\\(\\) has parameter \\$catch with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/HttpKernel.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\HttpKernel\\:\\:handle\\(\\) has parameter \\$type with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/HttpKernel.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\HttpKernel\\:\\:getProjectDir\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/HttpKernel.php
+
+		-
+			message: "#^Parameter \\#1 \\$filename of function file_exists expects string, string\\|false given\\.$#"
+			count: 1
+			path: src/Core/HttpKernel.php
+
+		-
+			message: "#^Parameter \\#1 \\$path of function dirname expects string, string\\|false given\\.$#"
+			count: 1
+			path: src/Core/HttpKernel.php
+
+		-
+			message: "#^Cannot call method getBundles\\(\\) on Shopware\\\\Core\\\\Framework\\\\Plugin\\\\KernelPluginLoader\\\\KernelPluginLoader\\|null\\.$#"
+			count: 1
+			path: src/Core/Kernel.php
+
+		-
+			message: "#^Cannot call method initializePlugins\\(\\) on Shopware\\\\Core\\\\Framework\\\\Plugin\\\\KernelPluginLoader\\\\KernelPluginLoader\\|null\\.$#"
+			count: 1
+			path: src/Core/Kernel.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Kernel\\:\\:getPluginLoader\\(\\) should return Shopware\\\\Core\\\\Framework\\\\Plugin\\\\KernelPluginLoader\\\\KernelPluginLoader but returns Shopware\\\\Core\\\\Framework\\\\Plugin\\\\KernelPluginLoader\\\\KernelPluginLoader\\|null\\.$#"
+			count: 1
+			path: src/Core/Kernel.php
+
+		-
+			message: "#^Cannot call method getPluginInstances\\(\\) on Shopware\\\\Core\\\\Framework\\\\Plugin\\\\KernelPluginLoader\\\\KernelPluginLoader\\|null\\.$#"
+			count: 2
+			path: src/Core/Kernel.php
+
+		-
+			message: "#^Cannot call method getPluginDir\\(\\) on Shopware\\\\Core\\\\Framework\\\\Plugin\\\\KernelPluginLoader\\\\KernelPluginLoader\\|null\\.$#"
+			count: 1
+			path: src/Core/Kernel.php
+
+		-
+			message: "#^Cannot call method getPluginInfos\\(\\) on Shopware\\\\Core\\\\Framework\\\\Plugin\\\\KernelPluginLoader\\\\KernelPluginLoader\\|null\\.$#"
+			count: 1
+			path: src/Core/Kernel.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Kernel\\:\\:getCacheHash\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Kernel.php
+
+		-
+			message: "#^Parameter \\#1 \\$str of function md5 expects string, string\\|false given\\.$#"
+			count: 1
+			path: src/Core/Kernel.php
+
+		-
+			message: "#^Parameter \\#1 \\$str of function mb_substr expects string, string\\|null given\\.$#"
+			count: 1
+			path: src/Core/Kernel.php
+
+		-
+			message: "#^Parameter \\#1 \\$str of function mb_substr expects string, string\\|false given\\.$#"
+			count: 1
+			path: src/Core/Migration/Migration1554199340AddImportExportProfile.php
+
+		-
+			message: "#^Cannot call method fetchColumn\\(\\) on Doctrine\\\\DBAL\\\\Driver\\\\Statement\\|int\\.$#"
+			count: 2
+			path: src/Core/Migration/Migration1561712450NewSystemConfigsAndDefaultValues.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Migration\\\\Migration1570621541UpdateDefaultMailTemplates\\:\\:fetchLanguageId\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Migration/Migration1570621541UpdateDefaultMailTemplates.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Migration\\\\Migration1570621541UpdateDefaultMailTemplates\\:\\:getRegisterTemplate_HTML_EN\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Migration/Migration1570621541UpdateDefaultMailTemplates.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Migration\\\\Migration1570621541UpdateDefaultMailTemplates\\:\\:getRegisterTemplate_PLAIN_EN\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Migration/Migration1570621541UpdateDefaultMailTemplates.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Migration\\\\Migration1570621541UpdateDefaultMailTemplates\\:\\:getRegisterTemplate_HTML_DE\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Migration/Migration1570621541UpdateDefaultMailTemplates.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Migration\\\\Migration1570621541UpdateDefaultMailTemplates\\:\\:getRegisterTemplate_PLAIN_DE\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Migration/Migration1570621541UpdateDefaultMailTemplates.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Migration\\\\Migration1570621541UpdateDefaultMailTemplates\\:\\:getOptInTemplate_HTML_EN\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Migration/Migration1570621541UpdateDefaultMailTemplates.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Migration\\\\Migration1570621541UpdateDefaultMailTemplates\\:\\:getOptInTemplate_PLAIN_EN\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Migration/Migration1570621541UpdateDefaultMailTemplates.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Migration\\\\Migration1570621541UpdateDefaultMailTemplates\\:\\:getOptInTemplate_HTML_DE\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Migration/Migration1570621541UpdateDefaultMailTemplates.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Migration\\\\Migration1570621541UpdateDefaultMailTemplates\\:\\:getOptInTemplate_PLAIN_DE\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Migration/Migration1570621541UpdateDefaultMailTemplates.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Migration\\\\Migration1570622696CustomerPasswordRecovery\\:\\:getLanguageIdByLocale\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Migration/Migration1570622696CustomerPasswordRecovery.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Migration\\\\Migration1571660203FixOrderDeliveryStateNames\\:\\:getMailTemplatesMapping\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Migration/Migration1571660203FixOrderDeliveryStateNames.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\Migration\\\\Migration1575021466AddCurrencies\\:\\:\\$deLanguage has no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Migration/Migration1575021466AddCurrencies.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\Migration\\\\Migration1575021466AddCurrencies\\:\\:\\$enLanguage has no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Migration/Migration1575021466AddCurrencies.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Migration\\\\Migration1575021466AddCurrencies\\:\\:getDeLanguageId\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Migration/Migration1575021466AddCurrencies.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Migration\\\\Migration1575021466AddCurrencies\\:\\:getEnLanguageId\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Migration/Migration1575021466AddCurrencies.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Migration\\\\Migration1575021466AddCurrencies\\:\\:fetchLanguageId\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Migration/Migration1575021466AddCurrencies.php
+
+		-
+			message: "#^Cannot call method fetchColumn\\(\\) on Doctrine\\\\DBAL\\\\Driver\\\\Statement\\|int\\.$#"
+			count: 1
+			path: src/Core/Migration/Migration1582011195FixCountryStateGermanTranslation.php
+
+		-
+			message: "#^Cannot call method fetchAll\\(\\) on Doctrine\\\\DBAL\\\\Driver\\\\Statement\\|int\\.$#"
+			count: 1
+			path: src/Core/Migration/Migration1582011195FixCountryStateGermanTranslation.php
+
+		-
+			message: "#^Parameter \\#3 \\$enLangId of method Shopware\\\\Core\\\\Migration\\\\Migration1584953715UpdateMailTemplatesAfterOrderLink\\:\\:updateMailTemplate\\(\\) expects string, string\\|null given\\.$#"
+			count: 17
+			path: src/Core/Migration/Migration1584953715UpdateMailTemplatesAfterOrderLink.php
+
+		-
+			message: "#^Parameter \\#4 \\$deLangId of method Shopware\\\\Core\\\\Migration\\\\Migration1584953715UpdateMailTemplatesAfterOrderLink\\:\\:updateMailTemplate\\(\\) expects string, string\\|null given\\.$#"
+			count: 17
+			path: src/Core/Migration/Migration1584953715UpdateMailTemplatesAfterOrderLink.php
+
+		-
+			message: "#^Parameter \\#3 \\$enLangId of method Shopware\\\\Core\\\\Migration\\\\Migration1588143272UpdateOrderStateChangeMailTemplates\\:\\:updateMailTemplate\\(\\) expects string, string\\|null given\\.$#"
+			count: 17
+			path: src/Core/Migration/Migration1588143272UpdateOrderStateChangeMailTemplates.php
+
+		-
+			message: "#^Parameter \\#4 \\$deLangId of method Shopware\\\\Core\\\\Migration\\\\Migration1588143272UpdateOrderStateChangeMailTemplates\\:\\:updateMailTemplate\\(\\) expects string, string\\|null given\\.$#"
+			count: 17
+			path: src/Core/Migration/Migration1588143272UpdateOrderStateChangeMailTemplates.php
+
+		-
+			message: "#^Parameter \\#1 \\$str of function substr expects string, string\\|null given\\.$#"
+			count: 1
+			path: src/Core/Migration/Migration1588143272UpdateOrderStateChangeMailTemplates.php
+
+		-
+			message: "#^Parameter \\#1 \\$str of function substr expects string, string\\|null given\\.$#"
+			count: 1
+			path: src/Core/Migration/Migration1588153272UpdateGermanMailTemplates.php
+
+		-
+			message: "#^Parameter \\#1 \\$str of function substr expects string, string\\|null given\\.$#"
+			count: 1
+			path: src/Core/Migration/Migration1591253089OrderDeeplinkForMailTemplates.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\Migration\\\\Migration1591259559AddMissingCurrency\\:\\:\\$deLanguage has no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Migration/Migration1591259559AddMissingCurrency.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\Migration\\\\Migration1591259559AddMissingCurrency\\:\\:\\$enLanguage has no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Migration/Migration1591259559AddMissingCurrency.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Migration\\\\Migration1591259559AddMissingCurrency\\:\\:getDeLanguageId\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Migration/Migration1591259559AddMissingCurrency.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Migration\\\\Migration1591259559AddMissingCurrency\\:\\:getEnLanguageId\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Migration/Migration1591259559AddMissingCurrency.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Migration\\\\Migration1591259559AddMissingCurrency\\:\\:fetchLanguageId\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Migration/Migration1591259559AddMissingCurrency.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Migration\\\\Migration1591259559AddMissingCurrency\\:\\:currencyExists\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Migration/Migration1591259559AddMissingCurrency.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Migration\\\\Migration1591361320ChargebackAndAuthorized\\:\\:getLanguageId\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Migration/Migration1591361320ChargebackAndAuthorized.php
+
+		-
+			message: "#^Parameter \\#1 \\$str of function substr expects string, string\\|null given\\.$#"
+			count: 1
+			path: src/Core/Migration/Migration1595553089FixOrderConfirmationMailForAllPayloads.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Migration\\\\Test\\\\NullConnection\\:\\:setOriginalConnection\\(\\) has parameter \\$originalConnection with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Migration/Test/NullConnection.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\Profiling\\\\Doctrine\\\\ConnectionProfiler\\:\\:\\$data has no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Profiling/Doctrine/ConnectionProfiler.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Profiling\\\\Doctrine\\\\ConnectionProfiler\\:\\:getQueryCount\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Profiling/Doctrine/ConnectionProfiler.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Profiling\\\\Doctrine\\\\ConnectionProfiler\\:\\:getQueries\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Profiling/Doctrine/ConnectionProfiler.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Profiling\\\\Doctrine\\\\ConnectionProfiler\\:\\:getTime\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Profiling/Doctrine/ConnectionProfiler.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Profiling\\\\Doctrine\\\\ConnectionProfiler\\:\\:sanitizeQueries\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Profiling/Doctrine/ConnectionProfiler.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Profiling\\\\Doctrine\\\\ConnectionProfiler\\:\\:sanitizeQuery\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/Profiling/Doctrine/ConnectionProfiler.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Profiling\\\\Doctrine\\\\ConnectionProfiler\\:\\:sanitizeQuery\\(\\) has parameter \\$query with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Profiling/Doctrine/ConnectionProfiler.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Profiling\\\\Doctrine\\\\ConnectionProfiler\\:\\:sanitizeParam\\(\\) has parameter \\$var with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Profiling/Doctrine/ConnectionProfiler.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\Profiling\\\\Doctrine\\\\DebugStack\\:\\:\\$writeSqlRegex has no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Profiling/Doctrine/DebugStack.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Profiling\\\\Profiling\\:\\:buildConfig\\(\\) has parameter \\$environment with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Profiling/Profiling.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Profiling\\\\Twig\\\\DoctrineExtension\\:\\:escapeFunction\\(\\) has parameter \\$parameter with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/Profiling/Twig/DoctrineExtension.php
+
+		-
+			message: "#^Parameter \\#2 \\$search of function array_key_exists expects array, array\\|bool\\|float\\|int\\|string\\|Symfony\\\\Component\\\\VarDumper\\\\Cloner\\\\Data\\|null given\\.$#"
+			count: 4
+			path: src/Core/Profiling/Twig/DoctrineExtension.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Profiling\\\\Twig\\\\DoctrineExtension\\:\\:replaceQueryParameters\\(\\) should return string but returns string\\|null\\.$#"
+			count: 1
+			path: src/Core/Profiling/Twig/DoctrineExtension.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\Profiling\\\\Twig\\\\DoctrineExtension\\:\\:formatQuery\\(\\) should return string but returns string\\|null\\.$#"
+			count: 1
+			path: src/Core/Profiling/Twig/DoctrineExtension.php
+
+		-
+			message: "#^Cannot call method sortByPositionAndName\\(\\) on Shopware\\\\Core\\\\System\\\\Country\\\\Aggregate\\\\CountryState\\\\CountryStateCollection\\|null\\.$#"
+			count: 1
+			path: src/Core/System/Country/CountryCollection.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\System\\\\Currency\\\\CurrencyFormatter\\:\\:formatCurrencyByLanguage\\(\\) should return string but returns string\\|null\\.$#"
+			count: 1
+			path: src/Core/System/Currency/CurrencyFormatter.php
+
+		-
+			message: "#^Parameter \\#1 \\$str of function md5 expects string, string\\|false given\\.$#"
+			count: 1
+			path: src/Core/System/Currency/CurrencyFormatter.php
+
+		-
+			message: "#^Cannot call method getCode\\(\\) on Shopware\\\\Core\\\\System\\\\Locale\\\\LocaleEntity\\|null\\.$#"
+			count: 1
+			path: src/Core/System/Currency/CurrencyFormatter.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\System\\\\Currency\\\\Rule\\\\CurrencyRule\\:\\:\\$currencyIds \\(array\\<string\\>\\) does not accept array\\|null\\.$#"
+			count: 1
+			path: src/Core/System/Currency/Rule/CurrencyRule.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\System\\\\DeliveryTime\\\\DeliveryTimeEntity\\:\\:getName\\(\\) should return string but returns string\\|null\\.$#"
+			count: 1
+			path: src/Core/System/DeliveryTime/DeliveryTimeEntity.php
+
+		-
+			message: "#^Parameter \\#1 \\$id of class Symfony\\\\Component\\\\DependencyInjection\\\\Reference constructor expects string, string\\|null given\\.$#"
+			count: 1
+			path: src/Core/System/DependencyInjection/CompilerPass/SalesChannelEntityCompilerPass.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\System\\\\Language\\\\Exception\\\\LanguageForeignKeyDeleteException\\:\\:__construct\\(\\) has parameter \\$e with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/System/Language/Exception/LanguageForeignKeyDeleteException.php
+
+		-
+			message: "#^Cannot call method fetchAll\\(\\) on Doctrine\\\\DBAL\\\\Driver\\\\Statement\\|int\\.$#"
+			count: 1
+			path: src/Core/System/Language/LanguageLoader.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\System\\\\Language\\\\LanguageValidator\\:\\:buildViolation\\(\\) has parameter \\$root with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/System/Language/LanguageValidator.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\System\\\\Language\\\\TranslationValidator\\:\\:buildViolation\\(\\) has parameter \\$root with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/System/Language/TranslationValidator.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\System\\\\NumberRange\\\\ValueGenerator\\\\NumberRangeValueGenerator\\:\\:parsePattern\\(\\) should return array\\|null but returns array\\<int, string\\>\\|false\\.$#"
+			count: 1
+			path: src/Core/System/NumberRange/ValueGenerator/NumberRangeValueGenerator.php
+
+		-
+			message: "#^Parameter \\#2 \\$subject of function preg_split expects string, string\\|null given\\.$#"
+			count: 1
+			path: src/Core/System/NumberRange/ValueGenerator/NumberRangeValueGenerator.php
+
+		-
+			message: "#^Argument of an invalid type array\\|null supplied for foreach, only iterables are supported\\.$#"
+			count: 1
+			path: src/Core/System/NumberRange/ValueGenerator/NumberRangeValueGenerator.php
+
+		-
+			message: "#^Parameter \\#1 \\$patternId of method Shopware\\\\Core\\\\System\\\\NumberRange\\\\ValueGenerator\\\\Pattern\\\\ValueGeneratorPatternRegistry\\:\\:getPatternResolver\\(\\) expects string, string\\|null given\\.$#"
+			count: 1
+			path: src/Core/System/NumberRange/ValueGenerator/NumberRangeValueGenerator.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\System\\\\NumberRange\\\\ValueGenerator\\\\Pattern\\\\IncrementStorage\\\\IncrementSqlStorage\\:\\:\\$connectorId has no typehint specified\\.$#"
+			count: 1
+			path: src/Core/System/NumberRange/ValueGenerator/Pattern/IncrementStorage/IncrementSqlStorage.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\System\\\\NumberRange\\\\ValueGenerator\\\\Pattern\\\\ValueGeneratorPatternRegistry\\:\\:\\$pattern \\(array\\<Shopware\\\\Core\\\\System\\\\NumberRange\\\\ValueGenerator\\\\Pattern\\\\ValueGeneratorPatternInterface\\>\\) does not accept iterable\\.$#"
+			count: 1
+			path: src/Core/System/NumberRange/ValueGenerator/Pattern/ValueGeneratorPatternRegistry.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\System\\\\SalesChannel\\\\Aggregate\\\\SalesChannelType\\\\SalesChannelTypeEntity\\:\\:getCoverUrl\\(\\) should return string but returns string\\|null\\.$#"
+			count: 1
+			path: src/Core/System/SalesChannel/Aggregate/SalesChannelType/SalesChannelTypeEntity.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\System\\\\SalesChannel\\\\Aggregate\\\\SalesChannelType\\\\SalesChannelTypeEntity\\:\\:getIconName\\(\\) should return string but returns string\\|null\\.$#"
+			count: 1
+			path: src/Core/System/SalesChannel/Aggregate/SalesChannelType/SalesChannelTypeEntity.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\System\\\\SalesChannel\\\\Aggregate\\\\SalesChannelType\\\\SalesChannelTypeEntity\\:\\:getScreenshotUrls\\(\\) should return array but returns array\\|null\\.$#"
+			count: 1
+			path: src/Core/System/SalesChannel/Aggregate/SalesChannelType/SalesChannelTypeEntity.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\System\\\\SalesChannel\\\\Api\\\\StructEncoder\\:\\:encodeStruct\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/System/SalesChannel/Api/StructEncoder.php
+
+		-
+			message: "#^Argument of an invalid type array\\|ArrayObject\\|bool\\|float\\|int\\|string\\|null supplied for foreach, only iterables are supported\\.$#"
+			count: 1
+			path: src/Core/System/SalesChannel/Api/StructEncoder.php
+
+		-
+			message: "#^Parameter \\#1 \\$struct of method Shopware\\\\Core\\\\System\\\\SalesChannel\\\\Api\\\\StructEncoder\\:\\:encode\\(\\) expects Shopware\\\\Core\\\\Framework\\\\Struct\\\\Struct, Shopware\\\\Core\\\\Framework\\\\Struct\\\\Struct\\|null given\\.$#"
+			count: 1
+			path: src/Core/System/SalesChannel/Api/StructEncoder.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\System\\\\SalesChannel\\\\Api\\\\StructEncoder\\:\\:isStructArray\\(\\) has parameter \\$object with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/System/SalesChannel/Api/StructEncoder.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\System\\\\SalesChannel\\\\Command\\\\SalesChannelCreateCommand\\:\\:getFirstActiveShippingMethodId\\(\\) should return string but returns array\\|string\\.$#"
+			count: 1
+			path: src/Core/System/SalesChannel/Command/SalesChannelCreateCommand.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\System\\\\SalesChannel\\\\Command\\\\SalesChannelCreateCommand\\:\\:getFirstActivePaymentMethodId\\(\\) should return string but returns array\\|string\\.$#"
+			count: 1
+			path: src/Core/System/SalesChannel/Command/SalesChannelCreateCommand.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\System\\\\SalesChannel\\\\Command\\\\SalesChannelCreateCommand\\:\\:getFirstActiveCountryId\\(\\) should return string but returns array\\|string\\.$#"
+			count: 1
+			path: src/Core/System/SalesChannel/Command/SalesChannelCreateCommand.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\System\\\\SalesChannel\\\\Command\\\\SalesChannelCreateCommand\\:\\:getSnippetSetId\\(\\) should return string but returns array\\|string\\.$#"
+			count: 1
+			path: src/Core/System/SalesChannel/Command/SalesChannelCreateCommand.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\System\\\\SalesChannel\\\\Command\\\\SalesChannelCreateCommand\\:\\:getRootCategoryId\\(\\) should return string but returns array\\|string\\|null\\.$#"
+			count: 1
+			path: src/Core/System/SalesChannel/Command/SalesChannelCreateCommand.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\System\\\\SalesChannel\\\\Command\\\\SalesChannelListCommand\\:\\:renderJson\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/System/SalesChannel/Command/SalesChannelListCommand.php
+
+		-
+			message: "#^Parameter \\#1 \\$messages of method Symfony\\\\Component\\\\Console\\\\Output\\\\OutputInterface\\:\\:write\\(\\) expects iterable\\|string, string\\|false given\\.$#"
+			count: 1
+			path: src/Core/System/SalesChannel/Command/SalesChannelListCommand.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\System\\\\SalesChannel\\\\Command\\\\SalesChannelListCommand\\:\\:renderTable\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/System/SalesChannel/Command/SalesChannelListCommand.php
+
+		-
+			message: "#^Parameter \\#1 \\$ids of method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Search\\\\Criteria\\:\\:setIds\\(\\) expects array, array\\<string\\>\\|string given\\.$#"
+			count: 1
+			path: src/Core/System/SalesChannel/Command/SalesChannelMaintenanceEnableCommand.php
+
+		-
+			message: "#^Parameter \\#1 \\$address of static method Shopware\\\\Core\\\\Checkout\\\\Cart\\\\Delivery\\\\Struct\\\\ShippingLocation\\:\\:createFromAddress\\(\\) expects Shopware\\\\Core\\\\Checkout\\\\Customer\\\\Aggregate\\\\CustomerAddress\\\\CustomerAddressEntity, Shopware\\\\Core\\\\Checkout\\\\Customer\\\\Aggregate\\\\CustomerAddress\\\\CustomerAddressEntity\\|null given\\.$#"
+			count: 1
+			path: src/Core/System/SalesChannel/Context/SalesChannelContextFactory.php
+
+		-
+			message: "#^Cannot call method filter\\(\\) on Shopware\\\\Core\\\\System\\\\Tax\\\\Aggregate\\\\TaxRule\\\\TaxRuleCollection\\|null\\.$#"
+			count: 1
+			path: src/Core/System/SalesChannel/Context/SalesChannelContextFactory.php
+
+		-
+			message: "#^Cannot access offset 'sales_channel…' on array\\|false\\.$#"
+			count: 6
+			path: src/Core/System/SalesChannel/Context/SalesChannelContextFactory.php
+
+		-
+			message: "#^Cannot call method fetchColumn\\(\\) on Doctrine\\\\DBAL\\\\Driver\\\\Statement\\|int\\.$#"
+			count: 1
+			path: src/Core/System/SalesChannel/Context/SalesChannelContextFactory.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\System\\\\SalesChannel\\\\DataAbstractionLayer\\\\SalesChannelIndexer\\:\\:iterate\\(\\) has parameter \\$offset with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/System/SalesChannel/DataAbstractionLayer/SalesChannelIndexer.php
+
+		-
+			message: "#^Parameter \\#3 \\$definition of method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Search\\\\RequestCriteriaBuilder\\:\\:handleRequest\\(\\) expects Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\EntityDefinition, Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\EntityDefinition\\|Shopware\\\\Core\\\\System\\\\SalesChannel\\\\Entity\\\\SalesChannelDefinitionInterface given\\.$#"
+			count: 3
+			path: src/Core/System/SalesChannel/Entity/SalesChannelApiController.php
+
+		-
+			message: "#^Parameter \\#2 \\$definition of method Shopware\\\\Core\\\\System\\\\SalesChannel\\\\Entity\\\\SalesChannelApiController\\:\\:checkProtectedAssociations\\(\\) expects Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\EntityDefinition, Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\EntityDefinition\\|Shopware\\\\Core\\\\System\\\\SalesChannel\\\\Entity\\\\SalesChannelDefinitionInterface given\\.$#"
+			count: 3
+			path: src/Core/System/SalesChannel/Entity/SalesChannelApiController.php
+
+		-
+			message: "#^Call to an undefined method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\EntityDefinition\\|Shopware\\\\Core\\\\System\\\\SalesChannel\\\\Entity\\\\SalesChannelDefinitionInterface\\:\\:processCriteria\\(\\)\\.$#"
+			count: 3
+			path: src/Core/System/SalesChannel/Entity/SalesChannelApiController.php
+
+		-
+			message: "#^Call to an undefined method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\EntityDefinition\\|Shopware\\\\Core\\\\System\\\\SalesChannel\\\\Entity\\\\SalesChannelDefinitionInterface\\:\\:getEntityName\\(\\)\\.$#"
+			count: 1
+			path: src/Core/System/SalesChannel/Entity/SalesChannelApiController.php
+
+		-
+			message: "#^Parameter \\#3 \\$definition of method Shopware\\\\Core\\\\Framework\\\\Api\\\\Response\\\\ResponseFactoryInterface\\:\\:createDetailResponse\\(\\) expects Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\EntityDefinition, Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\EntityDefinition\\|Shopware\\\\Core\\\\System\\\\SalesChannel\\\\Entity\\\\SalesChannelDefinitionInterface given\\.$#"
+			count: 1
+			path: src/Core/System/SalesChannel/Entity/SalesChannelApiController.php
+
+		-
+			message: "#^Parameter \\#3 \\$definition of method Shopware\\\\Core\\\\Framework\\\\Api\\\\Response\\\\ResponseFactoryInterface\\:\\:createListingResponse\\(\\) expects Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\EntityDefinition, Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\EntityDefinition\\|Shopware\\\\Core\\\\System\\\\SalesChannel\\\\Entity\\\\SalesChannelDefinitionInterface given\\.$#"
+			count: 1
+			path: src/Core/System/SalesChannel/Entity/SalesChannelApiController.php
+
+		-
+			message: "#^Parameter \\#1 \\$definition of static method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\RepositorySearchDetector\\:\\:isSearchRequired\\(\\) expects Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\EntityDefinition, Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\EntityDefinition\\|Shopware\\\\Core\\\\System\\\\SalesChannel\\\\Entity\\\\SalesChannelDefinitionInterface given\\.$#"
+			count: 1
+			path: src/Core/System/SalesChannel/Entity/SalesChannelRepository.php
+
+		-
+			message: "#^Parameter \\#1 \\$definition of class Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Event\\\\EntitySearchResultLoadedEvent constructor expects Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\EntityDefinition, Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\EntityDefinition\\|Shopware\\\\Core\\\\System\\\\SalesChannel\\\\Entity\\\\SalesChannelDefinitionInterface given\\.$#"
+			count: 1
+			path: src/Core/System/SalesChannel/Entity/SalesChannelRepository.php
+
+		-
+			message: "#^Parameter \\#1 \\$definition of class Shopware\\\\Core\\\\System\\\\SalesChannel\\\\Entity\\\\SalesChannelEntitySearchResultLoadedEvent constructor expects Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\EntityDefinition, Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\EntityDefinition\\|Shopware\\\\Core\\\\System\\\\SalesChannel\\\\Entity\\\\SalesChannelDefinitionInterface given\\.$#"
+			count: 1
+			path: src/Core/System/SalesChannel/Entity/SalesChannelRepository.php
+
+		-
+			message: "#^Parameter \\#1 \\$definition of method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Search\\\\EntityAggregatorInterface\\:\\:aggregate\\(\\) expects Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\EntityDefinition, Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\EntityDefinition\\|Shopware\\\\Core\\\\System\\\\SalesChannel\\\\Entity\\\\SalesChannelDefinitionInterface given\\.$#"
+			count: 1
+			path: src/Core/System/SalesChannel/Entity/SalesChannelRepository.php
+
+		-
+			message: "#^Parameter \\#1 \\$definition of class Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Event\\\\EntityAggregationResultLoadedEvent constructor expects Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\EntityDefinition, Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\EntityDefinition\\|Shopware\\\\Core\\\\System\\\\SalesChannel\\\\Entity\\\\SalesChannelDefinitionInterface given\\.$#"
+			count: 1
+			path: src/Core/System/SalesChannel/Entity/SalesChannelRepository.php
+
+		-
+			message: "#^Parameter \\#1 \\$definition of method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Read\\\\EntityReaderInterface\\:\\:read\\(\\) expects Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\EntityDefinition, Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\EntityDefinition\\|Shopware\\\\Core\\\\System\\\\SalesChannel\\\\Entity\\\\SalesChannelDefinitionInterface given\\.$#"
+			count: 1
+			path: src/Core/System/SalesChannel/Entity/SalesChannelRepository.php
+
+		-
+			message: "#^Parameter \\#1 \\$definition of class Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Event\\\\EntityLoadedEvent constructor expects Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\EntityDefinition, Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\EntityDefinition\\|Shopware\\\\Core\\\\System\\\\SalesChannel\\\\Entity\\\\SalesChannelDefinitionInterface given\\.$#"
+			count: 1
+			path: src/Core/System/SalesChannel/Entity/SalesChannelRepository.php
+
+		-
+			message: "#^Parameter \\#1 \\$definition of class Shopware\\\\Core\\\\System\\\\SalesChannel\\\\Entity\\\\SalesChannelEntityLoadedEvent constructor expects Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\EntityDefinition, Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\EntityDefinition\\|Shopware\\\\Core\\\\System\\\\SalesChannel\\\\Entity\\\\SalesChannelDefinitionInterface given\\.$#"
+			count: 1
+			path: src/Core/System/SalesChannel/Entity/SalesChannelRepository.php
+
+		-
+			message: "#^Parameter \\#1 \\$definition of method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Search\\\\EntitySearcherInterface\\:\\:search\\(\\) expects Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\EntityDefinition, Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\EntityDefinition\\|Shopware\\\\Core\\\\System\\\\SalesChannel\\\\Entity\\\\SalesChannelDefinitionInterface given\\.$#"
+			count: 1
+			path: src/Core/System/SalesChannel/Entity/SalesChannelRepository.php
+
+		-
+			message: "#^Parameter \\#1 \\$definition of class Shopware\\\\Core\\\\System\\\\SalesChannel\\\\Entity\\\\SalesChannelEntityIdSearchResultLoadedEvent constructor expects Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\EntityDefinition, Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\EntityDefinition\\|Shopware\\\\Core\\\\System\\\\SalesChannel\\\\Entity\\\\SalesChannelDefinitionInterface given\\.$#"
+			count: 1
+			path: src/Core/System/SalesChannel/Entity/SalesChannelRepository.php
+
+		-
+			message: "#^Offset 'definition' does not exist on array\\('criteria' \\=\\> mixed, 'definition' \\=\\> Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\EntityDefinition\\|Shopware\\\\Core\\\\System\\\\SalesChannel\\\\Entity\\\\SalesChannelDefinitionInterface\\)\\|null\\.$#"
+			count: 1
+			path: src/Core/System/SalesChannel/Entity/SalesChannelRepository.php
+
+		-
+			message: "#^Offset 'criteria' does not exist on array\\('criteria' \\=\\> mixed, 'definition' \\=\\> Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\EntityDefinition\\|Shopware\\\\Core\\\\System\\\\SalesChannel\\\\Entity\\\\SalesChannelDefinitionInterface\\)\\|null\\.$#"
+			count: 1
+			path: src/Core/System/SalesChannel/Entity/SalesChannelRepository.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\System\\\\SalesChannel\\\\Exception\\\\LanguageOfSalesChannelDomainDeleteException\\:\\:__construct\\(\\) has parameter \\$e with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/System/SalesChannel/Exception/LanguageOfSalesChannelDomainDeleteException.php
+
+		-
+			message: "#^Cannot call method getId\\(\\) on Shopware\\\\Core\\\\Checkout\\\\Customer\\\\CustomerEntity\\|null\\.$#"
+			count: 1
+			path: src/Core/System/SalesChannel/SalesChannel/ContextSwitchRoute.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\System\\\\SalesChannel\\\\SalesChannelEntity\\:\\:\\$maintenanceIpWhitelist \\(string\\) does not accept string\\|null\\.$#"
+			count: 1
+			path: src/Core/System/SalesChannel/SalesChannelEntity.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\System\\\\SalesChannel\\\\SalesChannelEntity\\:\\:\\$analyticsId \\(string\\) does not accept string\\|null\\.$#"
+			count: 1
+			path: src/Core/System/SalesChannel/SalesChannelEntity.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\System\\\\SalesChannel\\\\SalesChannelEntity\\:\\:\\$analytics \\(Shopware\\\\Core\\\\System\\\\SalesChannel\\\\Aggregate\\\\SalesChannelAnalytics\\\\SalesChannelAnalyticsEntity\\) does not accept Shopware\\\\Core\\\\System\\\\SalesChannel\\\\Aggregate\\\\SalesChannelAnalytics\\\\SalesChannelAnalyticsEntity\\|null\\.$#"
+			count: 1
+			path: src/Core/System/SalesChannel/SalesChannelEntity.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\System\\\\Salutation\\\\SalutationEntity\\:\\:\\$customers has no typehint specified\\.$#"
+			count: 1
+			path: src/Core/System/Salutation/SalutationEntity.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\System\\\\Salutation\\\\SalutationEntity\\:\\:\\$customerAddresses has no typehint specified\\.$#"
+			count: 1
+			path: src/Core/System/Salutation/SalutationEntity.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\System\\\\Salutation\\\\SalutationEntity\\:\\:\\$orderCustomers has no typehint specified\\.$#"
+			count: 1
+			path: src/Core/System/Salutation/SalutationEntity.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\System\\\\Salutation\\\\SalutationEntity\\:\\:\\$orderAddresses has no typehint specified\\.$#"
+			count: 1
+			path: src/Core/System/Salutation/SalutationEntity.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\System\\\\Snippet\\\\Files\\\\SnippetFileCollection\\:\\:getByName\\(\\) has parameter \\$key with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/System/Snippet/Files/SnippetFileCollection.php
+
+		-
+			message: "#^Cannot call method getActiveApps\\(\\) on Shopware\\\\Core\\\\Framework\\\\App\\\\ActiveAppsLoader\\|null\\.$#"
+			count: 1
+			path: src/Core/System/Snippet/Files/SnippetFileLoader.php
+
+		-
+			message: "#^Cannot call method loadSnippetFilesFromApp\\(\\) on Shopware\\\\Core\\\\System\\\\Snippet\\\\Files\\\\AppSnippetFileLoader\\|null\\.$#"
+			count: 1
+			path: src/Core/System/Snippet/Files/SnippetFileLoader.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\System\\\\Snippet\\\\Filter\\\\AddedFilter\\:\\:filter\\(\\) has parameter \\$requestFilterValue with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/System/Snippet/Filter/AddedFilter.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\System\\\\Snippet\\\\Filter\\\\AuthorFilter\\:\\:filter\\(\\) has parameter \\$requestFilterValue with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/System/Snippet/Filter/AuthorFilter.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\System\\\\Snippet\\\\Filter\\\\EditedFilter\\:\\:filter\\(\\) has parameter \\$requestFilterValue with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/System/Snippet/Filter/EditedFilter.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\System\\\\Snippet\\\\Filter\\\\EmptySnippetFilter\\:\\:filter\\(\\) has parameter \\$requestFilterValue with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/System/Snippet/Filter/EmptySnippetFilter.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\System\\\\Snippet\\\\Filter\\\\NamespaceFilter\\:\\:filter\\(\\) has parameter \\$requestFilterValue with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/System/Snippet/Filter/NamespaceFilter.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\System\\\\Snippet\\\\Filter\\\\SnippetFilterFactory\\:\\:\\$filters \\(array\\) does not accept iterable\\.$#"
+			count: 1
+			path: src/Core/System/Snippet/Filter/SnippetFilterFactory.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\System\\\\Snippet\\\\Filter\\\\SnippetFilterInterface\\:\\:filter\\(\\) has parameter \\$requestFilterValue with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/System/Snippet/Filter/SnippetFilterInterface.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\System\\\\Snippet\\\\Filter\\\\TermFilter\\:\\:filter\\(\\) has parameter \\$requestFilterValue with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/System/Snippet/Filter/TermFilter.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\System\\\\Snippet\\\\Filter\\\\TranslationKeyFilter\\:\\:filter\\(\\) has parameter \\$requestFilterValue with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/System/Snippet/Filter/TranslationKeyFilter.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\System\\\\Snippet\\\\SnippetEntity\\:\\:\\$value \\(string\\) does not accept string\\|null\\.$#"
+			count: 1
+			path: src/Core/System/Snippet/SnippetEntity.php
+
+		-
+			message: "#^Parameter \\#1 \\$json of function json_decode expects string, string\\|false given\\.$#"
+			count: 1
+			path: src/Core/System/Snippet/SnippetFileHandler.php
+
+		-
+			message: "#^Parameter \\#2 \\$translation of method Shopware\\\\Core\\\\System\\\\Snippet\\\\SnippetFixer\\:\\:addTranslationUsingSnippetKey\\(\\) expects string, string\\|null given\\.$#"
+			count: 1
+			path: src/Core/System/Snippet/SnippetFixer.php
+
+		-
+			message: "#^Cannot call method fetchAll\\(\\) on Doctrine\\\\DBAL\\\\Driver\\\\Statement\\|int\\.$#"
+			count: 1
+			path: src/Core/System/Snippet/SnippetService.php
+
+		-
+			message: "#^Parameter \\#1 \\$json of function json_decode expects string, string\\|false given\\.$#"
+			count: 2
+			path: src/Core/System/Snippet/SnippetService.php
+
+		-
+			message: "#^Cannot call method fetchColumn\\(\\) on Doctrine\\\\DBAL\\\\Driver\\\\Statement\\|int\\.$#"
+			count: 1
+			path: src/Core/System/Snippet/SnippetService.php
+
+		-
+			message: "#^Cannot call method getName\\(\\) on Shopware\\\\Core\\\\System\\\\StateMachine\\\\Aggregation\\\\StateMachineState\\\\StateMachineStateEntity\\|null\\.$#"
+			count: 1
+			path: src/Core/System/StateMachine/Api/StateMachineActionController.php
+
+		-
+			message: "#^Cannot call method getTechnicalName\\(\\) on Shopware\\\\Core\\\\System\\\\StateMachine\\\\Aggregation\\\\StateMachineState\\\\StateMachineStateEntity\\|null\\.$#"
+			count: 3
+			path: src/Core/System/StateMachine/Api/StateMachineActionController.php
+
+		-
+			message: "#^Parameter \\#2 \\$entity of method Shopware\\\\Core\\\\Framework\\\\Api\\\\Response\\\\ResponseFactoryInterface\\:\\:createDetailResponse\\(\\) expects Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Entity, Shopware\\\\Core\\\\System\\\\StateMachine\\\\Aggregation\\\\StateMachineState\\\\StateMachineStateEntity\\|null given\\.$#"
+			count: 1
+			path: src/Core/System/StateMachine/Api/StateMachineActionController.php
+
+		-
+			message: "#^Parameter \\#1 \\$name of method Shopware\\\\Core\\\\System\\\\StateMachine\\\\StateMachineRegistry\\:\\:getStateMachine\\(\\) expects string, array\\<string\\>\\|string\\|null given\\.$#"
+			count: 1
+			path: src/Core/System/StateMachine/Command/WorkflowDumpCommand.php
+
+		-
+			message: "#^Argument of an invalid type Shopware\\\\Core\\\\System\\\\StateMachine\\\\Aggregation\\\\StateMachineState\\\\StateMachineStateCollection\\|null supplied for foreach, only iterables are supported\\.$#"
+			count: 1
+			path: src/Core/System/StateMachine/StateMachineEntity.php
+
+		-
+			message: "#^Argument of an invalid type Shopware\\\\Core\\\\System\\\\StateMachine\\\\Aggregation\\\\StateMachineTransition\\\\StateMachineTransitionCollection\\|null supplied for foreach, only iterables are supported\\.$#"
+			count: 2
+			path: src/Core/System/StateMachine/StateMachineRegistry.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\System\\\\StateMachine\\\\Util\\\\StateMachineGraphvizDumper\\:\\:\\$defaultOptions has no typehint specified\\.$#"
+			count: 1
+			path: src/Core/System/StateMachine/Util/StateMachineGraphvizDumper.php
+
+		-
+			message: "#^Argument of an invalid type Shopware\\\\Core\\\\System\\\\StateMachine\\\\Aggregation\\\\StateMachineState\\\\StateMachineStateCollection\\|null supplied for foreach, only iterables are supported\\.$#"
+			count: 1
+			path: src/Core/System/StateMachine/Util/StateMachineGraphvizDumper.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\System\\\\StateMachine\\\\Util\\\\StateMachineGraphvizDumper\\:\\:dotize\\(\\) has parameter \\$id with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/System/StateMachine/Util/StateMachineGraphvizDumper.php
+
+		-
+			message: "#^Argument of an invalid type Shopware\\\\Core\\\\System\\\\StateMachine\\\\Aggregation\\\\StateMachineTransition\\\\StateMachineTransitionCollection\\|null supplied for foreach, only iterables are supported\\.$#"
+			count: 1
+			path: src/Core/System/StateMachine/Util/StateMachineGraphvizDumper.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\System\\\\System\\:\\:\\$name has no typehint specified\\.$#"
+			count: 1
+			path: src/Core/System/System.php
+
+		-
+			message: "#^Parameter \\#1 \\$salesChannelId of method Shopware\\\\Core\\\\System\\\\SystemConfig\\\\Api\\\\SystemConfigController\\:\\:saveKeyValues\\(\\) expects string\\|null, int\\|string\\|null given\\.$#"
+			count: 1
+			path: src/Core/System/SystemConfig/Api/SystemConfigController.php
+
+		-
+			message: "#^Parameter \\#1 \\$key of method Shopware\\\\Core\\\\System\\\\SystemConfig\\\\SystemConfigService\\:\\:get\\(\\) expects string, array\\<string\\>\\|string\\|null given\\.$#"
+			count: 1
+			path: src/Core/System/SystemConfig/Command/ConfigGet.php
+
+		-
+			message: "#^Parameter \\#2 \\$salesChannelId of method Shopware\\\\Core\\\\System\\\\SystemConfig\\\\SystemConfigService\\:\\:get\\(\\) expects string\\|null, array\\<string\\>\\|bool\\|string\\|null given\\.$#"
+			count: 1
+			path: src/Core/System/SystemConfig/Command/ConfigGet.php
+
+		-
+			message: "#^Parameter \\#1 \\$key of method Shopware\\\\Core\\\\System\\\\SystemConfig\\\\SystemConfigService\\:\\:set\\(\\) expects string, array\\<string\\>\\|string\\|null given\\.$#"
+			count: 1
+			path: src/Core/System/SystemConfig/Command/ConfigSet.php
+
+		-
+			message: "#^Parameter \\#3 \\$salesChannelId of method Shopware\\\\Core\\\\System\\\\SystemConfig\\\\SystemConfigService\\:\\:set\\(\\) expects string\\|null, array\\<string\\>\\|bool\\|string\\|null given\\.$#"
+			count: 1
+			path: src/Core/System/SystemConfig/Command/ConfigSet.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\System\\\\SystemConfig\\\\Service\\\\ConfigurationService\\:\\:\\$bundles \\(array\\) does not accept iterable\\<Symfony\\\\Component\\\\HttpKernel\\\\Bundle\\\\BundleInterface\\>\\.$#"
+			count: 1
+			path: src/Core/System/SystemConfig/Service/ConfigurationService.php
+
+		-
+			message: "#^Property Shopware\\\\Core\\\\System\\\\SystemConfig\\\\SystemConfigEntity\\:\\:\\$configurationValue has no typehint specified\\.$#"
+			count: 1
+			path: src/Core/System/SystemConfig/SystemConfigEntity.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\System\\\\SystemConfig\\\\SystemConfigEntity\\:\\:getConfigurationValue\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Core/System/SystemConfig/SystemConfigEntity.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\System\\\\SystemConfig\\\\SystemConfigEntity\\:\\:setConfigurationValue\\(\\) has parameter \\$configurationValue with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/System/SystemConfig/SystemConfigEntity.php
+
+		-
+			message: "#^Cannot call method fetchAll\\(\\) on Doctrine\\\\DBAL\\\\Driver\\\\Statement\\|int\\.$#"
+			count: 1
+			path: src/Core/System/SystemConfig/SystemConfigService.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\System\\\\SystemConfig\\\\SystemConfigService\\:\\:getSubArray\\(\\) has parameter \\$value with no typehint specified\\.$#"
+			count: 1
+			path: src/Core/System/SystemConfig/SystemConfigService.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\System\\\\SystemConfig\\\\SystemConfigService\\:\\:getId\\(\\) should return string\\|null but returns array\\|string\\|null\\.$#"
+			count: 1
+			path: src/Core/System/SystemConfig/SystemConfigService.php
+
+		-
+			message: "#^Cannot access property \\$nodeName on DOMElement\\|null\\.$#"
+			count: 1
+			path: src/Core/System/SystemConfig/Util/ConfigReader.php
+
+		-
+			message: "#^Cannot access property \\$nodeValue on DOMElement\\|null\\.$#"
+			count: 1
+			path: src/Core/System/SystemConfig/Util/ConfigReader.php
+
+		-
+			message: "#^Offset 'states' does not exist on array\\|null\\.$#"
+			count: 1
+			path: src/Core/System/Tax/TaxRuleType/IndividualStatesRuleTypeFilter.php
+
+		-
+			message: "#^Offset 'toZipCode' does not exist on array\\|null\\.$#"
+			count: 1
+			path: src/Core/System/Tax/TaxRuleType/ZipCodeRangeRuleTypeFilter.php
+
+		-
+			message: "#^Offset 'fromZipCode' does not exist on array\\|null\\.$#"
+			count: 1
+			path: src/Core/System/Tax/TaxRuleType/ZipCodeRangeRuleTypeFilter.php
+
+		-
+			message: "#^Offset 'zipCode' does not exist on array\\|null\\.$#"
+			count: 1
+			path: src/Core/System/Tax/TaxRuleType/ZipCodeRuleTypeFilter.php
+
+		-
+			message: "#^Parameter \\#1 \\$username of method Shopware\\\\Core\\\\System\\\\User\\\\Command\\\\UserChangePasswordCommand\\:\\:getUserId\\(\\) expects string, array\\<string\\>\\|string\\|null given\\.$#"
+			count: 1
+			path: src/Core/System/User/Command/UserChangePasswordCommand.php
+
+		-
+			message: "#^Parameter \\#2 \\.\\.\\.\\$args of function sprintf expects bool\\|float\\|int\\|string\\|null, array\\<string\\>\\|string\\|null given\\.$#"
+			count: 2
+			path: src/Core/System/User/Command/UserChangePasswordCommand.php
+
+		-
+			message: "#^Parameter \\#1 \\$username of method Shopware\\\\Core\\\\System\\\\User\\\\Service\\\\UserProvisioner\\:\\:provision\\(\\) expects string, array\\<string\\>\\|string\\|null given\\.$#"
+			count: 1
+			path: src/Core/System/User/Command/UserCreateCommand.php
+
+		-
+			message: "#^Parameter \\#2 \\.\\.\\.\\$args of function sprintf expects bool\\|float\\|int\\|string\\|null, array\\<string\\>\\|string\\|null given\\.$#"
+			count: 1
+			path: src/Core/System/User/Command/UserCreateCommand.php
+
+		-
+			message: "#^Cannot call method getEmail\\(\\) on Shopware\\\\Core\\\\System\\\\User\\\\UserEntity\\|null\\.$#"
+			count: 1
+			path: src/Core/System/User/Recovery/UserRecoveryRequestEvent.php
+
+		-
+			message: "#^Cannot call method getFirstName\\(\\) on Shopware\\\\Core\\\\System\\\\User\\\\UserEntity\\|null\\.$#"
+			count: 1
+			path: src/Core/System/User/Recovery/UserRecoveryRequestEvent.php
+
+		-
+			message: "#^Cannot call method getLastName\\(\\) on Shopware\\\\Core\\\\System\\\\User\\\\UserEntity\\|null\\.$#"
+			count: 1
+			path: src/Core/System/User/Recovery/UserRecoveryRequestEvent.php
+
+		-
+			message: "#^Cannot call method getUserId\\(\\) on Shopware\\\\Core\\\\System\\\\User\\\\Aggregate\\\\UserRecovery\\\\UserRecoveryEntity\\|null\\.$#"
+			count: 1
+			path: src/Core/System/User/Recovery/UserRecoveryService.php
+
+		-
+			message: "#^Parameter \\#1 \\$userRecoveryEntity of method Shopware\\\\Core\\\\System\\\\User\\\\Recovery\\\\UserRecoveryService\\:\\:deleteRecoveryForUser\\(\\) expects Shopware\\\\Core\\\\System\\\\User\\\\Aggregate\\\\UserRecovery\\\\UserRecoveryEntity, Shopware\\\\Core\\\\System\\\\User\\\\Aggregate\\\\UserRecovery\\\\UserRecoveryEntity\\|null given\\.$#"
+			count: 1
+			path: src/Core/System/User/Recovery/UserRecoveryService.php
+
+		-
+			message: "#^Cannot call method rowCount\\(\\) on Doctrine\\\\DBAL\\\\Driver\\\\Statement\\|int\\.$#"
+			count: 1
+			path: src/Core/System/User/Service/UserProvisioner.php
+
+		-
+			message: "#^Cannot call method fetchColumn\\(\\) on Doctrine\\\\DBAL\\\\Driver\\\\Statement\\|int\\.$#"
+			count: 1
+			path: src/Core/System/User/Service/UserProvisioner.php
+
+		-
+			message: "#^Method Shopware\\\\Core\\\\System\\\\User\\\\UserEntity\\:\\:getAclRoles\\(\\) should return Shopware\\\\Core\\\\Framework\\\\Api\\\\Acl\\\\Role\\\\AclRoleCollection but returns Shopware\\\\Core\\\\Framework\\\\Api\\\\Acl\\\\Role\\\\AclRoleCollection\\|null\\.$#"
+			count: 1
+			path: src/Core/System/User/UserEntity.php
+
+		-
+			message: "#^Property Shopware\\\\Docs\\\\Command\\\\ConvertMarkdownDocsCommand\\:\\:\\$environment \\(string\\) does not accept string\\|false\\.$#"
+			count: 1
+			path: src/Docs/Command/ConvertMarkdownDocsCommand.php
+
+		-
+			message: "#^Binary operation \"\\.\" between array\\<string\\>\\|bool\\|string\\|null and 'article\\.blacklist' results in an error\\.$#"
+			count: 1
+			path: src/Docs/Command/ConvertMarkdownDocsCommand.php
+
+		-
+			message: "#^Binary operation \"\\.\" between 'Scanning \\\\\\\\\"' and array\\<string\\>\\|bool\\|string\\|null results in an error\\.$#"
+			count: 1
+			path: src/Docs/Command/ConvertMarkdownDocsCommand.php
+
+		-
+			message: "#^Parameter \\#1 \\$fromPath of method Shopware\\\\Docs\\\\Command\\\\ConvertMarkdownDocsCommand\\:\\:loadDocuments\\(\\) expects string, array\\<string\\>\\|bool\\|string\\|null given\\.$#"
+			count: 1
+			path: src/Docs/Command/ConvertMarkdownDocsCommand.php
+
+		-
+			message: "#^Parameter \\#2 \\$baseUrl of method Shopware\\\\Docs\\\\Command\\\\ConvertMarkdownDocsCommand\\:\\:loadDocuments\\(\\) expects string, array\\<string\\>\\|bool\\|string\\|null given\\.$#"
+			count: 1
+			path: src/Docs/Command/ConvertMarkdownDocsCommand.php
+
+		-
+			message: "#^Parameter \\#3 \\$blacklist of method Shopware\\\\Docs\\\\Command\\\\ConvertMarkdownDocsCommand\\:\\:loadDocuments\\(\\) expects array, array\\<int, string\\>\\|false given\\.$#"
+			count: 1
+			path: src/Docs/Command/ConvertMarkdownDocsCommand.php
+
+		-
+			message: "#^Binary operation \"\\.\" between array\\<string\\>\\|bool\\|string and '/' results in an error\\.$#"
+			count: 1
+			path: src/Docs/Command/ConvertMarkdownDocsCommand.php
+
+		-
+			message: "#^Parameter \\#1 \\$dirs of method Symfony\\\\Component\\\\Filesystem\\\\Filesystem\\:\\:mkdir\\(\\) expects iterable\\|string, array\\<string\\>\\|bool\\|string given\\.$#"
+			count: 1
+			path: src/Docs/Command/ConvertMarkdownDocsCommand.php
+
+		-
+			message: "#^Property Shopware\\\\Docs\\\\Command\\\\DocsDumpErd\\:\\:\\$ignoredDefinitions has no typehint specified\\.$#"
+			count: 1
+			path: src/Docs/Command/DocsDumpErd.php
+
+		-
+			message: "#^Parameter \\#1 \\$files of method Symfony\\\\Component\\\\Filesystem\\\\Filesystem\\:\\:remove\\(\\) expects iterable\\|string, array\\<int, string\\>\\|false given\\.$#"
+			count: 1
+			path: src/Docs/Command/DocsDumpErd.php
+
+		-
+			message: "#^Property Shopware\\\\Docs\\\\Command\\\\RemoveArticlesAndCategoriesCommand\\:\\:\\$environment \\(string\\) does not accept string\\|false\\.$#"
+			count: 1
+			path: src/Docs/Command/RemoveArticlesAndCategoriesCommand.php
+
+		-
+			message: "#^Parameter \\#1 \\$json of function json_decode expects string, string\\|false given\\.$#"
+			count: 1
+			path: src/Docs/Convert/CredentialsService.php
+
+		-
+			message: "#^Method Shopware\\\\Docs\\\\Convert\\\\DocsParsedownExtra\\:\\:blockFencedCode\\(\\) has parameter \\$Line with no typehint specified\\.$#"
+			count: 1
+			path: src/Docs/Convert/DocsParsedownExtra.php
+
+		-
+			message: "#^Method Shopware\\\\Docs\\\\Convert\\\\DocsParsedownExtra\\:\\:blockFencedCodeComplete\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Docs/Convert/DocsParsedownExtra.php
+
+		-
+			message: "#^Method Shopware\\\\Docs\\\\Convert\\\\DocsParsedownExtra\\:\\:blockFencedCodeComplete\\(\\) has parameter \\$Block with no typehint specified\\.$#"
+			count: 1
+			path: src/Docs/Convert/DocsParsedownExtra.php
+
+		-
+			message: "#^Parameter \\#1 \\$path of function dirname expects string, string\\|false given\\.$#"
+			count: 1
+			path: src/Docs/Convert/DocsParsedownExtra.php
+
+		-
+			message: "#^Method Shopware\\\\Docs\\\\Convert\\\\DocsParsedownExtra\\:\\:docsExtractContentsFromIncludeFile\\(\\) has parameter \\$includeFile with no typehint specified\\.$#"
+			count: 1
+			path: src/Docs/Convert/DocsParsedownExtra.php
+
+		-
+			message: "#^Method Shopware\\\\Docs\\\\Convert\\\\DocsParsedownExtra\\:\\:docsExtractContentsFromIncludeFile\\(\\) has parameter \\$namespace with no typehint specified\\.$#"
+			count: 1
+			path: src/Docs/Convert/DocsParsedownExtra.php
+
+		-
+			message: "#^Argument of an invalid type array\\<int, string\\>\\|false supplied for foreach, only iterables are supported\\.$#"
+			count: 1
+			path: src/Docs/Convert/DocsParsedownExtra.php
+
+		-
+			message: "#^Method Shopware\\\\Docs\\\\Convert\\\\DocsParsedownExtra\\:\\:docsExtractContentsFromIncludeFile\\(\\) should return array but returns array\\<int, string\\>\\|false\\.$#"
+			count: 1
+			path: src/Docs/Convert/DocsParsedownExtra.php
+
+		-
+			message: "#^Parameter \\#1 \\$input of function array_slice expects array, array\\<int, string\\>\\|false given\\.$#"
+			count: 1
+			path: src/Docs/Convert/DocsParsedownExtra.php
+
+		-
+			message: "#^Parameter \\#2 \\$offset of function array_slice expects int, float\\|int given\\.$#"
+			count: 1
+			path: src/Docs/Convert/DocsParsedownExtra.php
+
+		-
+			message: "#^Parameter \\#1 \\$path of function dirname expects string, string\\|false given\\.$#"
+			count: 2
+			path: src/Docs/Convert/Document.php
+
+		-
+			message: "#^Argument of an invalid type array\\<int, string\\>\\|false supplied for foreach, only iterables are supported\\.$#"
+			count: 1
+			path: src/Docs/Convert/Document.php
+
+		-
+			message: "#^Property Shopware\\\\Docs\\\\Convert\\\\DocumentHtml\\:\\:\\$media has no typehint specified\\.$#"
+			count: 1
+			path: src/Docs/Convert/DocumentHtml.php
+
+		-
+			message: "#^Method Shopware\\\\Docs\\\\Convert\\\\DocumentHtml\\:\\:stripMetatags\\(\\) should return string but returns string\\|null\\.$#"
+			count: 1
+			path: src/Docs/Convert/DocumentHtml.php
+
+		-
+			message: "#^Parameter \\#1 \\$path of function dirname expects string, string\\|false given\\.$#"
+			count: 2
+			path: src/Docs/Convert/DocumentHtml.php
+
+		-
+			message: "#^Method Shopware\\\\Docs\\\\Convert\\\\DocumentMetadata\\:\\:requireMetadata\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Docs/Convert/DocumentMetadata.php
+
+		-
+			message: "#^Cannot call method getStatusCode\\(\\) on Psr\\\\Http\\\\Message\\\\ResponseInterface\\|null\\.$#"
+			count: 1
+			path: src/Docs/Convert/EntityHandler.php
+
+		-
+			message: "#^Method Shopware\\\\Docs\\\\Convert\\\\WikiApiService\\:\\:getOrCreateMissingCategoryTree\\(\\) should return int but returns int\\|null\\.$#"
+			count: 1
+			path: src/Docs/Convert/WikiApiService.php
+
+		-
+			message: "#^Parameter \\#1 \\$categoryId of method Shopware\\\\Docs\\\\Convert\\\\WikiApiService\\:\\:deleteCategory\\(\\) expects string, int\\|string given\\.$#"
+			count: 1
+			path: src/Docs/Convert/WikiApiService.php
+
+		-
+			message: "#^Parameter \\#1 \\$id of method Shopware\\\\Docs\\\\Convert\\\\EntityHandler\\:\\:deleteById\\(\\) expects int, int\\|string given\\.$#"
+			count: 1
+			path: src/Docs/Convert/WikiApiService.php
+
+		-
+			message: "#^Method Shopware\\\\Docs\\\\Convert\\\\WikiApiService\\:\\:disableArticle\\(\\) has parameter \\$articleId with no typehint specified\\.$#"
+			count: 1
+			path: src/Docs/Convert/WikiApiService.php
+
+		-
+			message: "#^Cannot call method getCategoryId\\(\\) on Shopware\\\\Docs\\\\Convert\\\\Document\\|null\\.$#"
+			count: 1
+			path: src/Docs/Convert/WikiApiService.php
+
+		-
+			message: "#^Cannot call method getHtml\\(\\) on Shopware\\\\Docs\\\\Convert\\\\Document\\|null\\.$#"
+			count: 1
+			path: src/Docs/Convert/WikiApiService.php
+
+		-
+			message: "#^Parameter \\#1 \\$hash of method Shopware\\\\Docs\\\\Convert\\\\EntityHandler\\:\\:deleteEntityHash\\(\\) expects string, int\\|string given\\.$#"
+			count: 2
+			path: src/Docs/Convert/WikiApiService.php
+
+		-
+			message: "#^Property Shopware\\\\Docs\\\\Docs\\:\\:\\$name has no typehint specified\\.$#"
+			count: 1
+			path: src/Docs/Docs.php
+
+		-
+			message: "#^Property Shopware\\\\Docs\\\\Inspection\\\\ArrayWriter\\:\\:\\$data has no typehint specified\\.$#"
+			count: 1
+			path: src/Docs/Inspection/ArrayWriter.php
+
+		-
+			message: "#^Property Shopware\\\\Docs\\\\Inspection\\\\ErdTypeMap\\:\\:\\$fieldTypeMap has no typehint specified\\.$#"
+			count: 1
+			path: src/Docs/Inspection/ErdTypeMap.php
+
+		-
+			message: "#^Property Shopware\\\\Docs\\\\Inspection\\\\MarkdownErdDumper\\:\\:\\$tables has no typehint specified\\.$#"
+			count: 1
+			path: src/Docs/Inspection/MarkdownErdDumper.php
+
+		-
+			message: "#^Property Shopware\\\\Docs\\\\Inspection\\\\ModuleInspector\\:\\:\\$defaultName has no typehint specified\\.$#"
+			count: 1
+			path: src/Docs/Inspection/ModuleInspector.php
+
+		-
+			message: "#^Parameter \\#2 \\$str of function explode expects string, string\\|false given\\.$#"
+			count: 1
+			path: src/Docs/Inspection/ModuleInspector.php
+
+		-
+			message: "#^Parameter \\#1 \\$dirs of method Symfony\\\\Component\\\\Finder\\\\Finder\\:\\:in\\(\\) expects array\\<string\\>\\|string, string\\|false given\\.$#"
+			count: 3
+			path: src/Docs/Inspection/ModuleInspector.php
+
+		-
+			message: "#^Parameter \\#1 \\$argument of class ReflectionClass constructor expects class\\-string\\<T of object\\>\\|T of object, string given\\.$#"
+			count: 2
+			path: src/Docs/Inspection/ModuleInspector.php
+
+		-
+			message: "#^Property Shopware\\\\Docs\\\\Inspection\\\\TemplateCustomRulesList\\:\\:\\$ruleListPath has no typehint specified\\.$#"
+			count: 1
+			path: src/Docs/Inspection/TemplateCustomRulesList.php
+
+		-
+			message: "#^Cannot call method booleanNode\\(\\) on Symfony\\\\Component\\\\Config\\\\Definition\\\\Builder\\\\NodeParentInterface\\|null\\.$#"
+			count: 1
+			path: src/Elasticsearch/DependencyInjection/Configuration.php
+
+		-
+			message: "#^Parameter \\#1 \\$configuration of method Symfony\\\\Component\\\\DependencyInjection\\\\Extension\\\\Extension\\:\\:processConfiguration\\(\\) expects Symfony\\\\Component\\\\Config\\\\Definition\\\\ConfigurationInterface, Symfony\\\\Component\\\\Config\\\\Definition\\\\ConfigurationInterface\\|null given\\.$#"
+			count: 1
+			path: src/Elasticsearch/DependencyInjection/ElasticsearchExtension.php
+
+		-
+			message: "#^Property Shopware\\\\Elasticsearch\\\\Elasticsearch\\:\\:\\$name has no typehint specified\\.$#"
+			count: 1
+			path: src/Elasticsearch/Elasticsearch.php
+
+		-
+			message: "#^Parameter \\#2 \\$query of class ONGR\\\\ElasticsearchDSL\\\\Query\\\\FullText\\\\MatchQuery constructor expects string, string\\|null given\\.$#"
+			count: 4
+			path: src/Elasticsearch/Framework/AbstractElasticsearchDefinition.php
+
+		-
+			message: "#^Parameter \\#2 \\$query of class ONGR\\\\ElasticsearchDSL\\\\Query\\\\FullText\\\\MatchPhrasePrefixQuery constructor expects string, string\\|null given\\.$#"
+			count: 1
+			path: src/Elasticsearch/Framework/AbstractElasticsearchDefinition.php
+
+		-
+			message: "#^Parameter \\#1 \\$str of function strtolower expects string, string\\|null given\\.$#"
+			count: 1
+			path: src/Elasticsearch/Framework/AbstractElasticsearchDefinition.php
+
+		-
+			message: "#^Method Shopware\\\\Elasticsearch\\\\Framework\\\\ClientFactory\\:\\:createClient\\(\\) has parameter \\$hosts with no typehint specified\\.$#"
+			count: 1
+			path: src/Elasticsearch/Framework/ClientFactory.php
+
+		-
+			message: "#^Parameter \\#1 \\$abstractAggregation of method ONGR\\\\ElasticsearchDSL\\\\Aggregation\\\\AbstractAggregation\\:\\:addAggregation\\(\\) expects ONGR\\\\ElasticsearchDSL\\\\Aggregation\\\\AbstractAggregation, ONGR\\\\ElasticsearchDSL\\\\Aggregation\\\\AbstractAggregation\\|null given\\.$#"
+			count: 3
+			path: src/Elasticsearch/Framework/DataAbstractionLayer/CriteriaParser.php
+
+		-
+			message: "#^Parameter \\#1 \\$aggregation of method Shopware\\\\Elasticsearch\\\\Framework\\\\DataAbstractionLayer\\\\CriteriaParser\\:\\:parseAggregation\\(\\) expects Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Search\\\\Aggregation\\\\Aggregation, Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Search\\\\Aggregation\\\\Aggregation\\|null given\\.$#"
+			count: 3
+			path: src/Elasticsearch/Framework/DataAbstractionLayer/CriteriaParser.php
+
+		-
+			message: "#^Cannot call method getField\\(\\) on Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Search\\\\Sorting\\\\FieldSorting\\|null\\.$#"
+			count: 2
+			path: src/Elasticsearch/Framework/DataAbstractionLayer/CriteriaParser.php
+
+		-
+			message: "#^Cannot call method getDirection\\(\\) on Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Search\\\\Sorting\\\\FieldSorting\\|null\\.$#"
+			count: 2
+			path: src/Elasticsearch/Framework/DataAbstractionLayer/CriteriaParser.php
+
+		-
+			message: "#^Parameter \\#4 \\$result of method Shopware\\\\Elasticsearch\\\\Framework\\\\DataAbstractionLayer\\\\AbstractElasticsearchAggregationHydrator\\:\\:hydrate\\(\\) expects array, array\\|\\(callable\\) given\\.$#"
+			count: 1
+			path: src/Elasticsearch/Framework/DataAbstractionLayer/ElasticsearchEntityAggregator.php
+
+		-
+			message: "#^Cannot call method getName\\(\\) on Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Search\\\\Aggregation\\\\Aggregation\\|null\\.$#"
+			count: 1
+			path: src/Elasticsearch/Framework/DataAbstractionLayer/ElasticsearchEntityAggregatorHydrator.php
+
+		-
+			message: "#^Parameter \\#1 \\$aggregation of method Shopware\\\\Elasticsearch\\\\Framework\\\\DataAbstractionLayer\\\\ElasticsearchEntityAggregatorHydrator\\:\\:hydrateAggregation\\(\\) expects Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Search\\\\Aggregation\\\\Aggregation, Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Search\\\\Aggregation\\\\Aggregation\\|null given\\.$#"
+			count: 1
+			path: src/Elasticsearch/Framework/DataAbstractionLayer/ElasticsearchEntityAggregatorHydrator.php
+
+		-
+			message: "#^Method Shopware\\\\Elasticsearch\\\\Framework\\\\DataAbstractionLayer\\\\ElasticsearchEntityAggregatorHydrator\\:\\:hydrateAggregation\\(\\) should return Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Search\\\\AggregationResult\\\\AggregationResult but returns Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Search\\\\AggregationResult\\\\Bucket\\\\TermsResult\\|null\\.$#"
+			count: 1
+			path: src/Elasticsearch/Framework/DataAbstractionLayer/ElasticsearchEntityAggregatorHydrator.php
+
+		-
+			message: "#^Method Shopware\\\\Elasticsearch\\\\Framework\\\\DataAbstractionLayer\\\\ElasticsearchEntityAggregatorHydrator\\:\\:hydrateDateHistogram\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Elasticsearch/Framework/DataAbstractionLayer/ElasticsearchEntityAggregatorHydrator.php
+
+		-
+			message: "#^Parameter \\#1 \\$format of method DateTime\\:\\:format\\(\\) expects string, string\\|null given\\.$#"
+			count: 1
+			path: src/Elasticsearch/Framework/DataAbstractionLayer/ElasticsearchEntityAggregatorHydrator.php
+
+		-
+			message: "#^Parameter \\#4 \\$result of method Shopware\\\\Elasticsearch\\\\Framework\\\\DataAbstractionLayer\\\\AbstractElasticsearchSearchHydrator\\:\\:hydrate\\(\\) expects array, array\\|\\(callable\\) given\\.$#"
+			count: 1
+			path: src/Elasticsearch/Framework/DataAbstractionLayer/ElasticsearchEntitySearcher.php
+
+		-
+			message: "#^Parameter \\#1 \\$size of method ONGR\\\\ElasticsearchDSL\\\\Search\\:\\:setSize\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Elasticsearch/Framework/DataAbstractionLayer/ElasticsearchEntitySearcher.php
+
+		-
+			message: "#^Parameter \\#1 \\$from of method ONGR\\\\ElasticsearchDSL\\\\Search\\:\\:setFrom\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Elasticsearch/Framework/DataAbstractionLayer/ElasticsearchEntitySearcher.php
+
+		-
+			message: "#^Cannot call method getField\\(\\) on Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Search\\\\Grouping\\\\FieldGrouping\\|null\\.$#"
+			count: 2
+			path: src/Elasticsearch/Framework/DataAbstractionLayer/ElasticsearchEntitySearcher.php
+
+		-
+			message: "#^Parameter \\#2 \\$search of function array_key_exists expects array, array\\|\\(callable\\) given\\.$#"
+			count: 1
+			path: src/Elasticsearch/Framework/ElasticsearchHelper.php
+
+		-
+			message: "#^Argument of an invalid type array\\|\\(callable\\) supplied for foreach, only iterables are supported\\.$#"
+			count: 1
+			path: src/Elasticsearch/Framework/ElasticsearchOutdatedIndexDetector.php
+
+		-
+			message: "#^Parameter \\#1 \\$input of function array_keys expects array, array\\|\\(callable\\) given\\.$#"
+			count: 1
+			path: src/Elasticsearch/Framework/Indexing/CreateAliasTaskHandler.php
+
+		-
+			message: "#^Cannot access offset 'errors' on array\\|\\(callable\\(\\)\\: mixed\\)\\.$#"
+			count: 1
+			path: src/Elasticsearch/Framework/Indexing/ElasticsearchIndexer.php
+
+		-
+			message: "#^Parameter \\#1 \\$result of method Shopware\\\\Elasticsearch\\\\Framework\\\\Indexing\\\\ElasticsearchIndexer\\:\\:parseErrors\\(\\) expects array, \\(array\\)\\|\\(callable\\) given\\.$#"
+			count: 1
+			path: src/Elasticsearch/Framework/Indexing/ElasticsearchIndexer.php
+
+		-
+			message: "#^Parameter \\#1 \\$json of function json_decode expects string, string\\|false given\\.$#"
+			count: 1
+			path: src/Elasticsearch/Framework/Indexing/ElasticsearchIndexer.php
+
+		-
+			message: "#^Method Shopware\\\\Elasticsearch\\\\Framework\\\\Indexing\\\\IndexerOffset\\:\\:__construct\\(\\) has parameter \\$lastId with no typehint specified\\.$#"
+			count: 1
+			path: src/Elasticsearch/Framework/Indexing/IndexerOffset.php
+
+		-
+			message: "#^Property Shopware\\\\Elasticsearch\\\\Framework\\\\Indexing\\\\IndexerOffset\\:\\:\\$definition \\(string\\) does not accept string\\|null\\.$#"
+			count: 2
+			path: src/Elasticsearch/Framework/Indexing/IndexerOffset.php
+
+		-
+			message: "#^Method Shopware\\\\Elasticsearch\\\\Framework\\\\Indexing\\\\IndexerOffset\\:\\:setNextLanguage\\(\\) should return string but returns string\\|null\\.$#"
+			count: 1
+			path: src/Elasticsearch/Framework/Indexing/IndexerOffset.php
+
+		-
+			message: "#^Property Shopware\\\\Elasticsearch\\\\Framework\\\\Indexing\\\\IndexerOffset\\:\\:\\$languageId \\(string\\) does not accept string\\|null\\.$#"
+			count: 1
+			path: src/Elasticsearch/Framework/Indexing/IndexerOffset.php
+
+		-
+			message: "#^Method Shopware\\\\Elasticsearch\\\\Framework\\\\Indexing\\\\IndexerOffset\\:\\:getLastId\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Elasticsearch/Framework/Indexing/IndexerOffset.php
+
+		-
+			message: "#^Parameter \\#2 \\$field of method Shopware\\\\Elasticsearch\\\\Framework\\\\Indexing\\\\EntityMapper\\:\\:mapField\\(\\) expects Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Field\\\\Field, Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Field\\\\Field\\|null given\\.$#"
+			count: 7
+			path: src/Elasticsearch/Product/ElasticsearchProductDefinition.php
+
+		-
+			message: "#^Parameter \\#2 \\$query of class ONGR\\\\ElasticsearchDSL\\\\Query\\\\FullText\\\\MatchQuery constructor expects string, string\\|null given\\.$#"
+			count: 1
+			path: src/Elasticsearch/Product/ElasticsearchProductDefinition.php
+
+		-
+			message: "#^Parameter \\#2 \\$field of method Shopware\\\\Elasticsearch\\\\Framework\\\\Indexing\\\\EntityMapper\\:\\:mapField\\(\\) expects Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Field\\\\Field, Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Field\\\\Field\\|null given\\.$#"
+			count: 8
+			path: src/Elasticsearch/Test/Product/ElasticsearchProductDefinitionExtension.php
+
+		-
+			message: "#^Cannot call method getGuest\\(\\) on Shopware\\\\Core\\\\Checkout\\\\Customer\\\\CustomerEntity\\|null\\.$#"
+			count: 1
+			path: src/Storefront/Controller/AccountOrderController.php
+
+		-
+			message: "#^Cannot call method setDefaultShippingAddress\\(\\) on Shopware\\\\Core\\\\Checkout\\\\Customer\\\\CustomerEntity\\|null\\.$#"
+			count: 1
+			path: src/Storefront/Controller/AddressController.php
+
+		-
+			message: "#^Cannot call method setDefaultBillingAddress\\(\\) on Shopware\\\\Core\\\\Checkout\\\\Customer\\\\CustomerEntity\\|null\\.$#"
+			count: 1
+			path: src/Storefront/Controller/AddressController.php
+
+		-
+			message: "#^Parameter \\#1 \\$id of method Shopware\\\\Core\\\\Content\\\\Product\\\\Cart\\\\ProductLineItemFactory\\:\\:create\\(\\) expects string, array\\|string\\|null given\\.$#"
+			count: 1
+			path: src/Storefront/Controller/CartLineItemController.php
+
+		-
+			message: "#^Cannot call method getId\\(\\) on Shopware\\\\Core\\\\Checkout\\\\Customer\\\\CustomerEntity\\|null\\.$#"
+			count: 1
+			path: src/Storefront/Controller/ContextController.php
+
+		-
+			message: "#^Cannot access offset 'port' on array\\(\\?'scheme' \\=\\> string, \\?'host' \\=\\> string, \\?'port' \\=\\> int, \\?'user' \\=\\> string, \\?'pass' \\=\\> string, \\?'path' \\=\\> string, \\?'query' \\=\\> string, \\?'fragment' \\=\\> string\\)\\|false\\.$#"
+			count: 1
+			path: src/Storefront/Controller/ContextController.php
+
+		-
+			message: "#^Cannot access offset 'host' on array\\(\\?'scheme' \\=\\> string, \\?'host' \\=\\> string, \\?'port' \\=\\> int, \\?'user' \\=\\> string, \\?'pass' \\=\\> string, \\?'path' \\=\\> string, \\?'query' \\=\\> string, \\?'fragment' \\=\\> string\\)\\|false\\.$#"
+			count: 1
+			path: src/Storefront/Controller/ContextController.php
+
+		-
+			message: "#^Cannot access offset 'path' on array\\(\\?'scheme' \\=\\> string, \\?'host' \\=\\> string, \\?'port' \\=\\> int, \\?'user' \\=\\> string, \\?'pass' \\=\\> string, \\?'path' \\=\\> string, \\?'query' \\=\\> string, \\?'fragment' \\=\\> string\\)\\|false\\.$#"
+			count: 1
+			path: src/Storefront/Controller/ContextController.php
+
+		-
+			message: "#^Cannot access property \\$attributes on Symfony\\\\Component\\\\HttpFoundation\\\\Request\\|null\\.$#"
+			count: 1
+			path: src/Storefront/Controller/ContextController.php
+
+		-
+			message: "#^Cannot call method isActive\\(\\) on Shopware\\\\Core\\\\System\\\\SalesChannel\\\\Aggregate\\\\SalesChannelAnalytics\\\\SalesChannelAnalyticsEntity\\|null\\.$#"
+			count: 1
+			path: src/Storefront/Controller/CookieController.php
+
+		-
+			message: "#^Cannot call method getStates\\(\\) on Shopware\\\\Core\\\\System\\\\Country\\\\CountryEntity\\|null\\.$#"
+			count: 2
+			path: src/Storefront/Controller/CountryStateController.php
+
+		-
+			message: "#^Cannot call method sortByPositionAndName\\(\\) on Shopware\\\\Core\\\\System\\\\Country\\\\Aggregate\\\\CountryState\\\\CountryStateCollection\\|null\\.$#"
+			count: 1
+			path: src/Storefront/Controller/CountryStateController.php
+
+		-
+			message: "#^Cannot call method getForceStateInRegistration\\(\\) on Shopware\\\\Core\\\\System\\\\Country\\\\CountryEntity\\|null\\.$#"
+			count: 1
+			path: src/Storefront/Controller/CountryStateController.php
+
+		-
+			message: "#^Parameter \\#2 \\$customer of method Shopware\\\\Storefront\\\\Controller\\\\NewsletterController\\:\\:hydrateFromCustomer\\(\\) expects Shopware\\\\Core\\\\Checkout\\\\Customer\\\\CustomerEntity, Shopware\\\\Core\\\\Checkout\\\\Customer\\\\CustomerEntity\\|null given\\.$#"
+			count: 2
+			path: src/Storefront/Controller/NewsletterController.php
+
+		-
+			message: "#^Parameter \\#1 \\$customer of method Shopware\\\\Storefront\\\\Controller\\\\NewsletterController\\:\\:setNewsletterFlag\\(\\) expects Shopware\\\\Core\\\\Checkout\\\\Customer\\\\CustomerEntity, Shopware\\\\Core\\\\Checkout\\\\Customer\\\\CustomerEntity\\|null given\\.$#"
+			count: 2
+			path: src/Storefront/Controller/NewsletterController.php
+
+		-
+			message: "#^Cannot call method getZipCode\\(\\) on Shopware\\\\Core\\\\Checkout\\\\Customer\\\\Aggregate\\\\CustomerAddress\\\\CustomerAddressEntity\\|null\\.$#"
+			count: 1
+			path: src/Storefront/Controller/NewsletterController.php
+
+		-
+			message: "#^Cannot call method getCity\\(\\) on Shopware\\\\Core\\\\Checkout\\\\Customer\\\\Aggregate\\\\CustomerAddress\\\\CustomerAddressEntity\\|null\\.$#"
+			count: 1
+			path: src/Storefront/Controller/NewsletterController.php
+
+		-
+			message: "#^Cannot call method getGuest\\(\\) on Shopware\\\\Core\\\\Checkout\\\\Customer\\\\CustomerEntity\\|null\\.$#"
+			count: 2
+			path: src/Storefront/Controller/RegisterController.php
+
+		-
+			message: "#^Cannot access property \\$attributes on Symfony\\\\Component\\\\HttpFoundation\\\\Request\\|null\\.$#"
+			count: 2
+			path: src/Storefront/Controller/StorefrontController.php
+
+		-
+			message: "#^Parameter \\#3 \\$request of class Shopware\\\\Storefront\\\\Event\\\\StorefrontRenderEvent constructor expects Symfony\\\\Component\\\\HttpFoundation\\\\Request, Symfony\\\\Component\\\\HttpFoundation\\\\Request\\|null given\\.$#"
+			count: 1
+			path: src/Storefront/Controller/StorefrontController.php
+
+		-
+			message: "#^Parameter \\#1 \\$content of method Shopware\\\\Core\\\\Content\\\\Seo\\\\SeoUrlPlaceholderHandlerInterface\\:\\:replace\\(\\) expects string, string\\|false given\\.$#"
+			count: 1
+			path: src/Storefront/Controller/StorefrontController.php
+
+		-
+			message: "#^Parameter \\#1 \\$sourceRequest of method Shopware\\\\Storefront\\\\Framework\\\\Routing\\\\RequestTransformer\\:\\:extractInheritableAttributes\\(\\) expects Symfony\\\\Component\\\\HttpFoundation\\\\Request, Symfony\\\\Component\\\\HttpFoundation\\\\Request\\|null given\\.$#"
+			count: 1
+			path: src/Storefront/Controller/StorefrontController.php
+
+		-
+			message: "#^Cannot call method getGuest\\(\\) on Shopware\\\\Core\\\\Checkout\\\\Customer\\\\CustomerEntity\\|null\\.$#"
+			count: 1
+			path: src/Storefront/Controller/StorefrontController.php
+
+		-
+			message: "#^Cannot call method enumNode\\(\\) on Symfony\\\\Component\\\\Config\\\\Definition\\\\Builder\\\\NodeParentInterface\\|null\\.$#"
+			count: 1
+			path: src/Storefront/DependencyInjection/Configuration.php
+
+		-
+			message: "#^Method Shopware\\\\Storefront\\\\Event\\\\StorefrontRenderEvent\\:\\:setParameter\\(\\) has parameter \\$value with no typehint specified\\.$#"
+			count: 1
+			path: src/Storefront/Event/StorefrontRenderEvent.php
+
+		-
+			message: "#^Property Shopware\\\\Storefront\\\\Framework\\\\Cache\\\\Annotation\\\\HttpCache\\:\\:\\$states \\(array\\) does not accept array\\|null\\.$#"
+			count: 1
+			path: src/Storefront/Framework/Cache/Annotation/HttpCache.php
+
+		-
+			message: "#^Parameter \\#1 \\$str of function md5 expects string, string\\|false given\\.$#"
+			count: 1
+			path: src/Storefront/Framework/Cache/CacheResponseSubscriber.php
+
+		-
+			message: "#^Parameter \\#1 \\$tags of method Symfony\\\\Component\\\\Cache\\\\CacheItem\\:\\:tag\\(\\) expects array\\<string\\>\\|string, array given\\.$#"
+			count: 1
+			path: src/Storefront/Framework/Cache/CacheStore.php
+
+		-
+			message: "#^Parameter \\#1 \\$uri of static method Symfony\\\\Component\\\\HttpFoundation\\\\Request\\:\\:create\\(\\) expects string, string\\|null given\\.$#"
+			count: 2
+			path: src/Storefront/Framework/Cache/CacheStore.php
+
+		-
+			message: "#^Property Shopware\\\\Storefront\\\\Framework\\\\Cache\\\\CacheWarmer\\\\CacheRouteWarmerRegistry\\:\\:\\$warmers \\(array\\<Shopware\\\\Storefront\\\\Framework\\\\Cache\\\\CacheWarmer\\\\CacheRouteWarmer\\>\\) does not accept iterable\\.$#"
+			count: 1
+			path: src/Storefront/Framework/Cache/CacheWarmer/CacheRouteWarmerRegistry.php
+
+		-
+			message: "#^Method Shopware\\\\Storefront\\\\Framework\\\\Cache\\\\CacheWarmer\\\\CacheWarmer\\:\\:handle\\(\\) has parameter \\$message with no typehint specified\\.$#"
+			count: 1
+			path: src/Storefront/Framework/Cache/CacheWarmer/CacheWarmer.php
+
+		-
+			message: "#^Method Shopware\\\\Storefront\\\\Framework\\\\Cache\\\\ObjectCacheKeyFinder\\:\\:loop\\(\\) has parameter \\$data with no typehint specified\\.$#"
+			count: 1
+			path: src/Storefront/Framework/Cache/ObjectCacheKeyFinder.php
+
+		-
+			message: "#^Method Shopware\\\\Storefront\\\\Framework\\\\Command\\\\SalesChannelCreateStorefrontCommand\\:\\:getRootCategoryId\\(\\) should return string but returns array\\|string\\|null\\.$#"
+			count: 1
+			path: src/Storefront/Framework/Command/SalesChannelCreateStorefrontCommand.php
+
+		-
+			message: "#^Parameter \\#3 \\$subject of function preg_replace_callback expects array\\|string, string\\|false given\\.$#"
+			count: 1
+			path: src/Storefront/Framework/Csrf/CsrfPlaceholderHandler.php
+
+		-
+			message: "#^Parameter \\#2 \\$mimeType of class Shopware\\\\Core\\\\Content\\\\Media\\\\File\\\\MediaFile constructor expects string, string\\|null given\\.$#"
+			count: 1
+			path: src/Storefront/Framework/Media/StorefrontMediaUploader.php
+
+		-
+			message: "#^Property Shopware\\\\Storefront\\\\Framework\\\\Media\\\\StorefrontMediaValidatorRegistry\\:\\:\\$validators \\(array\\<Shopware\\\\Storefront\\\\Framework\\\\Media\\\\StorefrontMediaValidatorInterface\\>\\) does not accept iterable\\.$#"
+			count: 1
+			path: src/Storefront/Framework/Media/StorefrontMediaValidatorRegistry.php
+
+		-
+			message: "#^Parameter \\#1 \\$mimeType of class Shopware\\\\Storefront\\\\Framework\\\\Media\\\\Exception\\\\FileTypeNotAllowedException constructor expects string, string\\|null given\\.$#"
+			count: 1
+			path: src/Storefront/Framework/Media/Validator/StorefrontMediaDocumentValidator.php
+
+		-
+			message: "#^Parameter \\#1 \\$mimeType of class Shopware\\\\Storefront\\\\Framework\\\\Media\\\\Exception\\\\FileTypeNotAllowedException constructor expects string, string\\|null given\\.$#"
+			count: 2
+			path: src/Storefront/Framework/Media/Validator/StorefrontMediaImageValidator.php
+
+		-
+			message: "#^Cannot access offset 'mime' on array\\|false\\.$#"
+			count: 1
+			path: src/Storefront/Framework/Media/Validator/StorefrontMediaImageValidator.php
+
+		-
+			message: "#^Method Shopware\\\\Storefront\\\\Framework\\\\Page\\\\StorefrontSearchResult\\:\\:getPageCount\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Storefront/Framework/Page/StorefrontSearchResult.php
+
+		-
+			message: "#^Method Shopware\\\\Storefront\\\\Framework\\\\Routing\\\\Router\\:\\:warmUp\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Storefront/Framework/Routing/Router.php
+
+		-
+			message: "#^Method Shopware\\\\Storefront\\\\Framework\\\\Routing\\\\Router\\:\\:setContext\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Storefront/Framework/Routing/Router.php
+
+		-
+			message: "#^Property Shopware\\\\Storefront\\\\Framework\\\\Routing\\\\StorefrontResponse\\:\\:\\$data \\(array\\) does not accept array\\|null\\.$#"
+			count: 1
+			path: src/Storefront/Framework/Routing/StorefrontResponse.php
+
+		-
+			message: "#^Parameter \\#2 \\$request of method Shopware\\\\Storefront\\\\Controller\\\\ErrorController\\:\\:error\\(\\) expects Symfony\\\\Component\\\\HttpFoundation\\\\Request, Symfony\\\\Component\\\\HttpFoundation\\\\Request\\|null given\\.$#"
+			count: 1
+			path: src/Storefront/Framework/Routing/StorefrontSubscriber.php
+
+		-
+			message: "#^Parameter \\#2 \\$token of method Shopware\\\\Core\\\\System\\\\SalesChannel\\\\Context\\\\SalesChannelContextServiceInterface\\:\\:get\\(\\) expects string, string\\|null given\\.$#"
+			count: 1
+			path: src/Storefront/Framework/Routing/StorefrontSubscriber.php
+
+		-
+			message: "#^Cannot call method filterBySalesChannelId\\(\\) on Shopware\\\\Core\\\\Content\\\\Seo\\\\MainCategory\\\\MainCategoryCollection\\|null\\.$#"
+			count: 1
+			path: src/Storefront/Framework/Seo/SeoUrlRoute/ProductPageSeoUrlRoute.php
+
+		-
+			message: "#^Cannot call method sortByPosition\\(\\) on Shopware\\\\Core\\\\Content\\\\Category\\\\CategoryCollection\\|null\\.$#"
+			count: 1
+			path: src/Storefront/Framework/Seo/SeoUrlRoute/ProductPageSeoUrlRoute.php
+
+		-
+			message: "#^Cannot call method fetchAll\\(\\) on Doctrine\\\\DBAL\\\\Driver\\\\Statement\\|int\\.$#"
+			count: 1
+			path: src/Storefront/Framework/Seo/SeoUrlRoute/SeoUrlUpdateListener.php
+
+		-
+			message: "#^Method Shopware\\\\Storefront\\\\Framework\\\\Twig\\\\ErrorTemplateStruct\\:\\:__construct\\(\\) has parameter \\$arguments with no typehint specified\\.$#"
+			count: 1
+			path: src/Storefront/Framework/Twig/ErrorTemplateStruct.php
+
+		-
+			message: "#^Method Shopware\\\\Storefront\\\\Framework\\\\Twig\\\\ErrorTemplateStruct\\:\\:__construct\\(\\) has parameter \\$templateName with no typehint specified\\.$#"
+			count: 1
+			path: src/Storefront/Framework/Twig/ErrorTemplateStruct.php
+
+		-
+			message: "#^Property Shopware\\\\Storefront\\\\Framework\\\\Twig\\\\Extension\\\\SwSanitizeTwigFilter\\:\\:\\$allowedElements has no typehint specified\\.$#"
+			count: 1
+			path: src/Storefront/Framework/Twig/Extension/SwSanitizeTwigFilter.php
+
+		-
+			message: "#^Property Shopware\\\\Storefront\\\\Framework\\\\Twig\\\\Extension\\\\SwSanitizeTwigFilter\\:\\:\\$allowedAttributes has no typehint specified\\.$#"
+			count: 1
+			path: src/Storefront/Framework/Twig/Extension/SwSanitizeTwigFilter.php
+
+		-
+			message: "#^Property Shopware\\\\Storefront\\\\Framework\\\\Twig\\\\Extension\\\\SwSanitizeTwigFilter\\:\\:\\$cacheDir \\(string\\) does not accept string\\|null\\.$#"
+			count: 1
+			path: src/Storefront/Framework/Twig/Extension/SwSanitizeTwigFilter.php
+
+		-
+			message: "#^Parameter \\#1 \\$str of function md5 expects string, string\\|false given\\.$#"
+			count: 1
+			path: src/Storefront/Framework/Twig/Extension/SwSanitizeTwigFilter.php
+
+		-
+			message: "#^Cannot access offset 'path' on array\\(\\?'scheme' \\=\\> string, \\?'host' \\=\\> string, \\?'port' \\=\\> int, \\?'user' \\=\\> string, \\?'pass' \\=\\> string, \\?'path' \\=\\> string, \\?'query' \\=\\> string, \\?'fragment' \\=\\> string\\)\\|false\\.$#"
+			count: 1
+			path: src/Storefront/Framework/Twig/Extension/UrlEncodingTwigFilter.php
+
+		-
+			message: "#^Cannot access offset 'query' on array\\(\\?'scheme' \\=\\> string, \\?'host' \\=\\> string, \\?'port' \\=\\> int, \\?'user' \\=\\> string, \\?'pass' \\=\\> string, \\?'path' \\=\\> string, \\?'query' \\=\\> string, \\?'fragment' \\=\\> string\\)\\|false\\.$#"
+			count: 1
+			path: src/Storefront/Framework/Twig/Extension/UrlEncodingTwigFilter.php
+
+		-
+			message: "#^Cannot access offset 'scheme' on array\\(\\?'scheme' \\=\\> string, \\?'host' \\=\\> string, \\?'port' \\=\\> int, \\?'user' \\=\\> string, \\?'pass' \\=\\> string, \\?'path' \\=\\> string, \\?'query' \\=\\> string, \\?'fragment' \\=\\> string\\)\\|false\\.$#"
+			count: 1
+			path: src/Storefront/Framework/Twig/Extension/UrlEncodingTwigFilter.php
+
+		-
+			message: "#^Cannot access offset 'host' on array\\(\\?'scheme' \\=\\> string, \\?'host' \\=\\> string, \\?'port' \\=\\> int, \\?'user' \\=\\> string, \\?'pass' \\=\\> string, \\?'path' \\=\\> string, \\?'query' \\=\\> string, \\?'fragment' \\=\\> string\\)\\|false\\.$#"
+			count: 1
+			path: src/Storefront/Framework/Twig/Extension/UrlEncodingTwigFilter.php
+
+		-
+			message: "#^Cannot access offset 'port' on array\\(\\?'scheme' \\=\\> string, \\?'host' \\=\\> string, \\?'port' \\=\\> int, \\?'user' \\=\\> string, \\?'pass' \\=\\> string, \\?'path' \\=\\> string, \\?'query' \\=\\> string, \\?'fragment' \\=\\> string\\)\\|false\\.$#"
+			count: 1
+			path: src/Storefront/Framework/Twig/Extension/UrlEncodingTwigFilter.php
+
+		-
+			message: "#^Cannot call method getId\\(\\) on Shopware\\\\Core\\\\Checkout\\\\Customer\\\\CustomerEntity\\|null\\.$#"
+			count: 2
+			path: src/Storefront/Page/Account/Order/AccountEditOrderPageLoader.php
+
+		-
+			message: "#^Cannot call method setMetaDescription\\(\\) on Shopware\\\\Storefront\\\\Page\\\\MetaInformation\\|null\\.$#"
+			count: 1
+			path: src/Storefront/Page/Navigation/NavigationPageLoader.php
+
+		-
+			message: "#^Cannot call method setMetaTitle\\(\\) on Shopware\\\\Storefront\\\\Page\\\\MetaInformation\\|null\\.$#"
+			count: 1
+			path: src/Storefront/Page/Navigation/NavigationPageLoader.php
+
+		-
+			message: "#^Cannot call method setMetaKeywords\\(\\) on Shopware\\\\Storefront\\\\Page\\\\MetaInformation\\|null\\.$#"
+			count: 1
+			path: src/Storefront/Page/Navigation/NavigationPageLoader.php
+
+		-
+			message: "#^Method Shopware\\\\Storefront\\\\Page\\\\Product\\\\Configurator\\\\ProductCombinationFinder\\:\\:searchForOptions\\(\\) should return string\\|null but returns array\\|string\\|null\\.$#"
+			count: 1
+			path: src/Storefront/Page/Product/Configurator/ProductCombinationFinder.php
+
+		-
+			message: "#^Parameter \\#1 \\$configurator of method Shopware\\\\Core\\\\Content\\\\Product\\\\SalesChannel\\\\SalesChannelProductEntity\\:\\:setConfigurator\\(\\) expects Shopware\\\\Core\\\\Content\\\\Property\\\\PropertyGroupCollection, Shopware\\\\Core\\\\Content\\\\Property\\\\PropertyGroupCollection\\|null given\\.$#"
+			count: 1
+			path: src/Storefront/Page/Product/ProductLoader.php
+
+		-
+			message: "#^Argument of an invalid type array\\|null supplied for foreach, only iterables are supported\\.$#"
+			count: 1
+			path: src/Storefront/Page/Product/ProductPageLoader.php
+
+		-
+			message: "#^Cannot call method setMetaDescription\\(\\) on Shopware\\\\Storefront\\\\Page\\\\MetaInformation\\|null\\.$#"
+			count: 1
+			path: src/Storefront/Page/Product/ProductPageLoader.php
+
+		-
+			message: "#^Cannot call method setMetaKeywords\\(\\) on Shopware\\\\Storefront\\\\Page\\\\MetaInformation\\|null\\.$#"
+			count: 1
+			path: src/Storefront/Page/Product/ProductPageLoader.php
+
+		-
+			message: "#^Cannot call method setMetaTitle\\(\\) on Shopware\\\\Storefront\\\\Page\\\\MetaInformation\\|null\\.$#"
+			count: 2
+			path: src/Storefront/Page/Product/ProductPageLoader.php
+
+		-
+			message: "#^Argument of an invalid type Shopware\\\\Core\\\\Content\\\\Cms\\\\Aggregate\\\\CmsSection\\\\CmsSectionCollection\\|null supplied for foreach, only iterables are supported\\.$#"
+			count: 1
+			path: src/Storefront/Page/Product/ProductPageLoader.php
+
+		-
+			message: "#^Parameter \\#4 \\$activeLanguage of class Shopware\\\\Storefront\\\\Pagelet\\\\Header\\\\HeaderPagelet constructor expects Shopware\\\\Core\\\\System\\\\Language\\\\LanguageEntity, Shopware\\\\Core\\\\System\\\\Language\\\\LanguageEntity\\|null given\\.$#"
+			count: 1
+			path: src/Storefront/Pagelet/Header/HeaderPageletLoader.php
+
+		-
+			message: "#^Property Shopware\\\\Storefront\\\\Storefront\\:\\:\\$name has no typehint specified\\.$#"
+			count: 1
+			path: src/Storefront/Storefront.php
+
+		-
+			message: "#^Method Shopware\\\\Storefront\\\\Storefront\\:\\:buildConfig\\(\\) has parameter \\$environment with no typehint specified\\.$#"
+			count: 1
+			path: src/Storefront/Storefront.php
+
+		-
+			message: "#^Method Shopware\\\\Storefront\\\\Theme\\\\Command\\\\ThemeChangeCommand\\:\\:parseSalesChannelAnswer\\(\\) has parameter \\$answer with no typehint specified\\.$#"
+			count: 1
+			path: src/Storefront/Theme/Command/ThemeChangeCommand.php
+
+		-
+			message: "#^Parameter \\#1 \\$str of function trim expects string, string\\|null given\\.$#"
+			count: 1
+			path: src/Storefront/Theme/Command/ThemeChangeCommand.php
+
+		-
+			message: "#^Method Shopware\\\\Storefront\\\\Theme\\\\Command\\\\ThemeCreateCommand\\:\\:getVariableOverridesTemplate\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Storefront/Theme/Command/ThemeCreateCommand.php
+
+		-
+			message: "#^Parameter \\#1 \\$name of method Shopware\\\\Storefront\\\\Theme\\\\StorefrontPluginConfiguration\\\\StorefrontPluginConfigurationCollection\\:\\:getByTechnicalName\\(\\) expects string, string\\|null given\\.$#"
+			count: 1
+			path: src/Storefront/Theme/Command/ThemeDumpCommand.php
+
+		-
+			message: "#^Parameter \\#1 \\$themeConfig of method Shopware\\\\Storefront\\\\Theme\\\\ThemeFileResolver\\:\\:resolveFiles\\(\\) expects Shopware\\\\Storefront\\\\Theme\\\\StorefrontPluginConfiguration\\\\StorefrontPluginConfiguration, Shopware\\\\Storefront\\\\Theme\\\\StorefrontPluginConfiguration\\\\StorefrontPluginConfiguration\\|null given\\.$#"
+			count: 1
+			path: src/Storefront/Theme/Command/ThemeDumpCommand.php
+
+		-
+			message: "#^Cannot call method getBasePath\\(\\) on Shopware\\\\Storefront\\\\Theme\\\\StorefrontPluginConfiguration\\\\StorefrontPluginConfiguration\\|null\\.$#"
+			count: 1
+			path: src/Storefront/Theme/Command/ThemeDumpCommand.php
+
+		-
+			message: "#^Method Shopware\\\\Storefront\\\\Theme\\\\Exception\\\\ThemeAssignmentException\\:\\:formatAssignments\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Storefront/Theme/Exception/ThemeAssignmentException.php
+
+		-
+			message: "#^Method Shopware\\\\Storefront\\\\Theme\\\\StorefrontPluginConfiguration\\\\FileCollection\\:\\:createFromArray\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Storefront/Theme/StorefrontPluginConfiguration/FileCollection.php
+
+		-
+			message: "#^Method Shopware\\\\Storefront\\\\Theme\\\\StorefrontPluginConfiguration\\\\StorefrontPluginConfiguration\\:\\:getBasePath\\(\\) should return string but returns string\\|null\\.$#"
+			count: 1
+			path: src/Storefront/Theme/StorefrontPluginConfiguration/StorefrontPluginConfiguration.php
+
+		-
+			message: "#^Property Shopware\\\\Storefront\\\\Theme\\\\StorefrontPluginConfiguration\\\\StorefrontPluginConfiguration\\:\\:\\$themeConfig \\(array\\) does not accept array\\|null\\.$#"
+			count: 1
+			path: src/Storefront/Theme/StorefrontPluginConfiguration/StorefrontPluginConfiguration.php
+
+		-
+			message: "#^Parameter \\#1 \\$json of function json_decode expects string, string\\|false given\\.$#"
+			count: 1
+			path: src/Storefront/Theme/StorefrontPluginConfiguration/StorefrontPluginConfigurationFactory.php
+
+		-
+			message: "#^Parameter \\#1 \\$basePath of method Shopware\\\\Storefront\\\\Theme\\\\StorefrontPluginConfiguration\\\\StorefrontPluginConfiguration\\:\\:setBasePath\\(\\) expects string, string\\|false given\\.$#"
+			count: 1
+			path: src/Storefront/Theme/StorefrontPluginConfiguration/StorefrontPluginConfigurationFactory.php
+
+		-
+			message: "#^Parameter \\#2 \\$basePath of method Shopware\\\\Storefront\\\\Theme\\\\StorefrontPluginConfiguration\\\\StorefrontPluginConfigurationFactory\\:\\:addBasePath\\(\\) expects string, string\\|false given\\.$#"
+			count: 1
+			path: src/Storefront/Theme/StorefrontPluginConfiguration/StorefrontPluginConfigurationFactory.php
+
+		-
+			message: "#^Parameter \\#2 \\$basePath of method Shopware\\\\Storefront\\\\Theme\\\\StorefrontPluginConfiguration\\\\StorefrontPluginConfigurationFactory\\:\\:addBasePathToCollection\\(\\) expects string, string\\|false given\\.$#"
+			count: 2
+			path: src/Storefront/Theme/StorefrontPluginConfiguration/StorefrontPluginConfigurationFactory.php
+
+		-
+			message: "#^Parameter \\#2 \\$basePath of method Shopware\\\\Storefront\\\\Theme\\\\StorefrontPluginConfiguration\\\\StorefrontPluginConfigurationFactory\\:\\:addBasePathToArray\\(\\) expects string, string\\|false given\\.$#"
+			count: 1
+			path: src/Storefront/Theme/StorefrontPluginConfiguration/StorefrontPluginConfigurationFactory.php
+
+		-
+			message: "#^Method Shopware\\\\Storefront\\\\Theme\\\\StorefrontPluginRegistry\\:\\:getConfigurations\\(\\) should return Shopware\\\\Storefront\\\\Theme\\\\StorefrontPluginConfiguration\\\\StorefrontPluginConfigurationCollection but returns Shopware\\\\Storefront\\\\Theme\\\\StorefrontPluginConfiguration\\\\StorefrontPluginConfigurationCollection\\|null\\.$#"
+			count: 1
+			path: src/Storefront/Theme/StorefrontPluginRegistry.php
+
+		-
+			message: "#^Cannot call method add\\(\\) on Shopware\\\\Storefront\\\\Theme\\\\StorefrontPluginConfiguration\\\\StorefrontPluginConfigurationCollection\\|null\\.$#"
+			count: 2
+			path: src/Storefront/Theme/StorefrontPluginRegistry.php
+
+		-
+			message: "#^Cannot call method getActiveApps\\(\\) on Shopware\\\\Core\\\\Framework\\\\App\\\\ActiveAppsLoader\\|null\\.$#"
+			count: 1
+			path: src/Storefront/Theme/StorefrontPluginRegistry.php
+
+		-
+			message: "#^Parameter \\#1 \\$pluginPath of method Shopware\\\\Storefront\\\\Theme\\\\Subscriber\\\\PluginLifecycleSubscriber\\:\\:createConfigFromClassName\\(\\) expects string, string\\|null given\\.$#"
+			count: 1
+			path: src/Storefront/Theme/Subscriber/PluginLifecycleSubscriber.php
+
+		-
+			message: "#^Property Shopware\\\\Storefront\\\\Theme\\\\ThemeCompiler\\:\\:\\$packages \\(array\\<Symfony\\\\Component\\\\Asset\\\\Package\\>\\) does not accept iterable\\.$#"
+			count: 1
+			path: src/Storefront/Theme/ThemeCompiler.php
+
+		-
+			message: "#^Parameter \\#1 \\$config of method Shopware\\\\Storefront\\\\Theme\\\\ThemeCompiler\\:\\:dumpVariables\\(\\) expects array, array\\|null given\\.$#"
+			count: 1
+			path: src/Storefront/Theme/ThemeCompiler.php
+
+		-
+			message: "#^Parameter \\#1 \\$themeName of class Shopware\\\\Storefront\\\\Theme\\\\Exception\\\\ThemeCompileException constructor expects string, string\\|null given\\.$#"
+			count: 1
+			path: src/Storefront/Theme/ThemeCompiler.php
+
+		-
+			message: "#^Property Shopware\\\\Storefront\\\\Theme\\\\ThemeConfigField\\:\\:\\$value has no typehint specified\\.$#"
+			count: 1
+			path: src/Storefront/Theme/ThemeConfigField.php
+
+		-
+			message: "#^Property Shopware\\\\Storefront\\\\Theme\\\\ThemeConfigField\\:\\:\\$label \\(array\\) does not accept array\\|null\\.$#"
+			count: 1
+			path: src/Storefront/Theme/ThemeConfigField.php
+
+		-
+			message: "#^Method Shopware\\\\Storefront\\\\Theme\\\\ThemeConfigField\\:\\:getValue\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Storefront/Theme/ThemeConfigField.php
+
+		-
+			message: "#^Method Shopware\\\\Storefront\\\\Theme\\\\ThemeConfigField\\:\\:setValue\\(\\) has parameter \\$value with no typehint specified\\.$#"
+			count: 1
+			path: src/Storefront/Theme/ThemeConfigField.php
+
+		-
+			message: "#^Parameter \\#1 \\$themeName of class Shopware\\\\Storefront\\\\Theme\\\\Exception\\\\ThemeCompileException constructor expects string, string\\|null given\\.$#"
+			count: 1
+			path: src/Storefront/Theme/ThemeFileImporter.php
+
+		-
+			message: "#^Parameter \\#1 \\$str of function mb_strtolower expects string, string\\|null given\\.$#"
+			count: 1
+			path: src/Storefront/Theme/ThemeFileImporter.php
+
+		-
+			message: "#^Cannot call method getFilepath\\(\\) on Shopware\\\\Storefront\\\\Theme\\\\StorefrontPluginConfiguration\\\\File\\|null\\.$#"
+			count: 2
+			path: src/Storefront/Theme/ThemeFileResolver.php
+
+		-
+			message: "#^Parameter \\#1 \\$filepath of class Shopware\\\\Storefront\\\\Theme\\\\StorefrontPluginConfiguration\\\\File constructor expects string, string\\|null given\\.$#"
+			count: 2
+			path: src/Storefront/Theme/ThemeFileResolver.php
+
+		-
+			message: "#^Parameter \\#1 \\$themeName of class Shopware\\\\Storefront\\\\Theme\\\\Exception\\\\ThemeCompileException constructor expects string, string\\|null given\\.$#"
+			count: 1
+			path: src/Storefront/Theme/ThemeFileResolver.php
+
+		-
+			message: "#^Parameter \\#1 \\$technicalName of method Shopware\\\\Storefront\\\\Theme\\\\ThemeLifecycleHandler\\:\\:changeThemeActive\\(\\) expects string, string\\|null given\\.$#"
+			count: 2
+			path: src/Storefront/Theme/ThemeLifecycleHandler.php
+
+		-
+			message: "#^Parameter \\#1 \\$technicalName of method Shopware\\\\Storefront\\\\Theme\\\\ThemeLifecycleHandler\\:\\:validateThemeAssignment\\(\\) expects string, string\\|null given\\.$#"
+			count: 1
+			path: src/Storefront/Theme/ThemeLifecycleHandler.php
+
+		-
+			message: "#^Cannot call method count\\(\\) on Shopware\\\\Core\\\\System\\\\SalesChannel\\\\SalesChannelCollection\\|null\\.$#"
+			count: 1
+			path: src/Storefront/Theme/ThemeLifecycleHandler.php
+
+		-
+			message: "#^Parameter \\#1 \\$salesChannels of method Shopware\\\\Storefront\\\\Theme\\\\ThemeLifecycleHandler\\:\\:getSalesChannelNames\\(\\) expects Shopware\\\\Core\\\\System\\\\SalesChannel\\\\SalesChannelCollection, Shopware\\\\Core\\\\System\\\\SalesChannel\\\\SalesChannelCollection\\|null given\\.$#"
+			count: 1
+			path: src/Storefront/Theme/ThemeLifecycleHandler.php
+
+		-
+			message: "#^Cannot call method getIds\\(\\) on Shopware\\\\Storefront\\\\Theme\\\\ThemeCollection\\|null\\.$#"
+			count: 1
+			path: src/Storefront/Theme/ThemeLifecycleHandler.php
+
+		-
+			message: "#^Parameter \\#1 \\$config of method Shopware\\\\Storefront\\\\Theme\\\\ThemeLifecycleService\\:\\:getLabelsFromConfig\\(\\) expects array, array\\|null given\\.$#"
+			count: 1
+			path: src/Storefront/Theme/ThemeLifecycleService.php
+
+		-
+			message: "#^Parameter \\#1 \\$config of method Shopware\\\\Storefront\\\\Theme\\\\ThemeLifecycleService\\:\\:getHelpTextsFromConfig\\(\\) expects array, array\\|null given\\.$#"
+			count: 1
+			path: src/Storefront/Theme/ThemeLifecycleService.php
+
+		-
+			message: "#^Parameter \\#1 \\$path of method Shopware\\\\Storefront\\\\Theme\\\\ThemeLifecycleService\\:\\:createMediaStruct\\(\\) expects string, string\\|null given\\.$#"
+			count: 1
+			path: src/Storefront/Theme/ThemeLifecycleService.php
+
+		-
+			message: "#^Parameter \\#3 \\$themeFolderId of method Shopware\\\\Storefront\\\\Theme\\\\ThemeLifecycleService\\:\\:createMediaStruct\\(\\) expects string, string\\|null given\\.$#"
+			count: 2
+			path: src/Storefront/Theme/ThemeLifecycleService.php
+
+		-
+			message: "#^Parameter \\#2 \\$search of function array_key_exists expects array, array\\|null given\\.$#"
+			count: 1
+			path: src/Storefront/Theme/ThemeLifecycleService.php
+
+		-
+			message: "#^Parameter \\#2 \\$mimeType of class Shopware\\\\Core\\\\Content\\\\Media\\\\File\\\\MediaFile constructor expects string, string\\|null given\\.$#"
+			count: 1
+			path: src/Storefront/Theme/ThemeLifecycleService.php
+
+		-
+			message: "#^Parameter \\#4 \\$fileSize of class Shopware\\\\Core\\\\Content\\\\Media\\\\File\\\\MediaFile constructor expects int, int\\|false given\\.$#"
+			count: 1
+			path: src/Storefront/Theme/ThemeLifecycleService.php
+
+		-
+			message: "#^Offset 'extension' does not exist on array\\('dirname' \\=\\> string, 'basename' \\=\\> string, 'filename' \\=\\> string, \\?'extension' \\=\\> string\\)\\.$#"
+			count: 1
+			path: src/Storefront/Theme/ThemeLifecycleService.php
+
+		-
+			message: "#^Cannot call method getCode\\(\\) on Shopware\\\\Core\\\\System\\\\Locale\\\\LocaleEntity\\|null\\.$#"
+			count: 1
+			path: src/Storefront/Theme/ThemeLifecycleService.php
+
+		-
+			message: "#^Parameter \\#1 \\$json of function json_decode expects string, string\\|false given\\.$#"
+			count: 1
+			path: src/Storefront/Theme/ThemeService.php
+
+		-
+			message: "#^Parameter \\#1 \\$name of method Shopware\\\\Storefront\\\\Theme\\\\StorefrontPluginConfiguration\\\\StorefrontPluginConfigurationCollection\\:\\:getByTechnicalName\\(\\) expects string, string\\|null given\\.$#"
+			count: 2
+			path: src/Storefront/Theme/ThemeService.php
+
+		-
+			message: "#^Parameter \\#1 \\$themeName of class Shopware\\\\Storefront\\\\Theme\\\\Exception\\\\InvalidThemeException constructor expects string, string\\|null given\\.$#"
+			count: 1
+			path: src/Storefront/Theme/ThemeService.php
+
+		-
+			message: "#^Parameter \\#1 \\$arr1 of function array_replace_recursive expects array, array\\|null given\\.$#"
+			count: 1
+			path: src/Storefront/Theme/ThemeService.php
+
+		-
+			message: "#^Parameter \\#2 \\$search of function array_key_exists expects array, array\\|null given\\.$#"
+			count: 1
+			path: src/Storefront/Theme/ThemeService.php
+
+		-
+			message: "#^Method Shopware\\\\Storefront\\\\Theme\\\\ThemeService\\:\\:mergeStaticConfig\\(\\) should return array but returns array\\|null\\.$#"
+			count: 1
+			path: src/Storefront/Theme/ThemeService.php
+
+		-
+			message: "#^Method Shopware\\\\Storefront\\\\Theme\\\\ThemeService\\:\\:getTab\\(\\) has parameter \\$fieldConfig with no typehint specified\\.$#"
+			count: 1
+			path: src/Storefront/Theme/ThemeService.php
+
+		-
+			message: "#^Method Shopware\\\\Storefront\\\\Theme\\\\ThemeService\\:\\:getBlock\\(\\) has parameter \\$fieldConfig with no typehint specified\\.$#"
+			count: 1
+			path: src/Storefront/Theme/ThemeService.php
+
+		-
+			message: "#^Method Shopware\\\\Storefront\\\\Theme\\\\ThemeService\\:\\:getSection\\(\\) has parameter \\$fieldConfig with no typehint specified\\.$#"
+			count: 1
+			path: src/Storefront/Theme/ThemeService.php
+
+		-
+			message: "#^Method Shopware\\\\Storefront\\\\Theme\\\\ThemeService\\:\\:getTabLabel\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Storefront/Theme/ThemeService.php
+
+		-
+			message: "#^Method Shopware\\\\Storefront\\\\Theme\\\\ThemeService\\:\\:getBlockLabel\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Storefront/Theme/ThemeService.php
+
+		-
+			message: "#^Method Shopware\\\\Storefront\\\\Theme\\\\ThemeService\\:\\:getSectionLabel\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Storefront/Theme/ThemeService.php
+
+		-
+			message: "#^Method Shopware\\\\Storefront\\\\Theme\\\\ThemeService\\:\\:translateLabels\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Storefront/Theme/ThemeService.php
+
+		-
+			message: "#^Method Shopware\\\\Storefront\\\\Theme\\\\ThemeService\\:\\:translateHelpTexts\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: src/Storefront/Theme/ThemeService.php
+
+		-
+			message: "#^Parameter \\#1 \\$theme of method Shopware\\\\Storefront\\\\Theme\\\\Twig\\\\ThemeInheritanceBuilder\\:\\:getThemeInheritance\\(\\) expects string, int\\|string\\|null given\\.$#"
+			count: 1
+			path: src/Storefront/Theme/Twig/ThemeInheritanceBuilder.php
+
+		-
+			message: "#^Parameter \\#1 \\$json of function json_decode expects string, string\\|false given\\.$#"
+			count: 1
+			path: src/Storefront/Theme/Twig/ThemeInheritanceBuilder.php
+
+		-
+			message: "#^Cannot call method find\\(\\) on Symfony\\\\Component\\\\Console\\\\Application\\|null\\.$#"
+			count: 1
+			path: ../src/Command/ConfigDebugCommand.php
+
+		-
+			message: "#^Method Shopware\\\\Development\\\\Command\\\\DatabaseDebugViewGenerator\\:\\:updateDatabaseView\\(\\) has parameter \\$tableName with no typehint specified\\.$#"
+			count: 1
+			path: ../src/Command/DatabaseDebugViewGenerator.php
+

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,6 +1,11 @@
+includes:
+    - phpstan-baseline.neon
+
 parameters:
-    level: 5
+    level: 8
     treatPhpDocTypesAsCertain: false
+    checkMissingIterableValueType: false
+    inferPrivatePropertyTypeFromConstructor: true
     tmpDir: %rootDir%/../../../../../../../var/cache/phpstan
     paths:
         - src
@@ -9,7 +14,6 @@ parameters:
         constant_hassers: false
         # the placeholder "%ShopwareHashedCacheDir%" will be replaced on execution by dev-ops/analyze/phpstan-config-generator.php script
         container_xml_path: '%rootDir%/../../../../../../..%ShopwareHashedCacheDir%/srcShopware_Development_KernelDevDebugContainer.xml'
-    inferPrivatePropertyTypeFromConstructor: true
 
     featureToggles:
         unusedClassElements: true
@@ -27,8 +31,6 @@ parameters:
         - src/Core/TestBootstrap.php
 
     ignoreErrors:
-        # https://github.com/phpstan/phpstan/issues/1060
-        - '#Call to an undefined method Symfony\\Component\\Config\\Definition\\Builder\\NodeParentInterface::(variableNode|scalarNode|end|integerNode|booleanNode|enumNode)\(\)\.#'
         # PhpStan does not recognize the Faker plugins correctly. They are called via magic methods
         - '#Access to an undefined property Faker\\Generator::\$[^.]+\.#'
         # For BC with Symfony 4

--- a/src/Administration/Administration.php
+++ b/src/Administration/Administration.php
@@ -9,6 +9,9 @@ use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 
 class Administration extends Bundle
 {
+    /**
+     * @var string
+     */
     protected $name = 'Administration';
 
     public function build(ContainerBuilder $container): void

--- a/src/Administration/Controller/AdministrationController.php
+++ b/src/Administration/Controller/AdministrationController.php
@@ -33,6 +33,9 @@ class AdministrationController extends AbstractController
      */
     private $snippetFinder;
 
+    /**
+     * @var array
+     */
     private $supportedApiVersions;
 
     /**
@@ -44,7 +47,7 @@ class AdministrationController extends AbstractController
         TemplateFinder $finder,
         FirstRunWizardClient $firstRunWizardClient,
         SnippetFinderInterface $snippetFinder,
-        $supportedApiVersions,
+        array $supportedApiVersions,
         KnownIpsCollectorInterface $knownIpsCollector
     ) {
         $this->finder = $finder;

--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-price-field/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-price-field/index.js
@@ -97,7 +97,6 @@ Component.register('sw-price-field', {
             default: null
         },
 
-        // @internal (flag:FEATURE_NEXT_9825)
         name: {
             type: String,
             required: false,
@@ -179,12 +178,10 @@ Component.register('sw-price-field', {
             return this.error ? this.error.net : null;
         },
 
-        // @internal (flag:FEATURE_NEXT_9825)
         grossFieldName() {
             return this.name ? `${this.name}-gross` : 'sw-price-field-gross';
         },
 
-        // @internal (flag:FEATURE_NEXT_9825)
         netFieldName() {
             return this.name ? `${this.name}-net` : 'sw-price-field-net';
         }

--- a/src/Administration/Resources/app/administration/src/app/component/rule/condition-type/sw-condition-line-item-purchase-price/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/rule/condition-type/sw-condition-line-item-purchase-price/index.js
@@ -14,7 +14,6 @@ Component.extend('sw-condition-line-item-purchase-price', 'sw-condition-base', {
             return this.conditionDataProviderService.getOperatorSet('number');
         },
 
-        // @internal (flag:FEATURE_NEXT_9825)
         isNetOperators() {
             return this.conditionDataProviderService.getOperatorSet('isNet');
         },

--- a/src/Administration/Resources/app/administration/src/app/component/rule/condition-type/sw-condition-line-item-purchase-price/sw-condition-line-item-purchase-price.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/rule/condition-type/sw-condition-line-item-purchase-price/sw-condition-line-item-purchase-price.html.twig
@@ -1,7 +1,7 @@
 {% block sw_condition_value_content %}
     <div class="sw-condition-line-item-purchase-price sw-condition__condition-value">
         {% block sw_condition_line_item_purchase_price_field_gross_net %}
-            <sw-condition-is-net-select v-if="feature.isActive('FEATURE_NEXT_9825')" v-bind="{ operators: isNetOperators, condition }"></sw-condition-is-net-select>
+            <sw-condition-is-net-select v-bind="{ operators: isNetOperators, condition }"></sw-condition-is-net-select>
         {% endblock %}
 
         {% block sw_condition_line_item_purchase_price_field_operator %}

--- a/src/Administration/Resources/app/administration/src/app/component/rule/condition-type/sw-condition-line-item-purchase-price/sw-condition-line-item-purchase-price.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/rule/condition-type/sw-condition-line-item-purchase-price/sw-condition-line-item-purchase-price.scss
@@ -1,4 +1,3 @@
-// @internal (flag:FEATURE_NEXT_9825)
 @import "~scss/variables";
 
 .sw-condition .sw-condition-line-item-purchase-price.sw-condition__condition-value {

--- a/src/Administration/Resources/app/administration/src/app/component/rule/sw-condition-is-net-select/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/rule/sw-condition-is-net-select/index.js
@@ -1,6 +1,5 @@
 const { Component } = Shopware;
 
-// @internal (flag:FEATURE_NEXT_9825)
 Component.extend('sw-condition-is-net-select', 'sw-condition-operator-select', {
     computed: {
         operator: {

--- a/src/Administration/Resources/app/administration/src/app/service/rule-condition.service.js
+++ b/src/Administration/Resources/app/administration/src/app/service/rule-condition.service.js
@@ -45,12 +45,10 @@ export default function createConditionService() {
             identifier: '!=',
             label: 'global.sw-condition.operator.isNoneOf'
         },
-        // @internal (flag:FEATURE_NEXT_9825)
         gross: {
             identifier: false,
             label: 'global.sw-condition.operator.gross'
         },
-        // @internal (flag:FEATURE_NEXT_9825)
         net: {
             identifier: true,
             label: 'global.sw-condition.operator.net'
@@ -94,7 +92,6 @@ export default function createConditionService() {
             operators.lowerThanEquals,
             operators.notEquals
         ],
-        // @internal (flag:FEATURE_NEXT_9825)
         isNet: [
             operators.gross,
             operators.net

--- a/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-price-form/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-price-form/index.js
@@ -7,8 +7,6 @@ const { mapPropertyErrors, mapState, mapGetters } = Shopware.Component.getCompon
 Component.register('sw-product-price-form', {
     template,
 
-    inject: ['feature'],
-
     mixins: [
         Mixin.getByName('placeholder')
     ],
@@ -34,7 +32,7 @@ Component.register('sw-product-price-form', {
             'currencies'
         ]),
 
-        ...mapPropertyErrors('product', ['taxId', 'price', (Shopware.Feature.isActive('FEATURE_NEXT_9825') ? 'purchasePrices' : 'purchasePrice')])
+        ...mapPropertyErrors('product', ['taxId', 'price', 'purchasePrices'])
     },
 
     methods: {

--- a/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-price-form/sw-product-price-form.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-price-form/sw-product-price-form.html.twig
@@ -32,7 +32,7 @@
                 {% endblock %}
 
                 {% block sw_product_price_form_purchase_price_field %}
-                    <sw-inherit-wrapper v-if="!isLoading && feature.isActive('FEATURE_NEXT_9825')"
+                    <sw-inherit-wrapper v-if="!isLoading"
                                         v-model="product.purchasePrices"
                                         label=" "
                                         class="sw-product-price-form__purchase-prices"
@@ -45,29 +45,6 @@
                                             :error="productPurchasePricesError ? productPurchasePricesError[0] : null"
                                             :currency="defaultCurrency">
                             </sw-purchase-price-field>
-                        </template>
-                    </sw-inherit-wrapper>
-
-                    <sw-inherit-wrapper v-else-if="!isLoading && !feature.isActive('FEATURE_NEXT_9825')"
-                                        v-model="product.purchasePrice"
-                                        :hasParent="!!parentProduct.id"
-                                        :inheritedValue="parentProduct.purchasePrice"
-                                        :label="$tc('sw-product.priceForm.labelPurchasePriceGross')">
-                        <template #content="{ currentValue, updateCurrentValue, isInherited }">
-
-                            <sw-field type="number"
-                                      :error="productPurchasePriceError"
-                                      :min="0"
-                                      :disabled="isInherited"
-                                      :placeholder="$tc('sw-product.priceForm.placeholderPurchasePriceGross')"
-                                      :value="currentValue"
-                                      @change="updateCurrentValue"
-                                      @keyup="keymonitor">
-                                <template #suffix>
-                                    <span class="sw-product-price-form__currency" v-if="defaultCurrency">{{ defaultCurrency.symbol }}</span>
-                                </template>
-                            </sw-field>
-
                         </template>
                     </sw-inherit-wrapper>
                 {% endblock %}

--- a/src/Administration/Resources/app/administration/src/module/sw-product/page/sw-product-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/page/sw-product-detail/index.js
@@ -315,9 +315,8 @@ Component.register('sw-product-detail', {
                     linked: true,
                     gross: null
                 }];
-                if (this.feature.isActive('FEATURE_NEXT_9825')) {
-                    this.product.purchasePrices = [];
-                }
+
+                this.product.purchasePrices = [];
 
                 this.product.featureSet = this.defaultFeatureSet;
 
@@ -334,10 +333,10 @@ Component.register('sw-product-detail', {
                 this.productCriteria
             ).then((res) => {
                 Shopware.State.commit('swProductDetail/setProduct', res);
-                if (this.feature.isActive('FEATURE_NEXT_9825')) {
-                    // Initialize an empty price collection if the product has no purchase prices
-                    this.product.purchasePrices = this.product.purchasePrices || [];
-                }
+
+                // Initialize an empty price collection if the product has no purchase prices
+                this.product.purchasePrices = this.product.purchasePrices || [];
+
 
                 if (this.product.parentId) {
                     this.loadParentProduct();

--- a/src/Administration/Resources/app/administration/test/e2e/cypress/integration/catalogue/sw-product/crud.spec.js
+++ b/src/Administration/Resources/app/administration/test/e2e/cypress/integration/catalogue/sw-product/crud.spec.js
@@ -63,12 +63,10 @@ describe('Product: Test crud operations', () => {
             cy.get('#sw-price-field-net').should('have.value', '8.4');
         });
         cy.window().then((win) => {
-            if (win.Shopware.Feature.isActive('FEATURE_NEXT_9825')) {
-                cy.get('#sw-purchase-price-field-gross').type('1');
-                cy.wait('@calculatePrice').then(() => {
-                    cy.get('#sw-purchase-price-field-net').should('have.value', '0.84');
-                });
-            }
+            cy.get('#sw-purchase-price-field-gross').type('1');
+            cy.wait('@calculatePrice').then(() => {
+                cy.get('#sw-purchase-price-field-net').should('have.value', '0.84');
+            });
         });
 
         cy.get('input[name=sw-field--product-stock]').type('100');

--- a/src/Administration/Snippet/SnippetFinder.php
+++ b/src/Administration/Snippet/SnippetFinder.php
@@ -77,7 +77,13 @@ class SnippetFinder implements SnippetFinderInterface
         $snippets = [[]];
 
         foreach ($files as $file) {
-            $snippets[] = json_decode(file_get_contents($file), true) ?? [];
+            if (is_file($file) === false) {
+                continue;
+            }
+            $content = file_get_contents($file);
+            if ($content !== false) {
+                $snippets[] = json_decode($content, true) ?? [];
+            }
         }
 
         $snippets = array_replace_recursive(...$snippets);

--- a/src/Core/Checkout/Test/Cart/Rule/LineItemPurchasePriceRuleTest.php
+++ b/src/Core/Checkout/Test/Cart/Rule/LineItemPurchasePriceRuleTest.php
@@ -11,7 +11,6 @@ use Shopware\Core\Checkout\Cart\Rule\LineItemPurchasePriceRule;
 use Shopware\Core\Checkout\Cart\Rule\LineItemScope;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\DataAbstractionLayer\Pricing\Price;
-use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Rule\Rule;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
@@ -45,11 +44,12 @@ class LineItemPurchasePriceRuleTest extends TestCase
     }
 
     /**
+     * @deprecated tag:v6.4.0 - purchasePrice will be removed in 6.4.0 use purchasePrices
+     *
      * @dataProvider getMatchingRuleTestData
      */
     public function testIfMatchesCorrectWithLineItem(string $operator, float $amount, float $lineItemAmount, bool $expected): void
     {
-        Feature::skipTestIfActive('FEATURE_NEXT_9825', $this);
         $this->rule->assign([
             'amount' => $amount,
             'operator' => $operator,
@@ -68,7 +68,6 @@ class LineItemPurchasePriceRuleTest extends TestCase
      */
     public function testIfMatchesCorrectWithLineItemPurchasePriceGross(string $operator, float $amount, float $lineItemPurchasePriceGross, bool $expected): void
     {
-        Feature::skipTestIfInActive('FEATURE_NEXT_9825', $this);
         $this->rule->assign([
             'isNet' => false,
             'amount' => $amount,
@@ -88,7 +87,6 @@ class LineItemPurchasePriceRuleTest extends TestCase
      */
     public function testIfMatchesCorrectWithLineItemPurchasePriceNet(string $operator, float $amount, float $lineItemPurchasePriceNet, bool $expected): void
     {
-        Feature::skipTestIfInActive('FEATURE_NEXT_9825', $this);
         $this->rule->assign([
             'isNet' => true,
             'amount' => $amount,
@@ -132,11 +130,12 @@ class LineItemPurchasePriceRuleTest extends TestCase
     }
 
     /**
+     * @deprecated tag:v6.4.0 - purchasePrice will be removed in 6.4.0 use purchasePrices
+     *
      * @dataProvider getCartRuleScopeTestData
      */
     public function testIfMatchesCorrectWithCartRuleScope(string $operator, float $amount, float $lineItemAmount1, float $lineItemAmount2, bool $expected): void
     {
-        Feature::skipTestIfActive('FEATURE_NEXT_9825', $this);
         $this->rule->assign([
             'amount' => $amount,
             'operator' => $operator,
@@ -163,7 +162,6 @@ class LineItemPurchasePriceRuleTest extends TestCase
      */
     public function testIfMatchesCorrectWithCartRuleScopePurchasePrice(string $operator, float $amount, float $lineItemPurchasePrice1, float $lineItemPurchasePrice2, bool $expected): void
     {
-        Feature::skipTestIfInActive('FEATURE_NEXT_9825', $this);
         $this->rule->assign([
             'isNet' => true,
             'amount' => $amount,
@@ -227,6 +225,9 @@ class LineItemPurchasePriceRuleTest extends TestCase
         static::assertFalse($match);
     }
 
+    /**
+     * @deprecated tag:v6.4.0 - purchasePrice will be removed in 6.4.0 use purchasePrices
+     */
     private function createLineItem(float $purchasePrice): LineItem
     {
         return (new LineItem(Uuid::randomHex(), 'product', null, 3))

--- a/src/Core/Content/DependencyInjection/product.xml
+++ b/src/Core/Content/DependencyInjection/product.xml
@@ -139,7 +139,6 @@
 
         <service id="Shopware\Core\Content\Product\Api\ProductPurchasePriceApiConverter" public="true" >
             <tag name="shopware.api.converter"/>
-            <tag name="shopware.feature" flag="FEATURE_NEXT_9825"/>
         </service>
 
         <service id="Shopware\Core\Content\Product\Aggregate\ProductVisibility\ProductVisibilityDefinition">

--- a/src/Core/Content/MailTemplate/Service/MailSender.php
+++ b/src/Core/Content/MailTemplate/Service/MailSender.php
@@ -35,8 +35,8 @@ class MailSender implements MailSenderInterface
             return;
         }
 
-        $deliveryAddress = $this->configService->get('core.mailerSettings.deliveryAddress');
-        if ($deliveryAddress) {
+        $deliveryAddress = $this->configService->getString('core.mailerSettings.deliveryAddress');
+        if ($deliveryAddress !== '') {
             $message->addBcc($deliveryAddress);
         }
 

--- a/src/Core/Content/MailTemplate/Service/MailerTransportFactory.php
+++ b/src/Core/Content/MailTemplate/Service/MailerTransportFactory.php
@@ -8,9 +8,9 @@ class MailerTransportFactory implements MailerTransportFactoryInterface
 {
     public function create(SystemConfigService $configService, \Swift_Transport $innerTransport): \Swift_Transport
     {
-        $emailAgent = $configService->get('core.mailerSettings.emailAgent');
+        $emailAgent = $configService->getString('core.mailerSettings.emailAgent');
 
-        if ($emailAgent === null) {
+        if ($emailAgent === '') {
             return $innerTransport;
         }
 
@@ -24,14 +24,11 @@ class MailerTransportFactory implements MailerTransportFactoryInterface
         }
     }
 
-    /**
-     * @param SystemConfigService $configService
-     */
-    protected function createSmtpTransport($configService): \Swift_Transport
+    protected function createSmtpTransport(SystemConfigService $configService): \Swift_Transport
     {
         $transport = new \Swift_SmtpTransport(
-            $configService->get('core.mailerSettings.host'),
-            $configService->get('core.mailerSettings.port'),
+            $configService->getString('core.mailerSettings.host'),
+            $configService->getInt('core.mailerSettings.port'),
             $this->getEncryption($configService)
         );
 
@@ -40,19 +37,15 @@ class MailerTransportFactory implements MailerTransportFactoryInterface
             $transport->setAuthMode($auth);
         }
 
-        $transport->setUsername(
-            (string) $configService->get('core.mailerSettings.username')
-        );
-        $transport->setPassword(
-            (string) $configService->get('core.mailerSettings.password')
-        );
+        $transport->setUsername($configService->getString('core.mailerSettings.username'));
+        $transport->setPassword($configService->getString('core.mailerSettings.password'));
 
         return $transport;
     }
 
     private function getEncryption(SystemConfigService $configService): ?string
     {
-        $encryption = $configService->get('core.mailerSettings.encryption');
+        $encryption = $configService->getString('core.mailerSettings.encryption');
 
         switch ($encryption) {
             case 'ssl':
@@ -66,7 +59,7 @@ class MailerTransportFactory implements MailerTransportFactoryInterface
 
     private function getAuthMode(SystemConfigService $configService): ?string
     {
-        $authenticationMethod = $configService->get('core.mailerSettings.authenticationMethod');
+        $authenticationMethod = $configService->getString('core.mailerSettings.authenticationMethod');
 
         switch ($authenticationMethod) {
             case 'plain':
@@ -84,14 +77,14 @@ class MailerTransportFactory implements MailerTransportFactoryInterface
     {
         $command = '/usr/sbin/sendmail ';
 
-        $option = $configService->get('core.mailerSettings.sendMailOptions');
+        $option = $configService->getString('core.mailerSettings.sendMailOptions');
 
-        if (empty($option)) {
+        if ($option === '') {
             $option = '-t';
         }
 
         if ($option !== '-bs' && $option !== '-t') {
-            throw new \RuntimeException('Given sendmail option "%s" is invalid', $option);
+            throw new \RuntimeException(sprintf('Given sendmail option "%s" is invalid', $option));
         }
 
         return $command . $option;

--- a/src/Core/Content/Product/Api/ProductPurchasePriceApiConverter.php
+++ b/src/Core/Content/Product/Api/ProductPurchasePriceApiConverter.php
@@ -5,8 +5,6 @@ namespace Shopware\Core\Content\Product\Api;
 use Shopware\Core\Framework\Api\Converter\ApiConverter;
 
 /**
- * @internal (flag:FEATURE_NEXT_9825)
- *
  * @deprecated tag:v6.4.0 - Will be removed in 6.4.0
  */
 class ProductPurchasePriceApiConverter extends ApiConverter

--- a/src/Core/Content/Product/Cart/ProductCartProcessor.php
+++ b/src/Core/Content/Product/Cart/ProductCartProcessor.php
@@ -17,7 +17,6 @@ use Shopware\Core\Checkout\Cart\Price\Struct\QuantityPriceDefinition;
 use Shopware\Core\Content\Product\SalesChannel\Price\ProductPriceDefinitionBuilderInterface;
 use Shopware\Core\Content\Product\SalesChannel\SalesChannelProductEntity;
 use Shopware\Core\Defaults;
-use Shopware\Core\Framework\Feature;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 
 class ProductCartProcessor implements CartProcessorInterface, CartDataCollectorInterface
@@ -246,11 +245,9 @@ class ProductCartProcessor implements CartProcessorInterface, CartDataCollectorI
         $lineItem->setQuantityInformation($quantityInformation);
 
         $purchasePrices = null;
-        if (Feature::isActive('FEATURE_NEXT_9825') && $product->getPurchasePrices()) {
-            $purchasePricesCollection = $product->getPurchasePrices();
-            if ($purchasePricesCollection !== null) {
-                $purchasePrices = $purchasePricesCollection->getCurrencyPrice(Defaults::CURRENCY);
-            }
+        $purchasePricesCollection = $product->getPurchasePrices();
+        if ($purchasePricesCollection !== null) {
+            $purchasePrices = $purchasePricesCollection->getCurrencyPrice(Defaults::CURRENCY);
         }
 
         $payload = [
@@ -262,6 +259,7 @@ class ProductCartProcessor implements CartProcessorInterface, CartDataCollectorI
             'markAsTopseller' => $product->getMarkAsTopseller(),
             // @deprecated tag:v6.4.0 - purchasePrice Will be removed in 6.4.0
             'purchasePrice' => $purchasePrices ? $purchasePrices->getGross() : null,
+            'purchasePrices' => $purchasePrices ? json_encode($purchasePrices) : null,
             'productNumber' => $product->getProductNumber(),
             'manufacturerId' => $product->getManufacturerId(),
             'taxId' => $product->getTaxId(),
@@ -271,12 +269,6 @@ class ProductCartProcessor implements CartProcessorInterface, CartDataCollectorI
             'optionIds' => $product->getOptionIds(),
             'options' => $this->getOptions($product),
         ];
-
-        if (Feature::isActive('FEATURE_NEXT_9825')) {
-            $payload = [
-                'purchasePrices' => $purchasePrices ? json_encode($purchasePrices) : null,
-            ];
-        }
 
         $payload['options'] = $product->getVariation();
 

--- a/src/Core/Content/Product/Cart/ProductCartProcessor.php
+++ b/src/Core/Content/Product/Cart/ProductCartProcessor.php
@@ -247,7 +247,10 @@ class ProductCartProcessor implements CartProcessorInterface, CartDataCollectorI
 
         $purchasePrices = null;
         if (Feature::isActive('FEATURE_NEXT_9825') && $product->getPurchasePrices()) {
-            $purchasePrices = $product->getPurchasePrices()->getCurrencyPrice(Defaults::CURRENCY);
+            $purchasePricesCollection = $product->getPurchasePrices();
+            if ($purchasePricesCollection !== null) {
+                $purchasePrices = $purchasePricesCollection->getCurrencyPrice(Defaults::CURRENCY);
+            }
         }
 
         $payload = [

--- a/src/Core/Content/Product/Exception/DuplicateProductSortingKeyException.php
+++ b/src/Core/Content/Product/Exception/DuplicateProductSortingKeyException.php
@@ -7,7 +7,7 @@ use Symfony\Component\HttpFoundation\Response;
 
 class DuplicateProductSortingKeyException extends ShopwareHttpException
 {
-    public function __construct(string $key, $e)
+    public function __construct(string $key, \Throwable $e)
     {
         parent::__construct(
             'Sorting with key "{{ key }}" already exists.',

--- a/src/Core/Content/Product/ProductDefinition.php
+++ b/src/Core/Content/Product/ProductDefinition.php
@@ -62,7 +62,6 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\TranslationsAssociationFi
 use Shopware\Core\Framework\DataAbstractionLayer\Field\VersionField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\WhitelistRuleField;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
-use Shopware\Core\Framework\Feature;
 use Shopware\Core\System\CustomField\Aggregate\CustomFieldSet\CustomFieldSetDefinition;
 use Shopware\Core\System\DeliveryTime\DeliveryTimeDefinition;
 use Shopware\Core\System\NumberRange\DataAbstractionLayer\NumberRangeField;
@@ -262,11 +261,9 @@ class ProductDefinition extends EntityDefinition
                 ->addFlags(new Inherited())
         );
 
-        if (Feature::isActive('FEATURE_NEXT_9825')) {
-            $collection->add(
-                (new PriceField('purchase_prices', 'purchasePrices'))->addFlags(new Inherited())
-            );
-        }
+        $collection->add(
+            (new PriceField('purchase_prices', 'purchasePrices'))->addFlags(new Inherited())
+        );
 
         return $collection;
     }

--- a/src/Core/Content/Product/ProductEntity.php
+++ b/src/Core/Content/Product/ProductEntity.php
@@ -168,8 +168,6 @@ class ProductEntity extends Entity
     protected $purchasePrice;
 
     /**
-     * @internal (flag:FEATURE_NEXT_9825)
-     *
      * @var PriceCollection|null
      */
     protected $purchasePrices;
@@ -654,17 +652,11 @@ class ProductEntity extends Entity
         $this->purchasePrice = $purchasePrice;
     }
 
-    /**
-     * @internal (flag:FEATURE_NEXT_9825)
-     */
     public function getPurchasePrices(): ?PriceCollection
     {
         return $this->purchasePrices;
     }
 
-    /**
-     * @internal (flag:FEATURE_NEXT_9825)
-     */
     public function setPurchasePrices(?PriceCollection $purchasePrices): void
     {
         $this->purchasePrices = $purchasePrices;

--- a/src/Core/Content/Product/SalesChannel/SalesChannelProductSubscriber.php
+++ b/src/Core/Content/Product/SalesChannel/SalesChannelProductSubscriber.php
@@ -87,12 +87,12 @@ class SalesChannelProductSubscriber implements EventSubscriberInterface
 
     private function calculateMaxPurchase(SalesChannelProductEntity $product, string $salesChannelId): int
     {
-        $fallback = (int) $this->systemConfigService->get('core.cart.maxQuantity', $salesChannelId);
+        $fallback = $this->systemConfigService->getInt('core.cart.maxQuantity', $salesChannelId);
 
         $max = $product->getMaxPurchase() ?? $fallback;
 
         if ($product->getIsCloseout() && $product->getAvailableStock() < $max) {
-            $max = $product->getAvailableStock();
+            $max = (int) $product->getAvailableStock();
         }
 
         return max($max, 0);

--- a/src/Core/Content/Product/SalesChannel/Sorting/ProductSortingCollection.php
+++ b/src/Core/Content/Product/SalesChannel/Sorting/ProductSortingCollection.php
@@ -20,8 +20,8 @@ class ProductSortingCollection extends EntityCollection
         $sorted = [];
 
         foreach ($keys as $key) {
-            if ($this->hasKey($key)) {
-                $sorting = $this->getByKey($key);
+            $sorting = $this->getByKey($key);
+            if ($sorting !== null) {
                 $sorted[$sorting->getId()] = $this->elements[$sorting->getId()];
             }
         }
@@ -32,11 +32,6 @@ class ProductSortingCollection extends EntityCollection
     public function getByKey(string $key): ?ProductSortingEntity
     {
         return $this->filterByProperty('key', $key)->first();
-    }
-
-    public function hasKey(?string $key): bool
-    {
-        return $this->filterByProperty('key', $key)->count() > 0;
     }
 
     public function getApiAlias(): string

--- a/src/Core/Content/Sitemap/ScheduledTask/SitemapGenerateTaskHandler.php
+++ b/src/Core/Content/Sitemap/ScheduledTask/SitemapGenerateTaskHandler.php
@@ -85,7 +85,8 @@ class SitemapGenerateTaskHandler extends ScheduledTaskHandler
      */
     public function handle($message): void
     {
-        if ((int) $this->systemConfigService->get('core.sitemap.sitemapRefreshStrategy') !== SitemapExporterInterface::STRATEGY_SCHEDULED_TASK) {
+        $sitemapRefreshStrategy = $this->systemConfigService->getInt('core.sitemap.sitemapRefreshStrategy');
+        if ($sitemapRefreshStrategy !== SitemapExporterInterface::STRATEGY_SCHEDULED_TASK) {
             return;
         }
 

--- a/src/Core/Content/Test/Product/Api/ProductApiConverterTest.php
+++ b/src/Core/Content/Test/Product/Api/ProductApiConverterTest.php
@@ -5,7 +5,6 @@ namespace Shopware\Core\Content\Test\Product\Api;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
-use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Test\TestCaseBase\AdminFunctionalTestBehaviour;
 use Shopware\Core\Framework\Test\TestDataCollection;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -21,7 +20,6 @@ class ProductApiConverterTest extends TestCase
 
     public function testPurchasePriceConverter(): void
     {
-        Feature::skipTestIfInActive('FEATURE_NEXT_9825', $this);
         $ids = new TestDataCollection(Context::createDefaultContext());
 
         $data = [

--- a/src/Core/Content/Test/Product/Cart/ProductCartProcessorTest.php
+++ b/src/Core/Content/Test/Product/Cart/ProductCartProcessorTest.php
@@ -15,7 +15,6 @@ use Shopware\Core\Content\Product\Cart\ProductLineItemFactory;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepositoryInterface;
-use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Test\TestDataCollection;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -139,7 +138,6 @@ class ProductCartProcessorTest extends TestCase
 
     public function testLineItemPropertiesPurchasePrice(): void
     {
-        Feature::skipTestIfInActive('FEATURE_NEXT_9825', $this);
         $this->createProduct();
 
         $token = $this->ids->create('token');
@@ -443,6 +441,10 @@ class ProductCartProcessorTest extends TestCase
                 ['currencyId' => Defaults::CURRENCY, 'gross' => 15, 'net' => 10, 'linked' => false],
             ],
             'purchasePrice' => 7.5,
+            'purchasePrices' => [
+                ['currencyId' => Defaults::CURRENCY, 'gross' => 7.5, 'net' => 5, 'linked' => false],
+                ['currencyId' => Uuid::randomHex(), 'gross' => 150, 'net' => 100, 'linked' => false],
+            ],
             'active' => true,
             'tax' => ['name' => 'test', 'taxRate' => 15],
             'weight' => 100,
@@ -458,12 +460,7 @@ class ProductCartProcessorTest extends TestCase
                 ],
             ],
         ];
-        if (Feature::isActive('FEATURE_NEXT_9825')) {
-            $data['purchasePrices'] = [
-                ['currencyId' => Defaults::CURRENCY, 'gross' => 7.5, 'net' => 5, 'linked' => false],
-                ['currencyId' => Uuid::randomHex(), 'gross' => 150, 'net' => 100, 'linked' => false],
-            ];
-        }
+
         $data = array_merge($data, $additionalData);
 
         $this->getContainer()->get('product.repository')

--- a/src/Core/Framework/App/ShopId/ShopIdProvider.php
+++ b/src/Core/Framework/App/ShopId/ShopIdProvider.php
@@ -21,11 +21,14 @@ class ShopIdProvider
         $this->systemConfigService = $systemConfigService;
     }
 
+    /**
+     * @throws AppUrlChangeDetectedException
+     */
     public function getShopId(): string
     {
         $shopId = $this->systemConfigService->get(self::SHOP_ID_SYSTEM_CONFIG_KEY);
 
-        if (!$shopId) {
+        if (!\is_array($shopId)) {
             $newShopId = $this->generateShopId();
             $this->systemConfigService->set(self::SHOP_ID_SYSTEM_CONFIG_KEY, [
                 'app_url' => $_SERVER['APP_URL'],

--- a/src/Core/Framework/Demodata/Generator/ProductGenerator.php
+++ b/src/Core/Framework/Demodata/Generator/ProductGenerator.php
@@ -12,7 +12,6 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
 use Shopware\Core\Framework\Demodata\DemodataContext;
 use Shopware\Core\Framework\Demodata\DemodataGeneratorInterface;
-use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Util\Random;
 use Shopware\Core\Framework\Uuid\Uuid;
 
@@ -154,17 +153,15 @@ class ProductGenerator implements DemodataGeneratorInterface
             'prices' => $this->createPrices($rules, $reverseTaxrate),
         ];
 
-        if (Feature::isActive('FEATURE_NEXT_9825')) {
-            $purchasePrice = $context->getFaker()->randomFloat(2, 1, 100);
-            $product['purchasePrices'] = [
-                [
-                    'currencyId' => Defaults::CURRENCY,
-                    'gross' => $purchasePrice,
-                    'net' => $purchasePrice / $reverseTaxrate,
-                    'linked' => true,
-                ],
-            ];
-        }
+        $purchasePrice = $context->getFaker()->randomFloat(2, 1, 100);
+        $product['purchasePrices'] = [
+            [
+                'currencyId' => Defaults::CURRENCY,
+                'gross' => $purchasePrice,
+                'net' => $purchasePrice / $reverseTaxrate,
+                'linked' => true,
+            ],
+        ];
 
         return $product;
     }

--- a/src/Core/Framework/Log/ScheduledTask/LogCleanupTaskHandler.php
+++ b/src/Core/Framework/Log/ScheduledTask/LogCleanupTaskHandler.php
@@ -37,8 +37,8 @@ class LogCleanupTaskHandler extends ScheduledTaskHandler
 
     public function run(): void
     {
-        $entryLifetimeSeconds = $this->systemConfigService->get('core.logging.entryLifetimeSeconds');
-        $maxEntries = $this->systemConfigService->get('core.logging.entryLimit');
+        $entryLifetimeSeconds = $this->systemConfigService->getInt('core.logging.entryLifetimeSeconds');
+        $maxEntries = $this->systemConfigService->getInt('core.logging.entryLimit');
 
         if ($entryLifetimeSeconds !== -1) {
             $deleteBefore = (new \DateTime(sprintf('- %s seconds', $entryLifetimeSeconds)))
@@ -53,7 +53,7 @@ class LogCleanupTaskHandler extends ScheduledTaskHandler
             $sql = 'DELETE ld FROM `log_entry` ld LEFT JOIN (
                         SELECT id
                         FROM `log_entry`
-                        ORDER BY `created_at` 
+                        ORDER BY `created_at`
                         DESC LIMIT :maxEntries
                     ) ls ON ld.ID = ls.ID
                     WHERE ls.ID IS NULL;';

--- a/src/Core/Framework/Resources/config/packages/shopware.yaml
+++ b/src/Core/Framework/Resources/config/packages/shopware.yaml
@@ -59,3 +59,4 @@ shopware:
             - FEATURE_NEXT_5983
             - FEATURE_NEXT_10286
             - FEATURE_NEXT_9825
+            - FEATURE_NEXT_9351

--- a/src/Core/Framework/Resources/config/packages/shopware.yaml
+++ b/src/Core/Framework/Resources/config/packages/shopware.yaml
@@ -58,5 +58,4 @@ shopware:
             - FEATURE_NEXT_3722
             - FEATURE_NEXT_5983
             - FEATURE_NEXT_10286
-            - FEATURE_NEXT_9825
             - FEATURE_NEXT_9351

--- a/src/Core/Framework/Store/Services/FirstRunWizardClient.php
+++ b/src/Core/Framework/Store/Services/FirstRunWizardClient.php
@@ -162,13 +162,13 @@ final class FirstRunWizardClient
 
     public function getFrwState(): FrwState
     {
-        $completedAt = $this->configService->get('core.frw.completedAt');
-        if ($completedAt) {
+        $completedAt = $this->configService->getString('core.frw.completedAt');
+        if ($completedAt !== '') {
             return FrwState::completedState(new \DateTimeImmutable($completedAt));
         }
-        $failedAt = $this->configService->get('core.frw.failedAt');
-        if ($failedAt) {
-            $failureCount = $this->configService->get('core.frw.failureCount') ?? 1;
+        $failedAt = $this->configService->getString('core.frw.failedAt');
+        if ($failedAt !== '') {
+            $failureCount = $this->configService->getInt('core.frw.failureCount') ?? 1;
 
             return FrwState::failedState(new \DateTimeImmutable($failedAt), $failureCount);
         }
@@ -283,7 +283,7 @@ final class FirstRunWizardClient
 
         $data = json_decode($response->getBody()->getContents(), true);
 
-        $currentLicenseDomain = $this->configService->get(StoreService::CONFIG_KEY_STORE_LICENSE_DOMAIN);
+        $currentLicenseDomain = $this->configService->getString(StoreService::CONFIG_KEY_STORE_LICENSE_DOMAIN);
         $currentLicenseDomain = $currentLicenseDomain ? idn_to_utf8($currentLicenseDomain) : null;
 
         $domains = array_map(static function ($data) use ($currentLicenseDomain) {

--- a/src/Core/Framework/Test/DataAbstractionLayer/Write/TranslationTest.php
+++ b/src/Core/Framework/Test/DataAbstractionLayer/Write/TranslationTest.php
@@ -22,7 +22,6 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityRepositoryInterface;
 use Shopware\Core\Framework\DataAbstractionLayer\Exception\MissingTranslationLanguageException;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\WriteException;
-use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Test\TestCaseBase\AssertArraySubsetBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -481,20 +480,15 @@ class TranslationTest extends TestCase
             'weight' => 0,
             'minPurchase' => 1,
             'shippingFree' => false,
-        ];
-
-        if (Feature::isActive('FEATURE_NEXT_9825')) {
-            $data['purchasePrices'] = [
+            'purchasePrices' => [
                 [
                     'currencyId' => Defaults::CURRENCY,
                     'gross' => 0,
                     'net' => 0,
                     'linked' => true,
                 ],
-            ];
-        } else {
-            $data['purchasePrice'] = 0;
-        }
+            ],
+        ];
 
         $result = $this->productRepository->create([$data], $this->context);
 
@@ -607,20 +601,16 @@ sors capulus se Quies, mox qui Sentus dum confirmo do iam. Iunceus postulator in
             'weight' => 0,
             'minPurchase' => 1,
             'shippingFree' => false,
-        ];
-
-        if (Feature::isActive('FEATURE_NEXT_9825')) {
-            $data['purchasePrices'] = [
+            'purchasePrices' => [
                 [
                     'currencyId' => Defaults::CURRENCY,
                     'gross' => 0,
                     'net' => 0,
                     'linked' => true,
                 ],
-            ];
-        } else {
-            $data['purchasePrice'] = 0;
-        }
+            ],
+        ];
+
         $productRepo = $this->getContainer()->get('product.repository');
         $affected = $productRepo->upsert([$data], Context::createDefaultContext());
 

--- a/src/Core/Framework/Update/Api/UpdateController.php
+++ b/src/Core/Framework/Update/Api/UpdateController.php
@@ -221,7 +221,7 @@ class UpdateController extends AbstractController
             $this->systemConfig->set(self::UPDATE_TOKEN_KEY, $updateToken);
 
             return new JsonResponse([
-                'redirectTo' => $request->getBaseUrl() . '/api/v' . PlatformRequest::API_VERSION . ' /_action/update/finish/' . $this->systemConfig->get(self::UPDATE_TOKEN_KEY),
+                'redirectTo' => $request->getBaseUrl() . '/api/v' . PlatformRequest::API_VERSION . ' /_action/update/finish/' . $updateToken,
             ]);
         }
 
@@ -302,7 +302,7 @@ class UpdateController extends AbstractController
     public function finish(string $token, Request $request, Context $context): Response
     {
         $offset = $request->query->getInt('offset');
-        $oldVersion = (string) $this->systemConfig->get(self::UPDATE_PREVIOUS_VERSION_KEY);
+        $oldVersion = $this->systemConfig->getString(self::UPDATE_PREVIOUS_VERSION_KEY);
         if ($offset === 0) {
             if (!$token) {
                 return $this->redirectToRoute('administration.index');

--- a/src/Core/Framework/Update/Steps/DeactivatePluginsStep.php
+++ b/src/Core/Framework/Update/Steps/DeactivatePluginsStep.php
@@ -75,7 +75,7 @@ class DeactivatePluginsStep
         foreach ($plugins as $plugin) {
             ++$offset;
             $this->pluginLifecycleService->deactivatePlugin($plugin, $this->context);
-            $deactivatedPlugins = $this->systemConfigService->get(self::UPDATE_DEACTIVATED_PLUGINS) ?: [];
+            $deactivatedPlugins = (array) $this->systemConfigService->get(self::UPDATE_DEACTIVATED_PLUGINS) ?: [];
             $deactivatedPlugins[] = $plugin->getId();
             $this->systemConfigService->set(self::UPDATE_DEACTIVATED_PLUGINS, $deactivatedPlugins);
 

--- a/src/Core/Framework/Update/Steps/ReactivatePluginsStep.php
+++ b/src/Core/Framework/Update/Steps/ReactivatePluginsStep.php
@@ -62,14 +62,14 @@ class ReactivatePluginsStep
     {
         $requestTime = time();
 
-        $deactivatedPlugins = $this->systemConfigService->get(self::UPDATE_DEACTIVATED_PLUGINS) ?: [];
-        $failed = $this->systemConfigService->get(self::UPDATE_FAILED_REACTIVATED_PLUGINS) ?: [];
+        $deactivatedPlugins = (array) $this->systemConfigService->get(self::UPDATE_DEACTIVATED_PLUGINS) ?: [];
+        $failed = (array) $this->systemConfigService->get(self::UPDATE_FAILED_REACTIVATED_PLUGINS) ?: [];
 
         $deactivatedPlugins = array_unique($deactivatedPlugins);
 
         $plugins = $this->pluginCompatibility->getPluginsToReactivate($deactivatedPlugins, $this->currentVersion, $this->context);
 
-        $pluginCount = count($deactivatedPlugins);
+        $pluginCount = \count($deactivatedPlugins);
 
         foreach ($plugins as $plugin) {
             ++$offset;

--- a/src/Core/Migration/Migration1595422169AddProductSorting.php
+++ b/src/Core/Migration/Migration1595422169AddProductSorting.php
@@ -171,7 +171,7 @@ class Migration1595422169AddProductSorting extends MigrationStep
         ];
     }
 
-    private function getLanguageId(string $locale, Connection $connection)
+    private function getLanguageId(string $locale, Connection $connection): string
     {
         return $connection->fetchColumn('
             SELECT LOWER(HEX(`language`.id))

--- a/src/Core/System/SystemConfig/Command/ConfigGet.php
+++ b/src/Core/System/SystemConfig/Command/ConfigGet.php
@@ -39,7 +39,11 @@ class ConfigGet extends Command
             $input->getOption('salesChannelId')
         );
 
-        $output->writeln($value);
+        if (\is_array($value)) {
+            $output->writeln($value);
+        } else {
+            $output->writeln((string) $value);
+        }
 
         return 0;
     }

--- a/src/Core/System/SystemConfig/Exception/InvalidSettingValueException.php
+++ b/src/Core/System/SystemConfig/Exception/InvalidSettingValueException.php
@@ -1,0 +1,36 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\System\SystemConfig\Exception;
+
+use Shopware\Core\Framework\ShopwareHttpException;
+use Symfony\Component\HttpFoundation\Response;
+
+class InvalidSettingValueException extends ShopwareHttpException
+{
+    public function __construct(string $key, ?string $neededType = null, ?string $actualType = null)
+    {
+        $message = "Invalid value for '{{ key }}'";
+        if ($neededType !== null) {
+            $message .= ". Must be of type '{{ neededType }}'";
+        }
+        if ($actualType !== null) {
+            $message .= ". But is of type '{{ actualType }}'";
+        }
+
+        parent::__construct($message, [
+            'key' => $key,
+            'neededType' => $neededType,
+            'actualType' => $actualType,
+        ]);
+    }
+
+    public function getStatusCode(): int
+    {
+        return Response::HTTP_BAD_REQUEST;
+    }
+
+    public function getErrorCode(): string
+    {
+        return 'SYSTEM__INVALID_SETTING_VALUE';
+    }
+}

--- a/src/Core/System/SystemConfig/SystemConfigService.php
+++ b/src/Core/System/SystemConfig/SystemConfigService.php
@@ -17,6 +17,7 @@ use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SystemConfig\Exception\BundleConfigNotFoundException;
 use Shopware\Core\System\SystemConfig\Exception\InvalidDomainException;
 use Shopware\Core\System\SystemConfig\Exception\InvalidKeyException;
+use Shopware\Core\System\SystemConfig\Exception\InvalidSettingValueException;
 use Shopware\Core\System\SystemConfig\Util\ConfigReader;
 use Symfony\Component\Config\Util\XmlUtils;
 
@@ -52,6 +53,9 @@ class SystemConfigService
         $this->configReader = $configReader;
     }
 
+    /**
+     * @return array|bool|float|int|null|string
+     */
     public function get(string $key, ?string $salesChannelId = null)
     {
         $config = $this->load($salesChannelId);
@@ -75,6 +79,41 @@ class SystemConfigService
         }
 
         return $pointer;
+    }
+
+    public function getString(string $key, ?string $salesChannelId = null): string
+    {
+        $value = $this->get($key, $salesChannelId);
+        if (!\is_array($value)) {
+            return (string) $value;
+        }
+
+        throw new InvalidSettingValueException($key, 'string', \gettype($value));
+    }
+
+    public function getInt(string $key, ?string $salesChannelId = null): int
+    {
+        $value = $this->get($key, $salesChannelId);
+        if (!\is_array($value)) {
+            return (int) $value;
+        }
+
+        throw new InvalidSettingValueException($key, 'int', \gettype($value));
+    }
+
+    public function getFloat(string $key, ?string $salesChannelId = null): float
+    {
+        $value = $this->get($key, $salesChannelId);
+        if (!\is_array($value)) {
+            return (float) $value;
+        }
+
+        throw new InvalidSettingValueException($key, 'float', \gettype($value));
+    }
+
+    public function getBool(string $key, ?string $salesChannelId = null): bool
+    {
+        return (bool) $this->get($key, $salesChannelId);
     }
 
     /**

--- a/src/Docs/Resources/current/60-references-internals/10-core/10-erd/_puml/erd-all.puml
+++ b/src/Docs/Resources/current/60-references-internals/10-core/10-erd/_puml/erd-all.puml
@@ -861,6 +861,7 @@ Table(ShopwareCoreContentProductProductDefinition, "product\n(Product)") {
    customFields translated
    variation list
    featureSetId foreignKey
+   purchasePrices price
    not_null(createdAt) createdAt
    updatedAt updatedAt
    translated json

--- a/src/Docs/Resources/current/60-references-internals/10-core/10-erd/_puml/erd-shopware-core-content-product.puml
+++ b/src/Docs/Resources/current/60-references-internals/10-core/10-erd/_puml/erd-shopware-core-content-product.puml
@@ -82,6 +82,7 @@ Table(ShopwareCoreContentProductProductDefinition, "product\n(Product)") {
    customFields translated
    variation list
    featureSetId foreignKey
+   purchasePrices price
    not_null(createdAt) createdAt
    updatedAt updatedAt
    translated json

--- a/src/Elasticsearch/Test/Product/ElasticsearchProductTest.php
+++ b/src/Elasticsearch/Test/Product/ElasticsearchProductTest.php
@@ -40,7 +40,6 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\MultiFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\RangeFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Grouping\FieldGrouping;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Sorting\FieldSorting;
-use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Test\DataAbstractionLayer\Field\DataAbstractionLayerFieldTestBehaviour;
 use Shopware\Core\Framework\Test\DataAbstractionLayer\Field\TestDefinition\ExtendedProductDefinition;
 use Shopware\Core\Framework\Test\DataAbstractionLayer\Field\TestDefinition\ProductExtension;
@@ -1308,7 +1307,6 @@ class ElasticsearchProductTest extends TestCase
      */
     public function testFilterPurchasePricesPriceField(TestDataCollection $data): void
     {
-        Feature::skipTestIfInActive('FEATURE_NEXT_9825', $this);
         $searcher = $this->createEntitySearcher();
 
         // Filter by the PriceField purchasePrices
@@ -1556,13 +1554,10 @@ class ElasticsearchProductTest extends TestCase
             'visibilities' => [
                 ['salesChannelId' => Defaults::SALES_CHANNEL, 'visibility' => ProductVisibilityDefinition::VISIBILITY_ALL],
             ],
-        ];
-
-        if (Feature::isActive('FEATURE_NEXT_9825')) {
-            $data['purchasePrices'] = [
+            'purchasePrices' => [
                 ['currencyId' => Defaults::CURRENCY, 'gross' => $purchasePrice, 'net' => $purchasePrice / 115 * 100, 'linked' => false],
-            ];
-        }
+            ],
+        ];
 
         $categories[] = ['id' => $this->navigationId];
         $data['categories'] = $categories;

--- a/src/Storefront/Controller/ErrorController.php
+++ b/src/Storefront/Controller/ErrorController.php
@@ -66,9 +66,9 @@ class ErrorController extends StorefrontController
             $request->attributes->set('navigationId', $context->getSalesChannel()->getNavigationCategoryId());
 
             $salesChannelId = $context->getSalesChannel()->getId();
-            $cmsErrorLayoutId = $this->systemConfigService->get('core.basicInformation.404Page', $salesChannelId);
-            if ($cmsErrorLayoutId && $is404StatusCode) {
-                $errorPage = $this->errorPageLoader->load((string) $cmsErrorLayoutId, $request, $context);
+            $cmsErrorLayoutId = $this->systemConfigService->getString('core.basicInformation.404Page', $salesChannelId);
+            if ($cmsErrorLayoutId !== '' && $is404StatusCode) {
+                $errorPage = $this->errorPageLoader->load($cmsErrorLayoutId, $request, $context);
 
                 $response = $this->renderStorefront(
                     '@Storefront/storefront/page/content/index.html.twig',

--- a/src/Storefront/Controller/MaintenanceController.php
+++ b/src/Storefront/Controller/MaintenanceController.php
@@ -49,15 +49,15 @@ class MaintenanceController extends StorefrontController
         }
 
         $salesChannelId = $salesChannel->getId();
-        $maintenanceLayoutId = $this->systemConfigService->get('core.basicInformation.maintenancePage', $salesChannelId);
+        $maintenanceLayoutId = $this->systemConfigService->getString('core.basicInformation.maintenancePage', $salesChannelId);
 
-        if (!$maintenanceLayoutId) {
+        if ($maintenanceLayoutId === '') {
             return $this->renderStorefront(
                 '@Storefront/storefront/page/error/error-maintenance.html.twig'
             );
         }
 
-        $maintenancePage = $this->maintenancePageLoader->load((string) $maintenanceLayoutId, $request, $context);
+        $maintenancePage = $this->maintenancePageLoader->load($maintenanceLayoutId, $request, $context);
 
         $response = $this->renderStorefront(
             '@Storefront/storefront/page/error/error-maintenance.html.twig',

--- a/src/Storefront/Framework/Routing/MaintenanceModeResolver.php
+++ b/src/Storefront/Framework/Routing/MaintenanceModeResolver.php
@@ -77,7 +77,7 @@ class MaintenanceModeResolver
     private function isClientAllowed(Request $request): bool
     {
         return IpUtils::checkIp(
-            $request->getClientIp(),
+            (string) $request->getClientIp(),
             $this->getMaintenanceWhitelist($this->requestStack->getMasterRequest())
         );
     }

--- a/src/Storefront/Page/Account/Order/AccountEditOrderPageLoader.php
+++ b/src/Storefront/Page/Account/Order/AccountEditOrderPageLoader.php
@@ -167,12 +167,17 @@ class AccountEditOrderPageLoader
     {
         $transactions = $order->getTransactions();
 
-        if (!$transactions || $transactions->count() === 0) {
+        if ($transactions === null) {
             return false;
         }
 
         $transaction = $transactions->last();
-        if (!$stateMachineState = $transaction->getStateMachineState()) {
+        if ($transaction === null) {
+            return false;
+        }
+
+        $stateMachineState = $transaction->getStateMachineState();
+        if ($stateMachineState === null) {
             return false;
         }
 

--- a/src/Storefront/Page/Sitemap/SitemapPageLoader.php
+++ b/src/Storefront/Page/Sitemap/SitemapPageLoader.php
@@ -61,7 +61,8 @@ class SitemapPageLoader
         $sitemaps = $this->sitemapLister->getSitemaps($salesChannelContext);
 
         // If there are no sitemaps yet (or they are too old) and the generation strategy is "live", generate sitemaps
-        if ((int) $this->systemConfigService->get('core.sitemap.sitemapRefreshStrategy') === SitemapExporterInterface::STRATEGY_LIVE) {
+        $sitemapRefreshStrategy = $this->systemConfigService->getInt('core.sitemap.sitemapRefreshStrategy');
+        if ($sitemapRefreshStrategy === SitemapExporterInterface::STRATEGY_LIVE) {
             // Close session to prevent session locking from waiting in case there is another request coming in
             $this->session->save();
 
@@ -84,8 +85,12 @@ class SitemapPageLoader
         return $page;
     }
 
-    private function generateSitemap(SalesChannelContext $salesChannelContext, bool $force, ?string $lastProvider = null, ?int $offset = null): void
-    {
+    private function generateSitemap(
+        SalesChannelContext $salesChannelContext,
+        bool $force,
+        ?string $lastProvider = null,
+        ?int $offset = null
+    ): void {
         $result = $this->sitemapExporter->generate($salesChannelContext, $force, $lastProvider, $offset);
         if ($result->isFinish() === false) {
             $this->generateSitemap($salesChannelContext, $force, $result->getProvider(), $result->getOffset());

--- a/src/Storefront/Theme/Command/ThemeRefreshCommand.php
+++ b/src/Storefront/Theme/Command/ThemeRefreshCommand.php
@@ -33,7 +33,7 @@ class ThemeRefreshCommand extends Command
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $refreshedThemes = $this->themeLifecycleService->refreshThemes($this->context);
-        
+
         $output->writeln('Refreshed themes: ' . implode(', ', $refreshedThemes));
 
         return 0;

--- a/src/Storefront/Theme/Command/ThemeRefreshCommand.php
+++ b/src/Storefront/Theme/Command/ThemeRefreshCommand.php
@@ -32,7 +32,9 @@ class ThemeRefreshCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $this->themeLifecycleService->refreshThemes($this->context);
+        $refreshedThemes = $this->themeLifecycleService->refreshThemes($this->context);
+        
+        $output->writeln('Refreshed themes: ' . implode(', ', $refreshedThemes));
 
         return 0;
     }

--- a/src/Storefront/Theme/ThemeLifecycleService.php
+++ b/src/Storefront/Theme/ThemeLifecycleService.php
@@ -90,15 +90,19 @@ class ThemeLifecycleService
     public function refreshThemes(
         Context $context,
         ?StorefrontPluginConfigurationCollection $configurationCollection = null
-    ): void {
+    ): array {
         if ($configurationCollection === null) {
             $configurationCollection = $this->pluginRegistry->getConfigurations()->getThemes();
         }
 
         // iterate over all theme configs in the filesystem (plugins/bundles)
+        $refreshed = [];
         foreach ($configurationCollection as $config) {
             $this->refreshTheme($config, $context);
+            $refreshed[] = $config->getTechnicalName();
         }
+
+        return $refreshed;
     }
 
     public function refreshTheme(StorefrontPluginConfiguration $configuration, Context $context): void


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
The `theme:refresh` command does not show any output, which might be confusing

### 2. What does this change do, exactly?
It outputs the names of the refreshed themes

### 3. Describe each step to reproduce the issue or behaviour.
`bin/console theme:refresh`

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.
