### PR TITLE
Use display prices setting for shipping and summary in documents

### DIFF
--- a/src/Core/Framework/Resources/views/documents/base.html.twig
+++ b/src/Core/Framework/Resources/views/documents/base.html.twig
@@ -323,14 +323,18 @@
                                             {% block document_line_item_table_shipping_quantity %}
                                                 <td class="align-right">1</td>
                                             {% endblock %}
-                                            {% block document_line_item_table_shipping_tax %}
-                                                <td class="align-right">{% for tax in order.deliveries.first.shippingCosts.calculatedTaxes %}{{ tax.taxRate }}%{% if loop.last %}{% else %}<br>{% endif %}{% endfor %}</td>
-                                            {% endblock %}
-                                            {% block document_line_item_table_unit_price %}
-                                                <td class="align-right">{{ order.shippingTotal|currency(currencyIsoCode) }}</td>
-                                            {% endblock %}
-                                            {% block document_line_item_table_total_price %}
-                                                <td class="align-right">{{ order.shippingTotal|currency(currencyIsoCode) }}</td>
+                                            {% block document_line_item_table_shipping_prices %}
+                                                {% if config.displayPrices %}
+                                                    {% block document_line_item_table_shipping_tax %}
+                                                        <td class="align-right">{% for tax in order.deliveries.first.shippingCosts.calculatedTaxes %}{{ tax.taxRate }}%{% if loop.last %}{% else %}<br>{% endif %}{% endfor %}</td>
+                                                    {% endblock %}
+                                                    {% block document_line_item_table_unit_price %}
+                                                        <td class="align-right">{{ order.shippingTotal|currency(currencyIsoCode) }}</td>
+                                                    {% endblock %}
+                                                    {% block document_line_item_table_total_price %}
+                                                        <td class="align-right">{{ order.shippingTotal|currency(currencyIsoCode) }}</td>
+                                                    {% endblock %}
+                                                {% endif %}
                                             {% endblock %}
                                         </tr>
                                     {% endif %}
@@ -345,62 +349,64 @@
             {% endif %}
 
             {% block document_sum %}
-                <div class="sum-container">
-                    {% block document_sum_table %}
-                        <table class="sum-table">
-                            {% block document_sum_table_inner %}
-                                {% block document_sum_total_net %}
-                                    <tr>
-                                        {% block document_sum_total_net_label %}
-                                            <td class="align-right">{{ 'document.lineItems.totalNet'|trans|sw_sanitize }}</td>
-                                        {% endblock %}
-                                        {% block document_sum_total_net_price %}
-                                            <td class="align-right">{{ order.amountNet|currency(currencyIsoCode) }}</td>
-                                        {% endblock %}
-                                    </tr>
-                                {% endblock %}
-
-                                {% block document_sum_shipping_costs %}
-                                    {% deprecated '@deprecated tag:v6.4.0 The "document_sum_shipping_costs" block is deprecated, use "document_line_item_table_shipping" instead.' %}
-                                    <tr>
-                                        {% block document_sum_shipping_costs_label %}
-                                            <td></td>
-                                            {% deprecated '@deprecated tag:v6.4.0 The "document_sum_shipping_costs_label" block is deprecated, use "document_line_item_table_shipping_label" instead.' %}
-                                        {% endblock %}
-                                        {% block document_sum_shipping_costs_price %}
-                                            <td></td>
-                                            {% deprecated '@deprecated tag:v6.4.0 The "document_sum_shipping_costs_price" block is deprecated, use "document_line_item_table_shipping_price" instead.' %}
-                                        {% endblock %}
-                                    </tr>
-                                {% endblock %}
-
-                                {% block document_sum_taxes %}
-                                    {% for calculatedTax in order.price.calculatedTaxes.sortByTax %}
+                {% if config.displayPrices %}
+                    <div class="sum-container">
+                        {% block document_sum_table %}
+                            <table class="sum-table">
+                                {% block document_sum_table_inner %}
+                                    {% block document_sum_total_net %}
                                         <tr>
-                                            {% block document_sum_tax_label %}
-                                                <td class="align-right">{{ 'document.lineItems.tax'|trans({'%taxRate%': calculatedTax.taxRate})|sw_sanitize }}</td>
+                                            {% block document_sum_total_net_label %}
+                                                <td class="align-right">{{ 'document.lineItems.totalNet'|trans|sw_sanitize }}</td>
                                             {% endblock %}
-                                            {% block document_sum_tax_rate %}
-                                                <td class="align-right">{{ calculatedTax.tax|currency(currencyIsoCode) }}</td>
+                                            {% block document_sum_total_net_price %}
+                                                <td class="align-right">{{ order.amountNet|currency(currencyIsoCode) }}</td>
                                             {% endblock %}
                                         </tr>
-                                    {% endfor %}
-                                {% endblock %}
+                                    {% endblock %}
 
-                                {% block document_sum_total %}
-                                    <tr class="bold">
-                                        {% block document_sum_total_label %}
-                                            <td class="align-right">{{ 'document.lineItems.total'|trans|sw_sanitize }}</td>
-                                        {% endblock %}
-                                        {% block document_sum_total_price %}
-                                            <td class="align-right">{{ order.amountTotal|currency(currencyIsoCode) }}</td>
-                                        {% endblock %}
-                                    </tr>
+                                    {% block document_sum_shipping_costs %}
+                                        {% deprecated '@deprecated tag:v6.4.0 The "document_sum_shipping_costs" block is deprecated, use "document_line_item_table_shipping" instead.' %}
+                                        <tr>
+                                            {% block document_sum_shipping_costs_label %}
+                                                <td></td>
+                                                {% deprecated '@deprecated tag:v6.4.0 The "document_sum_shipping_costs_label" block is deprecated, use "document_line_item_table_shipping_label" instead.' %}
+                                            {% endblock %}
+                                            {% block document_sum_shipping_costs_price %}
+                                                <td></td>
+                                                {% deprecated '@deprecated tag:v6.4.0 The "document_sum_shipping_costs_price" block is deprecated, use "document_line_item_table_shipping_price" instead.' %}
+                                            {% endblock %}
+                                        </tr>
+                                    {% endblock %}
+
+                                    {% block document_sum_taxes %}
+                                        {% for calculatedTax in order.price.calculatedTaxes.sortByTax %}
+                                            <tr>
+                                                {% block document_sum_tax_label %}
+                                                    <td class="align-right">{{ 'document.lineItems.tax'|trans({'%taxRate%': calculatedTax.taxRate})|sw_sanitize }}</td>
+                                                {% endblock %}
+                                                {% block document_sum_tax_rate %}
+                                                    <td class="align-right">{{ calculatedTax.tax|currency(currencyIsoCode) }}</td>
+                                                {% endblock %}
+                                            </tr>
+                                        {% endfor %}
+                                    {% endblock %}
+
+                                    {% block document_sum_total %}
+                                        <tr class="bold">
+                                            {% block document_sum_total_label %}
+                                                <td class="align-right">{{ 'document.lineItems.total'|trans|sw_sanitize }}</td>
+                                            {% endblock %}
+                                            {% block document_sum_total_price %}
+                                                <td class="align-right">{{ order.amountTotal|currency(currencyIsoCode) }}</td>
+                                            {% endblock %}
+                                        </tr>
+                                    {% endblock %}
                                 {% endblock %}
-                            {% endblock %}
-                        </table>
-                    {% endblock %}
-                </div>
+                            </table>
+                        {% endblock %}
+                    </div>
+                {% endif %}
             {% endblock %}
 
             {% block document_payment_shipping %}


### PR DESCRIPTION
### 1. Why is this change necessary?
If you disable the setting "display prices" in the document template the prices and tax details of shipping entries and also the summery are still visible on the document.

### 2. What does this change do, exactly?
Add a check for the displayPrices setting to the shipping entries and the sum block.

### 3. Describe each step to reproduce the issue or behaviour.
Generate a delivery note that contains a shipping position.

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
