### PR TITLE
Check invalid rules with DAL before fetching

### DIFF
--- a/src/Core/Checkout/Cart/CartRuleLoader.php
+++ b/src/Core/Checkout/Cart/CartRuleLoader.php
@@ -9,6 +9,7 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Dbal\Common\RepositoryIterator;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepositoryInterface;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Sorting\FieldSorting;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\Cache\Adapter\TagAwareAdapterInterface;
@@ -148,6 +149,7 @@ class CartRuleLoader
 
         $criteria = new Criteria();
         $criteria->addSorting(new FieldSorting('priority', FieldSorting::DESCENDING));
+        $criteria->addFilter(new EqualsFilter('invalid', false));
         $criteria->setLimit(500);
         $criteria->setTitle('cart-rule-loader::load-rules');
 
@@ -155,12 +157,9 @@ class CartRuleLoader
         $rules = new RuleCollection();
         while (($result = $repositoryIterator->fetch()) !== null) {
             foreach ($result->getEntities() as $rule) {
-                if (!$rule->isInvalid() && $rule->getPayload()) {
+                if ($rule->getPayload()) {
                     $rules->add($rule);
                 }
-            }
-            if ($result->count() < 500) {
-                break;
             }
         }
 


### PR DESCRIPTION
### 1. Why is this change necessary?
Having the DAL check for invalid rules is faster than fetching them first. So I just removed the php check and moved it to the DAL.

### 2. What does this change do, exactly?
Remove a early-loop-quit as I assume #1310 will get this RepositoryIterator feature by default into the core.
Add a filter to the DAL query.

### 3. Describe each step to reproduce the issue or behaviour.
1. Have a loads of rules that you optimized by being invalid
2. Still loads a lot

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
