### PR TITLE
NEXT-11569 Fix missing data-cms-element-ids

### DIFF
--- a/changelog/_unreleased/2020-10-22-fix-element-ids.md
+++ b/changelog/_unreleased/2020-10-22-fix-element-ids.md
@@ -1,0 +1,9 @@
+---
+title: Fix data cms element ids in storefront
+issue: NEXT-11569
+author: Sebastian König
+author_email: s.koenig@tinect.de
+author_github: @tinect
+---
+# Storefront
+*  Changed several cms-blocks to add `element.id` correctly

--- a/src/Storefront/Resources/views/storefront/block/cms-block-center-text.html.twig
+++ b/src/Storefront/Resources/views/storefront/block/cms-block-center-text.html.twig
@@ -1,11 +1,10 @@
 {% block block_center_text %}
     {% set columns = 3 %}
-    {% set id = element.id %}
 
     {% block block_center_text_left %}
         {% set element = block.slots.getSlot('left') %}
 
-        <div class="col-md-4" data-cms-element-id="{{ id }}">
+        <div class="col-md-4" data-cms-element-id="{{ element.id }}">
             {% block block_center_text_left_inner %}
                 {% sw_include "@Storefront/storefront/element/cms-element-" ~ element.type ~ ".html.twig" ignore missing %}
             {% endblock %}
@@ -15,7 +14,7 @@
     {% block block_center_text_center %}
         {% set element = block.slots.getSlot('center') %}
 
-        <div class="col-md-4" data-cms-element-id="{{ id }}">
+        <div class="col-md-4" data-cms-element-id="{{ element.id }}">
             {% block block_center_text_center_inner %}
                 {% sw_include "@Storefront/storefront/element/cms-element-" ~ element.type ~ ".html.twig" ignore missing %}
             {% endblock %}
@@ -25,7 +24,7 @@
     {% block block_center_text_right %}
         {% set element = block.slots.getSlot('right') %}
 
-        <div class="col-md-4" data-cms-element-id="{{ id }}">
+        <div class="col-md-4" data-cms-element-id="{{ element.id }}">
             {% block block_center_text_right_inner %}
                 {% sw_include "@Storefront/storefront/element/cms-element-" ~ element.type ~ ".html.twig" ignore missing %}
             {% endblock %}

--- a/src/Storefront/Resources/views/storefront/block/cms-block-image-bubble-row.html.twig
+++ b/src/Storefront/Resources/views/storefront/block/cms-block-image-bubble-row.html.twig
@@ -1,11 +1,10 @@
 {% block block_image_bubble_row %}
     {% set columns = 3 %}
-    {% set id = element.id %}
 
     {% block block_image_bubble_row_left %}
         {% set element = block.slots.getSlot('left') %}
 
-        <div class="col-md-4" data-cms-element-id="{{ id }}">
+        <div class="col-md-4" data-cms-element-id="{{ element.id }}">
             {% block block_image_bubble_row_left_inner %}
                 {% sw_include "@Storefront/storefront/element/cms-element-" ~ element.type ~ ".html.twig" ignore missing %}
             {% endblock %}
@@ -15,7 +14,7 @@
     {% block block_image_bubble_row_center %}
         {% set element = block.slots.getSlot('center') %}
 
-        <div class="col-md-4" data-cms-element-id="{{ id }}">
+        <div class="col-md-4" data-cms-element-id="{{ element.id }}">
             {% block block_image_bubble_row_center_inner %}
                 {% sw_include "@Storefront/storefront/element/cms-element-" ~ element.type ~ ".html.twig" ignore missing %}
             {% endblock %}
@@ -25,7 +24,7 @@
     {% block block_image_bubble_row_right %}
         {% set element = block.slots.getSlot('right') %}
 
-        <div class="col-md-4" data-cms-element-id="{{ id }}">
+        <div class="col-md-4" data-cms-element-id="{{ element.id }}">
             {% block block_image_text_row_right_inner %}
                 {% sw_include "@Storefront/storefront/element/cms-element-" ~ element.type ~ ".html.twig" ignore missing %}
             {% endblock %}

--- a/src/Storefront/Resources/views/storefront/block/cms-block-image-four-column.html.twig
+++ b/src/Storefront/Resources/views/storefront/block/cms-block-image-four-column.html.twig
@@ -1,11 +1,10 @@
 {% block block_image_four_column %}
     {% set columns = 4 %}
-    {% set id = element.id %}
 
     {% block block_image_four_column_left %}
         {% set element = block.slots.getSlot('left') %}
 
-        <div class="col-md-3" data-cms-element-id="{{ id }}">
+        <div class="col-md-3" data-cms-element-id="{{ element.id }}">
             {% block block_image_four_column_left_inner %}
                 {% sw_include "@Storefront/storefront/element/cms-element-" ~ element.type ~ ".html.twig" ignore missing %}
             {% endblock %}
@@ -15,7 +14,7 @@
     {% block block_image_four_column_center_left %}
         {% set element = block.slots.getSlot('center-left') %}
 
-        <div class="col-md-3" data-cms-element-id="{{ id }}">
+        <div class="col-md-3" data-cms-element-id="{{ element.id }}">
             {% block block_image_four_column_center_left_inner %}
                 {% sw_include "@Storefront/storefront/element/cms-element-" ~ element.type ~ ".html.twig" ignore missing %}
             {% endblock %}
@@ -25,7 +24,7 @@
     {% block block_image_four_column_center_right %}
         {% set element = block.slots.getSlot('center-right') %}
 
-        <div class="col-md-3" data-cms-element-id="{{ id }}">
+        <div class="col-md-3" data-cms-element-id="{{ element.id }}">
             {% block block_image_four_column_center_right_inner %}
                 {% sw_include "@Storefront/storefront/element/cms-element-" ~ element.type ~ ".html.twig" ignore missing %}
             {% endblock %}
@@ -35,7 +34,7 @@
     {% block block_image_four_column_right %}
         {% set element = block.slots.getSlot('right') %}
 
-        <div class="col-md-3" data-cms-element-id="{{ id }}">
+        <div class="col-md-3" data-cms-element-id="{{ element.id }}">
             {% block block_image_four_column_right_inner %}
                 {% sw_include "@Storefront/storefront/element/cms-element-" ~ element.type ~ ".html.twig" ignore missing %}
             {% endblock %}

--- a/src/Storefront/Resources/views/storefront/block/cms-block-image-highlight-row.html.twig
+++ b/src/Storefront/Resources/views/storefront/block/cms-block-image-highlight-row.html.twig
@@ -1,10 +1,10 @@
 {% block block_image_highlight_row %}
     {% set columns = 3 %}
-    {% set id = element.id %}
+
     {% block block_image_highlight_row_left %}
         {% set element = block.slots.getSlot('left') %}
 
-        <div class="col-md-4" data-cms-element-id="{{ id }}">
+        <div class="col-md-4" data-cms-element-id="{{ element.id }}">
             {% block block_image_highlight_row_left_inner %}
                 {% sw_include "@Storefront/storefront/element/cms-element-" ~ element.type ~ ".html.twig" ignore missing %}
             {% endblock %}
@@ -14,7 +14,7 @@
     {% block block_image_highlight_row_center %}
         {% set element = block.slots.getSlot('center') %}
 
-        <div class="col-md-4" data-cms-element-id="{{ id }}">
+        <div class="col-md-4" data-cms-element-id="{{ element.id }}">
             {% block block_image_highlight_row_center_inner %}
                 {% sw_include "@Storefront/storefront/element/cms-element-" ~ element.type ~ ".html.twig" ignore missing %}
             {% endblock %}
@@ -24,7 +24,7 @@
     {% block block_image_highlight_row_right %}
         {% set element = block.slots.getSlot('right') %}
 
-        <div class="col-md-4" data-cms-element-id="{{ id }}">
+        <div class="col-md-4" data-cms-element-id="{{ element.id }}">
             {% block block_image_highlight_row_right_inner %}
                 {% sw_include "@Storefront/storefront/element/cms-element-" ~ element.type ~ ".html.twig" ignore missing %}
             {% endblock %}

--- a/src/Storefront/Resources/views/storefront/block/cms-block-image-simple-grid.html.twig
+++ b/src/Storefront/Resources/views/storefront/block/cms-block-image-simple-grid.html.twig
@@ -1,12 +1,12 @@
 {% block block_image_simple_grid %}
     {% set columns = 2 %}
-    {% set id = element.id %}
+
     {% block block_image_simple_grid_left %}
         <div class="col-md-6">
             {% block block_image_simple_grid_left_top %}
                 {% set element = block.slots.getSlot('left-top') %}
 
-                <div class="left-top" data-cms-element-id="{{ id }}">
+                <div class="left-top" data-cms-element-id="{{ element.id }}">
                     {% sw_include "@Storefront/storefront/element/cms-element-" ~ element.type ~ ".html.twig" ignore missing %}
                 </div>
             {% endblock %}
@@ -14,7 +14,7 @@
             {% block block_image_simple_grid_left_bottom %}
                 {% set element = block.slots.getSlot('left-bottom') %}
 
-                <div class="left-bottom" data-cms-element-id="{{ id }}">
+                <div class="left-bottom" data-cms-element-id="{{ element.id }}">
                     {% sw_include "@Storefront/storefront/element/cms-element-" ~ element.type ~ ".html.twig" ignore missing %}
                 </div>
             {% endblock %}
@@ -26,7 +26,7 @@
             {% block block_image_simple_grid_right_inner %}
                 {% set element = block.slots.getSlot('right') %}
 
-                <div class="right" data-cms-element-id="{{ id }}">
+                <div class="right" data-cms-element-id="{{ element.id }}">
                     {% sw_include "@Storefront/storefront/element/cms-element-" ~ element.type ~ ".html.twig" ignore missing %}
                 </div>
             {% endblock %}

--- a/src/Storefront/Resources/views/storefront/block/cms-block-image-text-bubble.html.twig
+++ b/src/Storefront/Resources/views/storefront/block/cms-block-image-text-bubble.html.twig
@@ -1,13 +1,12 @@
 {% block block_image_text_bubble %}
     {% set columns = 3 %}
-    {% set id = element.id %}
 
     {% block block_image_text_bubble_left %}
         <div class="col-md-4">
             {% block block_image_text_bubble_left_image %}
                 {% set element = block.slots.getSlot('left-image') %}
 
-                <div data-cms-element-id="{{ id }}">
+                <div data-cms-element-id="{{ element.id }}">
                     {% sw_include "@Storefront/storefront/element/cms-element-" ~ element.type ~ ".html.twig" ignore missing %}
                 </div>
             {% endblock %}
@@ -15,7 +14,7 @@
             {% block block_image_text_bubble_left_text %}
                 {% set element = block.slots.getSlot('left-text') %}
 
-                <div data-cms-element-id="{{ id }}">
+                <div data-cms-element-id="{{ element.id }}">
                     {% sw_include "@Storefront/storefront/element/cms-element-" ~ element.type ~ ".html.twig" ignore missing %}
                 </div>
             {% endblock %}
@@ -27,7 +26,7 @@
             {% block block_image_text_bubble_center_image %}
                 {% set element = block.slots.getSlot('center-image') %}
 
-                <div data-cms-element-id="{{ id }}">
+                <div data-cms-element-id="{{ element.id }}">
                     {% sw_include "@Storefront/storefront/element/cms-element-" ~ element.type ~ ".html.twig" ignore missing %}
                 </div>
             {% endblock %}
@@ -35,7 +34,7 @@
             {% block block_image_text_bubble_center_text %}
                 {% set element = block.slots.getSlot('center-text') %}
 
-                <div data-cms-element-id="{{ id }}">
+                <div data-cms-element-id="{{ element.id }}">
                     {% sw_include "@Storefront/storefront/element/cms-element-" ~ element.type ~ ".html.twig" ignore missing %}
                 </div>
             {% endblock %}
@@ -47,7 +46,7 @@
             {% block block_image_text_bubble_right_image %}
                 {% set element = block.slots.getSlot('right-image') %}
 
-                <div data-cms-element-id="{{ id }}">
+                <div data-cms-element-id="{{ element.id }}">
                     {% sw_include "@Storefront/storefront/element/cms-element-" ~ element.type ~ ".html.twig" ignore missing %}
                 </div>
             {% endblock %}
@@ -55,7 +54,7 @@
             {% block block_image_text_bubble_right_text %}
                 {% set element = block.slots.getSlot('right-text') %}
 
-                <div data-cms-element-id="{{ id }}">
+                <div data-cms-element-id="{{ element.id }}">
                     {% sw_include "@Storefront/storefront/element/cms-element-" ~ element.type ~ ".html.twig" ignore missing %}
                 </div>
             {% endblock %}

--- a/src/Storefront/Resources/views/storefront/block/cms-block-image-text-cover.html.twig
+++ b/src/Storefront/Resources/views/storefront/block/cms-block-image-text-cover.html.twig
@@ -1,11 +1,10 @@
 {% block block_image_text_cover %}
     {% set columns = 2 %}
-    {% set id = element.id %}
 
     {% block block_image_text_cover_left %}
         {% set element = block.slots.getSlot('left') %}
 
-        <div class="col-md-6" data-cms-element-id="{{ id }}">
+        <div class="col-md-6" data-cms-element-id="{{ element.id }}">
             {% block block_image_text_cover_left_inner %}
                 {% sw_include "@Storefront/storefront/element/cms-element-" ~ element.type ~ ".html.twig" ignore missing %}
             {% endblock %}
@@ -15,7 +14,7 @@
     {% block block_image_text_cover_right %}
         {% set element = block.slots.getSlot('right') %}
 
-        <div class="col-md-6" data-cms-element-id="{{ id }}">
+        <div class="col-md-6" data-cms-element-id="{{ element.id }}">
             {% block block_image_text_cover_right_inner %}
                 {% sw_include "@Storefront/storefront/element/cms-element-" ~ element.type ~ ".html.twig" ignore missing %}
             {% endblock %}

--- a/src/Storefront/Resources/views/storefront/block/cms-block-image-text-gallery.html.twig
+++ b/src/Storefront/Resources/views/storefront/block/cms-block-image-text-gallery.html.twig
@@ -1,6 +1,5 @@
 {% block block_image_text_gallery %}
     {% set columns = 3 %}
-    {% set id = element.id %}
 
     {% block block_image_text_gallery_left %}
         <div class="col-md-4">
@@ -8,7 +7,7 @@
                 {% block block_image_text_gallery_left_image %}
                     {% set element = block.slots.getSlot('left-image') %}
 
-                    <div data-cms-element-id="{{ id }}">
+                    <div data-cms-element-id="{{ element.id }}">
                         {% sw_include "@Storefront/storefront/element/cms-element-" ~ element.type ~ ".html.twig" ignore missing %}
                     </div>
                 {% endblock %}
@@ -16,7 +15,7 @@
                 {% block block_image_text_gallery_left_text %}
                     {% set element = block.slots.getSlot('left-text') %}
 
-                    <div data-cms-element-id="{{ id }}">
+                    <div data-cms-element-id="{{ element.id }}">
                         {% sw_include "@Storefront/storefront/element/cms-element-" ~ element.type ~ ".html.twig" ignore missing %}
                     </div>
                 {% endblock %}
@@ -30,7 +29,7 @@
                 {% block block_image_text_gallery_center_image %}
                     {% set element = block.slots.getSlot('center-image') %}
 
-                    <div data-cms-element-id="{{ id }}">
+                    <div data-cms-element-id="{{ element.id }}">
                         {% sw_include "@Storefront/storefront/element/cms-element-" ~ element.type ~ ".html.twig" ignore missing %}
                     </div>
                 {% endblock %}
@@ -38,7 +37,7 @@
                 {% block block_image_text_gallery_center_text %}
                     {% set element = block.slots.getSlot('center-text') %}
 
-                    <div data-cms-element-id="{{ id }}">
+                    <div data-cms-element-id="{{ element.id }}">
                         {% sw_include "@Storefront/storefront/element/cms-element-" ~ element.type ~ ".html.twig" ignore missing %}
                     </div>
                 {% endblock %}
@@ -52,7 +51,7 @@
                 {% block block_image_text_gallery_right_image %}
                     {% set element = block.slots.getSlot('right-image') %}
 
-                    <div data-cms-element-id="{{ id }}">
+                    <div data-cms-element-id="{{ element.id }}">
                         {% sw_include "@Storefront/storefront/element/cms-element-" ~ element.type ~ ".html.twig" ignore missing %}
                     </div>
                 {% endblock %}
@@ -60,7 +59,7 @@
                 {% block block_image_text_gallery_right_text %}
                     {% set element = block.slots.getSlot('right-text') %}
 
-                    <div data-cms-element-id="{{ id }}">
+                    <div data-cms-element-id="{{ element.id }}">
                         {% sw_include "@Storefront/storefront/element/cms-element-" ~ element.type ~ ".html.twig" ignore missing %}
                     </div>
                 {% endblock %}

--- a/src/Storefront/Resources/views/storefront/block/cms-block-image-text-row.html.twig
+++ b/src/Storefront/Resources/views/storefront/block/cms-block-image-text-row.html.twig
@@ -1,13 +1,12 @@
 {% block block_image_text_row %}
     {% set columns = 3 %}
-    {% set id = element.id %}
 
     {% block block_image_text_row_left %}
         <div class="col-md-4">
             {% block block_image_text_row_left_image %}
                 {% set element = block.slots.getSlot('left-image') %}
 
-                <div data-cms-element-id="{{ id }}">
+                <div data-cms-element-id="{{ element.id }}">
                     {% sw_include "@Storefront/storefront/element/cms-element-" ~ element.type ~ ".html.twig" ignore missing %}
                 </div>
             {% endblock %}
@@ -15,7 +14,7 @@
             {% block block_image_text_row_left_text %}
                 {% set element = block.slots.getSlot('left-text') %}
 
-                <div data-cms-element-id="{{ id }}">
+                <div data-cms-element-id="{{ element.id }}">
                     {% sw_include "@Storefront/storefront/element/cms-element-" ~ element.type ~ ".html.twig" ignore missing %}
                 </div>
             {% endblock %}
@@ -27,7 +26,7 @@
             {% block block_image_text_row_center_image %}
                 {% set element = block.slots.getSlot('center-image') %}
 
-                <div data-cms-element-id="{{ id }}">
+                <div data-cms-element-id="{{ element.id }}">
                     {% sw_include "@Storefront/storefront/element/cms-element-" ~ element.type ~ ".html.twig" ignore missing %}
                 </div>
             {% endblock %}
@@ -35,7 +34,7 @@
             {% block block_image_text_row_center_text %}
                 {% set element = block.slots.getSlot('center-text') %}
 
-                <div data-cms-element-id="{{ id }}">
+                <div data-cms-element-id="{{ element.id }}">
                     {% sw_include "@Storefront/storefront/element/cms-element-" ~ element.type ~ ".html.twig" ignore missing %}
                 </div>
             {% endblock %}
@@ -47,7 +46,7 @@
             {% block block_image_text_row_right_image %}
                 {% set element = block.slots.getSlot('right-image') %}
 
-                <div data-cms-element-id="{{ id }}">
+                <div data-cms-element-id="{{ element.id }}">
                     {% sw_include "@Storefront/storefront/element/cms-element-" ~ element.type ~ ".html.twig" ignore missing %}
                 </div>
             {% endblock %}
@@ -55,7 +54,7 @@
             {% block block_image_text_row_right_text %}
                 {% set element = block.slots.getSlot('right-text') %}
 
-                <div data-cms-element-id="{{ id }}">
+                <div data-cms-element-id="{{ element.id }}">
                     {% sw_include "@Storefront/storefront/element/cms-element-" ~ element.type ~ ".html.twig" ignore missing %}
                 </div>
             {% endblock %}

--- a/src/Storefront/Resources/views/storefront/block/cms-block-image-text.html.twig
+++ b/src/Storefront/Resources/views/storefront/block/cms-block-image-text.html.twig
@@ -1,11 +1,10 @@
 {% block block_image_text %}
     {% set columns = 2 %}
-    {% set id = element.id %}
 
     {% block block_image_text_left %}
         {% set element = block.slots.getSlot('left') %}
 
-        <div class="col-md-6" data-cms-element-id="{{ id }}">
+        <div class="col-md-6" data-cms-element-id="{{ element.id }}">
             {% block block_image_text_left_inner %}
                 {% sw_include "@Storefront/storefront/element/cms-element-" ~ element.type ~ ".html.twig" ignore missing %}
             {% endblock %}
@@ -15,7 +14,7 @@
     {% block block_image_text_right %}
         {% set element = block.slots.getSlot('right') %}
 
-        <div class="col-md-6" data-cms-element-id="{{ id }}">
+        <div class="col-md-6" data-cms-element-id="{{ element.id }}">
             {% block block_image_text_right_inner %}
                 {% sw_include "@Storefront/storefront/element/cms-element-" ~ element.type ~ ".html.twig" ignore missing %}
             {% endblock %}

--- a/src/Storefront/Resources/views/storefront/block/cms-block-image-three-column.html.twig
+++ b/src/Storefront/Resources/views/storefront/block/cms-block-image-three-column.html.twig
@@ -1,11 +1,10 @@
 {% block block_image_three_column %}
     {% set columns = 3 %}
-    {% set id = element.id %}
 
     {% block block_image_three_column_left %}
         {% set element = block.slots.getSlot('left') %}
 
-        <div class="col-md-4" data-cms-element-id="{{ id }}">
+        <div class="col-md-4" data-cms-element-id="{{ element.id }}">
             {% block block_image_three_column_left_inner %}
                 {% sw_include "@Storefront/storefront/element/cms-element-" ~ element.type ~ ".html.twig" ignore missing %}
             {% endblock %}
@@ -15,7 +14,7 @@
     {% block block_image_three_column_center %}
         {% set element = block.slots.getSlot('center') %}
 
-        <div class="col-md-4" data-cms-element-id="{{ id }}">
+        <div class="col-md-4" data-cms-element-id="{{ element.id }}">
             {% block block_image_three_column_center_inner %}
                 {% sw_include "@Storefront/storefront/element/cms-element-" ~ element.type ~ ".html.twig" ignore missing %}
             {% endblock %}
@@ -25,7 +24,7 @@
     {% block block_image_three_column_right %}
         {% set element = block.slots.getSlot('right') %}
 
-        <div class="col-md-4" data-cms-element-id="{{ id }}">
+        <div class="col-md-4" data-cms-element-id="{{ element.id }}">
             {% block block_image_three_column_right_inner %}
                 {% sw_include "@Storefront/storefront/element/cms-element-" ~ element.type ~ ".html.twig" ignore missing %}
             {% endblock %}

--- a/src/Storefront/Resources/views/storefront/block/cms-block-image-three-cover.html.twig
+++ b/src/Storefront/Resources/views/storefront/block/cms-block-image-three-cover.html.twig
@@ -1,10 +1,10 @@
 {% block block_image_three_cover %}
     {% set columns = 3 %}
-    {% set id = element.id %}
+
     {% block block_image_three_cover_left %}
         {% set element = block.slots.getSlot('left') %}
 
-        <div class="col-md-4" data-cms-element-id="{{ id }}">
+        <div class="col-md-4" data-cms-element-id="{{ element.id }}">
             {% block block_image_three_cover_left_inner %}
                 {% sw_include "@Storefront/storefront/element/cms-element-" ~ element.type ~ ".html.twig" ignore missing %}
             {% endblock %}
@@ -14,7 +14,7 @@
     {% block block_image_three_cover_center %}
         {% set element = block.slots.getSlot('center') %}
 
-        <div class="col-md-4" data-cms-element-id="{{ id }}">
+        <div class="col-md-4" data-cms-element-id="{{ element.id }}">
             {% block block_image_three_cover_center_inner %}
                 {% sw_include "@Storefront/storefront/element/cms-element-" ~ element.type ~ ".html.twig" ignore missing %}
             {% endblock %}
@@ -24,7 +24,7 @@
     {% block block_image_three_cover_right %}
         {% set element = block.slots.getSlot('right') %}
 
-        <div class="col-md-4" data-cms-element-id="{{ id }}">
+        <div class="col-md-4" data-cms-element-id="{{ element.id }}">
             {% block block_image_three_cover_right_inner %}
                 {% sw_include "@Storefront/storefront/element/cms-element-" ~ element.type ~ ".html.twig" ignore missing %}
             {% endblock %}

--- a/src/Storefront/Resources/views/storefront/block/cms-block-image-two-column.html.twig
+++ b/src/Storefront/Resources/views/storefront/block/cms-block-image-two-column.html.twig
@@ -1,10 +1,10 @@
 {% block block_image_two_column %}
     {% set columns = 2 %}
-    {% set id = element.id %}
+
     {% block block_image_two_column_left %}
         {% set element = block.slots.getSlot('left') %}
 
-        <div class="col-md-6" data-cms-element-id="{{ id }}">
+        <div class="col-md-6" data-cms-element-id="{{ element.id }}">
             {% block block_image_two_column_left_inner %}
                 {% sw_include "@Storefront/storefront/element/cms-element-" ~ element.type ~ ".html.twig" ignore missing %}
             {% endblock %}
@@ -14,7 +14,7 @@
     {% block block_image_two_column_right %}
         {% set element = block.slots.getSlot('right') %}
 
-        <div class="col-md-6" data-cms-element-id="{{ id }}">
+        <div class="col-md-6" data-cms-element-id="{{ element.id }}">
             {% block block_image_two_column_right_inner %}
                 {% sw_include "@Storefront/storefront/element/cms-element-" ~ element.type ~ ".html.twig" ignore missing %}
             {% endblock %}

--- a/src/Storefront/Resources/views/storefront/block/cms-block-product-three-column.html.twig
+++ b/src/Storefront/Resources/views/storefront/block/cms-block-product-three-column.html.twig
@@ -1,10 +1,10 @@
 {% block block_product_three_column %}
     {% set columns = 3 %}
-    {% set id = element.id %}
+
     {% block block_product_three_column_left %}
         {% set element = block.slots.getSlot('left') %}
 
-        <div class="col-md-4 card-col" data-cms-element-id="{{ id }}">
+        <div class="col-md-4 card-col" data-cms-element-id="{{ element.id }}">
             {% block block_product_three_column_left_inner %}
                 {% sw_include "@Storefront/storefront/element/cms-element-" ~ element.type ~ ".html.twig" ignore missing %}
             {% endblock %}
@@ -14,7 +14,7 @@
     {% block block_product_three_column_center %}
         {% set element = block.slots.getSlot('center') %}
 
-        <div class="col-md-4 card-col" data-cms-element-id="{{ id }}">
+        <div class="col-md-4 card-col" data-cms-element-id="{{ element.id }}">
             {% block block_product_three_column_center_inner %}
                 {% sw_include "@Storefront/storefront/element/cms-element-" ~ element.type ~ ".html.twig" ignore missing %}
             {% endblock %}
@@ -24,7 +24,7 @@
     {% block block_product_three_column_right %}
         {% set element = block.slots.getSlot('right') %}
 
-        <div class="col-md-4 card-col" data-cms-element-id="{{ id }}">
+        <div class="col-md-4 card-col" data-cms-element-id="{{ element.id }}">
             {% block block_product_three_column_right_inner %}
                 {% sw_include "@Storefront/storefront/element/cms-element-" ~ element.type ~ ".html.twig" ignore missing %}
             {% endblock %}

--- a/src/Storefront/Resources/views/storefront/block/cms-block-text-teaser-section.html.twig
+++ b/src/Storefront/Resources/views/storefront/block/cms-block-text-teaser-section.html.twig
@@ -1,10 +1,10 @@
 {% block block_text_teaser_section %}
     {% set columns = 2 %}
-    {% set id = element.id %}
+
     {% block block_text_teaser_section_left %}
         {% set element = block.slots.getSlot('left') %}
 
-        <div class="col-md-4" data-cms-element-id="{{ id }}">
+        <div class="col-md-4" data-cms-element-id="{{ element.id }}">
             {% block block_text_teaser_section_left_inner %}
                 {% sw_include "@Storefront/storefront/element/cms-element-" ~ element.type ~ ".html.twig" ignore missing %}
             {% endblock %}
@@ -14,7 +14,7 @@
     {% block block_text_teaser_section_right %}
         {% set element = block.slots.getSlot('right') %}
 
-        <div class="col-md-8" data-cms-element-id="{{ id }}">
+        <div class="col-md-8" data-cms-element-id="{{ element.id }}">
             {% block block_text_teaser_section_right_inner %}
                 {% sw_include "@Storefront/storefront/element/cms-element-" ~ element.type ~ ".html.twig" ignore missing %}
             {% endblock %}

--- a/src/Storefront/Resources/views/storefront/block/cms-block-text-three-column.html.twig
+++ b/src/Storefront/Resources/views/storefront/block/cms-block-text-three-column.html.twig
@@ -1,10 +1,10 @@
 {% block block_text_three_column %}
     {% set columns = 3 %}
-    {% set id = element.id %}
+
     {% block block_text_three_column_left %}
         {% set element = block.slots.getSlot('left') %}
 
-        <div class="col-md-4" data-cms-element-id="{{ id }}">
+        <div class="col-md-4" data-cms-element-id="{{ element.id }}">
             {% block block_text_three_column_left_inner %}
                 {% sw_include "@Storefront/storefront/element/cms-element-" ~ element.type ~ ".html.twig" ignore missing %}
             {% endblock %}
@@ -14,7 +14,7 @@
     {% block block_text_three_column_center %}
         {% set element = block.slots.getSlot('center') %}
 
-        <div class="col-md-4" data-cms-element-id="{{ id }}">
+        <div class="col-md-4" data-cms-element-id="{{ element.id }}">
             {% block block_text_three_column_center_inner %}
                 {% sw_include "@Storefront/storefront/element/cms-element-" ~ element.type ~ ".html.twig" ignore missing %}
             {% endblock %}
@@ -24,7 +24,7 @@
     {% block block_text_three_column_right %}
         {% set element = block.slots.getSlot('right') %}
 
-        <div class="col-md-4" data-cms-element-id="{{ id }}">
+        <div class="col-md-4" data-cms-element-id="{{ element.id }}">
             {% block block_text_three_column_right_inner %}
                 {% sw_include "@Storefront/storefront/element/cms-element-" ~ element.type ~ ".html.twig" ignore missing %}
             {% endblock %}

--- a/src/Storefront/Resources/views/storefront/block/cms-block-text-two-column.html.twig
+++ b/src/Storefront/Resources/views/storefront/block/cms-block-text-two-column.html.twig
@@ -1,10 +1,10 @@
 {% block block_text_two_column %}
     {% set columns = 2 %}
-    {% set id = element.id %}
+
     {% block block_text_two_column_left %}
         {% set element = block.slots.getSlot('left') %}
 
-        <div class="col-md-6" data-cms-element-id="{{ id }}">
+        <div class="col-md-6" data-cms-element-id="{{ element.id }}">
             {% block block_text_two_column_left_inner %}
                 {% sw_include "@Storefront/storefront/element/cms-element-" ~ element.type ~ ".html.twig" ignore missing %}
             {% endblock %}
@@ -14,7 +14,7 @@
     {% block block_text_two_column_right %}
         {% set element = block.slots.getSlot('right') %}
 
-        <div class="col-md-6" data-cms-element-id="{{ id }}">
+        <div class="col-md-6" data-cms-element-id="{{ element.id }}">
             {% block block_text_two_column_right_inner %}
                 {% sw_include "@Storefront/storefront/element/cms-element-" ~ element.type ~ ".html.twig" ignore missing %}
             {% endblock %}


### PR DESCRIPTION
### 1. Why is this change necessary?
Cause https://github.com/shopware/platform/commit/62e9c8aa37171574687b45ed6b505cc0b4418635 destroyed all cms element ids.

### 2. What does this change do, exactly?
This PR corrects all ids in the cms-blocks. 

### 3. Describe each step to reproduce the issue or behaviour.
Make shopping experience with specific element and see no set `data-cms-element-id`

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/NEXT-11569

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
