### PR TITLE
fix(cms): seed parent-language override when removing field inheritance

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-inherit-wrapper/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-inherit-wrapper/index.ts
@@ -146,6 +146,14 @@ export default Shopware.Component.wrapComponentConfig({
                 return;
             }
 
+            /**
+             * Resolve the inherited field before scaffolding slotConfig, because the empty
+             * scaffold would otherwise shadow the parent-language entry in inheritedSlotConfig.
+             */
+            const inheritedField = cloneDeep(
+                this.inheritedFieldConfig ?? get(this.baseConfig, this.field, BASE_FIELD_FALLBACK),
+            );
+
             if (!this.contentEntity.slotConfig) {
                 this.contentEntity.slotConfig = {};
             }
@@ -154,14 +162,12 @@ export default Shopware.Component.wrapComponentConfig({
                 this.contentEntity.slotConfig[this.element.id] = {};
             }
 
-            const baseField = cloneDeep(get(this.baseConfig, this.field, BASE_FIELD_FALLBACK));
-
             if (!has(this.childConfig, this.field)) {
-                set(this.childConfig!, this.field, baseField);
+                set(this.childConfig!, this.field, inheritedField);
             }
 
-            set(this.childConfig!, this.fullPath, get(baseField, this.fieldPath));
-            set(this.runtimeConfig, this.fullPath, get(baseField, this.fieldPath));
+            set(this.childConfig!, this.fullPath, get(inheritedField, this.fieldPath));
+            set(this.runtimeConfig, this.fullPath, get(inheritedField, this.fieldPath));
 
             this.$emit(EVENTS.REMOVE);
         },

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-inherit-wrapper/sw-cms-inherit-wrapper.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-inherit-wrapper/sw-cms-inherit-wrapper.spec.js
@@ -443,6 +443,47 @@ describe('src/module/sw-cms/component/sw-cms-inherit-wrapper', () => {
             expect(contentEntity.slotConfig['test-slot-id'].otherField.value).toBe('existing');
             expect(contentEntity.slotConfig['test-slot-id'].testField.value).toBe('base-value');
         });
+
+        it('should seed inherited parent entity override instead of the base CMS config', async () => {
+            const contentEntity = {
+                slotConfig: null,
+                translations: [
+                    {
+                        languageId: 'parent-language-id',
+                        slotConfig: {
+                            'test-slot-id': {
+                                testField: { value: 'parent override', source: 'static' },
+                            },
+                        },
+                    },
+                ],
+            };
+            Shopware.Store.get('swCategoryDetail').category = contentEntity;
+            Shopware.Store.get('context').api.languageId = 'child-language-id';
+            Shopware.Store.get('context').api.language = { parentId: 'parent-language-id' };
+
+            const wrapper = await createWrapper({
+                element: new Entity('test-slot-id', 'cms_slot', {
+                    type: 'text',
+                    config: {
+                        testField: { value: 'parent override' },
+                    },
+                    translated: {
+                        config: {
+                            testField: { value: 'base-value', source: 'static' },
+                        },
+                    },
+                }),
+            });
+
+            wrapper.vm.onInheritanceRemove();
+
+            expect(contentEntity.slotConfig['test-slot-id'].testField).toStrictEqual({
+                value: 'parent override',
+                source: 'static',
+            });
+            expect(wrapper.vm.runtimeConfig.testField.value).toBe('parent override');
+        });
     });
 
     describe('onInheritanceRestore method', () => {


### PR DESCRIPTION
fixes **https://github.com/shopware/shopware/issues/16316**

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
Follow-up to #16026. When a user removes field-level CMS inheritance (the chain icon on a slot field) from a child language, Shopware resets the field to the CMS layout default value instead of seeding it with the parent language's entity-level override. Merchants then have to manually copy the parent-language content before they can edit it, which breaks the normal translation workflow.

### 2. What does this change do, exactly?
sw-cms-inherit-wrapper.onInheritanceRemove now prefers inheritedFieldConfig (the override from the configured parent language) over baseConfig (the base CMS layout default) when seeding the new child-language override. This mirrors the fix applied to onInheritanceRestore in #16026.

The lookup is performed before slotConfig / slotConfig[element.id] are scaffolded; otherwise the freshly-created empty child entry would shadow the parent entry in inheritedSlotConfig's top-level spread, and the fallback to baseConfig would kick in even though a parent override exists.

Behaviour matrix after this change:
- Child language with parent-language override present → seeds with the parent override (new)
- No parent-language override → seeds with the CMS layout default (unchanged)
- Language without an explicit parent → seeds with the CMS layout default (unchanged)

### 3. Describe each step to reproduce the issue or behaviour.
1. Create a CMS layout for a product with a text element containing a visible default, e.g. LAYOUT DEFAULT A.
2. Assign the layout to a product.
3. In the default language (e.g. English), override the text on entity level in the Layout tab, e.g. English A (customized), and save.
4. Create a child language (e.g. Canada) with Inherit from = English.
5. Switch the product detail page to the child language in Administration and open the Layout tab.
6. Click the Remove inheritance icon next to the text field.

Before this change:
- the field drops to LAYOUT DEFAULT A (the CMS layout default)

After this change:
- the field is seeded with English A (customized) (the parent-language entity override) so the merchant can edit it directly

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
