### PR TITLE
fix: a11y of plain text line item tables in mails

### DIFF
--- a/src/Core/Migration/Fixtures/mails/order_confirmation_mail/de-html.html.twig
+++ b/src/Core/Migration/Fixtures/mails/order_confirmation_mail/de-html.html.twig
@@ -155,7 +155,7 @@
         <br>
         Für Rückfragen stehen wir Ihnen jederzeit gerne zur Verfügung.
         <br>
-        {% if a11yDocuments is defined %}
+        {% if a11yDocuments is defined and a11yDocuments is not empty %}
             <br>
             Folgend stellen wir barrierefreie Dokumente als HTML-Version zur Verfügung:<br><br>
             <ul>

--- a/src/Core/Migration/Fixtures/mails/order_confirmation_mail/de-html.html.twig
+++ b/src/Core/Migration/Fixtures/mails/order_confirmation_mail/de-html.html.twig
@@ -1,42 +1,42 @@
 <div style="font-family:arial; font-size:12px;">
 
-{% set currencyIsoCode = order.currency.isoCode %}
+    {% set currencyIsoCode = order.currency.isoCode %}
 
-Hallo {% if order.orderCustomer.salutation %}{{ order.orderCustomer.salutation.translated.letterName ~ ' ' }}{% endif %}{{ order.orderCustomer.firstName }} {{ order.orderCustomer.lastName }},<br>
-<br>
-Ihre Bestellung ist am {{ order.orderDateTime|format_datetime('medium', 'short', locale='de-DE') }} bei uns eingegangen.<br>
-<br>
-Bestellnummer: {{ order.orderNumber }}<br>
-<br>
-Sobald ein Zahlungseingang erfolgt ist, erhalten Sie eine separate Benachrichtigung und Ihre Bestellung wird verarbeitet.<br>
-<br>
-Den aktuellen Status Ihrer Bestellung können Sie jederzeit über diesen Link abrufen: {{ rawUrl('frontend.account.order.single.page', { 'deepLinkCode': order.deepLinkCode }, salesChannel.domains|first.url) }}<br>
-Über diesen Link können Sie auch die Bestellung bearbeiten, die Zahlungsart wechseln oder nachträglich eine Zahlung durchführen.<br>
-<br>
-<strong>Informationen zu Ihrer Bestellung:</strong><br>
-<br>
+    Hallo {% if order.orderCustomer.salutation %}{{ order.orderCustomer.salutation.translated.letterName ~ ' ' }}{% endif %}{{ order.orderCustomer.firstName }} {{ order.orderCustomer.lastName }},<br>
+    <br>
+    Ihre Bestellung ist am {{ order.orderDateTime|format_datetime('medium', 'short', locale='de-DE') }} bei uns eingegangen.<br>
+    <br>
+    Bestellnummer: {{ order.orderNumber }}<br>
+    <br>
+    Sobald ein Zahlungseingang erfolgt ist, erhalten Sie eine separate Benachrichtigung und Ihre Bestellung wird verarbeitet.<br>
+    <br>
+    Den aktuellen Status Ihrer Bestellung können Sie jederzeit über diesen Link abrufen: {{ rawUrl('frontend.account.order.single.page', { 'deepLinkCode': order.deepLinkCode }, salesChannel.domains|first.url) }}<br>
+    Über diesen Link können Sie auch die Bestellung bearbeiten, die Zahlungsart wechseln oder nachträglich eine Zahlung durchführen.<br>
+    <br>
+    <strong>Informationen zu Ihrer Bestellung:</strong><br>
+    <br>
 
-<table border="0" style="font-family:Arial, Helvetica, sans-serif; font-size:12px;">
-    <tr>
-        <td bgcolor="#F7F7F2" style="border-bottom:1px solid #cccccc;"><strong>Produkt-Nr.</strong></td>
-        <td bgcolor="#F7F7F2" style="border-bottom:1px solid #cccccc;"><strong>Produktbild</strong></td>
-        <td bgcolor="#F7F7F2" style="border-bottom:1px solid #cccccc;"><strong>Bezeichnung</strong></td>
-        <td bgcolor="#F7F7F2" style="border-bottom:1px solid #cccccc;"><strong>Menge</strong></td>
-        <td bgcolor="#F7F7F2" style="border-bottom:1px solid #cccccc;"><strong>Preis</strong></td>
-        <td bgcolor="#F7F7F2" style="border-bottom:1px solid #cccccc;"><strong>Summe</strong></td>
-    </tr>
+    <table border="0" style="font-family:Arial, Helvetica, sans-serif; font-size:12px;">
+        <tr>
+            <td bgcolor="#F7F7F2" style="border-bottom:1px solid #cccccc;"><strong>Produkt-Nr.</strong></td>
+            <td bgcolor="#F7F7F2" style="border-bottom:1px solid #cccccc;"><strong>Produktbild</strong></td>
+            <td bgcolor="#F7F7F2" style="border-bottom:1px solid #cccccc;"><strong>Bezeichnung</strong></td>
+            <td bgcolor="#F7F7F2" style="border-bottom:1px solid #cccccc;"><strong>Menge</strong></td>
+            <td bgcolor="#F7F7F2" style="border-bottom:1px solid #cccccc;"><strong>Preis</strong></td>
+            <td bgcolor="#F7F7F2" style="border-bottom:1px solid #cccccc;"><strong>Summe</strong></td>
+        </tr>
 
-    {% for lineItem in order.nestedLineItems %}
-        {% set nestingLevel = 0 %}
-        {% set nestedItem = lineItem %}
-        {% block lineItem %}
-            <tr>
-                <td>{% if nestedItem.payload.productNumber is defined %}{{ nestedItem.payload.productNumber|u.wordwrap(80) }}{% endif %}</td>
-                <td>{% if nestedItem.cover is defined and nestedItem.cover is not null %}<img src="{{ nestedItem.cover.url }}" width="75" height="auto"/>{% endif %}</td>
-                <td>
-                    {% if nestingLevel > 0 %}
-                        {% for i in 1..nestingLevel %}
-                            <span style="position: relative;">
+        {% for lineItem in order.nestedLineItems %}
+            {% set nestingLevel = 0 %}
+            {% set nestedItem = lineItem %}
+            {% block lineItem %}
+                <tr>
+                    <td>{% if nestedItem.payload.productNumber is defined %}{{ nestedItem.payload.productNumber|u.wordwrap(80) }}{% endif %}</td>
+                    <td>{% if nestedItem.cover is defined and nestedItem.cover is not null %}<img src="{{ nestedItem.cover.url }}" width="75" height="auto"/>{% endif %}</td>
+                    <td>
+                        {% if nestingLevel > 0 %}
+                            {% for i in 1..nestingLevel %}
+                                <span style="position: relative;">
                                 <span style="display: inline-block;
                                     position: absolute;
                                     width: 6px;
@@ -45,109 +45,136 @@ Den aktuellen Status Ihrer Bestellung können Sie jederzeit über diesen Link ab
                                     border-left:  2px solid rgba(0, 0, 0, 0.15);
                                     margin-left: {{ i * 10 }}px;"></span>
                             </span>
-                        {% endfor %}
-                    {% endif %}
-
-                    <div{% if nestingLevel > 0 %} style="padding-left: {{ (nestingLevel + 1) * 10 }}px"{% endif %}>
-                        {{ nestedItem.label|u.wordwrap(80) }}
-                    </div>
-
-                    {% if nestedItem.payload.options is defined and nestedItem.payload.options|length >= 1 %}
-                        <div>
-                            {% for option in nestedItem.payload.options %}
-                                {{ option.group }}: {{ option.option }}
-                                {% if nestedItem.payload.options|last != option %}
-                                    {{ " | " }}
-                                {% endif %}
                             {% endfor %}
-                        </div>
-                    {% endif %}
+                        {% endif %}
 
-                    {% if nestedItem.payload.features is defined and nestedItem.payload.features|length >= 1 %}
-                        {% set referencePriceFeatures = nestedItem.payload.features|filter(feature => feature.type == 'referencePrice') %}
-                        {% if referencePriceFeatures|length >= 1 %}
-                            {% set referencePriceFeature = referencePriceFeatures|first %}
+                        <div{% if nestingLevel > 0 %} style="padding-left: {{ (nestingLevel + 1) * 10 }}px"{% endif %}>
+                            {{ nestedItem.label|u.wordwrap(80) }}
+                        </div>
+
+                        {% if nestedItem.payload.options is defined and nestedItem.payload.options|length >= 1 %}
                             <div>
-                                {{ referencePriceFeature.value.purchaseUnit }} {{ referencePriceFeature.value.unitName }}
-                                ({{ referencePriceFeature.value.price|currency(currencyIsoCode) }}* / {{ referencePriceFeature.value.referenceUnit }} {{ referencePriceFeature.value.unitName }})
+                                {% for option in nestedItem.payload.options %}
+                                    {{ option.group }}: {{ option.option }}
+                                    {% if nestedItem.payload.options|last != option %}
+                                        {{ " | " }}
+                                    {% endif %}
+                                {% endfor %}
                             </div>
                         {% endif %}
-                    {% endif %}
-                </td>
-                <td style="text-align: center">{{ nestedItem.quantity }}</td>
-                <td>{{ nestedItem.unitPrice|currency(currencyIsoCode) }}</td>
-                <td>{{ nestedItem.totalPrice|currency(currencyIsoCode) }}</td>
-            </tr>
 
-            {% if nestedItem.children.count > 0 %}
-                {% set nestingLevel = nestingLevel + 1 %}
-                {% for lineItem in nestedItem.children %}
-                    {% set nestedItem = lineItem %}
-                    {{ block('lineItem') }}
-                {% endfor %}
-            {% endif %}
-        {% endblock %}
-    {% endfor %}
-</table>
+                        {% if nestedItem.payload.features is defined and nestedItem.payload.features|length >= 1 %}
+                            {% set referencePriceFeatures = nestedItem.payload.features|filter(feature => feature.type == 'referencePrice') %}
+                            {% if referencePriceFeatures|length >= 1 %}
+                                {% set referencePriceFeature = referencePriceFeatures|first %}
+                                <div>
+                                    {{ referencePriceFeature.value.purchaseUnit }} {{ referencePriceFeature.value.unitName }}
+                                    ({{ referencePriceFeature.value.price|currency(currencyIsoCode) }} pro {{ referencePriceFeature.value.referenceUnit }} {{ referencePriceFeature.value.unitName }})
+                                </div>
+                            {% endif %}
+                        {% endif %}
+                    </td>
+                    <td style="text-align: center">{{ nestedItem.quantity }}</td>
+                    <td>{{ nestedItem.unitPrice|currency(currencyIsoCode) }}</td>
+                    <td>{{ nestedItem.totalPrice|currency(currencyIsoCode) }}</td>
+                </tr>
 
-{% set delivery = order.deliveries.first %}
+                {% if nestedItem.children.count > 0 %}
+                    {% set nestingLevel = nestingLevel + 1 %}
+                    {% for lineItem in nestedItem.children %}
+                        {% set nestedItem = lineItem %}
+                        {{ block('lineItem') }}
+                    {% endfor %}
+                {% endif %}
+            {% endblock %}
+        {% endfor %}
+    </table>
 
-{% set displayRounded = order.totalRounding.interval != 0.01 or order.totalRounding.decimals != order.itemRounding.decimals %}
-{% set decimals = order.totalRounding.decimals %}
-{% set total = order.price.totalPrice %}
-{% if displayRounded %}
-    {% set total = order.price.rawTotal %}
-    {% set decimals = order.itemRounding.decimals %}
-{% endif %}
-<p>
-    <br>
-    <br>
-    {% for shippingCost in order.deliveries %}
-        Versandkosten: {{ shippingCost.shippingCosts.totalPrice|currency(currencyIsoCode) }}<br>
-    {% endfor %}
-    Gesamtkosten Netto: {{ order.amountNet|currency(currencyIsoCode) }}<br>
+    {% set delivery = order.deliveries.first %}
+
+    {% set displayRounded = order.totalRounding.interval != 0.01 or order.totalRounding.decimals != order.itemRounding.decimals %}
+    {% set decimals = order.totalRounding.decimals %}
+    {% set total = order.price.totalPrice %}
+    {% if displayRounded %}
+        {% set total = order.price.rawTotal %}
+        {% set decimals = order.itemRounding.decimals %}
+    {% endif %}
+    <p>
+        <br>
+        <br>
+        {% for shippingCost in order.deliveries %}
+            Versandkosten: {{ shippingCost.shippingCosts.totalPrice|currency(currencyIsoCode) }}<br>
+        {% endfor %}
+        Gesamtkosten Netto: {{ order.amountNet|currency(currencyIsoCode) }}<br>
         {% for calculatedTax in order.price.calculatedTaxes %}
             {% if order.taxStatus is same as('net') %}zzgl.{% else %}inkl.{% endif %} {{ calculatedTax.taxRate }}% MwSt. {{ calculatedTax.tax|currency(currencyIsoCode) }}<br>
         {% endfor %}
-    {% if not displayRounded %}<strong>{% endif %}Gesamtkosten Brutto: {{ total|currency(currencyIsoCode,decimals=decimals) }}{% if not displayRounded %}</strong>{% endif %}<br>
-    {% if displayRounded %}
-        <strong>Gesamtkosten Brutto gerundet: {{ order.price.totalPrice|currency(currencyIsoCode,decimals=order.totalRounding.decimals) }}</strong><br>
-    {% endif %}
-    <br>
-
-    {% if delivery %}
-        <strong>Gewählte Versandart:</strong> {{ delivery.shippingMethod.translated.name }}<br>
-        {{ delivery.shippingMethod.translated.description }}<br>
+        {% if not displayRounded %}<strong>{% endif %}Gesamtkosten Brutto: {{ total|currency(currencyIsoCode,decimals=decimals) }}{% if not displayRounded %}</strong>{% endif %}<br>
+        {% if displayRounded %}
+            <strong>Gesamtkosten Brutto gerundet: {{ order.price.totalPrice|currency(currencyIsoCode,decimals=order.totalRounding.decimals) }}</strong><br>
+        {% endif %}
         <br>
-    {% endif %}
 
-    {% set billingAddress = order.addresses.get(order.billingAddressId) %}
-    <strong>Rechnungsadresse:</strong><br>
-    {{ billingAddress.company }}<br>
-    {{ billingAddress.firstName }} {{ billingAddress.lastName }}<br>
-    {{ billingAddress.street }} <br>
-    {{ billingAddress.zipcode }} {{ billingAddress.city }}<br>
-    {{ billingAddress.country.translated.name }}<br>
-    <br>
+        {% if order.transactions is defined and order.transactions is not empty %}
+            <strong>Gewählte Zahlungsart:</strong> {{ order.transactions.first.paymentMethod.translated.name }}<br>
+            {{ order.transactions.first.paymentMethod.translated.description }}<br>
+            <br>
+        {% endif %}
 
-    {% if delivery %}
-        <strong>Lieferadresse:</strong><br>
-        {{ delivery.shippingOrderAddress.company }}<br>
-        {{ delivery.shippingOrderAddress.firstName }} {{ delivery.shippingOrderAddress.lastName }}<br>
-        {{ delivery.shippingOrderAddress.street }} <br>
-        {{ delivery.shippingOrderAddress.zipcode}} {{ delivery.shippingOrderAddress.city }}<br>
-        {{ delivery.shippingOrderAddress.country.translated.name }}<br>
+        {% if delivery %}
+            <strong>Gewählte Versandart:</strong> {{ delivery.shippingMethod.translated.name }}<br>
+            {{ delivery.shippingMethod.translated.description }}<br>
+            <br>
+        {% endif %}
+
+        {% set billingAddress = order.addresses.get(order.billingAddressId) %}
+        <strong>Rechnungsadresse:</strong><br>
+        {{ billingAddress.company }}<br>
+        {{ billingAddress.firstName }} {{ billingAddress.lastName }}<br>
+        {{ billingAddress.street }} <br>
+        {{ billingAddress.zipcode }} {{ billingAddress.city }}<br>
+        {{ billingAddress.country.translated.name }}<br>
         <br>
-    {% endif %}
-    {% if order.orderCustomer.vatIds %}
-        Ihre Umsatzsteuer-ID: {{ order.orderCustomer.vatIds|first }}
-        Bei erfolgreicher Prüfung und sofern Sie aus dem EU-Ausland
-        bestellen, erhalten Sie Ihre Ware umsatzsteuerbefreit. <br>
-    {% endif %}
-    <br/>
-    Den aktuellen Status Ihrer Bestellung können Sie auch jederzeit auf unserer Webseite im  Bereich "Mein Konto" - "Meine Bestellungen" abrufen: {{ rawUrl('frontend.account.order.single.page', { 'deepLinkCode': order.deepLinkCode }, salesChannel.domains|first.url) }}
-    </br>
-    Für Rückfragen stehen wir Ihnen jederzeit gerne zur Verfügung.
-</p>
-<br>
+
+        {% if delivery %}
+            <strong>Lieferadresse:</strong><br>
+            {{ delivery.shippingOrderAddress.company }}<br>
+            {{ delivery.shippingOrderAddress.firstName }} {{ delivery.shippingOrderAddress.lastName }}<br>
+            {{ delivery.shippingOrderAddress.street }} <br>
+            {{ delivery.shippingOrderAddress.zipcode}} {{ delivery.shippingOrderAddress.city }}<br>
+            {{ delivery.shippingOrderAddress.country.translated.name }}<br>
+            <br>
+        {% endif %}
+        {% if order.orderCustomer.vatIds %}
+            Ihre Umsatzsteuer-ID: {{ order.orderCustomer.vatIds|first }}
+            Bei erfolgreicher Prüfung und sofern Sie aus dem EU-Ausland
+            bestellen, erhalten Sie Ihre Ware umsatzsteuerbefreit. <br>
+        {% endif %}
+        <br>
+        Den aktuellen Status Ihrer Bestellung können Sie auch jederzeit auf unserer Webseite im  Bereich "Mein Konto" - "Meine Bestellungen" abrufen: {{ rawUrl('frontend.account.order.single.page', { 'deepLinkCode': order.deepLinkCode }, salesChannel.domains|first.url) }}
+        <br>
+        Für Rückfragen stehen wir Ihnen jederzeit gerne zur Verfügung.
+        <br>
+        {% if a11yDocuments is defined %}
+            <br>
+            Folgend stellen wir barrierefreie Dokumente als HTML-Version zur Verfügung:<br><br>
+            <ul>
+                {% for a11y in a11yDocuments %}
+                    {% set documentLink = rawUrl(
+                        'frontend.account.order.single.document.a11y',
+                        {
+                            documentId: a11y.documentId,
+                            deepLinkCode: a11y.deepLinkCode,
+                            fileType: a11y.fileExtension,
+                        },
+                        salesChannel.domains|first.url
+                    )%}
+                    <li><a href="{{ documentLink }}" target="_blank">{{ documentLink }}</a></li>
+                {% endfor %}
+            </ul>
+            Aus Datenschutzgründen ist für die HTML-Version ein Login erforderlich.<br><br>
+            Im Falle einer Gastbestellung können Sie Ihre Postanschrift und die Postleitzahl der Rechnungsanschrift verwenden.<br>
+        {% endif %}
+    </p>
+    <br>
 </div>

--- a/src/Core/Migration/Fixtures/mails/order_confirmation_mail/de-plain.html.twig
+++ b/src/Core/Migration/Fixtures/mails/order_confirmation_mail/de-plain.html.twig
@@ -12,15 +12,34 @@ Den aktuellen Status Ihrer Bestellung können Sie jederzeit über diesen Link ab
 
 Informationen zu Ihrer Bestellung:
 
-Pos.   Artikel-Nr.			Produktbild(Alt-Text) 			Beschreibung			Menge			Preis			Summe
-
 {% for lineItem in order.lineItems %}
-{{ loop.index }}      {% if lineItem.payload.productNumber is defined %}{{ lineItem.payload.productNumber|u.wordwrap(80) }}{% endif %}      {% if nestedItem.cover is defined and nestedItem.cover is not null %}{{ lineItem.cover.alt }}{% endif %}        {{ lineItem.label|u.wordwrap(80) }}{% if lineItem.payload.options is defined and lineItem.payload.options|length >= 1 %}, {% for option in lineItem.payload.options %}{{ option.group }}: {{ option.option }}{% if lineItem.payload.options|last != option %}{{ " | " }}{% endif %}{% endfor %}{% endif %}{% if lineItem.payload.features is defined and lineItem.payload.features|length >= 1 %}{% set referencePriceFeatures = lineItem.payload.features|filter(feature => feature.type == 'referencePrice') %}{% if referencePriceFeatures|length >= 1 %}{% set referencePriceFeature = referencePriceFeatures|first %}, {{ referencePriceFeature.value.purchaseUnit }} {{ referencePriceFeature.value.unitName }}({{ referencePriceFeature.value.price|currency(currencyIsoCode) }}* / {{ referencePriceFeature.value.referenceUnit }} {{ referencePriceFeature.value.unitName }}){% endif %}{% endif %}
-    {{ lineItem.quantity }}			{{ lineItem.unitPrice|currency(currencyIsoCode) }}			{{ lineItem.totalPrice|currency(currencyIsoCode) }}
+Pos. {{ loop.index }}
+---------------------
+{% if lineItem.payload.productNumber is defined %}
+Artikel-Nr. {{ lineItem.payload.productNumber|u.wordwrap(80) }},
+{% endif %}
+{% if nestedItem.cover is defined and nestedItem.cover is not null %}
+Produktbild {{ lineItem.cover.alt }},
+{% endif %}
+Beschreibung {{ lineItem.label|u.wordwrap(80) }},
+{% if lineItem.payload.options is defined and lineItem.payload.options|length >= 1 %}
+{% for option in lineItem.payload.options %}
+{{ option.group }}: {{ option.option }}{{ ", " }}
 {% endfor %}
+{% endif %}
+{% if lineItem.payload.features is defined and lineItem.payload.features|length >= 1 %}
+{% set referencePriceFeatures = lineItem.payload.features|filter(feature => feature.type == 'referencePrice') %}
+{% if referencePriceFeatures|length >= 1 %}
+{% set referencePriceFeature = referencePriceFeatures|first %}
+{{ referencePriceFeature.value.purchaseUnit }} {{ referencePriceFeature.value.unitName }}({{ referencePriceFeature.value.price|currency(currencyIsoCode) }} pro {{ referencePriceFeature.value.referenceUnit }} {{ referencePriceFeature.value.unitName }}),
+{% endif %}
+{% endif %}
+Menge {{ lineItem.quantity }},
+Preis {{ lineItem.unitPrice|currency(currencyIsoCode) }},
+Summe {{ lineItem.totalPrice|currency(currencyIsoCode) }},
 
+{% endfor %}
 {% set delivery = order.deliveries.first %}
-
 {% set displayRounded = order.totalRounding.interval != 0.01 or order.totalRounding.decimals != order.itemRounding.decimals %}
 {% set decimals = order.totalRounding.decimals %}
 {% set total = order.price.totalPrice %}
@@ -28,9 +47,8 @@ Pos.   Artikel-Nr.			Produktbild(Alt-Text) 			Beschreibung			Menge			Preis			Sum
     {% set total = order.price.rawTotal %}
     {% set decimals = order.itemRounding.decimals %}
 {% endif %}
-
 {% for shippingCost in order.deliveries %}
-    Versandkosten: {{ shippingCost.shippingCosts.totalPrice|currency(currencyIsoCode) }}<br>
+Versandkosten: {{ shippingCost.shippingCosts.totalPrice|currency(currencyIsoCode) }}
 {% endfor %}
 Gesamtkosten Netto: {{ order.amountNet|currency(currencyIsoCode) }}
 {% for calculatedTax in order.price.calculatedTaxes %}
@@ -41,11 +59,15 @@ Gesamtkosten Brutto: {{ total|currency(currencyIsoCode,decimals=decimals) }}
 Gesamtkosten Brutto gerundet: {{ order.price.totalPrice|currency(currencyIsoCode,decimals=order.totalRounding.decimals) }}
 {% endif %}
 
+{% if order.transactions is defined and order.transactions is not empty %}
+Gewählte Zahlungsart: {{ order.transactions.first.paymentMethod.translated.name }}
+{{ order.transactions.first.paymentMethod.translated.description }}
+{% endif %}
+
 {% if delivery %}
 Gewählte Versandart: {{ delivery.shippingMethod.translated.name }}
 {{ delivery.shippingMethod.translated.description }}
 {% endif %}
-
 {% set billingAddress = order.addresses.get(order.billingAddressId) %}
 Rechnungsadresse:
 {{ billingAddress.company }}
@@ -67,7 +89,27 @@ Lieferadresse:
 Ihre Umsatzsteuer-ID: {{ order.orderCustomer.vatIds|first }}
 Bei erfolgreicher Prüfung und sofern Sie aus dem EU-Ausland
 bestellen, erhalten Sie Ihre Ware umsatzsteuerbefreit.
-{% endif %}
 
-Den aktuellen Status Ihrer Bestellung können Sie auch jederzeit auf unserer Webseite im  Bereich "Mein Konto" - "Meine Bestellungen" abrufen: {{ rawUrl('frontend.account.order.single.page', { 'deepLinkCode': order.deepLinkCode }, salesChannel.domains|first.url) }}
+{% endif %}
+Den aktuellen Status Ihrer Bestellung können Sie auch jederzeit auf unserer Webseite im Bereich "Mein Konto" - "Meine Bestellungen" abrufen: {{ rawUrl('frontend.account.order.single.page', { 'deepLinkCode': order.deepLinkCode }, salesChannel.domains|first.url) }}
 Für Rückfragen stehen wir Ihnen jederzeit gerne zur Verfügung.
+
+{% if a11yDocuments is defined %}
+Folgend stellen wir barrierefreie Dokumente als HTML-Version zur Verfügung:
+
+{% for a11y in a11yDocuments %}
+{% set documentLink = rawUrl(
+    'frontend.account.order.single.document.a11y',
+    {
+        documentId: a11y.documentId,
+        deepLinkCode: a11y.deepLinkCode,
+        fileType: a11y.fileExtension,
+    },
+    salesChannel.domains|first.url
+)%}
+- {{ documentLink }}
+{% endfor %}
+
+Aus Datenschutzgründen ist für die HTML-Version ein Login erforderlich.
+Im Falle einer Gastbestellung können Sie Ihre Postanschrift und die Postleitzahl der Rechnungsanschrift verwenden.
+{% endif %}

--- a/src/Core/Migration/Fixtures/mails/order_confirmation_mail/de-plain.html.twig
+++ b/src/Core/Migration/Fixtures/mails/order_confirmation_mail/de-plain.html.twig
@@ -94,7 +94,7 @@ bestellen, erhalten Sie Ihre Ware umsatzsteuerbefreit.
 Den aktuellen Status Ihrer Bestellung können Sie auch jederzeit auf unserer Webseite im Bereich "Mein Konto" - "Meine Bestellungen" abrufen: {{ rawUrl('frontend.account.order.single.page', { 'deepLinkCode': order.deepLinkCode }, salesChannel.domains|first.url) }}
 Für Rückfragen stehen wir Ihnen jederzeit gerne zur Verfügung.
 
-{% if a11yDocuments is defined %}
+{% if a11yDocuments is defined and a11yDocuments is not empty %}
 Folgend stellen wir barrierefreie Dokumente als HTML-Version zur Verfügung:
 
 {% for a11y in a11yDocuments %}

--- a/src/Core/Migration/Fixtures/mails/order_confirmation_mail/en-html.html.twig
+++ b/src/Core/Migration/Fixtures/mails/order_confirmation_mail/en-html.html.twig
@@ -1,41 +1,41 @@
 <div style="font-family:arial; font-size:12px;">
 
-{% set currencyIsoCode = order.currency.isoCode %}
-{% if order.orderCustomer.salutation %}{{ order.orderCustomer.salutation.translated.letterName ~ ' ' }}{% endif %}{{ order.orderCustomer.firstName }} {{ order.orderCustomer.lastName }},<br>
-<br>
-We have received your order from {{ order.orderDateTime|format_datetime('medium', 'short', locale='en-GB') }}.<br>
-<br>
-Order number: {{ order.orderNumber }}<br>
-<br>
-As soon as your payment has been made, you will receive a separate notification and your order will be processed.<br>
-<br>
-You may check the current status of your order with this link: {{ rawUrl('frontend.account.order.single.page', { 'deepLinkCode': order.deepLinkCode }, salesChannel.domains|first.url) }}<br>
-You may use this link to edit your order, change the payment method or make additional payments.<br>
-<br>
-<strong>Information on your order:</strong><br>
-<br>
+    {% set currencyIsoCode = order.currency.isoCode %}
+    {% if order.orderCustomer.salutation %}{{ order.orderCustomer.salutation.translated.letterName ~ ' ' }}{% endif %}{{ order.orderCustomer.firstName }} {{ order.orderCustomer.lastName }},<br>
+    <br>
+    We have received your order from {{ order.orderDateTime|format_datetime('medium', 'short', locale='en-GB') }}.<br>
+    <br>
+    Order number: {{ order.orderNumber }}<br>
+    <br>
+    As soon as your payment has been made, you will receive a separate notification and your order will be processed.<br>
+    <br>
+    You may check the current status of your order with this link: {{ rawUrl('frontend.account.order.single.page', { 'deepLinkCode': order.deepLinkCode }, salesChannel.domains|first.url) }}<br>
+    You may use this link to edit your order, change the payment method or make additional payments.<br>
+    <br>
+    <strong>Information on your order:</strong><br>
+    <br>
 
-<table border="0" style="font-family:Arial, Helvetica, sans-serif; font-size:12px;">
-    <tr>
-        <td bgcolor="#F7F7F2" style="border-bottom:1px solid #cccccc;"><strong>Prod. no.</strong></td>
-        <td bgcolor="#F7F7F2" style="border-bottom:1px solid #cccccc;"><strong>Product image</strong></td>
-        <td bgcolor="#F7F7F2" style="border-bottom:1px solid #cccccc;"><strong>Description</strong></td>
-        <td bgcolor="#F7F7F2" style="border-bottom:1px solid #cccccc;"><strong>Quantities</strong></td>
-        <td bgcolor="#F7F7F2" style="border-bottom:1px solid #cccccc;"><strong>Price</strong></td>
-        <td bgcolor="#F7F7F2" style="border-bottom:1px solid #cccccc;"><strong>Total</strong></td>
-    </tr>
-
-    {% for lineItem in order.nestedLineItems %}
-        {% set nestingLevel = 0 %}
-        {% set nestedItem = lineItem %}
-        {% block lineItem %}
+    <table border="0" style="font-family:Arial, Helvetica, sans-serif; font-size:12px;">
         <tr>
-            <td>{% if nestedItem.payload.productNumber is defined %}{{ nestedItem.payload.productNumber|u.wordwrap(80) }}{% endif %}</td>
-            <td>{% if nestedItem.cover is defined and nestedItem.cover is not null %}<img src="{{ nestedItem.cover.url }}" width="75" height="auto"/>{% endif %}</td>
-            <td>
-                {% if nestingLevel > 0 %}
-                    {% for i in 1..nestingLevel %}
-                        <span style="position: relative;">
+            <td bgcolor="#F7F7F2" style="border-bottom:1px solid #cccccc;"><strong>Prod. no.</strong></td>
+            <td bgcolor="#F7F7F2" style="border-bottom:1px solid #cccccc;"><strong>Product image</strong></td>
+            <td bgcolor="#F7F7F2" style="border-bottom:1px solid #cccccc;"><strong>Description</strong></td>
+            <td bgcolor="#F7F7F2" style="border-bottom:1px solid #cccccc;"><strong>Quantities</strong></td>
+            <td bgcolor="#F7F7F2" style="border-bottom:1px solid #cccccc;"><strong>Price</strong></td>
+            <td bgcolor="#F7F7F2" style="border-bottom:1px solid #cccccc;"><strong>Total</strong></td>
+        </tr>
+
+        {% for lineItem in order.nestedLineItems %}
+            {% set nestingLevel = 0 %}
+            {% set nestedItem = lineItem %}
+            {% block lineItem %}
+                <tr>
+                    <td>{% if nestedItem.payload.productNumber is defined %}{{ nestedItem.payload.productNumber|u.wordwrap(80) }}{% endif %}</td>
+                    <td>{% if nestedItem.cover is defined and nestedItem.cover is not null %}<img src="{{ nestedItem.cover.url }}" width="75" height="auto"/>{% endif %}</td>
+                    <td>
+                        {% if nestingLevel > 0 %}
+                            {% for i in 1..nestingLevel %}
+                                <span style="position: relative;">
                             <span style="display: inline-block;
                                 position: absolute;
                                 width: 6px;
@@ -44,110 +44,136 @@ You may use this link to edit your order, change the payment method or make addi
                                 border-left:  2px solid rgba(0, 0, 0, 0.15);
                                 margin-left: {{ i * 10 }}px;"></span>
                         </span>
+                            {% endfor %}
+                        {% endif %}
+
+                        <div{% if nestingLevel > 0 %} style="padding-left: {{ (nestingLevel + 1) * 10 }}px"{% endif %}>
+                            {{ nestedItem.label|u.wordwrap(80) }}
+                        </div>
+
+                        {% if nestedItem.payload.options is defined and nestedItem.payload.options|length >= 1 %}
+                            <div>
+                                {% for option in nestedItem.payload.options %}
+                                    {{ option.group }}: {{ option.option }}
+                                    {% if nestedItem.payload.options|last != option %}
+                                        {{ " | " }}
+                                    {% endif %}
+                                {% endfor %}
+                            </div>
+                        {% endif %}
+
+                        {% if nestedItem.payload.features is defined and nestedItem.payload.features|length >= 1 %}
+                            {% set referencePriceFeatures = nestedItem.payload.features|filter(feature => feature.type == 'referencePrice') %}
+                            {% if referencePriceFeatures|length >= 1 %}
+                                {% set referencePriceFeature = referencePriceFeatures|first %}
+                                <div>
+                                    {{ referencePriceFeature.value.purchaseUnit }} {{ referencePriceFeature.value.unitName }}
+                                    ({{ referencePriceFeature.value.price|currency(currencyIsoCode) }} per {{ referencePriceFeature.value.referenceUnit }} {{ referencePriceFeature.value.unitName }})
+                                </div>
+                            {% endif %}
+                        {% endif %}
+                    </td>
+                    <td style="text-align: center">{{ nestedItem.quantity }}</td>
+                    <td>{{ nestedItem.unitPrice|currency(currencyIsoCode) }}</td>
+                    <td>{{ nestedItem.totalPrice|currency(currencyIsoCode) }}</td>
+                </tr>
+
+                {% if nestedItem.children.count > 0 %}
+                    {% set nestingLevel = nestingLevel + 1 %}
+                    {% for lineItem in nestedItem.children %}
+                        {% set nestedItem = lineItem %}
+                        {{ block('lineItem') }}
                     {% endfor %}
                 {% endif %}
+            {% endblock %}
+        {% endfor %}
+    </table>
 
-                <div{% if nestingLevel > 0 %} style="padding-left: {{ (nestingLevel + 1) * 10 }}px"{% endif %}>
-                    {{ nestedItem.label|u.wordwrap(80) }}
-                </div>
+    {% set delivery = order.deliveries.first %}
 
-                {% if nestedItem.payload.options is defined and nestedItem.payload.options|length >= 1 %}
-                    <div>
-                        {% for option in nestedItem.payload.options %}
-                            {{ option.group }}: {{ option.option }}
-                            {% if nestedItem.payload.options|last != option %}
-                                {{ " | " }}
-                            {% endif %}
-                        {% endfor %}
-                    </div>
-                {% endif %}
-
-                {% if nestedItem.payload.features is defined and nestedItem.payload.features|length >= 1 %}
-                    {% set referencePriceFeatures = nestedItem.payload.features|filter(feature => feature.type == 'referencePrice') %}
-                    {% if referencePriceFeatures|length >= 1 %}
-                        {% set referencePriceFeature = referencePriceFeatures|first %}
-                        <div>
-                            {{ referencePriceFeature.value.purchaseUnit }} {{ referencePriceFeature.value.unitName }}
-                            ({{ referencePriceFeature.value.price|currency(currencyIsoCode) }}* / {{ referencePriceFeature.value.referenceUnit }} {{ referencePriceFeature.value.unitName }})
-                        </div>
-                    {% endif %}
-                {% endif %}
-            </td>
-            <td style="text-align: center">{{ nestedItem.quantity }}</td>
-            <td>{{ nestedItem.unitPrice|currency(currencyIsoCode) }}</td>
-            <td>{{ nestedItem.totalPrice|currency(currencyIsoCode) }}</td>
-        </tr>
-
-            {% if nestedItem.children.count > 0 %}
-                {% set nestingLevel = nestingLevel + 1 %}
-                {% for lineItem in nestedItem.children %}
-                    {% set nestedItem = lineItem %}
-                    {{ block('lineItem') }}
-                {% endfor %}
-            {% endif %}
-        {% endblock %}
-    {% endfor %}
-</table>
-
-{% set delivery = order.deliveries.first %}
-
-{% set displayRounded = order.totalRounding.interval != 0.01 or order.totalRounding.decimals != order.itemRounding.decimals %}
-{% set decimals = order.totalRounding.decimals %}
-{% set total = order.price.totalPrice %}
-{% if displayRounded %}
-    {% set total = order.price.rawTotal %}
-    {% set decimals = order.itemRounding.decimals %}
-{% endif %}
-<p>
-    <br>
-    <br>
-    {% for shippingCost in order.deliveries %}
-        Shipping costs: {{ shippingCost.shippingCosts.totalPrice|currency(currencyIsoCode) }}<br>
-    {% endfor %}
-
-    Net total: {{ order.amountNet|currency(currencyIsoCode) }}<br>
-    {% for calculatedTax in order.price.calculatedTaxes %}
-        {% if order.taxStatus is same as('net') %}plus{% else %}including{% endif %} {{ calculatedTax.taxRate }}% VAT. {{ calculatedTax.tax|currency(currencyIsoCode) }}<br>
-    {% endfor %}
-    {% if not displayRounded %}<strong>{% endif %}Total gross: {{ total|currency(currencyIsoCode,decimals=decimals) }}{% if not displayRounded %}</strong>{% endif %}<br>
+    {% set displayRounded = order.totalRounding.interval != 0.01 or order.totalRounding.decimals != order.itemRounding.decimals %}
+    {% set decimals = order.totalRounding.decimals %}
+    {% set total = order.price.totalPrice %}
     {% if displayRounded %}
-        <strong>Rounded total gross: {{ order.price.totalPrice|currency(currencyIsoCode,decimals=order.totalRounding.decimals) }}</strong><br>
+        {% set total = order.price.rawTotal %}
+        {% set decimals = order.itemRounding.decimals %}
     {% endif %}
-    <br>
-
-    {% if delivery %}
-        <strong>Selected shipping type:</strong> {{ delivery.shippingMethod.translated.name }}<br>
-        {{ delivery.shippingMethod.translated.description }}<br>
+    <p>
         <br>
-    {% endif %}
-
-    {% set billingAddress = order.addresses.get(order.billingAddressId) %}
-    <strong>Billing address:</strong><br>
-    {{ billingAddress.company }}<br>
-    {{ billingAddress.firstName }} {{ billingAddress.lastName }}<br>
-    {{ billingAddress.street }} <br>
-    {{ billingAddress.zipcode }} {{ billingAddress.city }}<br>
-    {{ billingAddress.country.translated.name }}<br>
-    <br>
-
-    {% if delivery %}
-        <strong>Shipping address:</strong><br>
-        {{ delivery.shippingOrderAddress.company }}<br>
-        {{ delivery.shippingOrderAddress.firstName }} {{ delivery.shippingOrderAddress.lastName }}<br>
-        {{ delivery.shippingOrderAddress.street }} <br>
-        {{ delivery.shippingOrderAddress.zipcode}} {{ delivery.shippingOrderAddress.city }}<br>
-        {{ delivery.shippingOrderAddress.country.translated.name }}<br>
         <br>
-    {% endif %}
-    {% if order.orderCustomer.vatIds %}
-        Your VAT-ID: {{ order.orderCustomer.vatIds|first }}
-        In case of a successful order and if you are based in one of the EU countries, you will receive your goods exempt from turnover tax.<br>
-    {% endif %}
-    <br/>
-    You can check the current status of your order on our website under "My account" - "My orders" anytime: {{ rawUrl('frontend.account.order.single.page', { 'deepLinkCode': order.deepLinkCode }, salesChannel.domains|first.url) }}
-    </br>
-    If you have any questions, do not hesitate to contact us.
+        {% for shippingCost in order.deliveries %}
+            Shipping costs: {{ shippingCost.shippingCosts.totalPrice|currency(currencyIsoCode) }}<br>
+        {% endfor %}
 
-</p>
-<br>
+        Net total: {{ order.amountNet|currency(currencyIsoCode) }}<br>
+        {% for calculatedTax in order.price.calculatedTaxes %}
+            {% if order.taxStatus is same as('net') %}plus{% else %}including{% endif %} {{ calculatedTax.taxRate }}% VAT. {{ calculatedTax.tax|currency(currencyIsoCode) }}<br>
+        {% endfor %}
+        {% if not displayRounded %}<strong>{% endif %}Total gross: {{ total|currency(currencyIsoCode,decimals=decimals) }}{% if not displayRounded %}</strong>{% endif %}<br>
+        {% if displayRounded %}
+            <strong>Rounded total gross: {{ order.price.totalPrice|currency(currencyIsoCode,decimals=order.totalRounding.decimals) }}</strong><br>
+        {% endif %}
+        <br>
+
+        {% if order.transactions is defined and order.transactions is not empty %}
+            <strong>Selected payment type:</strong> {{ order.transactions.first.paymentMethod.translated.name }}<br>
+            {{ order.transactions.first.paymentMethod.translated.description }}<br>
+            <br>
+        {% endif %}
+
+        {% if delivery %}
+            <strong>Selected shipping type:</strong> {{ delivery.shippingMethod.translated.name }}<br>
+            {{ delivery.shippingMethod.translated.description }}<br>
+            <br>
+        {% endif %}
+
+        {% set billingAddress = order.addresses.get(order.billingAddressId) %}
+        <strong>Billing address:</strong><br>
+        {{ billingAddress.company }}<br>
+        {{ billingAddress.firstName }} {{ billingAddress.lastName }}<br>
+        {{ billingAddress.street }} <br>
+        {{ billingAddress.zipcode }} {{ billingAddress.city }}<br>
+        {{ billingAddress.country.translated.name }}<br>
+        <br>
+
+        {% if delivery %}
+            <strong>Shipping address:</strong><br>
+            {{ delivery.shippingOrderAddress.company }}<br>
+            {{ delivery.shippingOrderAddress.firstName }} {{ delivery.shippingOrderAddress.lastName }}<br>
+            {{ delivery.shippingOrderAddress.street }} <br>
+            {{ delivery.shippingOrderAddress.zipcode}} {{ delivery.shippingOrderAddress.city }}<br>
+            {{ delivery.shippingOrderAddress.country.translated.name }}<br>
+            <br>
+        {% endif %}
+        {% if order.orderCustomer.vatIds %}
+            Your VAT-ID: {{ order.orderCustomer.vatIds|first }}
+            In case of a successful order and if you are based in one of the EU countries, you will receive your goods exempt from turnover tax.<br>
+        {% endif %}
+        <br>
+        You can check the current status of your order on our website under "My account" - "My orders" anytime: {{ rawUrl('frontend.account.order.single.page', { 'deepLinkCode': order.deepLinkCode }, salesChannel.domains|first.url) }}
+        <br>
+        If you have any questions, do not hesitate to contact us.
+        <br>
+        {% if a11yDocuments is defined %}
+            <br>
+            For better accessibility we also provide an HTML version of the documents here:<br><br>
+            <ul>
+                {% for a11y in a11yDocuments %}
+                    {% set documentLink = rawUrl(
+                        'frontend.account.order.single.document.a11y',
+                        {
+                            documentId: a11y.documentId,
+                            deepLinkCode: a11y.deepLinkCode,
+                            fileType: a11y.fileExtension,
+                        },
+                        salesChannel.domains|first.url
+                    )%}
+                    <li><a href="{{ documentLink }}" target="_blank">{{ documentLink }}</a></li>
+                {% endfor %}
+            </ul>
+            For data protection reasons the HTML version requires a login. <br><br>
+            In case of a guest order, you can use your mail address and postal code of the billing address.<br>
+        {% endif %}
+    </p>
+    <br>
 </div>

--- a/src/Core/Migration/Fixtures/mails/order_confirmation_mail/en-html.html.twig
+++ b/src/Core/Migration/Fixtures/mails/order_confirmation_mail/en-html.html.twig
@@ -154,7 +154,7 @@
         <br>
         If you have any questions, do not hesitate to contact us.
         <br>
-        {% if a11yDocuments is defined %}
+        {% if a11yDocuments is defined and a11yDocuments is not empty %}
             <br>
             For better accessibility we also provide an HTML version of the documents here:<br><br>
             <ul>

--- a/src/Core/Migration/Fixtures/mails/order_confirmation_mail/en-plain.html.twig
+++ b/src/Core/Migration/Fixtures/mails/order_confirmation_mail/en-plain.html.twig
@@ -93,7 +93,7 @@ In case of a successful order and if you are based in one of the EU countries, y
 You can check the current status of your order on our website under "My account" - "My orders" anytime: {{ rawUrl('frontend.account.order.single.page', { 'deepLinkCode': order.deepLinkCode }, salesChannel.domains|first.url) }}
 If you have any questions, do not hesitate to contact us.
 
-{% if a11yDocuments is defined %}
+{% if a11yDocuments is defined and a11yDocuments is not empty %}
 For better accessibility we also provide an HTML version of the documents here:
 
 {% for a11y in a11yDocuments %}

--- a/src/Core/Migration/Fixtures/mails/order_confirmation_mail/en-plain.html.twig
+++ b/src/Core/Migration/Fixtures/mails/order_confirmation_mail/en-plain.html.twig
@@ -12,15 +12,34 @@ You may use this link to edit your order, change the payment method or make addi
 
 Information on your order:
 
-Pos.   Prod. No.			Product image(Alt text)			Description			Quantities			Price			Total
-
 {% for lineItem in order.lineItems %}
-{{ loop.index }}      {% if lineItem.payload.productNumber is defined %}{{ lineItem.payload.productNumber|u.wordwrap(80) }}{% endif %}        {% if nestedItem.cover is defined and nestedItem.cover is not null %}{{ lineItem.cover.alt }}{% endif %}        {{ lineItem.label|u.wordwrap(80) }}{% if lineItem.payload.options is defined and lineItem.payload.options|length >= 1 %}, {% for option in lineItem.payload.options %}{{ option.group }}: {{ option.option }}{% if lineItem.payload.options|last != option %}{{ " | " }}{% endif %}{% endfor %}{% endif %}{% if lineItem.payload.features is defined and lineItem.payload.features|length >= 1 %}{% set referencePriceFeatures = lineItem.payload.features|filter(feature => feature.type == 'referencePrice') %}{% if referencePriceFeatures|length >= 1 %}{% set referencePriceFeature = referencePriceFeatures|first %}, {{ referencePriceFeature.value.purchaseUnit }} {{ referencePriceFeature.value.unitName }}({{ referencePriceFeature.value.price|currency(currencyIsoCode) }}* / {{ referencePriceFeature.value.referenceUnit }} {{ referencePriceFeature.value.unitName }}){% endif %}{% endif %}
-    {{ lineItem.quantity }}			{{ lineItem.unitPrice|currency(currencyIsoCode) }}			{{ lineItem.totalPrice|currency(currencyIsoCode) }}
+Pos. {{ loop.index }}
+---------------------
+{% if lineItem.payload.productNumber is defined %}
+Product number {{ lineItem.payload.productNumber|u.wordwrap(80) }},
+{% endif %}
+{% if nestedItem.cover is defined and nestedItem.cover is not null %}
+Image {{ lineItem.cover.alt }},
+{% endif %}
+Description {{ lineItem.label|u.wordwrap(80) }},
+{% if lineItem.payload.options is defined and lineItem.payload.options|length >= 1 %}
+{% for option in lineItem.payload.options %}
+{{ option.group }}: {{ option.option }}{{ ", " }}
 {% endfor %}
+{% endif %}
+{% if lineItem.payload.features is defined and lineItem.payload.features|length >= 1 %}
+{% set referencePriceFeatures = lineItem.payload.features|filter(feature => feature.type == 'referencePrice') %}
+{% if referencePriceFeatures|length >= 1 %}
+{% set referencePriceFeature = referencePriceFeatures|first %}
+{{ referencePriceFeature.value.purchaseUnit }} {{ referencePriceFeature.value.unitName }}({{ referencePriceFeature.value.price|currency(currencyIsoCode) }} per {{ referencePriceFeature.value.referenceUnit }} {{ referencePriceFeature.value.unitName }}),
+{% endif %}
+{% endif %}
+Quantity {{ lineItem.quantity }},
+Price {{ lineItem.unitPrice|currency(currencyIsoCode) }},
+Total {{ lineItem.totalPrice|currency(currencyIsoCode) }},
 
+{% endfor %}
 {% set delivery = order.deliveries.first %}
-
 {% set displayRounded = order.totalRounding.interval != 0.01 or order.totalRounding.decimals != order.itemRounding.decimals %}
 {% set decimals = order.totalRounding.decimals %}
 {% set total = order.price.totalPrice %}
@@ -28,9 +47,8 @@ Pos.   Prod. No.			Product image(Alt text)			Description			Quantities			Price			
     {% set total = order.price.rawTotal %}
     {% set decimals = order.itemRounding.decimals %}
 {% endif %}
-
 {% for shippingCost in order.deliveries %}
-    Shipping costs: {{ shippingCost.shippingCosts.totalPrice|currency(currencyIsoCode) }}<br>
+Shipping costs: {{ shippingCost.shippingCosts.totalPrice|currency(currencyIsoCode) }}
 {% endfor %}
 Net total: {{ order.amountNet|currency(currencyIsoCode) }}
 {% for calculatedTax in order.price.calculatedTaxes %}
@@ -41,11 +59,15 @@ Total gross: {{ total|currency(currencyIsoCode,decimals=decimals) }}
 Rounded total gross: {{ order.price.totalPrice|currency(currencyIsoCode,decimals=order.totalRounding.decimals) }}
 {% endif %}
 
+{% if order.transactions is defined and order.transactions is not empty %}
+Selected payment type: {{ order.transactions.first.paymentMethod.translated.name }}
+{{ order.transactions.first.paymentMethod.translated.description }}
+{% endif %}
+
 {% if delivery %}
 Selected shipping type: {{ delivery.shippingMethod.translated.name }}
 {{ delivery.shippingMethod.translated.description }}
 {% endif %}
-
 {% set billingAddress = order.addresses.get(order.billingAddressId) %}
 Billing address:
 {{ billingAddress.company }}
@@ -66,9 +88,27 @@ Shipping address:
 {% if order.orderCustomer.vatIds %}
 Your VAT-ID: {{ order.orderCustomer.vatIds|first }}
 In case of a successful order and if you are based in one of the EU countries, you will receive your goods exempt from turnover tax.
-{% endif %}
 
+{% endif %}
 You can check the current status of your order on our website under "My account" - "My orders" anytime: {{ rawUrl('frontend.account.order.single.page', { 'deepLinkCode': order.deepLinkCode }, salesChannel.domains|first.url) }}
 If you have any questions, do not hesitate to contact us.
 
-However, in case you have purchased without a registration or a customer account, you do not have this option.
+{% if a11yDocuments is defined %}
+For better accessibility we also provide an HTML version of the documents here:
+
+{% for a11y in a11yDocuments %}
+{% set documentLink = rawUrl(
+    'frontend.account.order.single.document.a11y',
+    {
+        documentId: a11y.documentId,
+        'deepLinkCode': a11y.deepLinkCode,
+        fileType: a11y.fileExtension,
+    },
+    salesChannel.domains|first.url
+)%}
+- {{ documentLink }}
+{% endfor %}
+
+For data protection reasons the HTML version requires a login.
+In case of a guest order, you can use your mail address and postal code of the billing address.
+{% endif %}

--- a/src/Core/Migration/Fixtures/mails/order_transaction.state.cancelled/de-html.html.twig
+++ b/src/Core/Migration/Fixtures/mails/order_transaction.state.cancelled/de-html.html.twig
@@ -151,7 +151,7 @@
         <br>
         Für Rückfragen stehen wir Ihnen jederzeit gerne zur Verfügung.
         <br>
-        {% if a11yDocuments is defined %}
+        {% if a11yDocuments is defined and a11yDocuments is not empty %}
             <br>
             Folgend stellen wir barrierefreie Dokumente als HTML-Version zur Verfügung:<br><br>
             <ul>

--- a/src/Core/Migration/Fixtures/mails/order_transaction.state.cancelled/de-html.html.twig
+++ b/src/Core/Migration/Fixtures/mails/order_transaction.state.cancelled/de-html.html.twig
@@ -1,36 +1,38 @@
 <div style="font-family:arial; font-size:12px;">
 
-{% set currencyIsoCode = order.currency.isoCode %}
-Hallo {% if order.orderCustomer.salutation %}{{ order.orderCustomer.salutation.translated.letterName ~ ' ' }}{% endif %}{{ order.orderCustomer.firstName }} {{ order.orderCustomer.lastName }},<br>
-<br>
-Ihre Bestellung ist am {{ order.orderDateTime|format_datetime('medium', 'short', locale='de-DE') }} bei uns eingegangen.<br>
-<br>
-Bestellnummer: {{ order.orderNumber }}
-<br>
-Der Zahlungsprozess mit {{ order.transactions.first.paymentMethod.translated.name }} ist noch nicht abgeschlossen. Sie können den Zahlungsprozess über die folgende URL wieder aufnehmen: {{ rawUrl('frontend.account.order.single.page', { 'deepLinkCode': order.deepLinkCode }, salesChannel.domains|first.url) }}<br>
-<br>
-<strong>Informationen zu Ihrer Bestellung:</strong><br>
-<br>
+    {% set currencyIsoCode = order.currency.isoCode %}
+    Hallo {% if order.orderCustomer.salutation %}{{ order.orderCustomer.salutation.translated.letterName ~ ' ' }}{% endif %}{{ order.orderCustomer.firstName }} {{ order.orderCustomer.lastName }},<br>
+    <br>
+    Ihre Bestellung ist am {{ order.orderDateTime|format_datetime('medium', 'short', locale='de-DE') }} bei uns eingegangen.<br>
+    <br>
+    Bestellnummer: {{ order.orderNumber }}
+    <br>
+    Der Zahlungsprozess mit {{ order.transactions.first.paymentMethod.translated.name }} ist noch nicht abgeschlossen. Sie können den Zahlungsprozess über die folgende URL wieder aufnehmen: {{ rawUrl('frontend.account.order.single.page', { 'deepLinkCode': order.deepLinkCode }, salesChannel.domains|first.url) }}<br>
+    <br>
+    <strong>Informationen zu Ihrer Bestellung:</strong><br>
+    <br>
 
-<table border="0" style="font-family:Arial, Helvetica, sans-serif; font-size:12px;">
-    <tr>
-        <td bgcolor="#F7F7F2" style="border-bottom:1px solid #cccccc;"><strong>Produkt-Nr.</strong></td>
-        <td bgcolor="#F7F7F2" style="border-bottom:1px solid #cccccc;"><strong>Bezeichnung</strong></td>
-        <td bgcolor="#F7F7F2" style="border-bottom:1px solid #cccccc;"><strong>Menge</strong></td>
-        <td bgcolor="#F7F7F2" style="border-bottom:1px solid #cccccc;"><strong>Preis</strong></td>
-        <td bgcolor="#F7F7F2" style="border-bottom:1px solid #cccccc;"><strong>Summe</strong></td>
-    </tr>
+    <table border="0" style="font-family:Arial, Helvetica, sans-serif; font-size:12px;">
+        <tr>
+            <td bgcolor="#F7F7F2" style="border-bottom:1px solid #cccccc;"><strong>Produkt-Nr.</strong></td>
+            <td bgcolor="#F7F7F2" style="border-bottom:1px solid #cccccc;"><strong>Produktbild</strong></td>
+            <td bgcolor="#F7F7F2" style="border-bottom:1px solid #cccccc;"><strong>Bezeichnung</strong></td>
+            <td bgcolor="#F7F7F2" style="border-bottom:1px solid #cccccc;"><strong>Menge</strong></td>
+            <td bgcolor="#F7F7F2" style="border-bottom:1px solid #cccccc;"><strong>Preis</strong></td>
+            <td bgcolor="#F7F7F2" style="border-bottom:1px solid #cccccc;"><strong>Summe</strong></td>
+        </tr>
 
-    {% for lineItem in order.nestedLineItems %}
-        {% set nestingLevel = 0 %}
-        {% set nestedItem = lineItem %}
-        {% block lineItem %}
-            <tr>
-                <td>{% if nestedItem.payload.productNumber is defined %}{{ nestedItem.payload.productNumber|u.wordwrap(80) }}{% endif %}</td>
-                <td>
-                    {% if nestingLevel > 0 %}
-                        {% for i in 1..nestingLevel %}
-                            <span style="position: relative;">
+        {% for lineItem in order.nestedLineItems %}
+            {% set nestingLevel = 0 %}
+            {% set nestedItem = lineItem %}
+            {% block lineItem %}
+                <tr>
+                    <td>{% if nestedItem.payload.productNumber is defined %}{{ nestedItem.payload.productNumber|u.wordwrap(80) }}{% endif %}</td>
+                    <td>{% if nestedItem.cover is defined and nestedItem.cover is not null %}<img src="{{ nestedItem.cover.url }}" width="75" height="auto"/>{% endif %}</td>
+                    <td>
+                        {% if nestingLevel > 0 %}
+                            {% for i in 1..nestingLevel %}
+                                <span style="position: relative;">
                                 <span style="display: inline-block;
                                     position: absolute;
                                     width: 6px;
@@ -39,135 +41,136 @@ Der Zahlungsprozess mit {{ order.transactions.first.paymentMethod.translated.nam
                                     border-left:  2px solid rgba(0, 0, 0, 0.15);
                                     margin-left: {{ i * 10 }}px;"></span>
                             </span>
-                        {% endfor %}
-                    {% endif %}
-
-                    <div{% if nestingLevel > 0 %} style="padding-left: {{ (nestingLevel + 1) * 10 }}px"{% endif %}>
-                        {{ nestedItem.label|u.wordwrap(80) }}
-                    </div>
-
-                    {% if nestedItem.payload.options is defined and nestedItem.payload.options|length >= 1 %}
-                        <div>
-                            {% for option in nestedItem.payload.options %}
-                                {{ option.group }}: {{ option.option }}
-                                {% if nestedItem.payload.options|last != option %}
-                                    {{ " | " }}
-                                {% endif %}
                             {% endfor %}
-                        </div>
-                    {% endif %}
+                        {% endif %}
 
-                    {% if nestedItem.payload.features is defined and nestedItem.payload.features|length >= 1 %}
-                        {% set referencePriceFeatures = nestedItem.payload.features|filter(feature => feature.type == 'referencePrice') %}
-                        {% if referencePriceFeatures|length >= 1 %}
-                            {% set referencePriceFeature = referencePriceFeatures|first %}
+                        <div{% if nestingLevel > 0 %} style="padding-left: {{ (nestingLevel + 1) * 10 }}px"{% endif %}>
+                            {{ nestedItem.label|u.wordwrap(80) }}
+                        </div>
+
+                        {% if nestedItem.payload.options is defined and nestedItem.payload.options|length >= 1 %}
                             <div>
-                                {{ referencePriceFeature.value.purchaseUnit }} {{ referencePriceFeature.value.unitName }}
-                                ({{ referencePriceFeature.value.price|currency(currencyIsoCode) }}* / {{ referencePriceFeature.value.referenceUnit }} {{ referencePriceFeature.value.unitName }})
+                                {% for option in nestedItem.payload.options %}
+                                    {{ option.group }}: {{ option.option }}
+                                    {% if nestedItem.payload.options|last != option %}
+                                        {{ " | " }}
+                                    {% endif %}
+                                {% endfor %}
                             </div>
                         {% endif %}
-                    {% endif %}
-                </td>
-                <td style="text-align: center">{{ nestedItem.quantity }}</td>
-                <td>{{ nestedItem.unitPrice|currency(currencyIsoCode) }}</td>
-                <td>{% if nestingLevel == 0 %}{{ nestedItem.totalPrice|currency(currencyIsoCode) }}{% endif %}</td>
-            </tr>
 
-            {% if nestedItem.children.count > 0 %}
-                {% set nestingLevel = nestingLevel + 1 %}
-                {% for lineItem in nestedItem.children %}
-                    {% set nestedItem = lineItem %}
-                    {{ block('lineItem') }}
-                {% endfor %}
-            {% endif %}
-        {% endblock %}
-    {% endfor %}
-</table>
+                        {% if nestedItem.payload.features is defined and nestedItem.payload.features|length >= 1 %}
+                            {% set referencePriceFeatures = nestedItem.payload.features|filter(feature => feature.type == 'referencePrice') %}
+                            {% if referencePriceFeatures|length >= 1 %}
+                                {% set referencePriceFeature = referencePriceFeatures|first %}
+                                <div>
+                                    {{ referencePriceFeature.value.purchaseUnit }} {{ referencePriceFeature.value.unitName }}
+                                    ({{ referencePriceFeature.value.price|currency(currencyIsoCode) }} pro {{ referencePriceFeature.value.referenceUnit }} {{ referencePriceFeature.value.unitName }})
+                                </div>
+                            {% endif %}
+                        {% endif %}
+                    </td>
+                    <td style="text-align: center">{{ nestedItem.quantity }}</td>
+                    <td>{{ nestedItem.unitPrice|currency(currencyIsoCode) }}</td>
+                    <td>{{ nestedItem.totalPrice|currency(currencyIsoCode) }}</td>
+                </tr>
 
-{% set delivery = order.deliveries.first %}
+                {% if nestedItem.children.count > 0 %}
+                    {% set nestingLevel = nestingLevel + 1 %}
+                    {% for lineItem in nestedItem.children %}
+                        {% set nestedItem = lineItem %}
+                        {{ block('lineItem') }}
+                    {% endfor %}
+                {% endif %}
+            {% endblock %}
+        {% endfor %}
+    </table>
 
-{% set displayRounded = order.totalRounding.interval != 0.01 or order.totalRounding.decimals != order.itemRounding.decimals %}
-{% set decimals = order.totalRounding.decimals %}
-{% set total = order.price.totalPrice %}
-{% if displayRounded %}
-    {% set total = order.price.rawTotal %}
-    {% set decimals = order.itemRounding.decimals %}
-{% endif %}
+    {% set delivery = order.deliveries.first %}
 
-<p>
-    <br>
-    <br>
-    {% for shippingCost in order.deliveries %}
-        Versandkosten: {{ shippingCost.shippingCosts.totalPrice|currency(currencyIsoCode) }}<br>
-    {% endfor %}
-    Gesamtkosten Netto: {{ order.amountNet|currency(currencyIsoCode) }}<br>
+    {% set displayRounded = order.totalRounding.interval != 0.01 or order.totalRounding.decimals != order.itemRounding.decimals %}
+    {% set decimals = order.totalRounding.decimals %}
+    {% set total = order.price.totalPrice %}
+    {% if displayRounded %}
+        {% set total = order.price.rawTotal %}
+        {% set decimals = order.itemRounding.decimals %}
+    {% endif %}
+    <p>
+        <br>
+        <br>
+        {% for shippingCost in order.deliveries %}
+            Versandkosten: {{ shippingCost.shippingCosts.totalPrice|currency(currencyIsoCode) }}<br>
+        {% endfor %}
+        Gesamtkosten Netto: {{ order.amountNet|currency(currencyIsoCode) }}<br>
         {% for calculatedTax in order.price.calculatedTaxes %}
             {% if order.taxStatus is same as('net') %}zzgl.{% else %}inkl.{% endif %} {{ calculatedTax.taxRate }}% MwSt. {{ calculatedTax.tax|currency(currencyIsoCode) }}<br>
         {% endfor %}
-    {% if not displayRounded %}<strong>{% endif %}Gesamtkosten Brutto: {{ total|currency(currencyIsoCode,decimals=decimals) }}{% if not displayRounded %}</strong>{% endif %}<br>
-    {% if displayRounded %}
-        <strong>Gesamtkosten Brutto gerundet: {{ order.price.totalPrice|currency(currencyIsoCode,decimals=order.totalRounding.decimals) }}</strong><br>
-    {% endif %}
-
-    <br>
-
-    <strong>Gewählte Zahlungsart:</strong> {{ order.transactions.first.paymentMethod.translated.name }}<br>
-    {{ order.transactions.first.paymentMethod.translated.description }}<br>
-    <br>
-
-    {% if delivery %}
-        <strong>Gewählte Versandart:</strong> {{ delivery.shippingMethod.translated.name }}<br>
-        {{ delivery.shippingMethod.translated.description }}<br>
+        {% if not displayRounded %}<strong>{% endif %}Gesamtkosten Brutto: {{ total|currency(currencyIsoCode,decimals=decimals) }}{% if not displayRounded %}</strong>{% endif %}<br>
+        {% if displayRounded %}
+            <strong>Gesamtkosten Brutto gerundet: {{ order.price.totalPrice|currency(currencyIsoCode,decimals=order.totalRounding.decimals) }}</strong><br>
+        {% endif %}
         <br>
-    {% endif %}
 
-    {% set billingAddress = order.addresses.get(order.billingAddressId) %}
-    <strong>Rechnungsadresse:</strong><br>
-    {{ billingAddress.company }}<br>
-    {{ billingAddress.firstName }} {{ billingAddress.lastName }}<br>
-    {{ billingAddress.street }} <br>
-    {{ billingAddress.zipcode }} {{ billingAddress.city }}<br>
-    {{ billingAddress.country.translated.name }}<br>
-    <br>
+        {% if order.transactions is defined and order.transactions is not empty %}
+            <strong>Gewählte Zahlungsart:</strong> {{ order.transactions.first.paymentMethod.translated.name }}<br>
+            {{ order.transactions.first.paymentMethod.translated.description }}<br>
+            <br>
+        {% endif %}
 
-    {% if delivery %}
-        <strong>Lieferadresse:</strong><br>
-        {{ delivery.shippingOrderAddress.company }}<br>
-        {{ delivery.shippingOrderAddress.firstName }} {{ delivery.shippingOrderAddress.lastName }}<br>
-        {{ delivery.shippingOrderAddress.street }} <br>
-        {{ delivery.shippingOrderAddress.zipcode}} {{ delivery.shippingOrderAddress.city }}<br>
-        {{ delivery.shippingOrderAddress.country.translated.name }}<br>
+        {% if delivery %}
+            <strong>Gewählte Versandart:</strong> {{ delivery.shippingMethod.translated.name }}<br>
+            {{ delivery.shippingMethod.translated.description }}<br>
+            <br>
+        {% endif %}
+
+        {% set billingAddress = order.addresses.get(order.billingAddressId) %}
+        <strong>Rechnungsadresse:</strong><br>
+        {{ billingAddress.company }}<br>
+        {{ billingAddress.firstName }} {{ billingAddress.lastName }}<br>
+        {{ billingAddress.street }} <br>
+        {{ billingAddress.zipcode }} {{ billingAddress.city }}<br>
+        {{ billingAddress.country.translated.name }}<br>
         <br>
-    {% endif %}
-    {% if order.orderCustomer.vatIds %}
-        Ihre Umsatzsteuer-ID: {{ order.orderCustomer.vatIds|first }}
-        Bei erfolgreicher Prüfung und sofern Sie aus dem EU-Ausland
-        bestellen, erhalten Sie Ihre Ware umsatzsteuerbefreit. <br>
-    {% endif %}
-    <br/>
-    Den aktuellen Status Ihrer Bestellung können Sie auch jederzeit auf unserer Webseite im  Bereich "Mein Konto" - "Meine Bestellungen" abrufen: {{ rawUrl('frontend.account.order.single.page', { 'deepLinkCode': order.deepLinkCode }, salesChannel.domains|first.url) }}
-    </br>
-    Für Rückfragen stehen wir Ihnen jederzeit gerne zur Verfügung.
-    <br><br>
-    {% if a11yDocuments %}
-        Folgend stellen wir barrierefreie Dokumente als HTML-Version zur Verfügung:<br><br>
-        {% for a11y in a11yDocuments %}
-            {% set documentLink = rawUrl(
-                'frontend.account.order.single.document.a11y',
-                {
-                    documentId: a11y.documentId,
-                    deepLinkCode: a11y.deepLinkCode,
-                    fileType: a11y.fileExtension,
-                },
-                salesChannel.domains|first.url
-            )%}
 
-            - <a href="{{ documentLink }}" target="_blank">{{ documentLink }}</a> <br>
-        {% endfor %}<br>
-
-        Aus Datenschutzgründen ist für die HTML-Version ein Login erforderlich.<br><br>
-        Im Falle einer Gastbestellung können Sie Ihre Postanschrift und die Postleitzahl der Rechnungsanschrift verwenden.<br>
-    {% endif %}
-</p>
-<br>
+        {% if delivery %}
+            <strong>Lieferadresse:</strong><br>
+            {{ delivery.shippingOrderAddress.company }}<br>
+            {{ delivery.shippingOrderAddress.firstName }} {{ delivery.shippingOrderAddress.lastName }}<br>
+            {{ delivery.shippingOrderAddress.street }} <br>
+            {{ delivery.shippingOrderAddress.zipcode}} {{ delivery.shippingOrderAddress.city }}<br>
+            {{ delivery.shippingOrderAddress.country.translated.name }}<br>
+            <br>
+        {% endif %}
+        {% if order.orderCustomer.vatIds %}
+            Ihre Umsatzsteuer-ID: {{ order.orderCustomer.vatIds|first }}
+            Bei erfolgreicher Prüfung und sofern Sie aus dem EU-Ausland
+            bestellen, erhalten Sie Ihre Ware umsatzsteuerbefreit. <br>
+        {% endif %}
+        <br>
+        Den aktuellen Status Ihrer Bestellung können Sie auch jederzeit auf unserer Webseite im  Bereich "Mein Konto" - "Meine Bestellungen" abrufen: {{ rawUrl('frontend.account.order.single.page', { 'deepLinkCode': order.deepLinkCode }, salesChannel.domains|first.url) }}
+        <br>
+        Für Rückfragen stehen wir Ihnen jederzeit gerne zur Verfügung.
+        <br>
+        {% if a11yDocuments is defined %}
+            <br>
+            Folgend stellen wir barrierefreie Dokumente als HTML-Version zur Verfügung:<br><br>
+            <ul>
+                {% for a11y in a11yDocuments %}
+                    {% set documentLink = rawUrl(
+                        'frontend.account.order.single.document.a11y',
+                        {
+                            documentId: a11y.documentId,
+                            deepLinkCode: a11y.deepLinkCode,
+                            fileType: a11y.fileExtension,
+                        },
+                        salesChannel.domains|first.url
+                    )%}
+                    <li><a href="{{ documentLink }}" target="_blank">{{ documentLink }}</a></li>
+                {% endfor %}
+            </ul>
+            Aus Datenschutzgründen ist für die HTML-Version ein Login erforderlich.<br><br>
+            Im Falle einer Gastbestellung können Sie Ihre Postanschrift und die Postleitzahl der Rechnungsanschrift verwenden.<br>
+        {% endif %}
+    </p>
+    <br>
 </div>

--- a/src/Core/Migration/Fixtures/mails/order_transaction.state.cancelled/de-plain.html.twig
+++ b/src/Core/Migration/Fixtures/mails/order_transaction.state.cancelled/de-plain.html.twig
@@ -9,14 +9,34 @@ Der Zahlungsprozess mit {{ order.transactions.first.paymentMethod.translated.nam
 
 Informationen zu Ihrer Bestellung:
 
-Pos.   Artikel-Nr.			Beschreibung			Menge			Preis			Summe
 {% for lineItem in order.lineItems %}
-{{ loop.index }}      {% if lineItem.payload.productNumber is defined %}{{ lineItem.payload.productNumber|u.wordwrap(80) }}{% endif %}				{{ lineItem.label|u.wordwrap(80) }}{% if lineItem.payload.options is defined and lineItem.payload.options|length >= 1 %}, {% for option in lineItem.payload.options %}{{ option.group }}: {{ option.option }}{% if lineItem.payload.options|last != option %}{{ " | " }}{% endif %}{% endfor %}{% endif %}{% if lineItem.payload.features is defined and lineItem.payload.features|length >= 1 %}{% set referencePriceFeatures = lineItem.payload.features|filter(feature => feature.type == 'referencePrice') %}{% if referencePriceFeatures|length >= 1 %}{% set referencePriceFeature = referencePriceFeatures|first %}, {{ referencePriceFeature.value.purchaseUnit }} {{ referencePriceFeature.value.unitName }}({{ referencePriceFeature.value.price|currency(currencyIsoCode) }}* / {{ referencePriceFeature.value.referenceUnit }} {{ referencePriceFeature.value.unitName }}){% endif %}{% endif %}
-    {{ lineItem.quantity }}			{{ lineItem.unitPrice|currency(currencyIsoCode) }}			{{ lineItem.totalPrice|currency(currencyIsoCode) }}
+Pos. {{ loop.index }}
+---------------------
+{% if lineItem.payload.productNumber is defined %}
+Artikel-Nr. {{ lineItem.payload.productNumber|u.wordwrap(80) }},
+{% endif %}
+{% if nestedItem.cover is defined and nestedItem.cover is not null %}
+Produktbild {{ lineItem.cover.alt }},
+{% endif %}
+Beschreibung {{ lineItem.label|u.wordwrap(80) }},
+{% if lineItem.payload.options is defined and lineItem.payload.options|length >= 1 %}
+{% for option in lineItem.payload.options %}
+{{ option.group }}: {{ option.option }}{{ ", " }}
 {% endfor %}
+{% endif %}
+{% if lineItem.payload.features is defined and lineItem.payload.features|length >= 1 %}
+{% set referencePriceFeatures = lineItem.payload.features|filter(feature => feature.type == 'referencePrice') %}
+{% if referencePriceFeatures|length >= 1 %}
+{% set referencePriceFeature = referencePriceFeatures|first %}
+{{ referencePriceFeature.value.purchaseUnit }} {{ referencePriceFeature.value.unitName }}({{ referencePriceFeature.value.price|currency(currencyIsoCode) }} pro {{ referencePriceFeature.value.referenceUnit }} {{ referencePriceFeature.value.unitName }}),
+{% endif %}
+{% endif %}
+Menge {{ lineItem.quantity }},
+Preis {{ lineItem.unitPrice|currency(currencyIsoCode) }},
+Summe {{ lineItem.totalPrice|currency(currencyIsoCode) }},
 
+{% endfor %}
 {% set delivery = order.deliveries.first %}
-
 {% set displayRounded = order.totalRounding.interval != 0.01 or order.totalRounding.decimals != order.itemRounding.decimals %}
 {% set decimals = order.totalRounding.decimals %}
 {% set total = order.price.totalPrice %}
@@ -24,27 +44,27 @@ Pos.   Artikel-Nr.			Beschreibung			Menge			Preis			Summe
     {% set total = order.price.rawTotal %}
     {% set decimals = order.itemRounding.decimals %}
 {% endif %}
-
 {% for shippingCost in order.deliveries %}
-    Versandkosten: {{ shippingCost.shippingCosts.totalPrice|currency(currencyIsoCode) }}<br>
+Versandkosten: {{ shippingCost.shippingCosts.totalPrice|currency(currencyIsoCode) }}
 {% endfor %}
 Gesamtkosten Netto: {{ order.amountNet|currency(currencyIsoCode) }}
-    {% for calculatedTax in order.price.calculatedTaxes %}
-        {% if order.taxStatus is same as('net') %}zzgl.{% else %}inkl.{% endif %} {{ calculatedTax.taxRate }}% MwSt. {{ calculatedTax.tax|currency(currencyIsoCode) }}
-    {% endfor %}
+{% for calculatedTax in order.price.calculatedTaxes %}
+{% if order.taxStatus is same as('net') %}zzgl.{% else %}inkl.{% endif %} {{ calculatedTax.taxRate }}% MwSt. {{ calculatedTax.tax|currency(currencyIsoCode) }}
+{% endfor %}
 Gesamtkosten Brutto: {{ total|currency(currencyIsoCode,decimals=decimals) }}
 {% if displayRounded %}
 Gesamtkosten Brutto gerundet: {{ order.price.totalPrice|currency(currencyIsoCode,decimals=order.totalRounding.decimals) }}
 {% endif %}
 
+{% if order.transactions is defined and order.transactions is not empty %}
 Gewählte Zahlungsart: {{ order.transactions.first.paymentMethod.translated.name }}
 {{ order.transactions.first.paymentMethod.translated.description }}
+{% endif %}
 
 {% if delivery %}
 Gewählte Versandart: {{ delivery.shippingMethod.translated.name }}
 {{ delivery.shippingMethod.translated.description }}
 {% endif %}
-
 {% set billingAddress = order.addresses.get(order.billingAddressId) %}
 Rechnungsadresse:
 {{ billingAddress.company }}
@@ -66,28 +86,27 @@ Lieferadresse:
 Ihre Umsatzsteuer-ID: {{ order.orderCustomer.vatIds|first }}
 Bei erfolgreicher Prüfung und sofern Sie aus dem EU-Ausland
 bestellen, erhalten Sie Ihre Ware umsatzsteuerbefreit.
-{% endif %}
 
-Den aktuellen Status Ihrer Bestellung können Sie auch jederzeit auf unserer Webseite im  Bereich "Mein Konto" - "Meine Bestellungen" abrufen: {{ rawUrl('frontend.account.order.single.page', { 'deepLinkCode': order.deepLinkCode }, salesChannel.domains|first.url) }}
+{% endif %}
+Den aktuellen Status Ihrer Bestellung können Sie auch jederzeit auf unserer Webseite im Bereich "Mein Konto" - "Meine Bestellungen" abrufen: {{ rawUrl('frontend.account.order.single.page', { 'deepLinkCode': order.deepLinkCode }, salesChannel.domains|first.url) }}
 Für Rückfragen stehen wir Ihnen jederzeit gerne zur Verfügung.
 
-{% if a11yDocuments %}
-    Folgend stellen wir barrierefreie Dokumente als HTML-Version zur Verfügung:
+{% if a11yDocuments is defined %}
+Folgend stellen wir barrierefreie Dokumente als HTML-Version zur Verfügung:
 
-    {% for a11y in a11yDocuments %}
-        {% set documentLink = rawUrl(
-            'frontend.account.order.single.document.a11y',
-            {
-                documentId: a11y.documentId,
-                deepLinkCode: a11y.deepLinkCode,
-                fileType: a11y.fileExtension,
-            },
-            salesChannel.domains|first.url
-        )%}
+{% for a11y in a11yDocuments %}
+{% set documentLink = rawUrl(
+    'frontend.account.order.single.document.a11y',
+    {
+        documentId: a11y.documentId,
+        deepLinkCode: a11y.deepLinkCode,
+        fileType: a11y.fileExtension,
+    },
+    salesChannel.domains|first.url
+)%}
+- {{ documentLink }}
+{% endfor %}
 
-        - {{ documentLink }}
-    {% endfor %}
-    Aus Datenschutzgründen ist für die HTML-Version ein Login erforderlich.
-
-    Im Falle einer Gastbestellung können Sie Ihre Postanschrift und die Postleitzahl der Rechnungsanschrift verwenden.
+Aus Datenschutzgründen ist für die HTML-Version ein Login erforderlich.
+Im Falle einer Gastbestellung können Sie Ihre Postanschrift und die Postleitzahl der Rechnungsanschrift verwenden.
 {% endif %}

--- a/src/Core/Migration/Fixtures/mails/order_transaction.state.cancelled/de-plain.html.twig
+++ b/src/Core/Migration/Fixtures/mails/order_transaction.state.cancelled/de-plain.html.twig
@@ -91,7 +91,7 @@ bestellen, erhalten Sie Ihre Ware umsatzsteuerbefreit.
 Den aktuellen Status Ihrer Bestellung können Sie auch jederzeit auf unserer Webseite im Bereich "Mein Konto" - "Meine Bestellungen" abrufen: {{ rawUrl('frontend.account.order.single.page', { 'deepLinkCode': order.deepLinkCode }, salesChannel.domains|first.url) }}
 Für Rückfragen stehen wir Ihnen jederzeit gerne zur Verfügung.
 
-{% if a11yDocuments is defined %}
+{% if a11yDocuments is defined and a11yDocuments is not empty %}
 Folgend stellen wir barrierefreie Dokumente als HTML-Version zur Verfügung:
 
 {% for a11y in a11yDocuments %}

--- a/src/Core/Migration/Fixtures/mails/order_transaction.state.cancelled/en-html.html.twig
+++ b/src/Core/Migration/Fixtures/mails/order_transaction.state.cancelled/en-html.html.twig
@@ -1,173 +1,176 @@
 <div style="font-family:arial; font-size:12px;">
 
-{% set currencyIsoCode = order.currency.isoCode %}
-{% if order.orderCustomer.salutation %}{{ order.orderCustomer.salutation.translated.letterName ~ ' ' }}{% endif %}{{ order.orderCustomer.firstName }} {{ order.orderCustomer.lastName }},<br>
-<br>
-We have received your order on {{ order.orderDateTime|format_datetime('medium', 'short', locale='en-GB') }}.<br>
-<br>
-Order number: {{ order.orderNumber }}.<br>
-<br>
-You have not completed your payment with {{ order.transactions.first.paymentMethod.translated.name }} yet. You can resume the payment process by using the following URL: {{ rawUrl('frontend.account.order.single.page', { 'deepLinkCode': order.deepLinkCode }, salesChannel.domains|first.url) }}<br>
-<br>
-<strong>Information on your order:</strong><br>
-<br>
+    {% set currencyIsoCode = order.currency.isoCode %}
+    {% if order.orderCustomer.salutation %}{{ order.orderCustomer.salutation.translated.letterName ~ ' ' }}{% endif %}{{ order.orderCustomer.firstName }} {{ order.orderCustomer.lastName }},<br>
+    <br>
+    We have received your order on {{ order.orderDateTime|format_datetime('medium', 'short', locale='en-GB') }}.<br>
+    <br>
+    Order number: {{ order.orderNumber }}.<br>
+    <br>
+    You have not completed your payment with {{ order.transactions.first.paymentMethod.translated.name }} yet. You can resume the payment process by using the following URL: {{ rawUrl('frontend.account.order.single.page', { 'deepLinkCode': order.deepLinkCode }, salesChannel.domains|first.url) }}<br>
+    <br>
+    <strong>Information on your order:</strong><br>
+    <br>
 
-<table border="0" style="font-family:Arial, Helvetica, sans-serif; font-size:12px;">
-    <tr>
-        <td bgcolor="#F7F7F2" style="border-bottom:1px solid #cccccc;"><strong>Prod. no.</strong></td>
-        <td bgcolor="#F7F7F2" style="border-bottom:1px solid #cccccc;"><strong>Description</strong></td>
-        <td bgcolor="#F7F7F2" style="border-bottom:1px solid #cccccc;"><strong>Quantities</strong></td>
-        <td bgcolor="#F7F7F2" style="border-bottom:1px solid #cccccc;"><strong>Price</strong></td>
-        <td bgcolor="#F7F7F2" style="border-bottom:1px solid #cccccc;"><strong>Total</strong></td>
-    </tr>
+    <table border="0" style="font-family:Arial, Helvetica, sans-serif; font-size:12px;">
+        <tr>
+            <td bgcolor="#F7F7F2" style="border-bottom:1px solid #cccccc;"><strong>Prod. no.</strong></td>
+            <td bgcolor="#F7F7F2" style="border-bottom:1px solid #cccccc;"><strong>Product image</strong></td>
+            <td bgcolor="#F7F7F2" style="border-bottom:1px solid #cccccc;"><strong>Description</strong></td>
+            <td bgcolor="#F7F7F2" style="border-bottom:1px solid #cccccc;"><strong>Quantities</strong></td>
+            <td bgcolor="#F7F7F2" style="border-bottom:1px solid #cccccc;"><strong>Price</strong></td>
+            <td bgcolor="#F7F7F2" style="border-bottom:1px solid #cccccc;"><strong>Total</strong></td>
+        </tr>
 
-    {% for lineItem in order.nestedLineItems %}
-        {% set nestingLevel = 0 %}
-        {% set nestedItem = lineItem %}
-        {% block lineItem %}
-            <tr>
-                <td>{% if nestedItem.payload.productNumber is defined %}{{ nestedItem.payload.productNumber|u.wordwrap(80) }}{% endif %}</td>
-                <td>
-                    {% if nestingLevel > 0 %}
-                        {% for i in 1..nestingLevel %}
-                            <span style="position: relative;">
-                                <span style="display: inline-block;
-                                    position: absolute;
-                                    width: 6px;
-                                    height: 20px;
-                                    top: 0;
-                                    border-left:  2px solid rgba(0, 0, 0, 0.15);
-                                    margin-left: {{ i * 10 }}px;"></span>
-                            </span>
-                        {% endfor %}
-                    {% endif %}
-
-                    <div{% if nestingLevel > 0 %} style="padding-left: {{ (nestingLevel + 1) * 10 }}px"{% endif %}>
-                        {{ nestedItem.label|u.wordwrap(80) }}
-                    </div>
-
-                    {% if nestedItem.payload.options is defined and nestedItem.payload.options|length >= 1 %}
-                        <div>
-                            {% for option in nestedItem.payload.options %}
-                                {{ option.group }}: {{ option.option }}
-                                {% if nestedItem.payload.options|last != option %}
-                                    {{ " | " }}
-                                {% endif %}
+        {% for lineItem in order.nestedLineItems %}
+            {% set nestingLevel = 0 %}
+            {% set nestedItem = lineItem %}
+            {% block lineItem %}
+                <tr>
+                    <td>{% if nestedItem.payload.productNumber is defined %}{{ nestedItem.payload.productNumber|u.wordwrap(80) }}{% endif %}</td>
+                    <td>{% if nestedItem.cover is defined and nestedItem.cover is not null %}<img src="{{ nestedItem.cover.url }}" width="75" height="auto"/>{% endif %}</td>
+                    <td>
+                        {% if nestingLevel > 0 %}
+                            {% for i in 1..nestingLevel %}
+                                <span style="position: relative;">
+                            <span style="display: inline-block;
+                                position: absolute;
+                                width: 6px;
+                                height: 20px;
+                                top: 0;
+                                border-left:  2px solid rgba(0, 0, 0, 0.15);
+                                margin-left: {{ i * 10 }}px;"></span>
+                        </span>
                             {% endfor %}
-                        </div>
-                    {% endif %}
+                        {% endif %}
 
-                    {% if nestedItem.payload.features is defined and nestedItem.payload.features|length >= 1 %}
-                        {% set referencePriceFeatures = nestedItem.payload.features|filter(feature => feature.type == 'referencePrice') %}
-                        {% if referencePriceFeatures|length >= 1 %}
-                            {% set referencePriceFeature = referencePriceFeatures|first %}
+                        <div{% if nestingLevel > 0 %} style="padding-left: {{ (nestingLevel + 1) * 10 }}px"{% endif %}>
+                            {{ nestedItem.label|u.wordwrap(80) }}
+                        </div>
+
+                        {% if nestedItem.payload.options is defined and nestedItem.payload.options|length >= 1 %}
                             <div>
-                                {{ referencePriceFeature.value.purchaseUnit }} {{ referencePriceFeature.value.unitName }}
-                                ({{ referencePriceFeature.value.price|currency(currencyIsoCode) }}* / {{ referencePriceFeature.value.referenceUnit }} {{ referencePriceFeature.value.unitName }})
+                                {% for option in nestedItem.payload.options %}
+                                    {{ option.group }}: {{ option.option }}
+                                    {% if nestedItem.payload.options|last != option %}
+                                        {{ " | " }}
+                                    {% endif %}
+                                {% endfor %}
                             </div>
                         {% endif %}
-                    {% endif %}
-                </td>
-                <td style="text-align: center">{{ nestedItem.quantity }}</td>
-                <td>{{ nestedItem.unitPrice|currency(currencyIsoCode) }}</td>
-                <td>{{ nestedItem.totalPrice|currency(currencyIsoCode) }}</td>
-            </tr>
 
-            {% if nestedItem.children.count > 0 %}
-                {% set nestingLevel = nestingLevel + 1 %}
-                {% for lineItem in nestedItem.children %}
-                    {% set nestedItem = lineItem %}
-                    {{ block('lineItem') }}
-                {% endfor %}
-            {% endif %}
-        {% endblock %}
-    {% endfor %}
-</table>
+                        {% if nestedItem.payload.features is defined and nestedItem.payload.features|length >= 1 %}
+                            {% set referencePriceFeatures = nestedItem.payload.features|filter(feature => feature.type == 'referencePrice') %}
+                            {% if referencePriceFeatures|length >= 1 %}
+                                {% set referencePriceFeature = referencePriceFeatures|first %}
+                                <div>
+                                    {{ referencePriceFeature.value.purchaseUnit }} {{ referencePriceFeature.value.unitName }}
+                                    ({{ referencePriceFeature.value.price|currency(currencyIsoCode) }} per {{ referencePriceFeature.value.referenceUnit }} {{ referencePriceFeature.value.unitName }})
+                                </div>
+                            {% endif %}
+                        {% endif %}
+                    </td>
+                    <td style="text-align: center">{{ nestedItem.quantity }}</td>
+                    <td>{{ nestedItem.unitPrice|currency(currencyIsoCode) }}</td>
+                    <td>{{ nestedItem.totalPrice|currency(currencyIsoCode) }}</td>
+                </tr>
 
-{% set delivery = order.deliveries.first %}
+                {% if nestedItem.children.count > 0 %}
+                    {% set nestingLevel = nestingLevel + 1 %}
+                    {% for lineItem in nestedItem.children %}
+                        {% set nestedItem = lineItem %}
+                        {{ block('lineItem') }}
+                    {% endfor %}
+                {% endif %}
+            {% endblock %}
+        {% endfor %}
+    </table>
 
-{% set displayRounded = order.totalRounding.interval != 0.01 or order.totalRounding.decimals != order.itemRounding.decimals %}
-{% set decimals = order.totalRounding.decimals %}
-{% set total = order.price.totalPrice %}
-{% if displayRounded %}
-    {% set total = order.price.rawTotal %}
-    {% set decimals = order.itemRounding.decimals %}
-{% endif %}
+    {% set delivery = order.deliveries.first %}
 
-<p>
-    <br>
-    <br>
-    {% for shippingCost in order.deliveries %}
-        Shipping costs: {{ shippingCost.shippingCosts.totalPrice|currency(currencyIsoCode) }}<br>
-    {% endfor %}
-
-    Net total: {{ order.amountNet|currency(currencyIsoCode) }}<br>
-    {% for calculatedTax in order.price.calculatedTaxes %}
-        {% if order.taxStatus is same as('net') %}plus{% else %}including{% endif %} {{ calculatedTax.taxRate }}% VAT. {{ calculatedTax.tax|currency(currencyIsoCode) }}<br>
-    {% endfor %}
-    {% if not displayRounded %}<strong>{% endif %}Total gross: {{ total|currency(currencyIsoCode,decimals=decimals) }}{% if not displayRounded %}</strong>{% endif %}<br>
+    {% set displayRounded = order.totalRounding.interval != 0.01 or order.totalRounding.decimals != order.itemRounding.decimals %}
+    {% set decimals = order.totalRounding.decimals %}
+    {% set total = order.price.totalPrice %}
     {% if displayRounded %}
-        <strong>Rounded total gross: {{ order.price.totalPrice|currency(currencyIsoCode,decimals=order.totalRounding.decimals) }}</strong><br>
+        {% set total = order.price.rawTotal %}
+        {% set decimals = order.itemRounding.decimals %}
     {% endif %}
-
-    <br>
-
-    <strong>Selected payment type:</strong> {{ order.transactions.first.paymentMethod.translated.name }}<br>
-    {{ order.transactions.first.paymentMethod.translated.description }}<br>
-    <br>
-
-    {% if delivery %}
-        <strong>Selected shipping type:</strong> {{ delivery.shippingMethod.translated.name }}<br>
-        {{ delivery.shippingMethod.translated.description }}<br>
+    <p>
         <br>
-    {% endif %}
-
-    {% set billingAddress = order.addresses.get(order.billingAddressId) %}
-    <strong>Billing address:</strong><br>
-    {{ billingAddress.company }}<br>
-    {{ billingAddress.firstName }} {{ billingAddress.lastName }}<br>
-    {{ billingAddress.street }} <br>
-    {{ billingAddress.zipcode }} {{ billingAddress.city }}<br>
-    {{ billingAddress.country.translated.name }}<br>
-    <br>
-
-    {% if delivery %}
-        <strong>Shipping address:</strong><br>
-        {{ delivery.shippingOrderAddress.company }}<br>
-        {{ delivery.shippingOrderAddress.firstName }} {{ delivery.shippingOrderAddress.lastName }}<br>
-        {{ delivery.shippingOrderAddress.street }} <br>
-        {{ delivery.shippingOrderAddress.zipcode}} {{ delivery.shippingOrderAddress.city }}<br>
-        {{ delivery.shippingOrderAddress.country.translated.name }}<br>
         <br>
-    {% endif %}
-    {% if order.orderCustomer.vatIds %}
-        Your VAT-ID: {{ order.orderCustomer.vatIds|first }}
-        In case of a successful order and if you are based in one of the EU countries, you will receive your goods exempt from turnover tax.<br>
-    {% endif %}
-    <br/>
-    You can check the current status of your order on our website under "My account" - "My orders" anytime: {{ rawUrl('frontend.account.order.single.page', { 'deepLinkCode': order.deepLinkCode }, salesChannel.domains|first.url) }}
-    </br>
-    If you have any questions, do not hesitate to contact us.
-    <br><br>
-    {% if a11yDocuments %}
-        For better accessibility we also provide an HTML version of the documents here:<br><br>
+        {% for shippingCost in order.deliveries %}
+            Shipping costs: {{ shippingCost.shippingCosts.totalPrice|currency(currencyIsoCode) }}<br>
+        {% endfor %}
 
-        {% for a11y in a11yDocuments %}
-            {% set documentLink = rawUrl(
-                'frontend.account.order.single.document.a11y',
-                {
-                    documentId: a11y.documentId,
-                    deepLinkCode: a11y.deepLinkCode,
-                    fileType: a11y.fileExtension,
-                },
-                salesChannel.domains|first.url
-            )%}
+        Net total: {{ order.amountNet|currency(currencyIsoCode) }}<br>
+        {% for calculatedTax in order.price.calculatedTaxes %}
+            {% if order.taxStatus is same as('net') %}plus{% else %}including{% endif %} {{ calculatedTax.taxRate }}% VAT. {{ calculatedTax.tax|currency(currencyIsoCode) }}<br>
+        {% endfor %}
+        {% if not displayRounded %}<strong>{% endif %}Total gross: {{ total|currency(currencyIsoCode,decimals=decimals) }}{% if not displayRounded %}</strong>{% endif %}<br>
+        {% if displayRounded %}
+            <strong>Rounded total gross: {{ order.price.totalPrice|currency(currencyIsoCode,decimals=order.totalRounding.decimals) }}</strong><br>
+        {% endif %}
+        <br>
 
-            - <a href="{{ documentLink }}" target="_blank">{{ documentLink }}</a> <br>
-        {% endfor %}<br>
-        For data protection reasons the HTML version requires a login. <br><br>
-        In case of a guest order, you can use your mail address and postal code of the billing address.<br>
-    {% endif %}
-</p>
-<br>
+        {% if order.transactions is defined and order.transactions is not empty %}
+            <strong>Selected payment type:</strong> {{ order.transactions.first.paymentMethod.translated.name }}<br>
+            {{ order.transactions.first.paymentMethod.translated.description }}<br>
+            <br>
+        {% endif %}
+
+        {% if delivery %}
+            <strong>Selected shipping type:</strong> {{ delivery.shippingMethod.translated.name }}<br>
+            {{ delivery.shippingMethod.translated.description }}<br>
+            <br>
+        {% endif %}
+
+        {% set billingAddress = order.addresses.get(order.billingAddressId) %}
+        <strong>Billing address:</strong><br>
+        {{ billingAddress.company }}<br>
+        {{ billingAddress.firstName }} {{ billingAddress.lastName }}<br>
+        {{ billingAddress.street }} <br>
+        {{ billingAddress.zipcode }} {{ billingAddress.city }}<br>
+        {{ billingAddress.country.translated.name }}<br>
+        <br>
+
+        {% if delivery %}
+            <strong>Shipping address:</strong><br>
+            {{ delivery.shippingOrderAddress.company }}<br>
+            {{ delivery.shippingOrderAddress.firstName }} {{ delivery.shippingOrderAddress.lastName }}<br>
+            {{ delivery.shippingOrderAddress.street }} <br>
+            {{ delivery.shippingOrderAddress.zipcode}} {{ delivery.shippingOrderAddress.city }}<br>
+            {{ delivery.shippingOrderAddress.country.translated.name }}<br>
+            <br>
+        {% endif %}
+        {% if order.orderCustomer.vatIds %}
+            Your VAT-ID: {{ order.orderCustomer.vatIds|first }}
+            In case of a successful order and if you are based in one of the EU countries, you will receive your goods exempt from turnover tax.<br>
+        {% endif %}
+        <br>
+        You can check the current status of your order on our website under "My account" - "My orders" anytime: {{ rawUrl('frontend.account.order.single.page', { 'deepLinkCode': order.deepLinkCode }, salesChannel.domains|first.url) }}
+        <br>
+        If you have any questions, do not hesitate to contact us.
+        <br>
+        {% if a11yDocuments is defined %}
+            <br>
+            For better accessibility we also provide an HTML version of the documents here:<br><br>
+            <ul>
+                {% for a11y in a11yDocuments %}
+                    {% set documentLink = rawUrl(
+                        'frontend.account.order.single.document.a11y',
+                        {
+                            documentId: a11y.documentId,
+                            deepLinkCode: a11y.deepLinkCode,
+                            fileType: a11y.fileExtension,
+                        },
+                        salesChannel.domains|first.url
+                    )%}
+                    <li><a href="{{ documentLink }}" target="_blank">{{ documentLink }}</a></li>
+                {% endfor %}
+            </ul>
+            For data protection reasons the HTML version requires a login. <br><br>
+            In case of a guest order, you can use your mail address and postal code of the billing address.<br>
+        {% endif %}
+    </p>
+    <br>
 </div>

--- a/src/Core/Migration/Fixtures/mails/order_transaction.state.cancelled/en-html.html.twig
+++ b/src/Core/Migration/Fixtures/mails/order_transaction.state.cancelled/en-html.html.twig
@@ -151,7 +151,7 @@
         <br>
         If you have any questions, do not hesitate to contact us.
         <br>
-        {% if a11yDocuments is defined %}
+        {% if a11yDocuments is defined and a11yDocuments is not empty %}
             <br>
             For better accessibility we also provide an HTML version of the documents here:<br><br>
             <ul>

--- a/src/Core/Migration/Fixtures/mails/order_transaction.state.cancelled/en-plain.html.twig
+++ b/src/Core/Migration/Fixtures/mails/order_transaction.state.cancelled/en-plain.html.twig
@@ -90,7 +90,7 @@ In case of a successful order and if you are based in one of the EU countries, y
 You can check the current status of your order on our website under "My account" - "My orders" anytime: {{ rawUrl('frontend.account.order.single.page', { 'deepLinkCode': order.deepLinkCode }, salesChannel.domains|first.url) }}
 If you have any questions, do not hesitate to contact us.
 
-{% if a11yDocuments is defined %}
+{% if a11yDocuments is defined and a11yDocuments is not empty %}
 For better accessibility we also provide an HTML version of the documents here:
 
 {% for a11y in a11yDocuments %}

--- a/src/Core/Migration/Fixtures/mails/order_transaction.state.cancelled/en-plain.html.twig
+++ b/src/Core/Migration/Fixtures/mails/order_transaction.state.cancelled/en-plain.html.twig
@@ -9,14 +9,34 @@ You have not completed your payment with {{ order.transactions.first.paymentMeth
 
 Information on your order:
 
-Pos.   Prod. No.			Description			Quantities			Price			Total
 {% for lineItem in order.lineItems %}
-{{ loop.index }}      {% if lineItem.payload.productNumber is defined %}{{ lineItem.payload.productNumber|u.wordwrap(80) }}{% endif %}				{{ lineItem.label|u.wordwrap(80) }}{% if lineItem.payload.options is defined and lineItem.payload.options|length >= 1 %}, {% for option in lineItem.payload.options %}{{ option.group }}: {{ option.option }}{% if lineItem.payload.options|last != option %}{{ " | " }}{% endif %}{% endfor %}{% endif %}{% if lineItem.payload.features is defined and lineItem.payload.features|length >= 1 %}{% set referencePriceFeatures = lineItem.payload.features|filter(feature => feature.type == 'referencePrice') %}{% if referencePriceFeatures|length >= 1 %}{% set referencePriceFeature = referencePriceFeatures|first %}, {{ referencePriceFeature.value.purchaseUnit }} {{ referencePriceFeature.value.unitName }}({{ referencePriceFeature.value.price|currency(currencyIsoCode) }}* / {{ referencePriceFeature.value.referenceUnit }} {{ referencePriceFeature.value.unitName }}){% endif %}{% endif %}
-    {{ lineItem.quantity }}			{{ lineItem.unitPrice|currency(currencyIsoCode) }}			{{ lineItem.totalPrice|currency(currencyIsoCode) }}
+Pos. {{ loop.index }}
+---------------------
+{% if lineItem.payload.productNumber is defined %}
+Product number {{ lineItem.payload.productNumber|u.wordwrap(80) }},
+{% endif %}
+{% if nestedItem.cover is defined and nestedItem.cover is not null %}
+Image {{ lineItem.cover.alt }},
+{% endif %}
+Description {{ lineItem.label|u.wordwrap(80) }},
+{% if lineItem.payload.options is defined and lineItem.payload.options|length >= 1 %}
+{% for option in lineItem.payload.options %}
+{{ option.group }}: {{ option.option }}{{ ", " }}
 {% endfor %}
+{% endif %}
+{% if lineItem.payload.features is defined and lineItem.payload.features|length >= 1 %}
+{% set referencePriceFeatures = lineItem.payload.features|filter(feature => feature.type == 'referencePrice') %}
+{% if referencePriceFeatures|length >= 1 %}
+{% set referencePriceFeature = referencePriceFeatures|first %}
+{{ referencePriceFeature.value.purchaseUnit }} {{ referencePriceFeature.value.unitName }}({{ referencePriceFeature.value.price|currency(currencyIsoCode) }} per {{ referencePriceFeature.value.referenceUnit }} {{ referencePriceFeature.value.unitName }}),
+{% endif %}
+{% endif %}
+Quantity {{ lineItem.quantity }},
+Price {{ lineItem.unitPrice|currency(currencyIsoCode) }},
+Total {{ lineItem.totalPrice|currency(currencyIsoCode) }},
 
+{% endfor %}
 {% set delivery = order.deliveries.first %}
-
 {% set displayRounded = order.totalRounding.interval != 0.01 or order.totalRounding.decimals != order.itemRounding.decimals %}
 {% set decimals = order.totalRounding.decimals %}
 {% set total = order.price.totalPrice %}
@@ -24,9 +44,8 @@ Pos.   Prod. No.			Description			Quantities			Price			Total
     {% set total = order.price.rawTotal %}
     {% set decimals = order.itemRounding.decimals %}
 {% endif %}
-
 {% for shippingCost in order.deliveries %}
-    Shipping costs: {{ shippingCost.shippingCosts.totalPrice|currency(currencyIsoCode) }}<br>
+Shipping costs: {{ shippingCost.shippingCosts.totalPrice|currency(currencyIsoCode) }}
 {% endfor %}
 Net total: {{ order.amountNet|currency(currencyIsoCode) }}
 {% for calculatedTax in order.price.calculatedTaxes %}
@@ -37,14 +56,15 @@ Total gross: {{ total|currency(currencyIsoCode,decimals=decimals) }}
 Rounded total gross: {{ order.price.totalPrice|currency(currencyIsoCode,decimals=order.totalRounding.decimals) }}
 {% endif %}
 
+{% if order.transactions is defined and order.transactions is not empty %}
 Selected payment type: {{ order.transactions.first.paymentMethod.translated.name }}
 {{ order.transactions.first.paymentMethod.translated.description }}
+{% endif %}
 
 {% if delivery %}
 Selected shipping type: {{ delivery.shippingMethod.translated.name }}
 {{ delivery.shippingMethod.translated.description }}
 {% endif %}
-
 {% set billingAddress = order.addresses.get(order.billingAddressId) %}
 Billing address:
 {{ billingAddress.company }}
@@ -65,31 +85,27 @@ Shipping address:
 {% if order.orderCustomer.vatIds %}
 Your VAT-ID: {{ order.orderCustomer.vatIds|first }}
 In case of a successful order and if you are based in one of the EU countries, you will receive your goods exempt from turnover tax.
-{% endif %}
 
+{% endif %}
 You can check the current status of your order on our website under "My account" - "My orders" anytime: {{ rawUrl('frontend.account.order.single.page', { 'deepLinkCode': order.deepLinkCode }, salesChannel.domains|first.url) }}
 If you have any questions, do not hesitate to contact us.
 
-However, in case you have purchased without a registration or a customer account, you do not have this option.
+{% if a11yDocuments is defined %}
+For better accessibility we also provide an HTML version of the documents here:
 
-{% if a11yDocuments %}
-    For better accessibility we also provide an HTML version of the documents here:
+{% for a11y in a11yDocuments %}
+{% set documentLink = rawUrl(
+    'frontend.account.order.single.document.a11y',
+    {
+        documentId: a11y.documentId,
+        'deepLinkCode': a11y.deepLinkCode,
+        fileType: a11y.fileExtension,
+    },
+    salesChannel.domains|first.url
+)%}
+- {{ documentLink }}
+{% endfor %}
 
-    {% for a11y in a11yDocuments %}
-        {% set documentLink = rawUrl(
-            'frontend.account.order.single.document.a11y',
-            {
-                documentId: a11y.documentId,
-                'deepLinkCode': a11y.deepLinkCode,
-                fileType: a11y.fileExtension,
-            },
-            salesChannel.domains|first.url
-        )%}
-
-        - {{ documentLink }}
-    {% endfor %}
-
-    For data protection reasons the HTML version requires a login.
-
-    In case of a guest order, you can use your mail address and postal code of the billing address.
+For data protection reasons the HTML version requires a login.
+In case of a guest order, you can use your mail address and postal code of the billing address.
 {% endif %}

--- a/src/Core/Migration/Fixtures/mails/order_transaction.state.paid/de-html.html.twig
+++ b/src/Core/Migration/Fixtures/mails/order_transaction.state.paid/de-html.html.twig
@@ -1,34 +1,36 @@
 <div style="font-family:arial; font-size:12px;">
 
-{% set currencyIsoCode = order.currency.isoCode %}
-Hallo {% if order.orderCustomer.salutation %}{{ order.orderCustomer.salutation.translated.letterName ~ ' ' }}{% endif %}{{ order.orderCustomer.firstName }} {{ order.orderCustomer.lastName }},<br>
-<br>
-Wir haben Ihre Zahlung erhalten und werden die Bestellung nun weiter verarbeiten.<br>
-<br>
-Bestellnummer: {{ order.orderNumber }}<br>
-<br>
-<strong>Informationen zu Ihrer Bestellung:</strong><br>
-<br>
+    {% set currencyIsoCode = order.currency.isoCode %}
+    Hallo {% if order.orderCustomer.salutation %}{{ order.orderCustomer.salutation.translated.letterName ~ ' ' }}{% endif %}{{ order.orderCustomer.firstName }} {{ order.orderCustomer.lastName }},<br>
+    <br>
+    Wir haben Ihre Zahlung erhalten und werden die Bestellung nun weiter verarbeiten.<br>
+    <br>
+    Bestellnummer: {{ order.orderNumber }}<br>
+    <br>
+    <strong>Informationen zu Ihrer Bestellung:</strong><br>
+    <br>
 
-<table border="0" style="font-family:Arial, Helvetica, sans-serif; font-size:12px;">
-    <tr>
-        <td bgcolor="#F7F7F2" style="border-bottom:1px solid #cccccc;"><strong>Produkt-Nr.</strong></td>
-        <td bgcolor="#F7F7F2" style="border-bottom:1px solid #cccccc;"><strong>Bezeichnung</strong></td>
-        <td bgcolor="#F7F7F2" style="border-bottom:1px solid #cccccc;"><strong>Menge</strong></td>
-        <td bgcolor="#F7F7F2" style="border-bottom:1px solid #cccccc;"><strong>Preis</strong></td>
-        <td bgcolor="#F7F7F2" style="border-bottom:1px solid #cccccc;"><strong>Summe</strong></td>
-    </tr>
+    <table border="0" style="font-family:Arial, Helvetica, sans-serif; font-size:12px;">
+        <tr>
+            <td bgcolor="#F7F7F2" style="border-bottom:1px solid #cccccc;"><strong>Produkt-Nr.</strong></td>
+            <td bgcolor="#F7F7F2" style="border-bottom:1px solid #cccccc;"><strong>Produktbild</strong></td>
+            <td bgcolor="#F7F7F2" style="border-bottom:1px solid #cccccc;"><strong>Bezeichnung</strong></td>
+            <td bgcolor="#F7F7F2" style="border-bottom:1px solid #cccccc;"><strong>Menge</strong></td>
+            <td bgcolor="#F7F7F2" style="border-bottom:1px solid #cccccc;"><strong>Preis</strong></td>
+            <td bgcolor="#F7F7F2" style="border-bottom:1px solid #cccccc;"><strong>Summe</strong></td>
+        </tr>
 
-    {% for lineItem in order.nestedLineItems %}
-        {% set nestingLevel = 0 %}
-        {% set nestedItem = lineItem %}
-        {% block lineItem %}
-            <tr>
-                <td>{% if nestedItem.payload.productNumber is defined %}{{ nestedItem.payload.productNumber|u.wordwrap(80) }}{% endif %}</td>
-                <td>
-                    {% if nestingLevel > 0 %}
-                        {% for i in 1..nestingLevel %}
-                            <span style="position: relative;">
+        {% for lineItem in order.nestedLineItems %}
+            {% set nestingLevel = 0 %}
+            {% set nestedItem = lineItem %}
+            {% block lineItem %}
+                <tr>
+                    <td>{% if nestedItem.payload.productNumber is defined %}{{ nestedItem.payload.productNumber|u.wordwrap(80) }}{% endif %}</td>
+                    <td>{% if nestedItem.cover is defined and nestedItem.cover is not null %}<img src="{{ nestedItem.cover.url }}" width="75" height="auto"/>{% endif %}</td>
+                    <td>
+                        {% if nestingLevel > 0 %}
+                            {% for i in 1..nestingLevel %}
+                                <span style="position: relative;">
                                 <span style="display: inline-block;
                                     position: absolute;
                                     width: 6px;
@@ -37,133 +39,136 @@ Bestellnummer: {{ order.orderNumber }}<br>
                                     border-left:  2px solid rgba(0, 0, 0, 0.15);
                                     margin-left: {{ i * 10 }}px;"></span>
                             </span>
-                        {% endfor %}
-                    {% endif %}
-
-                    <div{% if nestingLevel > 0 %} style="padding-left: {{ (nestingLevel + 1) * 10 }}px"{% endif %}>
-                        {{ nestedItem.label|u.wordwrap(80) }}
-                    </div>
-
-                    {% if nestedItem.payload.options is defined and nestedItem.payload.options|length >= 1 %}
-                        <div>
-                            {% for option in nestedItem.payload.options %}
-                                {{ option.group }}: {{ option.option }}
-                                {% if nestedItem.payload.options|last != option %}
-                                    {{ " | " }}
-                                {% endif %}
                             {% endfor %}
-                        </div>
-                    {% endif %}
+                        {% endif %}
 
-                    {% if nestedItem.payload.features is defined and nestedItem.payload.features|length >= 1 %}
-                        {% set referencePriceFeatures = nestedItem.payload.features|filter(feature => feature.type == 'referencePrice') %}
-                        {% if referencePriceFeatures|length >= 1 %}
-                            {% set referencePriceFeature = referencePriceFeatures|first %}
+                        <div{% if nestingLevel > 0 %} style="padding-left: {{ (nestingLevel + 1) * 10 }}px"{% endif %}>
+                            {{ nestedItem.label|u.wordwrap(80) }}
+                        </div>
+
+                        {% if nestedItem.payload.options is defined and nestedItem.payload.options|length >= 1 %}
                             <div>
-                                {{ referencePriceFeature.value.purchaseUnit }} {{ referencePriceFeature.value.unitName }}
-                                ({{ referencePriceFeature.value.price|currency(currencyIsoCode) }}* / {{ referencePriceFeature.value.referenceUnit }} {{ referencePriceFeature.value.unitName }})
+                                {% for option in nestedItem.payload.options %}
+                                    {{ option.group }}: {{ option.option }}
+                                    {% if nestedItem.payload.options|last != option %}
+                                        {{ " | " }}
+                                    {% endif %}
+                                {% endfor %}
                             </div>
                         {% endif %}
-                    {% endif %}
-                </td>
-                <td style="text-align: center">{{ nestedItem.quantity }}</td>
-                <td>{{ nestedItem.unitPrice|currency(currencyIsoCode) }}</td>
-                <td>{{ nestedItem.totalPrice|currency(currencyIsoCode) }}</td>
-            </tr>
 
-            {% if nestedItem.children.count > 0 %}
-                {% set nestingLevel = nestingLevel + 1 %}
-                {% for lineItem in nestedItem.children %}
-                    {% set nestedItem = lineItem %}
-                    {{ block('lineItem') }}
-                {% endfor %}
-            {% endif %}
-        {% endblock %}
-    {% endfor %}
-</table>
+                        {% if nestedItem.payload.features is defined and nestedItem.payload.features|length >= 1 %}
+                            {% set referencePriceFeatures = nestedItem.payload.features|filter(feature => feature.type == 'referencePrice') %}
+                            {% if referencePriceFeatures|length >= 1 %}
+                                {% set referencePriceFeature = referencePriceFeatures|first %}
+                                <div>
+                                    {{ referencePriceFeature.value.purchaseUnit }} {{ referencePriceFeature.value.unitName }}
+                                    ({{ referencePriceFeature.value.price|currency(currencyIsoCode) }} pro {{ referencePriceFeature.value.referenceUnit }} {{ referencePriceFeature.value.unitName }})
+                                </div>
+                            {% endif %}
+                        {% endif %}
+                    </td>
+                    <td style="text-align: center">{{ nestedItem.quantity }}</td>
+                    <td>{{ nestedItem.unitPrice|currency(currencyIsoCode) }}</td>
+                    <td>{{ nestedItem.totalPrice|currency(currencyIsoCode) }}</td>
+                </tr>
 
-{% set delivery = order.deliveries.first %}
+                {% if nestedItem.children.count > 0 %}
+                    {% set nestingLevel = nestingLevel + 1 %}
+                    {% for lineItem in nestedItem.children %}
+                        {% set nestedItem = lineItem %}
+                        {{ block('lineItem') }}
+                    {% endfor %}
+                {% endif %}
+            {% endblock %}
+        {% endfor %}
+    </table>
 
-{% set displayRounded = order.totalRounding.interval != 0.01 or order.totalRounding.decimals != order.itemRounding.decimals %}
-{% set decimals = order.totalRounding.decimals %}
-{% set total = order.price.totalPrice %}
-{% if displayRounded %}
-    {% set total = order.price.rawTotal %}
-    {% set decimals = order.itemRounding.decimals %}
-{% endif %}
-<p>
-    <br>
-    <br>
-    {% for shippingCost in order.deliveries %}
-        Versandkosten: {{ shippingCost.shippingCosts.totalPrice|currency(currencyIsoCode) }}<br>
-    {% endfor %}
-    Gesamtkosten Netto: {{ order.amountNet|currency(currencyIsoCode) }}<br>
+    {% set delivery = order.deliveries.first %}
+
+    {% set displayRounded = order.totalRounding.interval != 0.01 or order.totalRounding.decimals != order.itemRounding.decimals %}
+    {% set decimals = order.totalRounding.decimals %}
+    {% set total = order.price.totalPrice %}
+    {% if displayRounded %}
+        {% set total = order.price.rawTotal %}
+        {% set decimals = order.itemRounding.decimals %}
+    {% endif %}
+    <p>
+        <br>
+        <br>
+        {% for shippingCost in order.deliveries %}
+            Versandkosten: {{ shippingCost.shippingCosts.totalPrice|currency(currencyIsoCode) }}<br>
+        {% endfor %}
+        Gesamtkosten Netto: {{ order.amountNet|currency(currencyIsoCode) }}<br>
         {% for calculatedTax in order.price.calculatedTaxes %}
             {% if order.taxStatus is same as('net') %}zzgl.{% else %}inkl.{% endif %} {{ calculatedTax.taxRate }}% MwSt. {{ calculatedTax.tax|currency(currencyIsoCode) }}<br>
         {% endfor %}
-    {% if not displayRounded %}<strong>{% endif %}Gesamtkosten Brutto: {{ total|currency(currencyIsoCode,decimals=decimals) }}{% if not displayRounded %}</strong>{% endif %}<br>
-    {% if displayRounded %}
-        <strong>Gesamtkosten Brutto gerundet: {{ order.price.totalPrice|currency(currencyIsoCode,decimals=order.totalRounding.decimals) }}</strong><br>
-    {% endif %}
-    <br>
-
-    <strong>Gewählte Zahlungsart:</strong> {{ order.transactions.first.paymentMethod.translated.name }}<br>
-    {{ order.transactions.first.paymentMethod.translated.description }}<br>
-    <br>
-
-    {% if delivery %}
-        <strong>Gewählte Versandart:</strong> {{ delivery.shippingMethod.translated.name }}<br>
-        {{ delivery.shippingMethod.translated.description }}<br>
+        {% if not displayRounded %}<strong>{% endif %}Gesamtkosten Brutto: {{ total|currency(currencyIsoCode,decimals=decimals) }}{% if not displayRounded %}</strong>{% endif %}<br>
+        {% if displayRounded %}
+            <strong>Gesamtkosten Brutto gerundet: {{ order.price.totalPrice|currency(currencyIsoCode,decimals=order.totalRounding.decimals) }}</strong><br>
+        {% endif %}
         <br>
-    {% endif %}
 
-    {% set billingAddress = order.addresses.get(order.billingAddressId) %}
-    <strong>Rechnungsadresse:</strong><br>
-    {{ billingAddress.company }}<br>
-    {{ billingAddress.firstName }} {{ billingAddress.lastName }}<br>
-    {{ billingAddress.street }} <br>
-    {{ billingAddress.zipcode }} {{ billingAddress.city }}<br>
-    {{ billingAddress.country.translated.name }}<br>
-    <br>
+        {% if order.transactions is defined and order.transactions is not empty %}
+            <strong>Gewählte Zahlungsart:</strong> {{ order.transactions.first.paymentMethod.translated.name }}<br>
+            {{ order.transactions.first.paymentMethod.translated.description }}<br>
+            <br>
+        {% endif %}
 
-    {% if delivery %}
-        <strong>Lieferadresse:</strong><br>
-        {{ delivery.shippingOrderAddress.company }}<br>
-        {{ delivery.shippingOrderAddress.firstName }} {{ delivery.shippingOrderAddress.lastName }}<br>
-        {{ delivery.shippingOrderAddress.street }} <br>
-        {{ delivery.shippingOrderAddress.zipcode}} {{ delivery.shippingOrderAddress.city }}<br>
-        {{ delivery.shippingOrderAddress.country.translated.name }}<br>
+        {% if delivery %}
+            <strong>Gewählte Versandart:</strong> {{ delivery.shippingMethod.translated.name }}<br>
+            {{ delivery.shippingMethod.translated.description }}<br>
+            <br>
+        {% endif %}
+
+        {% set billingAddress = order.addresses.get(order.billingAddressId) %}
+        <strong>Rechnungsadresse:</strong><br>
+        {{ billingAddress.company }}<br>
+        {{ billingAddress.firstName }} {{ billingAddress.lastName }}<br>
+        {{ billingAddress.street }} <br>
+        {{ billingAddress.zipcode }} {{ billingAddress.city }}<br>
+        {{ billingAddress.country.translated.name }}<br>
         <br>
-    {% endif %}
-    {% if order.orderCustomer.vatIds %}
-        Ihre Umsatzsteuer-ID: {{ order.orderCustomer.vatIds|first }}
-        Bei erfolgreicher Prüfung und sofern Sie aus dem EU-Ausland
-        bestellen, erhalten Sie Ihre Ware umsatzsteuerbefreit. <br>
-    {% endif %}
-    <br/>
-    Den aktuellen Status Ihrer Bestellung können Sie auch jederzeit auf unserer Webseite im  Bereich "Mein Konto" - "Meine Bestellungen" abrufen: {{ rawUrl('frontend.account.order.single.page', { 'deepLinkCode': order.deepLinkCode }, salesChannel.domains|first.url) }}
-    </br>
-    Für Rückfragen stehen wir Ihnen jederzeit gerne zur Verfügung.
-    <br><br>
-    {% if a11yDocuments %}
-        Folgend stellen wir barrierefreie Dokumente als HTML-Version zur Verfügung:<br><br>
-        {% for a11y in a11yDocuments %}
-            {% set documentLink = rawUrl(
-                'frontend.account.order.single.document.a11y',
-                {
-                    documentId: a11y.documentId,
-                    deepLinkCode: a11y.deepLinkCode,
-                    fileType: a11y.fileExtension,
-                },
-                salesChannel.domains|first.url
-            )%}
 
-            - <a href="{{ documentLink }}" target="_blank">{{ documentLink }}</a> <br>
-        {% endfor %}<br>
-
-        Aus Datenschutzgründen ist für die HTML-Version ein Login erforderlich.<br><br>
-        Im Falle einer Gastbestellung können Sie Ihre Postanschrift und die Postleitzahl der Rechnungsanschrift verwenden.<br>
-    {% endif %}
-</p>
-<br>
+        {% if delivery %}
+            <strong>Lieferadresse:</strong><br>
+            {{ delivery.shippingOrderAddress.company }}<br>
+            {{ delivery.shippingOrderAddress.firstName }} {{ delivery.shippingOrderAddress.lastName }}<br>
+            {{ delivery.shippingOrderAddress.street }} <br>
+            {{ delivery.shippingOrderAddress.zipcode}} {{ delivery.shippingOrderAddress.city }}<br>
+            {{ delivery.shippingOrderAddress.country.translated.name }}<br>
+            <br>
+        {% endif %}
+        {% if order.orderCustomer.vatIds %}
+            Ihre Umsatzsteuer-ID: {{ order.orderCustomer.vatIds|first }}
+            Bei erfolgreicher Prüfung und sofern Sie aus dem EU-Ausland
+            bestellen, erhalten Sie Ihre Ware umsatzsteuerbefreit. <br>
+        {% endif %}
+        <br>
+        Den aktuellen Status Ihrer Bestellung können Sie auch jederzeit auf unserer Webseite im  Bereich "Mein Konto" - "Meine Bestellungen" abrufen: {{ rawUrl('frontend.account.order.single.page', { 'deepLinkCode': order.deepLinkCode }, salesChannel.domains|first.url) }}
+        <br>
+        Für Rückfragen stehen wir Ihnen jederzeit gerne zur Verfügung.
+        <br>
+        {% if a11yDocuments is defined %}
+            <br>
+            Folgend stellen wir barrierefreie Dokumente als HTML-Version zur Verfügung:<br><br>
+            <ul>
+                {% for a11y in a11yDocuments %}
+                    {% set documentLink = rawUrl(
+                        'frontend.account.order.single.document.a11y',
+                        {
+                            documentId: a11y.documentId,
+                            deepLinkCode: a11y.deepLinkCode,
+                            fileType: a11y.fileExtension,
+                        },
+                        salesChannel.domains|first.url
+                    )%}
+                    <li><a href="{{ documentLink }}" target="_blank">{{ documentLink }}</a></li>
+                {% endfor %}
+            </ul>
+            Aus Datenschutzgründen ist für die HTML-Version ein Login erforderlich.<br><br>
+            Im Falle einer Gastbestellung können Sie Ihre Postanschrift und die Postleitzahl der Rechnungsanschrift verwenden.<br>
+        {% endif %}
+    </p>
+    <br>
 </div>

--- a/src/Core/Migration/Fixtures/mails/order_transaction.state.paid/de-html.html.twig
+++ b/src/Core/Migration/Fixtures/mails/order_transaction.state.paid/de-html.html.twig
@@ -149,7 +149,7 @@
         <br>
         Für Rückfragen stehen wir Ihnen jederzeit gerne zur Verfügung.
         <br>
-        {% if a11yDocuments is defined %}
+        {% if a11yDocuments is defined and a11yDocuments is not empty %}
             <br>
             Folgend stellen wir barrierefreie Dokumente als HTML-Version zur Verfügung:<br><br>
             <ul>

--- a/src/Core/Migration/Fixtures/mails/order_transaction.state.paid/de-plain.html.twig
+++ b/src/Core/Migration/Fixtures/mails/order_transaction.state.paid/de-plain.html.twig
@@ -7,14 +7,34 @@ Bestellnummer: {{ order.orderNumber }}
 
 Informationen zu Ihrer Bestellung:
 
-Pos.   Artikel-Nr.			Beschreibung			Menge			Preis			Summe
 {% for lineItem in order.lineItems %}
-{{ loop.index }}      {% if lineItem.payload.productNumber is defined %}{{ lineItem.payload.productNumber|u.wordwrap(80) }}{% endif %}				{{ lineItem.label|u.wordwrap(80) }}{% if lineItem.payload.options is defined and lineItem.payload.options|length >= 1 %}, {% for option in lineItem.payload.options %}{{ option.group }}: {{ option.option }}{% if lineItem.payload.options|last != option %}{{ " | " }}{% endif %}{% endfor %}{% endif %}{% if lineItem.payload.features is defined and lineItem.payload.features|length >= 1 %}{% set referencePriceFeatures = lineItem.payload.features|filter(feature => feature.type == 'referencePrice') %}{% if referencePriceFeatures|length >= 1 %}{% set referencePriceFeature = referencePriceFeatures|first %}, {{ referencePriceFeature.value.purchaseUnit }} {{ referencePriceFeature.value.unitName }}({{ referencePriceFeature.value.price|currency(currencyIsoCode) }}* / {{ referencePriceFeature.value.referenceUnit }} {{ referencePriceFeature.value.unitName }}){% endif %}{% endif %}
-    {{ lineItem.quantity }}			{{ lineItem.unitPrice|currency(currencyIsoCode) }}			{{ lineItem.totalPrice|currency(currencyIsoCode) }}
+Pos. {{ loop.index }}
+---------------------
+{% if lineItem.payload.productNumber is defined %}
+Artikel-Nr. {{ lineItem.payload.productNumber|u.wordwrap(80) }},
+{% endif %}
+{% if nestedItem.cover is defined and nestedItem.cover is not null %}
+Produktbild {{ lineItem.cover.alt }},
+{% endif %}
+Beschreibung {{ lineItem.label|u.wordwrap(80) }},
+{% if lineItem.payload.options is defined and lineItem.payload.options|length >= 1 %}
+{% for option in lineItem.payload.options %}
+{{ option.group }}: {{ option.option }}{{ ", " }}
 {% endfor %}
+{% endif %}
+{% if lineItem.payload.features is defined and lineItem.payload.features|length >= 1 %}
+{% set referencePriceFeatures = lineItem.payload.features|filter(feature => feature.type == 'referencePrice') %}
+{% if referencePriceFeatures|length >= 1 %}
+{% set referencePriceFeature = referencePriceFeatures|first %}
+{{ referencePriceFeature.value.purchaseUnit }} {{ referencePriceFeature.value.unitName }}({{ referencePriceFeature.value.price|currency(currencyIsoCode) }} pro {{ referencePriceFeature.value.referenceUnit }} {{ referencePriceFeature.value.unitName }}),
+{% endif %}
+{% endif %}
+Menge {{ lineItem.quantity }},
+Preis {{ lineItem.unitPrice|currency(currencyIsoCode) }},
+Summe {{ lineItem.totalPrice|currency(currencyIsoCode) }},
 
+{% endfor %}
 {% set delivery = order.deliveries.first %}
-
 {% set displayRounded = order.totalRounding.interval != 0.01 or order.totalRounding.decimals != order.itemRounding.decimals %}
 {% set decimals = order.totalRounding.decimals %}
 {% set total = order.price.totalPrice %}
@@ -22,9 +42,8 @@ Pos.   Artikel-Nr.			Beschreibung			Menge			Preis			Summe
     {% set total = order.price.rawTotal %}
     {% set decimals = order.itemRounding.decimals %}
 {% endif %}
-
 {% for shippingCost in order.deliveries %}
-    Versandkosten: {{ shippingCost.shippingCosts.totalPrice|currency(currencyIsoCode) }}<br>
+Versandkosten: {{ shippingCost.shippingCosts.totalPrice|currency(currencyIsoCode) }}
 {% endfor %}
 Gesamtkosten Netto: {{ order.amountNet|currency(currencyIsoCode) }}
 {% for calculatedTax in order.price.calculatedTaxes %}
@@ -35,15 +54,15 @@ Gesamtkosten Brutto: {{ total|currency(currencyIsoCode,decimals=decimals) }}
 Gesamtkosten Brutto gerundet: {{ order.price.totalPrice|currency(currencyIsoCode,decimals=order.totalRounding.decimals) }}
 {% endif %}
 
-
+{% if order.transactions is defined and order.transactions is not empty %}
 Gewählte Zahlungsart: {{ order.transactions.first.paymentMethod.translated.name }}
 {{ order.transactions.first.paymentMethod.translated.description }}
+{% endif %}
 
 {% if delivery %}
 Gewählte Versandart: {{ delivery.shippingMethod.translated.name }}
 {{ delivery.shippingMethod.translated.description }}
 {% endif %}
-
 {% set billingAddress = order.addresses.get(order.billingAddressId) %}
 Rechnungsadresse:
 {{ billingAddress.company }}
@@ -65,28 +84,27 @@ Lieferadresse:
 Ihre Umsatzsteuer-ID: {{ order.orderCustomer.vatIds|first }}
 Bei erfolgreicher Prüfung und sofern Sie aus dem EU-Ausland
 bestellen, erhalten Sie Ihre Ware umsatzsteuerbefreit.
-{% endif %}
 
-Den aktuellen Status Ihrer Bestellung können Sie auch jederzeit auf unserer Webseite im  Bereich "Mein Konto" - "Meine Bestellungen" abrufen: {{ rawUrl('frontend.account.order.single.page', { 'deepLinkCode': order.deepLinkCode }, salesChannel.domains|first.url) }}
+{% endif %}
+Den aktuellen Status Ihrer Bestellung können Sie auch jederzeit auf unserer Webseite im Bereich "Mein Konto" - "Meine Bestellungen" abrufen: {{ rawUrl('frontend.account.order.single.page', { 'deepLinkCode': order.deepLinkCode }, salesChannel.domains|first.url) }}
 Für Rückfragen stehen wir Ihnen jederzeit gerne zur Verfügung.
 
-{% if a11yDocuments %}
-    Folgend stellen wir barrierefreie Dokumente als HTML-Version zur Verfügung:
+{% if a11yDocuments is defined %}
+Folgend stellen wir barrierefreie Dokumente als HTML-Version zur Verfügung:
 
-    {% for a11y in a11yDocuments %}
-        {% set documentLink = rawUrl(
-            'frontend.account.order.single.document.a11y',
-            {
-                documentId: a11y.documentId,
-                deepLinkCode: a11y.deepLinkCode,
-                fileType: a11y.fileExtension,
-            },
-            salesChannel.domains|first.url
-        )%}
+{% for a11y in a11yDocuments %}
+{% set documentLink = rawUrl(
+    'frontend.account.order.single.document.a11y',
+    {
+        documentId: a11y.documentId,
+        deepLinkCode: a11y.deepLinkCode,
+        fileType: a11y.fileExtension,
+    },
+    salesChannel.domains|first.url
+)%}
+- {{ documentLink }}
+{% endfor %}
 
-        - {{ documentLink }}
-    {% endfor %}
-    Aus Datenschutzgründen ist für die HTML-Version ein Login erforderlich.
-
-    Im Falle einer Gastbestellung können Sie Ihre Postanschrift und die Postleitzahl der Rechnungsanschrift verwenden.
+Aus Datenschutzgründen ist für die HTML-Version ein Login erforderlich.
+Im Falle einer Gastbestellung können Sie Ihre Postanschrift und die Postleitzahl der Rechnungsanschrift verwenden.
 {% endif %}

--- a/src/Core/Migration/Fixtures/mails/order_transaction.state.paid/de-plain.html.twig
+++ b/src/Core/Migration/Fixtures/mails/order_transaction.state.paid/de-plain.html.twig
@@ -89,7 +89,7 @@ bestellen, erhalten Sie Ihre Ware umsatzsteuerbefreit.
 Den aktuellen Status Ihrer Bestellung können Sie auch jederzeit auf unserer Webseite im Bereich "Mein Konto" - "Meine Bestellungen" abrufen: {{ rawUrl('frontend.account.order.single.page', { 'deepLinkCode': order.deepLinkCode }, salesChannel.domains|first.url) }}
 Für Rückfragen stehen wir Ihnen jederzeit gerne zur Verfügung.
 
-{% if a11yDocuments is defined %}
+{% if a11yDocuments is defined and a11yDocuments is not empty %}
 Folgend stellen wir barrierefreie Dokumente als HTML-Version zur Verfügung:
 
 {% for a11y in a11yDocuments %}

--- a/src/Core/Migration/Fixtures/mails/order_transaction.state.paid/en-html.html.twig
+++ b/src/Core/Migration/Fixtures/mails/order_transaction.state.paid/en-html.html.twig
@@ -149,7 +149,7 @@
         <br>
         If you have any questions, do not hesitate to contact us.
         <br>
-        {% if a11yDocuments is defined %}
+        {% if a11yDocuments is defined and a11yDocuments is not empty %}
             <br>
             For better accessibility we also provide an HTML version of the documents here:<br><br>
             <ul>

--- a/src/Core/Migration/Fixtures/mails/order_transaction.state.paid/en-html.html.twig
+++ b/src/Core/Migration/Fixtures/mails/order_transaction.state.paid/en-html.html.twig
@@ -1,169 +1,174 @@
 <div style="font-family:arial; font-size:12px;">
 
-{% set currencyIsoCode = order.currency.isoCode %}
-{% if order.orderCustomer.salutation %}{{ order.orderCustomer.salutation.translated.letterName ~ ' ' }}{% endif %}{{ order.orderCustomer.firstName }} {{ order.orderCustomer.lastName }},<br>
-<br>
-We received your payment and will now start processing the order.<br>
-Order number: {{ order.orderNumber }}<br>
-<br>
+    {% set currencyIsoCode = order.currency.isoCode %}
+    {% if order.orderCustomer.salutation %}{{ order.orderCustomer.salutation.translated.letterName ~ ' ' }}{% endif %}{{ order.orderCustomer.firstName }} {{ order.orderCustomer.lastName }},<br>
+    <br>
+    We received your payment and will now start processing the order.<br>
+    Order number: {{ order.orderNumber }}<br>
+    <br>
 
-<strong>Information on your order:</strong><br>
-<br>
+    <strong>Information on your order:</strong><br>
+    <br>
 
-<table border="0" style="font-family:Arial, Helvetica, sans-serif; font-size:12px;">
-    <tr>
-        <td bgcolor="#F7F7F2" style="border-bottom:1px solid #cccccc;"><strong>Prod. no.</strong></td>
-        <td bgcolor="#F7F7F2" style="border-bottom:1px solid #cccccc;"><strong>Description</strong></td>
-        <td bgcolor="#F7F7F2" style="border-bottom:1px solid #cccccc;"><strong>Quantities</strong></td>
-        <td bgcolor="#F7F7F2" style="border-bottom:1px solid #cccccc;"><strong>Price</strong></td>
-        <td bgcolor="#F7F7F2" style="border-bottom:1px solid #cccccc;"><strong>Total</strong></td>
-    </tr>
+    <table border="0" style="font-family:Arial, Helvetica, sans-serif; font-size:12px;">
+        <tr>
+            <td bgcolor="#F7F7F2" style="border-bottom:1px solid #cccccc;"><strong>Prod. no.</strong></td>
+            <td bgcolor="#F7F7F2" style="border-bottom:1px solid #cccccc;"><strong>Product image</strong></td>
+            <td bgcolor="#F7F7F2" style="border-bottom:1px solid #cccccc;"><strong>Description</strong></td>
+            <td bgcolor="#F7F7F2" style="border-bottom:1px solid #cccccc;"><strong>Quantities</strong></td>
+            <td bgcolor="#F7F7F2" style="border-bottom:1px solid #cccccc;"><strong>Price</strong></td>
+            <td bgcolor="#F7F7F2" style="border-bottom:1px solid #cccccc;"><strong>Total</strong></td>
+        </tr>
 
-    {% for lineItem in order.nestedLineItems %}
-        {% set nestingLevel = 0 %}
-        {% set nestedItem = lineItem %}
-        {% block lineItem %}
-            <tr>
-                <td>{% if nestedItem.payload.productNumber is defined %}{{ nestedItem.payload.productNumber|u.wordwrap(80) }}{% endif %}</td>
-                <td>
-                    {% if nestingLevel > 0 %}
-                        {% for i in 1..nestingLevel %}
-                            <span style="position: relative;">
-                                <span style="display: inline-block;
-                                    position: absolute;
-                                    width: 6px;
-                                    height: 20px;
-                                    top: 0;
-                                    border-left:  2px solid rgba(0, 0, 0, 0.15);
-                                    margin-left: {{ i * 10 }}px;"></span>
-                            </span>
-                        {% endfor %}
-                    {% endif %}
-
-                    <div{% if nestingLevel > 0 %} style="padding-left: {{ (nestingLevel + 1) * 10 }}px"{% endif %}>
-                        {{ nestedItem.label|u.wordwrap(80) }}
-                    </div>
-
-                    {% if nestedItem.payload.options is defined and nestedItem.payload.options|length >= 1 %}
-                        <div>
-                            {% for option in nestedItem.payload.options %}
-                                {{ option.group }}: {{ option.option }}
-                                {% if nestedItem.payload.options|last != option %}
-                                    {{ " | " }}
-                                {% endif %}
+        {% for lineItem in order.nestedLineItems %}
+            {% set nestingLevel = 0 %}
+            {% set nestedItem = lineItem %}
+            {% block lineItem %}
+                <tr>
+                    <td>{% if nestedItem.payload.productNumber is defined %}{{ nestedItem.payload.productNumber|u.wordwrap(80) }}{% endif %}</td>
+                    <td>{% if nestedItem.cover is defined and nestedItem.cover is not null %}<img src="{{ nestedItem.cover.url }}" width="75" height="auto"/>{% endif %}</td>
+                    <td>
+                        {% if nestingLevel > 0 %}
+                            {% for i in 1..nestingLevel %}
+                                <span style="position: relative;">
+                            <span style="display: inline-block;
+                                position: absolute;
+                                width: 6px;
+                                height: 20px;
+                                top: 0;
+                                border-left:  2px solid rgba(0, 0, 0, 0.15);
+                                margin-left: {{ i * 10 }}px;"></span>
+                        </span>
                             {% endfor %}
-                        </div>
-                    {% endif %}
+                        {% endif %}
 
-                    {% if nestedItem.payload.features is defined and nestedItem.payload.features|length >= 1 %}
-                        {% set referencePriceFeatures = nestedItem.payload.features|filter(feature => feature.type == 'referencePrice') %}
-                        {% if referencePriceFeatures|length >= 1 %}
-                            {% set referencePriceFeature = referencePriceFeatures|first %}
+                        <div{% if nestingLevel > 0 %} style="padding-left: {{ (nestingLevel + 1) * 10 }}px"{% endif %}>
+                            {{ nestedItem.label|u.wordwrap(80) }}
+                        </div>
+
+                        {% if nestedItem.payload.options is defined and nestedItem.payload.options|length >= 1 %}
                             <div>
-                                {{ referencePriceFeature.value.purchaseUnit }} {{ referencePriceFeature.value.unitName }}
-                                ({{ referencePriceFeature.value.price|currency(currencyIsoCode) }}* / {{ referencePriceFeature.value.referenceUnit }} {{ referencePriceFeature.value.unitName }})
+                                {% for option in nestedItem.payload.options %}
+                                    {{ option.group }}: {{ option.option }}
+                                    {% if nestedItem.payload.options|last != option %}
+                                        {{ " | " }}
+                                    {% endif %}
+                                {% endfor %}
                             </div>
                         {% endif %}
-                    {% endif %}
-                </td>
-                <td style="text-align: center">{{ nestedItem.quantity }}</td>
-                <td>{{ nestedItem.unitPrice|currency(currencyIsoCode) }}</td>
-                <td>{{ nestedItem.totalPrice|currency(currencyIsoCode) }}</td>
-            </tr>
 
-            {% if nestedItem.children.count > 0 %}
-                {% set nestingLevel = nestingLevel + 1 %}
-                {% for lineItem in nestedItem.children %}
-                    {% set nestedItem = lineItem %}
-                    {{ block('lineItem') }}
-                {% endfor %}
-            {% endif %}
-        {% endblock %}
-    {% endfor %}
-</table>
+                        {% if nestedItem.payload.features is defined and nestedItem.payload.features|length >= 1 %}
+                            {% set referencePriceFeatures = nestedItem.payload.features|filter(feature => feature.type == 'referencePrice') %}
+                            {% if referencePriceFeatures|length >= 1 %}
+                                {% set referencePriceFeature = referencePriceFeatures|first %}
+                                <div>
+                                    {{ referencePriceFeature.value.purchaseUnit }} {{ referencePriceFeature.value.unitName }}
+                                    ({{ referencePriceFeature.value.price|currency(currencyIsoCode) }} per {{ referencePriceFeature.value.referenceUnit }} {{ referencePriceFeature.value.unitName }})
+                                </div>
+                            {% endif %}
+                        {% endif %}
+                    </td>
+                    <td style="text-align: center">{{ nestedItem.quantity }}</td>
+                    <td>{{ nestedItem.unitPrice|currency(currencyIsoCode) }}</td>
+                    <td>{{ nestedItem.totalPrice|currency(currencyIsoCode) }}</td>
+                </tr>
 
-{% set delivery = order.deliveries.first %}
+                {% if nestedItem.children.count > 0 %}
+                    {% set nestingLevel = nestingLevel + 1 %}
+                    {% for lineItem in nestedItem.children %}
+                        {% set nestedItem = lineItem %}
+                        {{ block('lineItem') }}
+                    {% endfor %}
+                {% endif %}
+            {% endblock %}
+        {% endfor %}
+    </table>
 
-{% set displayRounded = order.totalRounding.interval != 0.01 or order.totalRounding.decimals != order.itemRounding.decimals %}
-{% set decimals = order.totalRounding.decimals %}
-{% set total = order.price.totalPrice %}
-{% if displayRounded %}
-    {% set total = order.price.rawTotal %}
-    {% set decimals = order.itemRounding.decimals %}
-{% endif %}
-<p>
-    <br>
-    <br>
-    {% for shippingCost in order.deliveries %}
-        Shipping costs: {{ shippingCost.shippingCosts.totalPrice|currency(currencyIsoCode) }}<br>
-    {% endfor %}
+    {% set delivery = order.deliveries.first %}
 
-    Net total: {{ order.amountNet|currency(currencyIsoCode) }}<br>
-    {% for calculatedTax in order.price.calculatedTaxes %}
-        {% if order.taxStatus is same as('net') %}plus{% else %}including{% endif %} {{ calculatedTax.taxRate }}% VAT. {{ calculatedTax.tax|currency(currencyIsoCode) }}<br>
-    {% endfor %}
-    {% if not displayRounded %}<strong>{% endif %}Total gross: {{ total|currency(currencyIsoCode,decimals=decimals) }}{% if not displayRounded %}</strong>{% endif %}<br>
+    {% set displayRounded = order.totalRounding.interval != 0.01 or order.totalRounding.decimals != order.itemRounding.decimals %}
+    {% set decimals = order.totalRounding.decimals %}
+    {% set total = order.price.totalPrice %}
     {% if displayRounded %}
-        <strong>Rounded total gross: {{ order.price.totalPrice|currency(currencyIsoCode,decimals=order.totalRounding.decimals) }}</strong><br>
+        {% set total = order.price.rawTotal %}
+        {% set decimals = order.itemRounding.decimals %}
     {% endif %}
-    <br>
-
-    <strong>Selected payment type:</strong> {{ order.transactions.first.paymentMethod.translated.name }}<br>
-    {{ order.transactions.first.paymentMethod.translated.description }}<br>
-    <br>
-
-    {% if delivery %}
-        <strong>Selected shipping type:</strong> {{ delivery.shippingMethod.translated.name }}<br>
-        {{ delivery.shippingMethod.translated.description }}<br>
+    <p>
         <br>
-    {% endif %}
-
-    {% set billingAddress = order.addresses.get(order.billingAddressId) %}
-    <strong>Billing address:</strong><br>
-    {{ billingAddress.company }}<br>
-    {{ billingAddress.firstName }} {{ billingAddress.lastName }}<br>
-    {{ billingAddress.street }} <br>
-    {{ billingAddress.zipcode }} {{ billingAddress.city }}<br>
-    {{ billingAddress.country.translated.name }}<br>
-    <br>
-
-    {% if delivery %}
-        <strong>Shipping address:</strong><br>
-        {{ delivery.shippingOrderAddress.company }}<br>
-        {{ delivery.shippingOrderAddress.firstName }} {{ delivery.shippingOrderAddress.lastName }}<br>
-        {{ delivery.shippingOrderAddress.street }} <br>
-        {{ delivery.shippingOrderAddress.zipcode}} {{ delivery.shippingOrderAddress.city }}<br>
-        {{ delivery.shippingOrderAddress.country.translated.name }}<br>
         <br>
-    {% endif %}
-    {% if order.orderCustomer.vatIds %}
-        Your VAT-ID: {{ order.orderCustomer.vatIds|first }}
-        In case of a successful order and if you are based in one of the EU countries, you will receive your goods exempt from turnover tax.<br>
-    {% endif %}
-    <br/>
-    You can check the current status of your order on our website under "My account" - "My orders" anytime: {{ rawUrl('frontend.account.order.single.page', { 'deepLinkCode': order.deepLinkCode }, salesChannel.domains|first.url) }}
-    </br>
-    If you have any questions, do not hesitate to contact us.
-    <br><br>
-    {% if a11yDocuments %}
-        For better accessibility we also provide an HTML version of the documents here:<br><br>
+        {% for shippingCost in order.deliveries %}
+            Shipping costs: {{ shippingCost.shippingCosts.totalPrice|currency(currencyIsoCode) }}<br>
+        {% endfor %}
 
-        {% for a11y in a11yDocuments %}
-            {% set documentLink = rawUrl(
-                'frontend.account.order.single.document.a11y',
-                {
-                    documentId: a11y.documentId,
-                    deepLinkCode: a11y.deepLinkCode,
-                    fileType: a11y.fileExtension,
-                },
-                salesChannel.domains|first.url
-            )%}
+        Net total: {{ order.amountNet|currency(currencyIsoCode) }}<br>
+        {% for calculatedTax in order.price.calculatedTaxes %}
+            {% if order.taxStatus is same as('net') %}plus{% else %}including{% endif %} {{ calculatedTax.taxRate }}% VAT. {{ calculatedTax.tax|currency(currencyIsoCode) }}<br>
+        {% endfor %}
+        {% if not displayRounded %}<strong>{% endif %}Total gross: {{ total|currency(currencyIsoCode,decimals=decimals) }}{% if not displayRounded %}</strong>{% endif %}<br>
+        {% if displayRounded %}
+            <strong>Rounded total gross: {{ order.price.totalPrice|currency(currencyIsoCode,decimals=order.totalRounding.decimals) }}</strong><br>
+        {% endif %}
+        <br>
 
-            - <a href="{{ documentLink }}" target="_blank">{{ documentLink }}</a> <br>
-        {% endfor %}<br>
-        For data protection reasons the HTML version requires a login. <br><br>
-        In case of a guest order, you can use your mail address and postal code of the billing address.<br>
-    {% endif %}
-</p>
-<br>
+        {% if order.transactions is defined and order.transactions is not empty %}
+            <strong>Selected payment type:</strong> {{ order.transactions.first.paymentMethod.translated.name }}<br>
+            {{ order.transactions.first.paymentMethod.translated.description }}<br>
+            <br>
+        {% endif %}
+
+        {% if delivery %}
+            <strong>Selected shipping type:</strong> {{ delivery.shippingMethod.translated.name }}<br>
+            {{ delivery.shippingMethod.translated.description }}<br>
+            <br>
+        {% endif %}
+
+        {% set billingAddress = order.addresses.get(order.billingAddressId) %}
+        <strong>Billing address:</strong><br>
+        {{ billingAddress.company }}<br>
+        {{ billingAddress.firstName }} {{ billingAddress.lastName }}<br>
+        {{ billingAddress.street }} <br>
+        {{ billingAddress.zipcode }} {{ billingAddress.city }}<br>
+        {{ billingAddress.country.translated.name }}<br>
+        <br>
+
+        {% if delivery %}
+            <strong>Shipping address:</strong><br>
+            {{ delivery.shippingOrderAddress.company }}<br>
+            {{ delivery.shippingOrderAddress.firstName }} {{ delivery.shippingOrderAddress.lastName }}<br>
+            {{ delivery.shippingOrderAddress.street }} <br>
+            {{ delivery.shippingOrderAddress.zipcode}} {{ delivery.shippingOrderAddress.city }}<br>
+            {{ delivery.shippingOrderAddress.country.translated.name }}<br>
+            <br>
+        {% endif %}
+        {% if order.orderCustomer.vatIds %}
+            Your VAT-ID: {{ order.orderCustomer.vatIds|first }}
+            In case of a successful order and if you are based in one of the EU countries, you will receive your goods exempt from turnover tax.<br>
+        {% endif %}
+        <br>
+        You can check the current status of your order on our website under "My account" - "My orders" anytime: {{ rawUrl('frontend.account.order.single.page', { 'deepLinkCode': order.deepLinkCode }, salesChannel.domains|first.url) }}
+        <br>
+        If you have any questions, do not hesitate to contact us.
+        <br>
+        {% if a11yDocuments is defined %}
+            <br>
+            For better accessibility we also provide an HTML version of the documents here:<br><br>
+            <ul>
+                {% for a11y in a11yDocuments %}
+                    {% set documentLink = rawUrl(
+                        'frontend.account.order.single.document.a11y',
+                        {
+                            documentId: a11y.documentId,
+                            deepLinkCode: a11y.deepLinkCode,
+                            fileType: a11y.fileExtension,
+                        },
+                        salesChannel.domains|first.url
+                    )%}
+                    <li><a href="{{ documentLink }}" target="_blank">{{ documentLink }}</a></li>
+                {% endfor %}
+            </ul>
+            For data protection reasons the HTML version requires a login. <br><br>
+            In case of a guest order, you can use your mail address and postal code of the billing address.<br>
+        {% endif %}
+    </p>
+    <br>
 </div>

--- a/src/Core/Migration/Fixtures/mails/order_transaction.state.paid/en-plain.html.twig
+++ b/src/Core/Migration/Fixtures/mails/order_transaction.state.paid/en-plain.html.twig
@@ -89,7 +89,7 @@ In case of a successful order and if you are based in one of the EU countries, y
 You can check the current status of your order on our website under "My account" - "My orders" anytime: {{ rawUrl('frontend.account.order.single.page', { 'deepLinkCode': order.deepLinkCode }, salesChannel.domains|first.url) }}
 If you have any questions, do not hesitate to contact us.
 
-{% if a11yDocuments is defined %}
+{% if a11yDocuments is defined and a11yDocuments is not empty %}
 For better accessibility we also provide an HTML version of the documents here:
 
 {% for a11y in a11yDocuments %}

--- a/src/Core/Migration/Fixtures/mails/order_transaction.state.paid/en-plain.html.twig
+++ b/src/Core/Migration/Fixtures/mails/order_transaction.state.paid/en-plain.html.twig
@@ -8,14 +8,34 @@ Order number: {{ order.orderNumber }}
 
 Information on your order:
 
-Pos.   Prod. No.			Description			Quantities			Price			Total
 {% for lineItem in order.lineItems %}
-{{ loop.index }}      {% if lineItem.payload.productNumber is defined %}{{ lineItem.payload.productNumber|u.wordwrap(80) }}{% endif %}				{{ lineItem.label|u.wordwrap(80) }}{% if lineItem.payload.options is defined and lineItem.payload.options|length >= 1 %}, {% for option in lineItem.payload.options %}{{ option.group }}: {{ option.option }}{% if lineItem.payload.options|last != option %}{{ " | " }}{% endif %}{% endfor %}{% endif %}{% if lineItem.payload.features is defined and lineItem.payload.features|length >= 1 %}{% set referencePriceFeatures = lineItem.payload.features|filter(feature => feature.type == 'referencePrice') %}{% if referencePriceFeatures|length >= 1 %}{% set referencePriceFeature = referencePriceFeatures|first %}, {{ referencePriceFeature.value.purchaseUnit }} {{ referencePriceFeature.value.unitName }}({{ referencePriceFeature.value.price|currency(currencyIsoCode) }}* / {{ referencePriceFeature.value.referenceUnit }} {{ referencePriceFeature.value.unitName }}){% endif %}{% endif %}
-    {{ lineItem.quantity }}			{{ lineItem.unitPrice|currency(currencyIsoCode) }}			{{ lineItem.totalPrice|currency(currencyIsoCode) }}
+Pos. {{ loop.index }}
+---------------------
+{% if lineItem.payload.productNumber is defined %}
+Product number {{ lineItem.payload.productNumber|u.wordwrap(80) }},
+{% endif %}
+{% if nestedItem.cover is defined and nestedItem.cover is not null %}
+Image {{ lineItem.cover.alt }},
+{% endif %}
+Description {{ lineItem.label|u.wordwrap(80) }},
+{% if lineItem.payload.options is defined and lineItem.payload.options|length >= 1 %}
+{% for option in lineItem.payload.options %}
+{{ option.group }}: {{ option.option }}{{ ", " }}
 {% endfor %}
+{% endif %}
+{% if lineItem.payload.features is defined and lineItem.payload.features|length >= 1 %}
+{% set referencePriceFeatures = lineItem.payload.features|filter(feature => feature.type == 'referencePrice') %}
+{% if referencePriceFeatures|length >= 1 %}
+{% set referencePriceFeature = referencePriceFeatures|first %}
+{{ referencePriceFeature.value.purchaseUnit }} {{ referencePriceFeature.value.unitName }}({{ referencePriceFeature.value.price|currency(currencyIsoCode) }} per {{ referencePriceFeature.value.referenceUnit }} {{ referencePriceFeature.value.unitName }}),
+{% endif %}
+{% endif %}
+Quantity {{ lineItem.quantity }},
+Price {{ lineItem.unitPrice|currency(currencyIsoCode) }},
+Total {{ lineItem.totalPrice|currency(currencyIsoCode) }},
 
+{% endfor %}
 {% set delivery = order.deliveries.first %}
-
 {% set displayRounded = order.totalRounding.interval != 0.01 or order.totalRounding.decimals != order.itemRounding.decimals %}
 {% set decimals = order.totalRounding.decimals %}
 {% set total = order.price.totalPrice %}
@@ -23,9 +43,8 @@ Pos.   Prod. No.			Description			Quantities			Price			Total
     {% set total = order.price.rawTotal %}
     {% set decimals = order.itemRounding.decimals %}
 {% endif %}
-
 {% for shippingCost in order.deliveries %}
-    Shipping costs: {{ shippingCost.shippingCosts.totalPrice|currency(currencyIsoCode) }}<br>
+Shipping costs: {{ shippingCost.shippingCosts.totalPrice|currency(currencyIsoCode) }}
 {% endfor %}
 Net total: {{ order.amountNet|currency(currencyIsoCode) }}
 {% for calculatedTax in order.price.calculatedTaxes %}
@@ -36,14 +55,15 @@ Total gross: {{ total|currency(currencyIsoCode,decimals=decimals) }}
 Rounded total gross: {{ order.price.totalPrice|currency(currencyIsoCode,decimals=order.totalRounding.decimals) }}
 {% endif %}
 
+{% if order.transactions is defined and order.transactions is not empty %}
 Selected payment type: {{ order.transactions.first.paymentMethod.translated.name }}
 {{ order.transactions.first.paymentMethod.translated.description }}
+{% endif %}
 
 {% if delivery %}
 Selected shipping type: {{ delivery.shippingMethod.translated.name }}
 {{ delivery.shippingMethod.translated.description }}
 {% endif %}
-
 {% set billingAddress = order.addresses.get(order.billingAddressId) %}
 Billing address:
 {{ billingAddress.company }}
@@ -64,31 +84,27 @@ Shipping address:
 {% if order.orderCustomer.vatIds %}
 Your VAT-ID: {{ order.orderCustomer.vatIds|first }}
 In case of a successful order and if you are based in one of the EU countries, you will receive your goods exempt from turnover tax.
-{% endif %}
 
+{% endif %}
 You can check the current status of your order on our website under "My account" - "My orders" anytime: {{ rawUrl('frontend.account.order.single.page', { 'deepLinkCode': order.deepLinkCode }, salesChannel.domains|first.url) }}
 If you have any questions, do not hesitate to contact us.
 
-However, in case you have purchased without a registration or a customer account, you do not have this option.
+{% if a11yDocuments is defined %}
+For better accessibility we also provide an HTML version of the documents here:
 
-{% if a11yDocuments %}
-    For better accessibility we also provide an HTML version of the documents here:
+{% for a11y in a11yDocuments %}
+{% set documentLink = rawUrl(
+    'frontend.account.order.single.document.a11y',
+    {
+        documentId: a11y.documentId,
+        'deepLinkCode': a11y.deepLinkCode,
+        fileType: a11y.fileExtension,
+    },
+    salesChannel.domains|first.url
+)%}
+- {{ documentLink }}
+{% endfor %}
 
-    {% for a11y in a11yDocuments %}
-        {% set documentLink = rawUrl(
-            'frontend.account.order.single.document.a11y',
-            {
-                documentId: a11y.documentId,
-                'deepLinkCode': a11y.deepLinkCode,
-                fileType: a11y.fileExtension,
-            },
-            salesChannel.domains|first.url
-        )%}
-
-        - {{ documentLink }}
-    {% endfor %}
-
-    For data protection reasons the HTML version requires a login.
-
-    In case of a guest order, you can use your mail address and postal code of the billing address.
+For data protection reasons the HTML version requires a login.
+In case of a guest order, you can use your mail address and postal code of the billing address.
 {% endif %}

--- a/src/Core/Migration/V6_7/Migration1748326970.php
+++ b/src/Core/Migration/V6_7/Migration1748326970.php
@@ -1,0 +1,54 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Migration\V6_7;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Content\MailTemplate\MailTemplateTypes;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Migration\MigrationStep;
+use Shopware\Core\Migration\Traits\MailUpdate;
+use Shopware\Core\Migration\Traits\UpdateMailTrait;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+class Migration1748326970 extends MigrationStep
+{
+    use UpdateMailTrait;
+
+    public function getCreationTimestamp(): int
+    {
+        return 1748326970;
+    }
+
+    public function update(Connection $connection): void
+    {
+        $update = new MailUpdate(
+            MailTemplateTypes::MAILTYPE_ORDER_CONFIRM,
+            (string) file_get_contents(__DIR__ . '/../Fixtures/mails/order_confirmation_mail/en-plain.html.twig'),
+            (string) file_get_contents(__DIR__ . '/../Fixtures/mails/order_confirmation_mail/en-html.html.twig'),
+            (string) file_get_contents(__DIR__ . '/../Fixtures/mails/order_confirmation_mail/de-plain.html.twig'),
+            (string) file_get_contents(__DIR__ . '/../Fixtures/mails/order_confirmation_mail/de-html.html.twig')
+        );
+        $this->updateMail($update, $connection);
+
+        $update = new MailUpdate(
+            MailTemplateTypes::MAILTYPE_STATE_ENTER_ORDER_TRANSACTION_STATE_PAID,
+            (string) file_get_contents(__DIR__ . '/../Fixtures/mails/order_transaction.state.paid/en-plain.html.twig'),
+            (string) file_get_contents(__DIR__ . '/../Fixtures/mails/order_transaction.state.paid/en-html.html.twig'),
+            (string) file_get_contents(__DIR__ . '/../Fixtures/mails/order_transaction.state.paid/de-plain.html.twig'),
+            (string) file_get_contents(__DIR__ . '/../Fixtures/mails/order_transaction.state.paid/de-html.html.twig')
+        );
+        $this->updateMail($update, $connection);
+
+        $update = new MailUpdate(
+            MailTemplateTypes::MAILTYPE_STATE_ENTER_ORDER_TRANSACTION_STATE_CANCELLED,
+            (string) file_get_contents(__DIR__ . '/../Fixtures/mails/order_transaction.state.cancelled/en-plain.html.twig'),
+            (string) file_get_contents(__DIR__ . '/../Fixtures/mails/order_transaction.state.cancelled/en-html.html.twig'),
+            (string) file_get_contents(__DIR__ . '/../Fixtures/mails/order_transaction.state.cancelled/de-plain.html.twig'),
+            (string) file_get_contents(__DIR__ . '/../Fixtures/mails/order_transaction.state.cancelled/de-html.html.twig')
+        );
+        $this->updateMail($update, $connection);
+    }
+}

--- a/src/Core/Migration/V6_7/Migration1748326970UpdateMailTemplatesForAccessibility.php
+++ b/src/Core/Migration/V6_7/Migration1748326970UpdateMailTemplatesForAccessibility.php
@@ -13,7 +13,7 @@ use Shopware\Core\Migration\Traits\UpdateMailTrait;
  * @internal
  */
 #[Package('framework')]
-class Migration1748326970 extends MigrationStep
+class Migration1748326970UpdateMailTemplatesForAccessibility extends MigrationStep
 {
     use UpdateMailTrait;
 

--- a/tests/migration/Core/V6_7/Migration1748326970UpdateMailTemplatesForAccessibilityTest.php
+++ b/tests/migration/Core/V6_7/Migration1748326970UpdateMailTemplatesForAccessibilityTest.php
@@ -1,0 +1,40 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Migration\Core\V6_7;
+
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
+use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
+use Shopware\Core\Migration\V6_7\Migration1748326970UpdateMailTemplatesForAccessibility;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+#[CoversClass(Migration1748326970UpdateMailTemplatesForAccessibility::class)]
+class Migration1748326970UpdateMailTemplatesForAccessibilityTest extends TestCase
+{
+    use IntegrationTestBehaviour;
+
+    private Connection $connection;
+
+    protected function setUp(): void
+    {
+        $this->connection = KernelLifecycleManager::getConnection();
+    }
+
+    public function testMigrationOfUnmodifiedTranslation(): void
+    {
+        $migration = new Migration1748326970UpdateMailTemplatesForAccessibility();
+        $migration->update($this->connection);
+        $migration->update($this->connection);
+
+        // at least check that the migrations run without exceptions
+
+        // there isn't much purpose in comparing the fixture contents with the DB,
+        // because future migrations might change them again, so let's skip all that boilerplate here
+    }
+}


### PR DESCRIPTION
closes #7208

Before:
![image](https://github.com/user-attachments/assets/b82e2ca0-fe61-4db5-b4fe-768a2b93034d)

After:
![image](https://github.com/user-attachments/assets/11791007-d31c-4f17-80e9-537b870253c7)


## Additional changes
Adjusted all default templates containing line items to be basically the same template except the first paragraph. These include:
- order_confirmation_mail
- order_transaction.state.paid
- order_transaction.state.cancelled

## Tips for easier code review
consider enabling this option, but keep in mind that whitespace matters for plain text emails.
![image](https://github.com/user-attachments/assets/4061c2b8-9e2c-44d8-8226-be161acbbac5)
