### PR TITLE
fix(admin): fix shipping costs saving issue when is being focused

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-order/view/sw-order-detail-details/sw-order-detail-details.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/view/sw-order-detail-details/sw-order-detail-details.html.twig
@@ -98,6 +98,7 @@
             :step="1"
             :min="0"
             :label="$t('sw-order.detailDeliveries.labelShippingCosts')"
+            @input-change="onShippingChargeEdited"
         >
             <template #suffix>
                 {{ order.currency.symbol }}

--- a/src/Administration/Resources/app/administration/src/module/sw-order/view/sw-order-detail-details/sw-order-detail-details.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/view/sw-order-detail-details/sw-order-detail-details.spec.js
@@ -232,6 +232,22 @@ describe('src/module/sw-order/view/sw-order-detail-details', () => {
         expect(wrapper.emitted('save-and-recalculate')).toBeTruthy();
     });
 
+    it('should recalculate shipping cost while the field is not out of focus yet', async () => {
+        jest.useFakeTimers();
+        global.activeAclRoles = ['order.editor'];
+        wrapper = await createWrapper();
+        const shippingCostInput = wrapper.find('.sw-order-detail-details__shipping-cost input');
+
+        shippingCostInput.element.value = '20';
+        await shippingCostInput.trigger('input');
+
+        jest.advanceTimersByTime(1000);
+
+        expect(wrapper.vm.delivery.shippingCosts.unitPrice).toBe(20);
+        expect(wrapper.vm.delivery.shippingCosts.totalPrice).toBe(20);
+        expect(wrapper.emitted('save-and-recalculate')).toBeTruthy();
+    });
+
     it('should be able to edit internal comment', async () => {
         global.activeAclRoles = ['order.editor'];
         wrapper = await createWrapper();


### PR DESCRIPTION
### 1. Why is this change necessary?
Change the Shipping costs value and still keep it focused.
The error shows up "An error occurred while calculating the price:"

### 2. What does this change do, exactly?
Fix the shipping costs not recalculated while still be in focus causing the error on saving

### 3. Describe each step to reproduce the issue or behaviour.
### To reproduce
1. On Admin, Open Order detail page 
2. Input a valid value into Shipping costs field manually
3. Keep the focus inside the field and Click Save button

### 4. Please link to the relevant issues (if any).
fixes https://github.com/shopware/shopware/issues/18696
### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
