### PR TITLE
Change check for Content-Type in fetchFile

### DIFF
--- a/changelog/_unreleased/2020-09-27-improve-REST-API-fetch-from-url.md
+++ b/changelog/_unreleased/2020-09-27-improve-REST-API-fetch-from-url.md
@@ -1,0 +1,10 @@
+---
+title: Change check for Content-Type in fetchfile()
+issue: (issue)[https://github.com/shopware/platform/issues/1372]
+author: Marcel Sotiropoulos
+author_email: marcel.sotiropoulos@soti-it.at
+---
+# API
+*  Changed the check for Content-Type in MediaService.php in function fetchFile(...) to  
+```strpos($contentType, 'application/json') !== false``` instead of  
+```$contentType === 'application/json'```

--- a/changelog/_unreleased/2020-09-27-improve-REST-API-fetch-from-url.md
+++ b/changelog/_unreleased/2020-09-27-improve-REST-API-fetch-from-url.md
@@ -5,6 +5,6 @@ author: Marcel Sotiropoulos
 author_email: marcel.sotiropoulos@soti-it.at
 ---
 # API
-*  Changed the check for Content-Type in MediaService.php in function fetchFile(...) to  
+*  Changed the content type check in `\Shopware\Core\Content\Media\MediaService::fetchFile()` to allow additional information
 ```strpos($contentType, 'application/json') !== false``` instead of  
 ```$contentType === 'application/json'```

--- a/changelog/_unreleased/2020-09-27-improve-REST-API-fetch-from-url.md
+++ b/changelog/_unreleased/2020-09-27-improve-REST-API-fetch-from-url.md
@@ -1,5 +1,5 @@
 ---
-title: Change check for Content-Type in fetchfile()
+title: Change content type check in `\Shopware\Core\Content\Media\MediaService::fetchFile()`
 issue: (issue)[https://github.com/shopware/platform/issues/1372]
 author: Marcel Sotiropoulos
 author_email: marcel.sotiropoulos@soti-it.at

--- a/changelog/_unreleased/2020-09-27-improve-REST-API-fetch-from-url.md
+++ b/changelog/_unreleased/2020-09-27-improve-REST-API-fetch-from-url.md
@@ -6,5 +6,3 @@ author_email: marcel.sotiropoulos@soti-it.at
 ---
 # API
 *  Changed the content type check in `\Shopware\Core\Content\Media\MediaService::fetchFile()` to allow additional information
-```strpos($contentType, 'application/json') !== false``` instead of  
-```$contentType === 'application/json'```

--- a/changelog/_unreleased/2020-09-27-improve-REST-API-fetch-from-url.md
+++ b/changelog/_unreleased/2020-09-27-improve-REST-API-fetch-from-url.md
@@ -1,0 +1,8 @@
+---
+title: Change content type check in `\Shopware\Core\Content\Media\MediaService::fetchFile()`
+issue: (issue)[https://github.com/shopware/platform/issues/1372]
+author: Marcel Sotiropoulos
+author_email: marcel.sotiropoulos@soti-it.at
+---
+# API
+*  Changed the content type check in `\Shopware\Core\Content\Media\MediaService::fetchFile()` to allow additional information

--- a/src/Core/Content/Media/MediaService.php
+++ b/src/Core/Content/Media/MediaService.php
@@ -120,7 +120,7 @@ class MediaService
         }
 
         $contentType = $request->headers->get('content_type');
-        if (strpos($contentType, 'application/json') !== false) {
+        if (strpos($contentType, 'application/json') === 0) {
             return $this->fileFetcher->fetchFileFromURL($request, $tempFile);
         }
 

--- a/src/Core/Content/Media/MediaService.php
+++ b/src/Core/Content/Media/MediaService.php
@@ -120,7 +120,7 @@ class MediaService
         }
 
         $contentType = $request->headers->get('content_type');
-        if ($contentType === 'application/json') {
+        if (strpos($contentType, 'application/json') !== false) {
             return $this->fileFetcher->fetchFileFromURL($request, $tempFile);
         }
 

--- a/src/Core/Content/Media/MediaService.php
+++ b/src/Core/Content/Media/MediaService.php
@@ -120,7 +120,7 @@ class MediaService
         }
 
         $contentType = $request->headers->get('content_type');
-        if ($contentType === 'application/json') {
+        if (strpos($contentType, 'application/json') === 0) {
             return $this->fileFetcher->fetchFileFromURL($request, $tempFile);
         }
 


### PR DESCRIPTION
### 1. Why is this change necessary?  
  Because in the cpprestsdk the Content-Type encoding is explicitly set to utf-8.
  Which results into getting the image not from the url provided but from the POST-Data itself  
  
### 2. What does this change do, exactly?
  Changes the check from ```$contentType === 'application/json'``` to  
  ```strpos($contentType, 'application/json') !== false```  
  
### 3. Describe each step to reproduce the issue or behaviour.
  Send the URL you want to import from and set the Content-Type to ```application/json; charset=utf-8```  
  It then creates a file with the JSON itself instead of importing it from the URL provided  
  
### 4. Please link to the relevant issues (if any).  
  [issue](https://github.com/shopware/platform/issues/1372)  
  
### 5. Checklist  
- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.