### PR TITLE
fix: review rating stars voiceover

### DIFF
--- a/src/Storefront/Resources/views/storefront/component/review/review-form.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/review/review-form.html.twig
@@ -59,6 +59,7 @@
                                                type="radio"
                                                name="points"
                                                value="{{ point }}"
+                                               aria-label="{{ "detail.review#{point}PointRatingText"|trans|sw_sanitize }}"
                                             {% if currentPoints >= point %} checked="checked"{% endif %}>
 
                                         {% sw_include '@Storefront/storefront/component/review/point.html.twig' with {


### PR DESCRIPTION
- added aria-label to review rating stars so voiceover can read it

fixes: [#13219](https://github.com/shopware/shopware/issues/13219)