### PR TITLE
NEXT-12109 | Upload media via Url can not upload media 

### DIFF
--- a/changelog/_unreleased/2020-12-10-decode-uri-string-in-file-reader-service.md
+++ b/changelog/_unreleased/2020-12-10-decode-uri-string-in-file-reader-service.md
@@ -1,0 +1,10 @@
+---
+title: Decode URI string in file reader service
+issue: 12109
+author: Alexander Schmidt
+author_email: support@kiplingi.de 
+author_github: @kiplingi
+---
+# Administration
+*  Changed return value to decoded url string, because an encoded URI is prone to get rejected by file saver logic.
+

--- a/src/Administration/Resources/app/administration/src/core/service/utils/file-reader.utils.js
+++ b/src/Administration/Resources/app/administration/src/core/service/utils/file-reader.utils.js
@@ -90,6 +90,8 @@ function getNameAndExtensionFromUrl(urlObject) {
         ref = ref.substring(0, indexOfQueryIndicator);
     }
 
+    ref = decodeURI(ref);
+
     return splitFileNameAndExtension(ref);
 }
 


### PR DESCRIPTION
### 1. Why is this change necessary?
Fixes problems caused through URL encoded image upload.

### 2. What does this change do, exactly?
Decodes URL string before it is sent to server.

### 3. Describe each step to reproduce the issue or behaviour.
See [Issue](https://issues.shopware.com/issues/NEXT-12109?products=SW-6&edition=community,starterEdition&projects=all&type=1,4&status=open,inProgress,done)

### 4. Please link to the relevant issues (if any).
[Issue](https://issues.shopware.com/issues/NEXT-12109?products=SW-6&edition=community,starterEdition&projects=all&type=1,4&status=open,inProgress,done)

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
