### PR TITLE
[FIX] Fixes cms element resolving for preview in administration

### DIFF
--- a/changelog/_unreleased/2021-01-13-fix-cms-element-resolving-for-administration-preview.md
+++ b/changelog/_unreleased/2021-01-13-fix-cms-element-resolving-for-administration-preview.md
@@ -1,0 +1,9 @@
+---
+title:              Fix cms element resolving for preview in administration
+issue:              -
+author:             Moritz Müller
+author_email:       moritz@momocode.de
+author_github:      @momocode-de
+---
+# Administration
+* Changed method `registerCmsElement()` in `module/sw-cms/service/cms.service.js` to fix the cms element resolving for preview if there are multiple configurations having the same entity

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/service/cms.service.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/service/cms.service.js
@@ -38,6 +38,10 @@ function registerCmsElement(config) {
                     const entityKey = entity.name;
                     const entityData = getEntityData(elem, configKey);
 
+                    if (criteriaList[`entity-${entityKey}`]) {
+                        entityData.value.push(...criteriaList[`entity-${entityKey}`].value);
+                    }
+
                     entityData.searchCriteria.setIds(entityData.value);
 
                     criteriaList[`entity-${entityKey}`] = entityData;
@@ -103,13 +107,11 @@ function getEntityData(element, configKey) {
 
         entityData = {
             value: entityIds,
-            key: configKey,
             ...entity
         };
     } else {
         entityData = {
             value: [configValue],
-            key: configKey,
             ...entity
         };
     }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?

If you have a custom cms element with multiple configurations having the same entity, e.g. a media upload for an image and a media upload for an icon, then the function "collect" of the cms.service is not handling this case correctly. It overrides the ``criteriaList[`entity-${entityKey}`]`` completely for every configuration with this entity.

### 2. What does this change do, exactly?

With this change the values of the ``criteriaList[`entity-${entityKey}`]`` are merged together if it already exist for an other configuration. On top of that I have removed the `key: configKey` in the `getEntityData` function because it was not used and in my opinion it does not belong to the "entityData" object. That object should exist for the entities of multiple configurations, not only for one.

### 3. Describe each step to reproduce the issue or behaviour.

- You need a cms element with multiple configurations of the same entity first (e.g. two configurations with media files)
- If you display the media in the preview you will see that always only one media will be visible because it is loaded only for one configuration

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
