### PR TITLE
Fix possible error on decrement message queue size

### DIFF
--- a/changelog/_unreleased/2020-10-19-fix-possible-error-on-decrement-message-queue-size.md
+++ b/changelog/_unreleased/2020-10-19-fix-possible-error-on-decrement-message-queue-size.md
@@ -1,0 +1,9 @@
+---
+title:              Fix possible error on decrement message queue size
+issue:              NEXT-11575
+author:             Christoph Pötz
+author_email:       christoph.poetz@acris.at
+author_github:      @acris-cp
+---
+# Core
+* Changed the sql statement for updating message queue stats for preventing errors on decrement message queue size smaller then 0

--- a/src/Core/Framework/MessageQueue/MonitoringBusDecorator.php
+++ b/src/Core/Framework/MessageQueue/MonitoringBusDecorator.php
@@ -88,7 +88,7 @@ class MonitoringBusDecorator implements MessageBusInterface
     {
         $this->connection->executeUpdate('
             UPDATE `message_queue_stats`
-            SET `size` = `size` - 1
+            SET `size` = IF(`size` - 1 >= 0, `size` - 1, 0)
             WHERE `name` = :name;
         ', [
             'name' => $name,


### PR DESCRIPTION
### 1. Why is this change necessary?

We are dealing with multiple queue tables (added a second queue table via plugin).
Now the messages are handled in two queues. That means, the monitoring bus decreases the size two times for each message.

That means, the size would be smaller then 0.

### 2. What does this change do, exactly?

The best would be, to prevent the constraint error on update a size that would be smaller 0.

### 3. Describe each step to reproduce the issue or behaviour.

It occurs if you handle the messages on multiple queues.

### 4. Please link to the relevant issues (if any).

Shopware partner account ticket: #147987

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
