### PR TITLE
Prevent unfiltered media search

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-settings-payment/page/sw-settings-payment-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-payment/page/sw-settings-payment-detail/index.js
@@ -196,6 +196,9 @@ Component.register('sw-settings-payment-detail', {
         },
 
         setMediaItem({ targetId }) {
+            if (!targetId) {
+                return;
+            }
             this.mediaRepository.get(targetId)
                 .then((updatedMedia) => {
                     this.mediaItem = updatedMedia;


### PR DESCRIPTION
The setMediaItem method is vulnerable to trigger an unfiltered media search, resulting in an application failure, because of a timeout (thousands of results could not be retrieved in time) or a blocking issue (the huge json response needs to be parsed, which is a blocking operation).

Unfortunately this vulnerability is already causing problems:

```js
this.paymentMethodRepository.get(this.paymentMethodId)
                .then((paymentMethod) => {
                    this.paymentMethod = paymentMethod;
                    this.setMediaItem({ targetId: this.paymentMethod.mediaId });
                })
                .finally(() => {
                    this.isLoading = false;
});
```
Here, if a payment method does not have a mediaId assigned to it, it causes all media items to be loaded.

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?


### 2. What does this change do, exactly?


### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.
