### PR TITLE
NEXT-11537 - Use upstream method to minify CSS in autoprefixer

### DIFF
--- a/changelog/_unreleased/2020-10-21-update-padaliyajay-php-autoprefixer.md
+++ b/changelog/_unreleased/2020-10-21-update-padaliyajay-php-autoprefixer.md
@@ -1,0 +1,10 @@
+---
+title: Update padaliyajay/php-autoprefixer
+issue: NEXT-11537
+author: Max
+author_email: max@swk-web.com
+author_github: @aragon999
+___
+# Storefront
+* Update `padaliyajay/php-autoprefixer` to version 1.3 in order to use upstream CSS minification
+* Deprecated `Shopware\Storefront\Theme\Autoprefixer` will be removed in Shopware 6.4.0

--- a/composer.json
+++ b/composer.json
@@ -63,7 +63,7 @@
         "marc1706/fast-image-size": "1.1.6",
         "nyholm/psr7": "1.2.1",
         "ongr/elasticsearch-dsl": "7.0.0",
-        "padaliyajay/php-autoprefixer": "1.2",
+        "padaliyajay/php-autoprefixer": "1.3",
         "psr/cache": "1.0.1",
         "psr/event-dispatcher": "1.0.0",
         "psr/http-factory": "1.0.1",

--- a/src/Storefront/Theme/Autoprefixer.php
+++ b/src/Storefront/Theme/Autoprefixer.php
@@ -3,39 +3,10 @@
 namespace Shopware\Storefront\Theme;
 
 use Padaliyajay\PHPAutoprefixer\Autoprefixer as PadaliyajayAutoprefixer;
-use Sabberworm\CSS\OutputFormat;
-use Sabberworm\CSS\Parser;
 
-/*
- * This class implements a pull request of the core autoprefixer, to enable
- * minification of the compiled CSS, if the update is released this
- * class should be removed and Padaliyajay\PHPAutoprefixer\Autoprefixer should
- * be used instead, see:
- * https://github.com/padaliyajay/php-autoprefixer/pull/8
- * https://github.com/padaliyajay/php-autoprefixer/issues/10
+/**
+ * @deprecated tag:v6.4.0 will be removed in v6.4.0
  */
 class Autoprefixer extends PadaliyajayAutoprefixer
 {
-    /**
-     * @var Parser
-     */
-    private $cssParser;
-
-    public function __construct(string $cssCode)
-    {
-        $this->cssParser = new Parser($cssCode);
-    }
-
-    public function compile(bool $prettyOutput = true): string
-    {
-        $cssDocument = $this->cssParser->parse();
-
-        $this->compileCSSList($cssDocument);
-
-        $outputFormat = $prettyOutput
-            ? OutputFormat::createPretty()
-            : OutputFormat::createCompact();
-
-        return $cssDocument->render($outputFormat);
-    }
 }

--- a/src/Storefront/Theme/ThemeCompiler.php
+++ b/src/Storefront/Theme/ThemeCompiler.php
@@ -3,6 +3,7 @@
 namespace Shopware\Storefront\Theme;
 
 use League\Flysystem\FilesystemInterface;
+use Padaliyajay\PHPAutoprefixer\Autoprefixer;
 use ScssPhp\ScssPhp\Compiler;
 use ScssPhp\ScssPhp\Formatter\Crunched;
 use ScssPhp\ScssPhp\Formatter\Expanded;

--- a/src/Storefront/composer.json
+++ b/src/Storefront/composer.json
@@ -26,7 +26,7 @@
         "cocur/slugify": "4.0.0",
         "doctrine/dbal": "2.10.1",
         "ezyang/htmlpurifier": "4.13.0",
-        "padaliyajay/php-autoprefixer": "1.2",
+        "padaliyajay/php-autoprefixer": "1.3",
         "scssphp/scssphp": "1.0.6",
         "shopware/core": "*",
         "symfony/cache": "~4.4.13",


### PR DESCRIPTION
### 1. Why is this change necessary?
A new release of the autprefixer has been released, therefore we can use the upstream method to minify the CSS. 

### 2. What does this change do, exactly?
Remove the temporary implementation of the CSS minification and use upstream.

### 3. Describe each step to reproduce the issue or behaviour.
Compile the CSS with debug enabled/disabled.

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/NEXT-11537

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
