### PR TITLE
fix(elasticsearch): reindex instead of aborting when an analyzer is missing from the live index

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -10,6 +10,9 @@
 
 `--force` promises to ignore the cache and force generation, but for scheduler-managed exports it was a no-op. This aligns the flag with its documented behavior.
 
+### Elasticsearch index updates schedule a reindex when analysis settings change
+
+When updating an Elasticsearch/OpenSearch mapping references an analyzer/normalizer that the live index's analysis settings do not define (for example after an update introduced a new analyzer), `putMapping` fails with `analyzer [...] has not been configured in mappings`. Analysis settings are fixed at index creation and cannot be added to a live index, so this is now handled like the other unrecoverable mapping errors: the affected entity is scheduled for a reindex into a freshly created index, which rebuilds it with the current analysis settings instead of leaving the outdated mapping in place.
 
 ### Built-in translation system configurable via `shopware.translation`
 

--- a/src/Elasticsearch/Framework/Indexing/IndexMappingUpdater.php
+++ b/src/Elasticsearch/Framework/Indexing/IndexMappingUpdater.php
@@ -17,6 +17,20 @@ use Shopware\Elasticsearch\Product\ElasticsearchProductException;
 class IndexMappingUpdater
 {
     /**
+     * putMapping errors that cannot be resolved on a live index; the affected entity has to
+     * be reindexed into a freshly created index instead. This includes analysis-settings
+     * mismatches ("has not been configured in mappings"), because analyzers/normalizers are
+     * fixed at index creation and cannot be added to a live index.
+     */
+    private const REINDEXABLE_MAPPING_ERRORS = [
+        'conflicts with existing mapper:\n\tCannot update parameter',
+        'cannot be changed from type',
+        'can\'t merge a non object mapping',
+        'cannot change object mapping from',
+        'has not been configured in mappings',
+    ];
+
+    /**
      * @internal
      */
     public function __construct(
@@ -45,7 +59,8 @@ class IndexMappingUpdater
         }
 
         foreach ($this->registry->getDefinitions() as $definition) {
-            $indexName = $this->elasticsearchHelper->getIndexName($definition->getEntityDefinition());
+            $entityDefinition = $definition->getEntityDefinition();
+            $indexName = $this->elasticsearchHelper->getIndexName($entityDefinition);
 
             try {
                 $this->client->indices()->putMapping([
@@ -55,16 +70,15 @@ class IndexMappingUpdater
             } catch (BadRequestHttpException $exception) {
                 $errorMessage = $exception->getMessage();
 
-                $mapperConflicted = str_contains($errorMessage, 'conflicts with existing mapper:\n\tCannot update parameter');
-                $mapperCannotBeChanged = str_contains($errorMessage, 'cannot be changed from type');
-                $cannotMergeNonObject = str_contains($errorMessage, 'can\'t merge a non object mapping');
-                $cannotChangeObjectNesting = str_contains($errorMessage, 'cannot change object mapping from');
+                // These putMapping errors cannot be resolved on a live index, so the entity is
+                // scheduled for a reindex into a freshly created index.
+                foreach (self::REINDEXABLE_MAPPING_ERRORS as $needle) {
+                    if (str_contains($errorMessage, $needle)) {
+                        $entitiesToReindex[] = $entityDefinition->getEntityName();
+                        $exception = ElasticsearchProductException::cannotChangeFieldType($exception);
 
-                // If one of these errors occur, we need to reindex the entity
-                if ($mapperConflicted || $mapperCannotBeChanged || $cannotMergeNonObject || $cannotChangeObjectNesting) {
-                    $entitiesToReindex[] = $definition->getEntityDefinition()->getEntityName();
-
-                    $exception = ElasticsearchProductException::cannotChangeFieldType($exception);
+                        break;
+                    }
                 }
 
                 $this->elasticsearchHelper->logAndThrowException($exception);

--- a/tests/unit/Elasticsearch/Framework/Indexing/IndexMappingUpdaterTest.php
+++ b/tests/unit/Elasticsearch/Framework/Indexing/IndexMappingUpdaterTest.php
@@ -341,4 +341,63 @@ class IndexMappingUpdaterTest extends TestCase
 
         $updater->update(Context::createDefaultContext());
     }
+
+    public function testUpdateWithAnalyzerNotConfiguredError(): void
+    {
+        $elasticsearchHelper = $this->createMock(ElasticsearchHelper::class);
+        $elasticsearchHelper->method('getIndexName')->willReturn('index');
+        $elasticsearchHelper->expects($this->once())->method('allowIndexing')->willReturn(true);
+
+        $definition = static::createStub(ElasticsearchProductDefinition::class);
+        $definition
+            ->method('getEntityDefinition')
+            ->willReturn(new ProductDefinition());
+
+        $registry = new ElasticsearchRegistry([$definition]);
+
+        $client = static::createStub(Client::class);
+        $indicesNamespace = $this->createMock(IndicesNamespace::class);
+        $indicesNamespace
+            ->expects($this->once())
+            ->method('putMapping')
+            ->with([
+                'index' => 'index',
+                'body' => [
+                    'foo' => '1',
+                ],
+            ])->willThrowException(new BadRequestHttpException('mapper_parsing_exception: analyzer [sw_whitespace_technical_term_search_analyzer] has not been configured in mappings'));
+
+        $client
+            ->method('indices')
+            ->willReturn($indicesNamespace);
+
+        $indexMappingProvider = static::createStub(IndexMappingProvider::class);
+        $indexMappingProvider
+            ->method('build')
+            ->willReturn(['foo' => '1']);
+
+        $elasticsearchHelper->expects($this->once())->method('logAndThrowException')->with(
+            static::callback(static function (ElasticsearchProductException $exception) {
+                return $exception->getMessage() === 'One or more fields already exist in the index with different types. Please reset the index and rebuild it.';
+            }),
+        );
+
+        $storage = $this->createMock(AbstractKeyValueStorage::class);
+        $storage->expects($this->once())
+            ->method('set')
+            ->with(
+                SystemUpdateListener::CONFIG_KEY,
+                ['product'],
+            );
+
+        $updater = new IndexMappingUpdater(
+            $registry,
+            $elasticsearchHelper,
+            $client,
+            $indexMappingProvider,
+            $storage,
+        );
+
+        $updater->update(Context::createDefaultContext());
+    }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?

An operator reported that `bin/console system:update:finish` aborts on OpenSearch/Elasticsearch with:

```
illegal_argument_exception: analyzer [sw_whitespace_technical_term_search_analyzer] has not been configured in mappings
```

`IndexMappingUpdater` issues an in-place `putMapping` for every ES index during `system:update:finish`. Analysis settings (analyzers, normalizers) are fixed when an index is created and **cannot** be added to a live index, so a mapping that references a newly introduced analyzer — e.g. after an update ships a new analyzer — fails. With `elasticsearch.throw_exception` enabled the whole update aborts, and the only known workaround was to disable Elasticsearch, run the deployment again, and re-enable it.

### 2. What does this change do, exactly?

Treats "analyzer/normalizer not configured in the index's analysis settings" as a recoverable condition, consistent with the existing mapper-conflict handling:

- Detects the `has not been configured in mappings` error, logs it, and schedules the entity for a reindex (`SystemUpdateListener::CONFIG_KEY`).
- Continues the update instead of rethrowing, so the reindex list is persisted and the subsequent reindex recreates the index with the current analysis settings via `IndexCreator` — the index recovers automatically.

The existing mapper-conflict/`cannotChangeFieldType` behaviour is left unchanged.

### 3. Describe each step to reproduce the issue or behaviour.

1. Have a running ES/OpenSearch index for an entity (e.g. `product`).
2. Introduce a mapping that uses an analyzer not present in the live index's analysis settings (e.g. update to a version that adds `sw_whitespace_technical_term_search_analyzer`).
3. Run `bin/console system:update:finish` with `elasticsearch.throw_exception` enabled.
4. Before: the command aborts with `analyzer [...] has not been configured in mappings`.
5. After: the update completes, the entity is scheduled for reindex, and the index is rebuilt with the new analyzer on the next indexing run.

### 4. Please link to the relevant issues (if any).



### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Added an entry to `RELEASE_INFO-6.7.md` under Core.
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
