### PR TITLE
fix min-height of bubble cms blocks

### DIFF
--- a/changelog/_unreleased/2021-01-23-fix-min-height-of-bubble-cms-blocks.md
+++ b/changelog/_unreleased/2021-01-23-fix-min-height-of-bubble-cms-blocks.md
@@ -1,0 +1,9 @@
+---
+title: Fix min-height of bubble CMS blocks
+issue: NEXT-13524
+author: Marius Faber
+author_email: mariusfaber98@gmail.com 
+author_github: @marius-faber
+---
+# Storefront
+*  Changed min-height of all bubble CMS blocks to 300px

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/image/image-bubble-row/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/image/image-bubble-row/index.js
@@ -19,7 +19,8 @@ Shopware.Service('cmsService').registerCmsBlock({
             type: 'image',
             default: {
                 config: {
-                    displayMode: { source: 'static', value: 'cover' }
+                    displayMode: { source: 'static', value: 'cover' },
+                    minHeight: { source: 'static', value: '300px' }
                 },
                 data: {
                     media: {
@@ -32,7 +33,8 @@ Shopware.Service('cmsService').registerCmsBlock({
             type: 'image',
             default: {
                 config: {
-                    displayMode: { source: 'static', value: 'cover' }
+                    displayMode: { source: 'static', value: 'cover' },
+                    minHeight: { source: 'static', value: '300px' }
                 },
                 data: {
                     media: {
@@ -45,7 +47,8 @@ Shopware.Service('cmsService').registerCmsBlock({
             type: 'image',
             default: {
                 config: {
-                    displayMode: { source: 'static', value: 'cover' }
+                    displayMode: { source: 'static', value: 'cover' },
+                    minHeight: { source: 'static', value: '300px' }
                 },
                 data: {
                     media: {

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/text-image/image-text-bubble/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/text-image/image-text-bubble/index.js
@@ -19,7 +19,8 @@ Shopware.Service('cmsService').registerCmsBlock({
             type: 'image',
             default: {
                 config: {
-                    displayMode: { source: 'static', value: 'cover' }
+                    displayMode: { source: 'static', value: 'cover' },
+                    minHeight: { source: 'static', value: '300px' }
                 },
                 data: {
                     media: {
@@ -36,8 +37,8 @@ Shopware.Service('cmsService').registerCmsBlock({
                         source: 'static',
                         value: `
                         <h2 style="text-align: center;">Lorem Ipsum dolor</h2>
-                        <p style="text-align: center;">Lorem ipsum dolor sit amet, consetetur sadipscing elitr, 
-                        sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, 
+                        <p style="text-align: center;">Lorem ipsum dolor sit amet, consetetur sadipscing elitr,
+                        sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat,
                         sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum.</p>
                         `.trim()
                     }
@@ -48,7 +49,8 @@ Shopware.Service('cmsService').registerCmsBlock({
             type: 'image',
             default: {
                 config: {
-                    displayMode: { source: 'static', value: 'cover' }
+                    displayMode: { source: 'static', value: 'cover' },
+                    minHeight: { source: 'static', value: '300px' }
                 },
                 data: {
                     media: {
@@ -65,8 +67,8 @@ Shopware.Service('cmsService').registerCmsBlock({
                         source: 'static',
                         value: `
                         <h2 style="text-align: center;">Lorem Ipsum dolor</h2>
-                        <p style="text-align: center;">Lorem ipsum dolor sit amet, consetetur sadipscing elitr, 
-                        sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, 
+                        <p style="text-align: center;">Lorem ipsum dolor sit amet, consetetur sadipscing elitr,
+                        sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat,
                         sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum.</p>
                         `.trim()
                     }
@@ -77,7 +79,8 @@ Shopware.Service('cmsService').registerCmsBlock({
             type: 'image',
             default: {
                 config: {
-                    displayMode: { source: 'static', value: 'cover' }
+                    displayMode: { source: 'static', value: 'cover' },
+                    minHeight: { source: 'static', value: '300px' }
                 },
                 data: {
                     media: {
@@ -94,8 +97,8 @@ Shopware.Service('cmsService').registerCmsBlock({
                         source: 'static',
                         value: `
                         <h2 style="text-align: center;">Lorem Ipsum dolor</h2>
-                        <p style="text-align: center;">Lorem ipsum dolor sit amet, consetetur sadipscing elitr, 
-                        sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, 
+                        <p style="text-align: center;">Lorem ipsum dolor sit amet, consetetur sadipscing elitr,
+                        sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat,
                         sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum.</p>
                         `.trim()
                     }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
The bubble CMS blocks are currently oval because they use the default 340px min-height. That should probably be changed to 300px to make the bubbles by default round.

### 2. What does this change do, exactly?
It changes the default min-height to 300px for all bubble CMS blocks.

### 3. Describe each step to reproduce the issue or behaviour.
Create an image bubble row or image text bubble CMS block.

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
