### PR TITLE
Fix typing error (pvivacy => privacy)

### DIFF
--- a/src/Storefront/Resources/views/storefront/element/cms-element-form/form-components/cms-element-form-privacy.html.twig
+++ b/src/Storefront/Resources/views/storefront/element/cms-element-form/form-components/cms-element-form-privacy.html.twig
@@ -8,12 +8,12 @@
             <input name="privacy"
                    type="checkbox"
                    class="custom-control-input"
-                   id="form-pvivacy-opt-in-{{ _key }}"
+                   id="form-privacy-opt-in-{{ _key }}"
                    required>
         {% endblock %}
 
         {% block cms_form_privacy_opt_in_label %}
-            <label for="form-pvivacy-opt-in-{{ _key }}" class=" custom-control-label">
+            <label for="form-privacy-opt-in-{{ _key }}" class=" custom-control-label">
                 {{ "general.privacyNotice"|trans({
                     '%url%': path('frontend.cms.page',{ id: shopware.config.core.basicInformation.privacyPage })
                 })|raw }}


### PR DESCRIPTION
Change pvivacy to privacy

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?


### 2. What does this change do, exactly?
This code change fix a typing error `pvivacy` to `privacy`

### 3. Describe each step to reproduce the issue or behaviour.

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
