### PR TITLE
chore: Adjust navigation test to not test offcanvas.

### DIFF
--- a/tests/acceptance/tests/Categories/NavigateThroughStorefrontMenu.spec.ts
+++ b/tests/acceptance/tests/Categories/NavigateThroughStorefrontMenu.spec.ts
@@ -20,7 +20,6 @@ test(
 
             await ShopCustomer.goesTo(StorefrontHome.url());
             await ShopCustomer.expects(mainCategoryLocators.menuNavigationItem).toHaveText(category1.name);
-            await ShopCustomer.expects(mainCategoryLocators.offcanvasNavigationItem).toHaveText(category1.name);
 
             await mainCategoryLocators.menuNavigationItem.hover();
             await ShopCustomer.expects(mainCategoryLocators.flyoutCategoryLink).not.toBeVisible();
@@ -42,7 +41,6 @@ test(
             await ShopCustomer.goesTo(StorefrontHome.url());
 
             await ShopCustomer.expects(mainCategoryLocators.menuNavigationItem).toHaveText(category2.name);
-            await ShopCustomer.expects(mainCategoryLocators.offcanvasNavigationItem).toHaveText(category2.name);
 
             await mainCategoryLocators.menuNavigationItem.hover();
             await ShopCustomer.expects(mainCategoryLocators.flyoutCategoryLink).toBeVisible();
@@ -64,7 +62,6 @@ test(
             await ShopCustomer.goesTo(StorefrontHome.url());
 
             await ShopCustomer.expects(mainCategoryLocators.menuNavigationItem).toHaveText(category3.name);
-            await ShopCustomer.expects(mainCategoryLocators.offcanvasNavigationItem).toHaveText(category3.name);
 
             await mainCategoryLocators.menuNavigationItem.hover();
             await ShopCustomer.expects(mainCategoryLocators.flyoutCategoryLink).not.toBeVisible();


### PR DESCRIPTION
This is a forward port of the changes in https://github.com/shopware/shopware/pull/7382

The test is still skipped because of other issues with the main navigation, which are already addressed in a separate issue.

