### PR TITLE
Fix struct encoding of extensions which are not loaded

### DIFF
--- a/src/Core/System/SalesChannel/Api/StructEncoder.php
+++ b/src/Core/System/SalesChannel/Api/StructEncoder.php
@@ -211,7 +211,12 @@ class StructEncoder
                 continue;
             }
 
-            $value[$name] = $this->encode($struct->getExtension($name), $apiVersion, $fields);
+            $extension = $struct->getExtension($name);
+            if ($extension === null) {
+                continue;
+            }
+
+            $value[$name] = $this->encode($extension, $apiVersion, $fields);
         }
 
         return $value;

--- a/src/Core/System/Test/SalesChannel/SalesChannel/StructEncoderTest.php
+++ b/src/Core/System/Test/SalesChannel/SalesChannel/StructEncoderTest.php
@@ -75,6 +75,29 @@ class StructEncoderTest extends TestCase
         );
     }
 
+    public function testSupportsNullExtensions(): void
+    {
+        $foo = new MyTestStruct('foo', 'bar');
+        $foo->addExtension('myExtension', null);
+
+        $fields = new ResponseFields([
+            'test-struct' => ['foo', 'myExtension'],
+        ]);
+
+        $encoded = $this->encoder->encode($foo, 1, $fields);
+
+        static::assertEquals(
+            [
+                'foo' => 'foo',
+                'extensions' => [
+                    'myExtension' => null,
+                ],
+                'apiAlias' => 'test-struct',
+            ],
+            $encoded
+        );
+    }
+
     public function testCollectionEncoding(): void
     {
         $collection = new StructCollection();


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?

Currently when e.g. creating an admin order the resulting order entity is encoded via the `StructEncoder`. It tries to [encode the extensions](https://github.com/shopware/platform/blob/c5e8720289167755bd51f40ed5c86731c9b4b2c2/src/Core/System/SalesChannel/Api/StructEncoder.php#L95) of all entities as well. When an entity extension is added by a plugin with `$autoload = false`, the extension will be `null` and [this call](https://github.com/shopware/platform/blob/c5e8720289167755bd51f40ed5c86731c9b4b2c2/src/Core/System/SalesChannel/Api/StructEncoder.php#L214) will crash, because it expects a `Struct` but receives `null`.


### 2. What does this change do, exactly?

This change checks if the extension is `null` and if so skips encoding it.


### 3. Describe each step to reproduce the issue or behaviour.

- Create an `OrderDelivery` Extension with `$autoload = false`:
```php
$collection->add(
    (new OneToOneAssociationField(
        'shippingMethodConfig',
        'id',
        'shipping_method_id',
        ShippingMethodConfigDefinition::class,
        false
    ))->addFlags(new CascadeDelete())
);
```
- Create an order in the administration
- Observe the request failing with `Argument 1 passed to Shopware\\Core\\System\\SalesChannel\\Api\\StructEncoder::encode() must be an instance of Shopware\\Core\\Framework\\Struct\\Struct, null given`

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
