### PR TITLE
NTR: The currency Filter should be able to handle both null and undefined

### DIFF
--- a/changelog/_unreleased/2020-10-15-the-currency-filter-can-now-handle-undefined-values-in-the-administration.md
+++ b/changelog/_unreleased/2020-10-15-the-currency-filter-can-now-handle-undefined-values-in-the-administration.md
@@ -1,0 +1,24 @@
+---
+title: The currency filter can now handle undefined values in the administration
+issue: NTR
+author: Steffen Beisenherz
+author_email: s.beisenherz@kellerkinder.de 
+author_github: Sironheart
+---
+# Core
+*  
+___
+# API
+*  
+___
+# Administration
+*  
+___
+# Storefront
+*  
+___
+# Upgrade Information
+## Topic 1
+### Topic 1a
+### Topic 1b
+## Topic 2

--- a/changelog/_unreleased/2020-10-15-the-currency-filter-can-now-handle-undefined-values-in-the-administration.md
+++ b/changelog/_unreleased/2020-10-15-the-currency-filter-can-now-handle-undefined-values-in-the-administration.md
@@ -4,21 +4,6 @@ issue: NTR
 author: Steffen Beisenherz
 author_email: s.beisenherz@kellerkinder.de 
 author_github: Sironheart
----
-# Core
-*  
-___
-# API
-*  
 ___
 # Administration
-*  
-___
-# Storefront
-*  
-___
-# Upgrade Information
-## Topic 1
-### Topic 1a
-### Topic 1b
-## Topic 2
+*  The currency filter is now able to handle more data types 

--- a/src/Administration/Resources/app/administration/src/app/filter/currency.filter.js
+++ b/src/Administration/Resources/app/administration/src/app/filter/currency.filter.js
@@ -3,7 +3,7 @@ const { types } = Shopware.Utils;
 const { currency } = Shopware.Utils.format;
 
 Filter.register('currency', (value, format, decimalPlaces) => {
-    if (!value && !types.isNumber(value)) {
+    if ((!value || value === true) && !types.isNumber(value)) {
         return '-';
     }
     return currency(value, format, decimalPlaces);

--- a/src/Administration/Resources/app/administration/src/app/filter/currency.filter.js
+++ b/src/Administration/Resources/app/administration/src/app/filter/currency.filter.js
@@ -3,8 +3,13 @@ const { types } = Shopware.Utils;
 const { currency } = Shopware.Utils.format;
 
 Filter.register('currency', (value, format, decimalPlaces) => {
-    if ((!value || value === true) && !types.isNumber(value)) {
+    if ((!value || value === true) && (!types.isNumber(value) || types.isEqual(value, NaN))) {
         return '-';
     }
+
+    if (types.isEqual(parseInt(value, 10), NaN)) {
+        return value;
+    }
+
     return currency(value, format, decimalPlaces);
 });

--- a/src/Administration/Resources/app/administration/src/app/filter/currency.filter.js
+++ b/src/Administration/Resources/app/administration/src/app/filter/currency.filter.js
@@ -11,5 +11,5 @@ Filter.register('currency', (value, format, decimalPlaces) => {
         return value;
     }
 
-    return currency(value, format, decimalPlaces);
+    return currency(parseFloat(value), format, decimalPlaces);
 });

--- a/src/Administration/Resources/app/administration/src/app/filter/currency.filter.js
+++ b/src/Administration/Resources/app/administration/src/app/filter/currency.filter.js
@@ -1,8 +1,9 @@
 const { Filter } = Shopware;
+const { types } = Shopware.Utils;
 const { currency } = Shopware.Utils.format;
 
 Filter.register('currency', (value, format, decimalPlaces) => {
-    if (value === null) {
+    if (!value && !types.isNumber(value)) {
         return '-';
     }
     return currency(value, format, decimalPlaces);

--- a/src/Administration/Resources/app/administration/test/app/filter/currency-filter.spec.js
+++ b/src/Administration/Resources/app/administration/test/app/filter/currency-filter.spec.js
@@ -18,7 +18,7 @@ describe('filter/currency.filter', () => {
     });
 
     it('should handle floats', async () => {
-        expect(currencyFilter(42.25, currency, precision)).toBe('€42,25');
+        expect(currencyFilter(42.20, currency, 2)).toBe('€42,20');
     });
 
     it('should handle strings', async () => {
@@ -39,7 +39,7 @@ describe('filter/currency.filter', () => {
     });
 
     it('should handle null', async () => {
-        expect(currencyFilter(undefined, currency, precision)).toBe('-');
+        expect(currencyFilter(null, currency, precision)).toBe('-');
     });
 
     it('should handle boolean', async () => {

--- a/src/Administration/Resources/app/administration/test/app/filter/currency-filter.spec.js
+++ b/src/Administration/Resources/app/administration/test/app/filter/currency-filter.spec.js
@@ -18,7 +18,7 @@ describe('filter/currency.filter', () => {
     });
 
     it('should handle floats', async () => {
-        expect(currencyFilter(42.20, currency, 2)).toBe('€42,20');
+        expect(currencyFilter(42.20, currency, 2)).toBe('€42.20');
     });
 
     it('should handle strings', async () => {

--- a/src/Administration/Resources/app/administration/test/app/filter/currency-filter.spec.js
+++ b/src/Administration/Resources/app/administration/test/app/filter/currency-filter.spec.js
@@ -10,15 +10,20 @@ describe('filter/currency.filter', () => {
     });
 
     it('should handle integers', async () => {
-        expect(currencyFilter(42, currency, precision)).toBe('42 €');
+        expect(currencyFilter(42, currency, precision)).toBe('€42');
     });
 
     it('should handle big int', async () => {
-        expect(currencyFilter(42n, currency, precision)).toBe('42 €');
+        expect(currencyFilter(42n, currency, precision)).toBe('€42');
+    });
+
+    it('should handle floats', async () => {
+        expect(currencyFilter(42.25, currency, precision)).toBe('€42,25');
     });
 
     it('should handle strings', async () => {
         expect(currencyFilter('foo bar', currency, precision)).toBe('foo bar');
+        expect(currencyFilter('42', currency, precision)).toBe('€42');
     });
 
     it('should handle empty strings', async () => {
@@ -26,7 +31,7 @@ describe('filter/currency.filter', () => {
     });
 
     it('should handle NaN', async () => {
-        expect(currencyFilter(NaN, currency, precision)).toBe('NaN €');
+        expect(currencyFilter(NaN, currency, precision)).toBe('-');
     });
 
     it('should handle undefined', async () => {

--- a/src/Administration/Resources/app/administration/test/app/filter/currency-filter.spec.js
+++ b/src/Administration/Resources/app/administration/test/app/filter/currency-filter.spec.js
@@ -1,0 +1,44 @@
+const { Filter } = Shopware;
+
+describe('filter/currency.filter', () => {
+    let currencyFilter;
+    const currency = 'EUR';
+    const precision = 0;
+
+    beforeAll(() => {
+        currencyFilter = Filter.getByName('currency');
+    });
+
+    it('should handle integers', async () => {
+        expect(currencyFilter(42, currency, precision)).toBe('42 €');
+    });
+
+    it('should handle big int', async () => {
+        expect(currencyFilter(42n, currency, precision)).toBe('42 €');
+    });
+
+    it('should handle strings', async () => {
+        expect(currencyFilter('foo bar', currency, precision)).toBe('foo bar');
+    });
+
+    it('should handle empty strings', async () => {
+        expect(currencyFilter('', currency, precision)).toBe('-');
+    });
+
+    it('should handle NaN', async () => {
+        expect(currencyFilter(NaN, currency, precision)).toBe('NaN €');
+    });
+
+    it('should handle undefined', async () => {
+        expect(currencyFilter(undefined, currency, precision)).toBe('-');
+    });
+
+    it('should handle null', async () => {
+        expect(currencyFilter(undefined, currency, precision)).toBe('-');
+    });
+
+    it('should handle boolean', async () => {
+        expect(currencyFilter(false, currency, precision)).toBe('-');
+        expect(currencyFilter(true, currency, precision)).toBe('-');
+    });
+});


### PR DESCRIPTION
### 1. Why is this change necessary?
When `value` is undefined for any reason there should not be a JS error. Instead there should be some default behaviour.

### 2. What does this change do, exactly?
Replace a `=== null` check with the better `!value` and a type check for 'number'

### 3. Describe each step to reproduce the issue or behaviour.
Call the currency filter with a 'undefined' value.

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
