### PR TITLE
refactor: move product slider random sort to PHP shuffle

### DIFF
--- a/src/Core/Content/Product/Cms/ProductSlider/ProductStreamProcessor.php
+++ b/src/Core/Content/Product/Cms/ProductSlider/ProductStreamProcessor.php
@@ -85,15 +85,17 @@ class ProductStreamProcessor extends AbstractProductSliderProcessor
         $slider = new ProductSliderStruct();
         $slot->setData($slider);
 
+        $config = $slot->getFieldConfig();
+        $randomize = $config->get('productStreamSorting')?->getStringValue() === 'random';
+
         $slider->setProducts(
             $this->handleProductStream(
                 $streamResult,
                 $resolverContext->getSalesChannelContext(),
-                $entitySearchResult->getCriteria()
+                $entitySearchResult->getCriteria(),
+                $randomize
             )
         );
-
-        $config = $slot->getFieldConfig();
 
         $productConfig = $config->get('products');
         \assert($productConfig instanceof FieldConfig);
@@ -133,9 +135,7 @@ class ProductStreamProcessor extends AbstractProductSliderProcessor
         $this->addGrouping($criteria);
         $sorting = $elementConfig->get('productStreamSorting')?->getStringValue() ?? 'name:' . FieldSorting::ASCENDING;
 
-        if ($sorting === 'random') {
-            $this->addRandomSort($criteria);
-        } else {
+        if ($sorting !== 'random') {
             $sorting = explode(':', $sorting);
             $field = $sorting[0];
             $direction = $sorting[1];
@@ -149,11 +149,16 @@ class ProductStreamProcessor extends AbstractProductSliderProcessor
     private function handleProductStream(
         ProductCollection $streamResult,
         SalesChannelContext $context,
-        Criteria $originCriteria
+        Criteria $originCriteria,
+        bool $randomize = false
     ): ProductCollection {
         $finalProductIds = $this->collectFinalProductIds($streamResult);
         if ($finalProductIds === []) {
             return new ProductCollection();
+        }
+
+        if ($randomize) {
+            shuffle($finalProductIds);
         }
 
         $criteria = $originCriteria->cloneForRead($finalProductIds);
@@ -191,27 +196,5 @@ class ProductStreamProcessor extends AbstractProductSliderProcessor
     {
         $criteria->addGroupField(new FieldGrouping('displayGroup'));
         $criteria->addFilter(new NotEqualsFilter('displayGroup', null));
-    }
-
-    private function addRandomSort(Criteria $criteria): void
-    {
-        // these fields should be compatible with Elasticsearch mapped fields for sorting, see: \Shopware\Elasticsearch\Product\ElasticsearchProductDefinition::getMapping
-        $fields = [
-            'id',
-            'stock',
-            'releaseDate',
-            'manufacturerId',
-            'deliveryTimeId',
-            'taxId',
-            'coverId',
-        ];
-        shuffle($fields);
-        $fields = \array_slice($fields, 0, 2);
-        $direction = [FieldSorting::ASCENDING, FieldSorting::DESCENDING];
-        $direction = $direction[random_int(0, 1)];
-
-        foreach ($fields as $field) {
-            $criteria->addSorting(new FieldSorting($field, $direction));
-        }
     }
 }

--- a/tests/unit/Core/Content/Product/Cms/ProductSlider/ProductStreamProcessorTest.php
+++ b/tests/unit/Core/Content/Product/Cms/ProductSlider/ProductStreamProcessorTest.php
@@ -188,7 +188,7 @@ class ProductStreamProcessorTest extends TestCase
         static::assertSame([], $criteria->getSorting());
     }
 
-    public function testEnrichRandomizesProductOrder(): void
+    public function testEnrichHandlesRandomSorting(): void
     {
         $slot = $this->getSlot();
         $resolverContext = $this->getResolverContext();
@@ -212,6 +212,7 @@ class ProductStreamProcessorTest extends TestCase
         $slider = $slot->getData();
         static::assertInstanceOf(ProductSliderStruct::class, $slider);
         static::assertSame('product-stream-1', $slider->getStreamId());
+        static::assertInstanceOf(ProductCollection::class, $slider->getProducts());
         static::assertCount(2, $slider->getProducts());
     }
 

--- a/tests/unit/Core/Content/Product/Cms/ProductSlider/ProductStreamProcessorTest.php
+++ b/tests/unit/Core/Content/Product/Cms/ProductSlider/ProductStreamProcessorTest.php
@@ -24,7 +24,6 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\ContainsFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\MultiFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\NotEqualsFilter;
-use Shopware\Core\Framework\DataAbstractionLayer\Search\Sorting\FieldSorting;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
 use Shopware\Core\System\SalesChannel\Entity\SalesChannelRepository;
@@ -166,7 +165,7 @@ class ProductStreamProcessorTest extends TestCase
         static::assertNull($this->getProcessor()->collect($slot, $this->config, $resolverContext));
     }
 
-    public function testCollectAddsRandomSortingIfRequired(): void
+    public function testCollectAddsNoSortingForRandom(): void
     {
         $slot = $this->getSlot();
         $resolverContext = $this->getResolverContext();
@@ -186,9 +185,34 @@ class ProductStreamProcessorTest extends TestCase
         $criteria = $list[ProductDefinition::class]['product-slider-entity-fallback_id'] ?? null;
         static::assertInstanceOf(Criteria::class, $criteria);
 
-        $sorting = $criteria->getSorting();
-        static::assertCount(2, $sorting);
-        static::assertContainsOnlyInstancesOf(FieldSorting::class, $sorting);
+        static::assertSame([], $criteria->getSorting());
+    }
+
+    public function testEnrichRandomizesProductOrder(): void
+    {
+        $slot = $this->getSlot();
+        $resolverContext = $this->getResolverContext();
+
+        $config = new FieldConfig('products', FieldConfig::SOURCE_PRODUCT_STREAM, 'product-stream-1');
+        $sortingConfig = new FieldConfig('productStreamSorting', FieldConfig::SOURCE_PRODUCT_STREAM, 'random');
+        $this->config->add($config);
+        $this->config->add($sortingConfig);
+
+        $products = $this->getProducts();
+        $searchResult = $this->getEntitySearchResult($products);
+
+        $data = new ElementDataCollection();
+        $data->add('product-slider-entity-fallback_id', $searchResult);
+
+        $this->productRepository->expects($this->once())
+            ->method('search')->willReturn($searchResult);
+
+        $this->getProcessor()->enrich($slot, $data, $resolverContext);
+
+        $slider = $slot->getData();
+        static::assertInstanceOf(ProductSliderStruct::class, $slider);
+        static::assertSame('product-stream-1', $slider->getStreamId());
+        static::assertCount(2, $slider->getProducts());
     }
 
     public function testEnrich(): void


### PR DESCRIPTION
### 1. Why is this change necessary?

The "random" sort option for product streams in the product slider takes some columns and randomly picks 2 of them, then randomizes their sort. The problem is that ordering by those  columns can't use any index (in combination with GROUP BY), so MySQL falls back to a filesort over the entire grouped stream result, which causes much longer loading times on any page in the Shopware 6 store with this product slider and random sort.

### 2. What does this change do, exactly?

It moves the randomization from MySQL into PHP, allowing usage of indexes.

### 3. Describe each step to reproduce the issue or behaviour.

1. Create product stream and slider element with that stream and random sort
2. Profile the MySQL query , use EXPLAIN to see the way MySQL tries to receive the products

### 4. Please link to the relevant issues (if any).

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
