### PR TITLE
Make hardcoded filter name dynamic

### DIFF
--- a/src/Storefront/Resources/app/storefront/src/plugin/listing/filter-rating.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/listing/filter-rating.plugin.js
@@ -100,7 +100,7 @@ export default class FilterRatingPlugin extends FilterBasePlugin {
                 label: `${this.options.snippets.filterRatingActiveLabelStart} 
                         ${currentRating} 
                         ${endSnippet}`,
-                id: 'rating'
+                id: this.options.name
             });
         } else {
             labels = [];
@@ -114,7 +114,7 @@ export default class FilterRatingPlugin extends FilterBasePlugin {
      * @public
      */
     reset(id) {
-        if (id !== 'rating') {
+        if (id !== this.options.name) {
             return;
         }
 


### PR DESCRIPTION
### 1. Why is this change necessary?
Currently the FilterRating Storefront-Plugin has the id 'rating' hardcoded, and doesn't use the name option, even though said option is already passed to it in the [filter-panel.html.twig](https://github.com/shopware/platform/blob/master/src/Storefront/Resources/views/storefront/component/listing/filter-panel.html.twig#L71) and [filter-rating.html.twig](https://github.com/shopware/platform/blob/master/src/Storefront/Resources/views/storefront/component/listing/filter/filter-rating.html.twig#L20) templates and also used in the [getValues](https://github.com/shopware/platform/blob/master/src/Storefront/Resources/app/storefront/src/plugin/listing/filter-rating.plugin.js#L64) and [setValuesFromUrl](https://github.com/shopware/platform/blob/master/src/Storefront/Resources/app/storefront/src/plugin/listing/filter-rating.plugin.js#L72) methods. While this doesn't cause any issues currently, it does limit the reusability of the filter.

### 2. What does this change do, exactly?
It replaces the id used in the getLabels and reset methods, by using this.options.name instead of a hardcoded string 'rating'.

### 3. Describe each step to reproduce the issue or behaviour.

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have created a changelog file with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
