### PR TITLE
NEXT-10187 - Build product detail breadcrumb by referer

### DIFF
--- a/changelog/_unreleased/2023-12-19-build-product-detail-breadcrumb-by-referer.md
+++ b/changelog/_unreleased/2023-12-19-build-product-detail-breadcrumb-by-referer.md
@@ -1,0 +1,12 @@
+---
+title: Build product detail breadcrumb by referer
+issue: NEXT-10187
+author: Elias Lackner
+author_email: lackner.elias@gmail.com
+author_github: @lacknere
+---
+# Core
+* Added `getCategoryByReferer` and `getCategoryByPath` methods to `CategoryBreadcrumbBuilder`.
+* Added optional `$request` parameter to `getProductSeoCategory` method of `CategoryBreadcrumbBuilder`.
+* Changed `getProductSeoCategory` method of `CategoryBreadcrumbBuilder` to consider last visited category by using `getCategoryByReferer` method.
+* Added `$request` parameter to `getProductSeoCategory` method call in `load` method of `ProductDetailRoute`.

--- a/src/Core/Content/DependencyInjection/category.xml
+++ b/src/Core/Content/DependencyInjection/category.xml
@@ -87,6 +87,8 @@
 
         <service id="Shopware\Core\Content\Category\Service\CategoryBreadcrumbBuilder">
             <argument type="service" id="category.repository"/>
+            <argument type="service" id="Shopware\Storefront\Framework\Routing\Router"/>
+            <argument type="service" id="Shopware\Core\Content\Seo\SeoResolver"/>
         </service>
 
         <service id="Shopware\Core\Content\Category\Service\CategoryUrlGenerator">

--- a/src/Core/Content/Product/SalesChannel/Detail/ProductDetailRoute.php
+++ b/src/Core/Content/Product/SalesChannel/Detail/ProductDetailRoute.php
@@ -70,7 +70,7 @@ class ProductDetailRoute extends AbstractProductDetailRoute
             }
 
             $product->setSeoCategory(
-                $this->breadcrumbBuilder->getProductSeoCategory($product, $context)
+                $this->breadcrumbBuilder->getProductSeoCategory($product, $context, $request)
             );
 
             $configurator = $this->configuratorLoader->load($product, $context);

--- a/tests/unit/Core/Content/Category/Service/CategoryBreadcrumbBuilderTest.php
+++ b/tests/unit/Core/Content/Category/Service/CategoryBreadcrumbBuilderTest.php
@@ -3,6 +3,7 @@
 namespace Shopware\Tests\Unit\Core\Content\Category\Service;
 
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\Cart\Delivery\Struct\ShippingLocation;
 use Shopware\Core\Checkout\Customer\Aggregate\CustomerGroup\CustomerGroupEntity;
@@ -13,6 +14,7 @@ use Shopware\Core\Content\Category\CategoryCollection;
 use Shopware\Core\Content\Category\CategoryEntity;
 use Shopware\Core\Content\Category\Service\CategoryBreadcrumbBuilder;
 use Shopware\Core\Content\Product\ProductEntity;
+use Shopware\Core\Content\Seo\AbstractSeoResolver;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Pricing\CashRoundingConfig;
@@ -24,6 +26,7 @@ use Shopware\Core\System\Currency\CurrencyEntity;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\System\SalesChannel\SalesChannelEntity;
 use Shopware\Core\System\Tax\TaxCollection;
+use Symfony\Component\Routing\RouterInterface;
 
 /**
  * @internal
@@ -35,10 +38,16 @@ class CategoryBreadcrumbBuilderTest extends TestCase
 {
     protected SalesChannelContext $context;
 
+    protected MockObject&RouterInterface $router;
+
+    protected MockObject&AbstractSeoResolver $seoResolver;
+
     protected function setUp(): void
     {
         parent::setUp();
         $this->context = $this->getSalesChannelContext();
+        $this->router = $this->createMock(RouterInterface::class);
+        $this->seoResolver = $this->createMock(AbstractSeoResolver::class);
     }
 
     public function testGetProductSeoCategoryShouldReturnMainCategory(): void
@@ -50,7 +59,7 @@ class CategoryBreadcrumbBuilderTest extends TestCase
         $categoryEntity->setId($categoryIds[0]);
         $categoryEntity->setName('category-name-1');
 
-        $categoryBreadcrumbBuilder = new CategoryBreadcrumbBuilder($this->getCategoryRepositoryMock([$categoryEntity], [$categoryEntity]));
+        $categoryBreadcrumbBuilder = new CategoryBreadcrumbBuilder($this->getCategoryRepositoryMock([$categoryEntity], [$categoryEntity]), $this->router, $this->seoResolver);
         $product = $this->getProductEntity($streamIds, $categoryIds);
         $categoryEntity = $categoryBreadcrumbBuilder->getProductSeoCategory($product, $this->context);
 
@@ -66,7 +75,7 @@ class CategoryBreadcrumbBuilderTest extends TestCase
         $categoryEntity->setId('');
         $categoryEntity->setName('category-name-1');
 
-        $categoryBreadcrumbBuilder = new CategoryBreadcrumbBuilder($this->getCategoryRepositoryMock([$categoryEntity], [$categoryEntity]));
+        $categoryBreadcrumbBuilder = new CategoryBreadcrumbBuilder($this->getCategoryRepositoryMock([$categoryEntity], [$categoryEntity]), $this->router, $this->seoResolver);
         $product = $this->getProductEntity($streamIds, $categoryIds);
         $categoryEntity = $categoryBreadcrumbBuilder->getProductSeoCategory($product, $this->context);
 
@@ -78,7 +87,7 @@ class CategoryBreadcrumbBuilderTest extends TestCase
         $categoryIds = [Uuid::randomHex()];
         $streamIds = [Uuid::randomHex()];
 
-        $categoryBreadcrumbBuilder = new CategoryBreadcrumbBuilder($this->getCategoryRepositoryMock([], []));
+        $categoryBreadcrumbBuilder = new CategoryBreadcrumbBuilder($this->getCategoryRepositoryMock([], []), $this->router, $this->seoResolver);
         $product = $this->getProductEntity($streamIds, $categoryIds);
         $categoryEntity = $categoryBreadcrumbBuilder->getProductSeoCategory($product, $this->context);
 
@@ -94,7 +103,7 @@ class CategoryBreadcrumbBuilderTest extends TestCase
         $categoryEntity->setId($categoryIds[0]);
         $categoryEntity->setName('category-name-1');
 
-        $categoryBreadcrumbBuilder = new CategoryBreadcrumbBuilder($this->getCategoryRepositoryMock([], [$categoryEntity]));
+        $categoryBreadcrumbBuilder = new CategoryBreadcrumbBuilder($this->getCategoryRepositoryMock([], [$categoryEntity]), $this->router, $this->seoResolver);
         $product = $this->getProductEntity($streamIds, $categoryIds);
         $categoryEntity = $categoryBreadcrumbBuilder->getProductSeoCategory($product, $this->context);
 
@@ -110,7 +119,7 @@ class CategoryBreadcrumbBuilderTest extends TestCase
         $categoryEntity->setId($categoryIds[0]);
         $categoryEntity->setName('category-name-1');
 
-        $categoryBreadcrumbBuilder = new CategoryBreadcrumbBuilder($this->getCategoryRepositoryMock([], [$categoryEntity]));
+        $categoryBreadcrumbBuilder = new CategoryBreadcrumbBuilder($this->getCategoryRepositoryMock([], [$categoryEntity]), $this->router, $this->seoResolver);
         $product = $this->getProductEntity($streamIds, []);
         $categoryEntity = $categoryBreadcrumbBuilder->getProductSeoCategory($product, $this->context);
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

Currently, when navigating to a product page, the last visited category is not taken into account while building the breadcrumb.

### 2. What does this change do, exactly?

Changed `CategoryBreadcrumbBuilder` to load the product breadcrumb category by referer.

### 3. Describe each step to reproduce the issue or behaviour.

1. Create two categories and one product.
2. Assign the product to both categories.
3. Navigate to the product page via category 1 > category 1 is used for the breadcrumb.
4. Navigate to the product page via category 2 > still, category 1 is used for the breadcrumb.

### 4. Please link to the relevant issues (if any).

[NEXT-10187](https://issues.shopware.com/issues/NEXT-10187)
[NEXT-22107](https://issues.shopware.com/issues/NEXT-22107)

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

copilot:summary

copilot:walkthrough


[NEXT-10187]: https://shopware.atlassian.net/browse/NEXT-10187?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ