### PR TITLE
Add payment refund handler interface

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/decorator/state-styling-provider.decorator.js
+++ b/src/Administration/Resources/app/administration/src/app/decorator/state-styling-provider.decorator.js
@@ -69,6 +69,37 @@ Application.addServiceProviderDecorator('stateStyleDataProviderService', (stateS
         variant: 'danger'
     });
 
+    // Order Refund Transaction State Styles
+    stateStyleService.addStyle('order_refund.state', 'open', {
+        icon: 'neutral',
+        color: 'neutral',
+        variant: 'neutral'
+    });
+
+    stateStyleService.addStyle('order_refund.state', 'in_progress', {
+        icon: 'progress',
+        color: 'progress',
+        variant: 'progress'
+    });
+
+    stateStyleService.addStyle('order_refund.state', 'completed', {
+        icon: 'done',
+        color: 'done',
+        variant: 'done'
+    });
+
+    stateStyleService.addStyle('order_refund.state', 'failed', {
+        icon: 'danger',
+        color: 'danger',
+        variant: 'danger'
+    });
+
+    stateStyleService.addStyle('order_refund.state', 'cancelled', {
+        icon: 'danger',
+        color: 'danger',
+        variant: 'danger'
+    });
+
     // Order Delivery State Styles
     stateStyleService.addStyle('order_delivery.state', 'open', {
         icon: 'neutral',

--- a/src/Administration/Resources/app/administration/src/core/data/error-resolver.data.js
+++ b/src/Administration/Resources/app/administration/src/core/data/error-resolver.data.js
@@ -122,7 +122,7 @@ export default class ErrorResolver {
         const field = definition.getField(fieldName);
 
         if (!field) {
-            this.errorStore.addSystemError(error);
+            Shopware.State.dispatch('error/addSystemError', { error });
             return;
         }
 

--- a/src/Administration/Resources/app/administration/src/core/service/api/order-refund.api.service.js
+++ b/src/Administration/Resources/app/administration/src/core/service/api/order-refund.api.service.js
@@ -1,0 +1,22 @@
+import ApiService from '../api.service';
+
+/**
+ * Gateway for the API end point "order-refund"
+ * @class
+ * @extends ApiService
+ */
+class OrderRefundApiService extends ApiService {
+    constructor(httpClient, loginService, apiEndpoint = 'order-refund') {
+        super(httpClient, loginService, apiEndpoint);
+        this.name = 'orderRefundService';
+    }
+
+    process(orderRefundId, additionalParams = {}, additionalHeaders = {}) {
+        const route = `/_action/order-refund/${orderRefundId}/process`;
+        const headers = this.getBasicHeaders(additionalHeaders);
+
+        return this.httpClient.post(route, {}, { additionalParams, headers });
+    }
+}
+
+export default OrderRefundApiService;

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-refund-card/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-refund-card/index.js
@@ -1,0 +1,447 @@
+import './sw-order-refund-card.scss';
+import { cloneDeep, flatMap, groupBy, round } from 'lodash';
+import template from './sw-order-refund-card.html.twig';
+
+const { Component, Mixin, Utils, Filter } = Shopware;
+const { Criteria } = Shopware.Data;
+
+const REFUND_STATE_OPEN = 'open';
+const REFUND_STATE_COMPLETED = 'completed';
+const REFUND_STATE_IN_PROGRESS = 'in_progress';
+const CAPTURE_STATE_COMPLETED = 'completed';
+
+Component.register('sw-order-refund-card', {
+    template,
+
+    mixins: [
+        Mixin.getByName('notification')
+    ],
+
+    inject: [
+        'repositoryFactory',
+        'orderRefundService',
+        'stateStyleDataProviderService'
+    ],
+    props: {
+        title: {
+            type: String,
+            required: true
+        },
+        order: {
+            type: Object,
+            required: true
+        },
+        transaction: {
+            type: Object,
+            required: true
+        },
+        isLoading: {
+            type: Boolean,
+            required: false,
+            default: false
+        }
+    },
+
+    data() {
+        return {
+            showModal: false,
+            orderRefundPositions: [],
+            paymentMethodRefundConfigs: null,
+            refundOptions: {},
+            isRefundSuccessful: false,
+            refundAmount: 0,
+            isRefundAmountEdited: false,
+            isRefunding: false,
+            selectedCaptureId: null
+        };
+    },
+
+    created() {
+        this.createdComponent();
+    },
+
+    computed: {
+        dateFilter() {
+            return Filter.getByName('date');
+        },
+
+        currencyFilter() {
+            return Filter.getByName('currency');
+        },
+
+        orderRefundRepository() {
+            return this.repositoryFactory.create('order_refund');
+        },
+
+        orderRefundPositionRepository() {
+            return this.repositoryFactory.create('order_refund_position');
+        },
+
+        stateMachineStateRepository() {
+            return this.repositoryFactory.create('state_machine_state');
+        },
+
+        paymentMethodRefundConfigRepository() {
+            return this.repositoryFactory.create('payment_method_refund_config');
+        },
+
+        refundingUnsupportedByPaymentMethod() {
+            return !this.transaction.paymentMethod.refundHandlerIdentifier;
+        },
+
+        selectedCapture() {
+            if (!this.selectedCaptureId) {
+                return null;
+            }
+
+            return this.eligibleCapturesForRefund.find(capture => capture.id === this.selectedCaptureId);
+        },
+
+        totalSelectedCaptureAmount() {
+            if (!this.selectedCaptureId) {
+                return 0;
+            }
+
+            return this.selectedCapture.amount;
+        },
+
+        remainingAmount() {
+            return this.totalSelectedCaptureAmount - this.refundedAmount;
+        },
+
+        refundedAmount() {
+            if (!this.selectedCaptureId) {
+                return 0;
+            }
+            const refundedAmount = this.order.refunds
+                .filter(orderRefund => orderRefund.stateMachineState.technicalName === REFUND_STATE_COMPLETED)
+                .filter(orderRefund => orderRefund.transactionCaptureId === this.selectedCaptureId)
+                .reduce((refundedAmountAccumulator, refund) => {
+                    return refundedAmountAccumulator + refund.amount;
+                }, 0);
+
+            return round(refundedAmount, this.order.currency.decimalPrecision);
+        },
+
+        captures() {
+            return this.transaction.captures || [];
+        },
+
+        capturesWithLabel() {
+            return this.captures
+                .map(capture => {
+                    let label = `${this.formatDate(capture.createdAt)} (${this.formatCurrency(
+                        capture.amount,
+                        this.order.currency.shortName,
+                        this.order.currency.decimalPrecision
+                    )})`;
+                    if (capture.externalReference) {
+                        label += ` - ${capture.externalReference}`;
+                    }
+
+                    return {
+                        ...capture,
+                        label
+                    };
+                });
+        },
+
+        completedCaptures() {
+            return this.capturesWithLabel
+                .filter(capture => capture.stateMachineState.technicalName === CAPTURE_STATE_COMPLETED);
+        },
+
+        eligibleCapturesForRefund() {
+            const completedOrInProgressRefunds = this.order.refunds.filter(orderRefund => {
+                const orderRefundStateTechnicalName = orderRefund.stateMachineState.technicalName;
+
+                return orderRefundStateTechnicalName === REFUND_STATE_COMPLETED
+                    || orderRefundStateTechnicalName === REFUND_STATE_IN_PROGRESS;
+            });
+            const completedOrInProgressRefundsByCaptureId = groupBy(
+                completedOrInProgressRefunds,
+                refund => refund.transactionCaptureId
+            );
+
+            return this.completedCaptures.filter(capture => {
+                const refundsForCapture = completedOrInProgressRefundsByCaptureId[capture.id] || [];
+                const alreadyRefundedAmount = refundsForCapture.reduce(
+                    (accumulator, refund) => accumulator + refund.amount,
+                    0
+                );
+                const remainingAmountToRefund = round(
+                    capture.amount - alreadyRefundedAmount,
+                    this.order.currency.decimalPrecision
+                );
+
+                return remainingAmountToRefund > 0;
+            });
+        },
+
+        orderRefundColumns() {
+            return [
+                {
+                    property: 'createdAt',
+                    label: this.$tc('sw-order.refundCard.refunds.columns.createdAt'),
+                    rawData: true
+                },
+                {
+                    property: 'paymentMethod',
+                    label: this.$tc('sw-order.refundCard.refunds.columns.paymentMethod'),
+                    rawData: true
+                },
+                {
+                    property: 'refundAmount',
+                    label: this.$tc('sw-order.refundCard.refunds.columns.refundAmount'),
+                    rawData: true,
+                    align: 'right'
+                },
+                {
+                    property: 'state',
+                    label: this.$tc('sw-order.refundCard.refunds.columns.state'),
+                    rawData: true
+                }
+            ];
+        },
+
+        paymentMethodRefundOptions() {
+            if (!this.paymentMethodRefundConfigs) {
+                return [];
+            }
+
+            return flatMap(this.paymentMethodRefundConfigs, config => config.options);
+        },
+
+        invalidRefundOptions() {
+            return this.paymentMethodRefundOptions
+                .filter(option => option.required)
+                .filter(option => this.refundOptions[option.name] === undefined
+                    || this.refundOptions[option.name] === null
+                    || this.refundOptions[option.name] === '');
+        }
+    },
+
+    methods: {
+        createdComponent() {
+            this.orderRefundPositions = this.createOrderRefundPositions();
+            if (this.eligibleCapturesForRefund.length > 0) {
+                this.selectedCaptureId = this.eligibleCapturesForRefund[0].id;
+            }
+        },
+
+        formatDate(dateTime) {
+            return this.dateFilter(dateTime, { hour: '2-digit', minute: '2-digit' });
+        },
+
+        formatCurrency(value, currencyName, decimalPlaces) {
+            return this.currencyFilter(value, currencyName, decimalPlaces);
+        },
+
+        async onCreateRefund() {
+            this.refundAmount = 0;
+            this.isRefundAmountEdited = false;
+            this.orderRefundPositions = this.createOrderRefundPositions();
+            this.showModal = true;
+            this.isRefundSuccessful = false;
+            await this.ensurePaymentMethodRefundConfigs();
+        },
+
+        closeModal() {
+            this.showModal = false;
+        },
+
+        onRefundFinished() {
+            this.isRefundSuccessful = false;
+            this.closeModal();
+            this.$nextTick(() => {
+                this.$emit('order-state-change');
+            });
+        },
+
+        onChangeRefundAmount(refundAmount) {
+            this.refundAmount = refundAmount;
+            this.isRefundAmountEdited = true;
+        },
+
+        onSelectItem(id, selected) {
+            const orderRefundPosition = this.getOrderRefundPositionById(id);
+            orderRefundPosition.selected = selected;
+
+            if (!this.isRefundAmountEdited) {
+                this.updateRefundAmount();
+            }
+        },
+
+        onChangeQuantity(id, quantity) {
+            const orderRefundPosition = this.getOrderRefundPositionById(id);
+            orderRefundPosition.refundPrice.quantity = quantity;
+            orderRefundPosition.refundPrice.totalPrice = round(
+                orderRefundPosition.refundPrice.unitPrice * quantity,
+                this.order.currency.decimalPrecision
+            );
+
+            if (!this.isRefundAmountEdited) {
+                this.updateRefundAmount();
+            }
+        },
+
+        getOrderRefundPositionById(id) {
+            return this.orderRefundPositions.find(
+                orderRefundPosition => orderRefundPosition.id === id
+            );
+        },
+
+        createOrderRefundPositions() {
+            return this.order.lineItems.map(lineItem => ({
+                selected: false,
+                id: Utils.createId(),
+                lineItemId: lineItem.id,
+                label: lineItem.label,
+                payload: cloneDeep(lineItem.payload),
+                lineItemPrice: cloneDeep(lineItem.price),
+                refundPrice: cloneDeep(lineItem.price)
+            }));
+        },
+
+        updateRefundAmount() {
+            const selectedOrderRefundPositionsAmount = this.orderRefundPositions
+                .filter(orderRefundPosition => orderRefundPosition.selected)
+                .reduce((refundAmount, orderRefundPosition) => {
+                    return refundAmount + orderRefundPosition.refundPrice.totalPrice;
+                }, 0);
+
+            this.refundAmount = Math.min(
+                round(selectedOrderRefundPositionsAmount, this.order.currency.decimalPrecision),
+                this.remainingAmount
+            );
+        },
+
+        getSelectedOrderRefundPositions() {
+            return this.orderRefundPositions
+                .filter(orderRefundPosition => orderRefundPosition.selected)
+                .map(orderRefundPositionPrototype => {
+                    const orderRefundPosition = this.orderRefundPositionRepository.create(Shopware.Context.api);
+                    orderRefundPosition.lineItemId = orderRefundPositionPrototype.lineItemId;
+                    orderRefundPosition.payload = orderRefundPositionPrototype.payload;
+                    orderRefundPosition.label = orderRefundPositionPrototype.label;
+                    orderRefundPosition.lineItemPrice = orderRefundPositionPrototype.lineItemPrice;
+                    orderRefundPosition.refundPrice = orderRefundPositionPrototype.refundPrice;
+
+                    return orderRefundPosition;
+                });
+        },
+
+        async ensurePaymentMethodRefundConfigs() {
+            if (this.paymentMethodRefundConfigs !== null) {
+                return;
+            }
+            const criteria = new Criteria();
+            criteria.addFilter(Criteria.equals('paymentMethodId', this.transaction.paymentMethodId));
+            this.isLoading = true;
+            try {
+                this.paymentMethodRefundConfigs = await this.paymentMethodRefundConfigRepository.search(
+                    criteria,
+                    Shopware.Context.api
+                );
+                this.createRefundOptionsWithDefaultValues();
+            } finally {
+                this.isLoading = false;
+            }
+        },
+
+        createRefundOptionsWithDefaultValues() {
+            this.paymentMethodRefundOptions
+                .filter(option => option.default !== undefined)
+                .forEach(option => {
+                    this.$set(this.refundOptions, option.name, option.default);
+                });
+        },
+
+        async getOrderRefundState(technicalName) {
+            const criteria = new Criteria();
+            criteria.addFilter(Criteria.equals(
+                'state_machine_state.stateMachine.technicalName',
+                'order_refund.state'
+            ));
+            criteria.addFilter(Criteria.equals(
+                'state_machine_state.technicalName',
+                technicalName
+            ));
+
+            const stateMachineStates = await this.stateMachineStateRepository.search(criteria, Shopware.Context.api);
+
+            return stateMachineStates.first();
+        },
+
+        getVariantFromOrderRefundState(orderRefund) {
+            return this.stateStyleDataProviderService.getStyle(
+                'order_refund.state', orderRefund.stateMachineState.technicalName
+            ).variant;
+        },
+
+        async refundOrderTransaction() {
+            if (this.refundAmount > this.remainingAmount) {
+                this.createNotificationError({
+                    title: 'Error',
+                    message: 'Refund amount can not be higher than remaining amount. '
+                        + `Tried to refund ${this.refundAmount} ${this.order.currency.symbol}, `
+                        + `but the maximum is ${this.remainingAmount} ${this.order.currency.symbol}.`
+                });
+                return;
+            }
+            if (this.invalidRefundOptions.length > 0) {
+                this.createNotificationError({
+                    title: 'Error',
+                    message: 'There are required fields, please fill them first.'
+                });
+                return;
+            }
+            this.isRefunding = true;
+            this.isRefundSuccessful = false;
+            try {
+                const orderRefund = this.orderRefundRepository.create(Shopware.Context.api);
+                orderRefund.orderId = this.order.id;
+                orderRefund.transactionId = this.transaction.id;
+                orderRefund.paymentMethodId = this.transaction.paymentMethodId;
+                orderRefund.amount = this.refundAmount;
+                orderRefund.options = this.refundOptions;
+                const openState = await this.getOrderRefundState(REFUND_STATE_OPEN);
+                orderRefund.stateId = openState.id;
+                const positions = this.getSelectedOrderRefundPositions();
+                positions.forEach(position => {
+                    orderRefund.positions.add(position);
+                });
+                if (this.selectedCaptureId) {
+                    orderRefund.transactionCaptureId = this.selectedCaptureId;
+                }
+
+                await this.orderRefundRepository.save(orderRefund, Shopware.Context.api);
+                await this.orderRefundService.process(orderRefund.id);
+                this.isRefundSuccessful = true;
+                this.createNotificationSuccess({
+                    title: 'Success',
+                    message: `Successfully refunded ${orderRefund.amount} ${this.order.currency.symbol}`
+                });
+            } catch (err) {
+                let errorMessage = err.message;
+                if (err.response && err.response.data) {
+                    errorMessage = err.response && err.response.data;
+                    if (err.response.data.errors && err.response.data.errors.length > 0) {
+                        errorMessage = err.response.data.errors.map(error => error.detail).join(', ');
+                    }
+                }
+                this.createNotificationError({
+                    title: 'Error',
+                    message: `Error refunding ${this.refundAmount} ${this.order.currency.symbol}: ${errorMessage}`
+                });
+                this.onRefundFinished();
+            } finally {
+                this.isRefunding = false;
+            }
+        },
+
+        onRefundConfigurationFieldChange(optionName, value) {
+            this.$set(this.refundOptions, optionName, value);
+        }
+    }
+});

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-refund-card/sw-order-refund-card.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-refund-card/sw-order-refund-card.html.twig
@@ -1,0 +1,142 @@
+{% block sw_order_refund_card %}
+    <sw-card :title="title"
+            :isLoading="isLoading"
+            class="sw-order-refund-card">
+        {% block sw_order_refund_card_container %}
+            <sw-container columns="1fr" gap="30px 30px">
+                {% block sw_order_refund_card_refunds %}
+                    <sw-data-grid v-if="order.refunds.length > 0"
+                                  :dataSource="order.refunds"
+                                  :columns="orderRefundColumns"
+                                  :showActions="false"
+                                  :showSelection="false"
+                                  :isLoading="isLoading">
+                                  identifier="sw-order-refunds-grid">
+
+                        <template slot="column-createdAt" slot-scope="{ item, isInlineEdit}">
+                            {{ item.createdAt | date({hour: '2-digit', minute: '2-digit'})}}
+                        </template>
+
+                        <template slot="column-paymentMethod" slot-scope="{ item, isInlineEdit}">
+                            {{ item.paymentMethod.translated.name }}
+                        </template>
+
+                        <template slot="column-refundAmount" slot-scope="{ item, isInlineEdit}">
+                            {{ item.amount | currency(order.currency.shortName) }}
+                        </template>
+
+                        <template slot="column-state" slot-scope="{ item, isInlineEdit}">
+                            <sw-label :variant="getVariantFromOrderRefundState(item)" appearance="pill">
+                                {{ item.stateMachineState.translated.name }}
+                            </sw-label>
+                        </template>
+                    </sw-data-grid>
+
+                    <sw-empty-state
+                        v-else
+                        :title="$tc('sw-order.refundCard.emptyRefunds')"
+                        :icon="'default-money-card'"
+                        :absolute="false">
+                        {% block sw_order_refund_card_create_refund_empty_state_content %}
+                            <span></span>
+                        {% endblock %}
+                    </sw-empty-state>
+                {% endblock %}
+
+                {% block sw_order_refund_card_create_refund %}
+                    <sw-button
+                        variant="primary"
+                        :disabled="refundingUnsupportedByPaymentMethod || eligibleCapturesForRefund.length === 0"
+                        @click="onCreateRefund">
+                        {{ $tc('sw-order.refundCard.createRefundButton') }}
+                    </sw-button>
+                {% endblock %}
+            </sw-container>
+        {% endblock %}
+
+        {% block sw_order_refund_card_create_refund_modal %}
+        <sw-modal v-if="showModal"
+                  variant="large"
+                  @modal-close="closeModal"
+                  :title="$tc(`sw-order.refundCard.createRefundModal.title`)"
+                  class="sw-order-refund-card--refund-modal"
+        >
+            <sw-loader v-if="isLoading || isRefunding"></sw-loader>
+            <sw-select-field v-model="selectedCaptureId"
+                             :label="$tc('sw-order.refundCard.createRefundModal.captureSelectionLabel')">
+                <option v-for="capture in eligibleCapturesForRefund"
+                        :value="capture.id">
+                    {{ capture.label }}
+                </option>
+            </sw-select-field>
+            <sw-order-refund-positions
+                :order="order"
+                :orderRefundPositions="orderRefundPositions"
+                :isLoading="isLoading"
+                v-on:select-item="onSelectItem"
+                v-on:change-quantity="onChangeQuantity">
+            </sw-order-refund-positions>
+
+            <div class="sw-order-refund-card--refund-modal--content">
+                <sw-container columns="1fr 1fr" gap="0 32px">
+                    <sw-text-field :disabled="true"
+                                   :label="$tc('sw-order.refundCard.createRefundModal.captureAmount')"
+                                   :value="totalSelectedCaptureAmount | currency(order.currency.shortName)"
+                    />
+                    <sw-text-field :disabled="true"
+                                   :label="$tc('sw-order.refundCard.createRefundModal.refundedAmount')"
+                                   :value="refundedAmount | currency(order.currency.shortName)"
+                    />
+                    <sw-text-field :disabled="true"
+                                   :label="$tc('sw-order.refundCard.createRefundModal.remainingAmount')"
+                                   :value="remainingAmount | currency(order.currency.shortName)"
+                    />
+                    <sw-number-field required="required"
+                                     numberType="float"
+                                     :digits="order.decimal_precision"
+                                     :label="$tc('sw-order.refundCard.createRefundModal.refundAmount')"
+                                     :value="refundAmount"
+                                     v-on:change="onChangeRefundAmount($event)"
+                                     :min="0">
+                        <template #suffix>
+                            {{ order.currency.shortName }}
+                        </template>
+                    </sw-number-field>
+                </sw-container>
+            </div>
+
+            <div
+                v-for="(option, index) in paymentMethodRefundOptions"
+                :key="index"
+            >
+                <sw-order-refund-configuration-field
+                    :element="option"
+                    :value="refundOptions[option.name]"
+                    @change="onRefundConfigurationFieldChange(option.name, $event)">
+                </sw-order-refund-configuration-field>
+            </div>
+
+            <template slot="modal-footer">
+                <sw-button :disabled="isLoading" @click="closeModal">
+                    {{ $tc('sw-order.refundCard.createRefundModal.close') }}
+                </sw-button>
+
+                <sw-button-process :isLoading="isRefunding"
+                                   :processSuccess="isRefundSuccessful"
+                                   @process-finish="onRefundFinished()"
+                                   :disabled="isLoading || isRefunding || refundAmount <= 0 || invalidRefundOptions.length > 0"
+                                   variant="primary"
+                                   @click="refundOrderTransaction">
+                    {{ $tc('sw-order.refundCard.createRefundModal.submit') }}
+                </sw-button-process>
+            </template>
+        </sw-modal>
+        {% endblock %}
+    </sw-card>
+{% endblock %}
+<script>
+    import Select from '../../../../app/component/form/sw-field';
+    export default {
+        components: { Select },
+    };
+</script>

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-refund-card/sw-order-refund-card.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-refund-card/sw-order-refund-card.scss
@@ -1,0 +1,15 @@
+@import "~scss/variables";
+
+.sw-order-refund-card--refund-modal {
+    .sw-data-grid__bulk {
+        display: none;
+    }
+
+    .sw-modal__footer {
+        border-top: 1px solid $color-gray-300;
+    }
+
+    .sw-order-refund-card--refund-modal--content {
+        padding-top: 30px;
+    }
+}

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-refund-configuration-field/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-refund-configuration-field/index.js
@@ -1,0 +1,57 @@
+import template from './sw-order-refund-configuration-field.html.twig';
+
+const { Component } = Shopware;
+
+Component.register('sw-order-refund-configuration-field', {
+    template,
+
+    props: {
+        element: {
+            type: Object,
+            required: true
+        },
+        value: {
+            type: [Object, String, Boolean, Number],
+            required: false
+        }
+    },
+
+    computed: {
+        currentLocale() {
+            return this.$root.$i18n.locale;
+        },
+        fieldLabel() {
+            if (!this.element.label || !this.element.label[this.currentLocale]) {
+                return 'missing label';
+            }
+
+            return this.element.label[this.currentLocale];
+        },
+        fieldId() {
+            return `order-refund-configuration-field--${this.element.name.replace(/\./g, '-')}`;
+        },
+        error() {
+            if (!this.element.required || !!this.value) {
+                return null;
+            }
+
+            return {
+                detail: this.$tc('sw-order.refundCard.createRefundModal.refundOptionRequired')
+            };
+        }
+    },
+
+    methods: {
+        getOptionLabel(option) {
+            if (!option.label || !option.label[this.currentLocale]) {
+                return 'missing label';
+            }
+
+            return option.label[this.currentLocale];
+        },
+
+        onChange(value) {
+            this.$emit('change', value);
+        }
+    }
+});

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-refund-configuration-field/sw-order-refund-configuration-field.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-refund-configuration-field/sw-order-refund-configuration-field.html.twig
@@ -1,0 +1,31 @@
+{% block sw_order_refund_configuration_field %}
+    <div>
+        <sw-select-field
+            v-if="element.type === 'single-select'"
+            :required="!!element.required"
+            :error="error"
+            :label="fieldLabel"
+            :name="fieldId"
+            :value="value"
+            @change="onChange"
+        >
+            <option
+                v-for="option in element.options"
+                :key="option.value"
+                :value="option.value"
+            >
+                {{ getOptionLabel(option) }}
+            </option>
+        </sw-select-field>
+
+        <sw-text-field
+            v-if="element.type === 'text'"
+            :value="value"
+            :required="!!element.required"
+            :error="error"
+            :label="fieldLabel"
+            :name="fieldId"
+            @change="onChange"
+        />
+    </div>
+{% endblock %}

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-refund-positions/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-refund-positions/index.js
@@ -1,0 +1,62 @@
+import template from './sw-order-refund-positions.html.twig';
+
+const { Component } = Shopware;
+
+Component.register('sw-order-refund-positions', {
+    template,
+
+    props: {
+        order: {
+            type: Object,
+            required: true
+        },
+        orderRefundPositions: {
+            type: Array,
+            required: true
+        },
+        isLoading: {
+            type: Boolean,
+            required: false,
+            default: false
+        }
+    },
+
+    computed: {
+        orderRefundPositionColumns() {
+            return [
+                {
+                    property: 'label',
+                    label: this.$tc('sw-order.refundCard.createRefundModal.columns.product'),
+                    rawData: true
+                },
+                {
+                    property: 'refundQuantity',
+                    label: this.$tc('sw-order.refundCard.createRefundModal.columns.quantity'),
+                    rawData: true
+                },
+                {
+                    property: 'refundUnitPrice',
+                    label: this.$tc('sw-order.refundCard.createRefundModal.columns.unitPrice'),
+                    rawData: true,
+                    align: 'right'
+                },
+                {
+                    property: 'refundTotalPrice',
+                    label: this.$tc('sw-order.refundCard.createRefundModal.columns.totalPrice'),
+                    rawData: true,
+                    align: 'right'
+                }
+            ];
+        }
+    },
+
+    methods: {
+        onSelectItem(_, item, selected) {
+            this.$emit('select-item', item.id, selected);
+        },
+
+        onChangeQuantity(value, id) {
+            this.$emit('change-quantity', id, value);
+        }
+    }
+});

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-refund-positions/sw-order-refund-positions.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-refund-positions/sw-order-refund-positions.html.twig
@@ -1,0 +1,36 @@
+{% block sw_order_refund_positions %}
+    <div>
+        <sw-data-grid :dataSource="orderRefundPositions"
+                      :columns="orderRefundPositionColumns"
+                      :showActions="false"
+                      :showSelection="true"
+                      v-on:select-item="onSelectItem">
+                      identifier="sw-order-refund-positions-grid">
+
+            <template slot="column-product" slot-scope="{ item, isInlineEdit}">
+                {{ item.label }}
+            </template>
+
+            <template slot="column-refundQuantity" slot-scope="{ item, isInlineEdit}">
+                <sw-field
+                    :value="item.refundPrice.quantity"
+                    type="number"
+                    :min="0"
+                    :max="item.lineItemPrice.quantity"
+                    slot="inline-edit"
+                    size="small"
+                    placeholder=0
+                    v-on:change="onChangeQuantity($event, item.id)">
+                </sw-field>
+            </template>
+
+            <template slot="column-refundUnitPrice" slot-scope="{ item, isInlineEdit}">
+                {{ item.refundPrice.unitPrice | currency(order.currency.shortName) }}
+            </template>
+
+            <template slot="column-refundTotalPrice" slot-scope="{ item, isInlineEdit}">
+                {{ item.refundPrice.totalPrice | currency(order.currency.shortName)  }}
+            </template>
+        </sw-data-grid>
+    </div>
+{% endblock %}

--- a/src/Administration/Resources/app/administration/src/module/sw-order/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/index.js
@@ -29,6 +29,9 @@ import './component/sw-order-new-customer-modal';
 import './component/sw-order-promotion-tag-field';
 import './component/sw-order-create-invalid-promotion-modal';
 import './component/sw-order-create-promotion-modal';
+import './component/sw-order-refund-card';
+import './component/sw-order-refund-positions';
+import './component/sw-order-refund-configuration-field';
 import './acl';
 
 const { Module } = Shopware;

--- a/src/Administration/Resources/app/administration/src/module/sw-order/snippet/de-DE.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/snippet/de-DE.json
@@ -249,6 +249,36 @@
       "labelNoTransactionState": "Keine Transaktionen vorhanden",
       "labelNoDeliveryState": "Keine Lieferungen vorhanden"
     },
+    "refundCard": {
+      "cardTitle": "Erstattung",
+      "createRefundButton": "Erstattung erstellen",
+      "emptyRefunds": "Es wurden noch keine Erstattungen erstellt",
+      "refunds": {
+        "columns": {
+          "createdAt": "Erstellt am",
+          "paymentMethod": "Bezahlart",
+          "refundAmount": "Erstattungsbetrag",
+          "state": "Status"
+        }
+      },
+      "createRefundModal": {
+        "title": "Erstattung erstellen",
+        "submit": "Erstattung erstellen",
+        "close": "Schließen",
+        "captureSelectionLabel": "Erfassung auswählen",
+        "refundAmount": "Erstattungsbetrag",
+        "captureAmount": "Erfassungsbetrag",
+        "remainingAmount": "Verbleibender Betrag",
+        "refundedAmount": "Erstatteter Betrag",
+        "refundOptionRequired": "Dieses Feld ist erforderlich",
+        "columns": {
+          "product": "Produkt",
+          "quantity": "Anzahl",
+          "unitPrice": "Stückpreis",
+          "totalPrice": "Gesamtpreis"
+        }
+      }
+    },
     "assignMailTemplateCard": {
       "cardTitle": "E-Mail-Template zuweisen",
       "headline": "Diesem Bestellstatus ist noch kein E-Mail-Template zugewiesen!",

--- a/src/Administration/Resources/app/administration/src/module/sw-order/snippet/en-GB.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/snippet/en-GB.json
@@ -249,6 +249,36 @@
       "labelNoTransactionState": "No transactions yet",
       "labelNoDeliveryState": "No deliveries yet"
     },
+    "refundCard": {
+      "cardTitle": "Refund",
+      "createRefundButton": "Create Refund",
+      "emptyRefunds": "No refunds created yet",
+      "refunds": {
+        "columns": {
+          "createdAt": "Created",
+          "paymentMethod": "Payment Method",
+          "refundAmount": "Refund Amount",
+          "state": "State"
+        }
+      },
+      "createRefundModal": {
+        "title": "Create Refund",
+        "submit": "Create Refund",
+        "close": "Close",
+        "captureSelectionLabel": "Select capture",
+        "refundAmount": "Refund amount",
+        "captureAmount": "Capture amount",
+        "remainingAmount": "Remaining amount",
+        "refundedAmount": "Refunded amount",
+        "refundOptionRequired": "This field is required",
+        "columns": {
+          "product": "Product",
+          "quantity": "Quantity",
+          "unitPrice": "Unit price",
+          "totalPrice": "Total Price"
+        }
+      }
+    },
     "assignMailTemplateCard": {
       "cardTitle": "Assign email template",
       "headline": "No email template assigned to this order status, please assign one.",

--- a/src/Administration/Resources/app/administration/src/module/sw-order/view/sw-order-detail-base/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/view/sw-order-detail-base/index.js
@@ -172,10 +172,14 @@ Component.register('sw-order-detail-base', {
                 .addAssociation('deliveries.shippingMethod')
                 .addAssociation('deliveries.shippingOrderAddress')
                 .addAssociation('transactions.paymentMethod')
+                .addAssociation('transactions.captures.stateMachineState')
+                .addAssociation('refunds.paymentMethod')
                 .addAssociation('documents.documentType')
                 .addAssociation('tags');
 
             criteria.getAssociation('transactions').addSorting(Criteria.sort('createdAt'));
+            criteria.getAssociation('refunds').addSorting(Criteria.sort('createdAt'));
+            criteria.getAssociation('transactions.captures').addSorting(Criteria.sort('createdAt'));
 
             return criteria;
         },

--- a/src/Administration/Resources/app/administration/src/module/sw-order/view/sw-order-detail-base/sw-order-detail-base.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/view/sw-order-detail-base/sw-order-detail-base.html.twig
@@ -192,6 +192,17 @@
             </sw-order-state-history-card>
         {% endblock %}
 
+        {% block sw_order_detail_base_refund_card %}
+            <sw-order-refund-card v-if="!isEditing && transaction"
+                                         :title="$tc('sw-order.refundCard.cardTitle')"
+                                         :isLoading="isLoading"
+                                         :order="order"
+                                         :transaction="transaction"
+                                         @order-state-change="reloadEntityData"
+                                         ref="refund-card">
+            </sw-order-refund-card>
+        {% endblock %}
+
         {% block sw_order_detail_delivery_metadata %}
             <sw-order-delivery-metadata v-if="delivery"
                                         class="sw-order-delivery-metadata"

--- a/src/Core/Checkout/Checkout.php
+++ b/src/Core/Checkout/Checkout.php
@@ -26,6 +26,7 @@ class Checkout extends Bundle
         $loader->load('payment.xml');
         $loader->load('rule.xml');
         $loader->load('promotion.xml');
+        $loader->load('refund.xml');
         $loader->load('shipping.xml');
     }
 }

--- a/src/Core/Checkout/DependencyInjection/order.xml
+++ b/src/Core/Checkout/DependencyInjection/order.xml
@@ -42,6 +42,18 @@
             <tag name="shopware.entity.definition"/>
         </service>
 
+        <service id="Shopware\Core\Checkout\Order\Aggregate\OrderRefund\OrderRefundDefinition">
+            <tag name="shopware.entity.definition"/>
+        </service>
+
+        <service id="Shopware\Core\Checkout\Order\Aggregate\OrderRefundPosition\OrderRefundPositionDefinition">
+            <tag name="shopware.entity.definition"/>
+        </service>
+
+        <service id="Shopware\Core\Checkout\Order\Aggregate\OrderTransactionCapture\OrderTransactionCaptureDefinition">
+            <tag name="shopware.entity.definition"/>
+        </service>
+
         <service id="Shopware\Core\Checkout\Order\SalesChannel\OrderService">
             <argument type="service" id="Shopware\Core\Framework\Validation\DataValidator"/>
             <argument type="service" id="Shopware\Core\Checkout\Order\Validation\OrderValidationFactory"/>
@@ -75,6 +87,21 @@
         </service>
 
         <service id="Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionStateHandler">
+            <argument type="service" id="Shopware\Core\System\StateMachine\StateMachineRegistry"/>
+        </service>
+
+        <service id="Shopware\Core\Checkout\Order\Aggregate\OrderRefund\OrderRefundStateHandler">
+            <argument type="service" id="Shopware\Core\System\StateMachine\StateMachineRegistry"/>
+        </service>
+
+        <service id="Shopware\Core\Checkout\Order\Aggregate\OrderTransactionCapture\OrderTransactionCaptureStateHandler">
+            <argument type="service" id="Shopware\Core\System\StateMachine\StateMachineRegistry"/>
+            <argument type="service" id="order_transaction_capture.repository"/>
+        </service>
+
+        <service id="Shopware\Core\Checkout\Order\Aggregate\OrderTransactionCapture\OrderTransactionCaptureService">
+            <argument type="service" id="order_transaction.repository"/>
+            <argument type="service" id="order_transaction_capture.repository"/>
             <argument type="service" id="Shopware\Core\System\StateMachine\StateMachineRegistry"/>
         </service>
 

--- a/src/Core/Checkout/DependencyInjection/refund.xml
+++ b/src/Core/Checkout/DependencyInjection/refund.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+        <service id="Shopware\Core\Checkout\Refund\PaymentMethodRefundConfigDefinition">
+            <tag name="shopware.entity.definition"/>
+        </service>
+
+        <service id="Shopware\Core\Checkout\Refund\PaymentRefundProcessor">
+            <argument type="service" id="order_refund.repository"/>
+            <argument type="service" id="Shopware\Core\Checkout\Refund\RefundHandler\PaymentRefundHandlerRegistry"/>
+            <argument type="service" id="Shopware\Core\Checkout\Order\Aggregate\OrderRefund\OrderRefundStateHandler"/>
+        </service>
+
+        <service id="Shopware\Core\Checkout\Refund\PaymentMethodRefundConfigService" public="true">
+            <argument type="service" id="payment_method_refund_config.repository" />
+        </service>
+
+        <service id="Shopware\Core\Checkout\Refund\Api\OrderRefundActionController" public="true">
+            <argument type="service" id="Shopware\Core\Checkout\Refund\PaymentRefundProcessor" />
+        </service>
+
+        <service id="Shopware\Core\Checkout\Refund\RefundHandler\PaymentRefundHandlerRegistry">
+            <argument type="tagged_locator" tag="shopware.refund.handler"/>
+        </service>
+    </services>
+</container>

--- a/src/Core/Checkout/Order/Aggregate/OrderLineItem/OrderLineItemDefinition.php
+++ b/src/Core/Checkout/Order/Aggregate/OrderLineItem/OrderLineItemDefinition.php
@@ -3,6 +3,7 @@
 namespace Shopware\Core\Checkout\Order\Aggregate\OrderLineItem;
 
 use Shopware\Core\Checkout\Order\Aggregate\OrderDeliveryPosition\OrderDeliveryPositionDefinition;
+use Shopware\Core\Checkout\Order\Aggregate\OrderRefundPosition\OrderRefundPositionDefinition;
 use Shopware\Core\Checkout\Order\OrderDefinition;
 use Shopware\Core\Content\Media\MediaDefinition;
 use Shopware\Core\Content\Product\ProductDefinition;
@@ -102,6 +103,7 @@ class OrderLineItemDefinition extends EntityDefinition
             new ManyToOneAssociationField('order', 'order_id', OrderDefinition::class, 'id', false),
             new ManyToOneAssociationField('product', 'product_id', ProductDefinition::class, 'id', false),
             (new OneToManyAssociationField('orderDeliveryPositions', OrderDeliveryPositionDefinition::class, 'order_line_item_id', 'id'))->addFlags(new CascadeDelete(), new WriteProtected()),
+            (new OneToManyAssociationField('orderRefundPositions', OrderRefundPositionDefinition::class, 'line_item_id', 'id'))->addFlags(new WriteProtected()),
         ]);
     }
 }

--- a/src/Core/Checkout/Order/Aggregate/OrderLineItem/OrderLineItemEntity.php
+++ b/src/Core/Checkout/Order/Aggregate/OrderLineItem/OrderLineItemEntity.php
@@ -5,6 +5,7 @@ namespace Shopware\Core\Checkout\Order\Aggregate\OrderLineItem;
 use Shopware\Core\Checkout\Cart\Price\Struct\CalculatedPrice;
 use Shopware\Core\Checkout\Cart\Price\Struct\PriceDefinitionInterface;
 use Shopware\Core\Checkout\Order\Aggregate\OrderDeliveryPosition\OrderDeliveryPositionCollection;
+use Shopware\Core\Checkout\Order\Aggregate\OrderRefundPosition\OrderRefundPositionCollection;
 use Shopware\Core\Checkout\Order\OrderEntity;
 use Shopware\Core\Content\Media\MediaEntity;
 use Shopware\Core\Content\Product\ProductEntity;
@@ -141,6 +142,11 @@ class OrderLineItemEntity extends Entity
      * @var ProductEntity|null
      */
     protected $product;
+
+    /**
+     * @var OrderRefundPositionCollection|null
+     */
+    protected $orderRefundPositions;
 
     public function getOrderId(): string
     {
@@ -390,5 +396,15 @@ class OrderLineItemEntity extends Entity
     public function setProduct(?ProductEntity $product): void
     {
         $this->product = $product;
+    }
+
+    public function getOrderRefundPositions(): ?OrderRefundPositionCollection
+    {
+        return $this->orderRefundPositions;
+    }
+
+    public function setOrderRefundPositions(OrderRefundPositionCollection $orderRefundPositions): void
+    {
+        $this->orderRefundPositions = $orderRefundPositions;
     }
 }

--- a/src/Core/Checkout/Order/Aggregate/OrderRefund/OrderRefundCollection.php
+++ b/src/Core/Checkout/Order/Aggregate/OrderRefund/OrderRefundCollection.php
@@ -1,0 +1,27 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Checkout\Order\Aggregate\OrderRefund;
+
+use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
+
+/**
+ * @method void                   add(OrderRefundEntity $entity)
+ * @method void                   set(string $key, OrderRefundEntity $entity)
+ * @method OrderRefundEntity[]    getIterator()
+ * @method OrderRefundEntity[]    getElements()
+ * @method OrderRefundEntity|null get(string $key)
+ * @method OrderRefundEntity|null first()
+ * @method OrderRefundEntity|null last()
+ */
+class OrderRefundCollection extends EntityCollection
+{
+    public function getApiAlias(): string
+    {
+        return 'order_refund_collection';
+    }
+
+    protected function getExpectedClass(): string
+    {
+        return OrderRefundEntity::class;
+    }
+}

--- a/src/Core/Checkout/Order/Aggregate/OrderRefund/OrderRefundDefinition.php
+++ b/src/Core/Checkout/Order/Aggregate/OrderRefund/OrderRefundDefinition.php
@@ -1,0 +1,82 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Checkout\Order\Aggregate\OrderRefund;
+
+use Shopware\Core\Checkout\Order\Aggregate\OrderRefundPosition\OrderRefundPositionDefinition;
+use Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionDefinition;
+use Shopware\Core\Checkout\Order\Aggregate\OrderTransactionCapture\OrderTransactionCaptureDefinition;
+use Shopware\Core\Checkout\Order\OrderDefinition;
+use Shopware\Core\Checkout\Payment\PaymentMethodDefinition;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\CustomFields;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\FkField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\CascadeDelete;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\PrimaryKey;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\Required;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\SearchRanking;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\FloatField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\IdField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\JsonField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\ManyToOneAssociationField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\OneToManyAssociationField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\ReferenceVersionField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\StateMachineStateField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\VersionField;
+use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
+use Shopware\Core\System\StateMachine\Aggregation\StateMachineState\StateMachineStateDefinition;
+
+class OrderRefundDefinition extends EntityDefinition
+{
+    public const ENTITY_NAME = 'order_refund';
+
+    public function getEntityName(): string
+    {
+        return self::ENTITY_NAME;
+    }
+
+    public function getCollectionClass(): string
+    {
+        return OrderRefundCollection::class;
+    }
+
+    public function getEntityClass(): string
+    {
+        return OrderRefundEntity::class;
+    }
+
+    public function since(): ?string
+    {
+        return '6.3.4.0';
+    }
+
+    protected function getParentDefinitionClass(): ?string
+    {
+        return OrderDefinition::class;
+    }
+
+    protected function defineFields(): FieldCollection
+    {
+        return new FieldCollection([
+            (new IdField('id', 'id'))->addFlags(new PrimaryKey(), new Required()),
+            new VersionField(),
+            (new FkField('order_id', 'orderId', OrderDefinition::class))->addFlags(new Required()),
+            (new ReferenceVersionField(OrderDefinition::class))->addFlags(new Required()),
+            (new FkField('payment_method_id', 'paymentMethodId', PaymentMethodDefinition::class))->addFlags(new Required()),
+            (new FloatField('amount', 'amount'))->addFlags(new Required()),
+            new JsonField('options', 'options'),
+
+            new FkField('transaction_id', 'transactionId', OrderTransactionDefinition::class),
+            (new ReferenceVersionField(OrderTransactionDefinition::class, 'transaction_version_id'))->addFlags(new Required()),
+
+            (new StateMachineStateField('state_id', 'stateId', OrderRefundStates::STATE_MACHINE))->addFlags(new Required()),
+            new ManyToOneAssociationField('stateMachineState', 'state_id', StateMachineStateDefinition::class, 'id', true),
+            new CustomFields(),
+            new ManyToOneAssociationField('order', 'order_id', OrderDefinition::class, 'id', false),
+            new ManyToOneAssociationField('transaction', 'transaction_id', OrderTransactionDefinition::class, 'id', false),
+            new ManyToOneAssociationField('paymentMethod', 'payment_method_id', PaymentMethodDefinition::class, 'id', false),
+            (new OneToManyAssociationField('positions', OrderRefundPositionDefinition::class, 'order_refund_id', 'id'))->addFlags(new CascadeDelete(), new SearchRanking(SearchRanking::ASSOCIATION_SEARCH_RANKING)),
+            new FkField('transaction_capture_id', 'transactionCaptureId', OrderTransactionCaptureDefinition::class),
+            new ManyToOneAssociationField('transactionCapture', 'transaction_capture_id', OrderTransactionCaptureDefinition::class, 'id', false),
+        ]);
+    }
+}

--- a/src/Core/Checkout/Order/Aggregate/OrderRefund/OrderRefundEntity.php
+++ b/src/Core/Checkout/Order/Aggregate/OrderRefund/OrderRefundEntity.php
@@ -1,0 +1,227 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Checkout\Order\Aggregate\OrderRefund;
+
+use Shopware\Core\Checkout\Order\Aggregate\OrderRefundPosition\OrderRefundPositionCollection;
+use Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionEntity;
+use Shopware\Core\Checkout\Order\Aggregate\OrderTransactionCapture\OrderTransactionCaptureEntity;
+use Shopware\Core\Checkout\Order\OrderEntity;
+use Shopware\Core\Checkout\Payment\PaymentMethodEntity;
+use Shopware\Core\Framework\DataAbstractionLayer\Entity;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityIdTrait;
+use Shopware\Core\System\StateMachine\Aggregation\StateMachineState\StateMachineStateEntity;
+
+class OrderRefundEntity extends Entity
+{
+    use EntityIdTrait;
+
+    /**
+     * @var string
+     */
+    protected $orderId;
+
+    /**
+     * @var string|null
+     */
+    protected $transactionId;
+
+    /**
+     * @var string
+     */
+    protected $paymentMethodId;
+
+    /**
+     * @var float
+     */
+    protected $amount;
+
+    /**
+     * @var PaymentMethodEntity|null
+     */
+    protected $paymentMethod;
+
+    /**
+     * @var OrderEntity|null
+     */
+    protected $order;
+
+    /**
+     * @var OrderTransactionEntity|null
+     */
+    protected $transaction;
+
+    /***
+     * @var StateMachineStateEntity|null
+     */
+    protected $stateMachineState;
+
+    /**
+     * @var string
+     */
+    protected $stateId;
+
+    /**
+     * @var array|null
+     */
+    protected $customFields;
+
+    /**
+     * @var string|null
+     */
+    protected $transactionCaptureId;
+
+    /**
+     * @var OrderTransactionCaptureEntity|null
+     */
+    protected $transactionCapture;
+
+    /**
+     * @var OrderRefundPositionCollection|null
+     */
+    protected $positions;
+
+    /**
+     * @var array|null
+     */
+    protected $options;
+
+    public function getOrderId(): string
+    {
+        return $this->orderId;
+    }
+
+    public function setOrderId(string $orderId): void
+    {
+        $this->orderId = $orderId;
+    }
+
+    public function getTransactionId(): ?string
+    {
+        return $this->transactionId;
+    }
+
+    public function setTransactionId(?string $transactionId): void
+    {
+        $this->transactionId = $transactionId;
+    }
+
+    public function getPaymentMethodId(): string
+    {
+        return $this->paymentMethodId;
+    }
+
+    public function setPaymentMethodId(string $paymentMethodId): void
+    {
+        $this->paymentMethodId = $paymentMethodId;
+    }
+
+    public function getAmount(): float
+    {
+        return $this->amount;
+    }
+
+    public function setAmount(float $amount): void
+    {
+        $this->amount = $amount;
+    }
+
+    public function getPaymentMethod(): ?PaymentMethodEntity
+    {
+        return $this->paymentMethod;
+    }
+
+    public function setPaymentMethod(PaymentMethodEntity $paymentMethod): void
+    {
+        $this->paymentMethod = $paymentMethod;
+    }
+
+    public function getOrder(): ?OrderEntity
+    {
+        return $this->order;
+    }
+
+    public function setOrder(OrderEntity $order): void
+    {
+        $this->order = $order;
+    }
+
+    public function getTransaction(): ?OrderTransactionEntity
+    {
+        return $this->transaction;
+    }
+
+    public function setTransaction(?OrderTransactionEntity $transaction): void
+    {
+        $this->transaction = $transaction;
+    }
+
+    public function getStateMachineState(): ?StateMachineStateEntity
+    {
+        return $this->stateMachineState;
+    }
+
+    public function setStateMachineState(StateMachineStateEntity $stateMachineState): void
+    {
+        $this->stateMachineState = $stateMachineState;
+    }
+
+    public function getStateId(): string
+    {
+        return $this->stateId;
+    }
+
+    public function setStateId(string $stateId): void
+    {
+        $this->stateId = $stateId;
+    }
+
+    public function getCustomFields(): ?array
+    {
+        return $this->customFields;
+    }
+
+    public function setCustomFields(?array $customFields): void
+    {
+        $this->customFields = $customFields;
+    }
+
+    public function getTransactionCaptureId(): ?string
+    {
+        return $this->transactionCaptureId;
+    }
+
+    public function setTransactionCaptureId(?string $transactionCaptureId): void
+    {
+        $this->transactionCaptureId = $transactionCaptureId;
+    }
+
+    public function getTransactionCapture(): ?OrderTransactionCaptureEntity
+    {
+        return $this->transactionCapture;
+    }
+
+    public function setTransactionCapture(OrderTransactionCaptureEntity $transactionCapture): void
+    {
+        $this->transactionCapture = $transactionCapture;
+    }
+
+    public function getPositions(): ?OrderRefundPositionCollection
+    {
+        return $this->positions;
+    }
+
+    public function setPositions(OrderRefundPositionCollection $positions): void
+    {
+        $this->positions = $positions;
+    }
+
+    public function getOptions(): ?array
+    {
+        return $this->options;
+    }
+
+    public function setOptions(?array $options): void
+    {
+        $this->options = $options;
+    }
+}

--- a/src/Core/Checkout/Order/Aggregate/OrderRefund/OrderRefundStateHandler.php
+++ b/src/Core/Checkout/Order/Aggregate/OrderRefund/OrderRefundStateHandler.php
@@ -1,0 +1,126 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Checkout\Order\Aggregate\OrderRefund;
+
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\Exception\InconsistentCriteriaIdsException;
+use Shopware\Core\System\StateMachine\Aggregation\StateMachineTransition\StateMachineTransitionActions;
+use Shopware\Core\System\StateMachine\Exception\IllegalTransitionException;
+use Shopware\Core\System\StateMachine\Exception\StateMachineInvalidEntityIdException;
+use Shopware\Core\System\StateMachine\Exception\StateMachineInvalidStateFieldException;
+use Shopware\Core\System\StateMachine\Exception\StateMachineNotFoundException;
+use Shopware\Core\System\StateMachine\StateMachineRegistry;
+use Shopware\Core\System\StateMachine\Transition;
+
+class OrderRefundStateHandler
+{
+    /**
+     * @var StateMachineRegistry
+     */
+    private $stateMachineRegistry;
+
+    public function __construct(StateMachineRegistry $stateMachineRegistry)
+    {
+        $this->stateMachineRegistry = $stateMachineRegistry;
+    }
+
+    /**
+     * @throws InconsistentCriteriaIdsException
+     * @throws StateMachineNotFoundException
+     * @throws IllegalTransitionException
+     * @throws StateMachineInvalidEntityIdException
+     * @throws StateMachineInvalidStateFieldException
+     */
+    public function reopen(string $refundId, Context $context): void
+    {
+        $this->stateMachineRegistry->transition(
+            new Transition(
+                OrderRefundDefinition::ENTITY_NAME,
+                $refundId,
+                StateMachineTransitionActions::ACTION_REOPEN,
+                'stateId'
+            ),
+            $context
+        );
+    }
+
+    /**
+     * @throws InconsistentCriteriaIdsException
+     * @throws StateMachineNotFoundException
+     * @throws IllegalTransitionException
+     * @throws StateMachineInvalidEntityIdException
+     * @throws StateMachineInvalidStateFieldException
+     */
+    public function fail(string $refundId, Context $context): void
+    {
+        $this->stateMachineRegistry->transition(
+            new Transition(
+                OrderRefundDefinition::ENTITY_NAME,
+                $refundId,
+                StateMachineTransitionActions::ACTION_FAIL,
+                'stateId'
+            ),
+            $context
+        );
+    }
+
+    /**
+     * @throws InconsistentCriteriaIdsException
+     * @throws StateMachineNotFoundException
+     * @throws IllegalTransitionException
+     * @throws StateMachineInvalidEntityIdException
+     * @throws StateMachineInvalidStateFieldException
+     */
+    public function process(string $refundId, Context $context): void
+    {
+        $this->stateMachineRegistry->transition(
+            new Transition(
+                OrderRefundDefinition::ENTITY_NAME,
+                $refundId,
+                StateMachineTransitionActions::ACTION_PROCESS,
+                'stateId'
+            ),
+            $context
+        );
+    }
+
+    /**
+     * @throws InconsistentCriteriaIdsException
+     * @throws StateMachineNotFoundException
+     * @throws IllegalTransitionException
+     * @throws StateMachineInvalidEntityIdException
+     * @throws StateMachineInvalidStateFieldException
+     */
+    public function complete(string $refundId, Context $context): void
+    {
+        $this->stateMachineRegistry->transition(
+            new Transition(
+                OrderRefundDefinition::ENTITY_NAME,
+                $refundId,
+                StateMachineTransitionActions::ACTION_COMPLETE,
+                'stateId'
+            ),
+            $context
+        );
+    }
+
+    /**
+     * @throws InconsistentCriteriaIdsException
+     * @throws StateMachineNotFoundException
+     * @throws IllegalTransitionException
+     * @throws StateMachineInvalidEntityIdException
+     * @throws StateMachineInvalidStateFieldException
+     */
+    public function cancel(string $refundId, Context $context): void
+    {
+        $this->stateMachineRegistry->transition(
+            new Transition(
+                OrderRefundDefinition::ENTITY_NAME,
+                $refundId,
+                StateMachineTransitionActions::ACTION_CANCEL,
+                'stateId'
+            ),
+            $context
+        );
+    }
+}

--- a/src/Core/Checkout/Order/Aggregate/OrderRefund/OrderRefundStates.php
+++ b/src/Core/Checkout/Order/Aggregate/OrderRefund/OrderRefundStates.php
@@ -1,0 +1,13 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Checkout\Order\Aggregate\OrderRefund;
+
+final class OrderRefundStates
+{
+    public const STATE_MACHINE = 'order_refund.state';
+    public const STATE_OPEN = 'open';
+    public const STATE_IN_PROGRESS = 'in_progress';
+    public const STATE_CANCELLED = 'cancelled';
+    public const STATE_FAILED = 'failed';
+    public const STATE_COMPLETED = 'completed';
+}

--- a/src/Core/Checkout/Order/Aggregate/OrderRefundPosition/OrderRefundPositionCollection.php
+++ b/src/Core/Checkout/Order/Aggregate/OrderRefundPosition/OrderRefundPositionCollection.php
@@ -1,0 +1,27 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Checkout\Order\Aggregate\OrderRefundPosition;
+
+use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
+
+/**
+ * @method void                           add(OrderRefundPositionEntity $entity)
+ * @method void                           set(string $key, OrderRefundPositionEntity $entity)
+ * @method OrderRefundPositionEntity[]    getIterator()
+ * @method OrderRefundPositionEntity[]    getElements()
+ * @method OrderRefundPositionEntity|null get(string $key)
+ * @method OrderRefundPositionEntity|null first()
+ * @method OrderRefundPositionEntity|null last()
+ */
+class OrderRefundPositionCollection extends EntityCollection
+{
+    public function getApiAlias(): string
+    {
+        return 'order_refund_position_collection';
+    }
+
+    protected function getExpectedClass(): string
+    {
+        return OrderRefundPositionEntity::class;
+    }
+}

--- a/src/Core/Checkout/Order/Aggregate/OrderRefundPosition/OrderRefundPositionDefinition.php
+++ b/src/Core/Checkout/Order/Aggregate/OrderRefundPosition/OrderRefundPositionDefinition.php
@@ -1,0 +1,80 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Checkout\Order\Aggregate\OrderRefundPosition;
+
+use Shopware\Core\Checkout\Order\Aggregate\OrderLineItem\OrderLineItemDefinition;
+use Shopware\Core\Checkout\Order\Aggregate\OrderRefund\OrderRefundDefinition;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\CalculatedPriceField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\CustomFields;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\FkField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\Computed;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\PrimaryKey;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\Required;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\FloatField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\IdField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\IntField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\JsonField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\ManyToOneAssociationField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\ReferenceVersionField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\StringField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\VersionField;
+use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
+
+class OrderRefundPositionDefinition extends EntityDefinition
+{
+    public const ENTITY_NAME = 'order_refund_position';
+
+    public function getEntityName(): string
+    {
+        return self::ENTITY_NAME;
+    }
+
+    public function getCollectionClass(): string
+    {
+        return OrderRefundPositionCollection::class;
+    }
+
+    public function getEntityClass(): string
+    {
+        return OrderRefundPositionEntity::class;
+    }
+
+    public function since(): ?string
+    {
+        return '6.3.4.0';
+    }
+
+    protected function getParentDefinitionClass(): ?string
+    {
+        return OrderRefundDefinition::class;
+    }
+
+    protected function defineFields(): FieldCollection
+    {
+        return new FieldCollection([
+            (new IdField('id', 'id'))->addFlags(new PrimaryKey(), new Required()),
+            new VersionField(),
+
+            (new FkField('order_refund_id', 'orderRefundId', OrderRefundDefinition::class))->addFlags(new Required()),
+            (new ReferenceVersionField(OrderRefundDefinition::class))->addFlags(new Required()),
+
+            new FkField('line_item_id', 'lineItemId', OrderLineItemDefinition::class),
+            (new ReferenceVersionField(OrderLineItemDefinition::class, 'line_item_version_id'))->addFlags(new Required()),
+            (new JsonField('payload', 'payload'))->addFlags(new Required()),
+            (new StringField('label', 'label'))->addFlags(new Required()),
+            (new CalculatedPriceField('line_item_price', 'lineItemPrice'))->addFlags(new Required()),
+            (new FloatField('line_item_unit_price', 'lineItemUnitPrice'))->addFlags(new Computed()),
+            (new FloatField('line_item_total_price', 'lineItemTotalPrice'))->addFlags(new Computed()),
+            (new IntField('line_item_quantity', 'lineItemQuantity'))->addFlags(new Computed()),
+
+            (new CalculatedPriceField('refund_price', 'refundPrice'))->addFlags(new Required()),
+            (new FloatField('refund_unit_price', 'refundUnitPrice'))->addFlags(new Computed()),
+            (new FloatField('refund_total_price', 'refundTotalPrice'))->addFlags(new Computed()),
+            (new IntField('refund_quantity', 'refundQuantity'))->addFlags(new Computed()),
+            new CustomFields(),
+            new ManyToOneAssociationField('orderRefund', 'order_refund_id', OrderRefundDefinition::class, 'id', false),
+            new ManyToOneAssociationField('lineItem', 'line_item_id', OrderLineItemDefinition::class, 'id', false),
+        ]);
+    }
+}

--- a/src/Core/Checkout/Order/Aggregate/OrderRefundPosition/OrderRefundPositionEntity.php
+++ b/src/Core/Checkout/Order/Aggregate/OrderRefundPosition/OrderRefundPositionEntity.php
@@ -1,0 +1,239 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Checkout\Order\Aggregate\OrderRefundPosition;
+
+use Shopware\Core\Checkout\Cart\Price\Struct\CalculatedPrice;
+use Shopware\Core\Checkout\Order\Aggregate\OrderLineItem\OrderLineItemEntity;
+use Shopware\Core\Checkout\Order\Aggregate\OrderRefund\OrderRefundEntity;
+use Shopware\Core\Framework\DataAbstractionLayer\Entity;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityIdTrait;
+
+class OrderRefundPositionEntity extends Entity
+{
+    use EntityIdTrait;
+
+    /**
+     * @var string
+     */
+    protected $orderRefundId;
+
+    /**
+     * @var string|null
+     */
+    protected $lineItemId;
+
+    /**
+     * @var string[]
+     */
+    protected $payload;
+
+    /**
+     * @var string
+     */
+    protected $label;
+
+    /**
+     * @var CalculatedPrice
+     */
+    protected $lineItemPrice;
+
+    /**
+     * @var float
+     */
+    protected $lineItemUnitPrice;
+
+    /**
+     * @var float
+     */
+    protected $lineItemTotalPrice;
+
+    /**
+     * @var int
+     */
+    protected $lineItemQuantity;
+
+    /**
+     * @var CalculatedPrice
+     */
+    protected $refundPrice;
+
+    /**
+     * @var float
+     */
+    protected $refundUnitPrice;
+
+    /**
+     * @var float
+     */
+    protected $refundTotalPrice;
+
+    /**
+     * @var int
+     */
+    protected $refundQuantity;
+
+    /**
+     * @var OrderLineItemEntity|null
+     */
+    protected $lineItem;
+
+    /**
+     * @var OrderRefundEntity|null
+     */
+    protected $orderRefund;
+
+    /**
+     * @var array|null
+     */
+    protected $customFields;
+
+    public function getOrderRefundId(): string
+    {
+        return $this->orderRefundId;
+    }
+
+    public function setOrderRefundId(string $orderRefundId): void
+    {
+        $this->orderRefundId = $orderRefundId;
+    }
+
+    public function getLineItemId(): ?string
+    {
+        return $this->lineItemId;
+    }
+
+    public function setLineItemId(?string $lineItemId): void
+    {
+        $this->lineItemId = $lineItemId;
+    }
+
+    public function getRefundUnitPrice(): float
+    {
+        return $this->refundUnitPrice;
+    }
+
+    public function setRefundUnitPrice(float $refundUnitPrice): void
+    {
+        $this->refundUnitPrice = $refundUnitPrice;
+    }
+
+    public function getRefundTotalPrice(): float
+    {
+        return $this->refundTotalPrice;
+    }
+
+    public function setRefundTotalPrice(float $refundTotalPrice): void
+    {
+        $this->refundTotalPrice = $refundTotalPrice;
+    }
+
+    public function getRefundQuantity(): int
+    {
+        return $this->refundQuantity;
+    }
+
+    public function setRefundQuantity(int $refundQuantity): void
+    {
+        $this->refundQuantity = $refundQuantity;
+    }
+
+    public function getPayload(): array
+    {
+        return $this->payload;
+    }
+
+    public function setPayload(array $payload): void
+    {
+        $this->payload = $payload;
+    }
+
+    public function getLabel(): string
+    {
+        return $this->label;
+    }
+
+    public function setLabel(string $label): void
+    {
+        $this->label = $label;
+    }
+
+    public function getLineItemPrice(): CalculatedPrice
+    {
+        return $this->lineItemPrice;
+    }
+
+    public function setLineItemPrice(CalculatedPrice $lineItemPrice): void
+    {
+        $this->lineItemPrice = $lineItemPrice;
+    }
+
+    public function getRefundPrice(): CalculatedPrice
+    {
+        return $this->refundPrice;
+    }
+
+    public function setRefundPrice(CalculatedPrice $refundPrice): void
+    {
+        $this->refundPrice = $refundPrice;
+    }
+
+    public function getLineItem(): ?OrderLineItemEntity
+    {
+        return $this->lineItem;
+    }
+
+    public function setLineItem(OrderLineItemEntity $lineItem): void
+    {
+        $this->lineItem = $lineItem;
+    }
+
+    public function getOrderRefund(): ?OrderRefundEntity
+    {
+        return $this->orderRefund;
+    }
+
+    public function setOrderRefund(OrderRefundEntity $orderRefund): void
+    {
+        $this->orderRefund = $orderRefund;
+    }
+
+    public function getLineItemUnitPrice(): float
+    {
+        return $this->lineItemUnitPrice;
+    }
+
+    public function setLineItemUnitPrice(float $lineItemUnitPrice): void
+    {
+        $this->lineItemUnitPrice = $lineItemUnitPrice;
+    }
+
+    public function getLineItemTotalPrice(): float
+    {
+        return $this->lineItemTotalPrice;
+    }
+
+    public function setLineItemTotalPrice(float $lineItemTotalPrice): void
+    {
+        $this->lineItemTotalPrice = $lineItemTotalPrice;
+    }
+
+    public function getLineItemQuantity(): int
+    {
+        return $this->lineItemQuantity;
+    }
+
+    public function setLineItemQuantity(int $lineItemQuantity): void
+    {
+        $this->lineItemQuantity = $lineItemQuantity;
+    }
+
+    public function getCustomFields(): ?array
+    {
+        return $this->customFields;
+    }
+
+    public function setCustomFields(?array $customFields): void
+    {
+        $this->customFields = $customFields;
+    }
+}

--- a/src/Core/Checkout/Order/Aggregate/OrderTransaction/OrderTransactionDefinition.php
+++ b/src/Core/Checkout/Order/Aggregate/OrderTransaction/OrderTransactionDefinition.php
@@ -2,6 +2,8 @@
 
 namespace Shopware\Core\Checkout\Order\Aggregate\OrderTransaction;
 
+use Shopware\Core\Checkout\Order\Aggregate\OrderRefund\OrderRefundDefinition;
+use Shopware\Core\Checkout\Order\Aggregate\OrderTransactionCapture\OrderTransactionCaptureDefinition;
 use Shopware\Core\Checkout\Order\OrderDefinition;
 use Shopware\Core\Checkout\Payment\PaymentMethodDefinition;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
@@ -12,6 +14,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\PrimaryKey;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\Required;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\IdField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\ManyToOneAssociationField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\OneToManyAssociationField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\ReferenceVersionField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\StateMachineStateField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\VersionField;
@@ -62,6 +65,8 @@ class OrderTransactionDefinition extends EntityDefinition
             new CustomFields(),
             new ManyToOneAssociationField('order', 'order_id', OrderDefinition::class, 'id', false),
             new ManyToOneAssociationField('paymentMethod', 'payment_method_id', PaymentMethodDefinition::class, 'id', false),
+            new OneToManyAssociationField('refunds', OrderRefundDefinition::class, 'transaction_id'),
+            new OneToManyAssociationField('captures', OrderTransactionCaptureDefinition::class, 'transaction_id'),
         ]);
     }
 }

--- a/src/Core/Checkout/Order/Aggregate/OrderTransaction/OrderTransactionEntity.php
+++ b/src/Core/Checkout/Order/Aggregate/OrderTransaction/OrderTransactionEntity.php
@@ -3,6 +3,8 @@
 namespace Shopware\Core\Checkout\Order\Aggregate\OrderTransaction;
 
 use Shopware\Core\Checkout\Cart\Price\Struct\CalculatedPrice;
+use Shopware\Core\Checkout\Order\Aggregate\OrderRefund\OrderRefundCollection;
+use Shopware\Core\Checkout\Order\Aggregate\OrderTransactionCapture\OrderTransactionCaptureCollection;
 use Shopware\Core\Checkout\Order\OrderEntity;
 use Shopware\Core\Checkout\Payment\PaymentMethodEntity;
 use Shopware\Core\Framework\DataAbstractionLayer\Entity;
@@ -52,6 +54,16 @@ class OrderTransactionEntity extends Entity
      * @var array|null
      */
     protected $customFields;
+
+    /**
+     * @var OrderRefundCollection|null
+     */
+    protected $refunds;
+
+    /**
+     * @var OrderTransactionCaptureCollection|null
+     */
+    protected $captures;
 
     public function getOrderId(): string
     {
@@ -131,5 +143,25 @@ class OrderTransactionEntity extends Entity
     public function setCustomFields(?array $customFields): void
     {
         $this->customFields = $customFields;
+    }
+
+    public function getRefunds(): ?OrderRefundCollection
+    {
+        return $this->refunds;
+    }
+
+    public function setRefunds(OrderRefundCollection $refunds): void
+    {
+        $this->refunds = $refunds;
+    }
+
+    public function getCaptures(): ?OrderTransactionCaptureCollection
+    {
+        return $this->captures;
+    }
+
+    public function setCaptures(OrderTransactionCaptureCollection $captures): void
+    {
+        $this->captures = $captures;
     }
 }

--- a/src/Core/Checkout/Order/Aggregate/OrderTransactionCapture/OrderTransactionCaptureCollection.php
+++ b/src/Core/Checkout/Order/Aggregate/OrderTransactionCapture/OrderTransactionCaptureCollection.php
@@ -1,0 +1,34 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Checkout\Order\Aggregate\OrderTransactionCapture;
+
+use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
+
+/**
+ * @method void                               add(OrderTransactionCaptureEntity $entity)
+ * @method void                               set(string $key, OrderTransactionCaptureEntity $entity)
+ * @method OrderTransactionCaptureEntity[]    getIterator()
+ * @method OrderTransactionCaptureEntity[]    getElements()
+ * @method OrderTransactionCaptureEntity|null get(string $key)
+ * @method OrderTransactionCaptureEntity|null first()
+ * @method OrderTransactionCaptureEntity|null last()
+ */
+class OrderTransactionCaptureCollection extends EntityCollection
+{
+    public function getApiAlias(): string
+    {
+        return 'order_transaction_capture_collection';
+    }
+
+    public function filterByExternalReference(string $externalReference): self
+    {
+        return $this->filter(function (OrderTransactionCaptureEntity $orderTransactionCapture) use ($externalReference) {
+            return $orderTransactionCapture->getExternalReference() === $externalReference;
+        });
+    }
+
+    protected function getExpectedClass(): string
+    {
+        return OrderTransactionCaptureEntity::class;
+    }
+}

--- a/src/Core/Checkout/Order/Aggregate/OrderTransactionCapture/OrderTransactionCaptureDefinition.php
+++ b/src/Core/Checkout/Order/Aggregate/OrderTransactionCapture/OrderTransactionCaptureDefinition.php
@@ -1,0 +1,69 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Checkout\Order\Aggregate\OrderTransactionCapture;
+
+use Shopware\Core\Checkout\Order\Aggregate\OrderRefund\OrderRefundDefinition;
+use Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionDefinition;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\CustomFields;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\FkField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\PrimaryKey;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\Required;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\FloatField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\IdField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\ManyToOneAssociationField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\OneToManyAssociationField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\ReferenceVersionField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\StateMachineStateField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\StringField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\VersionField;
+use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
+use Shopware\Core\System\StateMachine\Aggregation\StateMachineState\StateMachineStateDefinition;
+
+class OrderTransactionCaptureDefinition extends EntityDefinition
+{
+    public const ENTITY_NAME = 'order_transaction_capture';
+
+    public function getEntityName(): string
+    {
+        return self::ENTITY_NAME;
+    }
+
+    public function getCollectionClass(): string
+    {
+        return OrderTransactionCaptureCollection::class;
+    }
+
+    public function getEntityClass(): string
+    {
+        return OrderTransactionCaptureEntity::class;
+    }
+
+    public function since(): ?string
+    {
+        return '6.3.4.0';
+    }
+
+    protected function getParentDefinitionClass(): ?string
+    {
+        return OrderTransactionDefinition::class;
+    }
+
+    protected function defineFields(): FieldCollection
+    {
+        return new FieldCollection([
+            (new IdField('id', 'id'))->addFlags(new PrimaryKey(), new Required()),
+            new VersionField(),
+            (new FkField('transaction_id', 'transactionId', OrderTransactionDefinition::class))->addFlags(new Required()),
+            (new ReferenceVersionField(OrderTransactionDefinition::class, 'transaction_version_id'))->addFlags(new Required()),
+            (new FloatField('amount', 'amount'))->addFlags(new Required()),
+            new StringField('external_reference', 'externalReference'),
+
+            (new StateMachineStateField('state_id', 'stateId', OrderTransactionCaptureStates::STATE_MACHINE))->addFlags(new Required()),
+            new ManyToOneAssociationField('stateMachineState', 'state_id', StateMachineStateDefinition::class, 'id', true),
+            new CustomFields(),
+            new ManyToOneAssociationField('transaction', 'transaction_id', OrderTransactionDefinition::class, 'id', false),
+            new OneToManyAssociationField('refunds', OrderRefundDefinition::class, 'transaction_capture_id'),
+        ]);
+    }
+}

--- a/src/Core/Checkout/Order/Aggregate/OrderTransactionCapture/OrderTransactionCaptureEntity.php
+++ b/src/Core/Checkout/Order/Aggregate/OrderTransactionCapture/OrderTransactionCaptureEntity.php
@@ -1,0 +1,134 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Checkout\Order\Aggregate\OrderTransactionCapture;
+
+use Shopware\Core\Checkout\Order\Aggregate\OrderRefund\OrderRefundCollection;
+use Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionEntity;
+use Shopware\Core\Framework\DataAbstractionLayer\Entity;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityIdTrait;
+use Shopware\Core\System\StateMachine\Aggregation\StateMachineState\StateMachineStateEntity;
+
+class OrderTransactionCaptureEntity extends Entity
+{
+    use EntityIdTrait;
+
+    /**
+     * @var string
+     */
+    protected $transactionId;
+
+    /**
+     * @var float
+     */
+    protected $amount;
+
+    /**
+     * @var string|null
+     */
+    protected $externalReference;
+
+    /**
+     * @var OrderTransactionEntity|null
+     */
+    protected $transaction;
+
+    /***
+     * @var StateMachineStateEntity|null
+     */
+    protected $stateMachineState;
+
+    /**
+     * @var string
+     */
+    protected $stateId;
+
+    /**
+     * @var array|null
+     */
+    protected $customFields;
+
+    /**
+     * @var OrderRefundCollection|null
+     */
+    protected $refunds;
+
+    public function getTransactionId(): string
+    {
+        return $this->transactionId;
+    }
+
+    public function setTransactionId(string $transactionId): void
+    {
+        $this->transactionId = $transactionId;
+    }
+
+    public function getAmount(): float
+    {
+        return $this->amount;
+    }
+
+    public function setAmount(float $amount): void
+    {
+        $this->amount = $amount;
+    }
+
+    public function getTransaction(): ?OrderTransactionEntity
+    {
+        return $this->transaction;
+    }
+
+    public function setTransaction(?OrderTransactionEntity $transaction): void
+    {
+        $this->transaction = $transaction;
+    }
+
+    public function getStateMachineState(): ?StateMachineStateEntity
+    {
+        return $this->stateMachineState;
+    }
+
+    public function setStateMachineState(StateMachineStateEntity $stateMachineState): void
+    {
+        $this->stateMachineState = $stateMachineState;
+    }
+
+    public function getStateId(): string
+    {
+        return $this->stateId;
+    }
+
+    public function setStateId(string $stateId): void
+    {
+        $this->stateId = $stateId;
+    }
+
+    public function getCustomFields(): ?array
+    {
+        return $this->customFields;
+    }
+
+    public function setCustomFields(?array $customFields): void
+    {
+        $this->customFields = $customFields;
+    }
+
+    public function getRefunds(): ?OrderRefundCollection
+    {
+        return $this->refunds;
+    }
+
+    public function setRefunds(OrderRefundCollection $refunds): void
+    {
+        $this->refunds = $refunds;
+    }
+
+    public function getExternalReference(): ?string
+    {
+        return $this->externalReference;
+    }
+
+    public function setExternalReference(?string $externalReference): void
+    {
+        $this->externalReference = $externalReference;
+    }
+}

--- a/src/Core/Checkout/Order/Aggregate/OrderTransactionCapture/OrderTransactionCaptureService.php
+++ b/src/Core/Checkout/Order/Aggregate/OrderTransactionCapture/OrderTransactionCaptureService.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopware\Core\Checkout\Order\Aggregate\OrderTransactionCapture;
+
+use Shopware\Core\Checkout\Cart\Exception\OrderTransactionNotFoundException;
+use Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionEntity;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepositoryInterface;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Util\FloatComparator;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\System\StateMachine\StateMachineRegistry;
+
+class OrderTransactionCaptureService
+{
+    /**
+     * @var EntityRepositoryInterface
+     */
+    private $orderTransactionRepository;
+
+    /**
+     * @var EntityRepositoryInterface
+     */
+    private $orderTransactionCaptureRepository;
+
+    /**
+     * @var StateMachineRegistry
+     */
+    private $stateMachineRegistry;
+
+    public function __construct(
+        EntityRepositoryInterface $orderTransactionRepository,
+        EntityRepositoryInterface $orderTransactionCaptureRepository,
+        StateMachineRegistry $stateMachineRegistry
+    ) {
+        $this->orderTransactionRepository = $orderTransactionRepository;
+        $this->orderTransactionCaptureRepository = $orderTransactionCaptureRepository;
+        $this->stateMachineRegistry = $stateMachineRegistry;
+    }
+
+    public function createOrderTransactionCaptureForFullAmount(string $orderTransactionId, Context $context): string
+    {
+        $orderTransaction = $this->fetchOrderTransaction($orderTransactionId, $context);
+
+        return $this->createOrderTransactionCapture(
+            $orderTransactionId,
+            $orderTransaction->getAmount()->getTotalPrice(),
+            $context
+        );
+    }
+
+    public function createOrderTransactionCaptureForCustomAmount(
+        string $orderTransactionId,
+        float $customCaptureAmount,
+        Context $context
+    ): string {
+        $orderTransaction = $this->fetchOrderTransaction($orderTransactionId, $context);
+        if (FloatComparator::greaterThan($customCaptureAmount, $orderTransaction->getAmount()->getTotalPrice())) {
+            throw new \InvalidArgumentException(sprintf(
+                'Capture amount %f exceeds the order transactions amount of %f',
+                $customCaptureAmount,
+                $orderTransaction->getAmount()->getTotalPrice()
+            ));
+        }
+
+        return $this->createOrderTransactionCapture($orderTransactionId, $customCaptureAmount, $context);
+    }
+
+    public function deleteOrderTransactionCapture(string $orderTransactionCaptureId, Context $context): void
+    {
+        $this->orderTransactionRepository->delete([[
+            'id' => $orderTransactionCaptureId,
+        ]], $context);
+    }
+
+    private function fetchOrderTransaction(string $orderTransactionId, Context $context): OrderTransactionEntity
+    {
+        $criteria = new Criteria([$orderTransactionId]);
+        $criteria->addAssociation('amount');
+
+        $orderTransaction = $this->orderTransactionRepository->search($criteria, $context)->first();
+        if ($orderTransaction === null) {
+            throw new OrderTransactionNotFoundException($orderTransactionId);
+        }
+
+        return $orderTransaction;
+    }
+
+    private function createOrderTransactionCapture(
+        string $orderTransactionId,
+        float $captureAmount,
+        Context $context
+    ): string {
+        $orderTransactionCaptureId = Uuid::randomHex();
+        $this->orderTransactionCaptureRepository->create(
+            [
+                [
+                    'id' => $orderTransactionCaptureId,
+                    'transactionId' => $orderTransactionId,
+                    'amount' => $captureAmount,
+                    'stateId' => $this->stateMachineRegistry->getInitialState(
+                        OrderTransactionCaptureStates::STATE_MACHINE,
+                        $context
+                    )->getId(),
+                ],
+            ],
+            $context
+        );
+
+        return $orderTransactionCaptureId;
+    }
+}

--- a/src/Core/Checkout/Order/Aggregate/OrderTransactionCapture/OrderTransactionCaptureStateHandler.php
+++ b/src/Core/Checkout/Order/Aggregate/OrderTransactionCapture/OrderTransactionCaptureStateHandler.php
@@ -1,0 +1,100 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Checkout\Order\Aggregate\OrderTransactionCapture;
+
+use Shopware\Core\Checkout\Order\Exception\OrderTransactionCaptureNotFoundException;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepositoryInterface;
+use Shopware\Core\Framework\DataAbstractionLayer\Exception\InconsistentCriteriaIdsException;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\System\StateMachine\Aggregation\StateMachineTransition\StateMachineTransitionActions;
+use Shopware\Core\System\StateMachine\Exception\IllegalTransitionException;
+use Shopware\Core\System\StateMachine\Exception\StateMachineInvalidEntityIdException;
+use Shopware\Core\System\StateMachine\Exception\StateMachineInvalidStateFieldException;
+use Shopware\Core\System\StateMachine\Exception\StateMachineNotFoundException;
+use Shopware\Core\System\StateMachine\StateMachineRegistry;
+use Shopware\Core\System\StateMachine\Transition;
+
+class OrderTransactionCaptureStateHandler
+{
+    /**
+     * @var StateMachineRegistry
+     */
+    private $stateMachineRegistry;
+
+    /**
+     * @var EntityRepositoryInterface
+     */
+    private $orderTransactionCaptureRepository;
+
+    public function __construct(
+        StateMachineRegistry $stateMachineRegistry,
+        EntityRepositoryInterface $orderTransactionCaptureRepository
+    ) {
+        $this->stateMachineRegistry = $stateMachineRegistry;
+        $this->orderTransactionCaptureRepository = $orderTransactionCaptureRepository;
+    }
+
+    /**
+     * @throws InconsistentCriteriaIdsException
+     * @throws StateMachineNotFoundException
+     * @throws IllegalTransitionException
+     * @throws StateMachineInvalidEntityIdException
+     * @throws StateMachineInvalidStateFieldException
+     */
+    public function complete(string $transactionCaptureId, Context $context): void
+    {
+        $orderTransactionCapture = $this->fetchOrderTransactionCapture($transactionCaptureId, $context);
+        if ($orderTransactionCapture->getStateMachineState()->getTechnicalName() === OrderTransactionCaptureStates::STATE_COMPLETED) {
+            return;
+        }
+        $this->stateMachineRegistry->transition(
+            new Transition(
+                OrderTransactionCaptureDefinition::ENTITY_NAME,
+                $transactionCaptureId,
+                StateMachineTransitionActions::ACTION_COMPLETE,
+                'stateId'
+            ),
+            $context
+        );
+    }
+
+    /**
+     * @throws InconsistentCriteriaIdsException
+     * @throws StateMachineNotFoundException
+     * @throws IllegalTransitionException
+     * @throws StateMachineInvalidEntityIdException
+     * @throws StateMachineInvalidStateFieldException
+     */
+    public function fail(string $transactionCaptureId, Context $context): void
+    {
+        $orderTransactionCapture = $this->fetchOrderTransactionCapture($transactionCaptureId, $context);
+        if ($orderTransactionCapture->getStateMachineState()->getTechnicalName() === OrderTransactionCaptureStates::STATE_FAILED) {
+            return;
+        }
+        $this->stateMachineRegistry->transition(
+            new Transition(
+                OrderTransactionCaptureDefinition::ENTITY_NAME,
+                $transactionCaptureId,
+                StateMachineTransitionActions::ACTION_FAIL,
+                'stateId'
+            ),
+            $context
+        );
+    }
+
+    private function fetchOrderTransactionCapture(
+        string $orderTransactionCaptureId,
+        Context $context
+    ): OrderTransactionCaptureEntity {
+        $criteria = new Criteria([$orderTransactionCaptureId]);
+        $criteria->addAssociation('state');
+
+        $orderTransactionCapture = $this->orderTransactionCaptureRepository->search($criteria, $context)->first();
+        if ($orderTransactionCapture === null) {
+            throw new OrderTransactionCaptureNotFoundException($orderTransactionCaptureId);
+        }
+
+        return $orderTransactionCapture;
+    }
+}

--- a/src/Core/Checkout/Order/Aggregate/OrderTransactionCapture/OrderTransactionCaptureStates.php
+++ b/src/Core/Checkout/Order/Aggregate/OrderTransactionCapture/OrderTransactionCaptureStates.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Checkout\Order\Aggregate\OrderTransactionCapture;
+
+final class OrderTransactionCaptureStates
+{
+    public const STATE_MACHINE = 'order_transaction_capture.state';
+    public const STATE_PENDING = 'pending';
+    public const STATE_COMPLETED = 'completed';
+    public const STATE_FAILED = 'failed';
+}

--- a/src/Core/Checkout/Order/Exception/OrderTransactionCaptureAmountExceedsOrderTransactionAmountException.php
+++ b/src/Core/Checkout/Order/Exception/OrderTransactionCaptureAmountExceedsOrderTransactionAmountException.php
@@ -1,0 +1,30 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Checkout\Order\Exception;
+
+use Shopware\Core\Framework\ShopwareHttpException;
+use Symfony\Component\HttpFoundation\Response;
+
+class OrderTransactionCaptureAmountExceedsOrderTransactionAmountException extends ShopwareHttpException
+{
+    public function __construct(float $orderTransactionCaptureAmount, float $orderTransactionAmount)
+    {
+        parent::__construct(
+            'Capture amount {{ orderTransactionCaptureAmount }} exceeds the order transactions amount of {{ orderTransactionAmount }}',
+            [
+                'orderTransactionCaptureAmount' => $orderTransactionCaptureAmount,
+                'orderTransactionAmount' => $orderTransactionAmount,
+            ]
+        );
+    }
+
+    public function getErrorCode(): string
+    {
+        return 'CHECKOUT__ORDER_TRANSACTION_CAPTURE_AMOUNT_EXCEEDS_ORDER_TRANSACTION_AMOUNT';
+    }
+
+    public function getStatusCode(): int
+    {
+        return Response::HTTP_BAD_REQUEST;
+    }
+}

--- a/src/Core/Checkout/Order/Exception/OrderTransactionCaptureNotFoundException.php
+++ b/src/Core/Checkout/Order/Exception/OrderTransactionCaptureNotFoundException.php
@@ -1,0 +1,39 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Checkout\Order\Exception;
+
+use Shopware\Core\Framework\ShopwareHttpException;
+use Symfony\Component\HttpFoundation\Response;
+
+class OrderTransactionCaptureNotFoundException extends ShopwareHttpException
+{
+    /**
+     * @var string
+     */
+    private $orderTransactionCaptureId;
+
+    public function __construct(string $orderTransactionCaptureId)
+    {
+        parent::__construct(
+            'Order transaction capture with id "{{ orderTransactionCaptureId }}" not found.',
+            ['orderTransactionCaptureId' => $orderTransactionCaptureId]
+        );
+
+        $this->orderTransactionCaptureId = $orderTransactionCaptureId;
+    }
+
+    public function getErrorCode(): string
+    {
+        return 'CHECKOUT__ORDER_TRANSACTION_CAPTURE_NOT_FOUND';
+    }
+
+    public function getStatusCode(): int
+    {
+        return Response::HTTP_BAD_REQUEST;
+    }
+
+    public function getOrderTransactionCaptureId(): string
+    {
+        return $this->orderTransactionCaptureId;
+    }
+}

--- a/src/Core/Checkout/Order/OrderDefinition.php
+++ b/src/Core/Checkout/Order/OrderDefinition.php
@@ -7,6 +7,7 @@ use Shopware\Core\Checkout\Order\Aggregate\OrderAddress\OrderAddressDefinition;
 use Shopware\Core\Checkout\Order\Aggregate\OrderCustomer\OrderCustomerDefinition;
 use Shopware\Core\Checkout\Order\Aggregate\OrderDelivery\OrderDeliveryDefinition;
 use Shopware\Core\Checkout\Order\Aggregate\OrderLineItem\OrderLineItemDefinition;
+use Shopware\Core\Checkout\Order\Aggregate\OrderRefund\OrderRefundDefinition;
 use Shopware\Core\Checkout\Order\Aggregate\OrderTag\OrderTagDefinition;
 use Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionDefinition;
 use Shopware\Core\Framework\Api\Context\SalesChannelApiSource;
@@ -119,6 +120,7 @@ class OrderDefinition extends EntityDefinition
             (new OneToManyAssociationField('deliveries', OrderDeliveryDefinition::class, 'order_id'))->addFlags(new CascadeDelete(), new SearchRanking(SearchRanking::ASSOCIATION_SEARCH_RANKING)),
             (new OneToManyAssociationField('lineItems', OrderLineItemDefinition::class, 'order_id'))->addFlags(new CascadeDelete()),
             (new OneToManyAssociationField('transactions', OrderTransactionDefinition::class, 'order_id'))->addFlags(new CascadeDelete()),
+            (new OneToManyAssociationField('refunds', OrderRefundDefinition::class, 'order_id'))->addFlags(new CascadeDelete()),
             new OneToManyAssociationField('documents', DocumentDefinition::class, 'order_id'),
             (new ManyToManyAssociationField('tags', TagDefinition::class, OrderTagDefinition::class, 'order_id', 'tag_id'))->addFlags(new SearchRanking(SearchRanking::ASSOCIATION_SEARCH_RANKING)),
         ]);

--- a/src/Core/Checkout/Order/OrderEntity.php
+++ b/src/Core/Checkout/Order/OrderEntity.php
@@ -10,6 +10,7 @@ use Shopware\Core\Checkout\Order\Aggregate\OrderAddress\OrderAddressEntity;
 use Shopware\Core\Checkout\Order\Aggregate\OrderCustomer\OrderCustomerEntity;
 use Shopware\Core\Checkout\Order\Aggregate\OrderDelivery\OrderDeliveryCollection;
 use Shopware\Core\Checkout\Order\Aggregate\OrderLineItem\OrderLineItemCollection;
+use Shopware\Core\Checkout\Order\Aggregate\OrderRefund\OrderRefundCollection;
 use Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\Entity;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityIdTrait;
@@ -142,6 +143,11 @@ class OrderEntity extends Entity
      * @var OrderTransactionCollection|null
      */
     protected $transactions;
+
+    /**
+     * @var OrderRefundCollection|null
+     */
+    protected $refunds;
 
     /**
      * @var string|null
@@ -391,6 +397,16 @@ class OrderEntity extends Entity
     public function setTransactions(OrderTransactionCollection $transactions): void
     {
         $this->transactions = $transactions;
+    }
+
+    public function getRefunds(): ?OrderRefundCollection
+    {
+        return $this->refunds;
+    }
+
+    public function setRefunds(OrderRefundCollection $refunds): void
+    {
+        $this->refunds = $refunds;
     }
 
     public function getDeepLinkCode(): ?string

--- a/src/Core/Checkout/Payment/PaymentMethodDefinition.php
+++ b/src/Core/Checkout/Payment/PaymentMethodDefinition.php
@@ -3,8 +3,10 @@
 namespace Shopware\Core\Checkout\Payment;
 
 use Shopware\Core\Checkout\Customer\CustomerDefinition;
+use Shopware\Core\Checkout\Order\Aggregate\OrderRefund\OrderRefundDefinition;
 use Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionDefinition;
 use Shopware\Core\Checkout\Payment\Aggregate\PaymentMethodTranslation\PaymentMethodTranslationDefinition;
+use Shopware\Core\Checkout\Refund\PaymentMethodRefundConfigDefinition;
 use Shopware\Core\Content\Media\MediaDefinition;
 use Shopware\Core\Content\Rule\RuleDefinition;
 use Shopware\Core\Framework\Api\Context\AdminApiSource;
@@ -71,6 +73,7 @@ class PaymentMethodDefinition extends EntityDefinition
             new FkField('availability_rule_id', 'availabilityRuleId', RuleDefinition::class),
             new FkField('media_id', 'mediaId', MediaDefinition::class),
             (new StringField('formatted_handler_identifier', 'formattedHandlerIdentifier'))->addFlags(new WriteProtected(), new Runtime(), new ReadProtected(SalesChannelApiSource::class)),
+            (new StringField('refund_handler_identifier', 'refundHandlerIdentifier'))->addFlags(new ReadProtected(SalesChannelApiSource::class)),
 
             (new TranslationsAssociationField(PaymentMethodTranslationDefinition::class, 'payment_method_id'))->addFlags(new Required()),
 
@@ -84,6 +87,8 @@ class PaymentMethodDefinition extends EntityDefinition
             (new OneToManyAssociationField('customers', CustomerDefinition::class, 'last_payment_method_id', 'id'))->addFlags(new RestrictDelete(), new ReadProtected(SalesChannelApiSource::class)),
             (new OneToManyAssociationField('orderTransactions', OrderTransactionDefinition::class, 'payment_method_id', 'id'))->addFlags(new RestrictDelete(), new ReadProtected(SalesChannelApiSource::class)),
             (new ManyToManyAssociationField('salesChannels', SalesChannelDefinition::class, SalesChannelPaymentMethodDefinition::class, 'payment_method_id', 'sales_channel_id'))->addFlags(new ReadProtected(SalesChannelApiSource::class)),
+            (new OneToManyAssociationField('orderRefunds', OrderRefundDefinition::class, 'payment_method_id', 'id'))->addFlags(new RestrictDelete(), new ReadProtected(SalesChannelApiSource::class)),
+            (new OneToManyAssociationField('refundConfigs', PaymentMethodRefundConfigDefinition::class, 'payment_method_id', 'id'))->addFlags(new RestrictDelete(), new ReadProtected(SalesChannelApiSource::class)),
         ]);
     }
 }

--- a/src/Core/Checkout/Payment/PaymentMethodEntity.php
+++ b/src/Core/Checkout/Payment/PaymentMethodEntity.php
@@ -3,8 +3,10 @@
 namespace Shopware\Core\Checkout\Payment;
 
 use Shopware\Core\Checkout\Customer\CustomerCollection;
+use Shopware\Core\Checkout\Order\Aggregate\OrderRefund\OrderRefundCollection;
 use Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionCollection;
 use Shopware\Core\Checkout\Payment\Aggregate\PaymentMethodTranslation\PaymentMethodTranslationCollection;
+use Shopware\Core\Checkout\Refund\PaymentMethodRefundConfigCollection;
 use Shopware\Core\Content\Media\MediaEntity;
 use Shopware\Core\Content\Rule\RuleEntity;
 use Shopware\Core\Framework\DataAbstractionLayer\Entity;
@@ -25,6 +27,11 @@ class PaymentMethodEntity extends Entity
      * @var string
      */
     protected $handlerIdentifier;
+
+    /**
+     * @var string|null
+     */
+    protected $refundHandlerIdentifier;
 
     /**
      * @var string|null
@@ -65,6 +72,16 @@ class PaymentMethodEntity extends Entity
      * @var OrderTransactionCollection|null
      */
     protected $orderTransactions;
+
+    /**
+     * @var OrderRefundCollection|null
+     */
+    protected $orderRefunds;
+
+    /**
+     * @var PaymentMethodRefundConfigCollection|null
+     */
+    protected $refundConfigs;
 
     /**
      * @var CustomerCollection|null
@@ -146,6 +163,16 @@ class PaymentMethodEntity extends Entity
         return $this->formattedHandlerIdentifier;
     }
 
+    public function getRefundHandlerIdentifier(): ?string
+    {
+        return $this->refundHandlerIdentifier;
+    }
+
+    public function setRefundHandlerIdentifier(string $refundHandlerIdentifier): void
+    {
+        $this->refundHandlerIdentifier = $refundHandlerIdentifier;
+    }
+
     public function getName(): ?string
     {
         return $this->name;
@@ -214,6 +241,26 @@ class PaymentMethodEntity extends Entity
     public function setOrderTransactions(OrderTransactionCollection $orderTransactions): void
     {
         $this->orderTransactions = $orderTransactions;
+    }
+
+    public function getOrderRefunds(): ?OrderRefundCollection
+    {
+        return $this->orderRefunds;
+    }
+
+    public function setOrderRefunds(OrderRefundCollection $orderRefunds): void
+    {
+        $this->orderRefunds = $orderRefunds;
+    }
+
+    public function getRefundConfigs(): ?PaymentMethodRefundConfigCollection
+    {
+        return $this->refundConfigs;
+    }
+
+    public function setRefundConfigs(PaymentMethodRefundConfigCollection $refundConfigs): void
+    {
+        $this->refundConfigs = $refundConfigs;
     }
 
     public function getCustomers(): ?CustomerCollection

--- a/src/Core/Checkout/Refund/Api/OrderRefundActionController.php
+++ b/src/Core/Checkout/Refund/Api/OrderRefundActionController.php
@@ -1,0 +1,38 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Checkout\Refund\Api;
+
+use Shopware\Core\Checkout\Refund\PaymentRefundProcessor;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Routing\Annotation\RouteScope;
+use Shopware\Core\Framework\Routing\Annotation\Since;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+
+/**
+ * @RouteScope(scopes={"api"})
+ */
+class OrderRefundActionController extends AbstractController
+{
+    /**
+     * @var PaymentRefundProcessor
+     */
+    private $paymentRefundProcessor;
+
+    public function __construct(PaymentRefundProcessor $paymentRefundProcessor)
+    {
+        $this->paymentRefundProcessor = $paymentRefundProcessor;
+    }
+
+    /**
+     * @Since("6.3.4.0")
+     * @Route("/api/v{version}/_action/order-refund/{orderRefundId}/process", name="api.action.order-refund.process", methods={"POST"})
+     */
+    public function processOrderRefund(string $orderRefundId, Context $context): Response
+    {
+        $this->paymentRefundProcessor->processRefund($orderRefundId, $context);
+
+        return new Response('', Response::HTTP_NO_CONTENT);
+    }
+}

--- a/src/Core/Checkout/Refund/Exception/InvalidOrderRefundException.php
+++ b/src/Core/Checkout/Refund/Exception/InvalidOrderRefundException.php
@@ -1,0 +1,27 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Checkout\Refund\Exception;
+
+use Shopware\Core\Framework\ShopwareHttpException;
+use Symfony\Component\HttpFoundation\Response;
+
+class InvalidOrderRefundException extends ShopwareHttpException
+{
+    public function __construct(string $orderRefundId)
+    {
+        parent::__construct(
+            'The order refund with id {{ orderRefundId }} is invalid or could not be found.',
+            ['orderRefundId' => $orderRefundId]
+        );
+    }
+
+    public function getErrorCode(): string
+    {
+        return 'CHECKOUT__INVALID_ORDER_REFUND_ID';
+    }
+
+    public function getStatusCode(): int
+    {
+        return Response::HTTP_NOT_FOUND;
+    }
+}

--- a/src/Core/Checkout/Refund/Exception/PaymentRefundHandlerNotFoundException.php
+++ b/src/Core/Checkout/Refund/Exception/PaymentRefundHandlerNotFoundException.php
@@ -1,0 +1,27 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Checkout\Refund\Exception;
+
+use Shopware\Core\Framework\ShopwareHttpException;
+use Symfony\Component\HttpFoundation\Response;
+
+class PaymentRefundHandlerNotFoundException extends ShopwareHttpException
+{
+    public function __construct(string $refundHandlerIdentifier)
+    {
+        parent::__construct(
+            'The payment refund handler for identifier {{ refundHandlerIdentifier }} could not be found.',
+            ['refundHandlerIdentifier' => $refundHandlerIdentifier]
+        );
+    }
+
+    public function getErrorCode(): string
+    {
+        return 'CHECKOUT__PAYMENT_REFUND_HANDLER_NOT_FOUND';
+    }
+
+    public function getStatusCode(): int
+    {
+        return Response::HTTP_NOT_FOUND;
+    }
+}

--- a/src/Core/Checkout/Refund/Exception/PaymentRefundProcessException.php
+++ b/src/Core/Checkout/Refund/Exception/PaymentRefundProcessException.php
@@ -1,0 +1,36 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Checkout\Refund\Exception;
+
+use Shopware\Core\Framework\ShopwareHttpException;
+use Symfony\Component\HttpFoundation\Response;
+
+class PaymentRefundProcessException extends ShopwareHttpException
+{
+    /**
+     * @var string
+     */
+    private $orderRefundId;
+
+    public function __construct(string $orderRefundId, string $message, array $parameters = [])
+    {
+        $this->orderRefundId = $orderRefundId;
+
+        parent::__construct($message, $parameters);
+    }
+
+    public function getStatusCode(): int
+    {
+        return Response::HTTP_BAD_REQUEST;
+    }
+
+    public function getOrderRefundId(): string
+    {
+        return $this->orderRefundId;
+    }
+
+    public function getErrorCode(): string
+    {
+        return 'CHECKOUT__PAYMENT_REFUND_PROCESS_INTERRUPTED';
+    }
+}

--- a/src/Core/Checkout/Refund/Exception/PaymentRefundUnsupportedException.php
+++ b/src/Core/Checkout/Refund/Exception/PaymentRefundUnsupportedException.php
@@ -1,0 +1,27 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Checkout\Refund\Exception;
+
+use Shopware\Core\Framework\ShopwareHttpException;
+use Symfony\Component\HttpFoundation\Response;
+
+class PaymentRefundUnsupportedException extends ShopwareHttpException
+{
+    public function __construct(string $paymentMethodId)
+    {
+        parent::__construct(
+            'The payment method {{ paymentMethodId }} does not support refunds.',
+            ['paymentMethodId' => $paymentMethodId]
+        );
+    }
+
+    public function getErrorCode(): string
+    {
+        return 'CHECKOUT__PAYMENT_REFUND_UNSUPPORTED';
+    }
+
+    public function getStatusCode(): int
+    {
+        return Response::HTTP_NOT_FOUND;
+    }
+}

--- a/src/Core/Checkout/Refund/PaymentMethodRefundConfigCollection.php
+++ b/src/Core/Checkout/Refund/PaymentMethodRefundConfigCollection.php
@@ -1,0 +1,27 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Checkout\Refund;
+
+use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
+
+/**
+ * @method void                                 add(PaymentMethodRefundConfigEntity $entity)
+ * @method void                                 set(string $key, PaymentMethodRefundConfigEntity $entity)
+ * @method PaymentMethodRefundConfigEntity[]    getIterator()
+ * @method PaymentMethodRefundConfigEntity[]    getElements()
+ * @method PaymentMethodRefundConfigEntity|null get(string $key)
+ * @method PaymentMethodRefundConfigEntity|null first()
+ * @method PaymentMethodRefundConfigEntity|null last()
+ */
+class PaymentMethodRefundConfigCollection extends EntityCollection
+{
+    public function getApiAlias(): string
+    {
+        return 'payment_method_refund_config_collection';
+    }
+
+    protected function getExpectedClass(): string
+    {
+        return PaymentMethodRefundConfigEntity::class;
+    }
+}

--- a/src/Core/Checkout/Refund/PaymentMethodRefundConfigDefinition.php
+++ b/src/Core/Checkout/Refund/PaymentMethodRefundConfigDefinition.php
@@ -1,0 +1,51 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Checkout\Refund;
+
+use Shopware\Core\Checkout\Payment\PaymentMethodDefinition;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\FkField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\PrimaryKey;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\Required;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\IdField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\JsonField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\ManyToOneAssociationField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\StringField;
+use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
+
+class PaymentMethodRefundConfigDefinition extends EntityDefinition
+{
+    public const ENTITY_NAME = 'payment_method_refund_config';
+
+    public function getEntityName(): string
+    {
+        return self::ENTITY_NAME;
+    }
+
+    public function getCollectionClass(): string
+    {
+        return PaymentMethodRefundConfigCollection::class;
+    }
+
+    public function getEntityClass(): string
+    {
+        return PaymentMethodRefundConfigEntity::class;
+    }
+
+    public function since(): ?string
+    {
+        return '6.3.4.0';
+    }
+
+    protected function defineFields(): FieldCollection
+    {
+        return new FieldCollection([
+            (new IdField('id', 'id'))->addFlags(new PrimaryKey(), new Required()),
+            (new StringField('technical_name', 'technicalName'))->addFlags(new Required()),
+            (new FkField('payment_method_id', 'paymentMethodId', PaymentMethodDefinition::class))->addFlags(new Required()),
+            (new JsonField('options', 'options', [], []))->addFlags(new Required()),
+
+            new ManyToOneAssociationField('paymentMethod', 'payment_method_id', PaymentMethodDefinition::class, 'id', false),
+        ]);
+    }
+}

--- a/src/Core/Checkout/Refund/PaymentMethodRefundConfigEntity.php
+++ b/src/Core/Checkout/Refund/PaymentMethodRefundConfigEntity.php
@@ -1,0 +1,72 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Checkout\Refund;
+
+use Shopware\Core\Checkout\Payment\PaymentMethodEntity;
+use Shopware\Core\Framework\DataAbstractionLayer\Entity;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityIdTrait;
+
+class PaymentMethodRefundConfigEntity extends Entity
+{
+    use EntityIdTrait;
+
+    /**
+     * @var string
+     */
+    protected $paymentMethodId;
+
+    /**
+     * @var string
+     */
+    protected $technicalName;
+
+    /**
+     * @var array
+     */
+    protected $options;
+
+    /**
+     * @var PaymentMethodEntity|null
+     */
+    protected $paymentMethod;
+
+    public function getPaymentMethodId(): string
+    {
+        return $this->paymentMethodId;
+    }
+
+    public function setPaymentMethodId(string $paymentMethodId): void
+    {
+        $this->paymentMethodId = $paymentMethodId;
+    }
+
+    public function getTechnicalName(): string
+    {
+        return $this->technicalName;
+    }
+
+    public function setTechnicalName(string $technicalName): void
+    {
+        $this->technicalName = $technicalName;
+    }
+
+    public function getOptions(): array
+    {
+        return $this->options;
+    }
+
+    public function setOptions(array $options): void
+    {
+        $this->options = $options;
+    }
+
+    public function getPaymentMethod(): ?PaymentMethodEntity
+    {
+        return $this->paymentMethod;
+    }
+
+    public function setPaymentMethod(PaymentMethodEntity $paymentMethod): void
+    {
+        $this->paymentMethod = $paymentMethod;
+    }
+}

--- a/src/Core/Checkout/Refund/PaymentMethodRefundConfigService.php
+++ b/src/Core/Checkout/Refund/PaymentMethodRefundConfigService.php
@@ -1,0 +1,66 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Checkout\Refund;
+
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepositoryInterface;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Symfony\Component\Yaml\Exception\ParseException;
+use Symfony\Component\Yaml\Yaml;
+
+class PaymentMethodRefundConfigService
+{
+    /**
+     * @var EntityRepositoryInterface
+     */
+    private $paymentMethodRefundConfigRepository;
+
+    public function __construct(EntityRepositoryInterface $paymentMethodRefundConfigRepository)
+    {
+        $this->paymentMethodRefundConfigRepository = $paymentMethodRefundConfigRepository;
+    }
+
+    public function upsertPaymentMethodRefundConfigFromYaml(
+        string $paymentMethodId,
+        string $technicalName,
+        string $yamlFilePath,
+        Context $context
+    ): void {
+        try {
+            $options = Yaml::parseFile($yamlFilePath);
+        } catch (ParseException $e) {
+            throw new \RuntimeException(sprintf(
+                'Yaml file %s could not be parsed: %s',
+                $yamlFilePath,
+                $e->getMessage()
+            ), 0, $e);
+        }
+
+        $paymentMethodRefundConfigProto = [
+            'paymentMethodId' => $paymentMethodId,
+            'technicalName' => $technicalName,
+            'options' => $options,
+        ];
+        $existingRefundConfig = $this->getPaymentMethodRefundConfig($paymentMethodId, $technicalName, $context);
+        if ($existingRefundConfig !== null) {
+            $paymentMethodRefundConfigProto['id'] = $existingRefundConfig->getId();
+        }
+
+        $this->paymentMethodRefundConfigRepository->upsert([$paymentMethodRefundConfigProto], $context);
+    }
+
+    private function getPaymentMethodRefundConfig(
+        string $paymentMethodId,
+        string $technicalName,
+        Context $context
+    ): ?PaymentMethodRefundConfigEntity {
+        $criteria = new Criteria();
+        $criteria->addFilter(
+            new EqualsFilter('paymentMethodId', $paymentMethodId),
+            new EqualsFilter('technicalName', $technicalName)
+        );
+
+        return $this->paymentMethodRefundConfigRepository->search($criteria, $context)->first();
+    }
+}

--- a/src/Core/Checkout/Refund/PaymentRefundProcessor.php
+++ b/src/Core/Checkout/Refund/PaymentRefundProcessor.php
@@ -1,0 +1,101 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Checkout\Refund;
+
+use Shopware\Core\Checkout\Order\Aggregate\OrderRefund\OrderRefundEntity;
+use Shopware\Core\Checkout\Order\Aggregate\OrderRefund\OrderRefundStateHandler;
+use Shopware\Core\Checkout\Order\Aggregate\OrderRefund\OrderRefundStates;
+use Shopware\Core\Checkout\Payment\Exception\InvalidOrderException;
+use Shopware\Core\Checkout\Payment\Exception\UnknownPaymentMethodException;
+use Shopware\Core\Checkout\Refund\Exception\InvalidOrderRefundException;
+use Shopware\Core\Checkout\Refund\Exception\PaymentRefundHandlerNotFoundException;
+use Shopware\Core\Checkout\Refund\Exception\PaymentRefundProcessException;
+use Shopware\Core\Checkout\Refund\Exception\PaymentRefundUnsupportedException;
+use Shopware\Core\Checkout\Refund\RefundHandler\PaymentRefundHandlerRegistry;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepositoryInterface;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Uuid\Uuid;
+
+class PaymentRefundProcessor
+{
+    /**
+     * @var OrderRefundStateHandler
+     */
+    private $refundStateHandler;
+
+    /**
+     * @var EntityRepositoryInterface
+     */
+    private $orderRefundRepository;
+
+    /**
+     * @var PaymentRefundHandlerRegistry
+     */
+    private $paymentRefundHandlerRegistry;
+
+    public function __construct(
+        EntityRepositoryInterface $orderRefundRepository,
+        PaymentRefundHandlerRegistry $paymentRefundHandlerRegistry,
+        OrderRefundStateHandler $refundStateHandler
+    ) {
+        $this->orderRefundRepository = $orderRefundRepository;
+        $this->paymentRefundHandlerRegistry = $paymentRefundHandlerRegistry;
+        $this->refundStateHandler = $refundStateHandler;
+    }
+
+    /**
+     * @throws InvalidOrderRefundException
+     * @throws PaymentRefundProcessException
+     */
+    public function processRefund(
+        string $orderRefundId,
+        Context $context
+    ): void {
+        if (!Uuid::isValid($orderRefundId)) {
+            throw new InvalidOrderRefundException($orderRefundId);
+        }
+
+        $criteria = new Criteria([$orderRefundId]);
+        $criteria->addAssociation('stateMachineState');
+        $criteria->addAssociation('paymentMethod');
+        $criteria->addAssociation('order');
+
+        /** @var OrderRefundEntity|null $orderRefund */
+        $orderRefund = $this->orderRefundRepository->search($criteria, $context)->first();
+
+        if (!$orderRefund) {
+            throw new InvalidOrderRefundException($orderRefundId);
+        }
+        $order = $orderRefund->getOrder();
+        if (!$order) {
+            throw new InvalidOrderException($orderRefund->getOrderId());
+        }
+        $stateMachineState = $orderRefund->getStateMachineState();
+        if (!$stateMachineState || $stateMachineState->getTechnicalName() !== OrderRefundStates::STATE_OPEN) {
+            throw new InvalidOrderRefundException($orderRefundId);
+        }
+
+        $paymentMethod = $orderRefund->getPaymentMethod();
+        if (!$paymentMethod) {
+            throw new UnknownPaymentMethodException($orderRefund->getPaymentMethodId());
+        }
+        $refundHandlerIdentifier = $paymentMethod->getRefundHandlerIdentifier();
+        if (!$refundHandlerIdentifier) {
+            throw new PaymentRefundUnsupportedException($orderRefund->getPaymentMethodId());
+        }
+
+        $paymentRefundHandler = $this->paymentRefundHandlerRegistry->getRefundHandler($refundHandlerIdentifier);
+        if (!$paymentRefundHandler) {
+            throw new PaymentRefundHandlerNotFoundException($refundHandlerIdentifier);
+        }
+
+        try {
+            $paymentRefundHandler->refund($orderRefundId, $context);
+        } catch (PaymentRefundProcessException $e) {
+            $this->refundStateHandler->fail($orderRefundId, $context);
+
+            throw $e;
+        }
+    }
+}

--- a/src/Core/Checkout/Refund/RefundHandler/PaymentRefundHandlerInterface.php
+++ b/src/Core/Checkout/Refund/RefundHandler/PaymentRefundHandlerInterface.php
@@ -1,0 +1,20 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Checkout\Refund\RefundHandler;
+
+use Shopware\Core\Checkout\Order\Aggregate\OrderRefund\OrderRefundEntity;
+use Shopware\Core\Checkout\Refund\Exception\PaymentRefundProcessException;
+use Shopware\Core\Framework\Context;
+
+interface PaymentRefundHandlerInterface
+{
+    /**
+     * The refund method will be called after a @see OrderRefundEntity was created via the administration or the api.
+     * Allows to process the order refund and store additional information.
+     *
+     * Throw a @see PaymentRefundProcessException exception if an error ocurres while processing the refund
+     *
+     * @throws PaymentRefundProcessException
+     */
+    public function refund(string $orderRefundId, Context $context): void;
+}

--- a/src/Core/Checkout/Refund/RefundHandler/PaymentRefundHandlerRegistry.php
+++ b/src/Core/Checkout/Refund/RefundHandler/PaymentRefundHandlerRegistry.php
@@ -1,0 +1,26 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Checkout\Refund\RefundHandler;
+
+use Symfony\Contracts\Service\ServiceProviderInterface;
+
+class PaymentRefundHandlerRegistry
+{
+    /**
+     * @var PaymentRefundHandlerInterface[]
+     */
+    private $handlers = [];
+
+    public function __construct(ServiceProviderInterface $refundHandlers)
+    {
+        foreach (array_keys($refundHandlers->getProvidedServices()) as $serviceId) {
+            $handler = $refundHandlers->get($serviceId);
+            $this->handlers[$serviceId] = $handler;
+        }
+    }
+
+    public function getRefundHandler(string $handlerId): ?PaymentRefundHandlerInterface
+    {
+        return $this->handlers[$handlerId] ?? null;
+    }
+}

--- a/src/Core/Checkout/Resources/config/routes.xml
+++ b/src/Core/Checkout/Resources/config/routes.xml
@@ -13,6 +13,7 @@
     <import resource="../../Order/Api/**/*Controller.php" type="annotation" />
     <import resource="../../Customer/SalesChannel/**/*Route.php" type="annotation" />
     <import resource="../../Payment/SalesChannel/**/*Route.php" type="annotation" />
+    <import resource="../../Refund/Api/**/*Controller.php" type="annotation" />
     <import resource="../../Shipping/SalesChannel/**/*Route.php" type="annotation" />
     <import resource="../../Customer/Api/**/*Controller.php" type="annotation" />
     <import resource="../../Customer/SalesChannel/**/*Route.php" type="annotation" />

--- a/src/Core/Migration/Migration1597926384AddOrderRefundStates.php
+++ b/src/Core/Migration/Migration1597926384AddOrderRefundStates.php
@@ -1,0 +1,148 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Migration;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Checkout\Order\Aggregate\OrderRefund\OrderRefundStates;
+use Shopware\Core\Defaults;
+use Shopware\Core\Framework\Migration\MigrationStep;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\System\StateMachine\Aggregation\StateMachineTransition\StateMachineTransitionActions;
+
+class Migration1597926384AddOrderRefundStates extends MigrationStep
+{
+    public function getCreationTimestamp(): int
+    {
+        return 1597926384;
+    }
+
+    public function update(Connection $connection): void
+    {
+        $this->addOrderRefundStates($connection);
+    }
+
+    public function updateDestructive(Connection $connection): void
+    {
+    }
+
+    private function addOrderRefundStates(Connection $connection): void
+    {
+        $stateMachineId = Uuid::randomBytes();
+
+        $openId = Uuid::randomBytes();
+        $inProgressId = Uuid::randomBytes();
+        $cancelledId = Uuid::randomBytes();
+        $failedId = Uuid::randomBytes();
+        $completedId = Uuid::randomBytes();
+
+        $germanId = $this->fetchLanguageId('de-DE', $connection);
+        $englishId = $this->fetchLanguageId('en-GB', $connection);
+
+        $translationDE = ['language_id' => $germanId, 'created_at' => (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT)];
+        $translationEN = ['language_id' => $englishId, 'created_at' => (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT)];
+
+        // state machine
+        $connection->insert('state_machine', [
+            'id' => $stateMachineId,
+            'technical_name' => OrderRefundStates::STATE_MACHINE,
+            'created_at' => (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT),
+        ]);
+
+        if ($englishId) {
+            $connection->insert('state_machine_translation', array_merge($translationEN, [
+                'state_machine_id' => $stateMachineId,
+                'name' => 'Refund state',
+                'created_at' => (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT),
+            ]));
+        }
+        if ($germanId) {
+            $connection->insert('state_machine_translation', array_merge($translationDE, [
+                'state_machine_id' => $stateMachineId,
+                'name' => 'Erstattungsstatus',
+                'created_at' => (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT),
+            ]));
+        }
+
+        // states
+        $connection->insert('state_machine_state', ['id' => $openId, 'state_machine_id' => $stateMachineId, 'technical_name' => OrderRefundStates::STATE_OPEN, 'created_at' => (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT)]);
+        if ($englishId) {
+            $connection->insert('state_machine_state_translation', array_merge($translationEN, ['state_machine_state_id' => $openId, 'name' => 'Open']));
+        }
+        if ($germanId) {
+            $connection->insert('state_machine_state_translation', array_merge($translationDE, ['state_machine_state_id' => $openId, 'name' => 'Offen']));
+        }
+
+        $connection->insert('state_machine_state', ['id' => $inProgressId, 'state_machine_id' => $stateMachineId, 'technical_name' => OrderRefundStates::STATE_IN_PROGRESS, 'created_at' => (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT)]);
+        if ($englishId) {
+            $connection->insert('state_machine_state_translation', array_merge($translationEN, ['state_machine_state_id' => $inProgressId, 'name' => 'In Progress']));
+        }
+        if ($germanId) {
+            $connection->insert('state_machine_state_translation', array_merge($translationDE, ['state_machine_state_id' => $inProgressId, 'name' => 'In Bearbeitung']));
+        }
+
+        $connection->insert('state_machine_state', ['id' => $completedId, 'state_machine_id' => $stateMachineId, 'technical_name' => OrderRefundStates::STATE_COMPLETED, 'created_at' => (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT)]);
+        if ($englishId) {
+            $connection->insert('state_machine_state_translation', array_merge($translationEN, ['state_machine_state_id' => $completedId, 'name' => 'Completed']));
+        }
+        if ($germanId) {
+            $connection->insert('state_machine_state_translation', array_merge($translationDE, ['state_machine_state_id' => $completedId, 'name' => 'Abgeschlossen']));
+        }
+
+        $connection->insert('state_machine_state', ['id' => $cancelledId, 'state_machine_id' => $stateMachineId, 'technical_name' => OrderRefundStates::STATE_CANCELLED, 'created_at' => (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT)]);
+        if ($englishId) {
+            $connection->insert('state_machine_state_translation', array_merge($translationEN, ['state_machine_state_id' => $cancelledId, 'name' => 'Cancelled']));
+        }
+        if ($germanId) {
+            $connection->insert('state_machine_state_translation', array_merge($translationDE, ['state_machine_state_id' => $cancelledId, 'name' => 'Abgebrochen']));
+        }
+
+        $connection->insert('state_machine_state', ['id' => $failedId, 'state_machine_id' => $stateMachineId, 'technical_name' => OrderRefundStates::STATE_FAILED, 'created_at' => (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT)]);
+        if ($englishId) {
+            $connection->insert('state_machine_state_translation', array_merge($translationEN, ['state_machine_state_id' => $failedId, 'name' => 'Failed']));
+        }
+        if ($germanId) {
+            $connection->insert('state_machine_state_translation', array_merge($translationDE, ['state_machine_state_id' => $failedId, 'name' => 'Fehlgeschlagen']));
+        }
+
+        // transitions
+        // from "open" to *
+        $connection->insert('state_machine_transition', ['id' => Uuid::randomBytes(), 'state_machine_id' => $stateMachineId, 'action_name' => StateMachineTransitionActions::ACTION_COMPLETE, 'from_state_id' => $openId, 'to_state_id' => $completedId, 'created_at' => (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT)]);
+        $connection->insert('state_machine_transition', ['id' => Uuid::randomBytes(), 'state_machine_id' => $stateMachineId, 'action_name' => StateMachineTransitionActions::ACTION_PROCESS, 'from_state_id' => $openId, 'to_state_id' => $inProgressId, 'created_at' => (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT)]);
+        $connection->insert('state_machine_transition', ['id' => Uuid::randomBytes(), 'state_machine_id' => $stateMachineId, 'action_name' => StateMachineTransitionActions::ACTION_CANCEL, 'from_state_id' => $openId, 'to_state_id' => $cancelledId, 'created_at' => (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT)]);
+        $connection->insert('state_machine_transition', ['id' => Uuid::randomBytes(), 'state_machine_id' => $stateMachineId, 'action_name' => StateMachineTransitionActions::ACTION_FAIL, 'from_state_id' => $openId, 'to_state_id' => $failedId, 'created_at' => (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT)]);
+
+        // from "in_progress" to *
+        $connection->insert('state_machine_transition', ['id' => Uuid::randomBytes(), 'state_machine_id' => $stateMachineId, 'action_name' => StateMachineTransitionActions::ACTION_COMPLETE, 'from_state_id' => $inProgressId, 'to_state_id' => $completedId, 'created_at' => (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT)]);
+        $connection->insert('state_machine_transition', ['id' => Uuid::randomBytes(), 'state_machine_id' => $stateMachineId, 'action_name' => StateMachineTransitionActions::ACTION_CANCEL, 'from_state_id' => $inProgressId, 'to_state_id' => $cancelledId, 'created_at' => (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT)]);
+        $connection->insert('state_machine_transition', ['id' => Uuid::randomBytes(), 'state_machine_id' => $stateMachineId, 'action_name' => StateMachineTransitionActions::ACTION_FAIL, 'from_state_id' => $inProgressId, 'to_state_id' => $failedId, 'created_at' => (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT)]);
+
+        // from "completed" to *
+        $connection->insert('state_machine_transition', ['id' => Uuid::randomBytes(), 'state_machine_id' => $stateMachineId, 'action_name' => StateMachineTransitionActions::ACTION_REOPEN, 'from_state_id' => $completedId, 'to_state_id' => $openId, 'created_at' => (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT)]);
+
+        // from "cancelled" to *
+        $connection->insert('state_machine_transition', ['id' => Uuid::randomBytes(), 'state_machine_id' => $stateMachineId, 'action_name' => StateMachineTransitionActions::ACTION_REOPEN, 'from_state_id' => $cancelledId, 'to_state_id' => $openId, 'created_at' => (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT)]);
+
+        // from "failed" to *
+        $connection->insert('state_machine_transition', ['id' => Uuid::randomBytes(), 'state_machine_id' => $stateMachineId, 'action_name' => StateMachineTransitionActions::ACTION_REOPEN, 'from_state_id' => $failedId, 'to_state_id' => $openId, 'created_at' => (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT)]);
+
+        // set initial state
+        $connection->update('state_machine', ['initial_state_id' => $openId], ['id' => $stateMachineId]);
+    }
+
+    private function fetchLanguageId(string $code, Connection $connection): ?string
+    {
+        $langId = $connection->fetchColumn(
+            'SELECT `language`.`id`
+            FROM `language`
+            INNER JOIN `locale` ON `language`.`translation_code_id` = `locale`.`id`
+            WHERE `code` = :code
+            LIMIT 1',
+            ['code' => $code]
+        );
+        if ($langId === false) {
+            return null;
+        }
+
+        return (string) $langId;
+    }
+}

--- a/src/Core/Migration/Migration1597928854AddOrderRefund.php
+++ b/src/Core/Migration/Migration1597928854AddOrderRefund.php
@@ -1,0 +1,49 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Migration;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Framework\Migration\MigrationStep;
+
+class Migration1597928854AddOrderRefund extends MigrationStep
+{
+    public function getCreationTimestamp(): int
+    {
+        return 1597928854;
+    }
+
+    public function update(Connection $connection): void
+    {
+        $connection->executeUpdate('
+            CREATE TABLE `order_refund` (
+              `id` BINARY(16) NOT NULL,
+              `version_id` BINARY(16) NOT NULL,
+              `order_id` BINARY(16) NOT NULL,
+              `order_version_id` BINARY(16) NOT NULL,
+              `state_id` BINARY(16) NOT NULL,
+              `payment_method_id` BINARY(16) NOT NULL,
+              `transaction_id` BINARY(16) NULL,
+              `transaction_version_id` BINARY(16) NULL,
+              `amount` DOUBLE NOT NULL,
+              `custom_fields` JSON NULL,
+              `created_at` DATETIME(3) NOT NULL,
+              `updated_at` DATETIME(3) NULL,
+              PRIMARY KEY (`id`, `version_id`),
+              INDEX `idx.state_index` (`state_id`),
+              CONSTRAINT `json.order_refund.custom_fields` CHECK (JSON_VALID(`custom_fields`)),
+              CONSTRAINT `fk.order_refund.order_id` FOREIGN KEY (`order_id`, `order_version_id`)
+                REFERENCES `order` (`id`, `version_id`) ON DELETE CASCADE ON UPDATE CASCADE,
+              CONSTRAINT `fk.order_refund.state_id` FOREIGN KEY (`state_id`)
+                REFERENCES `state_machine_state` (`id`) ON DELETE RESTRICT ON UPDATE CASCADE,
+              CONSTRAINT `fk.order_refund.payment_method_id` FOREIGN KEY (`payment_method_id`)
+                REFERENCES `payment_method` (`id`) ON DELETE RESTRICT ON UPDATE CASCADE,
+              CONSTRAINT `fk.order_refund.transaction_id` FOREIGN KEY (`transaction_id`, `transaction_version_id`)
+                REFERENCES `order_transaction` (`id`, `version_id`) ON DELETE SET NULL ON UPDATE CASCADE
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+        ');
+    }
+
+    public function updateDestructive(Connection $connection): void
+    {
+    }
+}

--- a/src/Core/Migration/Migration1597929564AddOrderRefundPosition.php
+++ b/src/Core/Migration/Migration1597929564AddOrderRefundPosition.php
@@ -1,0 +1,54 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Migration;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Framework\Migration\MigrationStep;
+
+class Migration1597929564AddOrderRefundPosition extends MigrationStep
+{
+    public function getCreationTimestamp(): int
+    {
+        return 1597929564;
+    }
+
+    public function update(Connection $connection): void
+    {
+        $connection->executeUpdate('
+            CREATE TABLE `order_refund_position` (
+              `id` BINARY(16) NOT NULL,
+              `version_id` BINARY(16) NOT NULL,
+              `order_refund_id` BINARY(16) NOT NULL,
+              `order_refund_version_id` BINARY(16) NOT NULL,
+              `line_item_id` BINARY(16) NULL,
+              `line_item_version_id` BINARY(16) NULL,
+              `line_item_price` JSON NOT NULL,
+              `line_item_total_price` DOUBLE GENERATED ALWAYS AS (JSON_UNQUOTE(JSON_EXTRACT(`line_item_price`, "$.totalPrice"))) VIRTUAL,
+              `line_item_unit_price` DOUBLE GENERATED ALWAYS AS (JSON_UNQUOTE(JSON_EXTRACT(`line_item_price`, "$.unitPrice"))) VIRTUAL,
+              `line_item_quantity` INT(11) GENERATED ALWAYS AS (JSON_UNQUOTE(JSON_EXTRACT(`line_item_price`, "$.quantity"))) VIRTUAL,
+              `payload` JSON NOT NULL,
+              `label` VARCHAR(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+              `refund_price` JSON NOT NULL,
+              `refund_total_price` DOUBLE GENERATED ALWAYS AS (JSON_UNQUOTE(JSON_EXTRACT(`refund_price`, "$.totalPrice"))) VIRTUAL,
+              `refund_unit_price` DOUBLE GENERATED ALWAYS AS (JSON_UNQUOTE(JSON_EXTRACT(`refund_price`, "$.unitPrice"))) VIRTUAL,
+              `refund_quantity` INT(11) GENERATED ALWAYS AS (JSON_UNQUOTE(JSON_EXTRACT(`refund_price`, "$.quantity"))) VIRTUAL,
+              `custom_fields` JSON NULL,
+              `created_at` DATETIME(3) NOT NULL,
+              `updated_at` DATETIME(3) NULL,
+              PRIMARY KEY (`id`, `version_id`),
+              CONSTRAINT `json.order_refund_position.payload` CHECK (JSON_VALID(`payload`)),
+              CONSTRAINT `json.order_refund_position.line_item_price` CHECK (JSON_VALID(`line_item_price`)),
+              CONSTRAINT `json.order_refund_position.refund_price` CHECK (JSON_VALID(`refund_price`)),
+              CONSTRAINT `json.order_refund_position.custom_fields` CHECK (JSON_VALID(`custom_fields`)),
+              CONSTRAINT `fk.order_refund_position.order_refund_id` FOREIGN KEY (`order_refund_id`, `order_refund_version_id`)
+                REFERENCES `order_refund` (`id`, `version_id`) ON DELETE CASCADE ON UPDATE CASCADE,
+              CONSTRAINT `fk.order_refund_position.line_item_id` FOREIGN KEY (`line_item_id`, `line_item_version_id`)
+                REFERENCES `order_line_item` (`id`, `version_id`) ON DELETE SET NULL ON UPDATE CASCADE
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+        ');
+    }
+
+    public function updateDestructive(Connection $connection): void
+    {
+    }
+}

--- a/src/Core/Migration/Migration1597935198AddRefundHandlerIdentifier.php
+++ b/src/Core/Migration/Migration1597935198AddRefundHandlerIdentifier.php
@@ -1,0 +1,26 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Migration;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Framework\Migration\MigrationStep;
+
+class Migration1597935198AddRefundHandlerIdentifier extends MigrationStep
+{
+    public function getCreationTimestamp(): int
+    {
+        return 1597935198;
+    }
+
+    public function update(Connection $connection): void
+    {
+        $connection->executeUpdate('
+            ALTER TABLE `payment_method`
+            ADD `refund_handler_identifier` VARCHAR(255) COLLATE utf8mb4_unicode_ci NULL AFTER `handler_identifier`
+        ');
+    }
+
+    public function updateDestructive(Connection $connection): void
+    {
+    }
+}

--- a/src/Core/Migration/Migration1607429556AddOrderTransactionCapture.php
+++ b/src/Core/Migration/Migration1607429556AddOrderTransactionCapture.php
@@ -1,0 +1,50 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Migration;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Framework\Migration\MigrationStep;
+
+class Migration1607429556AddOrderTransactionCapture extends MigrationStep
+{
+    public function getCreationTimestamp(): int
+    {
+        return 1607429556;
+    }
+
+    public function update(Connection $connection): void
+    {
+        $connection->executeUpdate('
+            CREATE TABLE `order_transaction_capture` (
+              `id` BINARY(16) NOT NULL,
+              `version_id` BINARY(16) NOT NULL,
+              `transaction_id` BINARY(16) NOT NULL,
+              `transaction_version_id` BINARY(16) NOT NULL,
+              `state_id` BINARY(16) NOT NULL,
+              `amount` DOUBLE NOT NULL,
+              `external_reference` VARCHAR(255) NULL,
+              `custom_fields` JSON NULL,
+              `created_at` DATETIME(3) NOT NULL,
+              `updated_at` DATETIME(3) NULL,
+              PRIMARY KEY (`id`, `version_id`),
+              INDEX `idx.state_index` (`state_id`),
+              CONSTRAINT `json.order_transaction_capture.custom_fields` CHECK (JSON_VALID(`custom_fields`)),
+              CONSTRAINT `fk.order_transaction_capture.transaction_id` FOREIGN KEY (`transaction_id`, `transaction_version_id`)
+                REFERENCES `order_transaction` (`id`, `version_id`) ON DELETE CASCADE ON UPDATE CASCADE,
+              CONSTRAINT `fk.order_transaction_capture.state_id` FOREIGN KEY (`state_id`)
+                REFERENCES `state_machine_state` (`id`) ON DELETE RESTRICT ON UPDATE CASCADE
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+        ');
+
+        $connection->executeUpdate('
+            ALTER TABLE `order_refund`
+              ADD COLUMN `transaction_capture_id` BINARY(16) NULL AFTER `transaction_version_id`,
+              ADD CONSTRAINT `fk.order_refund.transaction_capture_id` FOREIGN KEY (`transaction_capture_id`)
+                REFERENCES `order_transaction_capture` (`id`) ON DELETE SET NULL ON UPDATE CASCADE;
+        ');
+    }
+
+    public function updateDestructive(Connection $connection): void
+    {
+    }
+}

--- a/src/Core/Migration/Migration1607429855AddOrderTransactionCaptureStates.php
+++ b/src/Core/Migration/Migration1607429855AddOrderTransactionCaptureStates.php
@@ -1,0 +1,114 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Migration;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Checkout\Order\Aggregate\OrderTransactionCapture\OrderTransactionCaptureStates;
+use Shopware\Core\Defaults;
+use Shopware\Core\Framework\Migration\MigrationStep;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\System\StateMachine\Aggregation\StateMachineTransition\StateMachineTransitionActions;
+
+class Migration1607429855AddOrderTransactionCaptureStates extends MigrationStep
+{
+    public function getCreationTimestamp(): int
+    {
+        return 1607429855;
+    }
+
+    public function update(Connection $connection): void
+    {
+        $this->addOrderTransactionCaptureStates($connection);
+    }
+
+    public function updateDestructive(Connection $connection): void
+    {
+    }
+
+    private function addOrderTransactionCaptureStates(Connection $connection): void
+    {
+        $stateMachineId = Uuid::randomBytes();
+
+        $pendingId = Uuid::randomBytes();
+        $failedId = Uuid::randomBytes();
+        $completedId = Uuid::randomBytes();
+
+        $germanId = $this->fetchLanguageId('de-DE', $connection);
+        $englishId = $this->fetchLanguageId('en-GB', $connection);
+
+        $translationDE = ['language_id' => $germanId, 'created_at' => (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT)];
+        $translationEN = ['language_id' => $englishId, 'created_at' => (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT)];
+
+        // state machine
+        $connection->insert('state_machine', [
+            'id' => $stateMachineId,
+            'technical_name' => OrderTransactionCaptureStates::STATE_MACHINE,
+            'created_at' => (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT),
+        ]);
+
+        if ($englishId) {
+            $connection->insert('state_machine_translation', array_merge($translationEN, [
+                'state_machine_id' => $stateMachineId,
+                'name' => 'Capture state',
+                'created_at' => (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT),
+            ]));
+        }
+        if ($germanId) {
+            $connection->insert('state_machine_translation', array_merge($translationDE, [
+                'state_machine_id' => $stateMachineId,
+                'name' => 'Erfassungsstatus',
+                'created_at' => (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT),
+            ]));
+        }
+
+        // states
+        $connection->insert('state_machine_state', ['id' => $pendingId, 'state_machine_id' => $stateMachineId, 'technical_name' => OrderTransactionCaptureStates::STATE_PENDING, 'created_at' => (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT)]);
+        if ($englishId) {
+            $connection->insert('state_machine_state_translation', array_merge($translationEN, ['state_machine_state_id' => $pendingId, 'name' => 'Pending']));
+        }
+        if ($germanId) {
+            $connection->insert('state_machine_state_translation', array_merge($translationDE, ['state_machine_state_id' => $pendingId, 'name' => 'Ausstehend']));
+        }
+
+        $connection->insert('state_machine_state', ['id' => $completedId, 'state_machine_id' => $stateMachineId, 'technical_name' => OrderTransactionCaptureStates::STATE_COMPLETED, 'created_at' => (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT)]);
+        if ($englishId) {
+            $connection->insert('state_machine_state_translation', array_merge($translationEN, ['state_machine_state_id' => $completedId, 'name' => 'Completed']));
+        }
+        if ($germanId) {
+            $connection->insert('state_machine_state_translation', array_merge($translationDE, ['state_machine_state_id' => $completedId, 'name' => 'Abgeschlossen']));
+        }
+
+        $connection->insert('state_machine_state', ['id' => $failedId, 'state_machine_id' => $stateMachineId, 'technical_name' => OrderTransactionCaptureStates::STATE_FAILED, 'created_at' => (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT)]);
+        if ($englishId) {
+            $connection->insert('state_machine_state_translation', array_merge($translationEN, ['state_machine_state_id' => $failedId, 'name' => 'Failed']));
+        }
+        if ($germanId) {
+            $connection->insert('state_machine_state_translation', array_merge($translationDE, ['state_machine_state_id' => $failedId, 'name' => 'Fehlgeschlagen']));
+        }
+
+        // transitions
+        // from "pending" to *
+        $connection->insert('state_machine_transition', ['id' => Uuid::randomBytes(), 'state_machine_id' => $stateMachineId, 'action_name' => StateMachineTransitionActions::ACTION_COMPLETE, 'from_state_id' => $pendingId, 'to_state_id' => $completedId, 'created_at' => (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT)]);
+        $connection->insert('state_machine_transition', ['id' => Uuid::randomBytes(), 'state_machine_id' => $stateMachineId, 'action_name' => StateMachineTransitionActions::ACTION_FAIL, 'from_state_id' => $pendingId, 'to_state_id' => $failedId, 'created_at' => (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT)]);
+
+        // set initial state
+        $connection->update('state_machine', ['initial_state_id' => $pendingId], ['id' => $stateMachineId]);
+    }
+
+    private function fetchLanguageId(string $code, Connection $connection): ?string
+    {
+        $langId = $connection->fetchColumn(
+            'SELECT `language`.`id`
+            FROM `language`
+            INNER JOIN `locale` ON `language`.`translation_code_id` = `locale`.`id`
+            WHERE `code` = :code
+            LIMIT 1',
+            ['code' => $code]
+        );
+        if ($langId === false) {
+            return null;
+        }
+
+        return (string) $langId;
+    }
+}

--- a/src/Core/Migration/Migration1608722331AddPaymentMethodRefundConfig.php
+++ b/src/Core/Migration/Migration1608722331AddPaymentMethodRefundConfig.php
@@ -1,0 +1,43 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Migration;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Framework\Migration\MigrationStep;
+
+class Migration1608722331AddPaymentMethodRefundConfig extends MigrationStep
+{
+    public function getCreationTimestamp(): int
+    {
+        return 1608722331;
+    }
+
+    public function update(Connection $connection): void
+    {
+        $connection->executeUpdate('
+            CREATE TABLE `payment_method_refund_config` (
+              `id` BINARY(16) NOT NULL,
+              `payment_method_id` BINARY(16) NOT NULL,
+              `technical_name` VARCHAR(255) NOT NULL,
+              `options` JSON NOT NULL,
+              `created_at` DATETIME(3) NOT NULL,
+              `updated_at` DATETIME(3) NULL,
+              PRIMARY KEY (`id`),
+              UNIQUE `uniq.payment_method_refund_config.technical_name` (`technical_name`, `payment_method_id`),
+              CONSTRAINT `json.payment_method_refund_config.options` CHECK (JSON_VALID(`options`)),
+              CONSTRAINT `fk.payment_method_refund_config.payment_method_id` FOREIGN KEY (`payment_method_id`)
+                REFERENCES `payment_method` (`id`) ON DELETE RESTRICT ON UPDATE CASCADE
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+        ');
+
+        $connection->executeUpdate('
+            ALTER TABLE `order_refund`
+              ADD COLUMN `options` JSON NULL AFTER `amount`,
+              ADD CONSTRAINT `json.order_refund.options` CHECK (JSON_VALID(`options`));
+        ');
+    }
+
+    public function updateDestructive(Connection $connection): void
+    {
+    }
+}

--- a/src/Core/System/StateMachine/Aggregation/StateMachineState/StateMachineStateDefinition.php
+++ b/src/Core/System/StateMachine/Aggregation/StateMachineState/StateMachineStateDefinition.php
@@ -3,7 +3,9 @@
 namespace Shopware\Core\System\StateMachine\Aggregation\StateMachineState;
 
 use Shopware\Core\Checkout\Order\Aggregate\OrderDelivery\OrderDeliveryDefinition;
+use Shopware\Core\Checkout\Order\Aggregate\OrderRefund\OrderRefundDefinition;
 use Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionDefinition;
+use Shopware\Core\Checkout\Order\Aggregate\OrderTransactionCapture\OrderTransactionCaptureDefinition;
 use Shopware\Core\Checkout\Order\OrderDefinition;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\FkField;
@@ -63,6 +65,8 @@ class StateMachineStateDefinition extends EntityDefinition
             (new TranslationsAssociationField(StateMachineStateTranslationDefinition::class, 'state_machine_state_id'))->setFlags(new Required(), new CascadeDelete()),
 
             new OneToManyAssociationField('orderTransactions', OrderTransactionDefinition::class, 'state_id'),
+            new OneToManyAssociationField('orderTransactionCaptures', OrderTransactionCaptureDefinition::class, 'state_id'),
+            new OneToManyAssociationField('orderRefunds', OrderRefundDefinition::class, 'state_id'),
             new OneToManyAssociationField('orderDeliveries', OrderDeliveryDefinition::class, 'state_id'),
             new OneToManyAssociationField('orders', OrderDefinition::class, 'state_id'),
 

--- a/src/Core/System/StateMachine/Aggregation/StateMachineState/StateMachineStateEntity.php
+++ b/src/Core/System/StateMachine/Aggregation/StateMachineState/StateMachineStateEntity.php
@@ -3,7 +3,9 @@
 namespace Shopware\Core\System\StateMachine\Aggregation\StateMachineState;
 
 use Shopware\Core\Checkout\Order\Aggregate\OrderDelivery\OrderDeliveryCollection;
+use Shopware\Core\Checkout\Order\Aggregate\OrderRefund\OrderRefundCollection;
 use Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionCollection;
+use Shopware\Core\Checkout\Order\Aggregate\OrderTransactionCapture\OrderTransactionCaptureCollection;
 use Shopware\Core\Checkout\Order\OrderCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\Entity;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityIdTrait;
@@ -59,6 +61,16 @@ class StateMachineStateEntity extends Entity
      * @var OrderTransactionCollection|null
      */
     protected $orderTransactions;
+
+    /**
+     * @var OrderTransactionCaptureCollection|null
+     */
+    protected $orderTransactionCaptures;
+
+    /**
+     * @var OrderRefundCollection|null
+     */
+    protected $orderRefunds;
 
     /**
      * @var OrderDeliveryCollection|null
@@ -190,6 +202,16 @@ class StateMachineStateEntity extends Entity
         $this->orderTransactions = $orderTransactions;
     }
 
+    public function getOrderRefunds(): ?OrderRefundCollection
+    {
+        return $this->orderRefunds;
+    }
+
+    public function setOrderRefunds(OrderRefundCollection $orderRefunds): void
+    {
+        $this->orderRefunds = $orderRefunds;
+    }
+
     public function getOrderDeliveries(): ?OrderDeliveryCollection
     {
         return $this->orderDeliveries;
@@ -208,5 +230,15 @@ class StateMachineStateEntity extends Entity
     public function setCustomFields(?array $customFields): void
     {
         $this->customFields = $customFields;
+    }
+
+    public function getOrderTransactionCaptures(): ?OrderTransactionCaptureCollection
+    {
+        return $this->orderTransactionCaptures;
+    }
+
+    public function setOrderTransactionCaptures(OrderTransactionCaptureCollection $orderTransactionCaptures): void
+    {
+        $this->orderTransactionCaptures = $orderTransactionCaptures;
     }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

## This PR is a first proposal up for community discussion. The UI and design aren't final and subject to change.

### 1. Why is this change necessary?

Currently each payment plugin handles refunding on its own, creating a wide variety of custom api endpoints, parameters and administration extensions. This makes creating refunds via an API (e.g. from an external system such as an ERP) extremely difficult as the api client would need to know each individual custom endpoint of each payment method and their respective parameters as well as any meta data the plugin might need to actually refund the payment.

As we discussed with @OliverSkroblin, @mitelg and @ssltg when planning this feature, this is a preliminary version of the PR. We would like to get feedback from the community, in particular from other people who build payment plugins for Shopware 6. Because of this, this PR does not have tests yet. The UI is also more of a draft and we hope to get some input from Shopware's design team on this.

There is a companion PR which adds support for this feature to the PayPal Plugin here: https://github.com/shopwareLabs/SwagPayPal/pull/14

### 2. What does this change do, exactly?

This PR adds a simple standardized api and interface to refund any arbitrary order as long as the payment plugin implements the refund interface, similar to how payment handlers work. Additionally, an `OrderTransactionCapture` entity is introduced to standardize the various representations of payment captures, so that refunding specific captures is possible as well.

### 3. How it works

#### 1. Implementation

The payment plugin adds a `PaymentRefundHandler` class, which implements the `PaymentRefundHandlerInterface`, to its payment method. This handler will be used to create refunds for the payment method.

#### 2. On plugin install and update

The payment plugin uses the `upsertPaymentMethodRefundConfigFromYaml()` method to upsert any additional options it might require to create refunds. This can include things like a description or a reason.

#### 3. During the payment process/flow 

The payment plugin creates `OrderTransactionCapture`s whenever a capture is created, and updates its state accordingly. The `OrderTransactionCapture` entities are used later on to reference a payment methods capture in a standardized way so that we can refund them.

#### 4. When creating a refund

The `PaymentRefundHandler`s `refund()` method uses the supplied `OrderRefund` to retrieve the amount to refund, the capture to refund (if there is one supplied) and any additional options specific to the payment method stored on the `OrderRefund` to create the refund and update its state accordingly.

https://user-images.githubusercontent.com/5189997/103900772-7cbffb00-50f8-11eb-87c9-832212485df3.mov

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
