### PR TITLE
Fix private twig instance extensions in template rendering

### DIFF
--- a/changelog/_unreleased/2021-01-07-fix-mail-template-timezone.md
+++ b/changelog/_unreleased/2021-01-07-fix-mail-template-timezone.md
@@ -1,0 +1,9 @@
+---
+title: Fix mail template timezone
+issue: NEXT-12450
+author: Hans Höchtl
+author_email: hhoechtl@1drop.de 
+author_github: hhoechtl
+---
+# Core
+* Extensions of the private twig instance inside the `StringTemplateRenderer` is now in sync with the global twig instance. Therefore timezone rendering in mail templates is fixed. 

--- a/src/Core/Content/MailTemplate/Api/MailActionController.php
+++ b/src/Core/Content/MailTemplate/Api/MailActionController.php
@@ -58,6 +58,7 @@ class MailActionController extends AbstractController
      */
     public function validate(RequestDataBag $post, Context $context): JsonResponse
     {
+        $this->templateRenderer->initialize();
         $this->templateRenderer->render($post->get('contentHtml', ''), [], $context);
         $this->templateRenderer->render($post->get('contentPlain', ''), [], $context);
 

--- a/src/Core/Content/MailTemplate/Service/MailService.php
+++ b/src/Core/Content/MailTemplate/Service/MailService.php
@@ -143,6 +143,7 @@ class MailService implements MailServiceInterface
         if (isset($data['testMode']) && (bool) $data['testMode'] === true) {
             $this->templateRenderer->enableTestMode();
         }
+        $this->templateRenderer->initialize();
 
         $template = $data['subject'];
 

--- a/src/Core/Framework/Test/Adapter/Twig/StringTemplateRendererTest.php
+++ b/src/Core/Framework/Test/Adapter/Twig/StringTemplateRendererTest.php
@@ -1,0 +1,55 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\Test\Adapter\Twig;
+
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Adapter\Twig\StringTemplateRenderer;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
+use Twig\Extension\CoreExtension;
+
+class StringTemplateRendererTest extends TestCase
+{
+    use KernelTestBehaviour;
+
+    /**
+     * @var StringTemplateRenderer
+     */
+    private $stringTemplateRenderer;
+
+    /**
+     * @var \Twig\Environment
+     */
+    private $twig;
+
+    protected function setUp(): void
+    {
+        $this->stringTemplateRenderer = $this->getContainer()->get(StringTemplateRenderer::class);
+        $this->twig = $this->getContainer()->get('twig');
+    }
+
+    public function testRender(): void
+    {
+        $templateMock = '{{ foo }}';
+        $dataMock = ['foo' => 'bar'];
+        $rendered = $this->stringTemplateRenderer->render($templateMock, $dataMock, Context::createDefaultContext());
+        static::assertEquals('bar', $rendered);
+    }
+
+    public function testInitialization(): void
+    {
+        $templateMock = '{{ testDate|format_date(pattern="HH:mm") }}';
+        $testDate = new \DateTimeImmutable('now', new \DateTimeZone('UTC'));
+        $context = Context::createDefaultContext();
+        $renderedTime = $this->stringTemplateRenderer->render($templateMock, ['testDate' => $testDate], $context);
+
+        /** @var CoreExtension $coreExtension */
+        $coreExtension = $this->twig->getExtension(CoreExtension::class);
+        $coreExtension->setTimezone('Europe/Berlin');
+        $this->stringTemplateRenderer->initialize();
+
+        $renderedWithTimezone = $this->stringTemplateRenderer->render($templateMock, ['testDate' => $testDate], $context);
+
+        static::assertNotEquals($renderedTime, $renderedWithTimezone);
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?

Because the DateTimes in rendered mails are wrong.

### 2. What does this change do, exactly?

The private Twig instance inside the `StringTemplateRenderer` is only initialized with the twig extensions from the global renderer. But those extensions change e.g. `TwigDateRequestListener` sets the `CoreExtension` with the correct timezone of the user. That never reaches the private twig instance, therefore all DateTimes rendered in mail templates are UTC.

### 3. Describe each step to reproduce the issue or behaviour.

Make an order and look at the time rendered in the mail.

### 4. Please link to the relevant issues (if any).

https://github.com/shopware/platform/issues/1333

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
