### PR TITLE
fix(core): allow user updates with unchanged admin flag

### DIFF
--- a/src/Core/Framework/Api/Controller/UserController.php
+++ b/src/Core/Framework/Api/Controller/UserController.php
@@ -229,10 +229,12 @@ class UserController extends AbstractController
             throw new PermissionDeniedException();
         }
 
-        $isTryingToChangeAdmin = isset($data['admin']);
+        if (!$source->isAdmin() && \array_key_exists('admin', $data)) {
+            if ($data['admin'] !== false) {
+                throw new PermissionDeniedException();
+            }
 
-        if (!$source->isAdmin() && $isTryingToChangeAdmin) {
-            throw new PermissionDeniedException();
+            unset($data['admin']);
         }
 
         $events = $context->scope(Context::SYSTEM_SCOPE, fn (Context $context) => $this->userRepository->upsert([$data], $context));

--- a/tests/integration/Core/Framework/Api/Controller/UserControllerTest.php
+++ b/tests/integration/Core/Framework/Api/Controller/UserControllerTest.php
@@ -318,6 +318,86 @@ class UserControllerTest extends TestCase
         static::assertSame(Response::HTTP_FORBIDDEN, $response->getStatusCode());
     }
 
+    public function testUpdateNonAdminUserWithUnchangedAdminFlagAsNonAdmin(): void
+    {
+        $ids = new IdsCollection();
+
+        $user = [
+            'id' => $ids->get('user'),
+            'email' => 'target@example.com',
+            'firstName' => 'Firstname',
+            'lastName' => 'Lastname',
+            'password' => TestDefaults::HASHED_PASSWORD,
+            'username' => 'target-user',
+            'localeId' => static::getContainer()->get(Connection::class)->fetchOne('SELECT LOWER(HEX(id)) FROM locale LIMIT 1'),
+            'admin' => false,
+        ];
+
+        static::getContainer()->get('user.repository')
+            ->create([$user], Context::createDefaultContext());
+
+        $this->authorizeBrowser($this->getBrowser(), [UserVerifiedScope::IDENTIFIER], ['user:read', 'user:update']);
+        $client = $this->getBrowser();
+
+        $client->jsonRequest(
+            'PATCH',
+            '/api/user/' . $ids->get('user'),
+            ['firstName' => 'Updated', 'admin' => false]
+        );
+
+        $response = $client->getResponse();
+        static::assertSame(Response::HTTP_NO_CONTENT, $response->getStatusCode(), (string) $response->getContent());
+
+        $client->jsonRequest('GET', '/api/user/' . $ids->get('user'));
+
+        $response = $client->getResponse();
+        static::assertSame(Response::HTTP_OK, $response->getStatusCode(), (string) $response->getContent());
+
+        $content = json_decode((string) $response->getContent(), true, 512, \JSON_THROW_ON_ERROR);
+        static::assertSame('Updated', $content['data']['attributes']['firstName']);
+        static::assertFalse($content['data']['attributes']['admin']);
+    }
+
+    public function testUpdateAdminUserWithFalseAdminFlagDoesNotDemoteAsNonAdmin(): void
+    {
+        $ids = new IdsCollection();
+
+        $user = [
+            'id' => $ids->get('admin-user'),
+            'email' => 'target-admin@example.com',
+            'firstName' => 'Firstname',
+            'lastName' => 'Lastname',
+            'password' => TestDefaults::HASHED_PASSWORD,
+            'username' => 'target-admin',
+            'localeId' => static::getContainer()->get(Connection::class)->fetchOne('SELECT LOWER(HEX(id)) FROM locale LIMIT 1'),
+            'admin' => true,
+        ];
+
+        static::getContainer()->get('user.repository')
+            ->create([$user], Context::createDefaultContext());
+
+        $this->authorizeBrowser($this->getBrowser(), [UserVerifiedScope::IDENTIFIER], ['user:read', 'user:update']);
+        $client = $this->getBrowser();
+
+        $client->jsonRequest(
+            'PATCH',
+            '/api/user/' . $ids->get('admin-user'),
+            ['firstName' => 'Updated', 'admin' => false]
+        );
+
+        $response = $client->getResponse();
+        static::assertSame(Response::HTTP_NO_CONTENT, $response->getStatusCode(), (string) $response->getContent());
+
+        $client->jsonRequest('GET', '/api/user/' . $ids->get('admin-user'));
+
+        $response = $client->getResponse();
+        static::assertSame(Response::HTTP_OK, $response->getStatusCode(), (string) $response->getContent());
+
+        $content = json_decode((string) $response->getContent(), true, 512, \JSON_THROW_ON_ERROR);
+        static::assertSame('Updated', $content['data']['attributes']['firstName']);
+        static::assertTrue($content['data']['attributes']['admin']);
+    }
+
     public function testCreateUserWithAdminFlagAsAdmin(): void
     {
         static::getContainer()->get(Connection::class)


### PR DESCRIPTION
### 1. Why is this change necessary?

  The Administration includes the current `admin` value when saving a user. For
  non-admin users, this value is `false`.

  `UserController::upsertUser()` currently treats the presence of the `admin`
  field as an attempt to change administrator status. As a result, a non-admin
  with the `user:update` privilege receives a permission-denied response when
  updating an ordinary user, even though administrator status is unchanged.

  ### 2. What does this change do, exactly?

  When a non-admin submits a literal `admin: false`, the field is removed from the
  write payload before persisting the remaining changes.

  Other supplied values, including `admin: true`, continue to result in a
  permission-denied response. Removing `admin: false` instead of persisting it
  also ensures a non-admin cannot demote an existing administrator.

  Integration tests cover updating a non-admin user and protecting an existing
  administrator from demotion.

  ### 3. Describe each step to reproduce the issue or behaviour.

  1. Create a non-admin user with the `user:read` and `user:update` privileges.
  2. Open another non-admin user in the Administration.
  3. Change an ordinary property such as the first name.
  4. Save the user.
  5. Observe that the request contains `admin: false`.
  6. Before this change, the API responds with `403 FRAMEWORK__PERMISSION_DENIED`.
  7. With this change, the ordinary property is updated and administrator status
     remains unchanged.

  ### 4. Please link to the relevant issues (if any).

  No related issue.

  ### 5. Checklist

  - [x] I have written tests and verified that they fail without my change
  - [x] I have updated developer-facing release notes if this change is **relevant** for external developers:
    - No release note is required for this narrow corrective bug fix.
  - [x] I have written or adjusted the documentation according to my changes
    - No documentation change is required.
  - [x] This change has comments for package types, values, functions, and non-obvious lines of code
  - [x] I have read the contribution requirements and fulfilled them
