### PR TITLE
fix: review rating rounding for screen readers

### DIFF
--- a/src/Storefront/Resources/views/storefront/component/review/rating.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/review/rating.html.twig
@@ -10,7 +10,7 @@
     {% set blank = 5 - full - half %}
 
     {% if altText is not defined %}
-        {% set altText = 'detail.reviewAvgRatingAltText'|trans({ '%points%': points|round(1, 'floor'), '%maxPoints%': 5 }) %}
+        {% set altText = 'detail.reviewAvgRatingAltText'|trans({ '%points%': points|round(2), '%maxPoints%': 5 }) %}
     {% endif %}
 
     {% block component_review_rating_output %}


### PR DESCRIPTION
resolves #13996

> Success criteria 1.3.1 (level A): review summary: fieldset is missing

→ not flagged by axe/arc on trunk or 6.7.3.1
→ second image shows `joinersbench` icon classes (third-party theme/plugin?)

> Success criteria 1.3.5 (level AA): review sorting select has no autocomplete attribute

→ not flagged by axe/arc on trunk or 6.7.3.1
→ [Success Criteria](https://www.w3.org/WAI/WCAG22/Understanding/identify-input-purpose.html) and [Failure](https://www.w3.org/WAI/WCAG22/Techniques/failures/F107) of 1.3.5 specifically applies to form inputs, not sorting dropdowns

> Success criteria 4.1.2 (level A): review summary: there are visible labels for hidden inputs

→ not flagged by axe/arc on trunk or 6.7.3.1
→ Shopware uses visible checkboxes, no hidden inputs (third-party theme/plugin?)

> Success criteria 1.3.1 (level A): Different rating is provided for screen reader user

→ Aligned the screen reader alt text rounding to match the visible rating display (this PR)