### PR TITLE
Fixes issue #1341

### DIFF
--- a/changelog/_unreleased/2020-09-22-fix-country-sorting-in-cart.md
+++ b/changelog/_unreleased/2020-09-22-fix-country-sorting-in-cart.md
@@ -3,9 +3,8 @@ title: Fix country sorting in cart
 issue: NA
 author: Huzaifa Mustafa
 author_email: 24492269+zaifastafa@users.noreply.github.com 
-author_github: zaifastafa
+author_github: @zaifastafa
 ---
 # Core
-*  Added criteria in `\Shopware\Storefront\Page\Checkout\Cart\CheckoutCartPageLoader::getCountries` to first sort by 
-position and then by name, so the countries are sorted properly.   
+*  Added sorting by position and name in `\Shopware\Storefront\Page\Checkout\Cart\CheckoutCartPageLoader::getCountries`
 ___

--- a/changelog/_unreleased/2020-09-22-fix-country-sorting-in-cart.md
+++ b/changelog/_unreleased/2020-09-22-fix-country-sorting-in-cart.md
@@ -1,0 +1,11 @@
+---
+title: Fix country sorting in cart
+issue: NA
+author: Huzaifa Mustafa
+author_email: 24492269+zaifastafa@users.noreply.github.com 
+author_github: zaifastafa
+---
+# Core
+*  Added criteria in `\Shopware\Storefront\Page\Checkout\Cart\CheckoutCartPageLoader::getCountries` to first sort by 
+position and then by name, so the countries are sorted properly.   
+___

--- a/src/Storefront/Page/Checkout/Cart/CheckoutCartPageLoader.php
+++ b/src/Storefront/Page/Checkout/Cart/CheckoutCartPageLoader.php
@@ -10,7 +10,6 @@ use Shopware\Core\Checkout\Shipping\ShippingMethodCollection;
 use Shopware\Core\Content\Category\Exception\CategoryNotFoundException;
 use Shopware\Core\Framework\DataAbstractionLayer\Exception\InconsistentCriteriaIdsException;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
-use Shopware\Core\Framework\DataAbstractionLayer\Search\Sorting\FieldSorting;
 use Shopware\Core\Framework\Routing\Exception\MissingRequestParameterException;
 use Shopware\Core\System\Country\CountryCollection;
 use Shopware\Core\System\Country\SalesChannel\AbstractCountryRoute;
@@ -114,10 +113,9 @@ class CheckoutCartPageLoader
 
     private function getCountries(SalesChannelContext $context): CountryCollection
     {
-        $criteria = new Criteria();
-        $criteria->addSorting(new FieldSorting('position'));
-        $criteria->addSorting(new FieldSorting('name'));
+        $countries = $this->countryRoute->load(new Criteria(), $context)->getCountries();
+        $countries->sortByPositionAndName();
 
-        return $this->countryRoute->load($criteria, $context)->getCountries();
+        return $countries;
     }
 }

--- a/src/Storefront/Page/Checkout/Cart/CheckoutCartPageLoader.php
+++ b/src/Storefront/Page/Checkout/Cart/CheckoutCartPageLoader.php
@@ -10,6 +10,7 @@ use Shopware\Core\Checkout\Shipping\ShippingMethodCollection;
 use Shopware\Core\Content\Category\Exception\CategoryNotFoundException;
 use Shopware\Core\Framework\DataAbstractionLayer\Exception\InconsistentCriteriaIdsException;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Sorting\FieldSorting;
 use Shopware\Core\Framework\Routing\Exception\MissingRequestParameterException;
 use Shopware\Core\System\Country\CountryCollection;
 use Shopware\Core\System\Country\SalesChannel\AbstractCountryRoute;
@@ -113,6 +114,10 @@ class CheckoutCartPageLoader
 
     private function getCountries(SalesChannelContext $context): CountryCollection
     {
-        return $this->countryRoute->load(new Criteria(), $context)->getCountries();
+        $criteria = new Criteria();
+        $criteria->addSorting(new FieldSorting('position'));
+        $criteria->addSorting(new FieldSorting('name'));
+
+        return $this->countryRoute->load($criteria, $context)->getCountries();
     }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?
In the cart / checkout page, the country dropdown is not sorted properly. This makes it difficult to look for a specific country.

### 2. What does this change do, exactly?
This change fixes the sorting so it is much easier to look for a country even if a position is set for any number of countries.

### 3. Describe each step to reproduce the issue or behaviour.
1. Add product to cart
2. Go to cart / checkout
3. Change shipping country

### 4. Please link to the relevant issues (if any).
#1341 

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
