### PR TITLE
Remove unused watch definition in sw-product-variants-delivery-order

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-variants/sw-product-variants-delivery/sw-product-variants-delivery-order/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-variants/sw-product-variants-delivery/sw-product-variants-delivery-order/index.js
@@ -25,8 +25,6 @@ Component.register('sw-product-variants-delivery-order', {
         };
     },
 
-    watch: {},
-
     mounted() {
         this.mountedComponent();
     },


### PR DESCRIPTION
### 1. Why is this change necessary?
It is not. But removing the code isn't hurting either.

### 2. What does this change do, exactly?
Remove an empty object that has only a purpose when filled.

### 3. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
