### PR TITLE
[codex] Fix #16232 shipping salutation override during registration

### DIFF
--- a/changelog/_unreleased/2026-04-22-fix-register-shipping-salutation.md
+++ b/changelog/_unreleased/2026-04-22-fix-register-shipping-salutation.md
@@ -1,0 +1,2 @@
+# Core
+* Fixed Store API customer registration so an explicitly provided shipping-address salutation is no longer overwritten by the top-level customer salutation.

--- a/src/Core/Checkout/Customer/SalesChannel/RegisterRoute.php
+++ b/src/Core/Checkout/Customer/SalesChannel/RegisterRoute.php
@@ -330,7 +330,9 @@ class RegisterRoute extends AbstractRegisterRoute
         }
 
         if ($shippingAddress instanceof DataBag) {
-            $shippingAddress->set('salutationId', $data->get('salutationId'));
+            if (!$shippingAddress->get('salutationId')) {
+                $shippingAddress->set('salutationId', $data->get('salutationId'));
+            }
         }
 
         $definition = $this->getCustomerCreateValidationDefinition($isGuest, $data, $context);

--- a/tests/unit/Core/Checkout/Customer/SalesChannel/RegisterRouteTest.php
+++ b/tests/unit/Core/Checkout/Customer/SalesChannel/RegisterRouteTest.php
@@ -1011,6 +1011,66 @@ class RegisterRouteTest extends TestCase
         );
     }
 
+    public function testRegisterPreservesShippingAddressSalutation(): void
+    {
+        $customerEntity = new CustomerEntity();
+        $customerEntity->setDoubleOptInRegistration(false);
+        $customerEntity->setId('customer-1');
+        $customerEntity->setGuest(false);
+
+        $result = $this->createMock(EntitySearchResult::class);
+        $result->method('getEntities')->willReturn(new CustomerCollection([$customerEntity]));
+
+        $customerRepository = $this->createMock(EntityRepository::class);
+        $customerRepository->method('getDefinition')->willReturn(new CustomerDefinition());
+        $customerRepository->method('search')->willReturn($result);
+        $customerRepository
+            ->expects($this->once())
+            ->method('create')
+            ->willReturnCallback(static function (array $create) {
+                static::assertCount(1, $create);
+                static::assertCount(2, $create[0]['addresses']);
+                $billingAddress = array_values(array_filter(
+                    $create[0]['addresses'],
+                    static fn (array $address): bool => $address['firstName'] === 'John'
+                ))[0];
+                $shippingAddress = array_values(array_filter(
+                    $create[0]['addresses'],
+                    static fn (array $address): bool => $address['firstName'] === 'Jane'
+                ))[0];
+
+                static::assertSame('billing-salutation', $billingAddress['salutationId']);
+                static::assertSame('shipping-salutation', $shippingAddress['salutationId']);
+
+                return new EntityWrittenContainerEvent(Context::createDefaultContext(), new NestedEventCollection([]), []);
+            });
+
+        $dataValidator = $this->createMock(DataValidator::class);
+        $dataValidator
+            ->expects($this->once())
+            ->method('getViolations')
+            ->willReturn(new ConstraintViolationList());
+
+        $registerRoute = $this->createRegisterRoute(
+            dataValidator: $dataValidator,
+            customerRepository: $customerRepository
+        );
+
+        $registerRoute->register(
+            new RequestDataBag($this->createRegistrationData([
+                'salutationId' => 'billing-salutation',
+                'shippingAddress' => [
+                    'firstName' => 'Jane',
+                    'lastName' => 'Doe',
+                    'countryId' => Uuid::randomHex(),
+                    'salutationId' => 'shipping-salutation',
+                ],
+            ])),
+            Generator::generateSalesChannelContext(),
+            false
+        );
+    }
+
     /**
      * @return StaticEntityRepository<CustomerCollection>
      */


### PR DESCRIPTION
## Summary
- only copy the profile salutation to the shipping address when the shipping payload has no salutation yet
- add a unit test covering the preserved shipping salutation case
- add the unreleased changelog entry

## Validation
- `php-cs-fixer`
- `phpstan`
- direct runtime payload check for registration data assembly

Closes #16232