### PR TITLE
fix(administration): remove data-removal switch from extension removal modal

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-extension-removal-modal/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-extension-removal-modal/index.js
@@ -28,12 +28,6 @@ export default {
         },
     },
 
-    data() {
-        return {
-            removePluginData: false,
-        };
-    },
-
     computed: {
         title() {
             return this.isLicensed

--- a/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-extension-removal-modal/sw-extension-removal-modal.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-extension-removal-modal/sw-extension-removal-modal.html.twig
@@ -15,15 +15,6 @@
         <p class="sw-extension-removal-modal__bold-paragraph">
             {{ alert }}
         </p>
-
-        <p>
-
-            <mt-switch
-                v-model="removePluginData"
-                :label="$t('sw-extension-store.component.sw-extension-uninstall-modal.labelRemovePluginData')"
-                :help-text="$t('sw-extension-store.component.sw-extension-uninstall-modal.helpTextRemovePluginData')"
-            />
-        </p>
         {% endblock %}
     </template>
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
The data-removal switch should only be available in the uninstall modal, not in the removal modal.

### 2. What does this change do, exactly?
- Remove mt-switch component for data removal from the removal modal template
- Remove removePluginData data property from the removal modal component

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
