### PR TITLE
Add changelog information to CONTRIBUTING information

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,8 @@ Shopware is available under MIT license. If you want to contribute code (feature
 If you want more details about available licensing or the contribution agreements we offer, you can contact us at <contact@shopware.com>.
 
 ## Contributing to the Shopware code base
-If you want to learn how to contribute code to Shopware, please refer to [Contributing Code](https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contributing-code?category=shopware-platform-dev-en/contribution).  
+If you want to learn how to contribute code to Shopware, please refer to [Contributing Code](https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contributing-code?category=shopware-platform-dev-en/contribution).
+Also make sure that you add a changelog file which describes your changes in a meaningful way. For more information refer to [this document](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md#workflow).
 
 ## Documentation
 


### PR DESCRIPTION
### 1. Why is this change necessary?
I always forget that the information on the guidelines for the changelog are located in `adr`.

### 2. What does this change do, exactly?
This PR adds a link to the document in the `CONTRIBUTING.md` which I first look at if I search for this document.
Is a changelog for this change required? :thinking: 

### 3. Describe each step to reproduce the issue or behaviour.
Make a change and forget how exactly you should write the changelog. 

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
