### PR TITLE
fix: keep inheritance of language chain during seo url update

### DIFF
--- a/changelog/_unreleased/2021-02-03-keep-inheritance-of-language-chain-during-seo-url-update.md
+++ b/changelog/_unreleased/2021-02-03-keep-inheritance-of-language-chain-during-seo-url-update.md
@@ -2,7 +2,7 @@
 title: Keep inheritance of language chain during SEO url update
 issue: NEXT-13575
 author: Benjamin Nussbaum
-author_email: benjamin.nussbaum@gmail.com 
+author_email: benjamin.nussbaum@moonshiner.at
 author_github: @bnussbau
 ---
 # Core

--- a/changelog/_unreleased/2021-02-03-keep-inheritance-of-language-chain-during-seo-url-update.md
+++ b/changelog/_unreleased/2021-02-03-keep-inheritance-of-language-chain-during-seo-url-update.md
@@ -1,0 +1,12 @@
+---
+title: Keep inheritance of language chain during SEO url update
+issue: NEXT-13575
+author: Benjamin Nussbaum
+author_email: benjamin.nussbaum@gmail.com 
+author_github: @bnussbau
+---
+# Core
+
+* Changed method `getParentLanguageId` in `Core/Content/Seo/SeoUrlUpdater.php` to correct the UUID in result query
+
+___

--- a/src/Core/Content/Seo/SeoUrlUpdater.php
+++ b/src/Core/Content/Seo/SeoUrlUpdater.php
@@ -10,6 +10,7 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepositoryInterface;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\Language\LanguageEntity;
 
 /**
@@ -196,7 +197,7 @@ class SeoUrlUpdater
     {
         // TODO: optimize to one query
         $result = $this->connection
-            ->executeQuery('SELECT LOWER(HEX(parent_id)) FROM language WHERE id = :id', ['id' => $languageId])
+            ->executeQuery('SELECT LOWER(HEX(parent_id)) FROM language WHERE id = :id', ['id' => Uuid::fromHexToBytes($languageId)])
             ->fetchColumn();
 
         return $result ? (string) $result : null;


### PR DESCRIPTION
NOTE: we validated this is a fix. we will update the PR note.


fixes wrong id comparison

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
language inheritance is broken when generating seo urls .
example: german (austria) extends german (germany).
current code falls back to system default language.

### 2. What does this change do, exactly?
fixes wrong uuid comparison

### 3. Describe each step to reproduce the issue or behaviour.
run dal:index:refresh

language interitance is broken when generating seo urls 
example: german (austria) extends german (germany).
current code falls back to system default language.

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
