### PR TITLE
fix: Missing currency text in offcanvas currency selection

### DIFF
--- a/changelog/_unreleased/2025-04-07-fix-currency-sleection-in-offcanvas.md
+++ b/changelog/_unreleased/2025-04-07-fix-currency-sleection-in-offcanvas.md
@@ -1,0 +1,7 @@
+---
+title: Fix missing currency text in offcanvas currency selection
+issue: #8190
+---
+# Storefront
+* Removed the `d-none` and `d-md-inline` CSS class from the currency button text in `storefront/layout/header/actions/currency-widget.html.twig` so the current selected currency is always displayed.
+* Changed the currency symbol reference, so the currency symbol is displayed correctly.

--- a/src/Storefront/Resources/views/storefront/layout/header/actions/currency-widget.html.twig
+++ b/src/Storefront/Resources/views/storefront/layout/header/actions/currency-widget.html.twig
@@ -21,8 +21,8 @@
                                         aria-expanded="false"
                                         aria-label="{{ 'header.currencyTrigger'|trans({ '%currency%': context.currency.translated.name })|striptags }}">
                                     {% block layout_header_actions_currency_widget_dropdown_toggle_name %}
-                                        <span aria-hidden="true">{{ context.currency.translated.symbol }}</span>
-                                        <span class="top-bar-nav-text d-none d-md-inline">{{ context.currency.translated.name }}</span>
+                                        <span aria-hidden="true">{{ context.currency.symbol }}</span>
+                                        <span class="top-bar-nav-text">{{ context.currency.translated.name }}</span>
                                     {% endblock %}
                                 </button>
                             {% endblock %}


### PR DESCRIPTION
Fixes #8190

### 1. Why is this change necessary?

The text for the current selected currency in the offcanvas currency selection was not displayed correctly. Also the currency symbol is missing in general.

### 2. What does this change do, exactly?

* The Twig reference of the currency symbol was fixed, so that it is displayed correctly.
* The `d-none` CSS class was removed from the text element within the button, so the text is always displayed.

![image](https://github.com/user-attachments/assets/a5c12a75-0b6d-4fd7-9dff-4ede71a76f71)
