### PR TITLE
NEXT-11588 Add title to account header widget

### DIFF
--- a/changelog/_unreleased/2020-10-23-add-title-to-account-header-widget.md
+++ b/changelog/_unreleased/2020-10-23-add-title-to-account-header-widget.md
@@ -1,0 +1,9 @@
+---
+title: Add title to account header widget
+issue: NEXT-11588
+author: Sebastian König
+author_email: s.koenig@tinect.de
+author_github: @tinect
+---
+# Storefront
+*  Changed button of block `layout_header_actions_account_widget_dropdown_button` in `layout/header/actions/account-widget.html.twig` to have a title

--- a/src/Storefront/Resources/views/storefront/layout/header/actions/account-widget.html.twig
+++ b/src/Storefront/Resources/views/storefront/layout/header/actions/account-widget.html.twig
@@ -8,7 +8,8 @@
                     data-toggle="dropdown"
                     aria-haspopup="true"
                     aria-expanded="false"
-                    aria-label="{{ "account.myAccount"|trans|striptags }}">
+                    aria-label="{{ "account.myAccount"|trans|striptags }}"
+                    title="{{ "account.myAccount"|trans|striptags }}">
                 {% sw_icon 'avatar' %}
             </button>
         {% endblock %}


### PR DESCRIPTION
### 1. Why is this change necessary?
For UX-reasons: The header-widget of account should have a title.

### 2. What does this change do, exactly?
*  Changed button of block `layout_header_actions_account_widget_dropdown_button` in `layout/header/actions/account-widget.html.twig` to have a title

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/NEXT-11588

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
