### PR TITLE
Change Product- and NavigationRouteWarmer to only warm active entities

### DIFF
--- a/changelog/_unreleased/2020-10-05-only-warm-active-entities.md
+++ b/changelog/_unreleased/2020-10-05-only-warm-active-entities.md
@@ -1,0 +1,9 @@
+---
+title: Only warmup active entities
+author: Hendrik Söbbing
+author_email: hendrik@soebbing 
+author_github: @soebbing
+issue: NEXT-10395
+---
+# Storefront
+* Only warmup active product and category entities

--- a/src/Core/Content/DependencyInjection/product.xml
+++ b/src/Core/Content/DependencyInjection/product.xml
@@ -22,7 +22,7 @@
 
         <service id="Shopware\Core\Content\Product\ProductDefinition">
             <tag name="shopware.entity.definition"/>
-            <tag name="shopware.composite_search.definition"  priority="600"/>
+            <tag name="shopware.composite_search.definition" priority="600"/>
         </service>
 
         <service id="Shopware\Core\Content\Product\SalesChannel\SalesChannelProductDefinition">
@@ -67,7 +67,7 @@
 
         <service id="Shopware\Core\Content\Product\Aggregate\ProductManufacturer\ProductManufacturerDefinition">
             <tag name="shopware.entity.definition"/>
-            <tag name="shopware.composite_search.definition"  priority="300"/>
+            <tag name="shopware.composite_search.definition" priority="300"/>
         </service>
 
         <service id="Shopware\Core\Content\Product\Aggregate\ProductManufacturerTranslation\ProductManufacturerTranslationDefinition">

--- a/src/Storefront/Framework/Cache/CacheWarmer/Navigation/NavigationRouteWarmer.php
+++ b/src/Storefront/Framework/Cache/CacheWarmer/Navigation/NavigationRouteWarmer.php
@@ -29,7 +29,10 @@ class NavigationRouteWarmer implements CacheRouteWarmer
     public function createMessage(SalesChannelDomainEntity $domain, ?array $offset): ?WarmUpMessage
     {
         $iterator = $this->iteratorFactory->createIterator($this->definition, $offset);
-        $iterator->getQuery()->setMaxResults(10);
+        $query = $iterator->getQuery();
+        $query
+            ->andWhere('`category`.active = 1')
+            ->setMaxResults(10);
 
         $ids = $iterator->fetch();
         if (empty($ids)) {

--- a/src/Storefront/Framework/Cache/CacheWarmer/Product/ProductRouteWarmer.php
+++ b/src/Storefront/Framework/Cache/CacheWarmer/Product/ProductRouteWarmer.php
@@ -29,7 +29,12 @@ class ProductRouteWarmer implements CacheRouteWarmer
     public function createMessage(SalesChannelDomainEntity $domain, ?array $offset): ?WarmUpMessage
     {
         $iterator = $this->iteratorFactory->createIterator($this->definition, $offset);
-        $iterator->getQuery()->setMaxResults(10);
+        $query = $iterator->getQuery();
+        $query
+            ->leftJoin('`product`', '`product`', 'pp', '`product`.id = pp.parent_id')
+            ->andWhere('COALESCE (`product`.active, `pp`.active)')
+            ->distinct()
+            ->setMaxResults(10);
 
         $ids = $iterator->fetch();
         if (empty($ids)) {


### PR DESCRIPTION
### 1. Why is this change necessary?

Currently every entity with a cachewarmer is being warmed up (at least it's tried) - even inactive ones. This results in a lot of unnecessary messages and requests, as well as the logs being flooded with EntityNotFound Exceptions.

### 2. What does this change do, exactly?

This change modifies the queries used in the `\Shopware\Storefront\Framework\Cache\CacheWarmer\Navigation\NavigationRouteWarmer` and `\Shopware\Storefront\Framework\Cache\CacheWarmer\Product\ProductRouteWarmer` to only load active products and categories.

### 3. Describe each step to reproduce the issue or behaviour.

Disable some products or categories, run the cachewarmer command, see the inactive products and categories warmed up.

### 4. Please link to the relevant issues (if any).

https://issues.shopware.com/issues/NEXT-10395

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [X] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.
