### PR TITLE
NEXT-10950 - theme-compile into temp folder

### DIFF
--- a/changelog/_unreleased/2020-09-19-theme-compile-into-temp-folder.md
+++ b/changelog/_unreleased/2020-09-19-theme-compile-into-temp-folder.md
@@ -1,0 +1,9 @@
+---
+title:              Theme-Compile into temp folder
+issue:              NEXT-10950
+author:             Sebastian König
+author_email:       s.koenig@tinect.de
+author_github:      @tinect
+---
+# Storefront
+*  Changed behaviour of `Shopware\Storefront\Theme\ThemeCompiler::compileTheme` to compile into temporarily folder, before removing existing folder


### PR DESCRIPTION
### 1. Why is this change necessary?
Currently, there is big chance, that visitors don't receive css and js while running `theme:compile`.

### 2. What does this change do, exactly?
We changed the behaviour of ThemeCompiler so it will compile into a temp folder before renaming the folder.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/NEXT-10950

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
