### PR TITLE
Replace deprecated ProductLoaderCriteriaEvent

### DIFF
--- a/src/Docs/Resources/current/50-how-to/010-indepth-guide-bundle/080-storefront.md
+++ b/src/Docs/Resources/current/50-how-to/010-indepth-guide-bundle/080-storefront.md
@@ -10,7 +10,7 @@ Those are for example associations like the product's prices or the associated m
 Yet, your bundles are not part of those "to be loaded" associations, because this association was never requested on the `Criteria` instance.
 
 Thus, you have to somehow manipulate the `Criteria` instance before it is used for a search. There's an event for this case, which is `product-detail.page.criteria`.
-Don't use it like this though, rather use the constant from the respective `Event` class: `\Shopware\Storefront\Page\Product\ProductLoaderCriteriaEvent::class`
+Don't use it like this though, rather use the constant from the respective `Event` class: `\Shopware\Storefront\Page\Product\ProductPageCriteriaEvent::class`
 
 But how do you handle events in the first place?
 This is done by using the [Symfony event subscriber](https://symfony.com/doc/current/event_dispatcher.html#creating-an-event-subscriber).
@@ -27,7 +27,7 @@ Just use the constant mentioned above and choose a method name to call once the 
 
 namespace Swag\BundleExample\Storefront\Page\Product\Subscriber;
 
-use Shopware\Storefront\Page\Product\ProductLoaderCriteriaEvent;
+use Shopware\Storefront\Page\Product\ProductPageCriteriaEvent;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 class ProductPageCriteriaSubscriber implements EventSubscriberInterface
@@ -35,7 +35,7 @@ class ProductPageCriteriaSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents()
     {
         return [
-            ProductLoaderCriteriaEvent::class => 'onProductCriteriaLoaded'
+            ProductPageCriteriaEvent::class => 'onProductCriteriaLoaded'
         ];
     }
 

--- a/src/Docs/Resources/current/50-how-to/010-indepth-guide-bundle/080-storefront.md
+++ b/src/Docs/Resources/current/50-how-to/010-indepth-guide-bundle/080-storefront.md
@@ -39,17 +39,17 @@ class ProductPageCriteriaSubscriber implements EventSubscriberInterface
         ];
     }
 
-    public function onProductCriteriaLoaded(ProductLoaderCriteriaEvent $event): void
+    public function onProductCriteriaLoaded(ProductPageCriteriaEvent $event): void
     {
     }
 }
 ```
 
-This example also already knows the method `onProductCriteriaLoaded`. Each event comes with its own event parameter, `ProductLoaderCriteriaEvent` in this case.
+This example also already knows the method `onProductCriteriaLoaded`. Each event comes with its own event parameter, `ProductPageCriteriaEvent` in this case.
 It grants access to the criteria object before it has been used for a search, so time to add your new association in there.
 
 ```php
-public function onProductCriteriaLoaded(ProductLoaderCriteriaEvent $event): void
+public function onProductCriteriaLoaded(ProductPageCriteriaEvent $event): void
 {
     $event->getCriteria()->addAssociation('bundles.products.cover');
 }


### PR DESCRIPTION
Add ProductPageCriteriaEvent class for Subscriber because of deprecated ProductLoaderCriteriaEvent

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
Because the ProductLoaderCriteriaEvent Event is deprecated since v6.4.0

### 2. What does this change do, exactly?
Replaces the deprectaed fiel with a new one.

