### PR TITLE
allow migrations for non standard namespaces

### DIFF
--- a/src/Core/Framework/Migration/Command/CreateMigrationCommand.php
+++ b/src/Core/Framework/Migration/Command/CreateMigrationCommand.php
@@ -63,6 +63,8 @@ class CreateMigrationCommand extends Command
         // Both dir and namespace were given
         if ($directory) {
             $this->createMigrationFile($name, $output, realpath($directory), $namespace);
+
+            return 0;
         }
 
         $pluginName = $input->getOption('plugin');


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
When the production template is forked and no "Shopware" namespace is used for a new bundle, the migration create command will try to create a migration for the shopware core, too. Leading to an exception after the bundle migration was created successfull 

Example Command:

./bin/console database:create-migration ~/Path/To/Production/src/Bundle/Migration MyBundle\\Migration --name=test

### 2. What does this change do, exactly?
Added an early return to disable plugin and core create migration magic.

### 3. Describe each step to reproduce the issue or behaviour.
- fork production template
- add new bundle with a different namespace
- create migration for new bundle

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.
