### PR TITLE
added optional argument for profile name

### DIFF
--- a/changelog/_unreleased/2020-10-02-import-with-optional-profile-name.md
+++ b/changelog/_unreleased/2020-10-02-import-with-optional-profile-name.md
@@ -1,0 +1,8 @@
+---
+title: Cronjobs can not handle interactive choice for profile name.  
+issue:  
+author: Björn Herzke  
+author_github: @wrongspot  
+---
+# Core
+*  Added new optional argument for profile name in `Shopware\Core\Content\ImportExport\Command\ImportEntityCommand`

--- a/src/Core/Content/ImportExport/Command/ImportEntityCommand.php
+++ b/src/Core/Content/ImportExport/Command/ImportEntityCommand.php
@@ -9,6 +9,7 @@ use Shopware\Core\Content\ImportExport\Struct\Progress;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepositoryInterface;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -35,8 +36,11 @@ class ImportEntityCommand extends Command
      */
     private $importExportFactory;
 
-    public function __construct(ImportExportService $initiationService, EntityRepositoryInterface $profileRepository, ImportExportFactory $importExportFactory)
-    {
+    public function __construct(
+        ImportExportService $initiationService,
+        EntityRepositoryInterface $profileRepository,
+        ImportExportFactory $importExportFactory
+    ) {
         parent::__construct();
         $this->initiationService = $initiationService;
         $this->profileRepository = $profileRepository;
@@ -47,7 +51,9 @@ class ImportEntityCommand extends Command
     {
         $this
             ->addArgument('file', InputArgument::REQUIRED, 'Path to import file')
-            ->addArgument('expireDate', InputArgument::REQUIRED, 'PHP DateTime compatible string');
+            ->addArgument('expireDate', InputArgument::REQUIRED, 'PHP DateTime compatible string')
+            ->addArgument('profile', InputArgument::OPTIONAL, 'Wrap profile names with whitespaces into quotation '
+                                   . 'marks, like \'Default Category\'');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
@@ -55,7 +61,10 @@ class ImportEntityCommand extends Command
         $io = new SymfonyStyle($input, $output);
         $context = Context::createDefaultContext();
 
-        $profile = $this->chooseProfile($context, $io);
+        $profileName = $input->getArgument('profile');
+        $profile = empty($profileName)
+            ? $this->chooseProfile($context, $io)
+            : $this->profileByName($profileName, $context);
         $filePath = $input->getArgument('file');
 
         try {
@@ -113,5 +122,21 @@ class ImportEntityCommand extends Command
         $answer = $io->choice('Please choose a profile', array_keys($byName));
 
         return $byName[$answer];
+    }
+
+    private function profileByName(string $profileName, Context $context): ImportExportProfileEntity
+    {
+        $result = $this->profileRepository->search(
+            (new Criteria())->addFilter(new EqualsFilter('name', $profileName)),
+            $context
+        );
+
+        if ($result->count() === 0) {
+            throw new \InvalidArgumentException(
+                sprintf('Can\'t find Import Profile by name "%s".', $profileName)
+            );
+        }
+
+        return $result->first();
     }
 }

--- a/src/Core/Content/Test/ImportExport/Commands/ImportEntityCommandTest.php
+++ b/src/Core/Content/Test/ImportExport/Commands/ImportEntityCommandTest.php
@@ -92,4 +92,28 @@ class ImportEntityCommandTest extends TestCase
 
         static::assertCount(2, $result->getIds());
     }
+
+    public function testImportWithProfile(): void
+    {
+        $num = 67;
+
+        $commandTester = new CommandTester($this->importEntityCommand);
+        $args = [
+            'file' => self::TEST_IMPORT_FILE_PATH,
+            'expireDate' => date('d.m.Y'),
+            'profile' => self::DEFAULT_CATEGORY_IMPORT_PROFILE,
+        ];
+        $commandTester->execute($args);
+
+        $message = $commandTester->getDisplay();
+        static::assertRegExp(sprintf('/\[OK\] Successfully imported %s records in \d+ seconds/', $num), $message);
+
+        $firstId = '017de84fb11a4e318fd3231317d7def4';
+        $lastId = 'fd98f6a0f00f4b05b40e63da076dfd7d';
+
+        $repository = $this->getContainer()->get('category.repository');
+        $result = $repository->searchIds(new Criteria([$firstId, $lastId]), Context::createDefaultContext());
+
+        static::assertCount(2, $result->getIds());
+    }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
Cronjobs can not handle interactive choice for profile name.

### 2. What does this change do, exactly?
With this change you can provide an optional profile name on `bin/console import:entity` command.  The interactive profile choice will skip and make Cronjobs happy.

### 3. Describe each step to reproduce the issue or behaviour.
Cronjobs can not handle interactive choices. 

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
