### PR TITLE
fix(media-modal): Fix auto-close of media modal on any click

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/media/sw-media-preview-v2/sw-media-preview-v2.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/media/sw-media-preview-v2/sw-media-preview-v2.scss
@@ -3,6 +3,8 @@
 $sw-media-preview-v2-play-button-size: 50%;
 $sw-media-preview-v2-play-button-z-index: 5;
 $sw-media-preview-v2-locked-icon-z-index: 5;
+$sw-media-preview-v2-play-icon-bg: rgba(250, 250, 250, 70%);
+$sw-media-preview-v2-play-icon-circle-size: 42px;
 
 .sw-media-preview-v2 {
     img {
@@ -57,16 +59,23 @@ $sw-media-preview-v2-locked-icon-z-index: 5;
 
     .sw-media-preview-v2__play-button {
         position: absolute;
-        visibility: hidden;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
         z-index: $sw-media-preview-v2-play-button-z-index;
         left: 50%;
         top: 50%;
         transform: translate(-50%, -50%);
         cursor: pointer;
+        width: $sw-media-preview-v2-play-icon-circle-size;
+        height: $sw-media-preview-v2-play-icon-circle-size;
+        border: 0;
+        border-radius: 50%;
+        background: $sw-media-preview-v2-play-icon-bg;
+        padding: 0 0 6px 3px;
     }
 
     .sw-media-preview-v2__play-icon {
-        visibility: visible;
         height: $sw-media-preview-v2-play-button-size;
         width: $sw-media-preview-v2-play-button-size;
         max-width: 35px;

--- a/src/Administration/Resources/app/administration/src/meta/baseline.ts
+++ b/src/Administration/Resources/app/administration/src/meta/baseline.ts
@@ -391,7 +391,6 @@ const missingTests = [
     'src/module/sw-media/component/sidebar/sw-media-tag/index.js',
     'src/module/sw-media/component/sw-media-breadcrumbs/index.js',
     'src/module/sw-media/component/sw-media-collapse/index.js',
-    'src/module/sw-media/component/sw-media-grid/index.js',
     'src/module/sw-media/default-search-configuration.js',
     'src/module/sw-media/index.js',
     'src/module/sw-media/mixin/media-grid-listener.mixin.js',

--- a/src/Administration/Resources/app/administration/src/module/sw-media/component/sw-media-grid/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-media/component/sw-media-grid/index.js
@@ -44,6 +44,8 @@ export default {
                 'sw-media-index__load-more',
                 'sw-media-index__options-container',
                 'sw-modal',
+                'mt-modal',
+                'mt-modal-root__backdrop',
             ];
         },
     },

--- a/src/Administration/Resources/app/administration/src/module/sw-media/component/sw-media-grid/sw-media-grid.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-media/component/sw-media-grid/sw-media-grid.spec.js
@@ -1,0 +1,48 @@
+/**
+ * @sw-package discovery
+ */
+import { mount } from '@vue/test-utils';
+
+function createClickEventWithPath(classes = []) {
+    return {
+        target: document.createElement('div'),
+        composedPath: () => {
+            return classes.map((cssClass) => {
+                return { classList: [cssClass] };
+            });
+        },
+    };
+}
+
+describe('src/module/sw-media/component/sw-media-grid', () => {
+    let wrapper;
+
+    afterEach(() => {
+        wrapper?.unmount();
+        wrapper = null;
+    });
+
+    it('emits selection clear on outside click', async () => {
+        wrapper = mount(await wrapTestComponent('sw-media-grid', { sync: true }));
+
+        wrapper.vm.clearSelectionOnClickOutside(createClickEventWithPath());
+
+        expect(wrapper.emitted('media-grid-selection-clear')).toHaveLength(1);
+    });
+
+    it('does not emit selection clear for clicks inside mt-modal', async () => {
+        wrapper = mount(await wrapTestComponent('sw-media-grid', { sync: true }));
+
+        wrapper.vm.clearSelectionOnClickOutside(createClickEventWithPath(['mt-modal']));
+
+        expect(wrapper.emitted('media-grid-selection-clear')).toBeUndefined();
+    });
+
+    it('does not emit selection clear for clicks on mt-modal backdrop', async () => {
+        wrapper = mount(await wrapTestComponent('sw-media-grid', { sync: true }));
+
+        wrapper.vm.clearSelectionOnClickOutside(createClickEventWithPath(['mt-modal-root__backdrop']));
+
+        expect(wrapper.emitted('media-grid-selection-clear')).toBeUndefined();
+    });
+});


### PR DESCRIPTION
fixes #14845

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

https://github.com/user-attachments/assets/3c9cdc86-d3fe-4ae7-9beb-21dedaabb6ff

### 1. Why is this change necessary?
The Media Modal auto closes on any click

### 2. What does this change do, exactly?
Adds mt classes to the allow list to be avoided when closed via click. It also fixes an a11y issue with the visibility of the video indicator icon on the way.

### 3. Describe each step to reproduce the issue or behaviour.
- Go to Media Modal
- Upload a video and an image
- Click the video and select a cover image
- Modal doesn't close

For Testing, please keep in mind:
Try the modal in all cases which come to your mind and click on different places in the modal, since there's an allow list to not auto close on click.

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
