### PR TITLE
Remove Reference in state_machine_history after a Backend-uer is deleted

### DIFF
--- a/changelog/_unreleased/2020-10-01-allow-deletion-of-users-with-statehistory.md
+++ b/changelog/_unreleased/2020-10-01-allow-deletion-of-users-with-statehistory.md
@@ -1,0 +1,9 @@
+---
+title: Allow deletion of users with statehistory entries
+issue: 
+author: Philipp Bucher
+author_email: bucher@netzreich.de
+author_github: @GerDner
+---
+# Core
+* Changed Foreign-Key definition of fk.state_machine_history.user_id to "SET NULL" to allow deletion of users.

--- a/src/Core/Migration/Migration1601556346CleanupStateHistoryOnUserDelete.php
+++ b/src/Core/Migration/Migration1601556346CleanupStateHistoryOnUserDelete.php
@@ -1,0 +1,29 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Migration;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Framework\Migration\MigrationStep;
+
+class Migration1601556346CleanupStateHistoryOnUserDelete extends MigrationStep
+{
+    public function getCreationTimestamp(): int
+    {
+        return 1601556346;
+    }
+
+    public function update(Connection $connection): void
+    {
+        $connection->executeUpdate('ALTER TABLE `state_machine_history` DROP FOREIGN KEY `fk.state_machine_history.user_id`;');
+        $connection->executeUpdate(
+            '
+            ALTER TABLE `state_machine_history` ADD CONSTRAINT `fk.state_machine_history.user_id` FOREIGN KEY (`user_id`)
+            REFERENCES `user` (`id`) ON DELETE SET NULL ON UPDATE CASCADE'
+        );
+    }
+
+    public function updateDestructive(Connection $connection): void
+    {
+        // implement update destructive
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?
You can't delete a backend user with entries in state_machine_history (order status, payment status) because a Foreign-Key contraint fails.

```
detail: "An exception occurred while executing 'DELETE FROM `user` WHERE id = ?' with params ["\x45\xcc\xfb\x8a\x71\xdc\x49\x60\x9a\x88\x93\x1f\xc6\xd4\x8e\x0c"]:↵↵SQLSTATE[23000]: Integrity constraint violation: 1451 Cannot delete or update a parent row: a foreign key constraint fails (`shopware`.`state_machine_history`, CONSTRAINT `fk.state_machine_history.user_id` FOREIGN KEY (`user_id`) REFERENCES `user` (`id`) ON DELETE NO ACTION ON UPDATE CASCADE)"
```



### 2. What does this change do, exactly?

This Patch fixes the foreign key definition by changing the behavior to `SET NULL` instead of `NO ACTION`.
See https://github.com/shopware/platform/blob/c5b78af033b1438e497e28ec7b10ab25cedb8a0d/src/Core/Migration/Migration1536233260StateMachineHistory.php#L37 for the initial definition.


### 3. Describe each step to reproduce the issue or behaviour.
Try to delete an user which has changed an order status and produced entries in `state_machine_history`.

### 4. Please link to the relevant issues (if any).

no issues so far.

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [X] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.
