### PR TITLE
Fix newsletter subscribe url for shops with urls like /de

### DIFF
--- a/src/Core/Content/Newsletter/SalesChannel/SalesChannelNewsletterController.php
+++ b/src/Core/Content/Newsletter/SalesChannel/SalesChannelNewsletterController.php
@@ -49,7 +49,7 @@ class SalesChannelNewsletterController extends AbstractController
      */
     public function subscribe(Request $request, RequestDataBag $data, SalesChannelContext $context): JsonResponse
     {
-        $data->set('storefrontUrl', $request->attributes->get('sw-sales-channel-absolute-base-url'));
+        $data->set('storefrontUrl', $request->attributes->get('sw-sales-channel-absolute-base-url') . $request->attributes->get('sw-sales-channel-base-url'));
         $data->set('option', 'subscribe');
 
         $this->newsletterSubscribeRoute->subscribe($data, $context, false);


### PR DESCRIPTION
### 1. Why is this change necessary?
Newsletter subscribe don't works for domains like "https://www.my-shop.at/de".
Same bug as in pull request https://github.com/shopware/platform/pull/1044

### 2. What does this change do, exactly?
Fix missing /de for subscribing newsletter create opt in link.

### 3. Describe each step to reproduce the issue or behaviour.
Our domain setup of our sales channel:

    https://www.my-shop.at/de
    https://www.my-shop.at/en

-> No domain with https://www.my-shop.at is set!

Now when we try the newsletter subscribe on one of the domains - it don't works because it validates the storefrontUrl "https://www.my-shop.at" to that non existing domain.
We changed it, that it sets the storefrontUrl as "https://www.my-shop.at/de" and not "https://www.my-shop.at".

### 4. Please link to the relevant issues (if any).
https://github.com/shopware/platform/pull/1044

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
