### PR TITLE
fix: document percentage in price schemas

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -9,6 +9,11 @@
 The login and OAuth token endpoints now support optional per user (`login_user`, `oauth_user`) and per IP (`login_client`, `oauth_client`) rate limiters, in addition to the existing combined user and IP limiter.
 These are optional and can be enabled via `shopware.api.rate_limiter` in `shopware.yaml`.
 
+### `Price` schemas now describe percentage and reference price fields
+
+The generated Admin API and Store API `Price` schemas now include property descriptions for `percentage`, `listPrice`, `regulationPrice`, and their nested values.
+This improves the generated OpenAPI and Stoplight documentation for integrations that inspect raw price payloads and need to distinguish between the current price, list price, discount percentage, and regulation price fields.
+
 ## Core
 
 ### Product `display_group` values use SHA-256

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/AdminApi/components/schemas/Price.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/AdminApi/components/schemas/Price.json
@@ -9,39 +9,62 @@
                 "description": "Price object",
                 "properties": {
                     "currencyId": {
+                        "description": "Unique identity of the associated currency.",
                         "type": "string",
                         "pattern": "^[0-9a-f]{32}$"
                     },
                     "gross": {
-                        "description": "",
+                        "description": "Gross price for the associated currency.",
                         "type": "number"
                     },
                     "net": {
-                        "description": "",
+                        "description": "Net price for the associated currency.",
                         "type": "number"
                     },
                     "linked": {
-                        "description": "",
+                        "description": "Whether gross and net prices are linked through the tax configuration.",
                         "type": "boolean"
                     },
+                    "percentage": {
+                        "description": "Discount percentage relative to the list price for the gross and net amounts. `null` when no list price is set.",
+                        "type": [
+                            "object",
+                            "null"
+                        ],
+                        "properties": {
+                            "gross": {
+                                "description": "Discount percentage relative to the gross list price.",
+                                "type": "number"
+                            },
+                            "net": {
+                                "description": "Discount percentage relative to the net list price.",
+                                "type": "number"
+                            }
+                        },
+                        "required": [
+                            "gross",
+                            "net"
+                        ]
+                    },
                     "listPrice": {
-                        "description": "",
+                        "description": "Reference list price for displaying discounts.",
                         "type": "object",
                         "properties": {
                             "currencyId": {
+                                "description": "Unique identity of the associated currency.",
                                 "type": "string",
                                 "pattern": "^[0-9a-f]{32}$"
                             },
                             "gross": {
-                                "description": "",
+                                "description": "Gross list price for the associated currency.",
                                 "type": "number"
                             },
                             "net": {
-                                "description": "",
+                                "description": "Net list price for the associated currency.",
                                 "type": "number"
                             },
                             "linked": {
-                                "description": "",
+                                "description": "Whether gross and net list prices are linked through the tax configuration.",
                                 "type": "boolean"
                             }
                         },
@@ -52,23 +75,24 @@
                         ]
                     },
                     "regulationPrice": {
-                        "description": "",
+                        "description": "Reference price used for legal price disclosures.",
                         "type": "object",
                         "properties": {
                             "currencyId": {
+                                "description": "Unique identity of the associated currency.",
                                 "type": "string",
                                 "pattern": "^[0-9a-f]{32}$"
                             },
                             "gross": {
-                                "description": "",
+                                "description": "Gross regulation price for the associated currency.",
                                 "type": "number"
                             },
                             "net": {
-                                "description": "",
+                                "description": "Net regulation price for the associated currency.",
                                 "type": "number"
                             },
                             "linked": {
-                                "description": "",
+                                "description": "Whether gross and net regulation prices are linked through the tax configuration.",
                                 "type": "boolean"
                             }
                         },

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/components/schemas/Price.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/components/schemas/Price.json
@@ -9,39 +9,62 @@
                 "description": "Price object",
                 "properties": {
                     "currencyId": {
+                        "description": "Unique identity of the associated currency.",
                         "type": "string",
                         "pattern": "^[0-9a-f]{32}$"
                     },
                     "gross": {
-                        "description": "",
+                        "description": "Gross price for the associated currency.",
                         "type": "number"
                     },
                     "net": {
-                        "description": "",
+                        "description": "Net price for the associated currency.",
                         "type": "number"
                     },
                     "linked": {
-                        "description": "",
+                        "description": "Whether gross and net prices are linked through the tax configuration.",
                         "type": "boolean"
                     },
+                    "percentage": {
+                        "description": "Discount percentage relative to the list price for the gross and net amounts. `null` when no list price is set.",
+                        "type": [
+                            "object",
+                            "null"
+                        ],
+                        "properties": {
+                            "gross": {
+                                "description": "Discount percentage relative to the gross list price.",
+                                "type": "number"
+                            },
+                            "net": {
+                                "description": "Discount percentage relative to the net list price.",
+                                "type": "number"
+                            }
+                        },
+                        "required": [
+                            "gross",
+                            "net"
+                        ]
+                    },
                     "listPrice": {
-                        "description": "",
+                        "description": "Reference list price for displaying discounts.",
                         "type": "object",
                         "properties": {
                             "currencyId": {
+                                "description": "Unique identity of the associated currency.",
                                 "type": "string",
                                 "pattern": "^[0-9a-f]{32}$"
                             },
                             "gross": {
-                                "description": "",
+                                "description": "Gross list price for the associated currency.",
                                 "type": "number"
                             },
                             "net": {
-                                "description": "",
+                                "description": "Net list price for the associated currency.",
                                 "type": "number"
                             },
                             "linked": {
-                                "description": "",
+                                "description": "Whether gross and net list prices are linked through the tax configuration.",
                                 "type": "boolean"
                             }
                         },
@@ -51,23 +74,24 @@
                         ]
                     },
                     "regulationPrice": {
-                        "description": "",
+                        "description": "Reference price used for legal price disclosures.",
                         "type": "object",
                         "properties": {
                             "currencyId": {
+                                "description": "Unique identity of the associated currency.",
                                 "type": "string",
                                 "pattern": "^[0-9a-f]{32}$"
                             },
                             "gross": {
-                                "description": "",
+                                "description": "Gross regulation price for the associated currency.",
                                 "type": "number"
                             },
                             "net": {
-                                "description": "",
+                                "description": "Net regulation price for the associated currency.",
                                 "type": "number"
                             },
                             "linked": {
-                                "description": "",
+                                "description": "Whether gross and net regulation prices are linked through the tax configuration.",
                                 "type": "boolean"
                             }
                         },


### PR DESCRIPTION
## Summary
- add the missing `percentage` property to the Admin API price schema
- add the missing `percentage` property to the Store API price schema

## Verification
- parsed both updated JSON schema files successfully

* Example data:
<img width="855" height="311" alt="Screenshot 2026-04-23 at 16 47 28" src="https://github.com/user-attachments/assets/793487eb-4af6-4a62-853f-4c1b0876b608" />

Fixes #16111