### PR TITLE
NEXT-10503 If a channel does not have an export, go to the next chann…

### DIFF
--- a/changelog/_unreleased/2020-01-12-productexport-all-channels.md
+++ b/changelog/_unreleased/2020-01-12-productexport-all-channels.md
@@ -1,0 +1,11 @@
+---
+title: Generate ProductExportPartialGeneration objects for all sales channels
+issue: NEXT-10503
+author: Ronald Bethlehem
+author_email: ronald@bethlehemit
+author_github: @bethlehemit
+---
+# Core
+* Changed method `run()` in ProductExportGenerateTaskHandler: Upon encountering a sales channel without a product export configuration,
+  the function returns, instead of continueing to the next sales channel. This results in feeds not being generated for sales channels
+  that are listed after a channel without a configuration

--- a/src/Core/Content/ProductExport/ScheduledTask/ProductExportGenerateTaskHandler.php
+++ b/src/Core/Content/ProductExport/ScheduledTask/ProductExportGenerateTaskHandler.php
@@ -82,7 +82,7 @@ class ProductExportGenerateTaskHandler extends ScheduledTaskHandler
             $productExports = $this->productExportRepository->search($criteria, $salesChannelContext->getContext());
 
             if ($productExports->count() === 0) {
-                return;
+                continue;
             }
 
             /** @var ProductExportEntity $productExport */


### PR DESCRIPTION
### 1. Why is this change necessary?
This change is necessary because we should export all feeds

### 2. What does this change do, exactly?
Replace a return with a continue, so all channels are checked

### 3. Describe each step to reproduce the issue or behaviour.
Create multiple sales channels, give one of them an export. Run the ProductExportGenerateTask and observe that if a channel has no configuration, all further channels are skipped

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/NEXT-10503

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
