### PR TITLE
Allow javascript to access the exposed headers in core requests

### DIFF
--- a/changelog/_unreleased/2021-01-03-allow-javascript-to-access-the-exposed-headers-in-core-requests.md
+++ b/changelog/_unreleased/2021-01-03-allow-javascript-to-access-the-exposed-headers-in-core-requests.md
@@ -1,0 +1,9 @@
+---
+title: Allow javascript to access the exposed headers in core requests
+issue: NEXT-13642
+author: Sascha Nowak
+author_email: sascha.nowak@netlogix.de 
+author_github: @nlx-sascha
+___
+# API
+* Allow javascript to access the exposed headers in core requests

--- a/src/Core/Framework/Api/EventListener/CorsListener.php
+++ b/src/Core/Framework/Api/EventListener/CorsListener.php
@@ -57,5 +57,6 @@ class CorsListener implements EventSubscriberInterface
         $response->headers->set('Access-Control-Allow-Origin', '*');
         $response->headers->set('Access-Control-Allow-Methods', 'GET,POST,PUT,PATCH,DELETE');
         $response->headers->set('Access-Control-Allow-Headers', implode(',', $corsHeaders));
+        $response->headers->set('Access-Control-Expose-Headers', implode(',', $corsHeaders));
     }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
Reading the `sw-context-token` in the javascript fetch response is currently not possible.
The Access-Control-Expose-Headers header lets a server whitelist headers that Javascript in browsers are allowed to access. 

### 2. What does this change do, exactly?
Adding the `Access-Control-Expose-Headers` header to the response.

### 3. Describe each step to reproduce the issue or behaviour.
Fetching the context 
```
fetch("https://some-api-domain/store-api/v3/context", {
  "headers": {
    "sw-access-key": ".....",
    "sw-context-token": "....."
  },
  "referrerPolicy": "same-origin",
  "body": null,
  "method": "GET",
  "mode": "cors",
  "credentials": "omit"
}).then(response => console.log(Array.from(response.headers.entries())));
```
without this change only the `cache-control` and `content-type` header is accessible.

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
