### PR TITLE
NEXT-8058: Added config to make phone number input optional for conta…

### DIFF
--- a/changelog/_unreleased/2020-10-26-adds-config-to-make-phone-input-optional-for-contact-form.md
+++ b/changelog/_unreleased/2020-10-26-adds-config-to-make-phone-input-optional-for-contact-form.md
@@ -1,0 +1,16 @@
+---
+title: Added config to make first name, last name and phone number input optional for contact form
+issue: NEXT-8058
+author: Claudio Bianco
+author_email: info@claudio-bianco.de 
+author_github: @claudiobianco
+---
+# Core
+* Added `BuildValidationEvent` in `ContactFormValidationFactory` in order to change the validation definition via subscriber.
+* Added `Shopware\Core\Migration\Migration1604499476AddDefaultSettingConfigValueForContactForm` to preserve the default behaviour that first name, last name and phone number are required. 
+___
+# Administration
+* Added configuration for optional first name, last name and phone number in "Basic information -> Security and Privacy".
+___
+# Storefront
+* Added check if first name, last name and and phone number input are required or optional in contact form.

--- a/src/Core/Content/ContactForm/Validation/ContactFormValidationFactory.php
+++ b/src/Core/Content/ContactForm/Validation/ContactFormValidationFactory.php
@@ -2,41 +2,76 @@
 
 namespace Shopware\Core\Content\ContactForm\Validation;
 
-use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Validation\EntityExists;
+use Shopware\Core\Framework\Validation\BuildValidationEvent;
 use Shopware\Core\Framework\Validation\DataValidationDefinition;
 use Shopware\Core\Framework\Validation\DataValidationFactoryInterface;
 use Shopware\Core\System\Annotation\Concept\ExtensionPattern\Decoratable;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Shopware\Core\System\SystemConfig\SystemConfigService;
 use Symfony\Component\Validator\Constraints\Email;
 use Symfony\Component\Validator\Constraints\NotBlank;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 /**
  * @Decoratable
  */
 class ContactFormValidationFactory implements DataValidationFactoryInterface
 {
+    /**
+     * @var EventDispatcherInterface
+     */
+    private $eventDispatcher;
+
+    /**
+     * @var SystemConfigService
+     */
+    private $systemConfigService;
+
+    public function __construct(
+        EventDispatcherInterface $eventDispatcher,
+        SystemConfigService $systemConfigService
+    ) {
+        $this->eventDispatcher = $eventDispatcher;
+        $this->systemConfigService = $systemConfigService;
+    }
+
     public function create(SalesChannelContext $context): DataValidationDefinition
     {
-        return $this->createContactFormValidation('contact_form.create', $context->getContext());
+        return $this->createContactFormValidation('contact_form.create', $context);
     }
 
     public function update(SalesChannelContext $context): DataValidationDefinition
     {
-        return $this->createContactFormValidation('contact_form.update', $context->getContext());
+        return $this->createContactFormValidation('contact_form.update', $context);
     }
 
-    private function createContactFormValidation(string $validationName, Context $context): DataValidationDefinition
+    private function createContactFormValidation(string $validationName, SalesChannelContext $context): DataValidationDefinition
     {
         $definition = new DataValidationDefinition($validationName);
 
-        $definition->add('salutationId', new NotBlank(), new EntityExists(['entity' => 'salutation', 'context' => $context]))
-            ->add('firstName', new NotBlank())
-            ->add('lastName', new NotBlank())
+        $definition->add('salutationId', new NotBlank(), new EntityExists(['entity' => 'salutation', 'context' => $context->getContext()]))
             ->add('email', new NotBlank(), new Email())
-            ->add('phone', new NotBlank())
             ->add('subject', new NotBlank())
             ->add('comment', new NotBlank());
+
+        $isFirstNameRequired = $this->systemConfigService->get('core.basicInformation.firstNameFieldRequired', $context->getSalesChannel()->getId());
+        if ($isFirstNameRequired) {
+            $definition->add('firstName', new NotBlank());
+        }
+
+        $isLastNameRequired = $this->systemConfigService->get('core.basicInformation.lastNameFieldRequired', $context->getSalesChannel()->getId());
+        if ($isLastNameRequired) {
+            $definition->add('lastName', new NotBlank());
+        }
+
+        $isPhoneRequired = $this->systemConfigService->get('core.basicInformation.phoneNumberFieldRequired', $context->getSalesChannel()->getId());
+        if ($isPhoneRequired) {
+            $definition->add('phone', new NotBlank());
+        }
+
+        $validationEvent = new BuildValidationEvent($definition, $context->getContext());
+        $this->eventDispatcher->dispatch($validationEvent, $validationEvent->getName());
 
         return $definition;
     }

--- a/src/Core/Content/DependencyInjection/contact_form.xml
+++ b/src/Core/Content/DependencyInjection/contact_form.xml
@@ -4,7 +4,10 @@
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
-        <service id="Shopware\Core\Content\ContactForm\Validation\ContactFormValidationFactory"/>
+        <service id="Shopware\Core\Content\ContactForm\Validation\ContactFormValidationFactory">
+            <argument type="service" id="event_dispatcher"/>
+            <argument type="service" id="Shopware\Core\System\SystemConfig\SystemConfigService"/>
+        </service>
 
         <service id="Shopware\Core\Content\ContactForm\SalesChannel\ContactFormRoute" public="true">
             <argument type="service" id="Shopware\Core\Content\ContactForm\Validation\ContactFormValidationFactory"/>

--- a/src/Core/Content/Test/ContactForm/ContactFormServiceTest.php
+++ b/src/Core/Content/Test/ContactForm/ContactFormServiceTest.php
@@ -10,7 +10,9 @@ use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\MailTemplateTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\Framework\Validation\DataBag\DataBag;
+use Shopware\Core\Framework\Validation\Exception\ConstraintViolationException;
 use Shopware\Core\System\SalesChannel\Context\SalesChannelContextFactory;
+use Shopware\Core\System\SystemConfig\SystemConfigService;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 
 class ContactFormServiceTest extends TestCase
@@ -49,6 +51,20 @@ class ContactFormServiceTest extends TestCase
 
         $dispatcher->addListener(MailSentEvent::class, $listenerClosure);
 
+        $validationEventDidRun = false;
+        $validationListenerClosure = function () use (&$validationEventDidRun, $phpunit): void {
+            $validationEventDidRun = true;
+        };
+
+        $validationEventName = 'framework.validation.contact_form.create';
+
+        $dispatcher->addListener($validationEventName, $validationListenerClosure);
+
+        $systemConfig = $this->getContainer()->get(SystemConfigService::class);
+        $systemConfig->set('core.basicInformation.firstNameFieldRequired', true);
+        $systemConfig->set('core.basicInformation.lastNameFieldRequired', true);
+        $systemConfig->set('core.basicInformation.phoneNumberFieldRequired', true);
+
         $dataBag = new DataBag();
         $dataBag->add([
             'salutationId' => $this->getValidSalutationId(),
@@ -56,6 +72,181 @@ class ContactFormServiceTest extends TestCase
             'lastName' => 'Lastname',
             'email' => 'test@shopware.com',
             'phone' => '12345/6789',
+            'subject' => 'Subject',
+            'comment' => 'Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.',
+        ]);
+
+        $this->contactFormRoute->load($dataBag->toRequestDataBag(), $context);
+
+        $dispatcher->removeListener(MailSentEvent::class, $listenerClosure);
+        $dispatcher->removeListener($validationEventName, $validationListenerClosure);
+
+        static::assertTrue($eventDidRun, 'The mail.sent Event did not run');
+        static::assertTrue($validationEventDidRun, "The $validationEventName Event did not run");
+    }
+
+    public function testContactFormFirstNameRequiredException(): void
+    {
+        /** @var SalesChannelContextFactory $salesChannelContextFactory */
+        $salesChannelContextFactory = $this->getContainer()->get(SalesChannelContextFactory::class);
+        $context = $salesChannelContextFactory->create(Uuid::randomHex(), Defaults::SALES_CHANNEL);
+
+        $this->assignMailtemplatesToSalesChannel(Defaults::SALES_CHANNEL, $context->getContext());
+
+        /** @var EventDispatcher $dispatcher */
+        $dispatcher = $this->getContainer()->get('event_dispatcher');
+
+        $phpunit = $this;
+        $eventDidRun = false;
+        $listenerClosure = function (MailSentEvent $event) use (&$eventDidRun, $phpunit): void {
+            $eventDidRun = true;
+            $phpunit->assertStringContainsString('Contact email address: test@shopware.com', $event->getContents()['text/html']);
+            $phpunit->assertStringContainsString('essage: Lorem ipsum dolor sit amet', $event->getContents()['text/html']);
+        };
+
+        $dispatcher->addListener(MailSentEvent::class, $listenerClosure);
+
+        $systemConfig = $this->getContainer()->get(SystemConfigService::class);
+        $systemConfig->set('core.basicInformation.firstNameFieldRequired', true);
+        $systemConfig->set('core.basicInformation.lastNameFieldRequired', false);
+        $systemConfig->set('core.basicInformation.phoneNumberFieldRequired', false);
+
+        $dataBag = new DataBag();
+        $dataBag->add([
+            'salutationId' => $this->getValidSalutationId(),
+            'firstName' => '',
+            'lastName' => 'Lastname',
+            'email' => 'test@shopware.com',
+            'phone' => '12345/6789',
+            'subject' => 'Subject',
+            'comment' => 'Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.',
+        ]);
+
+        static::expectException(ConstraintViolationException::class);
+        $this->contactFormRoute->load($dataBag->toRequestDataBag(), $context);
+
+        $dispatcher->removeListener(MailSentEvent::class, $listenerClosure);
+    }
+
+    public function testContactFormLastNameRequiredException(): void
+    {
+        /** @var SalesChannelContextFactory $salesChannelContextFactory */
+        $salesChannelContextFactory = $this->getContainer()->get(SalesChannelContextFactory::class);
+        $context = $salesChannelContextFactory->create(Uuid::randomHex(), Defaults::SALES_CHANNEL);
+
+        $this->assignMailtemplatesToSalesChannel(Defaults::SALES_CHANNEL, $context->getContext());
+
+        /** @var EventDispatcher $dispatcher */
+        $dispatcher = $this->getContainer()->get('event_dispatcher');
+
+        $phpunit = $this;
+        $eventDidRun = false;
+        $listenerClosure = function (MailSentEvent $event) use (&$eventDidRun, $phpunit): void {
+            $eventDidRun = true;
+            $phpunit->assertStringContainsString('Contact email address: test@shopware.com', $event->getContents()['text/html']);
+            $phpunit->assertStringContainsString('essage: Lorem ipsum dolor sit amet', $event->getContents()['text/html']);
+        };
+
+        $dispatcher->addListener(MailSentEvent::class, $listenerClosure);
+
+        $systemConfig = $this->getContainer()->get(SystemConfigService::class);
+        $systemConfig->set('core.basicInformation.firstNameFieldRequired', false);
+        $systemConfig->set('core.basicInformation.lastNameFieldRequired', true);
+        $systemConfig->set('core.basicInformation.phoneNumberFieldRequired', false);
+
+        $dataBag = new DataBag();
+        $dataBag->add([
+            'salutationId' => $this->getValidSalutationId(),
+            'firstName' => 'Firstname',
+            'lastName' => '',
+            'email' => 'test@shopware.com',
+            'phone' => '12345/6789',
+            'subject' => 'Subject',
+            'comment' => 'Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.',
+        ]);
+
+        static::expectException(ConstraintViolationException::class);
+        $this->contactFormRoute->load($dataBag->toRequestDataBag(), $context);
+
+        $dispatcher->removeListener(MailSentEvent::class, $listenerClosure);
+    }
+
+    public function testContactFormPhoneNumberRequiredException(): void
+    {
+        /** @var SalesChannelContextFactory $salesChannelContextFactory */
+        $salesChannelContextFactory = $this->getContainer()->get(SalesChannelContextFactory::class);
+        $context = $salesChannelContextFactory->create(Uuid::randomHex(), Defaults::SALES_CHANNEL);
+
+        $this->assignMailtemplatesToSalesChannel(Defaults::SALES_CHANNEL, $context->getContext());
+
+        /** @var EventDispatcher $dispatcher */
+        $dispatcher = $this->getContainer()->get('event_dispatcher');
+
+        $phpunit = $this;
+        $eventDidRun = false;
+        $listenerClosure = function (MailSentEvent $event) use (&$eventDidRun, $phpunit): void {
+            $eventDidRun = true;
+            $phpunit->assertStringContainsString('Contact email address: test@shopware.com', $event->getContents()['text/html']);
+            $phpunit->assertStringContainsString('essage: Lorem ipsum dolor sit amet', $event->getContents()['text/html']);
+        };
+
+        $dispatcher->addListener(MailSentEvent::class, $listenerClosure);
+
+        $systemConfig = $this->getContainer()->get(SystemConfigService::class);
+        $systemConfig->set('core.basicInformation.firstNameFieldRequired', false);
+        $systemConfig->set('core.basicInformation.lastNameFieldRequired', false);
+        $systemConfig->set('core.basicInformation.phoneNumberFieldRequired', true);
+
+        $dataBag = new DataBag();
+        $dataBag->add([
+            'salutationId' => $this->getValidSalutationId(),
+            'firstName' => 'Firstname',
+            'lastName' => 'Lastname',
+            'email' => 'test@shopware.com',
+            'phone' => '',
+            'subject' => 'Subject',
+            'comment' => 'Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.',
+        ]);
+
+        static::expectException(ConstraintViolationException::class);
+        $this->contactFormRoute->load($dataBag->toRequestDataBag(), $context);
+
+        $dispatcher->removeListener(MailSentEvent::class, $listenerClosure);
+    }
+
+    public function testContactFormOptionalFieldsSendMail(): void
+    {
+        /** @var SalesChannelContextFactory $salesChannelContextFactory */
+        $salesChannelContextFactory = $this->getContainer()->get(SalesChannelContextFactory::class);
+        $context = $salesChannelContextFactory->create(Uuid::randomHex(), Defaults::SALES_CHANNEL);
+
+        $this->assignMailtemplatesToSalesChannel(Defaults::SALES_CHANNEL, $context->getContext());
+
+        /** @var EventDispatcher $dispatcher */
+        $dispatcher = $this->getContainer()->get('event_dispatcher');
+
+        $phpunit = $this;
+        $eventDidRun = false;
+        $listenerClosure = function (MailSentEvent $event) use (&$eventDidRun, $phpunit): void {
+            $eventDidRun = true;
+            $phpunit->assertStringContainsString('Contact email address: test@shopware.com', $event->getContents()['text/html']);
+            $phpunit->assertStringContainsString('essage: Lorem ipsum dolor sit amet', $event->getContents()['text/html']);
+        };
+
+        $dispatcher->addListener(MailSentEvent::class, $listenerClosure);
+
+        $systemConfig = $this->getContainer()->get(SystemConfigService::class);
+        $systemConfig->set('core.basicInformation.firstNameFieldRequired', false);
+        $systemConfig->set('core.basicInformation.lastNameFieldRequired', false);
+        $systemConfig->set('core.basicInformation.phoneNumberFieldRequired', false);
+
+        $dataBag = new DataBag();
+        $dataBag->add([
+            'salutationId' => $this->getValidSalutationId(),
+            'firstName' => '',
+            'lastName' => '',
+            'email' => 'test@shopware.com',
+            'phone' => '',
             'subject' => 'Subject',
             'comment' => 'Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.',
         ]);

--- a/src/Core/Migration/Migration1604499476AddDefaultSettingConfigValueForContactForm.php
+++ b/src/Core/Migration/Migration1604499476AddDefaultSettingConfigValueForContactForm.php
@@ -1,0 +1,47 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Migration;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Defaults;
+use Shopware\Core\Framework\Migration\MigrationStep;
+use Shopware\Core\Framework\Uuid\Uuid;
+
+class Migration1604499476AddDefaultSettingConfigValueForContactForm extends MigrationStep
+{
+    private const CONFIG_KEYS = [
+        'core.basicInformation.firstNameFieldRequired',
+        'core.basicInformation.lastNameFieldRequired',
+        'core.basicInformation.phoneNumberFieldRequired',
+    ];
+
+    public function getCreationTimestamp(): int
+    {
+        return 1604499476;
+    }
+
+    public function update(Connection $connection): void
+    {
+        $createdAt = (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT);
+
+        foreach (self::CONFIG_KEYS as $configKey) {
+            $configPresent = $connection->fetchColumn('SELECT 1 FROM `system_config` WHERE `configuration_key` = ?', [$configKey]);
+
+            if ($configPresent !== false) {
+                continue;
+            }
+
+            $connection->insert('system_config', [
+                'id' => Uuid::randomBytes(),
+                'configuration_key' => $configKey,
+                'configuration_value' => '{"_value": true}',
+                'created_at' => $createdAt,
+            ]);
+        }
+    }
+
+    public function updateDestructive(Connection $connection): void
+    {
+        // implement update destructive
+    }
+}

--- a/src/Core/System/Resources/config/basicInformation.xml
+++ b/src/Core/System/Resources/config/basicInformation.xml
@@ -147,6 +147,33 @@
             <helpText>Shows a button which allows users to accept all cookies in the storefront</helpText>
             <helpText lang="de-DE">Zeigt einen Button an, der es Nutzern erlaubt alle Cookies in der Storefront zu akzeptieren</helpText>
         </component>
+
+        <component name="sw-switch-field">
+            <name>firstNameFieldRequired</name>
+            <bordered>bordered</bordered>
+            <label>Require first name in contact form</label>
+            <label lang="de-DE">Telefonnummer als Pflichtfeld in Kontaktformular behandeln</label>
+            <helpText>Sets first name input as required in contact form</helpText>
+            <helpText lang="de-DE">Setzt das Feld Vorname als Pflichtfeld im Kontaktformular</helpText>
+        </component>
+
+        <component name="sw-switch-field">
+            <name>lastNameFieldRequired</name>
+            <bordered>bordered</bordered>
+            <label>Require last name in contact form</label>
+            <label lang="de-DE">Nachname als Pflichtfeld in Kontaktformular behandeln</label>
+            <helpText>Sets last name input as required in contact form</helpText>
+            <helpText lang="de-DE">Setzt das Feld Nachname als Pflichtfeld im Kontaktformular</helpText>
+        </component>
+
+        <component name="sw-switch-field">
+            <name>phoneNumberFieldRequired</name>
+            <bordered>bordered</bordered>
+            <label>Require phone number in contact form</label>
+            <label lang="de-DE">Telefonummer als Pflichtfeld in Kontaktformular behandeln</label>
+            <helpText>Sets phone number input as required in contact form</helpText>
+            <helpText lang="de-DE">Setzt das Feld Telefonnummer als Pflichtfeld im Kontaktformular</helpText>
+        </component>
     </card>
 
 </config>

--- a/src/Storefront/Resources/views/storefront/element/cms-element-form/form-types/contact-form.html.twig
+++ b/src/Storefront/Resources/views/storefront/element/cms-element-form/form-types/contact-form.html.twig
@@ -16,10 +16,11 @@
             {% endblock %}
 
             {% block cms_form_contact_input_first_name %}
+                {% set firstNameFieldRequired = shopware.config.core.basicInformation.firstNameFieldRequired == true %}
                 {% sw_include '@Storefront/storefront/element/cms-element-form/form-components/cms-element-form-input.html.twig'
                     with {
                     fieldName: 'firstName',
-                    required: true,
+                    required: firstNameFieldRequired,
                     additionalClass: 'col-md-4',
                     label: 'account.personalFirstNameLabel',
                     placeholder: 'account.personalFirstNamePlaceholder'
@@ -28,10 +29,11 @@
             {% endblock %}
 
             {% block cms_form_contact_input_last_name %}
+                {% set lastNameFieldRequired = shopware.config.core.basicInformation.lastNameFieldRequired == true %}
                 {% sw_include '@Storefront/storefront/element/cms-element-form/form-components/cms-element-form-input.html.twig'
                     with {
                     fieldName: 'lastName',
-                    required: true,
+                    required: lastNameFieldRequired,
                     additionalClass: 'col-md-4',
                     label: 'account.personalLastNameLabel',
                     placeholder: 'account.personalLastNamePlaceholder'
@@ -55,10 +57,11 @@
             {% endblock %}
 
             {% block cms_form_contact_input_phome %}
+                {% set phoneNumberFieldRequired = shopware.config.core.basicInformation.phoneNumberFieldRequired == true %}
                 {% sw_include '@Storefront/storefront/element/cms-element-form/form-components/cms-element-form-input.html.twig'
                     with {
                     fieldName: 'phone',
-                    required: true,
+                    required: phoneNumberFieldRequired,
                     additionalClass: 'col-md-6',
                     label: 'account.personalPhoneLabel',
                     placeholder: 'account.personalPhonePlaceholder'


### PR DESCRIPTION
…ct form

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
The phone number input should be optional in the contact form.

### 2. What does this change do, exactly?
- Adds a configuration to basicInformation.xml to make first name, last name and phone number input optional in contact form
- Adds `BuildValidationEvent` in `ContactFormValidationFactory`
- Adds check in storefront if either field input should be marked as required 
- Adds migration to create the config values to preserve the default behaviour

### 3. Describe each step to reproduce the issue or behaviour.
- Submit contact form without phone number
- Enable optional phone number input
- Submit contact form without phone number

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/NEXT-8058

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
