### PR TITLE
fix: add missing refresh index product.indexer 6.6

### DIFF
--- a/src/Core/Migration/V6_6/Migration1776803396RegisterProductIndexer.php
+++ b/src/Core/Migration/V6_6/Migration1776803396RegisterProductIndexer.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Migration\V6_6;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Migration\MigrationStep;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+class Migration1776803396RegisterProductIndexer extends MigrationStep
+{
+    public function getCreationTimestamp(): int
+    {
+        return 1776803396;
+    }
+
+    public function update(Connection $connection): void
+    {
+        // Catch-up full re-index for shops that ran
+        // Migration1691662140MigrateAvailableStock or
+        // Migration1726049442UpdateVariantListingConfigInProductTable without
+        // a follow-up product.indexer refresh in the same major.
+        $this->registerIndexer($connection, 'product.indexer');
+    }
+}

--- a/tests/migration/Core/V6_6/Migration1776803396RegisterProductIndexerTest.php
+++ b/tests/migration/Core/V6_6/Migration1776803396RegisterProductIndexerTest.php
@@ -24,6 +24,13 @@ class Migration1776803396RegisterProductIndexerTest extends TestCase
         $this->connection = KernelLifecycleManager::getConnection();
     }
 
+    public function testGetCreationTimestamp(): void
+    {
+        $migration = new Migration1776803396RegisterProductIndexer();
+
+        static::assertSame(1776803396, $migration->getCreationTimestamp());
+    }
+
     public function testProductIndexerIsRegistered(): void
     {
         $migration = new Migration1776803396RegisterProductIndexer();

--- a/tests/migration/Core/V6_6/Migration1776803396RegisterProductIndexerTest.php
+++ b/tests/migration/Core/V6_6/Migration1776803396RegisterProductIndexerTest.php
@@ -1,0 +1,37 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Migration\Core\V6_6;
+
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Migration\IndexerQueuer;
+use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
+use Shopware\Core\Migration\V6_6\Migration1776803396RegisterProductIndexer;
+
+/**
+ * @internal
+ */
+#[CoversClass(Migration1776803396RegisterProductIndexer::class)]
+class Migration1776803396RegisterProductIndexerTest extends TestCase
+{
+    private Connection $connection;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->connection = KernelLifecycleManager::getConnection();
+    }
+
+    public function testProductIndexerIsRegistered(): void
+    {
+        $migration = new Migration1776803396RegisterProductIndexer();
+        $migration->update($this->connection);
+        $migration->update($this->connection);
+
+        $indexers = (new IndexerQueuer($this->connection))->getIndexers();
+
+        static::assertArrayHasKey('product.indexer', $indexers);
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?
Detected with https://github.com/shopware/shopware/pull/16340

<details><summary>Logs of MigrationIndexerSafeguardTest</summary>

```
Shopware\Tests\DevOps\Core\Migration\MigrationIndexerSafeguardTest::testIndexerIsRegisteredBySameMajorWriters with data set "product.indexer"
Migrations write tables feeding product.indexer without calling registerIndexer('product.indexer'):
  [CROSS_MAJOR_PARTIAL] Shopware\Core\Migration\V6_6\Migration1691662140MigrateAvailableStock
  [CROSS_MAJOR_PARTIAL] Shopware\Core\Migration\V6_6\Migration1726049442UpdateVariantListingConfigInProductTable

Label meaning:
  CROSS_MAJOR_PARTIAL — a later-major migration registers the indexer but restricts execution to a subset of updaters — cross-major coverage is partial, and miss-major pins remain uncovered.

Resolve each violation by one of:
  (1) add $this->registerIndexer($connection, 'product.indexer') in update()
  (2) add "@no-indexer-required: <reason>" to the migration docblock if the write cannot affect the indexer output
  (3) for a migration that is already shipped, introduce a follow-up migration that carries the registerIndexer() call

Failed asserting that Array &0 [
    0 => 'Shopware\Core\Migration\V6_6\Migration1691662140MigrateAvailableStock',
    1 => 'Shopware\Core\Migration\V6_6\Migration1726049442UpdateVariantListingConfigInProductTable',
] is strictly empty (iterable with zero elements).

.../Test/Assert/StrictEmpty.php:18
.../Core/Migration/MigrationIndexerSafeguardTest.php:55
```
</details>
The two existing V6_6 migrations both mutate the product table in ways the indexer's updaters care about:                                                                                                
                                                                                                                                                                                                           
  - Migration1691662140MigrateAvailableStock — UPDATE product SET stock = available_stock. ProductIndexer reconciles stock-related fields via its updaters; after this bulk rewrite the stored indexer outputs can be out of sync until something re-indexes.                                                                                                                                                   
  - Migration1726049442UpdateVariantListingConfigInProductTable — nulls variant_listing_config / display_group and rebuilds display_group from parent_id. That directly feeds the variant listing and inheritance updaters.                                                                                                                                                                                    
   
  Neither migration calls `$this->registerIndexer($connection, 'product.indexer')`, so on a shop that already ran them the indexer was never scheduled. Cached/denormalized product state (including ES documents) stays stale until something else triggers a reindex.
                                                                                                                                                                                                           
  Why V6_7's three existing product.indexer registrations don't cover this:                                                                                                                                
  1. They're partial — each passes an updater allow-list (['product.inheritance'], [ProductIndexer::VARIANT_LISTING_UPDATER]), so they only refresh a subset, not the stock/display-group writes from those V6_6 migrations.                                                                                                                                         
  2. A shop pinned on 6.6.x never executes V6_7 migrations at all, so cross-major registrations can't reach it regardless of partial-vs-full.

## 2. What does this change do, exactly?
Our new V6_6 migration with a later timestamp and a full registerIndexer call (no updater array) fixes both:                                                                                             
  - Same-major coverage: on the next deploy every 6.6.x shop schedules a full product reindex, catching up any stale state left by the two migrations.                                                    
  - Clears the new safeguard: findViolations skips a violation when latestByMajor['V6_6'] > violation_timestamp, which is now true (1776803396 > 1726049442).  

Add a migration test for the new migration.

### 3. Describe each step to reproduce the issue or behaviour.
Run the new test from https://github.com/shopware/shopware/pull/16340

Run the migrations for 6.6 only, and see the stale 

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them