### PR TITLE
perf: cache admin info routes

### DIFF
--- a/src/Administration/Controller/AdministrationController.php
+++ b/src/Administration/Controller/AdministrationController.php
@@ -26,6 +26,7 @@ use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Routing\RoutingException;
 use Shopware\Core\Framework\Store\Services\FirstRunWizardService;
+use Shopware\Core\Framework\Util\Hasher;
 use Shopware\Core\Framework\Util\HtmlSanitizer;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\Framework\Validation\Exception\ConstraintViolationException;
@@ -82,7 +83,7 @@ class AdministrationController extends AbstractController
         private readonly EntityRepository $currencyRepository,
         private readonly HtmlSanitizer $htmlSanitizer,
         private readonly DefinitionInstanceRegistry $definitionInstanceRegistry,
-        ParameterBagInterface $params,
+        private readonly ParameterBagInterface $params,
         private readonly FilesystemOperator $fileSystem,
         private readonly string $serviceRegistryUrl,
         private readonly EntityRepository $languageRepository,
@@ -132,6 +133,7 @@ class AdministrationController extends AbstractController
             'storefrontEsEnable' => $this->esStorefrontEnabled,
             'refreshTokenTtl' => $refreshTokenTtl * 1000,
             'serviceRegistryUrl' => $this->serviceRegistryUrl,
+            'adminInfoCacheKey' => $this->getAdminInfoCacheKey(),
             'productStreamIndexingEnabled' => $this->productStreamIndexingEnabled,
             'analyticsGatewayUrl' => $this->analyticsGatewayUrl,
         ]);
@@ -408,6 +410,27 @@ class AdministrationController extends AbstractController
         usort($sortedSupportedApiVersions, static fn (int $version1, int $version2) => \version_compare((string) $version1, (string) $version2));
 
         return array_pop($sortedSupportedApiVersions);
+    }
+
+    private function getAdminInfoCacheKey(): string
+    {
+        $kernelCacheHash = (string) $this->params->get('kernel.cache.hash');
+        $apps = [];
+
+        foreach ($this->connection->fetchAllAssociative('SELECT `name`, `version` FROM `app` WHERE `active` = 1') as $app) {
+            $apps[(string) $app['name']] = (string) ($app['version'] ?? '');
+        }
+
+        if ($apps === []) {
+            return $kernelCacheHash;
+        }
+
+        ksort($apps);
+
+        return Hasher::hash([
+            'kernelCacheHash' => $kernelCacheHash,
+            'apps' => $apps,
+        ]);
     }
 
     private function getCustomerById(string $customerId, Context $context): ?CustomerEntity

--- a/src/Administration/Framework/Adapter/Cache/Http/AdministrationCacheControlListener.php
+++ b/src/Administration/Framework/Adapter/Cache/Http/AdministrationCacheControlListener.php
@@ -14,6 +14,19 @@ use Shopware\Core\PlatformRequest;
 #[Package('framework')]
 readonly class AdministrationCacheControlListener
 {
+    private const STATIC_INFO_ROUTES = [
+        'api.info.actions',
+        'api.info.business-events',
+        'api.info.config',
+        'api.info.entity-schema',
+        'api.info.open-api-schema',
+        'api.info.openapi3',
+        'api.info.routes',
+        'api.info.rule-config',
+        'api.info.shopware.version',
+        'api.info.shopware.version_old_version',
+    ];
+
     public function __invoke(BeforeCacheControlEvent $event): void
     {
         if (!$this->isAdministrationRequest($event)) {
@@ -46,6 +59,10 @@ readonly class AdministrationCacheControlListener
         // Fallback: Check if the route name starts with 'administration.'
         $routeName = $request->attributes->get('_route');
         if (\is_string($routeName) && \str_starts_with($routeName, 'administration.')) {
+            return true;
+        }
+
+        if (\is_string($routeName) && \in_array($routeName, self::STATIC_INFO_ROUTES, true)) {
             return true;
         }
 

--- a/src/Administration/Resources/app/administration/src/app/composables/use-context.spec.ts
+++ b/src/Administration/Resources/app/administration/src/app/composables/use-context.spec.ts
@@ -52,6 +52,7 @@ describe('use-context', () => {
                 languageId: '2fbb5fe2e29a4d70aa5854ce7ce3e20b',
                 language: null,
                 apiVersion: null,
+                adminInfoCacheKey: null,
                 liveVersionId: '0fa91ce3e96a4bc2be4bd9ce752c3425',
                 systemLanguageId: '2fbb5fe2e29a4d70aa5854ce7ce3e20b',
                 currencyId: null,

--- a/src/Administration/Resources/app/administration/src/app/composables/use-context.ts
+++ b/src/Administration/Resources/app/administration/src/app/composables/use-context.ts
@@ -70,6 +70,7 @@ export interface ContextState {
             parentId?: string;
         };
         apiVersion: null | string;
+        adminInfoCacheKey: null | string;
         liveVersionId: null | string;
         systemLanguageId: null | string;
         currencyId: null | string;
@@ -113,6 +114,7 @@ const state: ContextState = reactive({
         languageId: null,
         language: null,
         apiVersion: null,
+        adminInfoCacheKey: null,
         liveVersionId: null,
         systemLanguageId: null,
         currencyId: null,

--- a/src/Administration/Resources/app/administration/src/core/factory/http.factory.js
+++ b/src/Administration/Resources/app/administration/src/core/factory/http.factory.js
@@ -8,6 +8,19 @@ import AxiosV1 from 'axios-v1';
 import cacheAdapterFactory from 'src/core/factory/cache-adapter.factory';
 import { createAxiosV0Adapter, createAxiosV1Adapter } from 'src/core/factory/http-client-adapter';
 
+const ADMIN_INFO_CACHE_KEY_PARAM = 'sw-admin-info-cache-key';
+const STATIC_INFO_ROUTES = [
+    '/_info/config',
+    '/_info/entity-schema.json',
+    '/_info/events.json',
+    '/_info/flow-actions.json',
+    '/_info/open-api-schema.json',
+    '/_info/openapi3.json',
+    '/_info/routes',
+    '/_info/rule-config',
+    '/_info/version',
+];
+
 /**
  * Initializes the HTTP client with the provided context. The context provides the API end point and will be used as
  * the base url for the HTTP client.
@@ -62,6 +75,9 @@ function createClient() {
 
     tracingInterceptor(axiosV0);
     tracingInterceptor(axiosV1);
+
+    adminInfoCacheKeyInterceptor(axiosV0);
+    adminInfoCacheKeyInterceptor(axiosV1);
 
     /**
      * Don´t use cache in unit tests because it is possible
@@ -182,6 +198,39 @@ function requestCacheAdapterInterceptorV1(client) {
 
         return config;
     });
+}
+
+/**
+ * Adds the Administration static-info cache key to cacheable _info routes.
+ *
+ * @param {AxiosInstance} client
+ * @returns {AxiosInstance}
+ */
+function adminInfoCacheKeyInterceptor(client) {
+    client.interceptors.request.use((config) => {
+        const cacheKey = Shopware.Context.api.adminInfoCacheKey;
+
+        if (!cacheKey || !isStaticInfoRoute(config.url)) {
+            return config;
+        }
+
+        if (config.url?.includes(`${ADMIN_INFO_CACHE_KEY_PARAM}=`) || config.params?.[ADMIN_INFO_CACHE_KEY_PARAM]) {
+            return config;
+        }
+
+        config.params = {
+            ...config.params,
+            [ADMIN_INFO_CACHE_KEY_PARAM]: cacheKey,
+        };
+
+        return config;
+    });
+}
+
+function isStaticInfoRoute(url = '') {
+    const path = `/${url.split('?')[0].replace(/^(https?:\/\/[^/]+)?\/?api\//, '').replace(/^\//, '')}`;
+
+    return STATIC_INFO_ROUTES.includes(path);
 }
 
 /**

--- a/src/Administration/Resources/app/administration/src/core/factory/http.factory.spec.js
+++ b/src/Administration/Resources/app/administration/src/core/factory/http.factory.spec.js
@@ -217,6 +217,48 @@ describe('core/factory/http.factory.js', () => {
         expect(typeof httpClient.request).toBe('function');
     });
 
+    it('should add the admin info cache key to static info requests', async () => {
+        const previousCacheKey = Shopware.Context.api.adminInfoCacheKey;
+        Shopware.Context.api.adminInfoCacheKey = 'test-cache-key';
+
+        try {
+            mock.onGet('/_info/config').reply(200, {});
+            mock.onGet('_info/entity-schema.json').reply(200, {});
+
+            await httpClient.get('/_info/config', {
+                params: {
+                    foo: 'bar',
+                },
+            });
+            await httpClient.get('_info/entity-schema.json');
+
+            expect(mock.history.get[0].params).toEqual({
+                foo: 'bar',
+                'sw-admin-info-cache-key': 'test-cache-key',
+            });
+            expect(mock.history.get[1].params).toEqual({
+                'sw-admin-info-cache-key': 'test-cache-key',
+            });
+        } finally {
+            Shopware.Context.api.adminInfoCacheKey = previousCacheKey;
+        }
+    });
+
+    it('should not add the admin info cache key to dynamic info requests', async () => {
+        const previousCacheKey = Shopware.Context.api.adminInfoCacheKey;
+        Shopware.Context.api.adminInfoCacheKey = 'test-cache-key';
+
+        try {
+            mock.onGet('/_info/config-me').reply(200, {});
+
+            await httpClient.get('/_info/config-me');
+
+            expect(mock.history.get[0].params).toBeUndefined();
+        } finally {
+            Shopware.Context.api.adminInfoCacheKey = previousCacheKey;
+        }
+    });
+
     it('should use axios v0 by default (without useAxiosV1 flag)', async () => {
         mock.onGet('/test-v0-default').reply(200, { version: 'v0' });
 

--- a/src/Administration/Resources/views/administration/index.html.twig
+++ b/src/Administration/Resources/views/administration/index.html.twig
@@ -64,6 +64,7 @@
                     liveVersionId: '{{ liveVersionId }}',
                     systemLanguageId: '{{ systemLanguageId }}',
                     apiVersion: {{ apiVersion }},
+                    adminInfoCacheKey: '{{ adminInfoCacheKey }}',
                     assetPath: '{{ asset('', 'asset') }}',
                     refreshTokenTtl: {{ refreshTokenTtl }},
                     serviceRegistryUrl: '{{ serviceRegistryUrl }}',

--- a/src/Core/Framework/Api/Controller/InfoController.php
+++ b/src/Core/Framework/Api/Controller/InfoController.php
@@ -41,6 +41,8 @@ use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 #[Package('framework')]
 class InfoController extends AbstractController
 {
+    private const STATIC_INFO_CACHE_MAX_AGE = 31536000;
+
     /**
      * @internal
      */
@@ -79,7 +81,10 @@ class InfoController extends AbstractController
 
         $data = $this->definitionService->generate(OpenApi3Generator::FORMAT, DefinitionService::API, $apiType);
 
-        return new JsonResponse($data);
+        $response = new JsonResponse($data);
+        $this->cacheStaticInfoResponse($response);
+
+        return $response;
     }
 
     /**
@@ -128,7 +133,10 @@ class InfoController extends AbstractController
     {
         $data = $this->definitionService->getSchema(OpenApi3Generator::FORMAT);
 
-        return new JsonResponse($data);
+        $response = new JsonResponse($data);
+        $this->cacheStaticInfoResponse($response);
+
+        return $response;
     }
 
     #[Route(path: '/api/_info/entity-schema.json', name: 'api.info.entity-schema', methods: ['GET'])]
@@ -136,7 +144,10 @@ class InfoController extends AbstractController
     {
         $data = $this->definitionService->getSchema(EntitySchemaGenerator::FORMAT);
 
-        return new JsonResponse($data);
+        $response = new JsonResponse($data);
+        $this->cacheStaticInfoResponse($response);
+
+        return $response;
     }
 
     #[Route(path: '/api/_info/events.json', name: 'api.info.business-events', methods: ['GET'])]
@@ -144,7 +155,10 @@ class InfoController extends AbstractController
     {
         $events = $this->eventCollector->collect($context);
 
-        return new JsonResponse($events);
+        $response = new JsonResponse($events);
+        $this->cacheStaticInfoResponse($response);
+
+        return $response;
     }
 
     #[Route(
@@ -213,22 +227,31 @@ class InfoController extends AbstractController
 
         $config = $this->eventDispatcher->dispatch(new AdminInfoConfigEvent($config))->getConfig();
 
-        return new JsonResponse($config);
+        $response = new JsonResponse($config);
+        $this->cacheStaticInfoResponse($response);
+
+        return $response;
     }
 
     #[Route(path: '/api/_info/version', name: 'api.info.shopware.version', methods: ['GET'])]
     #[Route(path: '/api/v1/_info/version', name: 'api.info.shopware.version_old_version', methods: ['GET'])]
     public function infoShopwareVersion(): JsonResponse
     {
-        return new JsonResponse([
+        $response = new JsonResponse([
             'version' => $this->getShopwareVersion(),
         ]);
+        $this->cacheStaticInfoResponse($response);
+
+        return $response;
     }
 
     #[Route(path: '/api/_info/flow-actions.json', name: 'api.info.actions', methods: ['GET'])]
     public function flowActions(Context $context): JsonResponse
     {
-        return new JsonResponse($this->flowActionCollector->collect($context));
+        $response = new JsonResponse($this->flowActionCollector->collect($context));
+        $this->cacheStaticInfoResponse($response);
+
+        return $response;
     }
 
     #[Route(
@@ -244,7 +267,10 @@ class InfoController extends AbstractController
             $this->apiRouteInfoResolver->getApiRoutes(ApiRouteScope::ID)
         );
 
-        return new JsonResponse(['endpoints' => $endpoints]);
+        $response = new JsonResponse(['endpoints' => $endpoints]);
+        $this->cacheStaticInfoResponse($response);
+
+        return $response;
     }
 
     /**
@@ -284,5 +310,12 @@ class InfoController extends AbstractController
         } catch (ShopIdChangeSuggestedException $e) {
             return $e->shopId->id;
         }
+    }
+
+    private function cacheStaticInfoResponse(JsonResponse $response): void
+    {
+        $response->setPrivate();
+        $response->setMaxAge(self::STATIC_INFO_CACHE_MAX_AGE);
+        $response->headers->addCacheControlDirective('immutable');
     }
 }

--- a/src/Core/Framework/Rule/Api/RuleConfigController.php
+++ b/src/Core/Framework/Rule/Api/RuleConfigController.php
@@ -14,6 +14,8 @@ use Symfony\Component\Routing\Attribute\Route;
 #[Package('fundamentals@after-sales')]
 class RuleConfigController extends AbstractController
 {
+    private const STATIC_INFO_CACHE_MAX_AGE = 31536000;
+
     /**
      * @var array<string, mixed[]>
      */
@@ -32,7 +34,12 @@ class RuleConfigController extends AbstractController
     #[Route(path: '/api/_info/rule-config', name: 'api.info.rule-config', methods: ['GET'])]
     public function getConditionsConfig(): JsonResponse
     {
-        return new JsonResponse($this->config);
+        $response = new JsonResponse($this->config);
+        $response->setPrivate();
+        $response->setMaxAge(self::STATIC_INFO_CACHE_MAX_AGE);
+        $response->headers->addCacheControlDirective('immutable');
+
+        return $response;
     }
 
     /**

--- a/tests/integration/Core/Framework/Rule/Api/RuleConfigControllerTest.php
+++ b/tests/integration/Core/Framework/Rule/Api/RuleConfigControllerTest.php
@@ -26,6 +26,8 @@ class RuleConfigControllerTest extends TestCase
         $response = $this->getBrowser()->getResponse();
 
         static::assertSame(200, $this->getBrowser()->getResponse()->getStatusCode());
+        static::assertSame(31536000, $response->getMaxAge());
+        static::assertTrue($response->headers->hasCacheControlDirective('private'));
 
         $content = json_decode($response->getContent() ?: '', true, 512, \JSON_THROW_ON_ERROR);
 

--- a/tests/unit/Administration/Controller/AdministrationControllerTest.php
+++ b/tests/unit/Administration/Controller/AdministrationControllerTest.php
@@ -29,6 +29,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Routing\RoutingException;
 use Shopware\Core\Framework\Store\Services\FirstRunWizardService;
+use Shopware\Core\Framework\Util\Hasher;
 use Shopware\Core\Framework\Util\HtmlSanitizer;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\Framework\Validation\Exception\ConstraintViolationException;
@@ -90,9 +91,15 @@ class AdministrationControllerTest extends TestCase
 
     private IdsCollection $ids;
 
+    /**
+     * @var list<array{name: string, version: string}>
+     */
+    private array $activeAppRows = [];
+
     protected function setUp(): void
     {
         $this->connection = $this->createMock(Connection::class);
+        $this->connection->method('fetchAllAssociative')->willReturnCallback(fn (): array => $this->activeAppRows);
         $this->context = Context::createDefaultContext();
         $this->definitionRegistry = $this->createMock(DefinitionInstanceRegistry::class);
         $this->currencyRepository = $this->createMock(EntityRepository::class);
@@ -137,6 +144,7 @@ class AdministrationControllerTest extends TestCase
                     'storefrontEsEnable' => true,
                     'serviceRegistryUrl' => $this->serviceRegistryUrl,
                     'refreshTokenTtl' => 7 * 86400 * 1000,
+                    'adminInfoCacheKey' => '1',
                     'productStreamIndexingEnabled' => true,
                     'analyticsGatewayUrl' => $this->analyticsGatewayUrl,
                 ]
@@ -166,6 +174,29 @@ class AdministrationControllerTest extends TestCase
 
         static::assertNotFalse($response->getContent());
         static::assertSame(Response::HTTP_OK, $response->getStatusCode());
+    }
+
+    public function testAdminInfoCacheKeyAddsActiveAppsToKernelCacheHash(): void
+    {
+        $this->activeAppRows = [
+            ['name' => 'BApp', 'version' => '2.0.0'],
+            ['name' => 'AApp', 'version' => '1.0.0'],
+        ];
+        $this->parameterBag->method('get')->with('kernel.cache.hash')->willReturn('kernel-hash');
+
+        $controller = $this->createAdministrationController();
+        $method = new \ReflectionMethod($controller, 'getAdminInfoCacheKey');
+
+        static::assertSame(
+            Hasher::hash([
+                'kernelCacheHash' => 'kernel-hash',
+                'apps' => [
+                    'AApp' => '1.0.0',
+                    'BApp' => '2.0.0',
+                ],
+            ]),
+            $method->invoke($controller)
+        );
     }
 
     public function testIndexSetsCacheHeaders(): void

--- a/tests/unit/Administration/Framework/Adapter/Cache/Http/AdministrationCacheControlListenerTest.php
+++ b/tests/unit/Administration/Framework/Adapter/Cache/Http/AdministrationCacheControlListenerTest.php
@@ -71,6 +71,14 @@ class AdministrationCacheControlListenerTest extends TestCase
             'expectedSkip' => true,
         ];
 
+        yield 'static info route name' => [
+            'request' => new Request(
+                attributes: ['_route' => 'api.info.config']
+            ),
+            'response' => new Response(),
+            'expectedSkip' => true,
+        ];
+
         yield 'multiple administration markers present' => [
             'request' => new Request(
                 attributes: [

--- a/tests/unit/Core/Framework/Adapter/Cache/Http/CacheControlListenerTest.php
+++ b/tests/unit/Core/Framework/Adapter/Cache/Http/CacheControlListenerTest.php
@@ -205,6 +205,17 @@ class CacheControlListenerTest extends TestCase
             'expectedCacheIdHeader' => null,
         ];
 
+        yield 'static info route name' => [
+            'request' => new Request(
+                attributes: ['_route' => 'api.info.config']
+            ),
+            'response' => new Response('', 200, [
+                'cache-control' => 'max-age=31536000, private, immutable',
+            ]),
+            'expectedCacheControl' => 'immutable, max-age=31536000, private',
+            'expectedCacheIdHeader' => null,
+        ];
+
         yield 'administration cache ID marker' => [
             'request' => new Request(),
             'response' => new Response('', 200, [

--- a/tests/unit/Core/Framework/Api/Controller/InfoControllerTest.php
+++ b/tests/unit/Core/Framework/Api/Controller/InfoControllerTest.php
@@ -69,8 +69,12 @@ class InfoControllerTest extends TestCase
             'APP_URL' => 'https://app.url',
         ]);
 
-        $content = $this->createController()->config(Context::createDefaultContext(), Request::create('http://localhost'))->getContent();
+        $response = $this->createController()->config(Context::createDefaultContext(), Request::create('http://localhost'));
+        $content = $response->getContent();
         static::assertIsString($content);
+        static::assertSame(31536000, $response->getMaxAge());
+        static::assertTrue($response->headers->hasCacheControlDirective('private'));
+        static::assertTrue($response->headers->hasCacheControlDirective('immutable'));
 
         $data = json_decode($content, true, flags: \JSON_THROW_ON_ERROR);
         static::assertIsArray($data);
@@ -190,8 +194,10 @@ class InfoControllerTest extends TestCase
                 new MessageStatsEntity(1, new \DateTime(), 1.00, new MessageTypeStatsCollection())
             )
         );
-        $content = $this->createController()->messageStats()->getContent();
+        $response = $this->createController()->messageStats();
+        $content = $response->getContent();
         static::assertIsString($content);
+        static::assertFalse($response->headers->hasCacheControlDirective('immutable'));
 
         $data = json_decode($content, true, flags: \JSON_THROW_ON_ERROR);
         static::assertIsArray($data);


### PR DESCRIPTION
### 1. Why is this change necessary?

The Administration was re-requesting static `_info` data on repeated module visits, even though the payload only changes when the installed app/plugin set or the relevant backend metadata changes.

### 2. What does this change do, exactly?

It adds browser caching for the static Administration `_info` routes and passes a cache-buster from the Admin bootstrap so cached responses are invalidated when the app/version inputs change.

### 3. Describe each step to reproduce the issue or behaviour.

1. Open the Administration.
2. Visit a module that loads `_info` data.
3. Navigate away and back to the same module.
4. Observe that the same static metadata is fetched again instead of being reused from the browser cache.

### 4. Please link to the relevant issues (if any).

N/A

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is relevant for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
