### PR TITLE
Make LineItems stackable before splitting them from cart

### DIFF
--- a/changelog/_unreleased/2020-11-22-fix-lineitem-quantity-splitter-splitting-unstackable-lineitems.md
+++ b/changelog/_unreleased/2020-11-22-fix-lineitem-quantity-splitter-splitting-unstackable-lineitems.md
@@ -1,0 +1,8 @@
+---
+title: Fix LineItemQuantitySplitter splitting unstackable LineItems
+author: Joshua Behrens
+author_email: code@joshua-behrens.de
+author_github: @JoshuaBehrens
+---
+# Core
+* Changed behaviour of `\Shopware\Core\Checkout\Cart\LineItem\LineItemQuantitySplitter` to ensure the cloned LineItems are stackable to change their quantity and no `\Shopware\Core\Checkout\Cart\Exception\LineItemNotStackableException` is thrown

--- a/src/Core/Checkout/Cart/LineItem/LineItemQuantitySplitter.php
+++ b/src/Core/Checkout/Cart/LineItem/LineItemQuantitySplitter.php
@@ -36,7 +36,10 @@ class LineItemQuantitySplitter
         $taxRules = $tmpItem->getPrice()->getTaxRules();
 
         // change the quantity to 1 single item
+        $isStackable = $tmpItem->isStackable();
+        $tmpItem->setStackable(true);
         $tmpItem->setQuantity($quantity);
+        $tmpItem->setStackable($isStackable);
 
         $quantityDefinition = new QuantityPriceDefinition(
             $unitPrice,

--- a/src/Core/Checkout/Test/Cart/LineItem/Group/LineItemGroupBuilderTest.php
+++ b/src/Core/Checkout/Test/Cart/LineItem/Group/LineItemGroupBuilderTest.php
@@ -266,6 +266,24 @@ class LineItemGroupBuilderTest extends TestCase
     }
 
     /**
+     * This test verifies line items that are not stackable are still able to get extracted
+     *
+     * @group lineitemgroup
+     */
+    public function testShouldGroupAlthoughLineItemsAreNotStackable(): void
+    {
+        $cart = $this->buildCart(1);
+        $cart->getLineItems()->first()->setStackable(false);
+
+        $group = $this->buildGroup(self::KEY_PACKAGER_COUNT, 2, self::KEY_SORTER_PRICE_ASC, new RuleCollection());
+        $result = $this->unitTestBuilder->findGroupPackages([$group], $cart, $this->context);
+        /** @var LineItemQuantity[] $items */
+        $items = array_values($result->getGroupTotalResult($group));
+
+        static::assertCount(1, $items);
+    }
+
+    /**
      * This test verifies a bug fix in the "rest-of-cart" algorithm with this set of products.
      * We add 3 different products (10x quantity for all products).
      * Our group builder rule should only consider the first 2 products (20 items).


### PR DESCRIPTION
### 1. Why is this change necessary?
When you use custom lineitem type that are not stackable by factory but want to apply discounts onto them (which is a hassle for an other issue/PR) and want to re-use the same implementation for products you stumble upon the `LineItemQuantitySplitter` that fails on setting their quantity. That is why I rather change the splitter but build my own so every lineitem type can support discounting in the future without implementing the promotion support themselves.

### 2. What does this change do, exactly?
Change the cloned LineItem to be stackable before changing the quantity to prevent the exception.

### 3. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
