### PR TITLE
fix(core): restrict the service registry URL to Shopware domains in production

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -177,6 +177,12 @@ shopware:
 
 Fallback sizes apply only in remote-thumbnail mode to media in known folders whose configuration has `createThumbnails: true` but no assigned thumbnail sizes. Configured folder-specific sizes remain the normal source when thumbnail creation is enabled. A folder with `createThumbnails: false` is an explicit opt-out and receives no thumbnail URLs, even when fallback sizes are configured. Media without a known folder mapping also receives no fallback thumbnail URLs.
 
+### `SERVICE_REGISTRY_URL` is limited to Shopware domains in production
+
+The service registry decides which Shopware Services a shop installs and where their code is downloaded from. With `APP_ENV=prod`, `SERVICE_REGISTRY_URL` is now only used when its host is `shopware.io` or a subdomain of it. Any other value is ignored and `https://registry.services.shopware.io` is used instead, so a mistyped registry URL no longer breaks service installation on a live shop.
+
+Other environments are unrestricted, so local setups and tests can still point at their own registry.
+
 # 6.7.13.0
 
 ## Critical Fixes

--- a/src/Administration/DependencyInjection/services.php
+++ b/src/Administration/DependencyInjection/services.php
@@ -100,7 +100,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             service(DefinitionInstanceRegistry::class),
             service('parameter_bag'),
             service('shopware.filesystem.asset'),
-            env('SERVICE_REGISTRY_URL'),
+            param('shopware.service_registry.url'),
             service('language.repository'),
             service(SymfonyBearerTokenValidator::class),
             env('PRODUCT_ANALYTICS_GATEWAY_URL'),

--- a/src/Core/Service/DependencyInjection/ServiceExtension.php
+++ b/src/Core/Service/DependencyInjection/ServiceExtension.php
@@ -7,19 +7,20 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
 
-/**
- * @codeCoverageIgnore
- */
 #[Package('framework')]
 class ServiceExtension extends Extension implements PrependExtensionInterface
 {
+    public const DEFAULT_REGISTRY_URL = 'https://registry.services.shopware.io';
+
     public function prepend(ContainerBuilder $container): void
     {
+        $container->setParameter('shopware.service_registry.url', $this->resolveRegistryUrl($container));
+
         $container->prependExtensionConfig('framework', [
             'http_client' => [
                 'scoped_clients' => [
                     'service_registry.http_client' => [
-                        'base_uri' => '%env(SERVICE_REGISTRY_URL)%',
+                        'base_uri' => '%shopware.service_registry.url%',
                         'max_duration' => 5,
                     ],
                 ],
@@ -32,5 +33,19 @@ class ServiceExtension extends Extension implements PrependExtensionInterface
      */
     public function load(array $configs, ContainerBuilder $container): void
     {
+    }
+
+    /**
+     * The registry decides which services a shop installs and where their code is downloaded from, so
+     * `SERVICE_REGISTRY_URL` is only read outside of production. In production the URL is fixed, which
+     * prevents a leaked or manipulated environment from pointing a live shop at a different registry.
+     */
+    private function resolveRegistryUrl(ContainerBuilder $container): string
+    {
+        if ($container->getParameter('kernel.environment') === 'prod') {
+            return self::DEFAULT_REGISTRY_URL;
+        }
+
+        return '%env(SERVICE_REGISTRY_URL)%';
     }
 }

--- a/src/Core/Service/DependencyInjection/ServiceExtension.php
+++ b/src/Core/Service/DependencyInjection/ServiceExtension.php
@@ -12,9 +12,16 @@ class ServiceExtension extends Extension implements PrependExtensionInterface
 {
     public const DEFAULT_REGISTRY_URL = 'https://registry.services.shopware.io';
 
+    /**
+     * Domains Shopware operates service registries on, covering the production registry as well as the ones
+     * used by staging installations.
+     */
+    private const TRUSTED_REGISTRY_DOMAINS = ['shopware.io'];
+
     public function prepend(ContainerBuilder $container): void
     {
-        $container->setParameter('shopware.service_registry.url', $this->resolveRegistryUrl($container));
+        $container->setParameter('shopware.service_registry.trusted_domains', $this->trustedDomains($container));
+        $container->setParameter('shopware.service_registry.url', '%env(service-registry-url:SERVICE_REGISTRY_URL)%');
 
         $container->prependExtensionConfig('framework', [
             'http_client' => [
@@ -36,16 +43,19 @@ class ServiceExtension extends Extension implements PrependExtensionInterface
     }
 
     /**
-     * The registry decides which services a shop installs and where their code is downloaded from, so
-     * `SERVICE_REGISTRY_URL` is only read outside of production. In production the URL is fixed, which
-     * prevents a leaked or manipulated environment from pointing a live shop at a different registry.
+     * The registry decides which services a shop installs and where their code is downloaded from, so in
+     * production `SERVICE_REGISTRY_URL` has to stay on a domain Shopware operates. Any other value is
+     * ignored, which prevents a mistyped or manipulated environment from pointing a live shop at a foreign
+     * registry. Other environments are unrestricted so they can use a local or mocked registry.
+     *
+     * @return list<string>
      */
-    private function resolveRegistryUrl(ContainerBuilder $container): string
+    private function trustedDomains(ContainerBuilder $container): array
     {
-        if ($container->getParameter('kernel.environment') === 'prod') {
-            return self::DEFAULT_REGISTRY_URL;
+        if ($container->getParameter('kernel.environment') !== 'prod') {
+            return [];
         }
 
-        return '%env(SERVICE_REGISTRY_URL)%';
+        return self::TRUSTED_REGISTRY_DOMAINS;
     }
 }

--- a/src/Core/Service/DependencyInjection/services.php
+++ b/src/Core/Service/DependencyInjection/services.php
@@ -60,7 +60,7 @@ use function Symfony\Component\DependencyInjection\Loader\Configurator\tagged_it
 
 return static function (ContainerConfigurator $containerConfigurator): void {
     $parameters = $containerConfigurator->parameters();
-    $parameters->set('env(SERVICE_REGISTRY_URL)', 'https://registry.services.shopware.io');
+    $parameters->set('env(SERVICE_REGISTRY_URL)', ServiceExtension::DEFAULT_REGISTRY_URL);
     $parameters->set('env(ENABLE_SERVICES)', 'auto');
 
     $services = $containerConfigurator->services();
@@ -89,7 +89,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
     $services->set(Client::class)
         ->args([
-            env('SERVICE_REGISTRY_URL'),
+            param('shopware.service_registry.url'),
             env('APP_URL'),
             service('service_registry.http_client'),
         ])

--- a/src/Core/Service/DependencyInjection/services.php
+++ b/src/Core/Service/DependencyInjection/services.php
@@ -37,6 +37,7 @@ use Shopware\Core\Service\ServiceHookableEventDescriber;
 use Shopware\Core\Service\ServiceLifecycle;
 use Shopware\Core\Service\ServiceRegistry\Client;
 use Shopware\Core\Service\ServiceRegistry\PermissionLogger;
+use Shopware\Core\Service\ServiceRegistry\RegistryUrlProcessor;
 use Shopware\Core\Service\ServiceSourceResolver;
 use Shopware\Core\Service\ServiceStorage;
 use Shopware\Core\Service\Subscriber\ExtensionCompatibilitiesResolvedSubscriber;
@@ -86,6 +87,13 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             service(LifecycleManager::class),
         ])
         ->tag('console.command');
+
+    $services->set(RegistryUrlProcessor::class)
+        ->args([
+            ServiceExtension::DEFAULT_REGISTRY_URL,
+            param('shopware.service_registry.trusted_domains'),
+        ])
+        ->tag('container.env_var_processor');
 
     $services->set(Client::class)
         ->args([

--- a/src/Core/Service/ServiceRegistry/RegistryUrlProcessor.php
+++ b/src/Core/Service/ServiceRegistry/RegistryUrlProcessor.php
@@ -1,0 +1,69 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Service\ServiceRegistry;
+
+use Shopware\Core\Framework\Log\Package;
+use Symfony\Component\DependencyInjection\EnvVarProcessorInterface;
+
+/**
+ * Resolves the configured registry URL and replaces it with the built-in one when it does not belong to a
+ * trusted domain. The registry decides which services a shop installs and where their code is downloaded
+ * from, so a mistyped or manipulated URL must not be able to point a live shop at a foreign registry.
+ *
+ * The value is resolved at runtime, so a container built without `SERVICE_REGISTRY_URL` still picks up the
+ * variable when it is injected into the environment later.
+ *
+ * @internal
+ */
+#[Package('framework')]
+class RegistryUrlProcessor implements EnvVarProcessorInterface
+{
+    /**
+     * @param list<string> $trustedDomains the URL host must be one of these domains or a subdomain of one.
+     *                                     An empty list accepts every URL, which is how non-production
+     *                                     environments point at a local registry.
+     */
+    public function __construct(
+        private readonly string $defaultUrl,
+        private readonly array $trustedDomains,
+    ) {
+    }
+
+    public function getEnv(string $prefix, string $name, \Closure $getEnv): string
+    {
+        $url = (string) $getEnv($name);
+
+        if ($this->trustedDomains === [] || $this->isTrusted($url)) {
+            return $url;
+        }
+
+        return $this->defaultUrl;
+    }
+
+    public static function getProvidedTypes(): array
+    {
+        return [
+            'service-registry-url' => 'string',
+        ];
+    }
+
+    private function isTrusted(string $url): bool
+    {
+        $host = parse_url($url, \PHP_URL_HOST);
+
+        if (!\is_string($host)) {
+            return false;
+        }
+
+        // a trailing dot denotes the same host, `parse_url()` keeps the casing of the configured value
+        $host = rtrim(mb_strtolower($host), '.');
+
+        foreach ($this->trustedDomains as $domain) {
+            if ($host === $domain || str_ends_with($host, '.' . $domain)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/tests/unit/Core/Service/DependencyInjection/ServiceExtensionTest.php
+++ b/tests/unit/Core/Service/DependencyInjection/ServiceExtensionTest.php
@@ -1,0 +1,65 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Service\DependencyInjection;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Service\DependencyInjection\ServiceExtension;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\ParameterBag\EnvPlaceholderParameterBag;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+#[CoversClass(ServiceExtension::class)]
+class ServiceExtensionTest extends TestCase
+{
+    #[DataProvider('nonProductionEnvironmentProvider')]
+    public function testRegistryUrlIsConfigurableOutsideOfProduction(string $environment): void
+    {
+        $container = new ContainerBuilder(new EnvPlaceholderParameterBag(['kernel.environment' => $environment]));
+
+        (new ServiceExtension())->prepend($container);
+
+        static::assertSame('%env(SERVICE_REGISTRY_URL)%', $container->getParameter('shopware.service_registry.url'));
+    }
+
+    public function testRegistryUrlIgnoresTheEnvironmentVariableInProduction(): void
+    {
+        $container = new ContainerBuilder(new EnvPlaceholderParameterBag(['kernel.environment' => 'prod']));
+
+        (new ServiceExtension())->prepend($container);
+
+        static::assertSame(ServiceExtension::DEFAULT_REGISTRY_URL, $container->getParameter('shopware.service_registry.url'));
+    }
+
+    public function testRegistryHttpClientUsesTheResolvedRegistryUrl(): void
+    {
+        $container = new ContainerBuilder(new EnvPlaceholderParameterBag(['kernel.environment' => 'prod']));
+
+        (new ServiceExtension())->prepend($container);
+
+        static::assertSame([[
+            'http_client' => [
+                'scoped_clients' => [
+                    'service_registry.http_client' => [
+                        'base_uri' => '%shopware.service_registry.url%',
+                        'max_duration' => 5,
+                    ],
+                ],
+            ],
+        ]], $container->getExtensionConfig('framework'));
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function nonProductionEnvironmentProvider(): iterable
+    {
+        yield 'development environment' => ['dev'];
+        yield 'test environment' => ['test'];
+    }
+}

--- a/tests/unit/Core/Service/DependencyInjection/ServiceExtensionTest.php
+++ b/tests/unit/Core/Service/DependencyInjection/ServiceExtensionTest.php
@@ -17,30 +17,32 @@ use Symfony\Component\DependencyInjection\ParameterBag\EnvPlaceholderParameterBa
 #[CoversClass(ServiceExtension::class)]
 class ServiceExtensionTest extends TestCase
 {
-    #[DataProvider('nonProductionEnvironmentProvider')]
-    public function testRegistryUrlIsConfigurableOutsideOfProduction(string $environment): void
+    #[DataProvider('environmentProvider')]
+    public function testRegistryUrlIsResolvedFromTheEnvironmentVariable(string $environment): void
     {
-        $container = new ContainerBuilder(new EnvPlaceholderParameterBag(['kernel.environment' => $environment]));
+        $container = $this->prepend($environment);
 
-        (new ServiceExtension())->prepend($container);
-
-        static::assertSame('%env(SERVICE_REGISTRY_URL)%', $container->getParameter('shopware.service_registry.url'));
+        static::assertSame('%env(service-registry-url:SERVICE_REGISTRY_URL)%', $container->getParameter('shopware.service_registry.url'));
     }
 
-    public function testRegistryUrlIgnoresTheEnvironmentVariableInProduction(): void
+    public function testRegistryUrlIsRestrictedToShopwareDomainsInProduction(): void
     {
-        $container = new ContainerBuilder(new EnvPlaceholderParameterBag(['kernel.environment' => 'prod']));
+        $container = $this->prepend('prod');
 
-        (new ServiceExtension())->prepend($container);
+        static::assertSame(['shopware.io'], $container->getParameter('shopware.service_registry.trusted_domains'));
+    }
 
-        static::assertSame(ServiceExtension::DEFAULT_REGISTRY_URL, $container->getParameter('shopware.service_registry.url'));
+    #[DataProvider('nonProductionEnvironmentProvider')]
+    public function testRegistryUrlIsUnrestrictedOutsideOfProduction(string $environment): void
+    {
+        $container = $this->prepend($environment);
+
+        static::assertSame([], $container->getParameter('shopware.service_registry.trusted_domains'));
     }
 
     public function testRegistryHttpClientUsesTheResolvedRegistryUrl(): void
     {
-        $container = new ContainerBuilder(new EnvPlaceholderParameterBag(['kernel.environment' => 'prod']));
-
-        (new ServiceExtension())->prepend($container);
+        $container = $this->prepend('prod');
 
         static::assertSame([[
             'http_client' => [
@@ -57,9 +59,28 @@ class ServiceExtensionTest extends TestCase
     /**
      * @return iterable<string, array{string}>
      */
+    public static function environmentProvider(): iterable
+    {
+        yield 'production environment' => ['prod'];
+
+        yield from self::nonProductionEnvironmentProvider();
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
     public static function nonProductionEnvironmentProvider(): iterable
     {
         yield 'development environment' => ['dev'];
         yield 'test environment' => ['test'];
+    }
+
+    private function prepend(string $environment): ContainerBuilder
+    {
+        $container = new ContainerBuilder(new EnvPlaceholderParameterBag(['kernel.environment' => $environment]));
+
+        (new ServiceExtension())->prepend($container);
+
+        return $container;
     }
 }

--- a/tests/unit/Core/Service/ServiceRegistry/RegistryUrlProcessorTest.php
+++ b/tests/unit/Core/Service/ServiceRegistry/RegistryUrlProcessorTest.php
@@ -1,0 +1,83 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Service\ServiceRegistry;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Service\ServiceRegistry\RegistryUrlProcessor;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+#[CoversClass(RegistryUrlProcessor::class)]
+class RegistryUrlProcessorTest extends TestCase
+{
+    private const DEFAULT_URL = 'https://registry.services.shopware.io';
+
+    #[DataProvider('trustedUrlProvider')]
+    public function testUrlOnATrustedDomainIsUsed(string $url): void
+    {
+        static::assertSame($url, $this->process($url, ['shopware.io']));
+    }
+
+    #[DataProvider('untrustedUrlProvider')]
+    public function testUrlOutsideOfTheTrustedDomainsFallsBackToTheDefaultUrl(string $url): void
+    {
+        static::assertSame(self::DEFAULT_URL, $this->process($url, ['shopware.io']));
+    }
+
+    #[DataProvider('untrustedUrlProvider')]
+    public function testAnyUrlIsUsedWhenNoDomainIsTrusted(string $url): void
+    {
+        static::assertSame($url, $this->process($url, []));
+    }
+
+    public function testGetProvidedTypes(): void
+    {
+        static::assertSame(
+            ['service-registry-url' => 'string'],
+            RegistryUrlProcessor::getProvidedTypes()
+        );
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function trustedUrlProvider(): iterable
+    {
+        yield 'production registry' => ['https://registry.services.shopware.io'];
+        yield 'staging registry' => ['https://registry.staging-services.shopware.io'];
+        yield 'registry with a path' => ['https://registry.services.shopware.io/api'];
+        yield 'trusted domain itself' => ['https://shopware.io'];
+        yield 'uppercase host' => ['https://REGISTRY.SERVICES.SHOPWARE.IO'];
+        yield 'host with a trailing dot' => ['https://registry.services.shopware.io.'];
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function untrustedUrlProvider(): iterable
+    {
+        yield 'foreign host' => ['https://registry.example.com'];
+        yield 'host ending in the trusted domain' => ['https://notshopware.io'];
+        yield 'trusted domain as a subdomain of a foreign host' => ['https://registry.services.shopware.io.example.com'];
+        yield 'trusted domain in the user info' => ['https://registry.services.shopware.io@example.com'];
+        yield 'trusted domain in the path' => ['https://example.com/registry.services.shopware.io'];
+        yield 'local registry' => ['http://host.docker.internal:8123'];
+        yield 'host without a scheme' => ['registry.services.shopware.io'];
+        yield 'empty value' => [''];
+    }
+
+    /**
+     * @param list<string> $trustedDomains
+     */
+    private function process(string $url, array $trustedDomains): string
+    {
+        $processor = new RegistryUrlProcessor(self::DEFAULT_URL, $trustedDomains);
+
+        return $processor->getEnv('service-registry-url', 'SERVICE_REGISTRY_URL', static fn () => $url);
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?

The service registry determines which services a shop installs and where their code is downloaded from. `SERVICE_REGISTRY_URL` could be overridden freely in every environment, so a mistyped value breaks service installation on a live shop, and anything able to write the environment of a live shop could point it at a different registry and have arbitrary apps installed from there. Many of our customers accidentally change this value and then have problems installing services. Let's make it harder to mess up, at least in prod.

The first version of this PR only read the variable outside of production. That measures the wrong thing: `APP_ENV` says which Symfony environment is booted, not whether a deployment may use a non-production registry. SaaS staging shops run with `APP_ENV=prod` and have to use the staging registry, so they would have been locked out.

### 2. What does this change do, exactly?

`SERVICE_REGISTRY_URL` is read in every environment, but in production it is only used when its host is a domain Shopware operates registries on. Any other value is ignored and the built-in registry URL is used instead.

* `ServiceExtension::prepend()` exposes two parameters: `shopware.service_registry.url`, which is `%env(service-registry-url:SERVICE_REGISTRY_URL)%`, and `shopware.service_registry.trusted_domains`, which is `['shopware.io']` with `APP_ENV=prod` and `[]` in every other environment. An empty list accepts every URL, so development and tests can keep using a local or mocked registry.
* `RegistryUrlProcessor` is the env var processor behind the `service-registry-url:` prefix. It returns the configured URL when its host is one of the trusted domains or a subdomain of one, and `ServiceExtension::DEFAULT_REGISTRY_URL` otherwise.
* The registry HTTP client's `base_uri`, `ServiceRegistry\Client` and the administration all consume `shopware.service_registry.url`.

The check runs as an env var processor instead of during container compilation, so the URL stays resolved at runtime: a container compiled without `SERVICE_REGISTRY_URL` still picks the variable up when it is injected into the environment afterwards, which is what deployments that build the container ahead of time rely on.

### 3. Describe each step to reproduce the issue or behaviour.

1. `APP_ENV=prod bin/console debug:container --parameter=shopware.service_registry.url` prints `%env(service-registry-url:SERVICE_REGISTRY_URL)%`, and in the compiled container `ServiceRegistry\Client`, `ScopingHttpClient::forBaseUri()` and `AdministrationController` all receive `$container->getEnv('service-registry-url:SERVICE_REGISTRY_URL')`.
2. Resolving that env against the same compiled prod container, without recompiling in between:
   * `SERVICE_REGISTRY_URL=https://registry.staging-services.shopware.io` resolves to `https://registry.staging-services.shopware.io`
   * `SERVICE_REGISTRY_URL=https://evil.example.com` resolves to `https://registry.services.shopware.io`
   * `SERVICE_REGISTRY_URL=http://localhost:8123` resolves to `https://registry.services.shopware.io`
3. With `APP_ENV=dev`, `shopware.service_registry.trusted_domains` is `[]` and every one of those values resolves unchanged.

### 4. Please link to the relevant issues (if any).

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
