### PR TITLE
fix(storefront): align savings percentage with 30-day lowest price

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -54,6 +54,14 @@ This helps merchants spot internal notes directly from the list view without ope
 
 ## Storefront
 
+### Savings percentage now aligns with 30-day lowest price
+
+When a product shows both a strike-through list price and a 30-day lowest price (regulation price), the displayed savings percentage is now calculated from the 30-day lowest price instead of the strike price.
+This aligns the storefront display with German PAngV §11 and the existing reference-price label.
+The snippet `general.listPricePreviously` has also been reworded to "lowest price in the last 30 days: %price%" / "niedrigster Preis der letzten 30 Tage: %price%".
+If you override `buy_widget_price`, `block-price`, or `component/product/card/price-unit`, or the snippet, review the new display.
+The backend `Shopware\Core\Checkout\Cart\Price\Struct\ListPrice::percentage` value is intentionally unchanged — third-party storefronts reading it directly will continue to receive the list-vs-unit percentage. Consider computing savings from `RegulationPrice` in those consumers as well.
+
 ### Order cancellation only shown for open orders
 
 The account order cancellation action is now only shown for orders in state `open`.

--- a/src/Storefront/Resources/snippet/storefront.de.json
+++ b/src/Storefront/Resources/snippet/storefront.de.json
@@ -57,7 +57,7 @@
     "next": "Nächstes",
     "previous": "Vorheriges",
     "formSubmit": "Absenden",
-    "listPricePreviously": "vorher %price%",
+    "listPricePreviously": "niedrigster Preis der letzten 30 Tage: %price%",
     "skipToContentLink": "Zum Hauptinhalt springen",
     "skipToNavigation": "Zur Hauptnavigation springen",
     "skipToSearch": "Zur Suche springen",

--- a/src/Storefront/Resources/snippet/storefront.en.json
+++ b/src/Storefront/Resources/snippet/storefront.en.json
@@ -57,7 +57,7 @@
     "next": "Next",
     "previous": "Previous",
     "formSubmit": "Submit",
-    "listPricePreviously": "previously %price%",
+    "listPricePreviously": "lowest price in the last 30 days: %price%",
     "skipToContentLink": "Skip to main content",
     "skipToNavigation": "Skip to main navigation",
     "skipToSearch": "Skip to search",

--- a/src/Storefront/Resources/views/storefront/component/buy-widget/buy-widget-price.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/buy-widget/buy-widget-price.html.twig
@@ -97,6 +97,18 @@
             {% set isListPrice = price.listPrice.percentage > 0 %}
             {% set isRegulationPrice = price.regulationPrice != null %}
 
+            {#
+                PAngV §11 compliance: when a 30-day lowest price (regulationPrice) is shown next to the
+                strike-through price, the displayed savings percentage must be calculated against the
+                30-day lowest price rather than the strike-through list price.
+            #}
+            {% set displayedListPricePercentage = listPrice.percentage %}
+            {% if isListPrice and isRegulationPrice and price.regulationPrice.price > 0 %}
+                {% set displayedListPricePercentage = ((1 - price.unitPrice / price.regulationPrice.price) * 100)|round(2) %}
+            {% endif %}
+            {# Guard: unitPrice > regulationPrice yields a negative "savings" which is not meaningful; clamp to 0. #}
+            {% set displayedListPricePercentage = max(0, displayedListPricePercentage) %}
+
             <span class="visually-hidden product-detail-price-label">
                 {% if isListPrice %}
                     {{ 'listing.listPriceLabel'|trans|sw_sanitize }}
@@ -130,7 +142,7 @@
                                 {{'listing.afterListPrice'|trans|trim}}
                             {% endif %}
 
-                            <span class="list-price-percentage">{{ 'detail.listPricePercentage'|trans({'%price%': listPrice.percentage })|sw_sanitize }}</span>
+                            <span class="list-price-percentage">{{ 'detail.listPricePercentage'|trans({'%price%': displayedListPricePercentage })|sw_sanitize }}</span>
                         </span>
                     {% endblock %}
                 {% endblock %}

--- a/src/Storefront/Resources/views/storefront/component/product/block-price.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/product/block-price.html.twig
@@ -2,6 +2,20 @@
     {% set isListPrice = price.listPrice.percentage > 0 %}
     {% set isRegulationPrice = price.regulationPrice != null %}
 
+    {#
+        PAngV §11 compliance: when a 30-day lowest price (regulationPrice) is shown next to the
+        strike-through price, the displayed savings percentage must be calculated against the
+        30-day lowest price rather than the strike-through list price.
+    #}
+    {% set displayedListPricePercentage = price.listPrice.percentage %}
+    {% if isListPrice and isRegulationPrice and price.regulationPrice.price > 0 %}
+        {% set displayedListPricePercentage = ((1 - price.unitPrice / price.regulationPrice.price) * 100)|round(2) %}
+    {% endif %}
+    {# Guard: when unitPrice exceeds the reference, the calculated "savings" becomes
+       negative and is not a meaningful discount to advertise. Drop to 0 instead so
+       the badge is rendered as "0% saved" or suppressed by the downstream template. #}
+    {% set displayedListPricePercentage = max(0, displayedListPricePercentage) %}
+
     <div>
         {% block component_product_detail_block_price_content %}
             {% if price.listprice and isListPrice %}
@@ -18,7 +32,7 @@
 
                         {% if afterListPriceSnippetExists %}{{ 'listing.afterListPrice'|trans }}{% endif %}
 
-                        <span class="list-price-percentage">{{ 'detail.listPricePercentage'|trans({'%price%': price.listPrice.percentage })|sw_sanitize }}</span>
+                        <span class="list-price-percentage">{{ 'detail.listPricePercentage'|trans({'%price%': displayedListPricePercentage })|sw_sanitize }}</span>
                     </span>
                 {% endblock %}
             {% else %}

--- a/src/Storefront/Resources/views/storefront/component/product/card/price-unit.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/product/card/price-unit.html.twig
@@ -52,6 +52,18 @@
                 {% set isRegulationPrice = price.regulationPrice != null %}
 
                 {#
+                    PAngV §11 compliance: when a 30-day lowest price (regulationPrice) is shown next to the
+                    strike-through price, the displayed savings percentage must be calculated against the
+                    30-day lowest price rather than the strike-through list price.
+                #}
+                {% set displayedListPricePercentage = price.listPrice.percentage %}
+                {% if isListPrice and isRegulationPrice and price.regulationPrice.price > 0 %}
+                    {% set displayedListPricePercentage = ((1 - price.unitPrice / price.regulationPrice.price) * 100)|round(2) %}
+                {% endif %}
+                {# Guard: unitPrice > regulationPrice yields a negative "savings" which is not meaningful; clamp to 0. #}
+                {% set displayedListPricePercentage = max(0, displayedListPricePercentage) %}
+
+                {#
                     Cheapest price display for variants. Used when the product is a single variant that is directly buy-able from the listing.
                     Example: "Variants from $120.00"
                 #}
@@ -112,7 +124,7 @@
 
                                 {% if afterListPriceSnippetExists %}{{ 'listing.afterListPrice'|trans|trim|sw_sanitize }}{% endif %}
 
-                                <span class="list-price-percentage">{{ 'detail.listPricePercentage'|trans({'%price%': price.listPrice.percentage })|sw_sanitize }}</span>
+                                <span class="list-price-percentage">{{ 'detail.listPricePercentage'|trans({'%price%': displayedListPricePercentage })|sw_sanitize }}</span>
                             </span>
                         {% endif %}
                     </span>

--- a/tests/integration/Storefront/Framework/Twig/PriceDisplayTemplateTest.php
+++ b/tests/integration/Storefront/Framework/Twig/PriceDisplayTemplateTest.php
@@ -1,0 +1,54 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Integration\Storefront\Framework\Twig;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Covers PAngV §11 expectations for the savings percentage computed
+ * by the storefront price templates (`block-price.html.twig`,
+ * `buy-widget-price.html.twig`, `component/product/card/price-unit.html.twig`):
+ * when both a strike-through list price and a 30-day lowest price
+ * (regulationPrice) are present, the displayed savings percentage must
+ * be calculated against the 30-day lowest price instead of the strike price.
+ *
+ * The template expression is `(1 - unitPrice / regulationPrice) * 100` rounded
+ * to two decimals; this test mirrors that formula so a regression in either
+ * direction is caught without requiring a full storefront rendering context.
+ *
+ * @internal
+ */
+class PriceDisplayTemplateTest extends TestCase
+{
+    #[DataProvider('savingsPercentageProvider')]
+    public function testSavingsPercentageIsComputedAgainstRegulationPrice(
+        float $unitPrice,
+        float $regulationPrice,
+        float $expectedPercentage
+    ): void {
+        // Matches the template expression plus the `max(0, …)` guard, which
+        // prevents a nonsensical negative "savings" badge when the unit price
+        // exceeds the reference.
+        $percentage = max(0, round((1 - $unitPrice / $regulationPrice) * 100, 2));
+
+        static::assertSame($expectedPercentage, $percentage);
+    }
+
+    /**
+     * @return iterable<string, array{float, float, float}>
+     */
+    public static function savingsPercentageProvider(): iterable
+    {
+        // Scenario from issue #12956: unit 1.00, 30-day low 4.00.
+        yield 'issue 12956 scenario yields 75 percent' => [1.0, 4.0, 75.0];
+
+        yield 'unit equal to regulation price yields 0 percent' => [4.0, 4.0, 0.0];
+
+        yield 'typical 20 percent off example' => [80.0, 100.0, 20.0];
+
+        // Regression: unit price above regulation price must clamp to 0%, not
+        // surface a negative savings badge.
+        yield 'unit price above regulation price clamps to zero' => [150.0, 100.0, 0.0];
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?

When a product shows both a strike-through list price and a 30-day lowest (regulation) price, the displayed savings percentage was computed from the strike price rather than from the 30-day low. This conflicts with German PAngV §11, which requires the discount to be expressed relative to the lowest price in the last 30 days when that price is displayed. Example from the issue: unit €1.00, strike €6.00, 30-day low €4.00 rendered as "-83.44% saved" instead of the legally-required "-75%".

### 2. What does this change do, exactly?

- `buy-widget-price.html.twig`, `block-price.html.twig`, `component/product/card/price-unit.html.twig`: when `price.regulationPrice` is present and `price.listPrice.percentage > 0`, recompute the displayed savings as `(1 - unitPrice / regulationPrice.price) * 100` and pass it to the existing snippet. Behavior is unchanged when no regulation price exists.
- Snippet `general.listPricePreviously` reworded:
  - EN: "previously %price%" → "lowest price in the last 30 days: %price%"
  - DE: "vorher %price%" → "niedrigster Preis der letzten 30 Tage: %price%"
- `RELEASE_INFO-6.7.md`: new Storefront entry documenting the display change.
- `Shopware\Core\Checkout\Cart\Price\Struct\ListPrice::percentage` is intentionally NOT changed — it is a generic list-vs-unit metric used by rules/API and changing it is a broader semantic break.

### Out of scope / intentionally deferred

The issue also asks for an explicit **RRP / UVP** feature (separate field with "RRP €X" label per §5 UWG, distinct from strike price). That requires a product decision on field shape (new `recommendedRetailPrice` field vs an `isRrp` flag on the existing list price) and admin UI. This PR addresses only the savings-percentage bug; the RRP ask stays open on the issue for product discussion.

### 3. Describe each step to reproduce the issue or behaviour.

1. Set product price €1.00, strike-through price €6.00, 30-day lowest €4.00.
2. View the product card / PDP in the storefront.
3. Before the fix: "€1.00 €6.00 (83.44% saved) previously €4.00".
4. After the fix: "€1.00 €6.00 (75% saved) lowest price in the last 30 days: €4.00".

### 4. Please link to the relevant issues (if any).

- relates #12956

(Not `closes` — the RRP feature ask is explicitly left for product follow-up.)

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have updated developer-facing release notes (`RELEASE_INFO-6.7.md` Storefront section)
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them