### PR TITLE
Fix elasticsearch field type mapping for advanced prices

### DIFF
--- a/src/Elasticsearch/Framework/Indexing/EntityMapper.php
+++ b/src/Elasticsearch/Framework/Indexing/EntityMapper.php
@@ -114,8 +114,18 @@ class EntityMapper
                     'type' => 'nested',
                     'properties' => [
                         'ruleId' => self::KEYWORD_FIELD,
-                        'from' => self::PRICE_FIELD,
-                        'to' => self::PRICE_FIELD,
+                        'from' => [
+                            'type' => 'object',
+                            'properties' => [
+                                'listPrice' => self::PRICE_FIELD,
+                            ],
+                        ],
+                        'to' => [
+                            'type' => 'object',
+                            'properties' => [
+                                'listPrice' => self::PRICE_FIELD,
+                            ],
+                        ],
                         'listPrice' => self::PRICE_FIELD,
                         'createdAt' => self::DATE_FIELD,
                         'updatedAt' => self::DATE_FIELD,


### PR DESCRIPTION
### 1. Why is this change necessary?
Fixed: Error when indexing products with extended prices into Elasticsearch.

### 2. What does this change do, exactly?
Adds new field mapping for extended prices.

### 3. Describe each step to reproduce the issue or behaviour.
- Add a product with extended prices
- enable the elasticsearch
- use the `shopware/enterprise-search-platform` plugin
- start the command `bin/console dal:refresh:index -v`

### 4. Please link to the relevant issues (if any).
#1527 

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
