### PR TITLE
Use timezone group including backwards compatible for validation

### DIFF
--- a/src/Core/Framework/DataAbstractionLayer/Search/Aggregation/Bucket/DateHistogramAggregation.php
+++ b/src/Core/Framework/DataAbstractionLayer/Search/Aggregation/Bucket/DateHistogramAggregation.php
@@ -48,7 +48,7 @@ class DateHistogramAggregation extends BucketAggregation
             throw new \RuntimeException('Provided date histogram interval is not supported');
         }
 
-        if (\is_string($timeZone) && !\in_array($timeZone, \DateTimeZone::listIdentifiers(), true)) {
+        if (\is_string($timeZone) && !\in_array($timeZone, \DateTimeZone::listIdentifiers(\DateTimeZone::ALL_WITH_BC), true)) {
             throw new \InvalidArgumentException(\sprintf('Given "%s" is not a valid timezone', $timeZone));
         }
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?

Symfony's `Intl` component uses some time zone names that have become obsolete e.g. `Asia/Saigon` or have a different spelling e.g. `Asia/Katmandu` but are still valid as aliases for `Asia/Ho_Chi_Minh` or `Asia/Kathmandu` respectively. However these aliases are not included in the returned array of `\DateTimeZone::listIdentifiers` by default. Thus an exception is thrown in the current state, claiming `Asia/Saigon` would not be a valid time zone, when it actually is.

### 2. What does this change do, exactly?

Simply provide a specific timezone group calling `\DateTimeZone::listIdentifiers(\DateTimeZone::ALL_WITH_BC)` which will then return an array that includes backward compatible aliases as well. That also includes multiple possible spellings of places (`Katmandu` vs `Kathmandu`)

### 3. Describe each step to reproduce the issue or behaviour.

Try to use `Asia/Saigon` as a time zone for `DateHistogramAggregation`

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
