### PR TITLE
Fix typing error (pvivacy->privacy) raised in #1472 and #526

### DIFF
--- a/changelog/_unreleased/2020-11-08-fix-type-in-privacy-id.md
+++ b/changelog/_unreleased/2020-11-08-fix-type-in-privacy-id.md
@@ -1,0 +1,9 @@
+---
+title: Fix typo in form-privacy-opt-in CSS ID prefix
+issue: /
+author: Alexander Menk
+author_email: menk@mestrona.net 
+author_github: @amenk
+---
+# Storefront
+* Renamed CSS ID prefix `form-pvivacy-opt-in-` in `cms-element-form-privacy.html`, use `form-privacy-opt-in-` instead

--- a/src/Storefront/Resources/views/storefront/element/cms-element-form/form-components/cms-element-form-privacy.html.twig
+++ b/src/Storefront/Resources/views/storefront/element/cms-element-form/form-components/cms-element-form-privacy.html.twig
@@ -8,12 +8,12 @@
             <input name="privacy"
                    type="checkbox"
                    class="custom-control-input"
-                   id="form-pvivacy-opt-in-{{ _key }}"
+                   id="form-privacy-opt-in-{{ _key }}"
                    required>
         {% endblock %}
 
         {% block cms_form_privacy_opt_in_label %}
-            <label for="form-pvivacy-opt-in-{{ _key }}" class=" custom-control-label">
+            <label for="form-privacy-opt-in-{{ _key }}" class=" custom-control-label">
                 {{ "general.privacyNotice"|trans({
                     '%url%': path('frontend.cms.page',{ id: shopware.config.core.basicInformation.privacyPage })
                 })|raw }}


### PR DESCRIPTION
### 1. Why is this change necessary?

The CSS ID has a typo

### 2. What does this change do, exactly?

fix a typo

### 3. Describe each step to reproduce the issue or behaviour.

read the code, spot typo

### 4. Please link to the relevant issues (if any).

see #1472 and #526

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
