### PR TITLE
fix: Improve accessibility of cookie settings

### DIFF
--- a/changelog/_unreleased/2025-03-26-cookie-constent-keyboard-nav.md
+++ b/changelog/_unreleased/2025-03-26-cookie-constent-keyboard-nav.md
@@ -1,0 +1,10 @@
+---
+title: Improve cookie settings accessibility
+issue: #7624
+---
+# Storefront
+* Changed `layout/cookie/cookie-configuration-group.html.twig` by wrapping the expand icon of the cookie groups in a proper button, including necessary accessibility attributes, to allow proper keyboard navigation.
+* Removed the individual click handling in `cookie-configuration.plugin.js` for the cookie group collapse panels and replaced it with the native Bootstrap collapse component by simply adding the necessary attributes on the button element.
+  * Removed method `_handleWrapperTrigger()` and corresponding event listeners.
+  * Removed option `wrapperToggleSelector` because it became obsolete.
+* Removed unnecessary styling in `scss/layout/_cookie-configuration.scss` that got obsolete from removing the custom click handler.

--- a/src/Storefront/Resources/app/storefront/src/plugin/cookie/cookie-configuration.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/cookie/cookie-configuration.plugin.js
@@ -43,7 +43,6 @@ export default class CookieConfiguration extends Plugin {
         buttonSubmitSelector: '.js-offcanvas-cookie-submit',
         buttonAcceptAllSelector: '.js-offcanvas-cookie-accept-all',
         globalButtonAcceptAllSelector: '.js-cookie-accept-all-button',
-        wrapperToggleSelector: '.offcanvas-cookie-entries span',
         parentInputSelector: '.offcanvas-cookie-parent-input',
         customLinkSelector: `[href="${window.router['frontend.cookie.offcanvas']}"]`,
         entriesActiveClass: 'offcanvas-cookie-entries--active',
@@ -92,14 +91,13 @@ export default class CookieConfiguration extends Plugin {
      * @private
      */
     _registerOffCanvasEvents() {
-        const { submitEvent, buttonSubmitSelector, buttonAcceptAllSelector, wrapperToggleSelector } = this.options;
+        const { submitEvent, buttonSubmitSelector, buttonAcceptAllSelector } = this.options;
         const offCanvas = this._getOffCanvas();
 
         if (offCanvas) {
             const button = offCanvas.querySelector(buttonSubmitSelector);
             const buttonAcceptAll = offCanvas.querySelector(buttonAcceptAllSelector);
             const checkboxes = Array.from(offCanvas.querySelectorAll('input[type="checkbox"]'));
-            const wrapperTrigger = Array.from(offCanvas.querySelectorAll(wrapperToggleSelector));
 
             if (button) {
                 button.addEventListener(submitEvent, this._handleSubmit.bind(this, CookieStorage));
@@ -111,10 +109,6 @@ export default class CookieConfiguration extends Plugin {
 
             checkboxes.forEach(checkbox => {
                 checkbox.addEventListener(submitEvent, this._handleCheckbox.bind(this));
-            });
-
-            wrapperTrigger.forEach(trigger => {
-                trigger.addEventListener(submitEvent, this._handleWrapperTrigger.bind(this));
             });
         }
     }
@@ -259,30 +253,6 @@ export default class CookieConfiguration extends Plugin {
             target.checked = true;
             this._childCheckboxEvent(target);
         });
-    }
-
-    /**
-     * From click target, try to find the cookie group container and toggle the open state
-     *
-     * @param event
-     * @private
-     */
-    _handleWrapperTrigger(event) {
-        event.preventDefault();
-        const { entriesActiveClass, entriesClass, groupClass } = this.options;
-        const { target } = event;
-
-        const cookieEntryContainer = this._findParentEl(target, entriesClass, groupClass);
-
-        if (cookieEntryContainer) {
-            const active = cookieEntryContainer.classList.contains(entriesActiveClass);
-
-            if (active) {
-                cookieEntryContainer.classList.remove(entriesActiveClass);
-            } else {
-                cookieEntryContainer.classList.add(entriesActiveClass);
-            }
-        }
     }
 
     /**

--- a/src/Storefront/Resources/app/storefront/src/scss/layout/_cookie-configuration.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/layout/_cookie-configuration.scss
@@ -48,7 +48,7 @@ Offcanvas containing a list of cookies which need to be manually selected by the
         transition: transform 0.3s ease;
     }
 
-    &[aria-expanded="true"] {
+    &[aria-expanded='true'] {
         svg {
             transform: rotate(90deg);
         }
@@ -56,7 +56,6 @@ Offcanvas containing a list of cookies which need to be manually selected by the
 }
 
 .offcanvas-cookie-entries {
-
     > p,
     .offcanvas-cookie-entry {
         padding: 8px 8px 0 24px;

--- a/src/Storefront/Resources/app/storefront/src/scss/layout/_cookie-configuration.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/layout/_cookie-configuration.scss
@@ -19,6 +19,7 @@ Offcanvas containing a list of cookies which need to be manually selected by the
 }
 
 .offcanvas-cookie-group {
+    position: relative;
     margin: 12px 0;
 
     input ~ label {
@@ -37,34 +38,29 @@ Offcanvas containing a list of cookies which need to be manually selected by the
     }
 }
 
-.offcanvas-cookie-entries {
-    position: relative;
-
-    .icon {
-        position: absolute;
-        transform: translateY(-100%);
-        top: -4px;
-        right: 0;
-        cursor: pointer;
-        user-select: none;
-    }
+.offcanvas-cookie-entries-toggle {
+    position: absolute;
+    top: -4px;
+    right: 0;
 
     svg {
         transform-origin: center center;
         transition: transform 0.3s ease;
     }
 
+    &[aria-expanded="true"] {
+        svg {
+            transform: rotate(90deg);
+        }
+    }
+}
+
+.offcanvas-cookie-entries {
+
     > p,
     .offcanvas-cookie-entry {
-        padding: 0 8px 0 24px;
-        height: 0;
-        opacity: 0;
-        transition:
-            opacity 0.3s ease,
-            padding-top 0.3s ease;
+        padding: 8px 8px 0 24px;
         margin: 0;
-        visibility: hidden;
-        overflow: hidden;
 
         > p {
             margin: 8px 0;
@@ -78,20 +74,6 @@ Offcanvas containing a list of cookies which need to be manually selected by the
         &.custom-control,
         &.form-check {
             min-height: unset;
-        }
-    }
-
-    &--active {
-        svg {
-            transform: rotate(90deg);
-        }
-
-        > p,
-        .offcanvas-cookie-entry {
-            height: auto;
-            opacity: 1;
-            padding-top: 8px;
-            visibility: visible;
         }
     }
 }

--- a/src/Storefront/Resources/views/storefront/layout/cookie/cookie-configuration-group.html.twig
+++ b/src/Storefront/Resources/views/storefront/layout/cookie/cookie-configuration-group.html.twig
@@ -9,12 +9,25 @@
             } only %}
 
             {% if cookieGroup.entries is not empty or cookieGroup.snippet_description is defined %}
-                <div class="offcanvas-cookie-entries">
-                    {% sw_icon 'arrow-head-right' style {
-                        size: 'sm',
-                        ariaHidden: false,
-                        ariaLabel: 'general.expand'|trans
-                    } %}
+
+                {% set cookieGroupName = cookieGroup.snippet_name|replace({'cookie.': ''}) %}
+                {% set cookieGroupId = 'offcanvas-cookie-entries-' ~ cookieGroupName %}
+
+                {% block cookie_configuration_group_collapse_button %}
+                    <button type="button"
+                            aria-label="{{ 'general.expand'|trans|sw_sanitize }}"
+                            aria-controls="{{ cookieGroupId }}"
+                            data-bs-toggle="collapse"
+                            data-bs-target="#{{ cookieGroupId }}"
+                            class="btn btn-link-inline offcanvas-cookie-entries-toggle">
+
+                        {% sw_icon 'arrow-head-right' style {
+                            size: 'sm',
+                        } %}
+                    </button>
+                {% endblock %}
+
+                <div id="{{ cookieGroupId }}" class="offcanvas-cookie-entries collapse">
 
                     {% if cookieGroup.snippet_description %}
                         <p>{{ cookieGroup.snippet_description|trans|sw_sanitize }}</p>


### PR DESCRIPTION
fixes #7624

### 1. Why is this change necessary?

The collapse panels of the cookie settings can currently not be navigated via keyboard.

### 2. What does this change do, exactly?

* Changed the collapse trigger into an actual button and added necessary accessibility attributes.
* Removed the custom click logic with general Bootstrap collapse component.
* Removed unnecessary styling.
