### PR TITLE
feat: add stable company-registration flag to customer group registration API response

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -1,3 +1,12 @@
+# 6.7.11.0 (upcoming)
+
+## API
+
+### Customer group registration config now returns a stable company-registration flag
+
+The Store API endpoint `GET /store-api/customer-group-registration/config/{customerGroupId}` now exposes `registrationOnlyCompanyRegistration` as a top-level response field.
+For backward compatibility, `translated.registrationOnlyCompanyRegistration` is still present but deprecated. If the value is not set for a customer group yet, the endpoint now returns `false` instead of `null`.
+
 # 6.7.10.0 (upcoming)
 
 ## Features
@@ -6,13 +15,6 @@
 
 A new "Agentic Commerce" sales channel type is available in this release. The OpenAI Merchant Center integration is the first supported provider for AI-powered product feed exports.
 The Administration includes dedicated views for configuration, product mapping, and usage insights.
-
-## API
-
-### Customer group registration config now returns a stable company-registration flag
-
-The Store API endpoint `GET /store-api/customer-group-registration/config/{customerGroupId}` now exposes `registrationOnlyCompanyRegistration` as a top-level response field.
-For backward compatibility, `translated.registrationOnlyCompanyRegistration` is still present but deprecated. If the value is not set for a customer group yet, the endpoint now returns `false` instead of `null`.
 
 ### Per-user and per-IP rate limiters for login and OAuth
 

--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -9,6 +9,11 @@ The Administration includes dedicated views for configuration, product mapping, 
 
 ## API
 
+### Customer group registration config now returns a stable company-registration flag
+
+The Store API endpoint `GET /store-api/customer-group-registration/config/{customerGroupId}` now exposes `registrationOnlyCompanyRegistration` as a top-level response field.
+For backward compatibility, `translated.registrationOnlyCompanyRegistration` is still present but deprecated. If the value is not set for a customer group yet, the endpoint now returns `false` instead of `null`.
+
 ### Per-user and per-IP rate limiters for login and OAuth
 
 The login and OAuth token endpoints now support optional per user (`login_user`, `oauth_user`) and per IP (`login_client`, `oauth_client`) rate limiters, in addition to the existing combined user and IP limiter.

--- a/src/Core/Checkout/Customer/SalesChannel/CustomerGroupRegistrationSettingsRouteResponse.php
+++ b/src/Core/Checkout/Customer/SalesChannel/CustomerGroupRegistrationSettingsRouteResponse.php
@@ -3,17 +3,37 @@
 namespace Shopware\Core\Checkout\Customer\SalesChannel;
 
 use Shopware\Core\Checkout\Customer\Aggregate\CustomerGroup\CustomerGroupEntity;
+use Shopware\Core\Framework\Struct\ArrayStruct;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\StoreApiResponse;
 
 /**
- * @extends StoreApiResponse<CustomerGroupEntity>
+ * @extends StoreApiResponse<ArrayStruct<array<string, mixed>>>
  */
 #[Package('checkout')]
 class CustomerGroupRegistrationSettingsRouteResponse extends StoreApiResponse
 {
+    public function __construct(
+        private readonly CustomerGroupEntity $registration,
+    ) {
+        $payload = $registration->getVars();
+        $translated = $payload['translated'] ?? [];
+
+        if (!\is_array($translated)) {
+            $translated = [];
+        }
+
+        $registrationOnlyCompanyRegistration = $translated['registrationOnlyCompanyRegistration'] ?? false;
+        $translated['registrationOnlyCompanyRegistration'] = (bool) $registrationOnlyCompanyRegistration;
+
+        $payload['translated'] = $translated;
+        $payload['registrationOnlyCompanyRegistration'] = (bool) $registrationOnlyCompanyRegistration;
+
+        parent::__construct(new ArrayStruct($payload, $registration->getApiAlias()));
+    }
+
     public function getRegistration(): CustomerGroupEntity
     {
-        return $this->object;
+        return $this->registration;
     }
 }

--- a/src/Core/Checkout/Customer/SalesChannel/CustomerGroupRegistrationSettingsRouteResponse.php
+++ b/src/Core/Checkout/Customer/SalesChannel/CustomerGroupRegistrationSettingsRouteResponse.php
@@ -3,6 +3,7 @@
 namespace Shopware\Core\Checkout\Customer\SalesChannel;
 
 use Shopware\Core\Checkout\Customer\Aggregate\CustomerGroup\CustomerGroupEntity;
+use Shopware\Core\Framework\Struct\Struct;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\ArrayStruct;
 use Shopware\Core\System\SalesChannel\StoreApiResponse;
@@ -13,11 +14,17 @@ use Shopware\Core\System\SalesChannel\StoreApiResponse;
 #[Package('checkout')]
 class CustomerGroupRegistrationSettingsRouteResponse extends StoreApiResponse
 {
+    private CustomerGroupEntity $registration;
+
     public function __construct(
-        private readonly CustomerGroupEntity $registration,
+        Struct $object,
     ) {
+        \assert($object instanceof CustomerGroupEntity);
+
+        $this->registration = $object;
+
         /** @var array<string, mixed> $payload */
-        $payload = $registration->getVars();
+        $payload = $object->getVars();
         $translated = $payload['translated'] ?? [];
 
         if (!\is_array($translated)) {
@@ -31,7 +38,7 @@ class CustomerGroupRegistrationSettingsRouteResponse extends StoreApiResponse
         $payload['registrationOnlyCompanyRegistration'] = (bool) $registrationOnlyCompanyRegistration;
 
         /** @var ArrayStruct<array<string, mixed>> $response */
-        $response = new ArrayStruct($payload, $registration->getApiAlias());
+        $response = new ArrayStruct($payload, $object->getApiAlias());
 
         parent::__construct($response);
     }

--- a/src/Core/Checkout/Customer/SalesChannel/CustomerGroupRegistrationSettingsRouteResponse.php
+++ b/src/Core/Checkout/Customer/SalesChannel/CustomerGroupRegistrationSettingsRouteResponse.php
@@ -3,19 +3,22 @@
 namespace Shopware\Core\Checkout\Customer\SalesChannel;
 
 use Shopware\Core\Checkout\Customer\Aggregate\CustomerGroup\CustomerGroupEntity;
-use Shopware\Core\Framework\Struct\Struct;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\ArrayStruct;
+use Shopware\Core\Framework\Struct\Struct;
 use Shopware\Core\System\SalesChannel\StoreApiResponse;
 
 /**
- * @extends StoreApiResponse<ArrayStruct<array<string, mixed>>>
+ * @extends StoreApiResponse<Struct>
  */
 #[Package('checkout')]
 class CustomerGroupRegistrationSettingsRouteResponse extends StoreApiResponse
 {
     private CustomerGroupEntity $registration;
 
+    /**
+     * @param CustomerGroupEntity $object
+     */
     public function __construct(
         Struct $object,
     ) {

--- a/src/Core/Checkout/Customer/SalesChannel/CustomerGroupRegistrationSettingsRouteResponse.php
+++ b/src/Core/Checkout/Customer/SalesChannel/CustomerGroupRegistrationSettingsRouteResponse.php
@@ -3,8 +3,8 @@
 namespace Shopware\Core\Checkout\Customer\SalesChannel;
 
 use Shopware\Core\Checkout\Customer\Aggregate\CustomerGroup\CustomerGroupEntity;
-use Shopware\Core\Framework\Struct\ArrayStruct;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Struct\ArrayStruct;
 use Shopware\Core\System\SalesChannel\StoreApiResponse;
 
 /**
@@ -16,6 +16,7 @@ class CustomerGroupRegistrationSettingsRouteResponse extends StoreApiResponse
     public function __construct(
         private readonly CustomerGroupEntity $registration,
     ) {
+        /** @var array<string, mixed> $payload */
         $payload = $registration->getVars();
         $translated = $payload['translated'] ?? [];
 
@@ -29,7 +30,10 @@ class CustomerGroupRegistrationSettingsRouteResponse extends StoreApiResponse
         $payload['translated'] = $translated;
         $payload['registrationOnlyCompanyRegistration'] = (bool) $registrationOnlyCompanyRegistration;
 
-        parent::__construct(new ArrayStruct($payload, $registration->getApiAlias()));
+        /** @var ArrayStruct<array<string, mixed>> $response */
+        $response = new ArrayStruct($payload, $registration->getApiAlias());
+
+        parent::__construct($response);
     }
 
     public function getRegistration(): CustomerGroupEntity

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/components/schemas/CustomerGroup.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/components/schemas/CustomerGroup.json
@@ -7,6 +7,12 @@
             "CustomerGroup": {
                 "required": ["translated"],
                 "properties": {
+                    "id": {
+                        "type": "string"
+                    },
+                    "registrationOnlyCompanyRegistration": {
+                        "type": "boolean"
+                    },
                     "translated": {
                         "type": "object",
                         "properties": {
@@ -18,6 +24,10 @@
                             },
                             "registrationSeoMetaDescription": {
                                 "type": "string"
+                            },
+                            "registrationOnlyCompanyRegistration": {
+                                "type": "boolean",
+                                "deprecated": true
                             },
                             "registrationTitle": {
                                 "type": "string"

--- a/tests/integration/Core/Checkout/Customer/SalesChannel/CustomerGroupRegistrationSettingsRouteTest.php
+++ b/tests/integration/Core/Checkout/Customer/SalesChannel/CustomerGroupRegistrationSettingsRouteTest.php
@@ -61,6 +61,7 @@ class CustomerGroupRegistrationSettingsRouteTest extends TestCase
                 'name' => 'foo',
                 'registrationActive' => true,
                 'registrationTitle' => 'test',
+                'registrationOnlyCompanyRegistration' => true,
                 'registrationSalesChannels' => [['id' => $this->getSalesChannelApiSalesChannelId()]],
             ],
         ], Context::createDefaultContext());
@@ -76,5 +77,36 @@ class CustomerGroupRegistrationSettingsRouteTest extends TestCase
 
         static::assertSame($this->ids->get('group'), $response['id']);
         static::assertSame('test', $response['registrationTitle']);
+        static::assertTrue($response['registrationOnlyCompanyRegistration']);
+        static::assertArrayHasKey('translated', $response);
+        static::assertTrue($response['translated']['registrationOnlyCompanyRegistration']);
+    }
+
+    public function testWithValidConfigWithoutCompanyRegistrationFlagDoesNotCrash(): void
+    {
+        $customerGroupRepository = static::getContainer()->get('customer_group.repository');
+        $customerGroupRepository->create([
+            [
+                'id' => $this->ids->create('group-without-flag'),
+                'name' => 'foo',
+                'registrationActive' => true,
+                'registrationTitle' => 'test',
+                'registrationSalesChannels' => [['id' => $this->getSalesChannelApiSalesChannelId()]],
+            ],
+        ], Context::createDefaultContext());
+
+        $this->browser
+            ->request(
+                'GET',
+                '/store-api/customer-group-registration/config/' . $this->ids->get('group-without-flag')
+            );
+
+        $response = json_decode($this->browser->getResponse()->getContent() ?: '', true, 512, \JSON_THROW_ON_ERROR);
+        static::assertSame(200, $this->browser->getResponse()->getStatusCode());
+
+        static::assertSame($this->ids->get('group-without-flag'), $response['id']);
+        static::assertFalse($response['registrationOnlyCompanyRegistration']);
+        static::assertArrayHasKey('translated', $response);
+        static::assertFalse($response['translated']['registrationOnlyCompanyRegistration']);
     }
 }

--- a/tests/unit/Core/Checkout/Customer/SalesChannel/CustomerGroupRegistrationSettingsRouteResponseTest.php
+++ b/tests/unit/Core/Checkout/Customer/SalesChannel/CustomerGroupRegistrationSettingsRouteResponseTest.php
@@ -1,0 +1,64 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Checkout\Customer\SalesChannel;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Checkout\Customer\Aggregate\CustomerGroup\CustomerGroupEntity;
+use Shopware\Core\Checkout\Customer\SalesChannel\CustomerGroupRegistrationSettingsRouteResponse;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Struct\ArrayStruct;
+
+/**
+ * @internal
+ */
+#[CoversClass(CustomerGroupRegistrationSettingsRouteResponse::class)]
+#[Package('checkout')]
+class CustomerGroupRegistrationSettingsRouteResponseTest extends TestCase
+{
+    public function testConstructMapsCompanyRegistrationFlagToRootAndKeepsRegistration(): void
+    {
+        $registration = new CustomerGroupEntity();
+        $registration->setName('Test group');
+        $registration->setTranslated([
+            'registrationOnlyCompanyRegistration' => true,
+            'registrationTitle' => 'Business registration',
+        ]);
+
+        $response = new CustomerGroupRegistrationSettingsRouteResponse($registration);
+        $object = $response->getObject();
+
+        static::assertSame($registration, $response->getRegistration());
+        static::assertInstanceOf(ArrayStruct::class, $object);
+        static::assertTrue($object->get('registrationOnlyCompanyRegistration'));
+        static::assertSame(
+            [
+                'registrationOnlyCompanyRegistration' => true,
+                'registrationTitle' => 'Business registration',
+            ],
+            $object->get('translated')
+        );
+    }
+
+    public function testConstructDefaultsMissingCompanyRegistrationFlagToFalse(): void
+    {
+        $registration = new CustomerGroupEntity();
+        $registration->setName('Test group');
+        $registration->setTranslated([
+            'registrationTitle' => 'Business registration',
+        ]);
+
+        $response = new CustomerGroupRegistrationSettingsRouteResponse($registration);
+        $object = $response->getObject();
+
+        static::assertInstanceOf(ArrayStruct::class, $object);
+        static::assertFalse($object->get('registrationOnlyCompanyRegistration'));
+        static::assertSame(
+            [
+                'registrationTitle' => 'Business registration',
+                'registrationOnlyCompanyRegistration' => false,
+            ],
+            $object->get('translated')
+        );
+    }
+}


### PR DESCRIPTION
closes #16461

This pull request updates the customer group registration API to provide a more stable and explicit company registration flag, improves the API schema, and enhances test coverage for this behavior. The main changes are grouped below:

**API Response Improvements:**

* The Store API endpoint `GET /store-api/customer-group-registration/config/{customerGroupId}` now exposes `registrationOnlyCompanyRegistration` as a top-level boolean field in its response. The value defaults to `false` if not set, instead of `null`. For backward compatibility, the same field remains in the `translated` object but is marked as deprecated. [[1]](diffhunk://#diff-819080d3452b5ad5bc86679c15267c543f1920c1f4dae27011f14ccd463ffcdcR12-R16) [[2]](diffhunk://#diff-97c5c4969cea6de1b12aa52a65951511454d6802828e887700ae3ac9811f0357R6-R37)

**API Schema Updates:**

* The OpenAPI schema (`CustomerGroup.json`) now documents `registrationOnlyCompanyRegistration` as a top-level boolean property and also as a deprecated property within `translated`. The `id` field is also explicitly included. [[1]](diffhunk://#diff-e743bc707f0275dfd096880ac5aff6308b772b95b7276c765e637ae2335aa8dbR10-R15) [[2]](diffhunk://#diff-e743bc707f0275dfd096880ac5aff6308b772b95b7276c765e637ae2335aa8dbR28-R31)