### PR TITLE
fix: Refactor manufacturer wrapper from <a> to <div> when link is missing

### DIFF
--- a/changelog/_unreleased/2025-05-21-refactor-manufacturer-wrapper-on-product-detail-page.md
+++ b/changelog/_unreleased/2025-05-21-refactor-manufacturer-wrapper-on-product-detail-page.md
@@ -5,6 +5,5 @@ author: Tam Dao
 author_email: t.dao@shopware.com
 author_github: @daothithientamm
 ---
-
 # Storefront
 * Changed the `element_manufacturer_logo_link` block in the `src/Storefront/Resources/views/storefront/element/cms-element-manufacturer-logo.html.twig` to render a `<div>` instead of an `<a>` tag when the manufacturer has no link, ensuring valid HTML structure and improved accessibility.

--- a/changelog/_unreleased/2025-05-21-refactor-manufacturer-wrapper-on-product-detail-page.md
+++ b/changelog/_unreleased/2025-05-21-refactor-manufacturer-wrapper-on-product-detail-page.md
@@ -1,0 +1,10 @@
+---
+title: Changed manufacturer wrapper from `<a>` to `<div>` when link is missing
+issue: #9615
+author: Tam Dao
+author_email: t.dao@shopware.com
+author_github: @daothithientamm
+---
+
+# Storefront
+* Changed the `element_manufacturer_logo_link` block in the `src/Storefront/Resources/views/storefront/element/cms-element-manufacturer-logo.html.twig` to render a `<div>` instead of an `<a>` tag when the manufacturer has no link, ensuring valid HTML structure and improved accessibility.

--- a/src/Storefront/Resources/views/storefront/element/cms-element-manufacturer-logo.html.twig
+++ b/src/Storefront/Resources/views/storefront/element/cms-element-manufacturer-logo.html.twig
@@ -25,10 +25,14 @@
 
             {% block element_manufacturer_logo_link %}
                 {% if manufacturer.name %}
-                    <a href="{{ manufacturer.link }}"
-                       class="cms-image-link product-detail-manufacturer-link"
-                       {% if config.newTab.value %}target="_blank" rel="noreferrer noopener"{% endif %}
-                       title="{{ manufacturer.name }}">
+                    {% if manufacturer.link %}
+                        <a href="{{ manufacturer.link }}"
+                            class="cms-image-link product-detail-manufacturer-link"
+                            {% if config.newTab.value %}target="_blank" rel="noreferrer noopener"{% endif %}
+                            title="{{ manufacturer.name }}">
+                    {% else %}
+                        <div class="cms-image-link product-detail-manufacturer-link">
+                    {% endif %}
                         {% if manufacturer.media %}
                             <div class="cms-image-container is-{{ config.displayMode.value }}"
                                 {% if config.minHeight.value and config.displayMode.value == "cover" %} style="min-height: {{ config.minHeight.value }};"{% endif %}>
@@ -61,7 +65,11 @@
                                 {{ manufacturer.name }}
                             {% endblock %}
                         {% endif %}
-                    </a>
+                    {% if manufacturer.link %}
+                        </a>
+                    {% else %}
+                        </div>
+                    {% endif %}
                 {% endif %}
             {% endblock %}
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

This change ensures valid HTML and better accessibility when the manufacturer has no link

### 2. What does this change do, exactly?

Refactored the manufacturer block in the product detail page to render a `<div>` instead of an `<a>` tag when the manufacturer has no link, ensuring valid HTML structure and improved accessibility.

| Desktop  | Mobile |
| ------------- | ------------- |
| <img width="1077" alt="image" src="https://github.com/user-attachments/assets/c82aa695-fc38-4bda-92a4-d6962ac173cc" />  | <img width="318" alt="image" src="https://github.com/user-attachments/assets/9b7160f1-fe15-48cb-99dc-a1fd04c22c56" />  |

### 3. Describe each step to reproduce the issue or behaviour.

1. Create a manufacturer without a link.
2. Create a product and assign that manufacturer to it.
3. View the product detail page in the Storefront.

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

In case of issue existing only on Jira, link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

- closes #9615  - closes the issue #9615 when the PR is merged

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.
