### PR TITLE
Improve docker installation steps for inexperienced docker and ssh users

### DIFF
--- a/src/Docs/Resources/current/10-system-guide/20-installation.md
+++ b/src/Docs/Resources/current/10-system-guide/20-installation.md
@@ -72,6 +72,18 @@ This may take a while since many caches need to be generated on first execution,
 
 To be sure that the installation succeeded, just open the following url in your favorite browser: [http://localhost:8000/](http://localhost:8000/)
 
+After exploring Shopware 6 you can terminate it with these two commands:
+
+1. Leave the shell:
+
+    ```bash
+    > exit
+
+2. Stop the containers:
+
+    ```bash
+    > ./psh.phar docker:stop
+
 ## Local installation
 
 If it's impossible to get docker up and running on your development environment you can install Shopware 6 locally.


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
Inexperienced docker and/or ssh users might get stuck after starting the docker container not knowing how to terminate it.

### 2. What does this change do, exactly?
It adds the necessary commands to end the ssh session and stop the docker container to the docs 

### 3. Describe each step to reproduce the issue or behaviour.
1. Somebody who has never used ssh before follows the installation docs
2. Now he wants to end Shopware and does not now how, he will probably just close the terminal after accepting a warning

### 4. Please link to the relevant issues (if any).
/

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ x] I have squashed any insignificant commits
- [ x] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ x] I have read the contribution requirements and fulfil them.
