### PR TITLE
fix: Google reCAPTCHA input visibility and error handling

### DIFF
--- a/src/Storefront/Resources/views/storefront/component/captcha/googleReCaptchaV2.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/captcha/googleReCaptchaV2.html.twig
@@ -8,8 +8,8 @@
          data-google-re-captcha-v2="true"
          data-google-re-captcha-v2-options="{{ googleReCaptchaV2Options|json_encode }}">
         <input
-            type="text"
-            class="d-none grecaptcha-v2-input"
+            type="hidden"
+            class="grecaptcha-v2-input"
             name="{{ constant('Shopware\\Storefront\\Framework\\Captcha\\GoogleReCaptchaV2::CAPTCHA_REQUEST_PARAMETER') }}"
             data-validation="grecaptcha,required"
             data-validate-hidden="true"
@@ -27,6 +27,6 @@
             {% endif %}
         {% endif %}
 
-        <div id="grecaptcha-feedback-container" class="form-field-feedback" style="display: none;"></div>
+        <div id="grecaptcha-feedback-container" class="form-field-feedback"></div>
     </div>
 {% endblock %}

--- a/src/Storefront/Resources/views/storefront/component/captcha/googleReCaptchaV3.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/captcha/googleReCaptchaV3.html.twig
@@ -7,8 +7,8 @@
          data-google-re-captcha-v3="true"
          data-google-re-captcha-v3-options="{{ googleReCaptchaV3Options|json_encode }}">
         <input
-            type="text"
-            class="d-none grecaptcha_v3-input"
+            type="hidden"
+            class="grecaptcha_v3-input"
             name="{{ constant('Shopware\\Storefront\\Framework\\Captcha\\GoogleReCaptchaV3::CAPTCHA_REQUEST_PARAMETER') }}"
             data-validation="grecaptcha,required"
             data-validate-hidden="true"


### PR DESCRIPTION

<img width="1042" height="729" alt="Screenshot 2026-01-27 at 09 17 52" src="https://github.com/user-attachments/assets/1763bf80-275d-45cf-a842-3252d7c5d3d0" />



<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
- There is no information about the error for Google reCAPTCHA field when cookies are not accepted

### 2. What does this change do, exactly?
- Fix the Google reCAPTCHA error displaying

### 3. Describe each step to reproduce the issue or behaviour.
- Enable Google reCAPTCHA verification
- Go to the registration form and fill form
- Send form without accepting cookies

### 4. Please link to the relevant issues (if any).
closes #6456 

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
