### PR TITLE
fix(storefront): harden listing filter merge and single-valued query keys

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -479,6 +479,14 @@ New entities for monitoring orders and customers for Agentic Commerce sales chan
 
 ## Storefront
 
+### Listing filter plugins: `p`, `order`, `limit` are now single-valued
+
+`Listing._mapFilters()` now treats the `p`, `order`, and `limit` query parameters as strictly single-valued (last value wins) instead of pipe-joining multiple contributions.
+A third-party filter plugin that returns `{ p: 2 }` from `getValues()` used to produce `p=1|2` when combined with the built-in pagination value, triggering a `400 Bad Request` on `/widgets/cms/navigation/...`. Multi-valued filter keys (`manufacturer`, `properties`, `rating`, `shipping-free`, ...) still pipe-join.
+
+The merge step also now normalises scalar / array / object contributions into arrays before merging and skips third-party filter plugins whose `getValues()` throws.
+Plugin authors who intentionally relied on the previous pipe-join behaviour for single-valued keys should either drop `p` / `order` / `limit` from their `getValues()` output or call `listing.changeListing(true, { p: nextPage })` directly.
+
 ### Order cancellation only shown for open orders
 
 The account order cancellation action is now only shown for orders in state `open`.

--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -483,15 +483,6 @@ The dataset updates reactively as the user selects a different media file.
 
 ## Storefront
 
-### Listing filter plugins: scalar query keys are no longer pipe-joined
-
-`Listing._mapFilters()` now treats every query parameter that the listing backend reads as a scalar (`p`, `order`, `limit`, `rating`, `shipping-free`, `min-price`, `max-price`) as strictly single-valued (last value wins) instead of pipe-joining multiple contributions.
-A third-party filter plugin that returns `{ p: 2 }` from `getValues()` used to produce `p=1|2` when combined with the built-in pagination value, triggering a `400 Bad Request` on `/widgets/cms/navigation/...`; `rating=3|4` used to cast to `3` server-side. Genuinely multi-valued filter keys (`manufacturer`, `properties`, ...) still pipe-join.
-For `p`, the built-in pagination plugin now always wins, regardless of the order in which filters registered.
-
-The merge step also now normalises scalar / array / object contributions into arrays before merging, drops empty values so they cannot leak into the query as a bare `|`, and skips third-party filter plugins whose `getValues()`, `getLabels()`, `reset()` or `resetAll()` throws.
-Plugin authors who intentionally relied on the previous pipe-join behaviour for these keys should drop them from their `getValues()` output and call `listing.changeListing(true, { p: nextPage })` directly instead.
-
 ### Theme CLI commands clean up unused theme directories
 
 Each theme compilation writes its CSS/JS into a new seeded directory under `public/theme/<hash>`. Removing the now-unused previous directories was handled exclusively by the daily `theme.delete_files` scheduled task (`Shopware\Storefront\Theme\ScheduledTask\DeleteThemeFilesTask`). In environments where that task does not run reliably — e.g. `bin/console theme:compile` during a build/deploy step, or setups relying on the admin worker without an open Administration session — these directories accumulated without bound and could grow to many gigabytes.

--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -483,6 +483,15 @@ The dataset updates reactively as the user selects a different media file.
 
 ## Storefront
 
+### Listing filter plugins: scalar query keys are no longer pipe-joined
+
+`Listing._mapFilters()` now treats every query parameter that the listing backend reads as a scalar (`p`, `order`, `limit`, `rating`, `shipping-free`, `min-price`, `max-price`) as strictly single-valued (last value wins) instead of pipe-joining multiple contributions.
+A third-party filter plugin that returns `{ p: 2 }` from `getValues()` used to produce `p=1|2` when combined with the built-in pagination value, triggering a `400 Bad Request` on `/widgets/cms/navigation/...`; `rating=3|4` used to cast to `3` server-side. Genuinely multi-valued filter keys (`manufacturer`, `properties`, ...) still pipe-join.
+For `p`, the built-in pagination plugin now always wins, regardless of the order in which filters registered.
+
+The merge step also now normalises scalar / array / object contributions into arrays before merging, drops empty values so they cannot leak into the query as a bare `|`, and skips third-party filter plugins whose `getValues()`, `getLabels()`, `reset()` or `resetAll()` throws.
+Plugin authors who intentionally relied on the previous pipe-join behaviour for these keys should drop them from their `getValues()` output and call `listing.changeListing(true, { p: nextPage })` directly instead.
+
 ### Theme CLI commands clean up unused theme directories
 
 Each theme compilation writes its CSS/JS into a new seeded directory under `public/theme/<hash>`. Removing the now-unused previous directories was handled exclusively by the daily `theme.delete_files` scheduled task (`Shopware\Storefront\Theme\ScheduledTask\DeleteThemeFilesTask`). In environments where that task does not run reliably — e.g. `bin/console theme:compile` during a build/deploy step, or setups relying on the admin worker without an open Administration session — these directories accumulated without bound and could grow to many gigabytes.
@@ -2222,15 +2231,6 @@ These sales channels have dedicated configuration options in the administration 
 New entities for monitoring orders and customers for Agentic Commerce sales channels are included.
 
 ## Storefront
-
-### Listing filter plugins: scalar query keys are no longer pipe-joined
-
-`Listing._mapFilters()` now treats every query parameter that the listing backend reads as a scalar (`p`, `order`, `limit`, `rating`, `shipping-free`, `min-price`, `max-price`) as strictly single-valued (last value wins) instead of pipe-joining multiple contributions.
-A third-party filter plugin that returns `{ p: 2 }` from `getValues()` used to produce `p=1|2` when combined with the built-in pagination value, triggering a `400 Bad Request` on `/widgets/cms/navigation/...`; `rating=3|4` used to cast to `3` server-side. Genuinely multi-valued filter keys (`manufacturer`, `properties`, ...) still pipe-join.
-For `p`, the built-in pagination plugin now always wins, regardless of the order in which filters registered.
-
-The merge step also now normalises scalar / array / object contributions into arrays before merging, drops empty values so they cannot leak into the query as a bare `|`, and skips third-party filter plugins whose `getValues()`, `getLabels()`, `reset()` or `resetAll()` throws.
-Plugin authors who intentionally relied on the previous pipe-join behaviour for these keys should drop them from their `getValues()` output and call `listing.changeListing(true, { p: nextPage })` directly instead.
 
 ### Order cancellation only shown for open orders
 

--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -2223,6 +2223,14 @@ New entities for monitoring orders and customers for Agentic Commerce sales chan
 
 ## Storefront
 
+### Listing filter plugins: `p`, `order`, `limit` are now single-valued
+
+`Listing._mapFilters()` now treats the `p`, `order`, and `limit` query parameters as strictly single-valued (last value wins) instead of pipe-joining multiple contributions.
+A third-party filter plugin that returns `{ p: 2 }` from `getValues()` used to produce `p=1|2` when combined with the built-in pagination value, triggering a `400 Bad Request` on `/widgets/cms/navigation/...`. Multi-valued filter keys (`manufacturer`, `properties`, `rating`, `shipping-free`, ...) still pipe-join.
+
+The merge step also now normalises scalar / array / object contributions into arrays before merging and skips third-party filter plugins whose `getValues()` throws.
+Plugin authors who intentionally relied on the previous pipe-join behaviour for single-valued keys should either drop `p` / `order` / `limit` from their `getValues()` output or call `listing.changeListing(true, { p: nextPage })` directly.
+
 ### Order cancellation only shown for open orders
 
 The account order cancellation action is now only shown for orders in state `open`.

--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -2223,13 +2223,14 @@ New entities for monitoring orders and customers for Agentic Commerce sales chan
 
 ## Storefront
 
-### Listing filter plugins: `p`, `order`, `limit` are now single-valued
+### Listing filter plugins: scalar query keys are no longer pipe-joined
 
-`Listing._mapFilters()` now treats the `p`, `order`, and `limit` query parameters as strictly single-valued (last value wins) instead of pipe-joining multiple contributions.
-A third-party filter plugin that returns `{ p: 2 }` from `getValues()` used to produce `p=1|2` when combined with the built-in pagination value, triggering a `400 Bad Request` on `/widgets/cms/navigation/...`. Multi-valued filter keys (`manufacturer`, `properties`, `rating`, `shipping-free`, ...) still pipe-join.
+`Listing._mapFilters()` now treats every query parameter that the listing backend reads as a scalar (`p`, `order`, `limit`, `rating`, `shipping-free`, `min-price`, `max-price`) as strictly single-valued (last value wins) instead of pipe-joining multiple contributions.
+A third-party filter plugin that returns `{ p: 2 }` from `getValues()` used to produce `p=1|2` when combined with the built-in pagination value, triggering a `400 Bad Request` on `/widgets/cms/navigation/...`; `rating=3|4` used to cast to `3` server-side. Genuinely multi-valued filter keys (`manufacturer`, `properties`, ...) still pipe-join.
+For `p`, the built-in pagination plugin now always wins, regardless of the order in which filters registered.
 
-The merge step also now normalises scalar / array / object contributions into arrays before merging and skips third-party filter plugins whose `getValues()` throws.
-Plugin authors who intentionally relied on the previous pipe-join behaviour for single-valued keys should either drop `p` / `order` / `limit` from their `getValues()` output or call `listing.changeListing(true, { p: nextPage })` directly.
+The merge step also now normalises scalar / array / object contributions into arrays before merging, drops empty values so they cannot leak into the query as a bare `|`, and skips third-party filter plugins whose `getValues()`, `getLabels()`, `reset()` or `resetAll()` throws.
+Plugin authors who intentionally relied on the previous pipe-join behaviour for these keys should drop them from their `getValues()` output and call `listing.changeListing(true, { p: nextPage })` directly instead.
 
 ### Order cancellation only shown for open orders
 

--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -54,6 +54,14 @@ This helps merchants spot internal notes directly from the list view without ope
 
 ## Storefront
 
+### Listing filter plugins: `p`, `order`, `limit` are now single-valued
+
+`Listing._mapFilters()` now treats the `p`, `order`, and `limit` query parameters as strictly single-valued (last value wins) instead of pipe-joining multiple contributions.
+A third-party filter plugin that returns `{ p: 2 }` from `getValues()` used to produce `p=1|2` when combined with the built-in pagination value, triggering a `400 Bad Request` on `/widgets/cms/navigation/...`. Multi-valued filter keys (`manufacturer`, `properties`, `rating`, `shipping-free`, ...) still pipe-join.
+
+The merge step also now normalises scalar / array / object contributions into arrays before merging and skips third-party filter plugins whose `getValues()` throws.
+Plugin authors who intentionally relied on the previous pipe-join behaviour for single-valued keys should either drop `p` / `order` / `limit` from their `getValues()` output or call `listing.changeListing(true, { p: nextPage })` directly.
+
 ### Order cancellation only shown for open orders
 
 The account order cancellation action is now only shown for orders in state `open`.

--- a/src/Storefront/Resources/app/storefront/src/plugin/listing/listing.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/listing/listing.plugin.js
@@ -3,6 +3,7 @@
  */
 
 import Plugin from 'src/plugin-system/plugin.class';
+import ListingPaginationPlugin from 'src/plugin/listing/listing-pagination.plugin';
 /** @deprecated tag:v6.8.0 - HttpClient is deprecated. Use native fetch API instead. */
 import HttpClient from 'src/service/http-client.service';
 import ElementReplaceHelper from 'src/helper/element-replace.helper';
@@ -140,6 +141,45 @@ export default class ListingPlugin extends Plugin {
     }
 
     /**
+     * Calls a method on a registered filter plugin without letting a broken third-party
+     * plugin break the entire listing update. Returns `fallback` if the method is missing
+     * or throws.
+     *
+     * @private
+     */
+    _callFilterPlugin(filterPlugin, method, fallback, ...args) {
+        if (typeof filterPlugin[method] !== 'function') {
+            return fallback;
+        }
+
+        try {
+            return filterPlugin[method](...args);
+        } catch (error) {
+            console.warn(`Listing filter plugin threw from ${method}(); skipping.`, error);
+
+            return fallback;
+        }
+    }
+
+    /**
+     * The built-in pagination plugin is authoritative for the single-valued `p` parameter.
+     * It is therefore merged last, so the last-value-wins rule in `_mapFilters()` resolves to
+     * its page regardless of the order in which third-party filters happened to register.
+     *
+     * @private
+     */
+    _getPrioritisedRegistry() {
+        const others = [];
+        const pagination = [];
+
+        this._registry.forEach((filterPlugin) => {
+            (filterPlugin instanceof ListingPaginationPlugin ? pagination : others).push(filterPlugin);
+        });
+
+        return [...others, ...pagination];
+    }
+
+    /**
      * Merges the values reported by every registered filter plugin into a single map.
      * Third-party plugins that throw from `getValues()` or return malformed shapes are
      * skipped instead of breaking the entire listing update.
@@ -149,17 +189,8 @@ export default class ListingPlugin extends Plugin {
     _fetchValuesOfRegisteredFilters() {
         const filters = {};
 
-        this._registry.forEach((filterPlugin) => {
-            let values = {};
-
-            if (typeof filterPlugin.getValues === 'function') {
-                try {
-                    values = filterPlugin.getValues();
-                } catch (error) {
-                    console.warn('Listing filter plugin threw from getValues(); skipping.', error);
-                    return;
-                }
-            }
+        this._getPrioritisedRegistry().forEach((filterPlugin) => {
+            const values = this._callFilterPlugin(filterPlugin, 'getValues', null);
 
             if (!values) {
                 return;
@@ -184,7 +215,10 @@ export default class ListingPlugin extends Plugin {
                 }
 
                 list.forEach((entry) => {
-                    if (entry !== null && entry !== undefined) {
+                    // An inactive filter reports an empty string (e.g. an unchecked boolean
+                    // filter). Keeping it would produce separator-only values such as `|` once
+                    // the list is pipe-joined below, which the backend reads as an active filter.
+                    if (entry !== null && entry !== undefined && entry !== '') {
                         filters[key].push(entry);
                     }
                 });
@@ -198,16 +232,25 @@ export default class ListingPlugin extends Plugin {
      * Serialises the merged filter map into the request query parameter map.
      *
      * Note: the `singleValuedKeys` set tracks query parameters that the listing backend
-     * expects as a single value (see `PagingListingProcessor` and `SortingListingProcessor`
-     * under `Core/Content/Product/SalesChannel/Listing/Processor/` on the PHP side).
-     * Pipe-joining them would produce invalid queries like `p=1|2`, which results in 400
-     * responses on `/widgets/cms/navigation/*`. Keep this in sync when the backend adds
-     * new single-valued listing params (e.g. a future pagination token).
+     * reads as a single value, either via `PagingListingProcessor` / `SortingListingProcessor`
+     * under `Core/Content/Product/SalesChannel/Listing/Processor/`, or via the scalar casts in
+     * the handlers under `Core/Content/Product/SalesChannel/Listing/Filter/` on the PHP side.
+     * Pipe-joining them produces either invalid queries like `p=1|2` (400 responses on
+     * `/widgets/cms/navigation/*`) or silently wrong filters like `rating=3|4`, which casts to
+     * `3`. Keep this in sync when the backend adds new single-valued listing params.
      *
      * @private
      */
     _mapFilters(filters) {
-        const singleValuedKeys = new Set(['p', 'order', 'limit']);
+        const singleValuedKeys = new Set([
+            'p',
+            'order',
+            'limit',
+            'rating',
+            'shipping-free',
+            'min-price',
+            'max-price',
+        ]);
         const mapped = {};
 
         Object.keys(filters).forEach((key) => {
@@ -326,7 +369,7 @@ export default class ListingPlugin extends Plugin {
         let labelHtml = '';
 
         this._registry.forEach((filterPlugin) => {
-            const labels = filterPlugin.getLabels();
+            const labels = this._callFilterPlugin(filterPlugin, 'getLabels', []);
 
             if (labels.length) {
                 labels.forEach((label) => {
@@ -380,7 +423,7 @@ export default class ListingPlugin extends Plugin {
      */
     resetFilter(label) {
         this._registry.forEach((filterPlugin) => {
-            filterPlugin.reset(label.dataset.id);
+            this._callFilterPlugin(filterPlugin, 'reset', undefined, label.dataset.id);
         });
 
         this._buildRequest();
@@ -392,7 +435,7 @@ export default class ListingPlugin extends Plugin {
      */
     resetAllFilter() {
         this._registry.forEach((filterPlugin) => {
-            filterPlugin.resetAll();
+            this._callFilterPlugin(filterPlugin, 'resetAll', undefined);
         });
 
         this._buildRequest();

--- a/src/Storefront/Resources/app/storefront/src/plugin/listing/listing.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/listing/listing.plugin.js
@@ -156,7 +156,6 @@ export default class ListingPlugin extends Plugin {
                 try {
                     values = filterPlugin.getValues();
                 } catch (error) {
-                    // eslint-disable-next-line no-console
                     console.warn('Listing filter plugin threw from getValues(); skipping.', error);
                     return;
                 }
@@ -199,11 +198,11 @@ export default class ListingPlugin extends Plugin {
      * Serialises the merged filter map into the request query parameter map.
      *
      * Note: the `singleValuedKeys` set tracks query parameters that the listing backend
-     * expects as a single value (see `ProductListingCriteriaBuilder` on the PHP side and
-     * the hints in the `Listing` storefront plugin documentation). Pipe-joining them
-     * would produce invalid queries like `p=1|2`, which results in 400 responses on
-     * `/widgets/cms/navigation/*`. Keep this in sync when the backend adds new
-     * single-valued listing params (e.g. a future pagination token).
+     * expects as a single value (see `PagingListingProcessor` and `SortingListingProcessor`
+     * under `Core/Content/Product/SalesChannel/Listing/Processor/` on the PHP side).
+     * Pipe-joining them would produce invalid queries like `p=1|2`, which results in 400
+     * responses on `/widgets/cms/navigation/*`. Keep this in sync when the backend adds
+     * new single-valued listing params (e.g. a future pagination token).
      *
      * @private
      */

--- a/src/Storefront/Resources/app/storefront/src/plugin/listing/listing.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/listing/listing.plugin.js
@@ -140,22 +140,55 @@ export default class ListingPlugin extends Plugin {
     }
 
     /**
+     * Merges the values reported by every registered filter plugin into a single map.
+     * Third-party plugins that throw from `getValues()` or return malformed shapes are
+     * skipped instead of breaking the entire listing update.
+     *
      * @private
      */
     _fetchValuesOfRegisteredFilters() {
         const filters = {};
 
         this._registry.forEach((filterPlugin) => {
-            const values = filterPlugin.getValues();
+            let values = {};
+
+            if (typeof filterPlugin.getValues === 'function') {
+                try {
+                    values = filterPlugin.getValues();
+                } catch (error) {
+                    // eslint-disable-next-line no-console
+                    console.warn('Listing filter plugin threw from getValues(); skipping.', error);
+                    return;
+                }
+            }
+
+            if (!values) {
+                return;
+            }
 
             Object.keys(values).forEach((key) => {
-                if (Object.prototype.hasOwnProperty.call(filters, key)) {
-                    Object.values(values[key]).forEach((value) => {
-                        filters[key].push(value);
-                    });
+                const value = values[key];
+                let list;
+
+                if (Array.isArray(value)) {
+                    list = value;
+                } else if (value !== null && typeof value === 'object') {
+                    list = Object.values(value);
+                } else if (value !== null && value !== undefined) {
+                    list = [value];
                 } else {
-                    filters[key] = values[key];
+                    list = [];
                 }
+
+                if (!Object.prototype.hasOwnProperty.call(filters, key)) {
+                    filters[key] = [];
+                }
+
+                list.forEach((entry) => {
+                    if (entry !== null && entry !== undefined) {
+                        filters[key].push(entry);
+                    }
+                });
             });
         });
 
@@ -163,20 +196,44 @@ export default class ListingPlugin extends Plugin {
     }
 
     /**
+     * Serialises the merged filter map into the request query parameter map.
+     *
+     * Note: the `singleValuedKeys` set tracks query parameters that the listing backend
+     * expects as a single value (see `ProductListingCriteriaBuilder` on the PHP side and
+     * the hints in the `Listing` storefront plugin documentation). Pipe-joining them
+     * would produce invalid queries like `p=1|2`, which results in 400 responses on
+     * `/widgets/cms/navigation/*`. Keep this in sync when the backend adds new
+     * single-valued listing params (e.g. a future pagination token).
+     *
      * @private
      */
     _mapFilters(filters) {
+        const singleValuedKeys = new Set(['p', 'order', 'limit']);
         const mapped = {};
+
         Object.keys(filters).forEach((key) => {
-            let value = filters[key];
+            const value = filters[key];
+            let resolved;
 
             if (Array.isArray(value)) {
-                value = value.join('|');
+                if (value.length === 0) {
+                    return;
+                }
+
+                if (singleValuedKeys.has(key)) {
+                    const last = value[value.length - 1];
+                    resolved = last === null || last === undefined ? '' : String(last);
+                } else {
+                    resolved = value.join('|');
+                }
+            } else if (value !== null && value !== undefined) {
+                resolved = singleValuedKeys.has(key) ? String(value) : value;
+            } else {
+                return;
             }
 
-            const string = `${value}`;
-            if (string.length) {
-                mapped[key] = value;
+            if (`${resolved}`.length) {
+                mapped[key] = resolved;
             }
         });
 

--- a/src/Storefront/Resources/app/storefront/test/plugin/listing/listing.plugin.test.js
+++ b/src/Storefront/Resources/app/storefront/test/plugin/listing/listing.plugin.test.js
@@ -352,6 +352,25 @@ describe('ListingPlugin tests', () => {
             expect(result.manufacturer).toEqual(['abc']);
             expect(result.rating).toEqual([]);
         });
+
+        test('skips filters whose getValues throws and continues with remaining filters', () => {
+            const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+            const throwingFilter = { getValues: () => { throw new Error('boom'); } };
+            const validFilter = { getValues: () => ({ manufacturer: ['abc'] }) };
+
+            listingPlugin._registry = [throwingFilter, validFilter];
+
+            expect(() => listingPlugin._fetchValuesOfRegisteredFilters()).not.toThrow();
+
+            const result = listingPlugin._fetchValuesOfRegisteredFilters();
+            expect(result.manufacturer).toEqual(['abc']);
+            expect(consoleWarnSpy).toHaveBeenCalledWith(
+                expect.stringContaining('Listing filter plugin threw from getValues()'),
+                expect.any(Error),
+            );
+
+            consoleWarnSpy.mockRestore();
+        });
     });
 
     describe('_mapFilters', () => {

--- a/src/Storefront/Resources/app/storefront/test/plugin/listing/listing.plugin.test.js
+++ b/src/Storefront/Resources/app/storefront/test/plugin/listing/listing.plugin.test.js
@@ -1,4 +1,5 @@
 import ListingPlugin from 'src/plugin/listing/listing.plugin';
+import ListingPaginationPlugin from 'src/plugin/listing/listing-pagination.plugin';
 
 describe('ListingPlugin tests', () => {
     let listingPlugin = undefined;
@@ -353,6 +354,18 @@ describe('ListingPlugin tests', () => {
             expect(result.rating).toEqual([]);
         });
 
+        test('drops empty values so they cannot leak into the query as a bare separator', () => {
+            const uncheckedA = { getValues: () => ({ 'shipping-free': '' }) };
+            const uncheckedB = { getValues: () => ({ 'shipping-free': '' }) };
+
+            listingPlugin._registry = [uncheckedA, uncheckedB];
+
+            const filters = listingPlugin._fetchValuesOfRegisteredFilters();
+
+            expect(filters['shipping-free']).toEqual([]);
+            expect(listingPlugin._mapFilters(filters)['shipping-free']).toBeUndefined();
+        });
+
         test('skips filters whose getValues throws and continues with remaining filters', () => {
             const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
             const throwingFilter = { getValues: () => { throw new Error('boom'); } };
@@ -420,6 +433,20 @@ describe('ListingPlugin tests', () => {
             expect(mapped.p).not.toBe('1|2');
         });
 
+        test('returns scalar backend filter params as single values', () => {
+            const mapped = listingPlugin._mapFilters({
+                rating: ['3', '4'],
+                'shipping-free': ['1', '1'],
+                'min-price': ['10', '20'],
+                'max-price': ['50', '60'],
+            });
+
+            expect(mapped.rating).toBe('4');
+            expect(mapped['shipping-free']).toBe('1');
+            expect(mapped['min-price']).toBe('20');
+            expect(mapped['max-price']).toBe('60');
+        });
+
         test('omits empty and nullish values', () => {
             const mapped = listingPlugin._mapFilters({
                 manufacturer: [],
@@ -435,6 +462,31 @@ describe('ListingPlugin tests', () => {
             expect(mapped.shippingFree).toBeUndefined();
             expect(mapped.order).toBe('name-asc');
         });
+    });
+
+    test('lets the built-in pagination plugin win the `p` param regardless of registration order', () => {
+        const paginationPlugin = Object.create(ListingPaginationPlugin.prototype);
+        paginationPlugin.getValues = () => ({ p: 5 });
+        const thirdPartyFilter = { getValues: () => ({ p: 2 }) };
+
+        listingPlugin._registry = [paginationPlugin, thirdPartyFilter];
+
+        const mapped = listingPlugin._mapFilters(listingPlugin._fetchValuesOfRegisteredFilters());
+
+        expect(mapped.p).toBe('5');
+    });
+
+    test('does not break the listing update when a filter plugin throws from getLabels', () => {
+        const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+        const throwingFilter = { getLabels: () => { throw new Error('boom'); } };
+        const validFilter = { getLabels: () => [{ id: 'abc', label: 'ABC' }] };
+
+        listingPlugin._registry = [throwingFilter, validFilter];
+
+        expect(() => listingPlugin._buildLabels()).not.toThrow();
+        expect(listingPlugin.activeFilterContainer.innerHTML).toContain('ABC');
+
+        consoleWarnSpy.mockRestore();
     });
 
     test('builds the labels for the active filters and renders them inside the filter panel', async () => {

--- a/src/Storefront/Resources/app/storefront/test/plugin/listing/listing.plugin.test.js
+++ b/src/Storefront/Resources/app/storefront/test/plugin/listing/listing.plugin.test.js
@@ -312,6 +312,112 @@ describe('ListingPlugin tests', () => {
         expect(document.querySelector('.filter-panel-aria-live').textContent).toBe('Showing 2 products.');
     });
 
+    describe('_fetchValuesOfRegisteredFilters', () => {
+        test('does not crash when multiple filters contribute the same scalar key', () => {
+            const filterA = { getValues: () => ({ p: 1 }) };
+            const filterB = { getValues: () => ({ p: 2 }) };
+
+            listingPlugin._registry = [filterA, filterB];
+
+            expect(() => listingPlugin._fetchValuesOfRegisteredFilters()).not.toThrow();
+
+            const result = listingPlugin._fetchValuesOfRegisteredFilters();
+            expect(result.p).toEqual([1, 2]);
+        });
+
+        test('normalizes scalars, arrays and objects into a single array per key', () => {
+            const scalarFilter = { getValues: () => ({ manufacturer: 'abc' }) };
+            const arrayFilter = { getValues: () => ({ manufacturer: ['def', 'ghi'] }) };
+            const objectFilter = { getValues: () => ({ properties: { a: 'p1', b: 'p2' } }) };
+
+            listingPlugin._registry = [scalarFilter, arrayFilter, objectFilter];
+
+            const result = listingPlugin._fetchValuesOfRegisteredFilters();
+
+            expect(result.manufacturer).toEqual(['abc', 'def', 'ghi']);
+            expect(result.properties).toEqual(['p1', 'p2']);
+        });
+
+        test('skips filters without getValues and handles null values gracefully', () => {
+            const brokenFilter = {};
+            const nullReturning = { getValues: () => null };
+            const withNullValue = { getValues: () => ({ manufacturer: null, rating: undefined }) };
+            const validFilter = { getValues: () => ({ manufacturer: ['abc'] }) };
+
+            listingPlugin._registry = [brokenFilter, nullReturning, withNullValue, validFilter];
+
+            expect(() => listingPlugin._fetchValuesOfRegisteredFilters()).not.toThrow();
+
+            const result = listingPlugin._fetchValuesOfRegisteredFilters();
+            expect(result.manufacturer).toEqual(['abc']);
+            expect(result.rating).toEqual([]);
+        });
+    });
+
+    describe('_mapFilters', () => {
+        test('returns single-valued keys like `p` as scalars even when multiple values were collected', () => {
+            const mapped = listingPlugin._mapFilters({
+                p: [1, 2],
+                order: ['name-asc', 'price-desc'],
+                limit: [24, 48],
+            });
+
+            expect(mapped.p).toBe('2');
+            expect(mapped.order).toBe('price-desc');
+            expect(mapped.limit).toBe('48');
+            expect(mapped.p).not.toContain('|');
+            expect(mapped.order).not.toContain('|');
+            expect(mapped.limit).not.toContain('|');
+        });
+
+        test('pipe-joins multi-valued filter keys like `manufacturer` and `properties`', () => {
+            const mapped = listingPlugin._mapFilters({
+                manufacturer: ['abc', 'def'],
+                properties: ['p1', 'p2', 'p3'],
+            });
+
+            expect(mapped.manufacturer).toBe('abc|def');
+            expect(mapped.properties).toBe('p1|p2|p3');
+        });
+
+        test('keeps scalar `p` as a string without pipe when only one value exists', () => {
+            const filter = { getValues: () => ({ p: 2 }) };
+            listingPlugin._registry = [filter];
+
+            const mapped = listingPlugin._mapFilters(listingPlugin._fetchValuesOfRegisteredFilters());
+
+            expect(mapped.p).toBe('2');
+            expect(mapped.p).not.toContain('|');
+        });
+
+        test('produces a valid scalar `p` when multiple filters contribute the page param', () => {
+            const filterA = { getValues: () => ({ p: 1 }) };
+            const filterB = { getValues: () => ({ p: 2 }) };
+            listingPlugin._registry = [filterA, filterB];
+
+            const mapped = listingPlugin._mapFilters(listingPlugin._fetchValuesOfRegisteredFilters());
+
+            expect(mapped.p).toBe('2');
+            expect(mapped.p).not.toBe('1|2');
+        });
+
+        test('omits empty and nullish values', () => {
+            const mapped = listingPlugin._mapFilters({
+                manufacturer: [],
+                properties: null,
+                rating: undefined,
+                shippingFree: '',
+                order: ['name-asc'],
+            });
+
+            expect(mapped.manufacturer).toBeUndefined();
+            expect(mapped.properties).toBeUndefined();
+            expect(mapped.rating).toBeUndefined();
+            expect(mapped.shippingFree).toBeUndefined();
+            expect(mapped.order).toBe('name-asc');
+        });
+    });
+
     test('builds the labels for the active filters and renders them inside the filter panel', async () => {
         global.fetch = jest.fn(() =>
             Promise.resolve({

--- a/src/Storefront/Resources/app/storefront/test/plugin/listing/listing.plugin.test.js
+++ b/src/Storefront/Resources/app/storefront/test/plugin/listing/listing.plugin.test.js
@@ -301,6 +301,112 @@ describe('ListingPlugin tests', () => {
         expect(document.querySelector('.filter-panel-aria-live').textContent).toBe('Showing 2 products.');
     });
 
+    describe('_fetchValuesOfRegisteredFilters', () => {
+        test('does not crash when multiple filters contribute the same scalar key', () => {
+            const filterA = { getValues: () => ({ p: 1 }) };
+            const filterB = { getValues: () => ({ p: 2 }) };
+
+            listingPlugin._registry = [filterA, filterB];
+
+            expect(() => listingPlugin._fetchValuesOfRegisteredFilters()).not.toThrow();
+
+            const result = listingPlugin._fetchValuesOfRegisteredFilters();
+            expect(result.p).toEqual([1, 2]);
+        });
+
+        test('normalizes scalars, arrays and objects into a single array per key', () => {
+            const scalarFilter = { getValues: () => ({ manufacturer: 'abc' }) };
+            const arrayFilter = { getValues: () => ({ manufacturer: ['def', 'ghi'] }) };
+            const objectFilter = { getValues: () => ({ properties: { a: 'p1', b: 'p2' } }) };
+
+            listingPlugin._registry = [scalarFilter, arrayFilter, objectFilter];
+
+            const result = listingPlugin._fetchValuesOfRegisteredFilters();
+
+            expect(result.manufacturer).toEqual(['abc', 'def', 'ghi']);
+            expect(result.properties).toEqual(['p1', 'p2']);
+        });
+
+        test('skips filters without getValues and handles null values gracefully', () => {
+            const brokenFilter = {};
+            const nullReturning = { getValues: () => null };
+            const withNullValue = { getValues: () => ({ manufacturer: null, rating: undefined }) };
+            const validFilter = { getValues: () => ({ manufacturer: ['abc'] }) };
+
+            listingPlugin._registry = [brokenFilter, nullReturning, withNullValue, validFilter];
+
+            expect(() => listingPlugin._fetchValuesOfRegisteredFilters()).not.toThrow();
+
+            const result = listingPlugin._fetchValuesOfRegisteredFilters();
+            expect(result.manufacturer).toEqual(['abc']);
+            expect(result.rating).toEqual([]);
+        });
+    });
+
+    describe('_mapFilters', () => {
+        test('returns single-valued keys like `p` as scalars even when multiple values were collected', () => {
+            const mapped = listingPlugin._mapFilters({
+                p: [1, 2],
+                order: ['name-asc', 'price-desc'],
+                limit: [24, 48],
+            });
+
+            expect(mapped.p).toBe('2');
+            expect(mapped.order).toBe('price-desc');
+            expect(mapped.limit).toBe('48');
+            expect(mapped.p).not.toContain('|');
+            expect(mapped.order).not.toContain('|');
+            expect(mapped.limit).not.toContain('|');
+        });
+
+        test('pipe-joins multi-valued filter keys like `manufacturer` and `properties`', () => {
+            const mapped = listingPlugin._mapFilters({
+                manufacturer: ['abc', 'def'],
+                properties: ['p1', 'p2', 'p3'],
+            });
+
+            expect(mapped.manufacturer).toBe('abc|def');
+            expect(mapped.properties).toBe('p1|p2|p3');
+        });
+
+        test('keeps scalar `p` as a string without pipe when only one value exists', () => {
+            const filter = { getValues: () => ({ p: 2 }) };
+            listingPlugin._registry = [filter];
+
+            const mapped = listingPlugin._mapFilters(listingPlugin._fetchValuesOfRegisteredFilters());
+
+            expect(mapped.p).toBe('2');
+            expect(mapped.p).not.toContain('|');
+        });
+
+        test('produces a valid scalar `p` when multiple filters contribute the page param', () => {
+            const filterA = { getValues: () => ({ p: 1 }) };
+            const filterB = { getValues: () => ({ p: 2 }) };
+            listingPlugin._registry = [filterA, filterB];
+
+            const mapped = listingPlugin._mapFilters(listingPlugin._fetchValuesOfRegisteredFilters());
+
+            expect(mapped.p).toBe('2');
+            expect(mapped.p).not.toBe('1|2');
+        });
+
+        test('omits empty and nullish values', () => {
+            const mapped = listingPlugin._mapFilters({
+                manufacturer: [],
+                properties: null,
+                rating: undefined,
+                shippingFree: '',
+                order: ['name-asc'],
+            });
+
+            expect(mapped.manufacturer).toBeUndefined();
+            expect(mapped.properties).toBeUndefined();
+            expect(mapped.rating).toBeUndefined();
+            expect(mapped.shippingFree).toBeUndefined();
+            expect(mapped.order).toBe('name-asc');
+        });
+    });
+
     test('builds the labels for the active filters and renders them inside the filter panel', async () => {
         global.fetch = jest.fn(() =>
             Promise.resolve({


### PR DESCRIPTION
### 1. Why is this change necessary?

Two bugs in the storefront listing plugin break pagination and filter updates when a third-party plugin contributes the `p` (page) key from its filter:

1. **Crash** in `_fetchValuesOfRegisteredFilters`: the accumulator stores the first value for a key as-is (scalar allowed), then calls `.push` on it when another filter provides the same key — `TypeError: e[t].push is not a function`.
2. **Invalid query** in `_mapFilters`: arrays are blindly pipe-joined for *all* keys, so multiple `p` contributions become `p=1|2` → `400 Bad Request` on `/widgets/cms/navigation/...`. Most visible in mobile/offcanvas listings.

### 2. What does this change do, exactly?

Applies the reporter's proposed hardening to `src/Storefront/Resources/app/storefront/src/plugin/listing/listing.plugin.js`:

- `_fetchValuesOfRegisteredFilters()` normalizes any filter value (scalar / array / object / null) into an array before merging, and tolerates filters without `getValues` or returning null.
- `_mapFilters()` treats `p`, `order`, `limit` as single-valued (last-value-wins as a string). Multi-valued keys (`manufacturer`, `properties`, `rating`, `shipping-free`, ...) still pipe-join.

Adds 9 Jest regression tests covering the scalar-scalar crash, the scalar `p` guarantee, mixed scalar/array/object for multi-valued keys, `order`/`limit` behaviour, filters without `getValues`, and empty/null value pruning.

### 3. Describe each step to reproduce the issue or behaviour.

Open a category page and run in DevTools:

```js
const el = document.querySelector('[data-listing]');
const inst = window.PluginManager.getPluginInstanceFromElement(el, 'Listing');
const makeFilter = (v) => ({ getValues() { return { p: v }; }, reset() {}, resetAll() {}, getLabels() { return []; } });
inst.registerFilter(makeFilter(1));
inst.registerFilter(makeFilter(2));
inst.changeListing();
```

Before the fix: `TypeError: e[t].push is not a function` (or `p=1|2` 400 response if the crash is guarded).
After the fix: a single `p=2` request is issued.

### 4. Please link to the relevant issues (if any).

- closes #12965

Credit to the reporter for the detailed analysis and the proposed patches.

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them