### PR TITLE
docs: move agentic commerce release notes from 6.7.9.0 to 6.7.10.0

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -2,6 +2,11 @@
 
 ## Features
 
+### [Experimental] Agentic Commerce sales channel
+
+A new "Agentic Commerce" sales channel type is available in this release. The OpenAI Merchant Center integration is the first supported provider for AI-powered product feed exports.
+The Administration includes dedicated views for configuration, product mapping, and usage insights.
+
 ## API
 
 ### Per-user and per-IP rate limiters for login and OAuth
@@ -40,6 +45,14 @@ Custom salutations keep the default value of `100` - review them in Administrati
 
 Deprecated the constants `Shopware\Core\Content\MailTemplate\MAIL_TEMPLATE_SALES_CHANNEL_{WRITTEN,DELETED,LOADED,SEARCH_RESULT_LOADED,AGGREGATION_LOADED,ID_SEARCH_RESULT_LOADED}_EVENT` as the entity has been removed with Shopware 6.5 and the events were not fired anymore.
 
+### JSONL product export format
+
+Product exports now support `ProductExportEntity::FILE_FORMAT_JSONL` as a third file format.
+
+### [Experimental] Agentic Commerce product export provider abstraction
+
+The new `AbstractAgenticCommerceProductExportProvider` can be used to implement custom Agentic Commerce export providers.
+
 ## Administration
 
 ### Fixed mixin-based route guards for lazy-loaded administration routes
@@ -56,6 +69,10 @@ This fixes stale iframe content when switching locations in Meteor Admin SDK int
 
 The Administration order list now shows internal order comments via a dedicated tooltip icon.
 This helps merchants spot internal notes directly from the list view without opening the order detail page.
+
+### [Experimental] Agentic Commerce sales channel views and tracking entities
+
+New Agentic Commerce sales channels types can be created. These sales channels have dedicated configuration options in the administration for property mapping, and usage insights. New entities for monitoring orders and customers for Agentic Commerce sales channels are included.
 
 ## Storefront
 
@@ -275,11 +292,6 @@ shopware:
 
 When `bin/console system:setup:staging` is executed, the configured keys are written to the database via `SystemConfigService`.
 
-### [Experimental] Agentic Commerce sales channel
-
-A new "Agentic Commerce" sales channel type is available in this release. The OpenAI Merchant Center integration is the first supported provider for AI-powered product feed exports.
-The Administration includes dedicated views for configuration, product mapping, and usage insights.
-
 ## API
 
 ### Minimum value constraints added to quantity fields in ProductPriceDefinition
@@ -424,23 +436,11 @@ public ?string $url = null;
 
 A value of `0` disables length validation entirely. This is pre-existing `StringFieldSerializer` behavior where any value below `1` is treated as unconstrained.
 
-### JSONL product export format
-
-Product exports now support `ProductExportEntity::FILE_FORMAT_JSONL` as a third file format.
-
-### [Experimental] Agentic Commerce product export provider abstraction
-
-The new `AbstractAgenticCommerceProductExportProvider` can be used to implement custom Agentic Commerce export providers.
-
 ## Administration
 
 ### CMS data mapping source for media custom fields
 
 Fixed media custom fields not being available as data mapping source for image elements in category and product CMS layouts. Shop Administrators can now reliably bind media custom fields to images in CMS pages without workarounds.
-
-### [Experimental] Agentic Commerce sales channel views and tracking entities
-
-New Agentic Commerce sales channels types can be created. These sales channels have dedicated configuration options in the administration for property mapping, and usage insights. New entities for monitoring orders and customers for Agentic Commerce sales channels are included.
 
 ## Storefront
 


### PR DESCRIPTION
### 1. Why is this change necessary?

The Agentic Commerce feature (PR #15550) merged to trunk on 2026-04-02, after the `6.7.9.x` branch was cut on 2026-03-27. It therefore did not ship in `v6.7.9.0` but in `6.7.10.0`. 

### 2. What does this change do, exactly?

Moves four release-notes sections in `RELEASE_INFO-6.7.md` from the `6.7.9.0` block to the `6.7.10.0` block:

- `[Experimental] Agentic Commerce sales channel` (Features)
- `JSONL product export format` (Core)
- `[Experimental] Agentic Commerce product export provider abstraction` (Core)
- `[Experimental] Agentic Commerce sales channel views and tracking entities` (Administration)

No code changes.

### 3. Describe each step to reproduce the issue or behaviour.

n/a — documentation-only correction.

### 4. Please link to the relevant issues (if any).

relates #15550

### 5. Checklist

- [x] I have written tests and verified that they fail without my change <!-- n/a, docs-only -->
- [x] I have updated developer-facing release notes if this change is **relevant** for external developers
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code <!-- n/a -->
- [x] I have read the contribution requirements and fulfilled them