### PR TITLE
Fix category.cmsPage.locked error

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-category/page/sw-category-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-category/page/sw-category-detail/index.js
@@ -636,7 +636,7 @@ Component.register('sw-category-detail', {
         },
 
         saveSlotConfig() {
-            if (this.category.cmsPage.locked || Object.values(this.category.slotConfig).length < 1) {
+            if ((this.category.cmsPage && this.category.cmsPage.locked) || Object.values(this.category.slotConfig).length < 1) {
                 return Promise.resolve();
             }
 


### PR DESCRIPTION
With Shopware 6.4.5.0 a new bug was introduced that can cause the application to fail, while saving category detail pages. 
If a category has no cmsPage assigned to it, the check if that cmsPage is locked or not will cause a javascript error and results in the user waiting for the saving process to finish. We therefore need to check if the category has an cmsPage assigned to it first.

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?


### 2. What does this change do, exactly?


### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.
