### PR TITLE
feat: let apps register document types and extend generation

### DIFF
--- a/.bc-exclude.php
+++ b/.bc-exclude.php
@@ -67,6 +67,12 @@ return [
         // class is @final, so making a parameter nullable is not a breaking change
         preg_quote('CHANGED: The parameter $fileType of Shopware\Core\Checkout\Document\Service\DocumentGenerator#readDocument() changed from string to string|null', '/'),
 
+        // document_type_id is now nullable
+        preg_quote('CHANGED: Type of property Shopware\Core\Checkout\Document\DocumentEntity#$documentTypeId changed from string to string|null', '/'),
+        preg_quote('CHANGED: The return type of Shopware\Core\Checkout\Document\DocumentEntity#getDocumentTypeId() changed from string to the non-covariant string|null', '/'),
+        preg_quote('CHANGED: The return type of Shopware\Core\Checkout\Document\DocumentEntity#getDocumentTypeId() changed from string to string|null', '/'),
+        preg_quote('CHANGED: The parameter $documentTypeId of Shopware\Core\Checkout\Document\DocumentEntity#setDocumentTypeId() changed from string to string|null', '/'),
+
         // SystemRestoreDatabaseCommand was marked @internal
         preg_quote('CHANGED: Shopware\\Core\\DevOps\\System\\Command\\SystemRestoreDatabaseCommand was marked "@internal"', '/'),
 

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-document-card/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-document-card/index.js
@@ -548,5 +548,9 @@ export default {
 
             return fileTypesArray.join(', ').toUpperCase();
         },
+
+        documentTypeLabel(item) {
+            return item.documentType?.name ?? item.config?.documentType ?? '';
+        },
     },
 };

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-document-card/sw-order-document-card.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-document-card/sw-order-document-card.html.twig
@@ -73,7 +73,9 @@
 
             {% block sw_order_document_card_grid_column_type %}
             <template #column-documentType.name="{ item }">
+                {% block sw_order_document_card_grid_column_type %}
                 {{ documentTypeLabel(item) }}
+                {% endblock %}
             </template>
             {% endblock %}
 

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-document-card/sw-order-document-card.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-document-card/sw-order-document-card.html.twig
@@ -71,6 +71,12 @@
             </template>
             {% endblock %}
 
+            {% block sw_order_document_card_grid_column_type %}
+            <template #column-documentType.name="{ item }">
+                {{ documentTypeLabel(item) }}
+            </template>
+            {% endblock %}
+
             {% block sw_order_document_card_grid_column_avaiable_formats %}
             <template #column-fileTypes="{ item }">
                 {% block sw_order_document_card_grid_column_available_formats_label %}

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-document-card/sw-order-document-card.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-document-card/sw-order-document-card.spec.js
@@ -814,6 +814,28 @@ describe('src/module/sw-order/component/sw-order-document-card', () => {
         expect(fileTypes.text()).toBe('PDF, HTML');
     });
 
+    it('should fall back to the config document type for app registered types', async () => {
+        wrapper = await createWrapper(defaultProps, 'sw.order.detail.documents');
+
+        await wrapper.setData({
+            documents: getCollection('document', [
+                {
+                    ...documentFixture,
+                    documentType: null,
+                    config: {
+                        ...documentFixture.config,
+                        documentType: 'swag_certificate',
+                    },
+                },
+            ]),
+        });
+
+        await flushPromises();
+
+        const row = wrapper.find('.sw-data-grid__row--0');
+        expect(row.find('.sw-data-grid__cell--documentType-name').text()).toBe('swag_certificate');
+    });
+
     it('should render the delete-button when attachView is false', async () => {
         global.activeAclRoles = ['document.deleter'];
         wrapper = await createWrapper();

--- a/src/Core/Checkout/DependencyInjection/documentV2.php
+++ b/src/Core/Checkout/DependencyInjection/documentV2.php
@@ -125,7 +125,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
     $services->set(AppDocumentTypeLoader::class)
         ->args([
-            service(Connection::class),
+            service('app_document_type.repository'),
         ])
         ->tag('kernel.reset', ['method' => 'reset']);
 

--- a/src/Core/Checkout/DependencyInjection/documentV2.php
+++ b/src/Core/Checkout/DependencyInjection/documentV2.php
@@ -24,9 +24,11 @@ use Shopware\Core\Checkout\DocumentV2\Renderer\HtmlRenderer;
 use Shopware\Core\Checkout\DocumentV2\Renderer\PdfRenderer;
 use Shopware\Core\Checkout\DocumentV2\Renderer\ZugferdEmbeddedPdfRenderer;
 use Shopware\Core\Checkout\DocumentV2\Renderer\ZugferdXmlRenderer;
+use Shopware\Core\Checkout\DocumentV2\Subscriber\AppDocumentNumberRangeSubscriber;
 use Shopware\Core\Checkout\DocumentV2\Subscriber\DocumentBaseConfigSyncSubscriber;
 use Shopware\Core\Checkout\DocumentV2\Template\DocumentTemplateRenderer;
 use Shopware\Core\Checkout\DocumentV2\Template\ZugferdTwigExtension;
+use Shopware\Core\Checkout\DocumentV2\Type\AppDocumentTypeLoader;
 use Shopware\Core\Checkout\DocumentV2\Type\CancellationInvoiceDocumentType;
 use Shopware\Core\Checkout\DocumentV2\Type\DeliveryNoteDocumentType;
 use Shopware\Core\Checkout\DocumentV2\Type\DocumentTypeRegistry;
@@ -65,12 +67,20 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             service('country.repository'),
             service('media.repository'),
             service(SystemConfigService::class),
+            service(AppDocumentTypeLoader::class),
         ])
         ->tag('kernel.event_subscriber');
 
     $services->set(DocumentBaseConfigSyncSubscriber::class)
         ->args([
             service(Connection::class),
+        ])
+        ->tag('kernel.event_subscriber');
+
+    $services->set(AppDocumentNumberRangeSubscriber::class)
+        ->args([
+            service('number_range_type.repository'),
+            service('number_range.repository'),
         ])
         ->tag('kernel.event_subscriber');
 
@@ -113,10 +123,18 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $services->set(DeliveryNoteDocumentType::class)
         ->tag('shopware.document_v2.type');
 
+    $services->set(AppDocumentTypeLoader::class)
+        ->args([
+            service(Connection::class),
+        ])
+        ->tag('kernel.reset', ['method' => 'reset']);
+
     $services->set(DocumentTypeRegistry::class)
         ->args([
             tagged_iterator('shopware.document_v2.type'),
-        ]);
+            service(AppDocumentTypeLoader::class),
+        ])
+        ->tag('kernel.reset', ['method' => 'reset']);
 
     $services->set(DocumentTemplateRenderer::class)
         ->public()

--- a/src/Core/Checkout/DependencyInjection/documentV2.php
+++ b/src/Core/Checkout/DependencyInjection/documentV2.php
@@ -36,6 +36,7 @@ use Shopware\Core\Content\Media\File\FileNameProvider;
 use Shopware\Core\Content\Media\MediaService;
 use Shopware\Core\Framework\Adapter\Translation\Translator;
 use Shopware\Core\Framework\Adapter\Twig\TemplateFinder;
+use Shopware\Core\Framework\Script\Execution\ScriptExecutor;
 use Shopware\Core\Framework\Validation\DataValidator;
 use Shopware\Core\System\NumberRange\ValueGenerator\NumberRangeValueGeneratorInterface;
 use Shopware\Core\System\SalesChannel\Context\SalesChannelContextFactory;
@@ -202,6 +203,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             service(DocumentDependencyResolver::class),
             service(ReferencedDocumentResolver::class),
             service('order.repository'),
+            service(ScriptExecutor::class),
         ]);
 
     $services->set(DocumentGenerationRequestResolver::class)

--- a/src/Core/Checkout/Document/DocumentDefinition.php
+++ b/src/Core/Checkout/Document/DocumentDefinition.php
@@ -59,7 +59,10 @@ class DocumentDefinition extends EntityDefinition
         return new FieldCollection([
             (new IdField('id', 'id'))->addFlags(new ApiAware(), new PrimaryKey(), new Required()),
 
-            (new FkField('document_type_id', 'documentTypeId', DocumentTypeDefinition::class))->addFlags(new ApiAware(), new Required()),
+            /**
+             * @deprecated tag:v6.8.0 - document_type_id becomes nullable. Slated for removal once v1 documents migrate off it.
+             */
+            (new FkField('document_type_id', 'documentTypeId', DocumentTypeDefinition::class))->addFlags(new ApiAware()),
             (new FkField('referenced_document_id', 'referencedDocumentId', self::class))->addFlags(new ApiAware()),
 
             (new FkField('order_id', 'orderId', OrderDefinition::class))->addFlags(new ApiAware(), new Required()),

--- a/src/Core/Checkout/Document/DocumentDefinition.php
+++ b/src/Core/Checkout/Document/DocumentDefinition.php
@@ -59,9 +59,6 @@ class DocumentDefinition extends EntityDefinition
         return new FieldCollection([
             (new IdField('id', 'id'))->addFlags(new ApiAware(), new PrimaryKey(), new Required()),
 
-            /**
-             * @deprecated tag:v6.8.0 - document_type_id becomes nullable. Slated for removal once v1 documents migrate off it.
-             */
             (new FkField('document_type_id', 'documentTypeId', DocumentTypeDefinition::class))->addFlags(new ApiAware()),
             (new FkField('referenced_document_id', 'referencedDocumentId', self::class))->addFlags(new ApiAware()),
 

--- a/src/Core/Checkout/Document/DocumentEntity.php
+++ b/src/Core/Checkout/Document/DocumentEntity.php
@@ -21,9 +21,6 @@ class DocumentEntity extends Entity
 
     protected string $orderVersionId;
 
-    /**
-     * @deprecated tag:v6.8.0 - documentTypeId becomes nullable
-     */
     protected ?string $documentTypeId = null;
 
     protected ?string $documentMediaFileId = null;

--- a/src/Core/Checkout/Document/DocumentEntity.php
+++ b/src/Core/Checkout/Document/DocumentEntity.php
@@ -21,7 +21,10 @@ class DocumentEntity extends Entity
 
     protected string $orderVersionId;
 
-    protected string $documentTypeId;
+    /**
+     * @deprecated tag:v6.8.0 - documentTypeId becomes nullable
+     */
+    protected ?string $documentTypeId = null;
 
     protected ?string $documentMediaFileId = null;
 
@@ -135,12 +138,12 @@ class DocumentEntity extends Entity
         $this->documentType = $documentType;
     }
 
-    public function getDocumentTypeId(): string
+    public function getDocumentTypeId(): ?string
     {
         return $this->documentTypeId;
     }
 
-    public function setDocumentTypeId(string $documentTypeId): void
+    public function setDocumentTypeId(?string $documentTypeId): void
     {
         $this->documentTypeId = $documentTypeId;
     }

--- a/src/Core/Checkout/DocumentV2/Config/DocumentConfigLoader.php
+++ b/src/Core/Checkout/DocumentV2/Config/DocumentConfigLoader.php
@@ -5,6 +5,7 @@ namespace Shopware\Core\Checkout\DocumentV2\Config;
 use Shopware\Core\Checkout\Document\Aggregate\DocumentBaseConfig\DocumentBaseConfigCollection;
 use Shopware\Core\Checkout\Document\Aggregate\DocumentBaseConfig\DocumentBaseConfigEntity;
 use Shopware\Core\Checkout\DocumentV2\DocumentV2Exception;
+use Shopware\Core\Checkout\DocumentV2\Type\AppDocumentTypeLoader;
 use Shopware\Core\Content\Media\MediaCollection;
 use Shopware\Core\Content\Media\MediaEntity;
 use Shopware\Core\Framework\Context;
@@ -76,6 +77,7 @@ final class DocumentConfigLoader implements EventSubscriberInterface, ResetInter
         private readonly EntityRepository $countryRepository,
         private readonly EntityRepository $mediaRepository,
         private readonly SystemConfigService $systemConfigService,
+        private readonly AppDocumentTypeLoader $appDocumentTypeLoader,
     ) {
     }
 
@@ -131,10 +133,11 @@ final class DocumentConfigLoader implements EventSubscriberInterface, ResetInter
         $legacyConfig = $this->mergeJsonConfig($globalRow, $salesChannelRow);
         $systemConfigCompanyInfo = $this->resolveCompanyInfoFromSystemConfig($salesChannelId);
         $effectiveCompanyInfo = $systemConfigCompanyInfo ?? $legacyConfig;
+        $appConfig = $this->appDocumentTypeLoader->loadConfig($documentType);
 
-        $documentConfig = $this->buildDocumentConfig($globalRow, $salesChannelRow, $systemConfigCompanyInfo, $documentType, $context);
+        $documentConfig = $this->buildDocumentConfig($globalRow, $salesChannelRow, $systemConfigCompanyInfo, $documentType, $context, $appConfig);
         $companyInfo = $this->buildDocumentCompanyInfo($effectiveCompanyInfo, $context, $documentType);
-        $displayOptions = $this->buildDisplayOptions($globalRow, $salesChannelRow, $legacyConfig);
+        $displayOptions = $this->buildDisplayOptions($globalRow, $salesChannelRow, $legacyConfig, $appConfig);
 
         $bundle = new DocumentConfigBundle(
             config: $documentConfig,
@@ -175,14 +178,29 @@ final class DocumentConfigLoader implements EventSubscriberInterface, ResetInter
 
     /**
      * @param array<string, mixed>|null $systemConfigCompanyInfo
+     * @param array<string, scalar> $appConfig
      */
     private function buildDocumentConfig(
         ?DocumentBaseConfigEntity $globalRow,
         ?DocumentBaseConfigEntity $salesChannelRow,
         ?array $systemConfigCompanyInfo,
         string $documentType,
-        Context $context
+        Context $context,
+        array $appConfig,
     ): DocumentConfig {
+        $isAppDocumentType = $globalRow === null && $salesChannelRow === null;
+
+        if ($isAppDocumentType) {
+            return new DocumentConfig(
+                pageSize: (string) ($appConfig['pageSize'] ?? 'a4'),
+                pageOrientation: (string) ($appConfig['pageOrientation'] ?? 'portrait'),
+                itemsPerPage: (int) ($appConfig['itemsPerPage'] ?? 10),
+                filenamePrefix: null,
+                filenameSuffix: null,
+                logo: null,
+            );
+        }
+
         $pageSize = $salesChannelRow?->getPageSize() ?? $globalRow?->getPageSize() ?? '';
         $pageOrientation = $salesChannelRow?->getPageOrientation() ?? $globalRow?->getPageOrientation() ?? '';
         $itemsPerPage = $salesChannelRow?->getItemsPerPage() ?? $globalRow?->getItemsPerPage() ?? 0;
@@ -280,22 +298,24 @@ final class DocumentConfigLoader implements EventSubscriberInterface, ResetInter
 
     /**
      * @param array<string, mixed> $legacyConfig
+     * @param array<string, scalar> $appConfig
      */
     private function buildDisplayOptions(
         ?DocumentBaseConfigEntity $globalRow,
         ?DocumentBaseConfigEntity $salesChannelRow,
         array $legacyConfig,
+        array $appConfig,
     ): DocumentDisplayOptions {
         return new DocumentDisplayOptions(
-            displayHeader: $salesChannelRow?->getDisplayHeader() ?? $globalRow?->getDisplayHeader() ?? false,
-            displayFooter: $salesChannelRow?->getDisplayFooter() ?? $globalRow?->getDisplayFooter() ?? false,
-            displayPageCount: $salesChannelRow?->getDisplayPageCount() ?? $globalRow?->getDisplayPageCount() ?? false,
+            displayHeader: (bool) ($appConfig['displayHeader'] ?? $salesChannelRow?->getDisplayHeader() ?? $globalRow?->getDisplayHeader() ?? false),
+            displayFooter: (bool) ($appConfig['displayFooter'] ?? $salesChannelRow?->getDisplayFooter() ?? $globalRow?->getDisplayFooter() ?? false),
+            displayPageCount: (bool) ($appConfig['displayPageCount'] ?? $salesChannelRow?->getDisplayPageCount() ?? $globalRow?->getDisplayPageCount() ?? false),
             displayCompanyAddress: $salesChannelRow?->getDisplayCompanyAddress() ?? $globalRow?->getDisplayCompanyAddress() ?? false,
             displayReturnAddress: $salesChannelRow?->getDisplayReturnAddress() ?? $globalRow?->getDisplayReturnAddress() ?? false,
             displayCustomerVatId: $salesChannelRow?->getDisplayCustomerVatId() ?? $globalRow?->getDisplayCustomerVatId() ?? false,
-            displayLineItems: (bool) ($legacyConfig['displayLineItems'] ?? false),
+            displayLineItems: (bool) ($appConfig['displayLineItems'] ?? $legacyConfig['displayLineItems'] ?? false),
             displayLineItemPosition: (bool) ($legacyConfig['displayLineItemPosition'] ?? false),
-            displayPrices: (bool) ($legacyConfig['displayPrices'] ?? false),
+            displayPrices: (bool) ($appConfig['displayPrices'] ?? $legacyConfig['displayPrices'] ?? false),
             displayDivergentDeliveryAddress: (bool) ($legacyConfig['displayDivergentDeliveryAddress'] ?? false),
             deliveryCountries: $legacyConfig['deliveryCountries'] ?? [],
         );

--- a/src/Core/Checkout/DocumentV2/Config/DocumentConfigLoader.php
+++ b/src/Core/Checkout/DocumentV2/Config/DocumentConfigLoader.php
@@ -4,6 +4,7 @@ namespace Shopware\Core\Checkout\DocumentV2\Config;
 
 use Shopware\Core\Checkout\Document\Aggregate\DocumentBaseConfig\DocumentBaseConfigCollection;
 use Shopware\Core\Checkout\Document\Aggregate\DocumentBaseConfig\DocumentBaseConfigEntity;
+use Shopware\Core\Checkout\DocumentV2\DocumentType;
 use Shopware\Core\Checkout\DocumentV2\DocumentV2Exception;
 use Shopware\Core\Checkout\DocumentV2\Type\AppDocumentTypeLoader;
 use Shopware\Core\Content\Media\MediaCollection;
@@ -133,7 +134,11 @@ final class DocumentConfigLoader implements EventSubscriberInterface, ResetInter
         $legacyConfig = $this->mergeJsonConfig($globalRow, $salesChannelRow);
         $systemConfigCompanyInfo = $this->resolveCompanyInfoFromSystemConfig($salesChannelId);
         $effectiveCompanyInfo = $systemConfigCompanyInfo ?? $legacyConfig;
-        $appConfig = $this->appDocumentTypeLoader->loadConfig($documentType);
+
+        // core types never carry app config; avoid the app_document_type lookup on their hot path
+        $appConfig = DocumentType::tryFrom($documentType) === null
+            ? $this->appDocumentTypeLoader->loadConfig($documentType)
+            : [];
 
         $documentConfig = $this->buildDocumentConfig($globalRow, $salesChannelRow, $systemConfigCompanyInfo, $documentType, $context, $appConfig);
         $companyInfo = $this->buildDocumentCompanyInfo($effectiveCompanyInfo, $context, $documentType);
@@ -188,9 +193,10 @@ final class DocumentConfigLoader implements EventSubscriberInterface, ResetInter
         Context $context,
         array $appConfig,
     ): DocumentConfig {
-        $isAppDocumentType = $globalRow === null && $salesChannelRow === null;
+        // no document_base_config row exists (app-provided types, or a type configured purely via appConfig defaults)
+        $hasNoBaseConfig = $globalRow === null && $salesChannelRow === null;
 
-        if ($isAppDocumentType) {
+        if ($hasNoBaseConfig) {
             return new DocumentConfig(
                 pageSize: (string) ($appConfig['pageSize'] ?? 'a4'),
                 pageOrientation: (string) ($appConfig['pageOrientation'] ?? 'portrait'),

--- a/src/Core/Checkout/DocumentV2/Config/DocumentConfigLoader.php
+++ b/src/Core/Checkout/DocumentV2/Config/DocumentConfigLoader.php
@@ -133,12 +133,10 @@ final class DocumentConfigLoader implements EventSubscriberInterface, ResetInter
 
         $legacyConfig = $this->mergeJsonConfig($globalRow, $salesChannelRow);
         $systemConfigCompanyInfo = $this->resolveCompanyInfoFromSystemConfig($salesChannelId);
+
         $effectiveCompanyInfo = $systemConfigCompanyInfo ?? $legacyConfig;
 
-        // core types never carry app config; avoid the app_document_type lookup on their hot path
-        $appConfig = DocumentType::tryFrom($documentType) === null
-            ? $this->appDocumentTypeLoader->loadConfig($documentType)
-            : [];
+        $appConfig = $this->appDocumentTypeLoader->loadConfig($documentType);
 
         $documentConfig = $this->buildDocumentConfig($globalRow, $salesChannelRow, $systemConfigCompanyInfo, $documentType, $context, $appConfig);
         $companyInfo = $this->buildDocumentCompanyInfo($effectiveCompanyInfo, $context, $documentType);
@@ -193,17 +191,19 @@ final class DocumentConfigLoader implements EventSubscriberInterface, ResetInter
         Context $context,
         array $appConfig,
     ): DocumentConfig {
-        // no document_base_config row exists (app-provided types, or a type configured purely via appConfig defaults)
-        $hasNoBaseConfig = $globalRow === null && $salesChannelRow === null;
+        // no document_base_config row exists, which is expected for app provided types
+        if ($globalRow === null && $salesChannelRow === null) {
+            if (DocumentType::tryFrom($documentType) !== null) {
+                throw DocumentV2Exception::invalidDocumentType($documentType);
+            }
 
-        if ($hasNoBaseConfig) {
             return new DocumentConfig(
                 pageSize: (string) ($appConfig['pageSize'] ?? 'a4'),
                 pageOrientation: (string) ($appConfig['pageOrientation'] ?? 'portrait'),
                 itemsPerPage: (int) ($appConfig['itemsPerPage'] ?? 10),
                 filenamePrefix: null,
                 filenameSuffix: null,
-                logo: null,
+                logo: $this->resolveLogo(null, null, $systemConfigCompanyInfo, $context),
             );
         }
 

--- a/src/Core/Checkout/DocumentV2/Controller/DocumentV2Controller.php
+++ b/src/Core/Checkout/DocumentV2/Controller/DocumentV2Controller.php
@@ -178,7 +178,7 @@ final class DocumentV2Controller extends AbstractController
                 'id' => $documentId,
                 'orderId' => $this->requirePayloadString($payload, 'orderId'),
                 'orderVersionId' => $this->requirePayloadString($payload, 'orderVersionId'),
-                'documentTypeId' => $this->getDocumentTypeId($documentType, $context),
+                'documentTypeId' => $this->resolveDocumentTypeId($documentType, $context),
                 'documentMediaFileId' => $mediaId,
                 'referencedDocumentId' => $payload->getString('referencedDocumentId') ?: null,
                 'static' => true,
@@ -187,6 +187,7 @@ final class DocumentV2Controller extends AbstractController
                     'documentComment' => $payload->getString('documentComment'),
                     'documentDate' => $payload->getString('documentDate') ?: null,
                     'documentNumber' => $payload->getString('documentNumber'),
+                    'documentType' => $documentType,
                 ],
             ],
         ], $context);
@@ -328,19 +329,16 @@ final class DocumentV2Controller extends AbstractController
         return $fileName !== '' ? $fileName : Uuid::randomHex();
     }
 
-    private function getDocumentTypeId(string $documentType, Context $context): string
+    /**
+     * Resolves the legacy `document_type` row id for a type, if one exists.
+     */
+    private function resolveDocumentTypeId(string $documentType, Context $context): ?string
     {
         $criteria = (new Criteria())
             ->addFilter(new EqualsFilter('technicalName', $documentType))
             ->setLimit(1);
 
-        $documentTypeId = $this->documentTypeRepository->searchIds($criteria, $context)->firstId();
-
-        if ($documentTypeId === null) {
-            throw DocumentV2Exception::documentTypeNotFound($documentType);
-        }
-
-        return $documentTypeId;
+        return $this->documentTypeRepository->searchIds($criteria, $context)->firstId();
     }
 
     private function createResponse(

--- a/src/Core/Checkout/DocumentV2/Controller/DocumentV2Controller.php
+++ b/src/Core/Checkout/DocumentV2/Controller/DocumentV2Controller.php
@@ -329,9 +329,6 @@ final class DocumentV2Controller extends AbstractController
         return $fileName !== '' ? $fileName : Uuid::randomHex();
     }
 
-    /**
-     * Resolves the legacy `document_type` row id for a type, if one exists.
-     */
     private function resolveDocumentTypeId(string $documentType, Context $context): ?string
     {
         $criteria = (new Criteria())

--- a/src/Core/Checkout/DocumentV2/Event/Hooks/DocumentGenerationHook.php
+++ b/src/Core/Checkout/DocumentV2/Event/Hooks/DocumentGenerationHook.php
@@ -10,12 +10,7 @@ use Shopware\Core\Framework\Script\Execution\Hook;
 use Shopware\Core\System\SystemConfig\Facade\SystemConfigFacadeHookFactory;
 
 /**
- * Triggered once per document generation, after the order is loaded and the document number is
- * allocated, but before any renderer runs.
- *
- * On the `generate()` path, a script that throws aborts generation after the order version was
- * created and the document number was already consumed from its number range, leaving a gap in
- * the invoice sequence.
+ * Triggered once per document generation, after the order is loaded and the document number is allocated, but before any renderer runs.
  *
  * @hook-use-case data_loading
  *

--- a/src/Core/Checkout/DocumentV2/Event/Hooks/DocumentGenerationHook.php
+++ b/src/Core/Checkout/DocumentV2/Event/Hooks/DocumentGenerationHook.php
@@ -1,0 +1,79 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Checkout\DocumentV2\Event\Hooks;
+
+use Shopware\Core\Checkout\Order\OrderEntity;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\Facade\RepositoryFacadeHookFactory;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Script\Execution\Hook;
+use Shopware\Core\System\SystemConfig\Facade\SystemConfigFacadeHookFactory;
+
+/**
+ * Triggered once per document generation, after the order is loaded and the document number is
+ * allocated, but before any renderer runs.
+ *
+ * On the `generate()` path, a script that throws aborts generation after the order version was
+ * created and the document number was already consumed from its number range, leaving a gap in
+ * the invoice sequence.
+ *
+ * @hook-use-case data_loading
+ *
+ * @since 6.7.13.0
+ */
+#[Package('after-sales')]
+final class DocumentGenerationHook extends Hook
+{
+    final public const HOOK_NAME = 'document-generation';
+
+    /**
+     * @param list<string> $formats
+     *
+     * @internal
+     */
+    public function __construct(
+        private readonly OrderEntity $order,
+        private readonly string $documentType,
+        private readonly string $documentNumber,
+        private readonly array $formats,
+        Context $context,
+    ) {
+        parent::__construct($context);
+    }
+
+    public function getName(): string
+    {
+        return self::HOOK_NAME;
+    }
+
+    public function getOrder(): OrderEntity
+    {
+        return $this->order;
+    }
+
+    public function getDocumentType(): string
+    {
+        return $this->documentType;
+    }
+
+    public function getDocumentNumber(): string
+    {
+        return $this->documentNumber;
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function getFormats(): array
+    {
+        return $this->formats;
+    }
+
+    public static function getServiceIds(): array
+    {
+        return [
+            RepositoryFacadeHookFactory::class,
+            SystemConfigFacadeHookFactory::class,
+        ];
+    }
+}

--- a/src/Core/Checkout/DocumentV2/Generation/DocumentGenerator.php
+++ b/src/Core/Checkout/DocumentV2/Generation/DocumentGenerator.php
@@ -6,6 +6,7 @@ use Shopware\Core\Checkout\Document\DocumentEntity;
 use Shopware\Core\Checkout\Document\Renderer\RenderedDocument;
 use Shopware\Core\Checkout\DocumentV2\Config\DocumentNumberGenerator;
 use Shopware\Core\Checkout\DocumentV2\DocumentV2Exception;
+use Shopware\Core\Checkout\DocumentV2\Event\Hooks\DocumentGenerationHook;
 use Shopware\Core\Checkout\DocumentV2\Provider\AbstractDocumentDataProvider;
 use Shopware\Core\Checkout\DocumentV2\Provider\DocumentDataProviderRegistry;
 use Shopware\Core\Checkout\DocumentV2\Provider\ReferencesDocument;
@@ -23,6 +24,7 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Script\Execution\ScriptExecutor;
 
 /**
  * @internal
@@ -41,6 +43,7 @@ final readonly class DocumentGenerator
         private DocumentDependencyResolver $dependencyResolver,
         private ReferencedDocumentResolver $referencedDocumentResolver,
         private EntityRepository $orderRepository,
+        private ScriptExecutor $scriptExecutor,
     ) {
     }
 
@@ -160,6 +163,14 @@ final readonly class DocumentGenerator
         );
 
         $generationRequest = $generationRequest->withDocumentNumber($documentNumber);
+
+        $this->scriptExecutor->execute(new DocumentGenerationHook(
+            $order,
+            $generationRequest->documentType,
+            $documentNumber,
+            $requestedFormats,
+            $languageAwareContext,
+        ));
 
         $providerData = $this->collectProviderData(
             $providers,

--- a/src/Core/Checkout/DocumentV2/Generation/DocumentPersister.php
+++ b/src/Core/Checkout/DocumentV2/Generation/DocumentPersister.php
@@ -76,11 +76,12 @@ final readonly class DocumentPersister
                 'id' => $documentId,
                 'orderId' => $generationRequest->orderId,
                 'orderVersionId' => $input->order->getVersionId(),
-                'documentTypeId' => $this->getDocumentTypeId($generationRequest, $context),
+                'documentTypeId' => $this->resolveDocumentTypeId($generationRequest, $context),
                 'referencedDocumentId' => $resolvedReference?->id,
                 'deepLinkCode' => Random::getAlphanumericString(32),
                 'config' => [
                     'documentNumber' => $input->documentNumber,
+                    'documentType' => $generationRequest->documentType,
                 ],
             ],
         ], $context);
@@ -159,23 +160,14 @@ final readonly class DocumentPersister
     }
 
     /**
-     * @throws DocumentV2Exception
+     * Resolves the legacy `document_type` row id for a type, if one exists.
      */
-    private function getDocumentTypeId(DocumentGenerationRequest $generationRequest, Context $context): string
+    private function resolveDocumentTypeId(DocumentGenerationRequest $generationRequest, Context $context): ?string
     {
-        // TODO: Remove this lookup once document generation no longer stores document types and formats in the database.
-        $documentType = $generationRequest->documentType;
-
         $criteria = (new Criteria())
-            ->addFilter(new EqualsFilter('technicalName', $documentType))
+            ->addFilter(new EqualsFilter('technicalName', $generationRequest->documentType))
             ->setLimit(1);
 
-        $documentTypeId = $this->documentTypeRepository->searchIds($criteria, $context)->firstId();
-
-        if ($documentTypeId === null) {
-            throw DocumentV2Exception::documentTypeNotFound($documentType);
-        }
-
-        return $documentTypeId;
+        return $this->documentTypeRepository->searchIds($criteria, $context)->firstId();
     }
 }

--- a/src/Core/Checkout/DocumentV2/Generation/DocumentPersister.php
+++ b/src/Core/Checkout/DocumentV2/Generation/DocumentPersister.php
@@ -61,9 +61,10 @@ final readonly class DocumentPersister
         Context $context,
     ): DocumentEntity {
         $documentId = Uuid::randomHex();
+        $documentTypeId = $this->resolveDocumentTypeId($generationRequest, $context);
 
         // TODO: Keep this guard until the reused document table can enforce document_number + document_type_id uniqueness.
-        $this->assertDocumentNumberIsUnique($generationRequest, $input->documentNumber, $context);
+        $this->assertDocumentNumberIsUnique($generationRequest, $documentTypeId, $input->documentNumber, $context);
 
         $persistedFiles = $this->writeMediaFiles(
             $state,
@@ -76,7 +77,7 @@ final readonly class DocumentPersister
                 'id' => $documentId,
                 'orderId' => $generationRequest->orderId,
                 'orderVersionId' => $input->order->getVersionId(),
-                'documentTypeId' => $this->resolveDocumentTypeId($generationRequest, $context),
+                'documentTypeId' => $documentTypeId,
                 'referencedDocumentId' => $resolvedReference?->id,
                 'deepLinkCode' => Random::getAlphanumericString(32),
                 'config' => [
@@ -144,12 +145,18 @@ final readonly class DocumentPersister
      */
     private function assertDocumentNumberIsUnique(
         DocumentGenerationRequest $generationRequest,
+        ?string $documentTypeId,
         string $documentNumber,
         Context $context,
     ): void {
+        // app provided types have no document_type row, so they are only identifiable via the config snapshot
+        $typeFilter = $documentTypeId !== null
+            ? new EqualsFilter('documentTypeId', $documentTypeId)
+            : new EqualsFilter('config.documentType', $generationRequest->documentType);
+
         $criteria = (new Criteria())
             ->addFilter(new EqualsFilter('documentNumber', $documentNumber))
-            ->addFilter(new EqualsFilter('documentType.technicalName', $generationRequest->documentType))
+            ->addFilter($typeFilter)
             ->setLimit(1);
 
         $exists = $this->documentRepository->searchIds($criteria, $context)->firstId() !== null;
@@ -159,9 +166,6 @@ final readonly class DocumentPersister
         }
     }
 
-    /**
-     * Resolves the legacy `document_type` row id for a type, if one exists.
-     */
     private function resolveDocumentTypeId(DocumentGenerationRequest $generationRequest, Context $context): ?string
     {
         $criteria = (new Criteria())

--- a/src/Core/Checkout/DocumentV2/Renderer/ZugferdXmlRenderer.php
+++ b/src/Core/Checkout/DocumentV2/Renderer/ZugferdXmlRenderer.php
@@ -3,8 +3,10 @@
 namespace Shopware\Core\Checkout\DocumentV2\Renderer;
 
 use Shopware\Core\Checkout\DocumentV2\DocumentFormat;
+use Shopware\Core\Checkout\DocumentV2\DocumentType;
 use Shopware\Core\Checkout\DocumentV2\Provider\DocumentMetaProvider;
 use Shopware\Core\Checkout\DocumentV2\Provider\RenderData\DocumentMetaRenderData;
+use Shopware\Core\Checkout\DocumentV2\Struct\AbstractRenderData;
 use Shopware\Core\Checkout\DocumentV2\Struct\RenderInput;
 use Shopware\Core\Checkout\DocumentV2\Struct\RenderResult;
 use Shopware\Core\Checkout\DocumentV2\Struct\RenderState;
@@ -52,8 +54,10 @@ final readonly class ZugferdXmlRenderer extends AbstractDocumentRenderer
         );
 
         // app document types legitimately have no typed render-data provider and ship their own
-        // template, so render data is optional here; core zugferd types populate it via their provider
-        $renderData = $input->getData($input->documentType);
+        // template, so render data is only optional for those
+        $renderData = DocumentType::tryFrom($input->documentType) !== null
+            ? $input->requireData($input->documentType, AbstractRenderData::class)
+            : $input->getData($input->documentType);
 
         $template = \sprintf(self::TEMPLATE_PATTERN, $input->documentType);
 

--- a/src/Core/Checkout/DocumentV2/Renderer/ZugferdXmlRenderer.php
+++ b/src/Core/Checkout/DocumentV2/Renderer/ZugferdXmlRenderer.php
@@ -5,7 +5,6 @@ namespace Shopware\Core\Checkout\DocumentV2\Renderer;
 use Shopware\Core\Checkout\DocumentV2\DocumentFormat;
 use Shopware\Core\Checkout\DocumentV2\Provider\DocumentMetaProvider;
 use Shopware\Core\Checkout\DocumentV2\Provider\RenderData\DocumentMetaRenderData;
-use Shopware\Core\Checkout\DocumentV2\Struct\AbstractRenderData;
 use Shopware\Core\Checkout\DocumentV2\Struct\RenderInput;
 use Shopware\Core\Checkout\DocumentV2\Struct\RenderResult;
 use Shopware\Core\Checkout\DocumentV2\Struct\RenderState;
@@ -17,7 +16,7 @@ use Shopware\Core\Framework\Log\Package;
 /**
  * Renders a document into XRechnung 3.0 (CII) XML.
  *
- * Consumes the shared meta and the invoice render data; the raw Twig markup is then piped through
+ * Consumes the shared meta. The raw Twig markup is then piped through
  * {@see XmlFormatter} for deterministic pretty-printing and well-formedness validation.
  *
  * @internal
@@ -52,10 +51,7 @@ final readonly class ZugferdXmlRenderer extends AbstractDocumentRenderer
             DocumentMetaRenderData::class,
         );
 
-        $renderData = $input->requireData(
-            $input->documentType,
-            AbstractRenderData::class,
-        );
+        $renderData = $input->getData($input->documentType);
 
         $template = \sprintf(self::TEMPLATE_PATTERN, $input->documentType);
 

--- a/src/Core/Checkout/DocumentV2/Renderer/ZugferdXmlRenderer.php
+++ b/src/Core/Checkout/DocumentV2/Renderer/ZugferdXmlRenderer.php
@@ -51,6 +51,8 @@ final readonly class ZugferdXmlRenderer extends AbstractDocumentRenderer
             DocumentMetaRenderData::class,
         );
 
+        // app document types legitimately have no typed render-data provider and ship their own
+        // template, so render data is optional here; core zugferd types populate it via their provider
         $renderData = $input->getData($input->documentType);
 
         $template = \sprintf(self::TEMPLATE_PATTERN, $input->documentType);

--- a/src/Core/Checkout/DocumentV2/Subscriber/AppDocumentNumberRangeSubscriber.php
+++ b/src/Core/Checkout/DocumentV2/Subscriber/AppDocumentNumberRangeSubscriber.php
@@ -1,0 +1,107 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Checkout\DocumentV2\Subscriber;
+
+use Shopware\Core\Checkout\DocumentV2\Config\DocumentNumberGenerator;
+use Shopware\Core\Checkout\DocumentV2\DocumentType;
+use Shopware\Core\Framework\App\Event\AppInstalledEvent;
+use Shopware\Core\Framework\App\Event\AppUpdatedEvent;
+use Shopware\Core\Framework\App\Event\ManifestChangedEvent;
+use Shopware\Core\Framework\App\Manifest\Xml\Document\DocumentType as AppDocumentType;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\System\NumberRange\Aggregate\NumberRangeType\NumberRangeTypeCollection;
+use Shopware\Core\System\NumberRange\NumberRangeCollection;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Seeds a `number_range_type` and matching `number_range` for every document type an app declares,
+ * so `DocumentNumberGenerator` (which looks up range type `document_<identifier>`) can generate
+ * numbers for app registered document types.
+ *
+ * @internal
+ *
+ * @codeCoverageIgnore
+ *
+ * @see \Shopware\Tests\Integration\Core\Checkout\DocumentV2\Subscriber\AppDocumentNumberRangeSubscriberTest
+ */
+#[Package('after-sales')]
+class AppDocumentNumberRangeSubscriber implements EventSubscriberInterface
+{
+    /**
+     * @param EntityRepository<NumberRangeTypeCollection> $numberRangeTypeRepository
+     * @param EntityRepository<NumberRangeCollection> $numberRangeRepository
+     */
+    public function __construct(
+        private readonly EntityRepository $numberRangeTypeRepository,
+        private readonly EntityRepository $numberRangeRepository
+    ) {
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            AppInstalledEvent::class => 'onAppInstalledOrUpdated',
+            AppUpdatedEvent::class => 'onAppInstalledOrUpdated',
+        ];
+    }
+
+    public function onAppInstalledOrUpdated(ManifestChangedEvent $event): void
+    {
+        $documents = $event->getManifest()->getDocuments();
+
+        if ($documents === null) {
+            return;
+        }
+
+        $context = $event->getContext();
+
+        foreach ($documents->getDocumentTypes() as $documentType) {
+            $this->createNumberRange($documentType, $context);
+        }
+    }
+
+    private function createNumberRange(AppDocumentType $documentType, Context $context): void
+    {
+        $identifier = $documentType->getIdentifier();
+
+        // prevent duplication of core type
+        if (DocumentType::tryFrom($identifier) !== null) {
+            return;
+        }
+
+        $technicalName = DocumentNumberGenerator::NUMBER_RANGE_DOCUMENT_TYPE_PREFIX . $identifier;
+
+        $criteria = (new Criteria())->addFilter(new EqualsFilter('technicalName', $technicalName));
+        $existingIds = $this->numberRangeTypeRepository->searchIds($criteria, $context);
+
+        if ($existingIds->firstId() !== null) {
+            return;
+        }
+
+        $typeId = Uuid::randomHex();
+
+        $this->numberRangeTypeRepository->create([[
+            'id' => $typeId,
+            'technicalName' => $technicalName,
+            'global' => true,
+            'typeName' => $identifier,
+        ]], $context);
+
+        $this->numberRangeRepository->create([[
+            'id' => Uuid::randomHex(),
+            'typeId' => $typeId,
+            'global' => true,
+            'name' => $identifier,
+            'pattern' => '{n}',
+            'start' => 1000,
+        ]], $context);
+    }
+}

--- a/src/Core/Checkout/DocumentV2/Subscriber/AppDocumentNumberRangeSubscriber.php
+++ b/src/Core/Checkout/DocumentV2/Subscriber/AppDocumentNumberRangeSubscriber.php
@@ -23,6 +23,11 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
  * so `DocumentNumberGenerator` (which looks up range type `document_<identifier>`) can generate
  * numbers for app registered document types.
  *
+ * The ranges are intentionally created `global` and are never removed on uninstall or when a type
+ * is dropped from a manifest: document numbers must stay unique per install, so a reinstalled (or
+ * differently-owned) identifier continues its existing sequence instead of restarting and re-issuing
+ * already-used numbers. Leftover range rows for gone types are harmless.
+ *
  * @internal
  *
  * @codeCoverageIgnore

--- a/src/Core/Checkout/DocumentV2/Type/AppDocumentTypeLoader.php
+++ b/src/Core/Checkout/DocumentV2/Type/AppDocumentTypeLoader.php
@@ -2,11 +2,14 @@
 
 namespace Shopware\Core\Checkout\DocumentV2\Type;
 
-use Doctrine\DBAL\Connection;
 use Shopware\Core\Checkout\DocumentV2\DocumentFormat;
 use Shopware\Core\Checkout\DocumentV2\DocumentType;
+use Shopware\Core\Framework\App\Aggregate\AppDocumentType\AppDocumentTypeCollection;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\Log\Package;
-use Shopware\Core\Framework\Util\Json;
 use Symfony\Contracts\Service\ResetInterface;
 
 /**
@@ -27,7 +30,10 @@ final class AppDocumentTypeLoader implements ResetInterface
      */
     private ?array $configByName = null;
 
-    public function __construct(private readonly Connection $connection)
+    /**
+     * @param EntityRepository<AppDocumentTypeCollection> $appDocumentTypeRepository
+     */
+    public function __construct(private readonly EntityRepository $appDocumentTypeRepository)
     {
     }
 
@@ -67,20 +73,19 @@ final class AppDocumentTypeLoader implements ResetInterface
             return;
         }
 
-        $rows = $this->connection->fetchAllAssociative(
-            'SELECT `app_document_type`.`technical_name`, `app_document_type`.`formats`, `app_document_type`.`config`
-            FROM `app_document_type`
-            INNER JOIN `app` ON `app`.`id` = `app_document_type`.`app_id`
-            WHERE `app`.`active` = 1'
-        );
+        $criteria = (new Criteria())->addFilter(new EqualsFilter('app.active', true));
+
+        $appDocumentTypes = $this->appDocumentTypeRepository
+            ->search($criteria, Context::createDefaultContext())
+            ->getEntities();
 
         $validFormats = array_column(DocumentFormat::cases(), 'value');
 
         $typesByName = [];
         $configByName = [];
 
-        foreach ($rows as $row) {
-            $technicalName = (string) $row['technical_name'];
+        foreach ($appDocumentTypes as $appDocumentType) {
+            $technicalName = $appDocumentType->getTechnicalName();
 
             // should never shadow core type
             if (DocumentType::tryFrom($technicalName) !== null) {
@@ -88,16 +93,17 @@ final class AppDocumentTypeLoader implements ResetInterface
             }
 
             /** @var list<string> $declaredFormats */
-            $declaredFormats = Json::decodeToList((string) $row['formats']);
+            $declaredFormats = $appDocumentType->getFormats() ?? [];
             $formats = array_values(array_intersect($declaredFormats, $validFormats));
 
             if ($formats !== []) {
                 $typesByName[$technicalName] = $formats;
             }
 
-            $configByName[$technicalName] = $row['config'] !== null
-                ? Json::decodeToArray((string) $row['config'])
-                : [];
+            /** @var array<string, scalar> $config */
+            $config = $appDocumentType->getConfig() ?? [];
+
+            $configByName[$technicalName] = $config;
         }
 
         $this->typesByName = $typesByName;

--- a/src/Core/Checkout/DocumentV2/Type/AppDocumentTypeLoader.php
+++ b/src/Core/Checkout/DocumentV2/Type/AppDocumentTypeLoader.php
@@ -1,0 +1,106 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Checkout\DocumentV2\Type;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Checkout\DocumentV2\DocumentFormat;
+use Shopware\Core\Checkout\DocumentV2\DocumentType;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Util\Json;
+use Symfony\Contracts\Service\ResetInterface;
+
+/**
+ * Loads document types registered by active apps via the `app_document_type` aggregate.
+ *
+ * @internal
+ */
+#[Package('after-sales')]
+final class AppDocumentTypeLoader implements ResetInterface
+{
+    /**
+     * @var array<string, list<string>>|null
+     */
+    private ?array $typesByName = null;
+
+    /**
+     * @var array<string, array<string, scalar>>|null
+     */
+    private ?array $configByName = null;
+
+    public function __construct(private readonly Connection $connection)
+    {
+    }
+
+    /**
+     * @return array<string, list<string>>
+     */
+    public function load(): array
+    {
+        $this->fetch();
+
+        \assert($this->typesByName !== null);
+
+        return $this->typesByName;
+    }
+
+    /**
+     * @return array<string, scalar>
+     */
+    public function loadConfig(string $technicalName): array
+    {
+        $this->fetch();
+
+        \assert($this->configByName !== null);
+
+        return $this->configByName[$technicalName] ?? [];
+    }
+
+    public function reset(): void
+    {
+        $this->typesByName = null;
+        $this->configByName = null;
+    }
+
+    private function fetch(): void
+    {
+        if ($this->typesByName !== null) {
+            return;
+        }
+
+        $rows = $this->connection->fetchAllAssociative(
+            'SELECT `app_document_type`.`technical_name`, `app_document_type`.`formats`, `app_document_type`.`config`
+            FROM `app_document_type`
+            INNER JOIN `app` ON `app`.`id` = `app_document_type`.`app_id`
+            WHERE `app`.`active` = 1'
+        );
+
+        $validFormats = array_column(DocumentFormat::cases(), 'value');
+
+        $typesByName = [];
+        $configByName = [];
+
+        foreach ($rows as $row) {
+            $technicalName = (string) $row['technical_name'];
+
+            // should never shadow core type
+            if (DocumentType::tryFrom($technicalName) !== null) {
+                continue;
+            }
+
+            /** @var list<string> $declaredFormats */
+            $declaredFormats = Json::decodeToList((string) $row['formats']);
+            $formats = array_values(array_intersect($declaredFormats, $validFormats));
+
+            if ($formats !== []) {
+                $typesByName[$technicalName] = $formats;
+            }
+
+            $configByName[$technicalName] = $row['config'] !== null
+                ? Json::decodeToArray((string) $row['config'])
+                : [];
+        }
+
+        $this->typesByName = $typesByName;
+        $this->configByName = $configByName;
+    }
+}

--- a/src/Core/Checkout/DocumentV2/Type/DocumentTypeRegistry.php
+++ b/src/Core/Checkout/DocumentV2/Type/DocumentTypeRegistry.php
@@ -4,37 +4,26 @@ namespace Shopware\Core\Checkout\DocumentV2\Type;
 
 use Shopware\Core\Checkout\DocumentV2\DocumentV2Exception;
 use Shopware\Core\Framework\Log\Package;
+use Symfony\Contracts\Service\ResetInterface;
 
 /**
  * @internal
  */
 #[Package('after-sales')]
-final readonly class DocumentTypeRegistry
+final class DocumentTypeRegistry implements ResetInterface
 {
     /**
-     * @var array<string, list<string>>
+     * @var array<string, list<string>>|null
      */
-    private array $formatsByType;
+    private ?array $formatsByType = null;
 
     /**
      * @param iterable<AbstractDocumentType> $documentTypes
      */
-    public function __construct(iterable $documentTypes)
-    {
-        $formatsByType = [];
-
-        foreach ($documentTypes as $documentType) {
-            $technicalName = $documentType->getTechnicalName();
-
-            foreach ($documentType->getSupportedFormats() as $format) {
-                $formatsByType[$technicalName][$format] = true;
-            }
-        }
-
-        $this->formatsByType = array_map(
-            static fn (array $formats): array => array_keys($formats),
-            $formatsByType,
-        );
+    public function __construct(
+        private readonly iterable $documentTypes,
+        private readonly AppDocumentTypeLoader $appDocumentTypeLoader,
+    ) {
     }
 
     /**
@@ -42,7 +31,7 @@ final readonly class DocumentTypeRegistry
      */
     public function getDocumentTypes(): array
     {
-        return array_keys($this->formatsByType);
+        return array_keys($this->formatsByType());
     }
 
     /**
@@ -50,12 +39,12 @@ final readonly class DocumentTypeRegistry
      */
     public function getSupportedFormats(string $documentType): array
     {
-        return $this->formatsByType[$documentType] ?? [];
+        return $this->formatsByType()[$documentType] ?? [];
     }
 
     public function supports(string $documentType): bool
     {
-        return isset($this->formatsByType[$documentType]);
+        return isset($this->formatsByType()[$documentType]);
     }
 
     /**
@@ -72,5 +61,42 @@ final readonly class DocumentTypeRegistry
                 throw DocumentV2Exception::unsupportedDocumentFormat($format, $documentType);
             }
         }
+    }
+
+    public function reset(): void
+    {
+        $this->formatsByType = null;
+    }
+
+    /**
+     * @return array<string, list<string>>
+     */
+    private function formatsByType(): array
+    {
+        if ($this->formatsByType !== null) {
+            return $this->formatsByType;
+        }
+
+        $formatsByType = [];
+
+        foreach ($this->documentTypes as $documentType) {
+            $technicalName = $documentType->getTechnicalName();
+
+            foreach ($documentType->getSupportedFormats() as $format) {
+                $formatsByType[$technicalName][$format] = true;
+            }
+        }
+
+        $merged = array_map(
+            static fn (array $formats): array => array_keys($formats),
+            $formatsByType,
+        );
+
+        foreach ($this->appDocumentTypeLoader->load() as $type => $formats) {
+            // app document types do not override core types
+            $merged[$type] ??= $formats;
+        }
+
+        return $this->formatsByType = $merged;
     }
 }

--- a/src/Core/Content/Flow/Rule/OrderDocumentTypeRule.php
+++ b/src/Core/Content/Flow/Rule/OrderDocumentTypeRule.php
@@ -58,6 +58,10 @@ class OrderDocumentTypeRule extends FlowRule
 
         $typeIds = [];
         foreach ($documents->getElements() as $document) {
+            if ($document->getDocumentTypeId() === null) {
+                continue;
+            }
+
             $typeIds[] = $document->getDocumentTypeId();
         }
 

--- a/src/Core/Content/Flow/Rule/OrderDocumentTypeSentRule.php
+++ b/src/Core/Content/Flow/Rule/OrderDocumentTypeSentRule.php
@@ -58,7 +58,7 @@ class OrderDocumentTypeSentRule extends FlowRule
 
         $sentTypeIds = [];
         foreach ($documents->getElements() as $document) {
-            if ($document->getSent()) {
+            if ($document->getSent() && $document->getDocumentTypeId() !== null) {
                 $sentTypeIds[] = $document->getDocumentTypeId();
             }
         }

--- a/src/Core/DevOps/Resources/generated/script-hooks-reference.md
+++ b/src/Core/DevOps/Resources/generated/script-hooks-reference.md
@@ -12,6 +12,18 @@ nav:
 
 All available Hooks that can be used to load additional data.
 
+### document-generation
+
+| <!-- -->               | <!-- -->                                |
+|:-----------------------|:----------------------------------------|
+| **Name**               | document-generation                         |
+| **Since**              | 6.7.13.0                        |
+| **Class**              | `Shopware\Core\Checkout\DocumentV2\Event\Hooks\DocumentGenerationHook`                      |
+| **Description**        | Triggered once per document generation, after the order is loaded and the document number is allocated, but before any renderer runs.<br>                  |
+| **Available Data**     | context: [`Shopware\Core\Framework\Context`](https://github.com/shopware/shopware/blob/trunk/src/Core/Framework/Context.php)<br>documentNumber: `string`<br>documentType: `string`<br>formats: `array`<br>order: [`Shopware\Core\Checkout\Order\OrderEntity`](https://github.com/shopware/shopware/blob/trunk/src/Core/Checkout/Order/OrderEntity.php)<br>        |
+| **Available Services** | [repository](./data-loading-script-services-reference#RepositoryFacade)<br>[config](./miscellaneous-script-services-reference#SystemConfigFacade)<br>[acl](./miscellaneous-script-services-reference#AclFacade)<br> |
+| **Stoppable**          | `false`                  |
+
 ### payment-method-route-request
 
 | <!-- -->               | <!-- -->                                |

--- a/src/Core/Framework/Api/ApiDefinition/Generator/StoreApiPhpGeneratedSchemaAllowlist.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/StoreApiPhpGeneratedSchemaAllowlist.json
@@ -5,6 +5,7 @@
         "AppActionButton",
         "AppAdministrationSnippet",
         "AppCmsBlock",
+          "AppDocumentType",
         "AppFlowAction",
         "AppFlowEvent",
         "AppMcpPrompt",

--- a/src/Core/Framework/Api/ApiDefinition/Generator/StoreApiPhpGeneratedSchemaAllowlist.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/StoreApiPhpGeneratedSchemaAllowlist.json
@@ -5,7 +5,7 @@
         "AppActionButton",
         "AppAdministrationSnippet",
         "AppCmsBlock",
-          "AppDocumentType",
+        "AppDocumentType",
         "AppFlowAction",
         "AppFlowEvent",
         "AppMcpPrompt",

--- a/src/Core/Framework/App/Aggregate/AppDocumentType/AppDocumentTypeCollection.php
+++ b/src/Core/Framework/App/Aggregate/AppDocumentType/AppDocumentTypeCollection.php
@@ -6,6 +6,8 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
 use Shopware\Core\Framework\Log\Package;
 
 /**
+ * @internal
+ *
  * @extends EntityCollection<AppDocumentTypeEntity>
  */
 #[Package('framework')]

--- a/src/Core/Framework/App/Aggregate/AppDocumentType/AppDocumentTypeCollection.php
+++ b/src/Core/Framework/App/Aggregate/AppDocumentType/AppDocumentTypeCollection.php
@@ -1,0 +1,23 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\App\Aggregate\AppDocumentType;
+
+use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * @extends EntityCollection<AppDocumentTypeEntity>
+ */
+#[Package('framework')]
+class AppDocumentTypeCollection extends EntityCollection
+{
+    public function getApiAlias(): string
+    {
+        return 'app_document_type_collection';
+    }
+
+    protected function getExpectedClass(): string
+    {
+        return AppDocumentTypeEntity::class;
+    }
+}

--- a/src/Core/Framework/App/Aggregate/AppDocumentType/AppDocumentTypeDefinition.php
+++ b/src/Core/Framework/App/Aggregate/AppDocumentType/AppDocumentTypeDefinition.php
@@ -5,6 +5,7 @@ namespace Shopware\Core\Framework\App\Aggregate\AppDocumentType;
 use Shopware\Core\Framework\App\Aggregate\AppDocumentTypeTranslation\AppDocumentTypeTranslationDefinition;
 use Shopware\Core\Framework\App\AppDefinition;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\CreatedAtField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\FkField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\CascadeDelete;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\PrimaryKey;
@@ -15,6 +16,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\ManyToOneAssociationField
 use Shopware\Core\Framework\DataAbstractionLayer\Field\StringField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\TranslatedField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\TranslationsAssociationField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\UpdatedAtField;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 
@@ -41,7 +43,7 @@ class AppDocumentTypeDefinition extends EntityDefinition
         return AppDocumentTypeEntity::class;
     }
 
-    public function since(): ?string
+    public function since(): string
     {
         return '6.7.13.0';
     }
@@ -51,17 +53,31 @@ class AppDocumentTypeDefinition extends EntityDefinition
         return AppDefinition::class;
     }
 
+    /**
+     * TODO: Intentionally disabled default timestamps for now so `createdAt` / `updatedAt` stay
+     */
+    protected function defaultFields(): array
+    {
+        return [];
+    }
+
     protected function defineFields(): FieldCollection
     {
         return new FieldCollection([
-            (new IdField('id', 'id'))->addFlags(new PrimaryKey(), new Required())->setDescription('Unique identity of apps document type.'),
-            (new StringField('technical_name', 'technicalName'))->addFlags(new Required())->setDescription('It is a unique identity of an AppDocumentType.'),
-            (new JsonField('config', 'config'))->setDescription('Specifies detailed information about the document type.'),
-            (new JsonField('formats', 'formats'))->setDescription('Output formats this document type supports.'),
+            (new IdField('id', 'id'))->addFlags(new PrimaryKey(), new Required()),
+
+            (new FkField('app_id', 'appId', AppDefinition::class))->addFlags(new CascadeDelete(), new Required()),
+
+            (new StringField('technical_name', 'technicalName'))->addFlags(new Required()),
+            new JsonField('config', 'config'),
+            new JsonField('formats', 'formats'),
             new TranslatedField('label'),
-            (new FkField('app_id', 'appId', AppDefinition::class))->addFlags(new CascadeDelete(), new Required())->setDescription('Unique identity of app.'),
+
             new ManyToOneAssociationField('app', 'app_id', AppDefinition::class),
             (new TranslationsAssociationField(AppDocumentTypeTranslationDefinition::class, 'app_document_type_id'))->addFlags(new Required()),
+
+            new CreatedAtField(),
+            new UpdatedAtField(),
         ]);
     }
 }

--- a/src/Core/Framework/App/Aggregate/AppDocumentType/AppDocumentTypeDefinition.php
+++ b/src/Core/Framework/App/Aggregate/AppDocumentType/AppDocumentTypeDefinition.php
@@ -1,0 +1,67 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\App\Aggregate\AppDocumentType;
+
+use Shopware\Core\Framework\App\Aggregate\AppDocumentTypeTranslation\AppDocumentTypeTranslationDefinition;
+use Shopware\Core\Framework\App\AppDefinition;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\FkField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\CascadeDelete;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\PrimaryKey;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\Required;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\IdField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\JsonField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\ManyToOneAssociationField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\StringField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\TranslatedField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\TranslationsAssociationField;
+use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+class AppDocumentTypeDefinition extends EntityDefinition
+{
+    final public const ENTITY_NAME = 'app_document_type';
+
+    public function getEntityName(): string
+    {
+        return self::ENTITY_NAME;
+    }
+
+    public function getCollectionClass(): string
+    {
+        return AppDocumentTypeCollection::class;
+    }
+
+    public function getEntityClass(): string
+    {
+        return AppDocumentTypeEntity::class;
+    }
+
+    public function since(): ?string
+    {
+        return '6.7.13.0';
+    }
+
+    protected function getParentDefinitionClass(): ?string
+    {
+        return AppDefinition::class;
+    }
+
+    protected function defineFields(): FieldCollection
+    {
+        return new FieldCollection([
+            (new IdField('id', 'id'))->addFlags(new PrimaryKey(), new Required())->setDescription('Unique identity of apps document type.'),
+            (new StringField('technical_name', 'technicalName'))->addFlags(new Required())->setDescription('It is a unique identity of an AppDocumentType.'),
+            (new JsonField('config', 'config'))->setDescription('Specifies detailed information about the document type.'),
+            (new JsonField('formats', 'formats'))->setDescription('Output formats this document type supports.'),
+            new TranslatedField('label'),
+            (new FkField('app_id', 'appId', AppDefinition::class))->addFlags(new CascadeDelete(), new Required())->setDescription('Unique identity of app.'),
+            new ManyToOneAssociationField('app', 'app_id', AppDefinition::class),
+            (new TranslationsAssociationField(AppDocumentTypeTranslationDefinition::class, 'app_document_type_id'))->addFlags(new Required()),
+        ]);
+    }
+}

--- a/src/Core/Framework/App/Aggregate/AppDocumentType/AppDocumentTypeEntity.php
+++ b/src/Core/Framework/App/Aggregate/AppDocumentType/AppDocumentTypeEntity.php
@@ -8,6 +8,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\Entity;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityIdTrait;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @internal
+ */
 #[Package('framework')]
 class AppDocumentTypeEntity extends Entity
 {

--- a/src/Core/Framework/App/Aggregate/AppDocumentType/AppDocumentTypeEntity.php
+++ b/src/Core/Framework/App/Aggregate/AppDocumentType/AppDocumentTypeEntity.php
@@ -1,0 +1,117 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\App\Aggregate\AppDocumentType;
+
+use Shopware\Core\Framework\App\Aggregate\AppDocumentTypeTranslation\AppDocumentTypeTranslationCollection;
+use Shopware\Core\Framework\App\AppEntity;
+use Shopware\Core\Framework\DataAbstractionLayer\Entity;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityIdTrait;
+use Shopware\Core\Framework\Log\Package;
+
+#[Package('framework')]
+class AppDocumentTypeEntity extends Entity
+{
+    use EntityIdTrait;
+
+    protected string $appId;
+
+    protected ?AppEntity $app = null;
+
+    protected string $technicalName;
+
+    /**
+     * @var array<string, mixed>|null
+     */
+    protected ?array $config = null;
+
+    /**
+     * @var list<string>|null
+     */
+    protected ?array $formats = null;
+
+    protected ?string $label = null;
+
+    protected ?AppDocumentTypeTranslationCollection $translations = null;
+
+    public function getAppId(): string
+    {
+        return $this->appId;
+    }
+
+    public function setAppId(string $appId): void
+    {
+        $this->appId = $appId;
+    }
+
+    public function getApp(): ?AppEntity
+    {
+        return $this->app;
+    }
+
+    public function setApp(?AppEntity $app): void
+    {
+        $this->app = $app;
+    }
+
+    public function getTechnicalName(): string
+    {
+        return $this->technicalName;
+    }
+
+    public function setTechnicalName(string $technicalName): void
+    {
+        $this->technicalName = $technicalName;
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    public function getConfig(): ?array
+    {
+        return $this->config;
+    }
+
+    /**
+     * @param array<string, mixed>|null $config
+     */
+    public function setConfig(?array $config): void
+    {
+        $this->config = $config;
+    }
+
+    /**
+     * @return list<string>|null
+     */
+    public function getFormats(): ?array
+    {
+        return $this->formats;
+    }
+
+    /**
+     * @param list<string>|null $formats
+     */
+    public function setFormats(?array $formats): void
+    {
+        $this->formats = $formats;
+    }
+
+    public function getLabel(): ?string
+    {
+        return $this->label;
+    }
+
+    public function setLabel(?string $label): void
+    {
+        $this->label = $label;
+    }
+
+    public function getTranslations(): ?AppDocumentTypeTranslationCollection
+    {
+        return $this->translations;
+    }
+
+    public function setTranslations(AppDocumentTypeTranslationCollection $translations): void
+    {
+        $this->translations = $translations;
+    }
+}

--- a/src/Core/Framework/App/Aggregate/AppDocumentTypeTranslation/AppDocumentTypeTranslationCollection.php
+++ b/src/Core/Framework/App/Aggregate/AppDocumentTypeTranslation/AppDocumentTypeTranslationCollection.php
@@ -1,0 +1,23 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\App\Aggregate\AppDocumentTypeTranslation;
+
+use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * @extends EntityCollection<AppDocumentTypeTranslationEntity>
+ */
+#[Package('framework')]
+class AppDocumentTypeTranslationCollection extends EntityCollection
+{
+    public function getApiAlias(): string
+    {
+        return 'app_document_type_translation_collection';
+    }
+
+    protected function getExpectedClass(): string
+    {
+        return AppDocumentTypeTranslationEntity::class;
+    }
+}

--- a/src/Core/Framework/App/Aggregate/AppDocumentTypeTranslation/AppDocumentTypeTranslationDefinition.php
+++ b/src/Core/Framework/App/Aggregate/AppDocumentTypeTranslation/AppDocumentTypeTranslationDefinition.php
@@ -5,11 +5,15 @@ namespace Shopware\Core\Framework\App\Aggregate\AppDocumentTypeTranslation;
 use Shopware\Core\Framework\App\Aggregate\AppDocumentType\AppDocumentTypeDefinition;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityTranslationDefinition;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\CreatedAtField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\FkField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\PrimaryKey;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\Required;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\ManyToOneAssociationField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\StringField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\UpdatedAtField;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\System\Language\LanguageDefinition;
 
 /**
  * @internal
@@ -50,6 +54,19 @@ class AppDocumentTypeTranslationDefinition extends EntityTranslationDefinition
     protected function defaultFields(): array
     {
         return [];
+    }
+
+    /**
+     * TODO: Mirrors {@see EntityTranslationDefinition::getBaseFields()} but without the `ApiAware` flag
+     */
+    protected function getBaseFields(): array
+    {
+        return [
+            (new FkField('app_document_type_id', 'appDocumentTypeId', AppDocumentTypeDefinition::ENTITY_NAME, 'id'))->addFlags(new PrimaryKey(), new Required()),
+            (new FkField('language_id', 'languageId', LanguageDefinition::ENTITY_NAME, 'id'))->addFlags(new PrimaryKey(), new Required()),
+            new ManyToOneAssociationField('appDocumentType', 'app_document_type_id', AppDocumentTypeDefinition::ENTITY_NAME, 'id', false),
+            new ManyToOneAssociationField('language', 'language_id', LanguageDefinition::ENTITY_NAME, 'id', false),
+        ];
     }
 
     protected function defineFields(): FieldCollection

--- a/src/Core/Framework/App/Aggregate/AppDocumentTypeTranslation/AppDocumentTypeTranslationDefinition.php
+++ b/src/Core/Framework/App/Aggregate/AppDocumentTypeTranslation/AppDocumentTypeTranslationDefinition.php
@@ -4,12 +4,16 @@ namespace Shopware\Core\Framework\App\Aggregate\AppDocumentTypeTranslation;
 
 use Shopware\Core\Framework\App\Aggregate\AppDocumentType\AppDocumentTypeDefinition;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityTranslationDefinition;
-use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\ApiAware;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\CreatedAtField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\Required;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\StringField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\UpdatedAtField;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @internal
+ */
 #[Package('framework')]
 class AppDocumentTypeTranslationDefinition extends EntityTranslationDefinition
 {
@@ -40,10 +44,21 @@ class AppDocumentTypeTranslationDefinition extends EntityTranslationDefinition
         return AppDocumentTypeDefinition::class;
     }
 
+    /**
+     * TODO: Intentionally disabled default timestamps for now so `createdAt` / `updatedAt` stay
+     */
+    protected function defaultFields(): array
+    {
+        return [];
+    }
+
     protected function defineFields(): FieldCollection
     {
         return new FieldCollection([
-            (new StringField('label', 'label'))->addFlags(new ApiAware(), new Required()),
+            (new StringField('label', 'label'))->addFlags(new Required()),
+
+            new CreatedAtField(),
+            new UpdatedAtField(),
         ]);
     }
 }

--- a/src/Core/Framework/App/Aggregate/AppDocumentTypeTranslation/AppDocumentTypeTranslationDefinition.php
+++ b/src/Core/Framework/App/Aggregate/AppDocumentTypeTranslation/AppDocumentTypeTranslationDefinition.php
@@ -1,0 +1,49 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\App\Aggregate\AppDocumentTypeTranslation;
+
+use Shopware\Core\Framework\App\Aggregate\AppDocumentType\AppDocumentTypeDefinition;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityTranslationDefinition;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\ApiAware;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\Required;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\StringField;
+use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
+use Shopware\Core\Framework\Log\Package;
+
+#[Package('framework')]
+class AppDocumentTypeTranslationDefinition extends EntityTranslationDefinition
+{
+    final public const ENTITY_NAME = 'app_document_type_translation';
+
+    public function getEntityName(): string
+    {
+        return self::ENTITY_NAME;
+    }
+
+    public function getCollectionClass(): string
+    {
+        return AppDocumentTypeTranslationCollection::class;
+    }
+
+    public function getEntityClass(): string
+    {
+        return AppDocumentTypeTranslationEntity::class;
+    }
+
+    public function since(): ?string
+    {
+        return '6.7.13.0';
+    }
+
+    protected function getParentDefinitionClass(): string
+    {
+        return AppDocumentTypeDefinition::class;
+    }
+
+    protected function defineFields(): FieldCollection
+    {
+        return new FieldCollection([
+            (new StringField('label', 'label'))->addFlags(new ApiAware(), new Required()),
+        ]);
+    }
+}

--- a/src/Core/Framework/App/Aggregate/AppDocumentTypeTranslation/AppDocumentTypeTranslationEntity.php
+++ b/src/Core/Framework/App/Aggregate/AppDocumentTypeTranslation/AppDocumentTypeTranslationEntity.php
@@ -1,0 +1,47 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\App\Aggregate\AppDocumentTypeTranslation;
+
+use Shopware\Core\Framework\App\Aggregate\AppDocumentType\AppDocumentTypeEntity;
+use Shopware\Core\Framework\DataAbstractionLayer\TranslationEntity;
+use Shopware\Core\Framework\Log\Package;
+
+#[Package('framework')]
+class AppDocumentTypeTranslationEntity extends TranslationEntity
+{
+    protected ?string $label = null;
+
+    protected ?AppDocumentTypeEntity $appDocumentType = null;
+
+    protected string $appDocumentTypeId;
+
+    public function getLabel(): ?string
+    {
+        return $this->label;
+    }
+
+    public function setLabel(string $label): void
+    {
+        $this->label = $label;
+    }
+
+    public function getAppDocumentType(): ?AppDocumentTypeEntity
+    {
+        return $this->appDocumentType;
+    }
+
+    public function setAppDocumentType(?AppDocumentTypeEntity $appDocumentType): void
+    {
+        $this->appDocumentType = $appDocumentType;
+    }
+
+    public function getAppDocumentTypeId(): string
+    {
+        return $this->appDocumentTypeId;
+    }
+
+    public function setAppDocumentTypeId(string $appDocumentTypeId): void
+    {
+        $this->appDocumentTypeId = $appDocumentTypeId;
+    }
+}

--- a/src/Core/Framework/App/AppDefinition.php
+++ b/src/Core/Framework/App/AppDefinition.php
@@ -4,6 +4,7 @@ namespace Shopware\Core\Framework\App;
 
 use Shopware\Core\Framework\Api\Acl\Role\AclRoleDefinition;
 use Shopware\Core\Framework\App\Aggregate\ActionButton\ActionButtonDefinition;
+use Shopware\Core\Framework\App\Aggregate\AppDocumentType\AppDocumentTypeDefinition;
 use Shopware\Core\Framework\App\Aggregate\AppMcpPrompt\AppMcpPromptDefinition;
 use Shopware\Core\Framework\App\Aggregate\AppMcpResource\AppMcpResourceDefinition;
 use Shopware\Core\Framework\App\Aggregate\AppMcpTool\AppMcpToolDefinition;
@@ -149,6 +150,7 @@ class AppDefinition extends EntityDefinition
             (new OneToManyAssociationField('mcpTools', AppMcpToolDefinition::class, 'app_id'))->addFlags(new CascadeDelete()),
             (new OneToManyAssociationField('mcpPrompts', AppMcpPromptDefinition::class, 'app_id'))->addFlags(new CascadeDelete()),
             (new OneToManyAssociationField('mcpResources', AppMcpResourceDefinition::class, 'app_id'))->addFlags(new CascadeDelete()),
+            (new OneToManyAssociationField('appDocumentTypes', AppDocumentTypeDefinition::class, 'app_id'))->addFlags(new CascadeDelete()),
         ]);
     }
 }

--- a/src/Core/Framework/App/AppEntity.php
+++ b/src/Core/Framework/App/AppEntity.php
@@ -4,6 +4,7 @@ namespace Shopware\Core\Framework\App;
 
 use Shopware\Core\Framework\Api\Acl\Role\AclRoleEntity;
 use Shopware\Core\Framework\App\Aggregate\ActionButton\ActionButtonCollection;
+use Shopware\Core\Framework\App\Aggregate\AppDocumentType\AppDocumentTypeCollection;
 use Shopware\Core\Framework\App\Aggregate\AppMcpPrompt\AppMcpPromptCollection;
 use Shopware\Core\Framework\App\Aggregate\AppMcpResource\AppMcpResourceCollection;
 use Shopware\Core\Framework\App\Aggregate\AppMcpTool\AppMcpToolCollection;
@@ -155,6 +156,8 @@ class AppEntity extends Entity
     protected ?AppMcpPromptCollection $mcpPrompts = null;
 
     protected ?AppMcpResourceCollection $mcpResources = null;
+
+    protected ?AppDocumentTypeCollection $appDocumentTypes = null;
 
     protected int $templateLoadPriority;
 
@@ -671,6 +674,16 @@ class AppEntity extends Entity
     public function setMcpResources(AppMcpResourceCollection $mcpResources): void
     {
         $this->mcpResources = $mcpResources;
+    }
+
+    public function getAppDocumentTypes(): ?AppDocumentTypeCollection
+    {
+        return $this->appDocumentTypes;
+    }
+
+    public function setAppDocumentTypes(AppDocumentTypeCollection $appDocumentTypes): void
+    {
+        $this->appDocumentTypes = $appDocumentTypes;
     }
 
     public function jsonSerialize(): array

--- a/src/Core/Framework/App/AppException.php
+++ b/src/Core/Framework/App/AppException.php
@@ -61,6 +61,7 @@ class AppException extends HttpException
     final public const APP_GATEWAY_REQUEST_FAILED = 'FRAMEWORK__APP_CONTEXT_GATEWAY_REQUEST_FAILED';
     final public const APP_RESTRICT_DELETE_PREVENTS_DEACTIVATION = 'FRAMEWORK__APP_RESTRICT_DELETE_PREVENTS_DEACTIVATION';
     final public const CONFLICTING_PRIVILEGE_UPDATE = 'FRAMEWORK__APP_CONFLICTING_PRIVILEGE_UPDATE';
+    final public const DOCUMENT_TYPE_ALREADY_REGISTERED = 'FRAMEWORK__APP_DOCUMENT_TYPE_ALREADY_REGISTERED';
     final public const INVALID_PERMISSIONS = 'FRAMEWORK__APP_INVALID_PERMISSIONS';
     final public const REQUIRES_ADMIN_API_SOURCE = 'FRAMEWORK__APP_ACTION_REQUIRES_ADMIN_API_SOURCE';
     final public const MISSING_USER_IN_CONTEXT_SOURCE = 'FRAMEWORK__APP_MISSING_USER_IN_CONTEXT_SOURCE';
@@ -492,6 +493,16 @@ class AppException extends HttpException
             Response::HTTP_BAD_REQUEST,
             self::CONFLICTING_PRIVILEGE_UPDATE,
             'A privilege cannot be present in both the accept and revoke lists simultaneously.'
+        );
+    }
+
+    public static function documentTypeAlreadyRegistered(string $identifier, string $owningAppName): self
+    {
+        return new self(
+            Response::HTTP_CONFLICT,
+            self::DOCUMENT_TYPE_ALREADY_REGISTERED,
+            'The document type "{{ identifier }}" is already registered by app "{{ owningAppName }}"',
+            ['identifier' => $identifier, 'owningAppName' => $owningAppName]
         );
     }
 

--- a/src/Core/Framework/App/Lifecycle/Handler/DocumentTypeLifecycleHandler.php
+++ b/src/Core/Framework/App/Lifecycle/Handler/DocumentTypeLifecycleHandler.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Core\Framework\App\Lifecycle\Handler;
 
+use Shopware\Core\Checkout\DocumentV2\DocumentType;
 use Shopware\Core\Framework\App\Aggregate\AppDocumentType\AppDocumentTypeCollection;
 use Shopware\Core\Framework\App\Lifecycle\Context\AppPersistContext;
 use Shopware\Core\Framework\Context;
@@ -48,17 +49,22 @@ class DocumentTypeLifecycleHandler extends AbstractLifecycleHandler
         $upserts = [];
 
         foreach ($documentTypes as $documentType) {
-            $payload = [
-                'appId' => $appId,
-                'technicalName' => $documentType->getIdentifier(),
-                'config' => $documentType->getConfig() ?: null,
-                'formats' => $documentType->getFormats(),
-                'label' => $documentType->getLabel(),
-            ];
+            $identifier = $documentType->getIdentifier();
+
+            // a core document type of the same name always wins; never persist a shadow row for it
+            if (DocumentType::tryFrom($identifier) !== null) {
+                continue;
+            }
+
+            $payload = $documentType->toArray($context->defaultLocale);
+            $payload['appId'] = $appId;
+            $payload['technicalName'] = $identifier;
+            $payload['config'] = $payload['config'] ?: null;
+            unset($payload['identifier']);
 
             $existing = $existingDocumentTypes->filterByProperty(
                 'technicalName',
-                $documentType->getIdentifier()
+                $identifier
             )->first();
 
             if ($existing) {

--- a/src/Core/Framework/App/Lifecycle/Handler/DocumentTypeLifecycleHandler.php
+++ b/src/Core/Framework/App/Lifecycle/Handler/DocumentTypeLifecycleHandler.php
@@ -4,11 +4,15 @@ namespace Shopware\Core\Framework\App\Lifecycle\Handler;
 
 use Shopware\Core\Checkout\DocumentV2\DocumentType;
 use Shopware\Core\Framework\App\Aggregate\AppDocumentType\AppDocumentTypeCollection;
+use Shopware\Core\Framework\App\AppException;
 use Shopware\Core\Framework\App\Lifecycle\Context\AppPersistContext;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsAnyFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\MultiFilter;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\NotFilter;
 use Shopware\Core\Framework\Log\Package;
 
 /**
@@ -51,7 +55,7 @@ class DocumentTypeLifecycleHandler extends AbstractLifecycleHandler
         foreach ($documentTypes as $documentType) {
             $identifier = $documentType->getIdentifier();
 
-            // a core document type of the same name always wins; never persist a shadow row for it
+            // never persist core type shadow
             if (DocumentType::tryFrom($identifier) !== null) {
                 continue;
             }
@@ -76,10 +80,35 @@ class DocumentTypeLifecycleHandler extends AbstractLifecycleHandler
         }
 
         if ($upserts !== []) {
+            $this->assertIdentifiersAreUnclaimed($upserts, $appId, $context->context);
+
             $this->appDocumentTypeRepository->upsert($upserts, $context->context);
         }
 
         $this->deleteRemovedDocumentTypes($existingDocumentTypes, $context->context);
+    }
+
+    /**
+     * @param list<array<string, mixed>> $upserts
+     */
+    private function assertIdentifiersAreUnclaimed(array $upserts, string $appId, Context $context): void
+    {
+        $identifiers = array_column($upserts, 'technicalName');
+
+        $criteria = new Criteria();
+        $criteria->addFilter(new EqualsAnyFilter('technicalName', $identifiers));
+        $criteria->addFilter(new NotFilter(MultiFilter::CONNECTION_AND, [new EqualsFilter('appId', $appId)]));
+        $criteria->addAssociation('app');
+        $criteria->setLimit(1);
+
+        $conflict = $this->appDocumentTypeRepository->search($criteria, $context)->getEntities()->first();
+
+        if ($conflict !== null) {
+            throw AppException::documentTypeAlreadyRegistered(
+                $conflict->getTechnicalName(),
+                $conflict->getApp()?->getName() ?? $conflict->getAppId(),
+            );
+        }
     }
 
     private function deleteRemovedDocumentTypes(AppDocumentTypeCollection $toBeRemoved, Context $context): void

--- a/src/Core/Framework/App/Lifecycle/Handler/DocumentTypeLifecycleHandler.php
+++ b/src/Core/Framework/App/Lifecycle/Handler/DocumentTypeLifecycleHandler.php
@@ -12,6 +12,10 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @internal only for use by the app-system
+ *
+ * @codeCoverageIgnore - coverd by integration test
+ *
+ * @see \Shopware\Tests\Integration\Core\Framework\App\Lifecycle\Handler\DocumentTypeLifecycleHandlerTest
  */
 #[Package('framework')]
 class DocumentTypeLifecycleHandler extends AbstractLifecycleHandler

--- a/src/Core/Framework/App/Lifecycle/Handler/DocumentTypeLifecycleHandler.php
+++ b/src/Core/Framework/App/Lifecycle/Handler/DocumentTypeLifecycleHandler.php
@@ -1,0 +1,93 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\App\Lifecycle\Handler;
+
+use Shopware\Core\Framework\App\Aggregate\AppDocumentType\AppDocumentTypeCollection;
+use Shopware\Core\Framework\App\Lifecycle\Context\AppPersistContext;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * @internal only for use by the app-system
+ */
+#[Package('framework')]
+class DocumentTypeLifecycleHandler extends AbstractLifecycleHandler
+{
+    /**
+     * @param EntityRepository<AppDocumentTypeCollection> $appDocumentTypeRepository
+     */
+    public function __construct(private readonly EntityRepository $appDocumentTypeRepository)
+    {
+    }
+
+    public function install(AppPersistContext $context): void
+    {
+        $this->sync($context);
+    }
+
+    public function update(AppPersistContext $context): void
+    {
+        $this->sync($context);
+    }
+
+    private function sync(AppPersistContext $context): void
+    {
+        $appId = $context->app->getId();
+        $existingDocumentTypes = $this->getExistingDocumentTypes($appId, $context->context);
+
+        $documents = $context->manifest->getDocuments();
+        $documentTypes = $documents !== null ? $documents->getDocumentTypes() : [];
+
+        $upserts = [];
+
+        foreach ($documentTypes as $documentType) {
+            $payload = [
+                'appId' => $appId,
+                'technicalName' => $documentType->getIdentifier(),
+                'config' => $documentType->getConfig() ?: null,
+                'formats' => $documentType->getFormats(),
+                'label' => $documentType->getLabel(),
+            ];
+
+            $existing = $existingDocumentTypes->filterByProperty(
+                'technicalName',
+                $documentType->getIdentifier()
+            )->first();
+
+            if ($existing) {
+                $payload['id'] = $existing->getId();
+                $existingDocumentTypes->remove($existing->getId());
+            }
+
+            $upserts[] = $payload;
+        }
+
+        if ($upserts !== []) {
+            $this->appDocumentTypeRepository->upsert($upserts, $context->context);
+        }
+
+        $this->deleteRemovedDocumentTypes($existingDocumentTypes, $context->context);
+    }
+
+    private function deleteRemovedDocumentTypes(AppDocumentTypeCollection $toBeRemoved, Context $context): void
+    {
+        $ids = $toBeRemoved->getIds();
+
+        if ($ids !== []) {
+            $ids = array_map(static fn (string $id): array => ['id' => $id], array_values($ids));
+
+            $this->appDocumentTypeRepository->delete($ids, $context);
+        }
+    }
+
+    private function getExistingDocumentTypes(string $appId, Context $context): AppDocumentTypeCollection
+    {
+        $criteria = new Criteria();
+        $criteria->addFilter(new EqualsFilter('appId', $appId));
+
+        return $this->appDocumentTypeRepository->search($criteria, $context)->getEntities();
+    }
+}

--- a/src/Core/Framework/App/Manifest/Manifest.php
+++ b/src/Core/Framework/App/Manifest/Manifest.php
@@ -8,6 +8,7 @@ use Shopware\Core\Framework\App\Exception\AppXmlParsingException;
 use Shopware\Core\Framework\App\Manifest\Xml\Administration\Admin;
 use Shopware\Core\Framework\App\Manifest\Xml\AllowedHost\AllowedHosts;
 use Shopware\Core\Framework\App\Manifest\Xml\Cookie\Cookies;
+use Shopware\Core\Framework\App\Manifest\Xml\Document\Documents;
 use Shopware\Core\Framework\App\Manifest\Xml\Gateway\Gateways;
 use Shopware\Core\Framework\App\Manifest\Xml\Meta\Metadata;
 use Shopware\Core\Framework\App\Manifest\Xml\PaymentMethod\Payments;
@@ -62,6 +63,7 @@ class Manifest
         private readonly ?Tax $tax,
         private readonly ?ShippingMethods $shippingMethods,
         private readonly ?Gateways $gateways,
+        private readonly ?Documents $documents,
     ) {
     }
 
@@ -203,6 +205,11 @@ class Manifest
         return $this->gateways;
     }
 
+    public function getDocuments(): ?Documents
+    {
+        return $this->documents;
+    }
+
     /**
      * @return array<string> all hosts referenced in the manifest file
      */
@@ -317,6 +324,8 @@ class Manifest
             $shippingMethods = $shippingMethods === null ? null : ShippingMethods::fromXml($shippingMethods);
             $gateways = $doc->getElementsByTagName('gateways')->item(0);
             $gateways = $gateways === null ? null : Gateways::fromXml($gateways);
+            $documents = $doc->getElementsByTagName('documents')->item(0);
+            $documents = $documents === null ? null : Documents::fromXml($documents);
         } catch (\Exception $e) {
             throw AppException::xmlParsingException($xmlFile, $e->getMessage());
         }
@@ -338,7 +347,8 @@ class Manifest
             $storefront,
             $tax,
             $shippingMethods,
-            $gateways
+            $gateways,
+            $documents
         );
     }
 

--- a/src/Core/Framework/App/Manifest/Schema/manifest-3.0.xsd
+++ b/src/Core/Framework/App/Manifest/Schema/manifest-3.0.xsd
@@ -141,6 +141,7 @@
                     </xs:unique>
                 </xs:element>
                 <xs:element name="gateways" type="gateways" minOccurs="0"/>
+                <xs:element name="documents" type="documents" minOccurs="0"/>
                 <xs:element name="requirements" type="requirements" minOccurs="0">
                     <xs:annotation>
                         <xs:documentation xml:lang="en">
@@ -598,6 +599,45 @@
             <xs:element type="xs:string" name="script"/>
             <xs:element name="constraints" maxOccurs="unbounded" type="custom-field-list"/>
         </xs:choice>
+    </xs:complexType>
+    <xs:complexType name="documents">
+        <xs:sequence>
+            <xs:element name="document-type" type="document-type" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="document-type">
+        <xs:choice maxOccurs="unbounded">
+            <xs:element type="xs:string" name="identifier"/>
+            <xs:element type="translatableString" name="label" maxOccurs="unbounded"/>
+            <xs:element type="document-type-formats" name="formats"/>
+            <xs:element type="document-type-config" name="config" minOccurs="0"/>
+        </xs:choice>
+    </xs:complexType>
+    <xs:complexType name="document-type-formats">
+        <xs:sequence>
+            <xs:element name="format" maxOccurs="unbounded">
+                <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                        <xs:enumeration value="html"/>
+                        <xs:enumeration value="pdf"/>
+                        <xs:enumeration value="zugferd_xml"/>
+                        <xs:enumeration value="zugferd_embedded_pdf"/>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="document-type-config">
+        <xs:all>
+            <xs:element type="xs:string" name="page-size" minOccurs="0"/>
+            <xs:element type="xs:string" name="page-orientation" minOccurs="0"/>
+            <xs:element type="xs:int" name="items-per-page" minOccurs="0"/>
+            <xs:element type="xs:boolean" name="display-header" minOccurs="0"/>
+            <xs:element type="xs:boolean" name="display-footer" minOccurs="0"/>
+            <xs:element type="xs:boolean" name="display-page-count" minOccurs="0"/>
+            <xs:element type="xs:boolean" name="display-line-items" minOccurs="0"/>
+            <xs:element type="xs:boolean" name="display-prices" minOccurs="0"/>
+        </xs:all>
     </xs:complexType>
     <xs:complexType name="tax">
         <xs:sequence>

--- a/src/Core/Framework/App/Manifest/Xml/Document/DocumentType.php
+++ b/src/Core/Framework/App/Manifest/Xml/Document/DocumentType.php
@@ -39,6 +39,22 @@ class DocumentType extends XmlElement
      */
     protected array $config = [];
 
+    public function toArray(string $defaultLocale): array
+    {
+        $data = parent::toArray($defaultLocale);
+
+        foreach (self::TRANSLATABLE_FIELDS as $field) {
+            $translatableField = self::kebabCaseToCamelCase($field);
+
+            $data[$translatableField] = $this->ensureTranslationForDefaultLanguageExist(
+                $data[$translatableField],
+                $defaultLocale
+            );
+        }
+
+        return $data;
+    }
+
     public function getIdentifier(): string
     {
         return $this->identifier;

--- a/src/Core/Framework/App/Manifest/Xml/Document/DocumentType.php
+++ b/src/Core/Framework/App/Manifest/Xml/Document/DocumentType.php
@@ -1,0 +1,97 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\App\Manifest\Xml\Document;
+
+use Shopware\Core\Framework\App\Manifest\Xml\XmlElement;
+use Shopware\Core\Framework\App\Manifest\XmlParserUtils;
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * @internal only for use by the app-system
+ */
+#[Package('framework')]
+class DocumentType extends XmlElement
+{
+    protected const REQUIRED_FIELDS = [
+        'identifier',
+        'label',
+        'formats',
+    ];
+
+    private const TRANSLATABLE_FIELDS = [
+        'label',
+    ];
+
+    protected string $identifier;
+
+    /**
+     * @var array<string, string>
+     */
+    protected array $label = [];
+
+    /**
+     * @var list<string>
+     */
+    protected array $formats = [];
+
+    /**
+     * @var array<string, scalar>
+     */
+    protected array $config = [];
+
+    public function getIdentifier(): string
+    {
+        return $this->identifier;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function getLabel(): array
+    {
+        return $this->label;
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function getFormats(): array
+    {
+        return $this->formats;
+    }
+
+    /**
+     * @return array<string, scalar>
+     */
+    public function getConfig(): array
+    {
+        return $this->config;
+    }
+
+    protected static function parse(\DOMElement $element): array
+    {
+        $values = XmlParserUtils::parseChildrenAndTranslate($element, self::TRANSLATABLE_FIELDS);
+
+        $formatsElement = $element->getElementsByTagName('formats')->item(0);
+        unset($values['formats']);
+
+        if ($formatsElement instanceof \DOMElement) {
+            $formats = [];
+
+            foreach ($formatsElement->getElementsByTagName('format') as $format) {
+                $formats[] = (string) $format->nodeValue;
+            }
+
+            $values['formats'] = $formats;
+        }
+
+        $config = $element->getElementsByTagName('config')->item(0);
+        unset($values['config']);
+
+        $values['config'] = $config instanceof \DOMElement
+            ? DocumentTypeConfig::fromXml($config)
+            : [];
+
+        return $values;
+    }
+}

--- a/src/Core/Framework/App/Manifest/Xml/Document/DocumentTypeConfig.php
+++ b/src/Core/Framework/App/Manifest/Xml/Document/DocumentTypeConfig.php
@@ -1,0 +1,49 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\App\Manifest\Xml\Document;
+
+use Shopware\Core\Framework\App\Manifest\XmlParserUtils;
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * @internal only for use by the app-system
+ */
+#[Package('framework')]
+class DocumentTypeConfig
+{
+    private const INTEGER_FIELDS = [
+        'itemsPerPage',
+    ];
+
+    private const BOOLEAN_FIELDS = [
+        'displayHeader',
+        'displayFooter',
+        'displayPageCount',
+        'displayLineItems',
+        'displayPrices',
+    ];
+
+    /**
+     * @return array<string, scalar>
+     */
+    public static function fromXml(\DOMElement $element): array
+    {
+        $config = [];
+
+        $values = XmlParserUtils::parseChildren($element);
+
+        foreach ($values as $key => $value) {
+            if ($value === null) {
+                continue;
+            }
+
+            $config[$key] = match (true) {
+                \in_array($key, self::INTEGER_FIELDS, true) => (int) $value,
+                \in_array($key, self::BOOLEAN_FIELDS, true) => filter_var($value, \FILTER_VALIDATE_BOOLEAN),
+                default => (string) $value,
+            };
+        }
+
+        return $config;
+    }
+}

--- a/src/Core/Framework/App/Manifest/Xml/Document/Documents.php
+++ b/src/Core/Framework/App/Manifest/Xml/Document/Documents.php
@@ -1,0 +1,37 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\App\Manifest\Xml\Document;
+
+use Shopware\Core\Framework\App\Manifest\Xml\XmlElement;
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * @internal only for use by the app-system
+ */
+#[Package('framework')]
+class Documents extends XmlElement
+{
+    /**
+     * @var list<DocumentType>
+     */
+    protected array $documentTypes = [];
+
+    /**
+     * @return list<DocumentType>
+     */
+    public function getDocumentTypes(): array
+    {
+        return $this->documentTypes;
+    }
+
+    protected static function parse(\DOMElement $element): array
+    {
+        $documentTypes = [];
+
+        foreach ($element->getElementsByTagName('document-type') as $documentType) {
+            $documentTypes[] = DocumentType::fromXml($documentType);
+        }
+
+        return ['documentTypes' => $documentTypes];
+    }
+}

--- a/src/Core/Framework/DependencyInjection/app.php
+++ b/src/Core/Framework/DependencyInjection/app.php
@@ -23,6 +23,8 @@ use Shopware\Core\Framework\App\ActionButton\Response\ReloadDataResponseFactory;
 use Shopware\Core\Framework\App\ActiveAppsLoader;
 use Shopware\Core\Framework\App\Aggregate\ActionButton\ActionButtonDefinition;
 use Shopware\Core\Framework\App\Aggregate\ActionButtonTranslation\ActionButtonTranslationDefinition;
+use Shopware\Core\Framework\App\Aggregate\AppDocumentType\AppDocumentTypeDefinition;
+use Shopware\Core\Framework\App\Aggregate\AppDocumentTypeTranslation\AppDocumentTypeTranslationDefinition;
 use Shopware\Core\Framework\App\Aggregate\AppPaymentMethod\AppPaymentMethodDefinition;
 use Shopware\Core\Framework\App\Aggregate\AppScriptCondition\AppScriptConditionDefinition;
 use Shopware\Core\Framework\App\Aggregate\AppScriptConditionTranslation\AppScriptConditionTranslationDefinition;
@@ -85,6 +87,7 @@ use Shopware\Core\Framework\App\Lifecycle\AppSecretRotationService;
 use Shopware\Core\Framework\App\Lifecycle\Handler\ActionButtonLifecycleHandler;
 use Shopware\Core\Framework\App\Lifecycle\Handler\CmsBlockLifecycleHandler;
 use Shopware\Core\Framework\App\Lifecycle\Handler\CustomFieldLifecycleHandler;
+use Shopware\Core\Framework\App\Lifecycle\Handler\DocumentTypeLifecycleHandler;
 use Shopware\Core\Framework\App\Lifecycle\Handler\FlowActionLifecycleHandler;
 use Shopware\Core\Framework\App\Lifecycle\Handler\FlowEventLifecycleHandler;
 use Shopware\Core\Framework\App\Lifecycle\Handler\ModuleLifecycleHandler;
@@ -359,6 +362,12 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             service(BlockTemplateLoader::class),
         ])
         ->tag('shopware.app_lifecycle.handler', ['priority' => -1200]);
+
+    $services->set(DocumentTypeLifecycleHandler::class)
+        ->args([
+            service('app_document_type.repository'),
+        ])
+        ->tag('shopware.app_lifecycle.handler', ['priority' => -1300]);
 
     $services->set(ScriptFileReader::class)
         ->args([
@@ -856,6 +865,12 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         ->tag('shopware.entity.definition');
 
     $services->set(AppScriptConditionTranslationDefinition::class)
+        ->tag('shopware.entity.definition');
+
+    $services->set(AppDocumentTypeDefinition::class)
+        ->tag('shopware.entity.definition');
+
+    $services->set(AppDocumentTypeTranslationDefinition::class)
         ->tag('shopware.entity.definition');
 
     $services->set(AppCmsBlockDefinition::class)

--- a/src/Core/Migration/V6_7/Migration1785414800MakeDocumentTypeIdNullable.php
+++ b/src/Core/Migration/V6_7/Migration1785414800MakeDocumentTypeIdNullable.php
@@ -5,6 +5,7 @@ namespace Shopware\Core\Migration\V6_7;
 use Doctrine\DBAL\Connection;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Migration\MigrationStep;
+use Shopware\Core\Framework\Util\Database\TableHelper;
 
 /**
  * @internal
@@ -12,6 +13,10 @@ use Shopware\Core\Framework\Migration\MigrationStep;
 #[Package('after-sales')]
 class Migration1785414800MakeDocumentTypeIdNullable extends MigrationStep
 {
+    private const TABLE = 'document';
+
+    private const COLUMN = 'document_type_id';
+
     public function getCreationTimestamp(): int
     {
         return 1785414800;
@@ -19,22 +24,10 @@ class Migration1785414800MakeDocumentTypeIdNullable extends MigrationStep
 
     public function update(Connection $connection): void
     {
-        /** @var array{Null: string}|false $column */
-        $column = $connection->fetchAssociative(
-            'SHOW COLUMNS FROM `document` WHERE `Field` = :field',
-            ['field' => 'document_type_id'],
-        );
-
-        if ($column === false || $column['Null'] === 'YES') {
+        if (!TableHelper::getColumnOfTable($connection, self::TABLE, self::COLUMN)->isNotNull) {
             return;
         }
 
-        $connection->executeStatement(
-            'ALTER TABLE `document` MODIFY `document_type_id` BINARY(16) NULL'
-        );
-    }
-
-    public function updateDestructive(Connection $connection): void
-    {
+        $connection->executeStatement('ALTER TABLE `document` MODIFY `document_type_id` BINARY(16) NULL');
     }
 }

--- a/src/Core/Migration/V6_7/Migration1785414800MakeDocumentTypeIdNullable.php
+++ b/src/Core/Migration/V6_7/Migration1785414800MakeDocumentTypeIdNullable.php
@@ -1,0 +1,40 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Migration\V6_7;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Migration\MigrationStep;
+
+/**
+ * @internal
+ */
+#[Package('after-sales')]
+class Migration1785414800MakeDocumentTypeIdNullable extends MigrationStep
+{
+    public function getCreationTimestamp(): int
+    {
+        return 1785414800;
+    }
+
+    public function update(Connection $connection): void
+    {
+        /** @var array{Null: string}|false $column */
+        $column = $connection->fetchAssociative(
+            'SHOW COLUMNS FROM `document` WHERE `Field` = :field',
+            ['field' => 'document_type_id'],
+        );
+
+        if ($column === false || $column['Null'] === 'YES') {
+            return;
+        }
+
+        $connection->executeStatement(
+            'ALTER TABLE `document` MODIFY `document_type_id` BINARY(16) NULL'
+        );
+    }
+
+    public function updateDestructive(Connection $connection): void
+    {
+    }
+}

--- a/src/Core/Migration/V6_7/Migration1785414800MakeDocumentTypeIdNullable.php
+++ b/src/Core/Migration/V6_7/Migration1785414800MakeDocumentTypeIdNullable.php
@@ -13,10 +13,6 @@ use Shopware\Core\Framework\Util\Database\TableHelper;
 #[Package('after-sales')]
 class Migration1785414800MakeDocumentTypeIdNullable extends MigrationStep
 {
-    private const TABLE = 'document';
-
-    private const COLUMN = 'document_type_id';
-
     public function getCreationTimestamp(): int
     {
         return 1785414800;
@@ -24,7 +20,7 @@ class Migration1785414800MakeDocumentTypeIdNullable extends MigrationStep
 
     public function update(Connection $connection): void
     {
-        if (!TableHelper::getColumnOfTable($connection, self::TABLE, self::COLUMN)->isNotNull) {
+        if (!TableHelper::getColumnOfTable($connection, 'document', 'document_type_id')->isNotNull) {
             return;
         }
 

--- a/src/Core/Migration/V6_7/Migration1785414844AddAppDocumentTypeAggregate.php
+++ b/src/Core/Migration/V6_7/Migration1785414844AddAppDocumentTypeAggregate.php
@@ -29,6 +29,7 @@ class Migration1785414844AddAppDocumentTypeAggregate extends MigrationStep
                 `created_at` DATETIME(3) NOT NULL,
                 `updated_at` DATETIME(3) NULL,
                 PRIMARY KEY (`id`),
+                UNIQUE KEY `uniq.app_document_type.technical_name` (`technical_name`),
                 KEY `fk.app_document_type.app_id` (`app_id`),
                 CONSTRAINT `fk.app_document_type.app_id` FOREIGN KEY (`app_id`) REFERENCES `app` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
             ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/src/Core/Migration/V6_7/Migration1785414844AddAppDocumentTypeAggregate.php
+++ b/src/Core/Migration/V6_7/Migration1785414844AddAppDocumentTypeAggregate.php
@@ -49,8 +49,4 @@ class Migration1785414844AddAppDocumentTypeAggregate extends MigrationStep
             ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
         ');
     }
-
-    public function updateDestructive(Connection $connection): void
-    {
-    }
 }

--- a/src/Core/Migration/V6_7/Migration1785414844AddAppDocumentTypeAggregate.php
+++ b/src/Core/Migration/V6_7/Migration1785414844AddAppDocumentTypeAggregate.php
@@ -1,0 +1,56 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Migration\V6_7;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Migration\MigrationStep;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+class Migration1785414844AddAppDocumentTypeAggregate extends MigrationStep
+{
+    public function getCreationTimestamp(): int
+    {
+        return 1785414844;
+    }
+
+    public function update(Connection $connection): void
+    {
+        $connection->executeStatement('
+            CREATE TABLE IF NOT EXISTS `app_document_type` (
+                `id` BINARY(16) NOT NULL,
+                `app_id` BINARY(16) NOT NULL,
+                `technical_name` VARCHAR(255) NOT NULL,
+                `config` JSON NULL,
+                `formats` JSON NULL,
+                `created_at` DATETIME(3) NOT NULL,
+                `updated_at` DATETIME(3) NULL,
+                PRIMARY KEY (`id`),
+                KEY `fk.app_document_type.app_id` (`app_id`),
+                CONSTRAINT `fk.app_document_type.app_id` FOREIGN KEY (`app_id`) REFERENCES `app` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+        ');
+
+        $connection->executeStatement('
+            CREATE TABLE IF NOT EXISTS `app_document_type_translation` (
+                `app_document_type_id` BINARY(16) NOT NULL,
+                `language_id` BINARY(16) NOT NULL,
+                `label` VARCHAR(255) NULL,
+                `created_at` DATETIME(3) NOT NULL,
+                `updated_at` DATETIME(3) NULL,
+                PRIMARY KEY (`app_document_type_id`,`language_id`),
+                KEY `fk.app_document_type_translation.app_document_type_id` (`app_document_type_id`),
+                KEY `fk.app_document_type_translation.language_id` (`language_id`),
+                CONSTRAINT `fk.app_document_type_translation.app_document_type_id` FOREIGN KEY (`app_document_type_id`) REFERENCES `app_document_type` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
+                CONSTRAINT `fk.app_document_type_translation.language_id` FOREIGN KEY (`language_id`) REFERENCES `language` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+        ');
+    }
+
+    public function updateDestructive(Connection $connection): void
+    {
+    }
+}

--- a/src/Core/System/Language/LanguageDefinition.php
+++ b/src/Core/System/Language/LanguageDefinition.php
@@ -33,6 +33,7 @@ use Shopware\Core\Content\Property\Aggregate\PropertyGroupOptionTranslation\Prop
 use Shopware\Core\Content\Property\Aggregate\PropertyGroupTranslation\PropertyGroupTranslationDefinition;
 use Shopware\Core\Content\Seo\SeoUrl\SeoUrlDefinition;
 use Shopware\Core\Framework\App\Aggregate\ActionButtonTranslation\ActionButtonTranslationDefinition;
+use Shopware\Core\Framework\App\Aggregate\AppDocumentTypeTranslation\AppDocumentTypeTranslationDefinition;
 use Shopware\Core\Framework\App\Aggregate\AppMcpPromptTranslation\AppMcpPromptTranslationDefinition;
 use Shopware\Core\Framework\App\Aggregate\AppMcpResourceTranslation\AppMcpResourceTranslationDefinition;
 use Shopware\Core\Framework\App\Aggregate\AppMcpToolTranslation\AppMcpToolTranslationDefinition;
@@ -184,6 +185,7 @@ class LanguageDefinition extends EntityDefinition
             (new OneToManyAssociationField('landingPageTranslations', LandingPageTranslationDefinition::class, 'language_id'))->addFlags(new CascadeDelete()),
             (new OneToManyAssociationField('appCmsBlockTranslations', AppCmsBlockTranslationDefinition::class, 'language_id'))->addFlags(new CascadeDelete()),
             (new OneToManyAssociationField('appScriptConditionTranslations', AppScriptConditionTranslationDefinition::class, 'language_id'))->addFlags(new CascadeDelete()),
+            (new OneToManyAssociationField('appDocumentTypeTranslations', AppDocumentTypeTranslationDefinition::class, 'language_id'))->addFlags(new CascadeDelete()),
             (new OneToManyAssociationField('appMcpToolTranslations', AppMcpToolTranslationDefinition::class, 'language_id'))->addFlags(new CascadeDelete()),
             (new OneToManyAssociationField('appMcpPromptTranslations', AppMcpPromptTranslationDefinition::class, 'language_id'))->addFlags(new CascadeDelete()),
             (new OneToManyAssociationField('appMcpResourceTranslations', AppMcpResourceTranslationDefinition::class, 'language_id'))->addFlags(new CascadeDelete()),

--- a/src/Core/System/Language/LanguageEntity.php
+++ b/src/Core/System/Language/LanguageEntity.php
@@ -33,6 +33,7 @@ use Shopware\Core\Content\Property\Aggregate\PropertyGroupOptionTranslation\Prop
 use Shopware\Core\Content\Property\Aggregate\PropertyGroupTranslation\PropertyGroupTranslationCollection;
 use Shopware\Core\Content\Seo\SeoUrl\SeoUrlCollection;
 use Shopware\Core\Framework\App\Aggregate\ActionButtonTranslation\ActionButtonTranslationCollection;
+use Shopware\Core\Framework\App\Aggregate\AppDocumentTypeTranslation\AppDocumentTypeTranslationCollection;
 use Shopware\Core\Framework\App\Aggregate\AppMcpPromptTranslation\AppMcpPromptTranslationCollection;
 use Shopware\Core\Framework\App\Aggregate\AppMcpResourceTranslation\AppMcpResourceTranslationCollection;
 use Shopware\Core\Framework\App\Aggregate\AppMcpToolTranslation\AppMcpToolTranslationCollection;
@@ -203,6 +204,8 @@ class LanguageEntity extends Entity
     protected ?AppCmsBlockTranslationCollection $appCmsBlockTranslations = null;
 
     protected ?AppScriptConditionTranslationCollection $appScriptConditionTranslations = null;
+
+    protected ?AppDocumentTypeTranslationCollection $appDocumentTypeTranslations = null;
 
     protected ?AppMcpToolTranslationCollection $appMcpToolTranslations = null;
 
@@ -862,6 +865,16 @@ class LanguageEntity extends Entity
     public function setAppScriptConditionTranslations(AppScriptConditionTranslationCollection $appScriptConditionTranslations): void
     {
         $this->appScriptConditionTranslations = $appScriptConditionTranslations;
+    }
+
+    public function getAppDocumentTypeTranslations(): ?AppDocumentTypeTranslationCollection
+    {
+        return $this->appDocumentTypeTranslations;
+    }
+
+    public function setAppDocumentTypeTranslations(AppDocumentTypeTranslationCollection $appDocumentTypeTranslations): void
+    {
+        $this->appDocumentTypeTranslations = $appDocumentTypeTranslations;
     }
 
     public function getAppMcpToolTranslations(): ?AppMcpToolTranslationCollection

--- a/tests/integration/Core/Checkout/DocumentV2/Controller/DocumentV2ControllerTest.php
+++ b/tests/integration/Core/Checkout/DocumentV2/Controller/DocumentV2ControllerTest.php
@@ -297,7 +297,7 @@ class DocumentV2ControllerTest extends TestCase
 
     public function testUploadStoresAppRegisteredDocumentTypeWithNullDocumentTypeId(): void
     {
-        $this->loadAppsFromDir(__DIR__ . '/../Generation/_fixtures/apps/withCertificateDocument');
+        $this->loadAppsFromDir(__DIR__ . '/../Generation/_fixtures/apps/withDocumentGeneration');
         $documentType = 'swag_certificate';
 
         $orderId = $this->createDraftOrder();

--- a/tests/integration/Core/Checkout/DocumentV2/Controller/DocumentV2ControllerTest.php
+++ b/tests/integration/Core/Checkout/DocumentV2/Controller/DocumentV2ControllerTest.php
@@ -3,6 +3,7 @@
 namespace Shopware\Tests\Integration\Core\Checkout\DocumentV2\Controller;
 
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Checkout\Document\DocumentCollection;
 use Shopware\Core\Checkout\Document\DocumentEntity;
 use Shopware\Core\Checkout\DocumentV2\Aggregate\DocumentFile\DocumentFileCollection;
 use Shopware\Core\Checkout\DocumentV2\Aggregate\DocumentFile\DocumentFileEntity;
@@ -18,6 +19,7 @@ use Shopware\Core\Framework\Test\TestCaseBase\AdminApiTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SalesChannel\Context\SalesChannelContextFactory;
 use Shopware\Core\System\SalesChannel\Context\SalesChannelContextService;
+use Shopware\Core\Test\AppSystemTestBehaviour;
 use Shopware\Core\Test\TestDefaults;
 use Shopware\Tests\Integration\Core\Checkout\DocumentV2\DocumentV2Trait;
 use Symfony\Component\HttpFoundation\Response;
@@ -29,6 +31,7 @@ use Symfony\Component\HttpFoundation\Response;
 class DocumentV2ControllerTest extends TestCase
 {
     use AdminApiTestBehaviour;
+    use AppSystemTestBehaviour;
     use DocumentV2Trait;
 
     /**
@@ -40,6 +43,11 @@ class DocumentV2ControllerTest extends TestCase
      * @var EntityRepository<DocumentFileCollection>
      */
     private EntityRepository $documentFileRepository;
+
+    /**
+     * @var EntityRepository<DocumentCollection>
+     */
+    private EntityRepository $documentRepository;
 
     protected function setUp(): void
     {
@@ -60,6 +68,7 @@ class DocumentV2ControllerTest extends TestCase
 
         $this->orderRepository = static::getContainer()->get('order.repository');
         $this->documentFileRepository = static::getContainer()->get('document_file.repository');
+        $this->documentRepository = static::getContainer()->get('document.repository');
     }
 
     public function testAvailableTypesReturnsImplementedDocumentTypesAndFormats(): void
@@ -284,6 +293,60 @@ class DocumentV2ControllerTest extends TestCase
         static::assertSame(DocumentFormat::PDF->mimeType(), $response->headers->get('content-type'));
         static::assertStringStartsWith('attachment;', (string) $response->headers->get('content-disposition'));
         static::assertStringContainsString('uploaded-invoice.pdf', (string) $response->headers->get('content-disposition'));
+    }
+
+    public function testUploadStoresAppRegisteredDocumentTypeWithNullDocumentTypeId(): void
+    {
+        $this->loadAppsFromDir(__DIR__ . '/../Generation/_fixtures/apps/withCertificateDocument');
+        $documentType = 'swag_certificate';
+
+        $orderId = $this->createDraftOrder();
+        $orderVersionId = $this->orderRepository->createVersion($orderId, $this->context, 'DRAFT');
+
+        $content = 'uploaded certificate';
+
+        $this->getBrowser()->request(
+            'POST',
+            '/api/_action/order/document-v2/upload?' . http_build_query([
+                'documentDate' => self::DOCUMENT_DATE,
+                'documentNumber' => '2001-' . Uuid::randomHex(),
+                'documentType' => $documentType,
+                'extension' => DocumentFormat::PDF->value,
+                'fileName' => 'uploaded-certificate',
+                'format' => DocumentFormat::PDF->value,
+                'orderId' => $orderId,
+                'orderVersionId' => $orderVersionId,
+            ], '', '&', \PHP_QUERY_RFC3986),
+            [],
+            [],
+            [
+                'HTTP_CONTENT_LENGTH' => \strlen($content),
+                'HTTP_CONTENT_TYPE' => DocumentFormat::PDF->mimeType(),
+            ],
+            $content,
+        );
+
+        $response = $this->getBrowser()->getResponse();
+        static::assertSame(Response::HTTP_OK, $response->getStatusCode(), (string) $response->getContent());
+
+        $payload = json_decode((string) $response->getContent(), true, 512, \JSON_THROW_ON_ERROR);
+        static::assertIsString($payload['documentId'] ?? null);
+
+        $document = $this->documentRepository
+            ->search(new Criteria([$payload['documentId']]), $this->context)
+            ->getEntities()
+            ->first();
+
+        static::assertInstanceOf(DocumentEntity::class, $document);
+        static::assertNull($document->getDocumentTypeId());
+        static::assertSame($documentType, $document->getConfig()['documentType'] ?? null);
+
+        $files = $this->loadDocumentFiles($payload['documentId']);
+        static::assertCount(1, $files);
+
+        $file = $files->first();
+        static::assertInstanceOf(DocumentFileEntity::class, $file);
+        static::assertSame(DocumentFormat::PDF->value, $file->getDocumentFormat());
     }
 
     private function createDraftOrder(): string

--- a/tests/integration/Core/Checkout/DocumentV2/Generation/AppDocumentTypeGenerationTest.php
+++ b/tests/integration/Core/Checkout/DocumentV2/Generation/AppDocumentTypeGenerationTest.php
@@ -1,0 +1,151 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Integration\Core\Checkout\DocumentV2\Generation;
+
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Checkout\Document\DocumentEntity;
+use Shopware\Core\Checkout\DocumentV2\Config\DocumentConfigLoader;
+use Shopware\Core\Checkout\DocumentV2\DocumentFormat;
+use Shopware\Core\Checkout\DocumentV2\Generation\DocumentGenerationRequest;
+use Shopware\Core\Checkout\DocumentV2\Generation\DocumentGenerator;
+use Shopware\Core\Checkout\DocumentV2\Type\DocumentTypeRegistry;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\System\SalesChannel\Context\SalesChannelContextFactory;
+use Shopware\Core\System\SalesChannel\Context\SalesChannelContextService;
+use Shopware\Core\System\SystemConfig\SystemConfigService;
+use Shopware\Core\Test\AppSystemTestBehaviour;
+use Shopware\Core\Test\TestDefaults;
+use Shopware\Tests\Integration\Core\Checkout\DocumentV2\DocumentV2Trait;
+
+/**
+ * @internal
+ */
+#[Package('after-sales')]
+class AppDocumentTypeGenerationTest extends TestCase
+{
+    use AppSystemTestBehaviour;
+    use DocumentV2Trait;
+
+    private const IDENTIFIER = 'swag_certificate';
+
+    private const ZUGFERD_XML_IDENTIFIER = 'swag_zugferd_certificate';
+
+    protected function setUp(): void
+    {
+        $this->context = Context::createDefaultContext();
+
+        $shippingAddressId = Uuid::randomHex();
+
+        $this->salesChannelContext = static::getContainer()->get(SalesChannelContextFactory::class)->create(
+            Uuid::randomHex(),
+            TestDefaults::SALES_CHANNEL,
+            [
+                SalesChannelContextService::CUSTOMER_ID => $this->createCustomer(
+                    ['defaultShippingAddressId' => $shippingAddressId],
+                    $this->buildDemoShippingAddress($shippingAddressId),
+                ),
+            ],
+        );
+
+        static::getContainer()->get(SystemConfigService::class)->setMultiple([
+            'core.basicInformation.companyName' => 'Example Company',
+            'core.basicInformation.companyStreet' => 'Example Street 1',
+            'core.basicInformation.companyZipcode' => '12345',
+            'core.basicInformation.companyCity' => 'Example City',
+            'core.basicInformation.companyCountryId' => $this->loadCompanyCountry()->getId(),
+        ]);
+    }
+
+    public function testInstallingAppRegisteredDocumentTypeGeneratesAndPersistsPdf(): void
+    {
+        $this->loadAppsFromDir(__DIR__ . '/_fixtures/apps/withDocumentGeneration');
+
+        $formats = static::getContainer()->get(DocumentTypeRegistry::class)->getSupportedFormats(self::IDENTIFIER);
+        static::assertEqualsCanonicalizing(
+            [DocumentFormat::HTML->value, DocumentFormat::PDF->value],
+            $formats,
+        );
+
+        $bundle = static::getContainer()->get(DocumentConfigLoader::class)->load(
+            self::IDENTIFIER,
+            $this->salesChannelContext->getSalesChannelId(),
+            $this->context,
+        );
+
+        static::assertSame('a5', $bundle->config->pageSize);
+        static::assertSame('landscape', $bundle->config->pageOrientation);
+        static::assertSame(20, $bundle->config->itemsPerPage);
+        static::assertTrue($bundle->display->displayHeader);
+        static::assertTrue($bundle->display->displayFooter);
+        static::assertTrue($bundle->display->displayPageCount);
+        static::assertTrue($bundle->display->displayLineItems);
+        static::assertTrue($bundle->display->displayPrices);
+
+        $orderId = $this->createDraftOrder();
+
+        $document = static::getContainer()->get(DocumentGenerator::class)->generate(
+            new DocumentGenerationRequest($orderId, self::IDENTIFIER, [DocumentFormat::PDF->value]),
+            $this->context,
+        );
+
+        static::assertInstanceOf(DocumentEntity::class, $document);
+        static::assertNull($document->getDocumentTypeId());
+        static::assertSame(self::IDENTIFIER, $document->getConfig()['documentType'] ?? null);
+
+        $documentFiles = $document->getDocumentFiles();
+        static::assertNotNull($documentFiles);
+        static::assertCount(1, $documentFiles);
+
+        $file = $documentFiles->first();
+        static::assertNotNull($file);
+        static::assertSame(DocumentFormat::PDF->value, $file->getDocumentFormat());
+        static::assertNotSame('', $file->getMediaId());
+        static::assertTrue(Uuid::isValid($file->getMediaId()));
+
+        $media = $file->getMedia();
+        static::assertSame(DocumentFormat::PDF->mimeType(), $media->getMimeType());
+    }
+
+    public function testInstallingAppRegisteredDocumentTypeGeneratesAndPersistsZugferdXml(): void
+    {
+        $this->loadAppsFromDir(__DIR__ . '/_fixtures/apps/withDocumentGeneration');
+
+        $formats = static::getContainer()->get(DocumentTypeRegistry::class)->getSupportedFormats(self::ZUGFERD_XML_IDENTIFIER);
+        static::assertSame([DocumentFormat::ZUGFERD_XML->value], $formats);
+
+        $orderId = $this->createDraftOrder();
+
+        $document = static::getContainer()->get(DocumentGenerator::class)->generate(
+            new DocumentGenerationRequest($orderId, self::ZUGFERD_XML_IDENTIFIER, [DocumentFormat::ZUGFERD_XML->value]),
+            $this->context,
+        );
+
+        static::assertInstanceOf(DocumentEntity::class, $document);
+        static::assertNull($document->getDocumentTypeId());
+        static::assertSame(self::ZUGFERD_XML_IDENTIFIER, $document->getConfig()['documentType'] ?? null);
+
+        $documentFiles = $document->getDocumentFiles();
+        static::assertNotNull($documentFiles);
+        static::assertCount(1, $documentFiles);
+
+        $file = $documentFiles->first();
+        static::assertNotNull($file);
+        static::assertSame(DocumentFormat::ZUGFERD_XML->value, $file->getDocumentFormat());
+        static::assertNotSame('', $file->getMediaId());
+        static::assertTrue(Uuid::isValid($file->getMediaId()));
+
+        $media = $file->getMedia();
+        static::assertSame(DocumentFormat::ZUGFERD_XML->mimeType(), $media->getMimeType());
+    }
+
+    private function createDraftOrder(): string
+    {
+        $cart = $this->generateDemoCartWithTaxes([19, 7]);
+        $orderId = $this->persistCart($cart);
+        $this->enrichOrderForRendering($orderId);
+
+        return $orderId;
+    }
+}

--- a/tests/integration/Core/Checkout/DocumentV2/Generation/DocumentGenerationHookTest.php
+++ b/tests/integration/Core/Checkout/DocumentV2/Generation/DocumentGenerationHookTest.php
@@ -1,0 +1,50 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Integration\Core\Checkout\DocumentV2\Generation;
+
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Checkout\DocumentV2\DocumentFormat;
+use Shopware\Core\Checkout\DocumentV2\DocumentType;
+use Shopware\Core\Checkout\DocumentV2\Event\Hooks\DocumentGenerationHook;
+use Shopware\Core\Checkout\Order\OrderEntity;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Script\Execution\ScriptExecutor;
+use Shopware\Core\Framework\Struct\ArrayStruct;
+use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\Test\AppSystemTestBehaviour;
+
+/**
+ * @internal
+ */
+#[Package('after-sales')]
+class DocumentGenerationHookTest extends TestCase
+{
+    use AppSystemTestBehaviour;
+    use IntegrationTestBehaviour;
+
+    public function testAppScriptExtendsTheOrder(): void
+    {
+        $this->loadAppsFromDir(__DIR__ . '/_fixtures/apps/documentDataExample');
+
+        $order = new OrderEntity();
+        $order->setId(Uuid::randomHex());
+
+        $hook = new DocumentGenerationHook(
+            $order,
+            DocumentType::INVOICE->value,
+            '1001',
+            [DocumentFormat::PDF->value],
+            Context::createDefaultContext(),
+        );
+
+        static::getContainer()->get(ScriptExecutor::class)->execute($hook);
+
+        $extension = $order->getExtension('document_data_example');
+
+        static::assertInstanceOf(ArrayStruct::class, $extension);
+        static::assertSame(DocumentType::INVOICE->value, $extension->get('documentType'));
+        static::assertSame('1001', $extension->get('documentNumber'));
+    }
+}

--- a/tests/integration/Core/Checkout/DocumentV2/Generation/_fixtures/apps/coreInvoiceEnricher/manifest.xml
+++ b/tests/integration/Core/Checkout/DocumentV2/Generation/_fixtures/apps/coreInvoiceEnricher/manifest.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/shopware/shopware/trunk/src/Core/Framework/App/Manifest/Schema/manifest-3.0.xsd">
+    <meta>
+        <name>coreInvoiceEnricher</name>
+        <label>Core Invoice Enricher</label>
+        <description>Test app enriching the core invoice document type via hook + sw_extends</description>
+        <author>shopware AG</author>
+        <copyright>(c) by shopware AG</copyright>
+        <version>1.0.0</version>
+        <license>MIT</license>
+    </meta>
+</manifest>

--- a/tests/integration/Core/Checkout/DocumentV2/Generation/_fixtures/apps/documentDataExample/Resources/scripts/document-generation/document-data.twig
+++ b/tests/integration/Core/Checkout/DocumentV2/Generation/_fixtures/apps/documentDataExample/Resources/scripts/document-generation/document-data.twig
@@ -1,0 +1,6 @@
+{% set order = hook.order %}
+
+{% do order.addArrayExtension('document_data_example', {
+    'documentType': hook.documentType,
+    'documentNumber': hook.documentNumber
+}) %}

--- a/tests/integration/Core/Checkout/DocumentV2/Generation/_fixtures/apps/documentDataExample/manifest.xml
+++ b/tests/integration/Core/Checkout/DocumentV2/Generation/_fixtures/apps/documentDataExample/manifest.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/shopware/shopware/trunk/src/Core/Framework/App/Manifest/Schema/manifest-3.0.xsd">
+    <meta>
+        <name>documentDataExample</name>
+        <label>Document Data Example</label>
+        <description>Test app for the document generation hook</description>
+        <author>shopware AG</author>
+        <copyright>(c) by shopware AG</copyright>
+        <version>1.0.0</version>
+        <license>MIT</license>
+    </meta>
+</manifest>

--- a/tests/integration/Core/Checkout/DocumentV2/Generation/_fixtures/apps/withDocumentGeneration/Resources/views/documents/swag_certificate.html.twig
+++ b/tests/integration/Core/Checkout/DocumentV2/Generation/_fixtures/apps/withDocumentGeneration/Resources/views/documents/swag_certificate.html.twig
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html>
+<body>
+<p>{{ order.orderNumber }}</p>
+</body>
+</html>

--- a/tests/integration/Core/Checkout/DocumentV2/Generation/_fixtures/apps/withDocumentGeneration/Resources/views/documents/zugferd/swag_zugferd_certificate.xml.twig
+++ b/tests/integration/Core/Checkout/DocumentV2/Generation/_fixtures/apps/withDocumentGeneration/Resources/views/documents/zugferd/swag_zugferd_certificate.xml.twig
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<certificate>
+    <orderNumber>{{ order.orderNumber }}</orderNumber>
+    <documentNumber>{{ meta.documentNumber }}</documentNumber>
+</certificate>

--- a/tests/integration/Core/Checkout/DocumentV2/Generation/_fixtures/apps/withDocumentGeneration/manifest.xml
+++ b/tests/integration/Core/Checkout/DocumentV2/Generation/_fixtures/apps/withDocumentGeneration/manifest.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/shopware/shopware/trunk/src/Core/Framework/App/Manifest/Schema/manifest-3.0.xsd">
+    <meta>
+        <name>withDocumentGeneration</name>
+        <label>Swag App Test with generatable document types</label>
+        <description>test</description>
+        <author>shopware AG</author>
+        <copyright>(c) by shopware AG</copyright>
+        <version>1.0.0</version>
+        <license>MIT</license>
+    </meta>
+    <documents>
+        <document-type>
+            <identifier>swag_certificate</identifier>
+            <label>Certificate</label>
+            <formats>
+                <format>html</format>
+                <format>pdf</format>
+            </formats>
+            <config>
+                <page-size>a5</page-size>
+                <page-orientation>landscape</page-orientation>
+                <items-per-page>20</items-per-page>
+                <display-header>true</display-header>
+                <display-footer>true</display-footer>
+                <display-page-count>true</display-page-count>
+                <display-line-items>true</display-line-items>
+                <display-prices>true</display-prices>
+            </config>
+        </document-type>
+        <document-type>
+            <identifier>swag_zugferd_certificate</identifier>
+            <label>Zugferd Certificate</label>
+            <formats>
+                <format>zugferd_xml</format>
+            </formats>
+        </document-type>
+    </documents>
+</manifest>

--- a/tests/integration/Core/Checkout/DocumentV2/Subscriber/AppDocumentNumberRangeSubscriberTest.php
+++ b/tests/integration/Core/Checkout/DocumentV2/Subscriber/AppDocumentNumberRangeSubscriberTest.php
@@ -1,0 +1,141 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Integration\Core\Checkout\DocumentV2\Subscriber;
+
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\App\AppCollection;
+use Shopware\Core\Framework\App\AppEntity;
+use Shopware\Core\Framework\App\Lifecycle\AppManager;
+use Shopware\Core\Framework\App\Lifecycle\Parameters\AppInstallParameters;
+use Shopware\Core\Framework\App\Lifecycle\Parameters\AppUpdateParameters;
+use Shopware\Core\Framework\App\Manifest\Manifest;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
+use Shopware\Core\System\NumberRange\Aggregate\NumberRangeType\NumberRangeTypeCollection;
+use Shopware\Core\System\NumberRange\NumberRangeCollection;
+use Shopware\Core\Test\AppSystemTestBehaviour;
+
+/**
+ * @internal
+ */
+#[Package('after-sales')]
+class AppDocumentNumberRangeSubscriberTest extends TestCase
+{
+    use AppSystemTestBehaviour;
+    use IntegrationTestBehaviour;
+
+    /**
+     * @var EntityRepository<NumberRangeTypeCollection>
+     */
+    private EntityRepository $numberRangeTypeRepository;
+
+    /**
+     * @var EntityRepository<NumberRangeCollection>
+     */
+    private EntityRepository $numberRangeRepository;
+
+    /**
+     * @var EntityRepository<AppCollection>
+     */
+    private EntityRepository $appRepository;
+
+    private AppManager $appManager;
+
+    private Context $context;
+
+    protected function setUp(): void
+    {
+        $this->numberRangeTypeRepository = static::getContainer()->get('number_range_type.repository');
+        $this->numberRangeRepository = static::getContainer()->get('number_range.repository');
+        $this->appRepository = static::getContainer()->get('app.repository');
+        $this->appManager = static::getContainer()->get(AppManager::class);
+        $this->context = Context::createDefaultContext();
+    }
+
+    public function testInstallingAppSeedsNumberRangeForNonCoreDocumentType(): void
+    {
+        $this->loadAppsFromDir(__DIR__ . '/_fixtures/withCertificateType');
+
+        $type = $this->numberRangeTypeRepository->search(
+            (new Criteria())->addFilter(new EqualsFilter('technicalName', 'document_swag_certificate')),
+            $this->context
+        )->getEntities()->first();
+
+        static::assertNotNull($type);
+        static::assertSame('document_swag_certificate', $type->getTechnicalName());
+        static::assertTrue($type->getGlobal());
+
+        $typeId = $type->getId();
+
+        $range = $this->numberRangeRepository->search(
+            (new Criteria())->addFilter(new EqualsFilter('typeId', $typeId)),
+            $this->context
+        )->getEntities()->first();
+
+        static::assertNotNull($range);
+        static::assertTrue($range->isGlobal());
+        static::assertSame('{n}', $range->getPattern());
+        static::assertSame(1000, $range->getStart());
+    }
+
+    public function testInstallingAppWithCoreCollidingIdentifierDoesNotTouchCoreRange(): void
+    {
+        $criteria = (new Criteria())->addFilter(new EqualsFilter('technicalName', 'document_invoice'));
+
+        $before = $this->numberRangeTypeRepository->searchIds($criteria, $this->context);
+        static::assertCount(1, $before->getIds());
+        $coreTypeId = $before->firstId();
+
+        $this->loadAppsFromDir(__DIR__ . '/_fixtures/withCoreCollisionType');
+
+        $after = $this->numberRangeTypeRepository->searchIds($criteria, $this->context);
+        static::assertCount(1, $after->getIds());
+        static::assertSame($coreTypeId, $after->firstId());
+    }
+
+    public function testUpdatingAnAppSeedsNumberRangeForNewlyDeclaredDocumentType(): void
+    {
+        $criteria = (new Criteria())->addFilter(new EqualsFilter('technicalName', 'document_swag_certificate'));
+        static::assertNull($this->numberRangeTypeRepository->searchIds($criteria, $this->context)->firstId());
+
+        $this->appManager->install(
+            Manifest::createFromXmlFile(__DIR__ . '/_fixtures/updatableApp/v1/manifest.xml'),
+            new AppInstallParameters(),
+            $this->context
+        );
+
+        static::assertNull($this->numberRangeTypeRepository->searchIds($criteria, $this->context)->firstId());
+
+        $app = $this->appRepository->search(
+            (new Criteria())->addFilter(new EqualsFilter('name', 'updatableApp')),
+            $this->context
+        )->getEntities()->first();
+
+        static::assertInstanceOf(AppEntity::class, $app);
+
+        $this->appManager->update(
+            Manifest::createFromXmlFile(__DIR__ . '/_fixtures/updatableApp/v2/manifest.xml'),
+            new AppUpdateParameters(),
+            $app,
+            $this->context
+        );
+
+        $type = $this->numberRangeTypeRepository->search($criteria, $this->context)->getEntities()->first();
+
+        static::assertNotNull($type);
+        static::assertTrue($type->getGlobal());
+
+        $range = $this->numberRangeRepository->search(
+            (new Criteria())->addFilter(new EqualsFilter('typeId', $type->getId())),
+            $this->context
+        )->getEntities()->first();
+
+        static::assertNotNull($range);
+        static::assertSame('{n}', $range->getPattern());
+        static::assertSame(1000, $range->getStart());
+    }
+}

--- a/tests/integration/Core/Checkout/DocumentV2/Subscriber/_fixtures/updatableApp/v1/manifest.xml
+++ b/tests/integration/Core/Checkout/DocumentV2/Subscriber/_fixtures/updatableApp/v1/manifest.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/shopware/shopware/trunk/src/Core/Framework/App/Manifest/Schema/manifest-3.0.xsd">
+    <meta>
+        <name>updatableApp</name>
+        <label>Swag App Test updatable app without document types</label>
+        <description>test</description>
+        <author>shopware AG</author>
+        <copyright>(c) by shopware AG</copyright>
+        <version>1.0.0</version>
+        <license>MIT</license>
+    </meta>
+</manifest>

--- a/tests/integration/Core/Checkout/DocumentV2/Subscriber/_fixtures/updatableApp/v2/manifest.xml
+++ b/tests/integration/Core/Checkout/DocumentV2/Subscriber/_fixtures/updatableApp/v2/manifest.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/shopware/shopware/trunk/src/Core/Framework/App/Manifest/Schema/manifest-3.0.xsd">
+    <meta>
+        <name>updatableApp</name>
+        <label>Swag App Test updatable app with a newly added document type</label>
+        <description>test</description>
+        <author>shopware AG</author>
+        <copyright>(c) by shopware AG</copyright>
+        <version>1.1.0</version>
+        <license>MIT</license>
+    </meta>
+    <documents>
+        <document-type>
+            <identifier>swag_certificate</identifier>
+            <label>Certificate</label>
+            <formats>
+                <format>html</format>
+                <format>pdf</format>
+            </formats>
+        </document-type>
+    </documents>
+</manifest>

--- a/tests/integration/Core/Checkout/DocumentV2/Subscriber/_fixtures/withCertificateType/manifest.xml
+++ b/tests/integration/Core/Checkout/DocumentV2/Subscriber/_fixtures/withCertificateType/manifest.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/shopware/shopware/trunk/src/Core/Framework/App/Manifest/Schema/manifest-3.0.xsd">
+    <meta>
+        <name>withCertificateType</name>
+        <label>Swag App Test with certificate document type</label>
+        <description>test</description>
+        <author>shopware AG</author>
+        <copyright>(c) by shopware AG</copyright>
+        <version>1.0.0</version>
+        <license>MIT</license>
+    </meta>
+    <documents>
+        <document-type>
+            <identifier>swag_certificate</identifier>
+            <label>Certificate</label>
+            <formats>
+                <format>html</format>
+                <format>pdf</format>
+            </formats>
+        </document-type>
+    </documents>
+</manifest>

--- a/tests/integration/Core/Checkout/DocumentV2/Subscriber/_fixtures/withCoreCollisionType/manifest.xml
+++ b/tests/integration/Core/Checkout/DocumentV2/Subscriber/_fixtures/withCoreCollisionType/manifest.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/shopware/shopware/trunk/src/Core/Framework/App/Manifest/Schema/manifest-3.0.xsd">
+    <meta>
+        <name>withCoreCollisionType</name>
+        <label>Swag App Test declaring a core document type identifier</label>
+        <description>test</description>
+        <author>shopware AG</author>
+        <copyright>(c) by shopware AG</copyright>
+        <version>1.0.0</version>
+        <license>MIT</license>
+    </meta>
+    <documents>
+        <document-type>
+            <identifier>invoice</identifier>
+            <label>Invoice</label>
+            <formats>
+                <format>html</format>
+                <format>pdf</format>
+            </formats>
+        </document-type>
+    </documents>
+</manifest>

--- a/tests/integration/Core/Framework/Api/fixtures/api-aware-fields.json
+++ b/tests/integration/Core/Framework/Api/fixtures/api-aware-fields.json
@@ -36,6 +36,7 @@
     "app_cms_block_translation.updatedAt",
     "app_cms_block_translation.appCmsBlockId",
     "app_cms_block_translation.languageId",
+    "app_document_type.translated",
     "app_flow_action.createdAt",
     "app_flow_action.updatedAt",
     "app_flow_action.translated",

--- a/tests/integration/Core/Framework/App/Lifecycle/AppManagerTest.php
+++ b/tests/integration/Core/Framework/App/Lifecycle/AppManagerTest.php
@@ -1080,6 +1080,34 @@ class AppManagerTest extends TestCase
         static::assertContains('example.com', $allowedHosts);
     }
 
+    public function testInstallWithDocuments(): void
+    {
+        $manifest = Manifest::createFromXmlFile(__DIR__ . '/_fixtures/withDocuments/manifest.xml');
+        $this->appManager->install($manifest, new AppInstallParameters(), $this->context);
+
+        $criteria = new Criteria();
+        $criteria->addAssociation('appDocumentTypes');
+        $apps = $this->appRepository->search($criteria, $this->context)->getEntities();
+
+        static::assertCount(1, $apps);
+
+        $app = $apps->first();
+        static::assertNotNull($app);
+        static::assertSame('withDocuments', $app->getName());
+
+        $documentTypes = $app->getAppDocumentTypes();
+        static::assertNotNull($documentTypes);
+        static::assertCount(2, $documentTypes);
+
+        $invoice = $documentTypes->filterByProperty('technicalName', 'swag_custom_invoice')->first();
+        static::assertNotNull($invoice);
+        static::assertSame('Custom invoice', $invoice->getLabel());
+
+        $deliveryNote = $documentTypes->filterByProperty('technicalName', 'swag_custom_delivery_note')->first();
+        static::assertNotNull($deliveryNote);
+        static::assertSame('Custom delivery note', $deliveryNote->getLabel());
+    }
+
     public function testUninstallFlowEventUsedInFlowBuilder(): void
     {
         $manifest = Manifest::createFromXmlFile(__DIR__ . '/../Manifest/_fixtures/test/manifest.xml');

--- a/tests/integration/Core/Framework/App/Lifecycle/Handler/DocumentTypeLifecycleHandlerTest.php
+++ b/tests/integration/Core/Framework/App/Lifecycle/Handler/DocumentTypeLifecycleHandlerTest.php
@@ -4,6 +4,7 @@ namespace Shopware\Tests\Integration\Core\Framework\App\Lifecycle\Handler;
 
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\App\Aggregate\AppDocumentType\AppDocumentTypeCollection;
+use Shopware\Core\Framework\App\AppException;
 use Shopware\Core\Framework\App\Lifecycle\Handler\DocumentTypeLifecycleHandler;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
@@ -132,6 +133,23 @@ class DocumentTypeLifecycleHandlerTest extends TestCase
         $valid = $documentTypes->filterByProperty('technicalName', 'swag_valid_type')->first();
         static::assertNotNull($valid);
         static::assertSame('Valid type', $valid->getLabel());
+    }
+
+    public function testInstallRejectsDocumentTypeIdentifierClaimedByAnotherApp(): void
+    {
+        $manifest = $this->appFixture->loadManifest(self::APP_DIR . '/manifest.xml');
+        $owningApp = $this->appFixture->createApp($manifest);
+
+        $this->handler->install($this->appFixture->createInstallContext($owningApp, $manifest));
+
+        $competingApp = $this->appFixture->createAppFromData(['name' => 'CompetingApp']);
+
+        $this->expectExceptionObject(AppException::documentTypeAlreadyRegistered(
+            'swag_type_with_config',
+            $owningApp->getName(),
+        ));
+
+        $this->handler->install($this->appFixture->createInstallContext($competingApp, $manifest));
     }
 
     private function getDocumentTypes(string $appId): AppDocumentTypeCollection

--- a/tests/integration/Core/Framework/App/Lifecycle/Handler/DocumentTypeLifecycleHandlerTest.php
+++ b/tests/integration/Core/Framework/App/Lifecycle/Handler/DocumentTypeLifecycleHandlerTest.php
@@ -25,6 +25,8 @@ class DocumentTypeLifecycleHandlerTest extends TestCase
 
     private const APP_DIR_V2 = __DIR__ . '/_fixtures/withDocumentTypesV2';
 
+    private const APP_DIR_CORE_COLLISION = __DIR__ . '/_fixtures/withCoreCollision';
+
     private DocumentTypeLifecycleHandler $handler;
 
     /**
@@ -113,6 +115,23 @@ class DocumentTypeLifecycleHandlerTest extends TestCase
         static::getContainer()->get('app.repository')->delete([['id' => $app->getId()]], $this->context);
 
         static::assertCount(0, $this->getDocumentTypes($app->getId()));
+    }
+
+    public function testInstallSkipsDocumentTypesCollidingWithCoreIdentifiers(): void
+    {
+        $manifest = $this->appFixture->loadManifest(self::APP_DIR_CORE_COLLISION . '/manifest.xml');
+        $app = $this->appFixture->createApp($manifest);
+
+        $this->handler->install($this->appFixture->createInstallContext($app, $manifest));
+
+        $documentTypes = $this->getDocumentTypes($app->getId());
+        static::assertCount(1, $documentTypes);
+
+        static::assertNull($documentTypes->filterByProperty('technicalName', 'invoice')->first());
+
+        $valid = $documentTypes->filterByProperty('technicalName', 'swag_valid_type')->first();
+        static::assertNotNull($valid);
+        static::assertSame('Valid type', $valid->getLabel());
     }
 
     private function getDocumentTypes(string $appId): AppDocumentTypeCollection

--- a/tests/integration/Core/Framework/App/Lifecycle/Handler/DocumentTypeLifecycleHandlerTest.php
+++ b/tests/integration/Core/Framework/App/Lifecycle/Handler/DocumentTypeLifecycleHandlerTest.php
@@ -1,0 +1,125 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Integration\Core\Framework\App\Lifecycle\Handler;
+
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\App\Aggregate\AppDocumentType\AppDocumentTypeCollection;
+use Shopware\Core\Framework\App\Lifecycle\Handler\DocumentTypeLifecycleHandler;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
+use Shopware\Tests\Integration\Core\Framework\App\AppFixture;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+class DocumentTypeLifecycleHandlerTest extends TestCase
+{
+    use IntegrationTestBehaviour;
+
+    private const APP_DIR = __DIR__ . '/_fixtures/withDocumentTypes';
+
+    private const APP_DIR_V2 = __DIR__ . '/_fixtures/withDocumentTypesV2';
+
+    private DocumentTypeLifecycleHandler $handler;
+
+    /**
+     * @var EntityRepository<AppDocumentTypeCollection>
+     */
+    private EntityRepository $appDocumentTypeRepository;
+
+    private AppFixture $appFixture;
+
+    private Context $context;
+
+    protected function setUp(): void
+    {
+        $this->handler = static::getContainer()->get(DocumentTypeLifecycleHandler::class);
+
+        /** @var EntityRepository<AppDocumentTypeCollection> $repository */
+        $repository = static::getContainer()->get('app_document_type.repository');
+        $this->appDocumentTypeRepository = $repository;
+
+        /** @var AppFixture $appFixture */
+        $appFixture = static::getContainer()->get(AppFixture::class);
+        $this->appFixture = $appFixture;
+
+        $this->context = Context::createDefaultContext();
+    }
+
+    public function testInstallCreatesDocumentTypesFromManifest(): void
+    {
+        $manifest = $this->appFixture->loadManifest(self::APP_DIR . '/manifest.xml');
+        $app = $this->appFixture->createApp($manifest);
+
+        $this->handler->install($this->appFixture->createInstallContext($app, $manifest));
+
+        $documentTypes = $this->getDocumentTypes($app->getId());
+        static::assertCount(2, $documentTypes);
+
+        $withConfig = $documentTypes->filterByProperty('technicalName', 'swag_type_with_config')->first();
+        static::assertNotNull($withConfig);
+        static::assertSame('Type with config', $withConfig->getLabel());
+        static::assertSame(['itemsPerPage' => 10, 'displayHeader' => true], $withConfig->getConfig());
+        static::assertSame(['html', 'pdf'], $withConfig->getFormats());
+
+        $withoutConfig = $documentTypes->filterByProperty('technicalName', 'swag_type_without_config')->first();
+        static::assertNotNull($withoutConfig);
+        static::assertSame('Type without config', $withoutConfig->getLabel());
+        static::assertNull($withoutConfig->getConfig());
+        static::assertSame(['html'], $withoutConfig->getFormats());
+    }
+
+    public function testUpdateReconcilesDroppedAndKeptDocumentTypes(): void
+    {
+        $manifest = $this->appFixture->loadManifest(self::APP_DIR . '/manifest.xml');
+        $app = $this->appFixture->createApp($manifest);
+
+        $this->handler->install($this->appFixture->createInstallContext($app, $manifest));
+
+        $documentTypes = $this->getDocumentTypes($app->getId());
+        $keptId = $documentTypes->filterByProperty('technicalName', 'swag_type_with_config')->first()?->getId();
+        static::assertNotNull($keptId);
+
+        $manifestV2 = $this->appFixture->loadManifest(self::APP_DIR_V2 . '/manifest.xml');
+        $this->handler->update($this->appFixture->createUpdateContext($app, $manifestV2));
+
+        $updatedDocumentTypes = $this->getDocumentTypes($app->getId());
+        static::assertCount(1, $updatedDocumentTypes);
+
+        $kept = $updatedDocumentTypes->filterByProperty('technicalName', 'swag_type_with_config')->first();
+        static::assertNotNull($kept);
+        static::assertSame($keptId, $kept->getId(), 'update must reuse the stable id instead of duplicating the row');
+        static::assertSame('Type with config, updated', $kept->getLabel());
+        static::assertSame(['itemsPerPage' => 20, 'displayHeader' => false], $kept->getConfig());
+        static::assertSame(['html'], $kept->getFormats());
+
+        static::assertNull($updatedDocumentTypes->filterByProperty('technicalName', 'swag_type_without_config')->first());
+    }
+
+    public function testDocumentTypesAreRemovedWhenAppIsDeleted(): void
+    {
+        $manifest = $this->appFixture->loadManifest(self::APP_DIR . '/manifest.xml');
+        $app = $this->appFixture->createApp($manifest);
+
+        $this->handler->install($this->appFixture->createInstallContext($app, $manifest));
+
+        static::assertCount(2, $this->getDocumentTypes($app->getId()));
+
+        static::getContainer()->get('app.repository')->delete([['id' => $app->getId()]], $this->context);
+
+        static::assertCount(0, $this->getDocumentTypes($app->getId()));
+    }
+
+    private function getDocumentTypes(string $appId): AppDocumentTypeCollection
+    {
+        $criteria = new Criteria();
+        $criteria->addFilter(new EqualsFilter('appId', $appId));
+
+        return $this->appDocumentTypeRepository->search($criteria, $this->context)->getEntities();
+    }
+}

--- a/tests/integration/Core/Framework/App/Lifecycle/Handler/_fixtures/withCoreCollision/manifest.xml
+++ b/tests/integration/Core/Framework/App/Lifecycle/Handler/_fixtures/withCoreCollision/manifest.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/shopware/shopware/trunk/src/Core/Framework/App/Manifest/Schema/manifest-3.0.xsd">
+    <meta>
+        <name>withCoreCollision</name>
+        <label>Swag App Test declaring a core document type identifier</label>
+        <author>shopware AG</author>
+        <copyright>(c) by shopware AG</copyright>
+        <version>1.0.0</version>
+        <license>MIT</license>
+    </meta>
+    <documents>
+        <document-type>
+            <identifier>invoice</identifier>
+            <label>Invoice</label>
+            <formats>
+                <format>html</format>
+            </formats>
+        </document-type>
+        <document-type>
+            <identifier>swag_valid_type</identifier>
+            <label>Valid type</label>
+            <formats>
+                <format>html</format>
+            </formats>
+        </document-type>
+    </documents>
+</manifest>

--- a/tests/integration/Core/Framework/App/Lifecycle/Handler/_fixtures/withDocumentTypes/manifest.xml
+++ b/tests/integration/Core/Framework/App/Lifecycle/Handler/_fixtures/withDocumentTypes/manifest.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/shopware/shopware/trunk/src/Core/Framework/App/Manifest/Schema/manifest-3.0.xsd">
+    <meta>
+        <name>withDocumentTypes</name>
+        <label>Swag App Test with document types</label>
+        <label lang="de-DE">Swag App Test mit Dokumenttypen</label>
+        <author>shopware AG</author>
+        <copyright>(c) by shopware AG</copyright>
+        <version>1.0.0</version>
+        <license>MIT</license>
+    </meta>
+    <documents>
+        <document-type>
+            <identifier>swag_type_with_config</identifier>
+            <label>Type with config</label>
+            <label lang="de-DE">Typ mit Konfiguration</label>
+            <formats>
+                <format>html</format>
+                <format>pdf</format>
+            </formats>
+            <config>
+                <items-per-page>10</items-per-page>
+                <display-header>true</display-header>
+            </config>
+        </document-type>
+        <document-type>
+            <identifier>swag_type_without_config</identifier>
+            <label>Type without config</label>
+            <formats>
+                <format>html</format>
+            </formats>
+        </document-type>
+    </documents>
+</manifest>

--- a/tests/integration/Core/Framework/App/Lifecycle/Handler/_fixtures/withDocumentTypesV2/manifest.xml
+++ b/tests/integration/Core/Framework/App/Lifecycle/Handler/_fixtures/withDocumentTypesV2/manifest.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/shopware/shopware/trunk/src/Core/Framework/App/Manifest/Schema/manifest-3.0.xsd">
+    <meta>
+        <name>withDocumentTypes</name>
+        <label>Swag App Test with document types</label>
+        <label lang="de-DE">Swag App Test mit Dokumenttypen</label>
+        <author>shopware AG</author>
+        <copyright>(c) by shopware AG</copyright>
+        <version>1.1.0</version>
+        <license>MIT</license>
+    </meta>
+    <documents>
+        <document-type>
+            <identifier>swag_type_with_config</identifier>
+            <label>Type with config, updated</label>
+            <label lang="de-DE">Typ mit Konfiguration, aktualisiert</label>
+            <formats>
+                <format>html</format>
+            </formats>
+            <config>
+                <items-per-page>20</items-per-page>
+                <display-header>false</display-header>
+            </config>
+        </document-type>
+    </documents>
+</manifest>

--- a/tests/integration/Core/Framework/App/Lifecycle/_fixtures/withDocuments/manifest.xml
+++ b/tests/integration/Core/Framework/App/Lifecycle/_fixtures/withDocuments/manifest.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/shopware/shopware/trunk/src/Core/Framework/App/Manifest/Schema/manifest-3.0.xsd">
+    <meta>
+        <name>withDocuments</name>
+        <label>Swag App Test with documents</label>
+        <label lang="de-DE">Swag App Test mit Dokumenten</label>
+        <description>test</description>
+        <description lang="de-DE">test</description>
+        <author>shopware AG</author>
+        <copyright>(c) by shopware AG</copyright>
+        <version>1.0.0</version>
+        <license>MIT</license>
+        <privacy>https://test.com/privacy</privacy>
+    </meta>
+    <documents>
+        <document-type>
+            <identifier>swag_custom_invoice</identifier>
+            <label>Custom invoice</label>
+            <label lang="de-DE">Individuelle Rechnung</label>
+            <formats>
+                <format>html</format>
+                <format>pdf</format>
+            </formats>
+        </document-type>
+        <document-type>
+            <identifier>swag_custom_delivery_note</identifier>
+            <label>Custom delivery note</label>
+            <formats>
+                <format>html</format>
+            </formats>
+        </document-type>
+    </documents>
+</manifest>

--- a/tests/migration/Core/V6_7/Migration1785414800MakeDocumentTypeIdNullableTest.php
+++ b/tests/migration/Core/V6_7/Migration1785414800MakeDocumentTypeIdNullableTest.php
@@ -1,0 +1,40 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Migration\Core\V6_7;
+
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
+use Shopware\Core\Migration\V6_7\Migration1785414800MakeDocumentTypeIdNullable;
+
+/**
+ * @internal
+ */
+#[Package('after-sales')]
+#[CoversClass(Migration1785414800MakeDocumentTypeIdNullable::class)]
+class Migration1785414800MakeDocumentTypeIdNullableTest extends TestCase
+{
+    private Connection $connection;
+
+    protected function setUp(): void
+    {
+        $this->connection = KernelLifecycleManager::getConnection();
+    }
+
+    public function testDocumentTypeIdBecomesNullable(): void
+    {
+        $migration = new Migration1785414800MakeDocumentTypeIdNullable();
+        $migration->update($this->connection);
+        $migration->update($this->connection);
+
+        /** @var array{Null: string} $column */
+        $column = $this->connection->fetchAssociative(
+            'SHOW COLUMNS FROM `document` WHERE `Field` = :field',
+            ['field' => 'document_type_id'],
+        );
+
+        static::assertSame('YES', $column['Null']);
+    }
+}

--- a/tests/migration/Core/V6_7/Migration1785414844AddAppDocumentTypeAggregateTest.php
+++ b/tests/migration/Core/V6_7/Migration1785414844AddAppDocumentTypeAggregateTest.php
@@ -1,0 +1,47 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Migration\Core\V6_7;
+
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
+use Shopware\Core\Framework\Util\Database\TableHelper;
+use Shopware\Core\Migration\V6_7\Migration1785414844AddAppDocumentTypeAggregate;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+#[CoversClass(Migration1785414844AddAppDocumentTypeAggregate::class)]
+class Migration1785414844AddAppDocumentTypeAggregateTest extends TestCase
+{
+    private Connection $connection;
+
+    protected function setUp(): void
+    {
+        $this->connection = KernelLifecycleManager::getConnection();
+
+        $this->connection->executeStatement('DROP TABLE IF EXISTS `app_document_type_translation`;');
+        $this->connection->executeStatement('DROP TABLE IF EXISTS `app_document_type`;');
+    }
+
+    public function testMigration(): void
+    {
+        static::assertFalse(TableHelper::tableExists($this->connection, 'app_document_type'));
+        static::assertFalse(TableHelper::tableExists($this->connection, 'app_document_type_translation'));
+
+        $migration = new Migration1785414844AddAppDocumentTypeAggregate();
+        static::assertSame(1785414844, $migration->getCreationTimestamp());
+
+        $migration->update($this->connection);
+        $migration->update($this->connection);
+
+        static::assertTrue(TableHelper::tableExists($this->connection, 'app_document_type'));
+        static::assertTrue(TableHelper::tableExists($this->connection, 'app_document_type_translation'));
+
+        static::assertCount(7, TableHelper::getTable($this->connection, 'app_document_type')->columns);
+        static::assertCount(5, TableHelper::getTable($this->connection, 'app_document_type_translation')->columns);
+    }
+}

--- a/tests/unit/Core/Checkout/DocumentV2/Config/DocumentConfigLoaderTest.php
+++ b/tests/unit/Core/Checkout/DocumentV2/Config/DocumentConfigLoaderTest.php
@@ -235,6 +235,117 @@ class DocumentConfigLoaderTest extends TestCase
         static::assertFalse($bundle->display->displayPrices);
     }
 
+    public function testLoadUsesSystemConfigLogoForTypesWithoutBaseConfigRow(): void
+    {
+        $salesChannelId = Uuid::randomHex();
+
+        /** @var StaticEntityRepository<DocumentBaseConfigCollection> $documentRepo */
+        $documentRepo = new StaticEntityRepository(
+            [new DocumentBaseConfigCollection([])],
+            new DocumentBaseConfigDefinition(),
+        );
+
+        /** @var StaticEntityRepository<CountryCollection> $countryRepo */
+        $countryRepo = new StaticEntityRepository(
+            [new CountryCollection([$this->createCountry()])],
+            new CountryDefinition(),
+        );
+
+        $loader = new DocumentConfigLoader(
+            $documentRepo,
+            $countryRepo,
+            $this->createMediaRepository(),
+            $this->createSystemConfigService([
+                'companyName' => 'App Type GmbH',
+                'companyStreet' => 'App Street 1',
+                'companyZipcode' => '11111',
+                'companyCity' => 'App City',
+                'companyCountryId' => self::COMPANY_COUNTRY_ID,
+                'companyLogoId' => self::COMPANY_INFO_LOGO_ID,
+            ], $salesChannelId),
+            $this->createAppDocumentTypeLoader(),
+        );
+
+        $bundle = $loader->load(
+            'app_registered_document_type',
+            $salesChannelId,
+            Context::createDefaultContext(),
+        );
+
+        static::assertSame(self::COMPANY_INFO_LOGO_ID, $bundle->config->logo?->getId());
+    }
+
+    public function testLoadReadsBaseConfigRowForPluginRegisteredType(): void
+    {
+        $globalRow = $this->createBaseConfig(
+            global: true,
+            pageSize: 'Letter',
+            companyName: 'Plugin GmbH',
+            itemsPerPage: 25,
+        );
+
+        /** @var StaticEntityRepository<DocumentBaseConfigCollection> $documentRepo */
+        $documentRepo = new StaticEntityRepository(
+            [new DocumentBaseConfigCollection([$globalRow])],
+            new DocumentBaseConfigDefinition(),
+        );
+
+        /** @var StaticEntityRepository<CountryCollection> $countryRepo */
+        $countryRepo = new StaticEntityRepository(
+            [new CountryCollection([$this->createCountry()])],
+            new CountryDefinition(),
+        );
+
+        $loader = new DocumentConfigLoader(
+            $documentRepo,
+            $countryRepo,
+            $this->createMediaRepository(),
+            $this->createSystemConfigService(),
+            $this->createAppDocumentTypeLoader(),
+        );
+
+        $bundle = $loader->load(
+            'plugin_registered_document_type',
+            Uuid::randomHex(),
+            Context::createDefaultContext(),
+        );
+
+        static::assertSame('Letter', $bundle->config->pageSize);
+        static::assertSame(25, $bundle->config->itemsPerPage);
+        static::assertSame('Plugin GmbH', $bundle->company->companyName);
+    }
+
+    public function testLoadRejectsCoreTypeWithoutBaseConfigRow(): void
+    {
+        /** @var StaticEntityRepository<DocumentBaseConfigCollection> $documentRepo */
+        $documentRepo = new StaticEntityRepository(
+            [new DocumentBaseConfigCollection([])],
+            new DocumentBaseConfigDefinition(),
+        );
+
+        /** @var StaticEntityRepository<CountryCollection> $countryRepo */
+        $countryRepo = new StaticEntityRepository(
+            [new CountryCollection([$this->createCountry()])],
+            new CountryDefinition(),
+        );
+
+        $loader = new DocumentConfigLoader(
+            $documentRepo,
+            $countryRepo,
+            $this->createMediaRepository(),
+            $this->createSystemConfigService(),
+            $this->createAppDocumentTypeLoader(),
+        );
+
+        $this->expectExceptionObject(DocumentV2Exception::invalidDocumentType(DocumentType::INVOICE->value));
+
+        $loader->load(
+            DocumentType::INVOICE->value,
+            Uuid::randomHex(),
+            Context::createDefaultContext(),
+        );
+    }
+
     public function testLoadRejectsZeroItemsPerPage(): void
     {
         $globalRow = $this->createBaseConfig(

--- a/tests/unit/Core/Checkout/DocumentV2/Config/DocumentConfigLoaderTest.php
+++ b/tests/unit/Core/Checkout/DocumentV2/Config/DocumentConfigLoaderTest.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Tests\Unit\Core\Checkout\DocumentV2\Config;
 
+use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\Document\Aggregate\DocumentBaseConfig\DocumentBaseConfigCollection;
@@ -12,6 +13,7 @@ use Shopware\Core\Checkout\Document\Aggregate\DocumentBaseConfigSalesChannel\Doc
 use Shopware\Core\Checkout\DocumentV2\Config\DocumentConfigLoader;
 use Shopware\Core\Checkout\DocumentV2\DocumentType;
 use Shopware\Core\Checkout\DocumentV2\DocumentV2Exception;
+use Shopware\Core\Checkout\DocumentV2\Type\AppDocumentTypeLoader;
 use Shopware\Core\Content\Media\MediaCollection;
 use Shopware\Core\Content\Media\MediaDefinition;
 use Shopware\Core\Content\Media\MediaEntity;
@@ -75,6 +77,7 @@ class DocumentConfigLoaderTest extends TestCase
             $countryRepo,
             $this->createMediaRepository(),
             $this->createSystemConfigService(),
+            $this->createAppDocumentTypeLoader(),
         );
 
         $bundle = $loader->load(
@@ -116,6 +119,7 @@ class DocumentConfigLoaderTest extends TestCase
             $countryRepo,
             $this->createMediaRepository(),
             $this->createSystemConfigService(),
+            $this->createAppDocumentTypeLoader(),
         );
 
         $bundle = $loader->load(
@@ -126,6 +130,108 @@ class DocumentConfigLoaderTest extends TestCase
 
         static::assertSame('A4', $bundle->config->pageSize);
         static::assertSame('Global GmbH', $bundle->company->companyName);
+    }
+
+    public function testLoadUsesDefaultLayoutWhenNoBaseConfigRowExists(): void
+    {
+        $salesChannelId = Uuid::randomHex();
+
+        /** @var StaticEntityRepository<DocumentBaseConfigCollection> $documentRepo */
+        $documentRepo = new StaticEntityRepository(
+            [new DocumentBaseConfigCollection([])],
+            new DocumentBaseConfigDefinition(),
+        );
+
+        /** @var StaticEntityRepository<CountryCollection> $countryRepo */
+        $countryRepo = new StaticEntityRepository(
+            [new CountryCollection([$this->createCountry()])],
+            new CountryDefinition(),
+        );
+
+        $loader = new DocumentConfigLoader(
+            $documentRepo,
+            $countryRepo,
+            $this->createMediaRepository(),
+            $this->createSystemConfigService([
+                'companyName' => 'App Type GmbH',
+                'companyStreet' => 'App Street 1',
+                'companyZipcode' => '11111',
+                'companyCity' => 'App City',
+                'companyCountryId' => self::COMPANY_COUNTRY_ID,
+            ], $salesChannelId),
+            $this->createAppDocumentTypeLoader(),
+        );
+
+        $bundle = $loader->load(
+            'app_registered_document_type',
+            $salesChannelId,
+            Context::createDefaultContext(),
+        );
+
+        static::assertSame('a4', $bundle->config->pageSize);
+        static::assertSame('portrait', $bundle->config->pageOrientation);
+        static::assertSame(10, $bundle->config->itemsPerPage);
+        static::assertNull($bundle->config->filenamePrefix);
+        static::assertNull($bundle->config->filenameSuffix);
+        static::assertNull($bundle->config->logo);
+        static::assertSame('App Type GmbH', $bundle->company->companyName);
+        static::assertFalse($bundle->display->displayHeader);
+        static::assertFalse($bundle->display->displayFooter);
+        static::assertFalse($bundle->display->displayPageCount);
+        static::assertFalse($bundle->display->displayLineItems);
+        static::assertFalse($bundle->display->displayPrices);
+    }
+
+    public function testLoadOverlaysAppDeclaredConfigForAppDocumentType(): void
+    {
+        $salesChannelId = Uuid::randomHex();
+
+        /** @var StaticEntityRepository<DocumentBaseConfigCollection> $documentRepo */
+        $documentRepo = new StaticEntityRepository(
+            [new DocumentBaseConfigCollection([])],
+            new DocumentBaseConfigDefinition(),
+        );
+
+        /** @var StaticEntityRepository<CountryCollection> $countryRepo */
+        $countryRepo = new StaticEntityRepository(
+            [new CountryCollection([$this->createCountry()])],
+            new CountryDefinition(),
+        );
+
+        $loader = new DocumentConfigLoader(
+            $documentRepo,
+            $countryRepo,
+            $this->createMediaRepository(),
+            $this->createSystemConfigService([
+                'companyName' => 'App Type GmbH',
+                'companyStreet' => 'App Street 1',
+                'companyZipcode' => '11111',
+                'companyCity' => 'App City',
+                'companyCountryId' => self::COMPANY_COUNTRY_ID,
+            ], $salesChannelId),
+            $this->createAppDocumentTypeLoader([
+                'app_registered_document_type_with_config' => [
+                    'pageOrientation' => 'landscape',
+                    'itemsPerPage' => 20,
+                    'displayHeader' => true,
+                ],
+            ]),
+        );
+
+        $bundle = $loader->load(
+            'app_registered_document_type_with_config',
+            $salesChannelId,
+            Context::createDefaultContext(),
+        );
+
+        static::assertSame('a4', $bundle->config->pageSize);
+        static::assertSame('landscape', $bundle->config->pageOrientation);
+        static::assertSame(20, $bundle->config->itemsPerPage);
+        static::assertTrue($bundle->display->displayHeader);
+        static::assertFalse($bundle->display->displayFooter);
+        static::assertFalse($bundle->display->displayPageCount);
+        static::assertFalse($bundle->display->displayLineItems);
+        static::assertFalse($bundle->display->displayPrices);
     }
 
     public function testLoadRejectsZeroItemsPerPage(): void
@@ -152,6 +258,7 @@ class DocumentConfigLoaderTest extends TestCase
             $countryRepo,
             $this->createMediaRepository(),
             $this->createSystemConfigService(),
+            $this->createAppDocumentTypeLoader(),
         );
 
         $this->expectException(DocumentV2Exception::class);
@@ -195,6 +302,7 @@ class DocumentConfigLoaderTest extends TestCase
                 'companyCountryId' => self::COMPANY_COUNTRY_ID,
                 'companyLogoId' => self::COMPANY_INFO_LOGO_ID,
             ], $salesChannelId),
+            $this->createAppDocumentTypeLoader(),
         );
 
         $bundle = $loader->load(
@@ -234,6 +342,7 @@ class DocumentConfigLoaderTest extends TestCase
             $this->createSystemConfigService([
                 'companyName' => 'System Config GmbH',
             ], $salesChannelId),
+            $this->createAppDocumentTypeLoader(),
         );
 
         $this->expectException(DocumentV2Exception::class);
@@ -277,6 +386,7 @@ class DocumentConfigLoaderTest extends TestCase
                 'companyCity' => 'System City',
                 'companyCountryId' => self::COMPANY_COUNTRY_ID,
             ], $salesChannelId),
+            $this->createAppDocumentTypeLoader(),
         );
 
         $bundle = $loader->load(
@@ -312,6 +422,7 @@ class DocumentConfigLoaderTest extends TestCase
             $countryRepo,
             $this->createMediaRepository(),
             $this->createSystemConfigService(),
+            $this->createAppDocumentTypeLoader(),
         );
 
         $bundle = $loader->load(
@@ -397,6 +508,27 @@ class DocumentConfigLoaderTest extends TestCase
         $media->setId($id);
 
         return $media;
+    }
+
+    /**
+     * @param array<string, array<string, scalar>> $configByTechnicalName
+     */
+    private function createAppDocumentTypeLoader(array $configByTechnicalName = []): AppDocumentTypeLoader
+    {
+        $rows = [];
+
+        foreach ($configByTechnicalName as $technicalName => $config) {
+            $rows[] = [
+                'technical_name' => $technicalName,
+                'formats' => '["html"]',
+                'config' => json_encode($config, \JSON_THROW_ON_ERROR),
+            ];
+        }
+
+        $connection = static::createStub(Connection::class);
+        $connection->method('fetchAllAssociative')->willReturn($rows);
+
+        return new AppDocumentTypeLoader($connection);
     }
 
     /**

--- a/tests/unit/Core/Checkout/DocumentV2/Config/DocumentConfigLoaderTest.php
+++ b/tests/unit/Core/Checkout/DocumentV2/Config/DocumentConfigLoaderTest.php
@@ -2,7 +2,6 @@
 
 namespace Shopware\Tests\Unit\Core\Checkout\DocumentV2\Config;
 
-use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\Document\Aggregate\DocumentBaseConfig\DocumentBaseConfigCollection;
@@ -17,6 +16,8 @@ use Shopware\Core\Checkout\DocumentV2\Type\AppDocumentTypeLoader;
 use Shopware\Core\Content\Media\MediaCollection;
 use Shopware\Core\Content\Media\MediaDefinition;
 use Shopware\Core\Content\Media\MediaEntity;
+use Shopware\Core\Framework\App\Aggregate\AppDocumentType\AppDocumentTypeCollection;
+use Shopware\Core\Framework\App\Aggregate\AppDocumentType\AppDocumentTypeEntity;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -515,20 +516,25 @@ class DocumentConfigLoaderTest extends TestCase
      */
     private function createAppDocumentTypeLoader(array $configByTechnicalName = []): AppDocumentTypeLoader
     {
-        $rows = [];
+        $entities = [];
 
         foreach ($configByTechnicalName as $technicalName => $config) {
-            $rows[] = [
-                'technical_name' => $technicalName,
-                'formats' => '["html"]',
-                'config' => json_encode($config, \JSON_THROW_ON_ERROR),
-            ];
+            $id = Uuid::randomHex();
+
+            $entity = new AppDocumentTypeEntity();
+            $entity->setUniqueIdentifier($id);
+            $entity->setId($id);
+            $entity->setTechnicalName($technicalName);
+            $entity->setFormats(['html']);
+            $entity->setConfig($config);
+
+            $entities[] = $entity;
         }
 
-        $connection = static::createStub(Connection::class);
-        $connection->method('fetchAllAssociative')->willReturn($rows);
-
-        return new AppDocumentTypeLoader($connection);
+        return new AppDocumentTypeLoader(StaticEntityRepository::of(
+            AppDocumentTypeCollection::class,
+            [new AppDocumentTypeCollection($entities)],
+        ));
     }
 
     /**

--- a/tests/unit/Core/Checkout/DocumentV2/Controller/DocumentV2ControllerTest.php
+++ b/tests/unit/Core/Checkout/DocumentV2/Controller/DocumentV2ControllerTest.php
@@ -27,6 +27,7 @@ use Shopware\Core\Checkout\DocumentV2\Generation\DocumentPersister;
 use Shopware\Core\Checkout\DocumentV2\Generation\ReferencedDocumentResolver;
 use Shopware\Core\Checkout\DocumentV2\Provider\DocumentDataProviderRegistry;
 use Shopware\Core\Checkout\DocumentV2\Renderer\DocumentRendererRegistry;
+use Shopware\Core\Checkout\DocumentV2\Type\AppDocumentTypeLoader;
 use Shopware\Core\Checkout\DocumentV2\Type\DocumentTypeRegistry;
 use Shopware\Core\Checkout\Order\OrderCollection;
 use Shopware\Core\Checkout\Order\OrderDefinition;
@@ -90,7 +91,7 @@ class DocumentV2ControllerTest extends TestCase
         $typeRegistry = new DocumentTypeRegistry([
             new StaticDocumentType(DocumentType::INVOICE->value, [DocumentFormat::HTML->value]),
             new StaticDocumentType('partial_cancellation', [DocumentFormat::HTML->value, DocumentFormat::PDF->value]),
-        ]);
+        ], $this->createAppDocumentTypeLoader());
 
         $controller = new DocumentV2Controller(
             $this->createGenerator($rendererRegistry, Uuid::randomHex()),
@@ -273,6 +274,7 @@ class DocumentV2ControllerTest extends TestCase
                     'documentComment' => '',
                     'documentDate' => '2026-07-13T00:00:00.000Z',
                     'documentNumber' => '1000',
+                    'documentType' => DocumentType::INVOICE->value,
                 ],
             ],
         ], $this->documentRepository->creates[0]);
@@ -684,7 +686,15 @@ class DocumentV2ControllerTest extends TestCase
     {
         return new DocumentTypeRegistry([
             new StaticDocumentType(DocumentType::INVOICE->value, $formats),
-        ]);
+        ], $this->createAppDocumentTypeLoader());
+    }
+
+    private function createAppDocumentTypeLoader(): AppDocumentTypeLoader
+    {
+        $connection = static::createStub(Connection::class);
+        $connection->method('fetchAllAssociative')->willReturn([]);
+
+        return new AppDocumentTypeLoader($connection);
     }
 
     private function createArchiveGenerator(MediaService $mediaService): DocumentArchiveGenerator

--- a/tests/unit/Core/Checkout/DocumentV2/Controller/DocumentV2ControllerTest.php
+++ b/tests/unit/Core/Checkout/DocumentV2/Controller/DocumentV2ControllerTest.php
@@ -40,6 +40,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Script\Execution\ScriptExecutor;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\NumberRange\ValueGenerator\NumberRangeValueGeneratorInterface;
 use Shopware\Core\Test\Stub\DataAbstractionLayer\StaticEntityRepository;
@@ -762,6 +763,7 @@ class DocumentV2ControllerTest extends TestCase
             new DocumentDependencyResolver($rendererRegistry),
             new ReferencedDocumentResolver(new ReferenceInvoiceLoader($connection), $connection),
             $orderRepository,
+            static::createStub(ScriptExecutor::class),
         );
     }
 }

--- a/tests/unit/Core/Checkout/DocumentV2/Controller/DocumentV2ControllerTest.php
+++ b/tests/unit/Core/Checkout/DocumentV2/Controller/DocumentV2ControllerTest.php
@@ -36,6 +36,7 @@ use Shopware\Core\Content\Media\File\FileNameProvider;
 use Shopware\Core\Content\Media\File\MediaFile;
 use Shopware\Core\Content\Media\MediaEntity;
 use Shopware\Core\Content\Media\MediaService;
+use Shopware\Core\Framework\App\Aggregate\AppDocumentType\AppDocumentTypeCollection;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
@@ -691,10 +692,12 @@ class DocumentV2ControllerTest extends TestCase
 
     private function createAppDocumentTypeLoader(): AppDocumentTypeLoader
     {
-        $connection = static::createStub(Connection::class);
-        $connection->method('fetchAllAssociative')->willReturn([]);
-
-        return new AppDocumentTypeLoader($connection);
+        return new AppDocumentTypeLoader(
+            StaticEntityRepository::of(
+                AppDocumentTypeCollection::class,
+                [new AppDocumentTypeCollection([])]
+            ),
+        );
     }
 
     private function createArchiveGenerator(MediaService $mediaService): DocumentArchiveGenerator

--- a/tests/unit/Core/Checkout/DocumentV2/Event/Hooks/DocumentGenerationHookTest.php
+++ b/tests/unit/Core/Checkout/DocumentV2/Event/Hooks/DocumentGenerationHookTest.php
@@ -9,10 +9,8 @@ use Shopware\Core\Checkout\DocumentV2\DocumentType;
 use Shopware\Core\Checkout\DocumentV2\Event\Hooks\DocumentGenerationHook;
 use Shopware\Core\Checkout\Order\OrderEntity;
 use Shopware\Core\Framework\Context;
-use Shopware\Core\Framework\DataAbstractionLayer\Facade\RepositoryFacadeHookFactory;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Uuid\Uuid;
-use Shopware\Core\System\SystemConfig\Facade\SystemConfigFacadeHookFactory;
 
 /**
  * @internal

--- a/tests/unit/Core/Checkout/DocumentV2/Event/Hooks/DocumentGenerationHookTest.php
+++ b/tests/unit/Core/Checkout/DocumentV2/Event/Hooks/DocumentGenerationHookTest.php
@@ -1,0 +1,65 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Checkout\DocumentV2\Event\Hooks;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Checkout\DocumentV2\DocumentFormat;
+use Shopware\Core\Checkout\DocumentV2\DocumentType;
+use Shopware\Core\Checkout\DocumentV2\Event\Hooks\DocumentGenerationHook;
+use Shopware\Core\Checkout\Order\OrderEntity;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\Facade\RepositoryFacadeHookFactory;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\System\SystemConfig\Facade\SystemConfigFacadeHookFactory;
+
+/**
+ * @internal
+ */
+#[Package('after-sales')]
+#[CoversClass(DocumentGenerationHook::class)]
+class DocumentGenerationHookTest extends TestCase
+{
+    public function testExposesGenerationData(): void
+    {
+        $orderId = Uuid::randomHex();
+        $context = Context::createDefaultContext();
+
+        $order = new OrderEntity();
+        $order->setId($orderId);
+
+        $hook = new DocumentGenerationHook(
+            $order,
+            DocumentType::INVOICE->value,
+            '1001',
+            [DocumentFormat::PDF->value],
+            $context,
+        );
+
+        static::assertSame('document-generation', $hook->getName());
+        static::assertSame($order, $hook->getOrder());
+        static::assertSame(DocumentType::INVOICE->value, $hook->getDocumentType());
+        static::assertSame('1001', $hook->getDocumentNumber());
+        static::assertSame([DocumentFormat::PDF->value], $hook->getFormats());
+        static::assertSame($context, $hook->getContext());
+    }
+
+    public function testScriptsCanExtendTheOrder(): void
+    {
+        $order = new OrderEntity();
+        $order->setId(Uuid::randomHex());
+
+        $hook = new DocumentGenerationHook(
+            $order,
+            DocumentType::INVOICE->value,
+            '1001',
+            [DocumentFormat::PDF->value],
+            Context::createDefaultContext(),
+        );
+
+        $hook->getOrder()->addArrayExtension('my_app', ['foo' => 'bar']);
+
+        static::assertTrue($order->hasExtension('my_app'));
+    }
+}

--- a/tests/unit/Core/Checkout/DocumentV2/Generation/DocumentGenerationRequestResolverTest.php
+++ b/tests/unit/Core/Checkout/DocumentV2/Generation/DocumentGenerationRequestResolverTest.php
@@ -2,7 +2,6 @@
 
 namespace Shopware\Tests\Unit\Core\Checkout\DocumentV2\Generation;
 
-use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
@@ -13,11 +12,13 @@ use Shopware\Core\Checkout\DocumentV2\Generation\DocumentGenerationRequest;
 use Shopware\Core\Checkout\DocumentV2\Generation\DocumentGenerationRequestResolver;
 use Shopware\Core\Checkout\DocumentV2\Type\AppDocumentTypeLoader;
 use Shopware\Core\Checkout\DocumentV2\Type\DocumentTypeRegistry;
+use Shopware\Core\Framework\App\Aggregate\AppDocumentType\AppDocumentTypeCollection;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Validation\DataValidator;
 use Shopware\Core\Framework\Validation\Exception\ConstraintViolationException;
 use Shopware\Core\PlatformRequest;
+use Shopware\Core\Test\Stub\DataAbstractionLayer\StaticEntityRepository;
 use Shopware\Tests\Unit\Core\Checkout\DocumentV2\Fixtures\StaticDocumentType;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadata;
@@ -239,10 +240,12 @@ class DocumentGenerationRequestResolverTest extends TestCase
 
     private function createAppDocumentTypeLoader(): AppDocumentTypeLoader
     {
-        $connection = static::createStub(Connection::class);
-        $connection->method('fetchAllAssociative')->willReturn([]);
-
-        return new AppDocumentTypeLoader($connection);
+        return new AppDocumentTypeLoader(
+            StaticEntityRepository::of(
+                AppDocumentTypeCollection::class,
+                [new AppDocumentTypeCollection([])]
+            ),
+        );
     }
 
     /**

--- a/tests/unit/Core/Checkout/DocumentV2/Generation/DocumentGenerationRequestResolverTest.php
+++ b/tests/unit/Core/Checkout/DocumentV2/Generation/DocumentGenerationRequestResolverTest.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Tests\Unit\Core\Checkout\DocumentV2\Generation;
 
+use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
@@ -10,6 +11,7 @@ use Shopware\Core\Checkout\DocumentV2\DocumentType;
 use Shopware\Core\Checkout\DocumentV2\DocumentV2Exception;
 use Shopware\Core\Checkout\DocumentV2\Generation\DocumentGenerationRequest;
 use Shopware\Core\Checkout\DocumentV2\Generation\DocumentGenerationRequestResolver;
+use Shopware\Core\Checkout\DocumentV2\Type\AppDocumentTypeLoader;
 use Shopware\Core\Checkout\DocumentV2\Type\DocumentTypeRegistry;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Log\Package;
@@ -163,7 +165,7 @@ class DocumentGenerationRequestResolverTest extends TestCase
             $request,
             new DocumentTypeRegistry([
                 new StaticDocumentType(DocumentType::INVOICE->value, [DocumentFormat::HTML->value]),
-            ]),
+            ], $this->createAppDocumentTypeLoader()),
         );
     }
 
@@ -186,7 +188,7 @@ class DocumentGenerationRequestResolverTest extends TestCase
             $request,
             new DocumentTypeRegistry([
                 new StaticDocumentType(DocumentType::INVOICE->value, [DocumentFormat::HTML->value]),
-            ]),
+            ], $this->createAppDocumentTypeLoader()),
         );
     }
 
@@ -231,8 +233,16 @@ class DocumentGenerationRequestResolverTest extends TestCase
                     DocumentFormat::HTML->value,
                     DocumentFormat::PDF->value,
                 ]),
-            ]),
+            ], $this->createAppDocumentTypeLoader()),
         );
+    }
+
+    private function createAppDocumentTypeLoader(): AppDocumentTypeLoader
+    {
+        $connection = static::createStub(Connection::class);
+        $connection->method('fetchAllAssociative')->willReturn([]);
+
+        return new AppDocumentTypeLoader($connection);
     }
 
     /**

--- a/tests/unit/Core/Checkout/DocumentV2/Generation/DocumentGeneratorTest.php
+++ b/tests/unit/Core/Checkout/DocumentV2/Generation/DocumentGeneratorTest.php
@@ -17,11 +17,13 @@ use Shopware\Core\Checkout\DocumentV2\Config\DocumentNumberGenerator;
 use Shopware\Core\Checkout\DocumentV2\DocumentFormat;
 use Shopware\Core\Checkout\DocumentV2\DocumentType;
 use Shopware\Core\Checkout\DocumentV2\DocumentV2Exception;
+use Shopware\Core\Checkout\DocumentV2\Event\Hooks\DocumentGenerationHook;
 use Shopware\Core\Checkout\DocumentV2\Generation\DocumentDependencyResolver;
 use Shopware\Core\Checkout\DocumentV2\Generation\DocumentGenerationRequest;
 use Shopware\Core\Checkout\DocumentV2\Generation\DocumentGenerator;
 use Shopware\Core\Checkout\DocumentV2\Generation\DocumentPersister;
 use Shopware\Core\Checkout\DocumentV2\Generation\ReferencedDocumentResolver;
+use Shopware\Core\Checkout\DocumentV2\Provider\AbstractDocumentDataProvider;
 use Shopware\Core\Checkout\DocumentV2\Provider\DocumentDataProviderRegistry;
 use Shopware\Core\Checkout\DocumentV2\Renderer\DocumentRendererRegistry;
 use Shopware\Core\Checkout\DocumentV2\Struct\ProviderInput;
@@ -35,6 +37,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Script\Execution\ScriptExecutor;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\NumberRange\ValueGenerator\NumberRangeValueGeneratorInterface;
 use Shopware\Core\Test\Stub\DataAbstractionLayer\StaticEntityRepository;
@@ -43,6 +46,7 @@ use Shopware\Tests\Unit\Core\Checkout\DocumentV2\Fixtures\StaticDocumentDataProv
 use Shopware\Tests\Unit\Core\Checkout\DocumentV2\Fixtures\StaticDocumentRenderer;
 use Shopware\Tests\Unit\Core\Checkout\DocumentV2\Fixtures\StaticReferencedSnapshotDocumentDataProvider;
 use Shopware\Tests\Unit\Core\Checkout\DocumentV2\Fixtures\StaticReferencingDocumentDataProvider;
+use Shopware\Tests\Unit\Core\Checkout\DocumentV2\Fixtures\StaticRenderData;
 
 /**
  * @internal
@@ -504,6 +508,147 @@ class DocumentGeneratorTest extends TestCase
         static::assertCount(0, $documentFileRepository->creates);
     }
 
+    public function testGenerateExecutesTheDocumentGenerationHook(): void
+    {
+        $orderId = Uuid::randomHex();
+        $createdOrderVersionId = Uuid::randomHex();
+        $salesChannelId = Uuid::randomHex();
+        $documentTypeId = Uuid::randomHex();
+        $orderLanguageId = Uuid::randomHex();
+        $context = Context::createDefaultContext();
+
+        $generationRequest = new DocumentGenerationRequest(
+            $orderId,
+            DocumentType::INVOICE,
+            [DocumentFormat::PDF],
+        );
+
+        $order = new OrderEntity();
+        $order->setId($orderId);
+        $order->setVersionId($createdOrderVersionId);
+        $order->setSalesChannelId($salesChannelId);
+        $order->setLanguageId($orderLanguageId);
+
+        $orderRepository = static::createStub(EntityRepository::class);
+        $orderRepository->method('createVersion')->willReturn($createdOrderVersionId);
+        $orderRepository
+            ->method('search')
+            ->willReturnCallback(function (
+                Criteria $criteria,
+                Context $searchContext,
+            ) use ($order): EntitySearchResult {
+                return new EntitySearchResult(
+                    OrderDefinition::ENTITY_NAME,
+                    1,
+                    new OrderCollection([$order]),
+                    null,
+                    $criteria,
+                    $searchContext,
+                );
+            });
+
+        $numberRangeValueGenerator = static::createStub(NumberRangeValueGeneratorInterface::class);
+        $numberRangeValueGenerator->method('getValue')->willReturn('generated-number');
+
+        $scriptExecutor = $this->createMock(ScriptExecutor::class);
+        $scriptExecutor
+            ->expects($this->once())
+            ->method('execute')
+            ->with(static::callback(function (DocumentGenerationHook $hook) use ($order): bool {
+                static::assertSame($order, $hook->getOrder());
+                static::assertSame(DocumentType::INVOICE->value, $hook->getDocumentType());
+                static::assertSame('generated-number', $hook->getDocumentNumber());
+                static::assertSame([DocumentFormat::PDF->value], $hook->getFormats());
+
+                return true;
+            }));
+
+        [$generator] = $this->createGenerator(
+            $orderRepository,
+            $numberRangeValueGenerator,
+            $documentTypeId,
+            new DocumentEntity(),
+            $scriptExecutor,
+        );
+
+        $generator->generate($generationRequest, $context);
+    }
+
+    public function testHookRunsBeforeProvidersCollectData(): void
+    {
+        $orderId = Uuid::randomHex();
+        $createdOrderVersionId = Uuid::randomHex();
+        $salesChannelId = Uuid::randomHex();
+        $orderLanguageId = Uuid::randomHex();
+        $context = Context::createDefaultContext();
+
+        $generationRequest = new DocumentGenerationRequest(
+            $orderId,
+            DocumentType::INVOICE,
+            [DocumentFormat::PDF],
+        );
+
+        $order = new OrderEntity();
+        $order->setId($orderId);
+        $order->setVersionId($createdOrderVersionId);
+        $order->setSalesChannelId($salesChannelId);
+        $order->setLanguageId($orderLanguageId);
+
+        $orderRepository = static::createStub(EntityRepository::class);
+        $orderRepository->method('createVersion')->willReturn($createdOrderVersionId);
+        $orderRepository
+            ->method('search')
+            ->willReturnCallback(function (
+                Criteria $criteria,
+                Context $searchContext,
+            ) use ($order): EntitySearchResult {
+                return new EntitySearchResult(
+                    OrderDefinition::ENTITY_NAME,
+                    1,
+                    new OrderCollection([$order]),
+                    null,
+                    $criteria,
+                    $searchContext,
+                );
+            });
+
+        $numberRangeValueGenerator = static::createStub(NumberRangeValueGeneratorInterface::class);
+        $numberRangeValueGenerator->method('getValue')->willReturn('generated-number');
+
+        $scriptExecutor = static::createStub(ScriptExecutor::class);
+        $scriptExecutor
+            ->method('execute')
+            ->willReturnCallback(function (DocumentGenerationHook $hook): void {
+                $hook->getOrder()->addArrayExtension('my_app', ['foo' => 'bar']);
+            });
+
+        $providerSawExtension = false;
+
+        $provider = static::createStub(AbstractDocumentDataProvider::class);
+        $provider->method('supports')->willReturn(true);
+        $provider->method('getKey')->willReturn(StaticDocumentDataProvider::KEY);
+        $provider
+            ->method('provideRenderingData')
+            ->willReturnCallback(function (ProviderInput $input) use (&$providerSawExtension): StaticRenderData {
+                $providerSawExtension = $input->order->hasExtension('my_app');
+
+                return new StaticRenderData();
+            });
+
+        [$generator] = $this->createGenerator(
+            $orderRepository,
+            $numberRangeValueGenerator,
+            Uuid::randomHex(),
+            new DocumentEntity(),
+            $scriptExecutor,
+            new DocumentDataProviderRegistry([$provider]),
+        );
+
+        $generator->generate($generationRequest, $context);
+
+        static::assertTrue($providerSawExtension);
+    }
+
     /**
      * @param EntityRepository<OrderCollection> $orderRepository
      * @param list<StaticDocumentDataProvider>|null $providers
@@ -520,6 +665,8 @@ class DocumentGeneratorTest extends TestCase
         NumberRangeValueGeneratorInterface $numberRangeValueGenerator,
         string $documentTypeId,
         DocumentEntity $document,
+        ?ScriptExecutor $scriptExecutor = null,
+        ?DocumentDataProviderRegistry $providerRegistry = null,
         ?array $providers = null,
         array $referenceRows = [],
     ): array {
@@ -545,7 +692,7 @@ class DocumentGeneratorTest extends TestCase
             [$documentTypeId],
         ], new DocumentTypeDefinition());
 
-        $providerRegistry = new DocumentDataProviderRegistry(
+        $providerRegistry ??= new DocumentDataProviderRegistry(
             $providers ?? [new StaticDocumentDataProvider([DocumentType::INVOICE->value])],
         );
 
@@ -579,6 +726,7 @@ class DocumentGeneratorTest extends TestCase
             new DocumentDependencyResolver($rendererRegistry),
             new ReferencedDocumentResolver(new ReferenceInvoiceLoader($connection), $connection),
             $orderRepository,
+            $scriptExecutor ?? static::createStub(ScriptExecutor::class),
         );
 
         return [$generator, $documentRepository, $documentFileRepository];

--- a/tests/unit/Core/Checkout/DocumentV2/Generation/DocumentPersisterTest.php
+++ b/tests/unit/Core/Checkout/DocumentV2/Generation/DocumentPersisterTest.php
@@ -115,10 +115,31 @@ class DocumentPersisterTest extends TestCase
         static::assertSame($documentTypeId, $documentRepository->creates[0][0]['documentTypeId']);
         static::assertSame($this->renderedOrderVersionId, $documentRepository->creates[0][0]['orderVersionId']);
         static::assertSame($resolvedReference->id, $documentRepository->creates[0][0]['referencedDocumentId']);
+        static::assertSame(self::DOCUMENT_TYPE, $documentRepository->creates[0][0]['config']['documentType']);
 
         static::assertCount(1, $documentFileRepository->creates);
         static::assertSame(self::FORMAT, $documentFileRepository->creates[0][0]['documentFormat']);
         static::assertSame($fileId, $documentFileRepository->creates[0][0]['mediaId']);
+    }
+
+    public function testPersistWithoutDocumentTypeRowStoresTypeInConfig(): void
+    {
+        [$persister, $documentRepository] = $this->createPersister(
+            documentTypeId: null,
+            mediaServiceReturn: Uuid::randomHex(),
+        );
+
+        $persister->persist(
+            $this->generationRequest,
+            $this->renderInput,
+            $this->renderState,
+            [self::FORMAT],
+            null,
+            $this->context,
+        );
+
+        static::assertNull($documentRepository->creates[0][0]['documentTypeId']);
+        static::assertSame(self::DOCUMENT_TYPE, $documentRepository->creates[0][0]['config']['documentType']);
     }
 
     #[DataProvider('persistExceptionProvider')]
@@ -164,12 +185,6 @@ class DocumentPersisterTest extends TestCase
             'documentTypeId' => Uuid::randomHex(),
             'exception' => DocumentV2Exception::documentNotPersisted('12345'),
         ];
-
-        yield 'document type not found' => [
-            'documentSearch' => null,
-            'documentTypeId' => '',
-            'exception' => DocumentV2Exception::documentTypeNotFound(self::DOCUMENT_TYPE),
-        ];
     }
 
     public function testPersistThrowsWhenDocumentNumberAlreadyExists(): void
@@ -201,7 +216,7 @@ class DocumentPersisterTest extends TestCase
      * }
      */
     private function createPersister(
-        string $documentTypeId,
+        ?string $documentTypeId,
         ?callable $documentSearch = null,
         array $existingDocumentIds = [],
         ?string $mediaServiceReturn = null,
@@ -231,7 +246,7 @@ class DocumentPersisterTest extends TestCase
             static function (Criteria $criteria) use ($documentTypeId): array {
                 static::assertSame(1, $criteria->getLimit());
 
-                if ($documentTypeId === '') {
+                if ($documentTypeId === null) {
                     return [];
                 }
 

--- a/tests/unit/Core/Checkout/DocumentV2/Generation/DocumentPersisterTest.php
+++ b/tests/unit/Core/Checkout/DocumentV2/Generation/DocumentPersisterTest.php
@@ -25,6 +25,7 @@ use Shopware\Core\Checkout\Order\OrderEntity;
 use Shopware\Core\Content\Media\MediaService;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\Test\Stub\DataAbstractionLayer\StaticEntityRepository;
@@ -206,6 +207,63 @@ class DocumentPersisterTest extends TestCase
         );
     }
 
+    public function testUniqueDocumentNumberCheckFiltersByDocumentTypeIdForCoreTypes(): void
+    {
+        $documentTypeId = Uuid::randomHex();
+        $filters = null;
+
+        [$persister] = $this->createPersister(
+            $documentTypeId,
+            uniquenessSearch: static function (Criteria $criteria) use (&$filters): array {
+                $filters = $criteria->getFilters();
+
+                return [];
+            },
+        );
+
+        $persister->persist(
+            $this->generationRequest,
+            $this->renderInput,
+            $this->renderState,
+            [self::FORMAT],
+            null,
+            $this->context,
+        );
+
+        static::assertEquals([
+            new EqualsFilter('documentNumber', '12345'),
+            new EqualsFilter('documentTypeId', $documentTypeId),
+        ], $filters);
+    }
+
+    public function testUniqueDocumentNumberCheckFiltersByConfigTypeWhenNoDocumentTypeRowExists(): void
+    {
+        $filters = null;
+
+        [$persister] = $this->createPersister(
+            documentTypeId: null,
+            uniquenessSearch: static function (Criteria $criteria) use (&$filters): array {
+                $filters = $criteria->getFilters();
+
+                return [];
+            },
+        );
+
+        $persister->persist(
+            $this->generationRequest,
+            $this->renderInput,
+            $this->renderState,
+            [self::FORMAT],
+            null,
+            $this->context,
+        );
+
+        static::assertEquals([
+            new EqualsFilter('documentNumber', '12345'),
+            new EqualsFilter('config.documentType', self::DOCUMENT_TYPE),
+        ], $filters);
+    }
+
     /**
      * @param list<string> $existingDocumentIds
      *
@@ -220,9 +278,10 @@ class DocumentPersisterTest extends TestCase
         ?callable $documentSearch = null,
         array $existingDocumentIds = [],
         ?string $mediaServiceReturn = null,
+        ?callable $uniquenessSearch = null,
     ): array {
         $documentRepository = StaticEntityRepository::of(DocumentCollection::class, [
-            $existingDocumentIds,
+            $uniquenessSearch ?? $existingDocumentIds,
             $documentSearch ?? static function (
                 Criteria $criteria,
                 Context $context,

--- a/tests/unit/Core/Checkout/DocumentV2/Provider/CancellationInvoiceDataProviderTest.php
+++ b/tests/unit/Core/Checkout/DocumentV2/Provider/CancellationInvoiceDataProviderTest.php
@@ -2,7 +2,6 @@
 
 namespace Shopware\Tests\Unit\Core\Checkout\DocumentV2\Provider;
 
-use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
@@ -32,6 +31,7 @@ use Shopware\Core\Checkout\Order\Aggregate\OrderLineItem\OrderLineItemEntity;
 use Shopware\Core\Checkout\Order\OrderEntity;
 use Shopware\Core\Content\Media\MediaCollection;
 use Shopware\Core\Content\Media\MediaDefinition;
+use Shopware\Core\Framework\App\Aggregate\AppDocumentType\AppDocumentTypeCollection;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Log\Package;
@@ -133,15 +133,17 @@ class CancellationInvoiceDataProviderTest extends TestCase
 
         $mediaRepository = new StaticEntityRepository([new MediaCollection()], new MediaDefinition());
 
-        $appDocumentTypeConnection = static::createStub(Connection::class);
-        $appDocumentTypeConnection->method('fetchAllAssociative')->willReturn([]);
+        $appDocumentTypeRepository = StaticEntityRepository::of(
+            AppDocumentTypeCollection::class,
+            [new AppDocumentTypeCollection([])],
+        );
 
         $configLoader = new DocumentConfigLoader(
             $documentConfigRepository,
             $countryRepository,
             $mediaRepository,
             static::createStub(SystemConfigService::class),
-            new AppDocumentTypeLoader($appDocumentTypeConnection),
+            new AppDocumentTypeLoader($appDocumentTypeRepository),
         );
 
         return new InvoiceDataProvider(

--- a/tests/unit/Core/Checkout/DocumentV2/Provider/CancellationInvoiceDataProviderTest.php
+++ b/tests/unit/Core/Checkout/DocumentV2/Provider/CancellationInvoiceDataProviderTest.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Tests\Unit\Core\Checkout\DocumentV2\Provider;
 
+use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
@@ -23,6 +24,7 @@ use Shopware\Core\Checkout\DocumentV2\Provider\InvoiceDataProvider;
 use Shopware\Core\Checkout\DocumentV2\Struct\ProviderInput;
 use Shopware\Core\Checkout\DocumentV2\Struct\ReferencedDocument;
 use Shopware\Core\Checkout\DocumentV2\Template\Enum\TypeCode;
+use Shopware\Core\Checkout\DocumentV2\Type\AppDocumentTypeLoader;
 use Shopware\Core\Checkout\Order\Aggregate\OrderAddress\OrderAddressEntity;
 use Shopware\Core\Checkout\Order\Aggregate\OrderCustomer\OrderCustomerEntity;
 use Shopware\Core\Checkout\Order\Aggregate\OrderLineItem\OrderLineItemCollection;
@@ -131,11 +133,15 @@ class CancellationInvoiceDataProviderTest extends TestCase
 
         $mediaRepository = new StaticEntityRepository([new MediaCollection()], new MediaDefinition());
 
+        $appDocumentTypeConnection = static::createStub(Connection::class);
+        $appDocumentTypeConnection->method('fetchAllAssociative')->willReturn([]);
+
         $configLoader = new DocumentConfigLoader(
             $documentConfigRepository,
             $countryRepository,
             $mediaRepository,
             static::createStub(SystemConfigService::class),
+            new AppDocumentTypeLoader($appDocumentTypeConnection),
         );
 
         return new InvoiceDataProvider(

--- a/tests/unit/Core/Checkout/DocumentV2/Provider/DocumentMetaProviderTest.php
+++ b/tests/unit/Core/Checkout/DocumentV2/Provider/DocumentMetaProviderTest.php
@@ -2,7 +2,6 @@
 
 namespace Shopware\Tests\Unit\Core\Checkout\DocumentV2\Provider;
 
-use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
@@ -20,6 +19,7 @@ use Shopware\Core\Checkout\DocumentV2\Type\AppDocumentTypeLoader;
 use Shopware\Core\Checkout\Order\OrderEntity;
 use Shopware\Core\Content\Media\MediaCollection;
 use Shopware\Core\Content\Media\MediaDefinition;
+use Shopware\Core\Framework\App\Aggregate\AppDocumentType\AppDocumentTypeCollection;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -141,16 +141,18 @@ class DocumentMetaProviderTest extends TestCase
             new MediaDefinition(),
         );
 
-        $connection = static::createStub(Connection::class);
-        $connection->method('fetchAllAssociative')->willReturn([]);
-
         return new DocumentMetaProvider(
             new DocumentConfigLoader(
                 $documentConfigRepository,
                 $countryRepository,
                 $mediaRepository,
                 static::createStub(SystemConfigService::class),
-                new AppDocumentTypeLoader($connection),
+                new AppDocumentTypeLoader(
+                    StaticEntityRepository::of(
+                        AppDocumentTypeCollection::class,
+                        [new AppDocumentTypeCollection([])]
+                    ),
+                ),
             ),
         );
     }

--- a/tests/unit/Core/Checkout/DocumentV2/Provider/DocumentMetaProviderTest.php
+++ b/tests/unit/Core/Checkout/DocumentV2/Provider/DocumentMetaProviderTest.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Tests\Unit\Core\Checkout\DocumentV2\Provider;
 
+use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
@@ -15,6 +16,7 @@ use Shopware\Core\Checkout\DocumentV2\DocumentV2Exception;
 use Shopware\Core\Checkout\DocumentV2\Generation\DocumentGenerationRequest;
 use Shopware\Core\Checkout\DocumentV2\Provider\DocumentMetaProvider;
 use Shopware\Core\Checkout\DocumentV2\Struct\ProviderInput;
+use Shopware\Core\Checkout\DocumentV2\Type\AppDocumentTypeLoader;
 use Shopware\Core\Checkout\Order\OrderEntity;
 use Shopware\Core\Content\Media\MediaCollection;
 use Shopware\Core\Content\Media\MediaDefinition;
@@ -139,12 +141,16 @@ class DocumentMetaProviderTest extends TestCase
             new MediaDefinition(),
         );
 
+        $connection = static::createStub(Connection::class);
+        $connection->method('fetchAllAssociative')->willReturn([]);
+
         return new DocumentMetaProvider(
             new DocumentConfigLoader(
                 $documentConfigRepository,
                 $countryRepository,
                 $mediaRepository,
                 static::createStub(SystemConfigService::class),
+                new AppDocumentTypeLoader($connection),
             ),
         );
     }

--- a/tests/unit/Core/Checkout/DocumentV2/Provider/InvoiceDataProviderTest.php
+++ b/tests/unit/Core/Checkout/DocumentV2/Provider/InvoiceDataProviderTest.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Tests\Unit\Core\Checkout\DocumentV2\Provider;
 
+use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
@@ -20,6 +21,7 @@ use Shopware\Core\Checkout\DocumentV2\DocumentV2Exception;
 use Shopware\Core\Checkout\DocumentV2\Generation\DocumentGenerationRequest;
 use Shopware\Core\Checkout\DocumentV2\Provider\InvoiceDataProvider;
 use Shopware\Core\Checkout\DocumentV2\Struct\ProviderInput;
+use Shopware\Core\Checkout\DocumentV2\Type\AppDocumentTypeLoader;
 use Shopware\Core\Checkout\Order\Aggregate\OrderAddress\OrderAddressEntity;
 use Shopware\Core\Checkout\Order\Aggregate\OrderCustomer\OrderCustomerEntity;
 use Shopware\Core\Checkout\Order\Aggregate\OrderDelivery\OrderDeliveryCollection;
@@ -397,11 +399,15 @@ class InvoiceDataProviderTest extends TestCase
 
         $mediaRepository = new StaticEntityRepository([new MediaCollection()], new MediaDefinition());
 
+        $connection = static::createStub(Connection::class);
+        $connection->method('fetchAllAssociative')->willReturn([]);
+
         $configLoader = new DocumentConfigLoader(
             $documentConfigRepository,
             $countryRepository,
             $mediaRepository,
             static::createStub(SystemConfigService::class),
+            new AppDocumentTypeLoader($connection),
         );
 
         return new InvoiceDataProvider(

--- a/tests/unit/Core/Checkout/DocumentV2/Provider/InvoiceDataProviderTest.php
+++ b/tests/unit/Core/Checkout/DocumentV2/Provider/InvoiceDataProviderTest.php
@@ -2,7 +2,6 @@
 
 namespace Shopware\Tests\Unit\Core\Checkout\DocumentV2\Provider;
 
-use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
@@ -30,6 +29,7 @@ use Shopware\Core\Checkout\Order\Aggregate\OrderLineItem\OrderLineItemCollection
 use Shopware\Core\Checkout\Order\OrderEntity;
 use Shopware\Core\Content\Media\MediaCollection;
 use Shopware\Core\Content\Media\MediaDefinition;
+use Shopware\Core\Framework\App\Aggregate\AppDocumentType\AppDocumentTypeCollection;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\TaxFreeConfig;
@@ -399,15 +399,17 @@ class InvoiceDataProviderTest extends TestCase
 
         $mediaRepository = new StaticEntityRepository([new MediaCollection()], new MediaDefinition());
 
-        $connection = static::createStub(Connection::class);
-        $connection->method('fetchAllAssociative')->willReturn([]);
-
         $configLoader = new DocumentConfigLoader(
             $documentConfigRepository,
             $countryRepository,
             $mediaRepository,
             static::createStub(SystemConfigService::class),
-            new AppDocumentTypeLoader($connection),
+            new AppDocumentTypeLoader(
+                StaticEntityRepository::of(
+                    AppDocumentTypeCollection::class,
+                    [new AppDocumentTypeCollection([])]
+                ),
+            ),
         );
 
         return new InvoiceDataProvider(

--- a/tests/unit/Core/Checkout/DocumentV2/Renderer/ZugferdXmlRendererTest.php
+++ b/tests/unit/Core/Checkout/DocumentV2/Renderer/ZugferdXmlRendererTest.php
@@ -15,6 +15,7 @@ use Shopware\Core\Checkout\DocumentV2\Provider\InvoiceDataProvider;
 use Shopware\Core\Checkout\DocumentV2\Provider\RenderData\DocumentMetaRenderData;
 use Shopware\Core\Checkout\DocumentV2\Provider\RenderData\InvoiceRenderData;
 use Shopware\Core\Checkout\DocumentV2\Renderer\ZugferdXmlRenderer;
+use Shopware\Core\Checkout\DocumentV2\Struct\AbstractRenderData;
 use Shopware\Core\Checkout\DocumentV2\Struct\RenderInput;
 use Shopware\Core\Checkout\DocumentV2\Struct\RenderState;
 use Shopware\Core\Checkout\DocumentV2\Template\DocumentTemplateRenderer;
@@ -191,6 +192,58 @@ class ZugferdXmlRendererTest extends TestCase
             new RenderState(),
             Context::createDefaultContext(),
         );
+    }
+
+    public function testShouldThrowWhenCoreTypeHasNoRenderData(): void
+    {
+        $renderer = $this->createRenderer(
+            static::createStub(TemplateFinder::class),
+            static::createStub(TwigEnvironment::class),
+        );
+
+        $this->expectExceptionObject(
+            DocumentV2Exception::unknownRenderData(DocumentType::INVOICE->value, AbstractRenderData::class),
+        );
+
+        $renderer->renderToString(
+            new RenderInput(
+                DocumentType::INVOICE->value,
+                '12345',
+                $this->createOrder(),
+                [DocumentMetaProvider::KEY => $this->createMeta()],
+            ),
+            new RenderState(),
+            Context::createDefaultContext(),
+        );
+    }
+
+    public function testShouldRenderAppTypeWithoutRenderData(): void
+    {
+        $expectedTemplate = '@Framework/documents/zugferd/swag_certificate.xml.twig';
+
+        $finder = $this->createMock(TemplateFinder::class);
+        $finder->expects($this->once())
+            ->method('find')
+            ->with($expectedTemplate)
+            ->willReturn($expectedTemplate);
+
+        $env = static::createStub(TwigEnvironment::class);
+        $env->method('renderWithTimezoneOverride')->willReturn('<root/>');
+
+        $renderer = $this->createRenderer($finder, $env);
+
+        $result = $renderer->renderToString(
+            new RenderInput(
+                'swag_certificate',
+                '12345',
+                $this->createOrder(),
+                [DocumentMetaProvider::KEY => $this->createMeta()],
+            ),
+            new RenderState(),
+            Context::createDefaultContext(),
+        );
+
+        static::assertSame(DocumentFormat::ZUGFERD_XML->value, $result->format);
     }
 
     private function createRenderer(TemplateFinder $finder, TwigEnvironment $env): ZugferdXmlRenderer

--- a/tests/unit/Core/Checkout/DocumentV2/Type/AppDocumentTypeLoaderTest.php
+++ b/tests/unit/Core/Checkout/DocumentV2/Type/AppDocumentTypeLoaderTest.php
@@ -2,11 +2,19 @@
 
 namespace Shopware\Tests\Unit\Core\Checkout\DocumentV2\Type;
 
-use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\DocumentV2\Type\AppDocumentTypeLoader;
+use Shopware\Core\Framework\App\Aggregate\AppDocumentType\AppDocumentTypeCollection;
+use Shopware\Core\Framework\App\Aggregate\AppDocumentType\AppDocumentTypeDefinition;
+use Shopware\Core\Framework\App\Aggregate\AppDocumentType\AppDocumentTypeEntity;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\Test\Stub\DataAbstractionLayer\StaticEntityRepository;
 
 /**
  * @internal
@@ -17,26 +25,16 @@ class AppDocumentTypeLoaderTest extends TestCase
 {
     public function testReturnsEmptyArrayWhenNoAppRegistersDocumentTypes(): void
     {
-        $connection = static::createStub(Connection::class);
-        $connection->method('fetchAllAssociative')->willReturn([]);
-
-        $loader = new AppDocumentTypeLoader($connection);
+        $loader = new AppDocumentTypeLoader($this->repository());
 
         static::assertSame([], $loader->load());
     }
 
     public function testAdmitsAllCoreFormatsIncludingZugferd(): void
     {
-        $connection = static::createStub(Connection::class);
-        $connection->method('fetchAllAssociative')->willReturn([
-            [
-                'technical_name' => 'swag_certificate',
-                'formats' => json_encode(['html', 'pdf', 'zugferd_xml', 'zugferd_embedded_pdf'], \JSON_THROW_ON_ERROR),
-                'config' => null,
-            ],
-        ]);
-
-        $loader = new AppDocumentTypeLoader($connection);
+        $loader = new AppDocumentTypeLoader($this->repository(
+            $this->appDocumentType('swag_certificate', ['html', 'pdf', 'zugferd_xml', 'zugferd_embedded_pdf']),
+        ));
 
         static::assertSame(
             ['swag_certificate' => ['html', 'pdf', 'zugferd_xml', 'zugferd_embedded_pdf']],
@@ -46,37 +44,19 @@ class AppDocumentTypeLoaderTest extends TestCase
 
     public function testDropsTypeWhenNoSupportedFormatRemains(): void
     {
-        $connection = static::createStub(Connection::class);
-        $connection->method('fetchAllAssociative')->willReturn([
-            [
-                'technical_name' => 'swag_certificate',
-                'formats' => json_encode(['bogus_format'], \JSON_THROW_ON_ERROR),
-                'config' => null,
-            ],
-        ]);
-
-        $loader = new AppDocumentTypeLoader($connection);
+        $loader = new AppDocumentTypeLoader($this->repository(
+            $this->appDocumentType('swag_certificate', ['bogus_format']),
+        ));
 
         static::assertSame([], $loader->load());
     }
 
     public function testMergesTypesFromMultipleActiveApps(): void
     {
-        $connection = static::createStub(Connection::class);
-        $connection->method('fetchAllAssociative')->willReturn([
-            [
-                'technical_name' => 'swag_certificate',
-                'formats' => json_encode(['html'], \JSON_THROW_ON_ERROR),
-                'config' => null,
-            ],
-            [
-                'technical_name' => 'swag_warranty',
-                'formats' => json_encode(['pdf'], \JSON_THROW_ON_ERROR),
-                'config' => null,
-            ],
-        ]);
-
-        $loader = new AppDocumentTypeLoader($connection);
+        $loader = new AppDocumentTypeLoader($this->repository(
+            $this->appDocumentType('swag_certificate', ['html']),
+            $this->appDocumentType('swag_warranty', ['pdf']),
+        ));
 
         static::assertSame([
             'swag_certificate' => ['html'],
@@ -86,10 +66,10 @@ class AppDocumentTypeLoaderTest extends TestCase
 
     public function testMemoizesResultUntilReset(): void
     {
-        $connection = $this->createMock(Connection::class);
-        $connection->expects($this->exactly(2))->method('fetchAllAssociative')->willReturn([]);
+        $repository = $this->createMock(EntityRepository::class);
+        $repository->expects($this->exactly(2))->method('search')->willReturn($this->searchResult());
 
-        $loader = new AppDocumentTypeLoader($connection);
+        $loader = new AppDocumentTypeLoader($repository);
 
         $loader->load();
         $loader->load();
@@ -99,18 +79,11 @@ class AppDocumentTypeLoaderTest extends TestCase
         $loader->load();
     }
 
-    public function testLoadConfigReturnsDecodedConfig(): void
+    public function testLoadConfigReturnsConfig(): void
     {
-        $connection = static::createStub(Connection::class);
-        $connection->method('fetchAllAssociative')->willReturn([
-            [
-                'technical_name' => 'swag_certificate',
-                'formats' => json_encode(['html', 'pdf'], \JSON_THROW_ON_ERROR),
-                'config' => json_encode(['pageOrientation' => 'landscape', 'pageSize' => 'a4'], \JSON_THROW_ON_ERROR),
-            ],
-        ]);
-
-        $loader = new AppDocumentTypeLoader($connection);
+        $loader = new AppDocumentTypeLoader($this->repository(
+            $this->appDocumentType('swag_certificate', ['html', 'pdf'], ['pageOrientation' => 'landscape', 'pageSize' => 'a4']),
+        ));
 
         static::assertSame(
             ['pageOrientation' => 'landscape', 'pageSize' => 'a4'],
@@ -120,44 +93,73 @@ class AppDocumentTypeLoaderTest extends TestCase
 
     public function testLoadConfigReturnsEmptyArrayForNullConfig(): void
     {
-        $connection = static::createStub(Connection::class);
-        $connection->method('fetchAllAssociative')->willReturn([
-            [
-                'technical_name' => 'swag_certificate',
-                'formats' => json_encode(['html'], \JSON_THROW_ON_ERROR),
-                'config' => null,
-            ],
-        ]);
-
-        $loader = new AppDocumentTypeLoader($connection);
+        $loader = new AppDocumentTypeLoader($this->repository(
+            $this->appDocumentType('swag_certificate', ['html']),
+        ));
 
         static::assertSame([], $loader->loadConfig('swag_certificate'));
     }
 
     public function testLoadConfigReturnsEmptyArrayForUnknownType(): void
     {
-        $connection = static::createStub(Connection::class);
-        $connection->method('fetchAllAssociative')->willReturn([]);
-
-        $loader = new AppDocumentTypeLoader($connection);
+        $loader = new AppDocumentTypeLoader($this->repository());
 
         static::assertSame([], $loader->loadConfig('unknown_type'));
     }
 
     public function testLoadAndLoadConfigShareOneMemoizedQuery(): void
     {
-        $connection = $this->createMock(Connection::class);
-        $connection->expects($this->once())->method('fetchAllAssociative')->willReturn([
-            [
-                'technical_name' => 'swag_certificate',
-                'formats' => json_encode(['html'], \JSON_THROW_ON_ERROR),
-                'config' => json_encode(['foo' => 'bar'], \JSON_THROW_ON_ERROR),
-            ],
-        ]);
-
-        $loader = new AppDocumentTypeLoader($connection);
+        $loader = new AppDocumentTypeLoader($this->repository(
+            $this->appDocumentType('swag_certificate', ['html'], ['foo' => 'bar']),
+        ));
 
         static::assertSame(['swag_certificate' => ['html']], $loader->load());
         static::assertSame(['foo' => 'bar'], $loader->loadConfig('swag_certificate'));
+    }
+
+    /**
+     * @param list<string>|null $formats
+     * @param array<string, scalar>|null $config
+     */
+    private function appDocumentType(string $technicalName, ?array $formats, ?array $config = null): AppDocumentTypeEntity
+    {
+        $id = Uuid::randomHex();
+
+        $appDocumentType = new AppDocumentTypeEntity();
+        $appDocumentType->setUniqueIdentifier($id);
+        $appDocumentType->setId($id);
+        $appDocumentType->setTechnicalName($technicalName);
+        $appDocumentType->setFormats($formats);
+        $appDocumentType->setConfig($config);
+
+        return $appDocumentType;
+    }
+
+    /**
+     * @return StaticEntityRepository<AppDocumentTypeCollection>
+     */
+    private function repository(AppDocumentTypeEntity ...$appDocumentTypes): StaticEntityRepository
+    {
+        return StaticEntityRepository::of(
+            AppDocumentTypeCollection::class,
+            [new AppDocumentTypeCollection($appDocumentTypes)],
+        );
+    }
+
+    /**
+     * @return EntitySearchResult<AppDocumentTypeCollection>
+     */
+    private function searchResult(AppDocumentTypeEntity ...$appDocumentTypes): EntitySearchResult
+    {
+        $collection = new AppDocumentTypeCollection($appDocumentTypes);
+
+        return new EntitySearchResult(
+            AppDocumentTypeDefinition::ENTITY_NAME,
+            $collection->count(),
+            $collection,
+            null,
+            new Criteria(),
+            Context::createDefaultContext(),
+        );
     }
 }

--- a/tests/unit/Core/Checkout/DocumentV2/Type/AppDocumentTypeLoaderTest.php
+++ b/tests/unit/Core/Checkout/DocumentV2/Type/AppDocumentTypeLoaderTest.php
@@ -1,0 +1,163 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Checkout\DocumentV2\Type;
+
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Checkout\DocumentV2\Type\AppDocumentTypeLoader;
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * @internal
+ */
+#[Package('after-sales')]
+#[CoversClass(AppDocumentTypeLoader::class)]
+class AppDocumentTypeLoaderTest extends TestCase
+{
+    public function testReturnsEmptyArrayWhenNoAppRegistersDocumentTypes(): void
+    {
+        $connection = static::createStub(Connection::class);
+        $connection->method('fetchAllAssociative')->willReturn([]);
+
+        $loader = new AppDocumentTypeLoader($connection);
+
+        static::assertSame([], $loader->load());
+    }
+
+    public function testAdmitsAllCoreFormatsIncludingZugferd(): void
+    {
+        $connection = static::createStub(Connection::class);
+        $connection->method('fetchAllAssociative')->willReturn([
+            [
+                'technical_name' => 'swag_certificate',
+                'formats' => json_encode(['html', 'pdf', 'zugferd_xml', 'zugferd_embedded_pdf'], \JSON_THROW_ON_ERROR),
+                'config' => null,
+            ],
+        ]);
+
+        $loader = new AppDocumentTypeLoader($connection);
+
+        static::assertSame(
+            ['swag_certificate' => ['html', 'pdf', 'zugferd_xml', 'zugferd_embedded_pdf']],
+            $loader->load(),
+        );
+    }
+
+    public function testDropsTypeWhenNoSupportedFormatRemains(): void
+    {
+        $connection = static::createStub(Connection::class);
+        $connection->method('fetchAllAssociative')->willReturn([
+            [
+                'technical_name' => 'swag_certificate',
+                'formats' => json_encode(['bogus_format'], \JSON_THROW_ON_ERROR),
+                'config' => null,
+            ],
+        ]);
+
+        $loader = new AppDocumentTypeLoader($connection);
+
+        static::assertSame([], $loader->load());
+    }
+
+    public function testMergesTypesFromMultipleActiveApps(): void
+    {
+        $connection = static::createStub(Connection::class);
+        $connection->method('fetchAllAssociative')->willReturn([
+            [
+                'technical_name' => 'swag_certificate',
+                'formats' => json_encode(['html'], \JSON_THROW_ON_ERROR),
+                'config' => null,
+            ],
+            [
+                'technical_name' => 'swag_warranty',
+                'formats' => json_encode(['pdf'], \JSON_THROW_ON_ERROR),
+                'config' => null,
+            ],
+        ]);
+
+        $loader = new AppDocumentTypeLoader($connection);
+
+        static::assertSame([
+            'swag_certificate' => ['html'],
+            'swag_warranty' => ['pdf'],
+        ], $loader->load());
+    }
+
+    public function testMemoizesResultUntilReset(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection->expects($this->exactly(2))->method('fetchAllAssociative')->willReturn([]);
+
+        $loader = new AppDocumentTypeLoader($connection);
+
+        $loader->load();
+        $loader->load();
+
+        $loader->reset();
+
+        $loader->load();
+    }
+
+    public function testLoadConfigReturnsDecodedConfig(): void
+    {
+        $connection = static::createStub(Connection::class);
+        $connection->method('fetchAllAssociative')->willReturn([
+            [
+                'technical_name' => 'swag_certificate',
+                'formats' => json_encode(['html', 'pdf'], \JSON_THROW_ON_ERROR),
+                'config' => json_encode(['pageOrientation' => 'landscape', 'pageSize' => 'a4'], \JSON_THROW_ON_ERROR),
+            ],
+        ]);
+
+        $loader = new AppDocumentTypeLoader($connection);
+
+        static::assertSame(
+            ['pageOrientation' => 'landscape', 'pageSize' => 'a4'],
+            $loader->loadConfig('swag_certificate'),
+        );
+    }
+
+    public function testLoadConfigReturnsEmptyArrayForNullConfig(): void
+    {
+        $connection = static::createStub(Connection::class);
+        $connection->method('fetchAllAssociative')->willReturn([
+            [
+                'technical_name' => 'swag_certificate',
+                'formats' => json_encode(['html'], \JSON_THROW_ON_ERROR),
+                'config' => null,
+            ],
+        ]);
+
+        $loader = new AppDocumentTypeLoader($connection);
+
+        static::assertSame([], $loader->loadConfig('swag_certificate'));
+    }
+
+    public function testLoadConfigReturnsEmptyArrayForUnknownType(): void
+    {
+        $connection = static::createStub(Connection::class);
+        $connection->method('fetchAllAssociative')->willReturn([]);
+
+        $loader = new AppDocumentTypeLoader($connection);
+
+        static::assertSame([], $loader->loadConfig('unknown_type'));
+    }
+
+    public function testLoadAndLoadConfigShareOneMemoizedQuery(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection->expects($this->once())->method('fetchAllAssociative')->willReturn([
+            [
+                'technical_name' => 'swag_certificate',
+                'formats' => json_encode(['html'], \JSON_THROW_ON_ERROR),
+                'config' => json_encode(['foo' => 'bar'], \JSON_THROW_ON_ERROR),
+            ],
+        ]);
+
+        $loader = new AppDocumentTypeLoader($connection);
+
+        static::assertSame(['swag_certificate' => ['html']], $loader->load());
+        static::assertSame(['foo' => 'bar'], $loader->loadConfig('swag_certificate'));
+    }
+}

--- a/tests/unit/Core/Checkout/DocumentV2/Type/DocumentTypeRegistryTest.php
+++ b/tests/unit/Core/Checkout/DocumentV2/Type/DocumentTypeRegistryTest.php
@@ -2,13 +2,16 @@
 
 namespace Shopware\Tests\Unit\Core\Checkout\DocumentV2\Type;
 
-use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\DocumentV2\DocumentV2Exception;
 use Shopware\Core\Checkout\DocumentV2\Type\AppDocumentTypeLoader;
 use Shopware\Core\Checkout\DocumentV2\Type\DocumentTypeRegistry;
+use Shopware\Core\Framework\App\Aggregate\AppDocumentType\AppDocumentTypeCollection;
+use Shopware\Core\Framework\App\Aggregate\AppDocumentType\AppDocumentTypeEntity;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\Test\Stub\DataAbstractionLayer\StaticEntityRepository;
 use Shopware\Tests\Unit\Core\Checkout\DocumentV2\Fixtures\StaticDocumentType;
 
 /**
@@ -84,13 +87,11 @@ class DocumentTypeRegistryTest extends TestCase
 
     public function testResetInvalidatesMemoizedMergeSoUpdatedAppTypesAreReflected(): void
     {
-        $connection = static::createStub(Connection::class);
-        $connection->method('fetchAllAssociative')->willReturnOnConsecutiveCalls(
-            $this->appTypeRows(['swag_certificate' => ['html']]),
-            $this->appTypeRows(['swag_warranty' => ['pdf']]),
-        );
+        $loader = new AppDocumentTypeLoader(StaticEntityRepository::of(AppDocumentTypeCollection::class, [
+            $this->appDocumentTypes(['swag_certificate' => ['html']]),
+            $this->appDocumentTypes(['swag_warranty' => ['pdf']]),
+        ]));
 
-        $loader = new AppDocumentTypeLoader($connection);
         $registry = new DocumentTypeRegistry([new StaticDocumentType('invoice', ['html', 'pdf'])], $loader);
 
         static::assertSame(['invoice', 'swag_certificate'], $registry->getDocumentTypes());
@@ -108,27 +109,32 @@ class DocumentTypeRegistryTest extends TestCase
      */
     private function appDocumentTypeLoader(array $appTypes = []): AppDocumentTypeLoader
     {
-        $connection = static::createStub(Connection::class);
-        $connection->method('fetchAllAssociative')->willReturn($this->appTypeRows($appTypes));
-
-        return new AppDocumentTypeLoader($connection);
+        return new AppDocumentTypeLoader(StaticEntityRepository::of(
+            AppDocumentTypeCollection::class,
+            [$this->appDocumentTypes($appTypes)],
+        ));
     }
 
     /**
      * @param array<string, list<string>> $appTypes
-     *
-     * @return list<array{technical_name: string, formats: string, config: null}>
      */
-    private function appTypeRows(array $appTypes): array
+    private function appDocumentTypes(array $appTypes): AppDocumentTypeCollection
     {
-        return array_map(
-            static fn (string $identifier, array $formats): array => [
-                'technical_name' => $identifier,
-                'formats' => (string) json_encode($formats, \JSON_THROW_ON_ERROR),
-                'config' => null,
-            ],
-            array_keys($appTypes),
-            array_values($appTypes),
-        );
+        $entities = [];
+
+        foreach ($appTypes as $identifier => $formats) {
+            $id = Uuid::randomHex();
+
+            $entity = new AppDocumentTypeEntity();
+            $entity->setUniqueIdentifier($id);
+            $entity->setId($id);
+            $entity->setTechnicalName($identifier);
+            $entity->setFormats($formats);
+            $entity->setConfig(null);
+
+            $entities[] = $entity;
+        }
+
+        return new AppDocumentTypeCollection($entities);
     }
 }

--- a/tests/unit/Core/Checkout/DocumentV2/Type/DocumentTypeRegistryTest.php
+++ b/tests/unit/Core/Checkout/DocumentV2/Type/DocumentTypeRegistryTest.php
@@ -2,9 +2,11 @@
 
 namespace Shopware\Tests\Unit\Core\Checkout\DocumentV2\Type;
 
+use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\DocumentV2\DocumentV2Exception;
+use Shopware\Core\Checkout\DocumentV2\Type\AppDocumentTypeLoader;
 use Shopware\Core\Checkout\DocumentV2\Type\DocumentTypeRegistry;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Tests\Unit\Core\Checkout\DocumentV2\Fixtures\StaticDocumentType;
@@ -21,7 +23,7 @@ class DocumentTypeRegistryTest extends TestCase
         $registry = new DocumentTypeRegistry([
             new StaticDocumentType('invoice', ['html', 'pdf']),
             new StaticDocumentType('delivery_note', ['html']),
-        ]);
+        ], $this->appDocumentTypeLoader());
 
         static::assertSame(['invoice', 'delivery_note'], $registry->getDocumentTypes());
         static::assertSame(['html', 'pdf'], $registry->getSupportedFormats('invoice'));
@@ -35,14 +37,14 @@ class DocumentTypeRegistryTest extends TestCase
         $registry = new DocumentTypeRegistry([
             new StaticDocumentType('delivery_note', ['html', 'pdf']),
             new StaticDocumentType('delivery_note', ['pdf', 'zugferd_xml']),
-        ]);
+        ], $this->appDocumentTypeLoader());
 
         static::assertSame(['html', 'pdf', 'zugferd_xml'], $registry->getSupportedFormats('delivery_note'));
     }
 
     public function testValidateFormatsPassesForSupported(): void
     {
-        $registry = new DocumentTypeRegistry([new StaticDocumentType('invoice', ['html', 'pdf'])]);
+        $registry = new DocumentTypeRegistry([new StaticDocumentType('invoice', ['html', 'pdf'])], $this->appDocumentTypeLoader());
 
         $registry->validateFormats('invoice', ['html', 'pdf']);
 
@@ -51,10 +53,82 @@ class DocumentTypeRegistryTest extends TestCase
 
     public function testValidateFormatsThrowsForUnsupported(): void
     {
-        $registry = new DocumentTypeRegistry([new StaticDocumentType('invoice', ['html'])]);
+        $registry = new DocumentTypeRegistry([new StaticDocumentType('invoice', ['html'])], $this->appDocumentTypeLoader());
 
         $this->expectExceptionObject(DocumentV2Exception::unsupportedDocumentFormat('pdf', 'invoice'));
 
         $registry->validateFormats('invoice', ['pdf']);
+    }
+
+    public function testAppRegisteredTypeAppearsInRegistry(): void
+    {
+        $registry = new DocumentTypeRegistry(
+            [new StaticDocumentType('invoice', ['html', 'pdf'])],
+            $this->appDocumentTypeLoader(['swag_certificate' => ['html', 'pdf']]),
+        );
+
+        static::assertSame(['invoice', 'swag_certificate'], $registry->getDocumentTypes());
+        static::assertSame(['html', 'pdf'], $registry->getSupportedFormats('swag_certificate'));
+        static::assertTrue($registry->supports('swag_certificate'));
+    }
+
+    public function testAppRegisteredTypeDoesNotOverrideCoreTypeOfSameName(): void
+    {
+        $registry = new DocumentTypeRegistry(
+            [new StaticDocumentType('invoice', ['html', 'pdf'])],
+            $this->appDocumentTypeLoader(['invoice' => ['pdf']]),
+        );
+
+        static::assertSame(['html', 'pdf'], $registry->getSupportedFormats('invoice'));
+    }
+
+    public function testResetInvalidatesMemoizedMergeSoUpdatedAppTypesAreReflected(): void
+    {
+        $connection = static::createStub(Connection::class);
+        $connection->method('fetchAllAssociative')->willReturnOnConsecutiveCalls(
+            $this->appTypeRows(['swag_certificate' => ['html']]),
+            $this->appTypeRows(['swag_warranty' => ['pdf']]),
+        );
+
+        $loader = new AppDocumentTypeLoader($connection);
+        $registry = new DocumentTypeRegistry([new StaticDocumentType('invoice', ['html', 'pdf'])], $loader);
+
+        static::assertSame(['invoice', 'swag_certificate'], $registry->getDocumentTypes());
+        // Memoized: a second read before reset must not requery, and must still reflect the old app type.
+        static::assertSame(['invoice', 'swag_certificate'], $registry->getDocumentTypes());
+
+        $registry->reset();
+        $loader->reset();
+
+        static::assertSame(['invoice', 'swag_warranty'], $registry->getDocumentTypes());
+    }
+
+    /**
+     * @param array<string, list<string>> $appTypes
+     */
+    private function appDocumentTypeLoader(array $appTypes = []): AppDocumentTypeLoader
+    {
+        $connection = static::createStub(Connection::class);
+        $connection->method('fetchAllAssociative')->willReturn($this->appTypeRows($appTypes));
+
+        return new AppDocumentTypeLoader($connection);
+    }
+
+    /**
+     * @param array<string, list<string>> $appTypes
+     *
+     * @return list<array{technical_name: string, formats: string, config: null}>
+     */
+    private function appTypeRows(array $appTypes): array
+    {
+        return array_map(
+            static fn (string $identifier, array $formats): array => [
+                'technical_name' => $identifier,
+                'formats' => (string) json_encode($formats, \JSON_THROW_ON_ERROR),
+                'config' => null,
+            ],
+            array_keys($appTypes),
+            array_values($appTypes),
+        );
     }
 }

--- a/tests/unit/Core/Framework/App/Manifest/Xml/Document/DocumentTypeConfigTest.php
+++ b/tests/unit/Core/Framework/App/Manifest/Xml/Document/DocumentTypeConfigTest.php
@@ -1,0 +1,32 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\App\Manifest\Xml\Document;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\App\Manifest\Manifest;
+use Shopware\Core\Framework\App\Manifest\Xml\Document\DocumentTypeConfig;
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+#[CoversClass(DocumentTypeConfig::class)]
+class DocumentTypeConfigTest extends TestCase
+{
+    public function testParsesConfigWithCoercedScalarTypes(): void
+    {
+        $manifest = Manifest::createFromXmlFile(__DIR__ . '/_fixtures/testDocument/manifest.xml');
+        $config = $manifest->getDocuments()?->getDocumentTypes()[0]->getConfig() ?? [];
+
+        static::assertSame('a4', $config['pageSize']);
+        static::assertSame('portrait', $config['pageOrientation']);
+        static::assertSame(10, $config['itemsPerPage']);
+        static::assertTrue($config['displayHeader']);
+        static::assertTrue($config['displayFooter']);
+        static::assertFalse($config['displayPageCount']);
+        static::assertTrue($config['displayLineItems']);
+        static::assertFalse($config['displayPrices']);
+    }
+}

--- a/tests/unit/Core/Framework/App/Manifest/Xml/Document/DocumentTypeTest.php
+++ b/tests/unit/Core/Framework/App/Manifest/Xml/Document/DocumentTypeTest.php
@@ -41,6 +41,23 @@ class DocumentTypeTest extends TestCase
         static::assertSame([], $documentType->getConfig());
     }
 
+    public function testToArrayBackfillsSystemDefaultLanguageLabel(): void
+    {
+        $manifest = Manifest::createFromXml($this->manifestWithDocumentType(
+            '<formats><format>html</format></formats>',
+            '<label lang="de-DE">Zertifikat</label>'
+        ));
+        $documentType = $manifest->getDocuments()?->getDocumentTypes()[0] ?? null;
+        static::assertNotNull($documentType);
+
+        $data = $documentType->toArray('en-GB');
+
+        static::assertSame(
+            ['de-DE' => 'Zertifikat', 'en-GB' => 'Zertifikat'],
+            $data['label'],
+        );
+    }
+
     public function testUnknownFormatFailsSchemaValidation(): void
     {
         $this->expectException(AppException::class);
@@ -65,7 +82,7 @@ class DocumentTypeTest extends TestCase
         return $documentType;
     }
 
-    private function manifestWithDocumentType(string $documentTypeBody): string
+    private function manifestWithDocumentType(string $documentTypeBody, string $label = '<label>Certificate</label>'): string
     {
         return <<<XML
             <?xml version="1.0" encoding="UTF-8"?>
@@ -82,7 +99,7 @@ class DocumentTypeTest extends TestCase
                 <documents>
                     <document-type>
                         <identifier>swag_certificate</identifier>
-                        <label>Certificate</label>
+                        {$label}
                         {$documentTypeBody}
                     </document-type>
                 </documents>

--- a/tests/unit/Core/Framework/App/Manifest/Xml/Document/DocumentTypeTest.php
+++ b/tests/unit/Core/Framework/App/Manifest/Xml/Document/DocumentTypeTest.php
@@ -1,0 +1,92 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\App\Manifest\Xml\Document;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\App\AppException;
+use Shopware\Core\Framework\App\Manifest\Manifest;
+use Shopware\Core\Framework\App\Manifest\Xml\Document\DocumentType;
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+#[CoversClass(DocumentType::class)]
+class DocumentTypeTest extends TestCase
+{
+    public function testParsesIdentifierLabelAndAllSupportedFormats(): void
+    {
+        $documentType = $this->firstDocumentType();
+
+        static::assertSame('swag_certificate', $documentType->getIdentifier());
+        static::assertSame(
+            ['en-GB' => 'Certificate', 'de-DE' => 'Zertifikat'],
+            $documentType->getLabel()
+        );
+        static::assertSame(
+            ['html', 'pdf', 'zugferd_xml', 'zugferd_embedded_pdf'],
+            $documentType->getFormats()
+        );
+    }
+
+    public function testConfigDefaultsToEmptyArrayWhenNotDeclared(): void
+    {
+        $manifest = Manifest::createFromXmlFile(__DIR__ . '/_fixtures/testDocument/manifest.xml');
+        $documentType = $manifest->getDocuments()?->getDocumentTypes()[1] ?? null;
+
+        static::assertNotNull($documentType);
+        static::assertSame('swag_certificate_no_config', $documentType->getIdentifier());
+        static::assertSame([], $documentType->getConfig());
+    }
+
+    public function testUnknownFormatFailsSchemaValidation(): void
+    {
+        $this->expectException(AppException::class);
+
+        Manifest::createFromXml($this->manifestWithDocumentType('<formats><format>bogus</format></formats>'));
+    }
+
+    public function testMissingFormatsElementFailsRequiredFieldValidation(): void
+    {
+        $this->expectExceptionObject(AppException::invalidArgument('formats must not be empty'));
+
+        Manifest::createFromXml($this->manifestWithDocumentType(''));
+    }
+
+    private function firstDocumentType(): DocumentType
+    {
+        $manifest = Manifest::createFromXmlFile(__DIR__ . '/_fixtures/testDocument/manifest.xml');
+        $documentType = $manifest->getDocuments()?->getDocumentTypes()[0] ?? null;
+
+        static::assertNotNull($documentType);
+
+        return $documentType;
+    }
+
+    private function manifestWithDocumentType(string $documentTypeBody): string
+    {
+        return <<<XML
+            <?xml version="1.0" encoding="UTF-8"?>
+            <manifest xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                      xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/shopware/shopware/trunk/src/Core/Framework/App/Manifest/Schema/manifest-3.0.xsd">
+                <meta>
+                    <name>testDocument</name>
+                    <label>Swag App Documents Test</label>
+                    <author>shopware AG</author>
+                    <copyright>(c) by shopware AG</copyright>
+                    <version>1.0.0</version>
+                    <license>MIT</license>
+                </meta>
+                <documents>
+                    <document-type>
+                        <identifier>swag_certificate</identifier>
+                        <label>Certificate</label>
+                        {$documentTypeBody}
+                    </document-type>
+                </documents>
+            </manifest>
+            XML;
+    }
+}

--- a/tests/unit/Core/Framework/App/Manifest/Xml/Document/DocumentsTest.php
+++ b/tests/unit/Core/Framework/App/Manifest/Xml/Document/DocumentsTest.php
@@ -1,0 +1,120 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\App\Manifest\Xml\Document;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\App\AppException;
+use Shopware\Core\Framework\App\Manifest\Manifest;
+use Shopware\Core\Framework\App\Manifest\Xml\Document\Documents;
+use Shopware\Core\Framework\App\Manifest\Xml\Document\DocumentType;
+use Shopware\Core\Framework\App\Manifest\Xml\Document\DocumentTypeConfig;
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+#[CoversClass(Documents::class)]
+#[CoversClass(DocumentType::class)]
+#[CoversClass(DocumentTypeConfig::class)]
+class DocumentsTest extends TestCase
+{
+    public function testParse(): void
+    {
+        $manifest = Manifest::createFromXmlFile(__DIR__ . '/_fixtures/testDocument/manifest.xml');
+
+        static::assertNotNull($manifest->getDocuments());
+
+        $documentTypes = $manifest->getDocuments()->getDocumentTypes();
+        static::assertCount(2, $documentTypes);
+
+        $documentType = $documentTypes[0];
+        static::assertSame('swag_certificate', $documentType->getIdentifier());
+        static::assertSame([
+            'en-GB' => 'Certificate',
+            'de-DE' => 'Zertifikat',
+        ], $documentType->getLabel());
+        static::assertSame(['html', 'pdf'], $documentType->getFormats());
+
+        $config = $documentType->getConfig();
+        static::assertSame('a4', $config['pageSize']);
+        static::assertSame('portrait', $config['pageOrientation']);
+        static::assertSame(10, $config['itemsPerPage']);
+        static::assertTrue($config['displayHeader']);
+        static::assertTrue($config['displayFooter']);
+        static::assertFalse($config['displayPageCount']);
+        static::assertTrue($config['displayLineItems']);
+        static::assertFalse($config['displayPrices']);
+
+        $documentTypeWithoutConfig = $documentTypes[1];
+        static::assertSame('swag_certificate_no_config', $documentTypeWithoutConfig->getIdentifier());
+        static::assertSame([], $documentTypeWithoutConfig->getConfig());
+    }
+
+    public function testGetDocumentsIsNullWhenNotDeclared(): void
+    {
+        $manifest = Manifest::createFromXmlFile(__DIR__ . '/../../_fixtures/test/manifest.xml');
+
+        static::assertNull($manifest->getDocuments());
+    }
+
+    public function testUnknownFormatFailsSchemaValidation(): void
+    {
+        $this->expectException(AppException::class);
+
+        Manifest::createFromXml($this->manifestWithDocumentType('<formats><format>bogus</format></formats>'));
+    }
+
+    public function testZugferdXmlFormatPassesSchemaValidation(): void
+    {
+        $manifest = Manifest::createFromXml(
+            $this->manifestWithDocumentType('<formats><format>zugferd_xml</format></formats>'),
+        );
+
+        static::assertNotNull($manifest->getDocuments());
+        static::assertSame(['zugferd_xml'], $manifest->getDocuments()->getDocumentTypes()[0]->getFormats());
+    }
+
+    public function testZugferdEmbeddedPdfFormatPassesSchemaValidation(): void
+    {
+        $manifest = Manifest::createFromXml(
+            $this->manifestWithDocumentType('<formats><format>zugferd_embedded_pdf</format></formats>'),
+        );
+
+        static::assertNotNull($manifest->getDocuments());
+        static::assertSame(['zugferd_embedded_pdf'], $manifest->getDocuments()->getDocumentTypes()[0]->getFormats());
+    }
+
+    public function testMissingFormatsElementFailsRequiredFieldValidation(): void
+    {
+        $this->expectExceptionObject(AppException::invalidArgument('formats must not be empty'));
+
+        Manifest::createFromXml($this->manifestWithDocumentType(''));
+    }
+
+    private function manifestWithDocumentType(string $documentTypeBody): string
+    {
+        return <<<XML
+            <?xml version="1.0" encoding="UTF-8"?>
+            <manifest xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                      xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/shopware/shopware/trunk/src/Core/Framework/App/Manifest/Schema/manifest-3.0.xsd">
+                <meta>
+                    <name>testDocument</name>
+                    <label>Swag App Documents Test</label>
+                    <author>shopware AG</author>
+                    <copyright>(c) by shopware AG</copyright>
+                    <version>1.0.0</version>
+                    <license>MIT</license>
+                </meta>
+                <documents>
+                    <document-type>
+                        <identifier>swag_certificate</identifier>
+                        <label>Certificate</label>
+                        {$documentTypeBody}
+                    </document-type>
+                </documents>
+            </manifest>
+            XML;
+    }
+}

--- a/tests/unit/Core/Framework/App/Manifest/Xml/Document/DocumentsTest.php
+++ b/tests/unit/Core/Framework/App/Manifest/Xml/Document/DocumentsTest.php
@@ -4,11 +4,8 @@ namespace Shopware\Tests\Unit\Core\Framework\App\Manifest\Xml\Document;
 
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
-use Shopware\Core\Framework\App\AppException;
 use Shopware\Core\Framework\App\Manifest\Manifest;
 use Shopware\Core\Framework\App\Manifest\Xml\Document\Documents;
-use Shopware\Core\Framework\App\Manifest\Xml\Document\DocumentType;
-use Shopware\Core\Framework\App\Manifest\Xml\Document\DocumentTypeConfig;
 use Shopware\Core\Framework\Log\Package;
 
 /**
@@ -16,40 +13,19 @@ use Shopware\Core\Framework\Log\Package;
  */
 #[Package('framework')]
 #[CoversClass(Documents::class)]
-#[CoversClass(DocumentType::class)]
-#[CoversClass(DocumentTypeConfig::class)]
 class DocumentsTest extends TestCase
 {
-    public function testParse(): void
+    public function testGetDocumentTypesReturnsEveryDeclaredType(): void
     {
         $manifest = Manifest::createFromXmlFile(__DIR__ . '/_fixtures/testDocument/manifest.xml');
 
-        static::assertNotNull($manifest->getDocuments());
+        $documents = $manifest->getDocuments();
+        static::assertNotNull($documents);
 
-        $documentTypes = $manifest->getDocuments()->getDocumentTypes();
+        $documentTypes = $documents->getDocumentTypes();
         static::assertCount(2, $documentTypes);
-
-        $documentType = $documentTypes[0];
-        static::assertSame('swag_certificate', $documentType->getIdentifier());
-        static::assertSame([
-            'en-GB' => 'Certificate',
-            'de-DE' => 'Zertifikat',
-        ], $documentType->getLabel());
-        static::assertSame(['html', 'pdf'], $documentType->getFormats());
-
-        $config = $documentType->getConfig();
-        static::assertSame('a4', $config['pageSize']);
-        static::assertSame('portrait', $config['pageOrientation']);
-        static::assertSame(10, $config['itemsPerPage']);
-        static::assertTrue($config['displayHeader']);
-        static::assertTrue($config['displayFooter']);
-        static::assertFalse($config['displayPageCount']);
-        static::assertTrue($config['displayLineItems']);
-        static::assertFalse($config['displayPrices']);
-
-        $documentTypeWithoutConfig = $documentTypes[1];
-        static::assertSame('swag_certificate_no_config', $documentTypeWithoutConfig->getIdentifier());
-        static::assertSame([], $documentTypeWithoutConfig->getConfig());
+        static::assertSame('swag_certificate', $documentTypes[0]->getIdentifier());
+        static::assertSame('swag_certificate_no_config', $documentTypes[1]->getIdentifier());
     }
 
     public function testGetDocumentsIsNullWhenNotDeclared(): void
@@ -57,64 +33,5 @@ class DocumentsTest extends TestCase
         $manifest = Manifest::createFromXmlFile(__DIR__ . '/../../_fixtures/test/manifest.xml');
 
         static::assertNull($manifest->getDocuments());
-    }
-
-    public function testUnknownFormatFailsSchemaValidation(): void
-    {
-        $this->expectException(AppException::class);
-
-        Manifest::createFromXml($this->manifestWithDocumentType('<formats><format>bogus</format></formats>'));
-    }
-
-    public function testZugferdXmlFormatPassesSchemaValidation(): void
-    {
-        $manifest = Manifest::createFromXml(
-            $this->manifestWithDocumentType('<formats><format>zugferd_xml</format></formats>'),
-        );
-
-        static::assertNotNull($manifest->getDocuments());
-        static::assertSame(['zugferd_xml'], $manifest->getDocuments()->getDocumentTypes()[0]->getFormats());
-    }
-
-    public function testZugferdEmbeddedPdfFormatPassesSchemaValidation(): void
-    {
-        $manifest = Manifest::createFromXml(
-            $this->manifestWithDocumentType('<formats><format>zugferd_embedded_pdf</format></formats>'),
-        );
-
-        static::assertNotNull($manifest->getDocuments());
-        static::assertSame(['zugferd_embedded_pdf'], $manifest->getDocuments()->getDocumentTypes()[0]->getFormats());
-    }
-
-    public function testMissingFormatsElementFailsRequiredFieldValidation(): void
-    {
-        $this->expectExceptionObject(AppException::invalidArgument('formats must not be empty'));
-
-        Manifest::createFromXml($this->manifestWithDocumentType(''));
-    }
-
-    private function manifestWithDocumentType(string $documentTypeBody): string
-    {
-        return <<<XML
-            <?xml version="1.0" encoding="UTF-8"?>
-            <manifest xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                      xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/shopware/shopware/trunk/src/Core/Framework/App/Manifest/Schema/manifest-3.0.xsd">
-                <meta>
-                    <name>testDocument</name>
-                    <label>Swag App Documents Test</label>
-                    <author>shopware AG</author>
-                    <copyright>(c) by shopware AG</copyright>
-                    <version>1.0.0</version>
-                    <license>MIT</license>
-                </meta>
-                <documents>
-                    <document-type>
-                        <identifier>swag_certificate</identifier>
-                        <label>Certificate</label>
-                        {$documentTypeBody}
-                    </document-type>
-                </documents>
-            </manifest>
-            XML;
     }
 }

--- a/tests/unit/Core/Framework/App/Manifest/Xml/Document/_fixtures/testDocument/manifest.xml
+++ b/tests/unit/Core/Framework/App/Manifest/Xml/Document/_fixtures/testDocument/manifest.xml
@@ -26,6 +26,8 @@
             <formats>
                 <format>html</format>
                 <format>pdf</format>
+                <format>zugferd_xml</format>
+                <format>zugferd_embedded_pdf</format>
             </formats>
             <config>
                 <page-size>a4</page-size>

--- a/tests/unit/Core/Framework/App/Manifest/Xml/Document/_fixtures/testDocument/manifest.xml
+++ b/tests/unit/Core/Framework/App/Manifest/Xml/Document/_fixtures/testDocument/manifest.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/shopware/shopware/trunk/src/Core/Framework/App/Manifest/Schema/manifest-3.0.xsd">
+    <meta>
+        <name>testDocument</name>
+        <label>Swag App Documents Test</label>
+        <label lang="de-DE">Swag App Dokumente Test</label>
+        <description>Test for App document types</description>
+        <description lang="de-DE">Test für App Dokumenttypen</description>
+        <author>shopware AG</author>
+        <copyright>(c) by shopware AG</copyright>
+        <version>1.0.0</version>
+        <icon>../../../../Manifest/_fixtures/test/icon.png</icon>
+        <license>MIT</license>
+        <privacy>https://test.com/privacy</privacy>
+    </meta>
+    <setup>
+        <registrationUrl>https://my.app.com/testDocument/registration</registrationUrl>
+        <secret>s3cr3t</secret>
+    </setup>
+    <documents>
+        <document-type>
+            <identifier>swag_certificate</identifier>
+            <label>Certificate</label>
+            <label lang="de-DE">Zertifikat</label>
+            <formats>
+                <format>html</format>
+                <format>pdf</format>
+            </formats>
+            <config>
+                <page-size>a4</page-size>
+                <page-orientation>portrait</page-orientation>
+                <items-per-page>10</items-per-page>
+                <display-header>true</display-header>
+                <display-footer>true</display-footer>
+                <display-page-count>false</display-page-count>
+                <display-line-items>true</display-line-items>
+                <display-prices>false</display-prices>
+            </config>
+        </document-type>
+        <document-type>
+            <identifier>swag_certificate_no_config</identifier>
+            <label>Certificate without config</label>
+            <formats>
+                <format>html</format>
+            </formats>
+        </document-type>
+    </documents>
+</manifest>


### PR DESCRIPTION
part of https://github.com/shopware/shopware/issues/16144

Extension points so apps can add their own DocumentV2 document types and enrich core documents

## Changes

#### Manifest
- New `<documents>` block: `document-type` with `identifier`, `label`, `formats`, optional `config`. Parsed by `{Documents,DocumentType,DocumentTypeConfig}`, validated by `manifest-3.0.xsd`, exposed via `Manifest::getDocuments()`.

#### Persistence
- New `app_document_type` & `app_document_type_translation` aggregate for app registered document types.

#### Lifecycle
- `DocumentTypeLifecycleHandler` reconciles app_document_type rows on app install/update/uninstall
- `AppDocumentNumberRangeSubscriber` seeds one `number_range` per app type so numbers generate

#### Generation runtime
- `AppDocumentTypeLoader` reads types from active apps and never shadows a core identifier, `DocumentTypeRegistry` merges core + app types, `DocumentConfigLoader` falls back to app-declared config (or sane defaults) when no `document_base_config` row exists.
- `ZugferdXmlRenderer` tolerates a missing render-data DTO, so app types can emit `zugferd_xml` / `zugferd_embedded_pdf`.

#### Nullable core type id
- `document.document_type_id` made nullable.
- `DocumentPersister::resolveDocumentTypeId()` returns null for app types and stores the type in `config.documentType`.

#### App hook
- `DocumentGenerationHook` runs before providers collect data. Apps can enrich the order and override core template blocks via `sw_extends`.

## App extension lifesycle

```mermaid
flowchart LR
    M["App manifest<br/>&lt;documents&gt;"] --> LC["Install / update<br/>DocumentTypeLifecycleHandler"]
    LC --> DB[("app_document_type<br/>(+ translation)")]
    LC --> SUB["AppDocumentNumberRangeSubscriber"]
    SUB --> NR[("number range<br/>per type")]

    DB --> LOAD["AppDocumentTypeLoader<br/>(active apps)"]
    LOAD --> REG["DocumentTypeRegistry<br/>types + formats"]
    LOAD --> CFG["DocumentConfigLoader<br/>config / defaults"]
    REG --> GEN["DocumentGenerator"]
    CFG --> GEN
    NR -.-> GEN

    X["App uninstall"] -.->|CascadeDelete| DB
```

## Example app manifest

```xml
<?xml version="1.0" encoding="UTF-8"?>
<manifest xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/shopware/shopware/trunk/src/Core/Framework/App/Manifest/Schema/manifest-3.0.xsd">
    <meta>
        <name>SwagDocumentExample</name>
        <label>Swag Document Example</label>
        <description>Registers a custom warranty document type</description>
        <author>shopware AG</author>
        <copyright>(c) shopware AG</copyright>
        <version>1.0.0</version>
        <license>MIT</license>
    </meta>

    <documents>
        <document-type>
            <identifier>swag_warranty</identifier>
            <label>Warranty</label>
            <label lang="de-DE">Garantie</label>
            <formats>
                <format>html</format>
                <format>pdf</format>
            </formats>
            <config>
                <page-size>a4</page-size>
                <page-orientation>portrait</page-orientation>
                <items-per-page>10</items-per-page>
                <display-header>true</display-header>
                <display-footer>true</display-footer>
                <display-line-items>true</display-line-items>
                <display-prices>true</display-prices>
            </config>
        </document-type>
    </documents>
</manifest>
```