### PR TITLE
docs(framework): stop pointing agents at the removed changelog format

### DIFF
--- a/.agents/skills/shopware-release-docs/SKILL.md
+++ b/.agents/skills/shopware-release-docs/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: shopware-release-docs
-description: Decide and write Shopware developer-facing release documentation (RELEASE_INFO / UPGRADE / changelog entries). Use when a change may affect extension authors, API consumers, operators, or storefront/theme developers — public APIs, deprecations, removals, configuration, or upgrade steps.
+description: Decide and write Shopware developer-facing release documentation (RELEASE_INFO / UPGRADE entries). Use when a change may affect extension authors, API consumers, operators, or storefront/theme developers — public APIs, deprecations, removals, configuration, or upgrade steps, or when you are about to write a changelog entry.
 license: MIT
 ---
 
@@ -27,6 +27,8 @@ Write into the following files, but only if the decision above applies:
   For deprecations, the old path still works; the entry tells developers what to change before it stops.
   Describe the concrete before and after, and write in past tense, as developers read this only after the next major release.
 - Public REST/Admin/Store API route additions or changes: add or update the matching OpenAPI JSON schema under `src/Core/Framework/Api/ApiDefinition/Generator/Schema/<AdminApi|StoreApi>/paths`.
+
+Never add a file under `changelog/_unreleased/`. That per-change format was replaced by the curated files above ([ADR](../../../adr/2025-10-28-changelog-release-info-process.md)), and the `DeprecatedChangelogFormat` Danger rule fails any pull request that touches it. The exhaustive changelog is generated from semantic pull request titles when a tag is created, so there is nothing to write by hand.
 
 ## What To Write
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,7 +62,7 @@ When a task matches a skill, open `.agents/skills/<name>/SKILL.md` and follow it
 
 - `shopware-knowledge-capture` — saving durable knowledge; routing it to AGENTS, coding guidelines, README, ADR, skills, or local notes.
 - `shopware-change-scope` — root-cause analysis, boyscouting, and cleanup scope.
-- `shopware-release-docs` — release notes, upgrade notes, developer-facing changelog decisions.
+- `shopware-release-docs` — RELEASE_INFO / UPGRADE entries; the old `changelog/_unreleased/` format is gone.
 - `shopware-pr-hygiene` — PR templates, conventional titles, review follow-up commits.
 - `shopware-php-code` — PHP architecture, API schema, migrations, deprecations, BC-sensitive code.
 - `shopware-admin-js` — Administration JavaScript, TypeScript, Vue, ACL, Jest.


### PR DESCRIPTION
### 1. Why is this change necessary?

Changelog entries are gone (in favor of RELEASE_INFO-6.7.md).

Agents still don't know:
- because they are trained on old dataset
- there are stale `changelog/_unreleased/` files in the repository

Only `sw-review` informs the agent about the new `RELEASE_INFO-6.7.md`.

If I want to opt out of `sw-review` and use a different review skill the agent complains about a missing changelog entry.

Example run:
```
Nothing under changelog/_unreleased and no UPGRADE-*.md touch in this PR (checked origin/native-setup/02-transform...HEAD).

AGENTS.md → "Behavioural change, feature, deprecation, or config change? → check shopware-release-docs".

[...] Continues to enumerate what should be put inside changelog entries [...]
```

### 2. What does this change do, exactly?

Adds a clear signal in `shopware-release-docs` that changelog entries are in fact legacy.

### 3. Describe each step to reproduce the issue or behaviour.
/

### 4. Please link to the relevant issues (if any).
/

### 5. Checklist

- [x] I have written tests and verified that they fail without my change <!-- N/A: documentation only -->
- [x] I have updated developer-facing release notes if this change is **relevant** for external developers <!-- N/A: internal contributor guidance, no external contract changes -->
- [x] I have written or adjusted the documentation and agent skills according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code <!-- N/A: no code -->
- [x] I have read the contribution requirements and fulfilled them
