### PR TITLE
test: flaky CreditNoteRendererTest

### DIFF
--- a/src/Core/Test/AppSystemTestBehaviour.php
+++ b/src/Core/Test/AppSystemTestBehaviour.php
@@ -2,8 +2,11 @@
 
 namespace Shopware\Core\Test;
 
+use Doctrine\DBAL\ArrayParameterType;
+use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\After;
 use Psr\Log\NullLogger;
+use Shopware\Core\Framework\App\ActiveAppsLoader;
 use Shopware\Core\Framework\App\AppService;
 use Shopware\Core\Framework\App\Lifecycle\AppLifecycle;
 use Shopware\Core\Framework\App\Lifecycle\AppLifecycleIterator;
@@ -18,6 +21,11 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 
 trait AppSystemTestBehaviour
 {
+    /**
+     * @var list<string>
+     */
+    private array $appSystemBehaviourAppsInstalledInThisTest = [];
+
     abstract protected static function getContainer(): ContainerInterface;
 
     protected function getAppLoader(string $appDir): AppLoader
@@ -30,6 +38,8 @@ trait AppSystemTestBehaviour
 
     protected function loadAppsFromDir(string $appDir, bool $activateApps = true): void
     {
+        $before = $this->appSystemBehaviourFetchInstalledAppNames();
+
         $appService = new AppService(
             new AppLifecycleIterator(
                 static::getContainer()->get('app.repository'),
@@ -47,6 +57,9 @@ trait AppSystemTestBehaviour
 
             static::fail('App synchronisation failed: ' . \print_r($errors, true));
         }
+
+        $after = $this->appSystemBehaviourFetchInstalledAppNames();
+        $this->appSystemBehaviourAppsInstalledInThisTest = \array_values(\array_diff($after, $before));
     }
 
     protected function reloadAppSnippets(): void
@@ -70,5 +83,47 @@ trait AppSystemTestBehaviour
     protected function deleteShopIdAndResetShopIdProvider(): void
     {
         static::getContainer()->get(ShopIdProvider::class)->deleteShopId();
+    }
+
+    /**
+     * Apps installed via loadAppsFromDir populate two in-memory caches the
+     * surrounding transaction rollback cannot reach: SnippetFileCollection
+     * (shared singleton) and ActiveAppsLoader::$activeApps. Reset them so
+     * fixture snippets (e.g. swagtheme.en.json overriding document.serviceDateNotice)
+     * don't leak into unrelated tests through the Translator catalogue.
+     *
+     * Done via a local DELETE so the re-scan gets a clean snapshot regardless
+     * of whether a transactional behavior's #[After] fires before or after this one.
+     */
+    #[After]
+    protected function cleanUpAppsInstalledInThisTest(): void
+    {
+        if ($this->appSystemBehaviourAppsInstalledInThisTest === []) {
+            return;
+        }
+
+        $container = static::getContainer();
+
+        $container->get(Connection::class)->executeStatement(
+            'DELETE FROM app WHERE name IN (:names)',
+            ['names' => $this->appSystemBehaviourAppsInstalledInThisTest],
+            ['names' => ArrayParameterType::STRING]
+        );
+
+        $container->get(ActiveAppsLoader::class)->reset();
+        $this->reloadAppSnippets();
+
+        $this->appSystemBehaviourAppsInstalledInThisTest = [];
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function appSystemBehaviourFetchInstalledAppNames(): array
+    {
+        /** @var list<string> $names */
+        $names = static::getContainer()->get(Connection::class)->fetchFirstColumn('SELECT name FROM app');
+
+        return $names;
     }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?

Nightly failure on [integration / PHP blue green 6.7 -> 6.8 -> 6.7](https://github.com/shopware/shopware/actions/runs/24699524319/job/72239555634#logs)

SnippetFileCollection (singleton) and ActiveAppsLoader::$activeApps are in-memory caches the surrounding transaction can't reach. Fixture snippets (like swagtheme.en.json) leaked into further tests and caused seed-dependent flakes like CreditNoteRendererTest. 

```
There was 1 failure:

1) Shopware\Tests\Integration\Core\Checkout\Document\Renderer\CreditNoteRendererTest::testDocumentSnapshot
HTML snapshot mismatch: credit_note_renderer_default
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
                                                                         <strong>Payment method:</strong> Payment<br>
                                                                         <strong>Shipping method:</strong> test shipping method<br><br>
                                                     Delivered goods remain our property until full payment has been made.<br>
-                                                    Service date equivalent to invoice date<br>
+                                                    Swag Theme serviceDateNotice EN<br>
                                                                                         </div>

/home/runner/work/shopware/shopware/src/Core/Test/Integration/Traits/SnapshotTesting.php:116
/home/runner/work/shopware/shopware/src/Core/Test/Integration/Traits/SnapshotTesting.php:38
/home/runner/work/shopware/shopware/tests/integration/Core/Checkout/Document/Renderer/CreditNoteRendererTest.php:182
```


### 2. What does this change do, exactly?

Reset app caches in AppSystemTestBehaviour teardown:
  - Tracks apps installed by loadAppsFromDir() via a new $appSystemBehaviourAppsInstalledInThisTest list (diffed before/after).
  - Adds #[After] cleanUpAppsInstalledInThisTest() that: DELETE FROM app WHERE name IN (...), calls ActiveAppsLoader::reset(), then reloadAppSnippets().                                                   
  - Local DELETE (vs relying on transaction rollback) keeps the hook order-independent from DatabaseTransactionBehaviour.    


### 3. Describe each step to reproduce the issue or behaviour.
Run integration tests with Random Seed:   1776735634
Reproducer: first commit https://github.com/shopware/shopware/pull/16309

Other way to reproduce (after teamcity used from full suite):
a local test suite, using `--order-by=default`
```
        <testsuite name="repro-window">
            <file>tests/integration/Core/Framework/Translation/TranslatorTest.php</file>
            <file>tests/integration/Core/Content/ProductExport/Tracking/SalesChannelTrackingListenerTest.php</file>
            <file>tests/integration/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Entity/CustomerSerializerTest.php</file>
            <file>tests/integration/Core/Checkout/Customer/Rule/BillingStateRuleTest.php</file>
            <file>tests/integration/Core/Framework/Store/Services/StoreSessionExpiredMiddlewareTest.php</file>
            <file>tests/integration/Core/Framework/Script/Execution/ScriptExecutorTest.php</file>
            <file>tests/integration/Core/Checkout/Cart/Promotion/Integration/Calculation/PromotionFixedPriceCalculationTest.php</file>
            <file>tests/integration/Core/Checkout/Cart/Rule/CartVolumeRuleTest.php</file>
            <file>tests/integration/Core/Checkout/Cart/Promotion/Integration/Calculation/PromotionSetGroupCalculationTest.php</file>
            <file>tests/integration/Core/Framework/Adapter/Twig/EntityTemplateLoaderTest.php</file>
            <file>tests/integration/Core/Framework/Store/Services/ExtensionDownloaderTest.php</file>
            <file>tests/integration/Core/Content/Flow/ChangeCustomerStatusActionTest.php</file>
            <file>tests/integration/Core/Content/ProductExport/Service/ProductExportValidatorTest.php</file>
            <file>tests/integration/Core/System/Integration/IntegrationRepositoryTest.php</file>
            <file>tests/integration/Core/Checkout/Customer/Repository/CustomerRepositoryTest.php</file>
            <file>tests/integration/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Entity/PromotionIndividualCodeSerializerTest.php</file>
            <file>tests/integration/Core/Framework/Routing/RouteScopeListenerTest.php</file>
            <file>tests/integration/Core/Content/Product/DataAbstractionLayer/ProductIndexerTest.php</file>
            <file>tests/integration/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Entity/CountrySerializerTest.php</file>
            <file>tests/integration/Core/Framework/DataAbstractionLayer/Field/LongTextFieldTest.php</file>
            <file>tests/integration/Core/Content/Product/DataAbstractionLayer/CheapestPrice/CheapestPriceTest.php</file>
            <file>tests/integration/Storefront/Framework/Seo/SeoUrlTemplateRepositoryTest.php</file>
            <file>tests/integration/Core/Checkout/Cart/SalesChannel/CartDeleteRouteTest.php</file>
            <file>tests/integration/Elasticsearch/Product/ProductCustomFieldsUsedUpdaterTest.php</file>
            <file>tests/integration/Core/Framework/Webhook/WebhookApiTest.php</file>
            <file>tests/integration/Core/Framework/DataAbstractionLayer/Field/ListFieldTest.php</file>
            <file>tests/integration/Core/Content/Cms/Subscriber/UnusedMediaSubscriberTest.php</file>
            <file>tests/integration/Core/Framework/DataAbstractionLayer/Version/VersioningCustomFieldTest.php</file>
            <file>tests/integration/Storefront/Theme/ThemeTest.php</file>
            <file>tests/integration/Core/Checkout/Document/Renderer/CreditNoteRendererTest.php</file>
        </testsuite>
```

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
