### PR TITLE
log broken thumbnail images and continue generating

### DIFF
--- a/src/Core/Content/DependencyInjection/media.xml
+++ b/src/Core/Content/DependencyInjection/media.xml
@@ -264,6 +264,7 @@
             <argument type="service" id="shopware.filesystem.private"/>
             <argument type="service" id="Shopware\Core\Content\Media\Pathname\UrlGeneratorInterface"/>
             <argument type="service" id="media_folder.repository"/>
+            <argument type="service" id="logger"/>
         </service>
 
         <service id="Shopware\Core\Content\Media\MediaService">


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
When generating thumbnail images with php bin/console media:generate-thumbnails, the generation stops once an image is broken/missing. This is not a big problem when having a small amount of images. You can easily find which are the broken images by the message thrown with the image id and fix them. However this is a problem when a shop has many images that has to be generated as thumbnails or with media that is migrated from another platform like Magento. It's irritating that the thumbnail generation script stops executing once it faces a broken image, instead of skipping the broken images and finishing with the rest.

### 2. Describe each step to reproduce the issue or behaviour
 - run php bin/console media:generate-thumbnails.
 -  If image is broken or missing an error with the image id is trown and the script stop executing: 
 ![thumbnail-generation-main](https://user-images.githubusercontent.com/65179649/94989615-7577d700-0576-11eb-8302-22a9b25ebf59.png)

### 3. What does this change do, exactly?
This change applies a try catch handling that will print every broken image when thumbnail generation command is executed and also logs the broken images in the var/log/(dev/prod.log)

- After the patch, the script logs the broken/missing image and continues executing til it's done: 
 ![thumbnail-generation-logging](https://user-images.githubusercontent.com/65179649/94989650-b40d9180-0576-11eb-9c23-ae8319f029a9.png)
- info.Error is trown in dev/prod.log:
 ![thumbnail-generation-error-2](https://user-images.githubusercontent.com/65179649/94989701-0058d180-0577-11eb-9e76-c48e55c7cbb3.png)

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
