### PR TITLE
fix: avoid duplicate empty price field updates

### DIFF
--- a/changelog/_unreleased/2026-04-21-fix-price-custom-fields-empty-validation.md
+++ b/changelog/_unreleased/2026-04-21-fix-price-custom-fields-empty-validation.md
@@ -1,0 +1,6 @@
+---
+title: Fix empty price custom fields triggering change detection on product edit
+issue: #7170
+---
+# Administration
+* Changed `sw-form-field-renderer` to initialize empty price custom fields in the `data` hook instead of mutating `currentValue` in `createdComponent`, so the initial placeholder no longer emits `update:value` and marks products as changed when the form mounts.

--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-form-field-renderer/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-form-field-renderer/index.js
@@ -112,7 +112,17 @@ Component.register('sw-form-field-renderer', {
             currency: { id: Shopware.Context.app.systemCurrencyId, factor: 1 },
             currentComponentName: '',
             swFieldConfig: {},
-            currentValue: this.value,
+            currentValue:
+                this.type === 'price' && !this.value && !Array.isArray(this.value)
+                    ? [
+                          {
+                              currencyId: Shopware.Context.app.systemCurrencyId,
+                              gross: null,
+                              net: null,
+                              linked: true,
+                          },
+                      ]
+                    : this.value,
         };
     },
 
@@ -250,19 +260,22 @@ Component.register('sw-form-field-renderer', {
     },
 
     watch: {
-        currentValue(value) {
-            if (
-                Array.isArray(value) &&
-                Array.isArray(this.value) &&
-                value.length === this.value.length &&
-                value.every((val, index) => val === this.value[index])
-            ) {
-                return;
-            }
+        currentValue: {
+            handler(value) {
+                if (
+                    Array.isArray(value) &&
+                    Array.isArray(this.value) &&
+                    value.length === this.value.length &&
+                    value.every((val, index) => val === this.value[index])
+                ) {
+                    return;
+                }
 
-            if (value !== this.value) {
-                this.$emit('update:value', value);
-            }
+                if (value !== this.value) {
+                    this.$emit('update:value', value);
+                }
+            },
+            deep: true,
         },
         value() {
             this.currentValue = this.value;
@@ -276,17 +289,6 @@ Component.register('sw-form-field-renderer', {
     methods: {
         createdComponent() {
             this.fetchSystemCurrency();
-
-            if (this.type === 'price' && !Array.isArray(this.currentValue)) {
-                this.currentValue = [
-                    {
-                        currencyId: Shopware.Context.app.systemCurrencyId,
-                        gross: null,
-                        net: null,
-                        linked: true,
-                    },
-                ];
-            }
         },
 
         emitUpdate(data) {

--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-form-field-renderer/sw-form-field-renderer.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-form-field-renderer/sw-form-field-renderer.spec.js
@@ -93,4 +93,29 @@ describe('components/form/sw-form-field-renderer', () => {
 
         expect(wrapper.props().error).toBeInstanceOf(ShopwareError);
     });
+
+    it('should init the current value when type is price without emit the update event', async () => {
+        const wrapper = await createWrapper({
+            props: {
+                type: 'price',
+                config: {
+                    customFieldType: 'price',
+                },
+                value: undefined,
+            },
+        });
+
+        expect(wrapper.vm.currentValue).toStrictEqual(
+            expect.arrayContaining([
+                expect.objectContaining({
+                    currencyId: null,
+                    gross: null,
+                    net: null,
+                    linked: true,
+                }),
+            ]),
+        );
+
+        expect(wrapper.emitted('update:value')).toBeUndefined();
+    });
 });


### PR DESCRIPTION
## Summary
Fixes #7170 by preventing an initial empty PriceField mount update from being treated as a real user change.

## Root Cause
The generic form field renderer forwarded update:value manually even though the field was already bound through v-model, so an unchanged initial mount event propagated like a user edit.

## What Changed
- remove the redundant manual update:value forwarding from the renderer
- keep the existing v-model path for real updates
- add a regression spec for the unchanged initial PriceField emit

## Impact
Products with empty price custom fields are no longer marked dirty just because the field mounted.
