### PR TITLE
Clone context in RepositoryIterator to support disabled cache in generators

### DIFF
--- a/src/Core/Framework/DataAbstractionLayer/Dbal/Common/RepositoryIterator.php
+++ b/src/Core/Framework/DataAbstractionLayer/Dbal/Common/RepositoryIterator.php
@@ -37,7 +37,7 @@ class RepositoryIterator
 
         $this->criteria = $criteria;
         $this->repository = $repository;
-        $this->context = $context;
+        $this->context = clone $context;
     }
 
     public function getTotal(): int


### PR DESCRIPTION
### 1. Why is this change necessary?

When you use the RepositoryIterator with a context that has its cache disabled inside a generator function, it will not operate with a disabled cache. This happens because a generator is only executed when you iterate through it and by that time the `disableCache` method will already have enabled the cache again.

### 2. What does this change do, exactly?

Clone the context in the RepositoryIterator constructor to lock its state and prevent changes from outside.

### 3. Describe each step to reproduce the issue or behaviour.

```php
$iterator = $context->disableCache(function (Context $context) use ($orderRepository) {
    return new RepositoryIterator($orderRepository, $context);
});

while (!is_null($orderIds = $iterator->fetchIds())) {
    foreach ($orderIds as $orderId) {
        yield new OrderStruct($orderId);
    }
}
```

### 4. Please link to the relevant issues (if any).

None.

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
