### PR TITLE
BUGFIX: If customFields is null this will cause an exception, therefore we need to fall back to an array value.

### DIFF
--- a/src/Core/Checkout/Cart/Rule/LineItemCustomFieldRule.php
+++ b/src/Core/Checkout/Cart/Rule/LineItemCustomFieldRule.php
@@ -83,7 +83,7 @@ class LineItemCustomFieldRule extends Rule
      */
     private function isCustomFieldValid(LineItem $lineItem): bool
     {
-        $customFields = $lineItem->getPayloadValue('customFields');
+        $customFields = $lineItem->getPayloadValue('customFields') ?? [];
 
         $actual = $this->getValue($customFields, $this->renderedField);
         if ($actual === null) {


### PR DESCRIPTION
### 1. Why is this change necessary?
BUGFIX: If customFields is null this will cause an exception, therefore we need to fall back to an array value.

### 2. What does this change do, exactly?


### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.
