### PR TITLE
feat: add navigation route extension point

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -115,6 +115,12 @@ Affected commands:
 - `bin/console dal:validate --json` → `bin/console dal:validate --format json`
 - `bin/console sales-channel:list --output json` → `bin/console sales-channel:list --format json`
 
+### Navigation route extension point
+
+The `/store-api/navigation` loading (`NavigationRoute::load`) is now wrapped with the `Extension` mechanism, so you can resolve or enrich the navigation categories through a plain event subscriber instead of decorating the route. This makes it simple to serve a customer-group filtered tree, custom child counts, or categories from an external source.
+
+Subscribe to `NavigationRouteExtension::onPre()` to take over the loading (assign `$extension->result` and call `stopPropagation()`), or to `NavigationRouteExtension::onPost()` to adjust the loaded categories. Without a subscriber the unchanged core loading runs.
+
 ## Administration
 
 ### Rule Builder cart total condition labels adjusted

--- a/src/Core/Content/Category/Extension/NavigationRouteExtension.php
+++ b/src/Core/Content/Category/Extension/NavigationRouteExtension.php
@@ -1,0 +1,64 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Content\Category\Extension;
+
+use Shopware\Core\Content\Category\SalesChannel\NavigationRouteResponse;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Extensions\Extension;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * @public This class is used as type-hint for all event listeners, so the class string is "public consumable" API
+ *
+ * @title Loads the navigation categories for the store-api navigation route
+ *
+ * @description Wraps the `/store-api/navigation` loading. A listener on the `.pre` event may resolve the categories itself — e.g. a customer-group filtered tree, custom child counts, or an external source — by assigning `$extension->result` and stopping propagation, short-circuiting the core. `.post` may enrich the loaded categories.
+ *
+ * @codeCoverageIgnore
+ *
+ * @extends Extension<NavigationRouteResponse>
+ */
+#[Package('discovery')]
+final class NavigationRouteExtension extends Extension
+{
+    public const NAME = 'navigation-route.load';
+
+    /**
+     * @internal Shopware owns the __constructor, but the properties are public API
+     */
+    public function __construct(
+        /**
+         * @public
+         *
+         * @description The active category id
+         */
+        public readonly string $activeId,
+        /**
+         * @public
+         *
+         * @description The root category id of the requested navigation
+         */
+        public readonly string $rootId,
+        /**
+         * @public
+         *
+         * @description The current store-api request
+         */
+        public readonly Request $request,
+        /**
+         * @public
+         *
+         * @description Allows access to the current sales-channel context
+         */
+        public readonly SalesChannelContext $context,
+        /**
+         * @public
+         *
+         * @description The criteria used to load the categories
+         */
+        public readonly Criteria $criteria,
+    ) {
+    }
+}

--- a/src/Core/Content/Category/SalesChannel/NavigationRoute.php
+++ b/src/Core/Content/Category/SalesChannel/NavigationRoute.php
@@ -6,6 +6,7 @@ use Doctrine\DBAL\Connection;
 use Shopware\Core\Content\Category\CategoryCollection;
 use Shopware\Core\Content\Category\CategoryDefinition;
 use Shopware\Core\Content\Category\CategoryException;
+use Shopware\Core\Content\Category\Extension\NavigationRouteExtension;
 use Shopware\Core\Content\Category\Service\DefaultCategoryLevelLoaderInterface;
 use Shopware\Core\Content\Category\Service\NavigationLoaderInterface;
 use Shopware\Core\Content\Category\Tree\CategoryTreePathResolver;
@@ -13,6 +14,7 @@ use Shopware\Core\Framework\Adapter\Cache\CacheTagCollector;
 use Shopware\Core\Framework\DataAbstractionLayer\Doctrine\FetchModeHelper;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsAnyFilter;
+use Shopware\Core\Framework\Extensions\ExtensionDispatcher;
 use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
@@ -44,6 +46,7 @@ class NavigationRoute extends AbstractNavigationRoute
         private readonly CacheTagCollector $cacheTagCollector,
         private readonly CategoryTreePathResolver $categoryTreePathResolver,
         private readonly DefaultCategoryLevelLoaderInterface $categoryLevelLoader,
+        private readonly ExtensionDispatcher $extensions,
     ) {
     }
 
@@ -72,6 +75,20 @@ class NavigationRoute extends AbstractNavigationRoute
         defaults: [PlatformRequest::ATTRIBUTE_ENTITY => CategoryDefinition::ENTITY_NAME, PlatformRequest::ATTRIBUTE_HTTP_CACHE => true],
     )]
     public function load(
+        string $activeId,
+        string $rootId,
+        Request $request,
+        SalesChannelContext $context,
+        Criteria $criteria
+    ): NavigationRouteResponse {
+        return $this->extensions->publish(
+            name: NavigationRouteExtension::NAME,
+            extension: new NavigationRouteExtension($activeId, $rootId, $request, $context, $criteria),
+            function: $this->_load(...),
+        );
+    }
+
+    private function _load(
         string $activeId,
         string $rootId,
         Request $request,

--- a/src/Core/Content/DependencyInjection/category.xml
+++ b/src/Core/Content/DependencyInjection/category.xml
@@ -33,6 +33,7 @@
             <argument type="service" id="Shopware\Core\Framework\Adapter\Cache\CacheTagCollector"/>
             <argument type="service" id="Shopware\Core\Content\Category\Tree\CategoryTreePathResolver"/>
             <argument type="service" id="Shopware\Core\Content\Category\Service\DefaultCategoryLevelLoader"/>
+            <argument type="service" id="Shopware\Core\Framework\Extensions\ExtensionDispatcher"/>
         </service>
 
         <service id="Shopware\Core\Content\Category\Service\DefaultCategoryLevelLoader">

--- a/tests/examples/NavigationRouteExample.php
+++ b/tests/examples/NavigationRouteExample.php
@@ -1,0 +1,36 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Examples;
+
+use Shopware\Core\Content\Category\CategoryCollection;
+use Shopware\Core\Content\Category\CategoryEntity;
+use Shopware\Core\Content\Category\Extension\NavigationRouteExtension;
+use Shopware\Core\Content\Category\SalesChannel\NavigationRouteResponse;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Resolves the navigation categories yourself — e.g. a customer-group filtered
+ * tree or an external source — instead of the core navigation loader.
+ */
+readonly class NavigationRouteExample implements EventSubscriberInterface
+{
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            NavigationRouteExtension::NAME . '.pre' => 'replace',
+        ];
+    }
+
+    public function replace(NavigationRouteExtension $event): void
+    {
+        // The request is exposed through the public properties:
+        // $event->activeId, $event->rootId, $event->request, $event->context, $event->criteria
+
+        $category = (new CategoryEntity())->assign(['id' => 'example-category']);
+
+        $event->result = new NavigationRouteResponse(new CategoryCollection([$category]));
+
+        // stop propagation so the core navigation loading is skipped
+        $event->stopPropagation();
+    }
+}

--- a/tests/unit/Core/Content/Category/Extension/NavigationRouteExtensionTest.php
+++ b/tests/unit/Core/Content/Category/Extension/NavigationRouteExtensionTest.php
@@ -1,0 +1,53 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Content\Category\Extension;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Category\CategoryCollection;
+use Shopware\Core\Content\Category\CategoryEntity;
+use Shopware\Core\Content\Category\Extension\NavigationRouteExtension;
+use Shopware\Core\Content\Category\SalesChannel\NavigationRouteResponse;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Extensions\ExtensionDispatcher;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Shopware\Tests\Examples\NavigationRouteExample;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * @internal
+ */
+#[CoversClass(NavigationRouteExtension::class)]
+#[CoversClass(NavigationRouteExample::class)]
+class NavigationRouteExtensionTest extends TestCase
+{
+    public function testSubscriberResolvesNavigation(): void
+    {
+        $dispatcher = new EventDispatcher();
+        $dispatcher->addSubscriber(new NavigationRouteExample());
+
+        $coreCalled = false;
+        $result = (new ExtensionDispatcher($dispatcher))->publish(
+            name: NavigationRouteExtension::NAME,
+            extension: new NavigationRouteExtension(
+                'active-id',
+                'root-id',
+                new Request(),
+                $this->createMock(SalesChannelContext::class),
+                new Criteria(),
+            ),
+            function: static function () use (&$coreCalled): NavigationRouteResponse {
+                $coreCalled = true;
+
+                return new NavigationRouteResponse(new CategoryCollection([
+                    (new CategoryEntity())->assign(['id' => 'core-category']),
+                ]));
+            },
+        );
+
+        static::assertFalse($coreCalled, 'The core navigation loading must be skipped when a subscriber resolves it.');
+        static::assertInstanceOf(NavigationRouteResponse::class, $result);
+        static::assertSame(['example-category'], array_values($result->getCategories()->getIds()));
+    }
+}

--- a/tests/unit/Core/Content/Category/SalesChannel/NavigationRouteTest.php
+++ b/tests/unit/Core/Content/Category/SalesChannel/NavigationRouteTest.php
@@ -13,12 +13,14 @@ use Shopware\Core\Content\Category\Service\DefaultCategoryLevelLoader;
 use Shopware\Core\Content\Category\Tree\CategoryTreePathResolver;
 use Shopware\Core\Framework\Adapter\Cache\CacheTagCollector;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Extensions\ExtensionDispatcher;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SalesChannel\Entity\SalesChannelRepository;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\Test\Annotation\DisabledFeatures;
 use Shopware\Core\Test\Generator;
+use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
@@ -59,6 +61,7 @@ class NavigationRouteTest extends TestCase
             $this->cacheTagCollector,
             $this->categoryTreePathResolver,
             $this->defaultCategoryLevelLoader,
+            new ExtensionDispatcher(new EventDispatcher()),
         );
 
         $this->salesChannelContext = Generator::generateSalesChannelContext();


### PR DESCRIPTION
### 1. Why is this change necessary?

Customizing the storefront navigation is a recurring need — a customer-group filtered category tree, recalculated child counts, "top products" per category, or categories from an external source. Today the only way is to **decorate `NavigationRoute`** and reimplement `load()`. There is no extension point to resolve or enrich the navigation result itself.

### 2. What does this change do, exactly?

Wraps `NavigationRoute::load()` with the existing `Extension` mechanism (`ExtensionDispatcher::publish`, the same pattern as `ProductListingLoader` / the `CmsSlotsData*` extensions). A subscriber on the `.pre` event can replace the loading (assign `$extension->result` + `stopPropagation()`), `.post` can enrich the categories, `.error` can recover. With no subscriber, `publish()` calls the original implementation, so behaviour is unchanged.

- New extension: `Shopware\Core\Content\Category\Extension\NavigationRouteExtension`
  - `NAME = 'navigation-route.load'`, result `NavigationRouteResponse`
  - request data exposed as public readonly properties: `$extension->activeId`, `$extension->rootId`, `$extension->request`, `$extension->context`, `$extension->criteria`
- The original `load()` body moves into a private `_load()`; the public `load()` keeps its exact signature and `#[Route]`.

### 3. Describe each step to reproduce the issue or behaviour.

This is an additive extension point, not a bug fix. To exercise it:

1. Register an `EventSubscriberInterface` with `NavigationRouteExtension::onPre() => 'replace'`.
2. In the listener read the public properties (`$extension->activeId`, `$extension->rootId`, `$extension->context`, …), resolve the categories yourself, then `$extension->result = $navigationRouteResponse; $extension->stopPropagation();`.
3. Call `/store-api/navigation/{activeId}/{rootId}` — the subscriber's categories are returned and the core loader is skipped.

Covered by `tests/unit/Core/Content/Category/Extension/NavigationRouteExtensionTest.php` (fails without the new extension). The existing `NavigationRouteTest` keeps passing through the subscriber-less `publish()` wrapper, proving the change is behaviour-neutral.

### 4. Please link to the relevant issues (if any).

n/a

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Entry added to `RELEASE_INFO-6.7.md` under “Upcoming” → `# Core`.
  - No `UPGRADE` entry needed — the change is purely additive (no breaking change).
- [x] I have written or adjusted the documentation according to my changes (RELEASE_INFO entry + runnable example subscriber under `tests/examples/`)
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
