### PR TITLE
Fix load more than 100 property groups and friends

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/base/sw-property-assignment/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/base/sw-property-assignment/index.js
@@ -1,8 +1,8 @@
 import template from './sw-property-assignment.html.twig';
 import './sw-property-assignment.scss';
 
-const { Component } = Shopware;
-const { Criteria } = Shopware.Data;
+const { Component, Context, Data } = Shopware;
+const { Criteria } = Data;
 
 Component.register('sw-property-assignment', {
     template,
@@ -124,10 +124,7 @@ Component.register('sw-property-assignment', {
                 Criteria.equalsAny('id', groupIds)
             );
 
-            // Fetch groups with options
-            this.groupRepository.search(groupSearchCriteria, Shopware.Context.api).then((res) => {
-                this.groups = res;
-            });
+            this.groupRepository.iterate(Context.api, groupSearchCriteria).then(groups => { this.groups = groups; });
 
             return true;
         }

--- a/src/Administration/Resources/app/administration/src/app/component/base/sw-property-search/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/base/sw-property-search/index.js
@@ -2,7 +2,8 @@ import template from './sw-property-search.html.twig';
 import './sw-property-search.scss';
 
 // @deprecated tag:v6.4.0.0 for StateDeprecated
-const { Component, StateDeprecated } = Shopware;
+const { Component, Data, StateDeprecated } = Shopware;
+const { Criteria } = Data;
 const utils = Shopware.Utils;
 
 Component.register('sw-property-search', {
@@ -210,7 +211,7 @@ Component.register('sw-property-search', {
                 page: this.optionPage,
                 limit: 10,
                 queries: queries,
-                'total-count-mode': 1,
+                'total-count-mode': Criteria.TOTAL_COUNT_MODE_EXACT,
                 associations: {
                     group: {}
                 }
@@ -238,7 +239,7 @@ Component.register('sw-property-search', {
             const params = {
                 page: this.groupPage,
                 limit: 10,
-                'total-count-mode': 1
+                'total-count-mode': Criteria.TOTAL_COUNT_MODE_EXACT
             };
 
             this.groupOptions = [];
@@ -253,7 +254,7 @@ Component.register('sw-property-search', {
             const params = {
                 page: this.optionPage,
                 limit: 10,
-                'total-count-mode': 1
+                'total-count-mode': Criteria.TOTAL_COUNT_MODE_EXACT
             };
 
             if (this.currentGroup.sortingType === 'position') {

--- a/src/Administration/Resources/app/administration/src/app/component/entity/sw-category-tree-field/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/entity/sw-category-tree-field/index.js
@@ -1,9 +1,9 @@
 import template from './sw-category-tree-field.html.twig';
 import './sw-category-tree-field.scss';
 
-const { Component } = Shopware;
+const { Component, Context, Data } = Shopware;
 const utils = Shopware.Utils;
-const { Criteria } = Shopware.Data;
+const { Criteria } = Data;
 
 Component.register('sw-category-tree-field', {
     template,
@@ -172,7 +172,7 @@ Component.register('sw-category-tree-field', {
             categoryCriteria.addFilter(Criteria.equals('parentId', parentId), 'AND', Criteria.equals('type', 'page'));
 
             // search for categories
-            return this.globalCategoryRepository.search(categoryCriteria, Shopware.Context.api).then((searchResult) => {
+            this.globalCategoryRepository.iterate(Context.api, categoryCriteria).then((searchResult) => {
                 // when requesting root categories, replace the data
                 if (parentId === null) {
                     this.categories = searchResult;
@@ -234,8 +234,7 @@ Component.register('sw-category-tree-field', {
             categorySearchCriteria.addFilter(Criteria.equals('type', 'page'));
             categorySearchCriteria.setTerm(term);
 
-            // search for categories
-            return this.globalCategoryRepository.search(categorySearchCriteria, Shopware.Context.api);
+            return this.globalCategoryRepository.iterate(Context.api, categorySearchCriteria);
         },
 
         isSearchItemChecked(itemId) {

--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-select-rule-create/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-select-rule-create/index.js
@@ -42,7 +42,7 @@ Component.register('sw-select-rule-create', {
             type: Object,
             required: false,
             default() {
-                const criteria = new Criteria(1, Shopware.Context.api);
+                const criteria = new Criteria();
                 criteria.addSorting(Criteria.sort('name', 'ASC', false));
 
                 return criteria;

--- a/src/Administration/Resources/app/administration/src/app/component/media/sw-media-folder-content/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/media/sw-media-folder-content/index.js
@@ -1,8 +1,8 @@
 import template from './sw-media-folder-content.html.twig';
 import './sw-media-folder-content.scss';
 
-const { Component, Context } = Shopware;
-const { Criteria } = Shopware.Data;
+const { Component, Context, Data } = Shopware;
+const { Criteria } = Data;
 
 Component.register('sw-media-folder-content', {
     template,
@@ -61,7 +61,7 @@ Component.register('sw-media-folder-content', {
                 .addAssociation('children')
                 .addSorting(Criteria.sort('name', 'asc'));
 
-            const searchResult = await this.mediaFolderRepository.search(criteria, Context.api);
+            const searchResult = await this.mediaFolderRepository.iterateAsync(Context.api, criteria);
             this.subFolders = searchResult.filter(this.filterItems);
         },
 

--- a/src/Administration/Resources/app/administration/src/app/component/media/sw-media-modal-folder-settings/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/media/sw-media-modal-folder-settings/index.js
@@ -1,8 +1,8 @@
 import template from './sw-media-modal-folder-settings.html.twig';
 import './sw-media-modal-folder-settings.scss';
 
-const { Component, Mixin, Context } = Shopware;
-const { Criteria } = Shopware.Data;
+const { Component, Data, Mixin, Context } = Shopware;
+const { Criteria } = Data;
 
 /**
  * @private
@@ -84,8 +84,7 @@ Component.register('sw-media-modal-folder-settings', {
                 this.configuration.mediaThumbnailSizes.source
             );
 
-            this.configuration.mediaThumbnailSizes = await this.mediaFolderConfigurationThumbnailSizeRepository
-                .search(new Criteria(), Context.api);
+            this.configuration.mediaThumbnailSizes = await this.mediaFolderConfigurationThumbnailSizeRepository.iterateAsync();
 
             if (this.folder.parentId !== null) {
                 this.parent = await this.mediaFolderRepository.get(this.folder.parentId, Context.api);

--- a/src/Administration/Resources/app/administration/src/app/component/media/sw-sidebar-media-item/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/media/sw-sidebar-media-item/index.js
@@ -1,8 +1,8 @@
 import template from './sw-sidebar-media-item.html.twig';
 import './sw-sidebar-media-item.scss';
 
-const { Component, Context } = Shopware;
-const { Criteria } = Shopware.Data;
+const { Component, Context, Data } = Shopware;
+const { Criteria } = Data;
 
 /**
  * @status ready
@@ -126,7 +126,7 @@ Component.register('sw-sidebar-media-item', {
             const criteria = new Criteria(1, 50);
             criteria.addFilter(Criteria.equals('parentId', this.mediaFolderId));
 
-            const folder = await this.mediaFolderRepository.search(criteria, Context.api);
+            const folder = await this.mediaFolderRepository.iterate(Context.api, criteria);
             this.subFolders = folder;
             return folder;
         },

--- a/src/Administration/Resources/app/administration/src/app/component/structure/sw-sales-channel-config/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/structure/sw-sales-channel-config/index.js
@@ -1,7 +1,7 @@
 import template from './sw-sales-channel-config.html.twig';
 
-const { Component } = Shopware;
-const { Criteria } = Shopware.Data;
+const { Component, Context, Data } = Shopware;
+const { Criteria } = Data;
 
 Component.register('sw-sales-channel-config', {
     template,
@@ -73,7 +73,7 @@ Component.register('sw-sales-channel-config', {
     methods: {
         createdComponent() {
             if (!this.salesChannel.length) {
-                this.salesChannelRepository.search(this.criteria, Shopware.Context.api).then(res => {
+                this.salesChannelRepository.iterate(Context.api, this.criteria).then(res => {
                     res.add({
                         id: null,
                         translated: {

--- a/src/Administration/Resources/app/administration/src/core/data-new/criteria.data.js
+++ b/src/Administration/Resources/app/administration/src/core/data-new/criteria.data.js
@@ -1,6 +1,27 @@
 import { types, object } from 'src/core/service/util.service';
 
 export default class Criteria {
+    /**
+     * no total count will be selected. Should be used if no pagination required (fastest)
+     */
+    static get TOTAL_COUNT_MODE_NONE() {
+        return 0;
+    }
+
+    /**
+     * exact total count will be selected. Should be used if an exact pagination is required (slow)
+     */
+    static get TOTAL_COUNT_MODE_EXACT() {
+        return 1;
+    }
+
+    /**
+     * fetches limit * 5 + 1. Should be used if pagination can work with "next page exists" (fast)
+     */
+    static get TOTAL_COUNT_MODE_NEXT_PAGES() {
+        return 2;
+    }
+
     constructor(page = 1, limit = 25) {
         this.page = page;
         this.limit = limit;
@@ -14,7 +35,8 @@ export default class Criteria {
         this.aggregations = [];
         this.grouping = [];
         this.groupFields = [];
-        this.totalCountMode = 1;
+        // \Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria::$totalCountMode defaults to TOTAL_COUNT_MODE_NONE
+        this.totalCountMode = this.TOTAL_COUNT_MODE_EXACT;
     }
 
     static fromCriteria(criteria) {
@@ -99,7 +121,7 @@ export default class Criteria {
             this.totalCountMode = null;
         }
 
-        this.totalCountMode = (mode < 0 || mode > 2) ? null : mode;
+        this.totalCountMode = (mode < this.TOTAL_COUNT_MODE_NONE || mode > this.TOTAL_COUNT_MODE_NEXT_PAGES) ? null : mode;
         return this;
     }
 

--- a/src/Administration/Resources/app/administration/src/core/data-new/index.js
+++ b/src/Administration/Resources/app/administration/src/core/data-new/index.js
@@ -6,6 +6,7 @@ import EntityDefinition from './entity-definition.data';
 import EntityFactory from './entity-factory.data';
 import EntityHydrator from './entity-hydrator.data';
 import Repository from './repository.data';
+import RepositoryIterator from './repository-iterator.data';
 
 export default {
     ChangesetGenerator,
@@ -15,5 +16,6 @@ export default {
     EntityDefinition,
     EntityFactory,
     EntityHydrator,
-    Repository
+    Repository,
+    RepositoryIterator
 };

--- a/src/Administration/Resources/app/administration/src/core/data-new/repository-iterator.data.js
+++ b/src/Administration/Resources/app/administration/src/core/data-new/repository-iterator.data.js
@@ -1,5 +1,20 @@
 import Criteria from './criteria.data';
 
+/**
+ * Callback for iterating entities
+ *
+ * @callback iterateEntitiesCallback
+ * @param {Array<Object>} entities
+ * @param {Object} response
+ */
+
+/**
+ * Callback for iterating entities
+ *
+ * @callback iterateIdsCallback
+ * @param {Array<String>} ids
+ */
+
 export default class RepositoryIterator {
     /**
      * @param {Repository} repository
@@ -41,6 +56,45 @@ export default class RepositoryIterator {
     }
 
     /**
+     * @param {iterateIdsCallback} callback
+     * @returns {Promise<Array<String>>}
+     */
+    iterateIds(callback = null) {
+        const fetch = (result) => {
+            return this.fetch().then(response => {
+                if (response === null) {
+                    return Promise.resolve(result);
+                }
+
+                result.push(...response);
+
+                if (callback !== null) {
+                    callback(response);
+                }
+
+                return fetch(result);
+            });
+        };
+
+        return fetch([]);
+    }
+
+    async * iterateIdsAsync() {
+        const fetchIds = async () => this.fetchIds();
+
+        do {
+            // eslint-disable-next-line no-await-in-loop
+            const ids = await fetchIds();
+
+            if (ids === null) {
+                break;
+            }
+
+            yield* ids;
+        } while (true);
+    }
+
+    /**
      * @return {Promise<Object>}
      */
     fetch() {
@@ -49,5 +103,46 @@ export default class RepositoryIterator {
         this.criteria.setPage(this.criteria.page + 1);
         return this.repository.search(criteria, this.context)
             .then(response => (response.data.length > 0 ? response : null));
+    }
+
+    /**
+     * @param {iterateEntitiesCallback} callback
+     * @returns {Promise<Array<Object>>}
+     */
+    iterate(callback = null) {
+        const fetch = (result) => {
+            return this.fetch().then(response => {
+                if (response === null) {
+                    return Promise.resolve(result);
+                }
+
+                result.push(...response.data);
+                result.criteria = response.criteria;
+                result.total = response.total;
+
+                if (callback !== null) {
+                    callback(response.data, response);
+                }
+
+                return fetch(result);
+            });
+        };
+
+        return fetch([]);
+    }
+
+    async * iterateAsync() {
+        const fetch = async () => this.fetch();
+
+        do {
+            // eslint-disable-next-line no-await-in-loop
+            const items = await fetch();
+
+            if (items === null) {
+                break;
+            }
+
+            yield* items.data;
+        } while (true);
     }
 }

--- a/src/Administration/Resources/app/administration/src/core/data-new/repository-iterator.data.js
+++ b/src/Administration/Resources/app/administration/src/core/data-new/repository-iterator.data.js
@@ -1,0 +1,53 @@
+import Criteria from './criteria.data';
+
+export default class RepositoryIterator {
+    /**
+     * @param {Repository} repository
+     * @param {Context} context
+     * @param {Criteria} criteria
+     */
+    constructor(repository, context = null, criteria = null) {
+        this.repository = repository;
+        this.context = context || Shopware.Context.api;
+        this.criteria = criteria || new Criteria();
+
+        if (this.criteria.limit === null || this.criteria.limit < 1) {
+            this.criteria.setLimit(25);
+        }
+    }
+
+    /**
+     * @return {Promise<number>}
+     */
+    getTotal() {
+        const criteria = Criteria.fromCriteria(this.criteria)
+            .setPage(1)
+            .setLimit(1)
+            .setTotalCountMode(Criteria.TOTAL_COUNT_MODE_EXACT);
+
+        return this.repository.searchIds(criteria, this.context)
+            .then(response => response.total);
+    }
+
+    /**
+     * @return {Promise<Array<string>>}
+     */
+    fetchIds() {
+        const criteria = Criteria.fromCriteria(this.criteria);
+        criteria.setTotalCountMode(Criteria.TOTAL_COUNT_MODE_NONE);
+        this.criteria.setPage(this.criteria.page + 1);
+        return this.repository.searchIds(criteria, this.context)
+            .then(response => (response.data.length > 0 ? response.data : null));
+    }
+
+    /**
+     * @return {Promise<Object>}
+     */
+    fetch() {
+        const criteria = Criteria.fromCriteria(this.criteria);
+        criteria.setTotalCountMode(Criteria.TOTAL_COUNT_MODE_NONE);
+        this.criteria.setPage(this.criteria.page + 1);
+        return this.repository.search(criteria, this.context)
+            .then(response => (response.data.length > 0 ? response : null));
+    }
+}

--- a/src/Administration/Resources/app/administration/src/core/data-new/repository.data.js
+++ b/src/Administration/Resources/app/administration/src/core/data-new/repository.data.js
@@ -1,4 +1,5 @@
 import Criteria from './criteria.data';
+import RepositoryIterator from './repository-iterator.data';
 
 export default class Repository {
     /**
@@ -72,6 +73,46 @@ export default class Repository {
             .then((response) => {
                 return this.hydrator.hydrateSearchResult(this.route, this.entityName, response, context, criteria);
             });
+    }
+
+    /**
+     * Iterates over a paginated search request for the repository entity.
+     * @param {Object} context
+     * @param {Criteria} criteria
+     * @returns {Promise}
+     */
+    iterate(context, criteria) {
+        return new RepositoryIterator(this, context, criteria).iterate(null);
+    }
+
+    /**
+     * Iterates over a paginated search request for the repository entity.
+     * @param {Object} context
+     * @param {Criteria} criteria
+     * @returns {Promise}
+     */
+    async iterateAsync(context, criteria) {
+        return new RepositoryIterator(this, context, criteria).iterateAsync();
+    }
+
+    /**
+     * Iterates over a paginated search request for the repository entity ids.
+     * @param {Object} context
+     * @param {Criteria} criteria
+     * @returns {Promise}
+     */
+    iterateIds(context, criteria) {
+        return new RepositoryIterator(this, context, criteria).iterateIds(null);
+    }
+
+    /**
+     * Iterates over a paginated search request for the repository entity ids.
+     * @param {Object} context
+     * @param {Criteria} criteria
+     * @returns {Promise}
+     */
+    async iterateIdsAsync(context, criteria) {
+        return new RepositoryIterator(this, context, criteria).iterateIdsAsync();
     }
 
     /**

--- a/src/Administration/Resources/app/administration/src/core/service/customer-group-registration-listener.service.js
+++ b/src/Administration/Resources/app/administration/src/core/service/customer-group-registration-listener.service.js
@@ -1,6 +1,5 @@
-const { Application, Service } = Shopware;
-const { Criteria } = Shopware.Data;
-
+const { Application, Context, Data, Service } = Shopware;
+const { Criteria } = Data;
 
 /**
  * @module core/service/customer-group-registration-listener
@@ -22,8 +21,7 @@ export default function addCustomerGroupRegistrationListener(loginService) {
         const criteria = new Criteria();
         criteria.addAssociation('requestedGroup');
         criteria.addFilter(Criteria.not('AND', [Criteria.equals('requestedGroupId', null)]));
-
-        const customers = await customerRepository.search(criteria, Shopware.Context.api);
+        const customers = await customerRepository.iterateAsync(Context.api, criteria);
 
         customers.forEach(createNotification);
     }

--- a/src/Administration/Resources/app/administration/src/module/sw-category/component/sw-category-tree/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-category/component/sw-category-tree/index.js
@@ -1,8 +1,8 @@
 import template from './sw-category-tree.html.twig';
 import './sw-category-tree.scss';
 
-const { Component } = Shopware;
-const { Criteria } = Shopware.Data;
+const { Component, Context, Data } = Shopware;
+const { Criteria } = Data;
 
 Component.register('sw-category-tree', {
     template,
@@ -234,7 +234,7 @@ Component.register('sw-category-tree', {
             const criteria = new Criteria();
             criteria.limit = 500;
             criteria.addFilter(Criteria.equals('parentId', null));
-            return this.categoryRepository.search(criteria, Shopware.Context.api).then((result) => {
+            return this.categoryRepository.iterate(Context.api, criteria).then((result) => {
                 this.addCategories(result);
             });
         },

--- a/src/Administration/Resources/app/administration/src/module/sw-category/page/sw-category-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-category/page/sw-category-detail/index.js
@@ -2,8 +2,8 @@ import pageState from './state';
 import template from './sw-category-detail.html.twig';
 import './sw-category-detail.scss';
 
-const { Component, Mixin } = Shopware;
-const { Criteria, ChangesetGenerator } = Shopware.Data;
+const { Component, Context, Data, Mixin } = Shopware;
+const { Criteria, ChangesetGenerator } = Data;
 const { cloneDeep, merge } = Shopware.Utils.object;
 const type = Shopware.Utils.types;
 
@@ -287,7 +287,7 @@ Component.register('sw-category-detail', {
         loadCustomFieldSet() {
             this.isCustomFieldLoading = true;
 
-            return this.customFieldSetRepository.search(this.customFieldSetCriteria, Shopware.Context.api)
+            return this.customFieldSetRepository.iterate(Context.api, this.customFieldSetCriteria)
                 .then((customFieldSet) => {
                     return this.$store.commit('swCategoryDetail/setCustomFieldSets', customFieldSet);
                 }).then(() => {

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/page/sw-cms-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/page/sw-cms-detail/index.js
@@ -1,10 +1,10 @@
 import template from './sw-cms-detail.html.twig';
 import './sw-cms-detail.scss';
 
-const { Component, Mixin } = Shopware;
+const { Component, Context, Data, Mixin } = Shopware;
+const { Criteria } = Data;
 const { cloneDeep, getObjectDiff } = Shopware.Utils.object;
 const { warn } = Shopware.Utils.debug;
-const Criteria = Shopware.Data.Criteria;
 
 Component.register('sw-cms-detail', {
     template,
@@ -214,7 +214,7 @@ Component.register('sw-cms-detail', {
                     Criteria.equals('typeId', defaultStorefrontId)
                 );
 
-                this.salesChannelRepository.search(criteria, Shopware.Context.api).then((response) => {
+                this.salesChannelRepository.iterate(Context.api, criteria).then((response) => {
                     this.salesChannels = response;
 
                     if (this.salesChannels.length > 0) {
@@ -354,7 +354,8 @@ Component.register('sw-cms-detail', {
         onChangeLanguage() {
             this.isLoading = true;
 
-            return this.salesChannelRepository.search(new Criteria(), Shopware.Context.api).then((response) => {
+            const iterator = new RepositoryIterator(this.salesChannelRepository);
+            return iterator.iterate().then((response) => {
                 this.salesChannels = response;
                 const isSystemDefaultLanguage = Shopware.State.getters['context/isSystemDefaultLanguage'];
                 this.$store.commit('cmsPageState/setIsSystemDefaultLanguage', isSystemDefaultLanguage);

--- a/src/Administration/Resources/app/administration/src/module/sw-customer/view/sw-customer-detail-addresses/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-customer/view/sw-customer-detail-addresses/index.js
@@ -2,8 +2,8 @@ import { required } from 'src/core/service/validation.service';
 import template from './sw-customer-detail-addresses.html.twig';
 import './sw-customer-detail-addresses.scss';
 
-const { Component, Mixin, EntityDefinition } = Shopware;
-const { Criteria } = Shopware.Data;
+const { Component, Context, Data, Mixin, EntityDefinition } = Shopware;
+const { Criteria } = Data;
 
 Component.register('sw-customer-detail-addresses', {
     template,
@@ -118,11 +118,11 @@ Component.register('sw-customer-detail-addresses', {
             customFieldSetCriteria.addFilter(Criteria.equals('relations.entityName', 'customer_address'))
                 .addAssociation('customFields');
 
-            this.customFieldSetRepository.search(customFieldSetCriteria, Shopware.Context.api).then((customFieldSets) => {
+            this.customFieldSetRepository.iterate(Context.api, customFieldSetCriteria).then((customFieldSets) => {
                 this.customerAddressCustomFieldSets = customFieldSets;
+            }).finally(() => {
+                this.isLoading = false;
             });
-
-            this.isLoading = false;
         },
 
         getAddressColumns() {

--- a/src/Administration/Resources/app/administration/src/module/sw-customer/view/sw-customer-detail-order/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-customer/view/sw-customer-detail-order/index.js
@@ -1,8 +1,8 @@
 import template from './sw-customer-detail-order.html.twig';
 import './sw-customer-detail-order.scss';
 
-const { Component } = Shopware;
-const { Criteria } = Shopware.Data;
+const { Component, Context, Data } = Shopware;
+const { Criteria } = Data;
 
 Component.register('sw-customer-detail-order', {
     template,
@@ -91,7 +91,7 @@ Component.register('sw-customer-detail-order', {
             criteria.addAssociation('stateMachineState')
                 .addAssociation('currency');
 
-            this.orderRepository.search(criteria, Shopware.Context.api).then((orders) => {
+            this.orderRepository.iterate(Context.api, criteria).then((orders) => {
                 this.orders = orders;
                 this.isLoading = false;
             });

--- a/src/Administration/Resources/app/administration/src/module/sw-import-export/component/sw-import-export-edit-profile-modal-mapping/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-import-export/component/sw-import-export-edit-profile-modal-mapping/index.js
@@ -2,7 +2,8 @@ import template from './sw-import-export-edit-profile-modal-mapping.html.twig';
 import './sw-import-export-edit-profile-modal-mapping.scss';
 
 const { debounce, createId } = Shopware.Utils;
-const Criteria = Shopware.Data.Criteria;
+const { Context, Data } = Shopware;
+const { Criteria } = Data;
 
 /**
  * @private
@@ -88,12 +89,12 @@ Shopware.Component.register('sw-import-export-edit-profile-modal-mapping', {
         createdComponent() {
             this.toggleAddMappingActionState(this.profile.sourceEntity);
 
-            this.languageRepository.search(this.languageCriteria, Shopware.Context.api).then(languages => {
+            this.languageRepository.iterate(Context.api, this.languageCriteria).then(languages => {
                 this.languages = languages;
                 this.languages.push({ locale: { code: 'DEFAULT' } });
             });
 
-            this.currencyRepository.search(this.currencyCriteria, Shopware.Context.api).then(currencies => {
+            this.currencyRepository.iterate(Context.api, this.currencyCriteria).then(currencies => {
                 this.currencies = currencies;
                 this.currencies.push({ isoCode: 'DEFAULT' });
             });

--- a/src/Administration/Resources/app/administration/src/module/sw-mail-template/page/sw-mail-template-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-mail-template/page/sw-mail-template-detail/index.js
@@ -1,8 +1,8 @@
 import template from './sw-mail-template-detail.html.twig';
 import './sw-mail-template-detail.scss';
 
-const { Component, Mixin } = Shopware;
-const { Criteria, EntityCollection } = Shopware.Data;
+const { Component, Context, Data, Mixin } = Shopware;
+const { Criteria, EntityCollection } = Data;
 const { warn } = Shopware.Utils.debug;
 
 Component.register('sw-mail-template-detail', {
@@ -286,7 +286,8 @@ Component.register('sw-mail-template-detail', {
             mailTemplateSalesChannelCriteria.addFilter(
                 Criteria.equals('mailTemplateTypeId', id)
             );
-            mailTemplateSalesChannelsEntry.search(mailTemplateSalesChannelCriteria, Shopware.Context.api).then(
+
+            mailTemplateSalesChannelsEntry.iterate(Context.api, mailTemplateSalesChannelCriteria).then(
                 (responseSalesChannels) => {
                     const assignedSalesChannelIds = [];
                     responseSalesChannels.forEach((salesChannel) => {
@@ -304,10 +305,8 @@ Component.register('sw-mail-template-detail', {
             const criteria = new Criteria();
             criteria.addFilter(Criteria.equals('mailTemplateId', this.mailTemplate.id));
             criteria.addAssociation('salesChannel');
-            this.mailTemplateSalesChannelAssociationRepository.search(
-                criteria,
-                Shopware.Context.api
-            ).then((responseAssoc) => {
+
+            this.mailTemplateSalesChannelAssociationRepository.iterate(Context.api, criteria).then((responseAssoc) => {
                 this.enrichAssocStores(responseAssoc);
             });
         },

--- a/src/Administration/Resources/app/administration/src/module/sw-media/component/sidebar/sw-media-quickinfo/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-media/component/sidebar/sw-media-quickinfo/index.js
@@ -79,7 +79,7 @@ Component.register('sw-media-quickinfo', {
                 .addSorting(Criteria.sort('config.customFieldPosition', 'ASC', true))
                 .setLimit(100);
 
-            const searchResult = await this.customFieldSetRepository.search(criteria, Shopware.Context.api);
+            const searchResult = await this.customFieldSetRepository.iterateAsync(Context.api, criteria);
             this.customFieldSets = searchResult.filter(set => set.customFields.length > 0);
         },
 

--- a/src/Administration/Resources/app/administration/src/module/sw-newsletter-recipient/page/sw-newsletter-recipient-list/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-newsletter-recipient/page/sw-newsletter-recipient-list/index.js
@@ -1,7 +1,8 @@
 import template from './sw-newsletter-recipient-list.html.twig';
 import './sw-newsletter-recipient-list.scss';
 
-const { Component, Mixin, Data: { Criteria, EntityCollection } } = Shopware;
+const { Component, Data, Mixin } = Shopware;
+const { Criteria, EntityCollection } = Data;
 
 Component.register('sw-newsletter-recipient-list', {
     template,
@@ -57,12 +58,11 @@ Component.register('sw-newsletter-recipient-list', {
         createdComponent() {
             this.tagCollection = new EntityCollection('/tag', 'tag', Shopware.Context.api, new Criteria());
 
-            const criteria = new Criteria(1, 100);
-            this.languageStore.search(criteria, Shopware.Context.api).then((items) => {
+            this.languageStore.iterate().then((items) => {
                 this.languageFilters = items;
             });
 
-            this.salesChannelRepository.search(new Criteria(1, 100), Shopware.Context.api).then((salesChannels) => {
+            this.salesChannelRepository.iterate().then((salesChannels) => {
                 this.salesChannelFilters = salesChannels;
             });
 

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-state-change-modal/sw-order-state-change-modal-assign-mail-template/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-state-change-modal/sw-order-state-change-modal-assign-mail-template/index.js
@@ -1,8 +1,8 @@
 import template from './sw-order-state-change-modal-assign-mail-template.html.twig';
 import './sw-order-state-change-modal-assign-mail-template.scss';
 
-const { Criteria } = Shopware.Data;
-const { Component } = Shopware;
+const { Component, Data } = Shopware;
+const { Criteria } = Data;
 
 Component.register('sw-order-state-change-modal-assign-mail-template', {
     template,
@@ -148,13 +148,9 @@ Component.register('sw-order-state-change-modal-assign-mail-template', {
                 );
             }
 
-            const allTechnicalNamesCriteria = new Criteria();
-
-            this.mailTemplateSalesChannelAssociationRepository
-                .search(allTechnicalNamesCriteria, Shopware.Context.api)
-                .then((items) => {
-                    this.allTechnicalNames = items;
-                });
+            this.mailTemplateSalesChannelAssociationRepository.iterate().then((items) => {
+                this.allTechnicalNames = items;
+            });
 
             this.mailTemplateRepository.search(criteria, Shopware.Context.api).then((items) => {
                 this.total = items.total;

--- a/src/Administration/Resources/app/administration/src/module/sw-product-stream/page/sw-product-stream-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product-stream/page/sw-product-stream-detail/index.js
@@ -1,9 +1,9 @@
 import template from './sw-product-stream-detail.html.twig';
 import './sw-product-stream-detail.scss';
 
-const { Component, Mixin, Context } = Shopware;
+const { Component, Context, Data, Mixin } = Shopware;
 const { mapPropertyErrors } = Shopware.Component.getComponentHelper();
-const { Criteria } = Shopware.Data;
+const { Criteria } = Data;
 
 Component.register('sw-product-stream-detail', {
     template,
@@ -161,7 +161,7 @@ Component.register('sw-product-stream-detail', {
                 const filterCriteria = new Criteria();
                 filterCriteria.addFilter(Criteria.equals('productStreamId', this.productStreamId));
 
-                return this.productStreamFiltersRepository.search(filterCriteria, Context.api).then((productFilter) => {
+                this.productStreamFiltersRepository.iterate(Context.api, filterCriteria).then((productFilter) => {
                     return this.loadFilters(productFilter);
                 });
             }
@@ -279,7 +279,7 @@ Component.register('sw-product-stream-detail', {
                 .addAssociation('customFields')
                 .addAssociation('relations');
 
-            this.customFieldSetRepository.search(customFieldsCriteria, Context.api).then((customFieldSets) => {
+            this.customFieldSetRepository.iterate(Context.api, customFieldsCriteria).then((customFieldSets) => {
                 customFieldSets.forEach((customFieldSet) => {
                     const customFields = customFieldSet.customFields
                         .reduce((acc, customField) => {

--- a/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-clone-modal/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-clone-modal/index.js
@@ -1,8 +1,8 @@
 import template from './sw-product-clone-modal.html.twig';
 import './sw-product-clone-modal.scss';
 
-const { Component } = Shopware;
-const { Criteria } = Shopware.Data;
+const { Component, Context, Data } = Shopware;
+const { Criteria } = Data;
 
 Component.register('sw-product-clone-modal', {
     template,
@@ -92,11 +92,7 @@ Component.register('sw-product-clone-modal', {
                 Criteria.equals('parentId', this.product.id)
             );
 
-            return this.repository
-                .searchIds(criteria, Shopware.Context.api)
-                .then((response) => {
-                    return response.data;
-                });
+            return this.repository.iterateIds(Context.api, criteria);
         },
 
         duplicateVariant(duplicate, ids, callback) {

--- a/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-cross-selling-form/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-cross-selling-form/index.js
@@ -1,8 +1,8 @@
 import template from './sw-product-cross-selling-form.html.twig';
 import './sw-product-cross-selling-form.scss';
 
-const { Criteria } = Shopware.Data;
-const { Component, Context } = Shopware;
+const { Component, Context, Data } = Shopware;
+const { Criteria } = Data;
 const { mapPropertyErrors, mapGetters, mapState } = Component.getComponentHelper();
 
 Component.register('sw-product-cross-selling-form', {
@@ -161,7 +161,7 @@ Component.register('sw-product-cross-selling-form', {
                     const criteria = new Criteria();
                     criteria.addFilter(Criteria.equals('productStreamId', this.crossSelling.productStreamId));
 
-                    return filterRepository.search(criteria, Context.api).then((productFilter) => {
+                    return filterRepository.iterate(Context.api, criteria).then((productFilter) => {
                         this.productStreamFilter = productFilter;
                     });
                 });

--- a/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-variants/sw-product-variants-configurator/sw-product-variants-configurator-prices/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-variants/sw-product-variants-configurator/sw-product-variants-configurator-prices/index.js
@@ -2,7 +2,6 @@ import template from './sw-product-variants-configurator-prices.html.twig';
 import './sw-product-variants-configurator-prices.scss';
 
 const { Component } = Shopware;
-const { Criteria } = Shopware.Data;
 
 Component.register('sw-product-variants-configurator-prices', {
     template,
@@ -89,11 +88,9 @@ Component.register('sw-product-variants-configurator-prices', {
         },
 
         loadCurrencies() {
-            this.currencyRepository
-                .search(new Criteria(), Shopware.Context.api)
-                .then((searchResult) => {
-                    this.currencies = searchResult;
-                });
+            this.currencyRepository.iterate().then((searchResult) => {
+                this.currencies = searchResult;
+            });
         },
 
         getOptionsForGroup() {

--- a/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-variants/sw-product-variants-overview/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-variants/sw-product-variants-overview/index.js
@@ -120,7 +120,7 @@ Component.register('sw-product-variants-overview', {
                 const searchCriteria = new Criteria();
 
                 // Criteria for Search
-                searchCriteria.setTotalCountMode(1);
+                searchCriteria.setTotalCountMode(Criteria.TOTAL_COUNT_MODE_EXACT);
                 searchCriteria
                     .setPage(this.page)
                     .setLimit(this.limit)

--- a/src/Administration/Resources/app/administration/src/module/sw-product/page/sw-product-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/page/sw-product-detail/index.js
@@ -3,8 +3,8 @@ import swProductDetailState from './state';
 import errorConfiguration from './error.cfg.json';
 import './sw-product-detail.scss';
 
-const { Component, Mixin } = Shopware;
-const { Criteria } = Shopware.Data;
+const { Component, Data, Mixin } = Shopware;
+const { Criteria } = Data;
 const { hasOwnProperty } = Shopware.Utils.object;
 const { mapPageErrors, mapState, mapGetters } = Shopware.Component.getComponentHelper();
 
@@ -362,7 +362,7 @@ Component.register('sw-product-detail', {
         loadCurrencies() {
             Shopware.State.commit('swProductDetail/setLoading', ['currencies', true]);
 
-            return this.currencyRepository.search(new Criteria(1, 500), Shopware.Context.api).then((res) => {
+            this.currencyRepository.iterate().then((res) => {
                 Shopware.State.commit('swProductDetail/setCurrencies', res);
             }).then(() => {
                 Shopware.State.commit('swProductDetail/setLoading', ['currencies', false]);
@@ -372,7 +372,7 @@ Component.register('sw-product-detail', {
         loadTaxes() {
             Shopware.State.commit('swProductDetail/setLoading', ['taxes', true]);
 
-            return this.taxRepository.search(new Criteria(1, 500), Shopware.Context.api).then((res) => {
+            this.taxRepository.iterate().then((res) => {
                 Shopware.State.commit('swProductDetail/setTaxes', res);
             }).then(() => {
                 Shopware.State.commit('swProductDetail/setLoading', ['taxes', false]);

--- a/src/Administration/Resources/app/administration/src/module/sw-product/page/sw-product-list/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/page/sw-product-list/index.js
@@ -1,8 +1,8 @@
 import template from './sw-product-list.twig';
 import './sw-product-list.scss';
 
-const { Component, Mixin } = Shopware;
-const { Criteria } = Shopware.Data;
+const { Component, Data, Mixin } = Shopware;
+const { Criteria } = Data;
 
 Component.register('sw-product-list', {
     template,
@@ -95,11 +95,9 @@ Component.register('sw-product-list', {
             productCriteria.addAssociation('cover');
             productCriteria.addAssociation('manufacturer');
 
-            const currencyCriteria = new Criteria(1, 500);
-
             return Promise.all([
                 this.productRepository.search(productCriteria, Shopware.Context.api),
-                this.currencyRepository.search(currencyCriteria, Shopware.Context.api)
+                this.currencyRepository.iterate()
             ]).then((result) => {
                 const products = result[0];
                 const currencies = result[1];

--- a/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-base/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-base/index.js
@@ -166,7 +166,7 @@ Component.register('sw-product-detail-base', {
             criteria.addFilter(Criteria.equals('productId', this.product.id));
             criteria.setPage(this.page);
             criteria.setLimit(this.limit);
-            criteria.setTotalCountMode(1);
+            criteria.setTotalCountMode(Criteria.TOTAL_COUNT_MODE_EXACT);
 
             // load all our individual codes of our promotion
             // into our local promotion object.

--- a/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-context-prices/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-context-prices/index.js
@@ -1,8 +1,8 @@
 import template from './sw-product-detail-context-prices.html.twig';
 import './sw-product-detail-context-prices.scss';
 
-const { Component, Mixin } = Shopware;
-const { Criteria } = Shopware.Data;
+const { Component, Context, Data, Mixin } = Shopware;
+const { Criteria } = Data;
 const { mapState, mapGetters } = Shopware.Component.getComponentHelper();
 
 Component.register('sw-product-detail-context-prices', {
@@ -172,7 +172,7 @@ Component.register('sw-product-detail-context-prices', {
             );
 
             Shopware.State.commit('swProductDetail/setLoading', ['rules', true]);
-            this.ruleRepository.search(ruleCriteria, Shopware.Context.api).then((res) => {
+            this.ruleRepository.iterate(Context.api, ruleCriteria).then((res) => {
                 this.rules = res;
                 this.totalRules = res.total;
 

--- a/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-cross-selling/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-cross-selling/index.js
@@ -1,8 +1,8 @@
 import template from './sw-product-detail-cross-selling.html.twig';
 import './sw-product-detail-cross-selling.scss';
 
-const { Component } = Shopware;
-const { Criteria } = Shopware.Data;
+const { Component, Context, Data } = Shopware;
+const { Criteria } = Data;
 const { mapState, mapGetters } = Shopware.Component.getComponentHelper();
 
 Component.register('sw-product-detail-cross-selling', {
@@ -50,10 +50,7 @@ Component.register('sw-product-detail-cross-selling', {
                 .addSorting(Criteria.sort('position', 'ASC'))
                 .addAssociation('product');
 
-            repository.search(
-                criteria,
-                { ...Shopware.Context.api, inheritance: true }
-            ).then((assignedProducts) => {
+            repository.iterate({ ...Context.api, inheritance: true }, criteria).then((assignedProducts) => {
                 crossSelling.assignedProducts = assignedProducts;
             });
 

--- a/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-properties/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-properties/index.js
@@ -1,8 +1,8 @@
 import template from './sw-product-detail-properties.html.twig';
 import './sw-product-detail-properties.scss';
 
-const { Component } = Shopware;
-const { Criteria } = Shopware.Data;
+const { Component, Data } = Shopware;
+const { RepositoryIterator } = Data;
 const { mapState, mapGetters } = Shopware.Component.getComponentHelper();
 
 Component.register('sw-product-detail-properties', {
@@ -51,8 +51,9 @@ Component.register('sw-product-detail-properties', {
         },
 
         checkIfPropertiesExists() {
-            this.propertyRepository.search(new Criteria(1, 1), Shopware.Context.api).then((res) => {
-                this.propertiesAvailable = res.total > 0;
+            const iterator = new RepositoryIterator(this.propertyRepository);
+            iterator.getTotal().then(total => {
+                this.propertiesAvailable = total > 0;
             });
         },
 

--- a/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-variants/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-variants/index.js
@@ -1,8 +1,8 @@
 import template from './sw-product-detail-variants.html.twig';
 import './sw-product-detail-variants.scss';
 
-const { Component } = Shopware;
-const { Criteria } = Shopware.Data;
+const { Component, Data } = Shopware;
+const { Criteria } = Data;
 const { mapState, mapGetters } = Shopware.Component.getComponentHelper();
 
 Component.register('sw-product-detail-variants', {
@@ -100,17 +100,12 @@ Component.register('sw-product-detail-variants', {
         },
 
         loadGroups() {
-            return new Promise((resolve) => {
+            return new Promise((resolve, reject) => {
                 this.$nextTick().then(() => {
-                    const groupCriteria = new Criteria();
-                    groupCriteria
-                        .setLimit(100)
-                        .setPage(1);
-
-                    this.groupRepository.search(groupCriteria, Shopware.Context.api).then((searchResult) => {
+                    this.groupRepository.iterate().then((searchResult) => {
                         this.groups = searchResult;
                         resolve();
-                    });
+                    }).catch(reject);
                 });
             });
         },

--- a/src/Administration/Resources/app/administration/src/module/sw-profile/page/sw-profile-index/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-profile/page/sw-profile-index/index.js
@@ -2,8 +2,8 @@ import { email } from 'src/core/service/validation.service';
 import CriteriaFactory from 'src/core/factory/criteria.factory';
 import template from './sw-profile-index.html.twig';
 
-const { Component, Mixin, State } = Shopware;
-const { Criteria } = Shopware.Data;
+const { Component, Context, Data, Mixin, State } = Shopware;
+const { Criteria } = Data;
 const { mapPropertyErrors } = Component.getComponentHelper();
 const types = Shopware.Utils.types;
 
@@ -147,7 +147,7 @@ Component.register('sw-profile-index', {
             languageCriteria.addFilter(Criteria.equalsAny('locale.code', registeredLocales));
             languageCriteria.limit = 500;
 
-            return this.languageRepository.search(languageCriteria, Shopware.Context.api).then((result) => {
+            this.languageRepository.iterate(Context.api, languageCriteria).then((result) => {
                 this.languages = [];
                 const localeIds = [];
                 let fallbackId = '';

--- a/src/Administration/Resources/app/administration/src/module/sw-promotion/component/sw-promotion-basic-form/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-promotion/component/sw-promotion-basic-form/index.js
@@ -1,9 +1,9 @@
 import template from './sw-promotion-basic-form.html.twig';
 import './sw-promotion-basic-form.scss';
 
-const { Component, Mixin } = Shopware;
+const { Component, Context, Data, Mixin } = Shopware;
 const { mapPropertyErrors } = Shopware.Component.getComponentHelper();
-const { Criteria, EntityCollection } = Shopware.Data;
+const { Criteria, EntityCollection } = Data;
 const types = Shopware.Utils.types;
 
 Component.register('sw-promotion-basic-form', {
@@ -60,7 +60,7 @@ Component.register('sw-promotion-basic-form', {
             const promotionRepository = this.repositoryFactory.create('promotion');
             const criteria = (new Criteria()).addFilter(Criteria.equalsAny('id', this.promotion.exclusionIds));
 
-            promotionRepository.search(criteria, Shopware.Context.api).then((excluded) => {
+            promotionRepository.iterate(Context.api, criteria).then((excluded) => {
                 this.excludedPromotions = excluded;
             });
         },

--- a/src/Administration/Resources/app/administration/src/module/sw-promotion/component/sw-promotion-cart-condition-form/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-promotion/component/sw-promotion-cart-condition-form/index.js
@@ -2,8 +2,8 @@ import { PromotionPermissions } from 'src/module/sw-promotion/helper/promotion.h
 import template from './sw-promotion-cart-condition-form.html.twig';
 import './sw-promotion-cart-condition-form.scss';
 
-const { Component } = Shopware;
-const { Criteria } = Shopware.Data;
+const { Component, Context, Data } = Shopware;
+const { Criteria } = Data;
 
 Component.register('sw-promotion-cart-condition-form', {
     template,
@@ -119,7 +119,7 @@ Component.register('sw-promotion-cart-condition-form', {
                 Criteria.equals('promotionId', this.promotion.id)
             );
 
-            this.repositoryGroups.search(criteria, Shopware.Context.api).then((groups) => {
+            this.repositoryGroups.iterate(Context.api, criteria).then((groups) => {
                 this.promotion.setgroups = groups;
             });
         },

--- a/src/Administration/Resources/app/administration/src/module/sw-promotion/component/sw-promotion-discount-component/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-promotion/component/sw-promotion-discount-component/index.js
@@ -3,8 +3,8 @@ import template from './sw-promotion-discount-component.html.twig';
 import './sw-promotion-discount-component.scss';
 import DiscountHandler from './handler';
 
-const { Component, Mixin } = Shopware;
-const { Criteria } = Shopware.Data;
+const { Component, Data, Mixin } = Shopware;
+const { Criteria } = Data;
 const discountHandler = new DiscountHandler();
 
 Component.register('sw-promotion-discount-component', {
@@ -246,7 +246,7 @@ Component.register('sw-promotion-discount-component', {
             this.syncService = Shopware.Service('syncService');
             this.httpClient = this.syncService.httpClient;
 
-            this.currencyRepository.search(new Criteria(), Shopware.Context.api).then((response) => {
+            this.currencyRepository.iterate().then((response) => {
                 this.currencies = response;
                 this.defaultCurrency = this.currencies.find(currency => currency.isSystemDefault);
                 this.currencySymbol = this.defaultCurrency.symbol;

--- a/src/Administration/Resources/app/administration/src/module/sw-promotion/component/sw-promotion-individualcodes/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-promotion/component/sw-promotion-individualcodes/index.js
@@ -303,7 +303,7 @@ Component.register('sw-promotion-individualcodes', {
             criteria.addFilter(Criteria.equals('promotionId', this.promotion.id));
             criteria.setPage(this.gridCurrentPageNr);
             criteria.setLimit(this.gridPageLimit);
-            criteria.setTotalCountMode(1);
+            criteria.setTotalCountMode(Criteria.TOTAL_COUNT_MODE_EXACT);
 
             // load all our individual codes of our promotion
             // into our local promotion object.

--- a/src/Administration/Resources/app/administration/src/module/sw-promotion/component/sw-promotion-sales-channel-select/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-promotion/component/sw-promotion-sales-channel-select/index.js
@@ -1,7 +1,6 @@
 import template from './sw-promotion-sales-channel-select.html.twig';
 
 const { Component } = Shopware;
-const { Criteria } = Shopware.Data;
 
 Component.register('sw-promotion-sales-channel-select', {
     template,
@@ -75,7 +74,7 @@ Component.register('sw-promotion-sales-channel-select', {
 
     methods: {
         createdComponent() {
-            this.salesChannelRepository.search(new Criteria(), Shopware.Context.api).then((searchresult) => {
+            this.salesChannelRepository.iterate().then((searchresult) => {
                 this.salesChannels = searchresult;
             });
         },

--- a/src/Administration/Resources/app/administration/src/module/sw-promotion/service/individual-code-generator.service.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-promotion/service/individual-code-generator.service.js
@@ -188,7 +188,7 @@ export default class IndividualCodeGenerator extends EventEmitter {
         const criteria = new Criteria();
         criteria.setLimit(1);
         criteria.addFilter(Criteria.equals('promotionId', this.promotionId));
-        criteria.setTotalCountMode(1);
+        criteria.setTotalCountMode(Criteria.TOTAL_COUNT_MODE_EXACT);
 
         let count = 0;
 

--- a/src/Administration/Resources/app/administration/src/module/sw-promotion/service/persona-customer-grid.service.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-promotion/service/persona-customer-grid.service.js
@@ -1,5 +1,3 @@
-const { Criteria } = Shopware.Data;
-
 export default class PersonaCustomerGridService {
     constructor(component, repoCustomers, repoPromotionCustomers, context) {
         this.component = component;
@@ -29,11 +27,7 @@ export default class PersonaCustomerGridService {
     }
 
     async reloadCustomers() {
-        const criteria = new Criteria();
-
-        // search all customer persona entries and load them
-        // into our customer list which will be shown using our vue grid.
-        await this.repoPromotionCustomers.search(criteria, this.context).then((customers) => {
+        await this.repoPromotionCustomers.iterateAsync(this.context).then((customers) => {
             this.dataSource = customers;
         });
     }

--- a/src/Administration/Resources/app/administration/src/module/sw-promotion/view/sw-promotion-detail-discounts/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-promotion/view/sw-promotion-detail-discounts/index.js
@@ -1,9 +1,8 @@
 import { DiscountTypes, DiscountScopes } from 'src/module/sw-promotion/helper/promotion.helper';
 import template from './sw-promotion-detail-discounts.html.twig';
 
-const { Component } = Shopware;
-const { Criteria } = Shopware.Data;
-
+const { Component, Data } = Shopware;
+const { Criteria } = Data;
 
 Component.register('sw-promotion-detail-discounts', {
     template,
@@ -68,7 +67,8 @@ Component.register('sw-promotion-detail-discounts', {
             const discountCriteria = (new Criteria()).addAssociation('promotionDiscountPrices');
 
             this.isLoading = true;
-            discountRepository.search(discountCriteria, this.promotion.discounts.context).then((discounts) => {
+
+            discountRepository.iterate(this.promotion.discounts.context, discountCriteria).then((discounts) => {
                 this.discounts = discounts;
                 this.isLoading = false;
             });

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/component/structure/sw-sales-channel-menu/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/component/structure/sw-sales-channel-menu/index.js
@@ -1,7 +1,7 @@
 import template from './sw-sales-channel-menu.html.twig';
 
-const { Component } = Shopware;
-const { Criteria } = Shopware.Data;
+const { Component, Context, Data } = Shopware;
+const { Criteria } = Data;
 const FlatTree = Shopware.Helper.FlatTreeHelper;
 
 Component.register('sw-sales-channel-menu', {
@@ -59,7 +59,7 @@ Component.register('sw-sales-channel-menu', {
             criteria.addSorting(Criteria.sort('sales_channel.name', 'ASC'));
             criteria.addAssociation('type');
 
-            this.salesChannelRepository.search(criteria, Shopware.Context.api).then((response) => {
+            this.salesChannelRepository.iterate(Context.api, criteria).then((response) => {
                 this.salesChannels = response;
                 this.createMenuTree();
             });

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/component/sw-sales-channel-modal-grid/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/component/sw-sales-channel-modal-grid/index.js
@@ -2,7 +2,6 @@ import template from './sw-sales-channel-modal-grid.html.twig';
 import './sw-sales-channel-modal-grid.scss';
 
 const { Component, Defaults } = Shopware;
-const { Criteria } = Shopware.Data;
 
 Component.register('sw-sales-channel-modal-grid', {
     template,
@@ -50,7 +49,7 @@ Component.register('sw-sales-channel-modal-grid', {
         createdComponent() {
             this.isLoading = true;
 
-            this.salesChannelTypeRepository.search(new Criteria(1, 500), Shopware.Context.api).then((response) => {
+            this.salesChannelTypeRepository.iterate().then((response) => {
                 this.total = response.total;
                 this.salesChannelTypes = response;
                 this.isLoading = false;

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/component/sw-sales-channel-modal/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/component/sw-sales-channel-modal/index.js
@@ -1,8 +1,8 @@
 import template from './sw-sales-channel-modal.html.twig';
 import './sw-sales-channel-modal.scss';
 
-const { Component, Defaults } = Shopware;
-const { Criteria } = Shopware.Data;
+const { Component, Data, Defaults } = Shopware;
+const { RepositoryIterator } = Data;
 
 Component.register('sw-sales-channel-modal', {
     template,
@@ -52,11 +52,9 @@ Component.register('sw-sales-channel-modal', {
     methods: {
         createdComponent() {
             this.productStreamsLoading = true;
-            this.productStreamRepository.search(new Criteria(1, 1), Shopware.Context.api).then((result) => {
-                if (result.total > 0) {
-                    this.productStreamsExist = true;
-                }
-                this.productStreamsLoading = false;
+            const iterator = new RepositoryIterator(this.productStreamRepository);
+            iterator.getTotal().then(total => {
+                this.productStreamsExist = total > 0;
             });
         },
 

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/page/sw-sales-channel-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/page/sw-sales-channel-detail/index.js
@@ -1,7 +1,7 @@
 import template from './sw-sales-channel-detail.html.twig';
 
-const { Component, Mixin, Context, Defaults } = Shopware;
-const { Criteria } = Shopware.Data;
+const { Component, Context, Data, Defaults, Mixin } = Shopware;
+const { Criteria } = Data;
 
 Component.register('sw-sales-channel-detail', {
     template,
@@ -236,11 +236,9 @@ Component.register('sw-sales-channel-detail', {
             criteria.getAssociation('customFields')
                 .addSorting(Criteria.sort('config.customFieldPosition', 'ASC', true));
 
-            this.customFieldRepository
-                .search(criteria, Context.api)
-                .then((searchResult) => {
-                    this.customFieldSets = searchResult;
-                });
+            this.customFieldRepository.iterate(Context.api, criteria).then((searchResult) => {
+                this.customFieldSets = searchResult;
+            });
         },
 
         generateAccessUrl() {

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/view/sw-sales-channel-detail-base/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/view/sw-sales-channel-detail-base/index.js
@@ -1,8 +1,8 @@
 import template from './sw-sales-channel-detail-base.html.twig';
 import './sw-sales-channel-detail-base.scss';
 
-const { Component, Mixin, Context, Defaults } = Shopware;
-const { Criteria } = Shopware.Data;
+const { Component, Context, Data, Defaults, Mixin } = Shopware;
+const { Criteria, RepositoryIterator } = Data;
 const domUtils = Shopware.Utils.dom;
 const ShopwareError = Shopware.Classes.ShopwareError;
 const utils = Shopware.Utils;
@@ -423,11 +423,9 @@ Component.register('sw-sales-channel-detail-base', {
 
             criteria.addFilter(Criteria.equals('salesChannelId', storefrontSalesChannelId));
 
-            this.globalDomainRepository
-                .search(criteria, Shopware.Context.api)
-                .then((searchResult) => {
-                    this.storefrontDomains = searchResult;
-                });
+            this.globalDomainRepository.iterate(Context.api, criteria).then((searchResult) => {
+                this.storefrontDomains = searchResult;
+            });
         },
 
         onChangeFileName() {

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/view/sw-sales-channel-detail-base/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/view/sw-sales-channel-detail-base/index.js
@@ -457,7 +457,8 @@ Component.register('sw-sales-channel-detail-base', {
                 )
             );
 
-            this.productExportRepository.search(criteria, Shopware.Context.api).then(({ total }) => {
+            const iterator = new RepositoryIterator(this.productExportRepository, Context.api, criteria);
+            iterator.getTotal().then(total => {
                 this.invalidFileName = total > 0;
                 this.isFileNameChecking = false;
             }).catch(() => {

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-custom-field/component/sw-custom-field-list/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-custom-field/component/sw-custom-field-list/index.js
@@ -1,8 +1,8 @@
 import template from './sw-custom-field-list.html.twig';
 import './sw-custom-field-list.scss';
 
-const { Criteria } = Shopware.Data;
-const { Component, Mixin } = Shopware;
+const { Component, Context, Data, Mixin } = Shopware;
+const { Criteria, RepositoryIterator } = Data;
 const types = Shopware.Utils.types;
 
 Component.register('sw-custom-field-list', {
@@ -178,8 +178,10 @@ Component.register('sw-custom-field-list', {
             // Search the server for the customField name
             const criteria = new Criteria();
             criteria.addFilter(Criteria.equals('name', customField.name));
-            return this.globalCustomFieldRepository.search(criteria, Shopware.Context.api).then((res) => {
-                return res.length === 0;
+
+            const iterator = new RepositoryIterator(this.globalCustomFieldRepository, Context.api, criteria);
+            return iterator.getTotal().then(total => {
+                return total === 0;
             });
         },
 

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-custom-field/page/sw-settings-custom-field-set-create/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-custom-field/page/sw-settings-custom-field-set-create/index.js
@@ -1,7 +1,7 @@
 import template from './sw-settings-custom-field-set-create.html.twig';
 
-const { Component } = Shopware;
-const { Criteria } = Shopware.Data;
+const { Component, Context, Data } = Shopware;
+const { Criteria, RepositoryIterator } = Data;
 const utils = Shopware.Utils;
 
 Component.extend('sw-settings-custom-field-set-create', 'sw-settings-custom-field-set-detail', {
@@ -31,8 +31,9 @@ Component.extend('sw-settings-custom-field-set-create', 'sw-settings-custom-fiel
             const criteria = new Criteria();
             criteria.addFilter(Criteria.equals('name', this.set.name));
 
-            return this.customFieldSetRepository.search(criteria, Shopware.Context.api).then((res) => {
-                if (res.length === 0) {
+            const iterator = new RepositoryIterator(this.customFieldSetRepository, Context.api, criteria);
+            return iterator.getTotal().then(total => {
+                if (total === 0) {
                     this.$super('onSave');
 
                     return;

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-customer-group/page/sw-settings-customer-group-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-customer-group/page/sw-settings-customer-group-detail/index.js
@@ -1,8 +1,8 @@
 import './sw-settings-customer-group-detail.scss';
 import template from './sw-settings-customer-group-detail.html.twig';
 
-const { Component, Mixin } = Shopware;
-const { Criteria } = Shopware.Data;
+const { Component, Context, Data, Mixin } = Shopware;
+const { Criteria } = Data;
 const { mapPropertyErrors } = Shopware.Component.getComponentHelper();
 const { ShopwareError } = Shopware.Classes;
 const types = Shopware.Utils.types;
@@ -150,7 +150,7 @@ Component.register('sw-settings-customer-group-detail', {
             criteria.addGroupField('seoPathInfo');
             criteria.addGroupField('salesChannelId');
 
-            this.seoUrls = await this.seoUrlRepository.search(criteria, Shopware.Context.api);
+            this.seoUrls = await this.seoUrlRepository.iterateAsync(Context.api, criteria);
         },
 
         onChangeLanguage() {

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-document/page/sw-settings-document-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-document/page/sw-settings-document-detail/index.js
@@ -1,8 +1,8 @@
 import template from './sw-settings-document-detail.html.twig';
 import './sw-settings-document-detail.scss';
 
-const { Component, Mixin } = Shopware;
-const { Criteria, EntityCollection } = Shopware.Data;
+const { Component, Data, Mixin } = Shopware;
+const { Criteria, EntityCollection } = Data;
 
 Component.register('sw-settings-document-detail', {
     template,
@@ -339,7 +339,7 @@ Component.register('sw-settings-document-detail', {
         },
 
         async loadAvailableSalesChannel() {
-            this.salesChannels = await this.salesChannelRepository.search(new Criteria(1, 500), Shopware.Context.api);
+            this.salesChannels = await this.salesChannelRepository.iterateAsync();
         },
 
         showOption(item) {

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-product-feature-sets/service/feature-grid-translation.service.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-product-feature-sets/service/feature-grid-translation.service.js
@@ -1,4 +1,5 @@
-const { Criteria } = Shopware.Data;
+const { Context, Data } = Shopware;
+const { Criteria } = Data;
 
 export default class FeatureGridTranslationService {
     /**
@@ -57,7 +58,7 @@ export default class FeatureGridTranslationService {
             identifier
         ));
 
-        return repo.search(criteria, Shopware.Context.api).then((items) => {
+        return repo.iterate(Context.api, criteria).then((items) => {
             this.entities[type] = items;
         });
     }

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-rule/page/sw-settings-rule-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-rule/page/sw-settings-rule-detail/index.js
@@ -2,8 +2,7 @@ import { mapPropertyErrors } from 'src/app/service/map-errors.service';
 import template from './sw-settings-rule-detail.html.twig';
 import './sw-settings-rule-detail.scss';
 
-const { Component, Mixin, Context } = Shopware;
-const { Criteria } = Shopware.Data;
+const { Component, Context, Mixin } = Shopware;
 
 Component.register('sw-settings-rule-detail', {
     template,
@@ -141,39 +140,10 @@ Component.register('sw-settings-rule-detail', {
 
             return this.ruleRepository.get(ruleId, Context.api).then((rule) => {
                 this.rule = rule;
-                return this.loadConditions();
-            });
-        },
 
-        loadConditions(conditions = null) {
-            const context = { ...Context.api, inheritance: true };
-
-            if (conditions === null) {
-                return this.conditionRepository.search(new Criteria(), context).then((searchResult) => {
-                    return this.loadConditions(searchResult);
+                return this.conditionRepository.iterate({ ...Context.api, inheritance: true }).then(conditions => {
+                    this.conditions = conditions;
                 });
-            }
-
-            if (conditions.total <= conditions.length) {
-                this.conditions = conditions;
-                return Promise.resolve();
-            }
-
-            const criteria = new Criteria(
-                conditions.criteria.page + 1,
-                conditions.criteria.limit
-            );
-
-            if (conditions.entity === 'product') {
-                criteria.addAssociation('options.group');
-            }
-
-            return this.conditionRepository.search(criteria, conditions.context).then((searchResult) => {
-                conditions.push(...searchResult);
-                conditions.criteria = searchResult.criteria;
-                conditions.total = searchResult.total;
-
-                return this.loadConditions(conditions);
             });
         },
 

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-salutation/page/sw-settings-salutation-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-salutation/page/sw-settings-salutation-detail/index.js
@@ -1,7 +1,7 @@
 import template from './sw-settings-salutation-detail.html.twig';
 
-const { Component, Mixin } = Shopware;
-const { Criteria } = Shopware.Data;
+const { Component, Context, Data, Mixin } = Shopware;
+const { Criteria, RepositoryIterator } = Data;
 const ShopwareError = Shopware.Classes.ShopwareError;
 const { mapPropertyErrors } = Shopware.Component.getComponentHelper();
 const utils = Shopware.Utils;
@@ -201,7 +201,8 @@ Component.register('sw-settings-salutation-detail', {
                 )
             );
 
-            this.salutationRepository.search(criteria, Shopware.Context.api).then(({ total }) => {
+            const iterator = new RepositoryIterator(this.salutationRepository, Context.api, criteria);
+            iterator.getTotal().then(total => {
                 this.invalidKey = total > 0;
                 this.isKeyChecking = false;
             }).catch(() => {

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-seo/component/sw-seo-url/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-seo/component/sw-seo-url/index.js
@@ -1,9 +1,8 @@
 import swSeoUrlState from './state';
 import template from './sw-seo-url.html.twig';
 
-const { Component } = Shopware;
-const Criteria = Shopware.Data.Criteria;
-const EntityCollection = Shopware.Data.EntityCollection;
+const { Component, Context, Data } = Shopware;
+const { Criteria, EntityCollection } = Data;
 
 Component.register('sw-seo-url', {
     template,
@@ -143,10 +142,9 @@ Component.register('sw-seo-url', {
 
         initSalesChannelCollection() {
             const salesChannelCriteria = new Criteria();
-            salesChannelCriteria.setIds([]);
             salesChannelCriteria.addAssociation('type');
 
-            this.salesChannelRepository.search(salesChannelCriteria, Shopware.Context.api).then((salesChannelCollection) => {
+            this.salesChannelRepository.iterate(Context.api, salesChannelCriteria).then((salesChannelCollection) => {
                 Shopware.State.commit('swSeoUrl/setSalesChannelCollection', salesChannelCollection);
             });
         },

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-shipping/page/sw-settings-shipping-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-shipping/page/sw-settings-shipping-detail/index.js
@@ -2,9 +2,9 @@ import template from './sw-settings-shipping-detail.html.twig';
 import './sw-settings-shipping-detail.scss';
 import swShippingDetailState from './state';
 
-const { Component, Mixin, Context } = Shopware;
+const { Component, Context, Data, Mixin } = Shopware;
 const { mapState } = Shopware.Component.getComponentHelper();
-const { Criteria } = Shopware.Data;
+const { Criteria } = Data;
 const { warn } = Shopware.Utils.debug;
 
 Component.register('sw-settings-shipping-detail', {
@@ -170,7 +170,8 @@ Component.register('sw-settings-shipping-detail', {
 
         loadCurrencies() {
             this.currenciesLoading = true;
-            this.currencyRepository.search(new Criteria(1, 500), Context.api).then((currencyResponse) => {
+
+            this.currencyRepository.iterate().then((currencyResponse) => {
                 Shopware.State.commit('swShippingDetail/setCurrencies', this.sortCurrencies(currencyResponse));
                 this.currenciesLoading = false;
             });

--- a/src/Core/Framework/DataAbstractionLayer/Dbal/Common/RepositoryIterator.php
+++ b/src/Core/Framework/DataAbstractionLayer/Dbal/Common/RepositoryIterator.php
@@ -65,6 +65,13 @@ class RepositoryIterator
         return null;
     }
 
+    public function iterateIds(): \Generator
+    {
+        while (($ids = $this->fetchIds()) !== null) {
+            yield from $ids;
+        }
+    }
+
     public function fetch(): ?EntitySearchResult
     {
         $this->criteria->setTotalCountMode(Criteria::TOTAL_COUNT_MODE_NONE);
@@ -79,5 +86,12 @@ class RepositoryIterator
         }
 
         return $result;
+    }
+
+    public function iterate(): \Generator
+    {
+        while (($result = $this->fetch()) !== null) {
+            yield from $result->getEntities()->getIterator();
+        }
     }
 }

--- a/src/Docs/Resources/current/20-developer-guide/100-administration/60-fetching-and-handling-data.md
+++ b/src/Docs/Resources/current/20-developer-guide/100-administration/60-fetching-and-handling-data.md
@@ -26,6 +26,9 @@ The data handling was created with **predictability** as its main design goal. I
 `Criteria`
  : Contains all information for a search request (filter, sorting, pagination, ...)
 
+`RepositoryIterator`
+ : A utility class to support paginated access on repository searches
+
 ## Get access to a repository
 
 To create a repository it is required to inject the RepositoryFactory:
@@ -127,6 +130,27 @@ Component.register('sw-show-case-list', {
             .get(entityId, Shopware.Context.api)
             .then((entity) => {
                 this.entity = entity;
+            });
+    }
+});
+```
+
+## How to fetch all entities
+
+The result size of a repository search is limited with a pagination by default. To iterate over all entities for a given query the RepositoryIterator powered methods iterate and iterateAsync are your choices:
+  
+```js
+Component.register('sw-show-case-list', {
+    inject: ['repositoryFactory'],
+    
+    created() {
+        // create a repository for the `product` entity
+        this.repository = this.repositoryFactory.create('product');
+        
+        this.repository
+            .iterate()
+            .then((result) => {
+                this.result = result;
             });
     }
 });
@@ -463,3 +487,11 @@ Component.register('sw-show-case-list', {
     }
 });
 ```
+
+## Possible pitfalls
+
+Although javascript Criteria class resembles the same class in php there are small differences.
+The javascript class works with pages instead to the limit-offset known from database operations.
+As the pagination should be used using the API it is preset to the first page and 25 results per page.
+Using the Criteria class in php has no limits by default.
+This can result in different expectations regarding their usage although the similar appearance.


### PR DESCRIPTION
### 1. Why is this change necessary?
There are lots of occassions where a complete list of objects is required but not requested properly. Most of these places are visible when you see a criteria limit of 100 or 500. These are tries to load all the data but this is not all the data. This might be the case because although it is tried to have php and admin-js behave identically regarding DAL operations it is not as the criteria in admin-js works with limited pages that have a preset of 1, 25 and the php criteria works with limit offset and has a preset of null, null. Those who work with the admin-js criteria and are familiar with it from php get fooled.

### 2. What does this change do, exactly?
Add the php-known RepositoryIterator and some constants from the criteria. Use the repository iterator at a lot of places that behave better now.

### 3. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/NEXT-10262
https://issues.shopware.com/issues/NEXT-10349
And probably some more

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
