### PR TITLE
fixed lineItem sorting in order detail view

### DIFF
--- a/changelog/_unreleased/2020-12-14-fix-order-line-item-sorting.md
+++ b/changelog/_unreleased/2020-12-14-fix-order-line-item-sorting.md
@@ -1,0 +1,8 @@
+---
+title: Fix order line item sorting in admin
+author: Jörg Lautenschlager
+author_email: joerg.lautenschlager@gmail.com
+author_github: jlaute
+---
+# Administration
+* Changed method `orderCriteria()` to add sorting by lineItems in `module/sw-order/view/sw-order-detail-base/index.js`

--- a/src/Administration/Resources/app/administration/src/module/sw-order/view/sw-order-detail-base/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/view/sw-order-detail-base/index.js
@@ -157,6 +157,8 @@ Component.register('sw-order-detail-base', {
                 .addAssociation('orderCustomer')
                 .addAssociation('language');
 
+            criteria.getAssociation('lineItems').addSorting(Criteria.sort('position'));
+
             criteria
                 .getAssociation('deliveries')
                 .addSorting(Criteria.sort('shippingCosts.unitPrice', 'DESC'));


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
lineItems in order detail view are sometimes not correctly sorted.

### 2. What does this change do, exactly?
Sort the order lineItems by position

### 3. Describe each step to reproduce the issue or behaviour.
I noticed that orders with 5+ positions have the lineItems sorted not by the position column

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
