### PR TITLE
fix(core): bound the unused media reference check to one batch of candidates

### DIFF
--- a/src/Core/Content/Media/Commands/DeleteNotUsedMediaCommand.php
+++ b/src/Core/Content/Media/Commands/DeleteNotUsedMediaCommand.php
@@ -97,7 +97,7 @@ class DeleteNotUsedMediaCommand extends Command
             public function start(UnusedMediaSearchStartEvent $event): void
             {
                 $this->totalMediaDeletionCandidates = $event->totalMediaDeletionCandidates;
-                $this->io->note(\sprintf('Out of a total of %d media items there are %d candidates for removal', $event->totalMedia, $event->totalMediaDeletionCandidates));
+                $this->io->note(\sprintf('Out of a total of %d media items, %d will be scanned for removal', $event->totalMedia, $event->totalMediaDeletionCandidates));
                 $this->progressBar = $this->io->createProgressBar($event->totalMediaDeletionCandidates);
                 $this->progressBar->setFormat('debug');
                 $this->progressBar->start();

--- a/src/Core/Content/Media/UnusedMediaPurger.php
+++ b/src/Core/Content/Media/UnusedMediaPurger.php
@@ -240,7 +240,9 @@ class UnusedMediaPurger
     {
         $criteria = new Criteria();
 
-        foreach ($this->mediaRepo->getDefinition()->getFields() as $field) {
+        $fields = $this->mediaRepo->getDefinition()->getFields();
+
+        foreach ($fields as $field) {
             if (!$field instanceof AssociationField) {
                 continue;
             }
@@ -260,6 +262,15 @@ class UnusedMediaPurger
             }
 
             if ($this->isInsideTopLevelDomain(MediaDefinition::ENTITY_NAME, $definition)) {
+                continue;
+            }
+
+            // When a specific folder entity is provided, only check the
+            // association that belongs to that entity. This avoids building
+            // a massive query with LEFT JOINs across all ~25 media
+            // associations, which can exceed MySQL's MAX_JOIN_SIZE on
+            // large datasets.
+            if ($folderEntity !== null && $definition->getEntityName() !== $folderEntity) {
                 continue;
             }
 

--- a/src/Core/Content/Media/UnusedMediaPurger.php
+++ b/src/Core/Content/Media/UnusedMediaPurger.php
@@ -62,7 +62,7 @@ class UnusedMediaPurger
 
         $context = Context::createDefaultContext();
 
-        $criteria = $this->createFilterForNotUsedMedia($folderEntity);
+        $criteria = $this->createCandidateCriteria($folderEntity);
         $criteria->addSorting(new FieldSorting('media.createdAt', FieldSorting::ASCENDING));
         $criteria->setLimit($limit);
 
@@ -71,6 +71,7 @@ class UnusedMediaPurger
             $criteria->setOffset($offset);
 
             $ids = $this->mediaRepo->searchIds($criteria, $context)->getIds();
+            $ids = $this->filterOutUsedMedia($ids, $context);
             $ids = $this->filterOutNewMedia($ids, $gracePeriodDays, $context);
             $ids = $this->dispatchEvent($ids, $context);
 
@@ -81,6 +82,7 @@ class UnusedMediaPurger
         $iterator = new RepositoryIterator($this->mediaRepo, $context, $criteria);
         while (($ids = $iterator->fetchIds()) !== null) {
             /** @phpstan-ignore argument.type (we can't narrow down argument type to list<string> in while loop) */
+            $ids = $this->filterOutUsedMedia($ids, $context);
             $ids = $this->filterOutNewMedia($ids, $gracePeriodDays, $context);
             $unusedIds = $this->dispatchEvent($ids, $context);
 
@@ -104,7 +106,10 @@ class UnusedMediaPurger
         $context = Context::createDefaultContext();
 
         $totalMedia = $this->getTotal(new Criteria(), $context);
-        $totalCandidates = $this->getTotal($this->createFilterForNotUsedMedia($folderEntity), $context);
+        // counts the media that will be scanned, not the media that turns out to be unused: an exact
+        // count cannot be bound to a single batch of ids, and counting across every media association
+        // is the query that exceeds MySQL's MAX_JOIN_SIZE on large datasets
+        $totalCandidates = $this->getTotal($this->createCandidateCriteria($folderEntity), $context);
 
         $this->eventDispatcher->dispatch(new UnusedMediaSearchStartEvent($totalMedia, $totalCandidates));
 
@@ -174,7 +179,7 @@ class UnusedMediaPurger
      */
     private function getUnusedMediaIds(Context $context, int $limit, ?int $offset = null, ?string $folderEntity = null): \Generator
     {
-        $criteria = $this->createFilterForNotUsedMedia($folderEntity);
+        $criteria = $this->createCandidateCriteria($folderEntity);
         $criteria->addSorting(new FieldSorting('id', FieldSorting::ASCENDING));
         $criteria->setLimit($limit);
 
@@ -184,7 +189,7 @@ class UnusedMediaPurger
 
             $ids = $this->mediaRepo->searchIds($criteria, $context)->getIds();
 
-            return yield $this->dispatchEvent($ids, $context);
+            return yield $this->dispatchEvent($this->filterOutUsedMedia($ids, $context), $context);
         }
 
         // Use last ID instead of offset for cursor-based pagination, which allows deletion of records between batches
@@ -200,8 +205,10 @@ class UnusedMediaPurger
                 break;
             }
 
+            // the cursor advances over the candidates, not over the unused subset, otherwise a batch
+            // without any unused media would restart the iteration from the same id
             $lastId = end($ids);
-            $unusedIds = $this->dispatchEvent($ids, $context);
+            $unusedIds = $this->dispatchEvent($this->filterOutUsedMedia($ids, $context), $context);
 
             yield $unusedIds;
         }
@@ -238,9 +245,60 @@ class UnusedMediaPurger
         return $this->isInsideTopLevelDomain($domain, $definition->getParentDefinition());
     }
 
-    private function createFilterForNotUsedMedia(?string $folderEntity = null): Criteria
+    /**
+     * Restricts the media that is scanned, without touching any media association: the candidate query
+     * has to stay cheap, because the reference check below is what makes the query expensive.
+     */
+    private function createCandidateCriteria(?string $folderEntity = null): Criteria
     {
         $criteria = new Criteria();
+
+        if ($folderEntity === null) {
+            return $criteria;
+        }
+
+        $rootMediaFolderId = $this->connection->fetchOne(
+            <<<'SQL'
+            SELECT HEX(media_folder.id) FROM media_default_folder
+            INNER JOIN media_folder ON (media_default_folder.id = media_folder.default_folder_id)
+            WHERE entity = :entity
+            SQL,
+            ['entity' => $folderEntity]
+        );
+
+        if (!$rootMediaFolderId) {
+            throw MediaException::defaultMediaFolderWithEntityNotFound($folderEntity);
+        }
+
+        /** @var array<string, array{id: string, parent_id: string}> $folders */
+        $folders = $this->connection->fetchAllAssociativeIndexed(
+            'SELECT HEX(id), HEX(id) as id, HEX(parent_id) as parent_id, name FROM media_folder WHERE id != :id',
+            ['id' => $rootMediaFolderId],
+        );
+
+        $ids = [$rootMediaFolderId, ...$this->getChildFolderIds($rootMediaFolderId, $folders)];
+
+        $criteria->addFilter(new EqualsAnyFilter('media.mediaFolder.id', $ids));
+
+        return $criteria;
+    }
+
+    /**
+     * Keeps the media that nothing references. Every media association is checked, folder membership says
+     * where a media file is placed and never whether something still points at it. The check is pinned to
+     * the given ids so the joins are evaluated for one batch instead of the whole media table.
+     *
+     * @param list<string> $mediaIds
+     *
+     * @return list<string>
+     */
+    private function filterOutUsedMedia(array $mediaIds, Context $context): array
+    {
+        if ($mediaIds === []) {
+            return [];
+        }
+
+        $criteria = new Criteria($mediaIds);
 
         foreach ($this->mediaRepo->getDefinition()->getFields() as $field) {
             if (!$field instanceof AssociationField) {
@@ -276,35 +334,7 @@ class UnusedMediaPurger
             );
         }
 
-        if ($folderEntity) {
-            $rootMediaFolderId = $this->connection->fetchOne(
-                <<<'SQL'
-                SELECT HEX(media_folder.id) FROM media_default_folder
-                INNER JOIN media_folder ON (media_default_folder.id = media_folder.default_folder_id)
-                WHERE entity = :entity
-                SQL,
-                ['entity' => $folderEntity]
-            )
-            ;
-
-            if (!$rootMediaFolderId) {
-                throw MediaException::defaultMediaFolderWithEntityNotFound($folderEntity);
-            }
-
-            /** @var array<string, array{id: string, parent_id: string}> $folders */
-            $folders = $this->connection->fetchAllAssociativeIndexed(
-                'SELECT HEX(id), HEX(id) as id, HEX(parent_id) as parent_id, name FROM media_folder WHERE id != :id',
-                ['id' => $rootMediaFolderId],
-            );
-
-            $ids = [$rootMediaFolderId, ...$this->getChildFolderIds($rootMediaFolderId, $folders)];
-
-            $criteria->addFilter(
-                new EqualsAnyFilter('media.mediaFolder.id', $ids)
-            );
-        }
-
-        return $criteria;
+        return $this->mediaRepo->searchIds($criteria, $context)->getIds();
     }
 
     /**

--- a/src/Core/Content/Media/UnusedMediaPurger.php
+++ b/src/Core/Content/Media/UnusedMediaPurger.php
@@ -235,7 +235,9 @@ class UnusedMediaPurger
     {
         $criteria = new Criteria();
 
-        foreach ($this->mediaRepo->getDefinition()->getFields() as $field) {
+        $fields = $this->mediaRepo->getDefinition()->getFields();
+
+        foreach ($fields as $field) {
             if (!$field instanceof AssociationField) {
                 continue;
             }
@@ -251,6 +253,15 @@ class UnusedMediaPurger
             }
 
             if ($this->isInsideTopLevelDomain(MediaDefinition::ENTITY_NAME, $definition)) {
+                continue;
+            }
+
+            // When a specific folder entity is provided, only check the
+            // association that belongs to that entity. This avoids building
+            // a massive query with LEFT JOINs across all ~25 media
+            // associations, which can exceed MySQL's MAX_JOIN_SIZE on
+            // large datasets.
+            if ($folderEntity !== null && $definition->getEntityName() !== $folderEntity) {
                 continue;
             }
 

--- a/tests/integration/Core/Content/Media/UnusedMediaPurgerTest.php
+++ b/tests/integration/Core/Content/Media/UnusedMediaPurgerTest.php
@@ -7,13 +7,16 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Media\Event\UnusedMediaSearchEvent;
 use Shopware\Core\Content\Media\MediaCollection;
 use Shopware\Core\Content\Media\UnusedMediaPurger;
+use Shopware\Core\Content\Product\Aggregate\ProductDownload\ProductDownloadDefinition;
 use Shopware\Core\Content\Test\Media\MediaFixtures;
+use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\QueueTestBehaviour;
+use Shopware\Core\Framework\Uuid\Uuid;
 use Symfony\Component\Clock\NativeClock;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 
@@ -248,5 +251,72 @@ class UnusedMediaPurgerTest extends TestCase
 
         static::assertTrue($this->getPublicFilesystem()->has($usedPath));
         static::assertFalse($this->getPublicFilesystem()->has($unusedPath));
+    }
+
+    public function testDeleteNotUsedMediaWithFolderEntityKeepsMediaUsedByAnotherEntity(): void
+    {
+        $connection = static::getContainer()->get(Connection::class);
+        static::assertInstanceOf(Connection::class, $connection);
+
+        $downloadFolderId = $connection->fetchOne(
+            'SELECT LOWER(HEX(media_folder.id)) FROM media_default_folder
+             INNER JOIN media_folder ON media_default_folder.id = media_folder.default_folder_id
+             WHERE entity = :entity',
+            ['entity' => ProductDownloadDefinition::ENTITY_NAME]
+        );
+        static::assertIsString($downloadFolderId);
+
+        $usedByProduct = Uuid::randomHex();
+        $unused = Uuid::randomHex();
+
+        // both media live in the product download folder, only one of them is referenced anywhere
+        $this->mediaRepo->create([
+            $this->mediaPayload($usedByProduct, $downloadFolderId),
+            $this->mediaPayload($unused, $downloadFolderId),
+        ], $this->context);
+
+        static::getContainer()->get('product.repository')->create([[
+            'id' => Uuid::randomHex(),
+            'productNumber' => 'product-' . $usedByProduct,
+            'name' => 'product using download folder media as image',
+            'stock' => 1,
+            'tax' => ['name' => 'test tax', 'taxRate' => 19],
+            'price' => [['currencyId' => Defaults::CURRENCY, 'gross' => 10, 'net' => 9, 'linked' => false]],
+            'media' => [['mediaId' => $usedByProduct, 'position' => 1]],
+        ]], $this->context);
+
+        $purger = new UnusedMediaPurger(
+            $this->mediaRepo,
+            $connection,
+            new EventDispatcher(),
+            new NativeClock()
+        );
+
+        $purger->deleteNotUsedMedia(folderEntity: ProductDownloadDefinition::ENTITY_NAME);
+        $this->runWorker();
+
+        $result = $this->mediaRepo->search(new Criteria([$usedByProduct, $unused]), $this->context)->getEntities();
+
+        static::assertNotNull(
+            $result->get($usedByProduct),
+            'media inside the product download folder must not be deleted while a product still references it as an image'
+        );
+        static::assertNull($result->get($unused));
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function mediaPayload(string $id, string $mediaFolderId): array
+    {
+        return [
+            'id' => $id,
+            'fileName' => 'media-' . $id,
+            'fileExtension' => 'png',
+            'mimeType' => 'image/png',
+            'fileSize' => 1024,
+            'private' => false,
+            'mediaFolderId' => $mediaFolderId,
+        ];
     }
 }

--- a/tests/unit/Core/Content/Media/UnusedMediaPurgerTest.php
+++ b/tests/unit/Core/Content/Media/UnusedMediaPurgerTest.php
@@ -31,6 +31,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsAnyFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\RangeFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\EntityWriteGatewayInterface;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -64,6 +65,13 @@ class UnusedMediaPurgerTest extends TestCase
             MediaCollection::class,
             [
                 static function (Criteria $criteria, Context $context) use ($id1, $id2) {
+                    self::assertCount(0, $criteria->getFilters());
+
+                    return [$id1, $id2];
+                },
+                static function (Criteria $criteria, Context $context) use ($id1, $id2) {
+                    self::assertSame([$id1, $id2], $criteria->getIds());
+
                     $filters = $criteria->getFilters();
 
                     self::assertCount(0, $filters);
@@ -108,10 +116,18 @@ class UnusedMediaPurgerTest extends TestCase
             MediaCollection::class,
             [
                 static function (Criteria $criteria, Context $context) use ($id1, $id2) {
+                    self::assertCount(0, $criteria->getFilters());
+
+                    self::assertSame(50, $criteria->getLimit());
+
+                    return [$id1, $id2];
+                },
+                static function (Criteria $criteria, Context $context) use ($id1, $id2) {
+                    self::assertSame([$id1, $id2], $criteria->getIds());
+
                     $filters = $criteria->getFilters();
 
                     self::assertCount(0, $filters);
-                    self::assertSame(50, $criteria->getLimit());
 
                     return [$id1, $id2];
                 },
@@ -121,10 +137,18 @@ class UnusedMediaPurgerTest extends TestCase
                     return new MediaCollection([$media1, $media2]);
                 },
                 static function (Criteria $criteria, Context $context) use ($id3, $id4) {
+                    self::assertCount(0, $criteria->getFilters());
+
+                    self::assertSame(50, $criteria->getLimit());
+
+                    return [$id3, $id4];
+                },
+                static function (Criteria $criteria, Context $context) use ($id3, $id4) {
+                    self::assertSame([$id3, $id4], $criteria->getIds());
+
                     $filters = $criteria->getFilters();
 
                     self::assertCount(0, $filters);
-                    self::assertSame(50, $criteria->getLimit());
 
                     return [$id3, $id4];
                 },
@@ -166,6 +190,13 @@ class UnusedMediaPurgerTest extends TestCase
             MediaCollection::class,
             [
                 static function (Criteria $criteria, Context $context) use ($id1, $id2, $id3, $id4) {
+                    self::assertCount(0, $criteria->getFilters());
+
+                    return [$id1, $id2, $id3, $id4];
+                },
+                static function (Criteria $criteria, Context $context) use ($id1, $id2, $id3, $id4) {
+                    self::assertSame([$id1, $id2, $id3, $id4], $criteria->getIds());
+
                     $filters = $criteria->getFilters();
 
                     self::assertCount(0, $filters);
@@ -207,6 +238,13 @@ class UnusedMediaPurgerTest extends TestCase
             MediaCollection::class,
             [
                 static function (Criteria $criteria, Context $context) use ($id1, $id2) {
+                    self::assertCount(0, $criteria->getFilters());
+
+                    return [$id1, $id2];
+                },
+                static function (Criteria $criteria, Context $context) use ($id1, $id2) {
+                    self::assertSame([$id1, $id2], $criteria->getIds());
+
                     $filters = $criteria->getFilters();
 
                     self::assertCount(1, $filters);
@@ -252,6 +290,13 @@ class UnusedMediaPurgerTest extends TestCase
             MediaCollection::class,
             [
                 static function (Criteria $criteria, Context $context) use ($id1, $id2) {
+                    self::assertCount(0, $criteria->getFilters());
+
+                    return [$id1, $id2];
+                },
+                static function (Criteria $criteria, Context $context) use ($id1, $id2) {
+                    self::assertSame([$id1, $id2], $criteria->getIds());
+
                     $filters = $criteria->getFilters();
 
                     self::assertCount(1, $filters);
@@ -304,6 +349,13 @@ class UnusedMediaPurgerTest extends TestCase
             MediaCollection::class,
             [
                 static function (Criteria $criteria, Context $context) use ($id1, $id2) {
+                    self::assertCount(0, $criteria->getFilters());
+
+                    return [$id1, $id2];
+                },
+                static function (Criteria $criteria, Context $context) use ($id1, $id2) {
+                    self::assertSame([$id1, $id2], $criteria->getIds());
+
                     $filters = $criteria->getFilters();
 
                     self::assertCount(1, $filters);
@@ -349,6 +401,13 @@ class UnusedMediaPurgerTest extends TestCase
             MediaCollection::class,
             [
                 static function (Criteria $criteria, Context $context) use ($id1, $id2) {
+                    self::assertCount(0, $criteria->getFilters());
+
+                    return [$id1, $id2];
+                },
+                static function (Criteria $criteria, Context $context) use ($id1, $id2) {
+                    self::assertSame([$id1, $id2], $criteria->getIds());
+
                     $filters = $criteria->getFilters();
 
                     self::assertCount(0, $filters);
@@ -397,6 +456,13 @@ class UnusedMediaPurgerTest extends TestCase
 
                     return [$id1, $id2];
                 },
+                static function (Criteria $criteria, Context $context) use ($id1, $id2) {
+                    self::assertSame([$id1, $id2], $criteria->getIds());
+
+                    self::assertCount(0, $criteria->getFilters());
+
+                    return [$id1, $id2];
+                },
                 static function (Criteria $criteria, Context $context) use ($id1, $id2, $media1, $media2) {
                     static::assertSame([$id1, $id2], $criteria->getIds());
 
@@ -429,6 +495,67 @@ class UnusedMediaPurgerTest extends TestCase
         static::assertSame([$media1, $media2], $media);
     }
 
+    public function testGetNotUsedMediaStillChecksEveryAssociationWhenFolderRestrictionIsPresent(): void
+    {
+        $this->configureRegistry([
+            'Media' => $mediaDefinition = $this->getMediaDefinition([
+                new OneToManyAssociationField('productMedia', 'ProductMedia', 'media_id', 'id'),
+            ]),
+            'ProductMedia' => $this->getProductMediaDefinition(),
+        ]);
+
+        $id1 = Uuid::randomHex();
+        $id2 = Uuid::randomHex();
+
+        $media1 = $this->createMedia($id1);
+
+        $repo = StaticEntityRepository::of(
+            MediaCollection::class,
+            [
+                static function (Criteria $criteria, Context $context) use ($id1, $id2) {
+                    $filters = $criteria->getFilters();
+
+                    // the folder restriction scopes which media is scanned
+                    self::assertCount(1, $filters);
+                    self::assertInstanceOf(EqualsAnyFilter::class, $filters[0]);
+                    self::assertSame('media.mediaFolder.id', $filters[0]->getField());
+
+                    return [$id1, $id2];
+                },
+                static function (Criteria $criteria, Context $context) use ($id1, $id2) {
+                    self::assertSame([$id1, $id2], $criteria->getIds());
+
+                    $filters = $criteria->getFilters();
+
+                    // folder membership says where a media file is placed, never whether something
+                    // still references it, so the association is checked even for a folder run
+                    self::assertCount(1, $filters);
+                    self::assertInstanceOf(EqualsFilter::class, $filters[0]);
+                    self::assertSame('media.productMedia.mediaId', $filters[0]->getField());
+                    self::assertNull($filters[0]->getValue());
+
+                    return [$id1];
+                },
+                static function (Criteria $criteria, Context $context) use ($id1, $media1) {
+                    static::assertSame([$id1], $criteria->getIds());
+
+                    return new MediaCollection([$media1]);
+                },
+                [],
+            ],
+            $mediaDefinition
+        );
+
+        $connection = static::createStub(Connection::class);
+        $connection->method('fetchOne')->willReturn('id1');
+        $connection->method('fetchAllAssociativeIndexed')->willReturn([]);
+
+        $purger = new UnusedMediaPurger($repo, $connection, new EventDispatcher(), new NativeClock());
+        $media = array_merge([], ...iterator_to_array($purger->getNotUsedMedia(null, null, null, 'media_gallery')));
+
+        static::assertSame([$media1], $media);
+    }
+
     public function testGetNotUsedMediaSkipsAssociationIfNoFkeyFound(): void
     {
         $this->configureRegistry([
@@ -448,6 +575,13 @@ class UnusedMediaPurgerTest extends TestCase
             MediaCollection::class,
             [
                 static function (Criteria $criteria, Context $context) use ($id1, $id2) {
+                    self::assertCount(0, $criteria->getFilters());
+
+                    return [$id1, $id2];
+                },
+                static function (Criteria $criteria, Context $context) use ($id1, $id2) {
+                    self::assertSame([$id1, $id2], $criteria->getIds());
+
                     $filters = $criteria->getFilters();
 
                     self::assertCount(0, $filters);
@@ -488,6 +622,13 @@ class UnusedMediaPurgerTest extends TestCase
             MediaCollection::class,
             [
                 static function (Criteria $criteria, Context $context) use ($id1, $id2) {
+                    self::assertCount(0, $criteria->getFilters());
+
+                    return [$id1, $id2];
+                },
+                static function (Criteria $criteria, Context $context) use ($id1, $id2) {
+                    self::assertSame([$id1, $id2], $criteria->getIds());
+
                     $filters = $criteria->getFilters();
 
                     self::assertCount(0, $filters);
@@ -530,6 +671,13 @@ class UnusedMediaPurgerTest extends TestCase
             MediaCollection::class,
             [
                 static function (Criteria $criteria, Context $context) use ($id1, $id2) {
+                    self::assertCount(0, $criteria->getFilters());
+
+                    return [$id1, $id2];
+                },
+                static function (Criteria $criteria, Context $context) use ($id1, $id2) {
+                    self::assertSame([$id1, $id2], $criteria->getIds());
+
                     $filters = $criteria->getFilters();
 
                     self::assertCount(0, $filters);
@@ -567,6 +715,13 @@ class UnusedMediaPurgerTest extends TestCase
             MediaCollection::class,
             [
                 static function (Criteria $criteria, Context $context) use ($id1, $id2) {
+                    self::assertCount(0, $criteria->getFilters());
+
+                    return [$id1, $id2];
+                },
+                static function (Criteria $criteria, Context $context) use ($id1, $id2) {
+                    self::assertSame([$id1, $id2], $criteria->getIds());
+
                     $filters = $criteria->getFilters();
 
                     self::assertCount(0, $filters);
@@ -607,6 +762,13 @@ class UnusedMediaPurgerTest extends TestCase
             MediaCollection::class,
             [
                 static function (Criteria $criteria, Context $context) use ($id1, $id2) {
+                    self::assertCount(0, $criteria->getFilters());
+
+                    return [$id1, $id2];
+                },
+                static function (Criteria $criteria, Context $context) use ($id1, $id2) {
+                    self::assertSame([$id1, $id2], $criteria->getIds());
+
                     $filters = $criteria->getFilters();
 
                     self::assertCount(0, $filters);
@@ -693,18 +855,37 @@ class UnusedMediaPurgerTest extends TestCase
                 static fn (Criteria $criteria, Context $context) => new EntitySearchResult('media', 2, new MediaCollection(), null, $criteria, $context), // purgable media count query
 
                 static function (Criteria $criteria, Context $context) use ($id1, $id2) {
+                    self::assertCount(0, $criteria->getFilters());
+
+                    self::assertSame(50, $criteria->getLimit());
+
+                    return [$id1, $id2];
+                },
+                static function (Criteria $criteria, Context $context) use ($id1, $id2) {
+                    self::assertSame([$id1, $id2], $criteria->getIds());
+
                     $filters = $criteria->getFilters();
 
                     self::assertCount(0, $filters);
-                    self::assertSame(50, $criteria->getLimit());
 
                     return [$id1, $id2];
                 },
                 static function (Criteria $criteria, Context $context) use ($id3, $id4) {
                     $filters = $criteria->getFilters();
 
+                    // the cursor moves the candidate query forward, the reference check stays unfiltered
                     self::assertCount(1, $filters);
+                    self::assertInstanceOf(RangeFilter::class, $filters[0]);
+                    self::assertSame('id', $filters[0]->getField());
+
                     self::assertSame(50, $criteria->getLimit());
+
+                    return [$id3, $id4];
+                },
+                static function (Criteria $criteria, Context $context) use ($id3, $id4) {
+                    self::assertSame([$id3, $id4], $criteria->getIds());
+
+                    self::assertCount(0, $criteria->getFilters());
 
                     return [$id3, $id4];
                 },
@@ -749,6 +930,13 @@ class UnusedMediaPurgerTest extends TestCase
                 static fn (Criteria $criteria, Context $context) => new EntitySearchResult('media', 2, new MediaCollection(), null, $criteria, $context), // purgable media count query
 
                 static function (Criteria $criteria, Context $context) use ($id1, $id2, $id3, $id4) {
+                    self::assertCount(0, $criteria->getFilters());
+
+                    return [$id1, $id2, $id3, $id4];
+                },
+                static function (Criteria $criteria, Context $context) use ($id1, $id2, $id3, $id4) {
+                    self::assertSame([$id1, $id2, $id3, $id4], $criteria->getIds());
+
                     $filters = $criteria->getFilters();
 
                     self::assertCount(0, $filters);
@@ -797,6 +985,13 @@ class UnusedMediaPurgerTest extends TestCase
                 static fn (Criteria $criteria, Context $context) => new EntitySearchResult('media', 10, new MediaCollection(), null, $criteria, $context), // total media count query
                 static fn (Criteria $criteria, Context $context) => new EntitySearchResult('media', 2, new MediaCollection(), null, $criteria, $context), // purgable media count query
                 static function (Criteria $criteria, Context $context) use ($id1, $id2) {
+                    self::assertCount(0, $criteria->getFilters());
+
+                    return [$id1, $id2];
+                },
+                static function (Criteria $criteria, Context $context) use ($id1, $id2) {
+                    self::assertSame([$id1, $id2], $criteria->getIds());
+
                     $filters = $criteria->getFilters();
 
                     self::assertCount(1, $filters);
@@ -846,6 +1041,13 @@ class UnusedMediaPurgerTest extends TestCase
                 static fn (Criteria $criteria, Context $context) => new EntitySearchResult('media', 10, new MediaCollection(), null, $criteria, $context), // total media count query
                 static fn (Criteria $criteria, Context $context) => new EntitySearchResult('media', 2, new MediaCollection(), null, $criteria, $context), // purgable media count query
                 static function (Criteria $criteria, Context $context) use ($id1, $id2) {
+                    self::assertCount(0, $criteria->getFilters());
+
+                    return [$id1, $id2];
+                },
+                static function (Criteria $criteria, Context $context) use ($id1, $id2) {
+                    self::assertSame([$id1, $id2], $criteria->getIds());
+
                     $filters = $criteria->getFilters();
 
                     self::assertCount(1, $filters);
@@ -902,6 +1104,13 @@ class UnusedMediaPurgerTest extends TestCase
                 static fn (Criteria $criteria, Context $context) => new EntitySearchResult('media', 10, new MediaCollection(), null, $criteria, $context), // total media count query
                 static fn (Criteria $criteria, Context $context) => new EntitySearchResult('media', 2, new MediaCollection(), null, $criteria, $context), // purgable media count query
                 static function (Criteria $criteria, Context $context) use ($id1, $id2) {
+                    self::assertCount(0, $criteria->getFilters());
+
+                    return [$id1, $id2];
+                },
+                static function (Criteria $criteria, Context $context) use ($id1, $id2) {
+                    self::assertSame([$id1, $id2], $criteria->getIds());
+
                     $filters = $criteria->getFilters();
 
                     self::assertCount(1, $filters);
@@ -951,6 +1160,13 @@ class UnusedMediaPurgerTest extends TestCase
                 static fn (Criteria $criteria, Context $context) => new EntitySearchResult('media', 10, new MediaCollection(), null, $criteria, $context), // total media count query
                 static fn (Criteria $criteria, Context $context) => new EntitySearchResult('media', 2, new MediaCollection(), null, $criteria, $context), // purgable media count query
                 static function (Criteria $criteria, Context $context) use ($id1, $id2) {
+                    self::assertCount(0, $criteria->getFilters());
+
+                    return [$id1, $id2];
+                },
+                static function (Criteria $criteria, Context $context) use ($id1, $id2) {
+                    self::assertSame([$id1, $id2], $criteria->getIds());
+
                     $filters = $criteria->getFilters();
 
                     self::assertCount(0, $filters);
@@ -1037,6 +1253,13 @@ class UnusedMediaPurgerTest extends TestCase
 
                     return [$id1, $id2];
                 },
+                static function (Criteria $criteria, Context $context) use ($id1, $id2) {
+                    self::assertSame([$id1, $id2], $criteria->getIds());
+
+                    self::assertCount(0, $criteria->getFilters());
+
+                    return [$id1, $id2];
+                },
                 // fake the grace period filter
                 static fn (Criteria $criteria) => $criteria->getIds(),
                 [],
@@ -1092,6 +1315,13 @@ class UnusedMediaPurgerTest extends TestCase
                 static fn (Criteria $criteria, Context $context) => new EntitySearchResult('media', 10, new MediaCollection(), null, $criteria, $context), // total media count query
                 static fn (Criteria $criteria, Context $context) => new EntitySearchResult('media', 2, new MediaCollection(), null, $criteria, $context), // purgable media count query
                 static function (Criteria $criteria, Context $context) use ($id1, $id2) {
+                    self::assertCount(0, $criteria->getFilters());
+
+                    return [$id1, $id2];
+                },
+                static function (Criteria $criteria, Context $context) use ($id1, $id2) {
+                    self::assertSame([$id1, $id2], $criteria->getIds());
+
                     $filters = $criteria->getFilters();
 
                     self::assertCount(0, $filters);
@@ -1136,6 +1366,13 @@ class UnusedMediaPurgerTest extends TestCase
                 static fn (Criteria $criteria, Context $context) => new EntitySearchResult('media', 10, new MediaCollection(), null, $criteria, $context), // total media count query
                 static fn (Criteria $criteria, Context $context) => new EntitySearchResult('media', 2, new MediaCollection(), null, $criteria, $context), // purgable media count query
                 static function (Criteria $criteria, Context $context) use ($id1, $id2) {
+                    self::assertCount(0, $criteria->getFilters());
+
+                    return [$id1, $id2];
+                },
+                static function (Criteria $criteria, Context $context) use ($id1, $id2) {
+                    self::assertSame([$id1, $id2], $criteria->getIds());
+
                     $filters = $criteria->getFilters();
 
                     self::assertCount(0, $filters);
@@ -1178,6 +1415,13 @@ class UnusedMediaPurgerTest extends TestCase
                 static fn (Criteria $criteria, Context $context) => new EntitySearchResult('media', 10, new MediaCollection(), null, $criteria, $context), // total media count query
                 static fn (Criteria $criteria, Context $context) => new EntitySearchResult('media', 2, new MediaCollection(), null, $criteria, $context), // purgable media count query
                 static function (Criteria $criteria, Context $context) use ($id1, $id2) {
+                    self::assertCount(0, $criteria->getFilters());
+
+                    return [$id1, $id2];
+                },
+                static function (Criteria $criteria, Context $context) use ($id1, $id2) {
+                    self::assertSame([$id1, $id2], $criteria->getIds());
+
                     $filters = $criteria->getFilters();
 
                     self::assertCount(0, $filters);
@@ -1224,6 +1468,13 @@ class UnusedMediaPurgerTest extends TestCase
                 static fn (Criteria $criteria, Context $context) => new EntitySearchResult('media', 10, new MediaCollection(), null, $criteria, $context), // total media count query
                 static fn (Criteria $criteria, Context $context) => new EntitySearchResult('media', 2, new MediaCollection(), null, $criteria, $context), // purgable media count query
                 static function (Criteria $criteria, Context $context) use ($id1, $id2) {
+                    self::assertCount(0, $criteria->getFilters());
+
+                    return [$id1, $id2];
+                },
+                static function (Criteria $criteria, Context $context) use ($id1, $id2) {
+                    self::assertSame([$id1, $id2], $criteria->getIds());
+
                     $filters = $criteria->getFilters();
 
                     self::assertCount(0, $filters);
@@ -1268,6 +1519,11 @@ class UnusedMediaPurgerTest extends TestCase
                 static fn (Criteria $criteria, Context $context) => new EntitySearchResult('media', 10, new MediaCollection(), null, $criteria, $context), // total media count query
                 static fn (Criteria $criteria, Context $context) => new EntitySearchResult('media', 2, new MediaCollection(), null, $criteria, $context), // purgable media count query
                 [$id1, $id2],
+                static function (Criteria $criteria) use ($id1, $id2) {
+                    static::assertSame([$id1, $id2], $criteria->getIds());
+
+                    return [$id1, $id2];
+                },
                 static function (Criteria $criteria) use ($id1, $id2) {
                     static::assertSame([$id1, $id2], $criteria->getIds());
 


### PR DESCRIPTION
### 1. Why is this change necessary?

The `product_download.media.cleanup` scheduled task fails on large shops with
`The SELECT would examine more than MAX_JOIN_SIZE rows`.

`max_join_size` is enforced against the optimizer's estimate for the whole plan,
which is the product of the per-table estimates. `createFilterForNotUsedMedia()`
built one criteria carrying a `LEFT JOIN` for every media association and fed it
to three call sites, none of which bounded the driving set:

- `getTotal()` in `deleteNotUsedMedia()`, issued before any batching. Under
  `TOTAL_COUNT_MODE_EXACT`, `EntitySearcher::getTotalCount()` drops limit and
  offset and wraps the joined id query in `SELECT COUNT(*)`, so every join runs
  over the whole media table, restricted only by the folder filter.
- the cursor loop in `getUnusedMediaIds()`, which carries a `LIMIT` and a cursor
  filter on `id`. That excludes earlier ids but does not cap the set the join
  considers.
- `getNotUsedMedia()`, which pages a `RepositoryIterator` by offset over the
  same joins. This is the `--dry-run` and `--report` path.

### 2. What does this change do, exactly?

The candidate query and the reference check are separated, and the reference
check is split across the associations:

- `createCandidateCriteria()` restricts which media is scanned. It applies the
  folder filter and touches no association, so it stays cheap. It filters on
  `media.mediaFolderId` rather than `media.mediaFolder.id`, because the
  association traversal resolves through `ManyToOneAssociationFieldResolver` and
  joins `media_folder` onto every candidate row for a value the foreign key on
  media already holds.
- `filterOutUsedMedia()` keeps the media that nothing references. It asks one
  query per association, from `getUsageFilters()`, so every plan is two or three
  tables resolved by the foreign key index. Each result narrows the input of the
  next, and the loop stops as soon as a batch is fully referenced.

Bounding the joined query to one batch of ids is not sufficient on its own. The
estimate is a product, and pinning the driving set caps the first factor only:
around 25 associations reach the loop (23 from `MediaDefinition`, plus `themes`
and `themeMedia` from the Storefront theme extension), so a single query
carrying all of them exceeds the limit however few ids drive it.

Every association is still checked, under the same `AND` of null conditions.
Folder membership records where a media file is placed, never whether something
still points at it, so it cannot stand in for the reference check. The loop
stays definition-driven, which keeps associations added through an
`EntityExtension` working and keeps `IgnoreInUnusedMediaSearch` as the single
explicit way to exclude one.

`getNotUsedMedia()` gets the same treatment, so `--dry-run` and `--report`
report what the deletion path would do.

A count cannot be pinned to one batch of ids, so `getTotal()` drops the
association joins and counts the candidates instead. This changes what
`UnusedMediaSearchStartEvent::$totalMediaDeletionCandidates` means: it now
reports the media that gets scanned rather than the media that turns out to be
unused. Its only consumer is the progress bar in `DeleteNotUsedMediaCommand`,
whose note is reworded accordingly. Without a folder entity the value is the
full media count.

Two consequences worth naming:

- `--offset` now counts candidates rather than unused media, because the offset
  is applied to the candidate query. `--offset=1000 --limit=50` can return
  nothing where it previously returned 50 deletions.
- The cursor previously walked only media that already satisfied every
  association filter, so it ran `ceil(unused / limit)` times. It now walks every
  candidate in the folder and runs `ceil(candidates / limit)` times, each batch
  costing at most one query per association. Where unused media is a small
  fraction of a folder this is more round trips; `--limit` is the lever, and
  raising it is safe now that the estimate grows linearly with the batch instead
  of compounding across joins.

### 3. Describe each step to reproduce the issue or behaviour.

1. Set up a shop with enough media and products that the joined query exceeds
   the configured `max_join_size`, for example
   `SET GLOBAL max_join_size = 1000000;`.
2. Run `bin/console media:delete-unused --folder-entity=product_download`, or
   let the `product_download.media.cleanup` scheduled task run.
3. Before this change the command aborts with
   `The SELECT would examine more than MAX_JOIN_SIZE rows`. After it, the
   command completes and deletes only media that nothing references.
4. Verify the reference check is intact: put a media file in the Product Media
   folder, attach it to a product as an image, and run
   `bin/console media:delete-unused --folder-entity=product` — the file is kept.

### 4. Please link to the relevant issues (if any).

- closes #5378

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
