### PR TITLE
Fix table layout in Startup guide documentation

### DIFF
--- a/src/Docs/Resources/current/10-system-guide/40-startup-guide/__categoryInfo.md
+++ b/src/Docs/Resources/current/10-system-guide/40-startup-guide/__categoryInfo.md
@@ -85,7 +85,7 @@ the [directory structure](./../../60-references-internals/70-other/10-directory-
 | :---- | :---- | :----
 | Backend | The symfony stack of the core application | `platform/src/Core`
 | Storefront  | The symfony stack of the storefront | `platform/src/Storefront`
-| Storefront template | The template for the storefront| | `platform/src/Storefront/Resources`
+| Storefront template | The template for the storefront| `platform/src/Storefront/Resources`
 | Administration | The symfony stack of the administration | `platform/src/Administration/`
 | Administration application | The Vue.js administration | `platform/src/Administration/Resources/app/administration`
 


### PR DESCRIPTION
### 1. Why is this change necessary?

The table under "The sources" on https://docs.shopware.com/en/shopware-platform-dev-en/system-guide/startup-guide is broken:
![image](https://user-images.githubusercontent.com/1217881/97081060-3500fb80-1600-11eb-94f0-32970bf65bea.png)

### 2. What does this change do, exactly?

The changes contained in this pull request will fix the table layout:
![image](https://user-images.githubusercontent.com/1217881/97081076-595cd800-1600-11eb-9d33-6e913d24e331.png)

### 3. Describe each step to reproduce the issue or behaviour.

1. Go to https://docs.shopware.com/en/shopware-platform-dev-en/system-guide/startup-guide
2. Scroll down to the table, shown below the headline "The sources"

### 4. Please link to the relevant issues (if any).

:heavy_minus_sign: 

### 5. Checklist

- [X] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [X] I have written or adjusted the documentation according to my changes
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.
