### PR TITLE
NEXT-12049 Add cache for frontend.detail.switch

### DIFF
--- a/changelog/_unreleased/2020-11-10-add-cache-for-frontend.detail.switch.md
+++ b/changelog/_unreleased/2020-11-10-add-cache-for-frontend.detail.switch.md
@@ -1,0 +1,9 @@
+---
+title: Add cache for route frontend.detail.switch
+issue: NEXT-12049
+author: Sebastian König
+author_email: s.koenig@tinect.de
+author_github: @tinect
+---
+# Storefront
+*  Changed route `frontend.detail.switch` in `ProductController.php` to set header for correct HttpCache usage

--- a/src/Storefront/Controller/ProductController.php
+++ b/src/Storefront/Controller/ProductController.php
@@ -20,6 +20,7 @@ use Shopware\Storefront\Page\Product\Review\ProductReviewLoader;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\EventListener\AbstractSessionListener;
 use Symfony\Component\Routing\Annotation\Route;
 
 /**
@@ -119,7 +120,10 @@ class ProductController extends StorefrontController
             $salesChannelContext
         );
 
-        return new JsonResponse(['url' => $url]);
+        $response = new JsonResponse(['url' => $url]);
+        $response->headers->set(AbstractSessionListener::NO_AUTO_CACHE_CONTROL_HEADER, '1');
+
+        return $response;
     }
 
     /**


### PR DESCRIPTION
### 1. Why is this change necessary?
The route `frontend.detail.switch` doesn't use the HttpCache proper as it's defined in the annotation. The header `AbstractSessionListener::NO_AUTO_CACHE_CONTROL_HEADER` is missing. It's just in renderStorefront.

### 2. What does this change do, exactly?
Add the header before sending result.

### 3. Describe each step to reproduce the issue or behaviour.
- Activate HttpCache
- Add `time()` to JsonResponse of route `fronted.detail.switch`
- Call a switch-url
- Notice the timestamp
- Refresh the switch-url
- See new timestamp
- Booooom, http-cache not correct used

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/NEXT-12049

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
