### PR TITLE
fix: reload variant detail state after delete

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-variants/sw-product-variants-overview/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-variants/sw-product-variants-overview/index.js
@@ -17,6 +17,7 @@ export default {
         'acl',
         'feature',
         'mediaService',
+        'swProductDetailLoadAll',
     ],
 
     emits: [
@@ -720,15 +721,18 @@ export default {
                 this.productRepository
                     .syncDeleted(variantIds)
                     .then(() => {
+                        this.$refs.variantGrid.resetSelection();
+
+                        return this.swProductDetailLoadAll()
+                            .then(() => this.getList());
+                    })
+                    .then(() => {
                         this.modalLoading = false;
                         this.toBeDeletedVariantIds = [];
 
                         this.createNotificationSuccess({
                             message: this.$t('sw-product.variations.generatedListMessageDeleteSuccess'),
                         });
-
-                        this.$refs.variantGrid.resetSelection();
-                        this.getList();
                     })
                     .catch(() => {
                         this.modalLoading = false;

--- a/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-variants/sw-product-variants-overview/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-variants/sw-product-variants-overview/index.js
@@ -723,8 +723,7 @@ export default {
                     .then(() => {
                         this.$refs.variantGrid.resetSelection();
 
-                        return this.swProductDetailLoadAll()
-                            .then(() => this.getList());
+                        return this.swProductDetailLoadAll().then(() => this.getList());
                     })
                     .then(() => {
                         this.modalLoading = false;

--- a/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-variants/sw-product-variants-overview/sw-product-variants-overview.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-variants/sw-product-variants-overview/sw-product-variants-overview.spec.js
@@ -539,8 +539,8 @@ describe('src/module/sw-product/component/sw-product-variants/sw-product-variant
         const wrapper = await createWrapper();
         await flushPromises();
 
-        const deleteContextButton = wrapper.find('.sw-context-menu-item.sw-context-menu-item--danger');
-        await deleteContextButton.trigger('click');
+        wrapper.vm.onVariationDelete({ id: 1 });
+        await wrapper.vm.$nextTick();
 
         await wrapper.findByText('button', 'sw-product.variations.generatedListDeleteModalButtonDelete').trigger('click');
         await flushPromises();

--- a/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-variants/sw-product-variants-overview/sw-product-variants-overview.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-variants/sw-product-variants-overview/sw-product-variants-overview.spec.js
@@ -8,6 +8,7 @@ let repositoryFactoryMock;
 let repositoryFactoryCreateMock;
 
 async function createWrapper(propsOverride = {}, repositoryFactoryOverride = {}) {
+    const swProductDetailLoadAll = jest.fn(() => Promise.resolve());
     const productMediaRepositoryMock = {
         create: jest.fn(() => {
             return {
@@ -85,6 +86,7 @@ async function createWrapper(propsOverride = {}, repositoryFactoryOverride = {})
                     stopEventListener: () => {},
                 },
                 fileValidationService: {},
+                swProductDetailLoadAll,
             },
             stubs: {
                 'sw-container': await wrapTestComponent('sw-container', {
@@ -529,6 +531,21 @@ describe('src/module/sw-product/component/sw-product-variants/sw-product-variant
         await flushPromises();
 
         expect(wrapper.vm.productRepository.save).toHaveBeenCalledTimes(1);
+    });
+
+    it('should reload product detail state after deleting variants', async () => {
+        global.activeAclRoles = ['product.deleter'];
+
+        const wrapper = await createWrapper();
+        await flushPromises();
+
+        const deleteContextButton = wrapper.find('.sw-context-menu-item.sw-context-menu-item--danger');
+        await deleteContextButton.trigger('click');
+
+        await wrapper.findByText('button', 'sw-product.variations.generatedListDeleteModalButtonDelete').trigger('click');
+        await flushPromises();
+
+        expect(wrapper.vm.swProductDetailLoadAll).toHaveBeenCalledTimes(1);
     });
 
     it('should contain a currencyColumns computed property', async () => {


### PR DESCRIPTION
## Summary
Fixes #8060 by reloading product detail state after deleting variants from the overview.

## Root Cause
Deleting variants updated the visible list, but the product detail store stayed stale and left the overview and generation state out of sync.

## What Changed
- refresh the product detail store after a successful delete
- reload the overview list from refreshed state
- add a regression spec for the refresh path

## Impact
Variant deletion from the overview now resynchronizes the admin state instead of leaving inconsistent variant data behind.
