### PR TITLE
enable autoplay for image slider

### DIFF
--- a/changelog/_unreleased/2020-11-25-add-autoplay-for-image-slider.md
+++ b/changelog/_unreleased/2020-11-25-add-autoplay-for-image-slider.md
@@ -1,0 +1,11 @@
+---
+title: Add autoplay for image slider
+issue: NEXT-8833
+author: Jonathan Wilke
+author_email: jonathan.wilke@green-connector.de 
+author_github: @jonathanwilke
+---
+# Administration
+* Added configuration fields to image slider cms element for autoplay and autoplay timeout
+# Storefront
+* Added the necessary config to the image slider template

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image-slider/config/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image-slider/config/index.js
@@ -158,6 +158,11 @@ Component.register('sw-cms-el-config-image-slider', {
             this.$emit('element-update', this.element);
         },
 
+        onChangeAutoplayInterval(value) {
+            this.element.config.autoplayTimeout.value = parseInt(value, 10);
+            this.$emit('element-update', this.element);
+        },
+
         emitUpdateEl() {
             this.$emit('element-update', this.element);
         }

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image-slider/config/sw-cms-el-config-image-slider.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image-slider/config/sw-cms-el-config-image-slider.html.twig
@@ -136,6 +136,27 @@
                                     </div>
                                 {% endblock %}
 
+                                {% block sw_cms_element_image_gallery_config_settings_autoplay %}
+                                    <div class="sw-cms-el-config-image-slider__settings-autoplay sw-cms-el-config-image-slider__setting-option">
+
+                                        {% block sw_cms_element_image_gallery_config_settings_autoplay_switch %}
+                                          <sw-field type="switch"
+                                                :label="$tc('sw-cms.elements.imageSlider.config.label.autoplay')"
+                                                v-model="element.config.autoplay.value">
+                                          </sw-field>
+                                        {% endblock %}
+
+                                        {% block sw_cms_element_image_gallery_config_settings_autoplay_timeout %}
+                                            <sw-text-field :label="$tc('sw-cms.elements.imageSlider.config.label.autoplayTimeout')"
+                                                   :disabled="!element.config.autoplay.value"
+                                                   v-model="element.config.autoplayTimeout.value"
+                                                   @input="onChangeAutoplayTimeout">
+                                            </sw-text-field>
+                                        {% endblock %}
+
+                                    </div>
+                                {% endblock %}
+
                                 {% block sw_cms_element_image_slider_config_settings_links %}
                                     <div class="sw-cms-el-config-image-slider__settings-links sw-cms-el-config-image-slider__setting-option">
                                         <div class="sw-cms-el-config-image-slider__settings-link"

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image-slider/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image-slider/index.js
@@ -36,7 +36,15 @@ Shopware.Service('cmsService').registerCmsElement({
         verticalAlign: {
             source: 'static',
             value: null
-        }
+        },
+        autoplay: {
+           source: "static",
+            value: true,
+        },
+        autoplayTimeout: {
+            source: "static",
+            value: 5000,
+        },
     },
     enrich: function enrich(elem, data) {
         if (Object.keys(data).length < 1) {

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/snippet/de-DE.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/snippet/de-DE.json
@@ -220,7 +220,9 @@
             "navigationPositionNone": "Keine",
             "navigationPositionInside": "Innen",
             "navigationPositionOutside": "Außen",
-            "navigationDots": "Punkte-Navigation"
+            "navigationDots": "Punkte-Navigation",
+            "autoplay": "Automatisch wechseln",
+            "autoplayTimeout": "Wechselinterval (in ms)"
           }
         }
       },

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/snippet/en-GB.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/snippet/en-GB.json
@@ -220,7 +220,9 @@
             "navigationPositionNone": "None",
             "navigationPositionInside": "Inside",
             "navigationPositionOutside": "Outside",
-            "navigationDots": "Dots navigation"
+            "navigationDots": "Dots navigation",
+            "autoplay": "Play automatically",
+            "autoplayTimeout": "Autoplay timeout (in ms)"
           }
         }
       },

--- a/src/Storefront/Resources/views/storefront/element/cms-element-image-slider.html.twig
+++ b/src/Storefront/Resources/views/storefront/element/cms-element-image-slider.html.twig
@@ -6,6 +6,9 @@
             slider: {
                 navPosition: 'bottom',
                 speed: 500,
+                autoplayButtonOutput: false,
+                autoplay: sliderConfig.autoplay.value ? true : false,
+                autoplayTimeout: sliderConfig.autoplayTimeout.value,
                 nav: sliderConfig.navigationDots.value ? true : false,
                 controls: sliderConfig.navigationArrows.value ? true : false,
                 autoHeight: (sliderConfig.displayMode.value == "standard") ? true : false


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
We needed the image slider automatically start playing when the page is loaded.

### 2. What does this change do, exactly?
This pull request adds to fields to the configuration panel of the image slider element in the CMS. 
1. Autoplay On/Off-Switch
2. Autoplay Timeout

When enabled, the image slider will automatically start playing using the defined timeout.

### 3. Describe each step to reproduce the issue or behaviour.
---

### 4. Please link to the relevant issues (if any). 
That also seems to be a requested feature in these issues: 
https://issues.shopware.com/issues/NEXT-8833
https://issues.shopware.com/issues/NEXT-6169


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
