### PR TITLE
fix: duplicate store session expired notification and Login action router crash

### DIFF
--- a/src/Administration/Resources/app/administration/src/core/factory/http.factory.js
+++ b/src/Administration/Resources/app/administration/src/core/factory/http.factory.js
@@ -240,9 +240,6 @@ function globalErrorHandlingInterceptor(client) {
  * @param {Object} data
  */
 function handleErrorStates({ status, errors, error = null, data }) {
-    // Get $tc for translations and bind the Vue component scope to make it working
-    const viewRoot = Shopware.Application.view.root;
-
     // Handle sync-api errors
     if (status === 400 && (error?.response?.config?.url ?? '').includes('_action/sync')) {
         if (!data) {
@@ -293,12 +290,17 @@ function handleErrorStates({ status, errors, error = null, data }) {
         });
     }
 
+    // Only show the notification after storeSessionExpiredInterceptor has already retried.
+    // storeSessionRequestRetries is set on the config before the retry fires, so it is >= 1
+    // on the final (failed) attempt and undefined on the first attempt that will be retried.
+    // When error is null (sync-api recursive call) there is no retry mechanism, so always show.
     if (
         status === 403 &&
         [
             'FRAMEWORK__STORE_SESSION_EXPIRED',
             'FRAMEWORK__STORE_SHOP_SECRET_INVALID',
-        ].includes(errors[0]?.code)
+        ].includes(errors[0]?.code) &&
+        (error === null || (error?.config?.storeSessionRequestRetries ?? 0) >= 1)
     ) {
         Shopware.Store.get('notification').createNotification({
             variant: 'warning',
@@ -311,7 +313,7 @@ function handleErrorStates({ status, errors, error = null, data }) {
                 {
                     label: Shopware.Snippet.tc('sw-extension.errors.storeSessionExpired.actionLabel'),
                     method: () => {
-                        viewRoot.$router.push({
+                        Shopware.Application.view.router?.push({
                             name: 'sw.extension.my-extensions.account',
                         });
                     },

--- a/src/Administration/Resources/app/administration/src/core/factory/http.factory.spec.js
+++ b/src/Administration/Resources/app/administration/src/core/factory/http.factory.spec.js
@@ -441,6 +441,99 @@ describe('core/factory/http.factory.js', () => {
         });
     });
 
+    describe('storeSessionExpired notification', () => {
+        let notificationStore;
+        let notificationSpy;
+
+        beforeEach(() => {
+            notificationStore = Shopware.Store.get('notification');
+            notificationSpy = jest.spyOn(notificationStore, 'createNotification').mockImplementation(() => {});
+        });
+
+        afterEach(() => {
+            notificationSpy.mockRestore();
+        });
+
+        it.each([
+            ['FRAMEWORK__STORE_SESSION_EXPIRED'],
+            ['FRAMEWORK__STORE_SHOP_SECRET_INVALID'],
+        ])('should show the session-expired notification exactly once when the retry also fails (%s)', async (errorCode) => {
+            mock.onGet('/store-route-requiring-auth').reply(403, {
+                errors: [{ code: errorCode }],
+            });
+
+            await httpClient.get('/store-route-requiring-auth').catch(() => {});
+
+            expect(notificationSpy).toHaveBeenCalledTimes(1);
+            expect(notificationSpy).toHaveBeenCalledWith(
+                expect.objectContaining({ variant: 'warning' }),
+            );
+        });
+
+        it.each([
+            ['FRAMEWORK__STORE_SESSION_EXPIRED'],
+            ['FRAMEWORK__STORE_SHOP_SECRET_INVALID'],
+        ])('should not show the session-expired notification when the retry succeeds (%s)', async (errorCode) => {
+            mock.onGet('/store-route-requiring-auth')
+                .replyOnce(403, { errors: [{ code: errorCode }] })
+                .onGet('/store-route-requiring-auth')
+                .replyOnce(200, {});
+
+            await httpClient.get('/store-route-requiring-auth');
+
+            expect(notificationSpy).not.toHaveBeenCalled();
+        });
+
+        it.each([
+            ['FRAMEWORK__STORE_SESSION_EXPIRED'],
+            ['FRAMEWORK__STORE_SHOP_SECRET_INVALID'],
+        ])('should show the session-expired notification for a sync-api nested error without retrying (%s)', async (errorCode) => {
+            // The sync-api path calls handleErrorStates with error=null (no retry mechanism).
+            // The guard must still show the notification in this case.
+            mock.onPost('/_action/sync').reply(400, {
+                errors: [],
+                data: {
+                    entity_writes: {
+                        result: [
+                            {
+                                errors: [{ code: errorCode, status: '403' }],
+                            },
+                        ],
+                    },
+                },
+            });
+
+            await httpClient.post('/_action/sync', {}).catch(() => {});
+
+            expect(notificationSpy).toHaveBeenCalledTimes(1);
+            expect(notificationSpy).toHaveBeenCalledWith(
+                expect.objectContaining({ variant: 'warning' }),
+            );
+        });
+
+        it('should navigate via Shopware.Application.view.router when the Login action is clicked', async () => {
+            const pushSpy = jest.fn();
+            const originalView = Shopware.Application.view;
+            Shopware.Application.view = {
+                ...originalView,
+                router: { push: pushSpy },
+            };
+
+            mock.onGet('/store-route-requiring-auth').reply(403, {
+                errors: [{ code: 'FRAMEWORK__STORE_SESSION_EXPIRED' }],
+            });
+
+            await httpClient.get('/store-route-requiring-auth').catch(() => {});
+
+            const notificationCall = notificationSpy.mock.calls[0][0];
+            notificationCall.actions[0].method();
+
+            expect(pushSpy).toHaveBeenCalledWith({ name: 'sw.extension.my-extensions.account' });
+
+            Shopware.Application.view = originalView;
+        });
+    });
+
     describe('refreshTokenInterceptor', () => {
         let loginService;
         let originalShopwareService;


### PR DESCRIPTION
### 1. Why is this change necessary?

When a Shopware Account store API request fails with a 403 FRAMEWORK__STORE_SESSION_EXPIRED or FRAMEWORK__STORE_SHOP_SECRET_INVALID error, the "Shopware Account session expired" notification is shown twice. Additionally, clicking the "Login" action in the notification throws a TypeError: undefined is not an object (evaluating 's.$router.push'), making the button non-functional.

### 2. What does this change do, exactly?


### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).

- closes #16273  - closes the issue #16273 when the PR is merged
- relates #16273 - relates to the issue #16273

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
