### PR TITLE
Sitemap only has to be generated for storefront sales channels

### DIFF
--- a/src/Core/Content/Sitemap/Commands/SitemapGenerateCommand.php
+++ b/src/Core/Content/Sitemap/Commands/SitemapGenerateCommand.php
@@ -105,7 +105,7 @@ class SitemapGenerateCommand extends Command
 
         /** @var SalesChannelEntity $salesChannel */
         foreach ($salesChannels as $salesChannel) {
-            if ($salesChannel->getType()->getId() === Defaults::SALES_CHANNEL_TYPE_API) {
+            if ($salesChannel->getType()->getId() !== Defaults::SALES_CHANNEL_TYPE_STOREFRONT) {
                 $output->writeln(sprintf('ignored headless sales channel %s (%s)', $salesChannel->getId(), $salesChannel->getName()));
 
                 continue;


### PR DESCRIPTION
### 1. Why is this change necessary?
On executing the console command for generating sitemaps Shopware tries to build sitemaps also for product comparison sales channels. This causes an error inside the SalesChannelContextFactory "Error thrown while running command "sitemap:generate". Message: "Provided language 2fbb5fe2e29a4d70aa5854ce7ce3e20b is not in list of available languages".

### 2. What does this change do, exactly?
The sitemap will only be created for storefront sales channels and prevents erros for product comparison sales channels.

### 3. Describe each step to reproduce the issue or behaviour.
1. Create a new product comparison sales channel.
2. Call the command "bin/console sitemap:generate"

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
