### PR TITLE
Correct bundle administration javascript paths

### DIFF
--- a/changelog/_unreleased/2021-01-15-correct-bundle-administration-paths.md
+++ b/changelog/_unreleased/2021-01-15-correct-bundle-administration-paths.md
@@ -1,0 +1,8 @@
+---
+title:              Correct resource path for administration javascript files of bundles 
+issue:              
+author:             Niklas Büchner
+author_email:       niklas.buechner@pickware.de
+---
+# Administration
+*  Corrected the resource path determination for administration javascript files of bundles.

--- a/src/Core/Framework/Api/Controller/InfoController.php
+++ b/src/Core/Framework/Api/Controller/InfoController.php
@@ -193,16 +193,16 @@ class InfoController extends AbstractController
                 continue;
             }
 
-            $bundleName = mb_strtolower($bundle->getName());
+            $bundleDirectoryName = preg_replace('/bundle$/', '', mb_strtolower($bundle->getName()));
 
-            $styles = array_map(static function (string $filename) use ($package, $bundleName) {
-                $url = 'bundles/' . $bundleName . '/' . $filename;
+            $styles = array_map(static function (string $filename) use ($package, $bundleDirectoryName) {
+                $url = 'bundles/' . $bundleDirectoryName . '/' . $filename;
 
                 return $package->getUrl($url);
             }, $this->getAdministrationStyles($bundle));
 
-            $scripts = array_map(static function (string $filename) use ($package, $bundleName) {
-                $url = 'bundles/' . $bundleName . '/' . $filename;
+            $scripts = array_map(static function (string $filename) use ($package, $bundleDirectoryName) {
+                $url = 'bundles/' . $bundleDirectoryName . '/' . $filename;
 
                 return $package->getUrl($url);
             }, $this->getAdministrationScripts($bundle));

--- a/src/Core/Framework/Test/Api/Controller/InfoControllerTest.php
+++ b/src/Core/Framework/Test/Api/Controller/InfoControllerTest.php
@@ -2,11 +2,21 @@
 
 namespace Shopware\Core\Framework\Test\Api\Controller;
 
+use Enqueue\Container\Container;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\Customer\CustomerDefinition;
 use Shopware\Core\Checkout\Order\OrderDefinition;
+use Shopware\Core\Framework\Api\ApiDefinition\DefinitionService;
+use Shopware\Core\Framework\Api\Controller\InfoController;
+use Shopware\Core\Framework\Event\BusinessEventCollector;
+use Shopware\Core\Framework\Event\BusinessEventRegistry;
+use Shopware\Core\Framework\Test\Adapter\Twig\fixtures\BundleFixture;
 use Shopware\Core\Framework\Test\TestCaseBase\AdminFunctionalTestBehaviour;
 use Shopware\Core\Kernel;
+use Shopware\Core\PlatformRequest;
+use Symfony\Component\Asset\Package;
+use Symfony\Component\Asset\Packages;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
 
 class InfoControllerTest extends TestCase
 {
@@ -140,5 +150,51 @@ class InfoControllerTest extends TestCase
             static::assertCount(1, $actualEvents);
             static::assertEquals($event, $actualEvents[0]);
         }
+    }
+
+    public function testBundlePaths(): void
+    {
+        $kernelMock = $this->createMock(Kernel::class);
+        $packagesMock = $this->createMock(Packages::class);
+        $infoController = new InfoController(
+            $this->createMock(DefinitionService::class),
+            new ParameterBag([
+                'kernel.shopware_version' => 'shopware-version',
+                'kernel.shopware_version_revision' => 'shopware-version-revision',
+                'shopware.admin_worker.enable_admin_worker' => 'enable-admin-worker',
+                'shopware.admin_worker.transports' => 'transports',
+            ]),
+            $kernelMock,
+            $packagesMock,
+            $this->createMock(BusinessEventCollector::class),
+            true,
+            []
+        );
+
+        $infoController->setContainer($this->createMock(Container::class));
+
+        $assetPackage = $this->createMock(Package::class);
+        $packagesMock
+            ->expects(static::exactly(1))
+            ->method('getPackage')
+            ->willReturn($assetPackage);
+        $assetPackage
+            ->expects(static::exactly(1))
+            ->method('getUrl')
+            ->willReturnArgument(0);
+
+        $kernelMock
+            ->expects(static::exactly(1))
+            ->method('getBundles')
+            ->willReturn([new BundleFixture('SomeFunctionalityBundle', __DIR__ . '/fixtures/InfoController')]);
+
+        $config = json_decode($infoController->config()->getContent(), true);
+        static::assertArrayHasKey('SomeFunctionalityBundle', $config['bundles']);
+
+        $jsFilePath = explode('?', $config['bundles']['SomeFunctionalityBundle']['js'][0])[0];
+        static::assertEquals(
+            'bundles/somefunctionality/administration/js/some-functionality-bundle.js',
+            $jsFilePath
+        );
     }
 }

--- a/src/Core/Framework/Test/Api/Controller/fixtures/InfoController/Resources/public/administration/js/some-functionality-bundle.js
+++ b/src/Core/Framework/Test/Api/Controller/fixtures/InfoController/Resources/public/administration/js/some-functionality-bundle.js
@@ -1,0 +1,1 @@
+// A javascript file of a bundle


### PR DESCRIPTION
### 1. Why is this change necessary?
The Shopware administration is unable to load a bundle's resources (CSS & JS) if the bundle's name contains `bundle`. This pr adjusts the path determination logic so that these resources can be loaded.

When installing a bundle's (e.g. `MyBundle`) assets, the asset installer copies all public files into a `public/bundles/` directory. It does, however, remove `bundle` from the directory name so that all files are copied to `public/bundles/my` (https://github.com/shopware/platform/blob/master/src/Core/Framework/Plugin/Util/AssetService.php#L79-L84). The administration does not alter the url when trying to load the resources (https://github.com/shopware/platform/blob/master/src/Core/Framework/Api/Controller/InfoController.php#L221-L233). As a result the administration is unable to load these files.


### 2. What does this change do, exactly?
This change adapts the path used to load bundle javascript files.


### 3. Describe each step to reproduce the issue or behaviour.
1. Create a bundle which ends with `bundle`.
2. Add an administration javascript or css resource to the bundle.
3. Install the bundle and reload the administration.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

Depends on https://github.com/shopware/development/pull/145