### PR TITLE
Hide properties on product detail page

### DIFF
--- a/changelog/_unreleased/2020-10-13-hide-properties-on-product-detail-page.md
+++ b/changelog/_unreleased/2020-10-13-hide-properties-on-product-detail-page.md
@@ -1,0 +1,17 @@
+---
+title: Hide properties on product detail page
+issue: /
+author: Rune Laenen
+author_email: rune@laenen.nu 
+author_github: @runelaenen
+---
+# Core
+*  Added `visible_on_detail` field on `property_group` entity
+___
+# Administration
+*  Added `sw_property_detail_filter_visible_container` and `sw_property_detail_base_visible_on_detail` blocks to `sw-property-detail-base`.
+*  Added switch field for `propertyGroup.visibleOnDetail` in `sw-property-detail-base`
+___
+# Storefront
+*  Added if-statement in `page_product_detail_properties_table_row` to filter out hidden properties
+*  Added block `page_product_detail_properties_item` around label and value block within if.

--- a/src/Administration/Resources/app/administration/src/module/sw-property/component/sw-property-detail-base/sw-property-detail-base.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-property/component/sw-property-detail-base/sw-property-detail-base.html.twig
@@ -21,14 +21,27 @@
                 :disabled="!allowEdit"/>
         {% endblock %}
 
-        {% block sw_property_detail_base_filterable %}
-            <sw-switch-field
-                name="propertyGroupFilterable"
-                class="sw-property-detail__filterable"
-                :label="$tc('sw-property.detail.labelFilterable')"
-                :disabled="!allowEdit"
-                v-model="propertyGroup.filterable">
-            </sw-switch-field>
+        {% block sw_property_detail_filter_visible_container %}
+            <sw-container columns="repeat(2, 1fr)" gap="0px 30px">
+                {% block sw_property_detail_base_filterable %}
+                    <sw-switch-field
+                        name="propertyGroupFilterable"
+                        class="sw-property-detail__filterable"
+                        :label="$tc('sw-property.detail.labelFilterable')"
+                        :disabled="!allowEdit"
+                        v-model="propertyGroup.filterable">
+                    </sw-switch-field>
+                {% endblock %}
+
+                {% block sw_property_detail_base_visible_on_detail %}
+                    <sw-switch-field
+                        name="propertyGroupVisibleOnDetail"
+                        class="sw-property-detail__visible-on-detail"
+                        :label="$tc('sw-property.detail.labelVisibleOnDetail')"
+                        v-model="propertyGroup.visibleOnDetail">
+                    </sw-switch-field>
+                {% endblock %}
+            </sw-container>
         {% endblock %}
 
         {% block sw_property_detail_sorting_display_container %}

--- a/src/Administration/Resources/app/administration/src/module/sw-property/snippet/de-DE.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-property/snippet/de-DE.json
@@ -31,6 +31,7 @@
       "labelName": "Name",
       "placeholderName": "Namen eingeben ...",
       "labelFilterable": "Im Produktfilter von Produktlisten anzeigen",
+      "labelVisibleOnDetail": "Auf der Produktdetailseite anzeigen",
       "labelDisplayType": "Darstellung der Ausprägungsauswahl",
       "labelSortingType": "Sortierung",
       "labelOptionName": "Name",

--- a/src/Administration/Resources/app/administration/src/module/sw-property/snippet/en-GB.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-property/snippet/en-GB.json
@@ -31,6 +31,7 @@
       "labelName": "Name",
       "placeholderName": "Enter name...",
       "labelFilterable": "Display in product filters",
+      "labelVisibleOnDetail": "Display on product detail page",
       "labelDisplayType": "Value display type",
       "labelSortingType": "Sorting",
       "labelOptionName": "Name",

--- a/src/Core/Content/Property/PropertyGroupDefinition.php
+++ b/src/Core/Content/Property/PropertyGroupDefinition.php
@@ -38,6 +38,8 @@ class PropertyGroupDefinition extends EntityDefinition
 
     public const FILTERABLE = true;
 
+    public const VISIBLE_ON_DETAIL = true;
+
     public function getEntityName(): string
     {
         return self::ENTITY_NAME;
@@ -59,6 +61,7 @@ class PropertyGroupDefinition extends EntityDefinition
             'displayType' => self::DISPLAY_TYPE_TEXT,
             'sortingType' => self::SORTING_TYPE_ALPHANUMERIC,
             'filterable' => self::FILTERABLE,
+            'visibleOnDetail' => self::VISIBLE_ON_DETAIL,
         ];
     }
 
@@ -70,7 +73,8 @@ class PropertyGroupDefinition extends EntityDefinition
             new TranslatedField('description'),
             (new StringField('display_type', 'displayType'))->setFlags(new Required()),
             (new StringField('sorting_type', 'sortingType'))->setFlags(new Required()),
-            new BoolField('filterable', 'filterable'),
+            (new BoolField('filterable', 'filterable'))->setFlags(new Required()),
+            (new BoolField('visible_on_detail', 'visibleOnDetail'))->setFlags(new Required()),
             new TranslatedField('position'),
             new TranslatedField('customFields'),
             (new OneToManyAssociationField('options', PropertyGroupOptionDefinition::class, 'property_group_id', 'id'))->addFlags(new CascadeDelete(), new SearchRanking(SearchRanking::ASSOCIATION_SEARCH_RANKING)),

--- a/src/Core/Content/Property/PropertyGroupEntity.php
+++ b/src/Core/Content/Property/PropertyGroupEntity.php
@@ -42,6 +42,11 @@ class PropertyGroupEntity extends Entity
     protected $filterable;
 
     /**
+     * @var bool
+     */
+    protected $visibleOnDetail;
+
+    /**
      * @var PropertyGroupOptionCollection|null
      */
     protected $options;
@@ -74,6 +79,16 @@ class PropertyGroupEntity extends Entity
     public function setFilterable(bool $filterable): void
     {
         $this->filterable = $filterable;
+    }
+
+    public function getVisibleOnDetail(): bool
+    {
+        return $this->visibleOnDetail;
+    }
+
+    public function setVisibleOnDetail(bool $visibleOnDetail): void
+    {
+        $this->visibleOnDetail = $visibleOnDetail;
     }
 
     public function getOptions(): ?PropertyGroupOptionCollection

--- a/src/Core/Migration/Migration1602616767AddVisibleOnDetailToPropertyGroup.php
+++ b/src/Core/Migration/Migration1602616767AddVisibleOnDetailToPropertyGroup.php
@@ -1,0 +1,27 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Migration;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Framework\Migration\MigrationStep;
+
+class Migration1602616767AddVisibleOnDetailToPropertyGroup extends MigrationStep
+{
+    public function getCreationTimestamp(): int
+    {
+        return 1602616767;
+    }
+
+    public function update(Connection $connection): void
+    {
+        $connection->executeUpdate('
+            ALTER TABLE `property_group`
+            ADD COLUMN `visible_on_detail` TINYINT(1) NOT NULL DEFAULT 1
+        ');
+    }
+
+    public function updateDestructive(Connection $connection): void
+    {
+        // implement update destructive
+    }
+}

--- a/src/Storefront/Resources/views/storefront/page/product-detail/properties.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/product-detail/properties.html.twig
@@ -9,21 +9,25 @@
                             {# @var product \Shopware\Core\Content\Product\SalesChannel\SalesChannelProductEntity #}
                             {% for group in page.product.sortedProperties %}
                                 {% block page_product_detail_properties_table_row %}
-                                    <tr class="properties-row">
-                                        {% block page_product_detail_properties_item_label %}
-                                            <th class="properties-label">{{ group.translated.name|e }}:</th>
+                                    {% if group.visibleOnDetail %}
+                                        {% block page_product_detail_properties_item %}
+                                            <tr class="properties-row">
+                                                {% block page_product_detail_properties_item_label %}
+                                                    <th class="properties-label">{{ group.translated.name|e }}:</th>
+                                                {% endblock %}
+                                                {% block page_product_detail_properties_item_value %}
+                                                    <td class="properties-value">
+                                                        {% apply spaceless %}
+                                                            {% for option in group.options %}
+                                                                {% set i = ( i | default(0) ) + 1 %}
+                                                                <span>{% if i > 1 %}, {% endif %}{{ option.translated.name|e }}</span>
+                                                            {% endfor %}
+                                                        {% endapply %}
+                                                    </td>
+                                                {% endblock %}
+                                            </tr>
                                         {% endblock %}
-                                        {% block page_product_detail_properties_item_value %}
-                                            <td class="properties-value">
-                                                {% apply spaceless %}
-                                                    {% for option in group.options %}
-                                                        {% set i = ( i | default(0) ) + 1 %}
-                                                        <span>{% if i > 1 %}, {% endif %}{{ option.translated.name|e }}</span>
-                                                    {% endfor %}
-                                                {% endapply %}
-                                            </td>
-                                        {% endblock %}
-                                    </tr>
+                                    {% endif %}
                                 {% endblock %}
                             {% endfor %}
                             </tbody>


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
Allows the admin to hide certain properties from product detail pages.

### 2. What does this change do, exactly?
Adds a checkbox to the Property Group administration view, adds a field to the PropertyGroupTranslation, filters the 'disabled' proeprty groups out of the sortedProperties in the ProductLoader.

### 3. Describe each step to reproduce the issue or behaviour.
![Screenshot 2020-07-19 at 11 25 39](https://user-images.githubusercontent.com/3930922/87871675-a0f51780-c9b2-11ea-88a9-7faedef11882.png)

### 4. Please link to the relevant issues (if any).
#1122 

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
