### PR TITLE
NEXT-11258, fix sorted properties of same group

### DIFF
--- a/changelog/_unreleased/2020-10-25-fix-sordeted-properties.md
+++ b/changelog/_unreleased/2020-10-25-fix-sordeted-properties.md
@@ -1,0 +1,8 @@
+---
+title: Fix sorted properties of same group
+issue: NEXT-11258
+author: Björn Herzke
+author_github:  @wrongspot
+___
+# CORE
+* Changed `Shopware\Core\Content\Product\Subscriber\ProductSubscriber::sortProperties` fix sorted properties of same group

--- a/src/Core/Content/Product/Subscriber/ProductSubscriber.php
+++ b/src/Core/Content/Product/Subscriber/ProductSubscriber.php
@@ -49,7 +49,6 @@ class ProductSubscriber implements EventSubscriberInterface
         $sorted = [];
         foreach ($properties as $option) {
             $origin = $option->getGroup();
-
             if (!$origin) {
                 continue;
             }
@@ -59,9 +58,17 @@ class ProductSubscriber implements EventSubscriberInterface
                 $group->setOptions(new PropertyGroupOptionCollection());
             }
 
-            $group->getOptions()->add($option);
+            $groupId = $group->getId();
+            if (array_key_exists($groupId, $sorted)) {
+                $group = $sorted[$groupId];
+                $group->getOptions()->add($option);
+                $sorted[$groupId] = $group;
 
-            $sorted[$group->getId()] = $group;
+                continue;
+            }
+
+            $group->getOptions()->add($option);
+            $sorted[$groupId] = $group;
         }
 
         $collection = new PropertyGroupCollection($sorted);


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
If a product have more than one properties of same group assigned, only one was shown.

### 2. What does this change do, exactly?
![Bildschirmfoto 2020-10-25 um 21 37 00](https://user-images.githubusercontent.com/907458/97118723-fe180c00-170b-11eb-8b18-f6f52df597d6.png)

### 3. Describe each step to reproduce the issue or behaviour.
- Create a product property with more than one values
- Assign more than one values of same group to a product 
- On Storefront only one value is visible 

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/NEXT-11258

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

