### PR TITLE
Check plugin options for being Object before merging

### DIFF
--- a/changelog/_unreleased/2020-10-04-fix-bug-on-merging-invalid-storefront-plugin-configuration.md
+++ b/changelog/_unreleased/2020-10-04-fix-bug-on-merging-invalid-storefront-plugin-configuration.md
@@ -1,0 +1,8 @@
+---
+title: Fix bug on merging invalid storefront plugin configuration
+author: Joshua Behrens
+author_email: code@joshua-behrens.de
+author_github: @JoshuaBehrens
+---
+# Storefront
+* Fixed a bug when an empty array is passed into the data-attribute for storefront plugin configuration to completely clear the options 

--- a/src/Storefront/Resources/app/storefront/src/plugin-system/plugin.class.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin-system/plugin.class.js
@@ -104,7 +104,11 @@ export default class Plugin {
             );
         }
 
-        return deepmerge.all(merge.map(config => config || {}));
+        return deepmerge.all(
+            merge.filter(config => config instanceof Object)
+                .filter(config => !(config instanceof Array))
+                .map(config => config || {})
+        );
     }
 
     /**

--- a/src/Storefront/Resources/app/storefront/test/plugin/system/plugin-configuration.template.html
+++ b/src/Storefront/Resources/app/storefront/test/plugin/system/plugin-configuration.template.html
@@ -1,0 +1,7 @@
+<div>
+    <div
+        id="test"
+        data-plugin-configuration="true"
+        data-plugin-configuration-options="[]"
+    ></div>
+</div>

--- a/src/Storefront/Resources/app/storefront/test/plugin/system/plugin-configuration.test.js
+++ b/src/Storefront/Resources/app/storefront/test/plugin/system/plugin-configuration.test.js
@@ -1,0 +1,52 @@
+/**
+ * @jest-environment jsdom
+ */
+
+/* eslint-disable */
+import template from './plugin-configuration.template.html';
+import Plugin from "../../../src/plugin-system/plugin.class";
+
+class PluginConfigurationPlugin extends Plugin {
+    static options = {
+        isSet: true
+    };
+
+    init() {}
+}
+
+describe('Load plugin configuration from empty array', () => {
+    let configurationPlugin = undefined;
+
+    beforeEach(() => {
+        document.body.innerHTML = template;
+
+        window.PluginManager = {
+            getPluginInstancesFromElement: () => {
+                return new Map();
+            },
+            getPlugin: () => {
+                return {
+                    get: () => []
+                };
+            }
+        };
+
+        configurationPlugin = new PluginConfigurationPlugin(
+            document.querySelector('#test'),
+            null,
+            'PluginConfiguration'
+        );
+    });
+
+    afterEach(() => {
+        configurationPlugin = undefined;
+    });
+
+    test('configuration plugin exists', () => {
+        expect(typeof configurationPlugin).toBe('object');
+    });
+
+    test('_isSet is set via options', () => {
+        expect(configurationPlugin.options.isSet).toBe(true);
+    });
+});


### PR DESCRIPTION
### 1. Why is this change necessary?
When you build a cms element you can configure it. To make the storefront behave dynamically you can use a javascript plugin. These two features are easily combined when you just pass the configuration onto a data attribute:
```twig
<div data-foobar="true" data-foobar-options='{{ element.config|merge({ foobar: true })|json_encode }}'></div>
```
Downside. When config is null you can't post merge configuration into it. So add a fallback.
```twig
<div data-foobar="true" data-foobar-options='{{ element.config|default({})|merge({ foobar: true })|json_encode }}'></div>
```
In a case where the config is empty `json_encode` encodes it to an empty array.
```html
<div data-foobar="true" data-foobar-options='[]'></div>
```
In theory the config can also be a string or an integer. The latter one is simply false usage but having an empty array of configuration is not bad at all. But when you pass an array as argument into the data attribute for the javascript plugin, the deep merge will fail and the options in the plugin will be just an empty array without the fallback values defined in the plugin. To prevent this right now you can just add the `JSON_FORCE_OBJECT` option to `json_encode`.
```twig
<div data-foobar="true" data-foobar-options='{{ element.config|default({})|merge({ foobar: true })|json_encode(JSON_FORCE_OBJECT) }}'></div>
```
But when you are not aware of it you will soon find out that you have to use the `constant` function in twig to get it.
```twig
<div data-foobar="true" data-foobar-options='{{ element.config|default({})|merge({ foobar: true })|json_encode(constant('JSON_FORCE_OBJECT')) }}'></div>
```
Or use the option value directly
```twig
<div data-foobar="true" data-foobar-options='{{ element.config|default({})|merge({ foobar: true })|json_encode(16) }}'></div>
```
but this will loose lot of readability. So I just make sure the deepmerge does not fail so the shopware devs don't have this hassle 😀

### 2. What does this change do, exactly?
Let only pass objects for plugin options down to the deepmerge.

### 3. Describe each step to reproduce the issue or behaviour.
1. Register a plugin with the name foobar and predefined options in the class
2. Add an element that the plugin gets registered on with the `options='{{ ({})|json_encode }}'`
3. `console.log(this.options)`
4. Get an empty array

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
