### PR TITLE
Translation fix for delivery time unit 'month'

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-settings-delivery-times/snippet/de-DE.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-delivery-times/snippet/de-DE.json
@@ -21,7 +21,7 @@
       "columnMax": "Maximum",
       "columnUnit_day": "Tag",
       "columnUnit_week": "Woche",
-      "columnUnit_month": "Woche",
+      "columnUnit_month": "Monat",
       "columnUnit_year": "Jahr",
       "errorLoad": "Die Lieferzeiten konnten nicht geladen werden."
     },


### PR DESCRIPTION
### 1. Why is this change necessary?
It will correct the german translation for month.

### 2. What does this change do, exactly?
It changes the german translation for the delivery time unit month.

### 3. Describe each step to reproduce the issue or behaviour.
Create a delivery time in the backend with unit month and go back to the delivery time listing.
Ensure your backend is in german.

### 4. Please link to the relevant issues (if any).
-

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
