### PR TITLE
Dispatch event after cart save

### DIFF
--- a/changelog/_unreleased/2020-09-11-dispatch-event-cart-save.md
+++ b/changelog/_unreleased/2020-09-11-dispatch-event-cart-save.md
@@ -1,0 +1,8 @@
+---
+title: dispatch event after cart save
+author: Kevin Chen
+author_email: kevin.chen@perfecthair.ch
+author_github: @maqavelli
+---
+# Core
+Dispatch the CartSavedEvent after the cart has been persisted

--- a/src/Core/Checkout/Cart/CartPersister.php
+++ b/src/Core/Checkout/Cart/CartPersister.php
@@ -4,12 +4,14 @@ namespace Shopware\Core\Checkout\Cart;
 
 use Doctrine\DBAL\Connection;
 use Shopware\Core\Checkout\Cart\Error\ErrorCollection;
+use Shopware\Core\Checkout\Cart\Event\CartSavedEvent;
 use Shopware\Core\Checkout\Cart\Exception\CartDeserializeFailedException;
 use Shopware\Core\Checkout\Cart\Exception\CartTokenNotFoundException;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Uuid\Exception\InvalidUuidException;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 class CartPersister implements CartPersisterInterface
 {
@@ -18,9 +20,15 @@ class CartPersister implements CartPersisterInterface
      */
     private $connection;
 
-    public function __construct(Connection $connection)
+    /**
+     * @var EventDispatcherInterface
+     */
+    private $eventDispatcher;
+
+    public function __construct(Connection $connection, EventDispatcherInterface $eventDispatcher)
     {
         $this->connection = $connection;
+        $this->eventDispatcher = $eventDispatcher;
     }
 
     public function load(string $token, SalesChannelContext $context): Cart
@@ -77,6 +85,8 @@ class CartPersister implements CartPersisterInterface
         ];
 
         $this->connection->insert('cart', $data);
+
+        $this->eventDispatcher->dispatch(new CartSavedEvent($context));
     }
 
     public function delete(string $token, SalesChannelContext $context): void

--- a/src/Core/Checkout/Cart/Event/CartSavedEvent.php
+++ b/src/Core/Checkout/Cart/Event/CartSavedEvent.php
@@ -1,0 +1,24 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Checkout\Cart\Event;
+
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Symfony\Contracts\EventDispatcher\Event;
+
+class CartSavedEvent extends Event
+{
+    /**
+     * @var SalesChannelContext
+     */
+    protected $context;
+
+    public function __construct(SalesChannelContext $context)
+    {
+        $this->context = $context;
+    }
+
+    public function getContext(): SalesChannelContext
+    {
+        return $this->context;
+    }
+}

--- a/src/Core/Checkout/DependencyInjection/cart.xml
+++ b/src/Core/Checkout/DependencyInjection/cart.xml
@@ -34,6 +34,7 @@
 
         <service id="Shopware\Core\Checkout\Cart\CartPersister">
             <argument type="service" id="Doctrine\DBAL\Connection"/>
+            <argument type="service" id="event_dispatcher"/>
         </service>
 
         <service id="Shopware\Core\Checkout\Cart\SalesChannel\CartService" public="true">


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
To get the whole cart with the added/removed/changed line item 

### 2. What does this change do, exactly?
dispatch CartSavedEvent after the cart has been persisted

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
