### PR TITLE
fix: Add title attribute to filter remove button

### DIFF
--- a/changelog/_unreleased/2025-03-27-add-title-to-filter-remove-button.md
+++ b/changelog/_unreleased/2025-03-27-add-title-to-filter-remove-button.md
@@ -1,0 +1,6 @@
+---
+title: Add title attribute to filter remove button
+issue: #7108
+---
+# Storefront
+* Changed `storefront/src/plugin/listing/listing.plugin.js` to add a title attribute to the filter remove button, to improve the accessibility.

--- a/src/Storefront/Resources/app/storefront/src/plugin/listing/listing.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/listing/listing.plugin.js
@@ -334,6 +334,7 @@ export default class ListingPlugin extends Plugin {
         <button
             class="${this.options.activeFilterLabelClasses}"
             data-id="${label.id}"
+            title="${this.options.snippets.removeFilterAriaLabel}: ${label.label}"
             aria-label="${this.options.snippets.removeFilterAriaLabel}: ${label.label}">
             ${this.getLabelPreviewTemplate(label)}
             ${label.label}


### PR DESCRIPTION
fixes: #7108

### 1. Why is this change necessary?

Labeling the switches for removing a filter is not easily understandable for people with visual or cognitive impairments.

### 2. What does this change do, exactly?

A title attribute with a description was added to the filter remove button.


