### PR TITLE
Fix deleting indices which are currently exported

### DIFF
--- a/src/Elasticsearch/Resources/config/services.xml
+++ b/src/Elasticsearch/Resources/config/services.xml
@@ -187,6 +187,7 @@
             <argument type="service" id="Shopware\Elasticsearch\Framework\ElasticsearchRegistry"/>
             <argument type="service" id="language.repository"/>
             <argument type="service" id="Shopware\Elasticsearch\Framework\ElasticsearchHelper"/>
+            <argument type="service" id="Doctrine\DBAL\Connection" />
         </service>
 
         <service id="Shopware\Elasticsearch\Framework\Indexing\ElasticsearchIndexer">


### PR DESCRIPTION

### 1. Why is this change necessary?
If the indices for with `bin/console dal:refresh:index --use-queue` are exported, then with `bin/console es:index:cleanup -f` also indices are deleted which are currently exported. This behavior is not very useful if the cleanup is done in a cronjob (a constant manual cleanup is not practical here).

### 2. What does this change do, exactly?
Checks if the indices to be deleted are currently exported. If so, it does not delete them.

### 3. Describe each step to reproduce the issue or behaviour.
- start the command `bin/console dal:refresh:index --use-queue`
- start the command `bin/console es:index:cleanup -f`

The new indices which are currently exported will be deleted

### 4. Please link to the relevant issues (if any).
#1528 

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
