### PR TITLE
Quote JSON path segments for query accessor.

### DIFF
--- a/changelog/_unreleased/2020-11-06-hyphenated-json-fields-in-dbal.md
+++ b/changelog/_unreleased/2020-11-06-hyphenated-json-fields-in-dbal.md
@@ -1,0 +1,9 @@
+---
+title: Hyphenated JSON fields in DBAL
+issue: 
+author: Uwe Kleinmann
+author_email: u.kleinmann@kellerkinder.de
+author_github: @kleinmann
+---
+# Core
+* Changed JSON accessor builder to quote field names. This allows for hyphenated fields (like `my-hyphenated-field`) in queries using JSON fields, where previously an "Invalid JSON path expression" error was thrown by MySQL.

--- a/src/Core/Framework/DataAbstractionLayer/Dbal/FieldAccessorBuilder/JsonFieldAccessorBuilder.php
+++ b/src/Core/Framework/DataAbstractionLayer/Dbal/FieldAccessorBuilder/JsonFieldAccessorBuilder.php
@@ -31,11 +31,19 @@ class JsonFieldAccessorBuilder implements FieldAccessorBuilderInterface
             return null;
         }
 
-        $jsonPath = preg_replace(
+        $jsonPathBase = preg_replace(
             '#^' . preg_quote($jsonField->getPropertyName(), '#') . '#',
             '',
             $accessor
         );
+
+        $jsonPath = '';
+        $jsonPathSegments = explode('.', (string) $jsonPathBase);
+        foreach ($jsonPathSegments as $jsonPathSegment) {
+            if (!empty($jsonPathSegment)) {
+                $jsonPath .= '."' . $jsonPathSegment . '"';
+            }
+        }
 
         if (empty($jsonPath)) {
             return EntityDefinitionQueryHelper::escape($root) . '.' . EntityDefinitionQueryHelper::escape($jsonField->getStorageName());

--- a/src/Core/Framework/Test/DataAbstractionLayer/Dbal/FieldAccessorBuilder/JsonFieldAccessorBuilderTest.php
+++ b/src/Core/Framework/Test/DataAbstractionLayer/Dbal/FieldAccessorBuilder/JsonFieldAccessorBuilderTest.php
@@ -1,0 +1,35 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\Test\DataAbstractionLayer\Dbal\FieldAccessorBuilder;
+
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\Dbal\FieldAccessorBuilder\JsonFieldAccessorBuilder;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\JsonField;
+use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
+
+class JsonFieldAccessorBuilderTest extends TestCase
+{
+    use IntegrationTestBehaviour;
+
+    public function testHyphenatedFieldAccessor(): void
+    {
+        $fieldName = 'aJsonField.my-hyphenated-field';
+
+        $accessorBuilder = new JsonFieldAccessorBuilder($this->getContainer()->get(Connection::class));
+        $jsonField = new JsonField('a_json_field', 'aJsonField');
+
+        static::assertEquals('IF(JSON_TYPE(JSON_EXTRACT(`some_entity`.`a_json_field`, \'$.\\"my-hyphenated-field\\"\')) != "NULL", CONVERT(JSON_UNQUOTE(JSON_EXTRACT(`some_entity`.`a_json_field`, \'$.\\"my-hyphenated-field\\"\')) USING "utf8mb4") COLLATE utf8mb4_unicode_ci, NULL)', $accessorBuilder->buildAccessor('some_entity', $jsonField, Context::createDefaultContext(), $fieldName));
+    }
+
+    public function testNestedFieldsAccessor(): void
+    {
+        $fieldName = 'aJsonField.my.nested.field';
+
+        $accessorBuilder = new JsonFieldAccessorBuilder($this->getContainer()->get(Connection::class));
+        $jsonField = new JsonField('a_json_field', 'aJsonField');
+
+        static::assertEquals('IF(JSON_TYPE(JSON_EXTRACT(`some_entity`.`a_json_field`, \'$.\\"my\\".\\"nested\\".\\"field\\"\')) != "NULL", CONVERT(JSON_UNQUOTE(JSON_EXTRACT(`some_entity`.`a_json_field`, \'$.\\"my\\".\\"nested\\".\\"field\\"\')) USING "utf8mb4") COLLATE utf8mb4_unicode_ci, NULL)', $accessorBuilder->buildAccessor('some_entity', $jsonField, Context::createDefaultContext(), $fieldName));
+    }
+}


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
Usage of hyphenated fields in JSON fields in a DAL query currently results in a MySQL error "Invalid JSON path expression". Such fields must be quoted to be used in a query.

### 2. What does this change do, exactly?
It quotes all segments (separated by `.`) when building the field accessor for the MySQL query.

### 3. Describe each step to reproduce the issue or behaviour.
* Create a custom field "my-hyphenated-field"
* Use the custom field in a query:
```
$criteria->addFilter(new EqualsFilter('customFields.my-hyphenated-field', 'some value'));
```
* See error during execution

### 4. Please link to the relevant issues (if any).
There's no issue yet, as far as I can tell.

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
