### PR TITLE
fix: improve basic captcha accessibility

### DIFF
--- a/changelog/_unreleased/2025-07-10-improve-basic-captcha-a11y.md
+++ b/changelog/_unreleased/2025-07-10-improve-basic-captcha-a11y.md
@@ -1,0 +1,10 @@
+---
+title: Improve basic captcha accessibility
+issue: #10870
+---
+# Storefront
+* Added an `alt` attribute to the captcha image.
+* Added an `aria-label` attribute to the cpatcha refresh button.
+___
+# Administration
+* Added a notice in the system settings, to inform users that the basic captcha solution is not considered as accessible.

--- a/src/Administration/Resources/app/administration/blocks-list.json
+++ b/src/Administration/Resources/app/administration/blocks-list.json
@@ -5697,6 +5697,7 @@
  "sw_settings_cache_smart_bar_header_title",
  "sw_settings_cache_smart_bar_header_title_text",
  "sw_settings_captcha_select_v2",
+ "sw_settings_captcha_select_v2_basic_captcha_notice",
  "sw_settings_captcha_select_v2_google_recaptcha_v2",
  "sw_settings_captcha_select_v2_google_recaptcha_v2_description",
  "sw_settings_captcha_select_v2_google_recaptcha_v2_invisible",

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-basic-information/component/sw-settings-captcha-select-v2/sw-settings-captcha-select-v2.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-basic-information/component/sw-settings-captcha-select-v2/sw-settings-captcha-select-v2.html.twig
@@ -104,14 +104,14 @@
 
     {% block sw_settings_captcha_select_v2_basic_captcha_notice %}
     <sw-container v-if="currentValue.basicCaptcha.isActive">
-        <mt-banner 
-            variant="neutral" 
-            :title="$tc('sw-settings-basic-information.captcha.basicCaptchaNoticeTitle')" 
-            class="sw-settings-captcha-select-v2__basic-captcha-notice">
+        <mt-banner
+            variant="neutral"
+            :title="$tc('sw-settings-basic-information.captcha.basicCaptchaNoticeTitle')"
+            class="sw-settings-captcha-select-v2__basic-captcha-notice"
+        >
             {{ $tc('sw-settings-basic-information.captcha.basicCaptchaNotice') }}
         </mt-banner>
     </sw-container>
     {% endblock %}
-
 </sw-container>
 {% endblock %}

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-basic-information/component/sw-settings-captcha-select-v2/sw-settings-captcha-select-v2.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-basic-information/component/sw-settings-captcha-select-v2/sw-settings-captcha-select-v2.html.twig
@@ -102,5 +102,16 @@
     </sw-container>
     {% endblock %}
 
+    {% block sw_settings_captcha_select_v2_basic_captcha_notice %}
+    <sw-container v-if="currentValue.basicCaptcha.isActive">
+        <mt-banner 
+            variant="neutral" 
+            :title="$tc('sw-settings-basic-information.captcha.basicCaptchaNoticeTitle')" 
+            class="sw-settings-captcha-select-v2__basic-captcha-notice">
+            {{ $tc('sw-settings-basic-information.captcha.basicCaptchaNotice') }}
+        </mt-banner>
+    </sw-container>
+    {% endblock %}
+
 </sw-container>
 {% endblock %}

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-basic-information/component/sw-settings-captcha-select-v2/sw-settings-captcha-select-v2.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-basic-information/component/sw-settings-captcha-select-v2/sw-settings-captcha-select-v2.scss
@@ -2,4 +2,8 @@
     &__description {
         margin-bottom: 32px;
     }
+
+    &__basic-captcha-notice {
+        width: 100%;
+    }
 }

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-basic-information/snippet/de-DE.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-basic-information/snippet/de-DE.json
@@ -23,7 +23,9 @@
         "googleReCaptchaV2InvisibleDescription": "Das unsichtbare reCAPTCHA-Abzeichen verpflichtet den Nutzer nicht auf eine Checkbox zu klicken, sondern wird entweder beim Klick des Nutzers auf einen existierenden Button in Deiner Seite oder durch einen JavaScript-API-Call aufgerufen. Für die Integration wird ein JavaScript-Callback benötigt, sobald die reCAPTCHA-Verifikation abgeschlossen ist. Standardmäßig wird nur bei sehr verdächtigen Aufrufen ein CAPTCHA-Abfrage erforderlich. Diese Einstellung können in den Seiten-Sicherheits-Einstellungen innerhalb der Erweiterten Einstellungen bearbeitet werden.",
         "googleReCaptchaV3Description": "Mit reCAPTCHA v3 können Interaktionen ohne Zutun des Nutzers verifiziert werden. Es handelt sich hierbei um eine reine JavaScript-API, die eine Punktzahl zurückgibt und es dadurch ermöglicht, im Kontext Deiner Seite tätig zu werden: Zum Beispiel können weitere Faktoren zur Authentifizierung angefordert, die Moderation informiert oder Bots, die Inhalte abgreifen, unterdrückt werden.",
         "googleReCaptchaV3DescriptionThresholdScore": "reCAPTCHA v3 vergibt für jede Nutzeranfrage eine Punktzahl, ohne den Nutzer zu behelligen. Die Punktzahl errechnet sich aus den Interaktionen mit Deiner Seite und versetzt Dich in die Lage, eine für Deine Seite angemessene Aktion auszuführen. Die Grenzwertpunktzahl kann Werte zwischen 0.0 und 1.0 annehmen."
-      }
+      },
+      "basicCaptchaNoticeTitle": "Hinweis",
+      "basicCaptchaNotice": "Die Basic Captcha Lösung wird nicht als barrierefrei betrachtet. Wir empfehlen, eine Lösung zu verwenden, die keine Benutzerinteraktion benötigt."
     }
   }
 }

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-basic-information/snippet/en-GB.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-basic-information/snippet/en-GB.json
@@ -23,7 +23,9 @@
         "googleReCaptchaV2InvisibleDescription": "The invisible reCAPTCHA badge does not require the user to click on a checkbox, instead it is invoked directly when the user clicks on an existing button on your site or can be invoked via a JavaScript API call. The integration requires a JavaScript callback when reCAPTCHA verification is complete. By default only the most suspicious traffic will be prompted to solve a CAPTCHA. To alter this behaviour edit your site security preference under advanced settings.",
         "googleReCaptchaV3Description": "reCAPTCHA v3 allows you to verify if an interaction is legitimate without any user interaction. It is a pure JavaScript API returning a score, giving you the ability to take action in the context of your site: for instance requiring additional factors of authentication, sending a post to moderation, or throttling bots that may be scraping content.",
         "googleReCaptchaV3DescriptionThresholdScore": "reCAPTCHA v3 returns a score for each request without user friction. The score is based on interactions with your site and enables you to take an appropriate action for your site. Threshold score values range from 0.0 to 1.0."
-      }
+      },
+      "basicCaptchaNoticeTitle": "Note",
+      "basicCaptchaNotice": "The Basic Captcha solution is not considered as accessible. We recommend using a solution that does not require user interaction."
     }
   }
 }

--- a/src/Storefront/Resources/snippet/de_DE/storefront.de-DE.json
+++ b/src/Storefront/Resources/snippet/de_DE/storefront.de-DE.json
@@ -782,7 +782,9 @@
     "googleReCaptcha": {
       "dataProtectionInformation": "Diese Seite ist durch reCAPTCHA geschützt und es gelten die <a href=\"https://policies.google.com/privacy?hl=de\">Datenschutzrichtlinie</a> und <a href=\"https://policies.google.com/terms?hl=de\">Nutzungsbedingungen</a>."
     },
-    "basicCaptchaLabel": "Um weiterzugehen, geben Sie die oben abgebildeten Zeichen ein*"
+    "basicCaptchaLabel": "Um weiterzugehen, geben Sie die oben abgebildeten Zeichen ein*",
+    "basicCaptchaRefreshButton": "Captcha-Aufgabe aktualisieren",
+    "basicCaptchaChallengeAltText": "Captcha-Aufgabe"
   },
   "cookie": {
     "messageText": "Diese Website verwendet Cookies, um eine bestmögliche Erfahrung bieten zu können. <a data-ajax-modal=\"true\" data-url=\"%url%\" href=\"%url%\" title=\"Mehr Informationen\">Mehr Informationen ...</a>",

--- a/src/Storefront/Resources/snippet/en_GB/storefront.en-GB.json
+++ b/src/Storefront/Resources/snippet/en_GB/storefront.en-GB.json
@@ -782,7 +782,9 @@
     "googleReCaptcha": {
       "dataProtectionInformation": "This site is protected by reCAPTCHA and the Google <a href=\"https://policies.google.com/privacy\">Privacy Policy</a> and <a href=\"https://policies.google.com/terms\">Terms of Service</a> apply."
     },
-    "basicCaptchaLabel": "To continue, enter the characters shown above*"
+    "basicCaptchaLabel": "To continue, enter the characters shown above*",
+    "basicCaptchaRefreshButton": "Refresh captcha challenge",
+    "basicCaptchaChallengeAltText": "Captcha challenge"
   },
   "cookie": {
     "messageText": "This website uses cookies to ensure the best experience possible. <a data-ajax-modal=\"true\" data-url=\"%url%\" href=\"%url%\" title=\"More information\">More information...</a>",

--- a/src/Storefront/Resources/views/storefront/component/captcha/basicCaptcha.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/captcha/basicCaptcha.html.twig
@@ -22,7 +22,10 @@
                     <div class="basic-captcha-content-image" id="{{ formId }}-basic-captcha-content-image"></div>
 
                     {% block component_basic_captcha_refresh_icon %}
-                        <button type="button" class="btn btn-outline-primary basic-captcha-content-refresh-icon" id="{{ formId }}-basic-captcha-content-refresh-icon">
+                        <button type="button" 
+                                class="btn btn-outline-primary basic-captcha-content-refresh-icon" 
+                                id="{{ formId }}-basic-captcha-content-refresh-icon"
+                                aria-label="{{ 'captcha.basicCaptchaRefreshButton'|trans|sw_sanitize }}">
                             {% sw_icon 'arrow-switch' %}
                         </button>
                     {% endblock %}

--- a/src/Storefront/Resources/views/storefront/component/captcha/basicCaptchaImage.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/captcha/basicCaptchaImage.html.twig
@@ -1,5 +1,5 @@
 {% block basic_captcha_content_image %}
     <div class="basic-captcha-content-image" id="{{ formId }}-basic-captcha-content-image">
-        <img src="data:image/png;base64, {{ page.getCaptcha.imageBase64 }}">
+        <img src="data:image/png;base64, {{ page.getCaptcha.imageBase64 }}" alt="{{ 'captcha.basicCaptchaChallengeAltText'|trans|sw_sanitize }}">
     </div>
 {% endblock %}


### PR DESCRIPTION
Fixes #10870

### 1. Why is this change necessary?

The basic captcha was missing some required HTML attributes, but it is in general not a very accessible captcha solution.


### 2. What does this change do, exactly?

* Added the necessary HTML attributes in the Storefront.
* Added a notice in the Administration with more information.

![image](https://github.com/user-attachments/assets/0f9384ab-33ab-4b6d-b3fb-1e755a59aa0f)
