### PR TITLE
fix: preserve sibling slot and parent-language field overrides

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-inherit-wrapper/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-inherit-wrapper/index.ts
@@ -133,6 +133,10 @@ export default Shopware.Component.wrapComponentConfig({
             unset(this.childConfig, this.field);
 
             if (isEmpty(this.childConfig)) {
+                unset(this.contentEntity!.slotConfig, this.element.id);
+            }
+
+            if (isEmpty(this.contentEntity!.slotConfig)) {
                 set(this.contentEntity!, 'slotConfig', null);
             }
 

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-inherit-wrapper/sw-cms-inherit-wrapper.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-inherit-wrapper/sw-cms-inherit-wrapper.spec.js
@@ -598,6 +598,29 @@ describe('src/module/sw-cms/component/sw-cms-inherit-wrapper', () => {
             expect(contentEntity.slotConfig).toBeNull();
         });
 
+        it('should preserve overrides on other slots when restoring this slots last field', async () => {
+            const contentEntity = {
+                slotConfig: {
+                    'test-slot-id': {
+                        testField: { value: 'child override' },
+                    },
+                    'other-slot-id': {
+                        otherField: { value: 'other slot override' },
+                    },
+                },
+            };
+            Shopware.Store.get('swCategoryDetail').category = contentEntity;
+            const wrapper = await createWrapper();
+
+            await wrapper.vm.onInheritanceRestore();
+
+            expect(contentEntity.slotConfig).not.toBeNull();
+            expect(contentEntity.slotConfig['test-slot-id']).toBeUndefined();
+            expect(contentEntity.slotConfig['other-slot-id']).toStrictEqual({
+                otherField: { value: 'other slot override' },
+            });
+        });
+
         it('should emit inheritance:restore event', async () => {
             Shopware.Store.get('swCategoryDetail').category = {
                 contentEntity: {

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-inherit-wrapper/sw-cms-inherit-wrapper.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-inherit-wrapper/sw-cms-inherit-wrapper.spec.js
@@ -444,6 +444,52 @@ describe('src/module/sw-cms/component/sw-cms-inherit-wrapper', () => {
             expect(contentEntity.slotConfig['test-slot-id'].testField.value).toBe('base-value');
         });
 
+        it('should seed from parent-language value when child has a partial override on the same slot', async () => {
+            const contentEntity = {
+                slotConfig: {
+                    'test-slot-id': {
+                        otherField: { value: 'child other' },
+                    },
+                },
+                translations: [
+                    {
+                        languageId: 'parent-language-id',
+                        slotConfig: {
+                            'test-slot-id': {
+                                testField: { value: 'parent override', source: 'static' },
+                                otherField: { value: 'parent other' },
+                            },
+                        },
+                    },
+                ],
+            };
+            Shopware.Store.get('swCategoryDetail').category = contentEntity;
+            Shopware.Store.get('context').api.languageId = 'child-language-id';
+            Shopware.Store.get('context').api.language = { parentId: 'parent-language-id' };
+
+            const wrapper = await createWrapper({
+                element: new Entity('test-slot-id', 'cms_slot', {
+                    type: 'text',
+                    config: {
+                        testField: { value: 'parent override' },
+                    },
+                    translated: {
+                        config: {
+                            testField: { value: 'base-value', source: 'static' },
+                        },
+                    },
+                }),
+            });
+
+            wrapper.vm.onInheritanceRemove();
+
+            expect(contentEntity.slotConfig['test-slot-id'].testField).toStrictEqual({
+                value: 'parent override',
+                source: 'static',
+            });
+            expect(wrapper.vm.runtimeConfig.testField.value).toBe('parent override');
+        });
+
         it('should seed inherited parent entity override instead of the base CMS config', async () => {
             const contentEntity = {
                 slotConfig: null,

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/mixin/sw-cms-state.mixin.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/mixin/sw-cms-state.mixin.spec.js
@@ -136,6 +136,38 @@ describe('module/sw-cms/mixin/sw-cms-state.mixin.js', () => {
         expect(wrapper.vm.inheritedSlotConfig).toBeNull();
     });
 
+    it('should retain parent-language fields when the child slot has a partial override', async () => {
+        const wrapper = await createWrapper('sw.category.detail.cms');
+
+        Shopware.Store.get('swCategoryDetail').category = {
+            slotConfig: {
+                'slot-id': {
+                    content: { value: 'child content' },
+                },
+            },
+            translations: [
+                {
+                    languageId: 'parent-language-id',
+                    slotConfig: {
+                        'slot-id': {
+                            title: { value: 'parent title' },
+                            content: { value: 'parent content' },
+                        },
+                    },
+                },
+            ],
+        };
+        Shopware.Store.get('context').api.languageId = 'child-language-id';
+        Shopware.Store.get('context').api.language = { parentId: 'parent-language-id' };
+
+        expect(wrapper.vm.inheritedSlotConfig).toStrictEqual({
+            'slot-id': {
+                title: { value: 'parent title' },
+                content: { value: 'child content' },
+            },
+        });
+    });
+
     it('should prefer the live current-language slotConfig over the stale translation row', async () => {
         const wrapper = await createWrapper('sw.category.detail.cms');
 

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/mixin/sw-cms-state.mixin.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/mixin/sw-cms-state.mixin.ts
@@ -106,14 +106,31 @@ export default Shopware.Mixin.register(
                 const currentSlotConfig = this.getSlotConfigForLanguage(currentLanguageId);
                 const parentSlotConfig = parentLanguageId ? this.getSlotConfigForLanguage(parentLanguageId) : null;
 
-                if (currentSlotConfig && parentSlotConfig) {
-                    return cloneDeep({
-                        ...parentSlotConfig,
-                        ...currentSlotConfig,
-                    });
+                if (!currentSlotConfig && !parentSlotConfig) {
+                    return null;
                 }
 
-                return cloneDeep(currentSlotConfig ?? parentSlotConfig ?? null);
+                /**
+                 * Merge field-by-field within each slot so a partial child-language override
+                 * does not shadow parent-language fields on the same slot.
+                 */
+                const merged: { [slotId: string]: CmsSlotConfig } = {};
+
+                for (const [
+                    slotId,
+                    fields,
+                ] of Object.entries(parentSlotConfig ?? {})) {
+                    merged[slotId] = { ...fields };
+                }
+
+                for (const [
+                    slotId,
+                    fields,
+                ] of Object.entries(currentSlotConfig ?? {})) {
+                    merged[slotId] = { ...(merged[slotId] ?? {}), ...fields };
+                }
+
+                return cloneDeep(merged);
             },
         },
         methods: {

--- a/src/Core/Content/Cms/Service/EntityCmsSlotConfigInheritanceBuilder.php
+++ b/src/Core/Content/Cms/Service/EntityCmsSlotConfigInheritanceBuilder.php
@@ -34,12 +34,17 @@ readonly class EntityCmsSlotConfigInheritanceBuilder
         $slotConfigs = $this->collectSlotConfigs($translations);
         $languageInheritanceChain = $this->getLanguageInheritanceChain($context);
 
-        $result = [];
+        /**
+         * Merge field-by-field within each slot so that partial slot overrides in the
+         * child language do not drop fields that are still inherited from the parent
+         * language. Later entries in the chain (child) win over earlier ones (parent).
+         */
+        $merged = [];
         foreach ($languageInheritanceChain as $currentLanguageId) {
-            $result[] = $slotConfigs[$currentLanguageId] ?? [];
+            foreach ($slotConfigs[$currentLanguageId] ?? [] as $slotId => $fields) {
+                $merged[$slotId] = \array_replace($merged[$slotId] ?? [], $fields);
+            }
         }
-
-        $merged = \array_merge(...$result);
 
         return $merged !== [] ? $merged : null;
     }

--- a/tests/unit/Core/Content/Cms/Service/EntityCmsSlotConfigInheritanceBuilderTest.php
+++ b/tests/unit/Core/Content/Cms/Service/EntityCmsSlotConfigInheritanceBuilderTest.php
@@ -59,6 +59,42 @@ class EntityCmsSlotConfigInheritanceBuilderTest extends TestCase
         ], $result);
     }
 
+    public function testBuildRetainsParentLanguageFieldsWhenChildOverridesPartialSlot(): void
+    {
+        $childLanguageId = Uuid::randomHex();
+        $parentLanguageId = Uuid::randomHex();
+
+        $builder = new EntityCmsSlotConfigInheritanceBuilder(
+            $this->createConnectionWithParentLanguageIds([
+                $parentLanguageId,
+                null,
+            ]),
+        );
+
+        $translations = new ProductTranslationCollection([
+            $this->createTranslation($parentLanguageId, [
+                'slot-a' => [
+                    'headline' => ['value' => 'parent headline'],
+                    'content' => ['value' => 'parent content'],
+                ],
+            ]),
+            $this->createTranslation($childLanguageId, [
+                'slot-a' => [
+                    'content' => ['value' => 'child content'],
+                ],
+            ]),
+        ]);
+
+        $result = $builder->build($translations, $this->createSalesChannelContext($childLanguageId));
+
+        static::assertSame([
+            'slot-a' => [
+                'headline' => ['value' => 'parent headline'],
+                'content' => ['value' => 'child content'],
+            ],
+        ], $result);
+    }
+
     public function testBuildDoesNotMergeSystemLanguageWithoutExplicitParent(): void
     {
         $childLanguageId = Uuid::randomHex();


### PR DESCRIPTION
fixes https://github.com/shopware/shopware/issues/16317

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
Follow-up to #16026 and #16393 (fix for #16316). Two remaining gaps in CMS content-language inheritance:

- Admin: Restoring field-level inheritance on a slot in the child language could silently wipe every other slot's entity-level overrides. When the restored field was the last override on that slot, the whole contentEntity.slotConfig object was nulled, dropping sibling slots' child-language content too. Closes #16317.
- Storefront: EntityCmsSlotConfigInheritanceBuilder merged parent- and child-language overrides with a slot-level array_merge. Any partial child-language override on a slot therefore replaced the parent's slot entry entirely; non-overridden fields fell back to the CMS layout default instead of the parent-language value. This is the storefront manifestation of both #16316 (after "Remove inheritance" on one field of a multi-field slot) and #16317 (after "Restore inheritance" on one field of a multi-field slot).

### 2. What does this change do, exactly?
Admin — sw-cms-inherit-wrapper.onInheritanceRestore (src/Administration/.../sw-cms-inherit-wrapper/index.ts): Scopes the empty-config cleanup to the current slot. When the restored field was the last override on that slot, only slotConfig[element.id] is removed; slotConfig itself is only nulled when every slot entry has become empty. Other slots' overrides are preserved.

Storefront / PHP — EntityCmsSlotConfigInheritanceBuilder::build()(src/Core/Content/Cms/Service/EntityCmsSlotConfigInheritanceBuilder.php):
  Replaces the slot-level array_merge with a per-slot array_replace, merging field-by-field along the language inheritance chain. Child-language fields still win over parent-language fields; parent-language fields
   the child did not override now survive into the merged result and reach the storefront, matching the admin view.

Single-field-per-slot scenarios produce the same output as before, so the existing tests added in #16026 continue to pass unchanged.

### 3. Describe each step to reproduce the issue or behaviour.
Admin scenario (#16317) — sibling slots wiped on restore
1. Create a CMS layout for a product with two text blocks Block A and Block B. Assign to a product.
2. In default language English, optionally override both to English A / English B and save.
3. Create a child language Canada with Inherit from = English.
4. Switch to Canada, override both blocks to Canada A / Canada B, save.
5. Click Restore inheritance on Block A's text field only. Confirm.

Before: Block A inherits English, and Block B also reverts to English B — the Canada override is gone.
After: Block A inherits English; Block B keeps Canada B.

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
