### PR TITLE
fix: fall back from instant add-column migrations

### DIFF
--- a/src/Core/Framework/Migration/AddColumnTrait.php
+++ b/src/Core/Framework/Migration/AddColumnTrait.php
@@ -41,9 +41,13 @@ trait AddColumnTrait
             // Try INSTANT first – fast metadata-only operation, no table rebuild.
             $connection->executeStatement($sql . ', ALGORITHM=INSTANT;');
         } catch (DBALException) {
-            // INSTANT not supported for this operation (e.g., expression defaults, fulltext tables).
-            // Fall back to regular ALTER TABLE and let MySQL pick the best algorithm.
-            $connection->executeStatement($sql . ';');
+            try {
+                // Some MySQL 8.4 operations reject INSTANT but still allow INPLACE.
+                $connection->executeStatement($sql . ', ALGORITHM=INPLACE;');
+            } catch (DBALException) {
+                // Fall back to a plain ALTER TABLE and let MySQL pick the best algorithm.
+                $connection->executeStatement($sql . ';');
+            }
         }
 
         return true;

--- a/tests/unit/Core/Framework/Migration/AddColumnTraitTest.php
+++ b/tests/unit/Core/Framework/Migration/AddColumnTraitTest.php
@@ -25,7 +25,24 @@ class AddColumnTraitTest extends TestCase
         $connection = $this->createConnectionMock(columnExists: true);
         $connection->expects($this->never())->method('executeStatement');
 
-        $migration = new TestAddColumnMigration();
+        $migration = new class {
+            use AddColumnTrait;
+
+            /**
+             * @param non-empty-string $table
+             * @param non-empty-string $column
+             */
+            public function callAddColumn(
+                Connection $connection,
+                string $table,
+                string $column,
+                string $type,
+                bool $nullable = true,
+                string $default = 'NULL'
+            ): bool {
+                return $this->addColumn($connection, $table, $column, $type, $nullable, $default);
+            }
+        };
 
         $result = $migration->callAddColumn($connection, 'product', 'states', 'JSON');
 
@@ -50,7 +67,24 @@ class AddColumnTraitTest extends TestCase
             ->method('executeStatement')
             ->with($expectedInstantSql);
 
-        $migration = new TestAddColumnMigration();
+        $migration = new class {
+            use AddColumnTrait;
+
+            /**
+             * @param non-empty-string $table
+             * @param non-empty-string $column
+             */
+            public function callAddColumn(
+                Connection $connection,
+                string $table,
+                string $column,
+                string $type,
+                bool $nullable = true,
+                string $default = 'NULL'
+            ): bool {
+                return $this->addColumn($connection, $table, $column, $type, $nullable, $default);
+            }
+        };
 
         $result = $migration->callAddColumn($connection, $table, $column, $type, $nullable, $default);
 
@@ -62,14 +96,15 @@ class AddColumnTraitTest extends TestCase
         $connection = $this->createConnectionMock(columnExists: false);
 
         $instantSql = 'ALTER TABLE `app` ADD COLUMN `source_config` JSON NOT NULL DEFAULT (JSON_OBJECT()), ALGORITHM=INSTANT;';
+        $inplaceSql = 'ALTER TABLE `app` ADD COLUMN `source_config` JSON NOT NULL DEFAULT (JSON_OBJECT()), ALGORITHM=INPLACE;';
         $fallbackSql = 'ALTER TABLE `app` ADD COLUMN `source_config` JSON NOT NULL DEFAULT (JSON_OBJECT());';
 
         $exception = new class('ALGORITHM=INSTANT is not supported') extends \Exception implements DBALException {};
 
-        $connection->expects($this->exactly(2))
+        $connection->expects($this->exactly(3))
             ->method('executeStatement')
-            ->willReturnCallback(static function (string $sql) use ($instantSql, $fallbackSql, $exception): int {
-                if ($sql === $instantSql) {
+            ->willReturnCallback(static function (string $sql) use ($instantSql, $inplaceSql, $fallbackSql, $exception): int {
+                if ($sql === $instantSql || $sql === $inplaceSql) {
                     throw $exception;
                 }
 
@@ -78,7 +113,24 @@ class AddColumnTraitTest extends TestCase
                 return 0;
             });
 
-        $migration = new TestAddColumnMigration();
+        $migration = new class {
+            use AddColumnTrait;
+
+            /**
+             * @param non-empty-string $table
+             * @param non-empty-string $column
+             */
+            public function callAddColumn(
+                Connection $connection,
+                string $table,
+                string $column,
+                string $type,
+                bool $nullable = true,
+                string $default = 'NULL'
+            ): bool {
+                return $this->addColumn($connection, $table, $column, $type, $nullable, $default);
+            }
+        };
 
         $result = $migration->callAddColumn($connection, 'app', 'source_config', 'JSON', false, '(JSON_OBJECT())');
 
@@ -131,30 +183,8 @@ class AddColumnTraitTest extends TestCase
 
         $connection = $this->createMock(Connection::class);
         $connection->method('createSchemaManager')->willReturn($schemaManager);
+        $connection->method('fetchOne')->willReturn($columnExists ? '1' : false);
 
         return $connection;
-    }
-}
-
-/**
- * @internal
- */
-class TestAddColumnMigration
-{
-    use AddColumnTrait;
-
-    /**
-     * @param non-empty-string $table
-     * @param non-empty-string $column
-     */
-    public function callAddColumn(
-        Connection $connection,
-        string $table,
-        string $column,
-        string $type,
-        bool $nullable = true,
-        string $default = 'NULL'
-    ): bool {
-        return $this->addColumn($connection, $table, $column, $type, $nullable, $default);
     }
 }


### PR DESCRIPTION
## Summary
- fall back from `ALGORITHM=INSTANT` to `ALGORITHM=INPLACE` before using the plain `ALTER TABLE` fallback
- extend the migration trait test coverage for the fallback chain

## Verification
- `php -l` on touched PHP files
- `vendor/bin/phpstan analyze --debug --memory-limit=2G` on touched files
- `vendor/bin/php-cs-fixer fix --config=/Users/tamvo/work/platform/.php-cs-fixer.dist.php --dry-run --diff --sequential` on touched files

Fixes #16240