### PR TITLE
Deprecate empty id arrays in criteria constructors

### DIFF
--- a/changelog/_unreleased/2020-10-14-deprecate-empty-id-arrays-in-criteria.md
+++ b/changelog/_unreleased/2020-10-14-deprecate-empty-id-arrays-in-criteria.md
@@ -1,0 +1,9 @@
+---
+title: Deprecate empty id arrays in Criteria constructors
+author: Hendrik Söbbing
+author_email: hendrik@soebbing.de 
+author_github: @soebbing
+---
+# Core
+* Deprecated the support for empty id arrays in `Critera` constructors due to inconsistencies. Use `null` instead or
+just no parameter at all.

--- a/src/Core/Framework/DataAbstractionLayer/Search/Criteria.php
+++ b/src/Core/Framework/DataAbstractionLayer/Search/Criteria.php
@@ -115,7 +115,7 @@ class Criteria extends Struct
      */
     public function __construct(?array $ids = null)
     {
-        if (\is_array($ids) && \count($ids) === 0) {
+        if ($ids === []) {
             @trigger_error('Empty id arrays in Criteria constructors are deprecated and will throw an InconsistentCriteriaIdsException in 6.4.0.', E_USER_DEPRECATED);
         }
 

--- a/src/Core/Framework/DataAbstractionLayer/Search/Criteria.php
+++ b/src/Core/Framework/DataAbstractionLayer/Search/Criteria.php
@@ -109,12 +109,20 @@ class Criteria extends Struct
     protected $title;
 
     /**
-     * @param string[]|array<int, string[]> $ids
+     * @param string[]|array<int, string[]>|null $ids
      *
      * @throws InconsistentCriteriaIdsException
      */
-    public function __construct(array $ids = [])
+    public function __construct(?array $ids = null)
     {
+        if (\is_array($ids) && \count($ids) === 0) {
+            @trigger_error('Empty id arrays in Criteria constructors are deprecated and will throw an InconsistentCriteriaIdsException in 6.4.0.', E_USER_DEPRECATED);
+        }
+
+        if ($ids === null) {
+            $ids = [];
+        }
+
         if (\count($ids) > \count(array_filter($ids))) {
             throw new InconsistentCriteriaIdsException();
         }
@@ -467,10 +475,18 @@ class Criteria extends Struct
     }
 
     /**
-     * @param string[]|array<int, string[]> $ids
+     * @param string[]|array<int, string[]>|null $ids
      */
-    public function cloneForRead(array $ids = []): Criteria
+    public function cloneForRead(?array $ids = null): Criteria
     {
+        if (\is_array($ids) && \count($ids) === 0) {
+            @trigger_error('Empty id arrays in Criteria `cloneForRead` method are deprecated and will throw an InconsistentCriteriaIdsException in 6.4.0.', E_USER_DEPRECATED);
+        }
+
+        if ($ids === null) {
+            $ids = [];
+        }
+
         $self = new self($ids);
         $self->setTitle($this->getTitle());
 

--- a/src/Core/Framework/DataAbstractionLayer/Search/Criteria.php
+++ b/src/Core/Framework/DataAbstractionLayer/Search/Criteria.php
@@ -479,7 +479,7 @@ class Criteria extends Struct
      */
     public function cloneForRead(?array $ids = null): Criteria
     {
-        if (\is_array($ids) && \count($ids) === 0) {
+        if ($ids === []) {
             @trigger_error('Empty id arrays in Criteria `cloneForRead` method are deprecated and will throw an InconsistentCriteriaIdsException in 6.4.0.', E_USER_DEPRECATED);
         }
 


### PR DESCRIPTION
### 1. Why is this change necessary?

This is necessary to improve the migration path to PR https://github.com/shopware/platform/pull/1400

### 2. What does this change do, exactly?

It triggers a deprecation message when an empty id array is passed to the constructor of a Criteria

### 3. Describe each step to reproduce the issue or behaviour.

/

### 4. Please link to the relevant issues (if any).

/

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [X] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.
