### PR TITLE
Allow guest account to change address after registration

### DIFF
--- a/changelog/_unreleased/2021-01-03-allow-guest-account-to-change-address-after-registration.md
+++ b/changelog/_unreleased/2021-01-03-allow-guest-account-to-change-address-after-registration.md
@@ -1,0 +1,9 @@
+---
+title: Allow guest account to change address after registration
+issue:
+author: Sascha Nowak
+author_email: sascha.nowak@netlogix.de
+author_github: @nlx-sascha
+___
+# API
+* Allow guest account to change address after registration

--- a/src/Core/Checkout/Customer/SalesChannel/UpsertAddressRoute.php
+++ b/src/Core/Checkout/Customer/SalesChannel/UpsertAddressRoute.php
@@ -109,7 +109,7 @@ class UpsertAddressRoute extends AbstractUpsertAddressRoute
      *          @OA\JsonContent(ref="#/components/schemas/customer_address_flat")
      *     )
      * )
-     * @LoginRequired()
+     * @LoginRequired(allowGuest=true)
      * @Route(path="/store-api/v{version}/account/address", name="store-api.account.address.create", methods={"POST"}, defaults={"addressId": null})
      * @Route(path="/store-api/v{version}/account/address/{addressId}", name="store-api.account.address.update", methods={"PATCH"})
      */


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
When an account is created with guest parameter it is not possible to change the shipping address afterwards

### 2. What does this change do, exactly?
Adding the allowGuest parameter to the annotation

### 3. Describe each step to reproduce the issue or behaviour.
* Create an account with the Store Api
* Try to update the activeShippingAddress with the "update an existing address" api
* Get 403 as response

### 4. Please link to the relevant issues (if any).
Didn't find one

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
