### PR TITLE
fix: document bulk download

### DIFF
--- a/src/Core/Checkout/Document/Service/DocumentMerger.php
+++ b/src/Core/Checkout/Document/Service/DocumentMerger.php
@@ -59,9 +59,6 @@ final class DocumentMerger
             return null;
         }
 
-        $fileName = Random::getAlphanumericString(32) . '.' . PdfRenderer::FILE_EXTENSION;
-        $renderedDocument = new RenderedDocument(name: $fileName);
-
         if ($documents->count() === 1) {
             $document = $documents->first();
             if ($document === null) {
@@ -74,16 +71,49 @@ final class DocumentMerger
             }
 
             $fileBlob = $context->scope(Context::SYSTEM_SCOPE, fn (Context $context): string => $this->mediaService->loadFile($documentMediaId, $context));
-            $renderedDocument->setContent($fileBlob);
 
-            return $renderedDocument;
+            return $this->createRenderedDocument($document, $fileBlob);
+        }
+
+        if (!$this->containsOnlyPdfs($documents)) {
+            return $this->createDocumentsZip($documents, $context);
         }
 
         try {
+            $fileName = Random::getAlphanumericString(32) . '.' . PdfRenderer::FILE_EXTENSION;
+            $renderedDocument = new RenderedDocument(name: $fileName);
+
             return $this->mergeWithFpdi($documents, $context, $renderedDocument);
         } catch (FpdiException $e) {
             return $this->createDocumentsZip($documents, $context);
         }
+    }
+
+    private function createRenderedDocument(DocumentEntity $document, string $fileBlob): RenderedDocument
+    {
+        $fileExtension = $this->resolveFileType($document);
+        $fileName = $document->getDocumentMediaFile()?->getFileName() ?? Random::getAlphanumericString(32);
+        $contentType = $document->getDocumentMediaFile()?->getMimeType() ?? $this->getContentType($fileExtension);
+
+        $renderedDocument = new RenderedDocument(
+            name: $fileName . '.' . $fileExtension,
+            fileExtension: $fileExtension,
+            contentType: $contentType,
+        );
+        $renderedDocument->setContent($fileBlob);
+
+        return $renderedDocument;
+    }
+
+    private function containsOnlyPdfs(DocumentCollection $documents): bool
+    {
+        foreach ($documents as $document) {
+            if ($this->resolveFileType($document) !== PdfRenderer::FILE_EXTENSION) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     private function mergeWithFpdi(DocumentCollection $documents, Context $context, RenderedDocument $renderedDocument): ?RenderedDocument
@@ -128,16 +158,16 @@ final class DocumentMerger
         return $renderedDocument;
     }
 
-    private function ensureDocumentMediaFileGenerated(DocumentEntity $document, Context $context): ?string
+    private function ensureDocumentMediaFileGenerated(DocumentEntity $document, Context $context): ?DocumentEntity
     {
         $documentMediaId = $document->getDocumentMediaFileId();
         if ($documentMediaId !== null || $document->isStatic()) {
-            return $documentMediaId;
+            return $document;
         }
 
         $operation = new DocumentGenerateOperation(
             $document->getOrderId(),
-            PdfRenderer::FILE_EXTENSION,
+            $this->resolveFileType($document),
             $document->getConfig(),
             $document->getReferencedDocumentId()
         );
@@ -165,7 +195,7 @@ final class DocumentMerger
         $document = $this->documentRepository->search($criteria, $context)->getEntities()->first();
         \assert($document !== null);
 
-        return $document->getDocumentMediaFileId();
+        return $document;
     }
 
     /**
@@ -175,23 +205,29 @@ final class DocumentMerger
     {
         $criteria = (new Criteria($documentIds))
             ->addAssociation('documentType')
+            ->addAssociation('documentMediaFile')
             ->addAssociation('order')
             ->addSorting(new FieldSorting('order.orderNumber'));
 
         $documents = $this->documentRepository->search($criteria, $context)->getEntities();
 
         $mediaCache = [];
+        $preparedDocuments = [];
 
         foreach ($documents as $document) {
-            $mediaId = $this->ensureDocumentMediaFileGenerated($document, $context);
+            $preparedDocument = $this->ensureDocumentMediaFileGenerated($document, $context) ?? $document;
+
+            $preparedDocuments[] = $preparedDocument;
+
+            $mediaId = $preparedDocument->getDocumentMediaFileId();
             if ($mediaId !== null) {
-                $mediaCache[$document->getId()] = $mediaId;
+                $mediaCache[$preparedDocument->getId()] = $mediaId;
             }
         }
 
         $this->documentMediaCache = $mediaCache;
 
-        return $documents;
+        return new DocumentCollection($preparedDocuments);
     }
 
     private function createDocumentsZip(DocumentCollection $documents, Context $context): ?RenderedDocument
@@ -218,7 +254,7 @@ final class DocumentMerger
             $technicalName = $document->getDocumentType()?->getTechnicalName() ?? 'unknown';
             $orderNumber = $document->getOrder()?->getOrderNumber() ?? $document->getOrderId();
             $documentNumber = $document->getDocumentNumber() ?? $document->getId();
-            $name = $orderNumber . '_' . $technicalName . '_' . $documentNumber . '.' . PdfRenderer::FILE_EXTENSION;
+            $name = $orderNumber . '_' . $technicalName . '_' . $documentNumber . '.' . $this->resolveFileType($document);
 
             $zip->addFromString($name, $fileContent);
 
@@ -253,5 +289,28 @@ final class DocumentMerger
                 $this->filesystem->remove($tempFile);
             }
         }
+    }
+
+    private function resolveFileType(DocumentEntity $document): string
+    {
+        $fileExtension = $document->getDocumentMediaFile()?->getFileExtension();
+        if (\is_string($fileExtension) && $fileExtension !== '') {
+            return $fileExtension;
+        }
+
+        $fileTypes = $document->getConfig()['fileTypes'] ?? null;
+        if (\is_array($fileTypes) && isset($fileTypes[0]) && \is_string($fileTypes[0]) && $fileTypes[0] !== '') {
+            return $fileTypes[0];
+        }
+
+        return PdfRenderer::FILE_EXTENSION;
+    }
+
+    private function getContentType(string $fileExtension): string
+    {
+        return match ($fileExtension) {
+            'xml' => 'application/xml',
+            default => PdfRenderer::FILE_CONTENT_TYPE,
+        };
     }
 }

--- a/tests/unit/Core/Checkout/Document/Service/DocumentMergerTest.php
+++ b/tests/unit/Core/Checkout/Document/Service/DocumentMergerTest.php
@@ -15,6 +15,7 @@ use Shopware\Core\Checkout\Document\DocumentGenerationResult;
 use Shopware\Core\Checkout\Document\DocumentIdStruct;
 use Shopware\Core\Checkout\Document\Service\DocumentGenerator;
 use Shopware\Core\Checkout\Document\Service\DocumentMerger;
+use Shopware\Core\Checkout\Document\Struct\DocumentGenerateOperation;
 use Shopware\Core\Content\Media\MediaEntity;
 use Shopware\Core\Content\Media\MediaService;
 use Shopware\Core\Framework\Context;
@@ -300,7 +301,8 @@ class DocumentMergerTest extends TestCase
         $documentGenerator->expects($this->once())
             ->method('generate')
             ->willReturnCallback(static function (string $documentType, array $operations) {
-                $operation = array_values($operations)[0];
+                $operation = reset($operations);
+                static::assertInstanceOf(DocumentGenerateOperation::class, $operation);
                 static::assertSame('invoice', $documentType);
                 static::assertSame('xml', $operation->getFileType());
 

--- a/tests/unit/Core/Checkout/Document/Service/DocumentMergerTest.php
+++ b/tests/unit/Core/Checkout/Document/Service/DocumentMergerTest.php
@@ -76,7 +76,60 @@ class DocumentMergerTest extends TestCase
 
         static::assertNotNull($result);
         static::assertSame('pdf', $result->getFileExtension());
+        static::assertSame('application/pdf', $result->getContentType());
         static::assertSame(self::PDF_CONTENT, $result->getContent());
+        static::assertSame('document.pdf', $result->getName());
+    }
+
+    public function testMergeOneXmlDocumentPreservesOriginalMetadata(): void
+    {
+        $document = $this->createDocument(
+            true,
+            true,
+            'xml',
+            'application/xml',
+            'invoice'
+        );
+
+        $fpdi = $this->createMock(Fpdi::class);
+        $fpdi->expects($this->never())->method('setSourceFile');
+
+        $documentGenerator = $this->createMock(DocumentGenerator::class);
+        $documentGenerator->expects($this->never())->method('generate');
+
+        $mediaService = $this->createMock(MediaService::class);
+        $mediaService->expects($this->once())->method('loadFile')->willReturn('<xml />');
+
+        $documentRepository = $this->createMock(EntityRepository::class);
+        $documentRepository->expects($this->once())->method('search')->willReturn(
+            new EntitySearchResult(
+                'document',
+                1,
+                new DocumentCollection([$document]),
+                null,
+                new Criteria(),
+                Context::createDefaultContext(),
+            )
+        );
+
+        $documentMerger = new DocumentMerger(
+            $documentRepository,
+            $mediaService,
+            $documentGenerator,
+            $fpdi,
+            $this->createMock(Filesystem::class),
+        );
+
+        $result = $documentMerger->merge(
+            [$document->getId()],
+            Context::createDefaultContext()
+        );
+
+        static::assertNotNull($result);
+        static::assertSame('xml', $result->getFileExtension());
+        static::assertSame('application/xml', $result->getContentType());
+        static::assertSame('<xml />', $result->getContent());
+        static::assertSame('invoice.xml', $result->getName());
     }
 
     public function testMergeMultipleDocumentsUsingFpdi(): void
@@ -138,6 +191,8 @@ class DocumentMergerTest extends TestCase
         $mediaEntity = new MediaEntity();
         $mediaEntity->setId(Uuid::randomHex());
         $mediaEntity->setFileExtension('pdf');
+        $mediaEntity->setMimeType('application/pdf');
+        $mediaEntity->setFileName('generated');
         $documentWithMedia->setDocumentMediaFileId($mediaEntity->getId());
         $documentWithMedia->setDocumentMediaFile($mediaEntity);
 
@@ -176,9 +231,12 @@ class DocumentMergerTest extends TestCase
                 return $result;
             });
 
+        $mediaService = $this->createMock(MediaService::class);
+        $mediaService->expects($this->once())->method('loadFile')->willReturn(self::PDF_CONTENT);
+
         $documentMerger = new DocumentMerger(
             $documentRepository,
-            $this->createMock(MediaService::class),
+            $mediaService,
             $documentGenerator,
             $this->createMock(Fpdi::class),
             $this->createMock(Filesystem::class),
@@ -191,6 +249,88 @@ class DocumentMergerTest extends TestCase
 
         static::assertNotNull($result);
         static::assertSame('pdf', $result->getFileExtension());
+        static::assertSame('application/pdf', $result->getContentType());
+        static::assertSame('generated.pdf', $result->getName());
+        static::assertSame(self::PDF_CONTENT, $result->getContent());
+    }
+
+    public function testMergeTriggersDocumentGenerationWithConfiguredFileTypeWhenMediaMissing(): void
+    {
+        $document = $this->createDocument(
+            false,
+            true,
+            'pdf',
+            'application/pdf',
+            'document',
+            ['fileTypes' => ['xml']]
+        );
+
+        $documentWithMedia = clone $document;
+        $mediaEntity = new MediaEntity();
+        $mediaEntity->setId(Uuid::randomHex());
+        $mediaEntity->setFileExtension('xml');
+        $mediaEntity->setMimeType('application/xml');
+        $mediaEntity->setFileName('generated-xml');
+        $documentWithMedia->setDocumentMediaFileId($mediaEntity->getId());
+        $documentWithMedia->setDocumentMediaFile($mediaEntity);
+
+        $documentRepository = $this->createMock(EntityRepository::class);
+        $documentRepository->expects($this->exactly(2))
+            ->method('search')
+            ->willReturnOnConsecutiveCalls(
+                new EntitySearchResult(
+                    'document',
+                    1,
+                    new DocumentCollection([$document]),
+                    null,
+                    new Criteria(),
+                    Context::createDefaultContext(),
+                ),
+                new EntitySearchResult(
+                    'document',
+                    1,
+                    new DocumentCollection([$documentWithMedia]),
+                    null,
+                    new Criteria(),
+                    Context::createDefaultContext(),
+                )
+            );
+
+        $documentGenerator = $this->createMock(DocumentGenerator::class);
+        $documentGenerator->expects($this->once())
+            ->method('generate')
+            ->willReturnCallback(static function (string $documentType, array $operations) {
+                $operation = array_values($operations)[0];
+                static::assertSame('invoice', $documentType);
+                static::assertSame('xml', $operation->getFileType());
+
+                $result = new DocumentGenerationResult();
+                $result->addSuccess(new DocumentIdStruct($operation->getDocumentId() ?? Uuid::randomHex(), '', Uuid::randomHex()));
+
+                return $result;
+            });
+
+        $mediaService = $this->createMock(MediaService::class);
+        $mediaService->expects($this->once())->method('loadFile')->willReturn('<xml />');
+
+        $documentMerger = new DocumentMerger(
+            $documentRepository,
+            $mediaService,
+            $documentGenerator,
+            $this->createMock(Fpdi::class),
+            $this->createMock(Filesystem::class),
+        );
+
+        $result = $documentMerger->merge(
+            [$document->getId()],
+            Context::createDefaultContext()
+        );
+
+        static::assertNotNull($result);
+        static::assertSame('xml', $result->getFileExtension());
+        static::assertSame('application/xml', $result->getContentType());
+        static::assertSame('generated-xml.xml', $result->getName());
+        static::assertSame('<xml />', $result->getContent());
     }
 
     public function testMergeMultipleDocumentsSkipsDocumentsWithoutMediaAndDocumentType(): void
@@ -284,6 +424,61 @@ class DocumentMergerTest extends TestCase
         static::assertSame('zip', $result->getFileExtension());
         static::assertSame('application/zip', $result->getContentType());
         static::assertNotEmpty($result->getContent());
+    }
+
+    public function testMergeMultipleDocumentsWithNonPdfFileTypesCreatesZip(): void
+    {
+        $firstDocument = $this->createDocument(true);
+        $secondDocument = $this->createDocument(
+            true,
+            true,
+            'xml',
+            'application/xml',
+            'invoice-xml'
+        );
+
+        $documentRepository = $this->createMock(EntityRepository::class);
+        $documentRepository->method('search')->willReturn(
+            new EntitySearchResult(
+                'document',
+                2,
+                new DocumentCollection([$firstDocument, $secondDocument]),
+                null,
+                new Criteria(),
+                Context::createDefaultContext(),
+            )
+        );
+
+        $fpdi = $this->createMock(Fpdi::class);
+        $fpdi->expects($this->never())->method('setSourceFile');
+
+        $mediaService = $this->createMock(MediaService::class);
+        $mediaService->expects($this->exactly(2))
+            ->method('loadFile')
+            ->willReturnOnConsecutiveCalls('pdf content', '<xml />');
+
+        $filesystem = $this->createMock(Filesystem::class);
+        $filesystem->method('exists')->willReturn(true);
+        $filesystem->method('readFile')->willReturn('zip file content');
+        $filesystem->expects($this->once())->method('remove');
+
+        $documentMerger = new DocumentMerger(
+            $documentRepository,
+            $mediaService,
+            $this->createMock(DocumentGenerator::class),
+            $fpdi,
+            $filesystem,
+        );
+
+        $result = $documentMerger->merge(
+            [$firstDocument->getId(), $secondDocument->getId()],
+            Context::createDefaultContext()
+        );
+
+        static::assertNotNull($result);
+        static::assertSame('zip', $result->getFileExtension());
+        static::assertSame('application/zip', $result->getContentType());
+        static::assertSame('zip file content', $result->getContent());
     }
 
     public function testCreateDocumentsZipThrowsExceptionWhenZipFileCannotBeRead(): void
@@ -453,13 +648,22 @@ class DocumentMergerTest extends TestCase
         static::assertNotNull($result);
     }
 
-    private function createDocument(bool $withMedia, bool $withDocumentType = true): DocumentEntity
-    {
+    /**
+     * @param array<string, array<string>> $config
+     */
+    private function createDocument(
+        bool $withMedia,
+        bool $withDocumentType = true,
+        string $fileExtension = 'pdf',
+        string $mimeType = 'application/pdf',
+        string $fileName = 'document',
+        array $config = [],
+    ): DocumentEntity {
         $document = new DocumentEntity();
         $document->setId(Uuid::randomHex());
         $document->setOrderId(Uuid::randomHex());
         $document->setStatic(false);
-        $document->setConfig([]);
+        $document->setConfig($config);
 
         if ($withDocumentType) {
             $documentType = new DocumentTypeEntity();
@@ -472,7 +676,9 @@ class DocumentMergerTest extends TestCase
         if ($withMedia) {
             $mediaEntity = new MediaEntity();
             $mediaEntity->setId(Uuid::randomHex());
-            $mediaEntity->setFileExtension('pdf');
+            $mediaEntity->setFileExtension($fileExtension);
+            $mediaEntity->setMimeType($mimeType);
+            $mediaEntity->setFileName($fileName);
             $document->setDocumentMediaFile($mediaEntity);
             $document->setDocumentMediaFileId($mediaEntity->getId());
         }


### PR DESCRIPTION
closes: #15710 

Preserves original file metadata for single downloads and falls back to ZIP for mixed or non-PDF bulk downloads. Also ensures regenerated documents use the configured file type.