### PR TITLE
test(content-system): add StaticSpecificationSource stub and use it in tests

### DIFF
--- a/src/Core/Test/Stub/ContentSystem/StaticSpecificationSource.php
+++ b/src/Core/Test/Stub/ContentSystem/StaticSpecificationSource.php
@@ -1,0 +1,66 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Test\Stub\ContentSystem;
+
+use Shopware\Core\Framework\ContentSystem\Adapter\AbstractSpecificationSource;
+use Shopware\Core\Framework\ContentSystem\SpecificationData;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * @final
+ */
+#[Package('framework')]
+class StaticSpecificationSource extends AbstractSpecificationSource
+{
+    /**
+     * @param list<string> $cacheTags
+     */
+    public function __construct(
+        private readonly bool $supports = true,
+        private readonly string $layoutId = '',
+        private readonly ?SpecificationData $specificationData = null,
+        private readonly ?string $targetElementId = null,
+        private readonly array $cacheTags = [],
+    ) {
+    }
+
+    public function getDecorated(): AbstractSpecificationSource
+    {
+        throw new DecorationPatternException(self::class);
+    }
+
+    public function supports(string $path, Request $request, SalesChannelContext $context): bool
+    {
+        return $this->supports;
+    }
+
+    public function resolveLayoutId(string $path, Request $request, SalesChannelContext $context): string
+    {
+        return $this->layoutId;
+    }
+
+    public function resolveSpecificationData(string $path, Request $request, SalesChannelContext $context): SpecificationData
+    {
+        if ($this->specificationData === null) {
+            throw new \LogicException('StaticSpecificationSource::resolveSpecificationData() called but no SpecificationData was configured.');
+        }
+
+        return $this->specificationData;
+    }
+
+    public function resolveTargetElementId(string $path, Request $request, SalesChannelContext $context): ?string
+    {
+        return $this->targetElementId;
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function resolveCacheTags(string $path, Request $request, SalesChannelContext $context): array
+    {
+        return $this->cacheTags;
+    }
+}

--- a/tests/unit/Core/Framework/ContentSystem/Adapter/RenderingSpecificationFactoryTest.php
+++ b/tests/unit/Core/Framework/ContentSystem/Adapter/RenderingSpecificationFactoryTest.php
@@ -5,11 +5,11 @@ namespace Shopware\Tests\Unit\Core\Framework\ContentSystem\Adapter;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\TestDox;
 use PHPUnit\Framework\TestCase;
-use Shopware\Core\Framework\ContentSystem\Adapter\AbstractSpecificationSource;
 use Shopware\Core\Framework\ContentSystem\Adapter\RenderingSpecificationFactory;
 use Shopware\Core\Framework\ContentSystem\PlaceholderValues;
 use Shopware\Core\Framework\ContentSystem\SpecificationData;
 use Shopware\Core\Test\Generator;
+use Shopware\Core\Test\Stub\ContentSystem\StaticSpecificationSource;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
@@ -27,11 +27,12 @@ class RenderingSpecificationFactoryTest extends TestCase
         $placeholders = PlaceholderValues::from(['productId' => 'abc123']);
         $specData = new SpecificationData([], $placeholders);
 
-        $source = static::createStub(AbstractSpecificationSource::class);
-        $source->method('resolveLayoutId')->willReturn('layout-1');
-        $source->method('resolveSpecificationData')->willReturn($specData);
-        $source->method('resolveTargetElementId')->willReturn('element-42');
-        $source->method('resolveCacheTags')->willReturn(['product-abc123']);
+        $source = new StaticSpecificationSource(
+            layoutId: 'layout-1',
+            specificationData: $specData,
+            targetElementId: 'element-42',
+            cacheTags: ['product-abc123'],
+        );
 
         $factory = new RenderingSpecificationFactory();
         $result = $factory->create($source, $path, $request, $context);
@@ -52,11 +53,10 @@ class RenderingSpecificationFactoryTest extends TestCase
         $path = '/category/xyz';
         $specData = new SpecificationData([], PlaceholderValues::from([]));
 
-        $source = static::createStub(AbstractSpecificationSource::class);
-        $source->method('resolveLayoutId')->willReturn('layout-2');
-        $source->method('resolveSpecificationData')->willReturn($specData);
-        $source->method('resolveTargetElementId')->willReturn(null);
-        $source->method('resolveCacheTags')->willReturn([]);
+        $source = new StaticSpecificationSource(
+            layoutId: 'layout-2',
+            specificationData: $specData,
+        );
 
         $factory = new RenderingSpecificationFactory();
         $result = $factory->create($source, $path, $request, $context);

--- a/tests/unit/Core/Framework/ContentSystem/Adapter/RenderingSpecificationResolverTest.php
+++ b/tests/unit/Core/Framework/ContentSystem/Adapter/RenderingSpecificationResolverTest.php
@@ -5,13 +5,13 @@ namespace Shopware\Tests\Unit\Core\Framework\ContentSystem\Adapter;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\TestDox;
 use PHPUnit\Framework\TestCase;
-use Shopware\Core\Framework\ContentSystem\Adapter\AbstractSpecificationSource;
 use Shopware\Core\Framework\ContentSystem\Adapter\RenderingSpecificationFactory;
 use Shopware\Core\Framework\ContentSystem\Adapter\RenderingSpecificationResolver;
 use Shopware\Core\Framework\ContentSystem\ContentSystemException;
 use Shopware\Core\Framework\ContentSystem\PlaceholderValues;
 use Shopware\Core\Framework\ContentSystem\SpecificationData;
 use Shopware\Core\Test\Generator;
+use Shopware\Core\Test\Stub\ContentSystem\StaticSpecificationSource;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
@@ -27,14 +27,13 @@ class RenderingSpecificationResolverTest extends TestCase
         $context = Generator::generateSalesChannelContext();
         $path = '/product/abc';
 
-        $source1 = static::createStub(AbstractSpecificationSource::class);
-        $source1->method('supports')->willReturn(true);
-        $source1->method('resolveLayoutId')->willReturn('layout-1');
-        $source1->method('resolveSpecificationData')->willReturn(new SpecificationData([], PlaceholderValues::from([])));
-        $source1->method('resolveTargetElementId')->willReturn(null);
-        $source1->method('resolveCacheTags')->willReturn([]);
+        $source1 = new StaticSpecificationSource(
+            supports: true,
+            layoutId: 'layout-1',
+            specificationData: new SpecificationData([], PlaceholderValues::from([])),
+        );
 
-        $source2 = static::createStub(AbstractSpecificationSource::class);
+        $source2 = new StaticSpecificationSource(supports: false);
 
         $factory = new RenderingSpecificationFactory();
 
@@ -53,15 +52,13 @@ class RenderingSpecificationResolverTest extends TestCase
         $context = Generator::generateSalesChannelContext();
         $path = '/category/xyz';
 
-        $source1 = static::createStub(AbstractSpecificationSource::class);
-        $source1->method('supports')->willReturn(false);
+        $source1 = new StaticSpecificationSource(supports: false);
 
-        $source2 = static::createStub(AbstractSpecificationSource::class);
-        $source2->method('supports')->willReturn(true);
-        $source2->method('resolveLayoutId')->willReturn('layout-2');
-        $source2->method('resolveSpecificationData')->willReturn(new SpecificationData([], PlaceholderValues::from([])));
-        $source2->method('resolveTargetElementId')->willReturn(null);
-        $source2->method('resolveCacheTags')->willReturn([]);
+        $source2 = new StaticSpecificationSource(
+            supports: true,
+            layoutId: 'layout-2',
+            specificationData: new SpecificationData([], PlaceholderValues::from([])),
+        );
 
         $factory = new RenderingSpecificationFactory();
 
@@ -79,8 +76,7 @@ class RenderingSpecificationResolverTest extends TestCase
         $context = Generator::generateSalesChannelContext();
         $path = '/unknown/path';
 
-        $source = static::createStub(AbstractSpecificationSource::class);
-        $source->method('supports')->willReturn(false);
+        $source = new StaticSpecificationSource(supports: false);
 
         $factory = new RenderingSpecificationFactory();
 


### PR DESCRIPTION
Follow-up to #15339. Adds `StaticSpecificationSource`, a constructor-injected test stub for `AbstractSpecificationSource`. Replaces repetitive `createStub()` + `method()->willReturn()` chains in `RenderingSpecificationFactoryTest` and `RenderingSpecificationResolverTest`.

Ref #15572