### PR TITLE
Feature/add migration down method

### DIFF
--- a/src/Core/Framework/Migration/MigrationCollection.php
+++ b/src/Core/Framework/Migration/MigrationCollection.php
@@ -77,6 +77,16 @@ class MigrationCollection
         return iterator_to_array($this->migrateDestructiveInSteps($until, $limit));
     }
 
+    public function migrateDownInSteps(?int $until = null, ?int $limit = null): \Generator
+    {
+        return $this->migrationRuntime->migrateDown($this->migrationSource, $until, $limit);
+    }
+
+    public function migrateDownInPlace(?int $until = null, ?int $limit = null): array
+    {
+        return iterator_to_array($this->migrateDownInSteps($until, $limit));
+    }
+
     public function getExecutableMigrations(?int $until = null, ?int $limit = null): array
     {
         return $this->migrationRuntime->getExecutableMigrations($this->migrationSource, $until, $limit);

--- a/src/Core/Framework/Migration/MigrationRuntime.php
+++ b/src/Core/Framework/Migration/MigrationRuntime.php
@@ -137,7 +137,7 @@ class MigrationRuntime
     {
         return $this->getExecutableMigrationsBaseQuery($source, $until, $limit)
             ->orderBy('`creation_timestamp`', 'DESC')
-            ->andWhere('(`update` IS NOT NULL OR WHERE `update_destructive` IS NOT NULL)')
+            ->andWhere('`update` IS NOT NULL')
             ->execute()
             ->fetchAll(FetchMode::COLUMN);
     }

--- a/src/Core/Framework/Migration/MigrationStep.php
+++ b/src/Core/Framework/Migration/MigrationStep.php
@@ -25,6 +25,11 @@ abstract class MigrationStep
      */
     abstract public function updateDestructive(Connection $connection): void;
 
+    /**
+     * down changes
+     */
+    abstract public function down(Connection $connection): void;
+
     public function removeTrigger(Connection $connection, string $name): void
     {
         try {

--- a/src/Core/Framework/Migration/MigrationStep.php
+++ b/src/Core/Framework/Migration/MigrationStep.php
@@ -28,7 +28,9 @@ abstract class MigrationStep
     /**
      * down changes
      */
-    abstract public function down(Connection $connection): void;
+    public function down(Connection $connection): void
+    {
+    }
 
     public function removeTrigger(Connection $connection, string $name): void
     {

--- a/src/Core/Framework/Migration/Template/MigrationTemplate.txt
+++ b/src/Core/Framework/Migration/Template/MigrationTemplate.txt
@@ -21,4 +21,9 @@ class Migration%%timestamp%%%%name%% extends MigrationStep
     {
         // implement update destructive
     }
+
+    public function down(Connection $connection): void
+    {
+        // implement down
+    }
 }

--- a/src/Core/Framework/Plugin/PluginLifecycleService.php
+++ b/src/Core/Framework/Plugin/PluginLifecycleService.php
@@ -229,6 +229,7 @@ class PluginLifecycleService
         $pluginBaseClass->uninstall($uninstallContext);
 
         if (!$uninstallContext->keepMigrations()) {
+            $this->downMigrations($uninstallContext);
             $pluginBaseClass->removeMigrations();
         }
 
@@ -506,6 +507,15 @@ class PluginLifecycleService
         }
 
         $context->getMigrationCollection()->migrateInPlace();
+    }
+
+    private function downMigrations(UninstallContext $uninstallContext): void
+    {
+        if ($uninstallContext->keepUserData()) {
+            return;
+        }
+
+        $uninstallContext->getMigrationCollection()->migrateDownInPlace();
     }
 
     private function hasPluginUpdate(string $updateVersion, string $currentVersion): bool

--- a/src/Core/Framework/Test/Migration/MigrationCollectionRuntimeTest.php
+++ b/src/Core/Framework/Test/Migration/MigrationCollectionRuntimeTest.php
@@ -182,6 +182,7 @@ class MigrationCollectionRuntimeTest extends TestCase
         static::assertNotNull($migrations[1]['update']);
 
         $this->validMigrationCollection->migrateDownInPlace();
+        $migrations = $this->getMigrations();
 
         static::assertNull($migrations[0]['update']);
         static::assertNull($migrations[1]['update']);

--- a/src/Core/Framework/Test/Migration/MigrationCollectionRuntimeTest.php
+++ b/src/Core/Framework/Test/Migration/MigrationCollectionRuntimeTest.php
@@ -173,6 +173,20 @@ class MigrationCollectionRuntimeTest extends TestCase
         static::assertNull($migrations[1]['update_destructive']);
     }
 
+    public function testDownIfUpdateRan(): void
+    {
+        $this->validMigrationCollection->migrateInPlace(null, null);
+        $migrations = $this->getMigrations();
+
+        static::assertNotNull($migrations[0]['update']);
+        static::assertNotNull($migrations[1]['update']);
+
+        $this->validMigrationCollection->migrateDownInPlace();
+
+        static::assertNull($migrations[0]['update']);
+        static::assertNull($migrations[1]['update']);
+    }
+
     public function testDestructiveIfMultipleNoneDestructive(): void
     {
         $migrations = $this->getMigrations();

--- a/src/Docs/Resources/current/60-references-internals/40-plugins/080-plugin-migrations.md
+++ b/src/Docs/Resources/current/60-references-internals/40-plugins/080-plugin-migrations.md
@@ -77,20 +77,27 @@ class Migration1546422281ExampleDescription extends MigrationStep
     {
         // implement update destructive
     }
+
+    public function down(Connection $connection): void
+    {
+        // implement down
+    }
 }
 ```
 *Migration/Migration1546422281ExampleDescription.php*
 
-As you can see your migration contains 3 methods:
+As you can see your migration contains 4 methods:
 * `getCreationTimestamp()`
 * `update()`
 * `updateDestructive()`
+* `down()`
 
 There is no need to change `getCreationTimestamp()`, it returns the timestamp that's also part of the file name.
 In the `update()` method you implement nondestructive changes. In other words, the `update()` method should always be reversible.
 The `updateDestructive()` method is the counterpart to `update()` and used for destructive none reversible changes,
-like dropping columns or tables.
-Below you find an example of a nondestructive migration, creating a new table for your plugin.
+like dropping columns or tables. Lastly, the `down()` method provides you to revert all the changes you did in the `update()` 
+to prevent your plugin from leaving data in the database on uninstall.
+Below you find an example of a nondestructive migration, creating a new table for your plugin on install and drop it on uninstall.
 
 ```php
 <?php declare(strict_types=1);
@@ -125,6 +132,11 @@ SQL;
 
     public function updateDestructive(Connection $connection): void
     {
+    }
+
+    public function down(Connection $connection): void
+    {
+        $connection->exec("DROP TABLE IF EXISTS `plugin_migration_example_general_settings`");
     }
 }
 ```


### PR DESCRIPTION
**This PR reopens an earlier PR as requested by @philipgatzka:**
https://github.com/shopware/platform/pull/1544

### 1. Why is this change necessary?
In the current situation, plugins have the opportunity to add data on install, but they don't have the opportunity to delete that created data on uninstall leaving junk data in the database and errors on reinstall. If for instance a custom field is added, but can't be deleted on uninstall, it will get a duplicate entry on the custom fields technical name the next install. 

### 2. What does this change do, exactly?
It gives all plugin developers the opportunity to clean up the data they have added with their plugins. If that plugin is getting uninstalled, it's very likely that there will be data in the database which do not have any functions anymore, resolving in a lot of junk data with no usage and a lot of error sensitivity when the plugin would get installed again later. 

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
