### PR TITLE
Fix product listing when 'Hide products after clearance' is active

### DIFF
--- a/src/Core/Content/Product/SalesChannel/Listing/ProductListingLoader.php
+++ b/src/Core/Content/Product/SalesChannel/Listing/ProductListingLoader.php
@@ -9,6 +9,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Entity;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\MultiFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\NotFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Grouping\FieldGrouping;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\IdSearchResult;
@@ -133,11 +134,11 @@ class ProductListingLoader
         }
 
         $criteria->addFilter(
-            new NotFilter(
-                NotFilter::CONNECTION_AND,
+            new MultiFilter(
+                MultiFilter::CONNECTION_OR,
                 [
-                    new EqualsFilter('product.isCloseout', true),
-                    new EqualsFilter('product.available', false),
+                    new EqualsFilter('product.isCloseout', false),
+                    new EqualsFilter('product.available', true),
                 ]
             )
         );


### PR DESCRIPTION
### 1. Why is this change necessary?
It will fix the product listings when Hide products after clearance and elastic search is active.

### 2. What does this change do, exactly?
It inverts the filter for isCloseout manually since it seems this is nothing elastic search can do by itself.

### 3. Describe each step to reproduce the issue or behaviour.
Activate Hide products after clearance in the administration.

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/NEXT-10003

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
