### PR TITLE
Fix inheritance updater for one-to-many associations

### DIFF
--- a/src/Core/Framework/DataAbstractionLayer/Indexing/InheritanceUpdater.php
+++ b/src/Core/Framework/DataAbstractionLayer/Indexing/InheritanceUpdater.php
@@ -100,6 +100,11 @@ class InheritanceUpdater
                 '#property#' => EntityDefinitionQueryHelper::escape($association->getPropertyName()),
                 '#reference#' => EntityDefinitionQueryHelper::escape($reference->getEntityName()),
             ];
+            
+            if ($association instanceof OneToManyAssociationField) {
+                $parameters['#entity_id#'] = EntityDefinitionQueryHelper::escape($association->getReferenceField());
+                $parameters['#property#'] = EntityDefinitionQueryHelper::escape($association->getLocalField());
+            }
 
             $params = ['ids' => $bytes];
 


### PR DESCRIPTION
### 1. Why is this change necessary?

The constructor of a `OneToManyAssociationField` allows for a `referenceField` and `localField`. This creates the impression that extension providers can actually _choose_ how the want to reference an entity. With my change those choices are respected in the `InheritanceUpdater` as well.

### 2. What does this change do, exactly?

If the association is a `OneToManyAssociationField`, its respective `referenceField` and `localField` are used for the join.

### 3. Describe each step to reproduce the issue or behaviour.

1. Make a product extension.
2. Add a new `OneToManyAssociationField` with an `Inherited` flag.
3. Link the extension by product number instead of product id.

```php
$collection->add(
    (new OneToManyAssociationField(
        'productSku',
        MyExtensionDefinition::class,
        'sku',
        'product_number'
    ))->addFlags(new Inherited())
);
```

Now try and update a product. The InheritanceUpdater will assume that the product table has a column called `productSku` and that your custom extension table has a column called `product_id`.

### 4. Please link to the relevant issues (if any).
None.

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
