### PR TITLE
NEXT-11875: Fix sorting of order line items

### DIFF
--- a/changelog/_unreleased/2020-11-16-fix-sorting-of-order-line-items-to-have-the-same-as-in-the-cart.md
+++ b/changelog/_unreleased/2020-11-16-fix-sorting-of-order-line-items-to-have-the-same-as-in-the-cart.md
@@ -1,0 +1,15 @@
+---
+title: Fix sorting of order line items to have the same as in the cart
+issue: NEXT-11875
+author: Claudio Bianco
+author_email: info@claudio-bianco.de 
+author_github: @claudiobianco
+---
+# Core
+*  Add order line items sorting (position) in `CartOrderRoute`, `DocumentService` and `OrderStateChangeEventListener`.
+___
+# Administration
+*  Add order line items sorting (position) in `sw-order-detail-base`.
+___
+# Storefront
+*  Add order line items sorting (position) in account overview and orders 

--- a/src/Administration/Resources/app/administration/src/module/sw-order/view/sw-order-detail-base/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/view/sw-order-detail-base/index.js
@@ -176,6 +176,7 @@ Component.register('sw-order-detail-base', {
                 .addAssociation('tags');
 
             criteria.getAssociation('transactions').addSorting(Criteria.sort('createdAt'));
+            criteria.getAssociation('lineItems').addSorting(Criteria.sort('position'));
 
             return criteria;
         },

--- a/src/Core/Checkout/Cart/SalesChannel/CartOrderRoute.php
+++ b/src/Core/Checkout/Cart/SalesChannel/CartOrderRoute.php
@@ -16,6 +16,7 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepositoryInterface;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Sorting\FieldSorting;
 use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
 use Shopware\Core\Framework\Routing\Annotation\RouteScope;
 use Shopware\Core\Framework\Routing\Annotation\Since;
@@ -116,6 +117,8 @@ class CartOrderRoute extends AbstractCartOrderRoute
             ->addAssociation('lineItems')
             ->addAssociation('currency')
             ->addAssociation('addresses.country');
+
+        $criteria->getAssociation('lineItems')->addSorting(new FieldSorting('position'));
 
         /** @var OrderEntity|null $orderEntity */
         $orderEntity = $this->orderRepository->search($criteria, $context->getContext())->first();

--- a/src/Core/Checkout/Document/DocumentService.php
+++ b/src/Core/Checkout/Document/DocumentService.php
@@ -22,6 +22,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Exception\InconsistentCriteriaI
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\MultiFilter;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Sorting\FieldSorting;
 use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Util\Random;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -473,7 +474,7 @@ class DocumentService
 
     private function getOrderBaseCriteria(string $orderId): Criteria
     {
-        return (new Criteria([$orderId]))
+        $criteria = (new Criteria([$orderId]))
             ->addAssociation('lineItems')
             ->addAssociation('transactions.paymentMethod')
             ->addAssociation('currency')
@@ -481,5 +482,9 @@ class DocumentService
             ->addAssociation('addresses.country')
             ->addAssociation('deliveries.positions')
             ->addAssociation('deliveries.shippingMethod');
+
+        $criteria->getAssociation('lineItems')->addSorting(new FieldSorting('position'));
+
+        return $criteria;
     }
 }

--- a/src/Core/Checkout/Order/Listener/OrderStateChangeEventListener.php
+++ b/src/Core/Checkout/Order/Listener/OrderStateChangeEventListener.php
@@ -15,6 +15,7 @@ use Shopware\Core\Checkout\Payment\PaymentMethodEntity;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepositoryInterface;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Sorting\FieldSorting;
 use Shopware\Core\Framework\Event\BusinessEventCollector;
 use Shopware\Core\Framework\Event\BusinessEventCollectorEvent;
 use Shopware\Core\System\StateMachine\Aggregation\StateMachineState\StateMachineStateEntity;
@@ -251,6 +252,7 @@ class OrderStateChangeEventListener implements EventSubscriberInterface
         $criteria->addAssociation('lineItems');
         $criteria->addAssociation('currency');
         $criteria->addAssociation('addresses.country');
+        $criteria->getAssociation('lineItems')->addSorting(new FieldSorting('position'));
 
         $event = new OrderStateChangeCriteriaEvent($orderId, $criteria);
         $this->eventDispatcher->dispatch($event);

--- a/src/Storefront/Page/Account/Order/AccountOrderDetailPageLoader.php
+++ b/src/Storefront/Page/Account/Order/AccountOrderDetailPageLoader.php
@@ -74,6 +74,9 @@ class AccountOrderDetailPageLoader
         $criteria->getAssociation('transactions')
             ->addSorting(new FieldSorting('createdAt'));
 
+        $criteria->getAssociation('lineItems')
+            ->addSorting(new FieldSorting('position'));
+
         $apiRequest = new Request();
 
         $event = new OrderRouteRequestEvent($request, $apiRequest, $salesChannelContext, $criteria);

--- a/src/Storefront/Page/Account/Order/AccountOrderPageLoader.php
+++ b/src/Storefront/Page/Account/Order/AccountOrderPageLoader.php
@@ -139,6 +139,10 @@ class AccountOrderPageLoader
             ->addSorting(new FieldSorting('createdAt'));
 
         $criteria
+            ->getAssociation('lineItems')
+            ->addSorting(new FieldSorting('position'));
+
+        $criteria
             ->addSorting(new FieldSorting('orderDateTime', FieldSorting::DESCENDING));
 
         if ($request->get('deepLinkCode')) {

--- a/src/Storefront/Page/Account/Overview/AccountOverviewPageLoader.php
+++ b/src/Storefront/Page/Account/Overview/AccountOverviewPageLoader.php
@@ -101,6 +101,10 @@ class AccountOverviewPageLoader
             ->setLimit(1)
             ->addAssociation('orderCustomer');
 
+        $criteria
+            ->getAssociation('lineItems')
+            ->addSorting(new FieldSorting('position'));
+
         $apiRequest = new Request();
 
         $event = new OrderRouteRequestEvent($request, $apiRequest, $context);


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
The order line items are in a different order than the cart line items.

### 2. What does this change do, exactly?
Adds sorting (position) of lineItems association.

### 3. Describe each step to reproduce the issue or behaviour.
Buy some stuff and compare the order of the line items from the cart to the order of the line items of the order.

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/NEXT-11875
https://issues.shopware.com/issues/NEXT-9869

New PR for #1512 because the source branch got deleted.

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
