### PR TITLE
fix: Head Request do not trigger account confirm

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -140,6 +140,10 @@ Previously, the clearable button was always hidden by default (`showClearableBut
 
 ## Storefront
 
+### `HEAD`-requests do not trigger the registration double-opt-in
+
+As some mail clients send `HEAD` requests to links which are contained in emails, the registration double-opt-in was sometimes already confirmed, as Symfony treats `HEAD`-requests the same as `GET`-request. Now `HEAD`-requests do not trigger the registration double-opt-in anymore, only "real" `GET`-requests.
+
 ### Selling and packaging information in the product detail page
 
 * Display the selling and packaging information with the product that has advanced pricing.

--- a/src/Core/Checkout/Customer/SalesChannel/RegisterRoute.php
+++ b/src/Core/Checkout/Customer/SalesChannel/RegisterRoute.php
@@ -621,13 +621,10 @@ class RegisterRoute extends AbstractRegisterRoute
 
     private function getConfirmUrl(SalesChannelContext $context, CustomerEntity $customer): string
     {
-        $urlTemplate = $this->systemConfigService->get(
+        $urlTemplate = $this->systemConfigService->getString(
             'core.loginRegistration.confirmationUrl',
             $context->getSalesChannelId()
-        );
-        if (!\is_string($urlTemplate)) {
-            $urlTemplate = '/registration/confirm?em=%%HASHEDEMAIL%%&hash=%%SUBSCRIBEHASH%%';
-        }
+        ) ?: '/registration/confirm?em=%%HASHEDEMAIL%%&hash=%%SUBSCRIBEHASH%%';
 
         $emailHash = Hasher::hash($customer->getEmail(), 'sha1');
 

--- a/src/Storefront/Controller/NewsletterController.php
+++ b/src/Storefront/Controller/NewsletterController.php
@@ -42,13 +42,7 @@ class NewsletterController extends StorefrontController
     )]
     public function subscribeMail(SalesChannelContext $context, Request $request, QueryDataBag $queryDataBag): Response
     {
-        /*
-         * Because some email-clients try to fetch previews for links in mails, they send a HEAD-request.
-         * But because Symfony is routing HEAD-requests as GET-requests, a subscriber would be confirmed without
-         * clicking the link, only by the HEAD-request.
-         * Beware: $request->getMethod() or $request->getRealMethod() will both return "GET"
-         */
-        if (isset($_SERVER['REQUEST_METHOD']) && $_SERVER['REQUEST_METHOD'] === 'HEAD') {
+        if ($this->isHeadRequest()) {
             return new Response(status: Response::HTTP_NO_CONTENT);
         }
 

--- a/src/Storefront/Controller/RegisterController.php
+++ b/src/Storefront/Controller/RegisterController.php
@@ -250,13 +250,7 @@ class RegisterController extends StorefrontController
     )]
     public function confirmRegistration(SalesChannelContext $context, QueryDataBag $queryDataBag): Response
     {
-        /*
-         * Because some email-clients try to fetch previews for links in mails, they send a HEAD-request.
-         * But because Symfony is routing HEAD-requests as GET-requests, a subscriber would be confirmed without
-         * clicking the link, only by the HEAD-request.
-         * Beware: $request->getMethod() or $request->getRealMethod() will both return "GET"
-         */
-        if (isset($_SERVER['REQUEST_METHOD']) && $_SERVER['REQUEST_METHOD'] === 'HEAD') {
+        if ($this->isHeadRequest()) {
             return new Response(status: Response::HTTP_NO_CONTENT);
         }
 

--- a/src/Storefront/Controller/RegisterController.php
+++ b/src/Storefront/Controller/RegisterController.php
@@ -250,6 +250,16 @@ class RegisterController extends StorefrontController
     )]
     public function confirmRegistration(SalesChannelContext $context, QueryDataBag $queryDataBag): Response
     {
+        /*
+         * Because some email-clients try to fetch previews for links in mails, they send a HEAD-request.
+         * But because Symfony is routing HEAD-requests as GET-requests, a subscriber would be confirmed without
+         * clicking the link, only by the HEAD-request.
+         * Beware: $request->getMethod() or $request->getRealMethod() will both return "GET"
+         */
+        if (isset($_SERVER['REQUEST_METHOD']) && $_SERVER['REQUEST_METHOD'] === 'HEAD') {
+            return new Response(status: Response::HTTP_NO_CONTENT);
+        }
+
         try {
             $customerId = $this->registerConfirmRoute
                 ->confirm($queryDataBag->toRequestDataBag(), $context)

--- a/src/Storefront/Controller/StorefrontController.php
+++ b/src/Storefront/Controller/StorefrontController.php
@@ -319,4 +319,19 @@ abstract class StorefrontController extends AbstractController
     {
         return $this->container->get(SystemConfigService::class);
     }
+
+    /*
+     * Because some email-clients try to fetch previews for links in mails,
+     * they send a HEAD-request. But because Symfony is routing HEAD-requests
+     * as GET-requests, a subscriber would be confirmed without clicking the link,
+     * only by the HEAD-request.
+     * To determine if the current request is a "HEAD" request or a "GET" request, this
+     * helper method exists.
+     *
+     * Beware: $request->getMethod() or $request->getRealMethod() will both return "GET".
+     */
+    protected function isHeadRequest(): bool
+    {
+        return isset($_SERVER['REQUEST_METHOD']) && $_SERVER['REQUEST_METHOD'] === 'HEAD';
+    }
 }

--- a/src/Storefront/Controller/StorefrontController.php
+++ b/src/Storefront/Controller/StorefrontController.php
@@ -320,7 +320,7 @@ abstract class StorefrontController extends AbstractController
         return $this->container->get(SystemConfigService::class);
     }
 
-    /*
+    /**
      * Because some email-clients try to fetch previews for links in mails,
      * they send a HEAD-request. But because Symfony is routing HEAD-requests
      * as GET-requests, a subscriber would be confirmed without clicking the link,


### PR DESCRIPTION
### 1. Why is this change necessary?
Similar to the following: https://github.com/shopware/shopware/commit/10ee661ff3abc7ccdae0a478e0c0a32402cbad55

When there was a mail sent to an office 365 account, it was automatically activated, and the customer only saw, that the hash does not exist. See also the original issue: https://github.com/shopware/shopware/issues/2984

I tried to come up with a test case, however it was quite ugly, as it needed to change the `$_SERVER` variable. Not sure if this should be tested?
Furthermore I am not sure if it needs an entry in the developer facing release notes? 

### 2. What does this change do, exactly?
Do not activate the account, when it is a `HEAD` request.

### 3. Describe each step to reproduce the issue or behaviour.
See https://github.com/shopware/shopware/issues/2984 but now for registration double opt in.

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
