### PR TITLE
fix: CMS content language inheritance

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-category/page/sw-category-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-category/page/sw-category-detail/index.js
@@ -227,6 +227,7 @@ export default {
 
             criteria.addAssociation('tags');
             criteria.addAssociation('salesChannels');
+            criteria.addAssociation('translations');
 
             return criteria;
         },

--- a/src/Administration/Resources/app/administration/src/module/sw-category/page/sw-category-detail/sw-category-detail.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-category/page/sw-category-detail/sw-category-detail.spec.js
@@ -281,4 +281,12 @@ describe('src/module/sw-category/page/sw-category-detail', () => {
 
         expect(result).toEqual(expectedSlotOverrides);
     });
+
+    it('should load landing page translations for CMS inheritance handling', async () => {
+        const wrapper = await createWrapper();
+
+        expect(wrapper.vm.landingPageCriteria.associations.some(({ association }) => association === 'translations')).toBe(
+            true,
+        );
+    });
 });

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-form-sync/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-form-sync/index.ts
@@ -65,6 +65,16 @@ export default Shopware.Component.wrapComponentConfig({
         },
         fieldChangeHandler(key: string, config: FieldConfig) {
             const path = `slotConfig.${this.element.id}.${key}`;
+            const inheritedConfig = this.inheritedSlotConfig?.[this.element.id]?.[key];
+            const baseConfig = get(this.element, `translated.config.${key}`);
+
+            if (
+                !get(this.contentEntity, path) &&
+                ((inheritedConfig && isEmpty(getObjectDiff(inheritedConfig, config))) ||
+                    (baseConfig && isEmpty(getObjectDiff(baseConfig, config))))
+            ) {
+                return;
+            }
 
             if (isEmpty(getObjectDiff(get(this.contentEntity, path, {}), config))) {
                 return;

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-form-sync/sw-cms-form-sync.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-form-sync/sw-cms-form-sync.spec.js
@@ -71,12 +71,22 @@ async function createWrapper(props = {}, options = {}, route = categoryDetailCms
 }
 
 describe('src/module/sw-cms/component/sw-cms-form-sync', () => {
+    let initialLanguageId;
+    let initialLanguage;
+
     beforeAll(() => {
         setupCmsEnvironment();
     });
 
     beforeEach(() => {
+        initialLanguageId = Shopware.Store.get('context').api.languageId;
+        initialLanguage = Shopware.Store.get('context').api.language;
         Shopware.Store.get('swCategoryDetail').$reset();
+    });
+
+    afterEach(() => {
+        Shopware.Store.get('context').api.languageId = initialLanguageId;
+        Shopware.Store.get('context').api.language = initialLanguage;
     });
 
     it('should not sync field changes if contentEntity is not provided', async () => {
@@ -161,5 +171,63 @@ describe('src/module/sw-cms/component/sw-cms-form-sync', () => {
 
         expect(contentEntity.slotConfig).toBeDefined();
         expect(contentEntity.slotConfig[defaultElementId].content.value).toBe('new value');
+    });
+
+    it('should not sync inherited entity-level slotConfig as local child override', async () => {
+        const contentEntity = {
+            slotConfig: {},
+            translations: [
+                {
+                    languageId: 'parent-language-id',
+                    slotConfig: {
+                        [defaultElementId]: {
+                            content: {
+                                value: 'default - override',
+                            },
+                        },
+                    },
+                },
+            ],
+        };
+
+        Shopware.Store.get('swCategoryDetail').category = contentEntity;
+        Shopware.Store.get('context').api.languageId = 'child-language-id';
+        Shopware.Store.get('context').api.language = { parentId: 'parent-language-id' };
+
+        const wrapper = await createWrapper();
+
+        wrapper.vm.fieldChangeHandler('content', {
+            value: 'default - override',
+        });
+
+        expect(contentEntity.slotConfig[defaultElementId]).toBeUndefined();
+    });
+
+    it('should not sync base CMS config as local override for the current language', async () => {
+        const contentEntity = {
+            slotConfig: {},
+            translations: [],
+        };
+
+        Shopware.Store.get('swCategoryDetail').category = contentEntity;
+
+        const wrapper = await createWrapper({
+            element: {
+                ...getDefaultElement(),
+                translated: {
+                    config: {
+                        content: {
+                            value: 'base content',
+                        },
+                    },
+                },
+            },
+        });
+
+        wrapper.vm.fieldChangeHandler('content', {
+            value: 'base content',
+        });
+
+        expect(contentEntity.slotConfig[defaultElementId]).toBeUndefined();
     });
 });

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-inherit-wrapper/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-inherit-wrapper/index.ts
@@ -113,6 +113,9 @@ export default Shopware.Component.wrapComponentConfig({
         fullPath() {
             return this.field.concat('.', this.fieldPath);
         },
+        inheritedFieldConfig() {
+            return get(this.inheritedSlotConfig?.[this.element.id], this.field);
+        },
         fieldDefaultValue() {
             return get(this.cmsElements[this.element.type]?.defaultConfig, this.fullPath, BASE_FIELD_FALLBACK.value);
         },
@@ -120,8 +123,6 @@ export default Shopware.Component.wrapComponentConfig({
     methods: {
         async onInheritanceRestore() {
             this.showModal = false;
-
-            set(this.runtimeConfig, this.field, cloneDeep(get(this.baseConfig, this.field, BASE_FIELD_FALLBACK)));
 
             /**
              * Run watchers before removing the slotConfig to ensure sw-cms-form-sync won't
@@ -134,6 +135,9 @@ export default Shopware.Component.wrapComponentConfig({
             if (isEmpty(this.childConfig)) {
                 set(this.contentEntity!, 'slotConfig', null);
             }
+
+            const inheritedField = this.inheritedFieldConfig ?? get(this.baseConfig, this.field, BASE_FIELD_FALLBACK);
+            set(this.runtimeConfig, this.field, cloneDeep(inheritedField));
 
             this.$emit(EVENTS.RESTORE);
         },

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-inherit-wrapper/sw-cms-inherit-wrapper.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-inherit-wrapper/sw-cms-inherit-wrapper.spec.js
@@ -98,8 +98,18 @@ async function createWrapper(props = {}, options = {}, route = categoryDetailCms
 }
 
 describe('src/module/sw-cms/component/sw-cms-inherit-wrapper', () => {
+    let initialLanguageId;
+    let initialLanguage;
+
     beforeEach(() => {
+        initialLanguageId = Shopware.Store.get('context').api.languageId;
+        initialLanguage = Shopware.Store.get('context').api.language;
         Shopware.Store.get('swCategoryDetail').$reset();
+    });
+
+    afterEach(() => {
+        Shopware.Store.get('context').api.languageId = initialLanguageId;
+        Shopware.Store.get('context').api.language = initialLanguage;
     });
 
     describe('computed properties', () => {
@@ -563,6 +573,47 @@ describe('src/module/sw-cms/component/sw-cms-inherit-wrapper', () => {
 
             expect(wrapper.emitted('inheritance:restore')).toBeTruthy();
             expect(wrapper.emitted('inheritance:restore')).toHaveLength(1);
+        });
+
+        it('should restore inherited parent entity override instead of the base CMS config', async () => {
+            Shopware.Store.get('swCategoryDetail').category = {
+                slotConfig: {
+                    'test-slot-id': {
+                        testField: { value: 'child override' },
+                    },
+                },
+                translations: [
+                    {
+                        languageId: 'parent-language-id',
+                        slotConfig: {
+                            'test-slot-id': {
+                                testField: { value: 'parent override' },
+                            },
+                        },
+                    },
+                ],
+            };
+            Shopware.Store.get('context').api.languageId = 'child-language-id';
+            Shopware.Store.get('context').api.language = { parentId: 'parent-language-id' };
+
+            const wrapper = await createWrapper({
+                element: new Entity('test-slot-id', 'cms_slot', {
+                    type: 'text',
+                    config: {
+                        testField: { value: 'child override' },
+                    },
+                    translated: {
+                        config: {
+                            testField: { value: 'base-value' },
+                        },
+                    },
+                }),
+            });
+
+            await wrapper.vm.onInheritanceRestore();
+
+            expect(wrapper.vm.runtimeConfig.testField.value).toBe('parent override');
+            expect(wrapper.vm.isInherited).toBe(true);
         });
     });
 

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/mixin/sw-cms-element.mixin.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/mixin/sw-cms-element.mixin.spec.js
@@ -38,6 +38,9 @@ async function createWrapper(element = defaultElement, routeName = '') {
 }
 
 describe('module/sw-cms/mixin/sw-cms-element.mixin.ts', () => {
+    let initialLanguageId;
+    let initialLanguage;
+
     beforeAll(async () => {
         await setupCmsEnvironment();
         await import('src/module/sw-cms/elements/text');
@@ -51,12 +54,16 @@ describe('module/sw-cms/mixin/sw-cms-element.mixin.ts', () => {
     });
 
     beforeEach(() => {
+        initialLanguageId = Shopware.Store.get('context').api.languageId;
+        initialLanguage = Shopware.Store.get('context').api.language;
         Shopware.Store.get('swCategoryDetail').$reset();
         Shopware.Store.get('swProductDetail').$reset();
     });
 
     afterEach(() => {
         Shopware.Store.get('cmsPage').resetCmsPageState();
+        Shopware.Store.get('context').api.languageId = initialLanguageId;
+        Shopware.Store.get('context').api.language = initialLanguage;
     });
 
     it('initElementConfig is properly merging configs from various sources', async () => {
@@ -80,6 +87,7 @@ describe('module/sw-cms/mixin/sw-cms-element.mixin.ts', () => {
                 source: 'static',
                 value: expect.any(String),
             },
+            overrideFromCategory: 'bar',
             verticalAlign: {
                 source: 'static',
                 value: null,
@@ -91,7 +99,7 @@ describe('module/sw-cms/mixin/sw-cms-element.mixin.ts', () => {
 
         /**
          * Existing properties on the element will remain ("overrideFromProp").
-         * Properties on the content-entity, that dont exist in the config are ignored ("overrideFromCategory").
+         * Content overrides on the entity are applied on top, even if the key does not exist in the default config.
          */
         expect(wrapper.vm.element.config).toEqual(expectedElementConfig);
     });

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/mixin/sw-cms-element.mixin.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/mixin/sw-cms-element.mixin.spec.js
@@ -175,4 +175,55 @@ describe('module/sw-cms/mixin/sw-cms-element.mixin.ts', () => {
 
         expect(wrapper.vm.product).toMatchObject(mockProduct);
     });
+
+    it('should apply inherited slotConfig from the explicit parent language', async () => {
+        Shopware.Store.get('swProductDetail').product = {
+            translations: [
+                {
+                    languageId: 'parent-language-id',
+                    slotConfig: {
+                        [defaultElement.id]: {
+                            content: {
+                                source: 'static',
+                                value: 'inherited override',
+                            },
+                        },
+                    },
+                },
+            ],
+        };
+        Shopware.Store.get('context').api.languageId = 'child-language-id';
+        Shopware.Store.get('context').api.language = { parentId: 'parent-language-id' };
+
+        const wrapper = await createWrapper(defaultElement, 'sw.product.detail');
+
+        expect(wrapper.vm.element.config.content).toStrictEqual({
+            source: 'static',
+            value: 'inherited override',
+        });
+    });
+
+    it('should not apply system language slotConfig without explicit parent language', async () => {
+        Shopware.Store.get('swProductDetail').product = {
+            translations: [
+                {
+                    languageId: Shopware.Context.api.systemLanguageId,
+                    slotConfig: {
+                        [defaultElement.id]: {
+                            content: {
+                                source: 'static',
+                                value: 'system override',
+                            },
+                        },
+                    },
+                },
+            ],
+        };
+        Shopware.Store.get('context').api.languageId = 'child-language-id';
+        Shopware.Store.get('context').api.language = { parentId: null };
+
+        const wrapper = await createWrapper(defaultElement, 'sw.product.detail');
+
+        expect(wrapper.vm.element.config.content.value).not.toBe('system override');
+    });
 });

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/mixin/sw-cms-element.mixin.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/mixin/sw-cms-element.mixin.spec.js
@@ -69,6 +69,11 @@ describe('module/sw-cms/mixin/sw-cms-element.mixin.ts', () => {
     it('initElementConfig is properly merging configs from various sources', async () => {
         Shopware.Store.get('swCategoryDetail').category = {
             id: '12345',
+            slotConfig: {
+                [defaultElement.id]: {
+                    overrideFromCategory: 'bar',
+                },
+            },
             translations: [
                 {
                     languageId: Shopware.Context.api.systemLanguageId,
@@ -233,5 +238,33 @@ describe('module/sw-cms/mixin/sw-cms-element.mixin.ts', () => {
         const wrapper = await createWrapper(defaultElement, 'sw.product.detail');
 
         expect(wrapper.vm.element.config.content.value).not.toBe('system override');
+    });
+
+    it('should not mutate the parent language slotConfig when editing inherited content', async () => {
+        const parentSlotConfig = {
+            [defaultElement.id]: {
+                content: {
+                    source: 'static',
+                    value: 'default - override',
+                },
+            },
+        };
+
+        Shopware.Store.get('swProductDetail').product = {
+            translations: [
+                {
+                    languageId: 'parent-language-id',
+                    slotConfig: parentSlotConfig,
+                },
+            ],
+        };
+        Shopware.Store.get('context').api.languageId = 'child-language-id';
+        Shopware.Store.get('context').api.language = { parentId: 'parent-language-id' };
+
+        const wrapper = await createWrapper(defaultElement, 'sw.product.detail');
+
+        wrapper.vm.element.config.content.value = 'child custom content';
+
+        expect(parentSlotConfig[defaultElement.id].content.value).toBe('default - override');
     });
 });

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/mixin/sw-cms-element.mixin.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/mixin/sw-cms-element.mixin.ts
@@ -99,7 +99,7 @@ export default Mixin.register(
                         key,
                         value,
                     ]) => {
-                        set(this.element, `config.${key}`, value);
+                        set(this.element, `config.${key}`, cloneDeep(value));
                     },
                 );
             },

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/mixin/sw-cms-element.mixin.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/mixin/sw-cms-element.mixin.ts
@@ -84,11 +84,11 @@ export default Mixin.register(
             },
 
             applyContentOverride() {
-                if (!this.contentEntity || !this.contentEntity.slotConfig || !this.element.id) {
+                if (!this.contentEntity || !this.inheritedSlotConfig || !this.element.id) {
                     return;
                 }
 
-                const overrideConfig = this.contentEntity.slotConfig[this.element.id];
+                const overrideConfig = this.inheritedSlotConfig[this.element.id];
 
                 if (!overrideConfig) {
                     return;

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/mixin/sw-cms-state.mixin.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/mixin/sw-cms-state.mixin.spec.js
@@ -135,4 +135,44 @@ describe('module/sw-cms/mixin/sw-cms-state.mixin.js', () => {
 
         expect(wrapper.vm.inheritedSlotConfig).toBeNull();
     });
+
+    it('should prefer the live current-language slotConfig over the stale translation row', async () => {
+        const wrapper = await createWrapper('sw.category.detail.cms');
+
+        Shopware.Store.get('swCategoryDetail').category = {
+            slotConfig: null,
+            translations: [
+                {
+                    languageId: 'child-language-id',
+                    slotConfig: {
+                        'slot-id': {
+                            content: {
+                                value: 'stale child override',
+                            },
+                        },
+                    },
+                },
+                {
+                    languageId: 'parent-language-id',
+                    slotConfig: {
+                        'slot-id': {
+                            content: {
+                                value: 'parent override',
+                            },
+                        },
+                    },
+                },
+            ],
+        };
+        Shopware.Store.get('context').api.languageId = 'child-language-id';
+        Shopware.Store.get('context').api.language = { parentId: 'parent-language-id' };
+
+        expect(wrapper.vm.inheritedSlotConfig).toStrictEqual({
+            'slot-id': {
+                content: {
+                    value: 'parent override',
+                },
+            },
+        });
+    });
 });

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/mixin/sw-cms-state.mixin.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/mixin/sw-cms-state.mixin.spec.js
@@ -30,12 +30,22 @@ const deviceViews = {
 };
 
 describe('module/sw-cms/mixin/sw-cms-state.mixin.js', () => {
+    let initialLanguageId;
+    let initialLanguage;
+
     beforeAll(async () => {
         await setupCmsEnvironment();
     });
 
+    beforeEach(() => {
+        initialLanguageId = Shopware.Store.get('context').api.languageId;
+        initialLanguage = Shopware.Store.get('context').api.language;
+    });
+
     afterEach(() => {
         Shopware.Store.get('cmsPage').resetCmsPageState();
+        Shopware.Store.get('context').api.languageId = initialLanguageId;
+        Shopware.Store.get('context').api.language = initialLanguage;
     });
 
     it('properties are properly written to and read from the shared store', () => {

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/mixin/sw-cms-state.mixin.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/mixin/sw-cms-state.mixin.spec.js
@@ -78,4 +78,51 @@ describe('module/sw-cms/mixin/sw-cms-state.mixin.js', () => {
 
         expect(wrapper.vm.contentEntity).toBeNull();
     });
+
+    it('should prefer parent translation slotConfig for inherited CMS overrides', async () => {
+        const wrapper = await createWrapper('sw.category.detail.cms');
+        const inheritedSlotConfig = {
+            'slot-id': {
+                content: {
+                    value: 'inherited',
+                },
+            },
+        };
+
+        Shopware.Store.get('swCategoryDetail').category = {
+            translations: [
+                {
+                    languageId: 'parent-language-id',
+                    slotConfig: inheritedSlotConfig,
+                },
+            ],
+        };
+        Shopware.Store.get('context').api.languageId = 'child-language-id';
+        Shopware.Store.get('context').api.language = { parentId: 'parent-language-id' };
+
+        expect(wrapper.vm.inheritedSlotConfig).toStrictEqual(inheritedSlotConfig);
+    });
+
+    it('should not fall back to system language slotConfig without explicit parent language', async () => {
+        const wrapper = await createWrapper('sw.category.detail.cms');
+
+        Shopware.Store.get('swCategoryDetail').category = {
+            translations: [
+                {
+                    languageId: Shopware.Context.api.systemLanguageId,
+                    slotConfig: {
+                        'slot-id': {
+                            content: {
+                                value: 'system',
+                            },
+                        },
+                    },
+                },
+            ],
+        };
+        Shopware.Store.get('context').api.languageId = 'child-language-id';
+        Shopware.Store.get('context').api.language = { parentId: null };
+
+        expect(wrapper.vm.inheritedSlotConfig).toBeNull();
+    });
 });

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/mixin/sw-cms-state.mixin.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/mixin/sw-cms-state.mixin.ts
@@ -6,6 +6,12 @@ type WithSlotConfig = {
     slotConfig?: {
         [slotId: string]: CmsSlotConfig;
     };
+    translations?: Array<{
+        languageId: string;
+        slotConfig?: {
+            [slotId: string]: CmsSlotConfig;
+        };
+    }>;
 };
 
 type ContentEntity<T extends keyof EntitySchema.Entities> = Entity<T> & WithSlotConfig;
@@ -89,6 +95,36 @@ export default Shopware.Mixin.register(
                 }
 
                 return null;
+            },
+
+            inheritedSlotConfig() {
+                const currentLanguageId = Shopware.Store.get('context').api.languageId;
+                const parentLanguageId = Shopware.Store.get('context').api.language?.parentId;
+
+                const currentSlotConfig = this.getSlotConfigForLanguage(currentLanguageId);
+                const parentSlotConfig = parentLanguageId ? this.getSlotConfigForLanguage(parentLanguageId) : null;
+
+                if (currentSlotConfig && parentSlotConfig) {
+                    return {
+                        ...parentSlotConfig,
+                        ...currentSlotConfig,
+                    };
+                }
+
+                return currentSlotConfig ?? parentSlotConfig ?? null;
+            },
+        },
+        methods: {
+            getSlotConfigForLanguage(languageId?: string | null) {
+                if (!languageId) {
+                    return null;
+                }
+
+                const translation = this.contentEntity?.translations?.find((entityTranslation) => {
+                    return entityTranslation.languageId === languageId;
+                });
+
+                return translation?.slotConfig ?? null;
             },
         },
     }),

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/mixin/sw-cms-state.mixin.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/mixin/sw-cms-state.mixin.ts
@@ -2,6 +2,8 @@ import { defineComponent } from 'vue';
 import '../store/cms-page.store';
 import type { CmsSlotConfig } from '../service/cms.service';
 
+const { cloneDeep } = Shopware.Utils.object;
+
 type WithSlotConfig = {
     slotConfig?: {
         [slotId: string]: CmsSlotConfig;
@@ -105,19 +107,23 @@ export default Shopware.Mixin.register(
                 const parentSlotConfig = parentLanguageId ? this.getSlotConfigForLanguage(parentLanguageId) : null;
 
                 if (currentSlotConfig && parentSlotConfig) {
-                    return {
+                    return cloneDeep({
                         ...parentSlotConfig,
                         ...currentSlotConfig,
-                    };
+                    });
                 }
 
-                return currentSlotConfig ?? parentSlotConfig ?? null;
+                return cloneDeep(currentSlotConfig ?? parentSlotConfig ?? null);
             },
         },
         methods: {
             getSlotConfigForLanguage(languageId?: string | null) {
                 if (!languageId) {
                     return null;
+                }
+
+                if (languageId === Shopware.Store.get('context').api.languageId) {
+                    return this.contentEntity?.slotConfig ?? null;
                 }
 
                 const translation = this.contentEntity?.translations?.find((entityTranslation) => {

--- a/src/Administration/Resources/app/administration/src/module/sw-product/page/sw-product-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/page/sw-product-detail/index.js
@@ -273,6 +273,7 @@ export default {
                 .addAssociation('customFieldSets')
                 .addAssociation('featureSet')
                 .addAssociation('cmsPage')
+                .addAssociation('translations')
                 .addAssociation('downloads.media');
 
             criteria.getAssociation('manufacturer').addAssociation('media');

--- a/src/Core/Content/Category/SalesChannel/CategoryRoute.php
+++ b/src/Core/Content/Category/SalesChannel/CategoryRoute.php
@@ -2,13 +2,13 @@
 
 namespace Shopware\Core\Content\Category\SalesChannel;
 
-use Shopware\Core\Content\Category\Aggregate\CategoryTranslation\CategoryTranslationEntity;
 use Shopware\Core\Content\Category\CategoryCollection;
 use Shopware\Core\Content\Category\CategoryDefinition;
 use Shopware\Core\Content\Category\CategoryEntity;
 use Shopware\Core\Content\Category\CategoryException;
 use Shopware\Core\Content\Cms\DataResolver\ResolverContext\EntityResolverContext;
 use Shopware\Core\Content\Cms\SalesChannel\SalesChannelCmsPageLoaderInterface;
+use Shopware\Core\Content\Cms\Service\EntityCmsSlotConfigInheritanceBuilder;
 use Shopware\Core\Framework\Adapter\Cache\CacheTagCollector;
 use Shopware\Core\Framework\Adapter\Request\RequestParamHelper;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
@@ -36,6 +36,7 @@ class CategoryRoute extends AbstractCategoryRoute
     public function __construct(
         private readonly SalesChannelRepository $categoryRepository,
         private readonly SalesChannelCmsPageLoaderInterface $cmsPageLoader,
+        private readonly EntityCmsSlotConfigInheritanceBuilder $cmsSlotConfigInheritanceBuilder,
         private readonly CategoryDefinition $categoryDefinition,
         private readonly CacheTagCollector $cacheTagCollector,
     ) {
@@ -157,36 +158,9 @@ class CategoryRoute extends AbstractCategoryRoute
      */
     private function buildMergedCmsSlotConfig(CategoryEntity $category, SalesChannelContext $context): ?array
     {
-        $inheritanceChain = $context->getLanguageIdChain();
-        if (\count($inheritanceChain) <= 1) {
-            return $category->getTranslation('slotConfig');
-        }
-
-        /** @var non-empty-list<string> $languageMergeOrder */
-        $languageMergeOrder = \array_reverse(\array_unique($inheritanceChain));
-        $translatedSlotConfigs = $this->getTranslatedSlotConfigs($category, $languageMergeOrder);
-
-        return \array_merge(...$translatedSlotConfigs);
-    }
-
-    /**
-     * @param non-empty-list<string> $languageMergeOrder
-     *
-     * @return non-empty-list<array<string, array<string, mixed>>>
-     */
-    private function getTranslatedSlotConfigs(CategoryEntity $category, array $languageMergeOrder): array
-    {
-        $getCategoryTranslationByLanguageId = static function (CategoryEntity $category, string $languageId): ?CategoryTranslationEntity {
-            return \array_find(
-                $category->getTranslations()?->getElements() ?? [],
-                static fn (CategoryTranslationEntity $translation) => $translation->getLanguageId() === $languageId,
-            );
-        };
-
-        return \array_map(static function (string $languageId) use ($category, $getCategoryTranslationByLanguageId) {
-            $currentTranslation = $getCategoryTranslationByLanguageId($category, $languageId);
-
-            return $currentTranslation?->getSlotConfig() ?? [];
-        }, $languageMergeOrder);
+        return $this->cmsSlotConfigInheritanceBuilder->build(
+            $category->getTranslations(),
+            $context,
+        );
     }
 }

--- a/src/Core/Content/Cms/Service/EntityCmsSlotConfigInheritanceBuilder.php
+++ b/src/Core/Content/Cms/Service/EntityCmsSlotConfigInheritanceBuilder.php
@@ -4,6 +4,7 @@ namespace Shopware\Core\Content\Cms\Service;
 
 use Doctrine\DBAL\Connection;
 use Shopware\Core\Content\Category\Aggregate\CategoryTranslation\CategoryTranslationEntity;
+use Shopware\Core\Content\LandingPage\Aggregate\LandingPageTranslation\LandingPageTranslationEntity;
 use Shopware\Core\Content\Product\Aggregate\ProductTranslation\ProductTranslationEntity;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
 use Shopware\Core\Framework\Log\Package;
@@ -22,7 +23,7 @@ readonly class EntityCmsSlotConfigInheritanceBuilder
     }
 
     /**
-     * @template TTranslation of CategoryTranslationEntity|ProductTranslationEntity
+     * @template TTranslation of CategoryTranslationEntity|LandingPageTranslationEntity|ProductTranslationEntity
      *
      * @param EntityCollection<TTranslation>|null $translations
      *
@@ -44,7 +45,7 @@ readonly class EntityCmsSlotConfigInheritanceBuilder
     }
 
     /**
-     * @template TTranslation of CategoryTranslationEntity|ProductTranslationEntity
+     * @template TTranslation of CategoryTranslationEntity|LandingPageTranslationEntity|ProductTranslationEntity
      *
      * @param EntityCollection<TTranslation>|null $translations
      *

--- a/src/Core/Content/Cms/Service/EntityCmsSlotConfigInheritanceBuilder.php
+++ b/src/Core/Content/Cms/Service/EntityCmsSlotConfigInheritanceBuilder.php
@@ -1,0 +1,118 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Content\Cms\Service;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Content\Category\Aggregate\CategoryTranslation\CategoryTranslationEntity;
+use Shopware\Core\Content\Product\Aggregate\ProductTranslation\ProductTranslationEntity;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
+
+#[Package('discovery')]
+readonly class EntityCmsSlotConfigInheritanceBuilder
+{
+    /**
+     * @internal
+     */
+    public function __construct(
+        private Connection $connection,
+    ) {
+    }
+
+    /**
+     * @template TTranslation of CategoryTranslationEntity|ProductTranslationEntity
+     *
+     * @param EntityCollection<TTranslation>|null $translations
+     *
+     * @return array<string, array<string, mixed>>|null
+     */
+    public function build(?EntityCollection $translations, SalesChannelContext $context): ?array
+    {
+        $slotConfigs = $this->collectSlotConfigs($translations);
+        $languageInheritanceChain = $this->getLanguageInheritanceChain($context);
+
+        $result = [];
+        foreach ($languageInheritanceChain as $currentLanguageId) {
+            $result[] = $slotConfigs[$currentLanguageId] ?? [];
+        }
+
+        $merged = \array_merge(...$result);
+
+        return $merged !== [] ? $merged : null;
+    }
+
+    /**
+     * @template TTranslation of CategoryTranslationEntity|ProductTranslationEntity
+     *
+     * @param EntityCollection<TTranslation>|null $translations
+     *
+     * @return array<string, array<string, array<string, mixed>>>
+     */
+    private function collectSlotConfigs(?EntityCollection $translations): array
+    {
+        if ($translations === null) {
+            return [];
+        }
+
+        $slotConfigs = [];
+        foreach ($translations as $translation) {
+            $slotConfig = $translation->getSlotConfig();
+            if ($slotConfig === null) {
+                continue;
+            }
+
+            $slotConfigs[$translation->getLanguageId()] = $slotConfig;
+        }
+
+        return $slotConfigs;
+    }
+
+    /**
+     * @return non-empty-list<string>
+     */
+    private function getLanguageInheritanceChain(SalesChannelContext $context): array
+    {
+        $languageId = $context->getLanguageId();
+
+        return [
+            ...$this->getParentLanguageInheritanceChain($languageId),
+            $languageId,
+        ];
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function getParentLanguageInheritanceChain(string $languageId): array
+    {
+        $parentLanguageId = $this->getParentLanguageId($languageId);
+
+        if ($parentLanguageId === null) {
+            return [];
+        }
+
+        return [
+            ...$this->getParentLanguageInheritanceChain($parentLanguageId),
+            $parentLanguageId,
+        ];
+    }
+
+    private function getParentLanguageId(string $languageId): ?string
+    {
+        $parentId = $this->connection->createQueryBuilder()
+            ->select('LOWER(HEX(language.parent_id))')
+            ->from('language', 'language')
+            ->where('language.id = :id')
+            ->setParameter('id', Uuid::fromHexToBytes($languageId))
+            ->executeQuery()
+            ->fetchOne();
+
+        if ($parentId === false) {
+            return null;
+        }
+
+        return $parentId;
+    }
+}

--- a/src/Core/Content/DependencyInjection/category.xml
+++ b/src/Core/Content/DependencyInjection/category.xml
@@ -56,6 +56,7 @@
         <service id="Shopware\Core\Content\Category\SalesChannel\CategoryRoute" public="true">
             <argument type="service" id="sales_channel.category.repository"/>
             <argument type="service" id="Shopware\Core\Content\Cms\SalesChannel\SalesChannelCmsPageLoader"/>
+            <argument type="service" id="Shopware\Core\Content\Cms\Service\EntityCmsSlotConfigInheritanceBuilder"/>
             <argument type="service" id="Shopware\Core\Content\Category\SalesChannel\SalesChannelCategoryDefinition"/>
             <argument type="service" id="Shopware\Core\Framework\Adapter\Cache\CacheTagCollector"/>
         </service>

--- a/src/Core/Content/DependencyInjection/cms.xml
+++ b/src/Core/Content/DependencyInjection/cms.xml
@@ -64,6 +64,10 @@
             <argument type="service" id="Shopware\Core\Framework\Adapter\Cache\CacheTagCollector"/>
         </service>
 
+        <service id="Shopware\Core\Content\Cms\Service\EntityCmsSlotConfigInheritanceBuilder">
+            <argument type="service" id="Doctrine\DBAL\Connection"/>
+        </service>
+
         <service id="Shopware\Core\Content\Cms\SalesChannel\CmsRoute" public="true">
             <argument type="service" id="Shopware\Core\Content\Cms\SalesChannel\SalesChannelCmsPageLoader"/>
         </service>

--- a/src/Core/Content/DependencyInjection/landing_page.xml
+++ b/src/Core/Content/DependencyInjection/landing_page.xml
@@ -35,6 +35,7 @@
         <service id="Shopware\Core\Content\LandingPage\SalesChannel\LandingPageRoute" public="true">
             <argument type="service" id="sales_channel.landing_page.repository"/>
             <argument type="service" id="Shopware\Core\Content\Cms\SalesChannel\SalesChannelCmsPageLoader"/>
+            <argument type="service" id="Shopware\Core\Content\Cms\Service\EntityCmsSlotConfigInheritanceBuilder"/>
             <argument type="service" id="Shopware\Core\Content\LandingPage\SalesChannel\SalesChannelLandingPageDefinition"/>
             <argument type="service" id="Shopware\Core\Framework\Adapter\Cache\CacheTagCollector"/>
         </service>

--- a/src/Core/Content/DependencyInjection/product.xml
+++ b/src/Core/Content/DependencyInjection/product.xml
@@ -505,6 +505,7 @@
             <argument type="service" id="Shopware\Core\Content\Product\SalesChannel\Detail\ProductConfiguratorLoader"/>
             <argument type="service" id="Shopware\Core\Content\Category\Service\CategoryBreadcrumbBuilder"/>
             <argument type="service" id="Shopware\Core\Content\Cms\SalesChannel\SalesChannelCmsPageLoader"/>
+            <argument type="service" id="Shopware\Core\Content\Cms\Service\EntityCmsSlotConfigInheritanceBuilder"/>
             <argument type="service" id="Shopware\Core\Content\Product\SalesChannel\SalesChannelProductDefinition"/>
             <argument type="service" id="Shopware\Core\Content\Product\SalesChannel\ProductCloseoutFilterFactory"/>
             <argument type="service" id="event_dispatcher"/>

--- a/src/Core/Content/DependencyInjection/product.xml
+++ b/src/Core/Content/DependencyInjection/product.xml
@@ -500,6 +500,7 @@
 
         <service id="Shopware\Core\Content\Product\SalesChannel\Detail\ProductDetailRoute" public="true">
             <argument type="service" id="sales_channel.product.repository"/>
+            <argument type="service" id="product_translation.repository"/>
             <argument type="service" id="Shopware\Core\System\SystemConfig\SystemConfigService"/>
             <argument type="service" id="Doctrine\DBAL\Connection"/>
             <argument type="service" id="Shopware\Core\Content\Product\SalesChannel\Detail\ProductConfiguratorLoader"/>

--- a/src/Core/Content/LandingPage/SalesChannel/LandingPageRoute.php
+++ b/src/Core/Content/LandingPage/SalesChannel/LandingPageRoute.php
@@ -4,6 +4,7 @@ namespace Shopware\Core\Content\LandingPage\SalesChannel;
 
 use Shopware\Core\Content\Cms\DataResolver\ResolverContext\EntityResolverContext;
 use Shopware\Core\Content\Cms\SalesChannel\SalesChannelCmsPageLoaderInterface;
+use Shopware\Core\Content\Cms\Service\EntityCmsSlotConfigInheritanceBuilder;
 use Shopware\Core\Content\LandingPage\LandingPageCollection;
 use Shopware\Core\Content\LandingPage\LandingPageDefinition;
 use Shopware\Core\Content\LandingPage\LandingPageEntity;
@@ -34,6 +35,7 @@ class LandingPageRoute extends AbstractLandingPageRoute
     public function __construct(
         private readonly SalesChannelRepository $landingPageRepository,
         private readonly SalesChannelCmsPageLoaderInterface $cmsPageLoader,
+        private readonly EntityCmsSlotConfigInheritanceBuilder $cmsSlotConfigInheritanceBuilder,
         private readonly LandingPageDefinition $landingPageDefinition,
         private readonly CacheTagCollector $cacheTagCollector,
     ) {
@@ -73,7 +75,7 @@ class LandingPageRoute extends AbstractLandingPageRoute
             $request,
             $this->createCriteria($pageId, $request),
             $context,
-            $landingPage->getTranslation('slotConfig'),
+            $this->buildMergedCmsSlotConfig($landingPage, $context),
             $resolverContext
         );
 
@@ -94,6 +96,7 @@ class LandingPageRoute extends AbstractLandingPageRoute
 
         $criteria->addFilter(new EqualsFilter('active', true));
         $criteria->addFilter(new EqualsFilter('salesChannels.id', $context->getSalesChannelId()));
+        $criteria->addAssociation('translations');
 
         $landingPage = $this->landingPageRepository->search($criteria, $context)->getEntities()->get($landingPageId);
         if (!$landingPage instanceof LandingPageEntity) {
@@ -121,5 +124,16 @@ class LandingPageRoute extends AbstractLandingPageRoute
         }
 
         return $criteria;
+    }
+
+    /**
+     * @return array<string, array<string, mixed>>|null
+     */
+    private function buildMergedCmsSlotConfig(LandingPageEntity $landingPage, SalesChannelContext $context): ?array
+    {
+        return $this->cmsSlotConfigInheritanceBuilder->build(
+            $landingPage->getTranslations(),
+            $context,
+        );
     }
 }

--- a/src/Core/Content/Product/SalesChannel/Detail/ProductDetailRoute.php
+++ b/src/Core/Content/Product/SalesChannel/Detail/ProductDetailRoute.php
@@ -6,6 +6,7 @@ use Doctrine\DBAL\Connection;
 use Shopware\Core\Content\Category\Service\CategoryBreadcrumbBuilder;
 use Shopware\Core\Content\Cms\DataResolver\ResolverContext\EntityResolverContext;
 use Shopware\Core\Content\Cms\SalesChannel\SalesChannelCmsPageLoaderInterface;
+use Shopware\Core\Content\Cms\Service\EntityCmsSlotConfigInheritanceBuilder;
 use Shopware\Core\Content\Product\Aggregate\ProductVisibility\ProductVisibilityDefinition;
 use Shopware\Core\Content\Product\ProductDefinition;
 use Shopware\Core\Content\Product\ProductException;
@@ -55,6 +56,7 @@ class ProductDetailRoute extends AbstractProductDetailRoute
         private readonly ProductConfiguratorLoader $configuratorLoader,
         private readonly CategoryBreadcrumbBuilder $breadcrumbBuilder,
         private readonly SalesChannelCmsPageLoaderInterface $cmsPageLoader,
+        private readonly EntityCmsSlotConfigInheritanceBuilder $cmsSlotConfigInheritanceBuilder,
         private readonly SalesChannelProductDefinition $productDefinition,
         private readonly AbstractProductCloseoutFilterFactory $productCloseoutFilterFactory,
         private readonly EventDispatcherInterface $dispatcher,
@@ -106,6 +108,7 @@ class ProductDetailRoute extends AbstractProductDetailRoute
 
             $criteria->setIds([$productId]);
             $criteria->setTitle('product-detail-route');
+            $criteria->addAssociation('translations');
 
             $loadCmsPage = !$request->query->getBoolean(self::SKIP_CMS_PAGE);
             $product = $this->productRepository->search($criteria, $context)->getEntities()->first();
@@ -133,7 +136,7 @@ class ProductDetailRoute extends AbstractProductDetailRoute
                     $request,
                     $this->createCriteria($pageId, $request),
                     $context,
-                    $product->getTranslation('slotConfig'),
+                    $this->buildMergedCmsSlotConfig($product, $context),
                     $resolverContext
                 );
 
@@ -162,6 +165,17 @@ class ProductDetailRoute extends AbstractProductDetailRoute
             $filter->addQuery(new EqualsFilter('product.parentId', null));
             $criteria->addFilter($filter);
         }
+    }
+
+    /**
+     * @return array<string, array<string, mixed>>|null
+     */
+    private function buildMergedCmsSlotConfig(SalesChannelProductEntity $product, SalesChannelContext $context): ?array
+    {
+        return $this->cmsSlotConfigInheritanceBuilder->build(
+            $product->getTranslations(),
+            $context,
+        );
     }
 
     private function checkVariantListingConfig(string $productId, SalesChannelContext $context): ?string

--- a/src/Core/Content/Product/SalesChannel/Detail/ProductDetailRoute.php
+++ b/src/Core/Content/Product/SalesChannel/Detail/ProductDetailRoute.php
@@ -7,6 +7,7 @@ use Shopware\Core\Content\Category\Service\CategoryBreadcrumbBuilder;
 use Shopware\Core\Content\Cms\DataResolver\ResolverContext\EntityResolverContext;
 use Shopware\Core\Content\Cms\SalesChannel\SalesChannelCmsPageLoaderInterface;
 use Shopware\Core\Content\Cms\Service\EntityCmsSlotConfigInheritanceBuilder;
+use Shopware\Core\Content\Product\Aggregate\ProductTranslation\ProductTranslationCollection;
 use Shopware\Core\Content\Product\Aggregate\ProductVisibility\ProductVisibilityDefinition;
 use Shopware\Core\Content\Product\ProductDefinition;
 use Shopware\Core\Content\Product\ProductException;
@@ -19,6 +20,7 @@ use Shopware\Core\Content\Product\SalesChannel\SalesChannelProductEntity;
 use Shopware\Core\Framework\Adapter\Cache\CacheTagCollector;
 use Shopware\Core\Framework\Adapter\Request\RequestParamHelper;
 use Shopware\Core\Framework\DataAbstractionLayer\Cache\EntityCacheKeyGenerator;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Exception\InconsistentCriteriaIdsException;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsAnyFilter;
@@ -48,9 +50,11 @@ class ProductDetailRoute extends AbstractProductDetailRoute
      * @internal
      *
      * @param SalesChannelRepository<SalesChannelProductCollection> $productRepository
+     * @param EntityRepository<ProductTranslationCollection> $productTranslationRepository
      */
     public function __construct(
         private readonly SalesChannelRepository $productRepository,
+        private readonly EntityRepository $productTranslationRepository,
         private readonly SystemConfigService $config,
         private readonly Connection $connection,
         private readonly ProductConfiguratorLoader $configuratorLoader,
@@ -108,7 +112,6 @@ class ProductDetailRoute extends AbstractProductDetailRoute
 
             $criteria->setIds([$productId]);
             $criteria->setTitle('product-detail-route');
-            $criteria->addAssociation('translations');
 
             $loadCmsPage = !$request->query->getBoolean(self::SKIP_CMS_PAGE);
             $product = $this->productRepository->search($criteria, $context)->getEntities()->first();
@@ -129,6 +132,8 @@ class ProductDetailRoute extends AbstractProductDetailRoute
 
             $pageId = $product->getCmsPageId();
             if ($loadCmsPage && $pageId) {
+                $slotConfig = $this->buildMergedCmsSlotConfig($product, $context);
+
                 // clone product to prevent recursion encoding (see NEXT-17603)
                 $resolverContext = new EntityResolverContext($context, $request, $this->productDefinition, clone $product);
 
@@ -136,7 +141,7 @@ class ProductDetailRoute extends AbstractProductDetailRoute
                     $request,
                     $this->createCriteria($pageId, $request),
                     $context,
-                    $this->buildMergedCmsSlotConfig($product, $context),
+                    $slotConfig,
                     $resolverContext
                 );
 
@@ -173,9 +178,25 @@ class ProductDetailRoute extends AbstractProductDetailRoute
     private function buildMergedCmsSlotConfig(SalesChannelProductEntity $product, SalesChannelContext $context): ?array
     {
         return $this->cmsSlotConfigInheritanceBuilder->build(
-            $product->getTranslations(),
+            $this->loadProductTranslations($product->getId(), $context),
             $context,
         );
+    }
+
+    private function loadProductTranslations(string $productId, SalesChannelContext $context): ?ProductTranslationCollection
+    {
+        $criteria = new Criteria();
+        $criteria->addFilter(new EqualsFilter('productId', $productId));
+        $criteria->addFilter(new EqualsFilter('productVersionId', $context->getVersionId()));
+
+        /** @var ProductTranslationCollection $translations */
+        $translations = $this->productTranslationRepository->search($criteria, $context->getContext())->getEntities();
+
+        if ($translations->count() === 0) {
+            return null;
+        }
+
+        return $translations;
     }
 
     private function checkVariantListingConfig(string $productId, SalesChannelContext $context): ?string

--- a/src/Core/Content/Product/SalesChannel/Detail/ProductDetailRoute.php
+++ b/src/Core/Content/Product/SalesChannel/Detail/ProductDetailRoute.php
@@ -191,7 +191,6 @@ class ProductDetailRoute extends AbstractProductDetailRoute
         $criteria->addFilter(new EqualsAnyFilter('productId', $productIds));
         $criteria->addFilter(new EqualsFilter('productVersionId', $context->getVersionId()));
 
-        /** @var ProductTranslationCollection $translations */
         $translations = $this->productTranslationRepository->search($criteria, $context->getContext())->getEntities();
 
         if ($translations->count() === 0) {

--- a/src/Core/Content/Product/SalesChannel/Detail/ProductDetailRoute.php
+++ b/src/Core/Content/Product/SalesChannel/Detail/ProductDetailRoute.php
@@ -178,15 +178,17 @@ class ProductDetailRoute extends AbstractProductDetailRoute
     private function buildMergedCmsSlotConfig(SalesChannelProductEntity $product, SalesChannelContext $context): ?array
     {
         return $this->cmsSlotConfigInheritanceBuilder->build(
-            $this->loadProductTranslations($product->getId(), $context),
+            $this->loadProductTranslations($product, $context),
             $context,
         );
     }
 
-    private function loadProductTranslations(string $productId, SalesChannelContext $context): ?ProductTranslationCollection
+    private function loadProductTranslations(SalesChannelProductEntity $product, SalesChannelContext $context): ?ProductTranslationCollection
     {
+        $productIds = array_filter([$product->getParentId(), $product->getId()]);
+
         $criteria = new Criteria();
-        $criteria->addFilter(new EqualsFilter('productId', $productId));
+        $criteria->addFilter(new EqualsAnyFilter('productId', $productIds));
         $criteria->addFilter(new EqualsFilter('productVersionId', $context->getVersionId()));
 
         /** @var ProductTranslationCollection $translations */
@@ -196,7 +198,33 @@ class ProductDetailRoute extends AbstractProductDetailRoute
             return null;
         }
 
-        return $translations;
+        return $this->buildInheritedProductTranslations($translations, $product);
+    }
+
+    private function buildInheritedProductTranslations(ProductTranslationCollection $translations, SalesChannelProductEntity $product): ProductTranslationCollection
+    {
+        $effectiveTranslations = [];
+        $parentId = $product->getParentId();
+
+        foreach ($translations as $translation) {
+            if ($translation->getSlotConfig() === null) {
+                continue;
+            }
+
+            $languageId = $translation->getLanguageId();
+
+            if ($translation->getProductId() === $parentId) {
+                $effectiveTranslations[$languageId] ??= $translation;
+
+                continue;
+            }
+
+            if ($translation->getProductId() === $product->getId()) {
+                $effectiveTranslations[$languageId] = $translation;
+            }
+        }
+
+        return new ProductTranslationCollection(array_values($effectiveTranslations));
     }
 
     private function checkVariantListingConfig(string $productId, SalesChannelContext $context): ?string

--- a/tests/integration/Core/Content/Category/SalesChannel/CategoryRouteTest.php
+++ b/tests/integration/Core/Content/Category/SalesChannel/CategoryRouteTest.php
@@ -181,7 +181,7 @@ class CategoryRouteTest extends TestCase
      *  - EN is System Default language
      *  - DE is without parent
      *  - AT inherits from DE
-     *  Expected hierarchy: Overrides of categories (AT > DE > EN) > Templates of categories (AT > DE > EN)
+     *  Expected hierarchy: Category overrides via explicit parents only (AT > DE), then templates via normal fallback (AT > DE > EN)
      *
      * @param CmsInheritanceDataProviderActual $actual
      */

--- a/tests/integration/Core/Content/Category/SalesChannel/fixtures/CategoryRouteInheritanceFixtures.php
+++ b/tests/integration/Core/Content/Category/SalesChannel/fixtures/CategoryRouteInheritanceFixtures.php
@@ -245,7 +245,7 @@ final class CategoryRouteInheritanceFixtures
                     'en', 'at',
                 ],
             ],
-            'expected' => 'en Override',
+            'expected' => 'de Template',
         ];
         yield 'AT Storefront, DE templates, EN/AT overrides' => [
             'actual' => [
@@ -324,7 +324,7 @@ final class CategoryRouteInheritanceFixtures
                     'en',
                 ],
             ],
-            'expected' => 'en Override',
+            'expected' => 'de Template',
         ];
         yield 'AT Storefront, EN/DE templates, EN overrides' => [
             'actual' => [
@@ -336,7 +336,7 @@ final class CategoryRouteInheritanceFixtures
                     'en',
                 ],
             ],
-            'expected' => 'en Override',
+            'expected' => 'de Template',
         ];
         yield 'AT Storefront, EN/AT templates, EN overrides' => [
             'actual' => [
@@ -348,7 +348,7 @@ final class CategoryRouteInheritanceFixtures
                     'en',
                 ],
             ],
-            'expected' => 'en Override',
+            'expected' => 'at Template',
         ];
         yield 'AT Storefront, EN/DE/AT templates, EN overrides' => [
             'actual' => [
@@ -360,7 +360,7 @@ final class CategoryRouteInheritanceFixtures
                     'en',
                 ],
             ],
-            'expected' => 'en Override',
+            'expected' => 'at Template',
         ];
     }
 

--- a/tests/integration/Core/Content/LandingPage/SalesChannel/LandingPageRouteTest.php
+++ b/tests/integration/Core/Content/LandingPage/SalesChannel/LandingPageRouteTest.php
@@ -6,13 +6,18 @@ use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Cms\CmsPageCollection;
 use Shopware\Core\Content\LandingPage\LandingPageCollection;
+use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\SalesChannelApiTestBehaviour;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\System\SalesChannel\Context\SalesChannelContextFactory;
+use Shopware\Core\System\SalesChannel\Context\SalesChannelContextService;
 use Shopware\Core\Test\Stub\Framework\IdsCollection;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Component\HttpFoundation\Request;
 
 /**
  * @internal
@@ -23,6 +28,11 @@ class LandingPageRouteTest extends TestCase
 {
     use IntegrationTestBehaviour;
     use SalesChannelApiTestBehaviour;
+
+    private const LANGUAGE_IDS = [
+        'en' => '2fbb5fe2e29a4d70aa5854ce7ce3e20b',
+        'de' => '0f4ac850f69643cfb03d8d6ea5dc2647',
+    ];
 
     private KernelBrowser $browser;
 
@@ -67,6 +77,102 @@ class LandingPageRouteTest extends TestCase
         static::assertSame(200, $this->browser->getResponse()->getStatusCode());
         static::assertSame($this->ids->get('landing-page'), $response['id']);
         static::assertArrayHasKey('cmsPage', $response);
+    }
+
+    public function testLoadLandingPageCmsSlotConfigFromParentLanguageOverride(): void
+    {
+        $this->createLanguages();
+
+        $slotId = $this->ids->create('translated-slot');
+        $landingPageId = $this->ids->create('translated-landing-page');
+
+        /** @var EntityRepository<CmsPageCollection> $cmsPageRepository */
+        $cmsPageRepository = static::getContainer()->get('cms_page.repository');
+        /** @var EntityRepository<LandingPageCollection> $landingPageRepository */
+        $landingPageRepository = static::getContainer()->get('landing_page.repository');
+
+        $cmsPageId = $this->ids->create('translated-cms-page');
+        $cmsPageRepository->create([[
+            'id' => $cmsPageId,
+            'name' => 'translated landing page',
+            'type' => 'landingpage',
+            'sections' => [[
+                'id' => $this->ids->create('translated-section'),
+                'type' => 'default',
+                'position' => 0,
+                'blocks' => [[
+                    'type' => 'text',
+                    'position' => 0,
+                    'slots' => [[
+                        'id' => $slotId,
+                        'type' => 'text',
+                        'slot' => 'content',
+                        'config' => [
+                            'content' => [
+                                'source' => 'static',
+                                'value' => 'layout placeholder',
+                            ],
+                        ],
+                    ]],
+                ]],
+            ]],
+        ]], Context::createDefaultContext());
+
+        $landingPageRepository->create([[
+            'id' => $landingPageId,
+            'name' => 'Translated landing page',
+            'url' => 'translated-landing-page',
+            'active' => true,
+            'cmsPageId' => $cmsPageId,
+            'salesChannels' => [[
+                'id' => $this->ids->get('sales-channel'),
+            ]],
+            'slotConfig' => [
+                $slotId => [
+                    'content' => [
+                        'source' => 'static',
+                        'value' => 'default language override',
+                    ],
+                ],
+            ],
+        ]], Context::createDefaultContext());
+
+        $this->browser = $this->createCustomSalesChannelBrowser([
+            'id' => $this->ids->get('sales-channel'),
+            'languageId' => self::LANGUAGE_IDS['de'],
+            'languages' => [
+                ['id' => self::LANGUAGE_IDS['en']],
+                ['id' => self::LANGUAGE_IDS['de']],
+            ],
+            'domains' => [[
+                'languageId' => self::LANGUAGE_IDS['de'],
+                'currencyId' => Defaults::CURRENCY,
+                'snippetSetId' => $this->getSnippetSetIdForLocale('en-GB'),
+                'url' => 'http://localhost/de-test',
+            ]],
+        ]);
+
+        $this->browser->request('GET', '/store-api/context');
+        $contextResponse = json_decode((string) $this->browser->getResponse()->getContent(), true, 512, \JSON_THROW_ON_ERROR);
+        $salesChannelContext = static::getContainer()->get(SalesChannelContextFactory::class)->create(
+            $contextResponse['token'],
+            $this->ids->get('sales-channel'),
+            [SalesChannelContextService::LANGUAGE_ID => self::LANGUAGE_IDS['de']],
+        );
+
+        $response = static::getContainer()->get(\Shopware\Core\Content\LandingPage\SalesChannel\LandingPageRoute::class)->load(
+            $landingPageId,
+            new Request(),
+            $salesChannelContext,
+        );
+
+        $slot = $response->getLandingPage()
+            ->getCmsPage()?->getSections()?->first()?->getBlocks()?->first()?->getSlots()?->first();
+
+        static::assertSame(
+            'default language override',
+            $slot?->getConfig()['content']['value'] ?? null
+        );
     }
 
     private function createData(): void
@@ -120,5 +226,37 @@ class LandingPageRouteTest extends TestCase
                 ],
             ],
         ], $context);
+    }
+
+    private function createLanguages(): void
+    {
+        static::getContainer()->get('language.repository')->upsert([
+            [
+                'id' => self::LANGUAGE_IDS['en'],
+                'name' => 'English',
+                'localeId' => $this->getLocaleId('en-GB'),
+                'translationCodeId' => $this->getLocaleId('en-GB'),
+            ],
+            [
+                'id' => self::LANGUAGE_IDS['de'],
+                'name' => 'German',
+                'localeId' => $this->getLocaleId('de-DE'),
+                'translationCodeId' => $this->getLocaleId('de-DE'),
+                'parentId' => self::LANGUAGE_IDS['en'],
+            ],
+        ], Context::createDefaultContext());
+    }
+
+    private function getLocaleId(string $code): string
+    {
+        $localeId = static::getContainer()->get(\Doctrine\DBAL\Connection::class)->fetchOne(
+            'SELECT LOWER(HEX(id)) FROM locale WHERE code = :code',
+            ['code' => $code],
+        );
+
+        static::assertIsString($localeId);
+        static::assertTrue(Uuid::isValid($localeId));
+
+        return $localeId;
     }
 }

--- a/tests/integration/Core/Content/Product/SalesChannel/Detail/ProductDetailRouteTest.php
+++ b/tests/integration/Core/Content/Product/SalesChannel/Detail/ProductDetailRouteTest.php
@@ -5,13 +5,18 @@ namespace Shopware\Tests\Integration\Core\Content\Product\SalesChannel\Detail;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Product\Aggregate\ProductVisibility\ProductVisibilityDefinition;
+use Shopware\Core\Content\Product\SalesChannel\Detail\ProductDetailRoute;
 use Shopware\Core\Content\Test\Product\ProductBuilder;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\SalesChannelApiTestBehaviour;
+use Shopware\Core\System\SalesChannel\Context\SalesChannelContextFactory;
+use Shopware\Core\System\SalesChannel\Context\SalesChannelContextService;
 use Shopware\Core\Test\Stub\Framework\IdsCollection;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
@@ -411,15 +416,35 @@ class ProductDetailRouteTest extends TestCase
                 ['id' => self::LANGUAGE_IDS['en']],
                 ['id' => self::LANGUAGE_IDS['de']],
             ],
+            'domains' => [[
+                'languageId' => self::LANGUAGE_IDS['de'],
+                'currencyId' => Defaults::CURRENCY,
+                'snippetSetId' => $this->getSnippetSetIdForLocale('en-GB'),
+                'url' => 'http://localhost/de-test',
+            ]],
         ]);
 
-        $this->browser->request('POST', $this->getUrl($this->ids->get('translated-product')));
+        $this->browser->request('GET', '/store-api/context');
+        $contextResponse = json_decode((string) $this->browser->getResponse()->getContent(), true, 512, \JSON_THROW_ON_ERROR);
+        $salesChannelContext = static::getContainer()->get(SalesChannelContextFactory::class)->create(
+            $contextResponse['token'],
+            $this->ids->get('sales-channel'),
+            [SalesChannelContextService::LANGUAGE_ID => self::LANGUAGE_IDS['de']],
+        );
 
-        $response = json_decode((string) $this->browser->getResponse()->getContent(), true, 512, \JSON_THROW_ON_ERROR);
+        $response = static::getContainer()->get(ProductDetailRoute::class)->load(
+            $this->ids->get('translated-product'),
+            new Request(),
+            $salesChannelContext,
+            new Criteria(),
+        );
+
+        $slot = $response->getProduct()
+            ->getCmsPage()?->getSections()?->first()?->getBlocks()?->first()?->getSlots()?->first();
 
         static::assertSame(
             'default language override',
-            $response['product']['cmsPage']['sections'][0]['blocks'][0]['slots'][0]['config']['content']['value']
+            $slot?->getConfig()['content']['value'] ?? null
         );
     }
 

--- a/tests/integration/Core/Content/Product/SalesChannel/Detail/ProductDetailRouteTest.php
+++ b/tests/integration/Core/Content/Product/SalesChannel/Detail/ProductDetailRouteTest.php
@@ -4,7 +4,9 @@ namespace Shopware\Tests\Integration\Core\Content\Product\SalesChannel\Detail;
 
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Product\Aggregate\ProductVisibility\ProductVisibilityDefinition;
 use Shopware\Core\Content\Test\Product\ProductBuilder;
+use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\SalesChannelApiTestBehaviour;
@@ -20,6 +22,11 @@ class ProductDetailRouteTest extends TestCase
 {
     use IntegrationTestBehaviour;
     use SalesChannelApiTestBehaviour;
+
+    private const LANGUAGE_IDS = [
+        'en' => Defaults::LANGUAGE_SYSTEM,
+        'de' => '20354d7ae4fe47af8ff6187bc0dedede',
+    ];
 
     private KernelBrowser $browser;
 
@@ -343,6 +350,79 @@ class ProductDetailRouteTest extends TestCase
         $this->assertArray($expected, $response);
     }
 
+    public function testLoadProductCmsSlotConfigFromParentLanguageOverride(): void
+    {
+        $context = Context::createDefaultContext();
+        $this->createLanguages($context);
+
+        $slotId = $this->ids->create('translated-slot');
+        static::getContainer()->get('product.repository')->create([[
+            'id' => $this->ids->create('translated-product'),
+            'name' => 'Translated product',
+            'productNumber' => 'translated-product',
+            'stock' => 10,
+            'active' => true,
+            'price' => [
+                ['currencyId' => Defaults::CURRENCY, 'gross' => 15, 'net' => 10, 'linked' => false],
+            ],
+            'tax' => ['name' => 'tax', 'taxRate' => 15],
+            'visibilities' => [
+                ['salesChannelId' => $this->ids->get('sales-channel'), 'visibility' => ProductVisibilityDefinition::VISIBILITY_ALL],
+            ],
+            'cmsPage' => [
+                'id' => $this->ids->create('translated-product-cms-page'),
+                'type' => 'product_detail',
+                'sections' => [[
+                    'id' => $this->ids->create('translated-section'),
+                    'type' => 'default',
+                    'position' => 0,
+                    'blocks' => [[
+                        'id' => $this->ids->create('translated-block'),
+                        'type' => 'text',
+                        'position' => 0,
+                        'slots' => [[
+                            'id' => $slotId,
+                            'type' => 'text',
+                            'slot' => 'content',
+                            'config' => [
+                                'content' => [
+                                    'source' => 'static',
+                                    'value' => 'layout placeholder',
+                                ],
+                            ],
+                        ]],
+                    ]],
+                ]],
+            ],
+            'slotConfig' => [
+                $slotId => [
+                    'content' => [
+                        'source' => 'static',
+                        'value' => 'default language override',
+                    ],
+                ],
+            ],
+        ]], $context);
+
+        $this->browser = $this->createCustomSalesChannelBrowser([
+            'id' => $this->ids->get('sales-channel'),
+            'languageId' => self::LANGUAGE_IDS['de'],
+            'languages' => [
+                ['id' => self::LANGUAGE_IDS['en']],
+                ['id' => self::LANGUAGE_IDS['de']],
+            ],
+        ]);
+
+        $this->browser->request('POST', $this->getUrl($this->ids->get('translated-product')));
+
+        $response = json_decode((string) $this->browser->getResponse()->getContent(), true, 512, \JSON_THROW_ON_ERROR);
+
+        static::assertSame(
+            'default language override',
+            $response['product']['cmsPage']['sections'][0]['blocks'][0]['slots'][0]['config']['content']['value']
+        );
+    }
+
     /**
      * @param array<string, string> $expected
      * @param array<string, string> $actual
@@ -391,6 +471,23 @@ class ProductDetailRouteTest extends TestCase
 
         static::getContainer()->get('product.repository')
             ->create($products, Context::createDefaultContext());
+    }
+
+    private function createLanguages(Context $context): void
+    {
+        static::getContainer()->get('language.repository')->create([[
+            'id' => self::LANGUAGE_IDS['de'],
+            'name' => 'TestGerman',
+            'parentId' => self::LANGUAGE_IDS['en'],
+            'active' => true,
+            'locale' => [
+                'id' => $this->ids->create('locale-de'),
+                'name' => 'TestGerman',
+                'territory' => 'TestGermany',
+                'code' => 'de-DE-test',
+            ],
+            'translationCodeId' => $this->ids->get('locale-de'),
+        ]], $context);
     }
 
     /**

--- a/tests/integration/Core/Content/Product/SalesChannel/Detail/ProductDetailRouteTest.php
+++ b/tests/integration/Core/Content/Product/SalesChannel/Detail/ProductDetailRouteTest.php
@@ -448,6 +448,115 @@ class ProductDetailRouteTest extends TestCase
         );
     }
 
+    public function testLoadInheritedProductCmsSlotConfigFromParentProductLanguageOverride(): void
+    {
+        $context = Context::createDefaultContext();
+        $this->createLanguages($context);
+
+        $slotId = $this->ids->create('translated-parent-slot');
+        $parentProductId = $this->ids->create('translated-parent-product');
+        $variantProductId = $this->ids->create('translated-variant-product');
+
+        static::getContainer()->get('product.repository')->create([[
+            'id' => $parentProductId,
+            'name' => 'Translated parent product',
+            'productNumber' => 'translated-parent-product',
+            'stock' => 10,
+            'active' => true,
+            'price' => [
+                ['currencyId' => Defaults::CURRENCY, 'gross' => 15, 'net' => 10, 'linked' => false],
+            ],
+            'tax' => ['name' => 'tax', 'taxRate' => 15],
+            'visibilities' => [
+                ['salesChannelId' => $this->ids->get('sales-channel'), 'visibility' => ProductVisibilityDefinition::VISIBILITY_ALL],
+            ],
+            'cmsPage' => [
+                'id' => $this->ids->create('translated-parent-product-cms-page'),
+                'type' => 'product_detail',
+                'sections' => [[
+                    'id' => $this->ids->create('translated-parent-section'),
+                    'type' => 'default',
+                    'position' => 0,
+                    'blocks' => [[
+                        'id' => $this->ids->create('translated-parent-block'),
+                        'type' => 'text',
+                        'position' => 0,
+                        'slots' => [[
+                            'id' => $slotId,
+                            'type' => 'text',
+                            'slot' => 'content',
+                            'config' => [
+                                'content' => [
+                                    'source' => 'static',
+                                    'value' => 'layout placeholder',
+                                ],
+                            ],
+                        ]],
+                    ]],
+                ]],
+            ],
+            'slotConfig' => [
+                $slotId => [
+                    'content' => [
+                        'source' => 'static',
+                        'value' => 'default language override',
+                    ],
+                ],
+            ],
+            'children' => [[
+                'id' => $variantProductId,
+                'productNumber' => 'translated-variant-product',
+                'stock' => 10,
+                'active' => true,
+                'options' => [],
+                'price' => [
+                    ['currencyId' => Defaults::CURRENCY, 'gross' => 15, 'net' => 10, 'linked' => false],
+                ],
+            ]],
+            'configuratorSettings' => [],
+        ]], $context);
+
+        $this->browser = $this->createCustomSalesChannelBrowser([
+            'id' => $this->ids->get('sales-channel'),
+            'languageId' => self::LANGUAGE_IDS['de'],
+            'languages' => [
+                ['id' => self::LANGUAGE_IDS['en']],
+                ['id' => self::LANGUAGE_IDS['de']],
+            ],
+            'domains' => [[
+                'languageId' => self::LANGUAGE_IDS['de'],
+                'currencyId' => Defaults::CURRENCY,
+                'snippetSetId' => $this->getSnippetSetIdForLocale('en-GB'),
+                'url' => 'http://localhost/de-test',
+            ]],
+        ]);
+
+        $this->browser->request('GET', '/store-api/context');
+        $contextResponse = json_decode((string) $this->browser->getResponse()->getContent(), true, 512, \JSON_THROW_ON_ERROR);
+        $salesChannelContext = static::getContainer()->get(SalesChannelContextFactory::class)->create(
+            $contextResponse['token'],
+            $this->ids->get('sales-channel'),
+            [SalesChannelContextService::LANGUAGE_ID => self::LANGUAGE_IDS['de']],
+        );
+
+        $response = static::getContainer()->get(ProductDetailRoute::class)->load(
+            $parentProductId,
+            new Request(),
+            $salesChannelContext,
+            new Criteria(),
+        );
+
+        static::assertSame($variantProductId, $response->getProduct()->getId());
+
+        $slot = $response->getProduct()
+            ->getCmsPage()?->getSections()?->first()?->getBlocks()?->first()?->getSlots()?->first();
+
+        static::assertSame(
+            'default language override',
+            $slot?->getConfig()['content']['value'] ?? null
+        );
+    }
+
     /**
      * @param array<string, string> $expected
      * @param array<string, string> $actual

--- a/tests/unit/Core/Content/Category/SalesChannel/CategoryRouteTest.php
+++ b/tests/unit/Core/Content/Category/SalesChannel/CategoryRouteTest.php
@@ -2,6 +2,9 @@
 
 namespace Shopware\Tests\Unit\Core\Content\Category\SalesChannel;
 
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Query\QueryBuilder;
+use Doctrine\DBAL\Result;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
@@ -24,6 +27,7 @@ use Shopware\Core\Content\Cms\CmsPageCollection;
 use Shopware\Core\Content\Cms\CmsPageEntity;
 use Shopware\Core\Content\Cms\DataResolver\ResolverContext\EntityResolverContext;
 use Shopware\Core\Content\Cms\SalesChannel\SalesChannelCmsPageLoaderInterface;
+use Shopware\Core\Content\Cms\Service\EntityCmsSlotConfigInheritanceBuilder;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Adapter\Cache\CacheTagCollector;
 use Shopware\Core\Framework\Api\Context\SalesChannelApiSource;
@@ -143,6 +147,9 @@ class CategoryRouteTest extends TestCase
         $categoryRoute = new CategoryRoute(
             $categoryRepositoryMock,
             $cmsPageLoader,
+            new EntityCmsSlotConfigInheritanceBuilder(
+                $this->createConnectionWithParentLanguageIds($languageCodeChain),
+            ),
             new CategoryDefinition(),
             $this->createMock(CacheTagCollector::class),
         );
@@ -286,6 +293,9 @@ class CategoryRouteTest extends TestCase
         $categoryRoute = new CategoryRoute(
             $categoryRepositoryMock,
             $this->createMock(SalesChannelCmsPageLoaderInterface::class),
+            new EntityCmsSlotConfigInheritanceBuilder(
+                $this->createConnectionWithParentLanguageIds(['en']),
+            ),
             new CategoryDefinition(),
             $this->createMock(CacheTagCollector::class),
         );
@@ -295,5 +305,37 @@ class CategoryRouteTest extends TestCase
             $request,
             $salesChannelContext,
         );
+    }
+
+    /**
+     * @param non-empty-list<string> $languageCodeChain
+     */
+    private function createConnectionWithParentLanguageIds(array $languageCodeChain): Connection
+    {
+        $connection = $this->createMock(Connection::class);
+        $queryBuilder = $this->createMock(QueryBuilder::class);
+
+        $queryBuilder->method('select')->willReturnSelf();
+        $queryBuilder->method('from')->willReturnSelf();
+        $queryBuilder->method('where')->willReturnSelf();
+        $queryBuilder->method('setParameter')->willReturnSelf();
+
+        $parentLanguageIds = [];
+        for ($i = \count($languageCodeChain) - 1; $i > 0; --$i) {
+            $parentLanguageIds[] = self::LANGUAGE_IDS[$languageCodeChain[$i - 1]];
+        }
+        $parentLanguageIds[] = null;
+
+        $results = array_map(function (?string $parentLanguageId): Result {
+            $result = $this->createMock(Result::class);
+            $result->method('fetchOne')->willReturn($parentLanguageId);
+
+            return $result;
+        }, $parentLanguageIds);
+
+        $queryBuilder->method('executeQuery')->willReturnOnConsecutiveCalls(...$results);
+        $connection->method('createQueryBuilder')->willReturn($queryBuilder);
+
+        return $connection;
     }
 }

--- a/tests/unit/Core/Content/Cms/Service/EntityCmsSlotConfigInheritanceBuilderTest.php
+++ b/tests/unit/Core/Content/Cms/Service/EntityCmsSlotConfigInheritanceBuilderTest.php
@@ -1,0 +1,129 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Content\Cms\Service;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Query\QueryBuilder;
+use Doctrine\DBAL\Result;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Cms\Service\EntityCmsSlotConfigInheritanceBuilder;
+use Shopware\Core\Content\Product\Aggregate\ProductTranslation\ProductTranslationCollection;
+use Shopware\Core\Content\Product\Aggregate\ProductTranslation\ProductTranslationEntity;
+use Shopware\Core\Framework\Api\Context\SalesChannelApiSource;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Shopware\Core\Test\Generator;
+
+/**
+ * @internal
+ */
+#[Group('store-api')]
+#[CoversClass(EntityCmsSlotConfigInheritanceBuilder::class)]
+class EntityCmsSlotConfigInheritanceBuilderTest extends TestCase
+{
+    public function testBuildMergesSlotConfigAlongExplicitParentLanguageChain(): void
+    {
+        $childLanguageId = Uuid::randomHex();
+        $parentLanguageId = Uuid::randomHex();
+        $grandParentLanguageId = Uuid::randomHex();
+
+        $builder = new EntityCmsSlotConfigInheritanceBuilder(
+            $this->createConnectionWithParentLanguageIds([
+                $parentLanguageId,
+                $grandParentLanguageId,
+                null,
+            ]),
+        );
+
+        $translations = new ProductTranslationCollection([
+            $this->createTranslation($grandParentLanguageId, [
+                'slot-a' => ['headline' => ['value' => 'grand-parent']],
+            ]),
+            $this->createTranslation($parentLanguageId, [
+                'slot-a' => ['headline' => ['value' => 'parent']],
+                'slot-b' => ['headline' => ['value' => 'parent']],
+            ]),
+            $this->createTranslation($childLanguageId, [
+                'slot-b' => ['headline' => ['value' => 'child']],
+            ]),
+        ]);
+
+        $result = $builder->build($translations, $this->createSalesChannelContext($childLanguageId));
+
+        static::assertSame([
+            'slot-a' => ['headline' => ['value' => 'parent']],
+            'slot-b' => ['headline' => ['value' => 'child']],
+        ], $result);
+    }
+
+    public function testBuildDoesNotMergeSystemLanguageWithoutExplicitParent(): void
+    {
+        $childLanguageId = Uuid::randomHex();
+        $systemLanguageId = Uuid::randomHex();
+
+        $builder = new EntityCmsSlotConfigInheritanceBuilder(
+            $this->createConnectionWithParentLanguageIds([null]),
+        );
+
+        $translations = new ProductTranslationCollection([
+            $this->createTranslation($systemLanguageId, [
+                'slot-a' => ['headline' => ['value' => 'system']],
+            ]),
+        ]);
+
+        $result = $builder->build($translations, $this->createSalesChannelContext($childLanguageId));
+
+        static::assertNull($result);
+    }
+
+    /**
+     * @param array<string, array<string, mixed>> $slotConfig
+     */
+    private function createTranslation(string $languageId, array $slotConfig): ProductTranslationEntity
+    {
+        $translation = new ProductTranslationEntity();
+        $translation->setUniqueIdentifier('translation-' . $languageId);
+        $translation->setLanguageId($languageId);
+        $translation->setSlotConfig($slotConfig);
+
+        return $translation;
+    }
+
+    /**
+     * @param list<?string> $parentLanguageIds
+     */
+    private function createConnectionWithParentLanguageIds(array $parentLanguageIds): Connection
+    {
+        $connection = $this->createMock(Connection::class);
+        $queryBuilder = $this->createMock(QueryBuilder::class);
+
+        $queryBuilder->method('select')->willReturnSelf();
+        $queryBuilder->method('from')->willReturnSelf();
+        $queryBuilder->method('where')->willReturnSelf();
+        $queryBuilder->method('setParameter')->willReturnSelf();
+
+        $results = array_map(function (?string $parentLanguageId): Result {
+            $result = $this->createMock(Result::class);
+            $result->method('fetchOne')->willReturn($parentLanguageId);
+
+            return $result;
+        }, $parentLanguageIds);
+
+        $queryBuilder->method('executeQuery')->willReturnOnConsecutiveCalls(...$results);
+        $connection->method('createQueryBuilder')->willReturn($queryBuilder);
+
+        return $connection;
+    }
+
+    private function createSalesChannelContext(string $languageId): SalesChannelContext
+    {
+        return Generator::generateSalesChannelContext(new Context(
+            new SalesChannelApiSource(Uuid::randomHex()),
+            [],
+            languageIdChain: [$languageId],
+        ));
+    }
+}

--- a/tests/unit/Core/Content/Product/SalesChannel/Detail/ProductDetailRouteTest.php
+++ b/tests/unit/Core/Content/Product/SalesChannel/Detail/ProductDetailRouteTest.php
@@ -11,6 +11,7 @@ use Shopware\Core\Content\Category\Service\CategoryBreadcrumbBuilder;
 use Shopware\Core\Content\Cms\CmsPageCollection;
 use Shopware\Core\Content\Cms\CmsPageEntity;
 use Shopware\Core\Content\Cms\SalesChannel\SalesChannelCmsPageLoader;
+use Shopware\Core\Content\Cms\Service\EntityCmsSlotConfigInheritanceBuilder;
 use Shopware\Core\Content\Product\Aggregate\ProductVisibility\ProductVisibilityDefinition;
 use Shopware\Core\Content\Product\Exception\ProductNotFoundException;
 use Shopware\Core\Content\Product\ProductCollection;
@@ -91,6 +92,7 @@ class ProductDetailRouteTest extends TestCase
             $configuratorLoader,
             $breadcrumbBuilder,
             $this->cmsPageLoader,
+            $this->createMock(EntityCmsSlotConfigInheritanceBuilder::class),
             new SalesChannelProductDefinition(),
             $this->productCloseoutFilterFactory,
             $this->eventDispatcher,

--- a/tests/unit/Core/Content/Product/SalesChannel/Detail/ProductDetailRouteTest.php
+++ b/tests/unit/Core/Content/Product/SalesChannel/Detail/ProductDetailRouteTest.php
@@ -12,6 +12,7 @@ use Shopware\Core\Content\Cms\CmsPageCollection;
 use Shopware\Core\Content\Cms\CmsPageEntity;
 use Shopware\Core\Content\Cms\SalesChannel\SalesChannelCmsPageLoader;
 use Shopware\Core\Content\Cms\Service\EntityCmsSlotConfigInheritanceBuilder;
+use Shopware\Core\Content\Product\Aggregate\ProductTranslation\ProductTranslationCollection;
 use Shopware\Core\Content\Product\Aggregate\ProductVisibility\ProductVisibilityDefinition;
 use Shopware\Core\Content\Product\Exception\ProductNotFoundException;
 use Shopware\Core\Content\Product\ProductCollection;
@@ -25,6 +26,7 @@ use Shopware\Core\Content\Product\SalesChannel\ProductCloseoutFilterFactory;
 use Shopware\Core\Content\Product\SalesChannel\SalesChannelProductDefinition;
 use Shopware\Core\Content\Product\SalesChannel\SalesChannelProductEntity;
 use Shopware\Core\Framework\Adapter\Cache\CacheTagCollector;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
@@ -56,6 +58,11 @@ class ProductDetailRouteTest extends TestCase
      */
     private SystemConfigService $systemConfig;
 
+    /**
+     * @var MockObject&EntityRepository<ProductTranslationCollection>
+     */
+    private MockObject&EntityRepository $productTranslationRepository;
+
     private MockObject&Connection $connection;
 
     private ProductDetailRoute $route;
@@ -76,6 +83,7 @@ class ProductDetailRouteTest extends TestCase
         $this->context = Generator::generateSalesChannelContext();
         $this->idsCollection = new IdsCollection();
         $this->productRepository = $this->createMock(SalesChannelRepository::class);
+        $this->productTranslationRepository = $this->createMock(EntityRepository::class);
         $this->systemConfig = $this->createMock(SystemConfigService::class);
         $this->connection = $this->createMock(Connection::class);
         $configuratorLoader = $this->createMock(ProductConfiguratorLoader::class);
@@ -87,6 +95,7 @@ class ProductDetailRouteTest extends TestCase
 
         $this->route = new ProductDetailRoute(
             $this->productRepository,
+            $this->productTranslationRepository,
             $this->systemConfig,
             $this->connection,
             $configuratorLoader,


### PR DESCRIPTION
fixes https://github.com/shopware/shopware/issues/15906

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
CMS content overrides on product and category level did not inherit correctly across languages. When a child language had no own override, Shopware could fall back to the base CMS layout or to the wrong language instead of using the explicit parent language override. This caused inconsistent CMS content in storefront and Store API and blocked merchants who rely on language inheritance for Shopping Experiences.

### 2. What does this change do, exactly?
This change fixes CMS slotConfig inheritance for product and category entity overrides so that Shopware now follows the explicit language parent chain correctly. Entity-level CMS overrides are inherited from the configured parent language, but no longer fall back implicitly to the system language when no parent relationship exists.

As a result:
- product and category CMS overrides behave consistently
- child languages correctly inherit parent-language entity overrides
- languages without an explicit parent no longer receive unintended entity override fallback

### 3. Describe each step to reproduce the issue or behaviour.
1. Create a CMS layout for a product or category with a text element containing a visible default value, for example LAYOUT DEFAULT.
2. Assign this layout to a product or category.
3. In the default language, override the text on entity level in the Layout tab, for example to DEFAULT LANGUAGE OVERRIDE.
4. Create a child language that inherits from that default language.
5. Switch the product or category detail page to the child language in Administration.
6. Open the Layout tab without creating a child-language override.

Before this change:
- Shopware could ignore the parent-language entity override
- the child language could fall back to the base CMS layout value instead

After this change:
- the child language correctly inherits the parent-language entity override

Additional corrected behaviour:
1. Create a language without any Inherit from parent.
2. Define a CMS entity override only in the system/default language.
3. Open the same product or category in the language without a parent.

Before this change:
- Shopware could still inherit the system-language entity override implicitly

After this change:
- no entity-level override is inherited unless there is an explicit parent language configured

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
