### PR TITLE
Add null check for customer password

### DIFF
--- a/src/Core/Checkout/Customer/SalesChannel/LoginRoute.php
+++ b/src/Core/Checkout/Customer/SalesChannel/LoginRoute.php
@@ -147,7 +147,8 @@ class LoginRoute extends AbstractLoginRoute
             return $customer;
         }
 
-        if (!password_verify($password, $customer->getPassword())) {
+        if ($customer->getPassword() === null
+            || !password_verify($password, $customer->getPassword())) {
             throw new BadCredentialsException();
         }
 


### PR DESCRIPTION
Signed-off-by: Jelle Deneweth <jelle.deneweth@gmail.com>


### 1. Why is this change necessary?

The customer password is null or string. The password_verify requires a string as second parameter so errors can occur while checking the customer password. If it is null there is an Uncaught PHP Exception possible.

### 2. What does this change do, exactly?

Add extra check before the call to the password_verify

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
