### PR TITLE
Documentation: Change POST to GET, as POST is not allowed

### DIFF
--- a/src/Docs/Resources/current/45-store-api-guide/40-account.md
+++ b/src/Docs/Resources/current/45-store-api-guide/40-account.md
@@ -149,7 +149,7 @@ Additionally can use the api basic parameters (`filter`,  `aggregations`, etc.) 
 **Note** that you need the `sw-context-token` header for this route, which contains the context token of the login route response.
 
 ```
-POST /store-api/v3/account/customer
+GET /store-api/v3/account/customer
 
 {
     "includes": {


### PR DESCRIPTION
As far as I have noticed, the POST method is not allow on this url. Only GET will work.