### PR TITLE
[codex] Fix #16275 unknown Twig feature flag handling

### DIFF
--- a/changelog/_unreleased/2026-04-22-fix-twig-unknown-feature-flags.md
+++ b/changelog/_unreleased/2026-04-22-fix-twig-unknown-feature-flags.md
@@ -1,0 +1,2 @@
+# Core
+* Changed Twig's `feature()` helper to treat unknown feature flags as inactive instead of turning them into runtime template errors in non-production environments.

--- a/src/Core/Framework/Adapter/Twig/Extension/FeatureFlagExtension.php
+++ b/src/Core/Framework/Adapter/Twig/Extension/FeatureFlagExtension.php
@@ -34,6 +34,10 @@ class FeatureFlagExtension extends AbstractExtension
 
     public function feature(string $flag): bool
     {
+        if (!Feature::has($flag)) {
+            return false;
+        }
+
         return Feature::isActive($flag);
     }
 

--- a/tests/integration/Core/Framework/FeatureFlag/FeatureTest.php
+++ b/tests/integration/Core/Framework/FeatureFlag/FeatureTest.php
@@ -151,10 +151,6 @@ class FeatureTest extends TestCase
 
     public function testTwigFeatureFlagNotRegistered(): void
     {
-        set_error_handler(static function (int $errno, string $errstr): never {
-            throw new \Exception($errstr, $errno);
-        }, \E_USER_WARNING);
-
         $_SERVER['APP_ENV'] = 'test';
         $_ENV['APP_ENV'] = 'test';
 
@@ -165,14 +161,7 @@ class FeatureTest extends TestCase
         $twig->addExtension(new FeatureFlagExtension());
         $template = $twig->loadTemplate($twig->getTemplateClass('featuretest_unregistered.html.twig'), 'featuretest_unregistered.html.twig');
 
-        $this->expectExceptionMessageMatches('/.*RANDOMFLAGTHATISNOTREGISTERDE471112.*/');
-
-        try {
-            $template->render([]);
-        } catch (\Exception $e) {
-            restore_error_handler();
-            throw $e;
-        }
+        static::assertSame('FeatureIsInactive', $template->render([]));
     }
 
     public function testTwigFeatureFlagNotRegisteredInProd(): void


### PR DESCRIPTION
## Summary
- make the Twig `feature()` helper return `false` for unknown feature flags instead of throwing in dev mode
- update the integration expectation accordingly
- add the unreleased changelog entry

## Validation
- `php-cs-fixer`
- `phpstan`
- direct Twig runtime check with an unknown feature flag

Closes #16275