### PR TITLE
Add twig blocks for contact form on administration & storefront

### DIFF
--- a/changelog/_unreleased/2020-10-05-form-element-config-type-options.md
+++ b/changelog/_unreleased/2020-10-05-form-element-config-type-options.md
@@ -7,3 +7,6 @@ author_github: runelaenen
 ---
 # Administration
 *  Add `sw_cms_el_form_config_content_form_type_options` block around select options of form type.
+---
+# Storefront
+*  Add `element_form_wrapper` block around form type renderers.

--- a/changelog/_unreleased/2020-10-05-form-element-config-type-options.md
+++ b/changelog/_unreleased/2020-10-05-form-element-config-type-options.md
@@ -6,7 +6,7 @@ author_email: rune@laenen.nu
 author_github: runelaenen
 ---
 # Administration
-*  Add `sw_cms_el_form_config_content_form_type_options` block around select options of form type.
----
+*  Added `sw_cms_el_form_config_content_form_type_options` block around select options of form type.
+___
 # Storefront
-*  Add `element_form_wrapper` block around form type renderers.
+*  Added `element_form_wrapper` block around form type renderers.

--- a/changelog/_unreleased/2020-10-05-form-element-config-type-options.md
+++ b/changelog/_unreleased/2020-10-05-form-element-config-type-options.md
@@ -1,0 +1,9 @@
+---
+title: Form element config type options
+issue: 
+author: Rune Laenen
+author_email: rune@laenen.nu 
+author_github: runelaenen
+---
+# Administration
+*  Add `sw_cms_el_form_config_content_form_type_options` block around select options of form type.

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/form/config/sw-cms-el-config-form.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/form/config/sw-cms-el-config-form.html.twig
@@ -1,7 +1,7 @@
 {% block sw_cms_el_config_form %}
      <sw-tabs class="sw-cms-el-config-form__tabs"
               defaultItem="content">
-    
+
         <template slot-scope="{ active }">
             {% block sw_cms_el_config_form_tab_content %}
                 <sw-tabs-item :title="$tc('sw-cms.elements.general.config.tab.content')"
@@ -29,9 +29,11 @@
                     {% block sw_cms_el_form_config_content_form_type %}
                         <sw-select-field :label="$tc('sw-cms.elements.form.config.label.type')"
                                          v-model="element.config.type.value">
-                            <option value="" disabled>{{ $tc('sw-cms.elements.form.config.label.type') }}</option>
-                            <option value="contact">{{ $tc('sw-cms.elements.form.config.label.typeContact') }}</option>
-                            <option value="newsletter">{{ $tc('sw-cms.elements.form.config.label.typeNewsletter') }}</option>
+                            {% block sw_cms_el_form_config_content_form_type_options %}
+                                <option value="" disabled>{{ $tc('sw-cms.elements.form.config.label.type') }}</option>
+                                <option value="contact">{{ $tc('sw-cms.elements.form.config.label.typeContact') }}</option>
+                                <option value="newsletter">{{ $tc('sw-cms.elements.form.config.label.typeNewsletter') }}</option>
+                            {% endblock %}
                         </sw-select-field>
                     {% endblock %}
 

--- a/src/Storefront/Resources/views/storefront/element/cms-element-form.html.twig
+++ b/src/Storefront/Resources/views/storefront/element/cms-element-form.html.twig
@@ -9,45 +9,47 @@
 
                 <div class="card">
                     <div class="card-body">
-                        {% if element.config.type.value is same as('contact') %}
-                            {% block element_form_contact_form_title %}
-                                <div class="card-title mb-4">
-                                    {% if element.config.title.value %}
-                                        {{ element.config.title.value }}
-                                    {%  else %}
-                                        {{ "contact.headline"|trans }}
-                                    {% endif %}
-                                </div>
-                            {% endblock %}
+                        {% block element_form_wrapper %}
+                            {% if element.config.type.value is same as('contact') %}
+                                {% block element_form_contact_form_title %}
+                                    <div class="card-title mb-4">
+                                        {% if element.config.title.value %}
+                                            {{ element.config.title.value }}
+                                        {%  else %}
+                                            {{ "contact.headline"|trans }}
+                                        {% endif %}
+                                    </div>
+                                {% endblock %}
 
-                            {% block element_form_contact_form_form %}
-                                {% sw_include '@Storefront/storefront/element/cms-element-form/form-types/contact-form.html.twig'
-                                    with {
-                                        action: 'frontend.form.contact.send',
-                                        submitText: 'contact.formSubmit'
-                                    }
-                                %}
-                            {% endblock %}
-                        {% elseif element.config.type.value is same as('newsletter') %}
-                            {% block element_form_newsletter_form_title %}
-                                <div class="card-title mb-4">
-                                    {% if element.config.title.value %}
-                                        {{ element.config.title.value }}
-                                    {%  else %}
-                                        {{ "newsletter.headline"|trans }}
-                                    {% endif %}
-                                </div>
-                            {% endblock %}
+                                {% block element_form_contact_form_form %}
+                                    {% sw_include '@Storefront/storefront/element/cms-element-form/form-types/contact-form.html.twig'
+                                        with {
+                                            action: 'frontend.form.contact.send',
+                                            submitText: 'contact.formSubmit'
+                                        }
+                                    %}
+                                {% endblock %}
+                            {% elseif element.config.type.value is same as('newsletter') %}
+                                {% block element_form_newsletter_form_title %}
+                                    <div class="card-title mb-4">
+                                        {% if element.config.title.value %}
+                                            {{ element.config.title.value }}
+                                        {%  else %}
+                                            {{ "newsletter.headline"|trans }}
+                                        {% endif %}
+                                    </div>
+                                {% endblock %}
 
-                            {% block element_form_newsletter_form_form %}
-                                {% sw_include '@Storefront/storefront/element/cms-element-form/form-types/newsletter-form.html.twig'
-                                    with {
-                                        action: 'frontend.form.newsletter.register.handle',
-                                        submitText: 'newsletter.formSubmit'
-                                    }
-                                %}
-                            {% endblock %}
-                        {% endif %}
+                                {% block element_form_newsletter_form_form %}
+                                    {% sw_include '@Storefront/storefront/element/cms-element-form/form-types/newsletter-form.html.twig'
+                                        with {
+                                            action: 'frontend.form.newsletter.register.handle',
+                                            submitText: 'newsletter.formSubmit'
+                                        }
+                                    %}
+                                {% endblock %}
+                            {% endif %}
+                        {% endblock %}
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
Allow proper customisation by plugins of the content forms.

### 2. What does this change do, exactly?
# Administration
*  Add `sw_cms_el_form_config_content_form_type_options` block around select options of form type.
---
# Storefront
*  Add `element_form_wrapper` block around form type renderers.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
