### PR TITLE
[NTR] Add plugin version to plugin informations

### DIFF
--- a/changelog/_unreleased/2020-10-13-plugin-version-plugininfos.md
+++ b/changelog/_unreleased/2020-10-13-plugin-version-plugininfos.md
@@ -1,0 +1,8 @@
+---
+title: Add plugin version to the plugin info
+author: Alexander Wink
+author_email: a.wink@kellerkinder.de 
+author_github: @jinnoflife
+---
+# Core
+* Added version to `kernel.plugin_infos`

--- a/src/Core/Framework/Plugin/KernelPluginLoader/DbalKernelPluginLoader.php
+++ b/src/Core/Framework/Plugin/KernelPluginLoader/DbalKernelPluginLoader.php
@@ -28,6 +28,7 @@ class DbalKernelPluginLoader extends KernelPluginLoader
                    `base_class` AS baseClass,
                    IF(`active` = 1 AND `installed_at` IS NOT NULL, 1, 0) AS active,
                    `path`,
+                   `version`,
                    `autoload`,
                    `managed_by_composer` AS managedByComposer
             FROM `plugin`


### PR DESCRIPTION
### 1. Why is this change necessary?
To check the plugin version inside of `kernel.plugin_infos`

### 2. What does this change do, exactly?
Add `version` to the query

### 3. Describe each step to reproduce the issue or behaviour.
///

### 4. Please link to the relevant issues (if any).
///

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.