### PR TITLE
Fix wrong parameter shortcut for `product-export:generate` command

### DIFF
--- a/changelog/_unreleased/2020-11-13-fix-wrong-productexport-shortcut.md
+++ b/changelog/_unreleased/2020-11-13-fix-wrong-productexport-shortcut.md
@@ -1,0 +1,8 @@
+---
+title: Fix wrong parameter shortcut for `product-export:generatge`
+author: Hendrik Söbbing
+author_email: hendrik@soebbing.de
+author_github: @soebbing
+---
+# Core
+* Fixed wrong parameter shortcut for command `product-export:generate`

--- a/src/Core/Content/ProductExport/Command/ProductExportGenerateCommand.php
+++ b/src/Core/Content/ProductExport/Command/ProductExportGenerateCommand.php
@@ -37,7 +37,7 @@ class ProductExportGenerateCommand extends Command
         $this
             ->setName('product-export:generate')
             ->addOption('force', 'f', InputOption::VALUE_NONE, 'Ignore cache and force generation')
-            ->addOption('include-inactive', 'inactive', InputOption::VALUE_NONE, 'Include inactive exports')
+            ->addOption('include-inactive', 'i', InputOption::VALUE_NONE, 'Include inactive exports')
             ->addArgument('sales-channel-id', InputArgument::REQUIRED, 'Sales channel to generate exports for')
             ->addArgument('product-export-id', InputArgument::OPTIONAL, 'Generate specific export');
     }


### PR DESCRIPTION
### 1. Why is this change necessary?

If you try to use the parameter `-inactive` of the command `product-export:generate` you'll receive the error `The "-i" option does not exist"`. This happens, since shortcuts in Symfony commands are supposed to be single letters.

### 2. What does this change do, exactly?

It changes the shortcut from `inactive` to `i`.

### 3. Describe each step to reproduce the issue or behaviour.

Try to run `bin/console product-export:generate -f -inactive <saleschannel id>` - you'll receive the error mentioned above

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [X] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.
