### PR TITLE
feat: add controller event for sales-channel context redirects and expose persisted session on the context

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -115,6 +115,12 @@ Affected commands:
 - `bin/console dal:validate --json` → `bin/console dal:validate --format json`
 - `bin/console sales-channel:list --output json` → `bin/console sales-channel:list --format json`
 
+### Sales-channel context: controller event for redirects + persisted session on the context
+
+A new `Shopware\Core\Framework\Routing\Event\SalesChannelContextResolvedControllerEvent` is dispatched in the kernel `controller` event, right after the sales-channel context has been resolved and stored on the request and before the matched controller runs. It wraps the Symfony `ControllerEvent`, so a listener can react to the resolved context however it needs to — for example redirect a not-logged-in customer via `getControllerEvent()->setController(...)`.
+
+In addition, `SalesChannelContext::getContextData()` now exposes the context session the context was built from — the persisted `sales_channel_api_context` payload merged with the request-derived overrides — as an array. You can read these parameters directly from the context, e.g. inside the new listener.
+
 ## Administration
 
 ### Rule Builder cart total condition labels adjusted

--- a/src/Core/Framework/DependencyInjection/services.xml
+++ b/src/Core/Framework/DependencyInjection/services.xml
@@ -199,6 +199,7 @@ frame-ancestors 'none';
         <!-- Routing -->
         <service id="Shopware\Core\Framework\Routing\ContextResolverListener">
             <argument type="service" id="Shopware\Core\Framework\Routing\ApiRequestContextResolver"/>
+            <argument type="service" id="event_dispatcher"/>
 
             <tag name="kernel.event_subscriber"/>
         </service>

--- a/src/Core/Framework/Routing/ContextResolverListener.php
+++ b/src/Core/Framework/Routing/ContextResolverListener.php
@@ -3,6 +3,10 @@
 namespace Shopware\Core\Framework\Routing;
 
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Routing\Event\SalesChannelContextResolvedControllerEvent;
+use Shopware\Core\PlatformRequest;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\Event\ControllerEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
@@ -16,8 +20,10 @@ class ContextResolverListener implements EventSubscriberInterface
     /**
      * @internal
      */
-    public function __construct(private readonly RequestContextResolverInterface $requestContextResolver)
-    {
+    public function __construct(
+        private readonly RequestContextResolverInterface $requestContextResolver,
+        private readonly EventDispatcherInterface $eventDispatcher
+    ) {
     }
 
     public static function getSubscribedEvents(): array
@@ -31,6 +37,15 @@ class ContextResolverListener implements EventSubscriberInterface
 
     public function resolveContext(ControllerEvent $event): void
     {
-        $this->requestContextResolver->resolve($event->getRequest());
+        $request = $event->getRequest();
+
+        $this->requestContextResolver->resolve($request);
+
+        $context = $request->attributes->get(PlatformRequest::ATTRIBUTE_SALES_CHANNEL_CONTEXT_OBJECT);
+        if (!$context instanceof SalesChannelContext) {
+            return;
+        }
+
+        $this->eventDispatcher->dispatch(new SalesChannelContextResolvedControllerEvent($event, $context));
     }
 }

--- a/src/Core/Framework/Routing/Event/SalesChannelContextResolvedControllerEvent.php
+++ b/src/Core/Framework/Routing/Event/SalesChannelContextResolvedControllerEvent.php
@@ -1,0 +1,48 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\Routing\Event;
+
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Event\ShopwareSalesChannelEvent;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\ControllerEvent;
+use Symfony\Contracts\EventDispatcher\Event;
+
+/**
+ * Dispatched in the kernel `controller` event, after the sales-channel context
+ * has been resolved and stored on the request and before the matched controller
+ * runs. The wrapped Symfony `ControllerEvent` is exposed so a listener can act on
+ * the resolved context however it needs to — for example redirect a not-logged-in
+ * customer via `getControllerEvent()->setController(...)`.
+ */
+#[Package('framework')]
+class SalesChannelContextResolvedControllerEvent extends Event implements ShopwareSalesChannelEvent
+{
+    public function __construct(
+        private readonly ControllerEvent $controllerEvent,
+        private readonly SalesChannelContext $salesChannelContext
+    ) {
+    }
+
+    public function getControllerEvent(): ControllerEvent
+    {
+        return $this->controllerEvent;
+    }
+
+    public function getRequest(): Request
+    {
+        return $this->controllerEvent->getRequest();
+    }
+
+    public function getSalesChannelContext(): SalesChannelContext
+    {
+        return $this->salesChannelContext;
+    }
+
+    public function getContext(): Context
+    {
+        return $this->salesChannelContext->getContext();
+    }
+}

--- a/src/Core/System/SalesChannel/Context/SalesChannelContextService.php
+++ b/src/Core/System/SalesChannel/Context/SalesChannelContextService.php
@@ -115,6 +115,8 @@ class SalesChannelContextService implements SalesChannelContextServiceInterface
                 $context->addState(Context::ELASTICSEARCH_EXPLAIN_MODE);
             }
 
+            $context->setContextData($session);
+
             $this->eventDispatcher->dispatch(new SalesChannelContextCreatedEvent($context, $token, $session));
 
             $currentRequest = $this->requestStack->getCurrentRequest();

--- a/src/Core/System/SalesChannel/SalesChannelContext.php
+++ b/src/Core/System/SalesChannel/SalesChannelContext.php
@@ -51,6 +51,16 @@ class SalesChannelContext extends Struct
     protected ?LockInterface $cartLock = null;
 
     /**
+     * The context session the context was built from — the persisted
+     * `sales_channel_api_context` payload merged with the request-derived
+     * overrides. Declared private so it is not serialized into the store-api
+     * response, just like the domain id.
+     *
+     * @var array<string, mixed>
+     */
+    private array $contextData = [];
+
+    /**
      * @internal
      *
      * @param array<string, array<string>> $areaRuleIds
@@ -242,6 +252,27 @@ class SalesChannelContext extends Struct
         }
 
         return $this->token;
+    }
+
+    /**
+     * The context session the context was built from — the persisted
+     * `sales_channel_api_context` payload merged with the request-derived overrides.
+     *
+     * @return array<string, mixed>
+     */
+    public function getContextData(): array
+    {
+        return $this->contextData;
+    }
+
+    /**
+     * @param array<string, mixed> $contextData
+     *
+     * @internal
+     */
+    public function setContextData(array $contextData): void
+    {
+        $this->contextData = $contextData;
     }
 
     public function getTaxState(): string

--- a/tests/unit/Core/Framework/Routing/ContextResolverListenerTest.php
+++ b/tests/unit/Core/Framework/Routing/ContextResolverListenerTest.php
@@ -1,0 +1,103 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\Routing;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Routing\ContextResolverListener;
+use Shopware\Core\Framework\Routing\Event\SalesChannelContextResolvedControllerEvent;
+use Shopware\Core\Framework\Routing\RequestContextResolverInterface;
+use Shopware\Core\PlatformRequest;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Event\ControllerEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+
+/**
+ * @internal
+ */
+#[CoversClass(ContextResolverListener::class)]
+class ContextResolverListenerTest extends TestCase
+{
+    public function testListenerCanRedirectViaControllerEvent(): void
+    {
+        $context = $this->createMock(SalesChannelContext::class);
+
+        $request = new Request();
+        $request->attributes->set(PlatformRequest::ATTRIBUTE_SALES_CHANNEL_CONTEXT_OBJECT, $context);
+
+        $redirect = new RedirectResponse('/account/login');
+
+        $dispatcher = new EventDispatcher();
+        $dispatcher->addListener(
+            SalesChannelContextResolvedControllerEvent::class,
+            static function (SalesChannelContextResolvedControllerEvent $event) use ($redirect, $request, $context): void {
+                static::assertSame($request, $event->getRequest());
+                static::assertSame($context, $event->getSalesChannelContext());
+
+                $event->getControllerEvent()->setController(static fn (): Response => $redirect);
+            }
+        );
+
+        $listener = new ContextResolverListener($this->createMock(RequestContextResolverInterface::class), $dispatcher);
+        $controllerEvent = $this->controllerEvent($request, static fn (): Response => new Response('original'));
+
+        $listener->resolveContext($controllerEvent);
+
+        static::assertSame($redirect, ($controllerEvent->getController())());
+    }
+
+    public function testControllerUntouchedWithoutSubscriber(): void
+    {
+        $request = new Request();
+        $request->attributes->set(
+            PlatformRequest::ATTRIBUTE_SALES_CHANNEL_CONTEXT_OBJECT,
+            $this->createMock(SalesChannelContext::class)
+        );
+
+        $listener = new ContextResolverListener(
+            $this->createMock(RequestContextResolverInterface::class),
+            new EventDispatcher()
+        );
+
+        $original = static fn (): Response => new Response('original');
+        $controllerEvent = $this->controllerEvent($request, $original);
+
+        $listener->resolveContext($controllerEvent);
+
+        static::assertSame($original, $controllerEvent->getController());
+    }
+
+    public function testNoEventWhenNoSalesChannelContext(): void
+    {
+        $dispatched = false;
+
+        $dispatcher = new EventDispatcher();
+        $dispatcher->addListener(
+            SalesChannelContextResolvedControllerEvent::class,
+            static function () use (&$dispatched): void {
+                $dispatched = true;
+            }
+        );
+
+        $listener = new ContextResolverListener($this->createMock(RequestContextResolverInterface::class), $dispatcher);
+        $controllerEvent = $this->controllerEvent(new Request(), static fn (): Response => new Response('original'));
+
+        $listener->resolveContext($controllerEvent);
+
+        static::assertFalse($dispatched);
+    }
+
+    private function controllerEvent(Request $request, callable $controller): ControllerEvent
+    {
+        return new ControllerEvent(
+            $this->createMock(HttpKernelInterface::class),
+            $controller,
+            $request,
+            HttpKernelInterface::MAIN_REQUEST
+        );
+    }
+}

--- a/tests/unit/Core/System/SalesChannel/Context/SalesChannelContextServiceTest.php
+++ b/tests/unit/Core/System/SalesChannel/Context/SalesChannelContextServiceTest.php
@@ -182,6 +182,37 @@ class SalesChannelContextServiceTest extends TestCase
         $this->service->get(new SalesChannelContextServiceParameters(TestDefaults::SALES_CHANNEL, $token));
     }
 
+    public function testSetsSessionAsContextData(): void
+    {
+        $token = 'test-token';
+        $persisted = ['expired' => false, SalesChannelContextService::CUSTOMER_ID => 'customer-1'];
+
+        $this->persister->method('load')->willReturn($persisted);
+
+        $context = Generator::generateSalesChannelContext();
+
+        // the session the context is built from has the request-derived languageId override merged in
+        $session = $persisted + [SalesChannelContextService::LANGUAGE_ID => Defaults::LANGUAGE_SYSTEM];
+
+        $this->factory->expects($this->once())
+            ->method('create')
+            ->with($token, TestDefaults::SALES_CHANNEL, $session)
+            ->willReturn($context);
+
+        $this->cartRuleLoader
+            ->method('loadByToken')
+            ->willReturn(new RuleLoaderResult(new Cart($token), new RuleCollection()));
+
+        $this->setupSessionAndRequest();
+
+        $result = $this->service->get(
+            new SalesChannelContextServiceParameters(TestDefaults::SALES_CHANNEL, $token, Defaults::LANGUAGE_SYSTEM)
+        );
+
+        // the full session the context was built from is exposed, including the request-derived languageId override
+        static::assertSame($session, $result->getContextData());
+    }
+
     #[DataProvider('skipCartCalculationIfAlreadyDoneAndESISubrequestProvider')]
     public function testSkipCartCalculationIfAlreadyDoneAndESISubrequest(Request $request, bool $hasCart, bool $expectCalculation): void
     {


### PR DESCRIPTION
### 1. Why is this change necessary?

After the sales-channel context is resolved and stored on the request (in the kernel `controller` event, by `ContextResolverListener`), there is no hook to react to it and short-circuit the request — for example to redirect a not-logged-in customer to the login page, or to redirect based on the resolved context (customer group, region/maintenance, a B2B gate). Doing this today means writing a separate kernel listener and re-implementing the ordering/scoping the core already handles.

Separately, the persisted context session — the `sales_channel_api_context` payload the context was built from — is only reachable inside the service's `SalesChannelContextCreatedEvent::getSession()`, not from the context itself.

### 2. What does this change do, exactly?

1. **`SalesChannelContextResolvedControllerEvent`** (new) — dispatched by `ContextResolverListener` in the kernel `controller` event, right after the context is resolved and stored on the request and before the matched controller runs. It wraps the Symfony `ControllerEvent` and exposes the `SalesChannelContext`, so a listener has full control over the resolved request — for example redirecting a not-logged-in customer via `getControllerEvent()->setController(static fn () => new RedirectResponse(...))`.
2. **`SalesChannelContext::getContextData(): array`** — exposes the context session the context was built from (the persisted `sales_channel_api_context` payload **merged with** the request-derived overrides — the same array passed to the factory and `SalesChannelContextCreatedEvent`). `SalesChannelContextService` sets it. The backing property is `private` (like `$domainId`), so it is **not** serialized into the `/store-api/context` response and the context token is not leaked.

### 3. Describe each step to reproduce the issue or behaviour.

This is an additive change, not a bug fix. To exercise it:

1. Add an `EventSubscriberInterface` / `#[AsEventListener]` for `SalesChannelContextResolvedControllerEvent`.
2. Inspect `$event->getSalesChannelContext()` (and `->getContextData()` for the persisted session) / `$event->getRequest()`, then redirect via `$event->getControllerEvent()->setController(static fn () => new RedirectResponse(...))`.
3. The matched controller is skipped and the redirect is returned.

Covered by unit tests (fail without the change): `ContextResolverListenerTest` (a listener redirects the resolved request via the wrapped controller event; without a subscriber the controller is untouched; no event when there is no sales-channel context) and `SalesChannelContextServiceTest::testSetsSessionAsContextData` (the session the context was built from is exposed on the context).

### 4. Please link to the relevant issues (if any).

n/a

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Entry added to `RELEASE_INFO-6.7.md` under “Upcoming” → `# Core`.
  - No `UPGRADE` entry needed — purely additive (new event class; the new context property is private and not serialized).
- [x] I have written or adjusted the documentation according to my changes (RELEASE_INFO entry)
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
