### PR TITLE
fix: preserve utf-8 characters in media filenames

### DIFF
--- a/changelog/_unreleased/2026-04-23-preserve-utf-8-characters-in-media-filenames.md
+++ b/changelog/_unreleased/2026-04-23-preserve-utf-8-characters-in-media-filenames.md
@@ -1,0 +1,7 @@
+---
+title: Preserve UTF-8 characters in media filenames
+author: Dennis Menken
+author_github: @dennismenken
+---
+# Core
+* Changed filename sanitization in `Shopware\Core\Content\Media\Api\MediaUploadController` and `Shopware\Core\Content\Media\Subscriber\MediaCreationSubscriber` to preserve UTF-8 characters such as umlauts. The previous byte-range regex `/[\x00-\x1F\x7F-\xFF]/` stripped every byte above `0x7F`, which destroyed multi-byte UTF-8 sequences (e.g. `Bäume.pdf` was saved as `Bme.pdf`). The sanitization now uses the Unicode-aware pattern `/\p{C}/u`, which removes Unicode control and format characters (categories `Cc`, `Cf`, `Cs`, `Co`, `Cn`) while keeping regular letters intact.

--- a/src/Core/Content/Media/Api/MediaUploadController.php
+++ b/src/Core/Content/Media/Api/MediaUploadController.php
@@ -46,7 +46,7 @@ class MediaUploadController extends AbstractController
         }
 
         $fileName = $request->query->getString('fileName', $mediaId);
-        $destination = preg_replace('/[\x00-\x1F\x7F-\xFF]/', '', $fileName);
+        $destination = preg_replace('/\p{C}/u', '', $fileName);
 
         if (!\is_string($destination)) {
             throw MediaException::illegalFileName($fileName, 'Filename must be a string');
@@ -73,7 +73,7 @@ class MediaUploadController extends AbstractController
     public function renameMediaFile(Request $request, string $mediaId, Context $context, ResponseFactoryInterface $responseFactory): Response
     {
         $fileName = $request->request->getString('fileName');
-        $destination = preg_replace('/[\x00-\x1F\x7F-\xFF]/', '', $fileName);
+        $destination = preg_replace('/\p{C}/u', '', $fileName);
 
         if ($destination === '') {
             throw MediaException::emptyMediaFilename();
@@ -92,7 +92,7 @@ class MediaUploadController extends AbstractController
     public function provideName(Request $request, Context $context): JsonResponse
     {
         $fileName = $request->query->getString('fileName');
-        $preferredFileName = preg_replace('/[\x00-\x1F\x7F-\xFF]/', '', $fileName);
+        $preferredFileName = preg_replace('/\p{C}/u', '', $fileName);
 
         if (!\is_string($preferredFileName)) {
             throw MediaException::illegalFileName($fileName, 'Filename must be a string');

--- a/src/Core/Content/Media/Subscriber/MediaCreationSubscriber.php
+++ b/src/Core/Content/Media/Subscriber/MediaCreationSubscriber.php
@@ -37,7 +37,7 @@ class MediaCreationSubscriber implements EventSubscriberInterface
     private function filterFilePath(array $commands): void
     {
         foreach ($commands as $command) {
-            $path = preg_replace('/[\x00-\x1F\x7F-\xFF]/', '', $command->getPayload()['path']);
+            $path = preg_replace('/\p{C}/u', '', $command->getPayload()['path']);
 
             $command->addPayload('path', \is_string($path) ? $path : null);
         }

--- a/tests/unit/Core/Content/Media/Api/MediaUploadControllerTest.php
+++ b/tests/unit/Core/Content/Media/Api/MediaUploadControllerTest.php
@@ -137,6 +137,91 @@ class MediaUploadControllerTest extends TestCase
         $mediaUploadController->provideName($request, $context);
     }
 
+    public function testPreservesUmlautsInFileNameBeforeUpload(): void
+    {
+        $fileName = 'Bäume_über_Wälder_schön.png';
+        $mediaId = Uuid::randomHex();
+        $context = Context::createDefaultContext();
+
+        $request = new Request(['fileName' => $fileName]);
+
+        $uploadFile = new MediaFile(
+            '/tmp/foo/bar/baz',
+            'image/png',
+            'png',
+            1000,
+            Uuid::randomHex()
+        );
+
+        $this->mediaService->expects($this->once())
+            ->method('fetchFile')
+            ->willReturn($uploadFile);
+
+        $this->fileSaver->expects($this->once())
+            ->method('persistFileToMedia')
+            ->with($uploadFile, $fileName, $mediaId, $context);
+
+        $mediaUploadController = new MediaUploadController(
+            $this->mediaService,
+            $this->fileSaver,
+            $this->fileNameProvider,
+            new MediaDefinition(),
+            new EventDispatcher()
+        );
+
+        $mediaUploadController->upload($request, $mediaId, $context, $this->responseFactory);
+    }
+
+    public function testPreservesUmlautsInFileNameBeforeRename(): void
+    {
+        $fileName = 'Bäume_über_Wälder_schön.png';
+        $mediaId = Uuid::randomHex();
+        $context = Context::createDefaultContext();
+
+        $request = new Request([], ['fileName' => $fileName]);
+
+        $this->fileSaver->expects($this->once())
+            ->method('renameMedia')
+            ->with($mediaId, $fileName, $context);
+
+        $mediaUploadController = new MediaUploadController(
+            $this->mediaService,
+            $this->fileSaver,
+            $this->fileNameProvider,
+            new MediaDefinition(),
+            new EventDispatcher()
+        );
+
+        $mediaUploadController->renameMediaFile($request, $mediaId, $context, $this->responseFactory);
+    }
+
+    public function testPreservesUmlautsInFileNameBeforeProvideName(): void
+    {
+        $fileName = 'Bäume_über_Wälder_schön.png';
+        $mediaId = Uuid::randomHex();
+        $context = Context::createDefaultContext();
+
+        $request = new Request([
+            'fileName' => $fileName,
+            'extension' => 'jpg',
+            'mediaId' => $mediaId,
+        ]);
+
+        $this->fileNameProvider->expects($this->once())
+            ->method('provide')
+            ->with($fileName, 'jpg', $mediaId, $context);
+
+        $mediaUploadController = new MediaUploadController(
+            $this->mediaService,
+            $this->fileSaver,
+            $this->fileNameProvider,
+            new MediaDefinition(),
+            new EventDispatcher()
+        );
+
+        $mediaUploadController->provideName($request, $context);
+    }
+
     public function testRenameThrowsWhenEmptyFileName(): void
     {
         $mediaId = Uuid::randomHex();

--- a/tests/unit/Core/Content/Media/Subscriber/MediaCreationSubscriberTest.php
+++ b/tests/unit/Core/Content/Media/Subscriber/MediaCreationSubscriberTest.php
@@ -130,4 +130,30 @@ class MediaCreationSubscriberTest extends TestCase
 
         static::assertSame('media/Bildschirmfoto 2023-06-24 um 16.30.36.png', $command->getPayload()['path']);
     }
+
+    public function testPathPreservesUmlauts(): void
+    {
+        $context = Context::createDefaultContext();
+
+        $subscriber = new MediaCreationSubscriber();
+
+        $definition = $this->getDefinition();
+
+        $command = new InsertCommand(
+            $definition,
+            ['path' => 'media/Bäume_über_Wälder_schön.png'],
+            ['id' => $this->ids->getBytes('media-1')],
+            $this->createMock(EntityExistence::class),
+            '/0'
+        );
+
+        $event = EntityWriteEvent::create(
+            WriteContext::createFromContext($context),
+            [$command],
+        );
+
+        $subscriber->beforeWrite($event);
+
+        static::assertSame('media/Bäume_über_Wälder_schön.png', $command->getPayload()['path']);
+    }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?

The filename sanitization in the media upload path uses a byte-range regex `/[\x00-\x1F\x7F-\xFF]/` that strips every byte above 0x7F. UTF-8 encodes non-ASCII characters as multi-byte sequences whose bytes all sit in that range, so every umlaut or other non-ASCII letter is destroyed on upload, rename and `provide-name`, as well as on every write to a media/thumbnail/folder `path` through `MediaCreationSubscriber::beforeWrite`.

Example: `Bäume.pdf` is saved as `Bme.pdf`. Renaming the media via the UI does not recover the characters — the same regex runs again on rename.

### 2. What does this change do, exactly?

Replaces the byte-range regex with the Unicode-aware `/\p{C}/u` in `MediaUploadController::upload`, `::renameMediaFile`, `::provideName` and `MediaCreationSubscriber::filterFilePath`.

`\p{C}` matches Unicode "other" characters (categories `Cc`, `Cf`, `Cs`, `Co`, `Cn`), which covers:

- ASCII control characters (0x00–0x1F, 0x7F) — already removed today.
- Unicode format characters such as `U+00AD SOFT HYPHEN`, zero-width spaces, BOM — already removed today (existing tests rely on this and keep passing).
- Regular letters (including umlauts, accented characters, CJK, etc.) are kept because they are in category `L`, not `C`.

### 3. Describe each step to reproduce the issue or behaviour.

1. Upload any image/document whose filename contains an umlaut, e.g. `Bäume.png`, via the admin media manager.
2. Observe that the stored filename is `Bme.png`.
3. Rename the media in the admin metadata form to re-add the umlaut — the characters are stripped again on save.

### 4. Please link to the relevant issues (if any).

- Related community reports:
  - https://forum.shopware.com/t/keine-umlaute-bei-medien-upload/106706
  - https://forum.shopware.com/t/medienverwaltung-problem-mit-umlaute/33758

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have updated developer-facing release notes if this change is relevant for external developers
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them