### PR TITLE
Add missing CustomFieldTypes constants

### DIFF
--- a/changelog/_unreleased/2020-10-05-add-missing-customfieldtypes-constants.md
+++ b/changelog/_unreleased/2020-10-05-add-missing-customfieldtypes-constants.md
@@ -1,0 +1,9 @@
+---
+title: Added missing CustomFieldTypes constants 
+issue: NEXT-6921
+---
+# Core
+* Added CustomFieldTypes constants:
+    - `Shopware\Core\System\CustomField::COLORPICKER`
+    - `Shopware\Core\System\CustomField::MEDIA`
+    - `Shopware\Core\System\CustomField::SWITCH`

--- a/src/Core/System/CustomField/CustomFieldTypes.php
+++ b/src/Core/System/CustomField/CustomFieldTypes.php
@@ -5,13 +5,16 @@ namespace Shopware\Core\System\CustomField;
 final class CustomFieldTypes
 {
     public const BOOL = 'bool';
+    public const COLORPICKER = 'colorpicker';
     public const DATETIME = 'datetime';
     public const FLOAT = 'float';
     public const INT = 'int';
     public const JSON = 'json';
-    public const TEXT = 'text';
     public const HTML = 'html';
+    public const MEDIA = 'media';
     public const SELECT = 'select';
+    public const SWITCH = 'switch';
+    public const TEXT = 'text';
 
     private function __construct()
     {


### PR DESCRIPTION
### 1. Why is this change necessary?

Plugins need to be able to create CustomFields automatically. To be able to do that securely, it is helpful to have constants for the field types that need to be created. Unfortunately, not all CustomFieldsTypes are available as constants atm.

### 2. What does this change do, exactly?

It adds constants for the field types `colorpicker`, `switch` and `media`. It also sorts these constants alphabetically. :)

### 3. Describe each step to reproduce the issue or behaviour.
/

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/NEXT-6921

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.
