### PR TITLE
fix: apply closeout filtering to product stream sliders

### DIFF
--- a/src/Core/Content/DependencyInjection/product.xml
+++ b/src/Core/Content/DependencyInjection/product.xml
@@ -256,6 +256,8 @@
         <service id="Shopware\Core\Content\Product\Cms\ProductSlider\ProductStreamProcessor">
             <argument type="service" id="Shopware\Core\Content\ProductStream\Service\ProductStreamBuilder"/>
             <argument type="service" id="sales_channel.product.repository"/>
+            <argument type="service" id="Shopware\Core\Content\Product\SalesChannel\AbstractProductCloseoutFilterFactory"/>
+            <argument type="service" id="Shopware\Core\System\SystemConfig\SystemConfigService"/>
             <argument type="service" id="event_dispatcher"/>
 
             <tag name="shopware.cms.product_slider.processor"/>

--- a/src/Core/Content/Product/Cms/ProductSlider/ProductStreamProcessor.php
+++ b/src/Core/Content/Product/Cms/ProductSlider/ProductStreamProcessor.php
@@ -12,6 +12,7 @@ use Shopware\Core\Content\Cms\SalesChannel\Struct\ProductSliderStruct;
 use Shopware\Core\Content\Product\Events\ProductSliderStreamCriteriaEvent;
 use Shopware\Core\Content\Product\ProductCollection;
 use Shopware\Core\Content\Product\ProductDefinition;
+use Shopware\Core\Content\Product\SalesChannel\AbstractProductCloseoutFilterFactory;
 use Shopware\Core\Content\ProductStream\Service\ProductStreamBuilderInterface;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\NotEqualsFilter;
@@ -21,6 +22,7 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
 use Shopware\Core\System\SalesChannel\Entity\SalesChannelRepository;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Shopware\Core\System\SystemConfig\SystemConfigService;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 #[Package('discovery')]
@@ -36,6 +38,8 @@ class ProductStreamProcessor extends AbstractProductSliderProcessor
     public function __construct(
         private readonly ProductStreamBuilderInterface $productStreamBuilder,
         private readonly SalesChannelRepository $productRepository,
+        private readonly AbstractProductCloseoutFilterFactory $productCloseoutFilterFactory,
+        private readonly SystemConfigService $systemConfigService,
         private readonly EventDispatcherInterface $eventDispatcher,
     ) {
     }
@@ -139,6 +143,10 @@ class ProductStreamProcessor extends AbstractProductSliderProcessor
         }
 
         $criteria = $originCriteria->cloneForRead($finalProductIds);
+
+        if ($this->systemConfigService->getBool('core.listing.hideCloseoutProductsWhenOutOfStock', $context->getSalesChannelId())) {
+            $criteria->addFilter($this->productCloseoutFilterFactory->create($context));
+        }
 
         $products = $this->productRepository->search($criteria, $context)->getEntities();
         $products->sortByIdArray($finalProductIds);

--- a/tests/unit/Core/Content/Product/Cms/ProductSlider/ProductStreamProcessorTest.php
+++ b/tests/unit/Core/Content/Product/Cms/ProductSlider/ProductStreamProcessorTest.php
@@ -14,6 +14,8 @@ use Shopware\Core\Content\Product\Cms\ProductSlider\ProductStreamProcessor;
 use Shopware\Core\Content\Product\Events\ProductSliderStreamCriteriaEvent;
 use Shopware\Core\Content\Product\ProductCollection;
 use Shopware\Core\Content\Product\ProductDefinition;
+use Shopware\Core\Content\Product\SalesChannel\AbstractProductCloseoutFilterFactory;
+use Shopware\Core\Content\Product\SalesChannel\ProductCloseoutFilter;
 use Shopware\Core\Content\ProductStream\Service\ProductStreamBuilderInterface;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
@@ -26,6 +28,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Sorting\FieldSorting;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
 use Shopware\Core\System\SalesChannel\Entity\SalesChannelRepository;
+use Shopware\Core\System\SystemConfig\SystemConfigService;
 use Shopware\Core\System\Tax\TaxCollection;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
@@ -47,6 +50,10 @@ class ProductStreamProcessorTest extends TestCase
      */
     private SalesChannelRepository&MockObject $productRepository;
 
+    private AbstractProductCloseoutFilterFactory&MockObject $productCloseoutFilterFactory;
+
+    private SystemConfigService&MockObject $systemConfigService;
+
     private EventDispatcherInterface&MockObject $eventDispatcher;
 
     protected function setUp(): void
@@ -55,6 +62,8 @@ class ProductStreamProcessorTest extends TestCase
         $this->productStreamBuilder->method('buildFilters')->willReturn([$this->getFilter()]);
 
         $this->productRepository = $this->createMock(SalesChannelRepository::class);
+        $this->productCloseoutFilterFactory = $this->createMock(AbstractProductCloseoutFilterFactory::class);
+        $this->systemConfigService = $this->createMock(SystemConfigService::class);
         $this->eventDispatcher = $this->createMock(EventDispatcherInterface::class);
         $this->config = new FieldConfigCollection();
     }
@@ -179,6 +188,60 @@ class ProductStreamProcessorTest extends TestCase
         static::assertSame($products, $slider->getProducts());
     }
 
+    public function testEnrichFiltersOutOutOfStockCloseoutProductsWhenConfigured(): void
+    {
+        $slot = $this->getSlot();
+        $resolverContext = $this->getResolverContext();
+
+        $config = new FieldConfig('products', FieldConfig::SOURCE_PRODUCT_STREAM, 'product-stream-1');
+        $this->config->add($config);
+
+        $products = $this->getProducts();
+        $searchResult = $this->getEntitySearchResult($products);
+        $filteredProduct = $products->get('product-1');
+        static::assertNotNull($filteredProduct);
+        $filteredProducts = new ProductCollection([$filteredProduct]);
+
+        $data = new ElementDataCollection();
+        $data->add('product-slider-entity-fallback_id', $searchResult);
+
+        $this->systemConfigService->expects($this->once())
+            ->method('getBool')
+            ->with('core.listing.hideCloseoutProductsWhenOutOfStock', $resolverContext->getSalesChannelContext()->getSalesChannelId())
+            ->willReturn(true);
+
+        $this->productCloseoutFilterFactory->expects($this->once())
+            ->method('create')
+            ->with($resolverContext->getSalesChannelContext())
+            ->willReturn(new ProductCloseoutFilter());
+
+        $this->productRepository->expects($this->once())
+            ->method('search')
+            ->willReturnCallback(static function (Criteria $criteria) use ($filteredProducts, $resolverContext): EntitySearchResult {
+                static::assertCount(1, $criteria->getFilters());
+                static::assertInstanceOf(ProductCloseoutFilter::class, $criteria->getFilters()[0]);
+
+                return new EntitySearchResult(
+                    'product',
+                    1,
+                    $filteredProducts,
+                    null,
+                    $criteria,
+                    $resolverContext->getSalesChannelContext()->getContext()
+                );
+            });
+
+        $this->getProcessor()->enrich($slot, $data, $resolverContext);
+
+        $slider = $slot->getData();
+        static::assertInstanceOf(ProductSliderStruct::class, $slider);
+        $sliderProducts = $slider->getProducts();
+        static::assertInstanceOf(ProductCollection::class, $sliderProducts);
+        static::assertCount(1, $sliderProducts);
+        static::assertNotNull($sliderProducts->get('product-1'));
+        static::assertNull($sliderProducts->get('product-2'));
+    }
+
     public function testEnrichDoesNothingWithoutEntitySearchResult(): void
     {
         $slot = $this->getSlot();
@@ -241,7 +304,13 @@ class ProductStreamProcessorTest extends TestCase
 
     private function getProcessor(): ProductStreamProcessor
     {
-        return new ProductStreamProcessor($this->productStreamBuilder, $this->productRepository, $this->eventDispatcher);
+        return new ProductStreamProcessor(
+            $this->productStreamBuilder,
+            $this->productRepository,
+            $this->productCloseoutFilterFactory,
+            $this->systemConfigService,
+            $this->eventDispatcher
+        );
     }
 
     private function getFilter(): MultiFilter


### PR DESCRIPTION
## Summary
- apply the existing closeout/out-of-stock filter when stream-based product sliders are resolved
- wire the slider processor to the closeout filter factory and system config
- add unit coverage for the configured filtering path

## Verification
- `php -l` on touched PHP files
- `vendor/bin/phpstan analyze --debug --memory-limit=2G` on touched files
- `vendor/bin/php-cs-fixer fix --config=/Users/tamvo/work/platform/.php-cs-fixer.dist.php --dry-run --diff --sequential` on touched files

Fixes #15902