### PR TITLE
NEXT-11955 Fix: Sometimes file downloads contain exception

### DIFF
--- a/src/Storefront/Framework/Csrf/CsrfPlaceholderHandler.php
+++ b/src/Storefront/Framework/Csrf/CsrfPlaceholderHandler.php
@@ -5,6 +5,7 @@ namespace Shopware\Storefront\Framework\Csrf;
 use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\StreamedResponse;
 use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
 
 class CsrfPlaceholderHandler
@@ -35,6 +36,10 @@ class CsrfPlaceholderHandler
 
     public function replaceCsrfToken(Response $response, Request $request): Response
     {
+        if ($response instanceof StreamedResponse) {
+            return $response;
+        }
+
         if (!$this->csrfEnabled || $this->csrfMode !== CsrfModes::MODE_TWIG) {
             return $response;
         }

--- a/src/Storefront/Test/Framework/Csrf/CsrfPlaceholderHandlerTest.php
+++ b/src/Storefront/Test/Framework/Csrf/CsrfPlaceholderHandlerTest.php
@@ -7,6 +7,7 @@ use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Storefront\Framework\Csrf\CsrfPlaceholderHandler;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\StreamedResponse;
 use Twig\Environment;
 use Twig\Loader\FilesystemLoader;
 use Twig\Loader\LoaderInterface;
@@ -92,6 +93,15 @@ class CsrfPlaceholderHandlerTest extends TestCase
     {
         $csrfPlaceholderHandler = $this->createCsrfPlaceholderHandler();
         $expectedResponse = new Response($this->getContentWithCsrfPLaceholder(), 404, ['Content-Type' => 'text/html']);
+        $response = $csrfPlaceholderHandler->replaceCsrfToken($expectedResponse, new Request());
+        static::assertSame($expectedResponse, $response);
+    }
+
+    public function testReplaceStreamedResponseShouldNotCrash(): void
+    {
+        $csrfPlaceholderHandler = $this->createCsrfPlaceholderHandler();
+        $expectedResponse = new StreamedResponse(function (): void {
+        }, 200, ['Content-Type' => 'text/csv']);
         $response = $csrfPlaceholderHandler->replaceCsrfToken($expectedResponse, new Request());
         static::assertSame($expectedResponse, $response);
     }


### PR DESCRIPTION
* CsrfToken Replacement is pointless on streamed responses
* Content will be false for streamed responses
* We do not have to replace anything at all, if the content is empty anyways, so we use "if empty"

### 1. Why is this change necessary?

see https://issues.shopware.com/issues/NEXT-11955

### 2. What does this change do, exactly?

Fix exception in case of file downloads (exports)

### 3. Describe each step to reproduce the issue or behaviour.

see https://issues.shopware.com/issues/NEXT-11955

1. Download a export file
2. Observe log

### 4. Please link to the relevant issues (if any).

see https://issues.shopware.com/issues/NEXT-11955

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [not necessary] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [not necessary] I have written or adjusted the documentation according to my changes
- [not necessary] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
