### PR TITLE
Remove product available business logic from Twig

### DIFF
--- a/changelog/_unreleased/2020-11-22-remove-product-available-business-logic-from-twig.md
+++ b/changelog/_unreleased/2020-11-22-remove-product-available-business-logic-from-twig.md
@@ -1,0 +1,8 @@
+---
+title: Remove product available business logic from Twig
+author: Joshua Behrens
+author_email: code@joshua-behrens.de
+author_github: @JoshuaBehrens
+---
+# Storefront
+* Changed source of product availability to be the available field instead of calculating it by closeout, minPurchase and stock information in Twig

--- a/src/Storefront/Resources/views/storefront/component/delivery-information.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/delivery-information.html.twig
@@ -41,7 +41,7 @@
                     })|sw_sanitize }}
                 </p>
             {% endblock %}
-        {% elseif product.isCloseout and product.availableStock < product.minPurchase %}
+        {% elseif not product.available %}
             {% block component_delivery_information_soldout %}
                 <link itemprop="availability" href="http://schema.org/LimitedAvailability"/>
                 <p class="delivery-information delivery-soldout">

--- a/src/Storefront/Resources/views/storefront/component/product/card/action.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/product/card/action.html.twig
@@ -3,7 +3,7 @@
 
     {% if shopware.config.core.listing.allowBuyInListing %}
         <div class="product-action">
-            {% set isAvailable = not product.isCloseout or (product.availableStock >= product.minPurchase) %}
+            {% set isAvailable = product.available %}
 
             {% if isAvailable and not product.isGrouped and product.childCount <= 0 and product.calculatedPrices.count <= 1 %}
                 {% block component_product_box_action_buy %}

--- a/src/Storefront/Resources/views/storefront/component/product/card/box-wishlist.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/product/card/box-wishlist.html.twig
@@ -69,7 +69,7 @@
                 {% endblock %}
 
                 {% block component_product_box_currently_not_available %}
-                    {% set noLongerAvailable = product.isCloseout and product.availableStock < product.minPurchase %}
+                    {% set noLongerAvailable = not product.available %}
 
                     <p class="product-wishlist-info-item product-wishlist-info-not-available">
                         {% if not product.available or noLongerAvailable %}

--- a/src/Storefront/Resources/views/storefront/component/wishlist/card/action.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/wishlist/card/action.html.twig
@@ -1,7 +1,7 @@
 {% sw_extends '@Storefront/storefront/component/product/card/action.html.twig' %}
 
 {% block component_product_box_action_detail %}
-    {% set noLongerAvailable = product.isCloseout and product.availableStock < product.minPurchase %}
+    {% set noLongerAvailable = not product.available %}
 
     <span {% if noLongerAvailable %}data-toggle="tooltip"
         title="{{ "wishlist.noLongerAvailableTooltip"|trans|striptags }}"{% endif %}>


### PR DESCRIPTION
### 1. Why is this change necessary?
There is already a field on a product that is updated during indexing and therefore is not needed to be calculated in twig. This also removes the business logic from the template and one could in theory influence this field with a product.loaded subscriber without having to overwrite multiple templates (that do not always have a block ready for this change).

### 2. What does this change do, exactly?
It removes the calculation of product availability flag from twig and uses the available field on a product instead.

### 3. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
