### PR TITLE
Store combinations that are available into the AvailableCombinationResult

### DIFF
--- a/changelog/_unreleased/2020-10-13-add-combination-list-to-available-combinations.md
+++ b/changelog/_unreleased/2020-10-13-add-combination-list-to-available-combinations.md
@@ -1,0 +1,12 @@
+---
+title: Add list of combinations to AvailableCombinationResult
+author: Joshua Behrens
+author_email: code@joshua-behrens.de
+author_github: @JoshuaBehrens
+---
+# Core
+* Added list of loaded combinations to return value of AvailableCombinationLoader
+___
+# Storefront
+* Added list of loaded combinations to return value of AvailableCombinationLoader
+___

--- a/src/Core/Content/Product/SalesChannel/Detail/AvailableCombinationResult.php
+++ b/src/Core/Content/Product/SalesChannel/Detail/AvailableCombinationResult.php
@@ -16,24 +16,21 @@ class AvailableCombinationResult extends Struct
      */
     protected $optionIds = [];
 
+    /**
+     * @var array
+     */
+    protected $combinations = [];
+
     public function hasCombination(array $optionIds): bool
     {
-        $optionIds = array_values($optionIds);
-        sort($optionIds);
-
-        $hash = md5(json_encode($optionIds));
-
-        return isset($this->hashes[$hash]);
+        return isset($this->hashes[$this->calculateHash($optionIds)]);
     }
 
     public function addCombination(array $optionIds): void
     {
-        $optionIds = array_values($optionIds);
-        sort($optionIds);
-
-        $hash = md5(json_encode($optionIds));
-
+        $hash = $this->calculateHash($optionIds);
         $this->hashes[$hash] = true;
+        $this->combinations[$hash] = $optionIds;
 
         foreach ($optionIds as $id) {
             $this->optionIds[$id] = true;
@@ -47,6 +44,19 @@ class AvailableCombinationResult extends Struct
 
     public function getHashes(): array
     {
-        return $this->hashes;
+        return \array_keys($this->hashes);
+    }
+
+    public function getCombinations(): array
+    {
+        return $this->combinations;
+    }
+
+    private function calculateHash(array $optionIds): string
+    {
+        $optionIds = array_values($optionIds);
+        sort($optionIds);
+
+        return md5((string) json_encode($optionIds));
     }
 }

--- a/src/Core/Content/Test/Product/SalesChannel/Detail/AvailableCombinationLoaderTest.php
+++ b/src/Core/Content/Test/Product/SalesChannel/Detail/AvailableCombinationLoaderTest.php
@@ -1,0 +1,142 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Content\Test\Product\SalesChannel\Detail;
+
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Product\Aggregate\ProductVisibility\ProductVisibilityDefinition;
+use Shopware\Core\Content\Product\SalesChannel\Detail\AvailableCombinationLoader;
+use Shopware\Core\Defaults;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepositoryInterface;
+use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
+use Shopware\Core\Framework\Uuid\Uuid;
+
+class AvailableCombinationLoaderTest extends TestCase
+{
+    use IntegrationTestBehaviour;
+
+    /**
+     * @var AvailableCombinationLoader|null
+     */
+    private $loader;
+
+    /**
+     * @var EntityRepositoryInterface|null
+     */
+    private $productRepository;
+
+    protected function setUp(): void
+    {
+        $this->productRepository = $this->getContainer()->get('product.repository');
+        $this->loader = $this->getContainer()->get(AvailableCombinationLoader::class);
+    }
+
+    public function testCombinationsAreInResult(): void
+    {
+        $context = Context::createDefaultContext();
+        $productId = $this->createProduct($context);
+        $result = $this->loader->load($productId, $context);
+
+        foreach ($result->getCombinations() as $combinationHash => $combination) {
+            static::assertTrue($result->hasCombination($combination));
+
+            foreach ($combination as $optionId) {
+                static::assertTrue($result->hasOptionId($optionId));
+            }
+
+            static::assertTrue(in_array($combinationHash, $result->getHashes(), true));
+        }
+    }
+
+    private static function ashuffle(array &$a)
+    {
+        $keys = array_keys($a);
+        shuffle($keys);
+        $shuffled = [];
+        foreach ($keys as $key) {
+            $shuffled[$key] = $a[$key];
+        }
+        $a = $shuffled;
+
+        return true;
+    }
+
+    private function createProduct(Context $context): string
+    {
+        // create product with property groups and 1 variant and get its configurator settings
+        $productId = Uuid::randomHex();
+        $variantId = Uuid::randomHex();
+
+        $groupIds = [
+            'a' => Uuid::randomHex(),
+            'b' => Uuid::randomHex(),
+            'c' => Uuid::randomHex(),
+            'd' => Uuid::randomHex(),
+            'e' => Uuid::randomHex(),
+            'f' => Uuid::randomHex(),
+        ];
+
+        $optionIds = [];
+
+        self::ashuffle($groupIds);
+
+        $configuratorSettings = [];
+        foreach ($groupIds as $groupName => $groupId) {
+            $group = [
+                'id' => $groupId,
+                'name' => $groupName,
+            ];
+
+            // 2 options for each group
+            $optionIds[$groupId] = [];
+            for ($i = 0; $i < 2; ++$i) {
+                $id = Uuid::randomHex();
+                $optionIds[$groupId][] = $id;
+                $configuratorSettings[] = [
+                    'option' => [
+                        'id' => $id,
+                        'name' => $groupName . $i,
+                        'group' => $group,
+                    ],
+                ];
+            }
+        }
+
+        $configuratorGroupConfig = null;
+        $data = [
+            [
+                'id' => $productId,
+                'name' => 'Test product',
+                'productNumber' => 'a.0',
+                'manufacturer' => ['name' => 'test'],
+                'tax' => ['id' => UUid::randomHex(), 'taxRate' => 19, 'name' => 'test'],
+                'stock' => 10,
+                'active' => true,
+                'price' => [['currencyId' => Defaults::CURRENCY, 'gross' => 10, 'net' => 9, 'linked' => true]],
+                'configuratorSettings' => $configuratorSettings,
+                'configuratorGroupConfig' => $configuratorGroupConfig,
+                'visibilities' => [
+                    [
+                        'salesChannelId' => Defaults::SALES_CHANNEL,
+                        'visibility' => ProductVisibilityDefinition::VISIBILITY_ALL,
+                    ],
+                ],
+            ],
+            [
+                'id' => $variantId,
+                'productNumber' => 'variant',
+                'stock' => 10,
+                'active' => true,
+                'parentId' => $productId,
+                'options' => array_map(static function (array $group) {
+                    // Assign first option from each group
+                    return ['id' => $group[0]];
+                }, $optionIds),
+            ],
+        ];
+
+        $this->productRepository->create($data, $context);
+
+        return $productId;
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?
This is a follow up to https://github.com/shopware/platform/pull/1283

When you use the combination loader you might want to have the combinations that are available -- like the name lets you expect -- you can get them out of there.

### 2. What does this change do, exactly?
Store every possible options set that is added as well as the original value to read via a getter.

### 3. Describe each step to reproduce the issue or behaviour.
Try to read the possible combinations without questioning every option set and check whether the hash is in the result.

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
