### PR TITLE
Improve exception message when missing language

### DIFF
--- a/src/Core/System/SalesChannel/Context/SalesChannelContextFactory.php
+++ b/src/Core/System/SalesChannel/Context/SalesChannelContextFactory.php
@@ -465,7 +465,9 @@ class SalesChannelContextFactory
 
         //check provided language is part of the available languages
         if (!\in_array($current, $availableLanguageIds, true)) {
-            throw new \RuntimeException('Provided language is not available');
+            throw new \RuntimeException(
+                sprintf('Provided language %s is not in list of available languages: %s', $current, implode(', ', $availableLanguageIds))
+            );
         }
 
         if ($current === Defaults::LANGUAGE_SYSTEM) {


### PR DESCRIPTION
Signed-off-by: Hendrik Söbbing <hendrik@soebbing.de>

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
When trying to create a sitemap, I ran into [this bug](https://issues.shopware.com/issues/NEXT-8708) lately, where the export crashes when a product feed sales channel exists.

Having a concise error message improves debugging such cases a lot.

### 2. What does this change do, exactly?
It adds all relevant information to the exception being thrown.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
Not directly related, but relevant nonetheless: https://issues.shopware.com/issues/NEXT-8708

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
