### PR TITLE
Add additional --sales-channel-doman-url option to "theme:dump" command

### DIFF
--- a/src/Storefront/Theme/Command/ThemeDumpCommand.php
+++ b/src/Storefront/Theme/Command/ThemeDumpCommand.php
@@ -87,7 +87,7 @@ class ThemeDumpCommand extends Command
                 $criteria->setIds([$id]);
             }
         }
-        
+
         if ($id === null && $input->getOption('sales-channel-domain-url') !== null) {
             $criteria->addFilter(new EqualsFilter('theme.salesChannels.domains.url', $input->getOption('sales-channel-domain-url')));
         }

--- a/src/Storefront/Theme/Command/ThemeDumpCommand.php
+++ b/src/Storefront/Theme/Command/ThemeDumpCommand.php
@@ -13,6 +13,7 @@ use Shopware\Storefront\Theme\ThemeFileResolver;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
@@ -68,6 +69,7 @@ class ThemeDumpCommand extends Command
     protected function configure(): void
     {
         $this->addArgument('theme-id', InputArgument::OPTIONAL, 'Theme ID');
+        $this->addOption('sales-channel-domain-url', 'u', InputOption::VALUE_REQUIRED, 'The URL of the Sales-Channel for which you want to dump the theme');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
@@ -84,6 +86,10 @@ class ThemeDumpCommand extends Command
             } else {
                 $criteria->setIds([$id]);
             }
+        }
+        
+        if ($id === null && $input->getOption('sales-channel-domain-url') !== null) {
+            $criteria->addFilter(new EqualsFilter('theme.salesChannels.domains.url', $input->getOption('sales-channel-domain-url')));
         }
 
         $themes = $this->themeRepository->search($criteria, $this->context);


### PR DESCRIPTION
For Stores with more than one storefront sales-channel installed, we want to be able to specify the theme we want to dump. Doing so using the theme ID is tedious for the developer, since it requires additional lookup and or documentation steps. In this non-breaking pull request I propose the addition of an input option that allows us to specify the theme by the sales-channel domain url instead. This pull request is an important stepping stone to make other development tasks, like `./psh.phar storefront:hot` and `./psh.phar storefront:hot-proxy` usable for development environments that work on more than one sales-channel theme at the same time.

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?


### 2. What does this change do, exactly?


### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.
