### PR TITLE
feat: add product search route extension point

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -115,6 +115,12 @@ Affected commands:
 - `bin/console dal:validate --json` → `bin/console dal:validate --format json`
 - `bin/console sales-channel:list --output json` → `bin/console sales-channel:list --format json`
 
+### Product search route extension point
+
+The `/store-api/search` product search (`ProductSearchRoute::load`) is now wrapped with the `Extension` mechanism, so you can resolve or enrich the search result through a plain event subscriber instead of decorating the route. This makes it simple to back the search with an external search service, or to add your own data to the result.
+
+Subscribe to `ProductSearchRouteExtension::onPre()` to take over the search (assign `$extension->result` and call `stopPropagation()`), or to `ProductSearchRouteExtension::onPost()` to adjust the loaded result. Without a subscriber the unchanged core search runs.
+
 ## Administration
 
 ### Rule Builder cart total condition labels adjusted

--- a/src/Core/Content/DependencyInjection/product.xml
+++ b/src/Core/Content/DependencyInjection/product.xml
@@ -382,6 +382,7 @@
         <service id="Shopware\Core\Content\Product\SalesChannel\Search\ProductSearchRoute" public="true">
             <argument type="service" id="Shopware\Core\Content\Product\SearchKeyword\ProductSearchBuilderInterface"/>
             <argument type="service" id="Shopware\Core\Content\Product\SalesChannel\Listing\ProductListingLoader"/>
+            <argument type="service" id="Shopware\Core\Framework\Extensions\ExtensionDispatcher"/>
         </service>
 
         <service id="Shopware\Core\Content\Product\SalesChannel\Search\ResolvedCriteriaProductSearchRoute" decorates="Shopware\Core\Content\Product\SalesChannel\Search\ProductSearchRoute" decoration-priority="-2000" public="true">

--- a/src/Core/Content/Product/Extension/ProductSearchRouteExtension.php
+++ b/src/Core/Content/Product/Extension/ProductSearchRouteExtension.php
@@ -1,0 +1,52 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Content\Product\Extension;
+
+use Shopware\Core\Content\Product\SalesChannel\Search\ProductSearchRouteResponse;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Extensions\Extension;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * @public This class is used as type-hint for all event listeners, so the class string is "public consumable" API
+ *
+ * @title Loads the product search result for the store-api search route
+ *
+ * @description Wraps the whole `/store-api/search` loading. A listener on the `.pre` event may resolve the search itself — e.g. against an external search service or with an enriched result — by assigning `$extension->result` and stopping propagation, short-circuiting the core. `.post` may adjust the loaded result.
+ *
+ * @codeCoverageIgnore
+ *
+ * @extends Extension<ProductSearchRouteResponse>
+ */
+#[Package('inventory')]
+final class ProductSearchRouteExtension extends Extension
+{
+    public const NAME = 'product-search-route.load';
+
+    /**
+     * @internal Shopware owns the __constructor, but the properties are public API
+     */
+    public function __construct(
+        /**
+         * @public
+         *
+         * @description The current store-api request
+         */
+        public readonly Request $request,
+        /**
+         * @public
+         *
+         * @description Allows access to the current sales-channel context
+         */
+        public readonly SalesChannelContext $context,
+        /**
+         * @public
+         *
+         * @description The criteria used for the product search
+         */
+        public readonly Criteria $criteria,
+    ) {
+    }
+}

--- a/src/Core/Content/Product/SalesChannel/Search/ProductSearchRoute.php
+++ b/src/Core/Content/Product/SalesChannel/Search/ProductSearchRoute.php
@@ -3,6 +3,7 @@
 namespace Shopware\Core\Content\Product\SalesChannel\Search;
 
 use Shopware\Core\Content\Product\Aggregate\ProductVisibility\ProductVisibilityDefinition;
+use Shopware\Core\Content\Product\Extension\ProductSearchRouteExtension;
 use Shopware\Core\Content\Product\ProductDefinition;
 use Shopware\Core\Content\Product\SalesChannel\Listing\ProductListingLoader;
 use Shopware\Core\Content\Product\SalesChannel\Listing\ProductListingResult;
@@ -10,6 +11,7 @@ use Shopware\Core\Content\Product\SalesChannel\ProductAvailableFilter;
 use Shopware\Core\Content\Product\SearchKeyword\ProductSearchBuilderInterface;
 use Shopware\Core\Framework\Adapter\Request\RequestParamHelper;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Extensions\ExtensionDispatcher;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
 use Shopware\Core\Framework\Routing\StoreApiRouteScope;
@@ -27,7 +29,8 @@ class ProductSearchRoute extends AbstractProductSearchRoute
      */
     public function __construct(
         private readonly ProductSearchBuilderInterface $searchBuilder,
-        private readonly ProductListingLoader $productListingLoader
+        private readonly ProductListingLoader $productListingLoader,
+        private readonly ExtensionDispatcher $extensions,
     ) {
     }
 
@@ -43,6 +46,15 @@ class ProductSearchRoute extends AbstractProductSearchRoute
         defaults: [PlatformRequest::ATTRIBUTE_ENTITY => ProductDefinition::ENTITY_NAME, PlatformRequest::ATTRIBUTE_HTTP_CACHE => true]
     )]
     public function load(Request $request, SalesChannelContext $context, Criteria $criteria): ProductSearchRouteResponse
+    {
+        return $this->extensions->publish(
+            name: ProductSearchRouteExtension::NAME,
+            extension: new ProductSearchRouteExtension($request, $context, $criteria),
+            function: $this->_load(...),
+        );
+    }
+
+    private function _load(Request $request, SalesChannelContext $context, Criteria $criteria): ProductSearchRouteResponse
     {
         $criteria->addState(Criteria::STATE_ELASTICSEARCH_AWARE);
 

--- a/tests/examples/ProductSearchRouteExample.php
+++ b/tests/examples/ProductSearchRouteExample.php
@@ -1,0 +1,44 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Examples;
+
+use Shopware\Core\Content\Product\Extension\ProductSearchRouteExtension;
+use Shopware\Core\Content\Product\ProductCollection;
+use Shopware\Core\Content\Product\ProductDefinition;
+use Shopware\Core\Content\Product\SalesChannel\Listing\ProductListingResult;
+use Shopware\Core\Content\Product\SalesChannel\Search\ProductSearchRouteResponse;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Resolves the product search yourself — e.g. against an external search service —
+ * instead of the core listing-loader based search.
+ */
+readonly class ProductSearchRouteExample implements EventSubscriberInterface
+{
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            ProductSearchRouteExtension::NAME . '.pre' => 'replace',
+        ];
+    }
+
+    public function replace(ProductSearchRouteExtension $event): void
+    {
+        // The request is exposed through the public properties:
+        // $event->request, $event->context, $event->criteria
+
+        $result = new ProductListingResult(
+            ProductDefinition::ENTITY_NAME,
+            0,
+            new ProductCollection(),
+            null,
+            $event->criteria,
+            $event->context->getContext(),
+        );
+
+        $event->result = new ProductSearchRouteResponse($result);
+
+        // stop propagation so the core product search is skipped
+        $event->stopPropagation();
+    }
+}

--- a/tests/unit/Core/Content/Product/Extension/ProductSearchRouteExtensionTest.php
+++ b/tests/unit/Core/Content/Product/Extension/ProductSearchRouteExtensionTest.php
@@ -1,0 +1,56 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Content\Product\Extension;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Product\Extension\ProductSearchRouteExtension;
+use Shopware\Core\Content\Product\ProductCollection;
+use Shopware\Core\Content\Product\ProductDefinition;
+use Shopware\Core\Content\Product\SalesChannel\Listing\ProductListingResult;
+use Shopware\Core\Content\Product\SalesChannel\Search\ProductSearchRouteResponse;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Extensions\ExtensionDispatcher;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Shopware\Tests\Examples\ProductSearchRouteExample;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * @internal
+ */
+#[CoversClass(ProductSearchRouteExtension::class)]
+#[CoversClass(ProductSearchRouteExample::class)]
+class ProductSearchRouteExtensionTest extends TestCase
+{
+    public function testSubscriberResolvesSearch(): void
+    {
+        $context = $this->createMock(SalesChannelContext::class);
+        $context->method('getContext')->willReturn(Context::createDefaultContext());
+
+        $dispatcher = new EventDispatcher();
+        $dispatcher->addSubscriber(new ProductSearchRouteExample());
+
+        $coreCalled = false;
+        $result = (new ExtensionDispatcher($dispatcher))->publish(
+            name: ProductSearchRouteExtension::NAME,
+            extension: new ProductSearchRouteExtension(new Request(), $context, new Criteria()),
+            function: static function () use (&$coreCalled): ProductSearchRouteResponse {
+                $coreCalled = true;
+
+                return new ProductSearchRouteResponse(new ProductListingResult(
+                    ProductDefinition::ENTITY_NAME,
+                    0,
+                    new ProductCollection(),
+                    null,
+                    new Criteria(),
+                    Context::createDefaultContext(),
+                ));
+            },
+        );
+
+        static::assertFalse($coreCalled, 'The core product search must be skipped when a subscriber resolves it.');
+        static::assertInstanceOf(ProductSearchRouteResponse::class, $result);
+    }
+}

--- a/tests/unit/Core/Content/Product/SalesChannel/Search/ProductSearchRouteTest.php
+++ b/tests/unit/Core/Content/Product/SalesChannel/Search/ProductSearchRouteTest.php
@@ -13,9 +13,11 @@ use Shopware\Core\Content\Product\SalesChannel\Search\ProductSearchRoute;
 use Shopware\Core\Content\Product\SearchKeyword\ProductSearchBuilderInterface;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Extensions\ExtensionDispatcher;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
@@ -121,7 +123,8 @@ class ProductSearchRouteTest extends TestCase
     {
         return new ProductSearchRoute(
             $this->searchBuilder,
-            $this->listingLoader
+            $this->listingLoader,
+            new ExtensionDispatcher(new EventDispatcher()),
         );
     }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?

Replacing or enriching the storefront product search is a common need — backing it with an external search service, returning B2B/customer-specific results, or attaching extra data to the response. Today the only way is to **decorate `ProductSearchRoute`** and reimplement `load()`. The listing route already has `ProductListingCriteriaExtension`, but the search route has no extension point to resolve the result itself.

### 2. What does this change do, exactly?

Wraps `ProductSearchRoute::load()` with the existing `Extension` mechanism (`ExtensionDispatcher::publish`, the same pattern as `ProductListingLoader` / the `CmsSlotsData*` extensions). A subscriber on the `.pre` event can replace the search (assign `$extension->result` + `stopPropagation()`), `.post` can enrich the result, `.error` can recover. With no subscriber, `publish()` calls the original implementation, so behaviour is unchanged.

- New extension: `Shopware\Core\Content\Product\Extension\ProductSearchRouteExtension`
  - `NAME = 'product-search-route.load'`, result `ProductSearchRouteResponse`
  - request data exposed as public readonly properties: `$extension->request`, `$extension->context`, `$extension->criteria`
- The original `load()` body moves into a private `_load()`; the public `load()` keeps its exact signature and `#[Route]`.

### 3. Describe each step to reproduce the issue or behaviour.

This is an additive extension point, not a bug fix. To exercise it:

1. Register an `EventSubscriberInterface` with `ProductSearchRouteExtension::onPre() => 'replace'`.
2. In the listener read the public properties (`$extension->request`, `$extension->context`, `$extension->criteria`), resolve the search yourself, then `$extension->result = $productSearchRouteResponse; $extension->stopPropagation();`.
3. Call `/store-api/search` — the subscriber's result is returned and the core search is skipped.

Covered by `tests/unit/Core/Content/Product/Extension/ProductSearchRouteExtensionTest.php` (fails without the new extension). The existing `ProductSearchRouteTest` keeps passing through the subscriber-less `publish()` wrapper, proving the change is behaviour-neutral.

### 4. Please link to the relevant issues (if any).

n/a

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Entry added to `RELEASE_INFO-6.7.md` under “Upcoming” → `# Core`.
  - No `UPGRADE` entry needed — the change is purely additive (no breaking change).
- [x] I have written or adjusted the documentation according to my changes (RELEASE_INFO entry + runnable example subscriber under `tests/examples/`)
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
