### PR TITLE
Added migration to fix swedish currency typo

### DIFF
--- a/src/Core/Migration/Migration1603293043FixCurrencyTypo.php
+++ b/src/Core/Migration/Migration1603293043FixCurrencyTypo.php
@@ -1,0 +1,48 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Migration;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Framework\Migration\MigrationStep;
+
+class Migration1603293043FixCurrencyTypo extends MigrationStep
+{
+    public function getCreationTimestamp(): int
+    {
+        return 1603293043;
+    }
+
+    public function update(Connection $connection): void
+    {
+    }
+
+    public function updateDestructive(Connection $connection): void
+    {
+        $this->updateCurrency($connection);
+    }
+
+    private function updateCurrency(Connection $connection): void
+    {
+        $englishLanguageId = $connection->createQueryBuilder()
+            ->select('lang.id')
+            ->from('language', 'lang')
+            ->innerJoin('lang', 'locale', 'loc', 'lang.translation_code_id = loc.id')
+            ->where('loc.code = :englishLocale')
+            ->setParameter(':englishLocale', 'en-GB')
+            ->execute()
+            ->fetchColumn();
+
+        if (!$englishLanguageId) {
+            return;
+        }
+
+        $connection->update(
+            'currency_translation',
+            ['name' => 'Swedish krona'],
+            [
+                'name' => 'Swedish krone',
+                'language_id' => $englishLanguageId,
+            ]
+        );
+    }
+}

--- a/src/Core/Migration/Test/Migration1603293043FixCurrencyTypoTest.php
+++ b/src/Core/Migration/Test/Migration1603293043FixCurrencyTypoTest.php
@@ -1,0 +1,58 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Migration\Test;
+
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
+use Shopware\Core\Migration\Migration1603293043FixCurrencyTypo;
+
+class Migration1603293043FixCurrencyTypoTest extends TestCase
+{
+    use KernelTestBehaviour;
+
+    public function testCurrencyName(): void
+    {
+        $connection = $this->getContainer()->get(Connection::class);
+
+        $englishLanguageId = $connection->createQueryBuilder()
+            ->select('lang.id')
+            ->from('language', 'lang')
+            ->innerJoin('lang', 'locale', 'loc', 'lang.translation_code_id = loc.id')
+            ->where('loc.code = :englishLocale')
+            ->setParameter(':englishLocale', 'en-GB')
+            ->execute()
+            ->fetchColumn();
+
+        if (!$englishLanguageId) {
+            static::expectNotToPerformAssertions();
+
+            return;
+        }
+
+        $kronaQuery = $connection->createQueryBuilder()
+            ->select('ct.name')
+            ->from('currency_translation', 'ct')
+            ->where('ct.name = :kronaEnglish')
+            ->andWhere('ct.language_id = :englishLanguageId')
+            ->setParameter('englishLanguageId', $englishLanguageId)
+            ->setParameter('kronaEnglish', 'Swedish Krone');
+
+        $kronaWithTypo = $kronaQuery->execute()->fetchColumn();
+
+        if (!$kronaWithTypo) {
+            static::expectNotToPerformAssertions();
+
+            return;
+        }
+
+        $migration = new Migration1603293043FixCurrencyTypo();
+        $migration->updateDestructive($connection);
+
+        $kronaQuery->setParameter('kronaEnglish', 'Swedish Krona');
+
+        $krona = $kronaQuery->execute()->fetchColumn();
+
+        static::assertSame('Swedish krona', $krona);
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?
Fixes typo in Swedish currency ('Swedish krone' to 'Swedish krona')

### 2. What does this change do, exactly?
Adding a migration to overwrite the English translation of the Swedish currency

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
https://github.com/shopware/platform/issues/1387

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
