### PR TITLE
add ellipsis to product box

### DIFF
--- a/src/Storefront/Resources/app/storefront/src/scss/component/_product-box.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/component/_product-box.scss
@@ -107,6 +107,10 @@ $box-image-height-img: 332px;
     font-size: 14px;
     line-height: 18px;
     overflow: hidden;
+    text-overflow: ellipsis;
+    display: -webkit-box;
+    -webkit-line-clamp: 3;
+    -webkit-box-orient: vertical;
 }
 
 .product-price-info {


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
The product description in the listing is abruptly cut off after 3 lines. In the frontend, this looks like an error to the visitor.

### 2. What does this change do, exactly?
If text is cut off, ellipsis are set with the help of CSS.

### 3. Describe each step to reproduce the issue or behaviour.
Create a product with a description that contains so many characters that it extends beyond 3 lines in the frontend.

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/NEXT-11628

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
