### PR TITLE
Fix parse boolean value error with elasticsearch

### DIFF
--- a/src/Elasticsearch/Framework/DataAbstractionLayer/CriteriaParser.php
+++ b/src/Elasticsearch/Framework/DataAbstractionLayer/CriteriaParser.php
@@ -21,6 +21,7 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Dbal\EntityDefinitionQueryHelper;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\AssociationField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\BoolField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\PriceField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\TranslatedField;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Aggregation\Aggregation;
@@ -264,11 +265,17 @@ class CriteriaParser
     {
         $fieldName = $this->buildAccessor($definition, $filter->getField(), $context);
 
-        if ($filter->getValue() === null) {
+        $value = $filter->getValue();
+        $field = $this->helper->getField($fieldName, $definition, $definition->getEntityName(), false);
+        if($field instanceof BoolField) {
+            $value = (bool) $value;
+        }
+
+        if ($value === null) {
             $query = new BoolQuery();
             $query->add(new ExistsQuery($fieldName), BoolQuery::MUST_NOT);
         } else {
-            $query = new TermQuery($fieldName, $filter->getValue());
+            $query = new TermQuery($fieldName, $value);
         }
 
         return $this->createNestedQuery($query, $definition, $filter->getField());


### PR DESCRIPTION
### 1. Why is this change necessary?
If I assign a dynamic product group to a category and assign the filter "active = 1" or a other boolean filter to the dynamic product group, an error "failed to create query: Can't parse boolean value [1], expected [true] or [false]" occures on searching. A fallback to the normal database search will happen - it shouldn't.

### 2. What does this change do, exactly?
It converts the values of boolean fields to boolean values before add it to the elasticsearch search query to prevent searching for values like 1 or 0 for boolean fields.

### 3. Describe each step to reproduce the issue or behaviour.
1. Create a dynamic product group
2. Add a filter there like "active": "Yes"
3. Assign the dynamic product group to be showed in a category listing.
4. Load the category in storefront - no error occures but a fallback search will happen to search in the normal database
5. If we print the error in Elasticsearch/Framework/DataAbstractionLayer/ElasticsearchEntitySearcher.php - line 90, the following error message will occur: 
{"error":{"root_cause":[{"type":"query_shard_exception","reason":"failed to create query: Can't parse boolean value [1], expected [true] or [false]","index_uuid":"QOA9DtcnTQGCt1pErCTvfA","index":"sw_cp6__product_6adfee4faa9c40369f7babd0c283bcb7_1604165948"}],"type":"search_phase_execution_exception","reason":"all shards failed","phase":"query","grouped":true,"failed_shards":[{"shard":0,"index":"sw_cp6__product_6adfee4faa9c40369f7babd0c283bcb7_1604165948","node":"6CVO0lrvS-qTYxt_QsPWZA","reason":{"type":"query_shard_exception","reason":"failed to create query: Can't parse boolean value [1], expected [true] or [false]","index_uuid":"QOA9DtcnTQGCt1pErCTvfA","index":"sw_cp6__product_6adfee4faa9c40369f7babd0c283bcb7_1604165948","caused_by":{"type":"illegal_argument_exception","reason":"Can't parse boolean value [1], expected [true] or [false]"}}}]},"status":400}

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/NEXT-11784

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
