### PR TITLE
Added payload field to BuildValidationEvent to help to build inter-field dependant rules

### DIFF
--- a/changelog/_unreleased/2020-11-22-add-payload-field-to-build-validation-event.md
+++ b/changelog/_unreleased/2020-11-22-add-payload-field-to-build-validation-event.md
@@ -1,0 +1,10 @@
+---
+title: Add payload field to BuildValidationEvent
+author: Joshua Behrens
+author_email: code@joshua-behrens.de
+author_github: @JoshuaBehrens
+---
+# Core
+* Added payload field to BuildValidationEvent to help to build inter-field dependant rules 
+* Changed behaviour of ContactFormValidationFactory to not dispatch the BuildValidationEvent anymore
+* Changed behaviour of ContactFormRoute to still dispatch the BuildValidationEvent but without the ContactFormValidationFactory

--- a/src/Core/Checkout/Customer/SalesChannel/ChangeCustomerProfileRoute.php
+++ b/src/Core/Checkout/Customer/SalesChannel/ChangeCustomerProfileRoute.php
@@ -108,7 +108,7 @@ class ChangeCustomerProfileRoute extends AbstractChangeCustomerProfileRoute
             $data->set('vatIds', null);
         }
 
-        $this->dispatchValidationEvent($validation, $context->getContext());
+        $this->dispatchValidationEvent($validation, $data->all(), $context->getContext());
 
         $this->validator->validate($data->all(), $validation);
 
@@ -134,9 +134,9 @@ class ChangeCustomerProfileRoute extends AbstractChangeCustomerProfileRoute
         return new SuccessResponse();
     }
 
-    private function dispatchValidationEvent(DataValidationDefinition $definition, Context $context): void
+    private function dispatchValidationEvent(DataValidationDefinition $definition, array $data, Context $context): void
     {
-        $validationEvent = new BuildValidationEvent($definition, $context);
+        $validationEvent = new BuildValidationEvent($definition, $context, $data);
         $this->eventDispatcher->dispatch($validationEvent, $validationEvent->getName());
     }
 

--- a/src/Core/Checkout/Customer/SalesChannel/ChangeEmailRoute.php
+++ b/src/Core/Checkout/Customer/SalesChannel/ChangeEmailRoute.php
@@ -123,16 +123,16 @@ class ChangeEmailRoute extends AbstractChangeEmailRoute
             )
             ->add('password', new CustomerPasswordMatches(['context' => $context]));
 
-        $this->dispatchValidationEvent($validation, $context->getContext());
+        $this->dispatchValidationEvent($validation, $data->all(), $context->getContext());
 
         $this->validator->validate($data->all(), $validation);
 
         $this->tryValidateEqualtoConstraint($data->all(), 'email', $validation);
     }
 
-    private function dispatchValidationEvent(DataValidationDefinition $definition, Context $context): void
+    private function dispatchValidationEvent(DataValidationDefinition $definition, array $data, Context $context): void
     {
-        $validationEvent = new BuildValidationEvent($definition, $context);
+        $validationEvent = new BuildValidationEvent($definition, $context, $data);
         $this->eventDispatcher->dispatch($validationEvent, $validationEvent->getName());
     }
 

--- a/src/Core/Checkout/Customer/SalesChannel/ChangePasswordRoute.php
+++ b/src/Core/Checkout/Customer/SalesChannel/ChangePasswordRoute.php
@@ -117,9 +117,9 @@ class ChangePasswordRoute extends AbstractChangePasswordRoute
         return new ContextTokenResponse($context->getToken());
     }
 
-    private function dispatchValidationEvent(DataValidationDefinition $definition, Context $context): void
+    private function dispatchValidationEvent(DataValidationDefinition $definition, array $data, Context $context): void
     {
-        $validationEvent = new BuildValidationEvent($definition, $context);
+        $validationEvent = new BuildValidationEvent($definition, $context, $data);
         $this->eventDispatcher->dispatch($validationEvent, $validationEvent->getName());
     }
 
@@ -136,7 +136,7 @@ class ChangePasswordRoute extends AbstractChangePasswordRoute
             ->add('newPassword', new NotBlank(), new Length(['min' => $minPasswordLength]), new EqualTo(['propertyPath' => 'newPasswordConfirm']))
             ->add('password', new CustomerPasswordMatches(['context' => $context]));
 
-        $this->dispatchValidationEvent($definition, $context->getContext());
+        $this->dispatchValidationEvent($definition, $data->all(), $context->getContext());
 
         $this->validator->validate($data->all(), $definition);
 

--- a/src/Core/Checkout/Customer/SalesChannel/ResetPasswordRoute.php
+++ b/src/Core/Checkout/Customer/SalesChannel/ResetPasswordRoute.php
@@ -155,16 +155,16 @@ class ResetPasswordRoute extends AbstractResetPasswordRoute
 
         $definition->add('newPassword', new NotBlank(), new Length(['min' => $minPasswordLength]), new EqualTo(['propertyPath' => 'newPasswordConfirm']));
 
-        $this->dispatchValidationEvent($definition, $context->getContext());
+        $this->dispatchValidationEvent($definition, $data->all(), $context->getContext());
 
         $this->validator->validate($data->all(), $definition);
 
         $this->tryValidateEqualtoConstraint($data->all(), 'newPassword', $definition);
     }
 
-    private function dispatchValidationEvent(DataValidationDefinition $definition, Context $context): void
+    private function dispatchValidationEvent(DataValidationDefinition $definition, array $data, Context $context): void
     {
-        $validationEvent = new BuildValidationEvent($definition, $context);
+        $validationEvent = new BuildValidationEvent($definition, $context, $data);
         $this->eventDispatcher->dispatch($validationEvent, $validationEvent->getName());
     }
 

--- a/src/Core/Checkout/Customer/SalesChannel/SendPasswordRecoveryMailRoute.php
+++ b/src/Core/Checkout/Customer/SalesChannel/SendPasswordRecoveryMailRoute.php
@@ -151,7 +151,7 @@ class SendPasswordRecoveryMailRoute extends AbstractSendPasswordRecoveryMailRout
                 ->add('storefrontUrl', new NotBlank(), new Choice(array_values($this->getDomainUrls($context))));
         }
 
-        $this->dispatchValidationEvent($validation, $context->getContext());
+        $this->dispatchValidationEvent($validation, $data->all(), $context->getContext());
 
         $this->validator->validate($data->all(), $validation);
 
@@ -165,9 +165,9 @@ class SendPasswordRecoveryMailRoute extends AbstractSendPasswordRecoveryMailRout
         }, $context->getSalesChannel()->getDomains()->getElements());
     }
 
-    private function dispatchValidationEvent(DataValidationDefinition $definition, Context $context): void
+    private function dispatchValidationEvent(DataValidationDefinition $definition, array $data, Context $context): void
     {
-        $validationEvent = new BuildValidationEvent($definition, $context);
+        $validationEvent = new BuildValidationEvent($definition, $context, $data);
         $this->eventDispatcher->dispatch($validationEvent, $validationEvent->getName());
     }
 

--- a/src/Core/Checkout/Customer/SalesChannel/UpsertAddressRoute.php
+++ b/src/Core/Checkout/Customer/SalesChannel/UpsertAddressRoute.php
@@ -129,8 +129,9 @@ class UpsertAddressRoute extends AbstractUpsertAddressRoute
         }
 
         $accountType = $data->get('accountType', CustomerEntity::ACCOUNT_TYPE_PRIVATE);
-        $definition = $this->getValidationDefinition($accountType, $isCreate, $context);
-        $this->validator->validate(array_merge(['id' => $addressId], $data->all()), $definition);
+        $validationData = array_merge(['id' => $addressId], $data->all());
+        $definition = $this->getValidationDefinition($accountType, $isCreate, $validationData, $context);
+        $this->validator->validate($validationData, $definition);
 
         $addressData = [
             'salutationId' => $data->get('salutationId'),
@@ -167,8 +168,12 @@ class UpsertAddressRoute extends AbstractUpsertAddressRoute
         return new UpsertAddressRouteResponse($address);
     }
 
-    private function getValidationDefinition(string $accountType, bool $isCreate, SalesChannelContext $context): DataValidationDefinition
-    {
+    private function getValidationDefinition(
+        string $accountType,
+        bool $isCreate,
+        array $data,
+        SalesChannelContext $context
+    ): DataValidationDefinition {
         if ($isCreate) {
             $validation = $this->addressValidationFactory->create($context);
         } else {
@@ -179,7 +184,7 @@ class UpsertAddressRoute extends AbstractUpsertAddressRoute
             $validation->add('company', new NotBlank());
         }
 
-        $validationEvent = new BuildValidationEvent($validation, $context->getContext());
+        $validationEvent = new BuildValidationEvent($validation, $context->getContext(), $data);
         $this->eventDispatcher->dispatch($validationEvent, $validationEvent->getName());
 
         return $validation;

--- a/src/Core/Checkout/Order/SalesChannel/OrderService.php
+++ b/src/Core/Checkout/Order/SalesChannel/OrderService.php
@@ -211,7 +211,7 @@ class OrderService
      */
     private function validateOrderData(ParameterBag $data, SalesChannelContext $context): void
     {
-        $definition = $this->getOrderCreateValidationDefinition($context);
+        $definition = $this->getOrderCreateValidationDefinition($data->all(), $context);
         $violations = $this->dataValidator->getViolations($data->all(), $definition);
 
         if ($violations->count() > 0) {
@@ -219,11 +219,11 @@ class OrderService
         }
     }
 
-    private function getOrderCreateValidationDefinition(SalesChannelContext $context): DataValidationDefinition
+    private function getOrderCreateValidationDefinition(array $data, SalesChannelContext $context): DataValidationDefinition
     {
         $validation = $this->orderValidationFactory->create($context);
 
-        $validationEvent = new BuildValidationEvent($validation, $context->getContext());
+        $validationEvent = new BuildValidationEvent($validation, $context->getContext(), $data);
         $this->eventDispatcher->dispatch($validationEvent, $validationEvent->getName());
 
         return $validation;

--- a/src/Core/Content/ContactForm/SalesChannel/ContactFormRoute.php
+++ b/src/Core/Content/ContactForm/SalesChannel/ContactFormRoute.php
@@ -10,6 +10,7 @@ use Shopware\Core\Framework\Event\EventData\MailRecipientStruct;
 use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
 use Shopware\Core\Framework\Routing\Annotation\RouteScope;
 use Shopware\Core\Framework\Routing\Annotation\Since;
+use Shopware\Core\Framework\Validation\BuildValidationEvent;
 use Shopware\Core\Framework\Validation\DataBag\DataBag;
 use Shopware\Core\Framework\Validation\DataBag\RequestDataBag;
 use Shopware\Core\Framework\Validation\DataValidationFactoryInterface;
@@ -142,6 +143,8 @@ class ContactFormRoute extends AbstractContactFormRoute
     private function validateContactForm(DataBag $data, SalesChannelContext $context): void
     {
         $definition = $this->contactFormValidationFactory->create($context);
+        $validationEvent = new BuildValidationEvent($definition, $context->getContext());
+        $this->eventDispatcher->dispatch($validationEvent, $validationEvent->getName());
         $violations = $this->validator->getViolations($data->all(), $definition);
 
         if ($violations->count() > 0) {

--- a/src/Core/Content/ContactForm/Validation/ContactFormValidationFactory.php
+++ b/src/Core/Content/ContactForm/Validation/ContactFormValidationFactory.php
@@ -3,7 +3,6 @@
 namespace Shopware\Core\Content\ContactForm\Validation;
 
 use Shopware\Core\Framework\DataAbstractionLayer\Validation\EntityExists;
-use Shopware\Core\Framework\Validation\BuildValidationEvent;
 use Shopware\Core\Framework\Validation\DataValidationDefinition;
 use Shopware\Core\Framework\Validation\DataValidationFactoryInterface;
 use Shopware\Core\System\Annotation\Concept\ExtensionPattern\Decoratable;
@@ -28,11 +27,8 @@ class ContactFormValidationFactory implements DataValidationFactoryInterface
      */
     private $systemConfigService;
 
-    public function __construct(
-        EventDispatcherInterface $eventDispatcher,
-        SystemConfigService $systemConfigService
-    ) {
-        $this->eventDispatcher = $eventDispatcher;
+    public function __construct(SystemConfigService $systemConfigService)
+    {
         $this->systemConfigService = $systemConfigService;
     }
 
@@ -69,9 +65,6 @@ class ContactFormValidationFactory implements DataValidationFactoryInterface
         if ($required) {
             $definition->add('phone', new NotBlank());
         }
-
-        $validationEvent = new BuildValidationEvent($definition, $context->getContext());
-        $this->eventDispatcher->dispatch($validationEvent, $validationEvent->getName());
 
         return $definition;
     }

--- a/src/Core/Content/DependencyInjection/contact_form.xml
+++ b/src/Core/Content/DependencyInjection/contact_form.xml
@@ -5,7 +5,6 @@
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
         <service id="Shopware\Core\Content\ContactForm\Validation\ContactFormValidationFactory">
-            <argument type="service" id="event_dispatcher"/>
             <argument type="service" id="Shopware\Core\System\SystemConfig\SystemConfigService"/>
         </service>
 

--- a/src/Core/Framework/Validation/BuildValidationEvent.php
+++ b/src/Core/Framework/Validation/BuildValidationEvent.php
@@ -19,10 +19,16 @@ class BuildValidationEvent extends Event implements ShopwareEvent, GenericEvent
      */
     private $context;
 
-    public function __construct(DataValidationDefinition $definition, Context $context)
+    /**
+     * @var array|null
+     */
+    private $payload;
+
+    public function __construct(DataValidationDefinition $definition, Context $context, ?array $payload = null)
     {
         $this->definition = $definition;
         $this->context = $context;
+        $this->payload = $payload;
     }
 
     public function getName(): string
@@ -38,5 +44,10 @@ class BuildValidationEvent extends Event implements ShopwareEvent, GenericEvent
     public function getContext(): Context
     {
         return $this->context;
+    }
+
+    public function getPayload(): ?array
+    {
+        return $this->payload;
     }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?
I had troubles to make one field on registration being required or not. It was possible with a sub definition but it was a hassle. Having the data to validate on validation building is helpful for that.

### 2. What does this change do, exactly?
Add an optional payload field and parameter to the \Shopware\Core\Framework\Validation\BuildValidationEvent. This is done in a non-breaking manner.

### 3. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
