### PR TITLE
Fixed visibility configuration for private filesystems

### DIFF
--- a/CHANGELOG-6.3.md
+++ b/CHANGELOG-6.3.md
@@ -106,6 +106,7 @@ NEXT
   * Deprecated `Shopware\Core\Content\Product\SalesChannel\Listing\ProductListingSorting` for v6.4.0.
     Use `\Shopware\Core\Content\Product\SalesChannel\Sorting\ProductSortingEntity` instead
 * Changed `\Shopware\Core\Content\Sitemap\Provider\CategoryUrlProvider` to list only categories associated to the current sales channels
+* Fixed `\Shopware\Core\Framework\DependencyInjection\Configuration::createFilesystemSection()` to pass `visibility` argument of private filesystems
 
 #### Storefront
 * Added ellipsis to the truncated long product name

--- a/src/Core/Framework/DependencyInjection/Configuration.php
+++ b/src/Core/Framework/DependencyInjection/Configuration.php
@@ -41,6 +41,7 @@ class Configuration implements ConfigurationInterface
                     ->performNoDeepMerging()
                     ->children()
                         ->scalarNode('type')->end()
+                        ->scalarNode('visibility')->end()
                         ->variableNode('config')->end()
                     ->end()
                 ->end()

--- a/src/Docs/Resources/current/50-how-to/310-use-s3-datastorage.md
+++ b/src/Docs/Resources/current/50-how-to/310-use-s3-datastorage.md
@@ -37,6 +37,7 @@ shopware:
       url: "{url-to-your-public-files}"
       # The Adapter Configuration
     private:
+      visibility: "private"
       # The Adapter Configuration
     theme:
       url: "{url-to-your-theme-files}"


### PR DESCRIPTION
### 1. Why is this change necessary?
When using S3 for private file storage, one should keep "Block public access" set in the buckets permission.
Doing so requires the S3 filesystem adapter to set the objects ACL to "private", otherwise Amazon will deny access.
This ACL is automatically set by Flysystem if the 'visibility' configuration is set to "private". Currently, this config is set [here](https://github.com/shopware/platform/blob/8b19dc93ea0215f5188d370d7ba901c640905b1b/src/Core/Framework/Adapter/Filesystem/FilesystemFactory.php#L46).

The problem is that the visibility argument is expected on the same level as `config` and `type` in the shopware configuration as seen [here](https://github.com/shopware/platform/blob/8b19dc93ea0215f5188d370d7ba901c640905b1b/src/Core/Framework/Adapter/Filesystem/FilesystemFactory.php#L95). If not found, it defaults to "public". 

If one was to now add this configuration to `/config/packages/shopware.yml`:
```
shopware:
  filesystem:
    private:
      type: "amazon-s3"
      visibility: "private"
      config:
     ...
```

Shopware would raise an exception because it doesn't expect the argument `visibility` here. Which is missing [here](https://github.com/shopware/platform/blob/8b19dc93ea0215f5188d370d7ba901c640905b1b/src/Core/Framework/DependencyInjection/Configuration.php#L43)

### 2. What does this change do, exactly?

This change allows the `visibility` argument to be passed when defining the private filesystem config.
It also updates the [docs](https://docs.shopware.com/en/shopware-platform-dev-en/how-to/use-s3-datastorage) to show how the parameter should be set to private. 

### 3. Describe each step to reproduce the issue or behaviour.

- Configure Shopware to use AWS as storage backend for private files according to the [docs](https://docs.shopware.com/en/shopware-platform-dev-en/how-to/use-s3-datastorage)
- Use a bucket that has no public access allowed
- Grant the permissions [recommended by Flysystem](https://flysystem.thephpleague.com/v1/docs/adapter/aws-s3-v3/) to the corresponding IAM user:
```
{
    "Version": "2012-10-17",
    "Statement": [
        {
            "Sid": "Stmt1420044805001",
            "Effect": "Allow",
            "Action": [
                "s3:ListBucket",
                "s3:GetObject",
                "s3:GetObjectAcl",
                "s3:PutObject",
                "s3:PutObjectAcl",
                "s3:ReplicateObject",
                "s3:DeleteObject"
            ],
            "Resource": [
                "arn:aws:s3:::your-bucket-name",
                "arn:aws:s3:::your-bucket-name/*"
            ]
        }
    ]
}
```

- Try to use the import/export feature of shopware to write a file to private storage.
- Shopware throws the error returned by AWS stating that access was denied.

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
