### PR TITLE
feat: list elasticsearch.yaml analyzers in es:test:analyzer

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -25,6 +25,11 @@ Arbitrary unknown top-level keys are still forwarded for backwards compatibility
 
 ## Core
 
+### `es:test:analyzer` lists analyzers configured in `elasticsearch.yaml`
+
+The `es:test:analyzer` command now also runs the analyzers defined under `elasticsearch.analysis.analyzer` (e.g. `sw_whitespace_analyzer`, `sw_ngram_analyzer`, `sw_english_analyzer`, `sw_german_analyzer`) against the given term, alongside the built-in default and language analyzers.
+The custom analyzers are sent to OpenSearch as inline `_analyze` requests with their tokenizer, char filters and filters resolved from `elasticsearch.analysis.filter`, so the command does not require an existing index that has the analyzer installed.
+
 ### Backward compatible invalid locales
 
 Added and deprecated `BackwardCompatibleNumberFormatter` to temporarily allow invalid locale strings without throwing exceptions in PHP >=8.4. It will be removed in Shopware 6.8.

--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -27,8 +27,9 @@ Arbitrary unknown top-level keys are still forwarded for backwards compatibility
 
 ### `es:test:analyzer` lists analyzers configured in `elasticsearch.yaml`
 
-The `es:test:analyzer` command now also runs the analyzers defined under `elasticsearch.analysis.analyzer` (e.g. `sw_whitespace_analyzer`, `sw_ngram_analyzer`, `sw_english_analyzer`, `sw_german_analyzer`) against the given term, alongside the built-in default and language analyzers.
+The `es:test:analyzer` command now runs the analyzers defined under `elasticsearch.analysis.analyzer` (e.g. `sw_whitespace_analyzer`, `sw_ngram_analyzer`, `sw_english_analyzer`, `sw_german_analyzer`) against the given term, alongside the built-in default analyzers.
 The custom analyzers are sent to OpenSearch as inline `_analyze` requests with their tokenizer, char filters and filters resolved from `elasticsearch.analysis.filter`, so the command does not require an existing index that has the analyzer installed.
+The long list of built-in language analyzers (`arabic`, `english`, `german`, ...) is no longer printed by default; pass `--with-language-analyzers` to include them when comparing custom analyzers against their built-in counterparts.
 
 ### Backward compatible invalid locales
 

--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -27,9 +27,9 @@ Arbitrary unknown top-level keys are still forwarded for backwards compatibility
 
 ### `es:test:analyzer` lists analyzers configured in `elasticsearch.yaml`
 
-The `es:test:analyzer` command now runs the analyzers defined under `elasticsearch.analysis.analyzer` (e.g. `sw_whitespace_analyzer`, `sw_ngram_analyzer`, `sw_english_analyzer`, `sw_german_analyzer`) against the given term, alongside the built-in default analyzers.
+The `es:test:analyzer` command now runs the analyzers defined under `elasticsearch.analysis.analyzer` (e.g. `sw_whitespace_analyzer`, `sw_ngram_analyzer`, `sw_english_analyzer`, `sw_german_analyzer`) against the given term.
 The custom analyzers are sent to OpenSearch as inline `_analyze` requests with their tokenizer, char filters and filters resolved from `elasticsearch.analysis.filter`, so the command does not require an existing index that has the analyzer installed.
-The long list of built-in language analyzers (`arabic`, `english`, `german`, ...) is no longer printed by default; pass `--with-language-analyzers` to include them when comparing custom analyzers against their built-in counterparts.
+By default only the custom analyzers are printed; pass `--all` (`-a`) to additionally run the built-in default and language analyzers (`standard`, `whitespace`, ..., `english`, `german`, ...) for comparison.
 
 ### Backward compatible invalid locales
 

--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -1801,6 +1801,11 @@ Arbitrary unknown top-level keys are still forwarded for backwards compatibility
 
 ## Core
 
+### `es:test:analyzer` lists analyzers configured in `elasticsearch.yaml`
+
+The `es:test:analyzer` command now also runs the analyzers defined under `elasticsearch.analysis.analyzer` (e.g. `sw_whitespace_analyzer`, `sw_ngram_analyzer`, `sw_english_analyzer`, `sw_german_analyzer`) against the given term, alongside the built-in default and language analyzers.
+The custom analyzers are sent to OpenSearch as inline `_analyze` requests with their tokenizer, char filters and filters resolved from `elasticsearch.analysis.filter`, so the command does not require an existing index that has the analyzer installed.
+
 ### Backward compatible invalid locales
 
 Added and deprecated `BackwardCompatibleNumberFormatter` to temporarily allow invalid locale strings without throwing exceptions in PHP >=8.4. It will be removed in Shopware 6.8.

--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -1803,8 +1803,9 @@ Arbitrary unknown top-level keys are still forwarded for backwards compatibility
 
 ### `es:test:analyzer` lists analyzers configured in `elasticsearch.yaml`
 
-The `es:test:analyzer` command now also runs the analyzers defined under `elasticsearch.analysis.analyzer` (e.g. `sw_whitespace_analyzer`, `sw_ngram_analyzer`, `sw_english_analyzer`, `sw_german_analyzer`) against the given term, alongside the built-in default and language analyzers.
+The `es:test:analyzer` command now runs the analyzers defined under `elasticsearch.analysis.analyzer` (e.g. `sw_whitespace_analyzer`, `sw_ngram_analyzer`, `sw_english_analyzer`, `sw_german_analyzer`) against the given term, alongside the built-in default analyzers.
 The custom analyzers are sent to OpenSearch as inline `_analyze` requests with their tokenizer, char filters and filters resolved from `elasticsearch.analysis.filter`, so the command does not require an existing index that has the analyzer installed.
+The long list of built-in language analyzers (`arabic`, `english`, `german`, ...) is no longer printed by default; pass `--with-language-analyzers` to include them when comparing custom analyzers against their built-in counterparts.
 
 ### Backward compatible invalid locales
 

--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -1803,8 +1803,8 @@ Arbitrary unknown top-level keys are still forwarded for backwards compatibility
 
 ### `es:test:analyzer` lists analyzers configured in `elasticsearch.yaml`
 
-The `es:test:analyzer` command now runs the analyzers defined under `elasticsearch.analysis.analyzer` (e.g. `sw_whitespace_analyzer`, `sw_ngram_analyzer`, `sw_english_analyzer`, `sw_german_analyzer`) against the given term.
-The custom analyzers are sent to OpenSearch as inline `_analyze` requests with their tokenizer, char filters and filters resolved from `elasticsearch.analysis.filter`, so the command does not require an existing index that has the analyzer installed.
+The `es:test:analyzer` command now runs the analyzers defined under `elasticsearch.analysis.analyzer` (e.g. `sw_whitespace_analyzer`, `sw_ngram_analyzer`, `sw_english_analyzer`, `sw_german_analyzer`) against the given term, followed by the admin analyzers from `elasticsearch.administration.analysis.analyzer`.
+The custom analyzers are sent to OpenSearch as inline `_analyze` requests, with their tokenizer, char filters and filters resolved from the matching `elasticsearch.analysis.tokenizer`, `.char_filter` and `.filter` sections, so the command does not require an existing index that has the analyzer installed. The chains reflect `SHOPWARE_ES_DIMENSION_NORMALIZE`, so the reported tokens match the ones the live index produces. Analyzers that are not of type `custom` cannot be expressed as an inline `_analyze` body and are listed as not testable instead.
 By default only the custom analyzers are printed; pass `--all` (`-a`) to additionally run the built-in default and language analyzers (`standard`, `whitespace`, ..., `english`, `german`, ...) for comparison.
 
 ### Backward compatible invalid locales

--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -123,6 +123,7 @@ A new `--orphans` (`-o`) option deletes only those orphaned files. Referenced th
 `Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria::resetFields()` drops an allowlist added via `addFields()`, `Criteria::resetExcludedFields()` drops a denylist added via `excludeFields()`. Both selections are mutually exclusive, so the new methods also allow switching a criteria from one to the other.
 
 They affect the database read, unlike `includes` and `excludes`, which only shape the API response.
+
 ### `es:test:analyzer` lists analyzers configured in `elasticsearch.yaml`
 
 The `es:test:analyzer` command now runs the analyzers defined under `elasticsearch.analysis.analyzer` (e.g. `sw_whitespace_analyzer`, `sw_ngram_analyzer`, `sw_english_analyzer`, `sw_german_analyzer`) against the given term, followed by the admin analyzers from `elasticsearch.administration.analysis.analyzer`.

--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -126,8 +126,8 @@ They affect the database read, unlike `includes` and `excludes`, which only shap
 
 ### `es:test:analyzer` lists analyzers configured in `elasticsearch.yaml`
 
-The `es:test:analyzer` command now runs the analyzers defined under `elasticsearch.analysis.analyzer` (e.g. `sw_whitespace_analyzer`, `sw_ngram_analyzer`, `sw_english_analyzer`, `sw_german_analyzer`) against the given term, followed by the admin analyzers from `elasticsearch.administration.analysis.analyzer`.
-The custom analyzers are sent to OpenSearch as inline `_analyze` requests, with their tokenizer, char filters and filters resolved from the matching `elasticsearch.analysis.tokenizer`, `.char_filter` and `.filter` sections, so the command does not require an existing index that has the analyzer installed. The chains reflect `SHOPWARE_ES_DIMENSION_NORMALIZE`, so the reported tokens match the ones the live index produces. Analyzers that are not of type `custom` cannot be expressed as an inline `_analyze` body and are listed as not testable instead.
+The `es:test:analyzer` command now runs the analyzers defined under `elasticsearch.analysis.analyzer` (e.g. `sw_whitespace_analyzer`, `sw_ngram_analyzer`, `sw_english_analyzer`, `sw_german_analyzer`) against the given term.
+The custom analyzers are sent to OpenSearch as inline `_analyze` requests, with their tokenizer, char filters and filters resolved from the matching `elasticsearch.analysis.tokenizer`, `.char_filter` and `.filter` sections, so the command does not require an existing index that has the analyzer installed. The chains reflect `SHOPWARE_ES_DIMENSION_NORMALIZE`, so the reported tokens match the ones the live index produces.
 By default only the custom analyzers are printed; pass `--all` (`-a`) to additionally run the built-in default and language analyzers (`standard`, `whitespace`, ..., `english`, `german`, ...) for comparison.
 
 ### GARAN commercial guarantee label and EU legal guarantee notice

--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -1803,9 +1803,9 @@ Arbitrary unknown top-level keys are still forwarded for backwards compatibility
 
 ### `es:test:analyzer` lists analyzers configured in `elasticsearch.yaml`
 
-The `es:test:analyzer` command now runs the analyzers defined under `elasticsearch.analysis.analyzer` (e.g. `sw_whitespace_analyzer`, `sw_ngram_analyzer`, `sw_english_analyzer`, `sw_german_analyzer`) against the given term, alongside the built-in default analyzers.
+The `es:test:analyzer` command now runs the analyzers defined under `elasticsearch.analysis.analyzer` (e.g. `sw_whitespace_analyzer`, `sw_ngram_analyzer`, `sw_english_analyzer`, `sw_german_analyzer`) against the given term.
 The custom analyzers are sent to OpenSearch as inline `_analyze` requests with their tokenizer, char filters and filters resolved from `elasticsearch.analysis.filter`, so the command does not require an existing index that has the analyzer installed.
-The long list of built-in language analyzers (`arabic`, `english`, `german`, ...) is no longer printed by default; pass `--with-language-analyzers` to include them when comparing custom analyzers against their built-in counterparts.
+By default only the custom analyzers are printed; pass `--all` (`-a`) to additionally run the built-in default and language analyzers (`standard`, `whitespace`, ..., `english`, `german`, ...) for comparison.
 
 ### Backward compatible invalid locales
 

--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -123,6 +123,11 @@ A new `--orphans` (`-o`) option deletes only those orphaned files. Referenced th
 `Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria::resetFields()` drops an allowlist added via `addFields()`, `Criteria::resetExcludedFields()` drops a denylist added via `excludeFields()`. Both selections are mutually exclusive, so the new methods also allow switching a criteria from one to the other.
 
 They affect the database read, unlike `includes` and `excludes`, which only shape the API response.
+### `es:test:analyzer` lists analyzers configured in `elasticsearch.yaml`
+
+The `es:test:analyzer` command now runs the analyzers defined under `elasticsearch.analysis.analyzer` (e.g. `sw_whitespace_analyzer`, `sw_ngram_analyzer`, `sw_english_analyzer`, `sw_german_analyzer`) against the given term, followed by the admin analyzers from `elasticsearch.administration.analysis.analyzer`.
+The custom analyzers are sent to OpenSearch as inline `_analyze` requests, with their tokenizer, char filters and filters resolved from the matching `elasticsearch.analysis.tokenizer`, `.char_filter` and `.filter` sections, so the command does not require an existing index that has the analyzer installed. The chains reflect `SHOPWARE_ES_DIMENSION_NORMALIZE`, so the reported tokens match the ones the live index produces. Analyzers that are not of type `custom` cannot be expressed as an inline `_analyze` body and are listed as not testable instead.
+By default only the custom analyzers are printed; pass `--all` (`-a`) to additionally run the built-in default and language analyzers (`standard`, `whitespace`, ..., `english`, `german`, ...) for comparison.
 
 ### GARAN commercial guarantee label and EU legal guarantee notice
 
@@ -1800,12 +1805,6 @@ The `/api/_action/mail-template/send` payload now also has a first-class `extens
 Arbitrary unknown top-level keys are still forwarded for backwards compatibility in 6.7, but they are deprecated and will stop being forwarded in Shopware 6.8.
 
 ## Core
-
-### `es:test:analyzer` lists analyzers configured in `elasticsearch.yaml`
-
-The `es:test:analyzer` command now runs the analyzers defined under `elasticsearch.analysis.analyzer` (e.g. `sw_whitespace_analyzer`, `sw_ngram_analyzer`, `sw_english_analyzer`, `sw_german_analyzer`) against the given term, followed by the admin analyzers from `elasticsearch.administration.analysis.analyzer`.
-The custom analyzers are sent to OpenSearch as inline `_analyze` requests, with their tokenizer, char filters and filters resolved from the matching `elasticsearch.analysis.tokenizer`, `.char_filter` and `.filter` sections, so the command does not require an existing index that has the analyzer installed. The chains reflect `SHOPWARE_ES_DIMENSION_NORMALIZE`, so the reported tokens match the ones the live index produces. Analyzers that are not of type `custom` cannot be expressed as an inline `_analyze` body and are listed as not testable instead.
-By default only the custom analyzers are printed; pass `--all` (`-a`) to additionally run the built-in default and language analyzers (`standard`, `whitespace`, ..., `english`, `german`, ...) for comparison.
 
 ### Backward compatible invalid locales
 

--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -1667,6 +1667,11 @@ Arbitrary unknown top-level keys are still forwarded for backwards compatibility
 
 ## Core
 
+### `es:test:analyzer` lists analyzers configured in `elasticsearch.yaml`
+
+The `es:test:analyzer` command now also runs the analyzers defined under `elasticsearch.analysis.analyzer` (e.g. `sw_whitespace_analyzer`, `sw_ngram_analyzer`, `sw_english_analyzer`, `sw_german_analyzer`) against the given term, alongside the built-in default and language analyzers.
+The custom analyzers are sent to OpenSearch as inline `_analyze` requests with their tokenizer, char filters and filters resolved from `elasticsearch.analysis.filter`, so the command does not require an existing index that has the analyzer installed.
+
 ### Backward compatible invalid locales
 
 Added and deprecated `BackwardCompatibleNumberFormatter` to temporarily allow invalid locale strings without throwing exceptions in PHP >=8.4. It will be removed in Shopware 6.8.

--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -1669,9 +1669,9 @@ Arbitrary unknown top-level keys are still forwarded for backwards compatibility
 
 ### `es:test:analyzer` lists analyzers configured in `elasticsearch.yaml`
 
-The `es:test:analyzer` command now runs the analyzers defined under `elasticsearch.analysis.analyzer` (e.g. `sw_whitespace_analyzer`, `sw_ngram_analyzer`, `sw_english_analyzer`, `sw_german_analyzer`) against the given term, alongside the built-in default analyzers.
+The `es:test:analyzer` command now runs the analyzers defined under `elasticsearch.analysis.analyzer` (e.g. `sw_whitespace_analyzer`, `sw_ngram_analyzer`, `sw_english_analyzer`, `sw_german_analyzer`) against the given term.
 The custom analyzers are sent to OpenSearch as inline `_analyze` requests with their tokenizer, char filters and filters resolved from `elasticsearch.analysis.filter`, so the command does not require an existing index that has the analyzer installed.
-The long list of built-in language analyzers (`arabic`, `english`, `german`, ...) is no longer printed by default; pass `--with-language-analyzers` to include them when comparing custom analyzers against their built-in counterparts.
+By default only the custom analyzers are printed; pass `--all` (`-a`) to additionally run the built-in default and language analyzers (`standard`, `whitespace`, ..., `english`, `german`, ...) for comparison.
 
 ### Backward compatible invalid locales
 

--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -1669,8 +1669,9 @@ Arbitrary unknown top-level keys are still forwarded for backwards compatibility
 
 ### `es:test:analyzer` lists analyzers configured in `elasticsearch.yaml`
 
-The `es:test:analyzer` command now also runs the analyzers defined under `elasticsearch.analysis.analyzer` (e.g. `sw_whitespace_analyzer`, `sw_ngram_analyzer`, `sw_english_analyzer`, `sw_german_analyzer`) against the given term, alongside the built-in default and language analyzers.
+The `es:test:analyzer` command now runs the analyzers defined under `elasticsearch.analysis.analyzer` (e.g. `sw_whitespace_analyzer`, `sw_ngram_analyzer`, `sw_english_analyzer`, `sw_german_analyzer`) against the given term, alongside the built-in default analyzers.
 The custom analyzers are sent to OpenSearch as inline `_analyze` requests with their tokenizer, char filters and filters resolved from `elasticsearch.analysis.filter`, so the command does not require an existing index that has the analyzer installed.
+The long list of built-in language analyzers (`arabic`, `english`, `german`, ...) is no longer printed by default; pass `--with-language-analyzers` to include them when comparing custom analyzers against their built-in counterparts.
 
 ### Backward compatible invalid locales
 

--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -1669,8 +1669,8 @@ Arbitrary unknown top-level keys are still forwarded for backwards compatibility
 
 ### `es:test:analyzer` lists analyzers configured in `elasticsearch.yaml`
 
-The `es:test:analyzer` command now runs the analyzers defined under `elasticsearch.analysis.analyzer` (e.g. `sw_whitespace_analyzer`, `sw_ngram_analyzer`, `sw_english_analyzer`, `sw_german_analyzer`) against the given term.
-The custom analyzers are sent to OpenSearch as inline `_analyze` requests with their tokenizer, char filters and filters resolved from `elasticsearch.analysis.filter`, so the command does not require an existing index that has the analyzer installed.
+The `es:test:analyzer` command now runs the analyzers defined under `elasticsearch.analysis.analyzer` (e.g. `sw_whitespace_analyzer`, `sw_ngram_analyzer`, `sw_english_analyzer`, `sw_german_analyzer`) against the given term, followed by the admin analyzers from `elasticsearch.administration.analysis.analyzer`.
+The custom analyzers are sent to OpenSearch as inline `_analyze` requests, with their tokenizer, char filters and filters resolved from the matching `elasticsearch.analysis.tokenizer`, `.char_filter` and `.filter` sections, so the command does not require an existing index that has the analyzer installed. The chains reflect `SHOPWARE_ES_DIMENSION_NORMALIZE`, so the reported tokens match the ones the live index produces. Analyzers that are not of type `custom` cannot be expressed as an inline `_analyze` body and are listed as not testable instead.
 By default only the custom analyzers are printed; pass `--all` (`-a`) to additionally run the built-in default and language analyzers (`standard`, `whitespace`, ..., `english`, `german`, ...) for comparison.
 
 ### Backward compatible invalid locales

--- a/src/Elasticsearch/DependencyInjection/services.php
+++ b/src/Elasticsearch/DependencyInjection/services.php
@@ -245,8 +245,9 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $services->set(ElasticsearchTestAnalyzerCommand::class)
         ->args([
             service(Client::class),
-            param('elasticsearch.analysis.analyzer'),
-            param('elasticsearch.analysis.filter'),
+            param('elasticsearch.analysis'),
+            param('elasticsearch.administration.analysis'),
+            param('elasticsearch.dimension_normalize'),
         ])
         ->tag('console.command');
 

--- a/src/Elasticsearch/DependencyInjection/services.php
+++ b/src/Elasticsearch/DependencyInjection/services.php
@@ -246,7 +246,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         ->args([
             service(Client::class),
             param('elasticsearch.analysis'),
-            param('elasticsearch.administration.analysis'),
             param('elasticsearch.dimension_normalize'),
         ])
         ->tag('console.command');

--- a/src/Elasticsearch/DependencyInjection/services.php
+++ b/src/Elasticsearch/DependencyInjection/services.php
@@ -245,6 +245,8 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $services->set(ElasticsearchTestAnalyzerCommand::class)
         ->args([
             service(Client::class),
+            param('elasticsearch.analysis.analyzer'),
+            param('elasticsearch.analysis.filter'),
         ])
         ->tag('console.command');
 

--- a/src/Elasticsearch/Framework/Command/ElasticsearchTestAnalyzerCommand.php
+++ b/src/Elasticsearch/Framework/Command/ElasticsearchTestAnalyzerCommand.php
@@ -9,6 +9,7 @@ use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 #[AsCommand(
@@ -37,7 +38,13 @@ class ElasticsearchTestAnalyzerCommand extends Command
     protected function configure(): void
     {
         $this
-            ->addArgument('term', InputArgument::REQUIRED);
+            ->addArgument('term', InputArgument::REQUIRED)
+            ->addOption(
+                'with-language-analyzers',
+                null,
+                InputOption::VALUE_NONE,
+                'Also run the built-in Elasticsearch language analyzers (arabic, english, german, ...).',
+            );
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
@@ -45,9 +52,10 @@ class ElasticsearchTestAnalyzerCommand extends Command
         $this->io = new ShopwareStyle($input, $output);
 
         $term = $input->getArgument('term');
+        $withLanguageAnalyzers = (bool) $input->getOption('with-language-analyzers');
 
         $rows = [];
-        foreach ($this->getSections() as $headline => $analyzers) {
+        foreach ($this->getSections($withLanguageAnalyzers) as $headline => $analyzers) {
             $rows[] = [$headline];
             $rows[] = ['###############'];
             foreach ($analyzers as $name => $body) {
@@ -76,9 +84,10 @@ class ElasticsearchTestAnalyzerCommand extends Command
      *
      * @return array<string, array<string, array<string, mixed>>>
      */
-    private function getSections(): array
+    private function getSections(bool $withLanguageAnalyzers): array
     {
-        return [
+        $sections = [
+            'Custom analyzers (elasticsearch.yaml)' => $this->buildCustomBodies(),
             'Default analyzers' => $this->buildBuiltInBodies([
                 'standard',
                 'simple',
@@ -88,16 +97,20 @@ class ElasticsearchTestAnalyzerCommand extends Command
                 'pattern',
                 'fingerprint',
             ]),
-            'Custom analyzers (elasticsearch.yaml)' => $this->buildCustomBodies(),
-            'Default language analyzers' => $this->buildBuiltInBodies([
+        ];
+
+        if ($withLanguageAnalyzers) {
+            $sections['Default language analyzers'] = $this->buildBuiltInBodies([
                 'arabic', 'armenian', 'basque', 'bengali', 'brazilian', 'bulgarian',
                 'catalan', 'cjk', 'czech', 'danish', 'dutch', 'english', 'finnish',
                 'french', 'galician', 'german', 'greek', 'hindi', 'hungarian',
                 'indonesian', 'irish', 'italian', 'latvian', 'lithuanian', 'norwegian',
                 'persian', 'portuguese', 'romanian', 'russian', 'sorani', 'spanish',
                 'swedish', 'turkish', 'thai',
-            ]),
-        ];
+            ]);
+        }
+
+        return $sections;
     }
 
     /**

--- a/src/Elasticsearch/Framework/Command/ElasticsearchTestAnalyzerCommand.php
+++ b/src/Elasticsearch/Framework/Command/ElasticsearchTestAnalyzerCommand.php
@@ -22,15 +22,18 @@ class ElasticsearchTestAnalyzerCommand extends Command
 
     /**
      * @internal
+     *
+     * @param array<string, array<string, mixed>> $customAnalyzers analyzer definitions from elasticsearch.analysis.analyzer
+     * @param array<string, array<string, mixed>> $customFilters filter definitions from elasticsearch.analysis.filter
      */
-    public function __construct(private readonly Client $client)
-    {
+    public function __construct(
+        private readonly Client $client,
+        private readonly array $customAnalyzers = [],
+        private readonly array $customFilters = [],
+    ) {
         parent::__construct();
     }
 
-    /**
-     * {@inheritdoc}
-     */
     protected function configure(): void
     {
         $this
@@ -43,23 +46,18 @@ class ElasticsearchTestAnalyzerCommand extends Command
 
         $term = $input->getArgument('term');
 
-        $iteration = $this->getAnalyzers();
-
         $rows = [];
-        foreach ($iteration as $headline => $analyzers) {
+        foreach ($this->getSections() as $headline => $analyzers) {
             $rows[] = [$headline];
             $rows[] = ['###############'];
-            foreach ($analyzers as $analyzer) {
+            foreach ($analyzers as $name => $body) {
+                $body['text'] = $term;
+
                 /** @var array{'tokens': array{token: string}[]} $analyzed */
-                $analyzed = $this->client->indices()->analyze([
-                    'body' => [
-                        'analyzer' => $analyzer,
-                        'text' => $term,
-                    ],
-                ]);
+                $analyzed = $this->client->indices()->analyze(['body' => $body]);
 
                 $rows[] = [
-                    'Analyzer' => $analyzer,
+                    'Analyzer' => $name,
                     'Tokens' => implode(' ', array_column($analyzed['tokens'], 'token')),
                 ];
             }
@@ -74,12 +72,14 @@ class ElasticsearchTestAnalyzerCommand extends Command
     }
 
     /**
-     * @return array<string, array<string>>
+     * Builds the table sections, each entry being an _analyze request body keyed by display name.
+     *
+     * @return array<string, array<string, array<string, mixed>>>
      */
-    protected function getAnalyzers(): array
+    private function getSections(): array
     {
         return [
-            'Default analyzers' => [
+            'Default analyzers' => $this->buildBuiltInBodies([
                 'standard',
                 'simple',
                 'whitespace',
@@ -87,44 +87,91 @@ class ElasticsearchTestAnalyzerCommand extends Command
                 'keyword',
                 'pattern',
                 'fingerprint',
-            ],
-            'Custom analyzers' => [],
-            'Default language analyzers' => [
-                'arabic',
-                'armenian',
-                'basque',
-                'bengali',
-                'brazilian',
-                'bulgarian',
-                'catalan',
-                'cjk',
-                'czech',
-                'danish',
-                'dutch',
-                'english',
-                'finnish',
-                'french',
-                'galician',
-                'german',
-                'greek',
-                'hindi',
-                'hungarian',
-                'indonesian',
-                'irish',
-                'italian',
-                'latvian',
-                'lithuanian',
-                'norwegian',
-                'persian',
-                'portuguese',
-                'romanian',
-                'russian',
-                'sorani',
-                'spanish',
-                'swedish',
-                'turkish',
-                'thai',
-            ],
+            ]),
+            'Custom analyzers (elasticsearch.yaml)' => $this->buildCustomBodies(),
+            'Default language analyzers' => $this->buildBuiltInBodies([
+                'arabic', 'armenian', 'basque', 'bengali', 'brazilian', 'bulgarian',
+                'catalan', 'cjk', 'czech', 'danish', 'dutch', 'english', 'finnish',
+                'french', 'galician', 'german', 'greek', 'hindi', 'hungarian',
+                'indonesian', 'irish', 'italian', 'latvian', 'lithuanian', 'norwegian',
+                'persian', 'portuguese', 'romanian', 'russian', 'sorani', 'spanish',
+                'swedish', 'turkish', 'thai',
+            ]),
         ];
+    }
+
+    /**
+     * @param list<string> $names
+     *
+     * @return array<string, array<string, mixed>>
+     */
+    private function buildBuiltInBodies(array $names): array
+    {
+        $bodies = [];
+        foreach ($names as $name) {
+            $bodies[$name] = ['analyzer' => $name];
+        }
+
+        return $bodies;
+    }
+
+    /**
+     * Resolves each configured analyzer to an inline _analyze body so it can be tested without
+     * requiring a live index that has the custom analyzer installed.
+     *
+     * @return array<string, array<string, mixed>>
+     */
+    private function buildCustomBodies(): array
+    {
+        $bodies = [];
+        foreach ($this->customAnalyzers as $name => $config) {
+            $type = $config['type'] ?? 'custom';
+
+            if ($type !== 'custom') {
+                // Built-in analyzer types (e.g. 'standard') configured with extra options — pass through.
+                $bodies[$name] = $config;
+
+                continue;
+            }
+
+            $body = [];
+            if (isset($config['tokenizer'])) {
+                $body['tokenizer'] = $config['tokenizer'];
+            }
+            if (isset($config['char_filter']) && \is_array($config['char_filter'])) {
+                $body['char_filter'] = $this->resolveFilters($config['char_filter']);
+            }
+            if (isset($config['filter']) && \is_array($config['filter'])) {
+                $body['filter'] = $this->resolveFilters($config['filter']);
+            }
+
+            $bodies[$name] = $body;
+        }
+
+        return $bodies;
+    }
+
+    /**
+     * Replaces filter name references with their inline definition from elasticsearch.analysis.filter
+     * so _analyze can resolve them without hitting a real index.
+     *
+     * @param array<mixed> $references
+     *
+     * @return list<mixed>
+     */
+    private function resolveFilters(array $references): array
+    {
+        $resolved = [];
+        foreach ($references as $reference) {
+            if (\is_string($reference) && isset($this->customFilters[$reference])) {
+                $resolved[] = $this->customFilters[$reference];
+
+                continue;
+            }
+
+            $resolved[] = $reference;
+        }
+
+        return $resolved;
     }
 }

--- a/src/Elasticsearch/Framework/Command/ElasticsearchTestAnalyzerCommand.php
+++ b/src/Elasticsearch/Framework/Command/ElasticsearchTestAnalyzerCommand.php
@@ -40,10 +40,10 @@ class ElasticsearchTestAnalyzerCommand extends Command
         $this
             ->addArgument('term', InputArgument::REQUIRED)
             ->addOption(
-                'with-language-analyzers',
-                null,
+                'all',
+                'a',
                 InputOption::VALUE_NONE,
-                'Also run the built-in Elasticsearch language analyzers (arabic, english, german, ...).',
+                'Also run the built-in Elasticsearch analyzers (standard, whitespace, ..., english, german, ...) for comparison.',
             );
     }
 
@@ -52,10 +52,10 @@ class ElasticsearchTestAnalyzerCommand extends Command
         $this->io = new ShopwareStyle($input, $output);
 
         $term = $input->getArgument('term');
-        $withLanguageAnalyzers = (bool) $input->getOption('with-language-analyzers');
+        $includeBuiltIn = (bool) $input->getOption('all');
 
         $rows = [];
-        foreach ($this->getSections($withLanguageAnalyzers) as $headline => $analyzers) {
+        foreach ($this->getSections($includeBuiltIn) as $headline => $analyzers) {
             $rows[] = [$headline];
             $rows[] = ['###############'];
             foreach ($analyzers as $name => $body) {
@@ -84,31 +84,34 @@ class ElasticsearchTestAnalyzerCommand extends Command
      *
      * @return array<string, array<string, array<string, mixed>>>
      */
-    private function getSections(bool $withLanguageAnalyzers): array
+    private function getSections(bool $includeBuiltIn): array
     {
         $sections = [
             'Custom analyzers (elasticsearch.yaml)' => $this->buildCustomBodies(),
-            'Default analyzers' => $this->buildBuiltInBodies([
-                'standard',
-                'simple',
-                'whitespace',
-                'stop',
-                'keyword',
-                'pattern',
-                'fingerprint',
-            ]),
         ];
 
-        if ($withLanguageAnalyzers) {
-            $sections['Default language analyzers'] = $this->buildBuiltInBodies([
-                'arabic', 'armenian', 'basque', 'bengali', 'brazilian', 'bulgarian',
-                'catalan', 'cjk', 'czech', 'danish', 'dutch', 'english', 'finnish',
-                'french', 'galician', 'german', 'greek', 'hindi', 'hungarian',
-                'indonesian', 'irish', 'italian', 'latvian', 'lithuanian', 'norwegian',
-                'persian', 'portuguese', 'romanian', 'russian', 'sorani', 'spanish',
-                'swedish', 'turkish', 'thai',
-            ]);
+        if (!$includeBuiltIn) {
+            return $sections;
         }
+
+        $sections['Default analyzers'] = $this->buildBuiltInBodies([
+            'standard',
+            'simple',
+            'whitespace',
+            'stop',
+            'keyword',
+            'pattern',
+            'fingerprint',
+        ]);
+
+        $sections['Default language analyzers'] = $this->buildBuiltInBodies([
+            'arabic', 'armenian', 'basque', 'bengali', 'brazilian', 'bulgarian',
+            'catalan', 'cjk', 'czech', 'danish', 'dutch', 'english', 'finnish',
+            'french', 'galician', 'german', 'greek', 'hindi', 'hungarian',
+            'indonesian', 'irish', 'italian', 'latvian', 'lithuanian', 'norwegian',
+            'persian', 'portuguese', 'romanian', 'russian', 'sorani', 'spanish',
+            'swedish', 'turkish', 'thai',
+        ]);
 
         return $sections;
     }

--- a/src/Elasticsearch/Framework/Command/ElasticsearchTestAnalyzerCommand.php
+++ b/src/Elasticsearch/Framework/Command/ElasticsearchTestAnalyzerCommand.php
@@ -80,6 +80,63 @@ class ElasticsearchTestAnalyzerCommand extends Command
     }
 
     /**
+     * @deprecated tag:v6.8.0 - reason:becomes-internal - No longer used by the command. The analyzer list is now built from `elasticsearch.analysis.analyzer` (custom) and the built-in default/language analyzers via internal helpers. Will be removed.
+     *
+     * @return array<string, array<string>>
+     */
+    protected function getAnalyzers(): array
+    {
+        return [
+            'Default analyzers' => [
+                'standard',
+                'simple',
+                'whitespace',
+                'stop',
+                'keyword',
+                'pattern',
+                'fingerprint',
+            ],
+            'Custom analyzers' => [],
+            'Default language analyzers' => [
+                'arabic',
+                'armenian',
+                'basque',
+                'bengali',
+                'brazilian',
+                'bulgarian',
+                'catalan',
+                'cjk',
+                'czech',
+                'danish',
+                'dutch',
+                'english',
+                'finnish',
+                'french',
+                'galician',
+                'german',
+                'greek',
+                'hindi',
+                'hungarian',
+                'indonesian',
+                'irish',
+                'italian',
+                'latvian',
+                'lithuanian',
+                'norwegian',
+                'persian',
+                'portuguese',
+                'romanian',
+                'russian',
+                'sorani',
+                'spanish',
+                'swedish',
+                'turkish',
+                'thai',
+            ],
+        ];
+    }
+
+    /**
      * Builds the table sections, each entry being an _analyze request body keyed by display name.
      *
      * @return array<string, array<string, array<string, mixed>>>

--- a/src/Elasticsearch/Framework/Command/ElasticsearchTestAnalyzerCommand.php
+++ b/src/Elasticsearch/Framework/Command/ElasticsearchTestAnalyzerCommand.php
@@ -8,6 +8,7 @@ use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
@@ -37,7 +38,13 @@ class ElasticsearchTestAnalyzerCommand extends Command
     protected function configure(): void
     {
         $this
-            ->addArgument('term', InputArgument::REQUIRED);
+            ->addArgument('term', InputArgument::REQUIRED)
+            ->addOption(
+                'with-language-analyzers',
+                null,
+                InputOption::VALUE_NONE,
+                'Also run the built-in Elasticsearch language analyzers (arabic, english, german, ...).',
+            );
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
@@ -45,9 +52,10 @@ class ElasticsearchTestAnalyzerCommand extends Command
         $this->io = new SymfonyStyle($input, $output);
 
         $term = $input->getArgument('term');
+        $withLanguageAnalyzers = (bool) $input->getOption('with-language-analyzers');
 
         $rows = [];
-        foreach ($this->getSections() as $headline => $analyzers) {
+        foreach ($this->getSections($withLanguageAnalyzers) as $headline => $analyzers) {
             $rows[] = [$headline];
             $rows[] = ['###############'];
             foreach ($analyzers as $name => $body) {
@@ -76,9 +84,10 @@ class ElasticsearchTestAnalyzerCommand extends Command
      *
      * @return array<string, array<string, array<string, mixed>>>
      */
-    private function getSections(): array
+    private function getSections(bool $withLanguageAnalyzers): array
     {
-        return [
+        $sections = [
+            'Custom analyzers (elasticsearch.yaml)' => $this->buildCustomBodies(),
             'Default analyzers' => $this->buildBuiltInBodies([
                 'standard',
                 'simple',
@@ -88,16 +97,20 @@ class ElasticsearchTestAnalyzerCommand extends Command
                 'pattern',
                 'fingerprint',
             ]),
-            'Custom analyzers (elasticsearch.yaml)' => $this->buildCustomBodies(),
-            'Default language analyzers' => $this->buildBuiltInBodies([
+        ];
+
+        if ($withLanguageAnalyzers) {
+            $sections['Default language analyzers'] = $this->buildBuiltInBodies([
                 'arabic', 'armenian', 'basque', 'bengali', 'brazilian', 'bulgarian',
                 'catalan', 'cjk', 'czech', 'danish', 'dutch', 'english', 'finnish',
                 'french', 'galician', 'german', 'greek', 'hindi', 'hungarian',
                 'indonesian', 'irish', 'italian', 'latvian', 'lithuanian', 'norwegian',
                 'persian', 'portuguese', 'romanian', 'russian', 'sorani', 'spanish',
                 'swedish', 'turkish', 'thai',
-            ]),
-        ];
+            ]);
+        }
+
+        return $sections;
     }
 
     /**

--- a/src/Elasticsearch/Framework/Command/ElasticsearchTestAnalyzerCommand.php
+++ b/src/Elasticsearch/Framework/Command/ElasticsearchTestAnalyzerCommand.php
@@ -4,6 +4,7 @@ namespace Shopware\Elasticsearch\Framework\Command;
 
 use OpenSearch\Client;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Elasticsearch\Framework\Indexing\IndexCreator;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
@@ -24,13 +25,14 @@ class ElasticsearchTestAnalyzerCommand extends Command
     /**
      * @internal
      *
-     * @param array<string, array<string, mixed>> $customAnalyzers analyzer definitions from elasticsearch.analysis.analyzer
-     * @param array<string, array<string, mixed>> $customFilters filter definitions from elasticsearch.analysis.filter
+     * @param array<string, mixed> $analysis the `elasticsearch.analysis` section (analyzer, tokenizer, char_filter, filter)
+     * @param array<string, mixed> $adminAnalysis the `elasticsearch.administration.analysis` section
      */
     public function __construct(
         private readonly Client $client,
-        private readonly array $customAnalyzers = [],
-        private readonly array $customFilters = [],
+        private readonly array $analysis = [],
+        private readonly array $adminAnalysis = [],
+        private readonly bool $dimensionNormalize = false,
     ) {
         parent::__construct();
     }
@@ -59,14 +61,9 @@ class ElasticsearchTestAnalyzerCommand extends Command
             $rows[] = [$headline];
             $rows[] = ['###############'];
             foreach ($analyzers as $name => $body) {
-                $body['text'] = $term;
-
-                /** @var array{'tokens': array{token: string}[]} $analyzed */
-                $analyzed = $this->client->indices()->analyze(['body' => $body]);
-
                 $rows[] = [
                     'Analyzer' => $name,
-                    'Tokens' => implode(' ', array_column($analyzed['tokens'], 'token')),
+                    'Tokens' => \is_string($body) ? $body : $this->analyze($body, $term),
                 ];
             }
 
@@ -80,8 +77,6 @@ class ElasticsearchTestAnalyzerCommand extends Command
     }
 
     /**
-     * @deprecated tag:v6.8.0 - reason:becomes-internal - No longer used by the command. The analyzer list is now built from `elasticsearch.analysis.analyzer` (custom) and the built-in default/language analyzers via internal helpers. Will be removed.
-     *
      * @return array<string, array<string>>
      */
     protected function getAnalyzers(): array
@@ -137,44 +132,55 @@ class ElasticsearchTestAnalyzerCommand extends Command
     }
 
     /**
-     * Builds the table sections, each entry being an _analyze request body keyed by display name.
+     * A single unusable analyzer must not abort the whole report, so failures are rendered
+     * in place of the tokens.
      *
-     * @return array<string, array<string, array<string, mixed>>>
+     * @param array<string, mixed> $body
+     */
+    private function analyze(array $body, mixed $term): string
+    {
+        $body['text'] = $term;
+
+        try {
+            /** @var array{'tokens': array{token: string}[]} $analyzed */
+            $analyzed = $this->client->indices()->analyze(['body' => $body]);
+        } catch (\Throwable $e) {
+            return \sprintf('<error: %s>', $e->getMessage());
+        }
+
+        return implode(' ', array_column($analyzed['tokens'], 'token'));
+    }
+
+    /**
+     * Builds the table sections. Each entry is either an _analyze request body or a string
+     * explaining why the analyzer cannot be tested, keyed by display name.
+     *
+     * @return array<string, array<string, array<string, mixed>|string>>
      */
     private function getSections(bool $includeBuiltIn): array
     {
         $sections = [
-            'Custom analyzers (elasticsearch.yaml)' => $this->buildCustomBodies(),
+            'Custom analyzers (elasticsearch.yaml)' => $this->buildCustomBodies($this->analysis, $this->dimensionNormalize),
+            'Custom admin analyzers (elasticsearch.yaml)' => $this->buildCustomBodies($this->adminAnalysis, false),
         ];
 
         if (!$includeBuiltIn) {
             return $sections;
         }
 
-        $sections['Default analyzers'] = $this->buildBuiltInBodies([
-            'standard',
-            'simple',
-            'whitespace',
-            'stop',
-            'keyword',
-            'pattern',
-            'fingerprint',
-        ]);
+        foreach ($this->getAnalyzers() as $headline => $analyzers) {
+            if ($analyzers === []) {
+                continue;
+            }
 
-        $sections['Default language analyzers'] = $this->buildBuiltInBodies([
-            'arabic', 'armenian', 'basque', 'bengali', 'brazilian', 'bulgarian',
-            'catalan', 'cjk', 'czech', 'danish', 'dutch', 'english', 'finnish',
-            'french', 'galician', 'german', 'greek', 'hindi', 'hungarian',
-            'indonesian', 'irish', 'italian', 'latvian', 'lithuanian', 'norwegian',
-            'persian', 'portuguese', 'romanian', 'russian', 'sorani', 'spanish',
-            'swedish', 'turkish', 'thai',
-        ]);
+            $sections[$headline] = $this->buildBuiltInBodies($analyzers);
+        }
 
         return $sections;
     }
 
     /**
-     * @param list<string> $names
+     * @param array<string> $names
      *
      * @return array<string, array<string, mixed>>
      */
@@ -192,30 +198,49 @@ class ElasticsearchTestAnalyzerCommand extends Command
      * Resolves each configured analyzer to an inline _analyze body so it can be tested without
      * requiring a live index that has the custom analyzer installed.
      *
-     * @return array<string, array<string, mixed>>
+     * @param array<string, mixed> $analysis
+     *
+     * @return array<string, array<string, mixed>|string>
      */
-    private function buildCustomBodies(): array
+    private function buildCustomBodies(array $analysis, bool $dimensionNormalize): array
     {
+        $analyzers = $analysis['analyzer'] ?? [];
+
+        if (!\is_array($analyzers)) {
+            return [];
+        }
+
+        if ($dimensionNormalize) {
+            // Mirror what IndexCreator does when creating the index, otherwise the reported
+            // tokens differ from the ones the live index actually produces.
+            $analyzers = IndexCreator::withDimensionNormalize($analyzers);
+        }
+
         $bodies = [];
-        foreach ($this->customAnalyzers as $name => $config) {
+        foreach ($analyzers as $name => $config) {
+            if (!\is_array($config)) {
+                continue;
+            }
+
             $type = $config['type'] ?? 'custom';
 
             if ($type !== 'custom') {
-                // Built-in analyzer types (e.g. 'standard') configured with extra options — pass through.
-                $bodies[$name] = $config;
+                // _analyze accepts no `type` parameter, so a built-in analyzer type configured
+                // with extra options can only be tested against an index that has it installed.
+                $bodies[$name] = \sprintf('<not testable inline: analyzer type "%s">', \is_string($type) ? $type : \get_debug_type($type));
 
                 continue;
             }
 
             $body = [];
             if (isset($config['tokenizer'])) {
-                $body['tokenizer'] = $config['tokenizer'];
+                $body['tokenizer'] = $this->resolveReference($config['tokenizer'], $analysis['tokenizer'] ?? []);
             }
             if (isset($config['char_filter']) && \is_array($config['char_filter'])) {
-                $body['char_filter'] = $this->resolveFilters($config['char_filter']);
+                $body['char_filter'] = $this->resolveReferences($config['char_filter'], $analysis['char_filter'] ?? []);
             }
             if (isset($config['filter']) && \is_array($config['filter'])) {
-                $body['filter'] = $this->resolveFilters($config['filter']);
+                $body['filter'] = $this->resolveReferences($config['filter'], $analysis['filter'] ?? []);
             }
 
             $bodies[$name] = $body;
@@ -225,26 +250,31 @@ class ElasticsearchTestAnalyzerCommand extends Command
     }
 
     /**
-     * Replaces filter name references with their inline definition from elasticsearch.analysis.filter
-     * so _analyze can resolve them without hitting a real index.
-     *
      * @param array<mixed> $references
      *
      * @return list<mixed>
      */
-    private function resolveFilters(array $references): array
+    private function resolveReferences(array $references, mixed $definitions): array
     {
         $resolved = [];
         foreach ($references as $reference) {
-            if (\is_string($reference) && isset($this->customFilters[$reference])) {
-                $resolved[] = $this->customFilters[$reference];
-
-                continue;
-            }
-
-            $resolved[] = $reference;
+            $resolved[] = $this->resolveReference($reference, $definitions);
         }
 
         return $resolved;
+    }
+
+    /**
+     * Replaces a name reference with its inline definition from the matching `analysis`
+     * section (tokenizer, char_filter, filter) so _analyze can resolve it without hitting
+     * a real index. Built-in names are passed through untouched.
+     */
+    private function resolveReference(mixed $reference, mixed $definitions): mixed
+    {
+        if (\is_string($reference) && \is_array($definitions) && isset($definitions[$reference])) {
+            return $definitions[$reference];
+        }
+
+        return $reference;
     }
 }

--- a/src/Elasticsearch/Framework/Command/ElasticsearchTestAnalyzerCommand.php
+++ b/src/Elasticsearch/Framework/Command/ElasticsearchTestAnalyzerCommand.php
@@ -26,12 +26,10 @@ class ElasticsearchTestAnalyzerCommand extends Command
      * @internal
      *
      * @param array<string, mixed> $analysis the `elasticsearch.analysis` section (analyzer, tokenizer, char_filter, filter)
-     * @param array<string, mixed> $adminAnalysis the `elasticsearch.administration.analysis` section
      */
     public function __construct(
         private readonly Client $client,
         private readonly array $analysis = [],
-        private readonly array $adminAnalysis = [],
         private readonly bool $dimensionNormalize = false,
     ) {
         parent::__construct();
@@ -63,7 +61,7 @@ class ElasticsearchTestAnalyzerCommand extends Command
             foreach ($analyzers as $name => $body) {
                 $rows[] = [
                     'Analyzer' => $name,
-                    'Tokens' => \is_string($body) ? $body : $this->analyze($body, $term),
+                    'Tokens' => $this->analyze($body, $term),
                 ];
             }
 
@@ -152,16 +150,14 @@ class ElasticsearchTestAnalyzerCommand extends Command
     }
 
     /**
-     * Builds the table sections. Each entry is either an _analyze request body or a string
-     * explaining why the analyzer cannot be tested, keyed by display name.
+     * Builds the table sections, each entry being an _analyze request body keyed by display name.
      *
-     * @return array<string, array<string, array<string, mixed>|string>>
+     * @return array<string, array<string, array<string, mixed>>>
      */
     private function getSections(bool $includeBuiltIn): array
     {
         $sections = [
-            'Custom analyzers (elasticsearch.yaml)' => $this->buildCustomBodies($this->analysis, $this->dimensionNormalize),
-            'Custom admin analyzers (elasticsearch.yaml)' => $this->buildCustomBodies($this->adminAnalysis, false),
+            'Custom analyzers (storefront elasticsearch.yaml)' => $this->buildCustomBodies($this->analysis, $this->dimensionNormalize),
         ];
 
         if (!$includeBuiltIn) {
@@ -200,7 +196,7 @@ class ElasticsearchTestAnalyzerCommand extends Command
      *
      * @param array<string, mixed> $analysis
      *
-     * @return array<string, array<string, mixed>|string>
+     * @return array<string, array<string, mixed>>
      */
     private function buildCustomBodies(array $analysis, bool $dimensionNormalize): array
     {
@@ -219,16 +215,6 @@ class ElasticsearchTestAnalyzerCommand extends Command
         $bodies = [];
         foreach ($analyzers as $name => $config) {
             if (!\is_array($config)) {
-                continue;
-            }
-
-            $type = $config['type'] ?? 'custom';
-
-            if ($type !== 'custom') {
-                // _analyze accepts no `type` parameter, so a built-in analyzer type configured
-                // with extra options can only be tested against an index that has it installed.
-                $bodies[$name] = \sprintf('<not testable inline: analyzer type "%s">', \is_string($type) ? $type : \get_debug_type($type));
-
                 continue;
             }
 

--- a/src/Elasticsearch/Framework/Command/ElasticsearchTestAnalyzerCommand.php
+++ b/src/Elasticsearch/Framework/Command/ElasticsearchTestAnalyzerCommand.php
@@ -40,10 +40,10 @@ class ElasticsearchTestAnalyzerCommand extends Command
         $this
             ->addArgument('term', InputArgument::REQUIRED)
             ->addOption(
-                'with-language-analyzers',
-                null,
+                'all',
+                'a',
                 InputOption::VALUE_NONE,
-                'Also run the built-in Elasticsearch language analyzers (arabic, english, german, ...).',
+                'Also run the built-in Elasticsearch analyzers (standard, whitespace, ..., english, german, ...) for comparison.',
             );
     }
 
@@ -52,10 +52,10 @@ class ElasticsearchTestAnalyzerCommand extends Command
         $this->io = new SymfonyStyle($input, $output);
 
         $term = $input->getArgument('term');
-        $withLanguageAnalyzers = (bool) $input->getOption('with-language-analyzers');
+        $includeBuiltIn = (bool) $input->getOption('all');
 
         $rows = [];
-        foreach ($this->getSections($withLanguageAnalyzers) as $headline => $analyzers) {
+        foreach ($this->getSections($includeBuiltIn) as $headline => $analyzers) {
             $rows[] = [$headline];
             $rows[] = ['###############'];
             foreach ($analyzers as $name => $body) {
@@ -84,31 +84,34 @@ class ElasticsearchTestAnalyzerCommand extends Command
      *
      * @return array<string, array<string, array<string, mixed>>>
      */
-    private function getSections(bool $withLanguageAnalyzers): array
+    private function getSections(bool $includeBuiltIn): array
     {
         $sections = [
             'Custom analyzers (elasticsearch.yaml)' => $this->buildCustomBodies(),
-            'Default analyzers' => $this->buildBuiltInBodies([
-                'standard',
-                'simple',
-                'whitespace',
-                'stop',
-                'keyword',
-                'pattern',
-                'fingerprint',
-            ]),
         ];
 
-        if ($withLanguageAnalyzers) {
-            $sections['Default language analyzers'] = $this->buildBuiltInBodies([
-                'arabic', 'armenian', 'basque', 'bengali', 'brazilian', 'bulgarian',
-                'catalan', 'cjk', 'czech', 'danish', 'dutch', 'english', 'finnish',
-                'french', 'galician', 'german', 'greek', 'hindi', 'hungarian',
-                'indonesian', 'irish', 'italian', 'latvian', 'lithuanian', 'norwegian',
-                'persian', 'portuguese', 'romanian', 'russian', 'sorani', 'spanish',
-                'swedish', 'turkish', 'thai',
-            ]);
+        if (!$includeBuiltIn) {
+            return $sections;
         }
+
+        $sections['Default analyzers'] = $this->buildBuiltInBodies([
+            'standard',
+            'simple',
+            'whitespace',
+            'stop',
+            'keyword',
+            'pattern',
+            'fingerprint',
+        ]);
+
+        $sections['Default language analyzers'] = $this->buildBuiltInBodies([
+            'arabic', 'armenian', 'basque', 'bengali', 'brazilian', 'bulgarian',
+            'catalan', 'cjk', 'czech', 'danish', 'dutch', 'english', 'finnish',
+            'french', 'galician', 'german', 'greek', 'hindi', 'hungarian',
+            'indonesian', 'irish', 'italian', 'latvian', 'lithuanian', 'norwegian',
+            'persian', 'portuguese', 'romanian', 'russian', 'sorani', 'spanish',
+            'swedish', 'turkish', 'thai',
+        ]);
 
         return $sections;
     }

--- a/src/Elasticsearch/Framework/Indexing/IndexCreator.php
+++ b/src/Elasticsearch/Framework/Indexing/IndexCreator.php
@@ -104,6 +104,47 @@ class IndexCreator
         return $this->client->indices()->existsAlias(['name' => $alias]);
     }
 
+    /**
+     * The analyzer-level part of {@see enableDimensionNormalize()}. Shared so diagnostics such as
+     * `es:test:analyzer` can reproduce the chains the live index actually uses instead of the raw
+     * `elasticsearch.yaml` ones.
+     *
+     * @internal
+     *
+     * @param array<mixed> $analyzers
+     *
+     * @return array<mixed>
+     */
+    public static function withDimensionNormalize(array $analyzers): array
+    {
+        foreach (self::TECHNICAL_TERM_ANALYZERS as $name) {
+            $analyzer = $analyzers[$name] ?? null;
+
+            if (!\is_array($analyzer)) {
+                continue;
+            }
+
+            $charFilters = $analyzer['char_filter'] ?? [];
+            \assert(\is_array($charFilters));
+
+            if (\in_array('sw_dimension_normalize', $charFilters, true)) {
+                continue;
+            }
+
+            // Prepend so the dimension regex runs before locale-scoped
+            // char_filters (e.g. sw_decimal_normalize on German) and before
+            // the universal sw_unit_glue. Order is immaterial for the
+            // canonical patterns but keeping the most-specific filter first
+            // matches the "analysis pipeline" mental model: pre-normalize
+            // specific notational variants, then bridge generic numeric
+            // boundaries.
+            $analyzer['char_filter'] = array_merge(['sw_dimension_normalize'], $charFilters);
+            $analyzers[$name] = $analyzer;
+        }
+
+        return $analyzers;
+    }
+
     private function indexExists(string $index): bool
     {
         return $this->client->indices()->exists(['index' => $index]);
@@ -127,30 +168,7 @@ class IndexCreator
             return $config;
         }
 
-        foreach (self::TECHNICAL_TERM_ANALYZERS as $analyzer) {
-            if (!isset($config['settings']['analysis']['analyzer'][$analyzer])) {
-                continue;
-            }
-
-            $charFilters = $config['settings']['analysis']['analyzer'][$analyzer]['char_filter'] ?? [];
-            \assert(\is_array($charFilters));
-
-            if (\in_array('sw_dimension_normalize', $charFilters, true)) {
-                continue;
-            }
-
-            // Prepend so the dimension regex runs before locale-scoped
-            // char_filters (e.g. sw_decimal_normalize on German) and before
-            // the universal sw_unit_glue. Order is immaterial for the
-            // canonical patterns but keeping the most-specific filter first
-            // matches the "analysis pipeline" mental model: pre-normalize
-            // specific notational variants, then bridge generic numeric
-            // boundaries.
-            $config['settings']['analysis']['analyzer'][$analyzer]['char_filter'] = array_merge(
-                ['sw_dimension_normalize'],
-                $charFilters,
-            );
-        }
+        $config['settings']['analysis']['analyzer'] = self::withDimensionNormalize($config['settings']['analysis']['analyzer']);
 
         return $config;
     }

--- a/src/Elasticsearch/Resources/config/services.xml
+++ b/src/Elasticsearch/Resources/config/services.xml
@@ -121,6 +121,8 @@
 
         <service id="Shopware\Elasticsearch\Framework\Command\ElasticsearchTestAnalyzerCommand">
             <argument type="service" id="OpenSearch\Client"/>
+            <argument>%elasticsearch.analysis.analyzer%</argument>
+            <argument>%elasticsearch.analysis.filter%</argument>
 
             <tag name="console.command"/>
         </service>

--- a/tests/unit/Elasticsearch/Framework/Command/ElasticsearchTestAnalyzerCommandTest.php
+++ b/tests/unit/Elasticsearch/Framework/Command/ElasticsearchTestAnalyzerCommandTest.php
@@ -89,4 +89,51 @@ class ElasticsearchTestAnalyzerCommandTest extends TestCase
         static::assertNotNull($standard);
         static::assertSame('foo', $standard['text']);
     }
+
+    public function testLanguageAnalyzersAreSkippedByDefault(): void
+    {
+        $indices = $this->createMock(IndicesNamespace::class);
+        $client = $this->createMock(Client::class);
+        $client->method('indices')->willReturn($indices);
+
+        $analyzedNames = [];
+        $indices->method('analyze')->willReturnCallback(function (array $params) use (&$analyzedNames): array {
+            if (isset($params['body']['analyzer'])) {
+                $analyzedNames[] = $params['body']['analyzer'];
+            }
+
+            return ['tokens' => []];
+        });
+
+        $tester = new CommandTester(new ElasticsearchTestAnalyzerCommand($client, [], []));
+        $tester->execute(['term' => 'foo']);
+
+        static::assertContains('standard', $analyzedNames);
+        static::assertNotContains('german', $analyzedNames);
+        static::assertNotContains('english', $analyzedNames);
+        static::assertStringNotContainsString('Default language analyzers', $tester->getDisplay());
+    }
+
+    public function testLanguageAnalyzersIncludedWithFlag(): void
+    {
+        $indices = $this->createMock(IndicesNamespace::class);
+        $client = $this->createMock(Client::class);
+        $client->method('indices')->willReturn($indices);
+
+        $analyzedNames = [];
+        $indices->method('analyze')->willReturnCallback(function (array $params) use (&$analyzedNames): array {
+            if (isset($params['body']['analyzer'])) {
+                $analyzedNames[] = $params['body']['analyzer'];
+            }
+
+            return ['tokens' => []];
+        });
+
+        $tester = new CommandTester(new ElasticsearchTestAnalyzerCommand($client, [], []));
+        $tester->execute(['term' => 'foo', '--with-language-analyzers' => true]);
+
+        static::assertContains('german', $analyzedNames);
+        static::assertContains('english', $analyzedNames);
+        static::assertStringContainsString('Default language analyzers', $tester->getDisplay());
+    }
 }

--- a/tests/unit/Elasticsearch/Framework/Command/ElasticsearchTestAnalyzerCommandTest.php
+++ b/tests/unit/Elasticsearch/Framework/Command/ElasticsearchTestAnalyzerCommandTest.php
@@ -1,0 +1,92 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Elasticsearch\Framework\Command;
+
+use OpenSearch\Client;
+use OpenSearch\Namespaces\IndicesNamespace;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Elasticsearch\Framework\Command\ElasticsearchTestAnalyzerCommand;
+use Symfony\Component\Console\Tester\CommandTester;
+
+/**
+ * @internal
+ */
+#[CoversClass(ElasticsearchTestAnalyzerCommand::class)]
+class ElasticsearchTestAnalyzerCommandTest extends TestCase
+{
+    public function testCustomAnalyzersAreSentInlineWithResolvedFilters(): void
+    {
+        $analyzers = [
+            'sw_ngram_analyzer' => [
+                'type' => 'custom',
+                'tokenizer' => 'whitespace',
+                'filter' => ['lowercase', 'sw_ngram_filter'],
+            ],
+        ];
+
+        $filters = [
+            'sw_ngram_filter' => ['type' => 'ngram', 'min_gram' => 4, 'max_gram' => 5],
+        ];
+
+        $indices = $this->createMock(IndicesNamespace::class);
+        $client = $this->createMock(Client::class);
+        $client->method('indices')->willReturn($indices);
+
+        $sentBodies = [];
+        $indices->method('analyze')->willReturnCallback(function (array $params) use (&$sentBodies): array {
+            $sentBodies[] = $params['body'];
+
+            return ['tokens' => [['token' => 'foo']]];
+        });
+
+        $tester = new CommandTester(new ElasticsearchTestAnalyzerCommand($client, $analyzers, $filters));
+        $tester->execute(['term' => 'foobar']);
+
+        $customBody = null;
+        foreach ($sentBodies as $body) {
+            if (($body['tokenizer'] ?? null) === 'whitespace') {
+                $customBody = $body;
+
+                break;
+            }
+        }
+
+        static::assertNotNull($customBody, 'expected custom analyzer body to be sent');
+        static::assertSame('foobar', $customBody['text']);
+        static::assertSame(
+            ['lowercase', ['type' => 'ngram', 'min_gram' => 4, 'max_gram' => 5]],
+            $customBody['filter'],
+        );
+        static::assertStringContainsString('sw_ngram_analyzer', $tester->getDisplay());
+    }
+
+    public function testBuiltInAnalyzersAreSentByName(): void
+    {
+        $indices = $this->createMock(IndicesNamespace::class);
+        $client = $this->createMock(Client::class);
+        $client->method('indices')->willReturn($indices);
+
+        $sentBodies = [];
+        $indices->method('analyze')->willReturnCallback(function (array $params) use (&$sentBodies): array {
+            $sentBodies[] = $params['body'];
+
+            return ['tokens' => [['token' => 'foo']]];
+        });
+
+        $tester = new CommandTester(new ElasticsearchTestAnalyzerCommand($client, [], []));
+        $tester->execute(['term' => 'foo']);
+
+        $standard = null;
+        foreach ($sentBodies as $body) {
+            if (($body['analyzer'] ?? null) === 'standard') {
+                $standard = $body;
+
+                break;
+            }
+        }
+
+        static::assertNotNull($standard);
+        static::assertSame('foo', $standard['text']);
+    }
+}

--- a/tests/unit/Elasticsearch/Framework/Command/ElasticsearchTestAnalyzerCommandTest.php
+++ b/tests/unit/Elasticsearch/Framework/Command/ElasticsearchTestAnalyzerCommandTest.php
@@ -61,43 +61,24 @@ class ElasticsearchTestAnalyzerCommandTest extends TestCase
         static::assertStringContainsString('sw_ngram_analyzer', $tester->getDisplay());
     }
 
-    public function testBuiltInAnalyzersAreSentByName(): void
+    public function testBuiltInAnalyzersAreSkippedByDefault(): void
     {
-        $indices = $this->createMock(IndicesNamespace::class);
-        $client = $this->createMock(Client::class);
-        $client->method('indices')->willReturn($indices);
+        $analyzers = [
+            'sw_whitespace_analyzer' => [
+                'type' => 'custom',
+                'tokenizer' => 'whitespace',
+                'filter' => ['lowercase'],
+            ],
+        ];
 
-        $sentBodies = [];
-        $indices->method('analyze')->willReturnCallback(function (array $params) use (&$sentBodies): array {
-            $sentBodies[] = $params['body'];
-
-            return ['tokens' => [['token' => 'foo']]];
-        });
-
-        $tester = new CommandTester(new ElasticsearchTestAnalyzerCommand($client, [], []));
-        $tester->execute(['term' => 'foo']);
-
-        $standard = null;
-        foreach ($sentBodies as $body) {
-            if (($body['analyzer'] ?? null) === 'standard') {
-                $standard = $body;
-
-                break;
-            }
-        }
-
-        static::assertNotNull($standard);
-        static::assertSame('foo', $standard['text']);
-    }
-
-    public function testLanguageAnalyzersAreSkippedByDefault(): void
-    {
         $indices = $this->createMock(IndicesNamespace::class);
         $client = $this->createMock(Client::class);
         $client->method('indices')->willReturn($indices);
 
         $analyzedNames = [];
-        $indices->method('analyze')->willReturnCallback(function (array $params) use (&$analyzedNames): array {
+        $sentBodies = [];
+        $indices->method('analyze')->willReturnCallback(function (array $params) use (&$analyzedNames, &$sentBodies): array {
+            $sentBodies[] = $params['body'];
             if (isset($params['body']['analyzer'])) {
                 $analyzedNames[] = $params['body']['analyzer'];
             }
@@ -105,16 +86,18 @@ class ElasticsearchTestAnalyzerCommandTest extends TestCase
             return ['tokens' => []];
         });
 
-        $tester = new CommandTester(new ElasticsearchTestAnalyzerCommand($client, [], []));
+        $tester = new CommandTester(new ElasticsearchTestAnalyzerCommand($client, $analyzers, []));
         $tester->execute(['term' => 'foo']);
 
-        static::assertContains('standard', $analyzedNames);
+        static::assertNotContains('standard', $analyzedNames);
         static::assertNotContains('german', $analyzedNames);
-        static::assertNotContains('english', $analyzedNames);
+        static::assertCount(1, $sentBodies, 'only the configured custom analyzer should run by default');
+        static::assertStringContainsString('Custom analyzers', $tester->getDisplay());
+        static::assertStringNotContainsString('Default analyzers', $tester->getDisplay());
         static::assertStringNotContainsString('Default language analyzers', $tester->getDisplay());
     }
 
-    public function testLanguageAnalyzersIncludedWithFlag(): void
+    public function testBuiltInAnalyzersIncludedWithAllFlag(): void
     {
         $indices = $this->createMock(IndicesNamespace::class);
         $client = $this->createMock(Client::class);
@@ -130,10 +113,12 @@ class ElasticsearchTestAnalyzerCommandTest extends TestCase
         });
 
         $tester = new CommandTester(new ElasticsearchTestAnalyzerCommand($client, [], []));
-        $tester->execute(['term' => 'foo', '--with-language-analyzers' => true]);
+        $tester->execute(['term' => 'foo', '--all' => true]);
 
+        static::assertContains('standard', $analyzedNames);
         static::assertContains('german', $analyzedNames);
         static::assertContains('english', $analyzedNames);
+        static::assertStringContainsString('Default analyzers', $tester->getDisplay());
         static::assertStringContainsString('Default language analyzers', $tester->getDisplay());
     }
 }

--- a/tests/unit/Elasticsearch/Framework/Command/ElasticsearchTestAnalyzerCommandTest.php
+++ b/tests/unit/Elasticsearch/Framework/Command/ElasticsearchTestAnalyzerCommandTest.php
@@ -37,7 +37,7 @@ class ElasticsearchTestAnalyzerCommandTest extends TestCase
 
         $commandTester = new CommandTester(new ElasticsearchTestAnalyzerCommand($client));
 
-        static::assertSame(Command::SUCCESS, $commandTester->execute(['term' => 'Shopware Test']));
+        static::assertSame(Command::SUCCESS, $commandTester->execute(['term' => 'Shopware Test', '--all' => true]));
 
         $display = $commandTester->getDisplay();
         static::assertStringContainsString('Default analyzers', $display);
@@ -47,80 +47,179 @@ class ElasticsearchTestAnalyzerCommandTest extends TestCase
 
     public function testCustomAnalyzersAreSentInlineWithResolvedFilters(): void
     {
-        $analyzers = [
-            'sw_ngram_analyzer' => [
-                'type' => 'custom',
-                'tokenizer' => 'whitespace',
-                'filter' => ['lowercase', 'sw_ngram_filter'],
+        $analysis = [
+            'analyzer' => [
+                'sw_ngram_analyzer' => [
+                    'type' => 'custom',
+                    'tokenizer' => 'whitespace',
+                    'filter' => ['lowercase', 'sw_ngram_filter'],
+                ],
+            ],
+            'filter' => [
+                'sw_ngram_filter' => ['type' => 'ngram', 'min_gram' => 4, 'max_gram' => 5],
             ],
         ];
 
-        $filters = [
-            'sw_ngram_filter' => ['type' => 'ngram', 'min_gram' => 4, 'max_gram' => 5],
-        ];
-
-        $indices = $this->createMock(IndicesNamespace::class);
-        $client = $this->createMock(Client::class);
-        $client->method('indices')->willReturn($indices);
-
         $sentBodies = [];
-        $indices->method('analyze')->willReturnCallback(function (array $params) use (&$sentBodies): array {
-            $sentBodies[] = $params['body'];
-
-            return ['tokens' => [['token' => 'foo']]];
-        });
-
-        $tester = new CommandTester(new ElasticsearchTestAnalyzerCommand($client, $analyzers, $filters));
+        $tester = new CommandTester(new ElasticsearchTestAnalyzerCommand($this->createClient($sentBodies), $analysis));
         $tester->execute(['term' => 'foobar']);
 
-        $customBody = null;
-        foreach ($sentBodies as $body) {
-            if (($body['tokenizer'] ?? null) === 'whitespace') {
-                $customBody = $body;
-
-                break;
-            }
-        }
-
-        static::assertNotNull($customBody, 'expected custom analyzer body to be sent');
-        static::assertSame('foobar', $customBody['text']);
+        static::assertCount(1, $sentBodies);
+        static::assertSame('foobar', $sentBodies[0]['text']);
+        static::assertSame('whitespace', $sentBodies[0]['tokenizer']);
         static::assertSame(
             ['lowercase', ['type' => 'ngram', 'min_gram' => 4, 'max_gram' => 5]],
-            $customBody['filter'],
+            $sentBodies[0]['filter'],
         );
         static::assertStringContainsString('sw_ngram_analyzer', $tester->getDisplay());
     }
 
-    public function testBuiltInAnalyzersAreSkippedByDefault(): void
+    public function testCharFiltersAndTokenizersAreResolvedFromTheirOwnSections(): void
     {
-        $analyzers = [
-            'sw_whitespace_analyzer' => [
-                'type' => 'custom',
-                'tokenizer' => 'whitespace',
-                'filter' => ['lowercase'],
+        $analysis = [
+            'analyzer' => [
+                'sw_technical_term_analyzer' => [
+                    'type' => 'custom',
+                    'tokenizer' => 'sw_edge',
+                    'char_filter' => ['sw_unit_glue', 'html_strip'],
+                    'filter' => ['lowercase'],
+                ],
+            ],
+            'tokenizer' => [
+                'sw_edge' => ['type' => 'edge_ngram', 'min_gram' => 2],
+            ],
+            'char_filter' => [
+                'sw_unit_glue' => ['type' => 'pattern_replace', 'pattern' => '(\d)\s+(\D)', 'replacement' => '$1$2'],
             ],
         ];
 
-        $indices = $this->createMock(IndicesNamespace::class);
-        $client = $this->createMock(Client::class);
-        $client->method('indices')->willReturn($indices);
-
-        $analyzedNames = [];
         $sentBodies = [];
-        $indices->method('analyze')->willReturnCallback(function (array $params) use (&$analyzedNames, &$sentBodies): array {
-            $sentBodies[] = $params['body'];
-            if (isset($params['body']['analyzer'])) {
-                $analyzedNames[] = $params['body']['analyzer'];
-            }
+        $tester = new CommandTester(new ElasticsearchTestAnalyzerCommand($this->createClient($sentBodies), $analysis));
+        $tester->execute(['term' => '100 ml']);
 
-            return ['tokens' => []];
-        });
+        static::assertCount(1, $sentBodies);
+        static::assertSame(['type' => 'edge_ngram', 'min_gram' => 2], $sentBodies[0]['tokenizer']);
+        static::assertSame(
+            [
+                ['type' => 'pattern_replace', 'pattern' => '(\d)\s+(\D)', 'replacement' => '$1$2'],
+                'html_strip',
+            ],
+            $sentBodies[0]['char_filter'],
+        );
+    }
 
-        $tester = new CommandTester(new ElasticsearchTestAnalyzerCommand($client, $analyzers, []));
+    #[TestDox('The reported chains match the live index when dimension normalization is enabled')]
+    public function testDimensionNormalizeIsMirroredFromIndexCreator(): void
+    {
+        $sentBodies = [];
+        $tester = new CommandTester(new ElasticsearchTestAnalyzerCommand($this->createClient($sentBodies), $this->dimensionAnalysis(), [], true));
+        $tester->execute(['term' => '5 x 70']);
+
+        static::assertCount(1, $sentBodies);
+        static::assertSame(
+            [
+                ['type' => 'pattern_replace', 'pattern' => 'dimension'],
+                ['type' => 'pattern_replace', 'pattern' => 'unit'],
+            ],
+            $sentBodies[0]['char_filter'],
+            'sw_dimension_normalize must be prepended exactly as IndexCreator does it',
+        );
+    }
+
+    public function testDimensionNormalizeIsNotAppliedWhenDisabled(): void
+    {
+        $sentBodies = [];
+        $tester = new CommandTester(new ElasticsearchTestAnalyzerCommand($this->createClient($sentBodies), $this->dimensionAnalysis()));
+        $tester->execute(['term' => '5 x 70']);
+
+        static::assertCount(1, $sentBodies);
+        static::assertSame(
+            [['type' => 'pattern_replace', 'pattern' => 'unit']],
+            $sentBodies[0]['char_filter'],
+        );
+    }
+
+    public function testAdminAnalyzersAreListedInTheirOwnSection(): void
+    {
+        $adminAnalysis = [
+            'analyzer' => [
+                'sw_admin_completion_index_analyzer' => [
+                    'type' => 'custom',
+                    'tokenizer' => 'whitespace',
+                    'filter' => ['lowercase'],
+                ],
+            ],
+        ];
+
+        $sentBodies = [];
+        $tester = new CommandTester(new ElasticsearchTestAnalyzerCommand($this->createClient($sentBodies), [], $adminAnalysis));
         $tester->execute(['term' => 'foo']);
 
-        static::assertNotContains('standard', $analyzedNames);
-        static::assertNotContains('german', $analyzedNames);
+        static::assertCount(1, $sentBodies);
+        static::assertStringContainsString('Custom admin analyzers', $tester->getDisplay());
+        static::assertStringContainsString('sw_admin_completion_index_analyzer', $tester->getDisplay());
+    }
+
+    public function testNonCustomAnalyzerTypesAreNotSentAsInlineBody(): void
+    {
+        $analysis = [
+            'analyzer' => [
+                'my_analyzer' => ['type' => 'standard', 'stopwords' => '_english_'],
+            ],
+        ];
+
+        $sentBodies = [];
+        $tester = new CommandTester(new ElasticsearchTestAnalyzerCommand($this->createClient($sentBodies), $analysis));
+        $tester->execute(['term' => 'foo']);
+
+        static::assertSame([], $sentBodies);
+        static::assertStringContainsString('my_analyzer', $tester->getDisplay());
+        static::assertStringContainsString('not testable inline', $tester->getDisplay());
+    }
+
+    public function testAFailingAnalyzerDoesNotAbortTheReport(): void
+    {
+        $analysis = [
+            'analyzer' => [
+                'broken_analyzer' => ['type' => 'custom', 'tokenizer' => 'nope'],
+                'sw_whitespace_analyzer' => ['type' => 'custom', 'tokenizer' => 'whitespace'],
+            ],
+        ];
+
+        $indices = static::createStub(IndicesNamespace::class);
+        $client = static::createStub(Client::class);
+        $client->method('indices')->willReturn($indices);
+        $indices->method('analyze')->willReturnCallback(function (array $params): array {
+            if ($params['body']['tokenizer'] === 'nope') {
+                throw new \RuntimeException('failed to find global tokenizer under [nope]');
+            }
+
+            return ['tokens' => [['token' => 'foo']]];
+        });
+
+        $tester = new CommandTester(new ElasticsearchTestAnalyzerCommand($client, $analysis));
+        $tester->execute(['term' => 'foo']);
+
+        static::assertStringContainsString('failed to find global tokenizer under [nope]', $tester->getDisplay());
+        static::assertStringContainsString('sw_whitespace_analyzer', $tester->getDisplay());
+    }
+
+    public function testBuiltInAnalyzersAreSkippedByDefault(): void
+    {
+        $analysis = [
+            'analyzer' => [
+                'sw_whitespace_analyzer' => [
+                    'type' => 'custom',
+                    'tokenizer' => 'whitespace',
+                    'filter' => ['lowercase'],
+                ],
+            ],
+        ];
+
+        $sentBodies = [];
+        $tester = new CommandTester(new ElasticsearchTestAnalyzerCommand($this->createClient($sentBodies), $analysis));
+        $tester->execute(['term' => 'foo']);
+
         static::assertCount(1, $sentBodies, 'only the configured custom analyzer should run by default');
         static::assertStringContainsString('Custom analyzers', $tester->getDisplay());
         static::assertStringNotContainsString('Default analyzers', $tester->getDisplay());
@@ -129,26 +228,76 @@ class ElasticsearchTestAnalyzerCommandTest extends TestCase
 
     public function testBuiltInAnalyzersIncludedWithAllFlag(): void
     {
-        $indices = $this->createMock(IndicesNamespace::class);
-        $client = $this->createMock(Client::class);
-        $client->method('indices')->willReturn($indices);
-
-        $analyzedNames = [];
-        $indices->method('analyze')->willReturnCallback(function (array $params) use (&$analyzedNames): array {
-            if (isset($params['body']['analyzer'])) {
-                $analyzedNames[] = $params['body']['analyzer'];
-            }
-
-            return ['tokens' => []];
-        });
-
-        $tester = new CommandTester(new ElasticsearchTestAnalyzerCommand($client, [], []));
+        $sentBodies = [];
+        $tester = new CommandTester(new ElasticsearchTestAnalyzerCommand($this->createClient($sentBodies), [], []));
         $tester->execute(['term' => 'foo', '--all' => true]);
+
+        $analyzedNames = array_column($sentBodies, 'analyzer');
 
         static::assertContains('standard', $analyzedNames);
         static::assertContains('german', $analyzedNames);
         static::assertContains('english', $analyzedNames);
         static::assertStringContainsString('Default analyzers', $tester->getDisplay());
         static::assertStringContainsString('Default language analyzers', $tester->getDisplay());
+    }
+
+    public function testBuiltInSectionsStillHonourGetAnalyzersOverride(): void
+    {
+        $sentBodies = [];
+        $command = new class($this->createClient($sentBodies)) extends ElasticsearchTestAnalyzerCommand {
+            /**
+             * @return array<string, array<string>>
+             */
+            protected function getAnalyzers(): array
+            {
+                return ['My analyzers' => ['my_plugin_analyzer']];
+            }
+        };
+
+        $tester = new CommandTester($command);
+        $tester->execute(['term' => 'foo', '--all' => true]);
+
+        static::assertSame([['analyzer' => 'my_plugin_analyzer', 'text' => 'foo']], $sentBodies);
+        static::assertStringContainsString('My analyzers', $tester->getDisplay());
+    }
+
+    /**
+     * One of the analyzers `IndexCreator` injects `sw_dimension_normalize` into.
+     *
+     * @return array<string, mixed>
+     */
+    private function dimensionAnalysis(): array
+    {
+        return [
+            'analyzer' => [
+                'sw_german_technical_term_index_analyzer' => [
+                    'type' => 'custom',
+                    'tokenizer' => 'whitespace',
+                    'char_filter' => ['sw_unit_glue'],
+                ],
+            ],
+            'char_filter' => [
+                'sw_dimension_normalize' => ['type' => 'pattern_replace', 'pattern' => 'dimension'],
+                'sw_unit_glue' => ['type' => 'pattern_replace', 'pattern' => 'unit'],
+            ],
+        ];
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $sentBodies
+     */
+    private function createClient(array &$sentBodies): Client
+    {
+        $indices = static::createStub(IndicesNamespace::class);
+        $client = static::createStub(Client::class);
+        $client->method('indices')->willReturn($indices);
+
+        $indices->method('analyze')->willReturnCallback(function (array $params) use (&$sentBodies): array {
+            $sentBodies[] = $params['body'];
+
+            return ['tokens' => [['token' => 'foo']]];
+        });
+
+        return $client;
     }
 }

--- a/tests/unit/Elasticsearch/Framework/Command/ElasticsearchTestAnalyzerCommandTest.php
+++ b/tests/unit/Elasticsearch/Framework/Command/ElasticsearchTestAnalyzerCommandTest.php
@@ -112,7 +112,7 @@ class ElasticsearchTestAnalyzerCommandTest extends TestCase
     public function testDimensionNormalizeIsMirroredFromIndexCreator(): void
     {
         $sentBodies = [];
-        $tester = new CommandTester(new ElasticsearchTestAnalyzerCommand($this->createClient($sentBodies), $this->dimensionAnalysis(), [], true));
+        $tester = new CommandTester(new ElasticsearchTestAnalyzerCommand($this->createClient($sentBodies), $this->dimensionAnalysis(), true));
         $tester->execute(['term' => '5 x 70']);
 
         static::assertCount(1, $sentBodies);
@@ -137,44 +137,6 @@ class ElasticsearchTestAnalyzerCommandTest extends TestCase
             [['type' => 'pattern_replace', 'pattern' => 'unit']],
             $sentBodies[0]['char_filter'],
         );
-    }
-
-    public function testAdminAnalyzersAreListedInTheirOwnSection(): void
-    {
-        $adminAnalysis = [
-            'analyzer' => [
-                'sw_admin_completion_index_analyzer' => [
-                    'type' => 'custom',
-                    'tokenizer' => 'whitespace',
-                    'filter' => ['lowercase'],
-                ],
-            ],
-        ];
-
-        $sentBodies = [];
-        $tester = new CommandTester(new ElasticsearchTestAnalyzerCommand($this->createClient($sentBodies), [], $adminAnalysis));
-        $tester->execute(['term' => 'foo']);
-
-        static::assertCount(1, $sentBodies);
-        static::assertStringContainsString('Custom admin analyzers', $tester->getDisplay());
-        static::assertStringContainsString('sw_admin_completion_index_analyzer', $tester->getDisplay());
-    }
-
-    public function testNonCustomAnalyzerTypesAreNotSentAsInlineBody(): void
-    {
-        $analysis = [
-            'analyzer' => [
-                'my_analyzer' => ['type' => 'standard', 'stopwords' => '_english_'],
-            ],
-        ];
-
-        $sentBodies = [];
-        $tester = new CommandTester(new ElasticsearchTestAnalyzerCommand($this->createClient($sentBodies), $analysis));
-        $tester->execute(['term' => 'foo']);
-
-        static::assertSame([], $sentBodies);
-        static::assertStringContainsString('my_analyzer', $tester->getDisplay());
-        static::assertStringContainsString('not testable inline', $tester->getDisplay());
     }
 
     public function testAFailingAnalyzerDoesNotAbortTheReport(): void
@@ -229,7 +191,7 @@ class ElasticsearchTestAnalyzerCommandTest extends TestCase
     public function testBuiltInAnalyzersIncludedWithAllFlag(): void
     {
         $sentBodies = [];
-        $tester = new CommandTester(new ElasticsearchTestAnalyzerCommand($this->createClient($sentBodies), [], []));
+        $tester = new CommandTester(new ElasticsearchTestAnalyzerCommand($this->createClient($sentBodies), []));
         $tester->execute(['term' => 'foo', '--all' => true]);
 
         $analyzedNames = array_column($sentBodies, 'analyzer');

--- a/tests/unit/Elasticsearch/Framework/Command/ElasticsearchTestAnalyzerCommandTest.php
+++ b/tests/unit/Elasticsearch/Framework/Command/ElasticsearchTestAnalyzerCommandTest.php
@@ -91,43 +91,24 @@ class ElasticsearchTestAnalyzerCommandTest extends TestCase
         static::assertStringContainsString('sw_ngram_analyzer', $tester->getDisplay());
     }
 
-    public function testBuiltInAnalyzersAreSentByName(): void
+    public function testBuiltInAnalyzersAreSkippedByDefault(): void
     {
-        $indices = $this->createMock(IndicesNamespace::class);
-        $client = $this->createMock(Client::class);
-        $client->method('indices')->willReturn($indices);
+        $analyzers = [
+            'sw_whitespace_analyzer' => [
+                'type' => 'custom',
+                'tokenizer' => 'whitespace',
+                'filter' => ['lowercase'],
+            ],
+        ];
 
-        $sentBodies = [];
-        $indices->method('analyze')->willReturnCallback(function (array $params) use (&$sentBodies): array {
-            $sentBodies[] = $params['body'];
-
-            return ['tokens' => [['token' => 'foo']]];
-        });
-
-        $tester = new CommandTester(new ElasticsearchTestAnalyzerCommand($client, [], []));
-        $tester->execute(['term' => 'foo']);
-
-        $standard = null;
-        foreach ($sentBodies as $body) {
-            if (($body['analyzer'] ?? null) === 'standard') {
-                $standard = $body;
-
-                break;
-            }
-        }
-
-        static::assertNotNull($standard);
-        static::assertSame('foo', $standard['text']);
-    }
-
-    public function testLanguageAnalyzersAreSkippedByDefault(): void
-    {
         $indices = $this->createMock(IndicesNamespace::class);
         $client = $this->createMock(Client::class);
         $client->method('indices')->willReturn($indices);
 
         $analyzedNames = [];
-        $indices->method('analyze')->willReturnCallback(function (array $params) use (&$analyzedNames): array {
+        $sentBodies = [];
+        $indices->method('analyze')->willReturnCallback(function (array $params) use (&$analyzedNames, &$sentBodies): array {
+            $sentBodies[] = $params['body'];
             if (isset($params['body']['analyzer'])) {
                 $analyzedNames[] = $params['body']['analyzer'];
             }
@@ -135,16 +116,18 @@ class ElasticsearchTestAnalyzerCommandTest extends TestCase
             return ['tokens' => []];
         });
 
-        $tester = new CommandTester(new ElasticsearchTestAnalyzerCommand($client, [], []));
+        $tester = new CommandTester(new ElasticsearchTestAnalyzerCommand($client, $analyzers, []));
         $tester->execute(['term' => 'foo']);
 
-        static::assertContains('standard', $analyzedNames);
+        static::assertNotContains('standard', $analyzedNames);
         static::assertNotContains('german', $analyzedNames);
-        static::assertNotContains('english', $analyzedNames);
+        static::assertCount(1, $sentBodies, 'only the configured custom analyzer should run by default');
+        static::assertStringContainsString('Custom analyzers', $tester->getDisplay());
+        static::assertStringNotContainsString('Default analyzers', $tester->getDisplay());
         static::assertStringNotContainsString('Default language analyzers', $tester->getDisplay());
     }
 
-    public function testLanguageAnalyzersIncludedWithFlag(): void
+    public function testBuiltInAnalyzersIncludedWithAllFlag(): void
     {
         $indices = $this->createMock(IndicesNamespace::class);
         $client = $this->createMock(Client::class);
@@ -160,10 +143,12 @@ class ElasticsearchTestAnalyzerCommandTest extends TestCase
         });
 
         $tester = new CommandTester(new ElasticsearchTestAnalyzerCommand($client, [], []));
-        $tester->execute(['term' => 'foo', '--with-language-analyzers' => true]);
+        $tester->execute(['term' => 'foo', '--all' => true]);
 
+        static::assertContains('standard', $analyzedNames);
         static::assertContains('german', $analyzedNames);
         static::assertContains('english', $analyzedNames);
+        static::assertStringContainsString('Default analyzers', $tester->getDisplay());
         static::assertStringContainsString('Default language analyzers', $tester->getDisplay());
     }
 }

--- a/tests/unit/Elasticsearch/Framework/Command/ElasticsearchTestAnalyzerCommandTest.php
+++ b/tests/unit/Elasticsearch/Framework/Command/ElasticsearchTestAnalyzerCommandTest.php
@@ -119,4 +119,51 @@ class ElasticsearchTestAnalyzerCommandTest extends TestCase
         static::assertNotNull($standard);
         static::assertSame('foo', $standard['text']);
     }
+
+    public function testLanguageAnalyzersAreSkippedByDefault(): void
+    {
+        $indices = $this->createMock(IndicesNamespace::class);
+        $client = $this->createMock(Client::class);
+        $client->method('indices')->willReturn($indices);
+
+        $analyzedNames = [];
+        $indices->method('analyze')->willReturnCallback(function (array $params) use (&$analyzedNames): array {
+            if (isset($params['body']['analyzer'])) {
+                $analyzedNames[] = $params['body']['analyzer'];
+            }
+
+            return ['tokens' => []];
+        });
+
+        $tester = new CommandTester(new ElasticsearchTestAnalyzerCommand($client, [], []));
+        $tester->execute(['term' => 'foo']);
+
+        static::assertContains('standard', $analyzedNames);
+        static::assertNotContains('german', $analyzedNames);
+        static::assertNotContains('english', $analyzedNames);
+        static::assertStringNotContainsString('Default language analyzers', $tester->getDisplay());
+    }
+
+    public function testLanguageAnalyzersIncludedWithFlag(): void
+    {
+        $indices = $this->createMock(IndicesNamespace::class);
+        $client = $this->createMock(Client::class);
+        $client->method('indices')->willReturn($indices);
+
+        $analyzedNames = [];
+        $indices->method('analyze')->willReturnCallback(function (array $params) use (&$analyzedNames): array {
+            if (isset($params['body']['analyzer'])) {
+                $analyzedNames[] = $params['body']['analyzer'];
+            }
+
+            return ['tokens' => []];
+        });
+
+        $tester = new CommandTester(new ElasticsearchTestAnalyzerCommand($client, [], []));
+        $tester->execute(['term' => 'foo', '--with-language-analyzers' => true]);
+
+        static::assertContains('german', $analyzedNames);
+        static::assertContains('english', $analyzedNames);
+        static::assertStringContainsString('Default language analyzers', $tester->getDisplay());
+    }
 }

--- a/tests/unit/Elasticsearch/Framework/Command/ElasticsearchTestAnalyzerCommandTest.php
+++ b/tests/unit/Elasticsearch/Framework/Command/ElasticsearchTestAnalyzerCommandTest.php
@@ -44,4 +44,79 @@ class ElasticsearchTestAnalyzerCommandTest extends TestCase
         static::assertStringContainsString('standard', $display);
         static::assertStringContainsString('shopware test', $display);
     }
+
+    public function testCustomAnalyzersAreSentInlineWithResolvedFilters(): void
+    {
+        $analyzers = [
+            'sw_ngram_analyzer' => [
+                'type' => 'custom',
+                'tokenizer' => 'whitespace',
+                'filter' => ['lowercase', 'sw_ngram_filter'],
+            ],
+        ];
+
+        $filters = [
+            'sw_ngram_filter' => ['type' => 'ngram', 'min_gram' => 4, 'max_gram' => 5],
+        ];
+
+        $indices = $this->createMock(IndicesNamespace::class);
+        $client = $this->createMock(Client::class);
+        $client->method('indices')->willReturn($indices);
+
+        $sentBodies = [];
+        $indices->method('analyze')->willReturnCallback(function (array $params) use (&$sentBodies): array {
+            $sentBodies[] = $params['body'];
+
+            return ['tokens' => [['token' => 'foo']]];
+        });
+
+        $tester = new CommandTester(new ElasticsearchTestAnalyzerCommand($client, $analyzers, $filters));
+        $tester->execute(['term' => 'foobar']);
+
+        $customBody = null;
+        foreach ($sentBodies as $body) {
+            if (($body['tokenizer'] ?? null) === 'whitespace') {
+                $customBody = $body;
+
+                break;
+            }
+        }
+
+        static::assertNotNull($customBody, 'expected custom analyzer body to be sent');
+        static::assertSame('foobar', $customBody['text']);
+        static::assertSame(
+            ['lowercase', ['type' => 'ngram', 'min_gram' => 4, 'max_gram' => 5]],
+            $customBody['filter'],
+        );
+        static::assertStringContainsString('sw_ngram_analyzer', $tester->getDisplay());
+    }
+
+    public function testBuiltInAnalyzersAreSentByName(): void
+    {
+        $indices = $this->createMock(IndicesNamespace::class);
+        $client = $this->createMock(Client::class);
+        $client->method('indices')->willReturn($indices);
+
+        $sentBodies = [];
+        $indices->method('analyze')->willReturnCallback(function (array $params) use (&$sentBodies): array {
+            $sentBodies[] = $params['body'];
+
+            return ['tokens' => [['token' => 'foo']]];
+        });
+
+        $tester = new CommandTester(new ElasticsearchTestAnalyzerCommand($client, [], []));
+        $tester->execute(['term' => 'foo']);
+
+        $standard = null;
+        foreach ($sentBodies as $body) {
+            if (($body['analyzer'] ?? null) === 'standard') {
+                $standard = $body;
+
+                break;
+            }
+        }
+
+        static::assertNotNull($standard);
+        static::assertSame('foo', $standard['text']);
+    }
 }


### PR DESCRIPTION
## Summary

- The `Custom analyzers` section in `bin/console es:test:analyzer` was an empty placeholder — running the command never showed how Shopware's own analyzers tokenize a term.
- The command now reads `elasticsearch.analysis.analyzer` (and `elasticsearch.analysis.filter`) from the container parameters that are already populated from `elasticsearch.yaml`, and runs each configured analyzer against the given term.
- Custom analyzers are sent as inline `_analyze` request bodies with their tokenizer, char filters and filters resolved from `elasticsearch.analysis.filter`. No existing index is required, so the command works on a fresh cluster too.
- The built-in default and language analyzer sections are kept so users can still compare e.g. `sw_german_analyzer` against the built-in `german` analyzer.

## Test plan

- [ ] `bin/console es:test:analyzer "Shopware ist toll"` against a running OpenSearch cluster shows tokens for `sw_whitespace_analyzer`, `sw_ngram_analyzer`, `sw_english_analyzer`, `sw_german_analyzer` in the `Custom analyzers (elasticsearch.yaml)` section.
- [ ] Default and language analyzer sections still render the same output as before.
- [ ] `vendor/bin/phpunit tests/unit/Elasticsearch/Framework/Command/ElasticsearchTestAnalyzerCommandTest.php` is green.