### PR TITLE
fix: restore ProxySQL connection multiplexing

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -162,6 +162,12 @@ Extension builds now set `output.uniqueName` to their technical name, which give
 
 ## Hosting & Configuration
 
+### ProxySQL connection multiplexing can be enabled
+
+Shopware no longer relies on MySQL user-defined session variables when loading limited many-to-many associations, which allows ProxySQL to multiplex these requests. ProxySQL operators can also set `SQL_SET_DEFAULT_SESSION_VARIABLES=0` to skip Shopware's connection initialization commands, which otherwise make connections session-specific and prevent multiplexing.
+
+When disabling the initialization commands, ensure the database or proxy configuration provides the required session defaults, in particular UTC as the session time zone, a sufficient `group_concat_max_len` of 320000 or higher, and an SQL mode without `ONLY_FULL_GROUP_BY`. The variable defaults to enabled, so existing installations are unaffected.
+
 ### Optional `Clear-Site-Data` header on customer logout
 
 On customer logout the storefront can send a [`Clear-Site-Data`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Clear-Site-Data) header, so the browser drops data left over from the session. Disabled by default:

--- a/src/Core/Framework/Adapter/Database/MySQLFactory.php
+++ b/src/Core/Framework/Adapter/Database/MySQLFactory.php
@@ -58,13 +58,14 @@ class MySQLFactory
             \PDO::ATTR_TIMEOUT => 5,
         ] + $dsnParameters['driverOptions'];
 
-        $initCommands = [
-            'SET @@session.time_zone = \'+00:00\'',
-            'SET @@group_concat_max_len = CAST(IF(@@group_concat_max_len > 320000, @@group_concat_max_len, 320000) AS UNSIGNED)',
-            'SET sql_mode=(SELECT REPLACE(@@sql_mode,\'ONLY_FULL_GROUP_BY\',\'\'))',
-        ];
-
-        $parameters['driverOptions'][Mysql::ATTR_INIT_COMMAND] = \implode(';', $initCommands);
+            if (EnvironmentHelper::getVariable('SQL_SET_DEFAULT_SESSION_VARIABLES', true)) {
+                $initCommands = [
+                    'SET @@session.time_zone = \'+00:00\'',
+                    'SET @@group_concat_max_len = CAST(IF(@@group_concat_max_len > 320000, @@group_concat_max_len, 320000) AS UNSIGNED)',
+                    'SET sql_mode=(SELECT REPLACE(@@sql_mode,\'ONLY_FULL_GROUP_BY\',\'\'))',
+                ];
+                $parameters['driverOptions'][Mysql::ATTR_INIT_COMMAND] = \implode(';', $initCommands);
+            }
 
         if ($sslCa = EnvironmentHelper::getVariable('DATABASE_SSL_CA')) {
             $parameters['driverOptions'][Mysql::ATTR_SSL_CA] = $sslCa;

--- a/src/Core/Framework/Adapter/Database/MySQLFactory.php
+++ b/src/Core/Framework/Adapter/Database/MySQLFactory.php
@@ -58,14 +58,14 @@ class MySQLFactory
             \PDO::ATTR_TIMEOUT => 5,
         ] + $dsnParameters['driverOptions'];
 
-            if (EnvironmentHelper::getVariable('SQL_SET_DEFAULT_SESSION_VARIABLES', true)) {
-                $initCommands = [
-                    'SET @@session.time_zone = \'+00:00\'',
-                    'SET @@group_concat_max_len = CAST(IF(@@group_concat_max_len > 320000, @@group_concat_max_len, 320000) AS UNSIGNED)',
-                    'SET sql_mode=(SELECT REPLACE(@@sql_mode,\'ONLY_FULL_GROUP_BY\',\'\'))',
-                ];
-                $parameters['driverOptions'][Mysql::ATTR_INIT_COMMAND] = \implode(';', $initCommands);
-            }
+        if (EnvironmentHelper::getVariable('SQL_SET_DEFAULT_SESSION_VARIABLES', true)) {
+            $initCommands = [
+                'SET @@session.time_zone = \'+00:00\'',
+                'SET @@group_concat_max_len = CAST(IF(@@group_concat_max_len > 320000, @@group_concat_max_len, 320000) AS UNSIGNED)',
+                'SET sql_mode=(SELECT REPLACE(@@sql_mode,\'ONLY_FULL_GROUP_BY\',\'\'))',
+            ];
+            $parameters['driverOptions'][Mysql::ATTR_INIT_COMMAND] = \implode(';', $initCommands);
+        }
 
         if ($sslCa = EnvironmentHelper::getVariable('DATABASE_SSL_CA')) {
             $parameters['driverOptions'][Mysql::ATTR_SSL_CA] = $sslCa;

--- a/src/Core/Framework/DataAbstractionLayer/Dbal/EntityReader.php
+++ b/src/Core/Framework/DataAbstractionLayer/Dbal/EntityReader.php
@@ -990,6 +990,9 @@ class EntityReader implements EntityReaderInterface
             $orderBy = ' ORDER BY ' . implode(', ', $parts);
             $query->resetOrderBy();
         }
+
+        $limitQuery = clone $query;
+
         // order by is handled in group_concat
         // Order of IDs in criteria will determine result order, when no order by is given
         $fieldCriteria->resetSorting();
@@ -1002,11 +1005,17 @@ class EntityReader implements EntityReaderInterface
         $query->addGroupBy($root . '.' . $localColumn);
 
         if ($fieldCriteria->getLimit() !== null) {
-            $limitQuery = $this->buildManyToManyLimitQuery($association);
+                $limitQuery = $this->buildManyToManyLimitQuery(
+                    $limitQuery,
+                    $root,
+                    $localColumn,
+                    $referenceColumn,
+                    $parts
+                );
 
             $params = [
-                '#source_column#' => EntityDefinitionQueryHelper::escape($association->getMappingLocalColumn()),
-                '#reference_column#' => EntityDefinitionQueryHelper::escape($association->getMappingReferenceColumn()),
+                '#source_column#' => $localColumn,
+                '#reference_column#' => $referenceColumn,
                 '#table#' => $root,
             ];
             $query->innerJoin(
@@ -1022,8 +1031,6 @@ class EntityReader implements EntityReaderInterface
                 )
             );
             $query->setParameter('limit', $fieldCriteria->getLimit());
-
-            $this->connection->executeQuery('SET @n = 0; SET @c = null;');
         }
 
         $mapping = $query->executeQuery()->fetchAllKeyValue();
@@ -1232,30 +1239,26 @@ class EntityReader implements EntityReaderInterface
         return $grouped;
     }
 
-    private function buildManyToManyLimitQuery(ManyToManyAssociationField $association): QueryBuilder
+    /**
+     * @param list<string> $orderByParts
+     */
+    private function buildManyToManyLimitQuery(
+        QueryBuilder $query,
+        string $table,
+        string $sourceColumn,
+        string $referenceColumn,
+        array $orderByParts
+    ): QueryBuilder
     {
-        $table = EntityDefinitionQueryHelper::escape($association->getMappingDefinition()->getEntityName());
+        $sourceAccessor = $table . '.' . $sourceColumn;
+        $referenceAccessor = $table . '.' . $referenceColumn;
 
-        $sourceColumn = EntityDefinitionQueryHelper::escape($association->getMappingLocalColumn());
-        $referenceColumn = EntityDefinitionQueryHelper::escape($association->getMappingReferenceColumn());
-
-        $params = [
-            '#table#' => $table,
-            '#source_column#' => $sourceColumn,
-        ];
-
-        $query = new QueryBuilder($this->connection);
         $query->select(
-            str_replace(
-                array_keys($params),
-                array_values($params),
-                '@n:=IF(@c=#table#.#source_column#, @n+1, IF(@c:=#table#.#source_column#,1,1)) as id_count'
-            ),
-            $table . '.' . $referenceColumn,
-            $table . '.' . $sourceColumn,
+            'ROW_NUMBER() OVER (PARTITION BY ' . $sourceAccessor . ' ORDER BY '
+            . implode(', ', [...$orderByParts, $referenceAccessor]) . ') as id_count',
+            $referenceAccessor,
+            $sourceAccessor,
         );
-        $query->from($table, $table);
-        $query->orderBy($table . '.' . $sourceColumn);
 
         return $query;
     }

--- a/src/Core/Framework/DataAbstractionLayer/Dbal/EntityReader.php
+++ b/src/Core/Framework/DataAbstractionLayer/Dbal/EntityReader.php
@@ -985,7 +985,7 @@ class EntityReader implements EntityReaderInterface
         }
 
         $orderBy = '';
-        $parts = $query->getOrderByParts();
+        $parts = array_values($query->getOrderByParts());
         if ($parts !== []) {
             $orderBy = ' ORDER BY ' . implode(', ', $parts);
             $query->resetOrderBy();
@@ -1005,13 +1005,13 @@ class EntityReader implements EntityReaderInterface
         $query->addGroupBy($root . '.' . $localColumn);
 
         if ($fieldCriteria->getLimit() !== null) {
-                $limitQuery = $this->buildManyToManyLimitQuery(
-                    $limitQuery,
-                    $root,
-                    $localColumn,
-                    $referenceColumn,
-                    $parts
-                );
+            $limitQuery = $this->buildManyToManyLimitQuery(
+                $limitQuery,
+                $root,
+                $localColumn,
+                $referenceColumn,
+                $parts
+            );
 
             $params = [
                 '#source_column#' => $localColumn,
@@ -1248,8 +1248,7 @@ class EntityReader implements EntityReaderInterface
         string $sourceColumn,
         string $referenceColumn,
         array $orderByParts
-    ): QueryBuilder
-    {
+    ): QueryBuilder {
         $sourceAccessor = $table . '.' . $sourceColumn;
         $referenceAccessor = $table . '.' . $referenceColumn;
 

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Reader/EntityReaderTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Reader/EntityReaderTest.php
@@ -2123,9 +2123,9 @@ class EntityReaderTest extends TestCase
         $this->productRepository->upsert($products, $context);
 
         $criteria = new Criteria([$id1, $id2]);
-            $criteria->getAssociation('categories')
-                ->addSorting(new FieldSorting('name', FieldSorting::ASCENDING))
-                ->setLimit(3);
+        $criteria->getAssociation('categories')
+            ->addSorting(new FieldSorting('name', FieldSorting::ASCENDING))
+            ->setLimit(3);
 
         $products = $this->productRepository
             ->search($criteria, $context)

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Reader/EntityReaderTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Reader/EntityReaderTest.php
@@ -2123,7 +2123,9 @@ class EntityReaderTest extends TestCase
         $this->productRepository->upsert($products, $context);
 
         $criteria = new Criteria([$id1, $id2]);
-        $criteria->getAssociation('categories')->setLimit(3);
+            $criteria->getAssociation('categories')
+                ->addSorting(new FieldSorting('name', FieldSorting::ASCENDING))
+                ->setLimit(3);
 
         $products = $this->productRepository
             ->search($criteria, $context)
@@ -2141,6 +2143,14 @@ class EntityReaderTest extends TestCase
 
         static::assertCount(3, $product1->getCategories());
         static::assertCount(3, $product2->getCategories());
+        static::assertSame(
+            ['test1', 'test2', 'test3'],
+            array_values($product1->getCategories()->map(static fn (CategoryEntity $category) => $category->getName()))
+        );
+        static::assertSame(
+            ['test10', 'test11', 'test12'],
+            array_values($product2->getCategories()->map(static fn (CategoryEntity $category) => $category->getName()))
+        );
     }
 
     public function testReadSupportsConditions(): void

--- a/tests/unit/Core/Framework/Adapter/Database/MySQLFactoryTest.php
+++ b/tests/unit/Core/Framework/Adapter/Database/MySQLFactoryTest.php
@@ -119,6 +119,30 @@ class MySQLFactoryTest extends TestCase
         static::assertSame($customValue, $params['driverOptions'][$customOption]);
     }
 
+    public function testDefaultSessionVariablesAreSetByDefault(): void
+    {
+        $this->setEnvVars([
+            'DATABASE_URL' => 'mysql://localhost:3306/shopware',
+            'SQL_SET_DEFAULT_SESSION_VARIABLES' => null,
+        ]);
+
+        $params = MySQLFactory::create()->getParams();
+
+        static::assertArrayHasKey(\Pdo\Mysql::ATTR_INIT_COMMAND, $params['driverOptions']);
+    }
+
+    public function testDefaultSessionVariablesCanBeSkipped(): void
+    {
+        $this->setEnvVars([
+            'DATABASE_URL' => 'mysql://localhost:3306/shopware',
+            'SQL_SET_DEFAULT_SESSION_VARIABLES' => '0',
+        ]);
+
+        $params = MySQLFactory::create()->getParams();
+
+        static::assertArrayNotHasKey(\Pdo\Mysql::ATTR_INIT_COMMAND, $params['driverOptions']);
+    }
+
     public function testDriverOptionsFromDsnArePreservedInReplicaConfiguration(): void
     {
         // PDO::MYSQL_ATTR_LOCAL_INFILE = 1001, PDO::MYSQL_ATTR_FOUND_ROWS = 1004

--- a/tests/unit/Core/Framework/Adapter/Database/MySQLFactoryTest.php
+++ b/tests/unit/Core/Framework/Adapter/Database/MySQLFactoryTest.php
@@ -7,6 +7,7 @@ use Doctrine\DBAL\Connections\PrimaryReadReplicaConnection;
 use Doctrine\DBAL\Driver;
 use Doctrine\DBAL\Driver\Middleware;
 use Doctrine\DBAL\Driver\Middleware\AbstractDriverMiddleware;
+use Pdo\Mysql;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Adapter\Database\MySQLFactory;
@@ -128,7 +129,8 @@ class MySQLFactoryTest extends TestCase
 
         $params = MySQLFactory::create()->getParams();
 
-        static::assertArrayHasKey(\Pdo\Mysql::ATTR_INIT_COMMAND, $params['driverOptions']);
+        static::assertArrayHasKey('driverOptions', $params);
+        static::assertArrayHasKey(Mysql::ATTR_INIT_COMMAND, $params['driverOptions']);
     }
 
     public function testDefaultSessionVariablesCanBeSkipped(): void
@@ -140,7 +142,8 @@ class MySQLFactoryTest extends TestCase
 
         $params = MySQLFactory::create()->getParams();
 
-        static::assertArrayNotHasKey(\Pdo\Mysql::ATTR_INIT_COMMAND, $params['driverOptions']);
+        static::assertArrayHasKey('driverOptions', $params);
+        static::assertArrayNotHasKey(Mysql::ATTR_INIT_COMMAND, $params['driverOptions']);
     }
 
     public function testDriverOptionsFromDsnArePreservedInReplicaConfiguration(): void


### PR DESCRIPTION
### 1. Why is this change necessary?

PR: https://github.com/shopware/shopware/pull/6730 removed the possibility to remove MySQL Init Parameters.
EntityReader uses SET statements.

Both break ProxySQLs query parsing and therefore Query Multiplexing resulting in both read and write queries hitting only one server.

### 2. What does this change do, exactly?

Restore MySQLFactory Switch still documented in https://developer.shopware.com/docs/guides/hosting/infrastructure/database.html#using-the-optimal-mysql-configuration

Refactor EntityReader::loadManyToManyWithCriteria to use ROW_NUMBER instead of SET statements like other parts already do.

Extend Tests to test not only for relation count but specific realtions to be loaded making the test more precise.

### 3. Describe each step to reproduce the issue or behaviour.

Use ProxySQL 3.x as a SQLProxy between any Shopware and MySQL. 
Observe logs:

```
2026-07-09 10:42:16 MySQL_Session.cpp:6533:handler___status_WAITING_CLIENT_DATA___STATE_SLEEP___MYSQL_COM_QUERY_qpo(): [WARNING] Unable to parse multi-statements command with SET statement from client 10.100.3.35:35070: setting lock hostgroup. Command: SET @@session.time_zone = '+00:00';SET @@group_concat_max_len = CAST(IF(@@group_concat_max_len > 320000, @@group_concat_max_len, 320000) AS UNSIGNED);SET sql_mode=(SELECT REPLACE(@@sql_mode,'ONLY_FULL_GROUP_BY',''))
```

### 4. Please link to the relevant issues (if any).

- closes #18204 
- partially revert https://github.com/shopware/shopware/pull/6730

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [x] I have written or adjusted the documentation and agent skills according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
