### PR TITLE
fix: Make it possible for Twig extensions to work again

### DIFF
--- a/src/Core/Framework/Adapter/Twig/Runtime/CachedEscaperRuntime.php
+++ b/src/Core/Framework/Adapter/Twig/Runtime/CachedEscaperRuntime.php
@@ -6,7 +6,6 @@ namespace Shopware\Core\Framework\Adapter\Twig\Runtime;
 
 use Shopware\Core\Framework\Log\Package;
 use Twig\Error\RuntimeError;
-use Twig\Extension\RuntimeExtensionInterface;
 use Twig\Markup;
 use Twig\Runtime\EscaperRuntime;
 
@@ -14,7 +13,7 @@ use Twig\Runtime\EscaperRuntime;
  * @internal
  */
 #[Package('framework')]
-final class CachedEscaperRuntime implements RuntimeExtensionInterface
+final class CachedEscaperRuntime
 {
     /**
      * Cache for escaped strings to avoid repeated escaping of the same content.
@@ -24,24 +23,26 @@ final class CachedEscaperRuntime implements RuntimeExtensionInterface
      */
     private static array $escapeCache = [];
 
-    public function __construct(
-        private readonly EscaperRuntime $originalEscaperRuntime,
-    ) {
+    private function __construct()
+    {
     }
 
     /**
-     * Mimics the public API of {@see EscaperRuntime} as it is final and cannot be extended
-     *
-     * Additionally caches the escaped value to increase the performance.
+     * Wraps the original Twig {@see EscaperRuntime} to cache the escaped value to increase the performance.
      * Caching other types than `string` brings no value, as the checks for those types cost more than the cache brings benefit.
-     * E.g. integers and floats are rarely occuring with the same value more than once.
+     * E.g. integers and floats are rarely occurring with the same value more than once.
      * Or e.g. {@see Markup} is directly returned anyway by original escaper, due to `$autoescape` set to true for the internal usage in Twig, so also not worth caching.
      * Changing the logic here should be proven with performance measuering tools like Blackfire.
      *
      * @throws RuntimeError
      */
-    public function escape(mixed $string, string $strategy = 'html', ?string $charset = null, bool $autoescape = false): mixed
-    {
+    public static function escape(
+        EscaperRuntime $escaper,
+        mixed $string,
+        string $strategy = 'html',
+        ?string $charset = null,
+        bool $autoescape = false
+    ): mixed {
         $cacheKey = null;
 
         if (\is_string($string)) {
@@ -51,7 +52,7 @@ final class CachedEscaperRuntime implements RuntimeExtensionInterface
             }
         }
 
-        $result = $this->originalEscaperRuntime->escape($string, $strategy, $charset, $autoescape);
+        $result = $escaper->escape($string, $strategy, $charset, $autoescape);
 
         if ($cacheKey === null) {
             return $result;
@@ -71,52 +72,5 @@ final class CachedEscaperRuntime implements RuntimeExtensionInterface
     public static function resetEscapeCache(): void
     {
         self::$escapeCache = [];
-    }
-
-    /**
-     * Mimics the public API of {@see EscaperRuntime} as it is final and cannot be extended
-     *
-     * @codeCoverageIgnore
-     */
-    public function setEscaper(string $strategy, callable $callable): void
-    {
-        $this->originalEscaperRuntime->setEscaper($strategy, $callable);
-    }
-
-    /**
-     * Mimics the public API of {@see EscaperRuntime} as it is final and cannot be extended
-     *
-     * @codeCoverageIgnore
-     *
-     * @return array<string, callable(string $string, string $charset): string>
-     */
-    public function getEscapers(): array
-    {
-        return $this->originalEscaperRuntime->getEscapers();
-    }
-
-    /**
-     * Mimics the public API of {@see EscaperRuntime} as it is final and cannot be extended
-     *
-     * @codeCoverageIgnore
-     *
-     * @param array<class-string<\Stringable>, string[]> $safeClasses
-     */
-    public function setSafeClasses(array $safeClasses = []): void
-    {
-        $this->originalEscaperRuntime->setSafeClasses($safeClasses);
-    }
-
-    /**
-     * Mimics the public API of {@see EscaperRuntime} as it is final and cannot be extended
-     *
-     * @codeCoverageIgnore
-     *
-     * @param class-string<\Stringable> $class
-     * @param list<string> $strategies
-     */
-    public function addSafeClass(string $class, array $strategies): void
-    {
-        $this->originalEscaperRuntime->addSafeClass($class, $strategies);
     }
 }

--- a/src/Core/Framework/Adapter/Twig/Runtime/CachedEscaperRuntime.php
+++ b/src/Core/Framework/Adapter/Twig/Runtime/CachedEscaperRuntime.php
@@ -37,7 +37,7 @@ final class CachedEscaperRuntime
      * @throws RuntimeError
      */
     public static function escape(
-        EscaperRuntime $escaper,
+        EscaperRuntime $originalEscaperRuntime,
         mixed $string,
         string $strategy = 'html',
         ?string $charset = null,
@@ -52,7 +52,7 @@ final class CachedEscaperRuntime
             }
         }
 
-        $result = $escaper->escape($string, $strategy, $charset, $autoescape);
+        $result = $originalEscaperRuntime->escape($string, $strategy, $charset, $autoescape);
 
         if ($cacheKey === null) {
             return $result;

--- a/src/Core/Framework/Adapter/Twig/Runtime/CachedEscaperRuntimeResetter.php
+++ b/src/Core/Framework/Adapter/Twig/Runtime/CachedEscaperRuntimeResetter.php
@@ -8,11 +8,11 @@ use Symfony\Contracts\Service\ResetInterface;
 /**
  * @internal
  *
- * Resets SwTwigFunction static caches between requests.
+ * Resets CachedEscaperRuntime static caches between requests.
  *
  * This is essential for long runner environments (RoadRunner, FrankenPHP, Swoole)
  * where the same PHP process handles multiple requests. Without reset,
- * the escape filter cache in SwTwigFunction would grow unbounded,
+ * the escape filter cache in CachedEscaperRuntime would grow unbounded,
  * causing memory leaks.
  */
 #[Package('framework')]

--- a/src/Core/Framework/Adapter/Twig/TwigEnvironment.php
+++ b/src/Core/Framework/Adapter/Twig/TwigEnvironment.php
@@ -5,11 +5,9 @@ namespace Shopware\Core\Framework\Adapter\Twig;
 use Shopware\Core\Framework\Adapter\Twig\Runtime\CachedEscaperRuntime;
 use Shopware\Core\Framework\Log\Package;
 use Twig\Environment;
-use Twig\Error\RuntimeError;
 use Twig\Loader\LoaderInterface;
 use Twig\Node\Node;
 use Twig\Runtime\EscaperRuntime;
-use Twig\RuntimeLoader\RuntimeLoaderInterface;
 
 /**
  * @internal
@@ -17,8 +15,6 @@ use Twig\RuntimeLoader\RuntimeLoaderInterface;
 #[Package('framework')]
 class TwigEnvironment extends Environment
 {
-    private ?CachedEscaperRuntime $escaperRuntime = null;
-
     /**
      * @param array<string, mixed> $options
      */
@@ -31,42 +27,16 @@ class TwigEnvironment extends Environment
     }
 
     /**
-     * Wraps the original method to inject the {@see CachedEscaperRuntime} into the Twig system.
-     * It is not possible to introduce a new {@see RuntimeLoaderInterface} with {@see Environment::addRuntimeLoader()},
-     * as the internal cache key is the FQCN, which cannot be influenced.
-     * Therefore it is also safe to instantiate the original {@see EscaperRuntime} directly.
-     * This is also faster than calling the original `getRuntime` method to get the {@see EscaperRuntime} instance.
-     *
-     * @template TRuntime of object
-     *
-     * @param class-string<TRuntime> $class
-     *
-     * @throws RuntimeError
-     *
-     * @return ($class is class-string<EscaperRuntime> ? CachedEscaperRuntime : TRuntime)
-     */
-    public function getRuntime(string $class): object
-    {
-        if ($class !== EscaperRuntime::class) {
-            return parent::getRuntime($class);
-        }
-
-        if ($this->escaperRuntime !== null) {
-            return $this->escaperRuntime;
-        }
-
-        $this->escaperRuntime = new CachedEscaperRuntime(new EscaperRuntime($this->getCharset()));
-
-        return $this->escaperRuntime;
-    }
-
-    /**
-     * Overrides Twig CoreExtension with SW custom wrapper {@see SwTwigFunction}
+     * Overrides Twig {@see CoreExtension} with SW custom wrapper {@see SwTwigFunction}.
+     * Overrides Twig {@see EscaperRuntime} with SW custom wrapper {@see CachedEscaperRuntime}
      */
     public function compile(Node $node): string
     {
         $source = parent::compile($node);
 
-        return str_replace('CoreExtension::getAttribute(', '\Shopware\Core\Framework\Adapter\Twig\SwTwigFunction::getAttribute(', $source);
+        return strtr($source, [
+            'CoreExtension::getAttribute(' => '\Shopware\Core\Framework\Adapter\Twig\SwTwigFunction::getAttribute(',
+            '$this->env->getRuntime(\'Twig\\Runtime\\EscaperRuntime\')->escape(' => '\Shopware\Core\Framework\Adapter\Twig\Runtime\CachedEscaperRuntime::escape($this->env->getRuntime(\'Twig\\Runtime\\EscaperRuntime\'), ',
+        ]);
     }
 }

--- a/tests/unit/Core/Framework/Adapter/Twig/Runtime/CachedEscaperRuntimeResetterTest.php
+++ b/tests/unit/Core/Framework/Adapter/Twig/Runtime/CachedEscaperRuntimeResetterTest.php
@@ -28,20 +28,20 @@ class CachedEscaperRuntimeResetterTest extends TestCase
     public function testResetOfCacheArray(): void
     {
         $callCount = 0;
-        $runtime = new EscaperRuntime();
-        $runtime->setEscaper('test', static function (string $string) use (&$callCount): string {
+        $originalEscaperRuntime = new EscaperRuntime();
+        $originalEscaperRuntime->setEscaper('test', static function (string $string) use (&$callCount): string {
             ++$callCount;
 
             return $string;
         });
 
-        CachedEscaperRuntime::escape($runtime, 'foo', 'test');
-        CachedEscaperRuntime::escape($runtime, 'foo', 'test');
+        CachedEscaperRuntime::escape($originalEscaperRuntime, 'foo', 'test');
+        CachedEscaperRuntime::escape($originalEscaperRuntime, 'foo', 'test');
 
         (new CachedEscaperRuntimeResetter())->reset();
 
-        CachedEscaperRuntime::escape($runtime, 'foo', 'test');
-        CachedEscaperRuntime::escape($runtime, 'foo', 'test');
+        CachedEscaperRuntime::escape($originalEscaperRuntime, 'foo', 'test');
+        CachedEscaperRuntime::escape($originalEscaperRuntime, 'foo', 'test');
 
         static::assertSame(2, $callCount, 'The inner runtime should be called once before and once after the reset');
     }

--- a/tests/unit/Core/Framework/Adapter/Twig/Runtime/CachedEscaperRuntimeResetterTest.php
+++ b/tests/unit/Core/Framework/Adapter/Twig/Runtime/CachedEscaperRuntimeResetterTest.php
@@ -35,15 +35,13 @@ class CachedEscaperRuntimeResetterTest extends TestCase
             return $string;
         });
 
-        $escaper = new CachedEscaperRuntime($runtime);
-
-        $escaper->escape('foo', 'test');
-        $escaper->escape('foo', 'test');
+        CachedEscaperRuntime::escape($runtime, 'foo', 'test');
+        CachedEscaperRuntime::escape($runtime, 'foo', 'test');
 
         (new CachedEscaperRuntimeResetter())->reset();
 
-        $escaper->escape('foo', 'test');
-        $escaper->escape('foo', 'test');
+        CachedEscaperRuntime::escape($runtime, 'foo', 'test');
+        CachedEscaperRuntime::escape($runtime, 'foo', 'test');
 
         static::assertSame(2, $callCount, 'The inner runtime should be called once before and once after the reset');
     }

--- a/tests/unit/Core/Framework/Adapter/Twig/Runtime/CachedEscaperRuntimeTest.php
+++ b/tests/unit/Core/Framework/Adapter/Twig/Runtime/CachedEscaperRuntimeTest.php
@@ -15,7 +15,7 @@ use Twig\Runtime\EscaperRuntime;
 #[CoversClass(CachedEscaperRuntime::class)]
 class CachedEscaperRuntimeTest extends TestCase
 {
-    private EscaperRuntime $ogEscaperRuntime;
+    private EscaperRuntime $originalEscaperRuntime;
 
     /**
      * All character encodings supported by htmlspecialchars().
@@ -173,7 +173,7 @@ class CachedEscaperRuntimeTest extends TestCase
     protected function setUp(): void
     {
         CachedEscaperRuntime::resetEscapeCache();
-        $this->ogEscaperRuntime = new EscaperRuntime();
+        $this->originalEscaperRuntime = new EscaperRuntime();
     }
 
     protected function tearDown(): void
@@ -184,21 +184,21 @@ class CachedEscaperRuntimeTest extends TestCase
     public function testHtmlEscapingConvertsSpecialChars(): void
     {
         foreach (self::$htmlSpecialChars as $key => $value) {
-            static::assertSame($value, CachedEscaperRuntime::escape($this->ogEscaperRuntime, $key), 'Failed to escape: ' . $key);
+            static::assertSame($value, CachedEscaperRuntime::escape($this->originalEscaperRuntime, $key), 'Failed to escape: ' . $key);
         }
     }
 
     public function testHtmlAttributeEscapingConvertsSpecialChars(): void
     {
         foreach (self::$htmlAttrSpecialChars as $key => $value) {
-            static::assertSame($value, CachedEscaperRuntime::escape($this->ogEscaperRuntime, $key, 'html_attr'), 'Failed to escape: ' . $key);
+            static::assertSame($value, CachedEscaperRuntime::escape($this->originalEscaperRuntime, $key, 'html_attr'), 'Failed to escape: ' . $key);
         }
     }
 
     public function testJavascriptEscapingConvertsSpecialChars(): void
     {
         foreach (self::$jsSpecialChars as $key => $value) {
-            static::assertSame($value, CachedEscaperRuntime::escape($this->ogEscaperRuntime, $key, 'js'), 'Failed to escape: ' . $key);
+            static::assertSame($value, CachedEscaperRuntime::escape($this->originalEscaperRuntime, $key, 'js'), 'Failed to escape: ' . $key);
         }
     }
 
@@ -209,7 +209,7 @@ class CachedEscaperRuntimeTest extends TestCase
         try {
             mb_internal_encoding('ISO-8859-1');
             foreach (self::$jsSpecialChars as $key => $value) {
-                static::assertSame($value, CachedEscaperRuntime::escape($this->ogEscaperRuntime, $key, 'js'), 'Failed to escape: ' . $key);
+                static::assertSame($value, CachedEscaperRuntime::escape($this->originalEscaperRuntime, $key, 'js'), 'Failed to escape: ' . $key);
             }
         } finally {
             if ($previousInternalEncoding !== false) {
@@ -220,35 +220,35 @@ class CachedEscaperRuntimeTest extends TestCase
 
     public function testJavascriptEscapingReturnsStringIfZeroLength(): void
     {
-        static::assertSame('', CachedEscaperRuntime::escape($this->ogEscaperRuntime, '', 'js'));
+        static::assertSame('', CachedEscaperRuntime::escape($this->originalEscaperRuntime, '', 'js'));
     }
 
     public function testJavascriptEscapingReturnsStringIfContainsOnlyDigits(): void
     {
-        static::assertSame('123', CachedEscaperRuntime::escape($this->ogEscaperRuntime, '123', 'js'));
+        static::assertSame('123', CachedEscaperRuntime::escape($this->originalEscaperRuntime, '123', 'js'));
     }
 
     public function testCssEscapingConvertsSpecialChars(): void
     {
         foreach (self::$cssSpecialChars as $key => $value) {
-            static::assertSame($value, CachedEscaperRuntime::escape($this->ogEscaperRuntime, $key, 'css'), 'Failed to escape: ' . $key);
+            static::assertSame($value, CachedEscaperRuntime::escape($this->originalEscaperRuntime, $key, 'css'), 'Failed to escape: ' . $key);
         }
     }
 
     public function testCssEscapingReturnsStringIfZeroLength(): void
     {
-        static::assertSame('', CachedEscaperRuntime::escape($this->ogEscaperRuntime, '', 'css'));
+        static::assertSame('', CachedEscaperRuntime::escape($this->originalEscaperRuntime, '', 'css'));
     }
 
     public function testCssEscapingReturnsStringIfContainsOnlyDigits(): void
     {
-        static::assertSame('123', CachedEscaperRuntime::escape($this->ogEscaperRuntime, '123', 'css'));
+        static::assertSame('123', CachedEscaperRuntime::escape($this->originalEscaperRuntime, '123', 'css'));
     }
 
     public function testUrlEscapingConvertsSpecialChars(): void
     {
         foreach (self::$urlSpecialChars as $key => $value) {
-            static::assertSame($value, CachedEscaperRuntime::escape($this->ogEscaperRuntime, $key, 'url'), 'Failed to escape: ' . $key);
+            static::assertSame($value, CachedEscaperRuntime::escape($this->originalEscaperRuntime, $key, 'url'), 'Failed to escape: ' . $key);
         }
     }
 
@@ -277,15 +277,15 @@ class CachedEscaperRuntimeTest extends TestCase
                 || ($chr >= 0x41 && $chr <= 0x5A)
                 || ($chr >= 0x61 && $chr <= 0x7A)) {
                 $literal = $this->codepointToUtf8($chr);
-                static::assertSame($literal, CachedEscaperRuntime::escape($this->ogEscaperRuntime, $literal, 'js'));
+                static::assertSame($literal, CachedEscaperRuntime::escape($this->originalEscaperRuntime, $literal, 'js'));
             } else {
                 $literal = $this->codepointToUtf8($chr);
                 if (\in_array($literal, $immune, true)) {
-                    static::assertSame($literal, CachedEscaperRuntime::escape($this->ogEscaperRuntime, $literal, 'js'));
+                    static::assertSame($literal, CachedEscaperRuntime::escape($this->originalEscaperRuntime, $literal, 'js'));
                 } else {
                     static::assertNotSame(
                         $literal,
-                        CachedEscaperRuntime::escape($this->ogEscaperRuntime, $literal, 'js'),
+                        CachedEscaperRuntime::escape($this->originalEscaperRuntime, $literal, 'js'),
                         "$literal should be escaped!"
                     );
                 }
@@ -301,15 +301,15 @@ class CachedEscaperRuntimeTest extends TestCase
                 || ($chr >= 0x41 && $chr <= 0x5A)
                 || ($chr >= 0x61 && $chr <= 0x7A)) {
                 $literal = $this->codepointToUtf8($chr);
-                static::assertSame($literal, CachedEscaperRuntime::escape($this->ogEscaperRuntime, $literal, 'html_attr'));
+                static::assertSame($literal, CachedEscaperRuntime::escape($this->originalEscaperRuntime, $literal, 'html_attr'));
             } else {
                 $literal = $this->codepointToUtf8($chr);
                 if (\in_array($literal, $immune, true)) {
-                    static::assertSame($literal, CachedEscaperRuntime::escape($this->ogEscaperRuntime, $literal, 'html_attr'));
+                    static::assertSame($literal, CachedEscaperRuntime::escape($this->originalEscaperRuntime, $literal, 'html_attr'));
                 } else {
                     static::assertNotSame(
                         $literal,
-                        CachedEscaperRuntime::escape($this->ogEscaperRuntime, $literal, 'html_attr'),
+                        CachedEscaperRuntime::escape($this->originalEscaperRuntime, $literal, 'html_attr'),
                         "$literal should be escaped!"
                     );
                 }
@@ -325,12 +325,12 @@ class CachedEscaperRuntimeTest extends TestCase
                 || ($chr >= 0x41 && $chr <= 0x5A)
                 || ($chr >= 0x61 && $chr <= 0x7A)) {
                 $literal = $this->codepointToUtf8($chr);
-                static::assertSame($literal, CachedEscaperRuntime::escape($this->ogEscaperRuntime, $literal, 'css'));
+                static::assertSame($literal, CachedEscaperRuntime::escape($this->originalEscaperRuntime, $literal, 'css'));
             } else {
                 $literal = $this->codepointToUtf8($chr);
                 static::assertNotSame(
                     $literal,
-                    CachedEscaperRuntime::escape($this->ogEscaperRuntime, $literal, 'css'),
+                    CachedEscaperRuntime::escape($this->originalEscaperRuntime, $literal, 'css'),
                     "$literal should be escaped!"
                 );
             }
@@ -340,10 +340,10 @@ class CachedEscaperRuntimeTest extends TestCase
     #[DataProvider('provideCustomEscaperCases')]
     public function testCustomEscaper(string $expected, string $string, string $strategy): void
     {
-        $runtime = new EscaperRuntime();
-        $runtime->setEscaper('foo', foo_escaper_for_test(...));
+        $originalEscaperRuntime = new EscaperRuntime();
+        $originalEscaperRuntime->setEscaper('foo', foo_escaper_for_test(...));
 
-        static::assertSame($expected, CachedEscaperRuntime::escape($runtime, $string, $strategy));
+        static::assertSame($expected, CachedEscaperRuntime::escape($originalEscaperRuntime, $string, $strategy));
     }
 
     /**
@@ -359,7 +359,7 @@ class CachedEscaperRuntimeTest extends TestCase
     public function testUnknownCustomEscaper(): void
     {
         $this->expectExceptionObject(new RuntimeError('Invalid escaping strategy "bar" (valid ones: "html", "js", "url", "css", "html_attr", "html_attr_relaxed")'));
-        CachedEscaperRuntime::escape($this->ogEscaperRuntime, 'foo', 'bar');
+        CachedEscaperRuntime::escape($this->originalEscaperRuntime, 'foo', 'bar');
     }
 
     /**
@@ -369,11 +369,11 @@ class CachedEscaperRuntimeTest extends TestCase
     public function testObjectEscaping(string $escapedHtml, string $escapedJs, array $safeClasses): void
     {
         $obj = new Extension_TestClass();
-        $runtime = new EscaperRuntime();
-        $runtime->setSafeClasses($safeClasses);
+        $originalEscaperRuntime = new EscaperRuntime();
+        $originalEscaperRuntime->setSafeClasses($safeClasses);
 
-        static::assertSame($escapedHtml, CachedEscaperRuntime::escape($runtime, $obj, 'html', null, true));
-        static::assertSame($escapedJs, CachedEscaperRuntime::escape($runtime, $obj, 'js', null, true));
+        static::assertSame($escapedHtml, CachedEscaperRuntime::escape($originalEscaperRuntime, $obj, 'html', null, true));
+        static::assertSame($escapedJs, CachedEscaperRuntime::escape($originalEscaperRuntime, $obj, 'js', null, true));
     }
 
     /**
@@ -429,7 +429,7 @@ class CachedEscaperRuntimeTest extends TestCase
     #[DataProvider('EscapeDataProvider')]
     public function testEscapeWithVariousInputs(array|int|float|string|null $input, array|int|float|string|null $expected): void
     {
-        $result = CachedEscaperRuntime::escape($this->ogEscaperRuntime, $input);
+        $result = CachedEscaperRuntime::escape($this->originalEscaperRuntime, $input);
 
         static::assertSame($expected, $result);
     }
@@ -437,16 +437,16 @@ class CachedEscaperRuntimeTest extends TestCase
     public function testEscapeWithCachedString(): void
     {
         $callCount = 0;
-        $runtime = new EscaperRuntime();
-        $runtime->setEscaper('test', static function (string $string) use (&$callCount): string {
+        $originalEscaperRuntime = new EscaperRuntime();
+        $originalEscaperRuntime->setEscaper('test', static function (string $string) use (&$callCount): string {
             ++$callCount;
 
             return strtoupper($string);
         });
 
-        static::assertSame('FOO', CachedEscaperRuntime::escape($runtime, 'foo', 'test'));
-        static::assertSame('FOO', CachedEscaperRuntime::escape($runtime, 'foo', 'test'));
-        static::assertSame('FOO', CachedEscaperRuntime::escape($runtime, 'foo', 'test'));
+        static::assertSame('FOO', CachedEscaperRuntime::escape($originalEscaperRuntime, 'foo', 'test'));
+        static::assertSame('FOO', CachedEscaperRuntime::escape($originalEscaperRuntime, 'foo', 'test'));
+        static::assertSame('FOO', CachedEscaperRuntime::escape($originalEscaperRuntime, 'foo', 'test'));
 
         static::assertSame(1, $callCount);
     }
@@ -454,22 +454,22 @@ class CachedEscaperRuntimeTest extends TestCase
     public function testDifferentStrategiesAreCachedSeparately(): void
     {
         $callCount = 0;
-        $runtime = new EscaperRuntime();
-        $runtime->setEscaper('upper', static function (string $string) use (&$callCount): string {
+        $originalEscaperRuntime = new EscaperRuntime();
+        $originalEscaperRuntime->setEscaper('upper', static function (string $string) use (&$callCount): string {
             ++$callCount;
 
             return strtoupper($string);
         });
-        $runtime->setEscaper('lower', static function (string $string) use (&$callCount): string {
+        $originalEscaperRuntime->setEscaper('lower', static function (string $string) use (&$callCount): string {
             ++$callCount;
 
             return strtolower($string);
         });
 
-        static::assertSame('FOO', CachedEscaperRuntime::escape($runtime, 'Foo', 'upper'));
-        static::assertSame('foo', CachedEscaperRuntime::escape($runtime, 'Foo', 'lower'));
-        static::assertSame('FOO', CachedEscaperRuntime::escape($runtime, 'Foo', 'upper'));
-        static::assertSame('foo', CachedEscaperRuntime::escape($runtime, 'Foo', 'lower'));
+        static::assertSame('FOO', CachedEscaperRuntime::escape($originalEscaperRuntime, 'Foo', 'upper'));
+        static::assertSame('foo', CachedEscaperRuntime::escape($originalEscaperRuntime, 'Foo', 'lower'));
+        static::assertSame('FOO', CachedEscaperRuntime::escape($originalEscaperRuntime, 'Foo', 'upper'));
+        static::assertSame('foo', CachedEscaperRuntime::escape($originalEscaperRuntime, 'Foo', 'lower'));
 
         static::assertSame(2, $callCount);
     }
@@ -477,8 +477,8 @@ class CachedEscaperRuntimeTest extends TestCase
     public function testEscapeWithStringableThatIsMutatedBetweenCallsIsNotConsideredForCaching(): void
     {
         $callCount = 0;
-        $runtime = new EscaperRuntime();
-        $runtime->setEscaper('test', static function (string $string) use (&$callCount): string {
+        $originalEscaperRuntime = new EscaperRuntime();
+        $originalEscaperRuntime->setEscaper('test', static function (string $string) use (&$callCount): string {
             ++$callCount;
 
             return strtoupper($string);
@@ -486,11 +486,11 @@ class CachedEscaperRuntimeTest extends TestCase
 
         $stringable = new Extension_TestClass('foo1');
 
-        static::assertSame('FOO1', CachedEscaperRuntime::escape($runtime, $stringable, 'test'));
+        static::assertSame('FOO1', CachedEscaperRuntime::escape($originalEscaperRuntime, $stringable, 'test'));
 
         $stringable->string = 'foo2';
 
-        static::assertSame('FOO2', CachedEscaperRuntime::escape($runtime, $stringable, 'test'));
+        static::assertSame('FOO2', CachedEscaperRuntime::escape($originalEscaperRuntime, $stringable, 'test'));
 
         static::assertSame(2, $callCount);
     }
@@ -498,17 +498,17 @@ class CachedEscaperRuntimeTest extends TestCase
     public function testEscapeDoesNotCacheBooleanInput(): void
     {
         $callCount = 0;
-        $runtime = new EscaperRuntime();
-        $runtime->setEscaper('test', static function (mixed $string) use (&$callCount): mixed {
+        $originalEscaperRuntime = new EscaperRuntime();
+        $originalEscaperRuntime->setEscaper('test', static function (mixed $string) use (&$callCount): mixed {
             ++$callCount;
 
             return $string;
         });
 
-        static::assertTrue(CachedEscaperRuntime::escape($runtime, true, 'test'));
-        static::assertTrue(CachedEscaperRuntime::escape($runtime, true, 'test'));
-        static::assertFalse(CachedEscaperRuntime::escape($runtime, false, 'test'));
-        static::assertFalse(CachedEscaperRuntime::escape($runtime, false, 'test'));
+        static::assertTrue(CachedEscaperRuntime::escape($originalEscaperRuntime, true, 'test'));
+        static::assertTrue(CachedEscaperRuntime::escape($originalEscaperRuntime, true, 'test'));
+        static::assertFalse(CachedEscaperRuntime::escape($originalEscaperRuntime, false, 'test'));
+        static::assertFalse(CachedEscaperRuntime::escape($originalEscaperRuntime, false, 'test'));
 
         static::assertSame(4, $callCount);
     }

--- a/tests/unit/Core/Framework/Adapter/Twig/Runtime/CachedEscaperRuntimeTest.php
+++ b/tests/unit/Core/Framework/Adapter/Twig/Runtime/CachedEscaperRuntimeTest.php
@@ -4,10 +4,8 @@ namespace Shopware\Tests\Unit\Core\Framework\Adapter\Twig\Runtime;
 
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\Attributes\TestDox;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Adapter\Twig\Runtime\CachedEscaperRuntime;
-use Shopware\Core\Test\Assert\StrictEmpty;
 use Twig\Error\RuntimeError;
 use Twig\Runtime\EscaperRuntime;
 
@@ -17,7 +15,7 @@ use Twig\Runtime\EscaperRuntime;
 #[CoversClass(CachedEscaperRuntime::class)]
 class CachedEscaperRuntimeTest extends TestCase
 {
-    private CachedEscaperRuntime $escaper;
+    private EscaperRuntime $ogEscaperRuntime;
 
     /**
      * All character encodings supported by htmlspecialchars().
@@ -175,7 +173,7 @@ class CachedEscaperRuntimeTest extends TestCase
     protected function setUp(): void
     {
         CachedEscaperRuntime::resetEscapeCache();
-        $this->escaper = new CachedEscaperRuntime(new EscaperRuntime());
+        $this->ogEscaperRuntime = new EscaperRuntime();
     }
 
     protected function tearDown(): void
@@ -183,39 +181,24 @@ class CachedEscaperRuntimeTest extends TestCase
         CachedEscaperRuntime::resetEscapeCache();
     }
 
-    #[TestDox('stays in sync with upstream EscaperRuntime public methods')]
-    public function testAllPublicMethodsAreMimicked(): void
-    {
-        $originalMethodNames = get_class_methods(EscaperRuntime::class);
-        $cachedMethodNames = get_class_methods(CachedEscaperRuntime::class);
-
-        $missingMethods = array_diff($originalMethodNames, $cachedMethodNames);
-
-        // Will fail, if methods are added upstream
-        StrictEmpty::assertEmpty(
-            $missingMethods,
-            \sprintf('%s is missing following methods: %s', CachedEscaperRuntime::class, implode(', ', $missingMethods))
-        );
-    }
-
     public function testHtmlEscapingConvertsSpecialChars(): void
     {
         foreach (self::$htmlSpecialChars as $key => $value) {
-            static::assertSame($value, $this->escaper->escape($key), 'Failed to escape: ' . $key);
+            static::assertSame($value, CachedEscaperRuntime::escape($this->ogEscaperRuntime, $key), 'Failed to escape: ' . $key);
         }
     }
 
     public function testHtmlAttributeEscapingConvertsSpecialChars(): void
     {
         foreach (self::$htmlAttrSpecialChars as $key => $value) {
-            static::assertSame($value, $this->escaper->escape($key, 'html_attr'), 'Failed to escape: ' . $key);
+            static::assertSame($value, CachedEscaperRuntime::escape($this->ogEscaperRuntime, $key, 'html_attr'), 'Failed to escape: ' . $key);
         }
     }
 
     public function testJavascriptEscapingConvertsSpecialChars(): void
     {
         foreach (self::$jsSpecialChars as $key => $value) {
-            static::assertSame($value, $this->escaper->escape($key, 'js'), 'Failed to escape: ' . $key);
+            static::assertSame($value, CachedEscaperRuntime::escape($this->ogEscaperRuntime, $key, 'js'), 'Failed to escape: ' . $key);
         }
     }
 
@@ -226,7 +209,7 @@ class CachedEscaperRuntimeTest extends TestCase
         try {
             mb_internal_encoding('ISO-8859-1');
             foreach (self::$jsSpecialChars as $key => $value) {
-                static::assertSame($value, $this->escaper->escape($key, 'js'), 'Failed to escape: ' . $key);
+                static::assertSame($value, CachedEscaperRuntime::escape($this->ogEscaperRuntime, $key, 'js'), 'Failed to escape: ' . $key);
             }
         } finally {
             if ($previousInternalEncoding !== false) {
@@ -237,35 +220,35 @@ class CachedEscaperRuntimeTest extends TestCase
 
     public function testJavascriptEscapingReturnsStringIfZeroLength(): void
     {
-        static::assertSame('', $this->escaper->escape('', 'js'));
+        static::assertSame('', CachedEscaperRuntime::escape($this->ogEscaperRuntime, '', 'js'));
     }
 
     public function testJavascriptEscapingReturnsStringIfContainsOnlyDigits(): void
     {
-        static::assertSame('123', $this->escaper->escape('123', 'js'));
+        static::assertSame('123', CachedEscaperRuntime::escape($this->ogEscaperRuntime, '123', 'js'));
     }
 
     public function testCssEscapingConvertsSpecialChars(): void
     {
         foreach (self::$cssSpecialChars as $key => $value) {
-            static::assertSame($value, $this->escaper->escape($key, 'css'), 'Failed to escape: ' . $key);
+            static::assertSame($value, CachedEscaperRuntime::escape($this->ogEscaperRuntime, $key, 'css'), 'Failed to escape: ' . $key);
         }
     }
 
     public function testCssEscapingReturnsStringIfZeroLength(): void
     {
-        static::assertSame('', $this->escaper->escape('', 'css'));
+        static::assertSame('', CachedEscaperRuntime::escape($this->ogEscaperRuntime, '', 'css'));
     }
 
     public function testCssEscapingReturnsStringIfContainsOnlyDigits(): void
     {
-        static::assertSame('123', $this->escaper->escape('123', 'css'));
+        static::assertSame('123', CachedEscaperRuntime::escape($this->ogEscaperRuntime, '123', 'css'));
     }
 
     public function testUrlEscapingConvertsSpecialChars(): void
     {
         foreach (self::$urlSpecialChars as $key => $value) {
-            static::assertSame($value, $this->escaper->escape($key, 'url'), 'Failed to escape: ' . $key);
+            static::assertSame($value, CachedEscaperRuntime::escape($this->ogEscaperRuntime, $key, 'url'), 'Failed to escape: ' . $key);
         }
     }
 
@@ -294,15 +277,15 @@ class CachedEscaperRuntimeTest extends TestCase
                 || ($chr >= 0x41 && $chr <= 0x5A)
                 || ($chr >= 0x61 && $chr <= 0x7A)) {
                 $literal = $this->codepointToUtf8($chr);
-                static::assertSame($literal, $this->escaper->escape($literal, 'js'));
+                static::assertSame($literal, CachedEscaperRuntime::escape($this->ogEscaperRuntime, $literal, 'js'));
             } else {
                 $literal = $this->codepointToUtf8($chr);
                 if (\in_array($literal, $immune, true)) {
-                    static::assertSame($literal, $this->escaper->escape($literal, 'js'));
+                    static::assertSame($literal, CachedEscaperRuntime::escape($this->ogEscaperRuntime, $literal, 'js'));
                 } else {
                     static::assertNotSame(
                         $literal,
-                        $this->escaper->escape($literal, 'js'),
+                        CachedEscaperRuntime::escape($this->ogEscaperRuntime, $literal, 'js'),
                         "$literal should be escaped!"
                     );
                 }
@@ -318,15 +301,15 @@ class CachedEscaperRuntimeTest extends TestCase
                 || ($chr >= 0x41 && $chr <= 0x5A)
                 || ($chr >= 0x61 && $chr <= 0x7A)) {
                 $literal = $this->codepointToUtf8($chr);
-                static::assertSame($literal, $this->escaper->escape($literal, 'html_attr'));
+                static::assertSame($literal, CachedEscaperRuntime::escape($this->ogEscaperRuntime, $literal, 'html_attr'));
             } else {
                 $literal = $this->codepointToUtf8($chr);
                 if (\in_array($literal, $immune, true)) {
-                    static::assertSame($literal, $this->escaper->escape($literal, 'html_attr'));
+                    static::assertSame($literal, CachedEscaperRuntime::escape($this->ogEscaperRuntime, $literal, 'html_attr'));
                 } else {
                     static::assertNotSame(
                         $literal,
-                        $this->escaper->escape($literal, 'html_attr'),
+                        CachedEscaperRuntime::escape($this->ogEscaperRuntime, $literal, 'html_attr'),
                         "$literal should be escaped!"
                     );
                 }
@@ -342,12 +325,12 @@ class CachedEscaperRuntimeTest extends TestCase
                 || ($chr >= 0x41 && $chr <= 0x5A)
                 || ($chr >= 0x61 && $chr <= 0x7A)) {
                 $literal = $this->codepointToUtf8($chr);
-                static::assertSame($literal, $this->escaper->escape($literal, 'css'));
+                static::assertSame($literal, CachedEscaperRuntime::escape($this->ogEscaperRuntime, $literal, 'css'));
             } else {
                 $literal = $this->codepointToUtf8($chr);
                 static::assertNotSame(
                     $literal,
-                    $this->escaper->escape($literal, 'css'),
+                    CachedEscaperRuntime::escape($this->ogEscaperRuntime, $literal, 'css'),
                     "$literal should be escaped!"
                 );
             }
@@ -357,11 +340,10 @@ class CachedEscaperRuntimeTest extends TestCase
     #[DataProvider('provideCustomEscaperCases')]
     public function testCustomEscaper(string $expected, string $string, string $strategy): void
     {
-        $escapeRuntime = new EscaperRuntime();
-        $escapeRuntime->setEscaper('foo', foo_escaper_for_test(...));
-        $cachedEscaper = new CachedEscaperRuntime($escapeRuntime);
+        $runtime = new EscaperRuntime();
+        $runtime->setEscaper('foo', foo_escaper_for_test(...));
 
-        static::assertSame($expected, $cachedEscaper->escape($string, $strategy));
+        static::assertSame($expected, CachedEscaperRuntime::escape($runtime, $string, $strategy));
     }
 
     /**
@@ -377,7 +359,7 @@ class CachedEscaperRuntimeTest extends TestCase
     public function testUnknownCustomEscaper(): void
     {
         $this->expectExceptionObject(new RuntimeError('Invalid escaping strategy "bar" (valid ones: "html", "js", "url", "css", "html_attr", "html_attr_relaxed")'));
-        $this->escaper->escape('foo', 'bar');
+        CachedEscaperRuntime::escape($this->ogEscaperRuntime, 'foo', 'bar');
     }
 
     /**
@@ -387,13 +369,11 @@ class CachedEscaperRuntimeTest extends TestCase
     public function testObjectEscaping(string $escapedHtml, string $escapedJs, array $safeClasses): void
     {
         $obj = new Extension_TestClass();
-        $escapeRuntime = new EscaperRuntime();
-        $escapeRuntime->setSafeClasses($safeClasses);
+        $runtime = new EscaperRuntime();
+        $runtime->setSafeClasses($safeClasses);
 
-        $cachedEscaper = new CachedEscaperRuntime($escapeRuntime);
-
-        static::assertSame($escapedHtml, $cachedEscaper->escape($obj, 'html', null, true));
-        static::assertSame($escapedJs, $cachedEscaper->escape($obj, 'js', null, true));
+        static::assertSame($escapedHtml, CachedEscaperRuntime::escape($runtime, $obj, 'html', null, true));
+        static::assertSame($escapedJs, CachedEscaperRuntime::escape($runtime, $obj, 'js', null, true));
     }
 
     /**
@@ -449,7 +429,7 @@ class CachedEscaperRuntimeTest extends TestCase
     #[DataProvider('EscapeDataProvider')]
     public function testEscapeWithVariousInputs(array|int|float|string|null $input, array|int|float|string|null $expected): void
     {
-        $result = $this->escaper->escape($input);
+        $result = CachedEscaperRuntime::escape($this->ogEscaperRuntime, $input);
 
         static::assertSame($expected, $result);
     }
@@ -464,11 +444,9 @@ class CachedEscaperRuntimeTest extends TestCase
             return strtoupper($string);
         });
 
-        $escaper = new CachedEscaperRuntime($runtime);
-
-        static::assertSame('FOO', $escaper->escape('foo', 'test'));
-        static::assertSame('FOO', $escaper->escape('foo', 'test'));
-        static::assertSame('FOO', $escaper->escape('foo', 'test'));
+        static::assertSame('FOO', CachedEscaperRuntime::escape($runtime, 'foo', 'test'));
+        static::assertSame('FOO', CachedEscaperRuntime::escape($runtime, 'foo', 'test'));
+        static::assertSame('FOO', CachedEscaperRuntime::escape($runtime, 'foo', 'test'));
 
         static::assertSame(1, $callCount);
     }
@@ -488,12 +466,10 @@ class CachedEscaperRuntimeTest extends TestCase
             return strtolower($string);
         });
 
-        $escaper = new CachedEscaperRuntime($runtime);
-
-        static::assertSame('FOO', $escaper->escape('Foo', 'upper'));
-        static::assertSame('foo', $escaper->escape('Foo', 'lower'));
-        static::assertSame('FOO', $escaper->escape('Foo', 'upper'));
-        static::assertSame('foo', $escaper->escape('Foo', 'lower'));
+        static::assertSame('FOO', CachedEscaperRuntime::escape($runtime, 'Foo', 'upper'));
+        static::assertSame('foo', CachedEscaperRuntime::escape($runtime, 'Foo', 'lower'));
+        static::assertSame('FOO', CachedEscaperRuntime::escape($runtime, 'Foo', 'upper'));
+        static::assertSame('foo', CachedEscaperRuntime::escape($runtime, 'Foo', 'lower'));
 
         static::assertSame(2, $callCount);
     }
@@ -508,15 +484,13 @@ class CachedEscaperRuntimeTest extends TestCase
             return strtoupper($string);
         });
 
-        $escaper = new CachedEscaperRuntime($runtime);
-
         $stringable = new Extension_TestClass('foo1');
 
-        static::assertSame('FOO1', $escaper->escape($stringable, 'test'));
+        static::assertSame('FOO1', CachedEscaperRuntime::escape($runtime, $stringable, 'test'));
 
         $stringable->string = 'foo2';
 
-        static::assertSame('FOO2', $escaper->escape($stringable, 'test'));
+        static::assertSame('FOO2', CachedEscaperRuntime::escape($runtime, $stringable, 'test'));
 
         static::assertSame(2, $callCount);
     }
@@ -531,11 +505,10 @@ class CachedEscaperRuntimeTest extends TestCase
             return $string;
         });
 
-        $escaper = new CachedEscaperRuntime($runtime);
-        static::assertTrue($escaper->escape(true, 'test'));
-        static::assertTrue($escaper->escape(true, 'test'));
-        static::assertFalse($escaper->escape(false, 'test'));
-        static::assertFalse($escaper->escape(false, 'test'));
+        static::assertTrue(CachedEscaperRuntime::escape($runtime, true, 'test'));
+        static::assertTrue(CachedEscaperRuntime::escape($runtime, true, 'test'));
+        static::assertFalse(CachedEscaperRuntime::escape($runtime, false, 'test'));
+        static::assertFalse(CachedEscaperRuntime::escape($runtime, false, 'test'));
 
         static::assertSame(4, $callCount);
     }

--- a/tests/unit/Core/Framework/Adapter/Twig/TwigEnvironmentTest.php
+++ b/tests/unit/Core/Framework/Adapter/Twig/TwigEnvironmentTest.php
@@ -4,11 +4,8 @@ namespace Shopware\Tests\Unit\Core\Framework\Adapter\Twig;
 
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
-use Shopware\Core\Framework\Adapter\Twig\Runtime\CachedEscaperRuntime;
 use Shopware\Core\Framework\Adapter\Twig\TwigEnvironment;
 use Twig\Loader\ArrayLoader;
-use Twig\Runtime\EscaperRuntime;
-use Twig\RuntimeLoader\RuntimeLoaderInterface;
 use Twig\Source;
 
 /**
@@ -17,48 +14,13 @@ use Twig\Source;
 #[CoversClass(TwigEnvironment::class)]
 class TwigEnvironmentTest extends TestCase
 {
-    public function testUsesShopwareFunctions(): void
+    public function testUsesShopwareGetAttributeFunctionAndCachedEscaperRuntime(): void
     {
-        $twig = new TwigEnvironment(new ArrayLoader(['bla' => '{{ test.bla }}']));
-
-        $code = $twig->compileSource(new Source('{{ test.bla }}', 'bla'));
+        $code = (new TwigEnvironment(new ArrayLoader(['bla' => '{{ test.bla }}'])))
+            ->compileSource(new Source('{{ test.bla }}', 'bla'));
 
         static::assertStringContainsString('\Shopware\Core\Framework\Adapter\Twig\SwTwigFunction::getAttribute', $code);
-    }
-
-    public function testGetRuntimeToReturnCachedEscaper(): void
-    {
-        $escaper = (new TwigEnvironment(new ArrayLoader([])))->getRuntime(EscaperRuntime::class);
-        static::assertInstanceOf(CachedEscaperRuntime::class, $escaper);
-    }
-
-    public function testGetRuntimeCachesEscaperInstance(): void
-    {
-        $twig = new TwigEnvironment(new ArrayLoader([]));
-
-        $escaper = $twig->getRuntime(EscaperRuntime::class);
-        $secondCallEscaper = $twig->getRuntime(EscaperRuntime::class);
-
-        // Assert internal caching of the class
-        static::assertSame($escaper, $secondCallEscaper);
-    }
-
-    public function testGetRuntimeDelegatesOtherClasses(): void
-    {
-        $twig = new TwigEnvironment(new ArrayLoader([]));
-        $twig->addRuntimeLoader(new class implements RuntimeLoaderInterface {
-            public function load(string $class): ?\stdClass
-            {
-                if ($class === \stdClass::class) {
-                    return new \stdClass();
-                }
-
-                return null;
-            }
-        });
-
-        $otherRuntime = $twig->getRuntime(\stdClass::class);
-        static::assertInstanceOf(\stdClass::class, $otherRuntime);
+        static::assertStringContainsString('\Shopware\Core\Framework\Adapter\Twig\Runtime\CachedEscaperRuntime::escape($this->env->getRuntime(\'Twig\\Runtime\\EscaperRuntime\'),', $code);
     }
 
     public function testMarkupEscapeIsWorkingCorrectly(): void
@@ -78,7 +40,8 @@ TWIG;
             'Harald Doe',
             'Will Doe',
         ];
-        $renderedTemplate = (new TwigEnvironment(new ArrayLoader(['test' => $template])))->render('test', ['names' => $names]);
+        $renderedTemplate = (new TwigEnvironment(new ArrayLoader(['test' => $template])))
+            ->render('test', ['names' => $names]);
 
         foreach ($names as $name) {
             static::assertStringContainsString('Hello ' . $name, $renderedTemplate);


### PR DESCRIPTION
### 1. Why is this change necessary?

`symfony/ux-twig-component` is relying on the `EscaperRuntime` to be returned. the type is hardcoded, so the overwrite is not working, once we will introduce the UX components.

### 2. What does this change do, exactly?

Refactor to the previous string replace solution. Performance stays similar in same tests it was even faster.

### 3. Describe each step to reproduce the issue or behaviour.

Use Twig UX components with the current solution

### 4. Please link to the relevant issues (if any).

- closes #16420 

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
