### PR TITLE
NEXT-13121 & NEXT-13191: Add CustomFields to Salutations

### DIFF
--- a/changelog/_unreleased/2021-01-07-customfields-for-salutations.md
+++ b/changelog/_unreleased/2021-01-07-customfields-for-salutations.md
@@ -1,0 +1,9 @@
+---
+title: CustomFields for Salutations
+issue: NEXT-13121
+author: Rune Laenen
+author_email: rune@laenen.me 
+author_github: runelaenen
+---
+# Core
+*  Added `CustomFields` field to `Salutation` entity

--- a/src/Core/Migration/Migration1610014592SalutationCustomFields.php
+++ b/src/Core/Migration/Migration1610014592SalutationCustomFields.php
@@ -1,0 +1,27 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Migration;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Framework\Migration\MigrationStep;
+
+class Migration1610014592SalutationCustomFields extends MigrationStep
+{
+    public function getCreationTimestamp(): int
+    {
+        return 1610014592;
+    }
+
+    public function update(Connection $connection): void
+    {
+        $connection->executeUpdate('
+            ALTER TABLE `salutation_translation`
+            ADD COLUMN `custom_fields` JSON NULL AFTER `letter_name`;
+        ');
+    }
+
+    public function updateDestructive(Connection $connection): void
+    {
+        // implement update destructive
+    }
+}

--- a/src/Core/System/Salutation/Aggregate/SalutationTranslation/SalutationTranslationDefinition.php
+++ b/src/Core/System/Salutation/Aggregate/SalutationTranslation/SalutationTranslationDefinition.php
@@ -3,6 +3,7 @@
 namespace Shopware\Core\System\Salutation\Aggregate\SalutationTranslation;
 
 use Shopware\Core\Framework\DataAbstractionLayer\EntityTranslationDefinition;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\CustomFields;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\Required;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\StringField;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
@@ -42,6 +43,7 @@ class SalutationTranslationDefinition extends EntityTranslationDefinition
         return new FieldCollection([
             (new StringField('display_name', 'displayName'))->addFlags(new Required()),
             (new StringField('letter_name', 'letterName'))->addFlags(new Required()),
+            (new CustomFields()),
         ]);
     }
 }

--- a/src/Core/System/Salutation/Aggregate/SalutationTranslation/SalutationTranslationEntity.php
+++ b/src/Core/System/Salutation/Aggregate/SalutationTranslation/SalutationTranslationEntity.php
@@ -23,6 +23,11 @@ class SalutationTranslationEntity extends TranslationEntity
     protected $letterName;
 
     /**
+     * @var array|null
+     */
+    protected $customFields;
+
+    /**
      * @var SalutationEntity|null
      */
     protected $salutation;
@@ -55,6 +60,16 @@ class SalutationTranslationEntity extends TranslationEntity
     public function setLetterName(?string $letterName): void
     {
         $this->letterName = $letterName;
+    }
+
+    public function getCustomFields(): ?array
+    {
+        return $this->customFields;
+    }
+
+    public function setCustomFields(?array $customFields): void
+    {
+        $this->customFields = $customFields;
     }
 
     public function getSalutation(): ?SalutationEntity

--- a/src/Core/System/Salutation/SalutationDefinition.php
+++ b/src/Core/System/Salutation/SalutationDefinition.php
@@ -53,6 +53,7 @@ class SalutationDefinition extends EntityDefinition
             (new StringField('salutation_key', 'salutationKey'))->addFlags(new Required(), new SearchRanking(SearchRanking::HIGH_SEARCH_RANKING)),
             (new TranslatedField('displayName'))->addFlags(new SearchRanking(SearchRanking::HIGH_SEARCH_RANKING)),
             (new TranslatedField('letterName'))->addFlags(new SearchRanking(SearchRanking::HIGH_SEARCH_RANKING)),
+            (new TranslatedField('customFields')),
 
             (new TranslationsAssociationField(SalutationTranslationDefinition::class, 'salutation_id'))->addFlags(new Required()),
 

--- a/src/Core/System/Salutation/SalutationEntity.php
+++ b/src/Core/System/Salutation/SalutationEntity.php
@@ -60,6 +60,11 @@ class SalutationEntity extends Entity
      */
     protected $newsletterRecipients;
 
+    /**
+     * @var array|null
+     */
+    protected $customFields;
+
     public function getSalutationKey(): string
     {
         return $this->salutationKey;
@@ -148,5 +153,15 @@ class SalutationEntity extends Entity
     public function setNewsletterRecipients(NewsletterRecipientCollection $newsletterRecipients): void
     {
         $this->newsletterRecipients = $newsletterRecipients;
+    }
+
+    public function getCustomFields(): ?array
+    {
+        return $this->customFields;
+    }
+
+    public function setCustomFields(?array $customFields): void
+    {
+        $this->customFields = $customFields;
     }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?
Salutations is (one of) the only entity in core shopware that has not got a customFields property.

### 2. What does this change do, exactly?
Add customFields to the Salutation and SalutationTranslation entities.

### 3. Describe each step to reproduce the issue or behaviour.
/

### 4. Please link to the relevant issues (if any).
https://github.com/shopware/platform/issues/1579
https://issues.shopware.com/issues/NEXT-13121

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
