### PR TITLE
[codex] Fix #16207 single-image gallery thumbnail sizes

### DIFF
--- a/changelog/_unreleased/2026-04-22-fix-single-image-gallery-thumbnail-sizes.md
+++ b/changelog/_unreleased/2026-04-22-fix-single-image-gallery-thumbnail-sizes.md
@@ -1,0 +1,2 @@
+# Storefront
+* Added the missing `sizes` configuration for single-image CMS galleries so storefront image selection matches the multi-image gallery variant.

--- a/src/Storefront/Resources/views/storefront/element/cms-element-image-gallery.html.twig
+++ b/src/Storefront/Resources/views/storefront/element/cms-element-image-gallery.html.twig
@@ -510,7 +510,15 @@
 
                                                                 {% sw_thumbnails 'gallery-slider-image-thumbnails' with {
                                                                     media: mediaItems|first,
-                                                                    attributes: attributes
+                                                                    attributes: attributes,
+                                                                    sizes: {
+                                                                        xs: '100vw',
+                                                                        sm: '100vw',
+                                                                        md: '100vw',
+                                                                        lg: '60vw',
+                                                                        xl: '50vw',
+                                                                        xxl: '800px'
+                                                                    }
                                                                 } %}
                                                             {% endblock %}
                                                         {% endif %}


### PR DESCRIPTION
## Summary
- pass the same `sizes` map to the single-image gallery thumbnail block as the multi-image block
- add the unreleased changelog entry

## Validation
- `php bin/console lint:twig /tmp/platform-16207-single-image-gallery-sizes/src/Storefront/Resources/views/storefront/element/cms-element-image-gallery.html.twig`

Closes #16207