### PR TITLE
feat: add cc and bcc recipients to event mails

### DIFF
--- a/src/Core/Content/MailTemplate/Subscriber/MailSendSubscriber.php
+++ b/src/Core/Content/MailTemplate/Subscriber/MailSendSubscriber.php
@@ -127,6 +127,8 @@ class MailSendSubscriber implements EventSubscriberInterface
         }
 
         $data->set('recipients', $recipients);
+        $data->set('recipientsCc', $mailEvent->getMailStruct()->getCc());
+        $data->set('recipientsBcc', $mailEvent->getMailStruct()->getBcc());
         $data->set('senderName', $mailTemplate->getTranslation('senderName'));
         $data->set('salesChannelId', $mailEvent->getSalesChannelId());
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
Currently, the properties cc and bcc of MailRecipientStruct do not have any impact.

### 2. What does this change do, exactly?
It adds the cc and bcc recipients stored in the MailRecipientStruct for Business Events by adding it to the data bag in MailSendSubscriber.

### 3. Describe each step to reproduce the issue or behaviour.
---

### 4. Please link to the relevant issues (if any).
---

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.
