### PR TITLE
NEXT-11068 - Fix range slider

### DIFF
--- a/changelog/_unreleased/2020-09-24-fix-validation-filter-range.md
+++ b/changelog/_unreleased/2020-09-24-fix-validation-filter-range.md
@@ -1,0 +1,16 @@
+---
+title:              Fix the filter range slider
+issue:              NEXT-11068
+author:             Sebastian König
+author_email:       s.koenig@tinect.de
+author_github:      @tinect
+---
+# Storefront
+*  Added attribute `step="any"` to input fields in `component/listing/filter/filter-range.html.twig` to respect decimal values
+*  Changed name of private method `_isInputInvalid` of `listing/filter-range.plugin.js` to `_isMinInvalid`
+*  Changed name of private method `_setError` of `listing/filter-range.plugin.js` to `_setMinError`
+*  Changed private method `_onChangeInput` of `listing/filter-range.plugin.js` to respect client side validation
+*  Changed private method `_getErrorMessageTemplate` of `listing/filter-range.plugin.js` to have message as argument
+*  Changed call of `this.listing.changeListing()` in private method `_onChangeInput` of `listing/filter-range.plugin.js` to be not called if any error occurred
+*  Added private method `_isInvalid` to `listing/filter-range.plugin.js` to validate input fields on client side correctly
+*  Added private method `_setDefaultError` to `listing/filter-range.plugin.js` to report validation errors to client

--- a/src/Storefront/Resources/views/storefront/component/listing/filter/filter-range.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/listing/filter/filter-range.html.twig
@@ -75,7 +75,8 @@
                                            type="number"
                                            name="min-price"
                                            min="0"
-                                           max="{{ price.max }}">
+                                           max="{{ price.max }}"
+                                           step="any">
                                 {% endblock %}
 
                                 {% block component_filter_range_min_currency_symbol %}
@@ -104,7 +105,8 @@
                                            type="number"
                                            name="max-price"
                                            min="0"
-                                           max="{{ price.max }}">
+                                           max="{{ price.max }}"
+                                           step="any">
                                 {% endblock %}
 
                                 {% block component_filter_range_max_currency_symbol %}


### PR DESCRIPTION
### 1. Why is this change necessary?
The current filter-range:
- does not stop updating listing if any validation error occurs / also not the current check if min higher than max
- does not respect any browser-validation (min and max value)


### 2. What does this change do, exactly?

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/NEXT-11068

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
