### PR TITLE
fix: add alt fall back to product name

### DIFF
--- a/src/Storefront/Resources/views/storefront/element/cms-element-image-gallery.html.twig
+++ b/src/Storefront/Resources/views/storefront/element/cms-element-image-gallery.html.twig
@@ -64,7 +64,7 @@
     {% endif %}
 
     {% if fallbackImageTitle is not defined %}
-        {% set fallbackImageTitle = '' %}
+        {% set fallbackImageTitle = page.product.translated.name|default('') %}
     {% endif %}
 
     {# @var mediaItems \Shopware\Core\Content\Media\MediaCollection #}


### PR DESCRIPTION
This pull request introduces a small improvement to the image gallery element in the Storefront. The change ensures that the fallback image title is set to the product's translated name if available, providing better accessibility and context for images.

* Set the `fallbackImageTitle` variable to use `page.product.translated.name` when available, instead of defaulting to an empty string.### Behavior:

- On product detail pages, if fallbackImageTitle is not passed, it uses page.product.translated.name.
- If page or page.product is missing (e.g. landing pages, other CMS layouts), it falls back to ''.

Product detail images without alt text will now have descriptive alt text, aligned with the product card component.

### Solution 

<img width="1652" height="898" alt="Screenshot 2026-02-27 at 11 34 56 AM" src="https://github.com/user-attachments/assets/2c11c481-813a-4317-8b44-a9c2d1a27e34" />
