### PR TITLE
fix: duplicate product collection API alias

### DIFF
--- a/src/Core/Content/Product/SalesChannel/SalesChannelProductCollection.php
+++ b/src/Core/Content/Product/SalesChannel/SalesChannelProductCollection.php
@@ -8,6 +8,11 @@ use Shopware\Core\Framework\Log\Package;
 #[Package('inventory')]
 class SalesChannelProductCollection extends ProductCollection
 {
+    public function getApiAlias(): string
+    {
+        return 'sales_channel_product_collection';
+    }
+
     protected function getExpectedClass(): string
     {
         return SalesChannelProductEntity::class;

--- a/tests/devops/Core/Framework/Api/ApiAliasTest.php
+++ b/tests/devops/Core/Framework/Api/ApiAliasTest.php
@@ -22,7 +22,6 @@ class ApiAliasTest extends TestCase
     // TODO: fix these duplicate aliases — known bugs to be treated
     private const KNOWN_DUPLICATE_ALIASES = [
         'customer_address_collection',
-        'product_collection',
         'dal_field_sorting',
         'calculated_price',
     ];


### PR DESCRIPTION
## Summary
- add a dedicated API alias for `SalesChannelProductCollection`
- remove the duplicate allowlist entry from `ApiAliasTest`
- add the unreleased changelog entry

## Validation
- `php-cs-fixer`
- `phpstan`
- direct runtime alias assertion for `sales_channel_product_collection`

Closes #16246