### PR TITLE
Reduce default poll-intervall of admin-worker

### DIFF
--- a/changelog/_unreleased/2020-11-03-reduce-default-poll-interva-of-admin-worker.md
+++ b/changelog/_unreleased/2020-11-03-reduce-default-poll-interva-of-admin-worker.md
@@ -1,5 +1,7 @@
 ---
 title: Reduce default poll-intervall of admin-worker
+author: Manuel Kress
+author_email: 6232639+windaishi@users.noreply.github.com
 ---
 # Core
 * Reduced the default `poll_interval` of the`admin_worker` from 30 to 20 seconds.

--- a/changelog/_unreleased/2020-11-03-reduce-default-poll-interva-of-admin-worker.md
+++ b/changelog/_unreleased/2020-11-03-reduce-default-poll-interva-of-admin-worker.md
@@ -1,0 +1,7 @@
+---
+title: Reduce default poll-intervall of admin-worker
+---
+# Core
+* Reduced the default `poll_interval` of the`admin_worker` from 30 to 20 seconds.
+  * This should stop the `consume`-request from failing with timeouts when the `max_execution_time` of PHP is set to 30 seconds (default).
+___

--- a/src/Core/Framework/DependencyInjection/Configuration.php
+++ b/src/Core/Framework/DependencyInjection/Configuration.php
@@ -147,7 +147,7 @@ class Configuration implements ConfigurationInterface
                     ->prototype('scalar')->end()
                 ->end()
                 ->integerNode('poll_interval')
-                    ->defaultValue(30)
+                    ->defaultValue(20)
                 ->end()
                 ->booleanNode('enable_admin_worker')
                     ->defaultValue(true)

--- a/src/Core/Framework/Resources/config/packages/shopware.yaml
+++ b/src/Core/Framework/Resources/config/packages/shopware.yaml
@@ -32,7 +32,8 @@ shopware:
 
     admin_worker:
         enable_admin_worker: true
-        poll_interval: 30
+        # This has to be lower than PHP's max_execution_time (default: 30s)
+        poll_interval: 20
         transports: ["default"]
 
     auto_update:

--- a/src/Docs/Resources/current/20-developer-guide/80-core/10-message-queue.md
+++ b/src/Docs/Resources/current/20-developer-guide/80-core/10-message-queue.md
@@ -320,6 +320,6 @@ The poll interval is the time in seconds that the admin-worker polls messages fr
 shopware:
     admin_worker:
         enable_admin_worker: true
-        poll_interval: 30
+        poll_interval: 20
         transports: ["default"]
 ``` 

--- a/src/Docs/Resources/deprecated/2-internals/1-core/00-module/message-queue.md
+++ b/src/Docs/Resources/deprecated/2-internals/1-core/00-module/message-queue.md
@@ -320,6 +320,6 @@ The poll interval is the time in seconds that the admin-worker polls messages fr
 shopware:
     admin_worker:
         enable_admin_worker: true
-        poll_interval: 30
+        poll_interval: 20
         transports: ["default"]
 ``` 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?

**Poll-Interval**
The `poll_interval` is used to set how long the `consume`-request is processed. This request always takes as long as the `poll_interval`. The admin-worker is implemented on the client in a way that he sends a new `consume`-request as soon as the answer of the previous one is available.

**Maximum runtime**
The `poll_interval` of the admin-worker is set to 30s by default. This is the same value as the minimum value required for `max_execution_time` of PHP. But because of the additional execution of framework-boilerplate-code, the processing of the `consume`-request always takes longer than 30s and PHP aborts the process. Now a number of problems start:

* The last messages may not be executed completely
* ngnix also waits only 30 seconds for PHP and therefore sends a 502 Bad Gateway Error to the client.
  * Together with Cloudflare's Always-On Technology this will show the shop as offline to the user. (Very bad)

### 2. What does this change do, exactly?

Shopware requires a minimum value for PHPs `max_execution_time` of 30s. So this PR reduces the default `poll_interval` to 20s. This should be enough for the `consume`-request to not end in a PHP timeout anymore.

### 3. Describe each step to reproduce the issue or behaviour.
Just open the administration, open the browser console and see the `consume`-request fail one after another with code 502.

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
