### PR TITLE
Delivery time translation fix

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-settings-delivery-times/snippet/de-DE.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-delivery-times/snippet/de-DE.json
@@ -21,7 +21,7 @@
       "columnMax": "Maximum",
       "columnUnit_day": "Tag",
       "columnUnit_week": "Woche",
-      "columnUnit_month": "Woche",
+      "columnUnit_month": "Monat",
       "columnUnit_year": "Jahr",
       "errorLoad": "Die Lieferzeiten konnten nicht geladen werden."
     },

--- a/src/Core/Content/Product/SalesChannel/Listing/ProductListingLoader.php
+++ b/src/Core/Content/Product/SalesChannel/Listing/ProductListingLoader.php
@@ -9,7 +9,6 @@ use Shopware\Core\Framework\DataAbstractionLayer\Entity;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
-use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\MultiFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\NotFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Grouping\FieldGrouping;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\IdSearchResult;
@@ -134,11 +133,11 @@ class ProductListingLoader
         }
 
         $criteria->addFilter(
-            new MultiFilter(
-                MultiFilter::CONNECTION_OR,
+            new NotFilter(
+                NotFilter::CONNECTION_AND,
                 [
-                    new EqualsFilter('product.isCloseout', false),
-                    new EqualsFilter('product.available', true),
+                    new EqualsFilter('product.isCloseout', true),
+                    new EqualsFilter('product.available', false),
                 ]
             )
         );

--- a/src/Core/Content/Product/SalesChannel/Listing/ProductListingLoader.php
+++ b/src/Core/Content/Product/SalesChannel/Listing/ProductListingLoader.php
@@ -9,6 +9,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Entity;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\MultiFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\NotFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Grouping\FieldGrouping;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\IdSearchResult;
@@ -133,11 +134,11 @@ class ProductListingLoader
         }
 
         $criteria->addFilter(
-            new NotFilter(
-                NotFilter::CONNECTION_AND,
+            new MultiFilter(
+                MultiFilter::CONNECTION_OR,
                 [
-                    new EqualsFilter('product.isCloseout', true),
-                    new EqualsFilter('product.available', false),
+                    new EqualsFilter('product.isCloseout', false),
+                    new EqualsFilter('product.available', true),
                 ]
             )
         );


### PR DESCRIPTION
### 1. Why is this change necessary?
It isn't, but it corrects the german translation for the delivery time unit month

### 2. What does this change do, exactly?
Changes a translation value

### 3. Describe each step to reproduce the issue or behaviour.
If the backend translation is not set to german switch to german.
Create a delivery time with unit month and go back to list view. 
There you will see "Woche" instead of expected "Monat"

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
