### PR TITLE
fix: adjacent form fields on narrow viewports

### DIFF
--- a/changelog/_unreleased/2025-04-08-fix-mobile-form-field-layouts.md
+++ b/changelog/_unreleased/2025-04-08-fix-mobile-form-field-layouts.md
@@ -1,0 +1,14 @@
+---
+title: Fix adjacent form fields on narrow viewports
+issue: #7056
+---
+# Storefront
+* Changed `Resources/views/storefront/component/account/login.html.twig` and adjust the following bootstrap grid columns to fix the layout on narrow viewports:
+    * Changed `#loginMail` column classes to `col-sm-6 col-lg-12`.
+    * Changed `#loginPassword` column classes to `col-sm-6 col-lg-12`.
+* Changed `Resources/views/storefront/page/account/profile/index.html.twig` and adjust the following bootstrap grid columns to fix the layout on narrow viewports:
+    * Changed `#personalMail` column classes to `col-sm-6`.
+    * Changed `#personalMailConfirmation` column classes to `col-sm-6`.
+    * Changed `#personalMailPasswordCurrent` column classes to `col-sm-6`.
+    * Changed `#newPassword` column classes to `col-sm-6`.
+    * Changed `#newPasswordConfirmation` column classes to `col-sm-6`.

--- a/src/Storefront/Resources/views/storefront/component/account/login.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/account/login.html.twig
@@ -63,7 +63,7 @@
                                     autocomplete: 'username webauthn',
                                     error: loginError,
                                     validationRules: 'required,email',
-                                    additionalClass: 'col-md-6',
+                                    additionalClass: 'col-sm-6 col-lg-12',
                                 } %}
                             {% endblock %}
 
@@ -76,7 +76,7 @@
                                     autocomplete: 'current-password',
                                     error: loginError,
                                     validationRules: 'required',
-                                    additionalClass: 'col-md-6',
+                                    additionalClass: 'col-sm-6 col-lg-12',
                                 } %}
                             {% endblock %}
                         </div>

--- a/src/Storefront/Resources/views/storefront/page/account/profile/index.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/account/profile/index.html.twig
@@ -142,7 +142,7 @@
                                                             autocomplete: 'section-personal email',
                                                             violationPath: '/email',
                                                             validationRules: 'required,email',
-                                                            additionalClass: 'col',
+                                                            additionalClass: 'col-sm-6',
                                                         } %}
                                                     {% endblock %}
 
@@ -155,7 +155,7 @@
                                                             autocomplete: 'section-personal email',
                                                             violationPath: '/email',
                                                             validationRules: 'required,confirmation',
-                                                            additionalClass: 'col',
+                                                            additionalClass: 'col-sm-6',
                                                         } %}
                                                     {% endblock %}
                                                 </div>
@@ -173,7 +173,7 @@
                                                         autocomplete: 'current-password',
                                                         violationPath: '/password',
                                                         validationRules: 'required',
-                                                        additionalClass: 'col-6',
+                                                        additionalClass: 'col-sm-6',
                                                     } %}
                                                 </div>
                                             {% endblock %}
@@ -238,7 +238,7 @@
                                                             violationPath: '/newPassword',
                                                             validationRules: 'required,minLength',
                                                             minlength: config('core.loginRegistration.passwordMinLength'),
-                                                            additionalClass: 'col',
+                                                            additionalClass: 'col-sm-6',
                                                         } %}
                                                     {% endblock %}
 
@@ -251,7 +251,7 @@
                                                             autocomplete: 'new-password',
                                                             violationPath: '/passwordConfirmation',
                                                             validationRules: 'required,confirmation',
-                                                            additionalClass: 'col',
+                                                            additionalClass: 'col-sm-6',
                                                         } %}
                                                     {% endblock %}
                                                 </div>
@@ -269,7 +269,7 @@
                                                         autocomplete: 'current-password',
                                                         violationPath: '/password',
                                                         validationRules: 'required',
-                                                        additionalClass: 'col-6',
+                                                        additionalClass: 'col-sm-6',
                                                     } %}
                                                 </div>
                                             {% endblock %}


### PR DESCRIPTION
fixes #7056

### 1. Why is this change necessary?

On some smaller viewports form fields are displayed in an ugly layout:
* login/register (iPad pro resolution)
* Account email and password change

### 2. What does this change do, exactly?

Adjust the bootstrap grid layout so the form fields are displayed underneath each other when there is not enough space

### 3. Describe each step to reproduce the issue or behaviour.

* Open the register/login form and view it in "iPad pro" viewport with the devtools
* Open the account email and password change with a smaller mobile viewport

### Before

![image](https://github.com/user-attachments/assets/e9025d53-d1ba-4ab3-8fbe-41339d3014f1)

![image](https://github.com/user-attachments/assets/1504c6b7-7202-497c-a318-e39a82ff04a9)

### After

![image](https://github.com/user-attachments/assets/763f55ba-174c-4ce2-be2c-552f448b8b1e)

![image](https://github.com/user-attachments/assets/19d8e19e-a2aa-4d96-b503-8bb59cfb947c)

