### PR TITLE
NEXT-11125 Initialize custom fields on categories

### DIFF
--- a/changelog/_unreleased/2020-12-18-load-custom-field-sets-on-category-change.md
+++ b/changelog/_unreleased/2020-12-18-load-custom-field-sets-on-category-change.md
@@ -1,0 +1,9 @@
+---
+title: Load custom field sets on category change
+issue: NEXT-11125
+author: Rune Laenen
+author_email: rune@laenen.me 
+author_github: runelaenen
+---
+# Administration
+* Change implementation of `onChangeCustomFieldSetSelectionActive` in `sw-custom-field-set-renderer` to handle entities without custom field values.

--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-custom-field-set-renderer/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-custom-field-set-renderer/index.js
@@ -322,6 +322,10 @@ Component.register('sw-custom-field-set-renderer', {
         onChangeCustomFieldSetSelectionActive(newVal) {
             this.onChangeCustomFieldSets();
             if (!newVal) {
+                if (!this.entity.customFieldSets) {
+                    this.initializeCustomFields();
+                    return;
+                }
                 this.entity.customFieldSets = this.entity.customFieldSets.filter(() => {
                     return false;
                 });

--- a/src/Administration/Resources/app/administration/test/app/component/form/sw-custom-field-set-renderer.spec.js
+++ b/src/Administration/Resources/app/administration/test/app/component/form/sw-custom-field-set-renderer.spec.js
@@ -860,6 +860,33 @@ describe('src/app/component/form/sw-custom-field-set-renderer', () => {
         expect(tabs).toHaveLength(1);
     });
 
+    it('should initialize new custom fields on entity change', async () => {
+        const props = {
+            entity: {
+                customFieldSetSelectionActive: false,
+                customFieldSets: undefined
+            },
+            sets: createEntityCollection([{
+                name: 'set1',
+                position: 2
+            }, {
+                name: 'set2',
+                position: 1
+            }]),
+            showCustomFieldSetSelection: true
+        };
+
+        wrapper = createWrapper(props);
+
+        const spyInitializeCustomFields = jest.spyOn(wrapper.vm, 'initializeCustomFields');
+
+        wrapper.vm.onChangeCustomFieldSetSelectionActive();
+
+        await wrapper.vm.$nextTick();
+
+        expect(spyInitializeCustomFields).toHaveBeenCalledTimes(1);
+    });
+
     it('should sort sets by position', async () => {
         const props = {
             entity: {


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
Fixes the issue of https://issues.shopware.com/issues/NEXT-11125

### 2. What does this change do, exactly?
Initialize the custom fields if they are not present in the entity.

### 3. Describe each step to reproduce the issue or behaviour.
Create a new CustomField set
Assign this set to category
Create a new CustomField in this set
Go to categories and switch from one category to another

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/NEXT-11125

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
-  x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
