### PR TITLE
fix: prevent guessing of cache hashes

### DIFF
--- a/src/Core/Framework/Adapter/Cache/Http/CacheHashService.php
+++ b/src/Core/Framework/Adapter/Cache/Http/CacheHashService.php
@@ -30,6 +30,7 @@ class CacheHashService
         private readonly ExtensionDispatcher $extensions,
         private readonly CacheRelevantRulesResolver $ruleResolver,
         private readonly array $cookies,
+        private readonly ?string $cacheHashSecret,
         private readonly EventDispatcherInterface $dispatcher,
     ) {
     }
@@ -71,6 +72,11 @@ class CacheHashService
                 $response->headers->clearCookie(HttpCacheKeyGenerator::CONTEXT_CACHE_COOKIE);
             }
 
+            if ($request->cookies->has(HttpCacheKeyGenerator::CONTEXT_CACHE_HASH_SIGNATURE)) {
+                $response->headers->removeCookie(HttpCacheKeyGenerator::CONTEXT_CACHE_HASH_SIGNATURE);
+                $response->headers->clearCookie(HttpCacheKeyGenerator::CONTEXT_CACHE_HASH_SIGNATURE);
+            }
+
             return;
         }
 
@@ -81,6 +87,8 @@ class CacheHashService
             $cookie->setSecureDefault($request->isSecure());
 
             $response->headers->setCookie($cookie);
+
+            $this->signCacheHash($newValue, $request, $response);
         }
 
         $response->headers->set(HttpCacheKeyGenerator::CONTEXT_CACHE_COOKIE, $newValue);
@@ -140,5 +148,19 @@ class CacheHashService
         }
 
         return false;
+    }
+
+    private function signCacheHash(string $newValue, Request $request, Response $response): void
+    {
+        if (!$this->cacheHashSecret) {
+            return;
+        }
+
+        $signature = '0x' . hash_hmac('sha256', $newValue . $request->cookies->get('session-', ''), $this->cacheHashSecret);
+
+        $cookie = Cookie::create(HttpCacheKeyGenerator::CONTEXT_CACHE_HASH_SIGNATURE, $signature);
+        $cookie->setSecureDefault($request->isSecure());
+
+        $response->headers->setCookie($cookie);
     }
 }

--- a/src/Core/Framework/Adapter/Cache/Http/HttpCacheKeyGenerator.php
+++ b/src/Core/Framework/Adapter/Cache/Http/HttpCacheKeyGenerator.php
@@ -25,6 +25,9 @@ class HttpCacheKeyGenerator
      */
     final public const CURRENCY_COOKIE = 'sw-currency';
     final public const CONTEXT_CACHE_COOKIE = 'sw-cache-hash';
+
+    final public const CONTEXT_CACHE_HASH_SIGNATURE = 'sw-cache-hash-signature';
+
     /**
      * @deprecated tag:v6.8.0 - Will be removed use cache cookie event instead
      */

--- a/src/Core/Framework/DependencyInjection/Configuration.php
+++ b/src/Core/Framework/DependencyInjection/Configuration.php
@@ -911,6 +911,7 @@ class Configuration implements ConfigurationInterface
                 ->arrayNode('reverse_proxy')
                     ->children()
                         ->booleanNode('enabled')->end()
+                        ->scalarNode('cache_hash_secret')->defaultNull()->end()
                         ->booleanNode('use_varnish_xkey')->defaultFalse()->end()
                         ->arrayNode('hosts')->performNoDeepMerging()
                             ->scalarPrototype()->end()

--- a/src/Core/Framework/DependencyInjection/cache.xml
+++ b/src/Core/Framework/DependencyInjection/cache.xml
@@ -169,6 +169,7 @@
             <argument type="service" id="Shopware\Core\Framework\Extensions\ExtensionDispatcher"/>
             <argument type="service" id="Shopware\Core\Framework\Adapter\Cache\Http\CacheRelevantRulesResolver"/>
             <argument>%shopware.http_cache.cookies%</argument>
+            <argument>%shopware.http_cache.reverse_proxy.cache_hash_secret%</argument>
             <argument type="service" id="event_dispatcher"/>
         </service>
 

--- a/src/Core/Framework/Resources/config/packages/shopware.yaml
+++ b/src/Core/Framework/Resources/config/packages/shopware.yaml
@@ -9,9 +9,10 @@ shopware:
         cookies: []
         soft_purge: false
         reverse_proxy:
-            enabled: false
+            enabled: true
+            cache_hash_secret: "S3CRET"
             ban_method: "BAN" # This can defer from used reverse proxy
-            hosts: [ "http://varnish" ]
+            hosts: [ "http://sw_varnish" ]
             max_parallel_invalidations: 2
             purge_all:
             fastly:


### PR DESCRIPTION
When caching is on for logged in customers you could guess the hash of a logged in customer and hope to get a cache hit and see the logged in page even thoug you are not logged in (e.g. in b2b context you could see cheaper prices, products that are not available for you etc)

IMHO it is debateable if we want to have that added complexity to prevent such things, especially on the reverse proxy side, currently it is designed to be opt-in, it should definetly be configurable
