### PR TITLE
Surround listing buy button in block for template overriding

### DIFF
--- a/changelog/_unreleased/2020-10-01-add-block-for-listing-buy-button.md
+++ b/changelog/_unreleased/2020-10-01-add-block-for-listing-buy-button.md
@@ -1,0 +1,10 @@
+---
+title: Add block for listing buy button
+issue: NA
+author: Huzaifa Mustafa
+author_email: 24492269+zaifastafa@users.noreply.github.com 
+author_github: @zaifastafa
+---
+# Storefront
+*  Added missing block `page_product_detail_product_buy_button` in `src/Storefront/Resources/views/storefront/component/product/card/action.html.twig`
+___

--- a/src/Storefront/Resources/views/storefront/component/product/card/action.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/product/card/action.html.twig
@@ -58,10 +58,12 @@
                                            value="{{ product.translated.name }}">
                                 {% endblock %}
 
-                                <button class="btn btn-block btn-buy"
-                                        title="{{ "listing.boxAddProduct"|trans|striptags }}">
-                                    {{ "listing.boxAddProduct"|trans|sw_sanitize }}
-                                </button>
+                                {% block page_product_detail_product_buy_button %}
+                                    <button class="btn btn-block btn-buy"
+                                            title="{{ "listing.boxAddProduct"|trans|striptags }}">
+                                        {{ "listing.boxAddProduct"|trans|sw_sanitize }}
+                                    </button>
+                                {% endblock %}
                             {% endblock %}
                         </form>
                 {% endblock %}


### PR DESCRIPTION
### 1. Why is this change necessary?
For easier template overriding

### 2. What does this change do, exactly?
It surrounds the listing buy button in a block 

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [x] I have read the contribution requirements and fulfil them.
