### PR TITLE
fix: Remove assertSame from NoAssertsOnObjectsRule PHPStan rule

### DIFF
--- a/src/Core/DevOps/StaticAnalyze/PHPStan/Rules/Tests/NoAssertsOnObjectsRule.php
+++ b/src/Core/DevOps/StaticAnalyze/PHPStan/Rules/Tests/NoAssertsOnObjectsRule.php
@@ -43,7 +43,7 @@ class NoAssertsOnObjectsRule implements Rule
             return [];
         }
 
-        if (!\in_array((string) $node->name, ['assertEquals', 'assertSame'], true)) {
+        if ((string) $node->name !== 'assertEquals') {
             return [];
         }
 

--- a/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/Tests/NoAssertsOnObjectsRuleTest.php
+++ b/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/Tests/NoAssertsOnObjectsRuleTest.php
@@ -24,7 +24,7 @@ class NoAssertsOnObjectsRuleTest extends RuleTestCase
             ],
             [
                 'Asserting for equality with Response Objects is not allowed. Responses contain a date time as header, and thus those comparisons are time sensitive and thus flaky. Please assert on the properties of the Response you are interested in directly or use the `AssertResponseHelper`.',
-                41,
+                44,
             ],
         ]);
     }

--- a/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/data/NoAssertOnResponseObject/shopware-unit-test.php
+++ b/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/data/NoAssertOnResponseObject/shopware-unit-test.php
@@ -17,6 +17,9 @@ class BarTest extends TestCase
 
         $expected = new Response();
         // not allowed
+        static::assertEquals($expected, $response);
+
+        // Allowed as `assertSame` checks for the same reference, not the actual contents of the object
         static::assertSame($expected, $response);
 
         $this->assertFoo($expected, $response);
@@ -38,7 +41,7 @@ class BarTest extends TestCase
         $expected = new RedirectResponse('bar');
 
         // not allowed
-        static::assertSame($expected, $response);
+        static::assertEquals($expected, $response);
     }
 
     public function assertFoo(mixed $expected, mixed $actual): void


### PR DESCRIPTION
### 1. Why is this change necessary?

It is not necessary to prevent usage of `assertSame` while comparing responses, as `assertSame` is checking the object reference, so two variables referencing the exact same object.

### 2. What does this change do, exactly?

Remove the check for `assertSame` in the custom PHPStan rule

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
