### PR TITLE
Replace star display with existing component

### DIFF
--- a/changelog/_unreleased/2020-12-29-use-rating-stars-component-for-ratings-on-administration-product-detail.md
+++ b/changelog/_unreleased/2020-12-29-use-rating-stars-component-for-ratings-on-administration-product-detail.md
@@ -1,0 +1,10 @@
+---
+title: Use sw-rating-stars on product detail review list
+author: Felix Gliesche
+author_email: felix@gliesche.net
+author_github: gliesche
+
+___
+# Administration
+* Replace current display of stars with new component `sw-rating-stars` (introduced in [commit 878d8](https://github.com/shopware/platform/commit/878d85bb2125b3811efb4cb5f4ddd9d2b15908dd)) in `src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-base/sw-product-detail-base.html.twig` in order to reuse existing component for rating stars and in order to allow float values
+

--- a/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-base/sw-product-detail-base.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-base/sw-product-detail-base.html.twig
@@ -228,14 +228,7 @@
                             {% block sw_product_detail_base_ratings_column_stars %}
                                 <template slot="column-points" slot-scope="{ item }">
                                     <div class="sw-review-detail-base__stars">
-                                        <sw-icon v-for="star, index in item.points" :key="`star-${index}`"
-                                                 name="default-review-star-full"
-                                                 size="14">
-                                        </sw-icon>
-                                        <sw-icon v-for="missingStar, index in (5-item.points)" :key="`missingStar-${index}`"
-                                                name="default-basic-shape-star"
-                                                size="14">
-                                        </sw-icon>
+                                        <sw-rating-stars v-model="item.points"></sw-rating-stars>
                                     </div>
                                 </template>
                             {% endblock %}


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?

This change reuses an existing component that allows the use of float values to be used as ratings. As this component is already being used (e.g.  in `sw-review-list` or `sw-review-detail`) the display of float values works perfectly there, but not 
within `sw-product-detail-base`. The new component `sw-rating-stars` has been introduced in [commit 878d8](https://github.com/shopware/platform/commit/878d85bb2125b3811efb4cb5f4ddd9d2b15908dd) while refactoring review related code. I assume it was accidentally forgotten to use the newly introduced component on this template. 

Without this change, reviews are not being displayed on the product detail page if one of the reviews consists of a float value. This can be the case due to an Plugin, API call, etc. as the database field is a double for a rating (column `points` in table `product_reviews`).

### 2. What does this change do, exactly?

It replaces existing code by using the component `sw-rating-stars`.

### 3. Describe each step to reproduce the issue or behaviour.

Add the `points` value or change an existing value to a float (e.g. 3.5)

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
