### PR TITLE
Make custom cache possible

### DIFF
--- a/changelog/_unreleased/2020-10-22-use-project-dir-for-bundle-dump.md
+++ b/changelog/_unreleased/2020-10-22-use-project-dir-for-bundle-dump.md
@@ -1,0 +1,9 @@
+---
+title: UseProjectDirForBundleDump
+issue: /
+author: Rune Laenen
+author_email: rune@laenen.nu 
+author_github: @runelaenen
+---
+# Core
+*  Change generation of `/var/plugins.json` location to use `%kernel.project_dir%`

--- a/src/Core/Framework/DependencyInjection/plugin.xml
+++ b/src/Core/Framework/DependencyInjection/plugin.xml
@@ -21,7 +21,7 @@
 
         <service id="Shopware\Core\Framework\Plugin\BundleConfigDumper">
             <argument type="service" id="Shopware\Core\Framework\Plugin\BundleConfigGenerator" />
-            <argument>%kernel.cache_dir%</argument>
+            <argument>%kernel.project_dir%</argument>
 
             <tag name="kernel.event_subscriber" />
         </service>

--- a/src/Core/Framework/Plugin/BundleConfigDumper.php
+++ b/src/Core/Framework/Plugin/BundleConfigDumper.php
@@ -16,14 +16,14 @@ class BundleConfigDumper implements EventSubscriberInterface
     /**
      * @var string
      */
-    private $cacheDir;
+    private $projectDir;
 
     public function __construct(
         BundleConfigGeneratorInterface $bundleConfigGenerator,
-        string $cacheDir
+        string $projectDir
     ) {
         $this->bundleConfigGenerator = $bundleConfigGenerator;
-        $this->cacheDir = $cacheDir;
+        $this->projectDir = $projectDir;
     }
 
     public static function getSubscribedEvents(): array
@@ -39,7 +39,7 @@ class BundleConfigDumper implements EventSubscriberInterface
         $config = $this->bundleConfigGenerator->getConfig();
 
         file_put_contents(
-            $this->cacheDir . '/../../plugins.json',
+            $this->projectDir . '/var/plugins.json',
             json_encode($config, JSON_PRETTY_PRINT)
         );
     }


### PR DESCRIPTION
### 1. Why is this change necessary?
It is not possible to define a custom cache directory as the bundle:dump command relies on the cache location to find the /var folder, while other places have the `var/plugins.json` hardcoded.

### 2. What does this change do, exactly?
I have updated the code to go to the /var folder using the projectDir param instead of cacheDir param.
Functionally, nothing changes.

### 3. Describe each step to reproduce the issue or behaviour.
 - Change the Kernel to use a different cache directory (https://symfony.com/doc/current/configuration/override_dir_structure.html#override-the-cache-directory)
 - The plugins.json will be put in the wrong directory when dumping bundles.

### 4. Please link to the relevant issues (if any).
/

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
