### PR TITLE
fix: Edit Order page

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -116,6 +116,11 @@ shopware:
 
 Removed dependency of the Core bundle to the Elasticsearch bundle, so that the Core bundle can be used without Elasticsearch again.
 
+### Fixed broke account/order/edit page.
+
+The account/order/edit page was broken due to the Symfony 7.4 update. After the Update the order was loaded from the query parameter which does not exists in the URL.
+
+
 # 6.7.7.0
 
 ## Features

--- a/src/Storefront/Page/Account/Order/AccountEditOrderPageLoader.php
+++ b/src/Storefront/Page/Account/Order/AccountEditOrderPageLoader.php
@@ -126,7 +126,12 @@ class AccountEditOrderPageLoader
     {
         $orderId = RequestParamHelper::get($request, 'orderId');
 
-        $criteria = new Criteria($orderId);
+        $criteria = new Criteria();
+
+        if($orderId !== null){
+            $criteria = new Criteria([$orderId]);
+        }
+
 
         $criteria
             ->addAssociation('primaryOrderDelivery.shippingOrderAddress.salutation')

--- a/src/Storefront/Page/Account/Order/AccountEditOrderPageLoader.php
+++ b/src/Storefront/Page/Account/Order/AccountEditOrderPageLoader.php
@@ -16,6 +16,7 @@ use Shopware\Core\Checkout\Order\SalesChannel\OrderRouteResponse;
 use Shopware\Core\Checkout\Order\SalesChannel\OrderService;
 use Shopware\Core\Checkout\Payment\PaymentMethodCollection;
 use Shopware\Core\Content\Category\Exception\CategoryNotFoundException;
+use Shopware\Core\Framework\Adapter\Request\RequestParamHelper;
 use Shopware\Core\Framework\Adapter\Translation\AbstractTranslator;
 use Shopware\Core\Framework\DataAbstractionLayer\Exception\InconsistentCriteriaIdsException;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
@@ -123,11 +124,10 @@ class AccountEditOrderPageLoader
 
     private function createCriteria(Request $request, SalesChannelContext $context): Criteria
     {
-        if ($request->query->get('orderId')) {
-            $criteria = new Criteria([$request->query->get('orderId')]);
-        } else {
-            $criteria = new Criteria();
-        }
+        $orderId = RequestParamHelper::get($request, 'orderId');
+
+        $criteria = new Criteria($orderId);
+
         $criteria
             ->addAssociation('primaryOrderDelivery.shippingOrderAddress.salutation')
             ->addAssociation('primaryOrderDelivery.shippingOrderAddress.country')


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
this pr fixes #14737

### 2. What does this change do, exactly?
if you open the URL account/order/edit/<orderId>
the actual order ID is loaded from URL

### 3. Describe each step to reproduce the issue or behaviour.
create a failed order
make sure you have different orders as customer
if you edit the order from the storefront you will see a different order

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
