### PR TITLE
Emit single item delete event in sw-entity-listing

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/entity/sw-entity-listing/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/entity/sw-entity-listing/index.js
@@ -129,6 +129,7 @@ Component.extend('sw-entity-listing', 'sw-data-grid', {
             // send delete request to the server, immediately
             return this.repository.delete(id, this.items.context).then(() => {
                 this.resetSelection();
+                this.$emit('delete-item-finish', id);
                 return this.doSearch();
             }).catch((errorResponse) => {
                 this.$emit('delete-item-failed', { id, errorResponse });


### PR DESCRIPTION
### 1. Why is this change necessary?

If there is a fail event, there should be a success event. Needed to functionally extend behaviour on deletion of items.

### 2. What does this change do, exactly?

Emits an event.

### 3. Describe each step to reproduce the issue or behaviour.

-

### 4. Please link to the relevant issues (if any).

-

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
