### PR TITLE
Allow quantity change only for cart root items

### DIFF
--- a/changelog/_unreleased/2020-10-19-hide-quantity-change-form-for-child-line-items.md
+++ b/changelog/_unreleased/2020-10-19-hide-quantity-change-form-for-child-line-items.md
@@ -1,0 +1,9 @@
+---
+title: Hide quantity change form for child line items
+issue: ---
+author: Joshua Behrens
+author_email: code@joshua-behrens.de
+author_github: JoshuaBehrens
+---
+# Storefront
+* Changed condition when the quantity change form for line items is shown. It is now hidden for child line items.

--- a/src/Storefront/Resources/views/storefront/page/checkout/checkout-item.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/checkout/checkout-item.html.twig
@@ -162,7 +162,7 @@
                             {% block page_checkout_item_quantity_select %}
                                 <div class="col-4 col-sm-12">
                                     {% block page_checkout_item_quantity_form %}
-                                        {% if lineItem.quantityInformation and lineItem.stackable %}
+                                        {% if lineItem.quantityInformation and lineItem.stackable and not isChild %}
                                             <form action="{{ path('frontend.checkout.line-item.change-quantity', {'id': lineItem.id}) }}"
                                                   class="cart-item-quantity-container"
                                                   method="post"


### PR DESCRIPTION
### 1. Why is this change necessary?
Behind the scenes the LineItemFactoryRegistry::update method is used. This method only performs updates on the cart root level and therefore a quantity change on child items is not working. To change that you need to do a breaking change (PR upcoming) to some interfaces and therefore can't fix it for now. By now we can just disable the quantity selection for children.

### 2. What does this change do, exactly?
Disable showing the quantity change form in the cart for cart child line items.

### 3. Describe each step to reproduce the issue or behaviour.
1. Use any plugin that has child items in the cart (e.g. bundle)
2. Have a child line item that is stackable
3. Try to change the quantity in the cart of the child line item

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
