### PR TITLE
fix: prevent text editor alignment spans

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-text-editor/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-text-editor/index.js
@@ -645,6 +645,11 @@ export default {
             ].includes(type);
         },
 
+        /**
+         * Some browsers wrap aligned plain text in presentation-only markup, e.g.
+         * `<div style="text-align: center;"><span style="font-size: 14px;">abc</span></div>`.
+         * The alignment belongs to the block element, so the generated span can be removed.
+         */
         removeBrowserGeneratedAlignmentStyleSpans() {
             if (!this.$refs.textEditor) {
                 return;
@@ -667,6 +672,10 @@ export default {
             });
         },
 
+        /**
+         * Only remove narrow browser artifacts, not intentional styling.
+         * Example: `font-size: 14px` is removable, `color: red` alone is not.
+         */
         isRemovableBrowserGeneratedStyleSpan(span) {
             if (span.attributes.length !== 1 || !span.hasAttribute('style')) {
                 return false;
@@ -699,6 +708,10 @@ export default {
             });
         },
 
+        /**
+         * Preserve all child nodes while removing a wrapper element.
+         * Example: `<span>abc <b>def</b></span>` becomes `abc <b>def</b>`.
+         */
         unwrapElement(element) {
             const parentElement = element.parentElement;
 

--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-text-editor/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-text-editor/index.js
@@ -627,7 +627,90 @@ export default {
             }
 
             document.execCommand(type, false, value);
+
+            if (this.isTextAlignmentCommand(type)) {
+                this.fixWrongNodes(true, false);
+                this.removeBrowserGeneratedAlignmentStyleSpans();
+            }
+
             this.emitContent();
+        },
+
+        isTextAlignmentCommand(type) {
+            return [
+                'justifyLeft',
+                'justifyCenter',
+                'justifyRight',
+                'justifyFull',
+            ].includes(type);
+        },
+
+        removeBrowserGeneratedAlignmentStyleSpans() {
+            if (!this.$refs.textEditor) {
+                return;
+            }
+
+            const blockElements = this.$refs.textEditor.querySelectorAll('p, h1, h2, h3, h4, h5, h6, blockquote');
+
+            blockElements.forEach((blockElement) => {
+                if (!blockElement.style.textAlign) {
+                    return;
+                }
+
+                blockElement.querySelectorAll('span[style]').forEach((span) => {
+                    if (!this.isRemovableBrowserGeneratedStyleSpan(span)) {
+                        return;
+                    }
+
+                    this.unwrapElement(span);
+                });
+            });
+        },
+
+        isRemovableBrowserGeneratedStyleSpan(span) {
+            if (span.attributes.length !== 1 || !span.hasAttribute('style')) {
+                return false;
+            }
+
+            const style = span.style;
+            const styleProperties = Array.from(style);
+
+            if (styleProperties.length < 1) {
+                return false;
+            }
+
+            const hasTransparentBackground = style.getPropertyValue('background-color') === 'transparent';
+            const hasOnlyFontSize = styleProperties.length === 1 && styleProperties.includes('font-size');
+
+            if (hasOnlyFontSize) {
+                return style.getPropertyValue('font-size').length > 0;
+            }
+
+            if (!hasTransparentBackground) {
+                return false;
+            }
+
+            return styleProperties.every((styleProperty) => {
+                return [
+                    'background-color',
+                    'color',
+                    'font-size',
+                ].includes(styleProperty);
+            });
+        },
+
+        unwrapElement(element) {
+            const parentElement = element.parentElement;
+
+            if (!parentElement) {
+                return;
+            }
+
+            while (element.firstChild) {
+                parentElement.insertBefore(element.firstChild, element);
+            }
+
+            parentElement.removeChild(element);
         },
 
         expandSelectionToNearestEndBracket() {
@@ -868,8 +951,9 @@ export default {
          * This helps to achieve a consistent text formatting.
          *
          * @param {boolean} replaceDivNodes - Defines if <div> nodes should be replaced. Defaults to false.
+         * @param {boolean} shouldEmitContent - Defines if the content should be emitted after fixing nodes. Defaults to true.
          */
-        fixWrongNodes(replaceDivNodes = false) {
+        fixWrongNodes(replaceDivNodes = false, shouldEmitContent = true) {
             // Valid section elements that should stay as they are.
             const sectionElements = this.sectionElementTags;
 
@@ -934,7 +1018,9 @@ export default {
                 }
             });
 
-            this.emitContent();
+            if (shouldEmitContent) {
+                this.emitContent();
+            }
         },
 
         /**

--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-text-editor/sw-text-editor.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-text-editor/sw-text-editor.spec.js
@@ -150,6 +150,7 @@ describe('src/app/component/form/sw-text-editor', () => {
 
     afterEach(() => {
         document.getSelection().removeAllRanges();
+        jest.restoreAllMocks();
     });
 
     it('should toggle placeholder', async () => {
@@ -1041,6 +1042,104 @@ describe('src/app/component/form/sw-text-editor', () => {
 
         const selection = document.getSelection();
         expect(selection.toString()).toBe('Hello World');
+    });
+
+    it('should remove browser-generated style spans after applying text alignment', async () => {
+        wrapper = await createWrapper();
+
+        const contentEditor = wrapper.find('.sw-text-editor__content-editor');
+
+        await addTextToEditor(wrapper, 'abc');
+        await addAndCheckSelection(wrapper, contentEditor.element, 0, 3, 'abc');
+
+        jest.spyOn(document, 'execCommand').mockImplementation((command) => {
+            if (command !== 'justifyCenter') {
+                return;
+            }
+
+            contentEditor.element.innerHTML =
+                '<p style="text-align: center;"><span style="background-color: transparent; color: rgb(30, 30, 36);">abc</span></p>';
+        });
+
+        wrapper.vm.onTextStyleChange('justifyCenter');
+
+        const expectedContent = '<p style="text-align: center;">abc</p>';
+        const emittedValues = wrapper.emitted('update:value');
+
+        expect(contentEditor.element.innerHTML).toBe(expectedContent);
+        expect(emittedValues[emittedValues.length - 1][0]).toBe(expectedContent);
+    });
+
+    it('should remove browser-generated font size spans after applying text alignment', async () => {
+        wrapper = await createWrapper();
+
+        const contentEditor = wrapper.find('.sw-text-editor__content-editor');
+
+        await addTextToEditor(wrapper, 'abc');
+        await addAndCheckSelection(wrapper, contentEditor.element, 0, 3, 'abc');
+
+        jest.spyOn(document, 'execCommand').mockImplementation((command) => {
+            if (command !== 'justifyCenter') {
+                return;
+            }
+
+            contentEditor.element.innerHTML = '<p style="text-align: center;"><span style="font-size: 14px;">abc</span></p>';
+        });
+
+        wrapper.vm.onTextStyleChange('justifyCenter');
+
+        expect(contentEditor.element.innerHTML).toBe('<p style="text-align: center;">abc</p>');
+    });
+
+    it('should normalize browser-generated divs after applying text alignment', async () => {
+        wrapper = await createWrapper();
+
+        const contentEditor = wrapper.find('.sw-text-editor__content-editor');
+
+        await addTextToEditor(wrapper, 'abc');
+        await addAndCheckSelection(wrapper, contentEditor.element, 0, 3, 'abc');
+
+        jest.spyOn(document, 'execCommand').mockImplementation((command) => {
+            if (command !== 'justifyCenter') {
+                return;
+            }
+
+            contentEditor.element.innerHTML =
+                '<div style="text-align: center;"><span style="font-size: 14px;">abc</span></div>';
+        });
+
+        wrapper.vm.onTextStyleChange('justifyCenter');
+
+        expect(contentEditor.element.innerHTML).toBe('<p style="text-align: center;">abc</p>');
+    });
+
+    it('should keep intentional spans when normalizing text alignment markup', async () => {
+        wrapper = await createWrapper();
+
+        const contentEditor = wrapper.find('.sw-text-editor__content-editor');
+        const browserGeneratedAlignmentContent = [
+            '<p style="text-align: center;">',
+            '<span data-foo="bar" style="background-color: transparent; color: rgb(30, 30, 36);">keep attribute</span>',
+            '<span style="background-color: transparent; color: rgb(30, 30, 36); font-weight: bold;">keep style</span>',
+            '<span style="color: rgb(255, 0, 0);">keep color</span>',
+            '</p>',
+            '<p><span style="background-color: transparent; color: rgb(30, 30, 36);">keep outside alignment</span></p>',
+        ].join('');
+
+        await addTextToEditor(wrapper, 'abc');
+        await addAndCheckSelection(wrapper, contentEditor.element, 0, 3, 'abc');
+
+        jest.spyOn(document, 'execCommand').mockImplementation((command) => {
+            if (command !== 'justifyCenter') {
+                return;
+            }
+
+            contentEditor.element.innerHTML = browserGeneratedAlignmentContent;
+        });
+
+        wrapper.vm.onTextStyleChange('justifyCenter');
+
+        expect(contentEditor.element.innerHTML).toBe(browserGeneratedAlignmentContent);
     });
 
     it('should fix loose text nodes and wrap them in paragraphs on "Enter" key press', async () => {


### PR DESCRIPTION
### 1. Why is this change necessary?

Applying text alignment to plain, unwrapped text in the legacy sw-text-editor lets the browser’s execCommand implementation create unnecessary inline markup. In Chrome/WebKit this can add a <span> with inline styles, which then overrides theme/CSS styling although the user only changed text alignment.

### 2. What does this change do, exactly?

Before running text alignment commands, the editor now normalizes loose text nodes into proper paragraph elements and restores the active selection afterward. This makes the browser apply alignment directly to the paragraph, producing clean markup like:

`<p style="text-align: center;">abc</p>`

instead of wrapping the text in an extra styled <span>. The node-normalization helper was also adjusted to move existing nodes instead of cloning them, so selections remain valid during that cleanup.

### 3. Describe each step to reproduce the issue or behaviour.

See https://github.com/shopware/shopware/issues/16668

### 4. Please link to the relevant issues (if any).

Closes https://github.com/shopware/shopware/issues/16668