### PR TITLE
fix(storefront-nav): Hide arrow when no children available, improve accessibility

### DIFF
--- a/src/Storefront/Resources/app/storefront/src/scss/skin/shopware/layout/_main-navigation.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/skin/shopware/layout/_main-navigation.scss
@@ -3,33 +3,24 @@ Main navigation
 ==============================================
 Custom styling for main navigation on larger screens.
 
+Active styling is handled by views/storefront/layout/navigation/active-styling.html.twig
+
 Based on bootstrap nav:
 https://getbootstrap.com/docs/5.2/components/navs-tabs
 */
 
 @include media-breakpoint-up(md) {
-    .main-navigation-link {
-        color: $body-color;
-        padding-left: 0;
-        padding-right: 32px;
+    .main-navigation-menu {
+        --#{$prefix}navbar-color: #{$body-color};
+        --#{$prefix}navbar-nav-link-padding-x: 0;
 
-        .main-navigation-link-text {
-            border-bottom: 2px solid transparent;
-            padding-bottom: 3px;
+        .nav-item:not(:last-child) {
+            padding-right: 1rem;
         }
+    }
 
-        &:hover,
-        &.is-open {
-            color: $primary;
-        }
-
-        &.active {
-            color: $gray-800;
-            font-weight: $font-weight-bold;
-
-            .main-navigation-link-text {
-                border-color: $primary;
-            }
-        }
+    .main-navigation-link-text {
+        border-bottom: 2px solid transparent;
+        padding-bottom: 3px;
     }
 }

--- a/src/Storefront/Resources/views/storefront/layout/navbar/navbar.html.twig
+++ b/src/Storefront/Resources/views/storefront/layout/navbar/navbar.html.twig
@@ -4,69 +4,68 @@
              id="main-navigation-menu"
              itemscope="itemscope"
              itemtype="https://schema.org/SiteNavigationElement"
-             data-navbar="true">
-            <div class="">
-                <div class="collapse navbar-collapse" id="main_nav">
-                    <ul class="navbar-nav d-flex flex-wrap">
-                        {% set homeLabel = context.salesChannel.translated.homeName|default('general.homeLink'|trans) %}
+             data-navbar="true"
+             aria-label="{{ 'header.navigationAriaLabel'|trans|striptags }}">
+            <div class="collapse navbar-collapse" id="main_nav">
+                <ul class="navbar-nav main-navigation-menu-list flex-wrap">
+                    {% set homeLabel = context.salesChannel.translated.homeName|default('general.homeLink'|trans) %}
 
-                        {% block layout_navbar_menu_home %}
-                            {% if context.salesChannel.translated.homeEnabled %}
-                                <li class="nav-item nav-item-{{ context.salesChannel.navigationCategoryId }}">
-                                    <a class="nav-link main-navigation-link home-link root nav-item-{{ context.salesChannel.navigationCategoryId }}-link"
-                                       href="{{ path('frontend.home.page') }}"
-                                       itemprop="url"
-                                       title="{{ homeLabel|striptags }}">
-                                        <span itemprop="name" class="main-navigation-link-text">{{ homeLabel|sw_sanitize }}</span>
-                                    </a>
-                                </li>
-                            {% endif %}
-                        {% endblock %}
+                    {% block layout_navbar_menu_home %}
+                        {% if context.salesChannel.translated.homeEnabled %}
+                            <li class="nav-item nav-item-{{ context.salesChannel.navigationCategoryId }}">
+                                <a class="nav-link main-navigation-link home-link root nav-item-{{ context.salesChannel.navigationCategoryId }}-link"
+                                   href="{{ path('frontend.home.page') }}"
+                                   itemprop="url"
+                                   title="{{ homeLabel|striptags }}">
+                                    <span itemprop="name" class="main-navigation-link-text">{{ homeLabel|sw_sanitize }}</span>
+                                </a>
+                            </li>
+                        {% endif %}
+                    {% endblock %}
 
-                        {% block layout_navbar_menu_items %}
+                    {% block layout_navbar_menu_items %}
 
-                            {% for treeItem in header.navigation.tree %}
-                                {% set category = treeItem.category %}
-                                {% set id = category.id %}
-                                {% set name = category.translated.name %}
-                                {% set hasChildren = treeItem.children|length > 0 %}
+                        {% for treeItem in header.navigation.tree %}
+                            {% set category = treeItem.category %}
+                            {% set id = category.id %}
+                            {% set name = category.translated.name %}
+                            {% set hasChildren = treeItem.children|length > 0 %}
 
-                                {% block layout_navbar_menu_item %}
-                                    {% if category.type == 'folder' %}
-                                        <li class="nav-item main-navigation-link nav-item-{{ id }} nav-link root nav-item-{{ id }}-link"
-                                            {% if hasChildren %}
-                                                data-flyout-menu-trigger="{{ id }}"
-                                            {% endif %}
-                                            title="{{ name }}">
+                            {% block layout_navbar_menu_item %}
+                                {% if category.type == 'folder' %}
+                                    <li class="nav-item main-navigation-link nav-item-{{ id }} nav-link root nav-item-{{ id }}-link"
+                                        {% if hasChildren %}
+                                            data-flyout-menu-trigger="{{ id }}"
+                                        {% endif %}
+                                        title="{{ name }}">
+                                        <span itemprop="name" class="main-navigation-link-text">{{ name }}</span>
+                                    </li>
+                                {% else %}
+                                    <li class="nav-item nav-item-{{ id }} {% if hasChildren %}dropdown position-static{% endif %}">
+                                        <a class="nav-link nav-item-{{ id }}-link root main-navigation-link p-2{% if hasChildren %} dropdown-toggle{% endif %}"
+                                           href="{{ category_url(category) }}"
+                                           {% if hasChildren %}data-bs-toggle="dropdown"{% endif %}
+                                           {% if category_linknewtab(category) %}target="_blank"{% endif %}
+                                           itemprop="url"
+                                           title="{{ name }}">
                                             <span itemprop="name" class="main-navigation-link-text">{{ name }}</span>
-                                        </li>
-                                    {% else %}
-                                        <li class="nav-item nav-item-{{ id }} {% if hasChildren %}dropdown position-static pe-2{% endif %}">
-                                            <a class="nav-link nav-item-{{ id }}-link root dropdown-toggle main-navigation-link p-2"
-                                               href="{{ category_url(category) }}"
-                                               data-bs-toggle="dropdown"
-                                               itemprop="url"
-                                               {% if category_linknewtab(category) %}target="_blank"{% endif %}
-                                               title="{{ name }}">
-                                                <span itemprop="name" class="main-navigation-link-text">{{ name }}</span>
-                                            </a>
-                                            {% if hasChildren %}
-                                                <div class="dropdown-menu w-100 p-4" role="menu">
-                                                    {% sw_include '@Storefront/storefront/layout/navbar/content.html.twig' with {
-                                                        themeIconConfig: themeIconConfig,
-                                                        navigationTree: treeItem,
-                                                        level: level+1,
-                                                        page: page
-                                                    } only %}
-                                                </div>
-                                            {% endif %}
-                                        </li>
-                                    {% endif %}
-                                {% endblock %}
-                            {% endfor %}
-                        {% endblock %}
-                    </ul>
-                </div>
+                                        </a>
+                                        {% if hasChildren %}
+                                            <div class="dropdown-menu w-100 p-4">
+                                                {% sw_include '@Storefront/storefront/layout/navbar/content.html.twig' with {
+                                                    themeIconConfig: themeIconConfig,
+                                                    navigationTree: treeItem,
+                                                    level: level+1,
+                                                    page: page
+                                                } only %}
+                                            </div>
+                                        {% endif %}
+                                    </li>
+                                {% endif %}
+                            {% endblock %}
+                        {% endfor %}
+                    {% endblock %}
+                </ul>
             </div>
         </nav>
     </div>

--- a/src/Storefront/Resources/views/storefront/layout/navigation/active-styling.html.twig
+++ b/src/Storefront/Resources/views/storefront/layout/navigation/active-styling.html.twig
@@ -11,7 +11,7 @@
         }
 
         .nav-item-{{ id }}-link.root:first-of-type {
-            color: var(--bs-gray-800);
+            color: var(--bs-body-color);
             font-weight: 700;
 
             .main-navigation-link-text {
@@ -27,7 +27,7 @@
         }
 
         .nav-item-{{ navigationId }}-link.root:first-of-type {
-            color: var(--bs-gray-800);
+            color: var(--bs-body-color);
             font-weight: 700;
 
             .main-navigation-link-text {


### PR DESCRIPTION
### 1. Why is this change necessary?

- Main navigation items that do not have children (flyout), always show a navigation arrow.
- The nav items are not visually aligned with the content.
- A JS error is shown in the console when a nav item without children is clicked.

### 2. What does this change do, exactly?

- Only apply `dropdown-toggle` for items with children.
- Only apply attr `data-bs-toggle="dropdown"` for items with children. (No more JS error)
- Remove inner wrapper div `<div class="">` inside the `<nav>`.
- Bring back `aria-label` with `header.navigationAriaLabel` for the `<nav>`.
- Remove `role="menu"` for sub-menus because it requirers special UX implementation that we do not have. It is also not recommended by Bootstrap.
- Fix alignment with the content.
- Remove unneeded active styling since it is done in twig because of ESI.
- Adjust active color so it is not brighter then the normal text color.

### 3. Describe each step to reproduce the issue or behaviour.

- Add a category in the admin that does not have sub-categories.
- The category shows a down arrow.
- When clicking the menu item, a JS error (uncaught) is briefly shown in the dev-console.

### 4. Please link to the relevant issues (if any).

- [NEXT-40871](https://shopware.atlassian.net/browse/NEXT-40871)

### Before

![image](https://github.com/user-attachments/assets/2f2dddb5-4ca9-4292-a409-abe330ded8e5)

### After

![image](https://github.com/user-attachments/assets/46881f5c-c574-4fff-a45f-f31d067d7412)


Do yourself a favour and hide white-space changes: 

![image](https://github.com/user-attachments/assets/f575f8ad-a8e7-4ec8-b25f-dd92164f51bb)




[NEXT-40871]: https://shopware.atlassian.net/browse/NEXT-40871?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ