### PR TITLE
fix: remove redundant form placeholders of cms form elements

### DIFF
--- a/src/Storefront/Resources/snippet/storefront.de.json
+++ b/src/Storefront/Resources/snippet/storefront.de.json
@@ -606,18 +606,13 @@
     "labelActionSelect": "Aktion",
     "labelMail": "E-Mail-Adresse",
     "labelFirstName": "Vorname",
-    "labelLastName": "Nachname",
-    "placeholderMail": "E-Mail-Adresse eingeben ...",
-    "placeholderFirstName": "Max",
-    "placeholderLastName": "Mustermann"
+    "labelLastName": "Nachname"
   },
   "contact": {
     "headline": "Kontaktformular",
     "info": "Wir freuen uns auf Ihre Kontaktaufnahme.",
     "subjectLabel": "Betreff",
-    "subjectPlaceholder": "Betreff eingeben ...",
     "commentLabel": "Kommentar",
-    "commentPlaceholder": "Kommentar eingeben ...",
     "privacyNoticeText": "Ich habe die <a data-ajax-modal=\"true\" data-url=\"%privacyUrl%\" href=\"%privacyUrl%\" data-prev-url=\"%prevUrl%\">Datenschutzbestimmungen</a> zur Kenntnis genommen und erkenne diese an.",
     "privacyNoticeTextModal": "Ich habe die %privacyModalTagOpen%Datenschutzbestimmungen%privacyModalTagClose% zur Kenntnis genommen und erkenne diese an.",
     "privacyNoticeTextPage": "Ich habe die <a href=\"%privacyUrl%\" title=\"Datenschutzbestimmungen\">Datenschutzbestimmungen</a> zur Kenntnis genommen und erkenne diese an.",
@@ -627,15 +622,10 @@
   "revocationRequest": {
     "headline": "Widerruf",
     "firstNameLabel": "Vorname",
-    "firstNamePlaceholder": "Vornamen eingeben ...",
     "lastNameLabel": "Nachname",
-    "lastNamePlaceholder": "Nachnamen eingeben ...",
     "eMailLabel": "E-Mail-Adresse",
-    "eMailPlaceholder": "E-Mail-Adresse eingeben ...",
     "contractNumberLabel": "Vertragsnummer (Bestellnummer, Abonnementnummer, ...)",
-    "contractNumberPlaceholder": "Vertragsnummer eingeben ...",
     "commentLabel": "Kommentar",
-    "commentPlaceholder": "Kommentar eingeben ...",
     "privacyNoticeTextModal": "Unsere Datenschutzhinweise finden Sie %privacyModalTagOpen%hier%privacyModalTagClose%.",
     "formSubmit": "Widerruf bestätigen",
     "success": "Wir haben Ihren Widerrufsantrag erhalten und werden ihn schnellstmöglich bearbeiten."

--- a/src/Storefront/Resources/snippet/storefront.en.json
+++ b/src/Storefront/Resources/snippet/storefront.en.json
@@ -606,18 +606,13 @@
     "labelActionSelect": "Action",
     "labelMail": "Email address",
     "labelFirstName": "First name",
-    "labelLastName": "Last name",
-    "placeholderMail": "Enter email address...",
-    "placeholderFirstName": "John",
-    "placeholderLastName": "Doe"
+    "labelLastName": "Last name"
   },
   "contact": {
     "headline": "Contact",
     "info": "We look forward to hearing from you.",
     "subjectLabel": "Subject",
-    "subjectPlaceholder": "Enter subject...",
     "commentLabel": "Comment",
-    "commentPlaceholder": "Enter comment...",
     "privacyNoticeText": "I have read and acknowledge the <a data-ajax-modal=\"true\" data-url=\"%privacyUrl%\" data-prev-url=\"%prevUrl%\" href=\"%privacyUrl%\" title=\"Privacy policy\">privacy policy</a>.",
     "privacyNoticeTextModal": "I have read and acknowledge the %privacyModalTagOpen%privacy policy%privacyModalTagClose%.",
     "privacyNoticeTextPage": "I have read and acknowledge the <a href=\"%privacyUrl%\" title=\"Privacy policy\">privacy policy</a>.",
@@ -627,15 +622,10 @@
   "revocationRequest": {
     "headline": "Revocation",
     "firstNameLabel": "First name",
-    "firstNamePlaceholder": "Enter first name...",
     "lastNameLabel": "Last name",
-    "lastNamePlaceholder": "Enter last name...",
     "eMailLabel": "Email address",
-    "eMailPlaceholder": "Enter email address...",
     "contractNumberLabel": "Contract number (order number, subscription number, ...)",
-    "contractNumberPlaceholder": "Enter contract number...",
     "commentLabel": "Comment",
-    "commentPlaceholder": "Enter comment...",
     "privacyNoticeTextModal": "Our Privacy Notice is available %privacyModalTagOpen%here%privacyModalTagClose%.",
     "formSubmit": "Confirm revocation",
     "success": "We have received your revocation request and will process it as soon as possible."

--- a/src/Storefront/Resources/views/storefront/element/cms-element-form/form-types/contact-form.html.twig
+++ b/src/Storefront/Resources/views/storefront/element/cms-element-form/form-types/contact-form.html.twig
@@ -27,7 +27,6 @@
                     required: firstNameFieldRequired,
                     additionalClass: 'col-md-4',
                     label: 'account.personalFirstNameLabel',
-                    placeholder: 'account.personalFirstNamePlaceholder'
                 }
                 %}
             {% endblock %}
@@ -41,7 +40,6 @@
                     required: lastNameFieldRequired,
                     additionalClass: 'col-md-4',
                     label: 'account.personalLastNameLabel',
-                    placeholder: 'account.personalLastNamePlaceholder'
                 }
                 %}
             {% endblock %}
@@ -57,7 +55,6 @@
                     required: true,
                     additionalClass: 'col-md-6',
                     label: 'account.loginMailLabel',
-                    placeholder: 'account.loginMailPlaceholder'
                 }
                 %}
             {% endblock %}
@@ -71,7 +68,6 @@
                     required: phoneNumberFieldRequired,
                     additionalClass: 'col-md-6',
                     label: 'account.personalPhoneLabel',
-                    placeholder: 'account.personalPhonePlaceholder'
                 }
                 %}
             {% endblock %}
@@ -85,7 +81,6 @@
                     fieldName: 'subject',
                     additionalClass: 'col-12',
                     label: 'contact.subjectLabel',
-                    placeholder: 'contact.subjectPlaceholder'
                 }
                 %}
             {% endblock %}
@@ -100,7 +95,6 @@
                     fieldName: 'comment',
                     additionalClass: 'col-12',
                     label: 'contact.commentLabel',
-                    placeholder: 'contact.commentPlaceholder'
                 }
                 %}
             {% endblock %}

--- a/src/Storefront/Resources/views/storefront/element/cms-element-form/form-types/newsletter-form.html.twig
+++ b/src/Storefront/Resources/views/storefront/element/cms-element-form/form-types/newsletter-form.html.twig
@@ -49,7 +49,6 @@
                         required: true,
                         additionalClass: 'col-12',
                         label: 'newsletter.labelMail',
-                        placeholder: 'newsletter.placeholderMail'
                     }
                     %}
                 {% endblock %}
@@ -73,7 +72,6 @@
                                 autocomplete: 'section-personal given-name',
                                 additionalClass: 'col-md-4',
                                 label: 'newsletter.labelFirstName',
-                                placeholder: 'newsletter.placeholderFirstName'
                             }
                             %}
                         {% endblock %}
@@ -85,7 +83,6 @@
                                 autocomplete: 'section-personal family-name',
                                 additionalClass: 'col-md-4',
                                 label: 'newsletter.labelLastName',
-                                placeholder: 'newsletter.placeholderLastName'
                             }
                             %}
                         {% endblock %}

--- a/src/Storefront/Resources/views/storefront/element/cms-element-form/form-types/online-revocation-request-form.html.twig
+++ b/src/Storefront/Resources/views/storefront/element/cms-element-form/form-types/online-revocation-request-form.html.twig
@@ -19,7 +19,6 @@
                         required: firstNameFieldRequired,
                         additionalClass: 'col-md-6',
                         label: 'revocationRequest.firstNameLabel',
-                        placeholder: 'revocationRequest.firstNamePlaceholder'
                     } %}
                 {% endblock %}
 
@@ -32,7 +31,6 @@
                         required: lastNameFieldRequired,
                         additionalClass: 'col-md-6',
                         label: 'revocationRequest.lastNameLabel',
-                        placeholder: 'revocationRequest.lastNamePlaceholder'
                     } %}
                 {% endblock %}
             </div>
@@ -47,7 +45,6 @@
                         required: true,
                         additionalClass: 'col-md-12',
                         label: 'revocationRequest.eMailLabel',
-                        placeholder: 'revocationRequest.eMailPlaceholder'
                     } %}
                 {% endblock %}
             </div>
@@ -60,7 +57,6 @@
                         required: true,
                         additionalClass: 'col-md-12',
                         label: 'revocationRequest.contractNumberLabel',
-                        placeholder: 'revocationRequest.contractNumberPlaceholder'
                     } %}
                 {% endblock %}
             </div>
@@ -73,7 +69,6 @@
                         fieldName: 'comment',
                         additionalClass: 'col-12',
                         label: 'revocationRequest.commentLabel',
-                        placeholder: 'revocationRequest.commentPlaceholder'
                     }
                     %}
                 {% endblock %}


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

The contact, newsletter, and revocation request forms display placeholders in addition to their visible field labels, which is redundant.

### 2. What does this change do, exactly?

Removes the placeholder configuration from the affected storefront form fields while retaining the snippet keys for theme and plugin compatibility.

Select fields are intentionally unchanged. Their empty option represents a functional unselected state: in the optional newsletter form, it ensures no `salutationId` is submitted unless the customer explicitly chooses a merchant-configured salutation. This also avoids preselecting a potentially incorrect salutation. Therefore, this implementation intentionally differs from the salutation select in the registration form.

<img width="1844" height="3778" alt="Bildschirmfoto am 2026-07-15 um 14 44 43" src="https://github.com/user-attachments/assets/3cb6552e-c3ec-44ae-ac87-f30f386055f1" />

### 3. Describe each step to reproduce the issue or behaviour.

1. Open a contact, newsletter, or revocation request form in the storefront.
2. Observe that fields with visible labels also render placeholder text.

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

- closes #18019

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
