### PR TITLE
Return IDs compatible with the delete method

### DIFF
--- a/changelog/_unreleased/2020-09-23-return-ids-array-to-be-used-in-the-delete-method-for-repository.md
+++ b/changelog/_unreleased/2020-09-23-return-ids-array-to-be-used-in-the-delete-method-for-repository.md
@@ -1,0 +1,11 @@
+---
+title: Return Ids array to be used in the delete method for repository
+issue: NA
+author: Huzaifa Mustafa
+author_email: 24492269+zaifastafa@users.noreply.github.com 
+author_github: zaifastafa
+---
+# Core
+*  Added `\Shopware\Core\Framework\DataAbstractionLayer\Search\IdSearchResult::getIdsForDelete` method to be used for
+`delete` method in the repository
+___

--- a/src/Core/Framework/DataAbstractionLayer/Search/IdSearchResult.php
+++ b/src/Core/Framework/DataAbstractionLayer/Search/IdSearchResult.php
@@ -124,4 +124,14 @@ class IdSearchResult extends Struct
     {
         return 'dal_id_search_result';
     }
+
+    public function getIdsForDelete(): array
+    {
+        $ids = [];
+        foreach ($this->ids as $id) {
+            $ids[] = ['id' => $id];
+        }
+
+        return $ids;
+    }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?
Since `delete()` method in the repository takes the array of IDs in a specific format, simply using `searchIds()->getIds()` is not enough as the returned format is not supported by the delete method. 

### 2. What does this change do, exactly?
This introduces another method in the `IdSearchResult` struct which returns the ID array that can be used directly in the delete method without further manipulation.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [x] I have read the contribution requirements and fulfil them.
