### PR TITLE
Add Elasticsearchmapping for listPrice

### DIFF
--- a/changelog/_unreleased/2020-10-26-add-listprice-to-elasticsearch-mapping.md
+++ b/changelog/_unreleased/2020-10-26-add-listprice-to-elasticsearch-mapping.md
@@ -1,0 +1,8 @@
+---
+title: Add `listPrice` to Elasticsearch mapping
+author: Hendrik Söbbintg
+author_email: hendrik@soebbing.de
+author_github: @soebbing
+---
+# Elasticsearch
+* Added mapping for `listPrice` in `ListingPriceField`

--- a/src/Elasticsearch/Framework/Indexing/EntityMapper.php
+++ b/src/Elasticsearch/Framework/Indexing/EntityMapper.php
@@ -116,6 +116,7 @@ class EntityMapper
                         'ruleId' => self::KEYWORD_FIELD,
                         'from' => self::PRICE_FIELD,
                         'to' => self::PRICE_FIELD,
+                        'listPrice' => self::PRICE_FIELD,
                         'createdAt' => self::DATE_FIELD,
                         'updatedAt' => self::DATE_FIELD,
                     ],


### PR DESCRIPTION
### 1. Why is this change necessary?

Elasticsearch indexing fails occasionally with the error `app.ERROR: mapper [listingPrices.from.listPrice.gross] cannot be changed from type [float] to [long]`.

This happens because the mapping of Listingprices contains definitions for `to` and `from`, but not for the `listPrice` element. So this get's mapped dynamically, failing sometimes.

### 2. What does this change do, exactly?

This change adds the same mapping for `listPrice`s as for `to` and `from` prices.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
