### PR TITLE
refactor(content-system): remove decoration pattern from strategy classes

### DIFF
--- a/src/Core/Content/Category/Aggregate/CategoryContentLayout/CategorySpecificationSource.php
+++ b/src/Core/Content/Category/Aggregate/CategoryContentLayout/CategorySpecificationSource.php
@@ -7,7 +7,6 @@ use Shopware\Core\Framework\ContentSystem\Adapter\FactoryHelper\EntityLayoutCont
 use Shopware\Core\Framework\ContentSystem\SpecificationData;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\Log\Package;
-use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -27,11 +26,6 @@ class CategorySpecificationSource extends AbstractSpecificationSource
         private readonly CategoryContentLayoutDefinition $definition,
         private readonly EntityLayoutContextFactory $contextFactory,
     ) {
-    }
-
-    public function getDecorated(): AbstractSpecificationSource
-    {
-        throw new DecorationPatternException(self::class);
     }
 
     public function supports(string $path, Request $request, SalesChannelContext $context): bool

--- a/src/Core/Content/LandingPage/Aggregate/LandingPageContentLayout/LandingPageSpecificationSource.php
+++ b/src/Core/Content/LandingPage/Aggregate/LandingPageContentLayout/LandingPageSpecificationSource.php
@@ -7,7 +7,6 @@ use Shopware\Core\Framework\ContentSystem\Adapter\FactoryHelper\EntityLayoutCont
 use Shopware\Core\Framework\ContentSystem\SpecificationData;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\Log\Package;
-use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -27,11 +26,6 @@ class LandingPageSpecificationSource extends AbstractSpecificationSource
         private readonly LandingPageContentLayoutDefinition $definition,
         private readonly EntityLayoutContextFactory $contextFactory,
     ) {
-    }
-
-    public function getDecorated(): AbstractSpecificationSource
-    {
-        throw new DecorationPatternException(self::class);
     }
 
     public function supports(string $path, Request $request, SalesChannelContext $context): bool

--- a/src/Core/Content/Product/Aggregate/ProductContentLayout/ProductSpecificationSource.php
+++ b/src/Core/Content/Product/Aggregate/ProductContentLayout/ProductSpecificationSource.php
@@ -7,7 +7,6 @@ use Shopware\Core\Framework\ContentSystem\Adapter\FactoryHelper\EntityLayoutCont
 use Shopware\Core\Framework\ContentSystem\SpecificationData;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\Log\Package;
-use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -27,11 +26,6 @@ class ProductSpecificationSource extends AbstractSpecificationSource
         private readonly ProductContentLayoutDefinition $definition,
         private readonly EntityLayoutContextFactory $contextFactory,
     ) {
-    }
-
-    public function getDecorated(): AbstractSpecificationSource
-    {
-        throw new DecorationPatternException(self::class);
     }
 
     public function supports(string $path, Request $request, SalesChannelContext $context): bool

--- a/src/Core/Framework/ContentSystem/Adapter/AbstractSpecificationSource.php
+++ b/src/Core/Framework/ContentSystem/Adapter/AbstractSpecificationSource.php
@@ -14,8 +14,6 @@ use Symfony\Component\HttpFoundation\Request;
 #[Package('framework')]
 abstract class AbstractSpecificationSource
 {
-    abstract public function getDecorated(): AbstractSpecificationSource;
-
     abstract public function supports(string $path, Request $request, SalesChannelContext $context): bool;
 
     abstract public function resolveLayoutId(string $path, Request $request, SalesChannelContext $context): string;

--- a/src/Core/Framework/ContentSystem/EXTENSION.md
+++ b/src/Core/Framework/ContentSystem/EXTENSION.md
@@ -45,9 +45,6 @@ final class BlogPostSpecificationSource extends AbstractSpecificationSource
         private readonly EntityRepository $blogLayoutAssignmentRepository,
     ) {}
 
-    public function getDecorated(): AbstractSpecificationSource
-    { throw new DecorationPatternException(self::class); }
-
     public function supports(string $path, Request $request, SalesChannelContext $context): bool
     { /* Return true if path starts with 'blog/' */ }
 
@@ -114,9 +111,6 @@ final readonly class WeatherLoaderConfig extends AbstractContentDataLoaderConfig
 ```php
 final class WeatherLoaderConfigSerializer extends AbstractContentDataLoaderConfigSerializer
 {
-    public function getDecorated(): AbstractContentDataLoaderConfigSerializer
-    { throw new DecorationPatternException(self::class); }
-
     public static function getSource(): string
     { return 'weather'; /* Must match loader's getRequirementType() */ }
 
@@ -134,9 +128,6 @@ final class WeatherLoaderConfigSerializer extends AbstractContentDataLoaderConfi
 final class WeatherLoader extends AbstractContentDataLoader
 {
     public function __construct(private readonly WeatherApiClient $weatherClient) {}
-
-    public function getDecorated(): AbstractContentDataLoader
-    { throw new DecorationPatternException(self::class); }
 
     public static function getRequirementType(): string
     { return 'weather'; /* Must match serializer's getSource() */ }

--- a/src/Core/Framework/ContentSystem/Hydration/DataLoader/AbstractContentDataLoader.php
+++ b/src/Core/Framework/ContentSystem/Hydration/DataLoader/AbstractContentDataLoader.php
@@ -22,8 +22,6 @@ use Symfony\Component\HttpFoundation\Request;
 #[Package('framework')]
 abstract class AbstractContentDataLoader
 {
-    abstract public function getDecorated(): AbstractContentDataLoader;
-
     /**
      * Returns the requirement type identifier for DI service location.
      * This method is used by the ServiceLocator for indexing.

--- a/src/Core/Framework/ContentSystem/Hydration/DataLoader/AbstractContentDataLoaderConfigSerializer.php
+++ b/src/Core/Framework/ContentSystem/Hydration/DataLoader/AbstractContentDataLoaderConfigSerializer.php
@@ -13,8 +13,6 @@ use Shopware\Core\Framework\Log\Package;
 #[Package('framework')]
 abstract class AbstractContentDataLoaderConfigSerializer
 {
-    abstract public function getDecorated(): AbstractContentDataLoaderConfigSerializer;
-
     /**
      * Returns the source identifier for DI service location.
      * This method is used by the ServiceLocator for indexing.

--- a/src/Core/Framework/ContentSystem/Hydration/DataLoader/CurrencyLoader/CurrencyDataLoader.php
+++ b/src/Core/Framework/ContentSystem/Hydration/DataLoader/CurrencyLoader/CurrencyDataLoader.php
@@ -8,7 +8,6 @@ use Shopware\Core\Framework\ContentSystem\Layout\Element\ContentElement;
 use Shopware\Core\Framework\ContentSystem\Layout\Element\DataRequirement\DataRequirement;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Log\Package;
-use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
 use Shopware\Core\System\Currency\SalesChannel\AbstractCurrencyRoute;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\HttpFoundation\Request;
@@ -31,11 +30,6 @@ class CurrencyDataLoader extends AbstractContentDataLoader
     public function __construct(
         private readonly AbstractCurrencyRoute $currencyRoute,
     ) {
-    }
-
-    public function getDecorated(): AbstractContentDataLoader
-    {
-        throw new DecorationPatternException(self::class);
     }
 
     public static function getRequirementType(): string

--- a/src/Core/Framework/ContentSystem/Hydration/DataLoader/CurrencyLoader/CurrencyLoaderConfigSerializer.php
+++ b/src/Core/Framework/ContentSystem/Hydration/DataLoader/CurrencyLoader/CurrencyLoaderConfigSerializer.php
@@ -6,7 +6,6 @@ use Shopware\Core\Framework\ContentSystem\ContentSystemException;
 use Shopware\Core\Framework\ContentSystem\Hydration\DataLoader\AbstractContentDataLoaderConfig;
 use Shopware\Core\Framework\ContentSystem\Hydration\DataLoader\AbstractContentDataLoaderConfigSerializer;
 use Shopware\Core\Framework\Log\Package;
-use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
 
 /**
  * @phpstan-import-type CurrencyLoaderConfigData from CurrencyLoaderConfig
@@ -18,11 +17,6 @@ use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
 #[Package('framework')]
 class CurrencyLoaderConfigSerializer extends AbstractContentDataLoaderConfigSerializer
 {
-    public function getDecorated(): AbstractContentDataLoaderConfigSerializer
-    {
-        throw new DecorationPatternException(self::class);
-    }
-
     public static function getSource(): string
     {
         return 'currency';

--- a/src/Core/Framework/ContentSystem/Hydration/DataLoader/EntityCollectionLoader/EntityCollectionLoader.php
+++ b/src/Core/Framework/ContentSystem/Hydration/DataLoader/EntityCollectionLoader/EntityCollectionLoader.php
@@ -13,7 +13,6 @@ use Shopware\Core\Framework\DataAbstractionLayer\Entity;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Log\Package;
-use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
 use Shopware\Core\System\SalesChannel\Entity\SalesChannelDefinitionInstanceRegistry;
 use Shopware\Core\System\SalesChannel\Exception\SalesChannelRepositoryNotFoundException;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
@@ -36,11 +35,6 @@ class EntityCollectionLoader extends AbstractContentDataLoader
         private readonly DefinitionInstanceRegistry $definitionRegistry,
         private readonly EntityCacheTagResolver $cacheTagResolver,
     ) {
-    }
-
-    public function getDecorated(): AbstractContentDataLoader
-    {
-        throw new DecorationPatternException(self::class);
     }
 
     public static function getRequirementType(): string

--- a/src/Core/Framework/ContentSystem/Hydration/DataLoader/EntityCollectionLoader/EntityCollectionLoaderConfigSerializer.php
+++ b/src/Core/Framework/ContentSystem/Hydration/DataLoader/EntityCollectionLoader/EntityCollectionLoaderConfigSerializer.php
@@ -6,7 +6,6 @@ use Shopware\Core\Framework\ContentSystem\Hydration\DataLoader\AbstractContentDa
 use Shopware\Core\Framework\ContentSystem\Hydration\DataLoader\AbstractContentDataLoaderConfigSerializer;
 use Shopware\Core\Framework\ContentSystem\Hydration\DataLoader\EntityLoader\EntityLoaderConfigSerializer;
 use Shopware\Core\Framework\Log\Package;
-use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
 
 /**
  * Serializer for entity_collection source delegates to EntityLoaderConfigSerializer
@@ -15,8 +14,6 @@ use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
  * @internal
  *
  * @final
- *
- * @phpstan-ignore shopware.decorationPattern (delegation, not decoration)
  */
 #[Package('framework')]
 class EntityCollectionLoaderConfigSerializer extends AbstractContentDataLoaderConfigSerializer
@@ -24,11 +21,6 @@ class EntityCollectionLoaderConfigSerializer extends AbstractContentDataLoaderCo
     public function __construct(
         private readonly EntityLoaderConfigSerializer $delegate
     ) {
-    }
-
-    public function getDecorated(): AbstractContentDataLoaderConfigSerializer
-    {
-        throw new DecorationPatternException(self::class);
     }
 
     public static function getSource(): string

--- a/src/Core/Framework/ContentSystem/Hydration/DataLoader/EntityLoader/EntityLoader.php
+++ b/src/Core/Framework/ContentSystem/Hydration/DataLoader/EntityLoader/EntityLoader.php
@@ -11,7 +11,6 @@ use Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry;
 use Shopware\Core\Framework\DataAbstractionLayer\Entity;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Log\Package;
-use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
 use Shopware\Core\System\SalesChannel\Entity\SalesChannelDefinitionInstanceRegistry;
 use Shopware\Core\System\SalesChannel\Exception\SalesChannelRepositoryNotFoundException;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
@@ -35,11 +34,6 @@ class EntityLoader extends AbstractContentDataLoader
         private readonly DefinitionInstanceRegistry $definitionRegistry,
         private readonly EntityCacheTagResolver $cacheTagResolver,
     ) {
-    }
-
-    public function getDecorated(): AbstractContentDataLoader
-    {
-        throw new DecorationPatternException(self::class);
     }
 
     public static function getRequirementType(): string

--- a/src/Core/Framework/ContentSystem/Hydration/DataLoader/EntityLoader/EntityLoaderConfigSerializer.php
+++ b/src/Core/Framework/ContentSystem/Hydration/DataLoader/EntityLoader/EntityLoaderConfigSerializer.php
@@ -6,7 +6,6 @@ use Shopware\Core\Framework\ContentSystem\ContentSystemException;
 use Shopware\Core\Framework\ContentSystem\Hydration\DataLoader\AbstractContentDataLoaderConfig;
 use Shopware\Core\Framework\ContentSystem\Hydration\DataLoader\AbstractContentDataLoaderConfigSerializer;
 use Shopware\Core\Framework\Log\Package;
-use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
 
 /**
  * @phpstan-import-type EntityLoaderConfigData from EntityLoaderConfig
@@ -18,11 +17,6 @@ use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
 #[Package('framework')]
 class EntityLoaderConfigSerializer extends AbstractContentDataLoaderConfigSerializer
 {
-    public function getDecorated(): AbstractContentDataLoaderConfigSerializer
-    {
-        throw new DecorationPatternException(self::class);
-    }
-
     public static function getSource(): string
     {
         return EntityLoader::SOURCE;

--- a/src/Core/Framework/ContentSystem/Hydration/DataLoader/LanguageLoader/LanguageDataLoader.php
+++ b/src/Core/Framework/ContentSystem/Hydration/DataLoader/LanguageLoader/LanguageDataLoader.php
@@ -8,7 +8,6 @@ use Shopware\Core\Framework\ContentSystem\Layout\Element\ContentElement;
 use Shopware\Core\Framework\ContentSystem\Layout\Element\DataRequirement\DataRequirement;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Log\Package;
-use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
 use Shopware\Core\System\Language\SalesChannel\AbstractLanguageRoute;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\HttpFoundation\Request;
@@ -31,11 +30,6 @@ class LanguageDataLoader extends AbstractContentDataLoader
     public function __construct(
         private readonly AbstractLanguageRoute $languageRoute,
     ) {
-    }
-
-    public function getDecorated(): AbstractContentDataLoader
-    {
-        throw new DecorationPatternException(self::class);
     }
 
     public static function getRequirementType(): string

--- a/src/Core/Framework/ContentSystem/Hydration/DataLoader/LanguageLoader/LanguageLoaderConfigSerializer.php
+++ b/src/Core/Framework/ContentSystem/Hydration/DataLoader/LanguageLoader/LanguageLoaderConfigSerializer.php
@@ -6,7 +6,6 @@ use Shopware\Core\Framework\ContentSystem\ContentSystemException;
 use Shopware\Core\Framework\ContentSystem\Hydration\DataLoader\AbstractContentDataLoaderConfig;
 use Shopware\Core\Framework\ContentSystem\Hydration\DataLoader\AbstractContentDataLoaderConfigSerializer;
 use Shopware\Core\Framework\Log\Package;
-use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
 
 /**
  * @phpstan-import-type LanguageLoaderConfigData from LanguageLoaderConfig
@@ -18,11 +17,6 @@ use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
 #[Package('framework')]
 class LanguageLoaderConfigSerializer extends AbstractContentDataLoaderConfigSerializer
 {
-    public function getDecorated(): AbstractContentDataLoaderConfigSerializer
-    {
-        throw new DecorationPatternException(self::class);
-    }
-
     public static function getSource(): string
     {
         return 'language';

--- a/src/Core/Framework/ContentSystem/Hydration/DataLoader/NavigationLoader/NavigationDataLoader.php
+++ b/src/Core/Framework/ContentSystem/Hydration/DataLoader/NavigationLoader/NavigationDataLoader.php
@@ -9,7 +9,6 @@ use Shopware\Core\Framework\ContentSystem\Hydration\DataLoader\ContentDataLoader
 use Shopware\Core\Framework\ContentSystem\Layout\Element\ContentElement;
 use Shopware\Core\Framework\ContentSystem\Layout\Element\DataRequirement\DataRequirement;
 use Shopware\Core\Framework\Log\Package;
-use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -34,11 +33,6 @@ class NavigationDataLoader extends AbstractContentDataLoader
         private readonly NavigationLoaderInterface $navigationLoader,
         private readonly NavigationAliasResolver $aliasResolver,
     ) {
-    }
-
-    public function getDecorated(): AbstractContentDataLoader
-    {
-        throw new DecorationPatternException(self::class);
     }
 
     public static function getRequirementType(): string

--- a/src/Core/Framework/ContentSystem/Hydration/DataLoader/NavigationLoader/NavigationLoaderConfigSerializer.php
+++ b/src/Core/Framework/ContentSystem/Hydration/DataLoader/NavigationLoader/NavigationLoaderConfigSerializer.php
@@ -6,7 +6,6 @@ use Shopware\Core\Framework\ContentSystem\ContentSystemException;
 use Shopware\Core\Framework\ContentSystem\Hydration\DataLoader\AbstractContentDataLoaderConfig;
 use Shopware\Core\Framework\ContentSystem\Hydration\DataLoader\AbstractContentDataLoaderConfigSerializer;
 use Shopware\Core\Framework\Log\Package;
-use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
 
 /**
  * @phpstan-import-type NavigationLoaderConfigData from NavigationLoaderConfig
@@ -18,11 +17,6 @@ use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
 #[Package('framework')]
 class NavigationLoaderConfigSerializer extends AbstractContentDataLoaderConfigSerializer
 {
-    public function getDecorated(): AbstractContentDataLoaderConfigSerializer
-    {
-        throw new DecorationPatternException(self::class);
-    }
-
     public static function getSource(): string
     {
         return 'navigation';

--- a/src/Core/Framework/ContentSystem/Hydration/DataLoader/PaymentMethodLoader/PaymentMethodDataLoader.php
+++ b/src/Core/Framework/ContentSystem/Hydration/DataLoader/PaymentMethodLoader/PaymentMethodDataLoader.php
@@ -9,7 +9,6 @@ use Shopware\Core\Framework\ContentSystem\Layout\Element\ContentElement;
 use Shopware\Core\Framework\ContentSystem\Layout\Element\DataRequirement\DataRequirement;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Log\Package;
-use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -32,11 +31,6 @@ class PaymentMethodDataLoader extends AbstractContentDataLoader
     public function __construct(
         private readonly AbstractPaymentMethodRoute $paymentMethodRoute,
     ) {
-    }
-
-    public function getDecorated(): AbstractContentDataLoader
-    {
-        throw new DecorationPatternException(self::class);
     }
 
     public static function getRequirementType(): string

--- a/src/Core/Framework/ContentSystem/Hydration/DataLoader/PaymentMethodLoader/PaymentMethodLoaderConfigSerializer.php
+++ b/src/Core/Framework/ContentSystem/Hydration/DataLoader/PaymentMethodLoader/PaymentMethodLoaderConfigSerializer.php
@@ -6,7 +6,6 @@ use Shopware\Core\Framework\ContentSystem\ContentSystemException;
 use Shopware\Core\Framework\ContentSystem\Hydration\DataLoader\AbstractContentDataLoaderConfig;
 use Shopware\Core\Framework\ContentSystem\Hydration\DataLoader\AbstractContentDataLoaderConfigSerializer;
 use Shopware\Core\Framework\Log\Package;
-use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
 
 /**
  * @phpstan-import-type PaymentMethodLoaderConfigData from PaymentMethodLoaderConfig
@@ -18,11 +17,6 @@ use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
 #[Package('framework')]
 class PaymentMethodLoaderConfigSerializer extends AbstractContentDataLoaderConfigSerializer
 {
-    public function getDecorated(): AbstractContentDataLoaderConfigSerializer
-    {
-        throw new DecorationPatternException(self::class);
-    }
-
     public static function getSource(): string
     {
         return 'payment_method';

--- a/src/Core/Framework/ContentSystem/Hydration/DataLoader/ProductListingLoader/ProductListingDataLoader.php
+++ b/src/Core/Framework/ContentSystem/Hydration/DataLoader/ProductListingLoader/ProductListingDataLoader.php
@@ -9,7 +9,6 @@ use Shopware\Core\Framework\ContentSystem\Layout\Element\ContentElement;
 use Shopware\Core\Framework\ContentSystem\Layout\Element\DataRequirement\DataRequirement;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Log\Package;
-use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -28,11 +27,6 @@ class ProductListingDataLoader extends AbstractContentDataLoader
     public function __construct(
         private readonly AbstractProductListingRoute $listingRoute
     ) {
-    }
-
-    public function getDecorated(): AbstractContentDataLoader
-    {
-        throw new DecorationPatternException(self::class);
     }
 
     public static function getRequirementType(): string

--- a/src/Core/Framework/ContentSystem/Hydration/DataLoader/ProductListingLoader/ProductListingLoaderConfigSerializer.php
+++ b/src/Core/Framework/ContentSystem/Hydration/DataLoader/ProductListingLoader/ProductListingLoaderConfigSerializer.php
@@ -6,7 +6,6 @@ use Shopware\Core\Framework\ContentSystem\ContentSystemException;
 use Shopware\Core\Framework\ContentSystem\Hydration\DataLoader\AbstractContentDataLoaderConfig;
 use Shopware\Core\Framework\ContentSystem\Hydration\DataLoader\AbstractContentDataLoaderConfigSerializer;
 use Shopware\Core\Framework\Log\Package;
-use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
 
 /**
  * @phpstan-import-type ProductListingLoaderConfigData from ProductListingLoaderConfig
@@ -18,11 +17,6 @@ use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
 #[Package('framework')]
 class ProductListingLoaderConfigSerializer extends AbstractContentDataLoaderConfigSerializer
 {
-    public function getDecorated(): AbstractContentDataLoaderConfigSerializer
-    {
-        throw new DecorationPatternException(self::class);
-    }
-
     public static function getSource(): string
     {
         return 'product_listing';

--- a/src/Core/Framework/ContentSystem/Hydration/DataLoader/ShippingMethodLoader/ShippingMethodDataLoader.php
+++ b/src/Core/Framework/ContentSystem/Hydration/DataLoader/ShippingMethodLoader/ShippingMethodDataLoader.php
@@ -9,7 +9,6 @@ use Shopware\Core\Framework\ContentSystem\Layout\Element\ContentElement;
 use Shopware\Core\Framework\ContentSystem\Layout\Element\DataRequirement\DataRequirement;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Log\Package;
-use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -32,11 +31,6 @@ class ShippingMethodDataLoader extends AbstractContentDataLoader
     public function __construct(
         private readonly AbstractShippingMethodRoute $shippingMethodRoute,
     ) {
-    }
-
-    public function getDecorated(): AbstractContentDataLoader
-    {
-        throw new DecorationPatternException(self::class);
     }
 
     public static function getRequirementType(): string

--- a/src/Core/Framework/ContentSystem/Hydration/DataLoader/ShippingMethodLoader/ShippingMethodLoaderConfigSerializer.php
+++ b/src/Core/Framework/ContentSystem/Hydration/DataLoader/ShippingMethodLoader/ShippingMethodLoaderConfigSerializer.php
@@ -6,7 +6,6 @@ use Shopware\Core\Framework\ContentSystem\ContentSystemException;
 use Shopware\Core\Framework\ContentSystem\Hydration\DataLoader\AbstractContentDataLoaderConfig;
 use Shopware\Core\Framework\ContentSystem\Hydration\DataLoader\AbstractContentDataLoaderConfigSerializer;
 use Shopware\Core\Framework\Log\Package;
-use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
 
 /**
  * @phpstan-import-type ShippingMethodLoaderConfigData from ShippingMethodLoaderConfig
@@ -18,11 +17,6 @@ use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
 #[Package('framework')]
 class ShippingMethodLoaderConfigSerializer extends AbstractContentDataLoaderConfigSerializer
 {
-    public function getDecorated(): AbstractContentDataLoaderConfigSerializer
-    {
-        throw new DecorationPatternException(self::class);
-    }
-
     public static function getSource(): string
     {
         return 'shipping_method';

--- a/src/Core/Test/Stub/ContentSystem/StaticSpecificationSource.php
+++ b/src/Core/Test/Stub/ContentSystem/StaticSpecificationSource.php
@@ -5,7 +5,6 @@ namespace Shopware\Core\Test\Stub\ContentSystem;
 use Shopware\Core\Framework\ContentSystem\Adapter\AbstractSpecificationSource;
 use Shopware\Core\Framework\ContentSystem\SpecificationData;
 use Shopware\Core\Framework\Log\Package;
-use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -25,11 +24,6 @@ class StaticSpecificationSource extends AbstractSpecificationSource
         private readonly ?string $targetElementId = null,
         private readonly array $cacheTags = [],
     ) {
-    }
-
-    public function getDecorated(): AbstractSpecificationSource
-    {
-        throw new DecorationPatternException(self::class);
     }
 
     public function supports(string $path, Request $request, SalesChannelContext $context): bool

--- a/src/Storefront/ContentSystem/FooterContentLayout/FooterSpecificationSource.php
+++ b/src/Storefront/ContentSystem/FooterContentLayout/FooterSpecificationSource.php
@@ -12,7 +12,6 @@ use Shopware\Core\Framework\ContentSystem\PlaceholderValues;
 use Shopware\Core\Framework\ContentSystem\SpecificationData;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\Log\Package;
-use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -34,14 +33,6 @@ class FooterSpecificationSource extends AbstractSpecificationSource
         private readonly EntityRepository $repository,
         private readonly RequestDataExtractor $requestDataExtractor,
     ) {
-    }
-
-    /**
-     * @codeCoverageIgnore
-     */
-    public function getDecorated(): AbstractSpecificationSource
-    {
-        throw new DecorationPatternException(self::class);
     }
 
     public function supports(string $path, Request $request, SalesChannelContext $context): bool

--- a/src/Storefront/ContentSystem/HeaderContentLayout/HeaderSpecificationSource.php
+++ b/src/Storefront/ContentSystem/HeaderContentLayout/HeaderSpecificationSource.php
@@ -12,7 +12,6 @@ use Shopware\Core\Framework\ContentSystem\PlaceholderValues;
 use Shopware\Core\Framework\ContentSystem\SpecificationData;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\Log\Package;
-use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -34,14 +33,6 @@ class HeaderSpecificationSource extends AbstractSpecificationSource
         private readonly EntityRepository $repository,
         private readonly RequestDataExtractor $requestDataExtractor,
     ) {
-    }
-
-    /**
-     * @codeCoverageIgnore
-     */
-    public function getDecorated(): AbstractSpecificationSource
-    {
-        throw new DecorationPatternException(self::class);
     }
 
     public function supports(string $path, Request $request, SalesChannelContext $context): bool

--- a/tests/unit/Core/Framework/ContentSystem/Hydration/DataLoader/CurrencyLoader/CurrencyDataLoaderTest.php
+++ b/tests/unit/Core/Framework/ContentSystem/Hydration/DataLoader/CurrencyLoader/CurrencyDataLoaderTest.php
@@ -12,7 +12,6 @@ use Shopware\Core\Framework\ContentSystem\Hydration\DataLoader\CurrencyLoader\Cu
 use Shopware\Core\Framework\ContentSystem\Layout\Element\ContentElement;
 use Shopware\Core\Framework\ContentSystem\Layout\Element\DataRequirement\DataRequirement;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
-use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
 use Shopware\Core\System\Currency\CurrencyCollection;
 use Shopware\Core\System\Currency\SalesChannel\AbstractCurrencyRoute;
 use Shopware\Core\System\Currency\SalesChannel\CurrencyRouteResponse;
@@ -112,13 +111,5 @@ class CurrencyDataLoaderTest extends TestCase
         static::assertSame($currencies, $result->data);
         static::assertTrue($result->isCacheAware());
         static::assertSame([], $result->getCacheTags());
-    }
-
-    #[TestDox('throws DecorationPatternException when getDecorated is called')]
-    public function testGetDecoratedThrowsDecorationPatternException(): void
-    {
-        $this->expectExceptionObject(new DecorationPatternException(CurrencyDataLoader::class));
-
-        $this->dataLoader->getDecorated();
     }
 }

--- a/tests/unit/Core/Framework/ContentSystem/Hydration/DataLoader/CurrencyLoader/CurrencyLoaderConfigSerializerTest.php
+++ b/tests/unit/Core/Framework/ContentSystem/Hydration/DataLoader/CurrencyLoader/CurrencyLoaderConfigSerializerTest.php
@@ -9,7 +9,6 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\ContentSystem\ContentSystemException;
 use Shopware\Core\Framework\ContentSystem\Hydration\DataLoader\CurrencyLoader\CurrencyLoaderConfig;
 use Shopware\Core\Framework\ContentSystem\Hydration\DataLoader\CurrencyLoader\CurrencyLoaderConfigSerializer;
-use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
 use Shopware\Core\Test\Stub\ContentSystem\StubLoaderConfig;
 
 /**
@@ -143,13 +142,5 @@ class CurrencyLoaderConfigSerializerTest extends TestCase
         $encoded = $this->serializer->encode($config);
 
         static::assertSame($original, $encoded);
-    }
-
-    #[TestDox('throws DecorationPatternException when getDecorated is called')]
-    public function testGetDecoratedThrowsDecorationPatternException(): void
-    {
-        $this->expectExceptionObject(new DecorationPatternException(CurrencyLoaderConfigSerializer::class));
-
-        $this->serializer->getDecorated();
     }
 }

--- a/tests/unit/Core/Framework/ContentSystem/Hydration/DataLoader/EntityCollectionLoader/EntityCollectionLoaderConfigSerializerTest.php
+++ b/tests/unit/Core/Framework/ContentSystem/Hydration/DataLoader/EntityCollectionLoader/EntityCollectionLoaderConfigSerializerTest.php
@@ -10,7 +10,6 @@ use Shopware\Core\Framework\ContentSystem\Hydration\DataLoader\EntityCollectionL
 use Shopware\Core\Framework\ContentSystem\Hydration\DataLoader\EntityCollectionLoader\EntityCollectionLoaderConfigSerializer;
 use Shopware\Core\Framework\ContentSystem\Hydration\DataLoader\EntityLoader\EntityLoaderConfig;
 use Shopware\Core\Framework\ContentSystem\Hydration\DataLoader\EntityLoader\EntityLoaderConfigSerializer;
-use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
 use Shopware\Core\Test\Stub\ContentSystem\StubLoaderConfig;
 
 /**
@@ -99,14 +98,6 @@ class EntityCollectionLoaderConfigSerializerTest extends TestCase
         $encoded = $this->serializer->encode($config);
 
         static::assertSame($original, $encoded);
-    }
-
-    #[TestDox('throws DecorationPatternException when getDecorated is called')]
-    public function testGetDecoratedThrowsDecorationPatternException(): void
-    {
-        $this->expectExceptionObject(new DecorationPatternException(EntityCollectionLoaderConfigSerializer::class));
-
-        $this->serializer->getDecorated();
     }
 
     #[TestDox('propagates exception from delegate when entity key is missing')]

--- a/tests/unit/Core/Framework/ContentSystem/Hydration/DataLoader/EntityCollectionLoader/EntityCollectionLoaderTest.php
+++ b/tests/unit/Core/Framework/ContentSystem/Hydration/DataLoader/EntityCollectionLoader/EntityCollectionLoaderTest.php
@@ -14,7 +14,6 @@ use Shopware\Core\Framework\DataAbstractionLayer\Entity;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
-use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SalesChannel\Entity\SalesChannelDefinitionInstanceRegistry;
 use Shopware\Core\System\SalesChannel\Exception\SalesChannelRepositoryNotFoundException;
@@ -336,16 +335,6 @@ class EntityCollectionLoaderTest extends TestCase
         static::assertNull($result->data);
         static::assertTrue($result->isCacheAware());
         static::assertSame([], $result->getCacheTags());
-    }
-
-    #[TestDox('throws DecorationPatternException when getDecorated is called')]
-    public function testGetDecoratedThrowsDecorationPatternException(): void
-    {
-        $loader = $this->createMinimalLoader();
-
-        $this->expectExceptionObject(new DecorationPatternException(EntityCollectionLoader::class));
-
-        $loader->getDecorated();
     }
 
     private function createMinimalLoader(): EntityCollectionLoader

--- a/tests/unit/Core/Framework/ContentSystem/Hydration/DataLoader/EntityLoader/EntityLoaderConfigSerializerTest.php
+++ b/tests/unit/Core/Framework/ContentSystem/Hydration/DataLoader/EntityLoader/EntityLoaderConfigSerializerTest.php
@@ -9,7 +9,6 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\ContentSystem\ContentSystemException;
 use Shopware\Core\Framework\ContentSystem\Hydration\DataLoader\EntityLoader\EntityLoaderConfig;
 use Shopware\Core\Framework\ContentSystem\Hydration\DataLoader\EntityLoader\EntityLoaderConfigSerializer;
-use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
 use Shopware\Core\Test\Stub\ContentSystem\StubLoaderConfig;
 
 /**
@@ -206,13 +205,5 @@ class EntityLoaderConfigSerializerTest extends TestCase
         $encoded = $this->serializer->encode($config);
 
         static::assertSame($original, $encoded);
-    }
-
-    #[TestDox('throws DecorationPatternException when getDecorated is called')]
-    public function testGetDecoratedThrowsDecorationPatternException(): void
-    {
-        $this->expectExceptionObject(new DecorationPatternException(EntityLoaderConfigSerializer::class));
-
-        $this->serializer->getDecorated();
     }
 }

--- a/tests/unit/Core/Framework/ContentSystem/Hydration/DataLoader/EntityLoader/EntityLoaderTest.php
+++ b/tests/unit/Core/Framework/ContentSystem/Hydration/DataLoader/EntityLoader/EntityLoaderTest.php
@@ -14,7 +14,6 @@ use Shopware\Core\Framework\DataAbstractionLayer\Entity;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
-use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SalesChannel\Entity\SalesChannelDefinitionInstanceRegistry;
 use Shopware\Core\System\SalesChannel\Exception\SalesChannelRepositoryNotFoundException;
@@ -327,16 +326,6 @@ class EntityLoaderTest extends TestCase
         static::assertNull($result->data);
         static::assertTrue($result->isCacheAware());
         static::assertSame([], $result->getCacheTags());
-    }
-
-    #[TestDox('throws DecorationPatternException when getDecorated is called')]
-    public function testGetDecoratedThrowsDecorationPatternException(): void
-    {
-        $loader = $this->createMinimalLoader();
-
-        $this->expectExceptionObject(new DecorationPatternException(EntityLoader::class));
-
-        $loader->getDecorated();
     }
 
     private function createMinimalLoader(): EntityLoader

--- a/tests/unit/Core/Framework/ContentSystem/Hydration/DataLoader/LanguageLoader/LanguageDataLoaderTest.php
+++ b/tests/unit/Core/Framework/ContentSystem/Hydration/DataLoader/LanguageLoader/LanguageDataLoaderTest.php
@@ -12,7 +12,6 @@ use Shopware\Core\Framework\ContentSystem\Hydration\DataLoader\LanguageLoader\La
 use Shopware\Core\Framework\ContentSystem\Layout\Element\ContentElement;
 use Shopware\Core\Framework\ContentSystem\Layout\Element\DataRequirement\DataRequirement;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
-use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\Language\LanguageCollection;
 use Shopware\Core\System\Language\SalesChannel\AbstractLanguageRoute;
@@ -118,14 +117,6 @@ class LanguageDataLoaderTest extends TestCase
         static::assertSame($languages, $result->data);
         static::assertTrue($result->isCacheAware());
         static::assertSame([], $result->getCacheTags());
-    }
-
-    #[TestDox('throws DecorationPatternException when getDecorated is called')]
-    public function testGetDecoratedThrowsDecorationPatternException(): void
-    {
-        $this->expectExceptionObject(new DecorationPatternException(LanguageDataLoader::class));
-
-        $this->dataLoader->getDecorated();
     }
 
     private function createLanguageRouteResponse(LanguageCollection $languages): LanguageRouteResponse

--- a/tests/unit/Core/Framework/ContentSystem/Hydration/DataLoader/LanguageLoader/LanguageLoaderConfigSerializerTest.php
+++ b/tests/unit/Core/Framework/ContentSystem/Hydration/DataLoader/LanguageLoader/LanguageLoaderConfigSerializerTest.php
@@ -9,7 +9,6 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\ContentSystem\ContentSystemException;
 use Shopware\Core\Framework\ContentSystem\Hydration\DataLoader\LanguageLoader\LanguageLoaderConfig;
 use Shopware\Core\Framework\ContentSystem\Hydration\DataLoader\LanguageLoader\LanguageLoaderConfigSerializer;
-use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
 use Shopware\Core\Test\Stub\ContentSystem\StubLoaderConfig;
 
 /**
@@ -143,13 +142,5 @@ class LanguageLoaderConfigSerializerTest extends TestCase
         $encoded = $this->serializer->encode($config);
 
         static::assertSame($original, $encoded);
-    }
-
-    #[TestDox('throws DecorationPatternException when getDecorated is called')]
-    public function testGetDecoratedThrowsDecorationPatternException(): void
-    {
-        $this->expectExceptionObject(new DecorationPatternException(LanguageLoaderConfigSerializer::class));
-
-        $this->serializer->getDecorated();
     }
 }

--- a/tests/unit/Core/Framework/ContentSystem/Hydration/DataLoader/NavigationLoader/NavigationDataLoaderTest.php
+++ b/tests/unit/Core/Framework/ContentSystem/Hydration/DataLoader/NavigationLoader/NavigationDataLoaderTest.php
@@ -14,7 +14,6 @@ use Shopware\Core\Framework\ContentSystem\Hydration\DataLoader\NavigationLoader\
 use Shopware\Core\Framework\ContentSystem\Hydration\DataLoader\NavigationLoader\NavigationLoaderConfig;
 use Shopware\Core\Framework\ContentSystem\Layout\Element\ContentElement;
 use Shopware\Core\Framework\ContentSystem\Layout\Element\DataRequirement\DataRequirement;
-use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\Test\Generator;
 use Symfony\Component\HttpFoundation\Request;
@@ -237,13 +236,5 @@ class NavigationDataLoaderTest extends TestCase
         static::assertFalse($result->hasData());
         static::assertTrue($result->isCacheAware());
         static::assertSame([], $result->getCacheTags());
-    }
-
-    #[TestDox('throws DecorationPatternException when getDecorated is called')]
-    public function testGetDecoratedThrowsDecorationPatternException(): void
-    {
-        $this->expectExceptionObject(new DecorationPatternException(NavigationDataLoader::class));
-
-        $this->dataLoader->getDecorated();
     }
 }

--- a/tests/unit/Core/Framework/ContentSystem/Hydration/DataLoader/NavigationLoader/NavigationLoaderConfigSerializerTest.php
+++ b/tests/unit/Core/Framework/ContentSystem/Hydration/DataLoader/NavigationLoader/NavigationLoaderConfigSerializerTest.php
@@ -9,7 +9,6 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\ContentSystem\ContentSystemException;
 use Shopware\Core\Framework\ContentSystem\Hydration\DataLoader\NavigationLoader\NavigationLoaderConfig;
 use Shopware\Core\Framework\ContentSystem\Hydration\DataLoader\NavigationLoader\NavigationLoaderConfigSerializer;
-use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
 use Shopware\Core\Test\Stub\ContentSystem\StubLoaderConfig;
 
 /**
@@ -228,13 +227,5 @@ class NavigationLoaderConfigSerializerTest extends TestCase
         $encoded = $this->serializer->encode($config);
 
         static::assertSame($original, $encoded);
-    }
-
-    #[TestDox('throws DecorationPatternException when getDecorated is called')]
-    public function testGetDecoratedThrowsDecorationPatternException(): void
-    {
-        $this->expectExceptionObject(new DecorationPatternException(NavigationLoaderConfigSerializer::class));
-
-        $this->serializer->getDecorated();
     }
 }

--- a/tests/unit/Core/Framework/ContentSystem/Hydration/DataLoader/PaymentMethodLoader/PaymentMethodDataLoaderTest.php
+++ b/tests/unit/Core/Framework/ContentSystem/Hydration/DataLoader/PaymentMethodLoader/PaymentMethodDataLoaderTest.php
@@ -16,7 +16,6 @@ use Shopware\Core\Framework\ContentSystem\Layout\Element\ContentElement;
 use Shopware\Core\Framework\ContentSystem\Layout\Element\DataRequirement\DataRequirement;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
-use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
 use Shopware\Core\Test\Generator;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -205,13 +204,5 @@ class PaymentMethodDataLoaderTest extends TestCase
         $this->dataLoader->load($element, $requirement, $context, $originalRequest);
 
         static::assertNull($originalRequest->query->get('onlyAvailable'));
-    }
-
-    #[TestDox('throws DecorationPatternException when getDecorated is called')]
-    public function testGetDecoratedThrowsDecorationPatternException(): void
-    {
-        $this->expectExceptionObject(new DecorationPatternException(PaymentMethodDataLoader::class));
-
-        $this->dataLoader->getDecorated();
     }
 }

--- a/tests/unit/Core/Framework/ContentSystem/Hydration/DataLoader/PaymentMethodLoader/PaymentMethodLoaderConfigSerializerTest.php
+++ b/tests/unit/Core/Framework/ContentSystem/Hydration/DataLoader/PaymentMethodLoader/PaymentMethodLoaderConfigSerializerTest.php
@@ -8,7 +8,6 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\ContentSystem\ContentSystemException;
 use Shopware\Core\Framework\ContentSystem\Hydration\DataLoader\PaymentMethodLoader\PaymentMethodLoaderConfig;
 use Shopware\Core\Framework\ContentSystem\Hydration\DataLoader\PaymentMethodLoader\PaymentMethodLoaderConfigSerializer;
-use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
 use Shopware\Core\Test\Stub\ContentSystem\StubLoaderConfig;
 
 /**
@@ -205,13 +204,5 @@ class PaymentMethodLoaderConfigSerializerTest extends TestCase
         );
 
         $this->serializer->encode(new StubLoaderConfig());
-    }
-
-    #[TestDox('throws DecorationPatternException when getDecorated is called')]
-    public function testGetDecoratedThrowsDecorationPatternException(): void
-    {
-        $this->expectExceptionObject(new DecorationPatternException(PaymentMethodLoaderConfigSerializer::class));
-
-        $this->serializer->getDecorated();
     }
 }

--- a/tests/unit/Core/Framework/ContentSystem/Hydration/DataLoader/ProductListingLoader/ProductListingDataLoaderTest.php
+++ b/tests/unit/Core/Framework/ContentSystem/Hydration/DataLoader/ProductListingLoader/ProductListingDataLoaderTest.php
@@ -14,7 +14,6 @@ use Shopware\Core\Framework\ContentSystem\Hydration\DataLoader\ProductListingLoa
 use Shopware\Core\Framework\ContentSystem\Hydration\DataLoader\ProductListingLoader\ProductListingLoaderConfig;
 use Shopware\Core\Framework\ContentSystem\Layout\Element\DataRequirement\DataRequirement;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
-use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\Test\Generator;
 use Shopware\Core\Test\Stub\ContentSystem\ContentElementBuilder;
@@ -297,13 +296,5 @@ class ProductListingDataLoaderTest extends TestCase
 
         static::assertNull($result->data);
         static::assertTrue($result->isCacheAware());
-    }
-
-    #[TestDox('throws DecorationPatternException when getDecorated is called')]
-    public function testGetDecoratedThrowsDecorationPatternException(): void
-    {
-        $this->expectExceptionObject(new DecorationPatternException(ProductListingDataLoader::class));
-
-        $this->loader->getDecorated();
     }
 }

--- a/tests/unit/Core/Framework/ContentSystem/Hydration/DataLoader/ProductListingLoader/ProductListingLoaderConfigSerializerTest.php
+++ b/tests/unit/Core/Framework/ContentSystem/Hydration/DataLoader/ProductListingLoader/ProductListingLoaderConfigSerializerTest.php
@@ -10,7 +10,6 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\ContentSystem\ContentSystemException;
 use Shopware\Core\Framework\ContentSystem\Hydration\DataLoader\ProductListingLoader\ProductListingLoaderConfig;
 use Shopware\Core\Framework\ContentSystem\Hydration\DataLoader\ProductListingLoader\ProductListingLoaderConfigSerializer;
-use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
 use Shopware\Core\Test\Stub\ContentSystem\StubLoaderConfig;
 
 /**
@@ -218,13 +217,5 @@ class ProductListingLoaderConfigSerializerTest extends TestCase
         );
 
         $this->serializer->encode(new StubLoaderConfig());
-    }
-
-    #[TestDox('throws DecorationPatternException when getDecorated is called')]
-    public function testGetDecoratedThrowsDecorationPatternException(): void
-    {
-        $this->expectExceptionObject(new DecorationPatternException(ProductListingLoaderConfigSerializer::class));
-
-        $this->serializer->getDecorated();
     }
 }

--- a/tests/unit/Core/Framework/ContentSystem/Hydration/DataLoader/ShippingMethodLoader/ShippingMethodDataLoaderTest.php
+++ b/tests/unit/Core/Framework/ContentSystem/Hydration/DataLoader/ShippingMethodLoader/ShippingMethodDataLoaderTest.php
@@ -15,7 +15,6 @@ use Shopware\Core\Framework\ContentSystem\Hydration\DataLoader\ShippingMethodLoa
 use Shopware\Core\Framework\ContentSystem\Layout\Element\ContentElement;
 use Shopware\Core\Framework\ContentSystem\Layout\Element\DataRequirement\DataRequirement;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
-use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
 use Shopware\Core\Test\Generator;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -171,14 +170,6 @@ class ShippingMethodDataLoaderTest extends TestCase
         static::assertSame($shippingMethods, $result->data);
         static::assertTrue($result->isCacheAware());
         static::assertSame([], $result->getCacheTags());
-    }
-
-    #[TestDox('throws DecorationPatternException when getDecorated is called')]
-    public function testGetDecoratedThrowsDecorationPatternException(): void
-    {
-        $this->expectExceptionObject(new DecorationPatternException(ShippingMethodDataLoader::class));
-
-        $this->dataLoader->getDecorated();
     }
 
     private function createShippingMethodRouteResponse(ShippingMethodCollection $shippingMethods): ShippingMethodRouteResponse

--- a/tests/unit/Core/Framework/ContentSystem/Hydration/DataLoader/ShippingMethodLoader/ShippingMethodLoaderConfigSerializerTest.php
+++ b/tests/unit/Core/Framework/ContentSystem/Hydration/DataLoader/ShippingMethodLoader/ShippingMethodLoaderConfigSerializerTest.php
@@ -8,7 +8,6 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\ContentSystem\ContentSystemException;
 use Shopware\Core\Framework\ContentSystem\Hydration\DataLoader\ShippingMethodLoader\ShippingMethodLoaderConfig;
 use Shopware\Core\Framework\ContentSystem\Hydration\DataLoader\ShippingMethodLoader\ShippingMethodLoaderConfigSerializer;
-use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
 use Shopware\Core\Test\Stub\ContentSystem\StubLoaderConfig;
 
 /**
@@ -205,13 +204,5 @@ class ShippingMethodLoaderConfigSerializerTest extends TestCase
         );
 
         $this->serializer->encode(new StubLoaderConfig());
-    }
-
-    #[TestDox('throws DecorationPatternException when getDecorated is called')]
-    public function testGetDecoratedThrowsDecorationPatternException(): void
-    {
-        $this->expectExceptionObject(new DecorationPatternException(ShippingMethodLoaderConfigSerializer::class));
-
-        $this->serializer->getDecorated();
     }
 }


### PR DESCRIPTION
Shopware uses `getDecorated()` on abstract classes to support its decorator pattern, a mechanism where services wrap each other in a chain, each delegating to the next via `$this->getDecorated()->method()`. The base implementation throws `DecorationPatternException` to signal the chain terminus. This pattern is enforced by `DecorationPatternRule` (PHPStan) and documented in `adr/2020-11-25-decoration-pattern.md`.

The pattern is architecturally meaningful when the DI container wires services via `decorates=`. Symfony replaces the original service with the outermost decorator, and `getDecorated()` provides chain traversal. Three abstract classes in the ContentSystem use tagged service dispatch instead:

| Abstract Class | DI Wiring | Pattern |
|---|---|---|
| `AbstractContentDataLoader` | `tagged_locator` indexed by `getRequirementType()` | Strategy |
| `AbstractContentDataLoaderConfigSerializer` | `tagged_locator` indexed by `getSource()` | Strategy |
| `AbstractSpecificationSource` | `tagged_iterator` with `supports()` | Chain of Responsibility |

Each implementation handles a distinct type or path. The container never wraps one service around another. A plugin extends by registering an additional tagged service, not by decorating an existing one. `getDecorated()` is unreachable in production and `DecorationPatternException` can never be thrown.

All concrete implementations were also marked `@internal @final`, which conflicts with `DecorationPatternRule`'s requirement that decoratable classes must not be `@internal`. `EntityCollectionLoaderConfigSerializer` carried a `@phpstan-ignore shopware.decorationPattern` suppression to work around this.

### What was removed

`getDecorated()` and `DecorationPatternException` from the three abstract classes and all their concrete implementations (data loaders, config serializers, specification sources, test stub). Updated EXTENSION.md examples accordingly.

Closes #15574