### PR TITLE
NEXT-8326 - Allow ports in sw-url-field

### DIFF
--- a/changelog/_unreleased/2020-10-19-allow-ports-in-administration-url-fields.md
+++ b/changelog/_unreleased/2020-10-19-allow-ports-in-administration-url-fields.md
@@ -1,0 +1,9 @@
+---
+title: Allow ports in administration URL fields
+issue: NEXT-8326
+author: Max
+author_email: max@swk-web.com
+author_github: @aragon999
+___
+# Administration
+* Changed `sw-url-field` to accept ports, e.g. to configure Sales Channels with a specific port

--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-url-field/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-url-field/index.js
@@ -100,7 +100,8 @@ Component.extend('sw-url-field', 'sw-text-field', {
                 try {
                     const url = new URL(`${this.urlPrefix}${this.currentValue}`);
                     const path = this.currentValue.endsWith('/') ? url.pathname : url.pathname.replace(/\/$/, '');
-                    this.currentValue = url.hostname + path;
+                    const host = url.host + (this.currentValue.endsWith(':') && url.port === '' && path === '' ? ':' : '');
+                    this.currentValue = host + path;
                     this.errorUrl = null;
                 } catch {
                     this.errorUrl = new ShopwareError({

--- a/src/Administration/Resources/app/administration/test/app/component/form/sw-url-field.spec.js
+++ b/src/Administration/Resources/app/administration/test/app/component/form/sw-url-field.spec.js
@@ -41,7 +41,19 @@ describe('components/form/sw-url-field', () => {
         await wrapper.find('.sw-url-input-field__input').setValue('www.test-domain.de');
         expect(wrapper.find('.sw-field__error').exists()).toBe(false);
 
+        await wrapper.find('.sw-url-input-field__input').setValue('www.test-domain.de:8080');
+        expect(wrapper.find('.sw-field__error').exists()).toBe(false);
+
+        await wrapper.find('.sw-url-input-field__input').setValue('www.test-domain.de:8080/foobar:foo');
+        expect(wrapper.find('.sw-field__error').exists()).toBe(false);
+
+        await wrapper.find('.sw-url-input-field__input').setValue('www.test-domain.de:8080:');
+        expect(wrapper.find('.sw-field__error').exists()).toBe(true);
+
         await wrapper.find('.sw-url-input-field__input').setValue('#');
+        expect(wrapper.find('.sw-field__error').exists()).toBe(true);
+
+        await wrapper.find('.sw-url-input-field__input').setValue(':');
         expect(wrapper.find('.sw-field__error').exists()).toBe(true);
     });
 


### PR DESCRIPTION
### 1. Why is this change necessary?
Otherwise it is not possible to specify an URL with a port.

### 2. What does this change do, exactly?
Take the host and not only the hostname into account when, specifiying an URL, see for example:
http://bl.ocks.org/abernier/3070589

### 3. Describe each step to reproduce the issue or behaviour.
Try to specify a domain with a port in the sales channel domains.

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/NEXT-8326

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
