### PR TITLE
Show Formviolations for additionalAddressFields

### DIFF
--- a/changelog/_unreleased/2021-01-13-formviolations-additionaladdressfields.md
+++ b/changelog/_unreleased/2021-01-13-formviolations-additionaladdressfields.md
@@ -1,0 +1,8 @@
+---
+title: Adding formviolations for additional address fields
+author: Alessandro Aussems
+author_email: me@alessandroaussems.be
+author_github: Alessandro Aussems
+---
+# Storefront
+* Make errors from backend validation visible for additional address fields.

--- a/src/Storefront/Resources/views/storefront/component/address/address-form.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/address/address-form.html.twig
@@ -248,6 +248,12 @@
 
             {% block component_address_form_additional_field1 %}
                 {% if shopware.config.core.loginRegistration.showAdditionalAddressField1 %}
+                    {% if formViolations.getViolations("/additionalAddressLine1") is not empty %}
+                        {% set violationPath = "/additionalAddressLine1" %}
+                    {% elseif formViolations.getViolations("/#{prefix}/additionalAddressLine1") is not empty %}
+                        {% set violationPath = "/#{prefix}/additionalAddressLine1" %}
+                    {% endif %}
+
                     <div class="form-group col-md-6">
                         {% block component_address_form_additional_field1_label %}
                             <label class="form-label"
@@ -258,12 +264,18 @@
 
                         {% block component_address_form_additional_field1_input %}
                             <input type="text"
-                                   class="form-control"
+                                   class="form-control {% if violationPath %} is-invalid{% endif %}"
                                    id="{{ prefix }}AdditionalField1"
                                    placeholder="{{ "address.additionalField1Placeholder"|trans|striptags }}"
                                    name="{{ prefix }}[additionalAddressLine1]"
                                    value="{{ data.get('additionalAddressLine1') }}"
                                     {{ shopware.config.core.loginRegistration.additionalAddressField1Required ? 'required="true"' }}>
+                        {% endblock %}
+
+                        {% block component_address_form_additional_field1_error %}
+                            {% if violationPath %}
+                                {% sw_include '@Storefront/storefront/utilities/form-violation.html.twig' %}
+                            {% endif %}
                         {% endblock %}
                     </div>
                 {% endif %}
@@ -271,6 +283,11 @@
 
             {% block component_address_form_additional_field2 %}
                 {% if shopware.config.core.loginRegistration.showAdditionalAddressField2 %}
+                    {% if formViolations.getViolations("/additionalAddressLine2") is not empty %}
+                        {% set violationPath = "/additionalAddressLine2" %}
+                    {% elseif formViolations.getViolations("/#{prefix}/additionalAddressLine2") is not empty %}
+                        {% set violationPath = "/#{prefix}/additionalAddressLine2" %}
+                    {% endif %}
                     <div class="form-group col-md-6">
                         {% block component_address_form_additional_field2_label %}
                             <label class="form-label"
@@ -281,12 +298,18 @@
 
                         {% block component_address_form_additional_field2_input %}
                             <input type="text"
-                                   class="form-control"
+                                   class="form-control {% if violationPath %} is-invalid{% endif %}"
                                    id="{{ prefix }}AdditionalField2"
                                    placeholder="{{ "address.additionalField2Placeholder"|trans|striptags }}"
                                    name="{{ prefix }}[additionalAddressLine2]"
                                    value="{{ data.get('additionalAddressLine2') }}"
                                     {{ shopware.config.core.loginRegistration.additionalAddressField2Required ? 'required="true"' }}>
+                        {% endblock %}
+
+                        {% block component_address_form_additional_field2_error %}
+                            {% if violationPath %}
+                                {% sw_include '@Storefront/storefront/utilities/form-violation.html.twig' %}
+                            {% endif %}
                         {% endblock %}
                     </div>
                 {% endif %}


### PR DESCRIPTION
### 1. Why is this change necessary?
Right now when you make an additionalField required on registration and the frontend validation is disabled no error message will be show.


### 2. What does this change do, exactly?
Show error messages for additionalFields when te backend validation fails.


### 3. Describe each step to reproduce the issue or behaviour
- Make additionalAddressField1 required in the administration (Login/Registration)
- Go to the signup page
- Remove the 'required' attribute from the additionalAddressField1 input field
- Submit the form
- No error will be shown.  (And it should say: additionalAddressField1 is required)

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
