### PR TITLE
fix: restore main-nav focus when closing dropdown via btn using keyboard

### DIFF
--- a/src/Storefront/Resources/app/storefront/src/plugin/navbar/navbar.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/navbar/navbar.plugin.js
@@ -135,8 +135,8 @@ export default class NavbarPlugin extends Plugin {
      * Restores focus to the main-navigation link related to the currently active dropdown navigation.
      * The focus state is lost when closing the dropdown via button using a keyboard.
      *
-     * @param {FocusEvent} event - The event object triggered by the close button interaction.
-     * @return {void} Does not return a value.
+     * @param {FocusEvent} event
+     * @return {void}
      */
     _restoreFocusAfterBtnClose(event) {
         if (event.relatedTarget || event.target.matches(this.options.topLevelLinksSelector)) {

--- a/src/Storefront/Resources/app/storefront/src/plugin/navbar/navbar.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/navbar/navbar.plugin.js
@@ -139,7 +139,7 @@ export default class NavbarPlugin extends Plugin {
      * @return {void} Does not return a value.
      */
     _restoreFocusAfterBtnClose(event) {
-        if (event.relatedTarget) {
+        if (event.relatedTarget || event.target.matches(this.options.topLevelLinksSelector)) {
             return;
         }
 

--- a/src/Storefront/Resources/app/storefront/src/plugin/navbar/navbar.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/navbar/navbar.plugin.js
@@ -8,6 +8,10 @@ export default class NavbarPlugin extends Plugin {
          */
         debounceTime: 125,
         /**
+         * Class to select the main navigation items, which contain both the top level link and the dropdown navigation.
+         */
+        navItemSelector: '.nav-item',
+        /**
          * Class to select the top level links.
          */
         topLevelLinksSelector: '.main-navigation-link',
@@ -29,6 +33,7 @@ export default class NavbarPlugin extends Plugin {
         const clickEvent = (DeviceDetection.isTouchDevice()) ? 'touchstart' : 'click';
 
         this.el.addEventListener('mouseleave', this._closeAllDropdowns.bind(this));
+        this.el.addEventListener('focusout', this._restoreFocusAfterBtnClose.bind(this));
 
         this._topLevelLinks.forEach(el => {
             el.addEventListener(openEvent, this._toggleNavbar.bind(this, el));
@@ -124,5 +129,26 @@ export default class NavbarPlugin extends Plugin {
         if (activeNavItem) {
             activeNavItem.setAttribute('aria-current', 'page');
         }
+    }
+
+    /**
+     * Restores focus to the main-navigation link related to the currently active dropdown navigation.
+     * The focus state is lost when closing the dropdown via button using a keyboard.
+     *
+     * @param {FocusEvent} event - The event object triggered by the close button interaction.
+     * @return {void} Does not return a value.
+     */
+    _restoreFocusAfterBtnClose(event) {
+        if (event.relatedTarget) {
+            return;
+        }
+
+        const link = event.target.closest(this.options.navItemSelector)?.querySelector(this.options.topLevelLinksSelector);
+
+        if (!link) {
+            return;
+        }
+
+        window.focusHandler.setFocus(link);
     }
 }

--- a/src/Storefront/Resources/app/storefront/test/plugin/navbar/navbar.plugin.test.js
+++ b/src/Storefront/Resources/app/storefront/test/plugin/navbar/navbar.plugin.test.js
@@ -1,4 +1,5 @@
 import NavbarPlugin from 'src/plugin/navbar/navbar.plugin';
+import FocusHandler from 'src/helper/focus-handler.helper';
 
 describe('NavbarPlugin', () => {
     let navbarPlugin;
@@ -211,5 +212,47 @@ describe('NavbarPlugin', () => {
         navbarPlugin._setAriaCurrentPage();
 
         expect(mockLink.getAttribute('aria-current')).toBe('page');
+    });
+
+    test('_restoreFocusAfterBtnClose should focus related dropdown top level link', () => {
+        window.focusHandler = new FocusHandler();
+
+        const mockNavItem = document.createElement('div');
+        mockNavItem.classList.add('nav-item');
+        const mockLink = document.createElement('a');
+        mockLink.classList.add('main-navigation-link');
+        mockLink.focus = jest.fn();
+        mockNavItem.appendChild(mockLink);
+        const mockDropdown = document.createElement('div');
+        mockNavItem.appendChild(mockDropdown);
+
+        const mockEvent = {
+            target: mockDropdown,
+            relatedTarget: null,
+        };
+
+        navbarPlugin._restoreFocusAfterBtnClose(mockEvent);
+
+        expect(mockLink.focus).toHaveBeenCalled();
+    });
+
+    test('_restoreFocusAfterBtnClose should skip events dispatched for top level links', () => {
+        window.focusHandler = new FocusHandler();
+
+        const mockNavItem = document.createElement('div');
+        mockNavItem.classList.add('nav-item');
+        const mockLink = document.createElement('a');
+        mockLink.classList.add('main-navigation-link');
+        mockLink.focus = jest.fn();
+        mockNavItem.appendChild(mockLink);
+
+        const mockEvent = {
+            target: mockLink,
+            relatedTarget: null,
+        };
+
+        navbarPlugin._restoreFocusAfterBtnClose(mockEvent);
+
+        expect(mockLink.focus).not.toHaveBeenCalled();
     });
 });


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
Using keyboard navigation: When closing a navigation dropdown via the close button, the element focus is not restored to the related main navigation link.

### 2. What does this change do, exactly?
Add a `focusout` event listener to the main navigation. If the event has no `relatedTarget`, it means that no element received focus instead, assuming that the dropdown was closed via JS. In this case get the "closest" main-navigation-link and focus it.

[Screencast from 2025-05-06 17-33-09.webm](https://github.com/user-attachments/assets/ad967538-76dc-4c22-8989-40bf0d2741dd)

### 3. Describe each step to reproduce the issue or behaviour.
0. Use the keyboard navigation
1. Navigate to any main navigation item with child categories and hit enter -> dropdown opens
2. Navigate to the close button ("X") and hit enter -> dropdown closes
3. Without the fix, no element will be focused

### 4. Please link to the relevant issues (if any).
- closes https://github.com/shopware/shopware/issues/8842

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.
