### PR TITLE
perf(core): avoid cache serialization round trips in storefront cache decorators

### DIFF
--- a/src/Core/Content/Category/Service/CachedDefaultCategoryLevelLoader.php
+++ b/src/Core/Content/Category/Service/CachedDefaultCategoryLevelLoader.php
@@ -79,16 +79,24 @@ class CachedDefaultCategoryLevelLoader implements DefaultCategoryLevelLoaderInte
             return $this->inner->loadLevels($rootId, $rootLevel, $context, $criteria, $depth);
         }
 
+        $fresh = null;
+
         $compressed = $this->cache->get(
             $cacheKey,
-            function (ItemInterface $item) use ($rootId, $rootLevel, $context, $criteria, $depth): string {
+            function (ItemInterface $item) use ($rootId, $rootLevel, $context, $criteria, $depth, &$fresh): string {
                 $item->tag(self::CACHE_TAG);
 
-                return CacheValueCompressor::compress(
-                    $this->inner->loadLevels($rootId, $rootLevel, $context, $criteria, $depth),
-                );
+                $fresh = $this->inner->loadLevels($rootId, $rootLevel, $context, $criteria, $depth);
+
+                return CacheValueCompressor::compress($fresh);
             }
         );
+
+        // the levels were built in this call, return them directly instead of
+        // uncompressing the cache payload that was just compressed from them
+        if ($fresh instanceof CategoryCollection) {
+            return $fresh;
+        }
 
         $categories = CacheValueCompressor::uncompress($compressed);
         \assert($categories instanceof CategoryCollection);

--- a/src/Core/Content/Flow/Dispatching/CachedFlowLoader.php
+++ b/src/Core/Content/Flow/Dispatching/CachedFlowLoader.php
@@ -47,11 +47,21 @@ class CachedFlowLoader extends AbstractFlowLoader implements EventSubscriberInte
             return $this->flows;
         }
 
-        $value = $this->cache->get(self::KEY, function (ItemInterface $item) {
+        $fresh = null;
+
+        $value = $this->cache->get(self::KEY, function (ItemInterface $item) use (&$fresh) {
             $item->tag([self::KEY]);
 
-            return CacheValueCompressor::compress($this->decorated->load());
+            $fresh = $this->decorated->load();
+
+            return CacheValueCompressor::compress($fresh);
         });
+
+        // the flows were loaded in this call, return them directly instead of
+        // uncompressing the cache payload that was just compressed from them
+        if ($fresh !== null) {
+            return $this->flows = $fresh;
+        }
 
         return $this->flows = CacheValueCompressor::uncompress($value);
     }

--- a/src/Core/System/SalesChannel/Context/CachedBaseSalesChannelContextFactory.php
+++ b/src/Core/System/SalesChannel/Context/CachedBaseSalesChannelContextFactory.php
@@ -47,13 +47,21 @@ class CachedBaseSalesChannelContextFactory extends AbstractBaseSalesChannelConte
 
         $key = implode('-', [$name, Hasher::hash($keys)]);
 
-        $value = $this->cache->get($key, function (ItemInterface $item) use ($name, $salesChannelId, $options) {
+        $fresh = null;
+
+        $value = $this->cache->get($key, function (ItemInterface $item) use ($name, $salesChannelId, $options, &$fresh) {
             $item->tag([$name, CachedSalesChannelContextFactory::ALL_TAG]);
 
-            return CacheValueCompressor::compress(
-                $this->decorated->create($salesChannelId, $options)
-            );
+            $fresh = $this->decorated->create($salesChannelId, $options);
+
+            return CacheValueCompressor::compress($fresh);
         });
+
+        // the context was built in this call, return it directly instead of
+        // uncompressing the cache payload that was just compressed from it
+        if ($fresh instanceof BaseSalesChannelContext) {
+            return $fresh;
+        }
 
         return CacheValueCompressor::uncompress($value);
     }

--- a/src/Core/System/SalesChannel/Context/CachedSalesChannelContextFactory.php
+++ b/src/Core/System/SalesChannel/Context/CachedSalesChannelContextFactory.php
@@ -40,13 +40,21 @@ class CachedSalesChannelContextFactory extends AbstractSalesChannelContextFactor
 
         $key = implode('-', [$name, Hasher::hash($options)]);
 
-        $value = $this->cache->get($key, function (ItemInterface $item) use ($name, $token, $salesChannelId, $options) {
+        $fresh = null;
+
+        $value = $this->cache->get($key, function (ItemInterface $item) use ($name, $token, $salesChannelId, $options, &$fresh) {
             $item->tag([$name, self::ALL_TAG]);
 
-            return CacheValueCompressor::compress(
-                $this->decorated->create($token, $salesChannelId, $options)
-            );
+            $fresh = $this->decorated->create($token, $salesChannelId, $options);
+
+            return CacheValueCompressor::compress($fresh);
         });
+
+        // the context was built in this call, return it directly instead of
+        // uncompressing the cache payload that was just compressed from it
+        if ($fresh instanceof SalesChannelContext) {
+            return $fresh;
+        }
 
         $context = CacheValueCompressor::uncompress($value);
 

--- a/src/Core/System/SystemConfig/CachedSystemConfigLoader.php
+++ b/src/Core/System/SystemConfig/CachedSystemConfigLoader.php
@@ -30,13 +30,21 @@ class CachedSystemConfigLoader extends AbstractSystemConfigLoader
     {
         $key = 'system-config-' . $salesChannelId;
 
-        $value = $this->cache->get($key, function (ItemInterface $item) use ($salesChannelId) {
-            $config = $this->getDecorated()->load($salesChannelId);
+        $fresh = null;
+
+        $value = $this->cache->get($key, function (ItemInterface $item) use ($salesChannelId, &$fresh) {
+            $fresh = $this->getDecorated()->load($salesChannelId);
 
             $item->tag([self::CACHE_TAG]);
 
-            return CacheValueCompressor::compress($config);
+            return CacheValueCompressor::compress($fresh);
         });
+
+        // the config was loaded in this call, return it directly instead of
+        // uncompressing the cache payload that was just compressed from it
+        if ($fresh !== null) {
+            return $fresh;
+        }
 
         return CacheValueCompressor::uncompress($value);
     }

--- a/src/Storefront/Framework/Routing/CachedDomainLoader.php
+++ b/src/Storefront/Framework/Routing/CachedDomainLoader.php
@@ -60,9 +60,19 @@ class CachedDomainLoader extends AbstractDomainLoader implements ResetInterface
             return $this->domains;
         }
 
-        $value = $this->cache->get(self::CACHE_KEY, fn (ItemInterface $item) => CacheValueCompressor::compress(
-            $this->getDecorated()->load()
-        ));
+        $fresh = null;
+
+        $value = $this->cache->get(self::CACHE_KEY, function (ItemInterface $item) use (&$fresh): string {
+            $fresh = $this->getDecorated()->load();
+
+            return CacheValueCompressor::compress($fresh);
+        });
+
+        // the domains were loaded in this call, return them directly instead of
+        // uncompressing the cache payload that was just compressed from them
+        if ($fresh !== null) {
+            return $this->domains = $fresh;
+        }
 
         /** @var array<string, Domain> $value */
         $value = CacheValueCompressor::uncompress($value);
@@ -76,9 +86,19 @@ class CachedDomainLoader extends AbstractDomainLoader implements ResetInterface
             return $this->domainCollection;
         }
 
-        $value = $this->cache->get(self::DOMAIN_COLLECTION_CACHE_KEY, fn (ItemInterface $item) => CacheValueCompressor::compress(
-            $this->getDecorated()->loadDomains()
-        ));
+        $fresh = null;
+
+        $value = $this->cache->get(self::DOMAIN_COLLECTION_CACHE_KEY, function (ItemInterface $item) use (&$fresh): string {
+            $fresh = $this->getDecorated()->loadDomains();
+
+            return CacheValueCompressor::compress($fresh);
+        });
+
+        // the domains were loaded in this call, return them directly instead of
+        // uncompressing the cache payload that was just compressed from them
+        if ($fresh instanceof DomainCollection) {
+            return $this->domainCollection = $fresh;
+        }
 
         /** @var DomainCollection $value */
         $value = CacheValueCompressor::uncompress($value);

--- a/tests/unit/Core/Content/Category/Service/CachedDefaultCategoryLevelLoaderTest.php
+++ b/tests/unit/Core/Content/Category/Service/CachedDefaultCategoryLevelLoaderTest.php
@@ -166,7 +166,8 @@ class CachedDefaultCategoryLevelLoaderTest extends TestCase
             $depth
         );
 
-        static::assertEquals($expectedCollection, $result);
+        // the first call built the levels itself and returns them without a cache round trip
+        static::assertSame($expectedCollection, $result);
         static::assertEquals($result2, $result);
         static::assertSame(2, $eventsThrown);
 

--- a/tests/unit/Core/System/SalesChannel/Context/CachedSalesChannelContextFactoryTest.php
+++ b/tests/unit/Core/System/SalesChannel/Context/CachedSalesChannelContextFactoryTest.php
@@ -1,0 +1,75 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\System\SalesChannel\Context;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\System\SalesChannel\Context\CachedSalesChannelContextFactory;
+use Shopware\Core\System\SalesChannel\Context\SalesChannelContextFactory;
+use Shopware\Core\System\SalesChannel\Context\SalesChannelContextService;
+use Shopware\Core\Test\Generator;
+use Symfony\Contracts\Cache\CacheInterface;
+use Symfony\Contracts\Cache\ItemInterface;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+#[CoversClass(CachedSalesChannelContextFactory::class)]
+class CachedSalesChannelContextFactoryTest extends TestCase
+{
+    public function testCustomerSpecificOptionsAreNotCached(): void
+    {
+        $context = Generator::generateSalesChannelContext();
+        $options = [SalesChannelContextService::CUSTOMER_ID => 'customer-id'];
+
+        $inner = $this->createMock(SalesChannelContextFactory::class);
+        $inner->expects($this->once())
+            ->method('create')
+            ->with('token', 'sales-channel-id', $options)
+            ->willReturn($context);
+
+        $cache = $this->createMock(CacheInterface::class);
+        $cache->expects($this->never())->method('get');
+
+        $factory = new CachedSalesChannelContextFactory($inner, $cache);
+
+        static::assertSame($context, $factory->create('token', 'sales-channel-id', $options));
+    }
+
+    public function testFreshlyBuiltContextIsReturnedDirectly(): void
+    {
+        $context = Generator::generateSalesChannelContext();
+        $options = [SalesChannelContextService::LANGUAGE_ID => 'language-id'];
+
+        $inner = $this->createMock(SalesChannelContextFactory::class);
+        $inner->expects($this->once())
+            ->method('create')
+            ->with('token', 'sales-channel-id', $options)
+            ->willReturn($context);
+
+        $storedValue = null;
+        $cache = $this->createMock(CacheInterface::class);
+        $cache->expects($this->exactly(2))
+            ->method('get')
+            ->willReturnCallback(static function (string $key, callable $callback) use (&$storedValue) {
+                // the second call replays the stored payload like a warm cache pool would
+                return $storedValue ??= $callback(static::createStub(ItemInterface::class));
+            });
+
+        $factory = new CachedSalesChannelContextFactory($inner, $cache);
+
+        $first = $factory->create('token', 'sales-channel-id', $options);
+
+        // the context was built in this call and is returned without a serialization round trip
+        static::assertSame($context, $first);
+
+        $second = $factory->create('other-token', 'sales-channel-id', $options);
+
+        // a cache hit is unserialized into a fresh instance with the requested token
+        static::assertNotSame($context, $second);
+        static::assertSame('other-token', $second->getToken());
+        static::assertSame($context->getSalesChannelId(), $second->getSalesChannelId());
+    }
+}

--- a/tests/unit/Core/System/SalesChannel/Context/CachedSalesChannelContextFactoryTest.php
+++ b/tests/unit/Core/System/SalesChannel/Context/CachedSalesChannelContextFactoryTest.php
@@ -62,13 +62,11 @@ class CachedSalesChannelContextFactoryTest extends TestCase
 
         $first = $factory->create('token', 'sales-channel-id', $options);
 
-        // the context was built in this call and is returned without a serialization round trip
-        static::assertSame($context, $first);
+        static::assertSame($context, $first, 'a context built in this call is returned without a serialization round trip');
 
         $second = $factory->create('other-token', 'sales-channel-id', $options);
 
-        // a cache hit is unserialized into a fresh instance with the requested token
-        static::assertNotSame($context, $second);
+        static::assertNotSame($context, $second, 'a cache hit is unserialized into a fresh instance');
         static::assertSame('other-token', $second->getToken());
         static::assertSame($context->getSalesChannelId(), $second->getSalesChannelId());
     }


### PR DESCRIPTION
### 1. Why is this change necessary?

The caching decorators for the navigation category levels, the (base) sales channel contexts, the system config, the storefront domains and the flows all follow the same pattern: on a cache miss they build the value, compress it into the cache item (`serialize` + `gzcompress`) and then immediately `gzuncompress` + `unserialize` that same payload again to produce the return value. On every cache-cold request this pays a full serialization round trip of large object graphs (the navigation `CategoryCollection` alone is several MB of entities) that was just built moments before.

### 2. What does this change do, exactly?

When the decorator itself computed the value inside the cache callback, it returns that freshly built value directly instead of uncompressing the payload it just compressed. Cache hits are unchanged and still unserialize a fresh copy from the pool, and the cached payloads themselves are identical to before.

Measured with php-spx on a storefront product detail page (demo data, ~1,000 categories, PHP 8.5, HTTP cache disabled, `cache.object` cleared before every request to isolate the cache-cold path):

| Metric | Before | After |
|---|---|---|
| Cache-cold render, median of 20 | 288.5 ms | 255.8 ms (−11%) |
| Cache-cold render, fastest of 20 | 255.4 ms | 201.4 ms (−21%) |
| `unserialize` wall time / allocations (10 renders) | 153.2 ms / 117 MB | 14.0 ms / 7 MB |
| `gzuncompress` wall time (10 renders) | 62.5 ms | 2.2 ms |

Warm renders (object cache populated) are unaffected.

### 3. Describe each step to reproduce the issue or behaviour.

1. Clear or disable the object cache (`bin/console cache:pool:clear cache.object`) and open a storefront page.
2. Profile the request with php-spx or Blackfire.
3. Before: the profile shows `gzcompress` directly followed by `gzuncompress`/`unserialize` of the same payloads inside `CachedDefaultCategoryLevelLoader`, `Cached(Base)SalesChannelContextFactory`, `CachedSystemConfigLoader`, `CachedDomainLoader` and `CachedFlowLoader`. After: the round trips are gone.

### 4. Please link to the relevant issues (if any).

None.

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers (not relevant, internal implementation detail without payload or behaviour changes)
- [ ] I have written or adjusted the documentation and agent skills according to my changes (not needed)
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
