### PR TITLE
Remove promotion code generator endless loop

### DIFF
--- a/changelog/_unreleased/2020-10-23-remove-endless-loop-in-promotion-code-generator.md
+++ b/changelog/_unreleased/2020-10-23-remove-endless-loop-in-promotion-code-generator.md
@@ -1,0 +1,8 @@
+---
+title: Remove endless loop in promotion code generator
+author: Joshua Behrens
+author_email: code@joshua-behrens.de
+author_github: @JoshuaBehrens
+---
+# Administration
+* Added check in loop in `individual-code-generator.service.js` to prevent further iterations when no further codes are possible by pattern definition

--- a/src/Administration/Resources/app/administration/src/module/sw-promotion/service/individual-code-generator.service.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-promotion/service/individual-code-generator.service.js
@@ -160,7 +160,7 @@ export default class IndividualCodeGenerator extends EventEmitter {
                     // calculate our DIFF value how many codes have been generated
                     countGenerated += databaseCount - existingCodes.length;
 
-                    if (countGenerated >= desiredCount) {
+                    if (countGenerated >= maxGenerationCount) {
                         // we're done with generation :)
                         onCompleted(countGenerated);
                         return;
@@ -173,7 +173,7 @@ export default class IndividualCodeGenerator extends EventEmitter {
                     }
 
                     // we're not yet done, and give it another shot with a new run
-                    const leftToGenerate = desiredCount - countGenerated;
+                    const leftToGenerate = maxGenerationCount - countGenerated;
                     this.startMainProcess(pattern, leftToGenerate, runCount, countGenerated, onCompleted);
                 });
             });
@@ -287,10 +287,11 @@ export default class IndividualCodeGenerator extends EventEmitter {
  * @param {Number} promotionId - The promotion Id of the new code
  */
 function createCodes(pattern, count, existingCodes, promotionId) {
+    const permutationCount = CodeGenerator.getPermutationCount(pattern);
     const plainNewCodesList = [];
     const allNewCodes = [];
 
-    for (let i = 1; i <= count; i += 1) {
+    for (let i = 1; i <= count; i = plainNewCodesList.length) {
         // generate a new random code
         const randomCode = CodeGenerator.generateCode(pattern);
 
@@ -303,12 +304,10 @@ function createCodes(pattern, count, existingCodes, promotionId) {
             allNewCodes.push(codeObject);
 
             plainNewCodesList.push(randomCode);
+        }
 
-            if (plainNewCodesList.length >= count) {
-                break;
-            }
-        } else {
-            i -= 1;
+        if (permutationCount <= (allNewCodes.length + existingCodes.length)) {
+            break;
         }
     }
 


### PR DESCRIPTION
### 1. Why is this change necessary?
You can get the promotion code generator into an endless loop. There are two "loops" which try to do similar: create codes whereas one is trying to generate codes as often in an asynchrounous manner as possible and the other generates a fixed amount of codes. The asynchronous outer loop tries to break an endless loop but the inner fixed-amount-code loop doesn't detect an endless loop by pattern definition.

### 2. What does this change do, exactly?
I made the loop criteria more obvious by removing a `c-=1` from a `for (i=0;i<length;i+=1)` body. The inner loop now checks for an endless loop by pattern definition as well.
I also swapped a variable that is reduced to the perlmutation count so the outer loop does not even try to request more codes from the inner loop when impossible which already seems to have been tried to avoid. So the retry loop check does not need to trigger.

### 3. Describe each step to reproduce the issue or behaviour.
1. Open promotion code generator in administration
2. Enter pattern `%d`
3. Request 100 codes
4. Wait for the frozen browser window to defrost by the CPU fan

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
