### PR TITLE
Fixed typo, backslash used instead of slash

### DIFF
--- a/src/Docs/Resources/current/20-developer-guide/80-core/10-message-queue.md
+++ b/src/Docs/Resources/current/20-developer-guide/80-core/10-message-queue.md
@@ -164,7 +164,7 @@ class MyHandler extends AbstractMessageHandler
 ## Consuming Messages
 
 There is a `console` command to start a worker that will receive incoming messages from your transport and dispatch them.
-Simply start the worker with `bin\console messenger:consume-messages default`, where `default` is the transport you want to consume messages from.
+Simply start the worker with `bin/console messenger:consume-messages default`, where `default` is the transport you want to consume messages from.
 There is also an API-Route that let you consume messages for a given transport. 
 Just post to the route `/api/v3/_action/message-queue/consume` and define the transport from which you want to consume messages as the receiver in the requests body:
 ```json


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?

The example code provided doesn't work because of a typo where "bin\console" was written instead of "bin/console"


### 2. What does this change do, exactly?

Only changes the backslash to a single forward slash.

### 3. Describe each step to reproduce the issue or behaviour.

1. Read the docs
2. See the backslash ;-)

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ X] I have written tests and verified that they fail without my change
- [X ] I have squashed any insignificant commits
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [X ] I have written or adjusted the documentation according to my changes
- [X ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.
