### PR TITLE
FIX address sender mailer config

### DIFF
--- a/changelog/_unreleased/2020-12-03-Fix-custom-sender-email.md
+++ b/changelog/_unreleased/2020-12-03-Fix-custom-sender-email.md
@@ -1,0 +1,8 @@
+---
+title:          Fix custom sender email address
+issue:
+author:         Timothee Montias
+author_email:   timothee.motnias@epita.fr
+---
+# Core
+    * Cahnged the MailService class by changing the senderEmail variable affectation begining with the custom email address.

--- a/changelog/_unreleased/2020-12-03-Fix-custom-sender-email.md
+++ b/changelog/_unreleased/2020-12-03-Fix-custom-sender-email.md
@@ -5,4 +5,4 @@ author:         Timothee Montias
 author_email:   timothee.motnias@epita.fr
 ---
 # Core
-    * Cahnged the MailService class by changing the senderEmail variable affectation begining with the custom email address.
+* Changed the `senderEmail` variable affectation beginning with the custom email address in the `Shopware\Core\Content\MailTemplate\Service\MailService`

--- a/src/Core/Content/MailTemplate/Service/MailService.php
+++ b/src/Core/Content/MailTemplate/Service/MailService.php
@@ -213,14 +213,14 @@ class MailService implements MailServiceInterface
 
     private function getSender($data, ?string $salesChannelId): ?string
     {
-        $senderEmail = $data['senderEmail'] ?? null;
+        $senderEmail = $this->systemConfigService->get('core.mailerSettings.senderAddress', $salesChannelId);
 
         if ($senderEmail === null || trim($senderEmail) === '') {
-            $senderEmail = $this->systemConfigService->get('core.basicInformation.email', $salesChannelId);
+            $senderEmail = $data['senderEmail'] ?? null;
         }
 
         if ($senderEmail === null || trim($senderEmail) === '') {
-            $senderEmail = $this->systemConfigService->get('core.mailerSettings.senderAddress', $salesChannelId);
+            $senderEmail = $this->systemConfigService->get('core.basicInformation.email', $salesChannelId);
         }
 
         if ($senderEmail === null || trim($senderEmail) === '') {


### PR DESCRIPTION
the address sender field in the mailer config in the backend was ignored
the order of affectation have been changed to take into account the custom
address sender according to the sales channel.

### 1. Why is this change necessary?
The address sender in the mailer settings in the backend was ignored.
When someone wanted to custom the sender email address for the customer it was simply ignored.

### 2. What does this change do, exactly?
The only thing that change is the variable affectation order.
In first position there is the custom sender email address, and then come the default one and in last the basic information.
So if someone fill the field sender address it will be set first.

### 3. Describe each step to reproduce the issue or behaviour.
First go to mailer settings
in backend : settings -> system -> mailer
here fill the fields to configure the mail server (chose SMTP server)
set also the sender address to what you want (must be email address)
then do to any mail template
in backend : settings -> shop -> email template
here chose any of them and send a test email
receiving the mail you can see the sender email address
after correction it would be the one set in the backend and before correction it would be the actual email address

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
