### PR TITLE
fix: Remove `base_navigation` block from checkout templates

### DIFF
--- a/src/Storefront/Resources/views/storefront/page/checkout/address/index.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/checkout/address/index.html.twig
@@ -4,8 +4,6 @@
     {% sw_include '@Storefront/storefront/layout/header/header-minimal.html.twig' %}
 {% endblock %}
 
-{% block base_navigation %}{% endblock %}
-
 {% block page_checkout_main_content %}
     {% block page_checkout_address %}
         {% block page_checkout_address_header %}

--- a/src/Storefront/Resources/views/storefront/page/checkout/confirm/index.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/checkout/confirm/index.html.twig
@@ -4,8 +4,6 @@
     {% sw_include '@Storefront/storefront/layout/header/header-minimal.html.twig' %}
 {% endblock %}
 
-{% block base_navigation %}{% endblock %}
-
 {% set showTaxPrice = config('core.cart.columnTaxInsteadUnitPrice') %}
 {% set showSubtotal = config('core.cart.showSubtotal') %}
 

--- a/src/Storefront/Resources/views/storefront/page/checkout/finish/index.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/checkout/finish/index.html.twig
@@ -4,8 +4,6 @@
     {% sw_include '@Storefront/storefront/layout/header/header-minimal.html.twig' %}
 {% endblock %}
 
-{% block base_navigation %}{% endblock %}
-
 {% set showTaxPrice = config('core.cart.columnTaxInsteadUnitPrice') %}
 {% set showSubtotal = config('core.cart.showSubtotal') %}
 


### PR DESCRIPTION
### 1. Why is this change necessary?
As the block does not exist in the parent template anymore (has been moved to the header), it is not needed anymore.

I could not think of a case, where it might be considered and a BC break, therefore I removed it, instead of deprecating it. If there is a valid reason (I did not thought about), we should deprecate it.

### 2. What does this change do, exactly?
Remove blocks which are never rendered.

### 3. Describe each step to reproduce the issue or behaviour.
:eyes: 

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
