### PR TITLE
Improve account profile credential section on mobile devices

### DIFF
--- a/changelog/_unreleased/2021-01-07-improve-responsive-profile-behavior.md
+++ b/changelog/_unreleased/2021-01-07-improve-responsive-profile-behavior.md
@@ -1,0 +1,8 @@
+---
+title: Improve responsive profile behavior 
+author: Giovanni Cascio
+author_email: giovanni@lyno.io
+author_github: gcascio
+---
+# Storefront
+* Added new breakpoints in `src/Storefront/Resources/views/storefront/page/account/profile/index.html.twig` to improve the profiles credential section on mobile devices

--- a/src/Storefront/Resources/views/storefront/page/account/profile/index.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/account/profile/index.html.twig
@@ -79,7 +79,7 @@
                             {% block page_account_profile_credentials_container %}
                                 <div class="row align-items-center">
                                     {% block page_account_profile_credentials_current_mail %}
-                                        <div class="col-6">
+                                        <div class="col-12 col-md-6">
                                             {% block page_account_profile_credentials_current_mail_label %}
                                                 <span class="account-profile-mail-label">{{ "account.profileCurrentMail"|trans|sw_sanitize }}</span>
                                                 <span class="account-profile-mail">{{ context.customer.email }}</span>
@@ -88,7 +88,7 @@
                                     {% endblock %}
 
                                     {% block page_account_profile_credentials_change_mail %}
-                                        <div class="col-3">
+                                        <div class="col-12 col-sm-6 col-md-3 mt-2 mt-md-0">
                                             <a class="account-profile-change{% if not emailFormViolation %} collapsed{% endif %}"
                                                data-toggle="collapse"
                                                href="#profile-email-form"
@@ -101,7 +101,7 @@
                                     {% endblock %}
 
                                     {% block page_account_profile_credentials_change_password %}
-                                        <div class="col-3">
+                                        <div class="col-12 col-sm-6 col-md-3 mt-2 mt-md-0">
                                             <a class="account-profile-change{% if not passwordFormViolation %} collapsed{% endif %}"
                                                data-toggle="collapse"
                                                href="#profile-password-form"


### PR DESCRIPTION
### 1. Why is this change necessary?

The mobile view of the credential section in the account profile is not responsive:

![Screenshot from 2021-01-07 11-12-00](https://user-images.githubusercontent.com/35739042/103881459-c0a40780-50da-11eb-8d3b-111089c403ba.png)

### 2. What does this change do, exactly?
This change introduces a improved responsive behavior, by adding bootstrap classes to the corresponding markup:

![Screenshot from 2021-01-07 11-13-33](https://user-images.githubusercontent.com/35739042/103881904-5f306880-50db-11eb-9e12-aa0850e4fd7a.png)


### 3. Describe each step to reproduce the issue or behaviour.
Login to shopware storefront on a mobile device and navigate to the credential section of your profile.

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
