### PR TITLE
test: reproducer for nightly failure with CreditNoteRenderer

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -496,28 +496,22 @@ jobs:
         run: symfony server:start -d
 
       - name: Install Shopware in previous major version on test DB
-        if: inputs.nightly == 'true'
         run: composer init:testdb
 
       - name: Run next major migrations on test DB
-        if: inputs.nightly == 'true'
         run: DATABASE_URL="mysql://root@127.0.0.1:3306/shopware_test" bin/console database:migrate --all core.V6_8
 
       - name: Run integration tests
-        if: inputs.nightly == 'true'
-        run: php -d memory_limit=-1 vendor/bin/phpunit --testsuite "integration" --stop-on-error --stop-on-failure
+        run: php -d memory_limit=-1 vendor/bin/phpunit --testsuite "integration" --stop-on-error --stop-on-failure --random-order-seed=1776735634 --log-junit junit.xml --log-teamcity teamcity.log
 
-      - name: Install Shopware in previous major version
-        if: inputs.nightly != 'true'
-        run: bin/console system:install --basic-setup --create-database --skip-assets-install
-
-      - name: Run next major migrations
-        if: inputs.nightly != 'true'
-        run: bin/console database:migrate --all core.V6_8
-
-      - name: Run blue-green check
-        if: inputs.nightly != 'true'
-        run: php .github/bin/blue-green-check.php
+      - name: Upload test order artefacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: blue-green-67-68-test-order
+          path: |
+            junit.xml
+            teamcity.log
 
   blue-green-66-67:
     name: "PHP blue green 6.6 -> 6.7 -> 6.6"

--- a/src/Core/Test/AppSystemTestBehaviour.php
+++ b/src/Core/Test/AppSystemTestBehaviour.php
@@ -2,8 +2,11 @@
 
 namespace Shopware\Core\Test;
 
+use Doctrine\DBAL\ArrayParameterType;
+use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\After;
 use Psr\Log\NullLogger;
+use Shopware\Core\Framework\App\ActiveAppsLoader;
 use Shopware\Core\Framework\App\AppService;
 use Shopware\Core\Framework\App\Lifecycle\AppLifecycle;
 use Shopware\Core\Framework\App\Lifecycle\AppLifecycleIterator;
@@ -18,6 +21,11 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 
 trait AppSystemTestBehaviour
 {
+    /**
+     * @var list<string>
+     */
+    private array $appSystemBehaviourAppsInstalledInThisTest = [];
+
     abstract protected static function getContainer(): ContainerInterface;
 
     protected function getAppLoader(string $appDir): AppLoader
@@ -30,6 +38,8 @@ trait AppSystemTestBehaviour
 
     protected function loadAppsFromDir(string $appDir, bool $activateApps = true): void
     {
+        $before = $this->appSystemBehaviourFetchInstalledAppNames();
+
         $appService = new AppService(
             new AppLifecycleIterator(
                 static::getContainer()->get('app.repository'),
@@ -47,6 +57,9 @@ trait AppSystemTestBehaviour
 
             static::fail('App synchronisation failed: ' . \print_r($errors, true));
         }
+
+        $after = $this->appSystemBehaviourFetchInstalledAppNames();
+        $this->appSystemBehaviourAppsInstalledInThisTest = \array_values(\array_diff($after, $before));
     }
 
     protected function reloadAppSnippets(): void
@@ -70,5 +83,47 @@ trait AppSystemTestBehaviour
     protected function deleteShopIdAndResetShopIdProvider(): void
     {
         static::getContainer()->get(ShopIdProvider::class)->deleteShopId();
+    }
+
+    /**
+     * Apps installed via loadAppsFromDir populate two in-memory caches the
+     * surrounding transaction rollback cannot reach: SnippetFileCollection
+     * (shared singleton) and ActiveAppsLoader::$activeApps. Reset them so
+     * fixture snippets (e.g. swagtheme.en.json overriding document.serviceDateNotice)
+     * don't leak into unrelated tests through the Translator catalogue.
+     *
+     * Done via a local DELETE so the re-scan gets a clean snapshot regardless
+     * of whether a transactional behavior's #[After] fires before or after this one.
+     */
+    #[After]
+    protected function cleanUpAppsInstalledInThisTest(): void
+    {
+        if ($this->appSystemBehaviourAppsInstalledInThisTest === []) {
+            return;
+        }
+
+        $container = static::getContainer();
+
+        $container->get(Connection::class)->executeStatement(
+            'DELETE FROM app WHERE name IN (:names)',
+            ['names' => $this->appSystemBehaviourAppsInstalledInThisTest],
+            ['names' => ArrayParameterType::STRING]
+        );
+
+        $container->get(ActiveAppsLoader::class)->reset();
+        $this->reloadAppSnippets();
+
+        $this->appSystemBehaviourAppsInstalledInThisTest = [];
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function appSystemBehaviourFetchInstalledAppNames(): array
+    {
+        /** @var list<string> $names */
+        $names = static::getContainer()->get(Connection::class)->fetchFirstColumn('SELECT name FROM app');
+
+        return $names;
     }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?
Throwaway branch to reproduce the CreditNoteRendererTest::testDocumentSnapshot flake seen in nightly run 24699524319. 

Do not merge.

### 2. What does this change do, exactly?
Forces the nightly-gated steps to run on every push, pins the PHPUnit random seed, and uploads junit.xml / teamcity.log so the test execution order up to the failure is extractable as an artefact.

### 3. Describe each step to reproduce the issue or behaviour.
CI only

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
