### PR TITLE
Add .well-known/change-password support for the storefront

### DIFF
--- a/changelog/_unreleased/2020-11-22-add-well-known-change-password.md
+++ b/changelog/_unreleased/2020-11-22-add-well-known-change-password.md
@@ -1,0 +1,8 @@
+---
+title: Add support for .well-known/change-password
+author: Joshua Behrens
+author_email: code@joshua-behrens.de
+author_github: @JoshuaBehrens
+---
+# Storefront
+* Added WellKnownController to redirect from /.well-known/change-password to the profile page where one can change the password

--- a/src/Storefront/Controller/WellKnownController.php
+++ b/src/Storefront/Controller/WellKnownController.php
@@ -1,0 +1,39 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Storefront\Controller;
+
+use Shopware\Core\Framework\Routing\Annotation\RouteScope;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\RouterInterface;
+
+/**
+ * @RouteScope(scopes={"storefront"})
+ * @Route(".well-known/");
+ */
+class WellKnownController extends StorefrontController
+{
+    /**
+     * @var RouterInterface
+     */
+    private $router;
+
+    public function __construct(RouterInterface $router)
+    {
+        $this->router = $router;
+    }
+
+    /**
+     * @Route("change-password", name="frontend.well-known.change-password", methods={"GET"})
+     */
+    public function changePassword(): Response
+    {
+        return new RedirectResponse(
+            $this->router->generate('frontend.account.profile.page', [
+                '_fragment' => '#profile-password-form',
+            ]),
+            Response::HTTP_FOUND
+        );
+    }
+}

--- a/src/Storefront/DependencyInjection/controller.xml
+++ b/src/Storefront/DependencyInjection/controller.xml
@@ -245,6 +245,10 @@
             <argument type="service" id="Symfony\Component\HttpFoundation\RequestStack"/>
         </service>
 
+        <service id="Shopware\Storefront\Controller\WellKnownController" public="true">
+            <argument type="service" id="router"/>
+        </service>
+
         <service id="Shopware\Storefront\Controller\WishlistController" public="true">
             <argument type="service" id="Shopware\Storefront\Page\Wishlist\WishlistPageLoader"/>
             <argument type="service" id="Shopware\Core\Checkout\Customer\SalesChannel\LoadWishlistRoute"/>


### PR DESCRIPTION
### 1. Why is this change necessary?
Supporting https://w3c.github.io/webappsec-change-password-url/ is nice as many password managers can link you to a page where you can change your password in case of a breach. When a shop can supply this info it'll be a joy for everyone.

### 2. What does this change do, exactly?
Add a controller that redirects .well-known/change-password to the form where one can change the password.
I decided to make it not available in the store api as this is not a business logic thing and the place where to change the password is highly dependant on the UI/UX decision which changes from storefront to storefront. Therefore we can only know it for the storefront we ship.

### 3. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
