### PR TITLE
Add StyleCompilerInterface

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -7428,7 +7428,7 @@ parameters:
 		-
 			message: "#^Parameter \\#1 \\$themeName of class Shopware\\\\Storefront\\\\Theme\\\\Exception\\\\ThemeCompileException constructor expects string, string\\|null given\\.$#"
 			count: 1
-			path: src/Storefront/Theme/ThemeCompiler.php
+			path: src/Storefront/Theme/PhpStyleCompiler.php
 
 		-
 			message: "#^Property Shopware\\\\Storefront\\\\Theme\\\\ThemeConfigField\\:\\:\\$value has no typehint specified\\.$#"

--- a/src/Core/Framework/DependencyInjection/CompilerPass/AssetRegistrationCompilerPass.php
+++ b/src/Core/Framework/DependencyInjection/CompilerPass/AssetRegistrationCompilerPass.php
@@ -22,7 +22,7 @@ class AssetRegistrationCompilerPass implements CompilerPassInterface
         $assetService->addMethodCall('setDefaultPackage', [$assets['asset']]);
 
         if ($container->hasDefinition(ThemeCompiler::class)) {
-            $container->getDefinition(ThemeCompiler::class)->replaceArgument(7, $assets);
+            $container->getDefinition(ThemeCompiler::class)->replaceArgument(6, $assets);
         }
     }
 }

--- a/src/Storefront/DependencyInjection/theme.xml
+++ b/src/Storefront/DependencyInjection/theme.xml
@@ -20,12 +20,16 @@
             <argument type="service" id="shopware.filesystem.theme"/>
             <argument type="service" id="shopware.filesystem.temp"/>
             <argument type="service" id="Shopware\Storefront\Theme\ThemeFileResolver" />
-            <argument>%kernel.debug%</argument>
             <argument type="service" id="Symfony\Component\EventDispatcher\EventDispatcherInterface" />
             <argument type="service" id="Shopware\Storefront\Theme\ThemeFileImporter"/>
             <argument type="service" id="media.repository"/>
             <argument type="tagged" tag="shopware.asset"/>
             <argument type="service" id="Shopware\Core\Framework\Adapter\Cache\CacheClearer"/>
+            <argument type="service" id="Shopware\Storefront\Theme\PhpStyleCompiler" />
+        </service>
+
+        <service id="Shopware\Storefront\Theme\PhpStyleCompiler">
+            <argument>%kernel.debug%</argument>
         </service>
 
         <service id="Shopware\Storefront\Theme\ThemeFileImporter"/>

--- a/src/Storefront/Test/Theme/PhpStyleCompilerTest.php
+++ b/src/Storefront/Test/Theme/PhpStyleCompilerTest.php
@@ -1,0 +1,64 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Storefront\Test\Theme;
+
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Test\TestCaseBase\DatabaseTransactionBehaviour;
+use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
+use Shopware\Storefront\Theme\PhpStyleCompiler;
+use Shopware\Storefront\Theme\StorefrontPluginConfiguration\StorefrontPluginConfiguration;
+use Shopware\Storefront\Theme\StyleCompileContext;
+
+class PhpStyleCompilerTest extends TestCase
+{
+    use KernelTestBehaviour;
+    use DatabaseTransactionBehaviour;
+
+    /**
+     * @var StyleCompileContext
+     */
+    private $styleCompileContext;
+
+    public function setUp(): void
+    {
+        $mockSalesChannelId = '98432def39fc4624b33213a56b8c944d';
+
+        $variables = <<<PHP_EOL
+\$sw-color-brand-primary: #008490;
+PHP_EOL;
+
+        $styleMock = <<<PHP_EOL
+.btn {
+    &--primary {
+        user-select: none;
+        background-color: \$sw-color-brand-primary;
+    }
+}
+PHP_EOL;
+
+        $mockThemeConfiguration = new StorefrontPluginConfiguration();
+        $mockThemeConfiguration->setTechnicalName('testTheme');
+
+        $this->styleCompileContext = new StyleCompileContext($variables, $styleMock, $mockThemeConfiguration, [], $mockSalesChannelId);
+    }
+
+    public function testDebugFlag(): void
+    {
+        $nonDebugCompiler = new PhpStyleCompiler(false);
+        $debugCompiler = new PhpStyleCompiler(true);
+
+        $productionCss = $nonDebugCompiler->compileStyles($this->styleCompileContext);
+        $debugCss = $debugCompiler->compileStyles($this->styleCompileContext);
+        static::assertNotEquals($productionCss, $debugCss);
+    }
+
+    public function testAutoPrefixer(): void
+    {
+        static::markTestSkipped('Not yet implemented');
+    }
+
+    public function testPathResolving(): void
+    {
+        static::markTestSkipped('Not yet implemented');
+    }
+}

--- a/src/Storefront/Test/Theme/ThemeCompilerTest.php
+++ b/src/Storefront/Test/Theme/ThemeCompilerTest.php
@@ -11,6 +11,7 @@ use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
 use Shopware\Storefront\Event\ThemeCompilerEnrichScssVariablesEvent;
 use Shopware\Storefront\Test\Theme\fixtures\MockThemeVariablesSubscriber;
+use Shopware\Storefront\Theme\PhpStyleCompiler;
 use Shopware\Storefront\Theme\ThemeCompiler;
 use Shopware\Storefront\Theme\ThemeFileImporter;
 use Shopware\Storefront\Theme\ThemeFileResolver;
@@ -64,12 +65,12 @@ class ThemeCompilerTest extends TestCase
             $mockFilesystem,
             $mockFilesystem,
             $themeFileResolver,
-            true,
             $eventDispatcher,
             $this->getContainer()->get(ThemeFileImporter::class),
             $mediaRepository,
             ['theme' => new UrlPackage(['http://localhost'], new EmptyVersionStrategy())],
-            $this->getContainer()->get(CacheClearer::class)
+            $this->getContainer()->get(CacheClearer::class),
+            $this->getContainer()->get(PhpStyleCompiler::class)
         );
     }
 

--- a/src/Storefront/Theme/AbstractStyleCompiler.php
+++ b/src/Storefront/Theme/AbstractStyleCompiler.php
@@ -1,0 +1,10 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Storefront\Theme;
+
+abstract class AbstractStyleCompiler
+{
+    abstract public function getDecorated(): AbstractStyleCompiler;
+
+    abstract public function compileStyles(StyleCompileContext $compileContext): string;
+}

--- a/src/Storefront/Theme/PhpStyleCompiler.php
+++ b/src/Storefront/Theme/PhpStyleCompiler.php
@@ -1,0 +1,72 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Storefront\Theme;
+
+use ScssPhp\ScssPhp\Compiler;
+use ScssPhp\ScssPhp\Formatter\Crunched;
+use ScssPhp\ScssPhp\Formatter\Expanded;
+use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
+use Shopware\Storefront\Theme\Exception\ThemeCompileException;
+
+class PhpStyleCompiler extends AbstractStyleCompiler
+{
+    /**
+     * @var Compiler
+     */
+    private $scssCompiler;
+
+    /**
+     * @var bool
+     */
+    private $debug;
+
+    public function __construct(bool $debug)
+    {
+        $this->scssCompiler = new Compiler();
+        $this->scssCompiler->setImportPaths('');
+        $this->scssCompiler->setFormatter($debug ? Expanded::class : Crunched::class);
+        $this->debug = $debug;
+    }
+
+    public function getDecorated(): AbstractStyleCompiler
+    {
+        throw new DecorationPatternException(self::class);
+    }
+
+    public function compileStyles(StyleCompileContext $compileContext): string
+    {
+        $this->scssCompiler->addImportPath(function ($originalPath) use ($compileContext) {
+            foreach ($compileContext->getResolveMappings() as $resolve => $resolvePath) {
+                $resolve = '~' . $resolve;
+                if (mb_strpos($originalPath, $resolve) === 0) {
+                    $dirname = $resolvePath . dirname(mb_substr($originalPath, mb_strlen($resolve)));
+                    $filename = basename($originalPath);
+                    $extension = pathinfo($filename, PATHINFO_EXTENSION) === '' ? '.scss' : '';
+                    $path = $dirname . DIRECTORY_SEPARATOR . $filename . $extension;
+                    if (file_exists($path)) {
+                        return $path;
+                    }
+
+                    $path = $dirname . DIRECTORY_SEPARATOR . '_' . $filename . $extension;
+                    if (file_exists($path)) {
+                        return $path;
+                    }
+                }
+            }
+
+            return null;
+        });
+
+        try {
+            $cssOutput = $this->scssCompiler->compile($compileContext->getFullStyles());
+        } catch (\Throwable $exception) {
+            throw new ThemeCompileException(
+                $compileContext->getThemeConfig()->getTechnicalName(),
+                $exception->getMessage()
+            );
+        }
+        $autoPreFixer = new Autoprefixer($cssOutput);
+
+        return $autoPreFixer->compile($this->debug);
+    }
+}

--- a/src/Storefront/Theme/StyleCompileContext.php
+++ b/src/Storefront/Theme/StyleCompileContext.php
@@ -1,0 +1,103 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Storefront\Theme;
+
+use Shopware\Core\Framework\Struct\Struct;
+use Shopware\Storefront\Theme\StorefrontPluginConfiguration\StorefrontPluginConfiguration;
+
+class StyleCompileContext extends Struct
+{
+    /**
+     * @var string
+     */
+    protected $variables;
+
+    /**
+     * @var string
+     */
+    protected $concatenatedStyles;
+
+    /**
+     * @var StorefrontPluginConfiguration
+     */
+    protected $themeConfig;
+
+    /**
+     * @var array
+     */
+    protected $resolveMappings;
+
+    /**
+     * @var string
+     */
+    protected $salesChannelId;
+
+    public function __construct(
+        string $variables,
+        string $concatenatedStyles,
+        StorefrontPluginConfiguration $themeConfig,
+        array $resolveMappings,
+        string $salesChannelId
+    ) {
+        $this->variables = $variables;
+        $this->concatenatedStyles = $concatenatedStyles;
+        $this->themeConfig = $themeConfig;
+        $this->resolveMappings = $resolveMappings;
+        $this->salesChannelId = $salesChannelId;
+    }
+
+    public function getVariables(): string
+    {
+        return $this->variables;
+    }
+
+    public function setVariables(string $variables): void
+    {
+        $this->variables = $variables;
+    }
+
+    public function getConcatenatedStyles(): string
+    {
+        return $this->concatenatedStyles;
+    }
+
+    public function setConcatenatedStyles(string $concatenatedStyles): void
+    {
+        $this->concatenatedStyles = $concatenatedStyles;
+    }
+
+    public function getFullStyles(): string
+    {
+        return $this->variables . $this->concatenatedStyles;
+    }
+
+    public function getThemeConfig(): StorefrontPluginConfiguration
+    {
+        return $this->themeConfig;
+    }
+
+    public function setThemeConfig(StorefrontPluginConfiguration $themeConfig): void
+    {
+        $this->themeConfig = $themeConfig;
+    }
+
+    public function getResolveMappings(): array
+    {
+        return $this->resolveMappings;
+    }
+
+    public function setResolveMappings(array $resolveMappings): void
+    {
+        $this->resolveMappings = $resolveMappings;
+    }
+
+    public function getSalesChannelId(): string
+    {
+        return $this->salesChannelId;
+    }
+
+    public function setSalesChannelId(string $salesChannelId): void
+    {
+        $this->salesChannelId = $salesChannelId;
+    }
+}


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?

It should be possible to have alternate ways than PHP scss and autoprefixer to compile the theme styles.
So we could add a CompilerPass that switches the style compiler e.g. to an implementation that uses webpack if nodeJS is available on the system (much faster and doesn't produce potentially broken CSS).

### 2. What does this change do, exactly?

It introduces an interface `StyleCompilerInterface` that is used by the `ThemeCompiler` to compile the SCSS variables and the concatenated SCSS files to the final CSS.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).

https://github.com/shopware/platform/issues/1246

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
