### PR TITLE
Add option `--keep-assets` to command `theme:compile`

### DIFF
--- a/changelog/_unreleased/2020-10-13-keep-assets-on-theme-compile.md
+++ b/changelog/_unreleased/2020-10-13-keep-assets-on-theme-compile.md
@@ -1,7 +1,7 @@
 ---
 title: Add option `--keep-assets` to command `theme:compile`
 author: Hendrik Söbbing
-author_email: hendrik@soebbing 
+author_email: hendrik@soebbing.de
 author_github: @soebbing
 ---
 # Storefront

--- a/changelog/_unreleased/2020-10-13-keep-assets-on-theme-compile.md
+++ b/changelog/_unreleased/2020-10-13-keep-assets-on-theme-compile.md
@@ -1,0 +1,8 @@
+---
+title: Add option `--keep-assets` to command `theme:compile`
+author: Hendrik Söbbing
+author_email: hendrik@soebbing 
+author_github: @soebbing
+---
+# Storefront
+* Added option `--keep-assets` to command `theme:compile`. Supplying it, the current assets aren't deleted.

--- a/src/Storefront/Theme/Command/ThemeCompileCommand.php
+++ b/src/Storefront/Theme/Command/ThemeCompileCommand.php
@@ -10,6 +10,7 @@ use Shopware\Storefront\Theme\ThemeCollection;
 use Shopware\Storefront\Theme\ThemeService;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
@@ -39,6 +40,12 @@ class ThemeCompileCommand extends Command
         $this->salesChannelRepository = $salesChannelRepository;
     }
 
+    public function configure(): void
+    {
+        $this
+            ->addOption('keep-assets', 'k', InputOption::VALUE_NONE, 'Keep current assets, do not delete them');
+    }
+
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $this->io = new SymfonyStyle($input, $output);
@@ -53,8 +60,7 @@ class ThemeCompileCommand extends Command
             if (!$themes || !$theme = $themes->first()) {
                 continue;
             }
-
-            $this->themeService->compileTheme($salesChannel->getId(), $theme->getId(), $context);
+            $this->themeService->compileTheme($salesChannel->getId(), $theme->getId(), $context, null, !$input->getOption('keep-assets'));
         }
 
         $this->io->note(sprintf('Took %f seconds', (float) microtime(true) - $start));


### PR DESCRIPTION
### 1. Why is this change necessary?

During theme compilation, the current assets are deleted before the new assets are generated. This means there is a time window, at which the shop does not have any assets.

### 2. What does this change do, exactly?

This change adds an option to the `theme:compile`-command, that disables deletion of the current assets, allowing them to be served during the generation of the new assets.

### 3. Describe each step to reproduce the issue or behaviour.

Run `theme:compile` and visit the storefront during that timeframe, the assets the storefront points to are gone.

### 4. Please link to the relevant issues (if any).

https://issues.shopware.com/issues/NEXT-10950

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [X] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.
