### PR TITLE
Add CmsSlotsDataResolverInterface

### DIFF
--- a/changelog/_unreleased/2020-09-22-added-cmsslotsdataresolverinterface.md
+++ b/changelog/_unreleased/2020-09-22-added-cmsslotsdataresolverinterface.md
@@ -1,0 +1,8 @@
+---
+title: Added CmsSlotsDataResolverInterface
+author: Florian
+author_email: florian@swk-web.com
+author_github: @313
+---
+# Core
+* Added new interface `CmsSlotsDataResolverInterface` for `Shopware\Core\Content\Cms\DataResolver\CmsSlotsDataResolver`

--- a/src/Core/Content/Cms/DataResolver/CmsSlotsDataResolver.php
+++ b/src/Core/Content/Cms/DataResolver/CmsSlotsDataResolver.php
@@ -17,7 +17,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
 use Shopware\Core\Framework\Struct\ArrayEntity;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 
-class CmsSlotsDataResolver
+class CmsSlotsDataResolver implements CmsSlotsDataResolverInterface
 {
     /**
      * @var CmsElementResolverInterface[]

--- a/src/Core/Content/Cms/DataResolver/CmsSlotsDataResolverInterface.php
+++ b/src/Core/Content/Cms/DataResolver/CmsSlotsDataResolverInterface.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Content\Cms\DataResolver;
+
+use Shopware\Core\Content\Cms\Aggregate\CmsSlot\CmsSlotCollection;
+use Shopware\Core\Content\Cms\DataResolver\ResolverContext\ResolverContext;
+
+interface CmsSlotsDataResolverInterface
+{
+    public function resolve(CmsSlotCollection $slots, ResolverContext $resolverContext): CmsSlotCollection;
+}

--- a/src/Core/Content/Cms/SalesChannel/SalesChannelCmsPageLoader.php
+++ b/src/Core/Content/Cms/SalesChannel/SalesChannelCmsPageLoader.php
@@ -5,7 +5,7 @@ namespace Shopware\Core\Content\Cms\SalesChannel;
 use Shopware\Core\Content\Cms\Aggregate\CmsBlock\CmsBlockEntity;
 use Shopware\Core\Content\Cms\Aggregate\CmsSection\CmsSectionEntity;
 use Shopware\Core\Content\Cms\CmsPageEntity;
-use Shopware\Core\Content\Cms\DataResolver\CmsSlotsDataResolver;
+use Shopware\Core\Content\Cms\DataResolver\CmsSlotsDataResolverInterface;
 use Shopware\Core\Content\Cms\DataResolver\ResolverContext\ResolverContext;
 use Shopware\Core\Content\Cms\Events\CmsPageLoadedEvent;
 use Shopware\Core\Content\Cms\Events\CmsPageLoaderCriteriaEvent;
@@ -24,7 +24,7 @@ class SalesChannelCmsPageLoader implements SalesChannelCmsPageLoaderInterface
     private $cmsPageRepository;
 
     /**
-     * @var CmsSlotsDataResolver
+     * @var CmsSlotsDataResolverInterface
      */
     private $slotDataResolver;
 
@@ -35,7 +35,7 @@ class SalesChannelCmsPageLoader implements SalesChannelCmsPageLoaderInterface
 
     public function __construct(
         EntityRepositoryInterface $cmsPageRepository,
-        CmsSlotsDataResolver $slotDataResolver,
+        CmsSlotsDataResolverInterface $slotDataResolver,
         EventDispatcherInterface $eventDispatcher
     ) {
         $this->cmsPageRepository = $cmsPageRepository;

--- a/src/Storefront/Page/Product/ProductPageLoader.php
+++ b/src/Storefront/Page/Product/ProductPageLoader.php
@@ -4,7 +4,7 @@ namespace Shopware\Storefront\Page\Product;
 
 use Shopware\Core\Content\Category\Exception\CategoryNotFoundException;
 use Shopware\Core\Content\Cms\CmsPageEntity;
-use Shopware\Core\Content\Cms\DataResolver\CmsSlotsDataResolver;
+use Shopware\Core\Content\Cms\DataResolver\CmsSlotsDataResolverInterface;
 use Shopware\Core\Content\Cms\DataResolver\ResolverContext\EntityResolverContext;
 use Shopware\Core\Content\Cms\SalesChannel\SalesChannelCmsPageRepository;
 use Shopware\Core\Content\Product\Exception\ProductNotFoundException;
@@ -38,7 +38,7 @@ class ProductPageLoader
     private $cmsPageRepository;
 
     /**
-     * @var CmsSlotsDataResolver
+     * @var CmsSlotsDataResolverInterface
      */
     private $slotDataResolver;
 
@@ -66,7 +66,7 @@ class ProductPageLoader
         GenericPageLoaderInterface $genericLoader,
         EventDispatcherInterface $eventDispatcher,
         SalesChannelCmsPageRepository $cmsPageRepository,
-        CmsSlotsDataResolver $slotDataResolver,
+        CmsSlotsDataResolverInterface $slotDataResolver,
         ProductDefinition $productDefinition,
         ProductLoader $productLoader,
         ProductReviewLoader $productReviewLoader,


### PR DESCRIPTION
### 1. Why is this change necessary?
\-

### 2. What does this change do, exactly?
Add a new interface for `Shopware\Core\Content\Cms\DataResolver\CmsSlotsDataResolver` to allow plugins to decorate that service.

### 3. Describe each step to reproduce the issue or behaviour.
\-

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.