### PR TITLE
fix: allow resetting canonical seo urls

### DIFF
--- a/src/Core/Content/Seo/Api/SeoActionController.php
+++ b/src/Core/Content/Seo/Api/SeoActionController.php
@@ -9,6 +9,7 @@ use Shopware\Core\Content\Seo\SeoUrl\SeoUrlEntity;
 use Shopware\Core\Content\Seo\SeoUrlGenerator;
 use Shopware\Core\Content\Seo\SeoUrlPersister;
 use Shopware\Core\Content\Seo\SeoUrlRoute\SeoUrlRouteConfig;
+use Shopware\Core\Content\Seo\SeoUrlRoute\SeoUrlRouteInterface;
 use Shopware\Core\Content\Seo\SeoUrlRoute\SeoUrlRouteRegistry;
 use Shopware\Core\Content\Seo\Validation\SeoUrlDataValidationFactoryInterface;
 use Shopware\Core\Content\Seo\Validation\SeoUrlValidationFactory;
@@ -123,7 +124,7 @@ class SeoActionController extends AbstractController
         $repository = $this->getRepository($config);
 
         $criteria = new Criteria();
-        if (!empty($fk)) {
+        if (\is_string($fk) && $fk !== '') {
             $criteria = new Criteria([$fk]);
         }
         $criteria->setLimit(1);
@@ -156,7 +157,6 @@ class SeoActionController extends AbstractController
         $validation = $this->seoUrlValidator->buildValidation($context, $seoUrlRoute->getConfig());
 
         $seoUrlData = $seoUrl->all();
-        $this->validator->validate($seoUrlData, $validation);
         $seoUrlData['isModified'] ??= true;
 
         $salesChannelId = $seoUrlData['salesChannelId'] ?? null;
@@ -174,6 +174,9 @@ class SeoActionController extends AbstractController
         if ($salesChannel->getTypeId() === Defaults::SALES_CHANNEL_TYPE_API) {
             return new Response('', Response::HTTP_NO_CONTENT);
         }
+
+        $seoUrlData = $this->normalizeCanonicalUpdateData($seoUrlData, $seoUrlRoute, $salesChannel, $context);
+        $this->validator->validate($seoUrlData, $validation);
 
         $this->seoUrlPersister->updateSeoUrls(
             $context,
@@ -327,6 +330,43 @@ class SeoActionController extends AbstractController
             ->search($criteria, $context)
             ->getEntities()
             ->first();
+    }
+
+    /**
+     * @param array<string, mixed> $seoUrlData
+     *
+     * @return array<string, mixed>
+     */
+    private function normalizeCanonicalUpdateData(
+        array $seoUrlData,
+        SeoUrlRouteInterface $seoUrlRoute,
+        SalesChannelEntity $salesChannel,
+        Context $context
+    ): array {
+        if (($seoUrlData['isModified'] ?? true) !== false || trim((string) ($seoUrlData['seoPathInfo'] ?? '')) !== '') {
+            return $seoUrlData;
+        }
+
+        $generatedSeoUrls = $this->seoUrlGenerator->generate(
+            [$seoUrlData['foreignKey']],
+            $seoUrlRoute->getConfig()->getTemplate(),
+            new ConfiguredSeoUrlRoute($seoUrlRoute, $seoUrlRoute->getConfig()),
+            $context,
+            $salesChannel
+        );
+
+        $generatedSeoUrls = \is_array($generatedSeoUrls) ? array_values($generatedSeoUrls) : array_values(iterator_to_array($generatedSeoUrls));
+        $generatedSeoUrl = array_shift($generatedSeoUrls);
+
+        if (!$generatedSeoUrl instanceof SeoUrlEntity) {
+            return $seoUrlData;
+        }
+
+        $seoUrlData['seoPathInfo'] = $generatedSeoUrl->getSeoPathInfo();
+        $seoUrlData['pathInfo'] = $generatedSeoUrl->getPathInfo();
+        $seoUrlData['_allowReset'] = true;
+
+        return $seoUrlData;
     }
 
     /**

--- a/src/Core/Content/Seo/SeoUrlPersister.php
+++ b/src/Core/Content/Seo/SeoUrlPersister.php
@@ -57,6 +57,10 @@ class SeoUrlPersister
             if ($seoUrl instanceof SeoUrlEntity) {
                 $seoUrl = $seoUrl->jsonSerialize();
             }
+
+            $allowReset = (bool) ($seoUrl['_allowReset'] ?? false);
+            unset($seoUrl['_allowReset']);
+
             $updates[] = $seoUrl;
 
             $fk = $seoUrl['foreignKey'];
@@ -74,7 +78,7 @@ class SeoUrlPersister
 
             $updatedFks[] = $fk;
 
-            if (!empty($seoUrl['error'])) {
+            if (($seoUrl['error'] ?? null) !== null && $seoUrl['error'] !== '') {
                 continue;
             }
             $existing = $canonicals[$fk][$salesChannelId] ?? null;
@@ -82,7 +86,7 @@ class SeoUrlPersister
             if ($existing) {
                 // entity has override or does not change
                 /** @phpstan-ignore-next-line PHPStan could not recognize the array generated from the jsonSerialize method of the SeoUrlEntity */
-                if ($this->skipUpdate($existing, $seoUrl)) {
+                if ($this->skipUpdate($existing, $seoUrl, $allowReset)) {
                     continue;
                 }
                 $obsoleted[] = $existing['id'];
@@ -138,9 +142,9 @@ class SeoUrlPersister
      * @param array{isModified: bool, seoPathInfo: string, salesChannelId: string} $existing
      * @param array{isModified?: bool, seoPathInfo: string, salesChannelId: string} $seoUrl
      */
-    private function skipUpdate(array $existing, array $seoUrl): bool
+    private function skipUpdate(array $existing, array $seoUrl, bool $allowReset): bool
     {
-        if ($existing['isModified'] && !($seoUrl['isModified'] ?? false) && trim($seoUrl['seoPathInfo']) !== '') {
+        if ($existing['isModified'] && !($seoUrl['isModified'] ?? false) && trim($seoUrl['seoPathInfo']) !== '' && !$allowReset) {
             return true;
         }
 

--- a/tests/integration/Storefront/Framework/Seo/Api/SeoActionControllerTest.php
+++ b/tests/integration/Storefront/Framework/Seo/Api/SeoActionControllerTest.php
@@ -338,6 +338,45 @@ class SeoActionControllerTest extends TestCase
         static::assertSame($newSeoPathInfo, $seoUrl['seoPathInfo']);
     }
 
+    public function testResetCanonicalToGeneratedValue(): void
+    {
+        $salesChannelId = Uuid::randomHex();
+        $this->createStorefrontSalesChannelContext($salesChannelId, 'test');
+
+        $id = $this->createTestProduct($salesChannelId);
+
+        $seoUrls = $this->getSeoUrls($id, true, $salesChannelId);
+        static::assertCount(1, $seoUrls);
+
+        $generatedSeoUrl = $seoUrls[0]['attributes'];
+        $generatedSeoPathInfo = $generatedSeoUrl['seoPathInfo'];
+
+        $generatedSeoUrl['seoPathInfo'] = 'my-awesome-seo-path';
+        $generatedSeoUrl['isModified'] = true;
+
+        $this->getBrowser()->jsonRequest('PATCH', '/api/_action/seo-url/canonical', $generatedSeoUrl);
+        $response = $this->getBrowser()->getResponse();
+        static::assertSame(204, $response->getStatusCode(), (string) $response->getContent());
+
+        $seoUrls = $this->getSeoUrls($id, true, $salesChannelId);
+        static::assertCount(1, $seoUrls);
+        static::assertSame('my-awesome-seo-path', $seoUrls[0]['attributes']['seoPathInfo']);
+        static::assertTrue($seoUrls[0]['attributes']['isModified']);
+
+        $resetSeoUrl = $seoUrls[0]['attributes'];
+        $resetSeoUrl['seoPathInfo'] = '';
+        $resetSeoUrl['isModified'] = false;
+
+        $this->getBrowser()->jsonRequest('PATCH', '/api/_action/seo-url/canonical', $resetSeoUrl);
+        $response = $this->getBrowser()->getResponse();
+        static::assertSame(204, $response->getStatusCode(), (string) $response->getContent());
+
+        $seoUrls = $this->getSeoUrls($id, true, $salesChannelId);
+        static::assertCount(1, $seoUrls);
+        static::assertSame($generatedSeoPathInfo, $seoUrls[0]['attributes']['seoPathInfo']);
+        static::assertFalse($seoUrls[0]['attributes']['isModified']);
+    }
+
     public function testUpdateDefaultCanonicalForHeadlessBehavesCorrectly(): void
     {
         $salesChannelId = Uuid::randomHex();


### PR DESCRIPTION
## Summary
- regenerate the canonical SEO URL when a blank canonical path is saved with `isModified=false`
- allow that internal reset path through the persister without exposing the internal reset flag to SEO update events
- add controller-level regression coverage for resetting a modified canonical URL back to its generated value

## Verification
- `php -l` on touched PHP files
- `vendor/bin/phpstan analyze --debug --memory-limit=2G` on touched files
- `vendor/bin/php-cs-fixer fix --config=/Users/tamvo/work/platform/.php-cs-fixer.dist.php --dry-run --diff --sequential` on touched files

Fixes #4413