### PR TITLE
Fix unavailable block type

### DIFF
--- a/changelog/_unreleased/2020-11-24-unavailable-block-type-fix.md
+++ b/changelog/_unreleased/2020-11-24-unavailable-block-type-fix.md
@@ -1,0 +1,9 @@
+---
+title: Unavailable block type fix
+issue: 1178
+author: Jan Schüring
+author_email: js@krusemedien.com 
+author_github: schuering 
+___
+# Administration
+* Added filter blocks based on the availability of block types  

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-section/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-section/index.js
@@ -6,7 +6,10 @@ const { Component, Mixin, Filter } = Shopware;
 Component.register('sw-cms-section', {
     template,
 
-    inject: ['repositoryFactory'],
+    inject: [
+        'cmsService',
+        'repositoryFactory'
+    ],
 
     mixins: [
         Mixin.getByName('cms-state')
@@ -107,17 +110,21 @@ Component.register('sw-cms-section', {
         },
 
         sideBarBlocks() {
-            const sideBarBlocks = this.section.blocks.filter((block => block.sectionPosition === 'sidebar'));
+            const sideBarBlocks = this.section.blocks.filter((block => this.blockTypeExists(block.type) && block.sectionPosition === 'sidebar'));
             return sideBarBlocks.sort((a, b) => a.position - b.position);
         },
 
         mainContentBlocks() {
-            const mainContentBlocks = this.section.blocks.filter((block => block.sectionPosition !== 'sidebar'));
+            const mainContentBlocks = this.section.blocks.filter((block => this.blockTypeExists(block.type) && block.sectionPosition !== 'sidebar'));
             return mainContentBlocks.sort((a, b) => a.position - b.position);
         },
 
         assetFilter() {
             return Filter.getByName('asset');
+        },
+
+        blockTypes() {
+            return Object.keys(this.cmsService.getCmsBlockRegistry())
         }
     },
 
@@ -171,6 +178,10 @@ Component.register('sw-cms-section', {
 
         getDropData(index, sectionPosition = 'main') {
             return { dropIndex: index, section: this.section, sectionPosition };
+        },
+
+        blockTypeExists(type) {
+            return this.blockTypes.includes(type)
         }
     }
 });

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-sidebar/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-sidebar/index.js
@@ -115,6 +115,10 @@ Component.register('sw-cms-sidebar', {
             }
 
             return Shopware.Context.api;
+        },
+
+        blockTypes() {
+            return Object.keys(this.cmsBlocks);
         }
     },
 
@@ -393,11 +397,11 @@ Component.register('sw-cms-sidebar', {
         },
 
         getMainContentBlocks(sectionBlocks) {
-            return sectionBlocks.filter((block) => block.sectionPosition === 'main');
+            return sectionBlocks.filter((block) => this.blockTypeExists(block.type) && block.sectionPosition === 'main');
         },
 
         getSidebarContentBlocks(sectionBlocks) {
-            return sectionBlocks.filter((block) => block.sectionPosition === 'sidebar');
+            return sectionBlocks.filter((block) => this.blockTypeExists(block.type) &&  block.sectionPosition === 'sidebar');
         },
 
         pageUpdate() {
@@ -406,6 +410,10 @@ Component.register('sw-cms-sidebar', {
 
         onOpenLayoutAssignment() {
             this.$emit('open-layout-assignment');
+        },
+
+        blockTypeExists(type) {
+            return this.blockTypes.includes(type)
         }
     }
 });

--- a/src/Administration/Resources/app/administration/test/module/sw-cms/component/sw-cms-section.spec.js
+++ b/src/Administration/Resources/app/administration/test/module/sw-cms/component/sw-cms-section.spec.js
@@ -24,6 +24,16 @@ function createWrapper() {
                         id: '3cd4',
                         sectionPosition: 'sidebar',
                         type: 'foo-bar'
+                    },
+                    {
+                        id: '5ef6',
+                        sectionPosition: 'sidebar',
+                        type: 'foo-bar-removed'
+                    },
+                    {
+                        id: '7gh8',
+                        sectionPosition: 'main',
+                        type: 'foo-bar-removed'
                     }
                 ]
             }
@@ -40,7 +50,14 @@ function createWrapper() {
             $store: Shopware.State._store
         },
         provide: {
-            repositoryFactory: {}
+            repositoryFactory: {},
+            cmsService: {
+                getCmsBlockRegistry: () => {
+                    return {
+                        'foo-bar': {}
+                    };
+                }
+            }
         }
     });
 }

--- a/src/Administration/Resources/app/administration/test/module/sw-cms/component/sw-cms-sidebar.spec.js
+++ b/src/Administration/Resources/app/administration/test/module/sw-cms/component/sw-cms-sidebar.spec.js
@@ -62,6 +62,16 @@ function createWrapper() {
                                 id: '3cd4',
                                 sectionPosition: 'sidebar',
                                 type: 'foo-bar'
+                            },
+                            {
+                                id: '5ef6',
+                                sectionPosition: 'sidebar',
+                                type: 'foo-bar-removed'
+                            },
+                            {
+                                id: '7gh8',
+                                sectionPosition: 'main',
+                                type: 'foo-bar-removed'
                             }
                         ]
                     }


### PR DESCRIPTION
### 1. Why is this change necessary?
If a block (based on a block type added by a plugin) is created and the plugin will be deactivated the administration throws the following TypeError: Cannot read property 'removable' of undefined

### 2. What does this change do, exactly?
This change filters blocks by available block types.

### 3. Describe each step to reproduce the issue or behaviour.
- Install a plugin which provides any new block type
- Add a shopping experience which at least one block based on the block type provided by the plugin
- Deactivate the plugin
- Try to edit the shopping experience (and see whats happening in the console)

### 4. Please link to the relevant issues (if any).
#1178 

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
