### PR TITLE
NEXT-11540 - Added quantity-selection

### DIFF
--- a/changelog/_unreleased/2020-10-21-add-quantity-selection-input-handling.md
+++ b/changelog/_unreleased/2020-10-21-add-quantity-selection-input-handling.md
@@ -1,0 +1,16 @@
+---
+title:              Add option to display input instead of select field for quantities
+issue:              NEXT-11540
+author:             Sebastian König
+author_email:       s.koenig@tinect.de
+author_github:      @tinect
+---
+# Storefront
+* Added new utility template `storefront/utilities/quantity-selection.html.twig` to take care of input or select output
+* Changed block `component_offcanvas_product_buy_quantity` in `component/checkout/offcanvas-item.html.twig` to use new utility
+* Changed block `page_product_detail_buy_quantity` in `page/checkout/checkout-item.html.twig` to use new utility
+* Changed block `page_product_detail_buy_quantity` in `page/product-detail/buy-widget-form.html.twig` to use new utility
+___
+# Administration
+* Added config `cart.maxSelectFieldOptions` in cart settings to specifiy when input field should be displayed instead of the select field
+___

--- a/src/Core/Migration/Migration1603286213NewSystemConfigMaxSelectFieldOptions.php
+++ b/src/Core/Migration/Migration1603286213NewSystemConfigMaxSelectFieldOptions.php
@@ -1,0 +1,30 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Migration;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Defaults;
+use Shopware\Core\Framework\Migration\MigrationStep;
+use Shopware\Core\Framework\Uuid\Uuid;
+
+class Migration1603286213NewSystemConfigMaxSelectFieldOptions extends MigrationStep
+{
+    public function getCreationTimestamp(): int
+    {
+        return 1603286213;
+    }
+
+    public function update(Connection $connection): void
+    {
+        $connection->insert('system_config', [
+            'id' => Uuid::randomBytes(),
+            'configuration_key' => 'core.cart.maxSelectFieldOptions',
+            'configuration_value' => '{"_value": "100"}',
+            'created_at' => (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT),
+        ]);
+    }
+
+    public function updateDestructive(Connection $connection): void
+    {
+    }
+}

--- a/src/Core/System/Resources/config/cart.xml
+++ b/src/Core/System/Resources/config/cart.xml
@@ -11,6 +11,16 @@
             <label lang="de-DE">Maximale Auswahlmenge</label>
         </input-field>
 
+        <input-field type="int">
+            <name>maxSelectFieldOptions</name>
+            <label>Maximum options in the select field up to the display of the input field</label>
+            <label lang="de-DE">Maximale Optionen im Auswahlfeld bis zur Darstellung des Eingabefeldes</label>
+            <helpText>As soon as the amount of the selection of the order amount exceeds this value, an input field is displayed instead of a selection field.
+                This increases the performance for the visitors. The default is 100.</helpText>
+            <helpText lang="de-DE">Sobald die Menge der Auswahl der Bestellmenge diesen Wert überschreitet, wird ein Eingabefeld, anstelle eines Auswahlfeldes angezeigt.
+            Dies erhöht die Performance für die Besucher. Standard beträgt 100.</helpText>
+        </input-field>
+
         <input-field type="bool">
             <name>showDeliveryTime</name>
             <label>Show delivery time in cart</label>

--- a/src/Storefront/Resources/views/storefront/component/checkout/offcanvas-item.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/checkout/offcanvas-item.html.twig
@@ -127,15 +127,14 @@
                                                             {% endif %}
 
                                                             {% block component_offcanvas_product_buy_quantity %}
-                                                                <select name="quantity"
-                                                                        class="custom-select quantity-select-{{ id }} js-offcanvas-cart-change-quantity">
-                                                                    {% for quantityItem in range(quantityInformation.minPurchase, maxQuantity, quantityInformation.purchaseSteps) %}
-                                                                        <option value="{{ quantityItem }}"
-                                                                            {% if quantityItem == quantity %} selected="selected"{% endif %}>
-                                                                            {{ quantityItem }}
-                                                                        </option>
-                                                                    {% endfor %}
-                                                                </select>
+                                                                {% sw_include '@Storefront/storefront/utilities/quantity-selection.html.twig' with {
+                                                                    name: 'quantity',
+                                                                    class: 'quantity-select-' ~ id ~ ' js-offcanvas-cart-change-quantity',
+                                                                    currentValue: quantity,
+                                                                    min: quantityInformation.minPurchase,
+                                                                    max: maxQuantity,
+                                                                    steps: quantityInformation.purchaseSteps
+                                                                } %}
                                                             {% endblock %}
                                                         </form>
                                                     {% endif %}

--- a/src/Storefront/Resources/views/storefront/page/checkout/checkout-item.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/checkout/checkout-item.html.twig
@@ -187,15 +187,14 @@
                                                 {% endif %}
 
                                                 {% block page_product_detail_buy_quantity %}
-                                                    <select name="quantity"
-                                                            class="custom-select quantity-select">
-                                                        {% for quantity in range(lineItem.quantityInformation.minPurchase, maxQuantity, lineItem.quantityInformation.purchaseSteps) %}
-                                                            <option value="{{ quantity }}"
-                                                                {% if quantity == lineItem.quantity %} selected="selected"{% endif %}>
-                                                                {{ quantity }}
-                                                            </option>
-                                                        {% endfor %}
-                                                    </select>
+                                                    {% sw_include '@Storefront/storefront/utilities/quantity-selection.html.twig' with {
+                                                        name: 'quantity',
+                                                        class: 'quantity-select',
+                                                        currentValue: lineItem.quantity,
+                                                        min: lineItem.quantityInformation.minPurchase,
+                                                        max: maxQuantity,
+                                                        steps: lineItem.quantityInformation.purchaseSteps
+                                                    } %}
                                                 {% endblock %}
                                             </form>
                                         {% else %}

--- a/src/Storefront/Resources/views/storefront/page/product-detail/buy-widget-form.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/product-detail/buy-widget-form.html.twig
@@ -22,23 +22,16 @@
                     {% block page_product_detail_buy_quantity_container %}
                         <div class="col-4">
                             {% block page_product_detail_buy_quantity %}
-                                <select name="lineItems[{{ product.id }}][quantity]"
-                                        class="custom-select product-detail-quantity-select">
-                                    {% for quantity in range(product.minPurchase, product.calculatedMaxPurchase, product.purchaseSteps) %}
-                                        <option value="{{ quantity }}">
-                                            {{ quantity }}
-                                            {% if quantity == 1 %}
-                                                {% if product.translated.packUnit %} {{ product.translated.packUnit }}{% endif %}
-                                            {% else %}
-                                                {% if product.translated.packUnitPlural %}
-                                                    {{ product.translated.packUnitPlural }}
-                                                {% elseif product.translated.packUnit %}
-                                                    {{ product.translated.packUnit }}
-                                                {% endif %}
-                                            {% endif %}
-                                        </option>
-                                    {% endfor %}
-                                </select>
+                                {% sw_include '@Storefront/storefront/utilities/quantity-selection.html.twig' with {
+                                    name: 'lineItems[' ~ product.id ~ '][quantity]',
+                                    class: 'product-detail-quantity-select',
+                                    currentValue: product.minPurchase,
+                                    min: product.minPurchase,
+                                    max: product.calculatedMaxPurchase,
+                                    steps: product.purchaseSteps,
+                                    packUnit: product.translated.packUnit,
+                                    packUnitPlural: product.translated.packUnitPlural
+                                } %}
                             {% endblock %}
                         </div>
                     {% endblock %}

--- a/src/Storefront/Resources/views/storefront/utilities/quantity-selection.html.twig
+++ b/src/Storefront/Resources/views/storefront/utilities/quantity-selection.html.twig
@@ -1,0 +1,39 @@
+{% block utilities_quantity_selection %}
+    {% set quantityList = range(min, max, steps) %}
+
+    {% if quantityList|length > shopware.config.core.cart.maxSelectFieldOptions %}
+        {% block utilities_quantity_selection_input %}
+            <input type="number"
+                   name="{{ name }}"
+                   class="form-control {{ class }}"
+                   value="{{ currentValue }}"
+                   step="{{ steps }}"
+                   min="{{ min }}"
+                   max="{{ max }}"
+                   title="{% if packUnitPlural %}
+                              {{ packUnitPlural }}
+                          {% elseif packUnit %}
+                              {{ packUnit }}
+                          {% endif %}">
+        {% endblock %}
+    {% else %}
+        {% block utilities_quantity_selection_select %}
+            <select name="{{ name }}" class="custom-select {{ class }}">
+                {% for quantity in quantityList %}
+                    <option value="{{ quantity }}" {% if quantity == currentValue %} selected="selected"{% endif %}>
+                        {{ quantity }}
+                        {% if quantity == 1 %}
+                            {% if packUnit %} {{ packUnit }}{% endif %}
+                        {% else %}
+                            {% if packUnitPlural %}
+                                {{ packUnitPlural }}
+                            {% elseif packUnit %}
+                                {{ packUnit }}
+                            {% endif %}
+                        {% endif %}
+                    </option>
+                {% endfor %}
+            </select>
+        {% endblock %}
+    {% endif %}
+{% endblock %}


### PR DESCRIPTION
### 1. Why is this change necessary?
We should switch to an input-field when quantity-selection would have too many options.

### 2. What does this change do, exactly?
#### Storefront
* Added new utility template `storefront/utilities/quantity-selection.html.twig` to take care of input or select output
* Changed block `component_offcanvas_product_buy_quantity` in `component/checkout/offcanvas-item.html.twig` to use new utility
* Changed block `page_product_detail_buy_quantity` in `page/checkout/checkout-item.html.twig` to use new utility
* Changed block `page_product_detail_buy_quantity` in `page/product-detail/buy-widget-form.html.twig` to use new utility
#### Administration
* Added config `cart.maxSelectFieldOptions` in cart settings to specifiy when input field should be displayed instead of the select field

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/NEXT-11540

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
