### PR TITLE
fix: add seo_url path_info canonical index

### DIFF
--- a/src/Core/Migration/V6_8/Migration1776816100AddSeoUrlPathInfoCanonicalIndex.php
+++ b/src/Core/Migration/V6_8/Migration1776816100AddSeoUrlPathInfoCanonicalIndex.php
@@ -1,0 +1,33 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Migration\V6_8;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Migration\MigrationStep;
+use Shopware\Core\Framework\Util\Database\TableHelper;
+
+/**
+ * @internal
+ */
+#[Package('inventory')]
+class Migration1776816100AddSeoUrlPathInfoCanonicalIndex extends MigrationStep
+{
+    public function getCreationTimestamp(): int
+    {
+        return 1776816100;
+    }
+
+    public function update(Connection $connection): void
+    {
+        if (TableHelper::indexExists($connection, 'seo_url', 'idx.path_info.is_canonical')) {
+            return;
+        }
+
+        $connection->executeStatement('CREATE INDEX `idx.path_info.is_canonical` ON `seo_url` (`path_info`, `is_canonical`)');
+    }
+
+    public function updateDestructive(Connection $connection): void
+    {
+    }
+}

--- a/tests/migration/Core/V6_8/Migration1776816100AddSeoUrlPathInfoCanonicalIndexTest.php
+++ b/tests/migration/Core/V6_8/Migration1776816100AddSeoUrlPathInfoCanonicalIndexTest.php
@@ -1,0 +1,56 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Migration\Core\V6_8;
+
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
+use Shopware\Core\Framework\Util\Database\TableHelper;
+use Shopware\Core\Migration\V6_8\Migration1776816100AddSeoUrlPathInfoCanonicalIndex;
+
+/**
+ * @internal
+ */
+#[CoversClass(Migration1776816100AddSeoUrlPathInfoCanonicalIndex::class)]
+class Migration1776816100AddSeoUrlPathInfoCanonicalIndexTest extends TestCase
+{
+    use KernelTestBehaviour;
+
+    private Connection $connection;
+
+    protected function setUp(): void
+    {
+        $this->connection = static::getContainer()->get(Connection::class);
+    }
+
+    public function testTimestamp(): void
+    {
+        static::assertSame(1776816100, (new Migration1776816100AddSeoUrlPathInfoCanonicalIndex())->getCreationTimestamp());
+    }
+
+    public function testMigration(): void
+    {
+        $this->undoMigration();
+
+        $migration = new Migration1776816100AddSeoUrlPathInfoCanonicalIndex();
+        $migration->update($this->connection);
+        $migration->update($this->connection);
+
+        static::assertTrue(TableHelper::indexSpansColumns(
+            $this->connection,
+            'seo_url',
+            'idx.path_info.is_canonical',
+            ['path_info', 'is_canonical']
+        ));
+    }
+
+    private function undoMigration(): void
+    {
+        if (!TableHelper::indexExists($this->connection, 'seo_url', 'idx.path_info.is_canonical')) {
+            return;
+        }
+
+        $this->connection->executeStatement('ALTER TABLE `seo_url` DROP INDEX `idx.path_info.is_canonical`');
+    }
+}


### PR DESCRIPTION
## Summary
- add the missing `seo_url(path_info, is_canonical)` index in a V6.8 migration
- add migration coverage that verifies the index span and idempotency

## Verification
- `php -l` on touched PHP files
- `vendor/bin/phpstan analyze --debug --memory-limit=2G` on touched files
- `vendor/bin/php-cs-fixer fix --config=/Users/tamvo/work/platform/.php-cs-fixer.dist.php --dry-run --diff --sequential` on touched files

Fixes #5121