### PR TITLE
Only expose new context token via sw-context-token header after regis…

### DIFF
--- a/changelog/_unreleased/2021-01-04-only-expose-single-context-token-after-registration.md
+++ b/changelog/_unreleased/2021-01-04-only-expose-single-context-token-after-registration.md
@@ -1,0 +1,9 @@
+---
+title: Only expose new context token via `sw-context-token` header after registration
+issue:
+author: Sascha Nowak
+author_email: sascha.nowak@netlogix.de
+author_github: @nlx-sascha
+___
+# API
+* Only expose new context token via `sw-context-token` header after registration

--- a/src/Core/Framework/Api/EventListener/ResponseHeaderListener.php
+++ b/src/Core/Framework/Api/EventListener/ResponseHeaderListener.php
@@ -26,11 +26,13 @@ class ResponseHeaderListener implements EventSubscriberInterface
     {
         $headersBag = $event->getResponse()->headers;
         foreach (self::HEADERS as $header) {
-            $headersBag->set(
-                $header,
-                $event->getRequest()->headers->get($header),
-                false
-            );
+            if (!$headersBag->has($header)) {
+                $headersBag->set(
+                    $header,
+                    $event->getRequest()->headers->get($header),
+                    false
+                );
+            }
         }
         if (!$headersBag->has(PlatformRequest::HEADER_FRAME_OPTIONS)) {
             $headersBag->set(


### PR DESCRIPTION
…tration

After a user registration the context token in the sw-context-token header is
not valid. The new and the old token are exposed as comma seperated values.

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
The documentation said you can use the `sw-context-token` header and use it for the next request.
The registration creates a new token but then the old and the new token are returned both comma separated.
When you use the token for the next request your context is not valid anymore.

### 2. What does this change do, exactly?
Only setting the sw-context-token from request when no token is present 

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
