### PR TITLE
NEXT-12173 - add required to sales channel and customer number fields

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-customer/component/sw-customer-base-form/sw-customer-base-form.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-customer/component/sw-customer-base-form/sw-customer-base-form.html.twig
@@ -98,6 +98,7 @@
 
             {% block sw_customer_base_form_sales_channel_field %}
                 <sw-entity-single-select
+                    required
                     class="sw-customer-base-form__sales-channel-select"
                     entity="sales_channel"
                     :label="$tc('sw-customer.baseForm.labelSalesChannel')"
@@ -122,6 +123,7 @@
 
             {% block sw_customer_base_form_customer_number_field %}
                 <sw-text-field
+                    required
                     :label="$tc('sw-customer.baseForm.labelCustomerNumber')"
                     :placeholder="$tc('sw-customer.baseForm.placeholderCustomerNumber')"
                     :error="customerCustomerNumberError"

--- a/src/Administration/Resources/app/administration/src/module/sw-customer/component/sw-customer-base-form/sw-customer-base-form.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-customer/component/sw-customer-base-form/sw-customer-base-form.html.twig
@@ -129,6 +129,7 @@
                     :error="customerCustomerNumberError"
                     v-model="customer.customerNumber">
                 </sw-text-field>
+
             {% endblock %}
         </sw-container>
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
The "Sales Channel" and "Customer number" field labels didn't have the required star symbol -> *

### 2. What does this change do, exactly?
It adds the required property to the vue components which render the field labels

### 3. Describe each step to reproduce the issue or behaviour.

1. Admin > Customers > Overview > Add customer
2. Fill all fields marked with "*"
3. Save

### 4. Please link to the relevant issues (if any).
[](https://github.com/shopwareBoostDay/platform/issues/187)

### 5. Checklist

- [] I have written tests and verified that they fail without my change
- [] I have squashed any insignificant commits
- [] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [] I have written or adjusted the documentation according to my changes
- [] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
