### PR TITLE
fix: cheapest price calculation for hidden closeout variants

### DIFF
--- a/src/Core/Content/Product/DataAbstractionLayer/CheapestPrice/CheapestPriceContainer.php
+++ b/src/Core/Content/Product/DataAbstractionLayer/CheapestPrice/CheapestPriceContainer.php
@@ -14,6 +14,8 @@ use Shopware\Core\Framework\Struct\Struct;
 #[Package('framework')]
 class CheapestPriceContainer extends Struct
 {
+    private const VARIANT_METADATA_KEY = '_metadata';
+
     /**
      * @var array<mixed>
      */
@@ -42,7 +44,7 @@ class CheapestPriceContainer extends Struct
         $this->value = $value;
     }
 
-    public function resolve(Context $context): ?CheapestPrice
+    public function resolve(Context $context, bool $hideCloseoutProductsWhenOutOfStock = false): ?CheapestPrice
     {
         $ruleIds = $context->getRuleIds();
         $ruleIds[] = 'default';
@@ -53,15 +55,20 @@ class CheapestPriceContainer extends Struct
         $currentSalesChannelId = $source instanceof SalesChannelApiSource ? $source->getSalesChannelId() : null;
 
         foreach ($this->value as $variantId => $group) {
+            $metadata = $this->getVariantMetadata($group);
+
+            if ($hideCloseoutProductsWhenOutOfStock && $this->isVariantHiddenByCloseoutFilter($metadata)) {
+                continue;
+            }
+
+            if ($currentSalesChannelId && !$this->isVariantPriceAvailableInSalesChannel($metadata, $currentSalesChannelId)) {
+                continue;
+            }
+
             foreach ($ruleIds as $ruleId) {
                 $price = $this->filterByRuleId($group, $ruleId, $defaultWasAdded);
 
                 if ($price === null) {
-                    continue;
-                }
-
-                // Check sales channel availability
-                if ($currentSalesChannelId && !$this->isVariantPriceAvailableInSalesChannel($price, $currentSalesChannelId)) {
                     continue;
                 }
 
@@ -287,17 +294,54 @@ class CheapestPriceContainer extends Struct
     }
 
     /**
-     * @param array<mixed> $price
+     * @param array<mixed> $group
+     *
+     * @return array<mixed>
      */
-    private function isVariantPriceAvailableInSalesChannel(array $price, string $salesChannelId): bool
+    private function getVariantMetadata(array $group): array
+    {
+        $metadata = $group[self::VARIANT_METADATA_KEY] ?? null;
+        if (\is_array($metadata)) {
+            return $metadata;
+        }
+
+        foreach ($group as $entry) {
+            if (!\is_array($entry)) {
+                continue;
+            }
+
+            if (\array_key_exists('sales_channel_ids', $entry) || \array_key_exists('available', $entry) || \array_key_exists('is_closeout', $entry)) {
+                return $entry;
+            }
+        }
+
+        return [];
+    }
+
+    /**
+     * @param array<mixed> $metadata
+     */
+    private function isVariantPriceAvailableInSalesChannel(array $metadata, string $salesChannelId): bool
     {
         // If no sales channel IDs are stored, assume it's available everywhere
-        if (!\array_key_exists('sales_channel_ids', $price)) {
+        if (!\array_key_exists('sales_channel_ids', $metadata)) {
             return true;
         }
 
-        $salesChannelIds = $price['sales_channel_ids'] ?? [];
+        $salesChannelIds = $metadata['sales_channel_ids'] ?? [];
 
         return \in_array($salesChannelId, $salesChannelIds, true);
+    }
+
+    /**
+     * @param array<mixed> $metadata
+     */
+    private function isVariantHiddenByCloseoutFilter(array $metadata): bool
+    {
+        if (!\array_key_exists('available', $metadata) || !\array_key_exists('is_closeout', $metadata)) {
+            return false;
+        }
+
+        return (bool) $metadata['is_closeout'] && !(bool) $metadata['available'];
     }
 }

--- a/src/Core/Content/Product/DataAbstractionLayer/CheapestPriceUpdater.php
+++ b/src/Core/Content/Product/DataAbstractionLayer/CheapestPriceUpdater.php
@@ -17,6 +17,8 @@ use Shopware\Core\Framework\Uuid\Uuid;
 #[Package('framework')]
 class CheapestPriceUpdater
 {
+    private const VARIANT_METADATA_KEY = '_metadata';
+
     /**
      * @internal
      */
@@ -219,6 +221,8 @@ class CheapestPriceUpdater
             'LOWER(HEX(IFNULL(product.unit_id, parent.unit_id))) as unit_id',
             'IFNULL(product.purchase_unit, parent.purchase_unit) as purchase_unit',
             'IFNULL(product.reference_unit, parent.reference_unit) as reference_unit',
+            'COALESCE(product.is_closeout, parent.is_closeout, 0) as is_closeout',
+            'product.available as available',
             'product.child_count as child_count',
         );
 
@@ -244,32 +248,55 @@ class CheapestPriceUpdater
 
         $grouped = [];
         foreach ($data as $row) {
+            $parentId = (string) $row['parent_id'];
+            $variantId = (string) $row['variant_id'];
+
             $row['price'] = json_decode((string) $row['price'], true, 512, \JSON_THROW_ON_ERROR);
-            $row['sales_channel_ids'] = $visibilityMap[$row['variant_id']] ?? $visibilityMap[$row['parent_id']] ?? [];
-            $grouped[(string) $row['parent_id']][(string) $row['variant_id']][(string) $row['rule_id']] = $row;
+            $row['sales_channel_ids'] = $visibilityMap[$variantId] ?? $visibilityMap[$parentId] ?? [];
+            $grouped[$parentId][$variantId][(string) $row['rule_id']] = $row;
         }
 
         foreach ($defaults as $row) {
+            $parentId = (string) $row['parent_id'];
+            $variantId = (string) $row['variant_id'];
+
+            $grouped[$parentId][$variantId][self::VARIANT_METADATA_KEY] = $this->buildVariantMetadata($row, $visibilityMap);
+
             if ($row['price'] === null) {
-                $grouped[(string) $row['parent_id']][(string) $row['variant_id']]['default'] = null;
+                $grouped[$parentId][$variantId]['default'] = null;
 
                 continue;
             }
 
             $row['price'] = json_decode((string) $row['price'], true, 512, \JSON_THROW_ON_ERROR);
             $row['price'] = $this->normalizePrices($row['price']);
-            $row['sales_channel_ids'] = $visibilityMap[$row['variant_id']] ?? $visibilityMap[$row['parent_id']] ?? [];
+            $row['sales_channel_ids'] = $visibilityMap[$variantId] ?? $visibilityMap[$parentId] ?? [];
 
             if ($row['child_count'] > 0) {
-                $grouped[(string) $row['parent_id']]['default'] = $row;
+                $grouped[$parentId]['default'] = $row;
 
                 continue;
             }
 
-            $grouped[(string) $row['parent_id']][(string) $row['variant_id']]['default'] = $row;
+            $grouped[$parentId][$variantId]['default'] = $row;
         }
 
         return $grouped;
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     * @param array<string, array<string>> $visibilityMap
+     *
+     * @return array{available: bool, is_closeout: bool, sales_channel_ids: array<string>}
+     */
+    private function buildVariantMetadata(array $row, array $visibilityMap): array
+    {
+        return [
+            'available' => (bool) ($row['available'] ?? false),
+            'is_closeout' => (bool) ($row['is_closeout'] ?? false),
+            'sales_channel_ids' => $visibilityMap[$row['variant_id']] ?? $visibilityMap[$row['parent_id']] ?? [],
+        ];
     }
 
     /**

--- a/src/Core/Content/Product/Subscriber/ProductSubscriber.php
+++ b/src/Core/Content/Product/Subscriber/ProductSubscriber.php
@@ -94,12 +94,17 @@ class ProductSubscriber implements EventSubscriberInterface
      */
     public function salesChannelLoaded(SalesChannelEntityLoadedEvent $event): void
     {
+        $hideCloseoutProductsWhenOutOfStock = $this->systemConfigService->getBool(
+            'core.listing.hideCloseoutProductsWhenOutOfStock',
+            $event->getSalesChannelContext()->getSalesChannelId()
+        );
+
         foreach ($event->getEntities() as $product) {
             $price = $product->get('cheapestPrice');
 
             if ($price instanceof CheapestPriceContainer) {
                 $product->assign([
-                    'cheapestPrice' => $price->resolve($event->getContext()),
+                    'cheapestPrice' => $price->resolve($event->getContext(), $hideCloseoutProductsWhenOutOfStock),
                     'cheapestPriceContainer' => $price,
                 ]);
             }

--- a/src/Core/Migration/V6_7/Migration1776000000RecalculateProductCheapestPriceAvailability.php
+++ b/src/Core/Migration/V6_7/Migration1776000000RecalculateProductCheapestPriceAvailability.php
@@ -1,0 +1,25 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Migration\V6_7;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Content\Product\DataAbstractionLayer\ProductIndexer;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Migration\MigrationStep;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+class Migration1776000000RecalculateProductCheapestPriceAvailability extends MigrationStep
+{
+    public function getCreationTimestamp(): int
+    {
+        return 1776000000;
+    }
+
+    public function update(Connection $connection): void
+    {
+        $this->registerIndexer($connection, 'product.indexer', [ProductIndexer::CHEAPEST_PRICE_UPDATER]);
+    }
+}

--- a/tests/integration/Core/Content/Product/Subscriber/ProductLoadedSubscriberTest.php
+++ b/tests/integration/Core/Content/Product/Subscriber/ProductLoadedSubscriberTest.php
@@ -30,6 +30,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Sorting\FieldSorting;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SalesChannel\Context\SalesChannelContextFactory;
+use Shopware\Core\System\SystemConfig\SystemConfigService;
 use Shopware\Core\Test\Stub\Framework\IdsCollection;
 use Shopware\Core\Test\TestDefaults;
 
@@ -101,6 +102,62 @@ class ProductLoadedSubscriberTest extends TestCase
         static::assertNotNull($productEntity);
         static::assertInstanceOf(CheapestPrice::class, $productEntity->get('cheapestPrice'));
         static::assertInstanceOf(CalculatedCheapestPrice::class, $productEntity->get('calculatedCheapestPrice'));
+    }
+
+    public function testCheapestPriceIgnoresHiddenCloseoutVariantsInSalesChannel(): void
+    {
+        $ids = new IdsCollection();
+        $systemConfigService = static::getContainer()->get(SystemConfigService::class);
+        $configKey = 'core.listing.hideCloseoutProductsWhenOutOfStock';
+        $previousValue = $systemConfigService->get($configKey, TestDefaults::SALES_CHANNEL);
+
+        try {
+            $systemConfigService->set($configKey, true, TestDefaults::SALES_CHANNEL);
+
+            static::getContainer()->get('product.repository')
+                ->create([
+                    (new ProductBuilder($ids, 'p.1'))
+                        ->price(130)
+                        ->visibility()
+                        ->variant(
+                            (new ProductBuilder($ids, 'p.1.v1'))
+                                ->price(80)
+                                ->stock(0)
+                                ->closeout()
+                                ->build()
+                        )
+                        ->variant(
+                            (new ProductBuilder($ids, 'p.1.v2'))
+                                ->price(90)
+                                ->stock(10)
+                                ->closeout()
+                                ->build()
+                        )
+                        ->build(),
+                ], Context::createDefaultContext());
+
+            $salesChannelContext = static::getContainer()->get(SalesChannelContextFactory::class)
+                ->create(Uuid::randomHex(), TestDefaults::SALES_CHANNEL);
+
+            $criteria = new Criteria([$ids->get('p.1')]);
+            $criteria->addFields(['id', 'cheapestPrice', 'taxId', 'price']);
+
+            $productEntity = static::getContainer()
+                ->get('sales_channel.product.repository')
+                ->search($criteria, $salesChannelContext)
+                ->first();
+
+            static::assertNotNull($productEntity);
+            $cheapestPrice = $productEntity->get('cheapestPrice');
+            $calculatedCheapestPrice = $productEntity->get('calculatedCheapestPrice');
+
+            static::assertInstanceOf(CheapestPrice::class, $cheapestPrice);
+            static::assertInstanceOf(CalculatedCheapestPrice::class, $calculatedCheapestPrice);
+            static::assertSame($ids->get('p.1.v2'), $cheapestPrice->getVariantId());
+            static::assertSame(90.0, $calculatedCheapestPrice->getUnitPrice());
+        } finally {
+            $systemConfigService->set($configKey, $previousValue, TestDefaults::SALES_CHANNEL);
+        }
     }
 
     /**

--- a/tests/unit/Core/Content/Product/DataAbstractionLayer/CheapestPrice/CheapestPriceContainerSalesChannelTest.php
+++ b/tests/unit/Core/Content/Product/DataAbstractionLayer/CheapestPrice/CheapestPriceContainerSalesChannelTest.php
@@ -194,4 +194,71 @@ class CheapestPriceContainerSalesChannelTest extends TestCase
 
         static::assertNull($cheapestPrice);
     }
+
+    public function testResolveSkipsUnavailableCloseoutVariantsWhenConfigured(): void
+    {
+        $currentSalesChannelId = Uuid::randomHex();
+
+        $testData = [
+            'variant1' => [
+                '_metadata' => [
+                    'sales_channel_ids' => [$currentSalesChannelId],
+                    'available' => false,
+                    'is_closeout' => true,
+                ],
+                'default' => [
+                    'price' => [
+                        ['currencyId' => Defaults::CURRENCY, 'gross' => 50.0, 'net' => 42.02, 'linked' => true],
+                    ],
+                    'is_ranged' => false,
+                    'rule_id' => 'default',
+                    'parent_id' => 'parent1',
+                    'purchase_unit' => 1.0,
+                    'reference_unit' => 1.0,
+                ],
+            ],
+            'variant2' => [
+                '_metadata' => [
+                    'sales_channel_ids' => [$currentSalesChannelId],
+                    'available' => true,
+                    'is_closeout' => true,
+                ],
+                'default' => [
+                    'price' => [
+                        ['currencyId' => Defaults::CURRENCY, 'gross' => 100.0, 'net' => 84.03, 'linked' => true],
+                    ],
+                    'is_ranged' => false,
+                    'rule_id' => 'default',
+                    'parent_id' => 'parent1',
+                    'purchase_unit' => 1.0,
+                    'reference_unit' => 1.0,
+                ],
+            ],
+        ];
+
+        $context = new Context(
+            new SalesChannelApiSource($currentSalesChannelId),
+            [],
+            Defaults::CURRENCY,
+            [Defaults::LANGUAGE_SYSTEM],
+            Defaults::LIVE_VERSION,
+            1.0,
+            true,
+            CartPrice::TAX_STATE_GROSS
+        );
+
+        $container = new CheapestPriceContainer($testData);
+
+        $cheapestPrice = $container->resolve($context, true);
+
+        static::assertNotNull($cheapestPrice);
+        static::assertSame('variant2', $cheapestPrice->getVariantId());
+        static::assertSame(100.0, $cheapestPrice->getPrice()->first()?->getGross());
+
+        $cheapestPriceWithoutCloseoutFilter = $container->resolve($context, false);
+
+        static::assertNotNull($cheapestPriceWithoutCloseoutFilter);
+        static::assertSame('variant1', $cheapestPriceWithoutCloseoutFilter->getVariantId());
+        static::assertSame(50.0, $cheapestPriceWithoutCloseoutFilter->getPrice()->first()?->getGross());
+    }
 }


### PR DESCRIPTION
## Summary
- Exclude sold-out closeout variants from cheapest-price resolution when `core.listing.hideCloseoutProductsWhenOutOfStock` is enabled.
- Keep sales-channel availability filtering aligned with the existing storefront listing rule.
- Reindex product cheapest-price data after update so existing rows are recalculated with the new behavior.

## Testing
- `phpunit tests/unit/Core/Content/Product/DataAbstractionLayer/CheapestPrice/CheapestPriceContainerSalesChannelTest.php`
- `phpunit tests/integration/Core/Content/Product/Subscriber/ProductLoadedSubscriberTest.php --filter testCheapestPriceIgnoresHiddenCloseoutVariantsInSalesChannel`
- `composer cs -- --config=.php-cs-fixer.dist.php --allow-unsupported-php-version=yes src/Core/Content/Product/DataAbstractionLayer/CheapestPriceUpdater.php`
- `composer phpstan -- src/Core/Content/Product/DataAbstractionLayer/CheapestPriceUpdater.php`