### PR TITLE
fix(core): compute search page offset from effective criteria limit

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -6,6 +6,10 @@
 
 ## Core
 
+### Rule Builder no longer duplicates conditions for large rules
+
+Rules with more than 500 conditions are now displayed correctly in the Administration Rule Builder. Previously such rules showed duplicated conditions and dropped the ones beyond the first 500, caused by incorrect pagination when a search request was sent without an explicit limit.
+
 ### Built-in translation system configurable via `shopware.translation`
 
 The built-in translation system's configuration (previously only editable by decorating `AbstractTranslationConfigLoader`) can now be overridden through the standard Symfony configuration in `config/packages`. Add a `shopware.translation` section to override individual options; any option left unset falls back to the shipped defaults in `translation.yaml`:

--- a/src/Core/Framework/DataAbstractionLayer/Search/RequestCriteriaBuilder.php
+++ b/src/Core/Framework/DataAbstractionLayer/Search/RequestCriteriaBuilder.php
@@ -388,7 +388,8 @@ class RequestCriteriaBuilder
         }
 
         $page = (int) $payload['page'];
-        $limit = (int) ($payload['limit'] ?? 0);
+        // Use the effective criteria limit, so that paginating without an explicit limit still produces disjoint pages.
+        $limit = $criteria->getLimit() ?? 0;
 
         if ($page <= 0) {
             $searchRequestException->add(new InvalidPageQueryException($page), '/page');

--- a/tests/unit/Core/Framework/DataAbstractionLayer/Search/RequestCriteriaBuilderTest.php
+++ b/tests/unit/Core/Framework/DataAbstractionLayer/Search/RequestCriteriaBuilderTest.php
@@ -646,6 +646,30 @@ class RequestCriteriaBuilderTest extends TestCase
         static::assertSame($expectedLimit, $criteria->getLimit());
     }
 
+    public function testPageOffsetUsesEffectiveLimitWhenRequestHasNoLimit(): void
+    {
+        $aggregationParser = new AggregationParser();
+        $maxLimit = 500;
+
+        $builder = new RequestCriteriaBuilder(
+            $aggregationParser,
+            new ApiCriteriaValidator($this->staticDefinitionRegistry),
+            new CriteriaArrayConverter($aggregationParser),
+            new CompressedCriteriaDecoder(),
+            $maxLimit
+        );
+
+        $criteria = $builder->fromArray(
+            ['page' => 2],
+            new Criteria(),
+            $this->staticDefinitionRegistry->get(ProductDefinition::class),
+            Context::createDefaultContext()
+        );
+
+        static::assertSame($maxLimit, $criteria->getLimit());
+        static::assertSame($maxLimit, $criteria->getOffset());
+    }
+
     public static function providerPaging(): \Generator
     {
         yield 'offset correctly calculated' => [


### PR DESCRIPTION
Paginating an API search request with a page but no explicit limit returned the same first slice of rows on every page: the max_limit fallback raised the criteria limit (e.g. 500), but the offset was still derived from the missing request limit (0). RequestCriteriaBuilder now computes the offset from the effective criteria limit, so pages are disjoint again.

This fixes the Administration Rule Builder duplicating and dropping conditions for rules with more than 500 conditions.

closes: #18652

### 1. Why is this change necessary?

Rule builder is broken for complex rules

### 2. What does this change do, exactly?

Fixes pagination

### 3. Describe each step to reproduce the issue or behaviour.

see  #18652
### 4. Please link to the relevant issues (if any).

see  #18652

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
