### PR TITLE
Dispatch event after cart has been saved

### DIFF
--- a/changelog/_unreleased/2020-09-11-dispatch-event-cart-save.md
+++ b/changelog/_unreleased/2020-09-11-dispatch-event-cart-save.md
@@ -1,0 +1,8 @@
+---
+title: Dispatch event after cart save
+author: Kevin Chen
+author_email: kevin.chen@perfecthair.ch
+author_github: @maqavelli
+---
+# Core
+Dispatch the new created event CartSavedEvent after the cart has been persisted

--- a/src/Core/Checkout/Cart/Event/CartSavedEvent.php
+++ b/src/Core/Checkout/Cart/Event/CartSavedEvent.php
@@ -1,0 +1,24 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Checkout\Cart\Event;
+
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Symfony\Contracts\EventDispatcher\Event;
+
+class CartSavedEvent extends Event
+{
+    /**
+     * @var SalesChannelContext
+     */
+    protected $context;
+
+    public function __construct(SalesChannelContext $context)
+    {
+        $this->context = $context;
+    }
+
+    public function getContext(): SalesChannelContext
+    {
+        return $this->context;
+    }
+}

--- a/src/Core/Checkout/Cart/SalesChannel/CartItemAddRoute.php
+++ b/src/Core/Checkout/Cart/SalesChannel/CartItemAddRoute.php
@@ -6,6 +6,7 @@ use OpenApi\Annotations as OA;
 use Shopware\Core\Checkout\Cart\Cart;
 use Shopware\Core\Checkout\Cart\CartCalculator;
 use Shopware\Core\Checkout\Cart\CartPersisterInterface;
+use Shopware\Core\Checkout\Cart\Event\CartSavedEvent;
 use Shopware\Core\Checkout\Cart\Event\LineItemAddedEvent;
 use Shopware\Core\Checkout\Cart\LineItemFactoryRegistry;
 use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
@@ -92,7 +93,7 @@ class CartItemAddRoute extends AbstractCartItemAddRoute
 
         $cart = $this->cartCalculator->calculate($cart, $context);
         $this->cartPersister->save($cart, $context);
-
+        $this->eventDispatcher->dispatch(new CartSavedEvent($context));
         return new CartResponse($cart);
     }
 }

--- a/src/Core/Checkout/Cart/SalesChannel/CartItemRemoveRoute.php
+++ b/src/Core/Checkout/Cart/SalesChannel/CartItemRemoveRoute.php
@@ -6,6 +6,7 @@ use OpenApi\Annotations as OA;
 use Shopware\Core\Checkout\Cart\Cart;
 use Shopware\Core\Checkout\Cart\CartCalculator;
 use Shopware\Core\Checkout\Cart\CartPersisterInterface;
+use Shopware\Core\Checkout\Cart\Event\CartSavedEvent;
 use Shopware\Core\Checkout\Cart\Event\LineItemRemovedEvent;
 use Shopware\Core\Checkout\Cart\Exception\LineItemNotFoundException;
 use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
@@ -82,7 +83,7 @@ class CartItemRemoveRoute extends AbstractCartItemRemoveRoute
 
         $cart = $this->cartCalculator->calculate($cart, $context);
         $this->cartPersister->save($cart, $context);
-
+        $this->eventDispatcher->dispatch(new CartSavedEvent($context));
         return new CartResponse($cart);
     }
 }

--- a/src/Core/Checkout/DependencyInjection/cart.xml
+++ b/src/Core/Checkout/DependencyInjection/cart.xml
@@ -56,6 +56,7 @@
             <argument type="service" id="Shopware\Core\Checkout\Cart\CartPersister"/>
             <argument type="service" id="Shopware\Core\Checkout\Cart\CartCalculator"/>
             <argument type="service" id="Shopware\Core\Checkout\Cart\LineItemFactoryRegistry"/>
+            <argument type="service" id="event_dispatcher"/>
         </service>
 
         <service id="Shopware\Core\Checkout\Cart\SalesChannel\CartLoadRoute" public="true">


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
To get the whole cart with the added/removed/changed line item 

### 2. What does this change do, exactly?
dispatch a new event after the cart has been persisted

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
