### PR TITLE
Next-11956: Add unique ID to Media input file

### DIFF
--- a/changelog/_unreleased/2020-11-08-media-component-non-unique-id.md
+++ b/changelog/_unreleased/2020-11-08-media-component-non-unique-id.md
@@ -1,0 +1,9 @@
+---
+title: Add unique ID to Media input file
+issue: NEXT-11956
+author: Christopher Dosin
+author_email: hello@christopherdosin.me
+author_github: @christopherdosin
+---
+# Administration
+*  Added `Shopware.utils.createId()` to the `<sw-media-upload-v2>` component, to create a unique ID for the file input

--- a/src/Administration/Resources/app/administration/src/app/component/media/sw-media-compact-upload-v2/sw-media-compact-upload-v2.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/media/sw-media-compact-upload-v2/sw-media-compact-upload-v2.html.twig
@@ -129,7 +129,7 @@
             <form class="sw-media-upload-v2__form" ref="fileForm">
                 <input class="sw-media-upload-v2__file-input"
                        type="file"
-                       id="files"
+                       :id="createUuid"
                        ref="fileInput"
                        :accept="fileAccept"
                        :multiple="multiSelect"

--- a/src/Administration/Resources/app/administration/src/app/component/media/sw-media-upload-v2/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/media/sw-media-upload-v2/index.js
@@ -2,7 +2,7 @@ import template from './sw-media-upload-v2.html.twig';
 import './sw-media-upload-v2.scss';
 
 const { Component, Mixin, Context } = Shopware;
-const { fileReader, debug } = Shopware.Utils;
+const { fileReader, debug, createId } = Shopware.Utils;
 const { Criteria } = Shopware.Data;
 const INPUT_TYPE_FILE_UPLOAD = 'file-upload';
 const INPUT_TYPE_URL_UPLOAD = 'url-upload';
@@ -152,6 +152,10 @@ Component.register('sw-media-upload-v2', {
 
         isFileUpload() {
             return this.inputType === INPUT_TYPE_FILE_UPLOAD;
+        },
+
+        createUuid() {
+            return createId();
         },
 
         // @deprecated tag:v6.4.0

--- a/src/Administration/Resources/app/administration/src/app/component/media/sw-media-upload-v2/sw-media-upload-v2.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/media/sw-media-upload-v2/sw-media-upload-v2.html.twig
@@ -168,7 +168,7 @@
             <form class="sw-media-upload-v2__form" ref="fileForm">
                 <input class="sw-media-upload-v2__file-input"
                        type="file"
-                       id="files"
+                       :id="createUuid"
                        ref="fileInput"
                        :accept="fileAccept"
                        :multiple="multiSelect"


### PR DESCRIPTION
### 1. Why is this change necessary?
If you are using multiple / more than 1 media components on the same page, you get a warning within the console,
because currently the `id` of each[ file input is hardcoded](https://github.com/shopware/platform/blob/master/src/Administration/Resources/app/administration/src/app/component/media/sw-media-upload-v2/sw-media-upload-v2.html.twig#L190)
 
### 2. What does this change do, exactly?
I am using `Shopware.utils.createId()` to create a unique ID for the file input 

### 3. Describe each step to reproduce the issue or behaviour.
Add more than 1 media components to a page

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/NEXT-11956
#761 

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
