### PR TITLE
feat: add handle uiSidebarSetActive

### DIFF
--- a/src/Administration/Resources/app/administration/package-lock.json
+++ b/src/Administration/Resources/app/administration/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "dependencies": {
         "@shopware-ag/dive": "2.3.4",
-        "@shopware-ag/meteor-admin-sdk": "6.8.0",
+        "@shopware-ag/meteor-admin-sdk": "6.9.0",
         "@shopware-ag/meteor-component-library": "4.24.0",
         "@shopware-ag/meteor-icon-kit": "5.4.0",
         "@swc/core": "1.10.7",
@@ -38,7 +38,7 @@
         "date-fns": "2.30.0",
         "date-fns-tz": "2.0.1",
         "debug": "4.4.3",
-        "dompurify": "^3.4.0",
+        "dompurify": "3.4.0",
         "eslint-plugin-listeners": "1.5.1",
         "flatpickr": "4.6.13",
         "fs-extra": "11.3.0",
@@ -6949,9 +6949,9 @@
       "license": "MIT"
     },
     "node_modules/@shopware-ag/meteor-admin-sdk": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/@shopware-ag/meteor-admin-sdk/-/meteor-admin-sdk-6.8.0.tgz",
-      "integrity": "sha512-BZDTd1i4VxWTtyn2k8yMspho4T1dI9WGQI7j/msp7+LMo/G+Ly5wjryKxt5MwqtD/50/i5jLaUtimToDLM4lfA==",
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@shopware-ag/meteor-admin-sdk/-/meteor-admin-sdk-6.9.0.tgz",
+      "integrity": "sha512-PfBxkYD8si3EGWkI3VXFVEdMHF+zTrill0Q+V+vI/OQV5GuYAJ45KW5F5KfaX5Mlmjh5gdAqnmu4bfsR/BsK6w==",
       "license": "MIT",
       "dependencies": {
         "jwt-decode": "^4.0.0",

--- a/src/Administration/Resources/app/administration/package.json
+++ b/src/Administration/Resources/app/administration/package.json
@@ -52,7 +52,7 @@
   ],
   "dependencies": {
     "@shopware-ag/dive": "2.3.4",
-    "@shopware-ag/meteor-admin-sdk": "6.8.0",
+    "@shopware-ag/meteor-admin-sdk": "6.9.0",
     "@shopware-ag/meteor-component-library": "4.24.0",
     "@shopware-ag/meteor-icon-kit": "5.4.0",
     "@swc/core": "1.10.7",

--- a/src/Administration/Resources/app/administration/src/app/init/sidebar.init.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/init/sidebar.init.spec.js
@@ -71,6 +71,27 @@ describe('src/app/init/sidebar.init', () => {
         expect(Shopware.Store.get('sidebar').sidebars[0].active).toBe(false);
     });
 
+    it('should handle uiSidebarSetActive', async () => {
+        // Add a sidebar
+        await ui.sidebar.add({
+            icon: 'regular-star',
+            title: 'Test sidebar',
+            locationId: 'test-sidebar',
+        });
+
+        // Check that sidebar store has the added sidebar
+        expect(Shopware.Store.get('sidebar').sidebars).toHaveLength(1);
+
+        // Check that sidebar is not active
+        expect(Shopware.Store.get('sidebar').sidebars[0].active).toBe(false);
+
+        // Open the sidebar
+        Shopware.Store.get('sidebar').sidebars[0].active = true;
+
+        // Check that sidebar is not active
+        expect(Shopware.Store.get('sidebar').sidebars[0].active).toBe(true);
+    });
+
     it('should handle uiSidebarRemove', async () => {
         // Add a sidebar
         await ui.sidebar.add({

--- a/src/Administration/Resources/app/administration/src/app/init/sidebar.init.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/init/sidebar.init.spec.js
@@ -85,8 +85,10 @@ describe('src/app/init/sidebar.init', () => {
         // Check that sidebar is not active
         expect(Shopware.Store.get('sidebar').sidebars[0].active).toBe(false);
 
-        // Open the sidebar
-        Shopware.Store.get('sidebar').sidebars[0].active = true;
+        // Activate the sidebar
+        await ui.sidebar.setActive({
+            locationId: 'test-sidebar',
+        });
 
         // Check that sidebar is not active
         expect(Shopware.Store.get('sidebar').sidebars[0].active).toBe(true);

--- a/src/Administration/Resources/app/administration/src/app/init/sidebar.init.ts
+++ b/src/Administration/Resources/app/administration/src/app/init/sidebar.init.ts
@@ -26,6 +26,10 @@ export default function initializeSidebar(): void {
         Shopware.Store.get('sidebar').closeSidebar(locationId);
     });
 
+    Shopware.ExtensionAPI.handle('uiSidebarSetActive', ({ locationId }) => {
+        Shopware.Store.get('sidebar').setActiveSidebar(locationId);
+    });
+
     Shopware.ExtensionAPI.handle('uiSidebarRemove', ({ locationId }) => {
         Shopware.Store.get('sidebar').removeSidebar(locationId);
     });

--- a/src/Administration/Resources/app/administration/src/app/store/sidebar.store.ts
+++ b/src/Administration/Resources/app/administration/src/app/store/sidebar.store.ts
@@ -60,7 +60,6 @@ const sidebarsStore = Shopware.Store.register({
             });
         },
 
-        // Store API
         setActiveSidebar(locationId: string): void {
             // reset all sidebars
             this.sidebars.forEach((sidebar) => {


### PR DESCRIPTION
### 1. Why is this change necessary?
[Meteor](https://github.com/shopware/meteor/releases/tag/%40shopware-ag%2Fmeteor-admin-sdk%406.9.0) already released the function to trigger open sidebar programmatically. 

### 2. What does this change do, exactly?
This pull request updates dependency versions and introduces a new API handler for activating sidebars in the administration UI. It also adds corresponding tests to ensure the new functionality works as expected.

Dependency updates:

* Updated `@shopware-ag/meteor-admin-sdk` from version `6.8.0` to `6.9.0` in both `package.json` and `package-lock.json`, ensuring the latest features and fixes are available.

Sidebar activation feature:

* Added a new `uiSidebarSetActive` handler in `sidebar.init.ts` to allow programmatic activation of sidebars via the Extension API.
* Confirmed the existence of the `setActiveSidebar` method in the sidebar store, which resets all sidebars and activates the specified one.

Testing:

* Added a test case in `sidebar.init.spec.js` to verify that the sidebar activation logic works correctly.

### 3. Describe each step to reproduce the issue or behaviour.
:shrug: 

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
