### PR TITLE
ci: make frw deactivation more stable

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -450,7 +450,12 @@ jobs:
       - name: Install
         working-directory: old-shopware
         run: |
-          sed -i -e "s/shopware.store.frw: '1'/shopware.store.frw: '0'"/ config/services.yaml
+          if grep -q "shopware.store.frw:" config/services.yaml; then
+            sed -i -e "s/shopware.store.frw: '1'/shopware.store.frw: '0'/" config/services.yaml
+            sed -i -e "s/shopware.store.frw: true/shopware.store.frw: false/" config/services.yaml
+          else
+            printf "\nparameters:\n shopware.store.frw: '0'\n" >> config/services.yaml
+          fi
           bin/console system:install --basic-setup --drop-database --create-database
 
       - name: Download latest WebInstaller


### PR DESCRIPTION
### 1. Why is this change necessary?
Sometimes the First Run Wizard was not deactivated after a fresh shopware instance generation. One possible reason could be that the config.yml does not contain the entry. 

### 2. What does this change do, exactly?
This pull request updates the installation step in the integration workflow to make the configuration of the `shopware.store.frw` parameter more robust. The new logic ensures that the parameter is correctly set regardless of its initial presence or format in the `config/services.yaml` file.

Configuration handling improvements:

* Updated the install step to check if `shopware.store.frw` exists in `config/services.yaml`. If present, it replaces both `'1'` with `'0'` and `true` with `false`; if not present, it appends the parameter with the value `'0'` to the file.


### 3. Describe each step to reproduce the issue or behaviour.
see pipelines in issue: #17447

### 4. Please link to the relevant issues (if any).
- closes: #17447

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
