### PR TITLE
feat: [POC] apply mysql fulltext search

### DIFF
--- a/src/Core/Framework/DataAbstractionLayer/Command/FulltextSearchCommand.php
+++ b/src/Core/Framework/DataAbstractionLayer/Command/FulltextSearchCommand.php
@@ -1,0 +1,320 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\DataAbstractionLayer\Command;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Shopware\Core\Framework\Adapter\Console\ShopwareStyle;
+use Shopware\Core\Framework\DataAbstractionLayer\Dbal\EntityDefinitionQueryHelper;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityTranslationDefinition;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\TranslatedField;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\FulltextSearchRegistry;
+use Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\SearchRanking;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\StringField;
+use Shopware\Core\Framework\Log\Package;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * @internal
+ */
+#[AsCommand(
+    name: 'dbal:fulltext-search',
+    description: 'Enable fulltext search by adding FULLTEXT indexes to searchable fields',
+)]
+#[Package('framework')]
+class FulltextSearchCommand extends Command
+{
+    /**
+     * @var array<string, bool>
+     */
+    private array $fulltextIndexCache = [];
+
+    /**
+     * @internal
+     */
+    public function __construct(
+        private readonly DefinitionInstanceRegistry $definitionRegistry,
+        private readonly Connection $connection,
+        private readonly FulltextSearchRegistry $fulltextRegistry
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this->setDescription('Enables fulltext search by dynamically adding FULLTEXT indexes to StringFields with SearchRanking flags');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new ShopwareStyle($input, $output);
+
+        // Check MySQL compatibility
+        if (!$this->isMySQLCompatible()) {
+            $io->error([
+                'This feature is only supported for MySQL or MariaDB databases.',
+                'Current database platform is not supported.',
+            ]);
+            return Command::FAILURE;
+        }
+
+        // Show warning about irreversibility
+        $io->warning([
+            '⚠️  This action modifies database indexes and cannot be rolled back automatically.',
+            '',
+            'MySQL Fulltext Configuration Notes:',
+            '• Default MySQL stopword list may ignore common words (e.g., "a", "the")',
+            '• Words shorter than 4 characters are ignored by default unless innodb_ft_min_token_size is changed',
+            '• This will improve search performance for LIKE %...% queries by replacing them with MATCH...AGAINST',
+        ]);
+
+        if (!$io->confirm('Do you want to continue?', false)) {
+            $io->note('Operation cancelled.');
+            return Command::SUCCESS;
+        }
+
+        $io->title('Enabling Fulltext Search');
+
+        // First, discover and persist all existing fulltext indexes
+        $this->discoverAndPersistExistingFulltextIndexes($io);
+
+        // Detect eligible fields
+        $eligibleFields = $this->detectEligibleFields($io);
+
+        if (empty($eligibleFields)) {
+            $io->success('No eligible fields found for fulltext indexing.');
+            return Command::SUCCESS;
+        }
+
+        $io->writeln(sprintf('Found %d eligible fields for fulltext indexing.', count($eligibleFields)));
+
+        // Add FULLTEXT indexes
+        $indexedFields = $this->addFulltextIndexes($eligibleFields, $io);
+
+        // Store state in registry
+        $this->storeIndexedFieldsState($indexedFields, $io);
+
+        $io->success([
+            sprintf('Successfully indexed %d fields for fulltext search.', count($indexedFields)),
+            'Fields with FULLTEXT indexes will now use MATCH...AGAINST instead of LIKE queries.',
+        ]);
+
+        return Command::SUCCESS;
+    }
+
+    private function isMySQLCompatible(): bool
+    {
+        $platform = $this->connection->getDatabasePlatform();
+        return $platform instanceof MySQLPlatform;
+    }
+
+    /**
+     * @return array<string, array{entity: string, field: string, table: string, column: string}>
+     */
+    private function detectEligibleFields(ShopwareStyle $io): array
+    {
+        $io->section('Detecting eligible fields...');
+
+        $eligibleFields = [];
+        $definitions = $this->definitionRegistry->getDefinitions();
+
+        foreach ($definitions as $definition) {
+            if ($definition instanceof EntityTranslationDefinition) {
+                continue;
+            }
+
+            $fields = $definition->getFields();
+
+            foreach ($fields as $field) {
+                if (!$field->is(SearchRanking::class)) {
+                    continue;
+                }
+
+                $tableName = $definition->getEntityName();
+                $entityName = $definition->getEntityName();
+
+                if ($field instanceof TranslatedField) {
+                    try {
+                        $field = EntityDefinitionQueryHelper::getTranslatedField($definition, $field);
+                        $translationDefinition = $definition->getTranslationDefinition();
+
+                        $tableName = $translationDefinition->getEntityName();
+                        $entityName = $translationDefinition->getEntityName();
+                    } catch (\Throwable $exception) {
+                        dd($definition->getEntityName(), $exception->getMessage(), $definition instanceof EntityTranslationDefinition);
+                    }
+                }
+
+
+                // Check if it's a StringField with SearchRanking flag
+                if (!$field instanceof StringField) {
+                    continue;
+                }
+
+                $fieldName = $field->getPropertyName();
+                $columnName = $field->getStorageName();
+
+                // Skip if already has FULLTEXT index
+                if ($this->hasFulltextIndex($tableName, $columnName)) {
+                    $io->writeln(sprintf('  <comment>Skipping %s.%s (already has FULLTEXT index)</comment>', $entityName, $fieldName));
+                    continue;
+                }
+
+                $key = sprintf('%s.%s', $entityName, $fieldName);
+                $eligibleFields[$key] = [
+                    'entity' => $entityName,
+                    'field' => $fieldName,
+                    'table' => $tableName,
+                    'column' => $columnName,
+                ];
+
+                $io->writeln(sprintf('  <info>Found eligible field: %s.%s</info>', $entityName, $fieldName));
+            }
+        }
+
+        return $eligibleFields;
+    }
+
+    private function hasFulltextIndex(string $tableName, string $columnName): bool
+    {
+        $cacheKey = sprintf('%s.%s', $tableName, $columnName);
+        
+        if (array_key_exists($cacheKey, $this->fulltextIndexCache)) {
+            return $this->fulltextIndexCache[$cacheKey];
+        }
+
+        try {
+            $schemaManager = $this->connection->createSchemaManager();
+            
+            if (!$schemaManager->tablesExist([$tableName])) {
+                return $this->fulltextIndexCache[$cacheKey] = false;
+            }
+
+            $table = $schemaManager->introspectTable($tableName);
+            $indexes = $table->getIndexes();
+
+            foreach ($indexes as $index) {
+                if ($index->hasFlag('fulltext') && in_array($columnName, $index->getColumns(), true)) {
+                    return $this->fulltextIndexCache[$cacheKey] = true;
+                }
+            }
+
+            return $this->fulltextIndexCache[$cacheKey] = false;
+        } catch (\Exception) {
+            return $this->fulltextIndexCache[$cacheKey] = false;
+        }
+    }
+
+    /**
+     * @param array<string, array{entity: string, field: string, table: string, column: string}> $eligibleFields
+     * @return array<string>
+     */
+    private function addFulltextIndexes(array $eligibleFields, ShopwareStyle $io): array
+    {
+        $io->section('Adding FULLTEXT indexes...');
+
+        $indexedFields = [];
+
+        foreach ($eligibleFields as $key => $fieldInfo) {
+            try {
+                $indexName = sprintf('ft_%s_%s', $fieldInfo['table'], $fieldInfo['column']);
+                $sql = sprintf(
+                    'ALTER TABLE `%s` ADD FULLTEXT KEY `%s` (`%s`)',
+                    $fieldInfo['table'],
+                    $indexName,
+                    $fieldInfo['column']
+                );
+
+                $this->connection->executeStatement($sql);
+                $indexedFields[] = $key;
+
+                $io->writeln(sprintf('  <info>✓ Added FULLTEXT index for %s.%s</info>', $fieldInfo['entity'], $fieldInfo['field']));
+            } catch (\Exception $e) {
+                $io->writeln(sprintf('  <error>✗ Failed to add FULLTEXT index for %s.%s: %s</error>', 
+                    $fieldInfo['entity'], 
+                    $fieldInfo['field'], 
+                    $e->getMessage()
+                ));
+            }
+        }
+
+        return $indexedFields;
+    }
+
+    /**
+     * @param array<string> $indexedFields
+     */
+    private function storeIndexedFieldsState(array $indexedFields, ShopwareStyle $io): void
+    {
+        $io->section('Storing indexed fields state...');
+
+        if (!empty($indexedFields)) {
+            $this->fulltextRegistry->addIndexedFields($indexedFields);
+        }
+
+        $io->writeln(sprintf('  <info>✓ Stored state for %d indexed fields</info>', count($indexedFields)));
+    }
+
+    private function discoverAndPersistExistingFulltextIndexes(ShopwareStyle $io): void
+    {
+        $io->section('Discovering existing FULLTEXT indexes...');
+
+        $existingIndexedFields = [];
+        $definitions = $this->definitionRegistry->getDefinitions();
+
+        foreach ($definitions as $definition) {
+            if ($definition instanceof EntityTranslationDefinition) {
+                continue;
+            }
+
+            $fields = $definition->getFields();
+
+            foreach ($fields as $field) {
+                if (!$field->is(SearchRanking::class)) {
+                    continue;
+                }
+
+                $tableName = $definition->getEntityName();
+                $entityName = $definition->getEntityName();
+
+                if ($field instanceof TranslatedField) {
+                    try {
+                        $field = EntityDefinitionQueryHelper::getTranslatedField($definition, $field);
+                        $translationDefinition = $definition->getTranslationDefinition();
+
+                        $tableName = $translationDefinition->getEntityName();
+                        $entityName = $translationDefinition->getEntityName();
+                    } catch (\Throwable) {
+                        continue;
+                    }
+                }
+
+                // Check if it's a StringField with SearchRanking flag
+                if (!$field instanceof StringField) {
+                    continue;
+                }
+
+                $fieldName = $field->getPropertyName();
+                $columnName = $field->getStorageName();
+
+                // Check if this field already has FULLTEXT index
+                if ($this->hasFulltextIndex($tableName, $columnName)) {
+                    $key = sprintf('%s.%s', $entityName, $fieldName);
+                    $existingIndexedFields[] = $key;
+                    $io->writeln(sprintf('  <info>Found existing FULLTEXT index: %s.%s</info>', $entityName, $fieldName));
+                }
+            }
+        }
+
+        if (!empty($existingIndexedFields)) {
+            $this->fulltextRegistry->addIndexedFields($existingIndexedFields);
+            $io->writeln(sprintf('  <info>✓ Persisted %d existing FULLTEXT indexes to registry</info>', count($existingIndexedFields)));
+        } else {
+            $io->writeln('  <comment>No existing FULLTEXT indexes found</comment>');
+        }
+    }
+} 

--- a/src/Core/Framework/DataAbstractionLayer/Dbal/EntityDefinitionQueryHelper.php
+++ b/src/Core/Framework/DataAbstractionLayer/Dbal/EntityDefinitionQueryHelper.php
@@ -294,6 +294,61 @@ class EntityDefinitionQueryHelper
         );
     }
 
+    public function getFieldAccessorAsArray(string $fieldName, EntityDefinition $definition, string $root, Context $context): array
+    {
+        $fieldName = str_replace('extensions.', '', $fieldName);
+
+        $original = $fieldName;
+        $prefix = $root . '.';
+
+        if (str_starts_with($fieldName, $prefix)) {
+            $fieldName = mb_substr($fieldName, mb_strlen($prefix));
+        } else {
+            $original = $prefix . $original;
+        }
+
+        $fields = $definition->getFields();
+        if ($fields->has($fieldName)) {
+            $field = $fields->get($fieldName);
+
+            return $this->buildInheritedAccessorAsArray($field, $root, $definition, $context, $fieldName);
+        }
+
+        $parts = explode('.', $fieldName);
+        $associationKey = array_shift($parts);
+
+        if ($associationKey === 'extensions') {
+            $associationKey = array_shift($parts);
+        }
+
+        if (!\is_string($associationKey) || !$fields->has($associationKey)) {
+            throw new UnmappedFieldException($original, $definition);
+        }
+
+        $field = $fields->get($associationKey);
+
+        // case for json object fields, other fields has now same option to act with more point notations but hasn't to be an association field. E.g. price.gross
+        if (!$field instanceof AssociationField && ($field instanceof StorageAware || $field instanceof TranslatedField)) {
+            return $this->buildInheritedAccessorAsArray($field, $root, $definition, $context, $fieldName);
+        }
+
+        if (!$field instanceof AssociationField) {
+            throw new \RuntimeException(\sprintf('Expected field "%s" to be instance of %s', $associationKey, AssociationField::class));
+        }
+
+        $referenceDefinition = $field->getReferenceDefinition();
+        if ($field instanceof ManyToManyAssociationField) {
+            $referenceDefinition = $field->getToManyReferenceDefinition();
+        }
+
+        return $this->getFieldAccessorAsArray(
+            $original,
+            $referenceDefinition,
+            $root . '.' . $field->getPropertyName(),
+            $context
+        );
+    }
+
     public static function getAssociationPath(string $accessor, EntityDefinition $definition): ?string
     {
         $fields = self::getFieldsOfAccessor($definition, $accessor);
@@ -751,5 +806,55 @@ class EntityDefinitionQueryHelper
         }
 
         return $accessor;
+    }
+
+    public function buildInheritedAccessorAsArray(
+        Field $field,
+        string $root,
+        EntityDefinition $definition,
+        Context $context,
+        string $original
+    ): array {
+        if ($field instanceof TranslatedField) {
+            $translationChain = self::buildTranslationChain(
+                $root,
+                $context,
+                includeParent: $definition->isInheritanceAware() && $context->considerInheritance(),
+            );
+
+            $translatedField = self::getTranslatedField($definition, $field);
+
+            return $this->getTranslationFieldAccessorAsArray($translatedField, $original, $translationChain, $context);
+        }
+
+        $select = $this->buildFieldSelector($root, $field, $context, $original);
+
+        if (!$field->is(Inherited::class) || !$context->considerInheritance()) {
+            return [$select];
+        }
+
+        $parentSelect = $this->buildFieldSelector($root . '.parent', $field, $context, $original);
+
+        return [$select, $parentSelect];
+    }
+
+    private function getTranslationFieldAccessorAsArray(Field $field, string $accessor, array $chain, Context $context): array
+    {
+        if (!$field instanceof StorageAware) {
+            throw new \RuntimeException('Only storage aware fields are supported as translated field');
+        }
+
+        $selects = [];
+        foreach ($chain as $part) {
+            $select = $this->buildFieldSelector($part, $field, $context, $accessor);
+
+            $selects[] = str_replace(
+                '`.' . self::escape($field->getStorageName()),
+                '.' . $field->getPropertyName() . '`',
+                $select
+            );
+        }
+
+        return $selects;
     }
 }

--- a/src/Core/Framework/DataAbstractionLayer/Search/FulltextSearchRegistry.php
+++ b/src/Core/Framework/DataAbstractionLayer/Search/FulltextSearchRegistry.php
@@ -1,0 +1,100 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\DataAbstractionLayer\Search;
+
+use Shopware\Core\Framework\Adapter\Storage\AbstractKeyValueStorage;
+use Shopware\Core\Framework\DataAbstractionLayer\Dbal\EntityDefinitionQueryHelper;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Field;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\TranslatedField;
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+class FulltextSearchRegistry
+{
+    private const CONFIG_KEY = 'fulltext_search.indexed_fields';
+
+    /**
+     * @var array<string, true>|null
+     */
+    private ?array $indexedFields = null;
+
+    /**
+     * @internal
+     */
+    public function __construct(
+        private readonly AbstractKeyValueStorage $keyValueStorage
+    ) {
+    }
+
+    public function isFieldFulltextEnabled(EntityDefinition $definition, string $fieldName, string $root): bool
+    {
+        $this->loadIndexedFields();
+
+        $real = EntityDefinitionQueryHelper::getField($fieldName, $definition, $root);
+        $definition = EntityDefinitionQueryHelper::getAssociatedDefinition(
+            $definition,
+            $fieldName
+        );
+
+        $entityName = $definition->getEntityName();
+
+        if ($real instanceof TranslatedField) {
+            $entityName = $definition->getTranslationDefinition()->getEntityName();
+        }
+
+        $key = sprintf('%s.%s', $entityName, $real->getPropertyName());
+
+        return isset($this->indexedFields[$key]);
+    }
+
+    /**
+     * @return array<string>
+     */
+    public function getAllFulltextEnabledFields(): array
+    {
+        $this->loadIndexedFields();
+
+        return array_keys($this->indexedFields ?? []);
+    }
+
+    /**
+     * @param array<string> $fieldKeys
+     */
+    public function addIndexedFields(array $fieldKeys): void
+    {
+        $this->loadIndexedFields();
+
+        foreach ($fieldKeys as $fieldKey) {
+            $this->indexedFields[$fieldKey] = true;
+        }
+
+        $this->saveIndexedFields();
+    }
+
+    public function reset(): void
+    {
+        $this->indexedFields = null;
+    }
+
+    private function loadIndexedFields(): void
+    {
+        if ($this->indexedFields !== null) {
+            return;
+        }
+
+        $data = $this->keyValueStorage->get(self::CONFIG_KEY, '{}');
+        $decoded = json_decode($data, true);
+
+        $this->indexedFields = is_array($decoded) ? $decoded : [];
+    }
+
+    private function saveIndexedFields(): void
+    {
+        $data = json_encode($this->indexedFields ?? []);
+        $this->keyValueStorage->set(self::CONFIG_KEY, $data);
+    }
+} 

--- a/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php
+++ b/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php
@@ -22,6 +22,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\RangeFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\SingleFieldFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\SuffixFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Query\ScoreQuery;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\FulltextSearchRegistry;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Uuid\Uuid;
 
@@ -36,7 +37,8 @@ class SqlQueryParser
      */
     public function __construct(
         private readonly EntityDefinitionQueryHelper $queryHelper,
-        private readonly Connection $connection
+        private readonly Connection $connection,
+        private readonly FulltextSearchRegistry $fulltextRegistry
     ) {
     }
 
@@ -64,14 +66,14 @@ class SqlQueryParser
                     );
 
                     $result->addWhere(
-                        \sprintf('IF(%s , %s * %s, 0)', $where, $this->connection->quote((string) $query->getScore()), $field)
+                        \sprintf('%s * %s * %s', $where, $this->connection->quote((string) $query->getScore()), $field)
                     );
 
                     continue;
                 }
 
                 $result->addWhere(
-                    \sprintf('IF(%s , %s, 0)', $where, $this->connection->quote((string) $query->getScore()))
+                    \sprintf('%s * %s', $where, $this->connection->quote((string) $query->getScore()))
                 );
             }
 
@@ -155,29 +157,67 @@ class SqlQueryParser
     private function parseContainsFilter(ContainsFilter $query, EntityDefinition $definition, string $root, Context $context): ParseResult
     {
         $key = $this->getKey();
-
-        $field = $this->queryHelper->getFieldAccessor($query->getField(), $definition, $root, $context);
-
         $result = new ParseResult();
-        $result->addWhere($field . ' LIKE :' . $key);
 
-        $escaped = addcslashes((string) $query->getValue(), '\\_%');
-        $result->addParameter($key, '%' . $escaped . '%');
+        // Check if this field has fulltext index enabled
+        if ($this->fulltextRegistry->isFieldFulltextEnabled($definition, $query->getField(), $root)) {
+            $searchValue = (string) $query->getValue();
+
+            $fulltextFields = $this->queryHelper->getFieldAccessorAsArray($query->getField(), $definition, $root, $context);
+            $query = $this->buildMatchFallbackChain($fulltextFields, $searchValue);
+
+            $result->addWhere($query);
+        } else {
+            // Fall back to LIKE for non-fulltext fields
+            $field = $this->queryHelper->getFieldAccessor($query->getField(), $definition, $root, $context);
+            $result->addWhere($field . ' LIKE :' . $key);
+            $escaped = addcslashes((string) $query->getValue(), '\\_%');
+            $result->addParameter($key, '%' . $escaped . '%');
+        }
 
         return $result;
+    }
+
+    private function buildMatchFallbackChain(array $columns, string $keyword, string $mode = 'NATURAL LANGUAGE MODE'): string {
+        $conditions = [];
+        $nullChecks = [];
+
+        foreach ($columns as $i => $col) {
+            if ($i > 0) {
+                $nullChecks[] = "{$columns[$i - 1]} IS NULL";
+            }
+
+            $conditionParts = $nullChecks;
+            $conditionParts[] = "{$col} IS NOT NULL";
+            $conditionParts[] = "MATCH({$col}) AGAINST ('{$keyword}' IN {$mode})";
+
+            $conditions[] = '(' . implode(' AND ', $conditionParts) . ')';
+        }
+
+        return implode(" OR ", $conditions);
     }
 
     private function parsePrefixFilter(PrefixFilter $query, EntityDefinition $definition, string $root, Context $context): ParseResult
     {
         $key = $this->getKey();
-
-        $field = $this->queryHelper->getFieldAccessor($query->getField(), $definition, $root, $context);
-
         $result = new ParseResult();
-        $result->addWhere($field . ' LIKE :' . $key);
 
-        $escaped = addcslashes($query->getValue(), '\\_%');
-        $result->addParameter($key, $escaped . '%');
+        // Check if this field has fulltext index enabled
+        if ($this->fulltextRegistry->isFieldFulltextEnabled($definition, $query->getField(), $root)) {
+            $searchValue = $query->getValue();
+            $searchValue = $searchValue . '*';
+
+            $fulltextFields = $this->queryHelper->getFieldAccessorAsArray($query->getField(), $definition, $root, $context);
+            $query = $this->buildMatchFallbackChain($fulltextFields, $searchValue);
+
+            $result->addWhere($query);
+        } else {
+            // Fall back to LIKE for non-fulltext fields
+            $field = $this->queryHelper->getFieldAccessor($query->getField(), $definition, $root, $context);
+            $result->addWhere($field . ' LIKE :' . $key);
+            $escaped = addcslashes($query->getValue(), '\\_%');
+            $result->addParameter($key, $escaped . '%');
+        }
 
         return $result;
     }
@@ -185,12 +225,12 @@ class SqlQueryParser
     private function parseSuffixFilter(SuffixFilter $query, EntityDefinition $definition, string $root, Context $context): ParseResult
     {
         $key = $this->getKey();
-
-        $field = $this->queryHelper->getFieldAccessor($query->getField(), $definition, $root, $context);
-
         $result = new ParseResult();
-        $result->addWhere($field . ' LIKE :' . $key);
 
+        // For SUFFIX searches, fulltext isn't as effective, so we fall back to LIKE
+        // MySQL fulltext doesn't natively support suffix matching well
+        $field = $this->queryHelper->getFieldAccessor($query->getField(), $definition, $root, $context);
+        $result->addWhere($field . ' LIKE :' . $key);
         $escaped = addcslashes($query->getValue(), '\\_%');
         $result->addParameter($key, '%' . $escaped);
 

--- a/src/Core/Framework/DependencyInjection/data-abstraction-layer.xml
+++ b/src/Core/Framework/DependencyInjection/data-abstraction-layer.xml
@@ -223,9 +223,14 @@
 
         <service id="Shopware\Core\Framework\DataAbstractionLayer\Write\Validation\ConstraintBuilder"/>
 
+        <service id="Shopware\Core\Framework\DataAbstractionLayer\Search\FulltextSearchRegistry">
+            <argument type="service" id="Shopware\Core\Framework\Adapter\Storage\AbstractKeyValueStorage"/>
+        </service>
+
         <service id="Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser">
             <argument type="service" id="Shopware\Core\Framework\DataAbstractionLayer\Dbal\EntityDefinitionQueryHelper"/>
             <argument type="service" id="Doctrine\DBAL\Connection"/>
+            <argument type="service" id="Shopware\Core\Framework\DataAbstractionLayer\Search\FulltextSearchRegistry"/>
         </service>
 
         <service id="Shopware\Core\Framework\DataAbstractionLayer\Dbal\EntityForeignKeyResolver">
@@ -301,6 +306,13 @@
             <tag name="console.command"/>
             <argument type="service" id="messenger.default_bus"/>
             <argument type="service" id="Doctrine\DBAL\Connection"/>
+        </service>
+
+        <service id="Shopware\Core\Framework\DataAbstractionLayer\Command\FulltextSearchCommand">
+            <argument type="service" id="Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry"/>
+            <argument type="service" id="Doctrine\DBAL\Connection"/>
+            <argument type="service" id="Shopware\Core\Framework\DataAbstractionLayer\Search\FulltextSearchRegistry"/>
+            <tag name="console.command"/>
         </service>
 
         <service id="Shopware\Core\Framework\DataAbstractionLayer\Indexing\Subscriber\RegisteredIndexerSubscriber">

--- a/tests/unit/Core/Framework/DataAbstractionLayer/Command/FulltextSearchCommandTest.php
+++ b/tests/unit/Core/Framework/DataAbstractionLayer/Command/FulltextSearchCommandTest.php
@@ -1,0 +1,153 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\DataAbstractionLayer\Command;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\DBAL\Schema\AbstractSchemaManager;
+use Doctrine\DBAL\Schema\Table;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\DataAbstractionLayer\Command\FulltextSearchCommand;
+use Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\FulltextSearchRegistry;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\SearchRanking;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\StringField;
+use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * @internal
+ * @covers \Shopware\Core\Framework\DataAbstractionLayer\Command\FulltextSearchCommand
+ */
+class FulltextSearchCommandTest extends TestCase
+{
+    private MockObject&DefinitionInstanceRegistry $definitionRegistry;
+    private MockObject&Connection $connection;
+    private MockObject&FulltextSearchRegistry $fulltextRegistry;
+    private FulltextSearchCommand $command;
+
+    protected function setUp(): void
+    {
+        $this->definitionRegistry = $this->createMock(DefinitionInstanceRegistry::class);
+        $this->connection = $this->createMock(Connection::class);
+        $this->fulltextRegistry = $this->createMock(FulltextSearchRegistry::class);
+
+        $this->command = new FulltextSearchCommand(
+            $this->definitionRegistry,
+            $this->connection,
+            $this->fulltextRegistry
+        );
+    }
+
+    public function testCommandFailsForNonMySQLPlatform(): void
+    {
+        $platform = $this->createMock(\Doctrine\DBAL\Platforms\PostgreSQLPlatform::class);
+        $this->connection->method('getDatabasePlatform')->willReturn($platform);
+
+        $input = $this->createMock(InputInterface::class);
+        $output = $this->createMock(OutputInterface::class);
+
+        $result = $this->command->run($input, $output);
+
+        static::assertEquals(Command::FAILURE, $result);
+    }
+
+    public function testCommandSucceedsForMySQLPlatform(): void
+    {
+        $platform = $this->createMock(MySQLPlatform::class);
+        $this->connection->method('getDatabasePlatform')->willReturn($platform);
+
+        // Mock an entity definition with searchable string field
+        $definition = $this->createMock(EntityDefinition::class);
+        $definition->method('getEntityName')->willReturn('test_entity');
+
+        $searchRanking = new SearchRanking(100);
+        $stringField = $this->createMock(StringField::class);
+        $stringField->method('getPropertyName')->willReturn('name');
+        $stringField->method('getStorageName')->willReturn('name');
+        $stringField->method('is')->with(SearchRanking::class)->willReturn(true);
+
+        $fields = new FieldCollection([$stringField]);
+        $definition->method('getFields')->willReturn($fields);
+
+        $this->definitionRegistry->method('getDefinitions')->willReturn([$definition]);
+
+        // Mock schema manager to simulate no existing fulltext index
+        $schemaManager = $this->createMock(AbstractSchemaManager::class);
+        $table = $this->createMock(Table::class);
+        $table->method('getIndexes')->willReturn([]);
+
+        $schemaManager->method('tablesExist')->willReturn(true);
+        $schemaManager->method('introspectTable')->willReturn($table);
+        $this->connection->method('createSchemaManager')->willReturn($schemaManager);
+
+        // Mock successful index creation
+        $this->connection->expects(static::once())
+            ->method('executeStatement')
+            ->with(static::stringContains('ALTER TABLE `test_entity` ADD FULLTEXT KEY'));
+
+        // Mock registry operations
+        $this->fulltextRegistry->expects(static::once())
+            ->method('addIndexedFields')
+            ->with(['test_entity.name']);
+
+        $input = $this->createMock(InputInterface::class);
+        $output = $this->createMock(OutputInterface::class);
+
+        // Mock user confirmation
+        $input->method('isInteractive')->willReturn(false);
+
+        $result = $this->command->run($input, $output);
+
+        static::assertEquals(Command::SUCCESS, $result);
+    }
+
+    public function testCommandSkipsFieldsWithExistingFulltextIndex(): void
+    {
+        $platform = $this->createMock(MySQLPlatform::class);
+        $this->connection->method('getDatabasePlatform')->willReturn($platform);
+
+        $definition = $this->createMock(EntityDefinition::class);
+        $definition->method('getEntityName')->willReturn('test_entity');
+
+        $stringField = $this->createMock(StringField::class);
+        $stringField->method('getPropertyName')->willReturn('name');
+        $stringField->method('getStorageName')->willReturn('name');
+        $stringField->method('is')->with(SearchRanking::class)->willReturn(true);
+
+        $fields = new FieldCollection([$stringField]);
+        $definition->method('getFields')->willReturn($fields);
+
+        $this->definitionRegistry->method('getDefinitions')->willReturn([$definition]);
+
+        // Mock schema manager to simulate existing fulltext index
+        $schemaManager = $this->createMock(AbstractSchemaManager::class);
+        $table = $this->createMock(Table::class);
+        
+        $index = $this->createMock(\Doctrine\DBAL\Schema\Index::class);
+        $index->method('hasFlag')->with('fulltext')->willReturn(true);
+        $index->method('getColumns')->willReturn(['name']);
+        
+        $table->method('getIndexes')->willReturn([$index]);
+
+        $schemaManager->method('tablesExist')->willReturn(true);
+        $schemaManager->method('introspectTable')->willReturn($table);
+        $this->connection->method('createSchemaManager')->willReturn($schemaManager);
+
+        // Should not execute any ALTER statements since index already exists
+        $this->connection->expects(static::never())->method('executeStatement');
+        $this->fulltextRegistry->expects(static::never())->method('addIndexedFields');
+
+        $input = $this->createMock(InputInterface::class);
+        $output = $this->createMock(OutputInterface::class);
+        $input->method('isInteractive')->willReturn(false);
+
+        $result = $this->command->run($input, $output);
+
+        static::assertEquals(Command::SUCCESS, $result);
+    }
+} 


### PR DESCRIPTION
To improve search performance in Shopware 6, we introduced an opt-in feature that allows selected searchable fields to be indexed using MySQL FULLTEXT indexing.

# New Symfony Command

A new CLI command bin/console dbal:fulltext-search was added.

When executed, it automatically applies FULLTEXT indexes to eligible fields in the database.

# Automatic Detection of Searchable Fields

Only fields of type StringField that also have the SearchRanking flag are considered.

This ensures that only fields used in keyword search are indexed.

Before adding a FULLTEXT index, the command checks whether the field already has one.

Indexed fields are recorded in the app_config table to avoid reprocessing and support query optimization logic.

# Query Optimization

When Shopware's DAL executes a search using \Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\ContainsFilter on a FULLTEXT-enabled field,
the system will automatically switch from LIKE %...% to MATCH(field) AGAINST (... IN BOOLEAN MODE).

This leads to significant performance improvements, especially on large datasets.

# Opt-In by Design

No changes are made unless the command is explicitly run.

Existing LIKE-based search behavior remains unchanged by default.

This change requires no database migrations and is safe to apply in production systems.
