### PR TITLE
fix: only require min value of quantity range with major version 6.8

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -294,12 +294,6 @@ shopware:
 
 When `bin/console system:setup:staging` is executed, the configured keys are written to the database via `SystemConfigService`.
 
-## API
-
-### Minimum value constraints added to quantity fields in ProductPriceDefinition
-
-The fields `quantityStart` and `quantityEnd` of ProductPriceDefinition now require a minimum value of `1`.
-
 ### Deprecation of newsletter route methods
 
 The following methods are deprecated and will be removed with the next major version:

--- a/UPGRADE-6.8.md
+++ b/UPGRADE-6.8.md
@@ -4,6 +4,10 @@
 
 <details>
 
+### Minimum value constraints added to quantity fields in ProductPriceDefinition
+
+The fields `quantityStart` and `quantityEnd` of ProductPriceDefinition now require a minimum value of `1`.
+
 ## Default CMS page ID now persisted for categories
 
 The default CMS page ID is now automatically written to the database when a category is saved without a `cmsPageId`.

--- a/src/Core/Content/Product/Aggregate/ProductPrice/ProductPriceDefinition.php
+++ b/src/Core/Content/Product/Aggregate/ProductPrice/ProductPriceDefinition.php
@@ -17,6 +17,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\PriceField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\ReferenceVersionField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\VersionField;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 
 #[Package('inventory')]
@@ -56,18 +57,27 @@ class ProductPriceDefinition extends EntityDefinition
 
     protected function defineFields(): FieldCollection
     {
-        return new FieldCollection([
+        $fields = new FieldCollection([
             (new IdField('id', 'id'))->addFlags(new PrimaryKey(), new Required())->setDescription('Unique identity of the product\'s price.'),
             new VersionField(),
             (new FkField('product_id', 'productId', ProductDefinition::class))->addFlags(new Required())->setDescription('Unique identity of the product.'),
             (new ReferenceVersionField(ProductDefinition::class))->addFlags(new Required()),
             (new FkField('rule_id', 'ruleId', RuleDefinition::class))->addFlags(new Required())->setDescription('Unique identity of the rule.'),
             (new PriceField('price', 'price'))->addFlags(new Required())->setDescription('Price of the Product.'),
-            (new IntField('quantity_start', 'quantityStart', 1))->addFlags(new Required())->setDescription('Starting range of quantity of an item.'),
-            (new IntField('quantity_end', 'quantityEnd', 1))->setDescription('Ending range of quantity of an item.'),
             (new ManyToOneAssociationField('product', 'product_id', ProductDefinition::class, 'id', false))->addFlags(new ReverseInherited('prices')),
             new ManyToOneAssociationField('rule', 'rule_id', RuleDefinition::class, 'id', false),
             (new CustomFields())->setDescription('Additional fields that offer a possibility to add own fields for the different program-areas.'),
         ]);
+
+        // @deprecated tag:v6.8.0 - add min value for quantity_start and quantity_end
+        if (Feature::isActive('v6.8.0.0')) {
+            $fields->add((new IntField('quantity_start', 'quantityStart', 1))->addFlags(new Required())->setDescription('Starting range of quantity of an item.'));
+            $fields->add((new IntField('quantity_end', 'quantityEnd', 1))->setDescription('Ending range of quantity of an item.'));
+        } else {
+            $fields->add((new IntField('quantity_start', 'quantityStart'))->addFlags(new Required())->setDescription('Starting range of quantity of an item.'));
+            $fields->add((new IntField('quantity_end', 'quantityEnd'))->setDescription('Ending range of quantity of an item.'));
+        }
+
+        return $fields;
     }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

Shopware 6.7.9 started rejecting product price payloads with `quantityStart` below `1`. This breaks existing 6.7 integrations such as the reported JTL Connector product sync case.

### 2. What does this change do, exactly?

Keeps the stricter `quantityStart`/`quantityEnd` minimum value validation for 6.8 and restores the previous 6.7 entity definition behavior.

### 3. Describe each step to reproduce the issue or behaviour.

Use the JTL Connector with Shopware 6.7.9 and push a product payload containing price records with `quantityStart: 0`. The sync fails with `This value should be 1 or more` on `/prices/*/quantityStart`.

### 4. Please link to the relevant issues (if any).

- relates https://feinwerk.software/blog/jtl-connector-shopware-6-7-9-quantitystart-fehler-per-eigenem-plugin-loesen
- relates #15771

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
