### PR TITLE
Fix product export generation in multi sales channel environments whe…

### DIFF
--- a/src/Core/Content/ProductExport/ScheduledTask/ProductExportGenerateTaskHandler.php
+++ b/src/Core/Content/ProductExport/ScheduledTask/ProductExportGenerateTaskHandler.php
@@ -82,7 +82,7 @@ class ProductExportGenerateTaskHandler extends ScheduledTaskHandler
             $productExports = $this->productExportRepository->search($criteria, $salesChannelContext->getContext());
 
             if ($productExports->count() === 0) {
-                return;
+                continue;
             }
 
             /** @var ProductExportEntity $productExport */


### PR DESCRIPTION
### 1. Why is this change necessary?
Currently the product export generation is only working if the first found sales channel has a product export. If not the foreach will just return void instead of moving on to the next sales channel.

### 2. What does this change do, exactly?
This change replaces the return void with a continue, so that not every sales channel has to have a product export.

### 3. Describe each step to reproduce the issue or behaviour.
* Create two sales channels in a shopware instance and add a product export (Product Comparison Sales Channel) for the second sales channel.
* Start the `product_export_generate_task` via the scheduled task runner and check if the product export is being generated.
* Currently the product export is not being generated

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.
