### PR TITLE
NEXT-11478 - Add clearing container cache

### DIFF
--- a/changelog/_unreleased/2020-10-19-add-clearing-container-cache.md
+++ b/changelog/_unreleased/2020-10-19-add-clearing-container-cache.md
@@ -1,0 +1,9 @@
+---
+title: Add clearing container cache
+issue: NEXT-11478
+author: Sebastian König
+author_email: s.koenig@tinect.de
+author_github: @tinect
+---
+# Administration
+* Changed method `clear` of `core/service/api/cache.api.service.js` to call api `/_action/container_cache`, too 

--- a/src/Administration/Resources/app/administration/src/core/service/api/cache.api.service.js
+++ b/src/Administration/Resources/app/administration/src/core/service/api/cache.api.service.js
@@ -17,7 +17,11 @@ class CacheApiService {
 
     clear() {
         const headers = this.getHeaders();
-        return this.httpClient.delete('/_action/cache', { headers });
+        return this.httpClient.delete('/_action/cache', { headers }).then((response) => {
+            if (response.status === 204) {
+                this.httpClient.delete('/_action/container_cache', { headers });
+            }
+        });
     }
 
     cleanupOldCaches() {


### PR DESCRIPTION
### 1. Why is this change necessary?
Updating the container through plugin when already activated makes it for shop owners difficult to get correct result. Because they need to clean the ContainerCache on their own.
So, we should also clear the ContainerCache when shop owner clears cache through administration.

### 2. What does this change do, exactly?
- Changed method `clear` of `core/service/api/cache.api.service.js` to call api `/_action/container_cache`, too 

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/NEXT-11478

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
