### PR TITLE
Dispatch event after token has been changed

### DIFF
--- a/changelog/_unreleased/2020-09-18-token-change-event.md
+++ b/changelog/_unreleased/2020-09-18-token-change-event.md
@@ -1,0 +1,9 @@
+---
+title: Dispatch event after token has been changed
+issue: NEXT-10941
+author: Kevin Chen
+author_email: kevin.chen@perfecthair.ch
+author_github: @maqavelli
+---
+# Core
+*  Added new event `Shopware\Core\System\SalesChannel\Event\SalesChannelContextTokenChangeEvent` and dispatch in `Shopware\Core\System\SalesChannel\Context\SalesChannelContextPersister` replace method

--- a/src/Administration/Test/Service/AdminOrderCartServiceTest.php
+++ b/src/Administration/Test/Service/AdminOrderCartServiceTest.php
@@ -13,6 +13,7 @@ use Shopware\Core\System\SalesChannel\Context\SalesChannelContextFactory;
 use Shopware\Core\System\SalesChannel\Context\SalesChannelContextPersister;
 use Shopware\Core\System\SalesChannel\Context\SalesChannelContextService;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Symfony\Component\EventDispatcher\EventDispatcher;
 
 class AdminOrderCartServiceTest extends TestCase
 {
@@ -41,7 +42,8 @@ class AdminOrderCartServiceTest extends TestCase
     protected function setUp(): void
     {
         $this->connection = $this->getContainer()->get(Connection::class);
-        $this->contextPersister = new SalesChannelContextPersister($this->connection);
+        $eventDispatcher = new EventDispatcher();
+        $this->contextPersister = new SalesChannelContextPersister($this->connection, $eventDispatcher);
         $this->salesChannelContext = $this->getContainer()->get(SalesChannelContextFactory::class)
             ->create(Uuid::randomHex(), Defaults::SALES_CHANNEL);
         $this->adminOrderCartService = $this->getContainer()->get(AdminOrderCartService::class);

--- a/src/Core/Checkout/Test/Cart/Delivery/DeliveryProcessorTest.php
+++ b/src/Core/Checkout/Test/Cart/Delivery/DeliveryProcessorTest.php
@@ -32,6 +32,7 @@ use Shopware\Core\System\Country\CountryEntity;
 use Shopware\Core\System\SalesChannel\Context\SalesChannelContextFactory;
 use Shopware\Core\System\SalesChannel\Context\SalesChannelContextPersister;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Symfony\Component\EventDispatcher\EventDispatcher;
 
 class DeliveryProcessorTest extends TestCase
 {
@@ -55,7 +56,8 @@ class DeliveryProcessorTest extends TestCase
     protected function setUp(): void
     {
         $this->connection = $this->getContainer()->get(Connection::class);
-        $this->contextPersister = new SalesChannelContextPersister($this->connection);
+        $eventDispatcher = new EventDispatcher();
+        $this->contextPersister = new SalesChannelContextPersister($this->connection, $eventDispatcher);
         $this->salesChannelContext = $this->getContainer()->get(SalesChannelContextFactory::class)
             ->create(Uuid::randomHex(), Defaults::SALES_CHANNEL);
 

--- a/src/Core/Framework/Test/Api/Controller/SalesChannelProxyControllerTest.php
+++ b/src/Core/Framework/Test/Api/Controller/SalesChannelProxyControllerTest.php
@@ -27,6 +27,7 @@ use Shopware\Core\System\SalesChannel\Context\SalesChannelContextPersister;
 use Shopware\Core\System\SalesChannel\Context\SalesChannelContextService;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\HttpFoundation\Response;
 
 class SalesChannelProxyControllerTest extends TestCase
@@ -95,7 +96,8 @@ class SalesChannelProxyControllerTest extends TestCase
         $this->context = Context::createDefaultContext();
         $this->customerRepository = $this->getContainer()->get('customer.repository');
         $this->connection = $this->getContainer()->get(Connection::class);
-        $this->contextPersister = new SalesChannelContextPersister($this->connection);
+        $eventDispatcher = new EventDispatcher();
+        $this->contextPersister = new SalesChannelContextPersister($this->connection, $eventDispatcher);
         $this->ids = new TestDataCollection($this->context);
     }
 

--- a/src/Core/System/DependencyInjection/sales_channel.xml
+++ b/src/Core/System/DependencyInjection/sales_channel.xml
@@ -51,6 +51,7 @@
 
         <service id="Shopware\Core\System\SalesChannel\Context\SalesChannelContextPersister">
             <argument type="service" id="Doctrine\DBAL\Connection"/>
+            <argument type="service" id="event_dispatcher"/>
         </service>
 
         <service id="Shopware\Core\System\SalesChannel\Context\SalesChannelContextFactory">

--- a/src/Core/System/SalesChannel/Context/SalesChannelContextPersister.php
+++ b/src/Core/System/SalesChannel/Context/SalesChannelContextPersister.php
@@ -4,7 +4,8 @@ namespace Shopware\Core\System\SalesChannel\Context;
 
 use Doctrine\DBAL\Connection;
 use Shopware\Core\Framework\Util\Random;
-use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Shopware\Core\System\SalesChannel\Event\SalesChannelContextTokenChangeEvent;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 class SalesChannelContextPersister
 {
@@ -13,9 +14,15 @@ class SalesChannelContextPersister
      */
     private $connection;
 
-    public function __construct(Connection $connection)
+    /**
+     * @var EventDispatcherInterface
+     */
+    private $eventDispatcher;
+
+    public function __construct(Connection $connection, EventDispatcherInterface $eventDispatcher)
     {
         $this->connection = $connection;
+        $this->eventDispatcher = $eventDispatcher;
     }
 
     public function save(string $token, array $parameters): void
@@ -78,6 +85,7 @@ class SalesChannelContextPersister
         if (func_num_args() === 2) {
             $context = func_get_arg(1);
             $context->assign(['token' => $newToken]);
+            $this->eventDispatcher->dispatch(new SalesChannelContextTokenChangeEvent($context, $oldToken, $newToken));
         }
 
         return $newToken;

--- a/src/Core/System/SalesChannel/Event/SalesChannelContextTokenChangeEvent.php
+++ b/src/Core/System/SalesChannel/Event/SalesChannelContextTokenChangeEvent.php
@@ -1,0 +1,46 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\System\SalesChannel\Event;
+
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Symfony\Contracts\EventDispatcher\Event;
+
+class SalesChannelContextTokenChangeEvent extends Event
+{
+    /**
+     * @var SalesChannelContext
+     */
+    protected $salesChannelContext;
+
+    /**
+     * @var string
+     */
+    protected $previousToken;
+
+    /**
+     * @var string
+     */
+    protected $currentToken;
+
+    public function __construct(SalesChannelContext $salesChannelContext, string $previousToken, string $currentToken)
+    {
+        $this->salesChannelContext = $salesChannelContext;
+        $this->previousToken = $previousToken;
+        $this->currentToken = $currentToken;
+    }
+
+    public function getSalesChannelContext(): SalesChannelContext
+    {
+        return $this->salesChannelContext;
+    }
+
+    public function getPreviousToken(): string
+    {
+        return $this->previousToken;
+    }
+
+    public function getCurrentToken(): string
+    {
+        return $this->currentToken;
+    }
+}

--- a/src/Core/System/Test/SalesChannel/Context/SalesChannelContextPersisterTest.php
+++ b/src/Core/System/Test/SalesChannel/Context/SalesChannelContextPersisterTest.php
@@ -9,6 +9,7 @@ use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Util\Random;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SalesChannel\Context\SalesChannelContextPersister;
+use Symfony\Component\EventDispatcher\EventDispatcher;
 
 class SalesChannelContextPersisterTest extends TestCase
 {
@@ -27,7 +28,8 @@ class SalesChannelContextPersisterTest extends TestCase
     public function setUp(): void
     {
         $this->connection = $this->getContainer()->get(Connection::class);
-        $this->contextPersister = new SalesChannelContextPersister($this->connection);
+        $eventDispatcher = new EventDispatcher();
+        $this->contextPersister = new SalesChannelContextPersister($this->connection, $eventDispatcher);
     }
 
     public function testLoad(): void


### PR DESCRIPTION
### 1. Why is this change necessary?
Since v6.3.1.0 the SalesChannelContextPersister assigns the new token into the SalesChannelContext, this results that CustomerLoginEvent loses the previous token.

### 2. What does this change do, exactly?
Dispatch a new event 'SalesChannelContextTokenChangeEvent' which contains both tokens.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
