### PR TITLE
Add order load listener to sort order line items by position

### DIFF
--- a/src/Core/Checkout/DependencyInjection/order.xml
+++ b/src/Core/Checkout/DependencyInjection/order.xml
@@ -107,6 +107,10 @@
         </service>
 
         <!-- events -->
+        <service id="Shopware\Core\Checkout\Order\Listener\OrderLoadedEventListener">
+            <tag name="kernel.event_subscriber"/>
+        </service>
+
         <service id="Shopware\Core\Checkout\Order\Listener\OrderStateChangeEventListener">
             <argument type="service" id="order.repository"/>
             <argument type="service" id="order_transaction.repository"/>

--- a/src/Core/Checkout/Order/Listener/OrderLoadedEventListener.php
+++ b/src/Core/Checkout/Order/Listener/OrderLoadedEventListener.php
@@ -1,0 +1,29 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Checkout\Order\Listener;
+
+use Shopware\Core\Checkout\Order\Aggregate\OrderLineItem\OrderLineItemCollection;
+use Shopware\Core\Checkout\Order\OrderEntity;
+use Shopware\Core\Checkout\Order\OrderEvents;
+use Shopware\Core\Framework\DataAbstractionLayer\Event\EntityLoadedEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+class OrderLoadedEventListener implements EventSubscriberInterface
+{
+    public static function getSubscribedEvents()
+    {
+        return [
+            OrderEvents::ORDER_LOADED_EVENT => 'orderLoaded',
+        ];
+    }
+
+    public function orderLoaded(EntityLoadedEvent $event): void
+    {
+        /** @var OrderEntity $order */
+        foreach ($event->getEntities() as $order) {
+            if ($order->getLineItems() instanceof OrderLineItemCollection) {
+                $order->getLineItems()->sortByPosition();
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
The order line items are in a different order than the cart line items.
Disclaimer: I'm not sure if this is a fix, workaround or a bad idea. If this is a proper way to fix this I'll gladly complete the PR (changelog, tests?,..).
If not suggestions are welcome ;).

### 2. What does this change do, exactly?
Adds an event listener to order loaded event and sorts order line items by position.

### 3. Describe each step to reproduce the issue or behaviour.
Buy some stuff and compare the order of the line items from the cart to the order of the line items of the order.


### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/NEXT-11875
https://issues.shopware.com/issues/NEXT-9869



### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.
