### PR TITLE
Add remove() method to DataValidationDefinition

### DIFF
--- a/changelog/_unreleased/2020-12-17-add-remove-constraint-property-method.md
+++ b/changelog/_unreleased/2020-12-17-add-remove-constraint-property-method.md
@@ -1,0 +1,9 @@
+---
+title: Add a remove() method to DataValidationDefinition
+author: Dennis Steffen
+author_email: steffen@die-etagen.de
+author_github: @Gugiman
+---
+
+# Core
+* Added `remove()` method to DataValidationDefinition

--- a/changelog/release-6-3-4-2/2020-12-17-add-remove-constraint-property-method.md
+++ b/changelog/release-6-3-4-2/2020-12-17-add-remove-constraint-property-method.md
@@ -1,0 +1,2 @@
+# Core
+* Added `remove()` method to DataValidationDefinition

--- a/src/Core/Framework/Validation/DataValidationDefinition.php
+++ b/src/Core/Framework/Validation/DataValidationDefinition.php
@@ -61,7 +61,7 @@ class DataValidationDefinition
 
         return $this;
     }
-    
+
     public function addSub(string $name, DataValidationDefinition $definition): self
     {
         $this->subDefinitions[$name] = $definition;

--- a/src/Core/Framework/Validation/DataValidationDefinition.php
+++ b/src/Core/Framework/Validation/DataValidationDefinition.php
@@ -53,6 +53,15 @@ class DataValidationDefinition
         return $this->add($name, ...$constraints);
     }
 
+    public function remove(string $name): self
+    {
+        if (\array_key_exists($name, $this->properties)) {
+            unset($this->properties[$name]);
+        }
+
+        return $this;
+    }
+    
     public function addSub(string $name, DataValidationDefinition $definition): self
     {
         $this->subDefinitions[$name] = $definition;


### PR DESCRIPTION
### 1. Why is this change necessary?
When subscribing to a BuildValidationEvent it is possible to replace a property with another Constraint.
But it's not possible to remove it without replacement

### 2. What does this change do, exactly?
Add a method to remove specific validation contraints

### 3. Describe each step to reproduce the issue or behaviour.
Subscribe to a BuildValidationEvent and try to remove a property key

### 4. Please link to the relevant issues (if any).
None

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
