### PR TITLE
Change IteratorFactory to only select active entities

### DIFF
--- a/changelog/_unreleased/2020-10-05-only-warm-active-entities.md
+++ b/changelog/_unreleased/2020-10-05-only-warm-active-entities.md
@@ -1,0 +1,6 @@
+---
+title: Only warmup active entities
+issue: NEXT-10395
+---
+# Storefront
+* Only warmup active entities

--- a/src/Core/Content/DependencyInjection/product.xml
+++ b/src/Core/Content/DependencyInjection/product.xml
@@ -22,7 +22,7 @@
 
         <service id="Shopware\Core\Content\Product\ProductDefinition">
             <tag name="shopware.entity.definition"/>
-            <tag name="shopware.composite_search.definition"  priority="600"/>
+            <tag name="shopware.composite_search.definition" priority="600"/>
         </service>
 
         <service id="Shopware\Core\Content\Product\SalesChannel\SalesChannelProductDefinition">
@@ -67,7 +67,7 @@
 
         <service id="Shopware\Core\Content\Product\Aggregate\ProductManufacturer\ProductManufacturerDefinition">
             <tag name="shopware.entity.definition"/>
-            <tag name="shopware.composite_search.definition"  priority="300"/>
+            <tag name="shopware.composite_search.definition" priority="300"/>
         </service>
 
         <service id="Shopware\Core\Content\Product\Aggregate\ProductManufacturerTranslation\ProductManufacturerTranslationDefinition">

--- a/src/Core/Framework/DataAbstractionLayer/Dbal/Common/IteratorFactory.php
+++ b/src/Core/Framework/DataAbstractionLayer/Dbal/Common/IteratorFactory.php
@@ -27,6 +27,10 @@ class IteratorFactory
         $query->from($escaped);
         $query->setMaxResults(50);
 
+        if ($definition->getFields()->has('active')) {
+            $query->andWhere($escaped . '.active = 1');
+        }
+
         if ($definition->getFields()->has('autoIncrement')) {
             $query->select([$escaped . '.auto_increment', 'LOWER(HEX(' . $escaped . '.id))']);
             $query->andWhere($escaped . '.auto_increment > :lastId');

--- a/src/Core/Framework/Test/DataAbstractionLayer/Dbal/IteratorFactoryTest.php
+++ b/src/Core/Framework/Test/DataAbstractionLayer/Dbal/IteratorFactoryTest.php
@@ -1,0 +1,41 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\Test\DataAbstractionLayer\Dbal;
+
+use Doctrine\DBAL\Query\Expression\CompositeExpression;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Cms\CmsPageDefinition;
+use Shopware\Core\Content\Product\ProductDefinition;
+use Shopware\Core\Framework\DataAbstractionLayer\Dbal\Common\IteratorFactory;
+use Shopware\Core\Framework\Test\DataAbstractionLayer\Field\DataAbstractionLayerFieldTestBehaviour;
+use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
+
+class IteratorFactoryTest extends TestCase
+{
+    use KernelTestBehaviour;
+    use DataAbstractionLayerFieldTestBehaviour;
+
+    public function testOnlyActiveEntitiesAreSelected(): void
+    {
+        /** @var IteratorFactory $iteratorFactory */
+        $iteratorFactory = $this->getContainer()->get(IteratorFactory::class);
+        $offsetQuery = $iteratorFactory->createIterator($this->getContainer()->get(ProductDefinition::class));
+
+        /** @var CompositeExpression $queryParts */
+        $queryParts = $offsetQuery->getQuery()
+            ->getQueryPart('where');
+
+        static::assertEquals(2, $queryParts->count());
+        static::assertEquals(CompositeExpression::TYPE_AND, $queryParts->getType());
+        static::assertEquals('(`product`.active = 1) AND (`product`.auto_increment > :lastId)', (string) $queryParts);
+    }
+
+    public function testEntitiesWithoutActiveFlag(): void
+    {
+        /** @var IteratorFactory $iteratorFactory */
+        $iteratorFactory = $this->getContainer()->get(IteratorFactory::class);
+        $offsetQuery = $iteratorFactory->createIterator($this->getContainer()->get(CmsPageDefinition::class));
+
+        static::assertNull($offsetQuery->getQuery()->getQueryPart('where'));
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?

Currently every entity with a cachewarmer is being warmed up (at least it's tried) - even inactive ones. This results in a lot of unnecessary messages and requests, as well as the logs being flooded with EntityNotFound Exceptions.

### 2. What does this change do, exactly?

It changes the `IteratorFactory` to filter entities by `active`-field, if available.

### 3. Describe each step to reproduce the issue or behaviour.

Disable some products or categories, run the cachewarmer command, see the inactive products and categories warmed up.

### 4. Please link to the relevant issues (if any).

https://issues.shopware.com/issues/NEXT-10395

### 5. Checklist

- [X] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.
