### PR TITLE
[codex] Fix #15357 external media URLs with Unicode characters

### DIFF
--- a/changelog/_unreleased/2026-04-22-fix-external-media-non-ascii-urls.md
+++ b/changelog/_unreleased/2026-04-22-fix-external-media-non-ascii-urls.md
@@ -1,0 +1,2 @@
+# Core
+* Fixed external media URLs and media file names so printable Unicode characters are preserved and already encoded URLs are no longer encoded a second time in the storefront.

--- a/src/Core/Content/Media/Api/MediaUploadController.php
+++ b/src/Core/Content/Media/Api/MediaUploadController.php
@@ -46,7 +46,7 @@ class MediaUploadController extends AbstractController
         }
 
         $fileName = $request->query->getString('fileName', $mediaId);
-        $destination = preg_replace('/[\x00-\x1F\x7F-\xFF]/', '', $fileName);
+        $destination = preg_replace('/\p{C}+/u', '', $fileName);
 
         if (!\is_string($destination)) {
             throw MediaException::illegalFileName($fileName, 'Filename must be a string');
@@ -73,7 +73,7 @@ class MediaUploadController extends AbstractController
     public function renameMediaFile(Request $request, string $mediaId, Context $context, ResponseFactoryInterface $responseFactory): Response
     {
         $fileName = $request->request->getString('fileName');
-        $destination = preg_replace('/[\x00-\x1F\x7F-\xFF]/', '', $fileName);
+        $destination = preg_replace('/\p{C}+/u', '', $fileName);
 
         if ($destination === '') {
             throw MediaException::emptyMediaFilename();
@@ -92,7 +92,7 @@ class MediaUploadController extends AbstractController
     public function provideName(Request $request, Context $context): JsonResponse
     {
         $fileName = $request->query->getString('fileName');
-        $preferredFileName = preg_replace('/[\x00-\x1F\x7F-\xFF]/', '', $fileName);
+        $preferredFileName = preg_replace('/\p{C}+/u', '', $fileName);
 
         if (!\is_string($preferredFileName)) {
             throw MediaException::illegalFileName($fileName, 'Filename must be a string');

--- a/src/Core/Content/Media/Subscriber/MediaCreationSubscriber.php
+++ b/src/Core/Content/Media/Subscriber/MediaCreationSubscriber.php
@@ -37,7 +37,7 @@ class MediaCreationSubscriber implements EventSubscriberInterface
     private function filterFilePath(array $commands): void
     {
         foreach ($commands as $command) {
-            $path = preg_replace('/[\x00-\x1F\x7F-\xFF]/', '', $command->getPayload()['path']);
+            $path = preg_replace('/\p{C}+/u', '', $command->getPayload()['path']);
 
             $command->addPayload('path', \is_string($path) ? $path : null);
         }

--- a/src/Core/Framework/Util/UrlEncoder.php
+++ b/src/Core/Framework/Util/UrlEncoder.php
@@ -22,7 +22,7 @@ class UrlEncoder
         $segments = explode('/', $urlInfo['path'] ?? '');
 
         foreach ($segments as $index => $segment) {
-            $segments[$index] = rawurlencode($segment);
+            $segments[$index] = rawurlencode(rawurldecode($segment));
         }
 
         $path = implode('/', $segments);

--- a/tests/unit/Core/Content/Media/Api/MediaUploadControllerTest.php
+++ b/tests/unit/Core/Content/Media/Api/MediaUploadControllerTest.php
@@ -137,6 +137,33 @@ class MediaUploadControllerTest extends TestCase
         $mediaUploadController->provideName($request, $context);
     }
 
+    public function testPreservePrintableUnicodeCharactersInFileNameBeforeProvideName(): void
+    {
+        $fileName = 'Geschenktüte.png';
+        $mediaId = Uuid::randomHex();
+        $context = Context::createDefaultContext();
+
+        $request = new Request([
+            'fileName' => $fileName,
+            'extension' => 'jpg',
+            'mediaId' => $mediaId,
+        ]);
+
+        $this->fileNameProvider->expects($this->once())
+            ->method('provide')
+            ->with($fileName, 'jpg', $mediaId, $context);
+
+        $mediaUploadController = new MediaUploadController(
+            $this->mediaService,
+            $this->fileSaver,
+            $this->fileNameProvider,
+            new MediaDefinition(),
+            new EventDispatcher()
+        );
+
+        $mediaUploadController->provideName($request, $context);
+    }
+
     public function testRenameThrowsWhenEmptyFileName(): void
     {
         $mediaId = Uuid::randomHex();

--- a/tests/unit/Core/Content/Media/Subscriber/MediaCreationSubscriberTest.php
+++ b/tests/unit/Core/Content/Media/Subscriber/MediaCreationSubscriberTest.php
@@ -130,4 +130,30 @@ class MediaCreationSubscriberTest extends TestCase
 
         static::assertSame('media/Bildschirmfoto 2023-06-24 um 16.30.36.png', $command->getPayload()['path']);
     }
+
+    public function testPathKeepsPrintableUnicodeCharacters(): void
+    {
+        $context = Context::createDefaultContext();
+
+        $subscriber = new MediaCreationSubscriber();
+
+        $definition = $this->getDefinition();
+
+        $command = new InsertCommand(
+            $definition,
+            ['path' => 'https://example.net/Geschenktüte.jpg'],
+            ['id' => $this->ids->getBytes('media-1')],
+            $this->createMock(EntityExistence::class),
+            '/0'
+        );
+
+        $event = EntityWriteEvent::create(
+            WriteContext::createFromContext($context),
+            [$command],
+        );
+
+        $subscriber->beforeWrite($event);
+
+        static::assertSame('https://example.net/Geschenktüte.jpg', $command->getPayload()['path']);
+    }
 }

--- a/tests/unit/Core/Framework/Util/UrlEncoderTest.php
+++ b/tests/unit/Core/Framework/Util/UrlEncoderTest.php
@@ -105,4 +105,12 @@ class UrlEncoderTest extends TestCase
             UrlEncoder::encodeUrl('../media/file name.jpg')
         );
     }
+
+    public function testItDoesNotDoubleEncodeAlreadyEncodedPaths(): void
+    {
+        static::assertSame(
+            'https://example.com/Geschenkt%C3%BCte.jpg',
+            UrlEncoder::encodeUrl('https://example.com/Geschenkt%C3%BCte.jpg')
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- preserve printable Unicode characters when sanitizing external media URLs and filenames
- avoid double-encoding already encoded URL segments
- add regression coverage and the unreleased changelog entry

## Validation
- `php-cs-fixer`
- `phpstan`
- direct runtime checks for encoded URLs and Unicode filenames

Closes #15357