### PR TITLE
ci: warn when release info entries land in a frozen section

### DIFF
--- a/.danger.php
+++ b/.danger.php
@@ -18,6 +18,7 @@ use Shopware\Core\DevOps\StaticAnalyze\Danger\Rules\MissingUnitTests;
 use Shopware\Core\DevOps\StaticAnalyze\Danger\Rules\PhpstanBaselineGrowth;
 use Shopware\Core\DevOps\StaticAnalyze\Danger\Rules\RedisGroupUsage;
 use Shopware\Core\DevOps\StaticAnalyze\Danger\Rules\ReflectionOnPrivateMethodsInTests;
+use Shopware\Core\DevOps\StaticAnalyze\Danger\Rules\ReleaseInfoSectionPlacement;
 use Shopware\Core\DevOps\StaticAnalyze\Danger\Rules\RemovedTwigBlocks;
 use Shopware\Core\DevOps\StaticAnalyze\Danger\Rules\RouteSnapshotExtension;
 use Shopware\Core\DevOps\StaticAnalyze\Danger\Rules\ShopwareYamlConfigSchemaHint;
@@ -36,6 +37,7 @@ return (new Config())
     ->useRule(new InlineRuleInDangerConfig())
     ->useRule(new DeprecatedChangelogFormat())
     ->useRule(new MissingReleaseInfo())
+    ->useRule(new ReleaseInfoSectionPlacement())
     ->useRule(new IgnoredPhpstanErrorsInTouchedFiles())
     ->useRule(new PhpstanBaselineGrowth())
     ->useRule(new EntityRepositoryInFrontendLayer())

--- a/src/Core/DevOps/StaticAnalyze/Danger/Rules/ReleaseInfoSectionPlacement.php
+++ b/src/Core/DevOps/StaticAnalyze/Danger/Rules/ReleaseInfoSectionPlacement.php
@@ -1,0 +1,232 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\DevOps\StaticAnalyze\Danger\Rules;
+
+use Danger\Context;
+use Danger\Struct\File;
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * A release info file collects new entries in exactly one section: the topmost version, marked
+ * `(upcoming)`. Every section below it has already been branched off or released and is frozen.
+ *
+ * An entry added to a frozen section never reaches the release notes of that version, because those
+ * are generated from the release branch. It only shows up later as drift between trunk and the
+ * release branch, which is confusing for everyone reading trunk in the meantime.
+ *
+ * This happens on merge, not on purpose: a pull request opened before the branch-off writes into the
+ * section that was still upcoming back then, and the merge keeps it there.
+ *
+ * @internal
+ */
+#[Package('framework')]
+class ReleaseInfoSectionPlacement
+{
+    public function __construct(private readonly string $releaseInfoFilePattern = 'RELEASE_INFO-*.md')
+    {
+    }
+
+    public function __invoke(Context $context): void
+    {
+        $pullRequest = $context->platform->pullRequest;
+
+        $releaseInfoFiles = $pullRequest->getFiles()
+            ->matches($this->releaseInfoFilePattern)
+            ->filter(static fn (File $file): bool => $file->status !== File::STATUS_REMOVED);
+
+        foreach ($releaseInfoFiles as $file) {
+            $this->checkFile($context, $file, $pullRequest->labels);
+        }
+    }
+
+    /**
+     * @param array<string> $labels
+     */
+    private function checkFile(Context $context, File $file, array $labels): void
+    {
+        // Only a new "### " heading starts a new entry. Keying on those keeps edits to existing
+        // entries — typo and wording fixes in released sections — out of the check.
+        $addedEntries = $this->addedEntries($file->patch);
+        if ($addedEntries === []) {
+            return;
+        }
+
+        $sections = $this->versionSections($file->getContent());
+        if ($sections === []) {
+            return;
+        }
+
+        $openSections = array_values(array_filter($sections, static fn (array $section): bool => $section['upcoming']));
+
+        // The section that accepts new entries: the one marked "(upcoming)", or — once that marker has
+        // been dropped for the release — the topmost one, since the file is ordered newest first.
+        $openSection = $openSections[0] ?? $sections[0];
+
+        $this->reportMisplacedEntries($context, $file, $sections, $addedEntries, $openSection['version']);
+
+        // A single unambiguous open section can be cross-checked against the milestone label, which
+        // branch-off keeps up to date. A mismatch means the section for that milestone is missing.
+        if (\count($openSections) <= 1) {
+            $this->reportMissingSection($context, $file, $openSection['version'], $labels);
+        }
+    }
+
+    /**
+     * @param list<array{version: string, line: int, upcoming: bool}> $sections
+     * @param array<int, string> $addedEntries
+     */
+    private function reportMisplacedEntries(Context $context, File $file, array $sections, array $addedEntries, string $openVersion): void
+    {
+        $misplaced = [];
+        foreach ($addedEntries as $line => $heading) {
+            $version = $this->versionOfLine($sections, $line);
+
+            if ($version !== null && $version !== $openVersion) {
+                // Entry headings contain code spans themselves, so they are quoted instead of wrapped in backticks.
+                $misplaced[] = \sprintf('* "%s" — added under `# %s`', $heading, $version);
+            }
+        }
+
+        if ($misplaced === []) {
+            return;
+        }
+
+        $context->warning(
+            \sprintf('These entries were added to a frozen section of `%s`:<br/><br/>', $file->name)
+            . implode('<br/>', $misplaced)
+            . \sprintf('<br/><br/>`# %s` is the only section that still accepts new entries.', $openVersion)
+            . ' Every section below it has already been branched off or released, so an entry added there'
+            . ' will not appear in the release notes of that version and shows up as drift between'
+            . ' `trunk` and the release branch instead.'
+            . \sprintf('<br/><br/>Please move them under `# %s`, into the matching category heading.', $openVersion)
+            . ' If this entry documents a change that really did ship in the older version, resolve this warning.'
+        );
+    }
+
+    /**
+     * @param array<string> $labels
+     */
+    private function reportMissingSection(Context $context, File $file, string $openVersion, array $labels): void
+    {
+        $milestone = $this->milestoneVersion($labels);
+        if ($milestone === null || $milestone === $openVersion) {
+            return;
+        }
+
+        // Only compare within the same minor: during a major transition both release info files
+        // exist side by side and the milestone label describes just one of them.
+        if ($this->minorOf($milestone) !== $this->minorOf($openVersion)) {
+            return;
+        }
+
+        $context->warning(
+            \sprintf('The `milestone/%s` label ships this pull request with **%s**,', $milestone, $milestone)
+            . \sprintf(' but the newest section in `%s` is `# %s`.', $file->name, $openVersion)
+            . \sprintf('<br/><br/>Please add a `# %s (upcoming)` section at the top of the file and put your', $milestone)
+            . ' entries there, or correct the milestone label if this pull request does ship with'
+            . \sprintf(' %s.', $openVersion)
+        );
+    }
+
+    /**
+     * Collects the entry headings added by this pull request, keyed by their line number in the
+     * resulting file.
+     *
+     * @return array<int, string>
+     */
+    private function addedEntries(string $patch): array
+    {
+        $entries = [];
+        $line = 0;
+
+        foreach (explode("\n", $patch) as $patchLine) {
+            // "@@ -203,6 +203,8 @@" — the second number is where this hunk starts in the new file.
+            if (preg_match('/^@@ -\d+(?:,\d+)? \+(\d+)/', $patchLine, $hunk) === 1) {
+                $line = (int) $hunk[1];
+                continue;
+            }
+
+            if ($line === 0) {
+                continue; // diff header, before the first hunk
+            }
+
+            // Removed lines and the "\ No newline at end of file" marker do not exist in the new file.
+            if (str_starts_with($patchLine, '-') || str_starts_with($patchLine, '\\')) {
+                continue;
+            }
+
+            if (preg_match('/^\+###[[:space:]]+(.+?)[[:space:]]*$/', $patchLine, $heading) === 1) {
+                $entries[$line] = $heading[1];
+            }
+
+            ++$line; // both added and context lines advance the new file
+        }
+
+        return $entries;
+    }
+
+    /**
+     * Collects the version sections of the file, in the order they appear.
+     *
+     * @return list<array{version: string, line: int, upcoming: bool}>
+     */
+    private function versionSections(string $content): array
+    {
+        $sections = [];
+        $line = 0;
+
+        foreach (explode("\n", $content) as $contentLine) {
+            ++$line;
+
+            // "# 6.7.14.0 (upcoming)". Category headings use "##" and YAML comments inside fenced
+            // code blocks never look like a version, so neither is picked up here.
+            if (preg_match('/^#[[:space:]]+(\d+\.\d+\.\d+\.\d+)[[:space:]]*(?:\((?<note>[^)]*)\))?[[:space:]]*$/', $contentLine, $matches) !== 1) {
+                continue;
+            }
+
+            $sections[] = [
+                'version' => $matches[1],
+                'line' => $line,
+                'upcoming' => stripos($matches['note'] ?? '', 'upcoming') !== false,
+            ];
+        }
+
+        return $sections;
+    }
+
+    /**
+     * @param list<array{version: string, line: int, upcoming: bool}> $sections
+     */
+    private function versionOfLine(array $sections, int $line): ?string
+    {
+        $version = null;
+        foreach ($sections as $section) {
+            if ($section['line'] > $line) {
+                break;
+            }
+
+            $version = $section['version'];
+        }
+
+        return $version;
+    }
+
+    /**
+     * @param array<string> $labels
+     */
+    private function milestoneVersion(array $labels): ?string
+    {
+        foreach ($labels as $label) {
+            if (preg_match('#^milestone/(\d+\.\d+\.\d+\.\d+)$#', $label, $matches) === 1) {
+                return $matches[1];
+            }
+        }
+
+        return null;
+    }
+
+    private function minorOf(string $version): string
+    {
+        return implode('.', \array_slice(explode('.', $version), 0, 2));
+    }
+}

--- a/src/Core/DevOps/StaticAnalyze/Danger/Rules/ReleaseInfoSectionPlacement.php
+++ b/src/Core/DevOps/StaticAnalyze/Danger/Rules/ReleaseInfoSectionPlacement.php
@@ -64,10 +64,9 @@ class ReleaseInfoSectionPlacement
 
         $this->reportMisplacedEntries($context, $file, $sections, $addedEntries, $openSection['version']);
 
-        // A single unambiguous open section can be cross-checked against the milestone label, which
-        // branch-off keeps up to date. A mismatch means the section for that milestone is missing.
+        // A single unambiguous open section can be cross-checked against the milestone label.
         if (\count($openSections) <= 1) {
-            $this->reportMissingSection($context, $file, $openSection['version'], $labels);
+            $this->reportMilestoneMismatch($context, $file, $openSection['version'], $labels);
         }
     }
 
@@ -104,9 +103,12 @@ class ReleaseInfoSectionPlacement
     }
 
     /**
+     * The milestone label and the open section should name the same version. They drift apart in two
+     * directions, and the direction decides which of the two is wrong.
+     *
      * @param array<string> $labels
      */
-    private function reportMissingSection(Context $context, File $file, string $openVersion, array $labels): void
+    private function reportMilestoneMismatch(Context $context, File $file, string $openVersion, array $labels): void
     {
         $milestone = $this->milestoneVersion($labels);
         if ($milestone === null || $milestone === $openVersion) {
@@ -119,6 +121,23 @@ class ReleaseInfoSectionPlacement
             return;
         }
 
+        // The label names an older version, whose section is already branched off or released. The
+        // label is stale — it is not updated on every open pull request when a branch-off happens.
+        if (version_compare($milestone, $openVersion, '<')) {
+            $context->warning(
+                \sprintf('The `milestone/%s` label puts this pull request into **%s**,', $milestone, $milestone)
+                . \sprintf(' but `# %s` has already been branched off in `%s`', $milestone, $file->name)
+                . \sprintf(' and `# %s` is the section that accepts new entries.', $openVersion)
+                . '<br/><br/>The label is most likely left over from before the branch-off. Please check which'
+                . \sprintf(' version this pull request ships with, and keep your entries under `# %s`', $openVersion)
+                . ' as long as that is the open section.'
+            );
+
+            return;
+        }
+
+        // The label names a newer version than any section in the file, so the section for it is
+        // missing — either the branch-off did not add it yet, or a patch release needs a new one.
         $context->warning(
             \sprintf('The `milestone/%s` label ships this pull request with **%s**,', $milestone, $milestone)
             . \sprintf(' but the newest section in `%s` is `# %s`.', $file->name, $openVersion)

--- a/tests/unit/Core/DevOps/StaticAnalyze/Danger/Rules/ReleaseInfoSectionPlacementTest.php
+++ b/tests/unit/Core/DevOps/StaticAnalyze/Danger/Rules/ReleaseInfoSectionPlacementTest.php
@@ -327,6 +327,34 @@ class ReleaseInfoSectionPlacementTest extends TestCase
         static::assertStringContainsString('add a `# 6.7.14.0 (upcoming)` section', $warning);
     }
 
+    #[TestDox('Points at the stale label when the milestone names a version that is already branched off')]
+    public function testWarnsAboutStaleMilestoneLabel(): void
+    {
+        // A pull request opened before the branch-off keeps its old milestone label: both MCP pull
+        // requests that caused this still carried `milestone/6.7.13.0` when they shipped with 6.7.14.0.
+        $patch = <<<'DIFF'
+            @@ -3,3 +3,5 @@
+             ## Features
+
+            +### Entry in the upcoming section
+            +
+             Description.
+            DIFF;
+
+        $context = $this->createContext([$this->releaseInfoFile($patch)], ['milestone/6.7.13.0']);
+
+        (new ReleaseInfoSectionPlacement())($context);
+
+        static::assertCount(1, $context->getWarnings());
+
+        $warning = $context->getWarnings()[0];
+        static::assertStringContainsString('`milestone/6.7.13.0` label puts this pull request into **6.7.13.0**', $warning);
+        static::assertStringContainsString('`# 6.7.13.0` has already been branched off', $warning);
+        static::assertStringContainsString('The label is most likely left over from before the branch-off', $warning);
+        // Recreating the frozen section is never the fix for a stale label.
+        static::assertStringNotContainsString('(upcoming)` section at the top', $warning);
+    }
+
     #[TestDox('Stays silent when the milestone label matches the upcoming section')]
     public function testSilentWhenMilestoneMatchesUpcomingSection(): void
     {

--- a/tests/unit/Core/DevOps/StaticAnalyze/Danger/Rules/ReleaseInfoSectionPlacementTest.php
+++ b/tests/unit/Core/DevOps/StaticAnalyze/Danger/Rules/ReleaseInfoSectionPlacementTest.php
@@ -1,0 +1,431 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\DevOps\StaticAnalyze\Danger\Rules;
+
+use Danger\Context;
+use Danger\Struct\File;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\TestDox;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\DevOps\StaticAnalyze\Danger\Rules\ReleaseInfoSectionPlacement;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Tests\Unit\Core\DevOps\StaticAnalyze\Danger\Stub\StubFile;
+use Shopware\Tests\Unit\Core\DevOps\StaticAnalyze\Danger\Stub\StubPlatform;
+use Shopware\Tests\Unit\Core\DevOps\StaticAnalyze\Danger\Stub\StubPullRequest;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+#[CoversClass(ReleaseInfoSectionPlacement::class)]
+class ReleaseInfoSectionPlacementTest extends TestCase
+{
+    private const RELEASE_INFO = 'RELEASE_INFO-6.7.md';
+
+    /**
+     * Three version sections, newest first: the upcoming one starts on line 1, the branched-off
+     * 6.7.13.0 on line 9 and the released 6.7.12.0 on line 17.
+     */
+    private const CONTENT = <<<'MD'
+        # 6.7.14.0 (upcoming)
+
+        ## Features
+
+        ### Entry in the upcoming section
+
+        Description.
+
+        # 6.7.13.0
+
+        ## Core
+
+        ### Entry in the branched off section
+
+        Description.
+
+        # 6.7.12.0
+
+        ### Entry in the released section
+
+        Description.
+        MD;
+
+    #[TestDox('Stays silent when the pull request does not touch a release info file')]
+    public function testSilentWithoutReleaseInfoFile(): void
+    {
+        $context = $this->createContext([new StubFile('src/Core/Framework/Framework.php')]);
+
+        (new ReleaseInfoSectionPlacement())($context);
+
+        static::assertFalse($context->hasReports());
+    }
+
+    #[TestDox('Stays silent when the entry is added to the upcoming section')]
+    public function testSilentForEntryInUpcomingSection(): void
+    {
+        // Adds "### Entry in the upcoming section" on line 5, inside "# 6.7.14.0 (upcoming)".
+        $patch = <<<'DIFF'
+            @@ -3,3 +3,5 @@
+             ## Features
+
+            +### Entry in the upcoming section
+            +
+             Description.
+            DIFF;
+
+        $context = $this->createContext([$this->releaseInfoFile($patch)]);
+
+        (new ReleaseInfoSectionPlacement())($context);
+
+        static::assertFalse($context->hasReports());
+    }
+
+    #[TestDox('Warns when the entry is added to a section that has already been branched off')]
+    public function testWarnsForEntryInBranchedOffSection(): void
+    {
+        // Adds "### Entry in the branched off section" on line 13, inside "# 6.7.13.0".
+        $patch = <<<'DIFF'
+            @@ -11,3 +11,5 @@
+             ## Core
+
+            +### Entry in the branched off section
+            +
+             Description.
+            DIFF;
+
+        $context = $this->createContext([$this->releaseInfoFile($patch)]);
+
+        (new ReleaseInfoSectionPlacement())($context);
+
+        static::assertCount(1, $context->getWarnings());
+
+        $warning = $context->getWarnings()[0];
+        static::assertStringContainsString('frozen section of `RELEASE_INFO-6.7.md`', $warning);
+        static::assertStringContainsString('* "Entry in the branched off section" — added under `# 6.7.13.0`', $warning);
+        static::assertStringContainsString('`# 6.7.14.0` is the only section that still accepts new entries', $warning);
+    }
+
+    #[TestDox('Reports every misplaced entry of a pull request in a single warning')]
+    public function testWarnsOnceForSeveralMisplacedEntries(): void
+    {
+        // Adds an entry on line 13, inside "# 6.7.13.0", and another on line 19, inside "# 6.7.12.0".
+        $patch = <<<'DIFF'
+            @@ -11,3 +11,5 @@
+             ## Core
+
+            +### Entry in the branched off section
+            +
+             Description.
+            @@ -17,3 +19,5 @@
+             # 6.7.12.0
+
+            +### Entry in the released section
+            +
+             Description.
+            DIFF;
+
+        $context = $this->createContext([$this->releaseInfoFile($patch)]);
+
+        (new ReleaseInfoSectionPlacement())($context);
+
+        static::assertCount(1, $context->getWarnings());
+
+        $warning = $context->getWarnings()[0];
+        static::assertStringContainsString('* "Entry in the branched off section" — added under `# 6.7.13.0`', $warning);
+        static::assertStringContainsString('* "Entry in the released section" — added under `# 6.7.12.0`', $warning);
+    }
+
+    #[TestDox('Stays silent when a released entry is only reworded, because no entry heading is added')]
+    public function testSilentForRewordedEntry(): void
+    {
+        $patch = <<<'DIFF'
+            @@ -19,3 +19,3 @@
+             ### Entry in the released section
+
+            -Descriptoin.
+            +Description.
+            DIFF;
+
+        $context = $this->createContext([$this->releaseInfoFile($patch)]);
+
+        (new ReleaseInfoSectionPlacement())($context);
+
+        static::assertFalse($context->hasReports());
+    }
+
+    #[TestDox('Stays silent when a misplaced entry is moved into the upcoming section')]
+    public function testSilentWhenEntryIsMovedIntoUpcomingSection(): void
+    {
+        $content = <<<'MD'
+            # 6.7.14.0 (upcoming)
+
+            ## Core
+
+            ### Moved entry
+
+            Description.
+
+            # 6.7.13.0
+            MD;
+
+        // Removes the entry from "# 6.7.13.0" and re-adds it on line 5, inside the upcoming section.
+        $patch = <<<'DIFF'
+            @@ -3,2 +3,6 @@
+             ## Core
+
+            +### Moved entry
+            +
+            +Description.
+            +
+            @@ -5,5 +9,1 @@
+             # 6.7.13.0
+            -
+            -### Moved entry
+            -
+            -Description.
+            DIFF;
+
+        $context = $this->createContext([$this->releaseInfoFile($patch, $content)]);
+
+        (new ReleaseInfoSectionPlacement())($context);
+
+        static::assertFalse($context->hasReports());
+    }
+
+    #[TestDox('Treats the topmost section as open once the upcoming marker has been dropped for the release')]
+    public function testTopmostSectionIsOpenWithoutUpcomingMarker(): void
+    {
+        $content = <<<'MD'
+            # 6.7.13.1
+
+            ## Core
+
+            ### Entry for the patch release
+
+            Description.
+
+            # 6.7.13.0
+
+            ### Entry in the released section
+
+            Description.
+            MD;
+
+        $patch = <<<'DIFF'
+            @@ -3,3 +3,5 @@
+             ## Core
+
+            +### Entry for the patch release
+            +
+             Description.
+            DIFF;
+
+        $context = $this->createContext([$this->releaseInfoFile($patch, $content)]);
+
+        (new ReleaseInfoSectionPlacement())($context);
+
+        static::assertFalse($context->hasReports());
+    }
+
+    #[TestDox('Ignores headings deeper than an entry heading')]
+    public function testIgnoresDeeperHeadings(): void
+    {
+        $patch = <<<'DIFF'
+            @@ -11,3 +11,5 @@
+             ## Core
+
+            +#### Detail of the branched off entry
+            +
+             Description.
+            DIFF;
+
+        $context = $this->createContext([$this->releaseInfoFile($patch)]);
+
+        (new ReleaseInfoSectionPlacement())($context);
+
+        static::assertFalse($context->hasReports());
+    }
+
+    #[TestDox('Stays silent when the pull request only removes an entry')]
+    public function testSilentForRemovedEntry(): void
+    {
+        $patch = <<<'DIFF'
+            @@ -13,3 +12,1 @@
+            -### Entry in the branched off section
+            -
+             Description.
+            DIFF;
+
+        $context = $this->createContext([$this->releaseInfoFile($patch)]);
+
+        (new ReleaseInfoSectionPlacement())($context);
+
+        static::assertFalse($context->hasReports());
+    }
+
+    #[TestDox('Stays silent when the patch is unavailable')]
+    public function testSilentWithoutPatch(): void
+    {
+        $context = $this->createContext([$this->releaseInfoFile('')]);
+
+        (new ReleaseInfoSectionPlacement())($context);
+
+        static::assertFalse($context->hasReports());
+    }
+
+    #[TestDox('Ignores a deleted release info file')]
+    public function testIgnoresRemovedReleaseInfoFile(): void
+    {
+        $patch = <<<'DIFF'
+            @@ -11,3 +11,5 @@
+             ## Core
+
+            +### Entry in the branched off section
+            +
+             Description.
+            DIFF;
+
+        $file = new StubFile(self::RELEASE_INFO, File::STATUS_REMOVED, self::CONTENT, $patch);
+        $context = $this->createContext([$file]);
+
+        (new ReleaseInfoSectionPlacement())($context);
+
+        static::assertFalse($context->hasReports());
+    }
+
+    #[TestDox('Warns when the milestone label names a version that has no section yet')]
+    public function testWarnsForMissingSectionOfTheMilestone(): void
+    {
+        $content = <<<'MD'
+            # 6.7.13.0 (upcoming)
+
+            ## Features
+
+            ### Entry in the upcoming section
+
+            Description.
+            MD;
+
+        $patch = <<<'DIFF'
+            @@ -3,3 +3,5 @@
+             ## Features
+
+            +### Entry in the upcoming section
+            +
+             Description.
+            DIFF;
+
+        $context = $this->createContext([$this->releaseInfoFile($patch, $content)], ['milestone/6.7.14.0']);
+
+        (new ReleaseInfoSectionPlacement())($context);
+
+        static::assertCount(1, $context->getWarnings());
+
+        $warning = $context->getWarnings()[0];
+        static::assertStringContainsString('`milestone/6.7.14.0` label ships this pull request with **6.7.14.0**', $warning);
+        static::assertStringContainsString('newest section in `RELEASE_INFO-6.7.md` is `# 6.7.13.0`', $warning);
+        static::assertStringContainsString('add a `# 6.7.14.0 (upcoming)` section', $warning);
+    }
+
+    #[TestDox('Stays silent when the milestone label matches the upcoming section')]
+    public function testSilentWhenMilestoneMatchesUpcomingSection(): void
+    {
+        $patch = <<<'DIFF'
+            @@ -3,3 +3,5 @@
+             ## Features
+
+            +### Entry in the upcoming section
+            +
+             Description.
+            DIFF;
+
+        $context = $this->createContext([$this->releaseInfoFile($patch)], ['milestone/6.7.14.0']);
+
+        (new ReleaseInfoSectionPlacement())($context);
+
+        static::assertFalse($context->hasReports());
+    }
+
+    #[TestDox('Ignores a milestone label of another minor, because its release info file is a different one')]
+    public function testIgnoresMilestoneOfAnotherMinor(): void
+    {
+        $patch = <<<'DIFF'
+            @@ -3,3 +3,5 @@
+             ## Features
+
+            +### Entry in the upcoming section
+            +
+             Description.
+            DIFF;
+
+        $context = $this->createContext([$this->releaseInfoFile($patch)], ['milestone/6.8.0.0']);
+
+        (new ReleaseInfoSectionPlacement())($context);
+
+        static::assertFalse($context->hasReports());
+    }
+
+    #[TestDox('Skips the milestone cross-check while several sections are marked as upcoming')]
+    public function testSkipsMilestoneCheckForSeveralUpcomingSections(): void
+    {
+        $content = <<<'MD'
+            # 6.7.14.0 (upcoming)
+
+            ## Features
+
+            ### Entry in the upcoming section
+
+            Description.
+
+            # 6.7.13.0 (upcoming)
+            MD;
+
+        $patch = <<<'DIFF'
+            @@ -3,3 +3,5 @@
+             ## Features
+
+            +### Entry in the upcoming section
+            +
+             Description.
+            DIFF;
+
+        $context = $this->createContext([$this->releaseInfoFile($patch, $content)], ['milestone/6.7.15.0']);
+
+        (new ReleaseInfoSectionPlacement())($context);
+
+        static::assertFalse($context->hasReports());
+    }
+
+    #[TestDox('The checked release info file pattern is configurable')]
+    public function testConfigurableReleaseInfoFilePattern(): void
+    {
+        $patch = <<<'DIFF'
+            @@ -11,3 +11,5 @@
+             ## Core
+
+            +### Entry in the branched off section
+            +
+             Description.
+            DIFF;
+
+        $context = $this->createContext([$this->releaseInfoFile($patch)]);
+
+        (new ReleaseInfoSectionPlacement('RELEASE_INFO-6.8.md'))($context);
+
+        static::assertFalse($context->hasReports());
+    }
+
+    private function releaseInfoFile(string $patch, ?string $content = null): StubFile
+    {
+        return new StubFile(self::RELEASE_INFO, File::STATUS_MODIFIED, $content ?? self::CONTENT, $patch);
+    }
+
+    /**
+     * @param list<File> $files
+     * @param list<string> $labels
+     */
+    private function createContext(array $files, array $labels = []): Context
+    {
+        return new Context(new StubPlatform(new StubPullRequest($files, [], $labels)));
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?

A pull request that is opened before a branch-off writes its `RELEASE_INFO` entry into the section that was upcoming at the time. After the branch-off that section is frozen, but merging keeps the entry there. The entry then never reaches the release notes of that version, because those are generated from the release branch, and it only surfaces later as drift between trunk and the branch.

This just happened for 6.7.13.0: nine entries sit in the wrong section on trunk (see #18842 for the correction). Trunk advertised features for a release that does not contain them, and it was noticed from a community-facing release summary rather than from CI.

`.github/bin/verify-release-content.php` already detects this, and it has been red on `6.7.13.x` since 28.07 ([run 30378203575](https://github.com/shopware/shopware/actions/runs/30378203575)). The problem is not detection, it is timing and attribution: the check runs on pushes to a release branch, so the failure appears long after the fact and lands on whoever's backport merged last. In that run the triggering push is an unrelated `entity seo url` backport.

Today nothing flags this on the pull request that causes it, so catching it depends on a reviewer noticing which section a diff hunk belongs to. That is exactly the kind of thing a reviewer should not have to do by hand.

### 2. What does this change do, exactly?

Adds the Danger rule `ReleaseInfoSectionPlacement`, which reports the problem on the pull request that causes it.

The invariant it relies on: a release info file collects new entries in exactly one section — the topmost version, marked `(upcoming)`. Every section below it has been branched off or released and is frozen.

For each touched `RELEASE_INFO-*.md` the rule:

1. Parses the pull request patch for added `### ` entry headings and their line numbers in the resulting file.
2. Parses the file content for `# X.Y.Z.W` version sections, tracking fenced code blocks so YAML comments inside snippets are not mistaken for headings.
3. Resolves every added heading to its enclosing version section and warns for the ones outside the open section, naming both the entry and the section it landed in.
4. Cross-checks the open section against the `milestone/*` label, in both directions:
   * Label **newer** than every section in the file: the section for it is missing. Covers the window after a branch-off where the new `(upcoming)` section has not been created yet, and a patch release that needs a fresh section.
   * Label **older** than the open section: that section is already branched off, so the label is the stale part. This is not hypothetical — #17997 and #17998 shipped with 6.7.14.0 and still carry `milestone/6.7.13.0`, so branch-off does not relabel every open pull request. Suggesting an `(upcoming)` section for an older version would recreate a frozen section, so this direction points at the label instead.

Two deliberate choices keep the false-positive rate down:

* **It keys on added entry headings, not on added lines.** Rewording, reformatting or fixing a typo in a released section produces no warning. Verified against #18820, which normalized heading spacing across every section of the file: silent.
* **When no section carries the `(upcoming)` marker**, the topmost section is treated as the open one. That marker is removed at release time, so on a release branch after its release the rule keeps working instead of warning on every backport.

It is a `warning()`, consistent with `MissingReleaseInfo`, so it posts a resolvable thread and does not fail CI. Some entries legitimately belong to an older section, for example when documenting something that really did ship there.

The rule does not replace `verify-release-content.php`. That check still catches what a single pull request cannot show: a cherry-pick that took the RELEASE_INFO text but not the feature code, and docs-only commits where the code landed separately.

**What this deliberately does not catch**

The rule is local to the pull request. It never queries tags, the release branch, or branched-off content — it derives "which section is open" from the `(upcoming)` marker in the file at the pull request head, plus the `milestone/*` label. Two consequences worth knowing before relying on it:

* **A pull request can go stale between its last push and its merge.** Danger runs on `opened`, `synchronize` and `reopened`, so it re-runs when the branch is pushed to, but not when trunk moves underneath it and not when a label changes. A pull request opened before a branch-off, never pushed to afterwards, and merged straight through presents a head whose RELEASE_INFO still shows the old section as `(upcoming)` — and the rule approves it. This is the original failure mode, so it is worth being explicit that the rule narrows the window rather than closing it. In practice the merge queue keeps branches current: all five pull requests that caused the 6.7.13.0 drift already had `# 6.7.14.0 (upcoming)` at their head, which is why the replay in section 3 uses a head SHA.
* **If both signals are stale at once, the rule is blind.** The marker is maintained by hand and the label is not reliably updated at branch-off (see #17997 and #17998). Either one alone is enough to catch the mistake, but nothing detects a branch-off where neither happened.

`verify-release-content.php` is the backstop for both cases, because it compares trunk against the release branch after the fact rather than reasoning about a single diff. That is the argument for giving its failures a visible route rather than leaving them as a red check on an unrelated backport merge — see the follow-ups at the end.

### 3. Describe each step to reproduce the issue or behaviour.

Unit tests:

```
vendor/bin/phpunit --testsuite=unit --filter ReleaseInfoSectionPlacementTest
```

16 tests cover placement in the open and in frozen sections, several misplaced entries in one pull request, reworded and removed entries, an entry moved into the open section, a missing `(upcoming)` marker, `####` sub-headings, an absent patch, a deleted file, and the four milestone-label branches.

To see it against real history, the rule was replayed over the commits that caused and did not cause the problem. The last row uses the pull request head SHA and its real label rather than the merge commit, to confirm the rule fires on what Danger actually sees during review:

| Commit | Expected | Result |
| --- | --- | --- |
| `df1f3dee`, `07fdab10`, `ae923b75`, `e973c74d`, `fdf28aac` — the misplaced entries | warn | flagged, pointing at `# 6.7.14.0` |
| `86dfd04c876` — adds the `6.7.14.0 (upcoming)` section | silent | silent |
| `28bb1f427cf` — correctly placed entry | silent | silent |
| #18820 — heading spacing normalized across all sections | silent | silent |
| `858023956ce` — pre-branch-off, label `milestone/6.7.14.0` | warn about the missing section | flagged |
| #17997 at its head `9cbcd60b40` with its real label `milestone/6.7.13.0` | warn about the entry **and** the stale label | both flagged |
| the correction in #18842 — moves entries into the open section | silent | silent |

Example output for `fdf28aac`:

> These entries were added to a frozen section of `RELEASE_INFO-6.7.md`:
>
> * "Product export pagination changed to keyset; `getTotal()` deprecated" — added under `# 6.7.13.0`
> * "`SalesChannelRepositoryIterator` supports autoIncrement keyset pagination" — added under `# 6.7.13.0`
>
> `# 6.7.14.0` is the only section that still accepts new entries. Every section below it has already been branched off or released, so an entry added there will not appear in the release notes of that version and shows up as drift between `trunk` and the release branch instead.
>
> Please move them under `# 6.7.14.0`, into the matching category heading. If this entry documents a change that really did ship in the older version, resolve this warning.

### 4. Please link to the relevant issues (if any).

relates #18842 — the content correction this rule prevents from happening again

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Not relevant. This is internal CI tooling with no effect on extensions, APIs, configuration or upgrade steps.
- [x] I have written or adjusted the documentation and agent skills according to my changes
  - The invariant is documented in the rule's class docblock, next to the code that enforces it.
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them

### Follow-ups this does not cover

Not part of this pull request, but worth doing while the context is fresh:

1. **Route the `verify-release-content` failure somewhere visible.** It is a real check whose signal currently goes nowhere. An issue or a Slack ping beats an anonymous red X on an unrelated backport merge.
2. **Automate the two manual branch-off steps.** Adding the new `# X.Y.(Z+1).0 (upcoming)` section (#18467) and removing `(upcoming)` from the released one (#17948) are still hand-written pull requests. Until they run at branch-off next to the milestone-label update, the milestone cross-check in this rule will fire for everyone in the window between the branch-off and the section-creation pull request. Correctly, but noisily.


