### PR TITLE
[codex] Fix #16208 manufacturer logo link resolution

### DIFF
--- a/changelog/_unreleased/2026-04-22-fix-manufacturer-logo-link.md
+++ b/changelog/_unreleased/2026-04-22-fix-manufacturer-logo-link.md
@@ -1,0 +1,2 @@
+# Storefront
+* Fixed manufacturer logo CMS elements so they link to the configured manufacturer URL again when no explicit CMS URL override is set.

--- a/src/Storefront/Resources/views/storefront/element/cms-element-manufacturer-logo.html.twig
+++ b/src/Storefront/Resources/views/storefront/element/cms-element-manufacturer-logo.html.twig
@@ -6,7 +6,7 @@
             'media': element.data.manufacturer.media,
             'name': element.data.manufacturer.translated.name,
             'alt': element.data.manufacturer.translated.name,
-            'link': config.url.value ? config.url.value : element.data.manufacturer.translated.link,
+            'link': config.url.value ? config.url.value : element.data.manufacturer.link,
         } %}
     {% else %}
         {% set manufacturer = {


### PR DESCRIPTION
## Summary
- use the manufacturer link field instead of the non-existent translated variant in the storefront CMS element
- add the unreleased changelog entry

## Validation
- `php bin/console lint:twig /tmp/platform-16208-manufacturer-logo-link/src/Storefront/Resources/views/storefront/element/cms-element-manufacturer-logo.html.twig`

Closes #16208