### PR TITLE
The products data in the cart are loaded again from the database on every request which is made in the shop

### DIFF
--- a/changelog/_unreleased/2021-01-13-improve-performance-loading-cart.md
+++ b/changelog/_unreleased/2021-01-13-improve-performance-loading-cart.md
@@ -1,0 +1,10 @@
+---
+title:              Improve performance on loading cart by loading rules on every request made
+issue:              NEXT-13250
+author:             Christoph Pötz
+author_email:       christoph.poetz@acris.at
+author_github:      @acris-cp
+---
+# Core
+*  Removed checking for description and cover in function `isComplete` and reduce loading products again which are already loaded in cart in `src/core/Content/Product/Cart/ProductCartProcessor.php`
+*  Added flag modified to already existing lineItems in cart `src/core/Checkout/Cart/SalesChannel/CartItemAddRoute.php`

--- a/src/Core/Checkout/Cart/SalesChannel/CartItemAddRoute.php
+++ b/src/Core/Checkout/Cart/SalesChannel/CartItemAddRoute.php
@@ -86,6 +86,9 @@ class CartItemAddRoute extends AbstractCartItemAddRoute
 
         foreach ($items as $item) {
             $alreadyExists = $cart->has($item->getId());
+            if($alreadyExists === true) {
+                $cart->get($item->getId())->markModified();
+            }
             $cart->add($item);
             $this->eventDispatcher->dispatch(new LineItemAddedEvent($item, $cart, $context, $alreadyExists));
         }


### PR DESCRIPTION
### 1. Why is this change necessary?
The products data in the cart are loaded again from the database on every request which is made in the shop (e.g. search, open a simple shop page, open a product page, ...)

### 2. What does this change do, exactly?
Optimisation of the function `isComplete` in the file `src/core/Content/Product/Cart/ProductCartProcessor.php` and some other things which have to be done according to this.

### 3. Describe each step to reproduce the issue or behaviour.
The problem is mainly due to the function `isComplete` in `src/core/Content/Product/Cart/ProductCartProcessor.php`.

There it asks whether the description of a product line item is null. However, this is ALWAYS zero, as it is never set for a product line item!
This has the consequence that Shopware reloads all products of the shopping basket in the line `$products = $this->productGateway->get($ids, $context);` in the method `collect` in the file mentioned above with EVERY request (i.e. also with the search, in the account area, every shop page, etc.).

This is exactly the opposite of what the new shopping cart was actually built for. An improvement brings a performance boost to every request made.

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/NEXT-13250

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
