### PR TITLE
fix: Fix issue reordered terms can return fewer obvious matches

### DIFF
--- a/src/Core/Content/Product/SearchKeyword/ProductSearchTermInterpreter.php
+++ b/src/Core/Content/Product/SearchKeyword/ProductSearchTermInterpreter.php
@@ -20,6 +20,7 @@ use Shopware\Core\Framework\Uuid\Uuid;
 class ProductSearchTermInterpreter implements ProductSearchTermInterpreterInterface
 {
     private const RELEVANT_KEYWORD_COUNT = 8;
+    private const BACKFILLED_KEYWORD_COUNT = 4;
 
     /**
      * @internal
@@ -62,12 +63,12 @@ class ProductSearchTermInterpreter implements ProductSearchTermInterpreterInterf
 
         $pattern = new SearchPattern(new SearchTerm($word));
 
-        $pattern->setBooleanClause($this->getConfigBooleanClause($context));
+        $booleanClauseAnd = $this->getConfigBooleanClause($context);
+        $pattern->setBooleanClause($booleanClauseAnd);
         $pattern->setTokenTerms($matches);
 
         $scoring = $this->score($tokens, $originalTokens, ArrayNormalizer::flatten($matches), $minSearchLength);
-        // only use the 8 best matches, otherwise the query might explode
-        $scoring = \array_slice($scoring, 0, self::RELEVANT_KEYWORD_COUNT, true);
+        $scoring = $this->selectRelevantKeywords($scoring, $originalTokens, $booleanClauseAnd, $minSearchLength);
 
         foreach ($scoring as $keyword => $score) {
             $this->logger->info('Search match: ' . $keyword . ' with score ' . (float) $score);
@@ -75,6 +76,50 @@ class ProductSearchTermInterpreter implements ProductSearchTermInterpreterInterf
         }
 
         return $pattern;
+    }
+
+    /**
+     * @param array<string, float> $scoring
+     * @param list<string> $originalTokens
+     *
+     * @return array<string, float>
+     */
+    private function selectRelevantKeywords(array $scoring, array $originalTokens, bool $booleanClauseAnd, ?int $minSearchLength): array
+    {
+        $primary = \array_slice($scoring, 0, self::RELEVANT_KEYWORD_COUNT, true);
+
+        if (!$booleanClauseAnd || \count($originalTokens) <= 1) {
+            return $primary;
+        }
+
+        $backfill = [];
+        foreach ($scoring as $keyword => $score) {
+            if (isset($primary[$keyword])) {
+                continue;
+            }
+
+            /** @phpstan-ignore arguments.count (This ignore should be removed when the deprecated method signature is updated) */
+            $keywordTokens = $this->tokenizer->tokenize($keyword, $minSearchLength);
+
+            if (!$this->containsAllOriginalTokens($originalTokens, $keywordTokens)) {
+                continue;
+            }
+
+            if ($this->isSameTokenSet($originalTokens, $keywordTokens)) {
+                continue;
+            }
+
+            $backfill[$keyword] = $score;
+
+            if (\count($backfill) >= self::BACKFILLED_KEYWORD_COUNT) {
+                break;
+            }
+        }
+
+        $selected = array_merge($primary, $backfill);
+        uasort($selected, static fn ($a, $b) => $b <=> $a);
+
+        return $selected;
     }
 
     /**
@@ -222,6 +267,25 @@ class ProductSearchTermInterpreter implements ProductSearchTermInterpreterInterf
         uasort($scoring, static fn ($a, $b) => $b <=> $a);
 
         return $scoring;
+    }
+
+    /**
+     * @param list<string> $originalTokens
+     * @param list<string> $keywordTokens
+     */
+    private function containsAllOriginalTokens(array $originalTokens, array $keywordTokens): bool
+    {
+        return array_diff($originalTokens, $keywordTokens) === [];
+    }
+
+    /**
+     * @param list<string> $originalTokens
+     * @param list<string> $keywordTokens
+     */
+    private function isSameTokenSet(array $originalTokens, array $keywordTokens): bool
+    {
+        return \count($keywordTokens) === \count($originalTokens)
+            && array_diff($originalTokens, $keywordTokens) === [];
     }
 
     private function getConfigBooleanClause(Context $context): bool

--- a/tests/integration/Core/Content/Product/SalesChannel/ProductSearchRouteTest.php
+++ b/tests/integration/Core/Content/Product/SalesChannel/ProductSearchRouteTest.php
@@ -375,6 +375,82 @@ class ProductSearchRouteTest extends TestCase
         static::assertSame('product', $response['elements'][0]['apiAlias']);
     }
 
+    public function testAndSearchKeepsMatchingProductsForReorderedNumericTerms(): void
+    {
+        $ids = new IdsCollection();
+
+        /** @var EntityRepository<ProductCollection> $productRepository */
+        $productRepository = static::getContainer()->get('product.repository');
+
+        $expected = [
+            'Seife Elina 100g Aloe Vera mit Glycerin',
+            'Seife Elina 100g Arganöl',
+            'Seife Elina 100g Arztseife',
+            'Seife Elina 100g Babyseife mit Babyöl & Honig',
+            'Seife Elina 100g Granatapfel mit Glycerin',
+            'Seife Elina 100g Sensitive Urea',
+            'Seife Elina 100g grüne Olive mit Glycerin',
+            'Seife Elina 100g Soft Fresh mit Glyzerin',
+            'Seife Elina 100g Soft Cream mit Milchextract',
+            'Seife Elina 100g Kernseife weiss',
+            'Seife Elina 100g Orangenblüte',
+            'Seife Elina 100g Pflege-Kernseife',
+        ];
+
+        $products = [];
+        $productIds = [];
+
+        foreach ($expected as $index => $name) {
+            $product = (new ProductBuilder($ids, 'elina-soap-' . $index))
+                ->name($name)
+                ->price(10, 9)
+                ->visibility(self::$ids->get('sales-channel'))
+                ->manufacturer('elina')
+                ->build();
+
+            $products[] = $product;
+            $productIds[] = $product['id'];
+        }
+
+        $productRepository->create($products, Context::createDefaultContext());
+        $this->searchKeywordUpdater->update($productIds, Context::createDefaultContext());
+
+        $this->productSearchConfigRepository->update([
+            ['id' => $this->productSearchConfigId, 'andLogic' => true],
+        ], Context::createDefaultContext());
+
+        $searchRoute = static::getContainer()->get(ProductSearchRoute::class);
+        $salesChannelContext = static::getContainer()->get(SalesChannelContextFactory::class)->create(
+            Uuid::randomHex(),
+            self::$ids->get('sales-channel')
+        );
+
+        $forwardNames = array_map(
+            static fn ($product): ?string => $product->getName(),
+            array_values($searchRoute->load(
+                new Request(['search' => 'seife elina 100g']),
+                $salesChannelContext,
+                new Criteria()
+            )->getListingResult()->getEntities()->getElements())
+        );
+
+        $reorderedNames = array_map(
+            static fn ($product): ?string => $product->getName(),
+            array_values($searchRoute->load(
+                new Request(['search' => 'elina seife 100g']),
+                $salesChannelContext,
+                new Criteria()
+            )->getListingResult()->getEntities()->getElements())
+        );
+
+        sort($expected);
+        sort($forwardNames);
+        sort($reorderedNames);
+
+        static::assertSame($expected, $forwardNames);
+        static::assertSame($expected, $reorderedNames);
+    }
+
     /**
      * @param array<array-key, bool> $searchTerms
      */

--- a/tests/integration/Core/Content/Product/SearchKeyword/ProductSearchTermInterpreterTest.php
+++ b/tests/integration/Core/Content/Product/SearchKeyword/ProductSearchTermInterpreterTest.php
@@ -159,6 +159,38 @@ class ProductSearchTermInterpreterTest extends TestCase
         static::assertSame($expected, \array_slice($terms, 0, \count($expected)));
     }
 
+    public function testAndSearchBackfillsOverflowKeywordsContainingAllOriginalTokens(): void
+    {
+        $context = Context::createDefaultContext();
+
+        $this->productSearchConfigRepository->update([
+            ['id' => $this->productSearchConfigId, 'andLogic' => true],
+        ], $context);
+
+        $expected = [
+            'seife elina 100g aloe vera mit glycerin',
+            'seife elina 100g arganöl',
+            'seife elina 100g arztseife',
+            'seife elina 100g babyseife mit babyöl honig',
+            'seife elina 100g granatapfel mit glycerin',
+            'seife elina 100g sensitive urea',
+            'seife elina 100g grüne olive mit glycerin',
+            'seife elina 100g soft fresh mit glyzerin',
+            'seife elina 100g soft cream mit milchextract',
+            'seife elina 100g kernseife weiss',
+            'seife elina 100g orangenblüte',
+            'seife elina 100g pflege-kernseife',
+        ];
+
+        $this->insertKeywords($expected);
+
+        $matches = $this->interpreter->interpret('elina seife 100g', $context);
+        $terms = array_map(static fn (SearchTerm $term) => $term->getTerm(), $matches->getTerms());
+
+        static::assertCount(12, $terms);
+        static::assertEqualsCanonicalizing($expected, $terms);
+    }
+
     /**
      * @return array<array{0: string, 1: list<string>}>
      */
@@ -487,6 +519,14 @@ class ProductSearchTermInterpreterTest extends TestCase
             'Klappbarer Camping Sessel',
         ];
 
+        $this->insertKeywords($keywords);
+    }
+
+    /**
+     * @param list<string> $keywords
+     */
+    private function insertKeywords(array $keywords): void
+    {
         $languageId = Uuid::fromHexToBytes(Defaults::LANGUAGE_SYSTEM);
 
         foreach ($keywords as $keyword) {


### PR DESCRIPTION
This pull request improves the product search functionality by ensuring that products matching all token groups remain in the result set, even when strong keyword interpretations are truncated for scoring. It also adds comprehensive unit and integration tests to verify the new fallback scoring logic.

**Product Search Logic Improvements:**

* Added a fallback scoring mechanism in `ProductSearchBuilder` to retain products that satisfy all token groups, even when higher-ranked interpreted keywords are truncated. This is achieved by adding a `ScoreQuery` with a low fallback score (`TOKEN_GROUP_FALLBACK_SCORE`). [[1]](diffhunk://#diff-954ede10776197ccb439a507a3cbf434e1f1eedac8eaa508e303727218b6898eR22-R23) [[2]](diffhunk://#diff-954ede10776197ccb439a507a3cbf434e1f1eedac8eaa508e303727218b6898eR98-R110)
