### PR TITLE
NEXT-11125: fixed error in category module 'Cannot read property 'swag_social_shopping_google_category' of null'

### DIFF
--- a/changelog/_unreleased/2020-11-11-fixed-saving-custom-fields-in-categories.md
+++ b/changelog/_unreleased/2020-11-11-fixed-saving-custom-fields-in-categories.md
@@ -1,0 +1,10 @@
+---
+title: fixed saving custom fields in categories
+issue: NEXT-11125
+author: Jeroen Aartse
+author_email: jeroen@webdesigntilburg.nl 
+author_github: aartse
+---
+# Administration
+*  Added watch on 'entity.customFields' in component 'sw-custom-field-set-renderer' to initialize customFields when this property is null.
+___

--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-custom-field-set-renderer/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-custom-field-set-renderer/index.js
@@ -149,6 +149,12 @@ Component.register('sw-custom-field-set-renderer', {
     },
 
     watch: {
+        'entity.customFields': {
+            handler() {
+                this.initializeCustomFields();
+            }
+        },
+
         'entity.customFieldSetSelectionActive': {
             handler(value) {
                 this.onChangeCustomFieldSetSelectionActive(value);


### PR DESCRIPTION
### 1. Why is this change necessary?
to fix javascript error 'Cannot read property 'custom_xxx' of null' described in NEXT-11125 and NEXT-10986

### 2. What does this change do, exactly?
category.customFields is null when a new category is created. This change initializes customFields when it is null.
With categories the component sw-custom-field-set-renderer is not recreated, so initializeCustomFields is only called on createdComponent().

This bug is caused by this change:
https://github.com/shopware/platform/commit/7941cc1d8d6b1e452355ce35578bf13395053197#diff-e7f8335dc99dfb03e96d1107e73043c962c80ea3ef7c32ae787340f3d629fd95L131

### 3. Describe each step to reproduce the issue or behaviour.
Create a new CustomField set
Assign this set to category
Create a new CustomField (Type Checkbox) in this set
Go to categories and switch from one category to another

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/NEXT-10986
https://issues.shopware.com/issues/NEXT-11125

### 5. Checklist
- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.