### PR TITLE
fix: remove padding override on sw-modal__body

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-inactivity-login/page/index/sw-inactivity-login.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-inactivity-login/page/index/sw-inactivity-login.scss
@@ -9,10 +9,6 @@
 }
 
 .sw-inactivity-login__modal {
-    div.sw-modal__body {
-        padding-bottom: 8px;
-    }
-
     footer.sw-modal__footer {
         display: flex;
         justify-content: space-between;


### PR DESCRIPTION
### Before
<img width="736" height="327" alt="sw-activity-login_before" src="https://github.com/user-attachments/assets/2aa9ae66-3dd8-4b30-a834-9ee97ca64336" />

### After
<img width="719" height="324" alt="sw-activity-login_after" src="https://github.com/user-attachments/assets/835f561e-b84e-41a2-9af6-b44ea7fc2e52" />
