### PR TITLE
Consider background enabled property for setting items

### DIFF
--- a/changelog/_unreleased/2020-09-14-consider-background-enabled-property.md
+++ b/changelog/_unreleased/2020-09-14-consider-background-enabled-property.md
@@ -1,0 +1,10 @@
+---
+title: Consider background enabled property for setting items
+issue:
+flag:
+author: sobyte
+author_email: j.spreng@kellerkinder.de
+author_github: sobyte
+---
+# Administration
+* Add background enabled property for setting items in the component `sw-settings-index`

--- a/src/Administration/Resources/app/administration/src/module/sw-settings/page/sw-settings-index/sw-settings-index.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings/page/sw-settings-index/sw-settings-index.html.twig
@@ -61,7 +61,8 @@
                                                                       :key="settingsItem.name"
                                                                       :label="$tc(settingsItem.label)"
                                                                       :to="{ name: settingsItem.to }"
-                                                                      :id="settingsItem.id">
+                                                                      :id="settingsItem.id"
+                                                                      :backgroundEnabled="settingsItem.backgroundEnabled">
                                                         <template #icon>
                                                             <component v-if="settingsItem.iconComponent" :is="settingsItem.iconComponent"></component>
                                                             <sw-icon v-else :name="settingsItem.icon"></sw-icon>
@@ -86,7 +87,8 @@
                                                                       :key="pluginSettingsItem.name"
                                                                       :label="$tc(pluginSettingsItem.label)"
                                                                       :to="{ name: pluginSettingsItem.to }"
-                                                                      :id="pluginSettingsItem.id">
+                                                                      :id="pluginSettingsItem.id"
+                                                                      :backgroundEnabled="pluginSettingsItem.backgroundEnabled">
                                                         <template #icon>
                                                             <component v-if="pluginSettingsItem.iconComponent" :is="pluginSettingsItem.iconComponent"></component>
                                                             <sw-icon v-else :name="pluginSettingsItem.icon"></sw-icon>


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
As a plugin developer I can't disable the background for the settings item of my plugin when I'm registering a new module like
```
Module.register('foo-configuration', {
    ...
    settingsItem: [{
        name:   'foo-configuration',
        to:     'foo.configuration.settings',
        label:  'foo.module.title',
        group:  'plugins',
        iconComponent: 'foo-plugin-icon',
        backgroundEnabled: false
    }]
});
```

### 2. What does this change do, exactly?
Make the property `backgroundEnabled` of component `sw-settings-item` configurable.


### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
