### PR TITLE
BUGFIX / NEXT-7517 - sw_extends: Use correct template inheritance order

### DIFF
--- a/changelog/_unreleased/2020-10-5-sw-extends-correct-template-inheritance-order.md
+++ b/changelog/_unreleased/2020-10-5-sw-extends-correct-template-inheritance-order.md
@@ -1,0 +1,7 @@
+---
+title: sw_extends: Use correct template inheritance order, if extending a different base file.
+issue: NEXT-7517
+---
+# Storefront
+* `sw_extends`: Use correct template inheritance order, if extending a different base file.
+    * This means that, if a theme overwrites the `@Storefront/storefront/base.html.twig`, extends the original file and also extends other templates that those templates will use the `storefront/base.html.twig` from the theme instead of falling back to the default Storefront template.

--- a/src/Core/Framework/Adapter/Twig/TemplateFinder.php
+++ b/src/Core/Framework/Adapter/Twig/TemplateFinder.php
@@ -3,7 +3,6 @@
 namespace Shopware\Core\Framework\Adapter\Twig;
 
 use Shopware\Core\Framework\Adapter\Twig\NamespaceHierarchy\NamespaceHierarchyBuilder;
-use Shopware\Core\Framework\Bundle;
 use Twig\Cache\FilesystemCache;
 use Twig\Environment;
 use Twig\Error\LoaderError;
@@ -68,17 +67,17 @@ class TemplateFinder implements TemplateFinderInterface
     public function find(string $template, $ignoreMissing = false, ?string $source = null): string
     {
         $templatePath = $this->getTemplateName($template);
+        $sourcePath = $source ? $this->getTemplateName($source) : null;
+        $sourceBundleName = $sourcePath ? $this->getSourceBundleName($source) : null;
         $originalTemplate = $source ? null : $template;
 
         $queue = $this->getNamespaceHierarchy();
 
-        if ($source) {
-            $index = array_search($source, $queue, true);
-
-            $queue = array_merge(
-                array_slice($queue, $index + 1),
-                array_slice($queue, 0, $index + 1)
-            );
+        // If we are trying to load the same file as the template, we do are not allowed to search the hierarchy
+        // up to the source file as that has already been searched and that would lead to an endless template inheritance.
+        if ($sourceBundleName !== null && $sourcePath === $templatePath) {
+            $index = array_search($sourceBundleName, $queue, true);
+            $queue = array_slice($queue, $index + 1);
         }
 
         // iterate over all bundles but exclude the originally requested bundle
@@ -86,6 +85,7 @@ class TemplateFinder implements TemplateFinderInterface
         foreach ($queue as $prefix) {
             $name = '@' . $prefix . '/' . $templatePath;
 
+            // original template is loaded last
             if ($name === $originalTemplate) {
                 continue;
             }
@@ -107,6 +107,19 @@ class TemplateFinder implements TemplateFinderInterface
         }
 
         throw new LoaderError(sprintf('Unable to load template "%s". (Looked into: %s)', $templatePath, implode(', ', array_values($queue))));
+    }
+
+    private function getSourceBundleName(string $source): ?string
+    {
+        if (mb_strpos($source, '@') !== 0) {
+            return null;
+        }
+
+        $source = explode('/', $source);
+        $source = array_shift($source);
+        $source = ltrim($source, '@');
+
+        return $source ?: null;
     }
 
     private function getNamespaceHierarchy(): array

--- a/src/Core/Framework/Adapter/Twig/TemplateFinderInterface.php
+++ b/src/Core/Framework/Adapter/Twig/TemplateFinderInterface.php
@@ -15,7 +15,8 @@ interface TemplateFinderInterface
      *
      * @param string      $template      Path of the requested template, ideally with @Bundle prefix
      * @param bool        $ignoreMissing If set to true no error is throw if the template is missing
-     * @param string|null $source        Name of the bundle which triggered the search
+     * @param string|null $source        Source template path that triggered the search includes @Bundle prefix.
+     *                                   The full source template path is necessary as extending a different file in the same bundle needs to use the normal inheritance hierarchy.
      *
      * @throws LoaderError
      */

--- a/src/Core/Framework/Adapter/Twig/TokenParser/ExtendsTokenParser.php
+++ b/src/Core/Framework/Adapter/Twig/TokenParser/ExtendsTokenParser.php
@@ -37,10 +37,6 @@ final class ExtendsTokenParser extends AbstractTokenParser
 
         $template = $stream->next()->getValue();
 
-        $source = explode('/', $source);
-        $source = array_shift($source);
-        $source = ltrim($source, '@');
-
         //resolves parent template
         //set pointer to next value (contains the template file name)
         $parent = $this->finder->find($template, false, $source);

--- a/src/Core/Framework/Test/Adapter/Twig/TwigSwExtendsTest.php
+++ b/src/Core/Framework/Test/Adapter/Twig/TwigSwExtendsTest.php
@@ -59,6 +59,36 @@ class TwigSwExtendsTest extends TestCase
         static::assertSame('Base/TestPlugin1/TestPlugin2', $template->render([]));
     }
 
+    public function testMultipleInheritanceIfExtendingTemplateInSamePlugin(): void
+    {
+        [$twig, $templateFinder] = $this->createFinder([
+            new BundleFixture('Storefront', __DIR__ . '/fixtures/Storefront/'),
+            new BundleFixture('TestPlugin1', __DIR__ . '/fixtures/Plugins/TestPlugin1'),
+            new BundleFixture('TestPlugin2', __DIR__ . '/fixtures/Plugins/TestPlugin2'),
+        ]);
+
+        $templatePath = $templateFinder->find('@Storefront/storefront/frontend/extend_template_in_same_plugin.html.twig');
+
+        $template = $twig->loadTemplate($templatePath);
+
+        static::assertSame('Base/TestPlugin1/TestPlugin2/TestPlugin2Content', $template->render([]));
+    }
+
+    public function testMultipleInheritanceIfExtendingBaseTemplateInSamePlugin(): void
+    {
+        [$twig, $templateFinder] = $this->createFinder([
+            new BundleFixture('Storefront', __DIR__ . '/fixtures/Storefront/'),
+            new BundleFixture('TestPlugin1', __DIR__ . '/fixtures/Plugins/TestPlugin1'),
+            new BundleFixture('TestPlugin2', __DIR__ . '/fixtures/Plugins/TestPlugin2'),
+        ]);
+
+        $templatePath = $templateFinder->find('@Storefront/storefront/frontend/extend_base_template_in_same_plugin.html.twig');
+
+        $template = $twig->loadTemplate($templatePath);
+
+        static::assertSame('Base/TestPlugin1/TestPlugin2/StorefrontContent/TestPlugin2Content', $template->render([]));
+    }
+
     public function testMultipleInheritanceWithChangingTemplateChain(): void
     {
         static::markTestSkipped('Twig cache is not invalidated');

--- a/src/Core/Framework/Test/Adapter/Twig/fixtures/Plugins/TestPlugin2/Resources/views/storefront/frontend/extend_base_template_in_same_plugin.html.twig
+++ b/src/Core/Framework/Test/Adapter/Twig/fixtures/Plugins/TestPlugin2/Resources/views/storefront/frontend/extend_base_template_in_same_plugin.html.twig
@@ -1,0 +1,2 @@
+{% sw_extends '@Storefront/storefront/frontend/extend_base_template_in_same_plugin.html.twig' %}
+{% block foo %}{{ parent() }}/TestPlugin2Content{% endblock %}

--- a/src/Core/Framework/Test/Adapter/Twig/fixtures/Plugins/TestPlugin2/Resources/views/storefront/frontend/extend_template_in_same_plugin.html.twig
+++ b/src/Core/Framework/Test/Adapter/Twig/fixtures/Plugins/TestPlugin2/Resources/views/storefront/frontend/extend_template_in_same_plugin.html.twig
@@ -1,0 +1,2 @@
+{% sw_extends '@Storefront/storefront/frontend/base.html.twig' %}
+{% block foo %}{{ parent() }}/TestPlugin2Content{% endblock %}

--- a/src/Core/Framework/Test/Adapter/Twig/fixtures/Storefront/Resources/views/storefront/frontend/extend_base_template_in_same_plugin.html.twig
+++ b/src/Core/Framework/Test/Adapter/Twig/fixtures/Storefront/Resources/views/storefront/frontend/extend_base_template_in_same_plugin.html.twig
@@ -1,0 +1,2 @@
+{% sw_extends '@Storefront/storefront/frontend/base.html.twig' %}
+{% block foo %}{{ parent() }}/StorefrontContent{% endblock %}


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?

To fix the issue https://issues.shopware.com/issues/NEXT-7517
Fixes: #614

Might also resolve: 
#707

### 2. What does this change do, exactly?
Sets the correct inheritence order if a source template is provided to the template finder.

### 3. Describe each step to reproduce the issue or behaviour.
See related issuess.

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/NEXT-7517
https://github.com/shopware/platform/issues/614

Might also resolve:
https://github.com/shopware/platform/issues/707
