### PR TITLE
Make ProductExport respect generatedAt field

### DIFF
--- a/changelog/_unreleased/2020-10-07-make-productexport-respect-generatedat-field.md
+++ b/changelog/_unreleased/2020-10-07-make-productexport-respect-generatedat-field.md
@@ -1,0 +1,9 @@
+---
+title:  Make ProductExport respect generatedAt and interval fields
+author:             Hendrik Söbbing
+author_email:       hendrik@soebbing.de
+author_github:      @soebbing
+---
+# Core
+- `\Shopware\Core\Content\ProductExport\ScheduledTask\ProductExportGenerateTaskHandler` now respects the product exports
+defined `generatedAt` and `interval` fields

--- a/src/Core/Content/ProductExport/ScheduledTask/ProductExportGenerateTaskHandler.php
+++ b/src/Core/Content/ProductExport/ScheduledTask/ProductExportGenerateTaskHandler.php
@@ -16,16 +16,24 @@ use Symfony\Component\Messenger\MessageBusInterface;
 
 class ProductExportGenerateTaskHandler extends ScheduledTaskHandler
 {
-    /** @var SalesChannelContextFactory */
+    /**
+     * @var SalesChannelContextFactory
+     */
     private $salesChannelContextFactory;
 
-    /** @var EntityRepositoryInterface */
+    /**
+     * @var EntityRepositoryInterface
+     */
     private $salesChannelRepository;
 
-    /** @var EntityRepositoryInterface */
+    /**
+     * @var EntityRepositoryInterface
+     */
     private $productExportRepository;
 
-    /** @var MessageBusInterface */
+    /**
+     * @var MessageBusInterface
+     */
     private $messageBus;
 
     public function __construct(
@@ -85,10 +93,17 @@ class ProductExportGenerateTaskHandler extends ScheduledTaskHandler
                 return;
             }
 
+            $now = new \DateTimeImmutable('now', new \DateTimeZone('UTC'));
+
             /** @var ProductExportEntity $productExport */
             foreach ($productExports as $productExport) {
-                $message = new ProductExportPartialGeneration($productExport->getId(), $salesChannelId);
-                $this->messageBus->dispatch($message);
+                // Make sure the product export is due to be exported
+                if ($productExport->getGeneratedAt()
+                    && $now->getTimestamp() - $productExport->getGeneratedAt()->getTimestamp() < $productExport->getInterval()) {
+                    continue;
+                }
+
+                $this->messageBus->dispatch(new ProductExportPartialGeneration($productExport->getId(), $salesChannelId));
             }
         }
     }

--- a/src/Core/Content/Test/ProductExport/ScheduledTask/ProductExportGenerateTaskHandlerTest.php
+++ b/src/Core/Content/Test/ProductExport/ScheduledTask/ProductExportGenerateTaskHandlerTest.php
@@ -43,7 +43,9 @@ class ProductExportGenerateTaskHandlerTest extends TestCase
      */
     private $salesChannelContext;
 
-    /** @var FilesystemInterface */
+    /**
+     * @var FilesystemInterface
+     */
     private $fileSystem;
 
     protected function setUp(): void
@@ -58,7 +60,8 @@ class ProductExportGenerateTaskHandlerTest extends TestCase
 
     public function testRun(): void
     {
-        $this->createTestEntity();
+        $this->createProductStream();
+        $this->createTestEntity(new \DateTimeImmutable('now', new \DateTimeZone('UTC')));
         $this->clearQueue();
         $this->getTaskHandler()->run();
 
@@ -84,7 +87,8 @@ class ProductExportGenerateTaskHandlerTest extends TestCase
 
     public function testSkipGenerateByCronjobFalseProductExports(): void
     {
-        $this->createTestEntity(false);
+        $this->createProductStream();
+        $this->createTestEntity(new \DateTimeImmutable('now', new \DateTimeZone('UTC')), 0, 'Testexport.csv', false);
         $this->clearQueue();
         $this->getTaskHandler()->run();
 
@@ -100,6 +104,50 @@ class ProductExportGenerateTaskHandlerTest extends TestCase
 
         $filePath = sprintf('%s/Testexport.csv', $this->getContainer()->getParameter('product_export.directory'));
         static::assertFalse($this->fileSystem->has($filePath));
+    }
+
+    public function testGeneratedAtAndIntervalsAreRespected(): void
+    {
+        $this->createProductStream();
+        $this->clearProductExports();
+
+        $now = new \DateTimeImmutable('now', new \DateTimeZone('UTC'));
+
+        // Create one ProductExport, last exported 30 days ago, to be exported every hour
+        $this->createTestEntity($now->sub(new \DateInterval('P30M')), 3600, 'Testexport.csv');
+
+        // Create a second ProductExport, last exported 30 minutes ago, to be exported every hour
+        $this->createTestEntity($now->sub(new \DateInterval('PT30M')), 3600, 'Testexport1.csv');
+
+        $this->clearQueue();
+        // Since clearing the queue doesn't seem to really work, check difference in message number
+        $messagesBefore = $this->getContainer()->get('messenger.bus.shopware')->getDispatchedMessages();
+        $this->getTaskHandler()->run();
+        $messagesAfter = $this->getContainer()->get('messenger.bus.shopware')->getDispatchedMessages();
+
+        static::assertCount(count($messagesBefore) + 1, $messagesAfter);
+    }
+
+    public function testGeneratedAtIsNullWorks(): void
+    {
+        $this->createProductStream();
+        $this->clearProductExports();
+
+        $now = new \DateTimeImmutable('now', new \DateTimeZone('UTC'));
+
+        // Create one ProductExport, last exported 30 days ago, to be exported every hour
+        $this->createTestEntity(null, 3600, 'Testexport.csv');
+
+        // Create a second ProductExport, last exported 30 minutes ago, to be exported every hour
+        $this->createTestEntity($now->sub(new \DateInterval('PT30M')), 3600, 'Testexport1.csv');
+
+        $this->clearQueue();
+        // Since clearing the queue doesn't seem to really work, check difference in message number
+        $messagesBefore = $this->getContainer()->get('messenger.bus.shopware')->getDispatchedMessages();
+        $this->getTaskHandler()->run();
+        $messagesAfter = $this->getContainer()->get('messenger.bus.shopware')->getDispatchedMessages();
+
+        static::assertCount(count($messagesBefore) + 1, $messagesAfter);
     }
 
     private function getTaskHandler(): ProductExportGenerateTaskHandler
@@ -134,25 +182,24 @@ class ProductExportGenerateTaskHandlerTest extends TestCase
         return $this->getSalesChannelDomain()->getId();
     }
 
-    private function createTestEntity(bool $generateByCronjob = true): string
+    private function createTestEntity(?\DateTimeInterface $generatedAt = null, int $interval = 0, string $filename = 'Testexport.csv', bool $generateByCronjob = true): string
     {
-        $this->createProductStream();
-
         $id = Uuid::randomHex();
         $this->repository->upsert([
             [
                 'id' => $id,
-                'fileName' => 'Testexport.csv',
+                'fileName' => $filename,
                 'accessKey' => Uuid::randomHex(),
                 'encoding' => ProductExportEntity::ENCODING_UTF8,
                 'fileFormat' => ProductExportEntity::FILE_FORMAT_CSV,
-                'interval' => 0,
+                'interval' => $interval,
                 'headerTemplate' => 'name,url',
                 'bodyTemplate' => "{{ product.name }},{{ seoUrl('frontend.detail.page', {'productId': product.id}) }}",
                 'productStreamId' => '137b079935714281ba80b40f83f8d7eb',
                 'storefrontSalesChannelId' => $this->getSalesChannelDomain()->getSalesChannelId(),
                 'salesChannelId' => $this->getSalesChannelId(),
                 'salesChannelDomainId' => $this->getSalesChannelDomainId(),
+                'generatedAt' => $generatedAt,
                 'generateByCronjob' => $generateByCronjob,
                 'currencyId' => Defaults::CURRENCY,
             ],
@@ -214,5 +261,13 @@ class ProductExportGenerateTaskHandlerTest extends TestCase
         $productRepository->create($products, $this->context);
 
         return $products;
+    }
+
+    private function clearProductExports(): void
+    {
+        $this->repository->delete(
+            $this->repository->searchIds(new Criteria(), $this->context)->getIds(),
+            $this->context
+        );
     }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?

Currently each ProductExport does contain the fields `generatedAt` and an `interval` when it is supposed to be exported, but actually every export is generated every time the task for ALL ProductExports is run. 

### 2. What does this change do, exactly?

This change modifies the ProductExportTaskHandler to respect if an export is due to a renewal or skip it, if the defined interval hasn't passed after a generation. 

### 3. Describe each step to reproduce the issue or behaviour.

Create two product exports, one set to an interval of every 30 minutes and one to an interval of once a day. Both exports currently will be created each time the scheduled task for the ProductExportTaskHandler is run.

### 4. Please link to the relevant issues (if any).

https://issues.shopware.com/issues/NEXT-10503 (in part)

### 5. Checklist

- [X] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [X] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.
