### PR TITLE
NEXT-10896 - Update jQuery to version 3.5.1

### DIFF
--- a/changelog/_unreleased/2020-09-16-update-jquery.md
+++ b/changelog/_unreleased/2020-09-16-update-jquery.md
@@ -1,0 +1,9 @@
+---
+title:              Update jQuery
+issue:              NEXT-10896
+author:             Sebastian König
+author_email:       s.koenig@tinect.de
+author_github:      @tinect
+---
+# Storefront
+*  Changed jQuery version in storefront to 3.5.1

--- a/src/Storefront/Resources/app/storefront/package-lock.json
+++ b/src/Storefront/Resources/app/storefront/package-lock.json
@@ -8669,9 +8669,9 @@
       }
     },
     "jquery": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.4.1.tgz",
-      "integrity": "sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw=="
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.5.1.tgz",
+      "integrity": "sha512-XwIBPqcMn57FxfT+Go5pzySnm4KWkT1Tv7gjrpT1srtf8Weynl6R273VJ5GjkRb51IzMp5nbaPjJXMWeju2MKg=="
     },
     "js-base64": {
       "version": "2.5.1",

--- a/src/Storefront/Resources/app/storefront/package.json
+++ b/src/Storefront/Resources/app/storefront/package.json
@@ -38,7 +38,7 @@
     "history": "4.9.0",
     "imports-loader": "0.8.0",
     "intersection-observer": "0.7.0",
-    "jquery": "3.4.1",
+    "jquery": "3.5.1",
     "mini-css-extract-plugin": "0.8.0",
     "nunito-fontface": "0.7.3",
     "object-fit-images": "3.2.4",


### PR DESCRIPTION
### 1. Why is this change necessary?
jQuery should be updated to recent version. Current version is marked vulnerable. https://snyk.io/vuln/npm:jquery?lh=3.4.1

### 2. What does this change do, exactly?


### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/NEXT-10896

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
