### PR TITLE
bugfix filesystem with google storage

### DIFF
--- a/src/Core/Framework/Adapter/Filesystem/Plugin/CopyBatch.php
+++ b/src/Core/Framework/Adapter/Filesystem/Plugin/CopyBatch.php
@@ -25,13 +25,15 @@ class CopyBatch implements PluginInterface
     public function handle(CopyBatchInput ...$files): void
     {
         foreach ($files as $batchInput) {
-            if (is_resource($batchInput->getSourceFile())) {
-                $handle = $batchInput->getSourceFile();
-            } else {
-                $handle = fopen($batchInput->getSourceFile(), 'rb');
-            }
+            $handle = null;
+            
+            foreach ($batchInput->getTargetFiles() as $targetFile) {                
+                if (is_resource($batchInput->getSourceFile())) {
+                    $handle = $batchInput->getSourceFile();
+                } elseif (!is_resource($handle)) {
+                    $handle = fopen($batchInput->getSourceFile(), 'rb');
+                }
 
-            foreach ($batchInput->getTargetFiles() as $targetFile) {
                 $this->filesystem->putStream($targetFile, $handle);
             }
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
The class `Shopware\Core\Framework\Adapter\Filesystem\Plugin\CopyBatch` can't handle multiple target files when using Google Storage Adapter. `GuzzleHttp\Psr7\Stream` closes the resource in the `__destruct()` function after the resource has been uploaded. The `$handle` is then a closed resource for the second `$targetFile` and `League\Flysystem\Filesystem` throws the `InvalidArgumentException`.

### 2. What does this change do, exactly?
The change checks if `$handle` is still a valid resource in each iteration and opens the source file again if necessary.

### 3. Describe each step to reproduce the issue or behaviour.

1. Use Google Storage as filesystem adapter. 
2. Run `bin/console theme:compile`

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
