### PR TITLE
Use prepareCriteria in SeoActionController

### DIFF
--- a/changelog/_unreleased/2020-10-27-prepare-criteria-for-seo-url-route.md
+++ b/changelog/_unreleased/2020-10-27-prepare-criteria-for-seo-url-route.md
@@ -1,0 +1,9 @@
+---
+title: Prepare criteria for Seo Url Route
+issue: /
+author: Rune Laenen
+author_email: rune@laenen.nu 
+author_github: @runelaenen
+---
+# Core
+*  Call `$seoUrlRoute->prepareCriteria` for Seo Url Context call so context can have multiple entities.

--- a/src/Core/Content/Seo/Api/SeoActionController.php
+++ b/src/Core/Content/Seo/Api/SeoActionController.php
@@ -164,9 +164,12 @@ class SeoActionController extends AbstractController
         $config = $seoUrlRoute->getConfig();
         $repository = $this->getRepository($config);
 
+        $criteria = (new Criteria($fk ? [$fk] : []))->setLimit(1);
+        $seoUrlRoute->prepareCriteria($criteria);
+
         /** @var Entity|null $entity */
         $entity = $repository
-            ->search((new Criteria($fk ? [$fk] : []))->setLimit(1), $context)
+            ->search($criteria, $context)
             ->first();
 
         if (!$entity) {


### PR DESCRIPTION
### 1. Why is this change necessary?
The Criteria changes in a SeoUrlRoute are not done when calculating the context dropdown.

### 2. What does this change do, exactly?
Use the criteria as intended.

### 3. Describe each step to reproduce the issue or behaviour.
Create custom SeoUrlRoute with multiple entities (through relations). The dropdown in the admin will only show your main entity, no matter how many are described in the `getMapping` method.

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
