### PR TITLE
Fix sw-plugin-box

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-settings-payment/component/sw-plugin-box/sw-plugin-box.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-payment/component/sw-plugin-box/sw-plugin-box.html.twig
@@ -14,7 +14,7 @@
                         {% block sw_plugin_box_container_plugin_data_description %}
                             <div class="sw-plugin-box__description">
                                 {% block sw_plugin_box_container_plugin_data_description_label %}
-                                    <p class="sw-plugin-box__label">{{ plugin.translation.label }}</p>
+                                    <p class="sw-plugin-box__label">{{ plugin.translated.label }}</p>
                                 {% endblock %}
                                 {% block sw_plugin_box_container_plugin_data_description_author %}
                                     <p class="sw-plugin-box__author">{{ plugin.author }}</p>


### PR DESCRIPTION
### 1. Why is this change necessary?
There is code for a 'plugin box' on the payments settings page for over a year, but it didn't work because of a typo. This PR fixes this typo.

### 2. What does this change do, exactly?
Changes `entity.transations.key` to `entity.translated.key` which is the correct way.

### 3. Describe each step to reproduce the issue or behaviour.
Go to a payment setting page of a plugin. It should look like this:
![Screenshot 2021-01-17 at 11 09 57](https://user-images.githubusercontent.com/3930922/104837417-9ad5ea00-58b4-11eb-9bda-30816a6fb9ef.png)

### 4. Please link to the relevant issues (if any).
/

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

_I have not created a changelog file as this is a really small change._