### PR TITLE
fix js error when loading a product page with a review

### DIFF
--- a/src/Storefront/Resources/app/storefront/src/plugin/forms/form-ajax-submit.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/forms/form-ajax-submit.plugin.js
@@ -102,8 +102,10 @@ export default class FormAjaxSubmitPlugin extends Plugin {
 
         if (this.options.submitOnChange) {
             Iterator.iterate(this._form.elements, element => {
-                element.removeEventListener('change', onSubmit);
-                element.addEventListener('change', onSubmit);
+                if( element.removeEventListener !== undefined) {
+                    element.removeEventListener('change', onSubmit);
+                    element.addEventListener('change', onSubmit);
+                }
             });
         }
     }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
Right now, there is a javascript error when you open a product page with at least one review.

### 2. What does this change do, exactly?
It adds an additional check for the `removeEventListener()` function. Therefore this method will only be called if it exists.

### 3. Describe each step to reproduce the issue or behaviour.
Write a review for a product. If necessary, make it visible via the administration. Now load the product page and open the browser console and you will see a javascript error like 'TypeError: e.removeEventListener is not a function'

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [] I have written tests and verified that they fail without my change
- [] I have squashed any insignificant commits
- [] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [] I have written or adjusted the documentation according to my changes
- [] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
