### PR TITLE
fix(a11y): labels in offcanvas cart

### DIFF
--- a/src/Storefront/Resources/snippet/storefront.de.json
+++ b/src/Storefront/Resources/snippet/storefront.de.json
@@ -465,6 +465,7 @@
     "cartItemInfoId": "Produkt-Nr.:",
     "addPromotionLabel": "Gutscheincode",
     "addPromotionPlaceholder": "Gutscheincode eingeben ...",
+    "addPromotionApplyAction": "Gutscheincode anwenden",
     "addProductLabel": "Produktnummer",
     "addProductPlaceholder": "Produktnummer eingeben ...",
     "summaryPositionPrice": "Zwischensumme",

--- a/src/Storefront/Resources/snippet/storefront.en.json
+++ b/src/Storefront/Resources/snippet/storefront.en.json
@@ -465,6 +465,7 @@
     "cartItemInfoId": "Product number:",
     "addPromotionLabel": "Promo code",
     "addPromotionPlaceholder": "Enter promo code...",
+    "addPromotionApplyAction": "Apply promo code",
     "addProductLabel": "Product number",
     "addProductPlaceholder": "Enter product number...",
     "summaryPositionPrice": "Total",

--- a/src/Storefront/Resources/views/storefront/component/checkout/offcanvas-cart-summary.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/checkout/offcanvas-cart-summary.html.twig
@@ -63,8 +63,8 @@
                             <input type="hidden" name="forwardTo" value="frontend.cart.offcanvas">
 
                             {% block component_offcanvas_summary_content_shipping_select %}
-                                <label class="visually-hidden" for="shippingMethodId">{{ 'checkout.shippingMethod'|trans|sw_sanitize }}</label>
-                                <select class="form-select mt-2 col-12" name="shippingMethodId">
+                                <label class="visually-hidden" for="offcanvasShippingMethodId">{{ 'checkout.shippingMethod'|trans|sw_sanitize }}</label>
+                                <select class="form-select mt-2 col-12" name="shippingMethodId" id="offcanvasShippingMethodId">
                                     <option disabled>{{ 'checkout.confirmChangeShipping'|trans|sw_sanitize }}</option>
 
                                     {% for shippingMethod in page.shippingMethods %}

--- a/src/Storefront/Resources/views/storefront/component/checkout/offcanvas-cart.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/checkout/offcanvas-cart.html.twig
@@ -117,7 +117,7 @@
                                                     <button class="btn btn-outline-secondary offcanvas-cart-promotion-button"
                                                             type="submit"
                                                             id="addPromotionOffcanvasCart"
-                                                            aria-labelledby="addPromotionOffcanvasCartInput">
+                                                            aria-label="{{ 'checkout.addPromotionApplyAction'|trans|striptags }}">
                                                         {% sw_icon 'checkmark' %}
                                                     </button>
                                                 {% endblock %}


### PR DESCRIPTION
### 1. Why is this change necessary?

* Label for Shipping method select is not bound to the input due to a missing ID.
* Label of the promo code submit button has no deliberate action text. It just says "Promo code" again - same as the label.

<img width="625" height="464" alt="Screenshot 2026-06-12 at 09 10 44" src="https://github.com/user-attachments/assets/8874f81f-dd59-41df-ace5-9477962e7fb8" />

### 2. What does this change do, exactly?

* Fix Shipping method select label by adding a matching ID
* Add "Apply promo code" text to the promo code submit button