### PR TITLE
BUGFIX: Reactivates foreign key checks after import database.

### DIFF
--- a/changelog/_unreleased/2020-10-19-reactivates-foreign-key-checks-after-database-import.md
+++ b/changelog/_unreleased/2020-10-19-reactivates-foreign-key-checks-after-database-import.md
@@ -1,0 +1,10 @@
+---
+title: Reactivates foreign key checks after database import in CLI mode.  
+issue:  
+author: Manuel Josef  
+author_email: manuel.josef89@gmail.com  
+author_github: @mjosef89  
+---
+# Recovery
+Changed method `importDatabase()` in `Shopware\Recovery\Install\Command\InstallCommand` to reactivate foreign key checks
+after database import.

--- a/src/Recovery/Install/src/Command/InstallCommand.php
+++ b/src/Recovery/Install/src/Command/InstallCommand.php
@@ -658,6 +658,12 @@ EOT;
         $this->dumpProgress($conn, $dump);
 
         $this->runMigrations();
+
+        $preSql = <<<'EOT'
+SET FOREIGN_KEY_CHECKS = 1;
+';
+EOT;
+        $conn->query($preSql);
     }
 
     private function dumpProgress(\PDO $conn, DumpIterator $dump): void


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
Avoid problems e.g. when swaping the default language to german.

### 2. What does this change do, exactly?
Reactivates foreign key checks after import database in CLI mode.

### 3. Describe each step to reproduce the issue or behaviour.
Run the following command:


```
php public/recovery/install/index.php \
        --no-interaction \
        --db-user=dbuser \
        --db-password=dbpassword \
        --db-name="database" \
        --db-host=localhost \
        --db-port=3306 \
        --shop-locale=de-DE \
        --shop-country=DEU \
        --shop-host=host \
        --shop-path="" \
        --shop-name='CLI Installer test' \
        --shop-currency=EUR \
        --shop-email="test@example.com" \
        --admin-username=admin \
        --admin-password=shopware \
        --admin-email=test@example.com \
        --admin-locale=de-DE \
        --admin-firstname=Test \
        --admin-lastname=Test
```
        
**Before bugfix**

In table `language` the entry "Deutsch" has the correct default id "2fbb5fe2e29a4d70aa5854ce7ce3e20b".
But because foreign key checks were disabled all `language.id` references are faulty.
For example in `country_translation` all english entries still reference the "2fbb5fe2e29a4d70aa5854ce7ce3e20b"
language_id that is now german and the german entries refer to a language_id that no longer exists.

**After bugfix**
All references to language.id are now correctly adjusted.

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [X] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.
