### PR TITLE
perf(core): reduce query count of dal:refresh:index indexers

### DIFF
--- a/phpstan-baseline.php
+++ b/phpstan-baseline.php
@@ -176,12 +176,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/src/Core/Content/Newsletter/SalesChannel/NewsletterUnsubscribeRoute.php',
 ];
 $ignoreErrors[] = [
-    'rawMessage' => 'Construct empty() is not allowed. Use more strict comparison.',
-    'identifier' => 'empty.notAllowed',
-    'count' => 1,
-    'path' => __DIR__ . '/src/Core/Content/Product/DataAbstractionLayer/ProductStreamUpdater.php',
-];
-$ignoreErrors[] = [
     'rawMessage' => 'Method Shopware\\Core\\Content\\Product\\SalesChannel\\FindVariant\\FoundCombination::getOptions() return type has no value type specified in iterable type array.',
     'identifier' => 'missingType.iterableValue',
     'count' => 1,

--- a/src/Core/Content/Media/DataAbstractionLayer/MediaIndexer.php
+++ b/src/Core/Content/Media/DataAbstractionLayer/MediaIndexer.php
@@ -8,7 +8,7 @@ use Shopware\Core\Content\Media\Event\MediaIndexerEvent;
 use Shopware\Core\Content\Media\MediaCollection;
 use Shopware\Core\Content\Media\MediaDefinition;
 use Shopware\Core\Framework\DataAbstractionLayer\Dbal\Common\IteratorFactory;
-use Shopware\Core\Framework\DataAbstractionLayer\Doctrine\RetryableQuery;
+use Shopware\Core\Framework\DataAbstractionLayer\Doctrine\MultiUpdateQueryQueue;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Event\EntityWrittenContainerEvent;
 use Shopware\Core\Framework\DataAbstractionLayer\Indexing\EntityIndexer;
@@ -97,10 +97,7 @@ class MediaIndexer extends EntityIndexer
 
         $context = $message->getContext();
 
-        $query = new RetryableQuery(
-            $this->connection,
-            $this->connection->prepare('UPDATE `media` SET thumbnails_ro = :thumbnails_ro WHERE id = :id')
-        );
+        $query = new MultiUpdateQueryQueue($this->connection, 'media');
 
         $all = $this->thumbnailRepository
             ->search($criteria, $context)
@@ -109,11 +106,10 @@ class MediaIndexer extends EntityIndexer
         foreach ($ids as $id) {
             $thumbnails = $all->filterByProperty('mediaId', $id);
 
-            $query->execute([
-                'thumbnails_ro' => serialize($thumbnails),
-                'id' => Uuid::fromHexToBytes($id),
-            ]);
+            $query->addUpdate(Uuid::fromHexToBytes($id), ['thumbnails_ro' => serialize($thumbnails)]);
         }
+
+        $query->execute();
 
         $this->eventDispatcher->dispatch(new MediaIndexerEvent($ids, $context, array_values($message->getSkip())));
     }

--- a/src/Core/Content/Product/DataAbstractionLayer/CheapestPriceUpdater.php
+++ b/src/Core/Content/Product/DataAbstractionLayer/CheapestPriceUpdater.php
@@ -9,7 +9,7 @@ use Shopware\Core\Content\Product\DataAbstractionLayer\CheapestPrice\CheapestPri
 use Shopware\Core\Content\Product\Events\ProductIndexerEvent;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Doctrine\FetchModeHelper;
-use Shopware\Core\Framework\DataAbstractionLayer\Doctrine\RetryableQuery;
+use Shopware\Core\Framework\DataAbstractionLayer\Doctrine\MultiUpdateQueryQueue;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Util\Json;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -42,15 +42,7 @@ class CheapestPriceUpdater
 
         $versionId = Uuid::fromHexToBytes($context->getVersionId());
 
-        $cheapestPrice = new RetryableQuery(
-            $this->connection,
-            $this->connection->prepare('UPDATE product SET cheapest_price = :price WHERE id = :id AND version_id = :version')
-        );
-
-        $accessorQuery = new RetryableQuery(
-            $this->connection,
-            $this->connection->prepare('UPDATE product SET cheapest_price_accessor = :accessor WHERE id = :id AND version_id = :version')
-        );
+        $updateQueue = new MultiUpdateQueryQueue($this->connection, 'product');
 
         // Pre-load the existing cheapest-price accessors of all variants for every parent in a single
         // query, keyed by parent id, instead of issuing one SELECT per parent inside the loop below.
@@ -74,11 +66,7 @@ class CheapestPriceUpdater
         foreach ($all as $productId => $prices) {
             $container = new CheapestPriceContainer($prices);
 
-            $cheapestPrice->execute([
-                'price' => serialize($container),
-                'id' => Uuid::fromHexToBytes($productId),
-                'version' => $versionId,
-            ]);
+            $updateQueue->addUpdate(Uuid::fromHexToBytes($productId), ['cheapest_price' => serialize($container)]);
 
             $variantIds = $container->getVariantIds();
 
@@ -99,13 +87,11 @@ class CheapestPriceUpdater
                     $variantIdsUpdated[] = $variantId;
                 }
 
-                $accessorQuery->execute([
-                    'accessor' => $accessor,
-                    'id' => Uuid::fromHexToBytes($variantId),
-                    'version' => $versionId,
-                ]);
+                $updateQueue->addUpdate(Uuid::fromHexToBytes($variantId), ['cheapest_price_accessor' => $accessor]);
             }
         }
+
+        $updateQueue->execute(['version_id' => $versionId]);
 
         if ($variantIdsUpdated !== []) {
             $this->dispatcher->dispatch(new ProductIndexerEvent($variantIdsUpdated, $context, ['product.seo-url']));

--- a/src/Core/Content/Product/DataAbstractionLayer/ProductCategoryDenormalizer.php
+++ b/src/Core/Content/Product/DataAbstractionLayer/ProductCategoryDenormalizer.php
@@ -8,8 +8,8 @@ use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Doctrine\FetchModeHelper;
 use Shopware\Core\Framework\DataAbstractionLayer\Doctrine\MultiInsertQueryQueue;
+use Shopware\Core\Framework\DataAbstractionLayer\Doctrine\MultiUpdateQueryQueue;
 use Shopware\Core\Framework\DataAbstractionLayer\Doctrine\RetryableTransaction;
-use Shopware\Core\Framework\DataAbstractionLayer\Util\StatementHelper;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Uuid\Uuid;
 
@@ -41,7 +41,7 @@ class ProductCategoryDenormalizer
         $liveVersionId = Uuid::fromHexToBytes(Defaults::LIVE_VERSION);
 
         $inserts = [];
-        $updates = [];
+        $updates = new MultiUpdateQueryQueue($this->connection, 'product');
         foreach ($categories as $productId => $mapping) {
             $productId = Uuid::fromHexToBytes($productId);
             $allIds[] = $productId;
@@ -52,7 +52,7 @@ class ProductCategoryDenormalizer
                 $json = json_encode($categoryIds, \JSON_THROW_ON_ERROR);
             }
 
-            $updates[] = ['id' => $productId, 'tree' => $json, 'version' => $versionId];
+            $updates->addUpdate($productId, ['category_tree' => $json]);
 
             if ($categoryIds === []) {
                 continue;
@@ -76,13 +76,7 @@ class ProductCategoryDenormalizer
             );
         });
 
-        RetryableTransaction::retryable($this->connection, function () use ($updates): void {
-            $query = $this->connection->prepare('UPDATE product SET category_tree = :tree WHERE id = :id AND version_id = :version');
-
-            foreach ($updates as $update) {
-                StatementHelper::executeStatement($query, $update);
-            }
-        });
+        $updates->execute(['version_id' => $versionId]);
 
         $this->insertTree($inserts);
     }

--- a/src/Core/Content/Product/DataAbstractionLayer/ProductStreamUpdater.php
+++ b/src/Core/Content/Product/DataAbstractionLayer/ProductStreamUpdater.php
@@ -10,6 +10,7 @@ use Shopware\Core\Content\ProductStream\Aggregate\ProductStreamFilter\ProductStr
 use Shopware\Core\Content\ProductStream\DataAbstractionLayer\ProductStreamWriteResultHelper;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\Dbal\EntityDefinitionQueryHelper;
 use Shopware\Core\Framework\DataAbstractionLayer\Dbal\Exception\UnmappedFieldException as DeprecatedUnmappedFieldException;
 use Shopware\Core\Framework\DataAbstractionLayer\Doctrine\MultiInsertQueryQueue;
 use Shopware\Core\Framework\DataAbstractionLayer\Doctrine\RetryableTransaction;
@@ -17,6 +18,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Event\EntityWrittenContainerEvent;
 use Shopware\Core\Framework\DataAbstractionLayer\Exception\SearchRequestException;
 use Shopware\Core\Framework\DataAbstractionLayer\Exception\UnmappedFieldException;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\TranslatedField;
 use Shopware\Core\Framework\DataAbstractionLayer\Indexing\EntityIndexer;
 use Shopware\Core\Framework\DataAbstractionLayer\Indexing\EntityIndexingMessage;
 use Shopware\Core\Framework\DataAbstractionLayer\Indexing\ManyToManyIdFieldUpdater;
@@ -102,7 +104,10 @@ class ProductStreamUpdater extends AbstractProductStreamUpdater
         );
 
         try {
-            $newMatches = $this->collectMatchingIdsInLanguageContexts($this->getLanguageContexts($message->getContext()), $criteria);
+            $newMatches = $this->collectMatchingIdsInLanguageContexts(
+                $this->getRelevantLanguageContexts($this->getLanguageContexts($message->getContext()), $criteria),
+                $criteria
+            );
         } catch (UnmappedFieldException|DeprecatedUnmappedFieldException) {
             // @deprecated tag:v6.8.0 - drop DeprecatedUnmappedFieldException, unmappedField() only returns UnmappedFieldException then
             // invalid filter, remove all mappings
@@ -204,7 +209,10 @@ class ProductStreamUpdater extends AbstractProductStreamUpdater
             }
 
             try {
-                $matchedIds = $this->collectMatchingIdsInLanguageContexts($languageContexts, $criteria);
+                $matchedIds = $this->collectMatchingIdsInLanguageContexts(
+                    $this->getRelevantLanguageContexts($languageContexts, $criteria),
+                    $criteria
+                );
             } catch (UnmappedFieldException|DeprecatedUnmappedFieldException) {
                 // @deprecated tag:v6.8.0 - drop DeprecatedUnmappedFieldException, unmappedField() only returns UnmappedFieldException then
                 // skip if filter field is not found
@@ -263,6 +271,36 @@ class ProductStreamUpdater extends AbstractProductStreamUpdater
         ]);
 
         return $languageContext;
+    }
+
+    /**
+     * Filters on non-translated fields match the same products in every language, so the
+     * criteria only has to be searched once per language when a translated field is involved.
+     *
+     * @param list<Context> $languageContexts
+     *
+     * @return list<Context>
+     */
+    private function getRelevantLanguageContexts(array $languageContexts, Criteria $criteria): array
+    {
+        try {
+            foreach ($criteria->getFilters() as $filter) {
+                foreach ($filter->getFields() as $accessor) {
+                    $fields = EntityDefinitionQueryHelper::getFieldsOfAccessor($this->productDefinition, $accessor, false);
+
+                    foreach ($fields as $field) {
+                        if ($field instanceof TranslatedField) {
+                            return $languageContexts;
+                        }
+                    }
+                }
+            }
+        } catch (\Throwable) {
+            // unresolvable accessors are handled by the entity searcher, search every language as before
+            return $languageContexts;
+        }
+
+        return \array_slice($languageContexts, 0, 1);
     }
 
     /**

--- a/src/Core/Content/Product/DataAbstractionLayer/ProductStreamUpdater.php
+++ b/src/Core/Content/Product/DataAbstractionLayer/ProductStreamUpdater.php
@@ -362,7 +362,7 @@ class ProductStreamUpdater extends AbstractProductStreamUpdater
     private function replaceCheapestPriceFilters(array $filters): array
     {
         foreach ($filters as $key => $filter) {
-            if (!empty($filter['queries'])) {
+            if (isset($filter['queries']) && \is_array($filter['queries']) && $filter['queries'] !== []) {
                 $filters[$key]['queries'] = $this->replaceCheapestPriceFilters($filter['queries']);
             }
 

--- a/src/Core/Content/Product/DataAbstractionLayer/SearchKeywordUpdater.php
+++ b/src/Core/Content/Product/DataAbstractionLayer/SearchKeywordUpdater.php
@@ -13,7 +13,6 @@ use Shopware\Core\Content\Product\SearchKeyword\ProductSearchKeywordAnalyzerInte
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Api\Context\SystemSource;
 use Shopware\Core\Framework\Context;
-use Shopware\Core\Framework\DataAbstractionLayer\Dbal\Common\RepositoryIterator;
 use Shopware\Core\Framework\DataAbstractionLayer\Dbal\EntityDefinitionQueryHelper;
 use Shopware\Core\Framework\DataAbstractionLayer\Doctrine\MultiInsertQueryQueue;
 use Shopware\Core\Framework\DataAbstractionLayer\Doctrine\RetryableQuery;
@@ -119,9 +118,16 @@ class SearchKeywordUpdater implements ResetInterface
         $keywords = [];
         $dictionary = [];
 
-        $iterator = $this->getIterator($ids, $context, $configFields);
+        $criteria = $this->getCriteria($ids, $context, $configFields);
 
-        while ($products = $iterator->fetch()) {
+        // The requested ids already bound the result set, so search them in fixed chunks
+        // instead of paginating with an iterator, which would need an additional, empty
+        // page query per call to detect the end of the result set.
+        foreach (array_chunk($criteria->getIds(), 50) as $chunkedIds) {
+            $criteria->setIds($chunkedIds);
+
+            $products = $this->productRepository->search($criteria, $context);
+
             foreach ($products->getEntities() as $product) {
                 // overwrite fetched products if translations for that product exists
                 // otherwise we use the already fetched product from the parent language
@@ -165,19 +171,16 @@ class SearchKeywordUpdater implements ResetInterface
     /**
      * @param array<string> $ids
      * @param array<int, ConfigField> $configFields
-     *
-     * @return RepositoryIterator<ProductCollection>
      */
-    private function getIterator(array $ids, Context $context, array $configFields): RepositoryIterator
+    private function getCriteria(array $ids, Context $context, array $configFields): Criteria
     {
         $context->setConsiderInheritance(true);
 
         $criteria = new Criteria($ids);
-        $criteria->setLimit(50);
 
         $this->buildCriteria(array_column($configFields, 'field'), $criteria, $context);
 
-        return new RepositoryIterator($this->productRepository, $context, $criteria);
+        return $criteria;
     }
 
     /**
@@ -207,7 +210,7 @@ class SearchKeywordUpdater implements ResetInterface
      */
     private function insertKeywords(array $keywords): void
     {
-        $queue = new MultiInsertQueryQueue($this->connection, 50, true);
+        $queue = new MultiInsertQueryQueue($this->connection, 250, true);
         foreach ($keywords as $insert) {
             $queue->addInsert(ProductSearchKeywordDefinition::ENTITY_NAME, $insert);
         }
@@ -219,7 +222,7 @@ class SearchKeywordUpdater implements ResetInterface
      */
     private function insertDictionary(array $dictionary): void
     {
-        $queue = new MultiInsertQueryQueue($this->connection, 50, true, true);
+        $queue = new MultiInsertQueryQueue($this->connection, 250, true, true);
 
         foreach ($dictionary as $insert) {
             $queue->addInsert(ProductKeywordDictionaryDefinition::ENTITY_NAME, $insert);
@@ -334,13 +337,14 @@ class SearchKeywordUpdater implements ResetInterface
             return;
         }
 
-        $criteria = new Criteria(array_keys($productsByParentId));
-        $criteria->setLimit(50);
+        $criteria = new Criteria();
         $criteria->addFields(['name']);
 
-        $iterator = new RepositoryIterator($this->productRepository, $context, $criteria);
+        foreach (array_chunk(array_keys($productsByParentId), 50) as $chunkedIds) {
+            $criteria->setIds($chunkedIds);
 
-        while ($parentProducts = $iterator->fetch()) {
+            $parentProducts = $this->productRepository->search($criteria, $context);
+
             foreach ($parentProducts->getEntities() as $parent) {
                 $parentProduct = new ProductEntity();
                 $parentProduct->setId($parent->getId());

--- a/src/Core/Content/Product/DataAbstractionLayer/VariantListingUpdater.php
+++ b/src/Core/Content/Product/DataAbstractionLayer/VariantListingUpdater.php
@@ -44,20 +44,9 @@ class VariantListingUpdater
 
         $listingConfiguration = $this->getListingConfiguration($ids, $context);
 
-        $displayParent = new RetryableQuery(
-            $this->connection,
-            $this->connection->prepare('UPDATE product SET display_group = SHA2(HEX(product.id), 256) WHERE product.id = :id AND product.version_id = :versionId')
-        );
-
-        $hideParent = new RetryableQuery(
-            $this->connection,
-            $this->connection->prepare('UPDATE product SET display_group = NULL WHERE product.id = :id AND product.version_id = :versionId')
-        );
-
-        $singleVariant = new RetryableQuery(
-            $this->connection,
-            $this->connection->prepare('UPDATE product SET display_group = SHA2(HEX(product.parent_id), 256) WHERE product.parent_id = :id AND product.version_id = :versionId')
-        );
+        $displayParentIds = [];
+        $hideParentIds = [];
+        $singleVariantIds = [];
 
         foreach ($listingConfiguration as $parentId => $config) {
             $childCount = (int) $config['child_count'];
@@ -69,15 +58,15 @@ class VariantListingUpdater
 
             if ($childCount <= 0) {
                 // display parent in listing
-                $displayParent->execute(['id' => $parentId, 'versionId' => $versionBytes]);
+                $displayParentIds[] = $parentId;
             } else {
                 // hide parent
-                $hideParent->execute(['id' => $parentId, 'versionId' => $versionBytes]);
+                $hideParentIds[] = $parentId;
             }
 
             if ($groups === []) {
                 // display single variant in listing
-                $singleVariant->execute(['id' => $parentId, 'versionId' => $versionBytes]);
+                $singleVariantIds[] = $parentId;
 
                 continue;
             }
@@ -115,6 +104,40 @@ class VariantListingUpdater
 
             RetryableQuery::retryable($this->connection, function () use ($sql, $params): void {
                 $this->connection->executeStatement($sql, $params);
+            });
+        }
+
+        $this->executeGroupUpdate(
+            'UPDATE product SET display_group = SHA2(HEX(product.id), 256) WHERE product.id IN (:ids) AND product.version_id = :versionId',
+            $displayParentIds,
+            $versionBytes
+        );
+
+        $this->executeGroupUpdate(
+            'UPDATE product SET display_group = NULL WHERE product.id IN (:ids) AND product.version_id = :versionId',
+            $hideParentIds,
+            $versionBytes
+        );
+
+        $this->executeGroupUpdate(
+            'UPDATE product SET display_group = SHA2(HEX(product.parent_id), 256) WHERE product.parent_id IN (:ids) AND product.version_id = :versionId',
+            $singleVariantIds,
+            $versionBytes
+        );
+    }
+
+    /**
+     * @param list<int|string> $ids binary ids
+     */
+    private function executeGroupUpdate(string $sql, array $ids, string $versionBytes): void
+    {
+        foreach (array_chunk($ids, 250) as $chunkedIds) {
+            RetryableQuery::retryable($this->connection, function () use ($sql, $chunkedIds, $versionBytes): void {
+                $this->connection->executeStatement(
+                    $sql,
+                    ['ids' => $chunkedIds, 'versionId' => $versionBytes],
+                    ['ids' => ArrayParameterType::BINARY]
+                );
             });
         }
     }

--- a/src/Core/Content/Seo/SeoUrlGenerator.php
+++ b/src/Core/Content/Seo/SeoUrlGenerator.php
@@ -10,7 +10,6 @@ use Shopware\Core\Content\Seo\SeoUrlRoute\SeoUrlRouteInterface;
 use Shopware\Core\Framework\Adapter\Twig\TwigVariableParser;
 use Shopware\Core\Framework\Adapter\Twig\TwigVariableParserFactory;
 use Shopware\Core\Framework\Context;
-use Shopware\Core\Framework\DataAbstractionLayer\Dbal\Common\RepositoryIterator;
 use Shopware\Core\Framework\DataAbstractionLayer\Dbal\EntityDefinitionQueryHelper;
 use Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry;
 use Shopware\Core\Framework\DataAbstractionLayer\Entity;
@@ -70,13 +69,19 @@ class SeoUrlGenerator
             $associations = $this->getAssociations($template, $repository->getDefinition());
             $criteria->addAssociations($associations);
 
-            $criteria->setLimit(50);
+            $templateName = $this->getTemplateName($template);
 
-            /** @var RepositoryIterator<EntityCollection<covariant Entity>> $iterator */
-            $iterator = $context->enableInheritance(static fn (Context $context): RepositoryIterator => new RepositoryIterator($repository, $context, $criteria));
+            // The requested ids already bound the result set, so search them in fixed chunks
+            // instead of paginating with an iterator, which would need an additional, empty
+            // page query per call to detect the end of the result set.
+            foreach (array_chunk($criteria->getIds(), 50) as $chunkedIds) {
+                $criteria->setIds($chunkedIds);
 
-            while ($searchResult = $iterator->fetch()) {
-                yield from $this->generateUrls($route, $config, $salesChannel, $searchResult, $this->getTemplateName($template));
+                $searchResult = $context->enableInheritance(
+                    static fn (Context $context): EntitySearchResult => $repository->search($criteria, $context)
+                );
+
+                yield from $this->generateUrls($route, $config, $salesChannel, $searchResult, $templateName);
             }
         }
     }

--- a/src/Core/Framework/DataAbstractionLayer/Doctrine/MultiUpdateQueryQueue.php
+++ b/src/Core/Framework/DataAbstractionLayer/Doctrine/MultiUpdateQueryQueue.php
@@ -1,0 +1,139 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\DataAbstractionLayer\Doctrine;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Framework\DataAbstractionLayer\DataAbstractionLayerException;
+use Shopware\Core\Framework\DataAbstractionLayer\Dbal\EntityDefinitionQueryHelper;
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * Collects single-row UPDATE payloads for one table and executes them as batched
+ * CASE WHEN statements instead of one statement (round trip) per row.
+ *
+ * Rows updating the same set of columns are combined into one statement per chunk.
+ * Additional equality conditions (e.g. the version id) can be applied to the whole
+ * batch on execute. Adding a second update for the same key and column set replaces
+ * the first one, matching the last-write-wins semantics of sequential updates.
+ *
+ * @internal
+ *
+ * @phpstan-type UpdateRow array{key: string, columns: array<string, string|int|float|null>}
+ */
+#[Package('framework')]
+class MultiUpdateQueryQueue
+{
+    /**
+     * @var array<string, array<string, UpdateRow>>
+     */
+    private array $updates = [];
+
+    /**
+     * @var int<1, max>
+     */
+    private readonly int $chunkSize;
+
+    public function __construct(
+        private readonly Connection $connection,
+        private readonly string $table,
+        private readonly string $keyColumn = 'id',
+        int $chunkSize = 250,
+    ) {
+        if ($chunkSize < 1) {
+            throw DataAbstractionLayerException::invalidChunkSize($chunkSize);
+        }
+        $this->chunkSize = $chunkSize;
+    }
+
+    /**
+     * @param string $key value of the key column identifying the row, e.g. the binary primary key
+     * @param array<string, string|int|float|null> $columns storage column => new value
+     */
+    public function addUpdate(string $key, array $columns): void
+    {
+        if ($columns === []) {
+            return;
+        }
+
+        $signature = implode(',', array_keys($columns));
+
+        $this->updates[$signature][$key] = ['key' => $key, 'columns' => $columns];
+    }
+
+    /**
+     * @param array<string, string|int|float> $conditions additional equality conditions applied to every batched row
+     */
+    public function execute(array $conditions = []): void
+    {
+        if ($this->updates === []) {
+            return;
+        }
+
+        $queries = $this->prepareQueries($conditions);
+
+        RetryableTransaction::retryable($this->connection, function () use ($queries): void {
+            foreach ($queries as $query) {
+                $this->connection->executeStatement($query['query'], $query['values']);
+            }
+        });
+
+        $this->updates = [];
+    }
+
+    /**
+     * @param array<string, string|int|float> $conditions
+     *
+     * @return list<array{query: string, values: list<string|int|float>}>
+     */
+    private function prepareQueries(array $conditions): array
+    {
+        $table = EntityDefinitionQueryHelper::escape($this->table);
+        $key = EntityDefinitionQueryHelper::escape($this->keyColumn);
+
+        $queries = [];
+
+        foreach ($this->updates as $rows) {
+            foreach (array_chunk(array_values($rows), $this->chunkSize) as $chunk) {
+                $values = [];
+
+                $sets = [];
+                foreach (array_keys($chunk[0]['columns']) as $column) {
+                    $cases = [];
+                    foreach ($chunk as $row) {
+                        if ($row['columns'][$column] === null) {
+                            $cases[] = 'WHEN ? THEN NULL';
+                            $values[] = $row['key'];
+
+                            continue;
+                        }
+
+                        $cases[] = 'WHEN ? THEN ?';
+                        $values[] = $row['key'];
+                        $values[] = $row['columns'][$column];
+                    }
+
+                    $escapedColumn = EntityDefinitionQueryHelper::escape($column);
+                    // the ELSE fallback keeps rows untouched that match the WHERE clause but no CASE key
+                    $sets[] = $escapedColumn . ' = CASE ' . $key . ' ' . implode(' ', $cases) . ' ELSE ' . $escapedColumn . ' END';
+                }
+
+                $wheres = [$key . ' IN (' . implode(',', array_fill(0, \count($chunk), '?')) . ')'];
+                foreach ($chunk as $row) {
+                    $values[] = $row['key'];
+                }
+
+                foreach ($conditions as $column => $value) {
+                    $wheres[] = EntityDefinitionQueryHelper::escape($column) . ' = ?';
+                    $values[] = $value;
+                }
+
+                $queries[] = [
+                    'query' => \sprintf('UPDATE %s SET %s WHERE %s;', $table, implode(', ', $sets), implode(' AND ', $wheres)),
+                    'values' => $values,
+                ];
+            }
+        }
+
+        return $queries;
+    }
+}

--- a/src/Core/Framework/DataAbstractionLayer/Indexing/TreeUpdater.php
+++ b/src/Core/Framework/DataAbstractionLayer/Indexing/TreeUpdater.php
@@ -10,11 +10,11 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\DataAbstractionLayerException;
 use Shopware\Core\Framework\DataAbstractionLayer\Dbal\EntityDefinitionQueryHelper;
 use Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry;
+use Shopware\Core\Framework\DataAbstractionLayer\Doctrine\MultiUpdateQueryQueue;
 use Shopware\Core\Framework\DataAbstractionLayer\Doctrine\RetryableQuery;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\TreeLevelField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\TreePathField;
-use Shopware\Core\Framework\DataAbstractionLayer\Util\StatementHelper;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Uuid\Exception\InvalidUuidException;
 use Shopware\Core\Framework\Uuid\Exception\InvalidUuidLengthException;
@@ -339,12 +339,21 @@ class TreeUpdater
         /** @var TreeLevelField|null $levelField */
         $levelField = $definition->getFields()->filterInstance(TreeLevelField::class)->first();
 
+        $updateQueue = new MultiUpdateQueryQueue($this->connection, $definition->getEntityName());
+
         foreach ($updateIds as $updateId) {
             $entity = $this->updatePath($updateId, $bag);
             if ($entity !== null) {
-                $this->updateEntity($entity, $definition, $pathField, $levelField, $context, $bag);
+                $this->updateEntity($entity, $definition, $pathField, $levelField, $bag, $updateQueue);
             }
         }
+
+        $conditions = [];
+        if ($definition->getField('version_id')) {
+            $conditions['version_id'] = Uuid::fromHexToBytes($context->getVersionId());
+        }
+
+        $updateQueue->execute($conditions);
 
         if ($recursive) {
             $childIds = $this->fetchByColumn($updateIds, $definition, 'parent_id', $context, $bag);
@@ -355,7 +364,7 @@ class TreeUpdater
     /**
      * @param array<string, mixed> $entity
      */
-    private function updateEntity(array $entity, EntityDefinition $definition, ?TreePathField $pathField, ?TreeLevelField $levelField, Context $context, TreeUpdaterBag $bag): void
+    private function updateEntity(array $entity, EntityDefinition $definition, ?TreePathField $pathField, ?TreeLevelField $levelField, TreeUpdaterBag $bag, MultiUpdateQueryQueue $updateQueue): void
     {
         if ($pathField === null && $levelField) {
             throw DataAbstractionLayerException::treeUpdateError('`TreePathField` or `TreeLevelField` required.');
@@ -365,50 +374,15 @@ class TreeUpdater
             return;
         }
 
-        $tableName = EntityDefinitionQueryHelper::escape($definition->getEntityName());
-        $sql = 'UPDATE ' . $tableName . ' SET ';
-
-        $sets = [];
+        $update = [];
         if ($pathField !== null) {
-            $sets[] = EntityDefinitionQueryHelper::escape($pathField->getStorageName()) . ' = :path';
-        }
-
-        if ($levelField !== null) {
-            $sets[] = EntityDefinitionQueryHelper::escape($levelField->getStorageName()) . ' = :level';
-        }
-
-        $sql .= implode(',', $sets);
-        $sql .= ' WHERE `id` = :id';
-
-        if ($definition->getField('version_id')) {
-            $sql .= ' AND `version_id` = :version';
-        }
-
-        $sql .= ';';
-
-        $statement = $this->connection->prepare($sql);
-
-        $update = [
-            'id' => $entity['id'],
-        ];
-
-        if ($definition->getField('version_id')) {
-            $update['version'] = Uuid::fromHexToBytes($context->getVersionId());
-        }
-
-        if ($pathField !== null) {
-            $update['path'] = $entity['path'];
+            $update[$pathField->getStorageName()] = $entity['path'];
         }
         if ($levelField !== null) {
-            $update['level'] = $entity['level'];
+            $update[$levelField->getStorageName()] = $entity['level'];
         }
 
-        RetryableQuery::retryable(
-            connection: $this->connection,
-            closure: static function () use ($statement, $update): void {
-                StatementHelper::executeStatement($statement, $update);
-            }
-        );
+        $updateQueue->addUpdate($entity['id'], $update);
 
         $bag->addUpdated($entity['id']);
     }

--- a/tests/unit/Core/Content/Product/DataAbstractionLayer/CheapestPriceUpdaterTest.php
+++ b/tests/unit/Core/Content/Product/DataAbstractionLayer/CheapestPriceUpdaterTest.php
@@ -5,7 +5,6 @@ namespace Shopware\Tests\Unit\Core\Content\Product\DataAbstractionLayer;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Query\QueryBuilder;
 use Doctrine\DBAL\Result;
-use Doctrine\DBAL\Statement;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\TestDox;
@@ -85,8 +84,8 @@ class CheapestPriceUpdaterTest extends TestCase
 
     /**
      * The fetched sales channel visibility only surfaces as the container serialized into the
-     * `cheapest_price` UPDATE, so the test captures that written value (see "Asserting writes
-     * when there is no other seam" in coding-guidelines/core/unit-tests.md).
+     * batched `cheapest_price` UPDATE, so the test captures that written value (see "Asserting
+     * writes when there is no other seam" in coding-guidelines/core/unit-tests.md).
      *
      * @param list<string> $salesChannelIds
      */
@@ -109,20 +108,20 @@ class CheapestPriceUpdaterTest extends TestCase
 
         $updater = $this->createMockedUpdater($mockedData, $mockedVisibility);
 
-        $writtenPrices = [];
-        $cheapestPriceStatement = $this->createMock(Statement::class);
-        $cheapestPriceStatement->method('bindValue')->willReturnCallback(
-            static function (string $param, mixed $value) use (&$writtenPrices): void {
-                if ($param === 'price') {
-                    $writtenPrices[] = (string) $value;
-                }
-            }
+        $this->connection->method('transactional')->willReturnCallback(
+            fn (\Closure $closure): mixed => $closure($this->connection)
         );
-        $cheapestPriceStatement->expects($this->once())->method('executeStatement')->willReturn(1);
 
-        $accessorStatement = static::createStub(Statement::class);
-        $this->connection->method('prepare')->willReturnCallback(
-            static fn (string $sql): Statement => str_contains($sql, 'cheapest_price_accessor') ? $accessorStatement : $cheapestPriceStatement
+        $writtenPrices = [];
+        $this->connection->method('executeStatement')->willReturnCallback(
+            static function (string $sql, array $params = []) use (&$writtenPrices): int {
+                // the payload of a single-row batch is the THEN value following the CASE key
+                if (str_contains($sql, '`cheapest_price` = CASE')) {
+                    $writtenPrices[] = (string) $params[1];
+                }
+
+                return 1;
+            }
         );
 
         $updater->update([$parentId], Context::createDefaultContext());

--- a/tests/unit/Core/Content/Product/DataAbstractionLayer/ProductStreamUpdaterTest.php
+++ b/tests/unit/Core/Content/Product/DataAbstractionLayer/ProductStreamUpdaterTest.php
@@ -6,6 +6,7 @@ use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Product\Aggregate\ProductTranslation\ProductTranslationDefinition;
 use Shopware\Core\Content\Product\DataAbstractionLayer\ProductStreamMappingIndexingMessage;
 use Shopware\Core\Content\Product\DataAbstractionLayer\ProductStreamUpdater;
 use Shopware\Core\Content\Product\ProductCollection;
@@ -30,9 +31,12 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\Language\LanguageCollection;
 use Shopware\Core\System\Language\LanguageEntity;
+use Shopware\Core\Test\Stub\DataAbstractionLayer\StaticDefinitionInstanceRegistry;
 use Shopware\Core\Test\Stub\DataAbstractionLayer\StaticEntityRepository;
+use Shopware\Core\Test\Stub\DataAbstractionLayer\StaticEntityWriterGateway;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Validator\Validation;
 
 /**
  * @internal
@@ -439,6 +443,74 @@ class ProductStreamUpdaterTest extends TestCase
     }
 
     /**
+     * Filters on non-translated fields match the same products in every language, so only
+     * one language context has to be searched for them.
+     */
+    #[DataProvider('languageContextProvider')]
+    public function testUpdateProductsSearchesLanguagesDependingOnTranslatedFields(string $field, int $expectedSearches): void
+    {
+        $connection = static::createStub(Connection::class);
+        $connection->method('fetchAllAssociative')->willReturn([
+            [
+                'id' => Uuid::randomBytes(),
+                'api_filter' => json_encode([[
+                    'type' => 'equals',
+                    'field' => $field,
+                    'value' => '1',
+                ]]),
+            ],
+        ]);
+
+        $registry = new StaticDefinitionInstanceRegistry(
+            [ProductDefinition::class, ProductTranslationDefinition::class],
+            Validation::createValidator(),
+            new StaticEntityWriterGateway()
+        );
+        $definition = $registry->getByEntityName(ProductDefinition::ENTITY_NAME);
+        static::assertInstanceOf(ProductDefinition::class, $definition);
+
+        $searches = 0;
+        $searchClosure = static function () use (&$searches): array {
+            ++$searches;
+
+            return [];
+        };
+
+        /** @var StaticEntityRepository<ProductCollection> */
+        $repository = new StaticEntityRepository(array_fill(0, $expectedSearches, $searchClosure), $definition);
+
+        $updater = new ProductStreamUpdater(
+            $connection,
+            $definition,
+            $repository,
+            static::createStub(MessageBusInterface::class),
+            static::createStub(ManyToManyIdFieldUpdater::class),
+            $this->createTwoLanguagesRepo(),
+            true,
+        );
+
+        $updater->updateProducts([Uuid::randomHex()], Context::createDefaultContext());
+
+        static::assertSame($expectedSearches, $searches);
+    }
+
+    /**
+     * @return iterable<string, array{field: string, expectedSearches: int}>
+     */
+    public static function languageContextProvider(): iterable
+    {
+        yield 'non-translated field is searched in one language' => [
+            'field' => 'active',
+            'expectedSearches' => 1,
+        ];
+
+        yield 'translated field is searched in every language' => [
+            'field' => 'name',
+            'expectedSearches' => 2,
+        ];
+    }
+
+    /**
      * @return iterable<string, array<int, array<int, array<string, bool|string>|string>|Criteria>>
      */
     public static function filterProvider(): iterable
@@ -606,5 +678,22 @@ class ProductStreamUpdaterTest extends TestCase
         $repo = new StaticEntityRepository([new LanguageCollection([$language])]);
 
         return $repo;
+    }
+
+    /**
+     * @return StaticEntityRepository<LanguageCollection>
+     */
+    private function createTwoLanguagesRepo(): StaticEntityRepository
+    {
+        $defaultLanguage = new LanguageEntity();
+        $defaultLanguage->setId(Defaults::LANGUAGE_SYSTEM);
+        $defaultLanguage->setUniqueIdentifier(Defaults::LANGUAGE_SYSTEM);
+
+        $secondLanguageId = Uuid::randomHex();
+        $secondLanguage = new LanguageEntity();
+        $secondLanguage->setId($secondLanguageId);
+        $secondLanguage->setUniqueIdentifier($secondLanguageId);
+
+        return new StaticEntityRepository([new LanguageCollection([$defaultLanguage, $secondLanguage])]);
     }
 }

--- a/tests/unit/Core/Content/Product/DataAbstractionLayer/SearchKeywordUpdaterTest.php
+++ b/tests/unit/Core/Content/Product/DataAbstractionLayer/SearchKeywordUpdaterTest.php
@@ -75,12 +75,10 @@ class SearchKeywordUpdaterTest extends TestCase
         $parent->setTranslated(['name' => 'Parent product']);
 
         $productRepository = new StaticEntityRepository([
-            // products to index, the second (empty) search stops the iterator
+            // products to index, searched in a single chunk
             new ProductCollection([$child, $standalone]),
-            new ProductCollection(),
             // parent products, hydrated for the `parent.name` config field
             new ProductCollection([$parent]),
-            new ProductCollection(),
         ], $this->createProductDefinition());
 
         $analyzedProducts = [];
@@ -117,11 +115,10 @@ class SearchKeywordUpdaterTest extends TestCase
         $childId = Uuid::randomHex();
         $child = $this->createProduct($childId, Uuid::randomHex());
 
-        // exactly the two searches of the product iterator: loading parent products
-        // would exhaust the repository and let it throw
+        // exactly the one chunked search for the products to index: loading parent
+        // products would exhaust the repository and let it throw
         $productRepository = new StaticEntityRepository([
             new ProductCollection([$child]),
-            new ProductCollection(),
         ], $this->createProductDefinition());
 
         $updater = $this->createUpdater(

--- a/tests/unit/Core/Framework/DataAbstractionLayer/Doctrine/MultiUpdateQueryQueueTest.php
+++ b/tests/unit/Core/Framework/DataAbstractionLayer/Doctrine/MultiUpdateQueryQueueTest.php
@@ -1,0 +1,202 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\DataAbstractionLayer\Doctrine;
+
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\DataAbstractionLayer\DataAbstractionLayerException;
+use Shopware\Core\Framework\DataAbstractionLayer\Doctrine\MultiUpdateQueryQueue;
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * @internal
+ *
+ * @phpstan-type Updates list<array{key: string, columns: array<string, string|int|float|null>}>
+ * @phpstan-type Queries list<array{query: string, values: list<string|int|float>}>
+ */
+#[Package('framework')]
+#[CoversClass(MultiUpdateQueryQueue::class)]
+class MultiUpdateQueryQueueTest extends TestCase
+{
+    /**
+     * @param Updates $updates
+     * @param Queries $queries
+     * @param array<string, string|int|float> $conditions
+     */
+    #[DataProvider('preparedQueriesDataProvider')]
+    public function testPrepareQueries(array $updates, array $queries, array $conditions = [], int $chunkSize = 250): void
+    {
+        $executed = [];
+        $queue = new MultiUpdateQueryQueue($this->createRecordingConnection($executed), 'product', 'id', $chunkSize);
+        foreach ($updates as $update) {
+            $queue->addUpdate($update['key'], $update['columns']);
+        }
+
+        $queue->execute($conditions);
+
+        static::assertCount(\count($queries), $executed);
+        foreach ($executed as $index => $query) {
+            static::assertSame($queries[$index]['query'], $query['query']);
+            static::assertSame($queries[$index]['values'], $query['values']);
+        }
+    }
+
+    /**
+     * @return iterable<string, array{
+     *     updates: Updates,
+     *     queries: Queries,
+     *     conditions?: array<string, string|int|float>,
+     *     chunkSize?: int
+     * }>
+     */
+    public static function preparedQueriesDataProvider(): iterable
+    {
+        yield 'single column update with condition' => [
+            'updates' => [
+                ['key' => 'key1', 'columns' => ['category_tree' => '["a"]']],
+                ['key' => 'key2', 'columns' => ['category_tree' => '["b"]']],
+            ],
+            'queries' => [
+                [
+                    'query' => 'UPDATE `product` SET `category_tree` = CASE `id` WHEN ? THEN ? WHEN ? THEN ? ELSE `category_tree` END WHERE `id` IN (?,?) AND `version_id` = ?;',
+                    'values' => ['key1', '["a"]', 'key2', '["b"]', 'key1', 'key2', 'version'],
+                ],
+            ],
+            'conditions' => ['version_id' => 'version'],
+        ];
+
+        yield 'null values are written as NULL' => [
+            'updates' => [
+                ['key' => 'key1', 'columns' => ['category_tree' => null]],
+                ['key' => 'key2', 'columns' => ['category_tree' => '["b"]']],
+            ],
+            'queries' => [
+                [
+                    'query' => 'UPDATE `product` SET `category_tree` = CASE `id` WHEN ? THEN NULL WHEN ? THEN ? ELSE `category_tree` END WHERE `id` IN (?,?);',
+                    'values' => ['key1', 'key2', '["b"]', 'key1', 'key2'],
+                ],
+            ],
+        ];
+
+        yield 'multi column update' => [
+            'updates' => [
+                ['key' => 'key1', 'columns' => ['path' => '|a|', 'level' => 2]],
+            ],
+            'queries' => [
+                [
+                    'query' => 'UPDATE `product` SET `path` = CASE `id` WHEN ? THEN ? ELSE `path` END, `level` = CASE `id` WHEN ? THEN ? ELSE `level` END WHERE `id` IN (?);',
+                    'values' => ['key1', '|a|', 'key1', 2, 'key1'],
+                ],
+            ],
+        ];
+
+        yield 'chunking' => [
+            'updates' => [
+                ['key' => 'key1', 'columns' => ['stock' => 1]],
+                ['key' => 'key2', 'columns' => ['stock' => 2]],
+                ['key' => 'key3', 'columns' => ['stock' => 3]],
+            ],
+            'queries' => [
+                [
+                    'query' => 'UPDATE `product` SET `stock` = CASE `id` WHEN ? THEN ? WHEN ? THEN ? ELSE `stock` END WHERE `id` IN (?,?);',
+                    'values' => ['key1', 1, 'key2', 2, 'key1', 'key2'],
+                ],
+                [
+                    'query' => 'UPDATE `product` SET `stock` = CASE `id` WHEN ? THEN ? ELSE `stock` END WHERE `id` IN (?);',
+                    'values' => ['key3', 3, 'key3'],
+                ],
+            ],
+            'chunkSize' => 2,
+        ];
+
+        yield 'different column sets are updated separately' => [
+            'updates' => [
+                ['key' => 'key1', 'columns' => ['cheapest_price' => 'price']],
+                ['key' => 'key2', 'columns' => ['cheapest_price_accessor' => 'accessor']],
+            ],
+            'queries' => [
+                [
+                    'query' => 'UPDATE `product` SET `cheapest_price` = CASE `id` WHEN ? THEN ? ELSE `cheapest_price` END WHERE `id` IN (?);',
+                    'values' => ['key1', 'price', 'key1'],
+                ],
+                [
+                    'query' => 'UPDATE `product` SET `cheapest_price_accessor` = CASE `id` WHEN ? THEN ? ELSE `cheapest_price_accessor` END WHERE `id` IN (?);',
+                    'values' => ['key2', 'accessor', 'key2'],
+                ],
+            ],
+        ];
+
+        yield 'last update for the same key and columns wins' => [
+            'updates' => [
+                ['key' => 'key1', 'columns' => ['stock' => 1]],
+                ['key' => 'key1', 'columns' => ['stock' => 2]],
+            ],
+            'queries' => [
+                [
+                    'query' => 'UPDATE `product` SET `stock` = CASE `id` WHEN ? THEN ? ELSE `stock` END WHERE `id` IN (?);',
+                    'values' => ['key1', 2, 'key1'],
+                ],
+            ],
+        ];
+
+        yield 'updates without columns are ignored' => [
+            'updates' => [
+                ['key' => 'key1', 'columns' => []],
+            ],
+            'queries' => [],
+        ];
+    }
+
+    public function testExecuteWithoutUpdatesDoesNotTouchTheConnection(): void
+    {
+        $executed = [];
+        $queue = new MultiUpdateQueryQueue($this->createRecordingConnection($executed), 'product');
+
+        $queue->execute();
+
+        static::assertSame([], $executed);
+    }
+
+    public function testExecuteClearsTheQueue(): void
+    {
+        $executed = [];
+        $queue = new MultiUpdateQueryQueue($this->createRecordingConnection($executed), 'product');
+        $queue->addUpdate('key1', ['stock' => 1]);
+
+        $queue->execute();
+        $queue->execute();
+
+        static::assertCount(1, $executed);
+    }
+
+    public function testConstructorThrowsOnWrongChunkSize(): void
+    {
+        $connection = static::createStub(Connection::class);
+        self::expectExceptionObject(DataAbstractionLayerException::invalidChunkSize(0));
+        new MultiUpdateQueryQueue($connection, 'product', 'id', 0);
+    }
+
+    /**
+     * Records the statements the queue executes, so the generated SQL can be asserted afterwards.
+     *
+     * @param list<array{query: string, values: array<mixed>}> $executed
+     */
+    private function createRecordingConnection(array &$executed): Connection
+    {
+        $connection = static::createStub(Connection::class);
+        $connection->method('transactional')->willReturnCallback(
+            static fn (\Closure $callback): mixed => $callback($connection)
+        );
+        $connection->method('executeStatement')->willReturnCallback(
+            function (string $sql, array $params = []) use (&$executed): int {
+                $executed[] = ['query' => $sql, 'values' => $params];
+
+                return 1;
+            }
+        );
+
+        return $connection;
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?

A full `bin/console dal:refresh:index` run spends most of its time in per-row SQL statements and avoidable queries:

- The cheapest price, category tree denormalization, variant listing, tree path/level and media thumbnail indexers issue one `UPDATE` statement per row (~7,000 single-row updates on a demo dataset).
- `SeoUrlGenerator` and `SearchKeywordUpdater` paginate over already-bounded id lists with a `RepositoryIterator`, paying one extra empty page query (with heavy translation joins) per batch to detect the end of the result set.
- `ProductStreamUpdater` matches every stream in every sales channel language, even when the stream filters only use non-translated fields whose matches are identical in every language.
- The search keyword inserts use a chunk size of 50 instead of the usual 250.

### 2. What does this change do, exactly?

- Adds an `@internal` `MultiUpdateQueryQueue` (mirroring `MultiInsertQueryQueue`) that batches single-row updates of the same columns into `CASE WHEN` statements, and uses it in the five indexers above. Each column keeps an `ELSE <column>` fallback, so rows matching the `WHERE` but no `CASE` key stay untouched, and adding the same key twice keeps last-write-wins semantics.
- Searches bounded id lists in fixed chunks instead of a `RepositoryIterator` in `SeoUrlGenerator` and `SearchKeywordUpdater`, removing the trailing empty page query per batch.
- Skips the per-language stream matching in `ProductStreamUpdater` when no filter accessor resolves to a `TranslatedField` (falling back to all languages when an accessor cannot be resolved).
- Raises the keyword insert chunk size from 50 to 250.

Measured on a demo dataset (1,711 products, 982 categories, 10 product streams, 2 sales channel languages, MariaDB 11.4, PHP 8.5):

| Metric | Before | After |
|---|---|---|
| `dal:refresh:index` wall time | 17.0 s | 13.7 s (−19%) |
| SQL queries | 13,350 | 5,730 (−57%) |

Verified that the indexed state is identical: hashes over all indexed columns (`category_tree`, `display_group`, `cheapest_price`, `cheapest_price_accessor`, category `path`/`level`, `thumbnails_ro`) and the full `product_stream_mapping` content are byte-identical before and after the change.

### 3. Describe each step to reproduce the issue or behaviour.

1. Enable the MySQL general log (`SET GLOBAL general_log = 'ON'`) or a profiler.
2. Run `bin/console dal:refresh:index` on a shop with demo data.
3. Before: the log shows thousands of consecutive single-row `UPDATE product SET cheapest_price/category_tree/display_group ... WHERE id = ?` statements, plus repeated empty `SELECT`s from the seo-url/search-keyword iterators. After: the updates arrive as batched `CASE WHEN` statements and the empty page queries are gone.

### 4. Please link to the relevant issues (if any).

None.

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers (not relevant, internal implementation detail; the new `MultiUpdateQueryQueue` is `@internal`)
- [ ] I have written or adjusted the documentation and agent skills according to my changes (not needed)
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
