### PR TITLE
NEXT-11733 - Allow to fetch customer that is registered as guest

### DIFF
--- a/changelog/_unreleased/2021-01-03-allow-fetching-created-guest-customer-via-store-api.md
+++ b/changelog/_unreleased/2021-01-03-allow-fetching-created-guest-customer-via-store-api.md
@@ -1,0 +1,9 @@
+---
+title: Allow fetching created guest customer via store api
+issue: NEXT-11733
+author: Sascha Nowak
+author_email: sascha.nowak@netlogix.de 
+author_github: @nlx-sascha
+___
+# API
+* Allow fetching created guest customer via store api

--- a/src/Core/Checkout/Customer/SalesChannel/CustomerRoute.php
+++ b/src/Core/Checkout/Customer/SalesChannel/CustomerRoute.php
@@ -67,7 +67,7 @@ class CustomerRoute extends AbstractCustomerRoute
      *          @OA\JsonContent(ref="#/components/schemas/customer_flat")
      *     )
      * )
-     * @LoginRequired()
+     * @LoginRequired(allowGuest=true)
      * @Route("/store-api/v{version}/account/customer", name="store-api.account.customer", methods={"GET", "POST"})
      */
     public function load(Request $request, SalesChannelContext $context, ?Criteria $criteria = null, ?CustomerEntity $customer = null): CustomerResponse


### PR DESCRIPTION
When using the guest parameter for the register api call, it is not possible to fetch the customer again.

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
Fetching the account as guest user

### 2. What does this change do, exactly?
Expose the api also for guest accounts

### 3. Describe each step to reproduce the issue or behaviour.
Create a new account `/store-api/v3/account/register` with guest parameter
Try to fetch account with the new token is not allowed 

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/NEXT-11733

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
