### PR TITLE
[codex] Fix #16233 translator snippet fallback outside prod

### DIFF
--- a/changelog/_unreleased/2026-04-22-fix-translator-fallback-non-prod.md
+++ b/changelog/_unreleased/2026-04-22-fix-translator-fallback-non-prod.md
@@ -1,0 +1,2 @@
+# Core
+* Restored storefront snippet fallback resolution outside production so non-production environments use the same translation fallback chain as production.

--- a/src/Core/Framework/Adapter/Translation/Translator.php
+++ b/src/Core/Framework/Adapter/Translation/Translator.php
@@ -69,7 +69,6 @@ class Translator extends AbstractTranslator
         private readonly RequestStack $requestStack,
         private readonly CacheInterface $cache,
         private readonly MessageFormatterInterface $formatter,
-        private readonly string $environment,
         private readonly Connection $connection,
         private readonly LanguageLocaleCodeProvider $languageLocaleProvider,
         private readonly SnippetService $snippetService,
@@ -126,11 +125,6 @@ class Translator extends AbstractTranslator
              * fallback locale and current locale has the same localization -> reset fallback
              * or locale is symfony style locale, so we shouldn't add shopware fallbacks as it may lead to circular references
              */
-            $fallbackLocale = null;
-        }
-
-        // disable fallback logic to display symfony warnings
-        if ($this->environment !== 'prod') {
             $fallbackLocale = null;
         }
 

--- a/src/Core/Framework/DependencyInjection/services.xml
+++ b/src/Core/Framework/DependencyInjection/services.xml
@@ -266,7 +266,6 @@ frame-ancestors 'none';
             <argument type="service" id="request_stack"/>
             <argument type="service" id="cache.object"/>
             <argument type="service" id="translator.formatter"/>
-            <argument>%kernel.environment%</argument>
             <argument type="service" id="Doctrine\DBAL\Connection"/>
             <argument type="service" id="Shopware\Core\System\Locale\LanguageLocaleCodeProvider"/>
             <argument type="service" id="Shopware\Core\System\Snippet\SnippetService"/>

--- a/tests/unit/Core/Framework/Adapter/Translation/TranslatorTest.php
+++ b/tests/unit/Core/Framework/Adapter/Translation/TranslatorTest.php
@@ -74,7 +74,6 @@ class TranslatorTest extends TestCase
             $requestStack,
             $cache,
             $this->createMock(MessageFormatterInterface::class),
-            'prod',
             $connection,
             $localeCodeProvider,
             $snippetServiceMock,
@@ -134,7 +133,6 @@ class TranslatorTest extends TestCase
             $requestStack,
             $this->createMock(CacheInterface::class),
             $this->createMock(MessageFormatterInterface::class),
-            'prod',
             $connection,
             $this->createMock(LanguageLocaleCodeProvider::class),
             $this->createMock(SnippetService::class),
@@ -173,7 +171,6 @@ class TranslatorTest extends TestCase
                 $key2 => [],
             ]),
             $this->createMock(MessageFormatterInterface::class),
-            'prod',
             $connection,
             $this->createMock(LanguageLocaleCodeProvider::class),
             $snippetService,
@@ -188,6 +185,64 @@ class TranslatorTest extends TestCase
         $requestStack->push(self::createRequest(TestDefaults::SALES_CHANNEL, $domainSnippetSetId));
         $translator->reset();
         static::assertSame($domainSnippetSetId, $translator->getSnippetSetId('en-GB'));
+    }
+
+    public function testGetCatalogueUsesFallbackLocaleOutsideProd(): void
+    {
+        $snippetSetId = Uuid::randomHex();
+
+        $decorated = $this->createMock(SymfonyTranslator::class);
+        $originCatalogue = new MessageCatalogue('de-DE', [
+            'messages' => [
+                'hello' => 'Hello',
+            ],
+        ]);
+        $fallbackCatalogue = new MessageCatalogue('de', [
+            'messages' => [
+                'hello' => 'Hello',
+            ],
+        ]);
+
+        $decorated->method('getCatalogue')->willReturnMap([
+            ['de-DE', $originCatalogue],
+            ['de', $fallbackCatalogue],
+        ]);
+
+        $cache = $this->createMock(CacheInterface::class);
+        $cache->expects($this->once())
+            ->method('get')
+            ->with(\sprintf('translation.catalog.DEFAULT.%s-de', $snippetSetId), static::isCallable())
+            ->willReturnCallback(static function (string $_key, callable $callback) {
+                return $callback(new CacheItem());
+            });
+
+        $snippetService = $this->createMock(SnippetService::class);
+        $snippetService->expects($this->once())
+            ->method('getStorefrontSnippets')
+            ->with(static::isInstanceOf(MessageCatalogue::class), $snippetSetId, 'de', null)
+            ->willReturn([]);
+
+        $localeCodeProvider = $this->createMock(LanguageLocaleCodeProvider::class);
+        $localeCodeProvider->method('getLocaleForLanguageId')->with(Defaults::LANGUAGE_SYSTEM)->willReturn('de-DE');
+
+        $connection = $this->createMock(Connection::class);
+        $connection->method('fetchFirstColumn')->willReturn([$snippetSetId]);
+
+        $translator = new Translator(
+            $decorated,
+            new RequestStack(),
+            $cache,
+            $this->createMock(MessageFormatterInterface::class),
+            $connection,
+            $localeCodeProvider,
+            $snippetService,
+            $this->createMock(CacheTagCollector::class),
+        );
+
+        $snippetSetIdProp = new \ReflectionProperty(Translator::class, 'snippetSetId');
+        $snippetSetIdProp->setValue($translator, $snippetSetId);
+
+        $translator->getCatalogue('de-DE');
     }
 
     /**


### PR DESCRIPTION
## Summary
- remove the non-prod gate that disables snippet fallback handling
- drop the now-unused environment constructor argument and service wiring
- add the unreleased changelog entry

## Validation
- `php-cs-fixer`
- `phpstan`
- branch-specific verification that the prod-only gate and environment wiring are removed

Closes #16233