### PR TITLE
missing getter of protected fields on product errors added

### DIFF
--- a/src/Core/Content/Product/Cart/ProductOutOfStockError.php
+++ b/src/Core/Content/Product/Cart/ProductOutOfStockError.php
@@ -37,6 +37,11 @@ class ProductOutOfStockError extends Error
         return $this->getMessageKey() . $this->id;
     }
 
+    public function getName():string
+    {
+        return $this->name;
+    }
+
     public function getMessageKey(): string
     {
         return 'product-out-of-stock';

--- a/src/Core/Content/Product/Cart/ProductOutOfStockError.php
+++ b/src/Core/Content/Product/Cart/ProductOutOfStockError.php
@@ -37,7 +37,7 @@ class ProductOutOfStockError extends Error
         return $this->getMessageKey() . $this->id;
     }
 
-    public function getName():string
+    public function getName(): string
     {
         return $this->name;
     }

--- a/src/Core/Content/Product/Cart/ProductStockReachedError.php
+++ b/src/Core/Content/Product/Cart/ProductStockReachedError.php
@@ -47,6 +47,16 @@ class ProductStockReachedError extends Error
         return $this->getMessageKey() . $this->id;
     }
 
+    public function getName():string
+    {
+        return $this->name;
+    }
+
+    public function getQuantity():int
+    {
+        return $this->quantity;
+    }
+
     public function getMessageKey(): string
     {
         return 'product-stock-reached';

--- a/src/Core/Content/Product/Cart/ProductStockReachedError.php
+++ b/src/Core/Content/Product/Cart/ProductStockReachedError.php
@@ -47,12 +47,12 @@ class ProductStockReachedError extends Error
         return $this->getMessageKey() . $this->id;
     }
 
-    public function getName():string
+    public function getName(): string
     {
         return $this->name;
     }
 
-    public function getQuantity():int
+    public function getQuantity(): int
     {
         return $this->quantity;
     }


### PR DESCRIPTION
In the ProductOutOfStockError is the name getter and in the ProductStockReachedError is also the name getter but also the quantity getter missing.

If you want to access the name property from twig, it is null, so the message, which the customer will see is incomplete. For example if you have at least 2 products in your cart and one of them is close out and available stock 0 and you process to the shopping cart overview, the message is " is not available at the moment." instead of "product_name is not available at the moment."

With this pull request this is fixed.
