### PR TITLE
feat: add CMS page loading extension point

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -115,6 +115,12 @@ Affected commands:
 - `bin/console dal:validate --json` → `bin/console dal:validate --format json`
 - `bin/console sales-channel:list --output json` → `bin/console sales-channel:list --format json`
 
+### CMS page loading extension point
+
+The CMS page loading (`SalesChannelCmsPageLoader::load`) is now wrapped with the `Extension` mechanism, so you can resolve the CMS page(s) for a request through a plain event subscriber instead of decorating the loader. This makes it simple to serve a customer-group specific layout, an A/B-test variant, or pages from an external source.
+
+Subscribe to `SalesChannelCmsPageLoaderExtension::onPre()` to take over the loading (assign `$extension->result` and call `stopPropagation()`), or to `SalesChannelCmsPageLoaderExtension::onPost()` to adjust the loaded result. Without a subscriber the unchanged core loading runs.
+
 ## Administration
 
 ### Rule Builder cart total condition labels adjusted

--- a/src/Core/Content/Cms/Extension/SalesChannelCmsPageLoaderExtension.php
+++ b/src/Core/Content/Cms/Extension/SalesChannelCmsPageLoaderExtension.php
@@ -1,0 +1,68 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Content\Cms\Extension;
+
+use Shopware\Core\Content\Cms\CmsPageCollection;
+use Shopware\Core\Content\Cms\DataResolver\ResolverContext\ResolverContext;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
+use Shopware\Core\Framework\Extensions\Extension;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * @public This class is used as type-hint for all event listeners, so the class string is "public consumable" API
+ *
+ * @title Loads the CMS page(s) for a storefront request
+ *
+ * @description Wraps the whole CMS page loading. A listener on the `.pre` event may resolve the pages itself — e.g. a customer-group specific layout, an A/B variant or an external source — by assigning `$extension->result` and stopping propagation, short-circuiting the core loader. `.post` may adjust the loaded result.
+ *
+ * @codeCoverageIgnore
+ *
+ * @extends Extension<EntitySearchResult<CmsPageCollection>>
+ */
+#[Package('discovery')]
+final class SalesChannelCmsPageLoaderExtension extends Extension
+{
+    public const NAME = 'cms-page-loader.load';
+
+    /**
+     * @internal Shopware owns the __constructor, but the properties are public API
+     *
+     * @param array<string, mixed>|null $config
+     */
+    public function __construct(
+        /**
+         * @public
+         *
+         * @description The current storefront request
+         */
+        public readonly Request $request,
+        /**
+         * @public
+         *
+         * @description The criteria used to load the CMS page(s)
+         */
+        public readonly Criteria $criteria,
+        /**
+         * @public
+         *
+         * @description Allows access to the current sales-channel context
+         */
+        public readonly SalesChannelContext $context,
+        /**
+         * @public
+         *
+         * @description Optional per-page slot config overrides
+         */
+        public readonly ?array $config = null,
+        /**
+         * @public
+         *
+         * @description Optional resolver context used to resolve the slot data
+         */
+        public readonly ?ResolverContext $resolverContext = null,
+    ) {
+    }
+}

--- a/src/Core/Content/Cms/SalesChannel/SalesChannelCmsPageLoader.php
+++ b/src/Core/Content/Cms/SalesChannel/SalesChannelCmsPageLoader.php
@@ -12,6 +12,7 @@ use Shopware\Core\Content\Cms\DataResolver\CmsSlotsDataResolver;
 use Shopware\Core\Content\Cms\DataResolver\ResolverContext\ResolverContext;
 use Shopware\Core\Content\Cms\Events\CmsPageLoadedEvent;
 use Shopware\Core\Content\Cms\Events\CmsPageLoaderCriteriaEvent;
+use Shopware\Core\Content\Cms\Extension\SalesChannelCmsPageLoaderExtension;
 use Shopware\Core\Content\Cms\SalesChannel\Struct\ProductBoxStruct;
 use Shopware\Core\Content\Cms\SalesChannel\Struct\ProductSliderStruct;
 use Shopware\Core\Framework\Adapter\Cache\CacheTagCollector;
@@ -20,6 +21,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
+use Shopware\Core\Framework\Extensions\ExtensionDispatcher;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
@@ -38,10 +40,30 @@ class SalesChannelCmsPageLoader implements SalesChannelCmsPageLoaderInterface
         private readonly CmsSlotsDataResolver $slotDataResolver,
         private readonly EventDispatcherInterface $dispatcher,
         private readonly CacheTagCollector $cacheTagCollector,
+        private readonly ExtensionDispatcher $extensions,
     ) {
     }
 
     public function load(
+        Request $request,
+        Criteria $criteria,
+        SalesChannelContext $context,
+        ?array $config = null,
+        ?ResolverContext $resolverContext = null
+    ): EntitySearchResult {
+        return $this->extensions->publish(
+            name: SalesChannelCmsPageLoaderExtension::NAME,
+            extension: new SalesChannelCmsPageLoaderExtension($request, $criteria, $context, $config, $resolverContext),
+            function: $this->_load(...),
+        );
+    }
+
+    /**
+     * @param array<string, mixed>|null $config
+     *
+     * @return EntitySearchResult<CmsPageCollection>
+     */
+    private function _load(
         Request $request,
         Criteria $criteria,
         SalesChannelContext $context,

--- a/src/Core/Content/DependencyInjection/cms.xml
+++ b/src/Core/Content/DependencyInjection/cms.xml
@@ -63,6 +63,7 @@
             <argument type="service" id="Shopware\Core\Content\Cms\DataResolver\CmsSlotsDataResolver"/>
             <argument type="service" id="event_dispatcher"/>
             <argument type="service" id="Shopware\Core\Framework\Adapter\Cache\CacheTagCollector"/>
+            <argument type="service" id="Shopware\Core\Framework\Extensions\ExtensionDispatcher"/>
         </service>
 
         <service id="Shopware\Core\Content\Cms\Service\EntityCmsSlotConfigInheritanceBuilder">

--- a/tests/examples/SalesChannelCmsPageLoaderExample.php
+++ b/tests/examples/SalesChannelCmsPageLoaderExample.php
@@ -1,0 +1,44 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Examples;
+
+use Shopware\Core\Content\Cms\CmsPageCollection;
+use Shopware\Core\Content\Cms\CmsPageDefinition;
+use Shopware\Core\Content\Cms\CmsPageEntity;
+use Shopware\Core\Content\Cms\Extension\SalesChannelCmsPageLoaderExtension;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Resolves the CMS page(s) yourself — e.g. a customer-group specific layout or an
+ * external source — instead of the core loader.
+ */
+readonly class SalesChannelCmsPageLoaderExample implements EventSubscriberInterface
+{
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            SalesChannelCmsPageLoaderExtension::NAME . '.pre' => 'replace',
+        ];
+    }
+
+    public function replace(SalesChannelCmsPageLoaderExtension $event): void
+    {
+        // The request is exposed through the public properties:
+        // $event->request, $event->criteria, $event->context, $event->config
+
+        $page = (new CmsPageEntity())->assign(['id' => 'example-page']);
+
+        $event->result = new EntitySearchResult(
+            CmsPageDefinition::ENTITY_NAME,
+            1,
+            new CmsPageCollection([$page]),
+            null,
+            $event->criteria,
+            $event->context->getContext(),
+        );
+
+        // stop propagation so the core CMS page loading is skipped
+        $event->stopPropagation();
+    }
+}

--- a/tests/unit/Core/Content/Cms/Extension/SalesChannelCmsPageLoaderExtensionTest.php
+++ b/tests/unit/Core/Content/Cms/Extension/SalesChannelCmsPageLoaderExtensionTest.php
@@ -1,0 +1,57 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Content\Cms\Extension;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Cms\CmsPageCollection;
+use Shopware\Core\Content\Cms\CmsPageDefinition;
+use Shopware\Core\Content\Cms\CmsPageEntity;
+use Shopware\Core\Content\Cms\Extension\SalesChannelCmsPageLoaderExtension;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
+use Shopware\Core\Framework\Extensions\ExtensionDispatcher;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Shopware\Tests\Examples\SalesChannelCmsPageLoaderExample;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * @internal
+ */
+#[CoversClass(SalesChannelCmsPageLoaderExtension::class)]
+#[CoversClass(SalesChannelCmsPageLoaderExample::class)]
+class SalesChannelCmsPageLoaderExtensionTest extends TestCase
+{
+    public function testSubscriberResolvesPageLoad(): void
+    {
+        $context = $this->createMock(SalesChannelContext::class);
+        $context->method('getContext')->willReturn(Context::createDefaultContext());
+
+        $dispatcher = new EventDispatcher();
+        $dispatcher->addSubscriber(new SalesChannelCmsPageLoaderExample());
+
+        $coreCalled = false;
+        $result = (new ExtensionDispatcher($dispatcher))->publish(
+            name: SalesChannelCmsPageLoaderExtension::NAME,
+            extension: new SalesChannelCmsPageLoaderExtension(new Request(), new Criteria(), $context),
+            function: static function () use (&$coreCalled): EntitySearchResult {
+                $coreCalled = true;
+
+                return new EntitySearchResult(
+                    CmsPageDefinition::ENTITY_NAME,
+                    1,
+                    new CmsPageCollection([(new CmsPageEntity())->assign(['id' => 'core-page'])]),
+                    null,
+                    new Criteria(),
+                    Context::createDefaultContext(),
+                );
+            },
+        );
+
+        static::assertFalse($coreCalled, 'The core CMS page loader must be skipped when a subscriber resolves it.');
+        static::assertInstanceOf(EntitySearchResult::class, $result);
+        static::assertSame(['example-page'], array_values($result->getEntities()->getIds()));
+    }
+}

--- a/tests/unit/Core/Content/Cms/SalesChannel/SalesChannelCmsPageLoaderTest.php
+++ b/tests/unit/Core/Content/Cms/SalesChannel/SalesChannelCmsPageLoaderTest.php
@@ -17,6 +17,7 @@ use Shopware\Core\Content\Cms\DataResolver\CmsSlotsDataResolver;
 use Shopware\Core\Content\Cms\SalesChannel\SalesChannelCmsPageLoader;
 use Shopware\Core\Framework\Adapter\Cache\CacheTagCollector;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Extensions\ExtensionDispatcher;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Test\Generator;
 use Shopware\Core\Test\Stub\DataAbstractionLayer\StaticEntityRepository;
@@ -42,6 +43,7 @@ class SalesChannelCmsPageLoaderTest extends TestCase
             $this->createMock(CmsSlotsDataResolver::class),
             $this->createMock(EventDispatcher::class),
             $this->createMock(CacheTagCollector::class),
+            new ExtensionDispatcher(new EventDispatcher()),
         );
 
         $result = $loader->load(new Request(), new Criteria(), Generator::generateSalesChannelContext());
@@ -68,6 +70,7 @@ class SalesChannelCmsPageLoaderTest extends TestCase
             $this->createMock(CmsSlotsDataResolver::class),
             $this->createMock(EventDispatcher::class),
             $this->createMock(CacheTagCollector::class),
+            new ExtensionDispatcher(new EventDispatcher()),
         );
 
         $config = [


### PR DESCRIPTION
### 1. Why is this change necessary?

Replacing or augmenting how a storefront resolves its CMS page is a common need — a customer-group specific layout, an A/B-test variant, a multi-tenant/region split, or pages served from an external source. Today the only way is to **decorate `SalesChannelCmsPageLoader`** and reimplement the whole `load()` flow. The loader emits a *criteria* event before and a *loaded* event after, but there is no way for an extension to resolve the page(s) itself and short-circuit the core.

### 2. What does this change do, exactly?

Wraps `SalesChannelCmsPageLoader::load()` with the existing `Extension` mechanism (`ExtensionDispatcher::publish`, the same pattern as `ProductListingLoader` / the `CmsSlotsData*` extensions). A subscriber on the `.pre` event can replace the loading (assign `$extension->result` + `stopPropagation()`), `.post` can adjust the result, `.error` can recover. With no subscriber, `publish()` calls the original implementation, so behaviour is unchanged.

- New extension: `Shopware\Core\Content\Cms\Extension\SalesChannelCmsPageLoaderExtension`
  - `NAME = 'cms-page-loader.load'`, result `EntitySearchResult<CmsPageCollection>`
  - request data exposed as public readonly properties: `$extension->request`, `$extension->criteria`, `$extension->context`, `$extension->config`, `$extension->resolverContext`
- The original `load()` body moves into a private `_load()`; the public `load()` keeps its exact signature.

### 3. Describe each step to reproduce the issue or behaviour.

This is an additive extension point, not a bug fix. To exercise it:

1. Register an `EventSubscriberInterface` with `SalesChannelCmsPageLoaderExtension::onPre() => 'replace'`.
2. In the listener read the public properties (`$extension->criteria`, `$extension->context`, …), build/resolve the CMS page(s) yourself, then `$extension->result = $entitySearchResult; $extension->stopPropagation();`.
3. Render any CMS page — the subscriber's result is used and the core loader is skipped.

Covered by `tests/unit/Core/Content/Cms/Extension/SalesChannelCmsPageLoaderExtensionTest.php` (fails without the new extension). The existing `SalesChannelCmsPageLoaderTest` keeps passing through the subscriber-less `publish()` wrapper, proving the change is behaviour-neutral.

### 4. Please link to the relevant issues (if any).

n/a

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Entry added to `RELEASE_INFO-6.7.md` under “Upcoming” → `# Core`.
  - No `UPGRADE` entry needed — the change is purely additive (no breaking change).
- [x] I have written or adjusted the documentation according to my changes (RELEASE_INFO entry + runnable example subscriber under `tests/examples/`)
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
