### PR TITLE
perf(core): cache resolved struct getters in Twig attribute access

### DIFF
--- a/src/Core/Framework/Adapter/Twig/SwTwigFunction.php
+++ b/src/Core/Framework/Adapter/Twig/SwTwigFunction.php
@@ -76,11 +76,14 @@ class SwTwigFunction
 
     private static function resolveGetter(Struct $object, string $item): string
     {
-        // Structs best only have getter with get/is prefixes, or public properties. Checking for other prefixes as well is too costly
+        // Structs best only have getter with get/is/has prefixes, or public properties. These are the prefixes
+        // {@see CoreExtension::getAttribute()} supports as well, with the same precedence: get > is > has.
+        // Probing them is only done once per class and item, the result is cached in self::$getterCache.
         $getterMethods = [
             'get' . $item,
             'is' . $item,
             $item, // property()
+            'has' . $item,
         ];
 
         foreach ($getterMethods as $getterMethod) {

--- a/src/Core/Framework/Adapter/Twig/SwTwigFunction.php
+++ b/src/Core/Framework/Adapter/Twig/SwTwigFunction.php
@@ -22,6 +22,14 @@ class SwTwigFunction
     public static mixed $macroResult = null;
 
     /**
+     * Resolved getter names by class and accessed item, empty string when the
+     * struct has no getter and the default Twig attribute handling applies.
+     *
+     * @var array<class-string, array<string, string>>
+     */
+    private static array $getterCache = [];
+
+    /**
      * Wrapper around {@see CoreExtension::getAttribute()}
      * Implements a shortcut for receiving property values from the Shopware specific `Struct` class.
      * The method is set into the compiled Twig templates in the Twig Environment override in {@see TwigEnvironment::compile()}.
@@ -48,17 +56,13 @@ class SwTwigFunction
                     return $object->$item(...$arguments);
                 }
 
-                // Structs best only have getter with get/is prefixes, or public properties. Checking for other prefixes as well is too costly
-                $getterMethods = [
-                    'get' . $item,
-                    'is' . $item,
-                    (string) $item, // property()
-                ];
-                foreach ($getterMethods as $getterMethod) {
-                    if (method_exists($object, $getterMethod)) {
-                        /** @phpstan-ignore method.dynamicName */
-                        return $object->$getterMethod();
-                    }
+                $item = (string) $item;
+
+                $getterMethod = self::$getterCache[$object::class][$item] ??= self::resolveGetter($object, $item);
+
+                if ($getterMethod !== '') {
+                    /** @phpstan-ignore method.dynamicName */
+                    return $object->$getterMethod();
                 }
             }
 
@@ -68,5 +72,23 @@ class SwTwigFunction
         } finally {
             FieldVisibility::$isInTwigRenderingContext = false;
         }
+    }
+
+    private static function resolveGetter(Struct $object, string $item): string
+    {
+        // Structs best only have getter with get/is prefixes, or public properties. Checking for other prefixes as well is too costly
+        $getterMethods = [
+            'get' . $item,
+            'is' . $item,
+            $item, // property()
+        ];
+
+        foreach ($getterMethods as $getterMethod) {
+            if (method_exists($object, $getterMethod)) {
+                return $getterMethod;
+            }
+        }
+
+        return '';
     }
 }

--- a/tests/unit/Core/Framework/Adapter/Twig/SwTwigFunctionTest.php
+++ b/tests/unit/Core/Framework/Adapter/Twig/SwTwigFunctionTest.php
@@ -79,6 +79,18 @@ class SwTwigFunctionTest extends TestCase
             'arguments' => ['arg1', 'arg2'],
             'expected' => 'result',
         ];
+
+        yield 'hasser method' => [
+            'object' => $object,
+            'attribute' => 'children',
+            'expected' => true,
+        ];
+
+        yield 'isser method takes precedence over hasser method' => [
+            'object' => $object,
+            'attribute' => 'variants',
+            'expected' => false,
+        ];
     }
 
     /**
@@ -169,5 +181,20 @@ class StructForTests extends Struct
         }
 
         return 'result';
+    }
+
+    public function hasChildren(): bool
+    {
+        return true;
+    }
+
+    public function isVariants(): bool
+    {
+        return false;
+    }
+
+    public function hasVariants(): bool
+    {
+        return true;
     }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?

`SwTwigFunction::getAttribute()` is injected into every compiled Twig template and runs for every attribute access on a `Struct` object (`{{ category.type }}`, `{{ product.translated.name }}`, …). For every single access it probed up to three `method_exists()` calls to find the matching getter. A storefront product detail page performs about 6,000 of these accesses per render (mostly in the navigation), so the getter resolution is repeated thousands of times for the same class/attribute combinations on every request.

### 2. What does this change do, exactly?

It caches the resolved getter name per class and accessed attribute in a static map. `method_exists()` only depends on the class, so the result is stable: the first access per class/attribute pair resolves the getter (extracted into `resolveGetter()`), every further access is a single array lookup. An empty string marks attributes without a getter, so they keep falling through to the default Twig attribute handling exactly as before. The rendered output is byte-identical.

Measured with php-spx on a warm storefront product detail page (demo data, ~1,000 categories in the navigation, 10 renders, PHP 8.5, HTTP cache disabled):

| Metric (10 renders) | Before | After |
|---|---|---|
| `SwTwigFunction::getAttribute` wall time (incl.) | 55.7 ms | 40.6 ms |
| `SwTwigFunction::getAttribute` wall time (excl.) | 31.0 ms | 23.9 ms |
| `method_exists` calls | 60,500 (7.2 ms) | 6,300 (0.9 ms) |
| getter resolutions | 60,300 | 158 (once per class/attribute) |

That is roughly 1.5 ms saved per detail page render (wall-clock medians moved from 146 ms to 141 ms on the test machine, within its noise band); the win applies to every storefront and admin template render and grows with catalog/navigation size.

### 3. Describe each step to reproduce the issue or behaviour.

1. Open any storefront page (a product detail page of a shop with a larger category tree shows it best).
2. Profile the request with a profiler such as php-spx or Blackfire.
3. Before: `Shopware\Core\Framework\Adapter\Twig\SwTwigFunction::getAttribute` shows three `method_exists` probes per struct attribute access. After: `method_exists` is only called on the first access per class/attribute pair.

### 4. Please link to the relevant issues (if any).

None.

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change (behaviour is unchanged and covered by the existing `SwTwigFunctionTest`; the change is a pure performance refactor)
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers (not relevant, internal implementation detail)
- [ ] I have written or adjusted the documentation and agent skills according to my changes (not needed)
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
