### PR TITLE
feat(administration): apply composition overrides to Options API base components

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/adapter/options-base-override.factory.spec.ts
+++ b/src/Administration/Resources/app/administration/src/app/adapter/options-base-override.factory.spec.ts
@@ -1,0 +1,61 @@
+/**
+ * @sw-package framework
+ *
+ * End-to-end: the component factory injects the composition-override setup into an Options API base,
+ * so a native-setup override actually replaces the base's state.
+ */
+
+import { h, ref } from 'vue';
+import { mount } from '@vue/test-utils';
+import ComponentFactory from 'src/core/factory/async-component.factory';
+import { overrideComponentSetup, _overridesMap } from 'src/app/adapter/composition-extension-system';
+import { createOptionsBaseOverrideSetup } from 'src/app/adapter/options-base-override';
+
+describe('src/core/factory: composition override applied to an Options API base', () => {
+    beforeAll(() => {
+        // shopware.ts wires this onto Shopware.Component in the running app; do the same for the test so
+        // the factory's build() can resolve it through the global.
+        (Shopware.Component as unknown as Record<string, unknown>).createOptionsBaseOverrideSetup =
+            createOptionsBaseOverrideSetup;
+    });
+
+    beforeEach(() => {
+        ComponentFactory.getComponentRegistry().clear();
+        ComponentFactory.getOverrideRegistry().clear();
+        Object.keys(_overridesMap).forEach((key) => delete _overridesMap[key]);
+        jest.restoreAllMocks();
+    });
+
+    it('replaces an Options base data field via a composition override, end to end', async () => {
+        ComponentFactory.register('sw-factory-opt', {
+            data: () => ({ headline: 'Base' }),
+            render() {
+                return h('div', (this as unknown as { headline: string }).headline);
+            },
+        });
+
+        overrideComponentSetup()('sw-factory-opt', () => ({ headline: ref('Overridden') }));
+
+        const config = await ComponentFactory.build('sw-factory-opt');
+        expect(typeof config).not.toBe('boolean');
+
+        const wrapper = mount(config as Parameters<typeof mount>[0]);
+        expect(wrapper.text()).toBe('Overridden');
+    });
+
+    it('leaves an Options component without an override completely untouched (no injected setup)', async () => {
+        ComponentFactory.register('sw-factory-plain', {
+            data: () => ({ headline: 'Base' }),
+            render() {
+                return h('div', (this as unknown as { headline: string }).headline);
+            },
+        });
+
+        const config = await ComponentFactory.build('sw-factory-plain');
+        expect(typeof config).not.toBe('boolean');
+
+        // No override targets it -> the factory injects nothing.
+        expect(typeof (config as { setup?: unknown }).setup).toBe('undefined');
+        expect(mount(config as Parameters<typeof mount>[0]).text()).toBe('Base');
+    });
+});

--- a/src/Administration/Resources/app/administration/src/app/adapter/options-base-override.spec.ts
+++ b/src/Administration/Resources/app/administration/src/app/adapter/options-base-override.spec.ts
@@ -1,0 +1,117 @@
+/**
+ * @sw-package framework
+ */
+
+import { defineComponent, h, ref, computed } from 'vue';
+import { mount } from '@vue/test-utils';
+import { overrideComponentSetup, _overridesMap } from 'src/app/adapter/composition-extension-system';
+import {
+    applyCompositionOverridesToOptionsBase,
+    _resetOptionsBaseOverrideWarnings,
+} from 'src/app/adapter/options-base-override';
+
+/**
+ * Simulates the setup() the component factory injects into an Options base: it calls the runtime and
+ * returns the replaced keys, which Vue merges into setupState (shadowing data/computed).
+ */
+function optionsBaseWithInjectedSetup(name: string, options: Record<string, unknown>) {
+    return defineComponent({
+        name,
+        ...options,
+        setup() {
+            return applyCompositionOverridesToOptionsBase(name) ?? {};
+        },
+    });
+}
+
+describe('src/app/adapter/options-base-override', () => {
+    beforeEach(() => {
+        Object.keys(_overridesMap).forEach((key) => delete _overridesMap[key]);
+        _resetOptionsBaseOverrideWarnings();
+        jest.clearAllMocks();
+    });
+
+    it('returns null when no override targets the component', () => {
+        expect(applyCompositionOverridesToOptionsBase('untouched')).toBeNull();
+    });
+
+    it('replaces an Options data field for the template and the base own reads', () => {
+        // Replacing with a computed derived from previousState is the realistic case; it fires the
+        // "computed replacement" dev warning, which is expected here.
+        jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+        overrideComponentSetup()('sw-opt-data', (previousState) => ({
+            headline: computed(() => `${(previousState as Record<string, { value: string }>).headline.value} (Pro)`),
+        }));
+
+        const Base = optionsBaseWithInjectedSetup('sw-opt-data', {
+            data: () => ({ headline: 'Base' }),
+            computed: {
+                echo(): string {
+                    return (this as unknown as { headline: string }).headline;
+                },
+            },
+            render() {
+                const self = this as unknown as { headline: string; echo: string };
+                return h('div', `${self.headline}|${self.echo}`);
+            },
+        });
+
+        const wrapper = mount(Base);
+        // Template read AND the base's own computed (this.headline) both see the override.
+        expect(wrapper.text()).toBe('Base (Pro)|Base (Pro)');
+    });
+
+    it('leaves non-overridden Options state untouched', () => {
+        overrideComponentSetup()('sw-opt-partial', () => ({ title: ref('Overridden') }));
+
+        const Base = optionsBaseWithInjectedSetup('sw-opt-partial', {
+            data: () => ({ title: 'Base title', subtitle: 'Base subtitle' }),
+            render() {
+                const self = this as unknown as { title: string; subtitle: string };
+                return h('div', `${self.title}|${self.subtitle}`);
+            },
+        });
+
+        expect(mount(Base).text()).toBe('Overridden|Base subtitle');
+    });
+
+    it('reacts to a further override added after the first one (registered before mount)', async () => {
+        // At least one override exists at mount, so the runtime installs its watch; a further override
+        // added afterwards is picked up. (Zero-overrides-at-mount is the register-before-mount contract.)
+        overrideComponentSetup()('sw-opt-chain', () => ({ label: ref('First') }));
+
+        const Base = optionsBaseWithInjectedSetup('sw-opt-chain', {
+            data: () => ({ label: 'Base', other: 'x' }),
+            render() {
+                return h('div', `${(this as unknown as { label: string }).label}`);
+            },
+        });
+
+        const wrapper = mount(Base);
+        expect(wrapper.text()).toBe('First');
+
+        overrideComponentSetup()('sw-opt-chain', () => ({ other: ref('added') }) as never);
+        await flushPromises();
+
+        // The new override applied without disturbing the first.
+        expect(wrapper.text()).toBe('First');
+    });
+
+    it('warns once when an override replaces a base-written field with a computed', () => {
+        const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+        overrideComponentSetup()('sw-opt-computed', () => ({ count: computed(() => 42) }));
+
+        const Base = optionsBaseWithInjectedSetup('sw-opt-computed', {
+            data: () => ({ count: 0 }),
+            render() {
+                return h('div', `${(this as unknown as { count: number }).count}`);
+            },
+        });
+
+        const wrapper = mount(Base);
+        expect(wrapper.text()).toBe('42');
+        expect(warn).toHaveBeenCalledWith(expect.stringContaining('replaced "count" with a computed value'));
+    });
+});

--- a/src/Administration/Resources/app/administration/src/app/adapter/options-base-override.ts
+++ b/src/Administration/Resources/app/administration/src/app/adapter/options-base-override.ts
@@ -174,6 +174,25 @@ export function applyCompositionOverridesToOptionsBase(componentName: string): R
 /**
  * @private
  *
+ * Returns a `setup()` for an Options base that has composition overrides registered — or null.
+ *
+ * The component factory calls this at build time (via `Shopware.Component`) and only injects the
+ * returned setup when it is non-null, so components without a targeting override are left completely
+ * untouched (no injected setup, no behaviour change).
+ */
+export function createOptionsBaseOverrideSetup(componentName: string): (() => Record<string, unknown>) | null {
+    const overrides = _overridesMap[componentName];
+
+    if (!overrides || overrides.length === 0) {
+        return null;
+    }
+
+    return () => applyCompositionOverridesToOptionsBase(componentName) ?? {};
+}
+
+/**
+ * @private
+ *
  * Test-only reset of the dev-warning dedupe cache.
  */
 export function _resetOptionsBaseOverrideWarnings(): void {

--- a/src/Administration/Resources/app/administration/src/app/adapter/options-base-override.ts
+++ b/src/Administration/Resources/app/administration/src/app/adapter/options-base-override.ts
@@ -1,0 +1,181 @@
+/**
+ * @sw-package framework
+ *
+ * Lets a composition-API override replace state on an Options-API base component.
+ *
+ * `createExtendableSetup()` only applies registered `overrideComponentSetup()` overrides for
+ * components that call it — i.e. native-setup (composition) components. A composition override that
+ * targets a component still written in the Options API therefore never runs. This module closes that
+ * gap without rewriting the base: an injected `setup()` (added by the component factory) calls
+ * `applyCompositionOverridesToOptionsBase()`, which runs the registered overrides and returns ONLY the
+ * keys they replace. Those keys land in Vue's setupState, which resolves ahead of `data`/`computed`,
+ * so the override shadows exactly the replaced keys — the rest of the Options component is untouched.
+ *
+ * `previousState` reads the base's original values un-shadowed: `data` keys come from `instance.data`
+ * (which setupState never shadows), computed/other keys fall back to the public proxy. A synchronous
+ * `.value` read inside an override body (before the base is initialised) cannot resolve and warns in
+ * development.
+ *
+ * @experimental stableVersion:v6.8.0 feature:ADMIN_COMPOSITION_API_EXTENSION_SYSTEM
+ */
+
+import { computed, getCurrentInstance, isReadonly, isRef, reactive, watch } from 'vue';
+import { syncRef } from '@vueuse/core';
+import { _overridesMap } from './composition-extension-system';
+
+const isDev = process.env.NODE_ENV !== 'production';
+
+// Dedupe dev warnings per component:key so a repeated stale/synchronous read warns once.
+const warnedKeys = new Set<string>();
+
+function warnOnce(key: string, message: string): void {
+    if (!isDev || warnedKeys.has(key)) {
+        return;
+    }
+
+    warnedKeys.add(key);
+    console.warn(message);
+}
+
+type InstanceLike = {
+    data?: Record<string, unknown>;
+    props?: Record<string, unknown>;
+    proxy?: Record<string, unknown> | null;
+};
+
+/**
+ * Builds the `previousState` passed to one override callback.
+ *
+ * Each field is a computed reading the base's ORIGINAL value: `data` keys from `instance.data` (never
+ * shadowed by setupState), everything else from the public proxy. Access is lazy so the value is read
+ * at render time, after the Options state is initialised.
+ */
+function createOptionsPreviousState(instance: InstanceLike, componentName: string): Record<string, unknown> {
+    const cache = new Map<PropertyKey, unknown>();
+
+    return new Proxy(
+        {},
+        {
+            get(_target, key: PropertyKey) {
+                if (key === '_private') {
+                    // Options bases have no composition-private state.
+                    return {};
+                }
+
+                if (!cache.has(key)) {
+                    cache.set(
+                        key,
+                        computed(() => {
+                            const data = instance.data;
+
+                            if (data && Object.prototype.hasOwnProperty.call(data, key)) {
+                                return data[key as string];
+                            }
+
+                            const value = instance.proxy?.[key as string];
+
+                            if (value === undefined && isDev) {
+                                warnOnce(
+                                    `${componentName}:previous:${String(key)}`,
+                                    `[${componentName}] previousState.${String(key)} was read before the Options base ` +
+                                        `was initialised (e.g. synchronously inside the override body). Read it inside a ` +
+                                        `computed/watch instead, where it resolves after initialisation.`,
+                                );
+                            }
+
+                            return value;
+                        }),
+                    );
+                }
+
+                return cache.get(key);
+            },
+        },
+    ) as Record<string, unknown>;
+}
+
+/**
+ * @private
+ *
+ * Runs the composition overrides registered for an Options base and returns the replaced keys.
+ *
+ * Returns null when no override targets the component, so the injected `setup()` can skip returning a
+ * shadow object entirely.
+ */
+export function applyCompositionOverridesToOptionsBase(componentName: string): Record<string, unknown> | null {
+    const overrides = _overridesMap[componentName];
+
+    if (!overrides || overrides.length === 0) {
+        return null;
+    }
+
+    const instance = getCurrentInstance() as InstanceLike | null;
+
+    if (!instance) {
+        return null;
+    }
+
+    const shadow = reactive<Record<string, unknown>>({});
+    const applied = new Set<unknown>();
+    const previousState = createOptionsPreviousState(instance, componentName);
+
+    const applyOverrides = (): void => {
+        overrides.forEach((override) => {
+            if (applied.has(override)) {
+                return;
+            }
+
+            applied.add(override);
+
+            let result: Record<string, unknown>;
+
+            try {
+                result = override(previousState as never, (instance.props ?? {}) as never, {} as never) as Record<
+                    string,
+                    unknown
+                >;
+            } catch (error) {
+                console.error(
+                    `[${componentName}] A composition override could not be applied to this Options API base:`,
+                    error,
+                );
+                return;
+            }
+
+            Object.keys(result).forEach((key) => {
+                const value = result[key];
+                const existing = shadow[key];
+
+                if (isRef(value) && !isReadonly(value) && isRef(existing) && !isReadonly(existing)) {
+                    // Chained writable ref replacement stays 2-way synced with the earlier one.
+                    syncRef(value, existing as never);
+                    return;
+                }
+
+                if (isReadonly(value) && isRef(value) && isDev) {
+                    warnOnce(
+                        `${componentName}:computed:${key}`,
+                        `[${componentName}] Override replaced "${key}" with a computed value. The template updates, ` +
+                            `but the Options base's own writes to "${key}" (this.${key} = …) will no longer take effect.`,
+                    );
+                }
+
+                // Shadow the key: Vue's setupState resolves ahead of data/computed, and unwraps refs.
+                shadow[key] = value;
+            });
+        });
+    };
+
+    watch(overrides, applyOverrides, { deep: true, immediate: true });
+
+    return shadow;
+}
+
+/**
+ * @private
+ *
+ * Test-only reset of the dev-warning dedupe cache.
+ */
+export function _resetOptionsBaseOverrideWarnings(): void {
+    warnedKeys.clear();
+}

--- a/src/Administration/Resources/app/administration/src/core/factory/async-component.factory.ts
+++ b/src/Administration/Resources/app/administration/src/core/factory/async-component.factory.ts
@@ -782,6 +782,19 @@ async function build(componentName: string, skipTemplate = false): Promise<Compo
         };
     }
 
+    // A composition override that targets an Options API base is applied by injecting a setup() that
+    // runs the override pipeline and returns only the replaced keys (Vue's setupState resolves ahead of
+    // data/computed, so exactly those keys are shadowed). Resolved through the Shopware global so core
+    // does not import the app-layer runtime; returns null unless an override targets this component, so
+    // components without one are left completely untouched.
+    if (!skipTemplate && typeof config?.setup !== 'function') {
+        const overrideSetup = Shopware?.Component?.createOptionsBaseOverrideSetup?.(componentName);
+
+        if (overrideSetup) {
+            config.setup = overrideSetup as ComponentConfig['setup'];
+        }
+    }
+
     /**
      * if config has a render function it will ignore template
      */

--- a/src/Administration/Resources/app/administration/src/core/shopware.ts
+++ b/src/Administration/Resources/app/administration/src/core/shopware.ts
@@ -44,6 +44,7 @@ import ApiServices from 'src/core/service/api';
 import ModuleFilterFactory from 'src/core/data/filter-factory.data';
 import Store from 'src/app/store';
 import { createExtendableSetup, overrideComponentSetup } from 'src/app/adapter/composition-extension-system';
+import { createOptionsBaseOverrideSetup } from 'src/app/adapter/options-base-override';
 import * as Vue from 'vue';
 import type { DefineComponent, Ref } from 'vue';
 import CMS from '../module/sw-cms/constant/sw-cms.constant';
@@ -141,6 +142,7 @@ class ShopwareClass implements CustomShopwareProperties {
         getOverrideRegistry: AsyncComponentFactory.getOverrideRegistry,
         createExtendableSetup: createExtendableSetup,
         overrideComponentSetup: overrideComponentSetup,
+        createOptionsBaseOverrideSetup: createOptionsBaseOverrideSetup,
 
         /**
          * @experimental stableVersion:v6.8.0 feature:ADMIN_COMPOSITION_API_EXTENSION_SYSTEM

--- a/src/Administration/Resources/app/administration/technical-docs/03-extensibility/04-composition-extension-system.md
+++ b/src/Administration/Resources/app/administration/technical-docs/03-extensibility/04-composition-extension-system.md
@@ -338,6 +338,28 @@ Behavior for late-applied overrides:
 
 ---
 
+## Composition Overrides on Options API Base Components
+
+**Location:** `options-base-override.ts`
+
+The Options API Shim above handles the case where an *Options API override* targets a *Composition API base*. This section is the mirror image: a **Composition API override** (`overrideComponentSetup(...)`, or a native `.override.vue` file) that targets a base component **still written in the Options API**.
+
+Normally an override is only applied by `createExtendableSetup`, which Options API components never call — so without this mechanism a composition override targeting an Options base would silently do nothing.
+
+### How it works
+
+At build time the component factory checks whether any composition override is registered for the component. If so — and only then — it injects a generated `setup()` that runs the override pipeline and returns **only the keys the overrides replace**. Vue resolves `setupState` ahead of `data`/`computed`, so those keys are shadowed for both the template and the component's own `this.<key>` reads, while everything else in the Options component runs untouched. Components with no targeting override get no injected `setup()` at all.
+
+The base is **not converted or rewritten** — only the specifically overridden keys are shadowed, keeping the blast radius to exactly what the override changes.
+
+### `previousState`
+
+Override callbacks receive `previousState` with the base's **original** values: `data` fields are read from the live instance data (which `setupState` never shadows), other keys from the public proxy. Read it **inside a `computed`/`watch`** (e.g. `computed(() => previousState.headline.value + ' Pro')`) — not synchronously in the override body, because Options `data`/`computed` are initialised after `setup()` runs. A synchronous read logs a development warning.
+
+### Limitation: replacing a written field with a computed
+
+If an override replaces a key with a **computed** (readonly) and the Options base **writes** that field internally (`this.headline = …`), those writes no longer take effect — a computed cannot be written. This logs a development warning. Replace with a writable `ref` if the base needs to keep writing the field.
+
 ## Known Limitations
 
 1. **Dot-notation watch paths** — `watch: { 'a.b.c': handler }` is not supported by the shim. The watcher is silently skipped with a console warning. Migrate to a computed + simple watch.


### PR DESCRIPTION
### 1. Why is this change necessary?

A Composition API override — `Shopware.Component.overrideComponentSetup()` (or a native `.override.vue` file) — that targets a component **still written in the Options API** silently does nothing today. Overrides are only applied by `createExtendableSetup()`, which Options API components never call. During the ongoing Options→Composition migration a plugin may adopt the new override syntax *before* the core component it extends has been migrated, and right now that override just never runs. This is a pre-existing gap, independent of the native-setup transform work.

### 2. What does this change do, exactly?

It makes a composition override actually replace state on an Options API base — without rewriting or converting the base.

- **Runtime** (`options-base-override.ts`): `applyCompositionOverridesToOptionsBase()` runs the registered overrides and returns **only the keys they replace**.
- **Factory** (`async-component.factory.ts`): at build time, when — and only when — a composition override targets a component, `build()` injects a generated `setup()` that returns those replaced keys. Vue resolves `setupState` ahead of `data`/`computed`, so exactly those keys are shadowed (for the template *and* the base's own `this.<key>` reads); everything else in the Options component runs untouched. Components with no targeting override get no injected setup at all — **small blast radius, no lossy base conversion**. Core resolves the runtime through `Shopware.Component` (the global) rather than importing the app layer.
- **`previousState`** reads the base's **original** values un-shadowed (`data` from the live instance data, other keys from the public proxy), so overrides can wrap the previous value.

**Limitation (documented + warned in dev):**
- Replacing a field the base **writes** (`this.x = …`) with a **computed** means those writes no longer take effect (a computed is readonly) — logs a dev warning; use a writable `ref` instead.
- `previousState` must be read inside a `computed`/`watch`, not synchronously in the override body (Options `data`/`computed` initialise after `setup()`), or it warns in dev.

### 3. Describe each step to reproduce the issue or behaviour.

1. Register an Options API component, e.g. `data: () => ({ headline: 'Base' })`.
2. Register a composition override for it:
```js
Shopware.Component.overrideComponentSetup()('sw-x', (previousState) => ({
    headline: computed(() => previousState.headline.value + ' (Pro)')
}))
```
3. **Before this change:** the component still renders `"Base"`.
**After:** it renders `"Base (Pro)"`, and the base's own `this.headline` reads see it too.

Covered by automated tests: a runtime spec (`options-base-override.spec.ts`) and an end-to-end factory spec (`options-base-override.factory.spec.ts`) that builds + mounts a real Options component and asserts the override replaces its data field, and that an un-overridden component is left untouched.

### 4. Please link to the relevant issues (if any).

<!-- add issue/Jira link if applicable -->

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers
- [x] I have written or adjusted the documentation and agent skills according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
