### PR TITLE
Load administration even if plugin js does not exist

### DIFF
--- a/changelog/_unreleased/2021-01-15-prevent-missing-plugin-file-from-crashing-administration.md
+++ b/changelog/_unreleased/2021-01-15-prevent-missing-plugin-file-from-crashing-administration.md
@@ -1,0 +1,8 @@
+---
+title:              Prevent error in loading plugin administration files from crashing the administration.
+issue:              
+author:             Niklas Büchner
+author_email:       niklas.buechner@pickware.de
+---
+# Administration
+* Changed the plugin loading process to gracefully handle a missing javascript file of a plugin instead of crashing.


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
If a plugin's administration javascript file can't be loaded the whole administration fails to initialize and only shows a white page.

Currently, if a plugin's javascript file fails to load, the administration will fail to initialize since the error is not handled adequately (https://github.com/shopware/platform/blob/master/src/Administration/Resources/app/administration/src/core/application.js#L378-L383). This pr allows the loading of the plugin to fail but ensures that the administration will load.


### 2. What does this change do, exactly?
This change allows the including of administration files of plugins to fail without taking down the whole administration.

Since the build process only uses `core-js` in version 2, I refactored the method to handle the error correctly. With `core-js` >= 3 we could have used `allSettled` here so a version upgrade would be great.

### 3. Describe each step to reproduce the issue or behaviour.
1. Install a plugin with an administration javascript file.
2. Rename the javascript file so that the administration can load it.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
