### PR TITLE
fix: prevent overencoding external urls and control character filtering

### DIFF
--- a/src/Core/Checkout/Document/Controller/DocumentController.php
+++ b/src/Core/Checkout/Document/Controller/DocumentController.php
@@ -7,6 +7,8 @@ use Shopware\Core\Checkout\Document\Service\DocumentGenerator;
 use Shopware\Core\Checkout\Document\Service\DocumentMerger;
 use Shopware\Core\Checkout\Document\Service\PdfRenderer;
 use Shopware\Core\Checkout\Document\Struct\DocumentGenerateOperation;
+use Shopware\Core\Content\Media\Exception\IllegalFileNameException;
+use Shopware\Core\Content\Media\Util\PathHelper;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Routing\ApiRouteScope;
@@ -121,11 +123,17 @@ class DocumentController extends AbstractController
     {
         $response = new Response($content);
 
+        try {
+            $filenameFallback = PathHelper::stripNonAsciiAndControlChars($filename, '_');
+        } catch (IllegalFileNameException) {
+            $filenameFallback = '';
+        }
+
         $disposition = HeaderUtils::makeDisposition(
             $forceDownload ? HeaderUtils::DISPOSITION_ATTACHMENT : HeaderUtils::DISPOSITION_INLINE,
             $filename,
             // only printable ascii
-            preg_replace('/[\x00-\x1F\x7F-\xFF]/', '_', $filename) ?? ''
+            $filenameFallback
         );
 
         $response->headers->set('Content-Type', $contentType);

--- a/src/Core/Checkout/Document/SalesChannel/DocumentRoute.php
+++ b/src/Core/Checkout/Document/SalesChannel/DocumentRoute.php
@@ -13,6 +13,8 @@ use Shopware\Core\Checkout\Document\Service\DocumentGenerator;
 use Shopware\Core\Checkout\Document\Service\PdfRenderer;
 use Shopware\Core\Checkout\Order\Aggregate\OrderCustomer\OrderCustomerEntity;
 use Shopware\Core\Checkout\Order\OrderEntity;
+use Shopware\Core\Content\Media\Exception\IllegalFileNameException;
+use Shopware\Core\Content\Media\Util\PathHelper;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
@@ -156,11 +158,17 @@ final class DocumentRoute extends AbstractDocumentRoute
     {
         $response = new Response($content);
 
+        try {
+            $filenameFallback = PathHelper::stripNonAsciiAndControlChars($filename, '_');
+        } catch (IllegalFileNameException) {
+            $filenameFallback = '';
+        }
+
         $disposition = HeaderUtils::makeDisposition(
             $forceDownload ? HeaderUtils::DISPOSITION_ATTACHMENT : HeaderUtils::DISPOSITION_INLINE,
             $filename,
             // only printable ascii
-            preg_replace('/[\x00-\x1F\x7F-\xFF]/', '_', $filename) ?? ''
+            $filenameFallback
         );
 
         $response->headers->set('Content-Type', $contentType);

--- a/src/Core/Content/ImportExport/Service/DownloadService.php
+++ b/src/Core/Content/ImportExport/Service/DownloadService.php
@@ -7,7 +7,9 @@ use League\Flysystem\UnableToGenerateTemporaryUrl;
 use Psr\Log\LoggerInterface;
 use Shopware\Core\Content\ImportExport\Aggregate\ImportExportFile\ImportExportFileEntity;
 use Shopware\Core\Content\ImportExport\ImportExportException;
+use Shopware\Core\Content\Media\Exception\IllegalFileNameException;
 use Shopware\Core\Content\Media\File\DownloadResponseGenerator;
+use Shopware\Core\Content\Media\Util\PathHelper;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
@@ -132,12 +134,18 @@ class DownloadService
     {
         $originalName = (string) preg_replace('/[\/\\\]/', '', $entity->getOriginalName());
 
+        try {
+            $filenameFallback = PathHelper::stripNonAsciiAndControlChars($originalName);
+        } catch (IllegalFileNameException) {
+            $filenameFallback = '';
+        }
+
         return [
             'Content-Disposition' => HeaderUtils::makeDisposition(
                 'attachment',
                 $originalName,
                 // only printable ascii
-                (string) preg_replace('/[\x00-\x1F\x7F-\xFF]/', '', $originalName)
+                $filenameFallback
             ),
             'Content-Length' => $this->filesystem->fileSize($entity->getPath()),
             'Content-Type' => $this->resolveContentType($originalName),

--- a/src/Core/Content/Media/Api/MediaUploadController.php
+++ b/src/Core/Content/Media/Api/MediaUploadController.php
@@ -8,6 +8,7 @@ use Shopware\Core\Content\Media\File\FileSaver;
 use Shopware\Core\Content\Media\MediaDefinition;
 use Shopware\Core\Content\Media\MediaException;
 use Shopware\Core\Content\Media\MediaService;
+use Shopware\Core\Content\Media\Util\PathHelper;
 use Shopware\Core\Framework\Api\Response\ResponseFactoryInterface;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Log\Package;
@@ -46,11 +47,7 @@ class MediaUploadController extends AbstractController
         }
 
         $fileName = $request->query->getString('fileName', $mediaId);
-        $destination = preg_replace('/[\x00-\x1F\x7F-\xFF]/', '', $fileName);
-
-        if (!\is_string($destination)) {
-            throw MediaException::illegalFileName($fileName, 'Filename must be a string');
-        }
+        $destination = PathHelper::stripControlAndFormatChars($fileName);
 
         try {
             $uploadedFile = $this->mediaService->fetchFile($request, $tempFile);
@@ -73,14 +70,10 @@ class MediaUploadController extends AbstractController
     public function renameMediaFile(Request $request, string $mediaId, Context $context, ResponseFactoryInterface $responseFactory): Response
     {
         $fileName = $request->request->getString('fileName');
-        $destination = preg_replace('/[\x00-\x1F\x7F-\xFF]/', '', $fileName);
+        $destination = PathHelper::stripControlAndFormatChars($fileName);
 
         if ($destination === '') {
             throw MediaException::emptyMediaFilename();
-        }
-
-        if (!\is_string($destination)) {
-            throw MediaException::illegalFileName($fileName, 'Filename must be a string');
         }
 
         $this->fileSaver->renameMedia($mediaId, $destination, $context);
@@ -92,11 +85,7 @@ class MediaUploadController extends AbstractController
     public function provideName(Request $request, Context $context): JsonResponse
     {
         $fileName = $request->query->getString('fileName');
-        $preferredFileName = preg_replace('/[\x00-\x1F\x7F-\xFF]/', '', $fileName);
-
-        if (!\is_string($preferredFileName)) {
-            throw MediaException::illegalFileName($fileName, 'Filename must be a string');
-        }
+        $preferredFileName = PathHelper::stripControlAndFormatChars($fileName);
 
         $fileExtension = $request->query->getString('extension');
         $mediaId = $request->query->has('mediaId') ? $request->query->getString('mediaId') : null;

--- a/src/Core/Content/Media/Exception/IllegalFileNameException.php
+++ b/src/Core/Content/Media/Exception/IllegalFileNameException.php
@@ -1,0 +1,21 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Content\Media\Exception;
+
+use Shopware\Core\Content\Media\MediaException;
+use Shopware\Core\Framework\Log\Package;
+use Symfony\Component\HttpFoundation\Response;
+
+#[Package('discovery')]
+class IllegalFileNameException extends MediaException
+{
+    public function __construct(string $filename, string $cause)
+    {
+        parent::__construct(
+            Response::HTTP_BAD_REQUEST,
+            self::MEDIA_ILLEGAL_FILE_NAME,
+            'Provided filename "{{ fileName }}" is not permitted: {{ cause }}',
+            ['fileName' => $filename, 'cause' => $cause]
+        );
+    }
+}

--- a/src/Core/Content/Media/File/DownloadResponseGenerator.php
+++ b/src/Core/Content/Media/File/DownloadResponseGenerator.php
@@ -9,9 +9,11 @@ use Psr\Http\Message\StreamInterface;
 use Psr\Log\LoggerInterface;
 use Shopware\Core\Content\Media\Core\Application\AbstractMediaUrlGenerator;
 use Shopware\Core\Content\Media\Core\Params\UrlParams;
+use Shopware\Core\Content\Media\Exception\IllegalFileNameException;
 use Shopware\Core\Content\Media\MediaEntity;
 use Shopware\Core\Content\Media\MediaException;
 use Shopware\Core\Content\Media\MediaService;
+use Shopware\Core\Content\Media\Util\PathHelper;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
@@ -149,12 +151,18 @@ class DownloadResponseGenerator
     {
         $filename = $media->getFileName() . '.' . $media->getFileExtension();
 
+        try {
+            $filenameFallback = PathHelper::stripNonAsciiAndControlChars($filename);
+        } catch (IllegalFileNameException) {
+            $filenameFallback = '';
+        }
+
         return [
             'Content-Disposition' => HeaderUtils::makeDisposition(
                 HeaderUtils::DISPOSITION_ATTACHMENT,
                 $filename,
                 // only printable ascii
-                preg_replace('/[\x00-\x1F\x7F-\xFF]/', '', $filename) ?? ''
+                $filenameFallback
             ),
             'Content-Length' => $media->getFileSize() ?? 0,
             'Content-Type' => 'application/octet-stream',

--- a/src/Core/Content/Media/MediaException.php
+++ b/src/Core/Content/Media/MediaException.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Core\Content\Media;
 
+use Shopware\Core\Content\Media\Exception\IllegalFileNameException;
 use Shopware\Core\Framework\HttpException;
 use Shopware\Core\Framework\Log\Package;
 use Symfony\Component\HttpFoundation\Response;
@@ -180,12 +181,7 @@ class MediaException extends HttpException
 
     public static function illegalFileName(string $filename, string $cause): self
     {
-        return new self(
-            Response::HTTP_BAD_REQUEST,
-            self::MEDIA_ILLEGAL_FILE_NAME,
-            'Provided filename "{{ fileName }}" is not permitted: {{ cause }}',
-            ['fileName' => $filename, 'cause' => $cause]
-        );
+        return new IllegalFileNameException($filename, $cause);
     }
 
     public static function mediaNotFound(string $mediaId): self

--- a/src/Core/Content/Media/Subscriber/MediaCreationSubscriber.php
+++ b/src/Core/Content/Media/Subscriber/MediaCreationSubscriber.php
@@ -4,7 +4,9 @@ namespace Shopware\Core\Content\Media\Subscriber;
 
 use Shopware\Core\Content\Media\Aggregate\MediaFolder\MediaFolderDefinition;
 use Shopware\Core\Content\Media\Aggregate\MediaThumbnail\MediaThumbnailDefinition;
+use Shopware\Core\Content\Media\Exception\IllegalFileNameException;
 use Shopware\Core\Content\Media\MediaDefinition;
+use Shopware\Core\Content\Media\Util\PathHelper;
 use Shopware\Core\Framework\DataAbstractionLayer\Event\EntityWriteEvent;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\Command\DeleteCommand;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\Command\WriteCommand;
@@ -37,9 +39,14 @@ class MediaCreationSubscriber implements EventSubscriberInterface
     private function filterFilePath(array $commands): void
     {
         foreach ($commands as $command) {
-            $path = preg_replace('/[\x00-\x1F\x7F-\xFF]/', '', $command->getPayload()['path']);
+            // Remove control characters and invisible formatting characters
+            try {
+                $path = PathHelper::stripControlAndFormatChars($command->getPayload()['path']);
+            } catch (IllegalFileNameException) {
+                $path = null;
+            }
 
-            $command->addPayload('path', \is_string($path) ? $path : null);
+            $command->addPayload('path', $path);
         }
     }
 

--- a/src/Core/Content/Media/Upload/MediaUploadService.php
+++ b/src/Core/Content/Media/Upload/MediaUploadService.php
@@ -16,6 +16,7 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\OrFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\PrefixFilter;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Util\Hasher;
@@ -136,7 +137,8 @@ readonly class MediaUploadService
         Context $context,
         MediaUploadParameters $params = new MediaUploadParameters()
     ): string {
-        $params->fillDefaultFileName(basename($url));
+        $decodedUrl = urldecode($url);
+        $params->fillDefaultFileName(basename($decodedUrl));
 
         if ($params->mimeType === null) {
             throw MediaException::mimeTypeNotProvided();
@@ -144,7 +146,10 @@ readonly class MediaUploadService
 
         if ($params->deduplicate) {
             $criteria = new Criteria();
-            $criteria->addFilter(new EqualsFilter('path', $url));
+            $criteria->addFilter(new OrFilter([
+                new EqualsFilter('path', $url),
+                new EqualsFilter('path', $decodedUrl),
+            ]));
 
             if ($mediaId = $this->mediaRepository->searchIds($criteria, $context)->firstId()) {
                 return $mediaId;
@@ -155,7 +160,7 @@ readonly class MediaUploadService
             'id' => $params->id ?? Uuid::randomHex(),
             'userId' => $this->getUserIdFromContext($context),
             'private' => $params->private ?? false,
-            'path' => $url,
+            'path' => $decodedUrl,
             'fileSize' => $this->getContentSizeFromValidExternalUrl($url),
             'fileName' => $params->getFileNameWithoutExtension(),
             'fileExtension' => $params->getFileNameExtension(),
@@ -314,13 +319,14 @@ readonly class MediaUploadService
 
         foreach ($thumbnails as $thumbnail) {
             $this->validateExternalUrl($thumbnail->url);
+            $decodedUrl = urldecode($thumbnail->url);
 
             $sizeId = $this->getOrCreateThumbnailSize($thumbnail->width, $thumbnail->height, $context);
 
             $thumbnailPayloads[] = [
                 'id' => Uuid::randomHex(),
                 'mediaId' => $mediaId,
-                'path' => $thumbnail->url,
+                'path' => $decodedUrl,
                 'width' => $thumbnail->width,
                 'height' => $thumbnail->height,
                 'mediaThumbnailSizeId' => $sizeId,

--- a/src/Core/Content/Media/Util/PathHelper.php
+++ b/src/Core/Content/Media/Util/PathHelper.php
@@ -1,0 +1,36 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Content\Media\Util;
+
+use Shopware\Core\Content\Media\MediaException;
+use Shopware\Core\Framework\Log\Package;
+
+#[Package('discovery')]
+class PathHelper
+{
+    private const REGEX_CONTROL_AND_INVISIBLE_FORMAT_CHARACTERS = '/[\x00-\x1F\x7F\p{Cf}]/u';
+
+    private const REGEX_NON_ASCII_AND_CONTROL_BYTE_RANGES = '/[\x00-\x1F\x7F-\xFF]/';
+
+    public static function stripControlAndFormatChars(string $path, string $replace = ''): string
+    {
+        $stripped = preg_replace(self::REGEX_CONTROL_AND_INVISIBLE_FORMAT_CHARACTERS, $replace, $path);
+
+        if ($stripped === null) {
+            throw MediaException::illegalFileName($path, 'Path encoding is invalid');
+        }
+
+        return $stripped;
+    }
+
+    public static function stripNonAsciiAndControlChars(string $path, string $replace = ''): string
+    {
+        $stripped = preg_replace(self::REGEX_NON_ASCII_AND_CONTROL_BYTE_RANGES, $replace, $path);
+
+        if ($stripped === null) {
+            throw MediaException::illegalFileName($path, 'Path encoding is invalid');
+        }
+
+        return $stripped;
+    }
+}

--- a/src/Core/Content/Sitemap/SalesChannel/SitemapFileRoute.php
+++ b/src/Core/Content/Sitemap/SalesChannel/SitemapFileRoute.php
@@ -3,6 +3,8 @@
 namespace Shopware\Core\Content\Sitemap\SalesChannel;
 
 use League\Flysystem\FilesystemOperator;
+use Shopware\Core\Content\Media\Exception\IllegalFileNameException;
+use Shopware\Core\Content\Media\Util\PathHelper;
 use Shopware\Core\Content\Sitemap\Extension\SitemapFileExtension;
 use Shopware\Core\Framework\Extensions\ExtensionDispatcher;
 use Shopware\Core\Framework\Log\Package;
@@ -54,13 +56,18 @@ class SitemapFileRoute
         }
 
         $fileName = basename($filePath);
+        try {
+            $filenameFallback = PathHelper::stripNonAsciiAndControlChars($fileName);
+        } catch (IllegalFileNameException) {
+            $filenameFallback = '';
+        }
 
         $headers = [
             'Content-Disposition' => HeaderUtils::makeDisposition(
                 HeaderUtils::DISPOSITION_ATTACHMENT,
                 $fileName,
                 // only printable ascii
-                preg_replace('/[\x00-\x1F\x7F-\xFF]/', '', $fileName) ?: ''
+                $filenameFallback
             ),
             'Content-Length' => $this->fileSystem->fileSize($filePath),
             'Content-Type' => 'application/octet-stream',

--- a/tests/integration/Core/Content/Media/Api/MediaUploadV2ControllerTest.php
+++ b/tests/integration/Core/Content/Media/Api/MediaUploadV2ControllerTest.php
@@ -63,11 +63,11 @@ class MediaUploadV2ControllerTest extends TestCase
             'POST',
             '/api/_action/media/external-link',
             [
-                'url' => 'https://localhost:8000/image.jpg',
+                'url' => 'https://localhost:8000/Geschenkt%C3%BCte.jpg',
                 'mimeType' => 'image/jpeg',
                 'thumbnails' => [
-                    ['url' => 'https://localhost:8000/image-200.jpg', 'width' => 200, 'height' => 150],
-                    ['url' => 'https://localhost:8000/image-400.jpg', 'width' => 400, 'height' => 300],
+                    ['url' => 'https://localhost:8000/Geschenkt%C3%BCte-200.jpg', 'width' => 200, 'height' => 150],
+                    ['url' => 'https://localhost:8000/Geschenkt%C3%BCte-400.jpg', 'width' => 400, 'height' => 300],
                 ],
             ],
         );
@@ -79,6 +79,11 @@ class MediaUploadV2ControllerTest extends TestCase
         static::assertArrayHasKey('id', $responseData);
         $mediaId = $responseData['id'];
 
+        $media = $this->mediaRepository->search(new Criteria([$mediaId]), $context)->first();
+
+        static::assertNotNull($media);
+        static::assertSame('https://localhost:8000/Geschenktüte.jpg', $media->getPath());
+
         $criteria = new Criteria();
         $criteria->addFilter(new EqualsFilter('mediaId', $mediaId));
         $thumbnails = $this->mediaThumbnailRepository->search($criteria, $context);
@@ -86,8 +91,8 @@ class MediaUploadV2ControllerTest extends TestCase
         static::assertSame(2, $thumbnails->getTotal());
 
         $urls = $thumbnails->map(static fn ($t) => $t->getPath());
-        static::assertContains('https://localhost:8000/image-200.jpg', $urls);
-        static::assertContains('https://localhost:8000/image-400.jpg', $urls);
+        static::assertContains('https://localhost:8000/Geschenktüte-200.jpg', $urls);
+        static::assertContains('https://localhost:8000/Geschenktüte-400.jpg', $urls);
     }
 
     public function testAddAndDeleteExternalThumbnailsForMedia(): void

--- a/tests/unit/Core/Content/Media/Api/MediaUploadControllerTest.php
+++ b/tests/unit/Core/Content/Media/Api/MediaUploadControllerTest.php
@@ -28,8 +28,6 @@ class MediaUploadControllerTest extends TestCase
 {
     public static bool $simulateFailedTempnam = false;
 
-    public static bool $simulateNullPregReplace = false;
-
     private FileSaver&MockObject $fileSaver;
 
     private MediaService&MockObject $mediaService;
@@ -49,7 +47,6 @@ class MediaUploadControllerTest extends TestCase
     protected function tearDown(): void
     {
         self::$simulateFailedTempnam = false;
-        self::$simulateNullPregReplace = false;
     }
 
     public function testRemoveNonPrintingCharactersInFileNameBeforeUpload(): void
@@ -215,8 +212,6 @@ class MediaUploadControllerTest extends TestCase
 
     public function testUploadThrowsOnIllegalFileName(): void
     {
-        self::$simulateNullPregReplace = true;
-
         static::expectException(MediaException::class);
         static::expectExceptionMessage('is not permitted');
 
@@ -228,13 +223,11 @@ class MediaUploadControllerTest extends TestCase
             new EventDispatcher()
         );
 
-        $controller->upload(new Request(['fileName' => 'test.png']), Uuid::randomHex(), Context::createDefaultContext(), $this->responseFactory);
+        $controller->upload(new Request(['fileName' => "\xFF\xFE"]), Uuid::randomHex(), Context::createDefaultContext(), $this->responseFactory);
     }
 
     public function testRenameThrowsOnIllegalFileName(): void
     {
-        self::$simulateNullPregReplace = true;
-
         static::expectException(MediaException::class);
         static::expectExceptionMessage('is not permitted');
 
@@ -246,13 +239,11 @@ class MediaUploadControllerTest extends TestCase
             new EventDispatcher()
         );
 
-        $controller->renameMediaFile(new Request([], ['fileName' => 'test.png']), Uuid::randomHex(), Context::createDefaultContext(), $this->responseFactory);
+        $controller->renameMediaFile(new Request([], ['fileName' => "\xFF\xFE"]), Uuid::randomHex(), Context::createDefaultContext(), $this->responseFactory);
     }
 
     public function testProvideNameThrowsOnIllegalFileName(): void
     {
-        self::$simulateNullPregReplace = true;
-
         static::expectException(MediaException::class);
         static::expectExceptionMessage('is not permitted');
 
@@ -264,7 +255,7 @@ class MediaUploadControllerTest extends TestCase
             new EventDispatcher()
         );
 
-        $controller->provideName(new Request(['fileName' => 'test.png', 'extension' => 'png']), Context::createDefaultContext());
+        $controller->provideName(new Request(['fileName' => "\xFF\xFE", 'extension' => 'png']), Context::createDefaultContext());
     }
 }
 
@@ -279,25 +270,4 @@ function tempnam(string $dir, string $prefix): string|false
     }
 
     return \tempnam($dir, $prefix);
-}
-
-/**
- * @param string|array<string> $pattern
- * @param string|array<string> $replacement
- * @param string|array<string> $subject
- *
- * @return string|array<string>|null
- */
-function preg_replace(
-    string|array $pattern,
-    string|array $replacement,
-    string|array $subject,
-    int $limit = -1,
-    ?int &$count = null
-): string|array|null {
-    if (MediaUploadControllerTest::$simulateNullPregReplace) {
-        return null;
-    }
-
-    return \preg_replace($pattern, $replacement, $subject, $limit, $count);
 }

--- a/tests/unit/Core/Content/Media/Subscriber/MediaCreationSubscriberTest.php
+++ b/tests/unit/Core/Content/Media/Subscriber/MediaCreationSubscriberTest.php
@@ -63,7 +63,7 @@ class MediaCreationSubscriberTest extends TestCase
 
         $command = new InsertCommand(
             $definition,
-            ['path' => 'media/Bildschirm­foto 2023-06-24 um 16.30.36.png'],
+            ['path' => 'media/Bildschirm­fotö 2023-06-24 um 16.30.36.png'],
             ['id' => $this->ids->getBytes('media-1')],
             $this->createMock(EntityExistence::class),
             '/0'
@@ -76,7 +76,7 @@ class MediaCreationSubscriberTest extends TestCase
 
         $subscriber->beforeWrite($event);
 
-        static::assertSame('media/Bildschirmfoto 2023-06-24 um 16.30.36.png', $command->getPayload()['path']);
+        static::assertSame('media/Bildschirmfotö 2023-06-24 um 16.30.36.png', $command->getPayload()['path']);
     }
 
     public function testPathIsReplacedOnInsert(): void

--- a/tests/unit/Core/Content/Media/Util/PathHelperTest.php
+++ b/tests/unit/Core/Content/Media/Util/PathHelperTest.php
@@ -1,0 +1,52 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Content\Media\Util;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Media\Util\PathHelper;
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * @internal
+ */
+#[Package('discovery')]
+#[CoversClass(PathHelper::class)]
+class PathHelperTest extends TestCase
+{
+    #[DataProvider('controlAndFormatCharsProvider')]
+    public function testItStripsControlAndFormatChars(string $input, string $expected): void
+    {
+        $output = PathHelper::stripControlAndFormatChars($input);
+
+        static::assertSame($expected, $output);
+    }
+
+    public static function controlAndFormatCharsProvider(): \Generator
+    {
+        yield ['#Föö' . "\u{200B}" . 'bár', '#Fööbár'];
+        yield ["#Foo\tBar\nBaz", '#FooBarBaz'];
+        yield ['#Föö🚀bár', '#Föö🚀bár'];
+        yield ['#Foo' . "\u{202E}" . 'Bar', '#FooBar'];
+        yield ['#Föö­bár', '#Fööbár'];
+    }
+
+    #[DataProvider('nonAsciiAndControlCharsProvider')]
+    public function testItStripsNonAsciiAndControlChars(string $input, string $expected): void
+    {
+        $output = PathHelper::stripNonAsciiAndControlChars($input);
+
+        static::assertSame($expected, $output);
+    }
+
+    public static function nonAsciiAndControlCharsProvider(): \Generator
+    {
+        yield ['#Fööbár', '#Fbr'];
+        yield ['#Foo🚀Bar', '#FooBar'];
+        yield ["#Foo\tBar\nBaz", '#FooBarBaz'];
+        yield ['#Föo-123_bár!', '#Fo-123_br!'];
+        yield ['#Foo-Bar_123', '#Foo-Bar_123'];
+        yield ['#ääööüübär🚀', '#br'];
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?
* Media pointing to an external URL that was created using an URL that includes encoded Characters get re-encoded (overencoded) in the Storefront without the URL having been decoded before.
* With external URLs that weren't encoded but included for example umlauts (ä, ü, ö), the filtering for non-printable characters is too aggressive and removed the umlauts aus well.

The combination of these two issues essentially prevented use of external URL media that includes characters like umlauts.

### 2. What does this change do, exactly?
* URL-decode any URL used with `/api/_action/media/external-link` to create media from. Only store decoded paths so they may safely be encoded in the Storefront again.
* Loosen the regex to not so aggressively strip characters in paths but instead only strip control characters or invisible formatting characters.

### 3. Describe each step to reproduce the issue or behaviour.
* Upload media using `/api/_action/media/external-link` with a URL that includes encoded or unencoded umlauts.
* Assign that media to a product
   * If URL was encoded: Media-URL in the storefront will be "double" URL encoded
   * If URL was NOT encoded: Media-URL in the storefront will lack the umlauts

### 4. Please link to the relevant issues (if any).

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
