### PR TITLE
Change the used property for showing the birthday field in the account overview

### DIFF
--- a/changelog/_unreleased/2020-09-14-show-birthday-field.md
+++ b/changelog/_unreleased/2020-09-14-show-birthday-field.md
@@ -1,0 +1,10 @@
+---
+title: Show birthday field
+issue:
+flag:
+author: sobyte
+author_email: j.spreng@kellerkinder.de
+author_github: sobyte
+---
+# Storefront
+* Changed the used property for showing the birthday field in the account overview 

--- a/src/Storefront/Resources/views/storefront/page/account/profile/index.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/account/profile/index.html.twig
@@ -38,7 +38,7 @@
 
                                     {% block page_account_profile_personal_fields %}
                                         {% sw_include '@Storefront/storefront/page/account/profile/personal.html.twig' with {
-                                            'showBirthdayField': shopware.config.core.loginRegistration.birthdayFieldRequired,
+                                            'showBirthdayField': shopware.config.core.loginRegistration.showBirthdayField,
                                             'data': context.customer
                                         } %}
                                     {% endblock %}


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
Isn't it obvious? 😉

### 2. What does this change do, exactly?
Change the property for showing the birthday field in the account overview

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
