### PR TITLE
fix(a11y): remove unnecessary labelledby attribute

### DIFF
--- a/src/Storefront/Resources/views/storefront/layout/header/actions/wishlist-widget.html.twig
+++ b/src/Storefront/Resources/views/storefront/layout/header/actions/wishlist-widget.html.twig
@@ -21,7 +21,6 @@
           data-wishlist-storage-options="{{ wishlistStorageOptions|json_encode }}"
           data-wishlist-widget="true"
           data-wishlist-widget-options="{{ wishlistWidgetOptions|json_encode }}"
-          aria-labelledby="wishlist-basket-live-area"
     ></span>
 
     <span class="visually-hidden"


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
The `aria-labelledby` used on the wishlist decoration is not allowed according to WCAG guidelines.

### 2. What does this change do, exactly?
Remove the label, as it is not necessary in this case. The surrounding elements are already properly accessible.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
- closes #13975 

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
