### PR TITLE
refactor(content-system): carry layout identity via value objects

### DIFF
--- a/src/Core/Framework/ContentSystem/AGENTS.md
+++ b/src/Core/Framework/ContentSystem/AGENTS.md
@@ -6,7 +6,8 @@
 - **Header/Footer Sources**: `Storefront/ContentSystem/HeaderContentLayout/HeaderSpecificationSource`, `Storefront/ContentSystem/FooterContentLayout/FooterSpecificationSource`
 - **Resolver**: `Adapter/RenderingSpecificationResolver` (3 instances: main, header, footer — see DI config)
 - **Events**: `Event/PreContentHydrationEvent`, `Event/PostHydrationEvent`
-- **Pipeline**: `ContentPipeline` (steps 2-5), `RenderingMode` (FULL vs SKELETON)
+- **Pipeline**: `ContentPipeline` (steps 3-5), `RenderingMode` (FULL vs SKELETON)
+- **Layout Value Objects**: `RenderableLayout` (reference + elements), `LayoutReference` (id, name, version), `ResolvedContentLayout` (layout ID + `RenderingSpecification`)
 - **Store API**: `SalesChannel/ContentRoute` (single class, DI-parameterized per format + section)
 - **Schema**: `Schema/ContentSystemDataLoaderTypeResolver`, `Schema/ContentSystemDataLoaderTypeMap`, `Schema/ContentSystemDataLoaderTypeSchemaGenerator`
 - **Entity Type Schema**: `Schema/ContentLayoutAssignableEntitySchemaGenerator`
@@ -19,8 +20,8 @@
 ## Constraints
 
 - `RenderingSpecificationResolver`: iterates sources via `supports()` bool check, first match wins — NOT null-return
-- `ContentPipeline::load()`: layout load → PreHydration events → hydration (FULL mode only) → PostHydration events
-- Specification resolution happens in `ContentRoute`, NOT in `ContentPipeline`
+- `ContentPipeline::load()`: receives a loaded `RenderableLayout` → PreHydration events → hydration (FULL mode only) → PostHydration events
+- Specification resolution and layout-entity loading happen in `ContentRoute`, NOT in `ContentPipeline`
 - OpenAPI schemas: update `src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/` when modifying endpoints
 - Data loader type introspection: `ContentSystemDataLoaderTypeCompilerPass` calls `getProvidedData()` on all tagged loaders at build time — loaders MUST have `@extends AbstractContentDataLoader<T>` PHPDoc; wildcard loaders listen to `ContentSystemDataLoaderTypesResolvedEvent` for runtime expansion
 - Schema API endpoint: `GET /api/_info/content-system-data-loader-types.json` (registered in `InfoController`)

--- a/src/Core/Framework/ContentSystem/Adapter/AGENTS.md
+++ b/src/Core/Framework/ContentSystem/Adapter/AGENTS.md
@@ -4,7 +4,7 @@
 
 - `AbstractSpecificationSource` - Base: `supports()`, `resolveLayoutId()`, `resolveSpecificationData()`, `resolveTargetElementId()`, `resolveCacheTags()`
 - `RenderingSpecificationResolver` - Iterates sources, checks `supports()`, calls `RenderingSpecificationFactory::create()`
-- `RenderingSpecificationFactory` - Assembles `RenderingSpecification` from source steps
+- `RenderingSpecificationFactory` - Assembles `ResolvedContentLayout` (layout ID plus `RenderingSpecification`) from source steps
 - Entity sources co-located with domain aggregates: `Content/Product/.../ProductSpecificationSource`, `Content/Category/.../CategorySpecificationSource`, `Content/LandingPage/.../LandingPageSpecificationSource`
 - Domain-aware sources in Storefront: `Storefront/ContentSystem/HeaderContentLayout/HeaderSpecificationSource`, `Storefront/ContentSystem/FooterContentLayout/FooterSpecificationSource`
 - `EntityLayoutResolver`, `EntityLayoutContextFactory` (FactoryHelper/) - Shared entity resolution

--- a/src/Core/Framework/ContentSystem/Adapter/README.md
+++ b/src/Core/Framework/ContentSystem/Adapter/README.md
@@ -1,6 +1,6 @@
 # Adapter
 
-Connects CMS-capable entities (Product, Category, Landing Page) and domain-scoped content (Header, Footer) to the rendering pipeline. Specification sources implement `supports()` to claim paths, then `RenderingSpecificationFactory` assembles `RenderingSpecification` objects from discrete resolution steps.
+Connects CMS-capable entities (Product, Category, Landing Page) and domain-scoped content (Header, Footer) to the rendering pipeline. Specification sources implement `supports()` to claim paths, then `RenderingSpecificationFactory` assembles a `ResolvedContentLayout` (layout ID plus `RenderingSpecification`) from discrete resolution steps.
 
 ## Resolution Strategies
 
@@ -11,7 +11,7 @@ Connects CMS-capable entities (Product, Category, Landing Page) and domain-scope
 ## Key Classes
 
 - `RenderingSpecificationResolver` - Iterates sources via `supports()`, delegates to `RenderingSpecificationFactory`
-- `RenderingSpecificationFactory` - Assembles specification from source's discrete resolution steps
+- `RenderingSpecificationFactory` - Assembles a `ResolvedContentLayout` from the source's discrete resolution steps
 - `AbstractSpecificationSource` - Base class: `supports()`, `resolveLayoutId()`, `resolveSpecificationData()`, `resolveTargetElementId()`, `resolveCacheTags()`
 - Entity sources moved to domain aggregates: `Content/Product/.../ProductSpecificationSource`, `Content/Category/.../CategorySpecificationSource`, `Content/LandingPage/.../LandingPageSpecificationSource`
 - Domain-aware sources moved to Storefront: `Storefront/ContentSystem/HeaderContentLayout/HeaderSpecificationSource`, `Storefront/ContentSystem/FooterContentLayout/FooterSpecificationSource`

--- a/src/Core/Framework/ContentSystem/Adapter/RenderingSpecificationFactory.php
+++ b/src/Core/Framework/ContentSystem/Adapter/RenderingSpecificationFactory.php
@@ -3,6 +3,7 @@
 namespace Shopware\Core\Framework\ContentSystem\Adapter;
 
 use Shopware\Core\Framework\ContentSystem\RenderingSpecification;
+use Shopware\Core\Framework\ContentSystem\ResolvedContentLayout;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\HttpFoundation\Request;
@@ -20,16 +21,19 @@ class RenderingSpecificationFactory
         string $path,
         Request $request,
         SalesChannelContext $context,
-    ): RenderingSpecification {
+    ): ResolvedContentLayout {
+        $layoutId = $source->resolveLayoutId($path, $request, $context);
         $data = $source->resolveSpecificationData($path, $request, $context);
 
-        return new RenderingSpecification(
-            layoutId: $source->resolveLayoutId($path, $request, $context),
-            dataRequirements: $data->dataRequirements,
-            placeholderValues: $data->placeholderValues,
-            request: $request,
-            targetElementId: $source->resolveTargetElementId($path, $request, $context),
-            cacheTags: $source->resolveCacheTags($path, $request, $context),
+        return ResolvedContentLayout::create(
+            $layoutId,
+            new RenderingSpecification(
+                dataRequirements: $data->dataRequirements,
+                placeholderValues: $data->placeholderValues,
+                request: $request,
+                targetElementId: $source->resolveTargetElementId($path, $request, $context),
+                cacheTags: $source->resolveCacheTags($path, $request, $context),
+            ),
         );
     }
 }

--- a/src/Core/Framework/ContentSystem/Adapter/RenderingSpecificationResolver.php
+++ b/src/Core/Framework/ContentSystem/Adapter/RenderingSpecificationResolver.php
@@ -3,7 +3,7 @@
 namespace Shopware\Core\Framework\ContentSystem\Adapter;
 
 use Shopware\Core\Framework\ContentSystem\ContentSystemException;
-use Shopware\Core\Framework\ContentSystem\RenderingSpecification;
+use Shopware\Core\Framework\ContentSystem\ResolvedContentLayout;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\HttpFoundation\Request;
@@ -32,7 +32,7 @@ class RenderingSpecificationResolver
         string $path,
         Request $request,
         SalesChannelContext $context
-    ): RenderingSpecification {
+    ): ResolvedContentLayout {
         foreach ($this->sources as $source) {
             if ($source->supports($path, $request, $context)) {
                 return $this->factory->create($source, $path, $request, $context);

--- a/src/Core/Framework/ContentSystem/ContentPipeline.php
+++ b/src/Core/Framework/ContentSystem/ContentPipeline.php
@@ -6,11 +6,7 @@ use Shopware\Core\Framework\ContentSystem\Cache\RenderingCacheContext;
 use Shopware\Core\Framework\ContentSystem\Event\PostHydrationEvent;
 use Shopware\Core\Framework\ContentSystem\Event\PreContentHydrationEvent;
 use Shopware\Core\Framework\ContentSystem\Hydration\ContentElementHydrator;
-use Shopware\Core\Framework\ContentSystem\Layout\Entity\ContentLayoutCollection;
-use Shopware\Core\Framework\ContentSystem\Layout\Entity\ContentLayoutEntity;
 use Shopware\Core\Framework\ContentSystem\Output\Struct\ContentPage;
-use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
-use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
@@ -23,34 +19,22 @@ use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 #[Package('framework')]
 class ContentPipeline
 {
-    /**
-     * @param EntityRepository<ContentLayoutCollection> $contentLayoutRepository
-     */
     public function __construct(
-        private readonly EntityRepository $contentLayoutRepository,
         private readonly ContentElementHydrator $hydrationService,
         private readonly EventDispatcherInterface $eventDispatcher
     ) {
     }
 
     public function load(
+        RenderableLayout $layout,
         RenderingSpecification $specification,
         RenderingCacheContext $cacheContext,
         RenderingMode $mode,
         SalesChannelContext $salesChannelContext,
     ): ContentPage {
-        $criteria = new Criteria([$specification->layoutId]);
-        $layoutEntity = $this->contentLayoutRepository->search($criteria, $salesChannelContext->getContext())->first();
-
-        if (!$layoutEntity instanceof ContentLayoutEntity) {
-            throw ContentSystemException::layoutNotFound($specification->layoutId);
-        }
-
         $preHydrationEvent = new PreContentHydrationEvent(
-            $layoutEntity->getLayout(),
-            $layoutEntity->getId(),
-            $layoutEntity->getName(),
-            $layoutEntity->getVersionId(),
+            $layout->elements,
+            $layout->reference,
             $specification,
             $mode,
             $salesChannelContext,
@@ -71,9 +55,7 @@ class ContentPipeline
 
         $afterHydrationEvent = new PostHydrationEvent(
             $elements,
-            $layoutEntity->getId(),
-            $layoutEntity->getName(),
-            $layoutEntity->getVersionId(),
+            $layout->reference,
             $specification,
             $mode,
             $salesChannelContext,
@@ -81,11 +63,13 @@ class ContentPipeline
         );
         $this->eventDispatcher->dispatch($afterHydrationEvent);
 
+        $reference = $afterHydrationEvent->layout;
+
         return new ContentPage(
-            $specification->layoutId,
+            $reference->id,
             $afterHydrationEvent->elements,
-            $afterHydrationEvent->layoutName,
-            $afterHydrationEvent->layoutVersionId
+            $reference->name,
+            $reference->version,
         );
     }
 }

--- a/src/Core/Framework/ContentSystem/EXTENSION.md
+++ b/src/Core/Framework/ContentSystem/EXTENSION.md
@@ -281,7 +281,7 @@ Listeners modify elements before or after hydration—computing derived values, 
 Both events expose the same properties. Only `elements` is mutable:
 
 - `elements` — `list<ContentElement>`, mutable
-- `layoutId`, `layoutName`, `layoutVersionId` — layout metadata (readonly)
+- `layout` — `LayoutReference` exposing `id`, `name`, `version` of the rendered layout (readonly)
 - `specification` — `RenderingSpecification` (readonly)
 - `mode` — `RenderingMode` (readonly)
 - `salesChannelContext` — `SalesChannelContext` (readonly)

--- a/src/Core/Framework/ContentSystem/EXTENSION.md
+++ b/src/Core/Framework/ContentSystem/EXTENSION.md
@@ -382,7 +382,10 @@ Key types extension developers encounter when working with the ContentSystem:
 | `ContentDataLoaderResult` | Loader return value with cache info                                                    |
 | `SpecificationData`       | Return type of `resolveSpecificationData()` (bundles data requirements + placeholders) |
 | `PlaceholderValues`       | Immutable placeholder map, created via `PlaceholderValues::from(array $values)`        |
-| `RenderingSpecification`  | Layout ID, data requirements, placeholders, request, target element, cache tags        |
+| `RenderingSpecification`  | Data requirements, placeholders, request, target element, cache tags                  |
+| `ResolvedContentLayout`   | Resolver output: layout ID plus the `RenderingSpecification`                           |
+| `LayoutReference`         | Immutable layout identity: `id`, `name`, `version`                                     |
+| `RenderableLayout`        | Loaded layout handed to the pipeline: a `LayoutReference` plus its element list        |
 
 ### Enums
 

--- a/src/Core/Framework/ContentSystem/Event/PostHydrationEvent.php
+++ b/src/Core/Framework/ContentSystem/Event/PostHydrationEvent.php
@@ -4,6 +4,7 @@ namespace Shopware\Core\Framework\ContentSystem\Event;
 
 use Shopware\Core\Framework\ContentSystem\Cache\RenderingCacheContext;
 use Shopware\Core\Framework\ContentSystem\Layout\Element\ContentElement;
+use Shopware\Core\Framework\ContentSystem\LayoutReference;
 use Shopware\Core\Framework\ContentSystem\RenderingMode;
 use Shopware\Core\Framework\ContentSystem\RenderingSpecification;
 use Shopware\Core\Framework\Context;
@@ -41,9 +42,7 @@ class PostHydrationEvent implements ShopwareSalesChannelEvent
      */
     public function __construct(
         public array $elements,
-        public readonly string $layoutId,
-        public readonly string $layoutName,
-        public readonly ?string $layoutVersionId,
+        public readonly LayoutReference $layout,
         public readonly RenderingSpecification $specification,
         public readonly RenderingMode $mode,
         public readonly SalesChannelContext $salesChannelContext,

--- a/src/Core/Framework/ContentSystem/Event/PreContentHydrationEvent.php
+++ b/src/Core/Framework/ContentSystem/Event/PreContentHydrationEvent.php
@@ -4,6 +4,7 @@ namespace Shopware\Core\Framework\ContentSystem\Event;
 
 use Shopware\Core\Framework\ContentSystem\Cache\RenderingCacheContext;
 use Shopware\Core\Framework\ContentSystem\Layout\Element\ContentElement;
+use Shopware\Core\Framework\ContentSystem\LayoutReference;
 use Shopware\Core\Framework\ContentSystem\RenderingMode;
 use Shopware\Core\Framework\ContentSystem\RenderingSpecification;
 use Shopware\Core\Framework\Context;
@@ -41,9 +42,7 @@ class PreContentHydrationEvent implements ShopwareSalesChannelEvent
      */
     public function __construct(
         public array $elements,
-        public readonly string $layoutId,
-        public readonly string $layoutName,
-        public readonly ?string $layoutVersionId,
+        public readonly LayoutReference $layout,
         public readonly RenderingSpecification $specification,
         public readonly RenderingMode $mode,
         public readonly SalesChannelContext $salesChannelContext,

--- a/src/Core/Framework/ContentSystem/LayoutReference.php
+++ b/src/Core/Framework/ContentSystem/LayoutReference.php
@@ -22,6 +22,6 @@ final readonly class LayoutReference
 
     public static function fromEntity(ContentLayoutEntity $entity): self
     {
-        return self::create($entity->getId(), $entity->getName(), $entity->getVersionId());
+        return self::create($entity->getId(), $entity->getName(), $entity->getVersion());
     }
 }

--- a/src/Core/Framework/ContentSystem/LayoutReference.php
+++ b/src/Core/Framework/ContentSystem/LayoutReference.php
@@ -1,0 +1,27 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\ContentSystem;
+
+use Shopware\Core\Framework\ContentSystem\Layout\Entity\ContentLayoutEntity;
+use Shopware\Core\Framework\Log\Package;
+
+#[Package('framework')]
+final readonly class LayoutReference
+{
+    private function __construct(
+        public string $id,
+        public string $name,
+        public ?string $version,
+    ) {
+    }
+
+    public static function create(string $id, string $name, ?string $version): self
+    {
+        return new self($id, $name, $version);
+    }
+
+    public static function fromEntity(ContentLayoutEntity $entity): self
+    {
+        return self::create($entity->getId(), $entity->getName(), $entity->getVersionId());
+    }
+}

--- a/src/Core/Framework/ContentSystem/README.md
+++ b/src/Core/Framework/ContentSystem/README.md
@@ -18,10 +18,10 @@ Each section supports four response formats: full, decomposed, skeleton, and dat
 
 ## Rendering Pipeline
 
-The pipeline is source-independent — specification sources translate entity IDs into `RenderingSpecification` objects, and `ContentPipeline` renders without knowing the original data source.
+The pipeline is source-independent — specification sources translate entity IDs into a `ResolvedContentLayout` (layout ID plus `RenderingSpecification`), and `ContentPipeline` renders without knowing the original data source.
 
-1. **Specification Resolution** — Route calls `RenderingSpecificationResolver` (Adapter/) which iterates sources via `supports()` check, then assembles the specification. See Adapter/.
-2. **Layout Loading** — `LayoutLoader` retrieves `ContentLayoutEntity` from repository.
+1. **Specification Resolution** — Route calls `RenderingSpecificationResolver` (Adapter/) which iterates sources via `supports()` check, then assembles the `ResolvedContentLayout`. See Adapter/.
+2. **Layout Loading** — `ContentRoute` retrieves the `ContentLayoutEntity` from the content-layout repository and wraps it in a `RenderableLayout` passed into the pipeline.
 3. **PreHydration Events** — Listeners prepare layout: placeholder resolution, virtual root wrapping, partial rendering pruning. See Event/Listener/.
 4. **Hydration** (FULL mode only) — `ContentElementHydrator` loads data per element's requirements, then distributes context. Skipped in SKELETON mode. See Hydration/.
 5. **PostHydration Events** — Listeners finalize: virtual root cleanup, partial extraction. See Event/Listener/.
@@ -29,9 +29,12 @@ The pipeline is source-independent — specification sources translate entity ID
 ## Key Classes
 
 Module root:
-- `ContentPipeline` - Orchestrates steps 2-5 of the rendering pipeline
+- `ContentPipeline` - Orchestrates steps 3-5 of the rendering pipeline; receives the loaded `RenderableLayout` from the route
+- `RenderableLayout` - Loaded layout handed to the pipeline: a `LayoutReference` plus its `list<ContentElement>`
+- `LayoutReference` - Immutable layout identity: id, name, version
+- `ResolvedContentLayout` - Resolver output: layout ID plus the `RenderingSpecification`
 - `ContentSection` - Enum: HEADER, FOOTER, MAIN
-- `RenderingSpecification` - Layout ID, data requirements, placeholders, request, target element, cache tags
+- `RenderingSpecification` - Data requirements, placeholders, request, target element, cache tags
 - `RenderingMode` - Enum: FULL (hydrate), SKELETON (structure only)
 - `PlaceholderValues` - Immutable placeholder value map
 - `SpecificationData` - Bundles data requirements + placeholders from layout resolution

--- a/src/Core/Framework/ContentSystem/RenderableLayout.php
+++ b/src/Core/Framework/ContentSystem/RenderableLayout.php
@@ -1,0 +1,33 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\ContentSystem;
+
+use Shopware\Core\Framework\ContentSystem\Layout\Element\ContentElement;
+use Shopware\Core\Framework\ContentSystem\Layout\Entity\ContentLayoutEntity;
+use Shopware\Core\Framework\Log\Package;
+
+#[Package('framework')]
+final readonly class RenderableLayout
+{
+    /**
+     * @param list<ContentElement> $elements
+     */
+    private function __construct(
+        public LayoutReference $reference,
+        public array $elements,
+    ) {
+    }
+
+    /**
+     * @param list<ContentElement> $elements
+     */
+    public static function create(LayoutReference $reference, array $elements): self
+    {
+        return new self($reference, $elements);
+    }
+
+    public static function fromEntity(ContentLayoutEntity $entity): self
+    {
+        return self::create(LayoutReference::fromEntity($entity), $entity->getLayout());
+    }
+}

--- a/src/Core/Framework/ContentSystem/RenderingSpecification.php
+++ b/src/Core/Framework/ContentSystem/RenderingSpecification.php
@@ -14,7 +14,6 @@ final readonly class RenderingSpecification
      * @param list<string> $cacheTags
      */
     public function __construct(
-        public string $layoutId,
         public array $dataRequirements,
         public PlaceholderValues $placeholderValues,
         public Request $request,

--- a/src/Core/Framework/ContentSystem/ResolvedContentLayout.php
+++ b/src/Core/Framework/ContentSystem/ResolvedContentLayout.php
@@ -1,0 +1,20 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\ContentSystem;
+
+use Shopware\Core\Framework\Log\Package;
+
+#[Package('framework')]
+final readonly class ResolvedContentLayout
+{
+    private function __construct(
+        public string $layoutId,
+        public RenderingSpecification $specification,
+    ) {
+    }
+
+    public static function create(string $layoutId, RenderingSpecification $specification): self
+    {
+        return new self($layoutId, $specification);
+    }
+}

--- a/src/Core/Framework/ContentSystem/SalesChannel/AGENTS.md
+++ b/src/Core/Framework/ContentSystem/SalesChannel/AGENTS.md
@@ -3,6 +3,6 @@
 ## Constraints
 
 - Routes registered via `ContentRouteLoader` + `ContentRouteCompilerPass`, NOT via PHP attributes
-- `ContentRoute` parameterized via DI: `RenderingSpecificationResolver` (section) + `AbstractResponseFactory` (format) + `ContentSection`
-- Route calls resolver → pipeline.load() → cacheFinalizer → responseFactory — specification resolution is in route, not pipeline
+- `ContentRoute` parameterized via DI: `RenderingSpecificationResolver` (section) + `ContentSection` + content-layout `EntityRepository` + `AbstractResponseFactory` (format)
+- Route calls resolver → loads `ContentLayoutEntity` (wrapped as `RenderableLayout`) → pipeline.load() → cacheFinalizer → responseFactory — specification resolution and layout-entity loading are in route, not pipeline
 - Extension: decorate `AbstractContentRoute`

--- a/src/Core/Framework/ContentSystem/SalesChannel/ContentRoute.php
+++ b/src/Core/Framework/ContentSystem/SalesChannel/ContentRoute.php
@@ -8,7 +8,13 @@ use Shopware\Core\Framework\ContentSystem\Cache\CacheFinalizer;
 use Shopware\Core\Framework\ContentSystem\Cache\RenderingCacheContext;
 use Shopware\Core\Framework\ContentSystem\ContentPipeline;
 use Shopware\Core\Framework\ContentSystem\ContentSection;
+use Shopware\Core\Framework\ContentSystem\ContentSystemException;
+use Shopware\Core\Framework\ContentSystem\Layout\Entity\ContentLayoutCollection;
+use Shopware\Core\Framework\ContentSystem\Layout\Entity\ContentLayoutEntity;
 use Shopware\Core\Framework\ContentSystem\Output\Format\AbstractResponseFactory;
+use Shopware\Core\Framework\ContentSystem\RenderableLayout;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
@@ -22,11 +28,14 @@ class ContentRoute extends AbstractContentRoute
 {
     /**
      * @internal
+     *
+     * @param EntityRepository<ContentLayoutCollection> $contentLayoutRepository
      */
     public function __construct(
         private readonly RenderingSpecificationResolver $specificationResolver,
         private readonly ContentSection $section,
         private readonly CacheTagCollector $cacheTagCollector,
+        private readonly EntityRepository $contentLayoutRepository,
         private readonly AbstractResponseFactory $responseFactory,
         private readonly ContentPipeline $contentPipeline,
         private readonly CacheFinalizer $cacheFinalizer,
@@ -40,16 +49,31 @@ class ContentRoute extends AbstractContentRoute
 
     public function load(string $path, Request $request, SalesChannelContext $context): AbstractContentRouteResponse
     {
-        $renderingSpecification = $this->specificationResolver->resolve($path, $request, $context);
+        $resolved = $this->specificationResolver->resolve($path, $request, $context);
+        $specification = $resolved->specification;
 
-        foreach ($this->section->buildRouteCacheTags($renderingSpecification->layoutId) as $tag) {
+        foreach ($this->section->buildRouteCacheTags($resolved->layoutId) as $tag) {
             $this->cacheTagCollector->addTag($tag);
         }
 
-        $cacheContext = new RenderingCacheContext();
-        $cacheContext->addTags($renderingSpecification->cacheTags);
+        $layoutEntity = $this->contentLayoutRepository
+            ->search(new Criteria([$resolved->layoutId]), $context->getContext())
+            ->first();
 
-        $contentPage = $this->contentPipeline->load($renderingSpecification, $cacheContext, $this->responseFactory->getRenderingMode(), $context);
+        if (!$layoutEntity instanceof ContentLayoutEntity) {
+            throw ContentSystemException::layoutNotFound($resolved->layoutId);
+        }
+
+        $cacheContext = new RenderingCacheContext();
+        $cacheContext->addTags($specification->cacheTags);
+
+        $contentPage = $this->contentPipeline->load(
+            RenderableLayout::fromEntity($layoutEntity),
+            $specification,
+            $cacheContext,
+            $this->responseFactory->getRenderingMode(),
+            $context,
+        );
 
         $this->cacheFinalizer->finalize($request, $cacheContext);
 

--- a/src/Core/Framework/ContentSystem/SalesChannel/README.md
+++ b/src/Core/Framework/ContentSystem/SalesChannel/README.md
@@ -5,7 +5,7 @@ Store API entry point. A single `ContentRoute` class serves all formats and cont
 ## Key Classes
 
 - `AbstractContentRoute` - Decorator base for route extension
-- `ContentRoute` - DI-parameterized: `RenderingSpecificationResolver` + `ContentSection` + `AbstractResponseFactory`
+- `ContentRoute` - DI-parameterized: `RenderingSpecificationResolver` + `ContentSection` + content-layout `EntityRepository` + `AbstractResponseFactory`
 
 ## Endpoints
 

--- a/src/Core/Framework/DependencyInjection/CompilerPass/ContentRouteCompilerPass.php
+++ b/src/Core/Framework/DependencyInjection/CompilerPass/ContentRouteCompilerPass.php
@@ -54,6 +54,7 @@ class ContentRouteCompilerPass implements CompilerPassInterface
                     new Reference($resolverId),
                     $section,
                     new Reference(CacheTagCollector::class),
+                    new Reference('content_layout.repository'),
                     new Reference($formatHandlerId),
                     new Reference(ContentPipeline::class),
                     new Reference(CacheFinalizer::class),

--- a/src/Core/Framework/DependencyInjection/content-system.xml
+++ b/src/Core/Framework/DependencyInjection/content-system.xml
@@ -182,7 +182,6 @@
 
         <!-- Content Pipeline -->
         <service id="Shopware\Core\Framework\ContentSystem\ContentPipeline" public="true">
-            <argument type="service" id="content_layout.repository"/>
             <argument type="service" id="Shopware\Core\Framework\ContentSystem\Hydration\ContentElementHydrator"/>
             <argument type="service" id="event_dispatcher"/>
         </service>

--- a/src/Core/Test/Stub/ContentSystem/EventFactory.php
+++ b/src/Core/Test/Stub/ContentSystem/EventFactory.php
@@ -7,6 +7,7 @@ use Shopware\Core\Framework\ContentSystem\Event\PostHydrationEvent;
 use Shopware\Core\Framework\ContentSystem\Event\PreContentHydrationEvent;
 use Shopware\Core\Framework\ContentSystem\Layout\Element\ContentElement;
 use Shopware\Core\Framework\ContentSystem\Layout\Element\DataRequirement\DataRequirement;
+use Shopware\Core\Framework\ContentSystem\LayoutReference;
 use Shopware\Core\Framework\ContentSystem\PlaceholderValues;
 use Shopware\Core\Framework\ContentSystem\RenderingMode;
 use Shopware\Core\Framework\ContentSystem\RenderingSpecification;
@@ -36,11 +37,8 @@ class EventFactory
     ): PreContentHydrationEvent {
         return new PreContentHydrationEvent(
             $elements,
-            'layout-1',
-            'Test',
-            null,
+            LayoutReference::create('layout-1', 'Test', null),
             new RenderingSpecification(
-                'layout-1',
                 $dataRequirements,
                 $placeholderValues ?? PlaceholderValues::from([]),
                 new Request(),
@@ -63,11 +61,8 @@ class EventFactory
     ): PostHydrationEvent {
         return new PostHydrationEvent(
             $elements,
-            'layout-1',
-            'Test',
-            null,
+            LayoutReference::create('layout-1', 'Test', null),
             new RenderingSpecification(
-                'layout-1',
                 $dataRequirements,
                 PlaceholderValues::from([]),
                 new Request(),

--- a/tests/unit/Core/Framework/ContentSystem/Adapter/RenderingSpecificationFactoryTest.php
+++ b/tests/unit/Core/Framework/ContentSystem/Adapter/RenderingSpecificationFactoryTest.php
@@ -18,7 +18,7 @@ use Symfony\Component\HttpFoundation\Request;
 #[CoversClass(RenderingSpecificationFactory::class)]
 class RenderingSpecificationFactoryTest extends TestCase
 {
-    #[TestDox('assembles specification from all source methods including cache tags')]
+    #[TestDox('pairs the resolved layout id with a specification assembled from all source methods')]
     public function testCreateAssemblesSpecificationFromAllSourceMethods(): void
     {
         $request = new Request();
@@ -38,14 +38,14 @@ class RenderingSpecificationFactoryTest extends TestCase
         $result = $factory->create($source, $path, $request, $context);
 
         static::assertSame('layout-1', $result->layoutId);
-        static::assertSame([], $result->dataRequirements);
-        static::assertSame($placeholders, $result->placeholderValues);
-        static::assertSame($request, $result->request);
-        static::assertSame('element-42', $result->targetElementId);
-        static::assertSame(['product-abc123'], $result->cacheTags);
+        static::assertSame([], $result->specification->dataRequirements);
+        static::assertSame($placeholders, $result->specification->placeholderValues);
+        static::assertSame($request, $result->specification->request);
+        static::assertSame('element-42', $result->specification->targetElementId);
+        static::assertSame(['product-abc123'], $result->specification->cacheTags);
     }
 
-    #[TestDox('assembles specification with null target element and empty cache tags')]
+    #[TestDox('pairs the resolved layout id with a specification with null target element and empty cache tags')]
     public function testCreateAssemblesSpecificationWithNullTargetAndEmptyCacheTags(): void
     {
         $request = new Request();
@@ -62,7 +62,7 @@ class RenderingSpecificationFactoryTest extends TestCase
         $result = $factory->create($source, $path, $request, $context);
 
         static::assertSame('layout-2', $result->layoutId);
-        static::assertNull($result->targetElementId);
-        static::assertSame([], $result->cacheTags);
+        static::assertNull($result->specification->targetElementId);
+        static::assertSame([], $result->specification->cacheTags);
     }
 }

--- a/tests/unit/Core/Framework/ContentSystem/Adapter/RenderingSpecificationFactoryTest.php
+++ b/tests/unit/Core/Framework/ContentSystem/Adapter/RenderingSpecificationFactoryTest.php
@@ -43,26 +43,16 @@ class RenderingSpecificationFactoryTest extends TestCase
         static::assertSame($request, $result->specification->request);
         static::assertSame('element-42', $result->specification->targetElementId);
         static::assertSame(['product-abc123'], $result->specification->cacheTags);
-    }
 
-    #[TestDox('pairs the resolved layout id with a specification with null target element and empty cache tags')]
-    public function testCreateAssemblesSpecificationWithNullTargetAndEmptyCacheTags(): void
-    {
-        $request = new Request();
-        $context = Generator::generateSalesChannelContext();
-        $path = '/category/xyz';
-        $specData = new SpecificationData([], PlaceholderValues::from([]));
-
-        $source = new StaticSpecificationSource(
+        $defaultsSource = new StaticSpecificationSource(
             layoutId: 'layout-2',
-            specificationData: $specData,
+            specificationData: new SpecificationData([], PlaceholderValues::from([])),
         );
 
-        $factory = new RenderingSpecificationFactory();
-        $result = $factory->create($source, $path, $request, $context);
+        $defaultsResult = $factory->create($defaultsSource, $path, $request, $context);
 
-        static::assertSame('layout-2', $result->layoutId);
-        static::assertNull($result->specification->targetElementId);
-        static::assertSame([], $result->specification->cacheTags);
+        static::assertSame('layout-2', $defaultsResult->layoutId);
+        static::assertNull($defaultsResult->specification->targetElementId);
+        static::assertSame([], $defaultsResult->specification->cacheTags);
     }
 }

--- a/tests/unit/Core/Framework/ContentSystem/Adapter/RenderingSpecificationResolverTest.php
+++ b/tests/unit/Core/Framework/ContentSystem/Adapter/RenderingSpecificationResolverTest.php
@@ -42,7 +42,7 @@ class RenderingSpecificationResolverTest extends TestCase
         $result = $resolver->resolve($path, $request, $context);
 
         static::assertSame('layout-1', $result->layoutId);
-        static::assertSame($request, $result->request);
+        static::assertSame($request, $result->specification->request);
     }
 
     #[TestDox('skips sources that do not support the path')]

--- a/tests/unit/Core/Framework/ContentSystem/ContentPipelineTest.php
+++ b/tests/unit/Core/Framework/ContentSystem/ContentPipelineTest.php
@@ -8,22 +8,20 @@ use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\ContentSystem\Cache\RenderingCacheContext;
 use Shopware\Core\Framework\ContentSystem\ContentPipeline;
-use Shopware\Core\Framework\ContentSystem\ContentSystemException;
 use Shopware\Core\Framework\ContentSystem\Event\PostHydrationEvent;
 use Shopware\Core\Framework\ContentSystem\Event\PreContentHydrationEvent;
 use Shopware\Core\Framework\ContentSystem\Hydration\ContentElementHydrator;
 use Shopware\Core\Framework\ContentSystem\Hydration\DataContext\ContextPathResolver;
 use Shopware\Core\Framework\ContentSystem\Hydration\DataContext\DataContextResolver;
 use Shopware\Core\Framework\ContentSystem\Hydration\DataLoader\DataLoaderProvider;
-use Shopware\Core\Framework\ContentSystem\Layout\Entity\ContentLayoutCollection;
 use Shopware\Core\Framework\ContentSystem\Layout\Entity\ContentLayoutEntity;
 use Shopware\Core\Framework\ContentSystem\PlaceholderValues;
+use Shopware\Core\Framework\ContentSystem\RenderableLayout;
 use Shopware\Core\Framework\ContentSystem\RenderingMode;
 use Shopware\Core\Framework\ContentSystem\RenderingSpecification;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\Test\Generator;
 use Shopware\Core\Test\Stub\ContentSystem\ContentElementBuilder;
-use Shopware\Core\Test\Stub\DataAbstractionLayer\StaticEntityRepository;
 use Symfony\Component\DependencyInjection\ServiceLocator;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
@@ -50,10 +48,7 @@ class ContentPipelineTest extends TestCase
     #[TestDox('hydrates elements and dispatches lifecycle events in FULL mode')]
     public function testLoadHydratesElementsInFullMode(): void
     {
-        $layoutId = Uuid::randomHex();
-        $layoutEntity = $this->createLayoutEntity($layoutId);
-
-        $repository = $this->createLayoutRepository($layoutEntity);
+        $layout = RenderableLayout::fromEntity($this->createLayoutEntity(Uuid::randomHex()));
 
         $dispatchedEvents = [];
         $this->eventDispatcher->method('dispatch')->willReturnCallback(
@@ -64,10 +59,10 @@ class ContentPipelineTest extends TestCase
             }
         );
 
-        $pipeline = new ContentPipeline($repository, $this->hydrator, $this->eventDispatcher);
-        $specification = new RenderingSpecification($layoutId, [], PlaceholderValues::from([]), new Request());
+        $pipeline = new ContentPipeline($this->hydrator, $this->eventDispatcher);
+        $specification = new RenderingSpecification([], PlaceholderValues::from([]), new Request());
 
-        $result = $pipeline->load($specification, new RenderingCacheContext(), RenderingMode::FULL, Generator::generateSalesChannelContext());
+        $result = $pipeline->load($layout, $specification, new RenderingCacheContext(), RenderingMode::FULL, Generator::generateSalesChannelContext());
 
         static::assertSame([PreContentHydrationEvent::class, PostHydrationEvent::class], $dispatchedEvents);
         static::assertNotEmpty($result->elements);
@@ -77,48 +72,20 @@ class ContentPipelineTest extends TestCase
     public function testLoadReturnsContentPageInSkeletonMode(): void
     {
         $layoutId = Uuid::randomHex();
-        $layoutEntity = $this->createLayoutEntity($layoutId, 'My Layout');
-
-        $repository = $this->createLayoutRepository($layoutEntity);
+        $layout = RenderableLayout::fromEntity($this->createLayoutEntity($layoutId, 'My Layout'));
 
         $this->eventDispatcher->method('dispatch')->willReturnArgument(0);
 
-        $pipeline = new ContentPipeline($repository, $this->hydrator, $this->eventDispatcher);
-        $specification = new RenderingSpecification($layoutId, [], PlaceholderValues::from([]), new Request());
+        $pipeline = new ContentPipeline($this->hydrator, $this->eventDispatcher);
+        $specification = new RenderingSpecification([], PlaceholderValues::from([]), new Request());
 
-        $result = $pipeline->load($specification, new RenderingCacheContext(), RenderingMode::SKELETON, Generator::generateSalesChannelContext());
+        $result = $pipeline->load($layout, $specification, new RenderingCacheContext(), RenderingMode::SKELETON, Generator::generateSalesChannelContext());
 
         $elements = iterator_to_array($result->elements, false);
         static::assertNotEmpty($elements);
         static::assertSame('section', $elements[0]->getComponent());
         static::assertSame($layoutId, $result->layoutId);
         static::assertSame('My Layout', $result->layoutName);
-    }
-
-    #[TestDox('throws layout not found when layout does not exist')]
-    public function testLoadThrowsLayoutNotFoundWhenLayoutDoesNotExist(): void
-    {
-        $layoutId = Uuid::randomHex();
-
-        $repository = $this->createLayoutRepository();
-
-        $pipeline = new ContentPipeline($repository, $this->hydrator, $this->eventDispatcher);
-        $specification = new RenderingSpecification($layoutId, [], PlaceholderValues::from([]), new Request());
-
-        $this->expectExceptionObject(ContentSystemException::layoutNotFound($layoutId));
-
-        $pipeline->load($specification, new RenderingCacheContext(), RenderingMode::FULL, Generator::generateSalesChannelContext());
-    }
-
-    /**
-     * @return StaticEntityRepository<ContentLayoutCollection>
-     */
-    private function createLayoutRepository(ContentLayoutEntity ...$entities): StaticEntityRepository
-    {
-        /** @var StaticEntityRepository<ContentLayoutCollection> $repository */
-        $repository = new StaticEntityRepository([$entities]);
-
-        return $repository;
     }
 
     private function createLayoutEntity(string $layoutId, string $name = 'Test Layout'): ContentLayoutEntity

--- a/tests/unit/Core/Framework/ContentSystem/ContentPipelineTest.php
+++ b/tests/unit/Core/Framework/ContentSystem/ContentPipelineTest.php
@@ -45,8 +45,8 @@ class ContentPipelineTest extends TestCase
         $this->eventDispatcher = static::createStub(EventDispatcherInterface::class);
     }
 
-    #[TestDox('hydrates elements and dispatches lifecycle events in FULL mode')]
-    public function testLoadHydratesElementsInFullMode(): void
+    #[TestDox('dispatches pre- and post-hydration lifecycle events in order in FULL mode')]
+    public function testLoadDispatchesLifecycleEventsInFullMode(): void
     {
         $layout = RenderableLayout::fromEntity($this->createLayoutEntity(Uuid::randomHex()));
 
@@ -62,9 +62,23 @@ class ContentPipelineTest extends TestCase
         $pipeline = new ContentPipeline($this->hydrator, $this->eventDispatcher);
         $specification = new RenderingSpecification([], PlaceholderValues::from([]), new Request());
 
-        $result = $pipeline->load($layout, $specification, new RenderingCacheContext(), RenderingMode::FULL, Generator::generateSalesChannelContext());
+        $pipeline->load($layout, $specification, new RenderingCacheContext(), RenderingMode::FULL, Generator::generateSalesChannelContext());
 
         static::assertSame([PreContentHydrationEvent::class, PostHydrationEvent::class], $dispatchedEvents);
+    }
+
+    #[TestDox('hydrates elements in FULL mode')]
+    public function testLoadHydratesElementsInFullMode(): void
+    {
+        $layout = RenderableLayout::fromEntity($this->createLayoutEntity(Uuid::randomHex()));
+
+        $this->eventDispatcher->method('dispatch')->willReturnArgument(0);
+
+        $pipeline = new ContentPipeline($this->hydrator, $this->eventDispatcher);
+        $specification = new RenderingSpecification([], PlaceholderValues::from([]), new Request());
+
+        $result = $pipeline->load($layout, $specification, new RenderingCacheContext(), RenderingMode::FULL, Generator::generateSalesChannelContext());
+
         static::assertNotEmpty($result->elements);
     }
 
@@ -86,6 +100,33 @@ class ContentPipelineTest extends TestCase
         static::assertSame('section', $elements[0]->getComponent());
         static::assertSame($layoutId, $result->layoutId);
         static::assertSame('My Layout', $result->layoutName);
+        static::assertSame('1.0', $result->layoutVersion);
+    }
+
+    #[TestDox('renders elements mutated by a PreContentHydration subscriber instead of the original layout')]
+    public function testLoadRendersElementsMutatedDuringPreHydration(): void
+    {
+        $layout = RenderableLayout::fromEntity($this->createLayoutEntity(Uuid::randomHex()));
+
+        $injected = ContentElementBuilder::create('injected', 'injected-id')->build();
+        $this->eventDispatcher->method('dispatch')->willReturnCallback(
+            function (object $event) use ($injected) {
+                if ($event instanceof PreContentHydrationEvent) {
+                    $event->elements = [$injected];
+                }
+
+                return $event;
+            }
+        );
+
+        $pipeline = new ContentPipeline($this->hydrator, $this->eventDispatcher);
+        $specification = new RenderingSpecification([], PlaceholderValues::from([]), new Request());
+
+        $result = $pipeline->load($layout, $specification, new RenderingCacheContext(), RenderingMode::SKELETON, Generator::generateSalesChannelContext());
+
+        $elements = iterator_to_array($result->elements, false);
+        static::assertCount(1, $elements);
+        static::assertSame('injected-id', $elements[0]->getId());
     }
 
     private function createLayoutEntity(string $layoutId, string $name = 'Test Layout'): ContentLayoutEntity

--- a/tests/unit/Core/Framework/ContentSystem/Event/Listener/PostHydration/VirtualRootCleanupSubscriberTest.php
+++ b/tests/unit/Core/Framework/ContentSystem/Event/Listener/PostHydration/VirtualRootCleanupSubscriberTest.php
@@ -21,14 +21,11 @@ use Symfony\Component\HttpFoundation\Request;
 #[CoversClass(VirtualRootCleanupSubscriber::class)]
 class VirtualRootCleanupSubscriberTest extends TestCase
 {
-    private VirtualRootWrapper $wrapper;
-
     private VirtualRootCleanupSubscriber $subscriber;
 
     protected function setUp(): void
     {
-        $this->wrapper = new VirtualRootWrapper();
-        $this->subscriber = new VirtualRootCleanupSubscriber($this->wrapper);
+        $this->subscriber = new VirtualRootCleanupSubscriber(new VirtualRootWrapper());
     }
 
     #[TestDox('unwraps virtual root after hydration, restoring original elements')]
@@ -44,7 +41,8 @@ class VirtualRootCleanupSubscriberTest extends TestCase
             new Request(),
         );
 
-        $virtualRoot = $this->wrapper->wrap([$root1, $root2], $specification);
+        $wrapper = new VirtualRootWrapper();
+        $virtualRoot = $wrapper->wrap([$root1, $root2], $specification);
         $event = EventFactory::postHydration([$virtualRoot], [$requirement]);
 
         $this->subscriber->__invoke($event);

--- a/tests/unit/Core/Framework/ContentSystem/Event/Listener/PostHydration/VirtualRootCleanupSubscriberTest.php
+++ b/tests/unit/Core/Framework/ContentSystem/Event/Listener/PostHydration/VirtualRootCleanupSubscriberTest.php
@@ -39,7 +39,6 @@ class VirtualRootCleanupSubscriberTest extends TestCase
 
         $requirement = new DataRequirement('language', 'language', new LanguageLoaderConfig());
         $specification = new RenderingSpecification(
-            'layout-1',
             [$requirement],
             PlaceholderValues::from([]),
             new Request(),

--- a/tests/unit/Core/Framework/ContentSystem/Layout/Element/ContentElementTest.php
+++ b/tests/unit/Core/Framework/ContentSystem/Layout/Element/ContentElementTest.php
@@ -23,16 +23,6 @@ use Symfony\Component\HttpFoundation\Request;
 #[CoversClass(ContentElement::class)]
 class ContentElementTest extends TestCase
 {
-    private ContentElement $element;
-
-    protected function setUp(): void
-    {
-        $this->element = ContentElementBuilder::create('test-component')
-            ->withProperty('label', 'hello')
-            ->withProperty('myStruct', new StubStruct())
-            ->build();
-    }
-
     #[TestDox('stores Struct value and scalar value separately via setProperty')]
     public function testSetPropertyDispatchesStructAndScalarToDifferentBuckets(): void
     {
@@ -55,14 +45,6 @@ class ContentElementTest extends TestCase
 
         static::assertSame($struct, $element->getProperty('myStruct'));
         static::assertSame('hello', $element->getProperty('myScalar'));
-    }
-
-    #[TestDox('returns null when property key does not exist')]
-    public function testGetPropertyReturnsNullForMissingKey(): void
-    {
-        $element = ContentElementBuilder::create('test-component')->build();
-
-        static::assertNull($element->getProperty('nonexistent'));
     }
 
     #[TestDox('merges struct and non-struct properties into a single array')]
@@ -100,7 +82,20 @@ class ContentElementTest extends TestCase
     #[TestDox('returns correct boolean for hasProperty when key is $key')]
     public function testHasPropertyReturnsTrueForExistingAndFalseForMissing(string $key, bool $expected): void
     {
-        static::assertSame($expected, $this->element->hasProperty($key));
+        $element = ContentElementBuilder::create('test-component')
+            ->withProperty('label', 'hello')
+            ->withProperty('myStruct', new StubStruct())
+            ->build();
+
+        static::assertSame($expected, $element->hasProperty($key));
+    }
+
+    #[TestDox('returns null when property key does not exist')]
+    public function testGetPropertyReturnsNullForMissingKey(): void
+    {
+        $element = ContentElementBuilder::create('test-component')->build();
+
+        static::assertNull($element->getProperty('nonexistent'));
     }
 
     #[TestDox('returns true when at least one data requirement is declared')]

--- a/tests/unit/Core/Framework/ContentSystem/Layout/Element/ContentElementTest.php
+++ b/tests/unit/Core/Framework/ContentSystem/Layout/Element/ContentElementTest.php
@@ -319,7 +319,6 @@ class ContentElementTest extends TestCase
     private function createRenderingSpecification(array $values): RenderingSpecification
     {
         return new RenderingSpecification(
-            'layout-id',
             [],
             PlaceholderValues::from($values),
             new Request(),

--- a/tests/unit/Core/Framework/ContentSystem/Layout/Scaffolding/VirtualRootWrapperTest.php
+++ b/tests/unit/Core/Framework/ContentSystem/Layout/Scaffolding/VirtualRootWrapperTest.php
@@ -42,7 +42,6 @@ class VirtualRootWrapperTest extends TestCase
     public function testRequiresWrappingNoRequirements(): void
     {
         $specification = new RenderingSpecification(
-            'layout-1',
             [],
             PlaceholderValues::from([]),
             new Request(),
@@ -166,7 +165,6 @@ class VirtualRootWrapperTest extends TestCase
         $requirement = new DataRequirement('language', 'language', new LanguageLoaderConfig());
 
         return new RenderingSpecification(
-            'layout-1',
             [$requirement],
             PlaceholderValues::from([]),
             new Request(),

--- a/tests/unit/Core/Framework/ContentSystem/SalesChannel/ContentRouteTest.php
+++ b/tests/unit/Core/Framework/ContentSystem/SalesChannel/ContentRouteTest.php
@@ -9,6 +9,7 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Adapter\Cache\CacheTagCollector;
 use Shopware\Core\Framework\ContentSystem\Adapter\RenderingSpecificationResolver;
 use Shopware\Core\Framework\ContentSystem\Cache\CacheFinalizer;
+use Shopware\Core\Framework\ContentSystem\Cache\RenderingCacheContext;
 use Shopware\Core\Framework\ContentSystem\ContentPipeline;
 use Shopware\Core\Framework\ContentSystem\ContentSection;
 use Shopware\Core\Framework\ContentSystem\ContentSystemException;
@@ -17,6 +18,7 @@ use Shopware\Core\Framework\ContentSystem\Layout\Entity\ContentLayoutEntity;
 use Shopware\Core\Framework\ContentSystem\Output\Format\AbstractResponseFactory;
 use Shopware\Core\Framework\ContentSystem\Output\Struct\ContentPage;
 use Shopware\Core\Framework\ContentSystem\PlaceholderValues;
+use Shopware\Core\Framework\ContentSystem\RenderableLayout;
 use Shopware\Core\Framework\ContentSystem\RenderingMode;
 use Shopware\Core\Framework\ContentSystem\RenderingSpecification;
 use Shopware\Core\Framework\ContentSystem\ResolvedContentLayout;
@@ -51,27 +53,8 @@ class ContentRouteTest extends TestCase
         $this->contentPipeline = static::createStub(ContentPipeline::class);
     }
 
-    #[TestDox('returns content page from pipeline via response factory')]
-    public function testLoadReturnsContentPageFromPipeline(): void
-    {
-        $request = new Request();
-        $contentPage = new ContentPage('layout-1', [ContentElementBuilder::create('root')->build()], 'Test', null);
-
-        $this->specificationResolver->method('resolve')->willReturn($this->createResolved($request));
-        $this->responseFactory->method('getRenderingMode')->willReturn(RenderingMode::FULL);
-        $this->contentPipeline->method('load')->willReturn($contentPage);
-        $this->responseFactory->method('createResponse')->willReturn(new ContentRouteResponse($contentPage));
-
-        $route = $this->createRoute($this->createLayoutRepository($this->createLayoutEntity()));
-
-        $result = $route->load('/product/abc', $request, Generator::generateSalesChannelContext());
-
-        static::assertInstanceOf(ContentRouteResponse::class, $result);
-        static::assertSame($contentPage, $result->getContentPage());
-    }
-
-    #[TestDox('collects layout and specification cache tags')]
-    public function testLoadCollectsLayoutAndSpecificationCacheTags(): void
+    #[TestDox('returns content page from pipeline and collects layout and specification cache tags')]
+    public function testLoadReturnsContentPageAndCollectsCacheTags(): void
     {
         $request = new Request();
         $contentPage = new ContentPage('layout-1', [ContentElementBuilder::create('root')->build()], 'Test', null);
@@ -89,28 +72,36 @@ class ContentRouteTest extends TestCase
 
         $route = $this->createRoute($this->createLayoutRepository($this->createLayoutEntity()));
 
-        $route->load('/product/abc', $request, Generator::generateSalesChannelContext());
+        $result = $route->load('/product/abc', $request, Generator::generateSalesChannelContext());
 
+        static::assertInstanceOf(ContentRouteResponse::class, $result);
+        static::assertSame($contentPage, $result->getContentPage());
         static::assertContains('content-layout-layout-1', $collectedTags);
         static::assertContains('product-abc', $collectedTags);
     }
 
-    #[TestDox('finalizes cache context on request')]
-    public function testLoadFinalizesCacheContextOnRequest(): void
+    #[TestDox('marks the request uncacheable when the pipeline disables the cache context')]
+    public function testLoadDisablesHttpCacheWhenPipelineDisablesCacheContext(): void
     {
         $request = new Request();
         $contentPage = new ContentPage('layout-1', [ContentElementBuilder::create('root')->build()], 'Test', null);
 
         $this->specificationResolver->method('resolve')->willReturn($this->createResolved($request));
         $this->responseFactory->method('getRenderingMode')->willReturn(RenderingMode::FULL);
-        $this->contentPipeline->method('load')->willReturn($contentPage);
+        $this->contentPipeline->method('load')->willReturnCallback(
+            function (RenderableLayout $layout, RenderingSpecification $specification, RenderingCacheContext $cacheContext) use ($contentPage): ContentPage {
+                $cacheContext->disable();
+
+                return $contentPage;
+            }
+        );
         $this->responseFactory->method('createResponse')->willReturn(new ContentRouteResponse($contentPage));
 
         $route = $this->createRoute($this->createLayoutRepository($this->createLayoutEntity()));
 
         $route->load('/product/abc', $request, Generator::generateSalesChannelContext());
 
-        static::assertNull($request->attributes->get(PlatformRequest::ATTRIBUTE_HTTP_CACHE));
+        static::assertFalse($request->attributes->get(PlatformRequest::ATTRIBUTE_HTTP_CACHE));
     }
 
     #[TestDox('throws layout not found when the resolved layout does not exist')]

--- a/tests/unit/Core/Framework/ContentSystem/SalesChannel/ContentRouteTest.php
+++ b/tests/unit/Core/Framework/ContentSystem/SalesChannel/ContentRouteTest.php
@@ -11,17 +11,22 @@ use Shopware\Core\Framework\ContentSystem\Adapter\RenderingSpecificationResolver
 use Shopware\Core\Framework\ContentSystem\Cache\CacheFinalizer;
 use Shopware\Core\Framework\ContentSystem\ContentPipeline;
 use Shopware\Core\Framework\ContentSystem\ContentSection;
+use Shopware\Core\Framework\ContentSystem\ContentSystemException;
+use Shopware\Core\Framework\ContentSystem\Layout\Entity\ContentLayoutCollection;
+use Shopware\Core\Framework\ContentSystem\Layout\Entity\ContentLayoutEntity;
 use Shopware\Core\Framework\ContentSystem\Output\Format\AbstractResponseFactory;
 use Shopware\Core\Framework\ContentSystem\Output\Struct\ContentPage;
 use Shopware\Core\Framework\ContentSystem\PlaceholderValues;
 use Shopware\Core\Framework\ContentSystem\RenderingMode;
 use Shopware\Core\Framework\ContentSystem\RenderingSpecification;
+use Shopware\Core\Framework\ContentSystem\ResolvedContentLayout;
 use Shopware\Core\Framework\ContentSystem\SalesChannel\ContentRoute;
 use Shopware\Core\Framework\ContentSystem\SalesChannel\ContentRouteResponse;
 use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
 use Shopware\Core\PlatformRequest;
 use Shopware\Core\Test\Generator;
 use Shopware\Core\Test\Stub\ContentSystem\ContentElementBuilder;
+use Shopware\Core\Test\Stub\DataAbstractionLayer\StaticEntityRepository;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
@@ -38,23 +43,12 @@ class ContentRouteTest extends TestCase
 
     private ContentPipeline&Stub $contentPipeline;
 
-    private ContentRoute $route;
-
     protected function setUp(): void
     {
         $this->specificationResolver = static::createStub(RenderingSpecificationResolver::class);
         $this->cacheTagCollector = static::createStub(CacheTagCollector::class);
         $this->responseFactory = static::createStub(AbstractResponseFactory::class);
         $this->contentPipeline = static::createStub(ContentPipeline::class);
-
-        $this->route = new ContentRoute(
-            $this->specificationResolver,
-            ContentSection::MAIN,
-            $this->cacheTagCollector,
-            $this->responseFactory,
-            $this->contentPipeline,
-            new CacheFinalizer($this->cacheTagCollector),
-        );
     }
 
     #[TestDox('returns content page from pipeline via response factory')]
@@ -63,14 +57,14 @@ class ContentRouteTest extends TestCase
         $request = new Request();
         $contentPage = new ContentPage('layout-1', [ContentElementBuilder::create('root')->build()], 'Test', null);
 
-        $this->specificationResolver->method('resolve')->willReturn(
-            new RenderingSpecification('layout-1', [], PlaceholderValues::from([]), $request, null, [])
-        );
+        $this->specificationResolver->method('resolve')->willReturn($this->createResolved($request));
         $this->responseFactory->method('getRenderingMode')->willReturn(RenderingMode::FULL);
         $this->contentPipeline->method('load')->willReturn($contentPage);
         $this->responseFactory->method('createResponse')->willReturn(new ContentRouteResponse($contentPage));
 
-        $result = $this->route->load('/product/abc', $request, Generator::generateSalesChannelContext());
+        $route = $this->createRoute($this->createLayoutRepository($this->createLayoutEntity()));
+
+        $result = $route->load('/product/abc', $request, Generator::generateSalesChannelContext());
 
         static::assertInstanceOf(ContentRouteResponse::class, $result);
         static::assertSame($contentPage, $result->getContentPage());
@@ -88,14 +82,14 @@ class ContentRouteTest extends TestCase
                 array_push($collectedTags, ...$tags);
             });
 
-        $this->specificationResolver->method('resolve')->willReturn(
-            new RenderingSpecification('layout-1', [], PlaceholderValues::from([]), $request, null, ['product-abc'])
-        );
+        $this->specificationResolver->method('resolve')->willReturn($this->createResolved($request, ['product-abc']));
         $this->responseFactory->method('getRenderingMode')->willReturn(RenderingMode::FULL);
         $this->contentPipeline->method('load')->willReturn($contentPage);
         $this->responseFactory->method('createResponse')->willReturn(new ContentRouteResponse($contentPage));
 
-        $this->route->load('/product/abc', $request, Generator::generateSalesChannelContext());
+        $route = $this->createRoute($this->createLayoutRepository($this->createLayoutEntity()));
+
+        $route->load('/product/abc', $request, Generator::generateSalesChannelContext());
 
         static::assertContains('content-layout-layout-1', $collectedTags);
         static::assertContains('product-abc', $collectedTags);
@@ -107,16 +101,30 @@ class ContentRouteTest extends TestCase
         $request = new Request();
         $contentPage = new ContentPage('layout-1', [ContentElementBuilder::create('root')->build()], 'Test', null);
 
-        $this->specificationResolver->method('resolve')->willReturn(
-            new RenderingSpecification('layout-1', [], PlaceholderValues::from([]), $request, null, [])
-        );
+        $this->specificationResolver->method('resolve')->willReturn($this->createResolved($request));
         $this->responseFactory->method('getRenderingMode')->willReturn(RenderingMode::FULL);
         $this->contentPipeline->method('load')->willReturn($contentPage);
         $this->responseFactory->method('createResponse')->willReturn(new ContentRouteResponse($contentPage));
 
-        $this->route->load('/product/abc', $request, Generator::generateSalesChannelContext());
+        $route = $this->createRoute($this->createLayoutRepository($this->createLayoutEntity()));
+
+        $route->load('/product/abc', $request, Generator::generateSalesChannelContext());
 
         static::assertNull($request->attributes->get(PlatformRequest::ATTRIBUTE_HTTP_CACHE));
+    }
+
+    #[TestDox('throws layout not found when the resolved layout does not exist')]
+    public function testLoadThrowsLayoutNotFoundWhenLayoutDoesNotExist(): void
+    {
+        $request = new Request();
+
+        $this->specificationResolver->method('resolve')->willReturn($this->createResolved($request));
+
+        $route = $this->createRoute($this->createLayoutRepository());
+
+        $this->expectExceptionObject(ContentSystemException::layoutNotFound('layout-1'));
+
+        $route->load('/product/abc', $request, Generator::generateSalesChannelContext());
     }
 
     #[TestDox('throws DecorationPatternException from getDecorated')]
@@ -124,6 +132,55 @@ class ContentRouteTest extends TestCase
     {
         $this->expectExceptionObject(new DecorationPatternException(ContentRoute::class));
 
-        $this->route->getDecorated();
+        $this->createRoute($this->createLayoutRepository())->getDecorated();
+    }
+
+    /**
+     * @param StaticEntityRepository<ContentLayoutCollection> $repository
+     */
+    private function createRoute(StaticEntityRepository $repository): ContentRoute
+    {
+        return new ContentRoute(
+            $this->specificationResolver,
+            ContentSection::MAIN,
+            $this->cacheTagCollector,
+            $repository,
+            $this->responseFactory,
+            $this->contentPipeline,
+            new CacheFinalizer($this->cacheTagCollector),
+        );
+    }
+
+    /**
+     * @param list<string> $cacheTags
+     */
+    private function createResolved(Request $request, array $cacheTags = []): ResolvedContentLayout
+    {
+        return ResolvedContentLayout::create(
+            'layout-1',
+            new RenderingSpecification([], PlaceholderValues::from([]), $request, null, $cacheTags),
+        );
+    }
+
+    /**
+     * @return StaticEntityRepository<ContentLayoutCollection>
+     */
+    private function createLayoutRepository(ContentLayoutEntity ...$entities): StaticEntityRepository
+    {
+        /** @var StaticEntityRepository<ContentLayoutCollection> $repository */
+        $repository = new StaticEntityRepository([$entities]);
+
+        return $repository;
+    }
+
+    private function createLayoutEntity(string $id = 'layout-1', string $name = 'Test'): ContentLayoutEntity
+    {
+        $entity = new ContentLayoutEntity();
+        $entity->setId($id);
+        $entity->setName($name);
+        $entity->setVersion('1.0');
+        $entity->setLayout([ContentElementBuilder::create('root')->build()]);
+
+        return $entity;
     }
 }


### PR DESCRIPTION
The rendering pipeline owned a data-access concern that belongs to its caller. `ContentPipeline::load()` queried the content-layout repository to turn a `layoutId` into a `ContentLayoutEntity`, then rendered from it. That coupled rendering to the DAL and to `ContentLayoutEntity`, and it blocks the upcoming content-layout preview, which must render an externally supplied, unsaved layout for which no persisted entity exists. This PR moves the fetch to the route and hands the pipeline a self-contained, DAL-free input. Capturing layout identity once as a value object also closes a latent split-source defect, where the output page took its `layoutId` from the resolved assignment but its name and version from the rendered entity.

Store-API behavior is preserved. The single observable change from the refactor is that `layoutNotFound` now throws from `ContentRoute` instead of `ContentPipeline`, with the same exception class and message. A separate, intentional fix corrects the `layoutVersion` value (see below).

### Value objects

Three immutable value objects carry identity and pipeline input. Each has a private constructor with named factories, matching the module's `PlaceholderValues` precedent.

| Type | Holds | Built by |
|---|---|---|
| `LayoutReference` | `id`, `name`, `version` | `create()` for synthetic identities, `fromEntity()` for persisted ones |
| `RenderableLayout` | a `LayoutReference` plus its `list<ContentElement>` | `fromEntity()` on the route, `create()` for callers that already hold decoded elements |
| `ResolvedContentLayout` | the resolved `layoutId` plus the `RenderingSpecification` | `create()`, returned by the resolver and factory |

### Pipeline decoupled from the fetch

`ContentPipeline::load()` now accepts a `RenderableLayout` and no longer touches the DAL. It drops the `EntityRepository` dependency, the `Criteria` fetch, the missing-layout check, and the `ContentLayoutEntity` import. `ContentRoute` performs the fetch between specification resolution and rendering, adapts the entity with `RenderableLayout::fromEntity()`, and throws `layoutNotFound` when the row is absent. The route reads a non-null `layoutId` from `ResolvedContentLayout` for the cache-tag derivation and the fetch.

### `layoutId` removed from `RenderingSpecification`

`layoutId` was a route-side concern (cache tags, fetch, `layoutNotFound`) that the pipeline never read. Rather than leave it on the rendering input or make it nullable for a future assignment-free caller, it is removed from `RenderingSpecification` and returned beside the specification in `ResolvedContentLayout`. The route reads it as a non-null `string`, with no assertion and no consumer-side narrowing.

### Event identity as one value object

`PreContentHydrationEvent` and `PostHydrationEvent` replace the `(layoutId, layoutName, layoutVersionId)` scalar triple with a single `LayoutReference $layout`. No listener read the triple, so this is a pure contract simplification. `ContentPage` is now built entirely from the post-hydration event's reference, so all three identity fields share one source and the split-source defect disappears.

### Layout version semantics

`ContentPage.layoutVersion` now carries the layout's domain version (`getVersion()`, for example `"1.0"`) instead of the DAL entity-versioning UUID (`getVersionId()`). The field is named `layoutVersion`, and the previous value exposed internal live/draft versioning machinery rather than the layout's own version.

### Wiring, docs, and tests

`ContentRoute` gains the content-layout repository as its fourth constructor argument, ordered by use. `ContentRouteCompilerPass` and `content-system.xml` follow, and `ContentPipeline` drops the repository argument. Module docs (`README`, `AGENTS`, `EXTENSION`) are updated to describe the value objects and the route-owned fetch. Unit tests move with the contract change and gain coverage for pre-hydration element mutation, cache-context disabling propagation, and the corrected layout version.