### PR TITLE
fix: replace wrong bundle name

### DIFF
--- a/src/Docs/Resources/current/50-how-to/010-indepth-guide-bundle/030-database.md
+++ b/src/Docs/Resources/current/50-how-to/010-indepth-guide-bundle/030-database.md
@@ -55,7 +55,7 @@ Since your base class' location is the `src` directory, that's also where the `M
 
 After creating the directory, you can use symfony's `bin/console` to create boilerplate migration files.
 
-    bin/console database:create-migration --plugin SwagBundleExample --name Bundle
+    bin/console database:create-migration --plugin BundleExample --name Bundle
     
 <dl>
 <dt>`--plugin`</dt>


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
Using `SwagBundleExample` as plugin name while following the  [Bundle example: An InDepth guide](https://docs.shopware.com/en/shopware-platform-dev-en/how-to/indepth-guide-bundle) causes the error: `Plugin "SwagBundleExample" could not be found.`.

### 2. What does this change do, exactly?
It replaces the wrong plugin name with the correct one.

### 3. Describe each step to reproduce the issue or behaviour.
Following the [Bundle example: An InDepth guide](https://docs.shopware.com/en/shopware-platform-dev-en/how-to/indepth-guide-bundle) one comes across the command `bin/console database:create-migration --plugin SwagBundleExample --name Bundle` which causes the before mentioned error.

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
