### PR TITLE
Refactor delivery.information.html.twig template

### DIFF
--- a/changelog/_unreleased/2020-10-09-refactor-delivery-information-template.md
+++ b/changelog/_unreleased/2020-10-09-refactor-delivery-information-template.md
@@ -6,3 +6,4 @@ author_github: @aragon999
 ---
 # Storefront
 * Added blocks `component_delivery_information_available`, `component_delivery_information_soldout` and `component_delivery_information_restock` in `src/Storefront/Resources/views/storefront/component/delivery-information.html.twig`
+* Added classes `delivery-not-available`, `delivery-preorder`, `delivery-available`, `delivery-soldout` and `delivery-restock` in `src/Storefront/Resources/views/storefront/component/delivery-information.html.twig`

--- a/changelog/_unreleased/2020-10-09-refactor-delivery-information-template.md
+++ b/changelog/_unreleased/2020-10-09-refactor-delivery-information-template.md
@@ -1,0 +1,8 @@
+---
+title: Refactor delivery-information template
+author: Max
+author_email: max@swk-web.com
+author_github: @aragon999
+---
+# Storefront
+* Added blocks `component_delivery_information_available`, `component_delivery_information_soldout` and `component_delivery_information_restock` in `src/Storefront/Resources/views/storefront/component/delivery-information.html.twig`

--- a/src/Storefront/Resources/views/storefront/component/delivery-information.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/delivery-information.html.twig
@@ -30,36 +30,37 @@
                     {{ "general.deliveryShipping"|trans|sw_sanitize }} {{ product.releaseDate|format_date('long', locale=app.request.locale) }}
                 </p>
             {% endblock %}
-
         {% elseif product.availableStock >= product.minPurchase and product.deliveryTime %}
+            {% block component_delivery_information_available %}
+                <link itemprop="availability" href="http://schema.org/InStock"/>
+                <p class="delivery-information">
+                    <span class="delivery-status-indicator bg-success"></span>
 
-            <link itemprop="availability" href="http://schema.org/InStock"/>
-            <p class="delivery-information">
-                <span class="delivery-status-indicator bg-success"></span>
-
-                {{ "detail.deliveryTimeAvailable"|trans({
-                    '%name%': product.deliveryTime.translation('name')
-                })|sw_sanitize }}
-            </p>
+                    {{ "detail.deliveryTimeAvailable"|trans({
+                        '%name%': product.deliveryTime.translation('name')
+                    })|sw_sanitize }}
+                </p>
+            {% endblock %}
         {% elseif product.isCloseout and product.availableStock < product.minPurchase %}
-
-            <link itemprop="availability" href="http://schema.org/LimitedAvailability"/>
-            <p class="delivery-information">
-                <span class="delivery-status-indicator bg-danger"></span>
-                {{ "detail.soldOut"|trans|sw_sanitize }}
-            </p>
-
+            {% block component_delivery_information_soldout %}
+                <link itemprop="availability" href="http://schema.org/LimitedAvailability"/>
+                <p class="delivery-information">
+                    <span class="delivery-status-indicator bg-danger"></span>
+                    {{ "detail.soldOut"|trans|sw_sanitize }}
+                </p>
+            {% endblock %}
         {% elseif product.availableStock < product.minPurchase and product.deliveryTime and product.restockTime %}
-
-            <link itemprop="availability" href="http://schema.org/LimitedAvailability"/>
-            <p class="delivery-information">
-                <span class="delivery-status-indicator bg-warning"></span>
-                {{ "detail.deliveryTimeRestock"|trans({
-                    '%count%': product.restockTime,
-                    '%restockTime%': product.restockTime,
-                    '%name%': product.deliveryTime.translation('name')
-                })|sw_sanitize }}
-            </p>
+            {% block component_delivery_information_restock %}
+                <link itemprop="availability" href="http://schema.org/LimitedAvailability"/>
+                <p class="delivery-information">
+                    <span class="delivery-status-indicator bg-warning"></span>
+                    {{ "detail.deliveryTimeRestock"|trans({
+                        '%count%': product.restockTime,
+                        '%restockTime%': product.restockTime,
+                        '%name%': product.deliveryTime.translation('name')
+                    })|sw_sanitize }}
+                </p>
+            {% endblock %}
         {% endif %}
     </div>
 {% endblock %}

--- a/src/Storefront/Resources/views/storefront/component/delivery-information.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/delivery-information.html.twig
@@ -16,7 +16,7 @@
             {% block component_delivery_information_not_available %}
                 <link itemprop="availability"
                       href="http://schema.org/LimitedAvailability"/>
-                <p class="delivery-information">
+                <p class="delivery-information delivery-not-available">
                     <span class="delivery-status-indicator bg-danger"></span>
                     {{ "general.deliveryNotAvailable"|trans|sw_sanitize }}
                 </p>
@@ -25,7 +25,7 @@
             {% block component_delivery_information_pre_order %}
                 <link itemprop="availability"
                       href="http://schema.org/PreOrder"/>
-                <p class="delivery-information">
+                <p class="delivery-information delivery-preorder">
                     <span class="delivery-status-indicator bg-warning"></span>
                     {{ "general.deliveryShipping"|trans|sw_sanitize }} {{ product.releaseDate|format_date('long', locale=app.request.locale) }}
                 </p>
@@ -33,7 +33,7 @@
         {% elseif product.availableStock >= product.minPurchase and product.deliveryTime %}
             {% block component_delivery_information_available %}
                 <link itemprop="availability" href="http://schema.org/InStock"/>
-                <p class="delivery-information">
+                <p class="delivery-information delivery-available">
                     <span class="delivery-status-indicator bg-success"></span>
 
                     {{ "detail.deliveryTimeAvailable"|trans({
@@ -44,7 +44,7 @@
         {% elseif product.isCloseout and product.availableStock < product.minPurchase %}
             {% block component_delivery_information_soldout %}
                 <link itemprop="availability" href="http://schema.org/LimitedAvailability"/>
-                <p class="delivery-information">
+                <p class="delivery-information delivery-soldout">
                     <span class="delivery-status-indicator bg-danger"></span>
                     {{ "detail.soldOut"|trans|sw_sanitize }}
                 </p>
@@ -52,7 +52,7 @@
         {% elseif product.availableStock < product.minPurchase and product.deliveryTime and product.restockTime %}
             {% block component_delivery_information_restock %}
                 <link itemprop="availability" href="http://schema.org/LimitedAvailability"/>
-                <p class="delivery-information">
+                <p class="delivery-information delivery-restock">
                     <span class="delivery-status-indicator bg-warning"></span>
                     {{ "detail.deliveryTimeRestock"|trans({
                         '%count%': product.restockTime,


### PR DESCRIPTION
### 1. Why is this change necessary?
Currently it is nearly impossible to adjust the delivery template without copying large portions of the delivery template, since the blocks are missing.
Also it is not possible to style the different delivery states, since there are no classes. 

### 2. What does this change do, exactly?
Add blocks and classes to the `delivery.information.html.twig` template

### 3. Describe each step to reproduce the issue or behaviour.
\-

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
