### PR TITLE
fix: empty footer service menu list style

### DIFF
--- a/src/Storefront/Resources/views/storefront/layout/footer/footer.html.twig
+++ b/src/Storefront/Resources/views/storefront/layout/footer/footer.html.twig
@@ -249,7 +249,7 @@
                 <div class="container">
                     {% block layout_footer_service_menu_content %}
                         <ul class="footer-service-menu-list list-unstyled d-flex flex-wrap justify-content-center">
-                            {% for serviceMenuItem in footer.serviceMenu %}
+                            {%- for serviceMenuItem in footer.serviceMenu -%}
                                 {% block layout_footer_service_menu_item %}
                                     <li class="footer-service-menu-item">
                                         <a class="footer-service-menu-link"
@@ -260,7 +260,7 @@
                                         </a>
                                     </li>
                                 {% endblock %}
-                            {% endfor %}
+                            {%- endfor -%}
                         </ul>
                     {% endblock %}
                 </div>


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
With 4734bc5f75477c9ffcec75739d1d9b88fcc2483e the spaceless filter in `layout_footer_service_menu_content` was removed. Since then, the `:empty` styling ([see](https://github.com/shopware/shopware/blob/f4287891e84fde65c7c070f53921bd33ab0bb2f3/src/Storefront/Resources/app/storefront/src/scss/layout/_footer.scss#L63)) does not work anymore because there is whitespace rendered inside the `ul` element. This leads to unwanted spacing (padding and margin) inside the footer when no service menu is defined.

<img width="1463" height="235" alt="image" src="https://github.com/user-attachments/assets/aff4f119-470f-457b-9211-bbcf672f14fb" />

### 2. What does this change do, exactly?
Remove whitespace with `{%-` and `-%}`

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
