### PR TITLE
NEXT-8326/9171 Fix being unable to set a port in a Domain

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-url-field/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-url-field/index.js
@@ -100,7 +100,7 @@ Component.extend('sw-url-field', 'sw-text-field', {
                 try {
                     const url = new URL(`${this.urlPrefix}${this.currentValue}`);
                     const path = this.currentValue.endsWith('/') ? url.pathname : url.pathname.replace(/\/$/, '');
-                    this.currentValue = url.hostname + path;
+                    this.currentValue = url.host + path;
                     this.errorUrl = null;
                 } catch {
                     this.errorUrl = new ShopwareError({


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
Because it is currently impossible to specify a port number on a domain in the administration, which is quite useful in development setups.

### 2. What does this change do, exactly?
It uses [`URL.host` ](https://developer.mozilla.org/en-US/docs/Web/API/URL/host) instead of [`URL.hostname`](https://developer.mozilla.org/en-US/docs/Web/API/URL/hostname). `host` has the port number, `hostname` does not.

### 3. Describe each step to reproduce the issue or behaviour.
Edit a SalesChannelDomain in the adminstration and try adding a colon to specify the port number.

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/NEXT-9171
https://issues.shopware.com/issues/NEXT-8326

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
