### PR TITLE
fix: persist product export context for storefront channel

### DIFF
--- a/src/Core/Content/ProductExport/Service/ProductExportGenerator.php
+++ b/src/Core/Content/ProductExport/Service/ProductExportGenerator.php
@@ -79,7 +79,7 @@ class ProductExportGenerator implements ProductExportGeneratorInterface
             [
                 SalesChannelContextService::CURRENCY_ID => $productExport->getCurrencyId(),
             ],
-            $productExport->getSalesChannelId()
+            $productExport->getStorefrontSalesChannelId()
         );
 
         $languageId = $domain->getLanguageId();

--- a/tests/unit/Core/Content/ProductExport/Service/ProductExportGeneratorTest.php
+++ b/tests/unit/Core/Content/ProductExport/Service/ProductExportGeneratorTest.php
@@ -96,7 +96,13 @@ class ProductExportGeneratorTest extends TestCase
     {
         $productExport = $this->getProductExportEntity();
 
-        $this->contextPersister->expects($this->once())->method('save');
+        $this->contextPersister->expects($this->once())
+            ->method('save')
+            ->with(
+                static::callback(static fn (mixed $token): bool => \is_string($token)),
+                ['currencyId' => 'currencyId'],
+                'storefrontSalesChannelId'
+            );
         $this->salesChannelContextService->expects($this->once())->method('get');
         $this->parserFactory->expects($this->once())->method('getParser');
 


### PR DESCRIPTION
## Summary
- persist the temporary export context against the storefront sales channel instead of the technical export sales channel
- cover the sales-channel-specific save call in the generator unit test

## Verification
- `php -l` on touched PHP files
- `vendor/bin/phpstan analyze --debug --memory-limit=2G` on touched files
- `vendor/bin/php-cs-fixer fix --config=/Users/tamvo/work/platform/.php-cs-fixer.dist.php --dry-run --diff --sequential` on touched files

Fixes #12647