### PR TITLE
fix: reject percent signs in seo urls

### DIFF
--- a/src/Core/Content/Seo/Validation/SeoUrlValidationFactory.php
+++ b/src/Core/Content/Seo/Validation/SeoUrlValidationFactory.php
@@ -10,6 +10,7 @@ use Shopware\Core\Framework\Routing\Validation\Constraint\RouteNotBlocked;
 use Shopware\Core\Framework\Validation\DataValidationDefinition;
 use Shopware\Core\System\SalesChannel\SalesChannelDefinition;
 use Symfony\Component\Validator\Constraints\NotBlank;
+use Symfony\Component\Validator\Constraints\Regex;
 use Symfony\Component\Validator\Constraints\Type;
 
 #[Package('inventory')]
@@ -42,7 +43,7 @@ class SeoUrlValidationFactory implements SeoUrlDataValidationFactoryInterface
             ->add('foreignKey', ...$fkConstraints)
             ->add('routeName', new NotBlank(), new Type('string'))
             ->add('pathInfo', new NotBlank(), new Type('string'))
-            ->add('seoPathInfo', new NotBlank(), new Type('string'), new RouteNotBlocked())
+            ->add('seoPathInfo', new NotBlank(), new Type('string'), new Regex(pattern: '/%/', match: false), new RouteNotBlocked())
             ->add('salesChannelId', new NotBlank(), new EntityExists(
                 entity: SalesChannelDefinition::ENTITY_NAME,
                 context: $context,

--- a/tests/integration/Storefront/Framework/Seo/Api/SeoActionControllerTest.php
+++ b/tests/integration/Storefront/Framework/Seo/Api/SeoActionControllerTest.php
@@ -293,6 +293,32 @@ class SeoActionControllerTest extends TestCase
         static::assertSame($newSeoPathInfo, $seoUrl['seoPathInfo']);
     }
 
+    public function testUpdateCanonicalRejectsSeoPathInfoContainingPercent(): void
+    {
+        $salesChannelId = Uuid::randomHex();
+        $this->createStorefrontSalesChannelContext($salesChannelId, 'test');
+
+        $id = $this->createTestProduct($salesChannelId);
+
+        $seoUrls = $this->getSeoUrls($id, true, $salesChannelId);
+        static::assertCount(1, $seoUrls);
+
+        $seoUrl = $seoUrls[0]['attributes'];
+        $seoUrl['seoPathInfo'] = 'seo/url%/1';
+        $seoUrl['isModified'] = true;
+
+        $this->getBrowser()->jsonRequest('PATCH', '/api/_action/seo-url/canonical', $seoUrl);
+        $response = $this->getBrowser()->getResponse();
+
+        static::assertSame(400, $response->getStatusCode(), (string) $response->getContent());
+
+        $content = $response->getContent();
+        static::assertIsString($content);
+        $result = json_decode($content, true, 512, \JSON_THROW_ON_ERROR);
+
+        static::assertSame('/seoPathInfo', $result['errors'][0]['source']['pointer']);
+    }
+
     public function testUpdateCanonicalWithCustomSalesChannel(): void
     {
         $salesChannelId = Uuid::randomHex();


### PR DESCRIPTION
## Summary
- reject `%` in `seoPathInfo` during SEO URL validation instead of allowing an invalid path to reach storefront routing
- add controller-level regression coverage for canonical updates containing `%`

## Verification
- `php -l` on touched PHP files
- `vendor/bin/phpstan analyze --debug --memory-limit=2G` on touched files
- `vendor/bin/php-cs-fixer fix --config=/Users/tamvo/work/platform/.php-cs-fixer.dist.php --dry-run --diff --sequential` on touched files

Fixes #13796