### PR TITLE
Fix cross selling empty state

### DIFF
--- a/changelog/_unreleased/2020-10-15-fix-cross-selling-empty-state.md
+++ b/changelog/_unreleased/2020-10-15-fix-cross-selling-empty-state.md
@@ -1,0 +1,9 @@
+---
+title: Fix Cross Selling empty state
+issue: /
+author: Rune Laenen
+author_email: rune@laenen.nu 
+author_github: @runelaenen
+---
+# Administration
+* Added `:absolute="false"` to cross selling `sw-empty-state` in `sw-product-cross-selling-assignment.html.twig`

--- a/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-cross-selling-assignment/sw-product-cross-selling-assignment.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-cross-selling-assignment/sw-product-cross-selling-assignment.html.twig
@@ -75,6 +75,7 @@
                     v-if="!total && !isLoadingGrid"
                     class="sw-product-cross-selling-assignment__option-list-empty-state"
                     title=""
+                    :absolute="false"
                     :subline="$tc('sw-product.crossselling.assignEmptyStateDescription')">
                         <template #icon>
                             <img :src="'/administration/static/img/empty-states/products-empty-state.svg' | asset">


### PR DESCRIPTION
### 1. Why is this change necessary?
The empty state of manual selection cross sellings was broken

### 2. What does this change do, exactly?
Add the 'absolute = false' property to the sw-empty-state element.

### 3. Describe each step to reproduce the issue or behaviour.
Create new cross selling list on a product, select the 'Manual selection' type.

Broken:
![broken](https://user-images.githubusercontent.com/3930922/95753762-5aa61080-0ca2-11eb-86f9-3dc3c34657bc.png)

Fixed:
![fixed](https://user-images.githubusercontent.com/3930922/95753756-5843b680-0ca2-11eb-8980-84e9bfaa8634.png)


### 4. Please link to the relevant issues (if any).
/

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

* I have not added a changelog file as this is a really small change.