### PR TITLE
fix: reading of the cart widget by screen readers

### DIFF
--- a/changelog/_unreleased/2025-07-04-fix-the-reading-of-the-cart-widget-by-screen-readers.md
+++ b/changelog/_unreleased/2025-07-04-fix-the-reading-of-the-cart-widget-by-screen-readers.md
@@ -1,0 +1,10 @@
+---
+title: Fix the reading of the cart widget by screen readers
+issue: #9229
+author: Michel Bade
+author_email: m.bade@shopware.com
+author_github: @cyl3x
+---
+# Storefront
+* Changed the `header-cart` in `views/storefront/layout/header/header.html.twig` to be aria labelled by the `cart-widget.html.twig`.
+* Changed `views/storefront/layout/header/actions/cart-widget.html.twig` to contain an aria label including cart details.

--- a/src/Storefront/Resources/views/storefront/layout/header/actions/cart-widget.html.twig
+++ b/src/Storefront/Resources/views/storefront/layout/header/actions/cart-widget.html.twig
@@ -8,4 +8,14 @@
     <span class="header-cart-total d-none d-sm-inline-block ms-sm-2">
         {{ page.cart.price.positionPrice|currency }}
     </span>
+
+    {# Live updates of the cart will be shown by the offcanvas #}
+    <span
+        class="visually-hidden"
+        id="cart-widget-aria-label"
+        aria-label="{{ 'checkout.cartScreenReaderUpdate'|trans({
+            '%count%': page.cart.lineItems|length,
+            '%total%': page.cart.price.positionPrice|currency,
+        })|sw_sanitize }}"
+    ></span>
 {% endblock %}

--- a/src/Storefront/Resources/views/storefront/layout/header/actions/cart-widget.html.twig
+++ b/src/Storefront/Resources/views/storefront/layout/header/actions/cart-widget.html.twig
@@ -13,9 +13,10 @@
     <span
         class="visually-hidden"
         id="cart-widget-aria-label"
-        aria-label="{{ 'checkout.cartScreenReaderUpdate'|trans({
-            '%count%': page.cart.lineItems|length,
-            '%total%': page.cart.price.positionPrice|currency,
-        })|sw_sanitize }}"
-    ></span>
+    >
+        {{ 'checkout.cartScreenReaderUpdate'|trans({
+                '%count%': page.cart.lineItems|length,
+                '%total%': page.cart.price.positionPrice|currency,
+            })|sw_sanitize }}
+    </span>
 {% endblock %}

--- a/src/Storefront/Resources/views/storefront/layout/header/header.html.twig
+++ b/src/Storefront/Resources/views/storefront/layout/header/header.html.twig
@@ -107,11 +107,14 @@
                                     class="header-cart"
                                     data-off-canvas-cart="true"
                                 >
-                                    <a class="btn header-cart-btn header-actions-btn"
-                                       href="{{ path('frontend.checkout.cart.page') }}"
-                                       data-cart-widget="true"
-                                       title="{{ 'checkout.cartTitle'|trans|striptags }}"
-                                       aria-label="{{ 'checkout.cartTitle'|trans|striptags }}">
+                                    <a
+                                        class="btn header-cart-btn header-actions-btn"
+                                        href="{{ path('frontend.checkout.cart.page') }}"
+                                        data-cart-widget="true"
+                                        title="{{ 'checkout.cartTitle'|trans|striptags }}"
+                                        aria-labelledby="cart-widget-aria-label"
+                                        aria-haspopup="true"
+                                    >
                                         {% sw_include '@Storefront/storefront/layout/header/actions/cart-widget.html.twig' %}
                                     </a>
                                 </div>


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
>When a user visits the Storefront and Screen Readers read out the page structure/content, the header cart widget is described as a link, the content (number of items, total amount) is ignored.

### 2. What does this change do, exactly?
- Add an aria label element to the `cart-widget` to display up-to-date cart information, since this template is hot-replaced in the storefront when changes occur.
- the cart header link points to the widget label instead of defining one on its own

### 3. Describe each step to reproduce the issue or behaviour.

>- Enable a Screen Reader
>- Visit the Storefront and let it do it's thing describing the page / tab-navigate to the header cart icon
>- VO describes the link, but not the content


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->
- fixes #9229

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
