### PR TITLE
Simplify composer dependency autoloading for plugin developers

### DIFF
--- a/changelog/_unreleased/2020-10-23-simplify-plugin-composer-dependency-autoloading.md
+++ b/changelog/_unreleased/2020-10-23-simplify-plugin-composer-dependency-autoloading.md
@@ -1,0 +1,8 @@
+---
+title: Simplify plugin composer dependency autoloading
+author: Joshua Behrens
+author_email: code@joshua-behrens.de
+author_github: @JoshuaBehrens
+---
+# Core
+* Added plugin entrypoint `loadAdditionalClassLoaders` and support method `appendClassLoaderFile` for loading additionally required PHP files composer class loaders.

--- a/src/Core/Framework/Bundle.php
+++ b/src/Core/Framework/Bundle.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Core\Framework;
 
+use Composer\Autoload\ClassLoader;
 use Shopware\Core\Framework\Adapter\Asset\AssetPackageService;
 use Shopware\Core\Framework\Adapter\Filesystem\PrefixFilesystem;
 use Shopware\Core\Framework\Event\BusinessEventRegistry;
@@ -27,7 +28,7 @@ abstract class Bundle extends SymfonyBundle
     public function build(ContainerBuilder $container): void
     {
         parent::build($container);
-
+        $this->loadAdditionalClassLoaders();
         $this->registerContainerFile($container);
         $this->registerMigrationPath($container);
         $this->registerFilesystem($container, 'private');
@@ -97,6 +98,22 @@ abstract class Bundle extends SymfonyBundle
 
         if ($fileSystem->exists($confDir)) {
             $routes->import($confDir . '/{routes_overwrite}' . Kernel::CONFIG_EXTS, '/', 'glob');
+        }
+    }
+
+    public function loadAdditionalClassLoaders(): void
+    {
+    }
+
+    protected function appendClassLoaderFile(string $file): void
+    {
+        if (is_file($file)) {
+            $classLoader = require_once $file;
+
+            if ($classLoader instanceof ClassLoader) {
+                $classLoader->unregister();
+                $classLoader->register(false);
+            }
         }
     }
 

--- a/src/Docs/Resources/current/50-how-to/770-load-composer-packages.md
+++ b/src/Docs/Resources/current/50-how-to/770-load-composer-packages.md
@@ -1,0 +1,32 @@
+[titleEn]: <>(Use composer packages within a plugin)
+[metaDescriptionEn]: <>(This HowTo will show how you load composer packages for your plugin)
+[hash]: <>(article:how_to_use_composer_packages_in_a_plugin)
+
+## Overview
+
+This guide will show you how to load custom composer packages. A common issue is to find the right entry point for loading additional composer dependencies. There are multiple pitfalls that you should avoid:
+* You should not require the `autoload.php` in the top of your plugin file as this will load them before your plugin is activated and can break a whole system without your plugin being active.
+* When you use classes from the external dependencies within your service definition you have to load them before the container is built.
+* When you require an `autoload.php` the provided `ClassLoader` will prepend onto the class loader stack. This overrides class implementations with your shipped classes which might not match in the exact version and breaks the system.
+* The `autoload.php` might exist in a ZIP file installation of your plugin but not when it is installed via composer in a composer project. So you have to detect different installation types.
+
+## Load custom autoload file
+
+Shopware is aware of this difficult task and solves it for you. You just have to implement the `loadAdditionalClassLoaders` method within your plugin. This will always be the right timing. Sometimes it is wanted to prepend the new `ClassLoader` onto the stack but it is more common task to append the `ClassLoader`. There is also a helping method for you to use that prevents every mentioned pitfall:
+
+```php
+<?php
+
+namespace FooBar;
+
+use Shopware\Core\Framework\Plugin;
+
+class FooBar extends Plugin
+{
+    public function loadAdditionalClassLoaders(): void
+    {
+        parent::loadAdditionalClassLoaders();
+        $this->appendClassLoaderFile(__DIR__ . '/vendor/autoload.php');
+    }
+}
+```


### PR DESCRIPTION
### 1. Why is this change necessary?
This is a common task that plugin developers face and it'll be nice when shopware simplifies the pitfalls mentioned in the added docs.

### 2. What does this change do, exactly?
Add an entrypoint for plugins to register autoloaders and a supporting method to do it correctly.

### 3. Describe each step to reproduce the issue or behaviour.
1. Provide a plugin via packagist with additional dependencies
2. Provide the same plugin via ZIP file installation
3. Support both installation types

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
