### PR TITLE
Fix user grid gets stuck in infinite loop

### DIFF
--- a/changelog/_unreleased/2020-11-17-fix-admin-user-grid.md
+++ b/changelog/_unreleased/2020-11-17-fix-admin-user-grid.md
@@ -1,0 +1,9 @@
+---
+title: fix-admin-user-grid
+issue: NEXT-9427
+author: Sebastian Lember
+author_email: sebi.lember@gmx.de 
+author_github: @sebi007
+---
+# Administration
+*  Changed `src/Administration/Resources/app/administration/src(app/component/base/sw-avatar/index.js` to `cloneDeep(this.sourceContext.avatarMedia)` 

--- a/src/Administration/Resources/app/administration/src/app/component/base/sw-avatar/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/base/sw-avatar/index.js
@@ -2,6 +2,7 @@ import template from './sw-avatar.html.twig';
 import './sw-avatar.scss';
 
 const { Component } = Shopware;
+const { cloneDeep } = Shopware.Utils.object;
 
 const colors = [
     '#FFD700',
@@ -134,7 +135,7 @@ Component.register('sw-avatar', {
                 return null;
             }
 
-            const avatarMedia = this.sourceContext.avatarMedia;
+            const avatarMedia = cloneDeep(this.sourceContext.avatarMedia);
             const thumbnailImage = avatarMedia.thumbnails.sort((a, b) => a.width - b.width)[0];
             const previewImageUrl = thumbnailImage ? thumbnailImage.url : avatarMedia.url;
 


### PR DESCRIPTION
### 1. Why is this change necessary?
This Change is necessary because the user grid in the administration gets stuck in an infinite loop, if at least two users have the same avatar image. This is caused by an infinite loop in the render method of Vue. The function avatarImage, which changes an object that causes the component to rerender, gets called in the template.

### 2. What does this change do, exactly?
Instead of assigning the avatarMedia object directly to the variable, it creates a deep clone, so that Vue does not get stuck in the infinite render loop.

### 3. Describe each step to reproduce the issue or behaviour.
- Install shopware.
- Create two users and assign the same image to both users.
- Reload the user grid.

### 4. Please link to the relevant issues (if any).
[NEXT-9427](https://issues.shopware.com/issues/NEXT-9427)

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
