### PR TITLE
Consider property group names when searching

### DIFF
--- a/src/Core/Content/Property/PropertyGroupDefinition.php
+++ b/src/Core/Content/Property/PropertyGroupDefinition.php
@@ -66,7 +66,7 @@ class PropertyGroupDefinition extends EntityDefinition
     {
         return new FieldCollection([
             (new IdField('id', 'id'))->addFlags(new PrimaryKey(), new Required()),
-            new TranslatedField('name'),
+            (new TranslatedField('name'))->addFlags(new SearchRanking(SearchRanking::HIGH_SEARCH_RANKING)),
             new TranslatedField('description'),
             (new StringField('display_type', 'displayType'))->setFlags(new Required()),
             (new StringField('sorting_type', 'sortingType'))->setFlags(new Required()),


### PR DESCRIPTION
When searching for property groups, the name of the property group was ignored before.


### 1. Why is this change necessary?
The property search does not consider the name at all. If you search for a property by name you get zero results if this group does not have a property option with the query term contained.

### 2. What does this change do, exactly?
Adds the name of the property group to the search ranking.

### 3. Describe each step to reproduce the issue or behavior.
Create a new property with no options. Try to find it using the administration's search. It does not work.

Fresh installed shop with demo data installed **without ElasticSearch**:
![image](https://user-images.githubusercontent.com/45566296/97362665-a27f8700-18a1-11eb-8b4a-0b431a8e1c7b.png)
![image](https://user-images.githubusercontent.com/45566296/97362790-cfcc3500-18a1-11eb-9dfa-493205cc86b7.png)


### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/NEXT-8967

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.
