### PR TITLE
[codex] Fix #15608 repeat newsletter confirmation handling

### DIFF
--- a/changelog/_unreleased/2026-04-22-fix-newsletter-repeat-confirm.md
+++ b/changelog/_unreleased/2026-04-22-fix-newsletter-repeat-confirm.md
@@ -1,0 +1,2 @@
+# Core
+* Fixed newsletter confirmation so reopening an already-used confirmation link no longer fails for already confirmed recipients.

--- a/src/Core/Content/Newsletter/SalesChannel/NewsletterConfirmRoute.php
+++ b/src/Core/Content/Newsletter/SalesChannel/NewsletterConfirmRoute.php
@@ -80,6 +80,16 @@ class NewsletterConfirmRoute extends AbstractNewsletterConfirmRoute
     public function confirmWithResponse(RequestDataBag $dataBag, SalesChannelContext $context): SuccessResponse
     {
         $recipient = $this->getNewsletterRecipient('hash', $dataBag->get('hash', ''), $context->getContext());
+        $emHash = Hasher::hash($recipient->getEmail(), 'sha1');
+
+        if ($recipient->getStatus() === NewsletterSubscribeRoute::STATUS_OPT_IN) {
+            $this->validator->validate([
+                'id' => $recipient->getId(),
+                'em' => $dataBag->get('em'),
+            ], $this->getConfirmValidation($emHash));
+
+            return new SuccessResponse();
+        }
 
         $data = [
             'id' => $recipient->getId(),
@@ -88,7 +98,7 @@ class NewsletterConfirmRoute extends AbstractNewsletterConfirmRoute
             'em' => $dataBag->get('em'),
         ];
 
-        $this->validator->validate($data, $this->getBeforeConfirmSubscribeValidation(Hasher::hash($recipient->getEmail(), 'sha1')));
+        $this->validator->validate($data, $this->getBeforeConfirmSubscribeValidation($emHash));
 
         $data['status'] = NewsletterSubscribeRoute::STATUS_OPT_IN;
         $data['confirmedAt'] = new \DateTime();
@@ -119,9 +129,16 @@ class NewsletterConfirmRoute extends AbstractNewsletterConfirmRoute
 
     private function getBeforeConfirmSubscribeValidation(string $emHash): DataValidationDefinition
     {
+        $definition = $this->getConfirmValidation($emHash);
+        $definition->add('status', new EqualTo(value: NewsletterSubscribeRoute::STATUS_NOT_SET));
+
+        return $definition;
+    }
+
+    private function getConfirmValidation(string $emHash): DataValidationDefinition
+    {
         $definition = new DataValidationDefinition('newsletter_recipient.opt_in_before');
         $definition->add('id', new NotBlank())
-            ->add('status', new EqualTo(value: NewsletterSubscribeRoute::STATUS_NOT_SET))
             ->add('em', new EqualTo(value: $emHash));
 
         return $definition;

--- a/tests/integration/Core/Content/Newsletter/SalesChannel/NewsletterConfirmRouteTest.php
+++ b/tests/integration/Core/Content/Newsletter/SalesChannel/NewsletterConfirmRouteTest.php
@@ -8,6 +8,7 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\SalesChannelApiTestBehaviour;
+use Shopware\Core\Framework\Util\Hasher;
 use Shopware\Core\Test\Stub\Framework\IdsCollection;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 use Symfony\Component\HttpFoundation\Response;
@@ -122,6 +123,36 @@ class NewsletterConfirmRouteTest extends TestCase
         static::assertSame(Response::HTTP_OK, $response->getStatusCode());
 
         $status = static::getContainer()->get(Connection::class)->fetchOne('SELECT status FROM newsletter_recipient WHERE email = "test@test.de"');
+        static::assertSame('optIn', $status);
+    }
+
+    public function testConfirmAlreadyConfirmedRecipient(): void
+    {
+        $this->browser
+            ->request(
+                'POST',
+                '/store-api/newsletter/subscribe',
+                [
+                    'email' => 'repeat-confirm@test.de',
+                    'option' => 'subscribe',
+                    'storefrontUrl' => 'http://localhost',
+                ]
+            );
+
+        $hash = static::getContainer()->get(Connection::class)->fetchOne('SELECT hash FROM newsletter_recipient WHERE email = "repeat-confirm@test.de"');
+
+        $payload = [
+            'em' => Hasher::hash('repeat-confirm@test.de', 'sha1'),
+            'hash' => $hash,
+        ];
+
+        $this->browser->request('POST', '/store-api/newsletter/confirm', $payload);
+        static::assertSame(Response::HTTP_OK, $this->browser->getResponse()->getStatusCode());
+
+        $this->browser->request('POST', '/store-api/newsletter/confirm', $payload);
+        static::assertSame(Response::HTTP_OK, $this->browser->getResponse()->getStatusCode());
+
+        $status = static::getContainer()->get(Connection::class)->fetchOne('SELECT status FROM newsletter_recipient WHERE email = "repeat-confirm@test.de"');
         static::assertSame('optIn', $status);
     }
 }


### PR DESCRIPTION
## Summary
- short-circuit repeated newsletter confirmations after validating the signed email hash
- keep the original first-confirmation flow unchanged
- add the unreleased changelog entry

## Validation
- `php-cs-fixer`
- `phpstan`
- direct route verification for both repeated and first confirmation flows

Closes #15608