### PR TITLE
Fix parsing of Not filter

### DIFF
--- a/src/Elasticsearch/Framework/DataAbstractionLayer/CriteriaParser.php
+++ b/src/Elasticsearch/Framework/DataAbstractionLayer/CriteriaParser.php
@@ -312,13 +312,17 @@ class CriteriaParser
 
     private function parseNotFilter(NotFilter $filter, EntityDefinition $definition, string $root, Context $context): BuilderInterface
     {
-        $bool = new BoolQuery();
+        $boolMust = new BoolQuery();
+
         foreach ($filter->getQueries() as $nested) {
-            $bool->add(
+            $boolMust->add(
                 $this->parseFilter($nested, $definition, $root, $context),
-                BoolQuery::MUST_NOT
+                BoolQuery::MUST
             );
         }
+
+        $bool = new BoolQuery();
+        $bool->add($boolMust, BoolQuery::MUST_NOT);
 
         return $bool;
     }


### PR DESCRIPTION
For multiple conditions for the 'not filter', there needs to be a 'must' wrapper, so that elasticsearch is working properly.

Fixes https://issues.shopware.com/issues/NEXT-10003

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
When using elasticsearch any product having the laststock option is not displayed regardless of its stock value, because the NotFilter is not parsed correct for elasticsearch.

### 2. What does this change do, exactly?
Change the way the NotFilter is parsed.

### 3. Describe each step to reproduce the issue or behaviour.
Create a laststock product in the admin that has a stock of 50
Activate the option "Hide products after clearance" at Settings > Products
(-> Product is shown in listing because it has stock)

Activate elasticsearch and clear the cache, index the dal, create alias
-> Product no longer shown in listing unless you deactivate the laststock option completely

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/NEXT-10003

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
