### PR TITLE
[codex] Fix #16245 duplicate customer address collection API alias

### DIFF
--- a/changelog/_unreleased/2026-04-22-fix-sales-channel-customer-address-api-alias.md
+++ b/changelog/_unreleased/2026-04-22-fix-sales-channel-customer-address-api-alias.md
@@ -1,0 +1,2 @@
+# Core
+* Added a dedicated Store API alias for `SalesChannelCustomerAddressCollection` to avoid the duplicate `customer_address_collection` API alias.

--- a/src/Core/Checkout/Customer/SalesChannel/SalesChannelCustomerAddressCollection.php
+++ b/src/Core/Checkout/Customer/SalesChannel/SalesChannelCustomerAddressCollection.php
@@ -8,6 +8,11 @@ use Shopware\Core\Framework\Log\Package;
 #[Package('checkout')]
 class SalesChannelCustomerAddressCollection extends CustomerAddressCollection
 {
+    public function getApiAlias(): string
+    {
+        return 'sales_channel_customer_address_collection';
+    }
+
     protected function getExpectedClass(): string
     {
         return SalesChannelCustomerAddressEntity::class;

--- a/tests/devops/Core/Framework/Api/ApiAliasTest.php
+++ b/tests/devops/Core/Framework/Api/ApiAliasTest.php
@@ -21,7 +21,6 @@ class ApiAliasTest extends TestCase
 
     // TODO: fix these duplicate aliases — known bugs to be treated
     private const KNOWN_DUPLICATE_ALIASES = [
-        'customer_address_collection',
         'product_collection',
         'dal_field_sorting',
         'calculated_price',


### PR DESCRIPTION
## Summary
- add a dedicated API alias for `SalesChannelCustomerAddressCollection`
- remove the duplicate allowlist entry from `ApiAliasTest`
- add the unreleased changelog entry

## Validation
- `php-cs-fixer`
- `phpstan`
- direct runtime alias assertion for `sales_channel_customer_address_collection`

Closes #16245