### PR TITLE
fix: dynamic product group with multiple properties AND filter

### DIFF
--- a/src/Core/Framework/DataAbstractionLayer/Dbal/JoinGroupBuilder.php
+++ b/src/Core/Framework/DataAbstractionLayer/Dbal/JoinGroupBuilder.php
@@ -61,6 +61,15 @@ class JoinGroupBuilder
             unset($groups['operator'], $groups['negated']);
 
             foreach ($groups as $path => $groupFilters) {
+                if (\is_string($operator) && !$negated && $this->shouldSplitPrimaryFilters($groupFilters, $operator)) {
+                    foreach ($groupFilters as $groupFilter) {
+                        $new[] = new JoinGroup([$groupFilter], $path, '_' . $level, $operator);
+                        ++$level;
+                    }
+
+                    continue;
+                }
+
                 $relevant = \in_array($path, $duplicates, true) || $negated;
 
                 if (!$relevant) {
@@ -208,5 +217,40 @@ class JoinGroupBuilder
         $duplicates = array_filter($duplicates, static fn (int $count) => $count > 1);
 
         return array_keys($duplicates);
+    }
+
+    /**
+     * Repeated primary-key constraints on the same to-many field cannot be satisfied by a single joined row.
+     * Split them into individual join groups so each constraint gets its own EXISTS subquery.
+     *
+     * @param list<SingleFieldFilter> $groupFilters
+     */
+    private function shouldSplitPrimaryFilters(array $groupFilters, string $operator): bool
+    {
+        if ($operator !== MultiFilter::CONNECTION_AND || \count($groupFilters) < 2) {
+            return false;
+        }
+
+        $field = null;
+
+        foreach ($groupFilters as $groupFilter) {
+            if (!$groupFilter->isPrimary()) {
+                return false;
+            }
+
+            $currentField = $groupFilter->getField();
+
+            if ($field === null) {
+                $field = $currentField;
+
+                continue;
+            }
+
+            if ($field !== $currentField) {
+                return false;
+            }
+        }
+
+        return true;
     }
 }

--- a/tests/integration/Administration/Controller/AdminProductStreamControllerTest.php
+++ b/tests/integration/Administration/Controller/AdminProductStreamControllerTest.php
@@ -139,6 +139,71 @@ class AdminProductStreamControllerTest extends TestCase
         static::assertNotContains('v.2.2', $names);
     }
 
+    public function testRepeatedPropertyFiltersInAndPreview(): void
+    {
+        $this->ids->create('rot');
+        $this->ids->create('grün');
+
+        $data = [
+            'page' => 1,
+            'limit' => 25,
+            'filter' => [
+                [
+                    'field' => null,
+                    'type' => 'multi',
+                    'operator' => 'OR',
+                    'value' => null,
+                    'parameters' => null,
+                    'queries' => [
+                        [
+                            'field' => null,
+                            'type' => 'multi',
+                            'operator' => 'AND',
+                            'value' => null,
+                            'parameters' => null,
+                            'queries' => [
+                                [
+                                    'field' => 'properties.id',
+                                    'type' => 'equals',
+                                    'operator' => null,
+                                    'value' => $this->ids->get('rot'),
+                                    'parameters' => null,
+                                    'queries' => [],
+                                ],
+                                [
+                                    'field' => 'properties.id',
+                                    'type' => 'equalsAny',
+                                    'operator' => null,
+                                    'value' => $this->ids->get('grün'),
+                                    'parameters' => null,
+                                    'queries' => [],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $this->getBrowser()->jsonRequest(
+            'POST',
+            '/api/_admin/product-stream-preview/' . TestDefaults::SALES_CHANNEL,
+            $data
+        );
+        $response = $this->getBrowser()->getResponse();
+
+        static::assertSame(200, $this->getBrowser()->getResponse()->getStatusCode());
+
+        $content = json_decode($response->getContent() ?: '', true, 512, \JSON_THROW_ON_ERROR);
+
+        static::assertCount(3, $content['elements']);
+        $names = array_column($content['elements'], 'name');
+        static::assertContains('v.1.1', $names);
+        static::assertContains('v.1.2', $names);
+        static::assertNotContains('v.2.1', $names);
+        static::assertNotContains('v.2.2', $names);
+    }
+
     private function prepareTestData(): void
     {
         $products = [

--- a/tests/unit/Core/Framework/DataAbstractionLayer/Dbal/JoinGroupBuilderTest.php
+++ b/tests/unit/Core/Framework/DataAbstractionLayer/Dbal/JoinGroupBuilderTest.php
@@ -15,6 +15,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Dbal\JoinGroup;
 use Shopware\Core\Framework\DataAbstractionLayer\Dbal\JoinGroupBuilder;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\CriteriaPartInterface;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\AndFilter;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsAnyFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\Filter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\MultiFilter;
@@ -131,6 +132,23 @@ class JoinGroupBuilderTest extends TestCase
             ],
         ];
 
+        yield 'Single many filter, repeated primary filter, grouping required' => [
+            [
+                new MultiFilter(MultiFilter::CONNECTION_AND, [
+                    new EqualsFilter('transactions.id', 'first'),
+                    new EqualsAnyFilter('transactions.id', ['second', 'third']),
+                ]),
+            ],
+            [
+                new JoinGroup([
+                    self::primaryEqualsFilter('transactions.id', 'first'),
+                ], 'order.transactions', '_1', MultiFilter::CONNECTION_AND),
+                new JoinGroup([
+                    self::primaryEqualsAnyFilter('transactions.id', ['second', 'third']),
+                ], 'order.transactions', '_2', MultiFilter::CONNECTION_AND),
+            ],
+        ];
+
         yield 'Multiple filters, multiple many filter, no grouping' => [
             [
                 new EqualsFilter('currencyFactor', 1),
@@ -197,5 +215,24 @@ class JoinGroupBuilderTest extends TestCase
                 new EqualsFilter('lineItems.label', 'foo'),
             ],
         ];
+    }
+
+    private static function primaryEqualsFilter(string $field, string $value): EqualsFilter
+    {
+        $filter = new EqualsFilter($field, $value);
+        $filter->setIsPrimary(true);
+
+        return $filter;
+    }
+
+    /**
+     * @param list<string> $values
+     */
+    private static function primaryEqualsAnyFilter(string $field, array $values): EqualsAnyFilter
+    {
+        $filter = new EqualsAnyFilter($field, $values);
+        $filter->setIsPrimary(true);
+
+        return $filter;
     }
 }


### PR DESCRIPTION
### Actual behaviour

Using multiple property group filters in product streams will return 0 results.

Stream:
<img width="1030" height="363" alt="Image" src="https://github.com/user-attachments/assets/398b6aee-3fae-4858-9d3b-8866e0a25668" />

Product:
<img width="983" height="374" alt="Image" src="https://github.com/user-attachments/assets/20cb036d-22a1-48fd-aac6-f2650cddfc5f" />

This is an issue since a while, see also #1977.

As for some technical notes... Shopware builds an SQL query similiar like this:
```
SELECT p.id, p.product_number, p.auto_increment
FROM product p
LEFT JOIN product pp ON p.parent_id = pp.id AND p.parent_version_id = pp.version_id 
LEFT JOIN product_property properties_mapping ON p.properties = properties_mapping.product_id  AND p.version_id = properties_mapping.product_version_id 
LEFT JOIN product_visibility pv ON p.visibilities = pv.product_id AND p.version_id = pv.product_version_id 
LEFT JOIN property_group_option po ON properties_mapping.property_group_option_id = po.id  
WHERE p.version_id = 0x0FA91CE3E96A4BC2BE4BD9CE752C3425
  AND po.id = 0x61A83D3A762D404CB11FE397913486BD
  AND po.id IN (0x019C68338FFE7138938C7C661F5A9A4C, 0x019C7C56504A70289B5061EBF23984F1, 0x019C6820B62671B9AB5492D2865DD534, 0x019C7C4897E3729BBBBE831FD10200FD)
  AND pv.visibility >= 30 
  AND pv.sales_channel_id = 0x3998319529534235817ABD5A0C2DF1CD
GROUP BY p.id LIMIT 25;
```
=> Multiple conditions on the same product_property table will fail

Instead, each condition should've been added as an extra join:
```
SELECT p.id, p.product_number, p.auto_increment
FROM product p
LEFT JOIN product pp ON p.parent_id = pp.id AND p.parent_version_id = pp.version_id 
LEFT JOIN product_visibility pv ON p.visibilities = pv.product_id AND p.version_id = pv.product_version_id 
LEFT JOIN product_property mapping1 ON p.properties = mapping1.product_id  AND p.version_id = mapping1.product_version_id 
LEFT JOIN product_property mapping2 ON p.properties = mapping2.product_id  AND p.version_id = mapping2.product_version_id 
WHERE p.version_id = 0x0FA91CE3E96A4BC2BE4BD9CE752C3425
  AND mapping1.property_group_option_id = 0x61A83D3A762D404CB11FE397913486BD
  AND mapping2.property_group_option_id IN (0x019C68338FFE7138938C7C661F5A9A4C, 0x019C7C56504A70289B5061EBF23984F1, 0x019C6820B62671B9AB5492D2865DD534, 0x019C7C4897E3729BBBBE831FD10200FD)
  AND pv.visibility >= 30 
  AND pv.sales_channel_id = 0x3998319529534235817ABD5A0C2DF1CD
GROUP BY p.id LIMIT 25;
```

### Expected behaviour

When applying multiple property option filters, I expect to get all products that have given options in their properties.

It is possible in some cases to use the "EqualsAny" or "EqualsAll" operator. However we need to combine multiple  property options in our shop, for example: "Season: Summer" AND "VehicleModels oneOf (Audi A1, Audi A2, ...)".

### How to reproduce

Recreate the rules, test the return of the preview search.