### PR TITLE
feat(a11y): Allow `strong` and `em` for html sanitizers

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/structure/sw-modals-renderer/index.ts
+++ b/src/Administration/Resources/app/administration/src/app/component/structure/sw-modals-renderer/index.ts
@@ -67,7 +67,9 @@ export default Shopware.Component.wrapComponentConfig({
                 ALLOWED_TAGS: [
                     'a',
                     'b',
+                    'strong',
                     'i',
+                    'em',
                     'u',
                     's',
                     'li',

--- a/src/Administration/Resources/app/administration/src/app/component/utils/sw-notification-center-item/sw-notification-center-item.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/utils/sw-notification-center-item/sw-notification-center-item.html.twig
@@ -30,7 +30,7 @@
         {% block sw_notification_center_item_content_message %}
         <p
             class="sw-notification-center-item__message"
-            v-html="$sanitize(notification.message, { ALLOWED_TAGS: ['a', 'b', 'i', 'u', 'br'], ALLOWED_ATTR: ['href', 'target'] })"
+            v-html="$sanitize(notification.message, { ALLOWED_TAGS: ['a', 'b', 'i', 'u', 'strong', 'em', 'br'], ALLOWED_ATTR: ['href', 'target'] })"
         ></p>
         {% endblock %}
         {% block sw_notification_center_item_loader %}

--- a/src/Administration/Resources/app/administration/src/app/component/utils/sw-notifications/sw-notifications.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/utils/sw-notifications/sw-notifications.html.twig
@@ -26,7 +26,7 @@
                 {% block sw_notifications_item_content %}
                 <div
                     class="sw-notifications__message"
-                    v-html="$sanitize(notification.message, { ALLOWED_TAGS: ['a', 'b', 'i', 'u', 'br'], ALLOWED_ATTR: ['href', 'target'] })"
+                    v-html="$sanitize(notification.message, { ALLOWED_TAGS: ['a', 'b', 'i', 'u', 'strong', 'em', 'br'], ALLOWED_ATTR: ['href', 'target'] })"
                 ></div>
                 {% endblock %}
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
In terms of accessibility, `strong` and `em` are mostly better choices than `b` and `i`

### 2. What does this change do, exactly?
Add those terms to our sanitizers


### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
