### PR TITLE
fix: update offcanvas.plugin.js to support aria-labelledby

### DIFF
--- a/changelog/_unreleased/2025-03-05-add-new-data-id-to-set-off-canvas-aria-labelledby.md
+++ b/changelog/_unreleased/2025-03-05-add-new-data-id-to-set-off-canvas-aria-labelledby.md
@@ -1,0 +1,12 @@
+---
+title: Add new data id to set off-canvas aria-labelledby
+issue: NEXT-40818
+author: Björn Meyer
+author_email: b.meyer@shopware.com
+author_github: @BrocksiNet
+---
+# Storefront
+* Changed `offcanvas.plugin.js` it will search for `data-id="off-canvas-headline"` in the content and if found it will set the `aria-labelledby` attribute to the OffCanvas.
+* Added `data-id="off-canvas-headline"` to the `h2` element in the `filter-panel.html.twig` template.
+* Added `data-id="off-canvas-headline"` to the `h4` element in the `offcanvas-cart.html.twig` template.
+* Added `data-id="off-canvas-headline"` to the `div` element in the `general-headline.html.twig` template.

--- a/src/Storefront/Resources/app/storefront/src/plugin/offcanvas-filter/offcanvas-filter.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/offcanvas-filter/offcanvas-filter.plugin.js
@@ -53,10 +53,8 @@ export default class OffCanvasFilter extends Plugin {
             'offcanvas-filter'
         );
 
-        const filterPanel = filterContent.querySelector('.filter-panel');
-
-        // move filter from original place to offcanvas
-        filterPanel.remove();
+        // remove filter content from original place
+        filterContent.innerHTML = '';
 
         window.PluginManager.getPluginInstances('Listing')[0].refreshRegistry();
         document.$emitter.subscribe('onCloseOffcanvas', this._onCloseOffCanvas.bind(this));

--- a/src/Storefront/Resources/app/storefront/src/plugin/offcanvas/offcanvas.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/offcanvas/offcanvas.plugin.js
@@ -51,11 +51,11 @@ class OffCanvasSingleton {
 
         // register events again
         this._registerEvents(delay);
+        this._setAriaAttrs();
     }
 
     /**
-     * adds an additional class to the offcanvas
-     *
+     * Methode to add additional class to the first OffCanvas
      * @param {string} className
      */
     setAdditionalClassName(className) {
@@ -158,6 +158,17 @@ class OffCanvasSingleton {
         window.addEventListener('popstate', this.close.bind(this, delay), { once: true });
         const closeTriggers = document.querySelectorAll(`.${OFF_CANVAS_CLOSE_TRIGGER_CLASS}`);
         closeTriggers.forEach(trigger => trigger.addEventListener(event, this.close.bind(this, delay)));
+    }
+
+    _setAriaAttrs() {
+        const offCanvas = this.getOffCanvas()[0];
+        const headlineId = 'off-canvas-headline';
+        const headline = offCanvas.querySelector(`[data-id="${headlineId}"]`);
+
+        if (headline && !offCanvas.hasAttribute('aria-labelledby')) {
+            headline.setAttribute('id', headlineId);
+            offCanvas.setAttribute('aria-labelledby', headlineId);
+        }
     }
 
     /**

--- a/src/Storefront/Resources/app/storefront/src/plugin/offcanvas/offcanvas.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/offcanvas/offcanvas.plugin.js
@@ -55,7 +55,7 @@ class OffCanvasSingleton {
     }
 
     /**
-     * Methode to add additional class to the first OffCanvas
+     * Method to add additional class to the first OffCanvas
      * @param {string} className
      */
     setAdditionalClassName(className) {

--- a/src/Storefront/Resources/app/storefront/test/plugin/offcanvas/offcanvas.plugin.test.js
+++ b/src/Storefront/Resources/app/storefront/test/plugin/offcanvas/offcanvas.plugin.test.js
@@ -227,6 +227,26 @@ describe('OffCanvas tests', () => {
         }).toThrowError('The type "object" is not supported. Please pass an array or a string.');
     });
 
+    it('should add aria-labelledby attribute to the OffCanvas', () => {
+        jest.useFakeTimers();
+
+        OffCanvas.open(
+            '<div class="offcanvas-body">Lorem ipsum<div data-id="off-canvas-headline">Nice headline</div></div>',
+            () => {},
+            'right',
+            true,
+            100,
+            true,
+            'custom-class',
+        );
+        jest.runAllTimers();
+
+        const offCanvasElement = document.querySelector('.offcanvas');
+
+        // Should have aria-labelledby attribute on OffCanvas element
+        expect(offCanvasElement.getAttribute('aria-labelledby')).toBe('off-canvas-headline');
+    });
+
     const offCanvasPositions = [
         {  passedPosition: 'start', expectedPositionClass: 'offcanvas-start' },
         {  passedPosition: 'end', expectedPositionClass: 'offcanvas-end' },

--- a/src/Storefront/Resources/views/storefront/component/checkout/offcanvas-cart.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/checkout/offcanvas-cart.html.twig
@@ -23,7 +23,9 @@
                 <div class="row align-items-center offcanvas-cart-header">
 
                     <div class="col">
-                        <h4>{{- 'checkout.cartHeader'|trans|sw_sanitize -}}</h4>
+                        <h4 data-id="off-canvas-headline">
+                            {{- 'checkout.cartHeader'|trans|sw_sanitize -}}
+                        </h4>
                     </div>
 
                     {% set checkoutItemCounter = page.cart.lineItems|length %}

--- a/src/Storefront/Resources/views/storefront/component/listing/filter-panel.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/listing/filter-panel.html.twig
@@ -1,7 +1,9 @@
 {% block component_filter_panel %}
     {% block component_filter_panel_header %}
         <div class="filter-panel-offcanvas-header">
-            <h2 class="filter-panel-offcanvas-only filter-panel-offcanvas-title">{{ "listing.filterTitleText"|trans }}</h2>
+            <h2 data-id="off-canvas-headline" class="filter-panel-offcanvas-only filter-panel-offcanvas-title">
+                {{ "listing.filterTitleText"|trans }}
+            </h2>
 
             <button type="button" class="btn-close filter-panel-offcanvas-only filter-panel-offcanvas-close js-offcanvas-close" aria-label="{{ 'listing.filterClose'|trans|striptags }}">
             </button>

--- a/src/Storefront/Resources/views/storefront/layout/navigation/offcanvas/general-headline.html.twig
+++ b/src/Storefront/Resources/views/storefront/layout/navigation/offcanvas/general-headline.html.twig
@@ -1,5 +1,5 @@
 {% block layout_navigation_offcanvas_navigation_categories_headline %}
-    <div class="navigation-offcanvas-headline">
+    <div data-id="off-canvas-headline" class="navigation-offcanvas-headline">
         {% block layout_navigation_offcanvas_navigation_categories_headline_text %}
             {{ 'general.categories'|trans|sw_sanitize }}
         {% endblock %}


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
The filter panel, cart, and category menu in OffCanvas (mobile) currently lack an `aria-labelledby`.

### 2. What does this change do, exactly?
- Adds `data-id="off-canvas-headline"` to the Twig templates
- Updates the offcanvas js plugins and search for the data-id

### 3. Describe each step to reproduce the issue or behaviour.
- Check the DOM structure for the different OffCanvas and search for the `aria-labelledby`

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

In case of issue existing only on Jira, link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->
- closes #7051
- Jira issue: https://shopware.atlassian.net/browse/NEXT-40818

### 5. Checklist

- [X] I have written tests and verified that they fail without my change
- [X] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfill them.
