### PR TITLE
perf(core): batch queries that scaled with the number of records

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -54,6 +54,15 @@ The new privileges are part of the existing "Plugin maintain" (`system:app:chang
 
 ## Core
 
+### Snippet and product export writes are batched into one event
+
+Several places that used to write one record per loop iteration now write all records of a run at once, to remove queries that scaled with the number of processed records. Two of them are observable for extensions:
+
+* `SystemLanguageChangedSubscriber` reassigned app administration snippets with one `update()` per app. It now writes the snippets of every app in a single `update()`, so a listener on `snippet.written` receives one event carrying every changed snippet instead of one event per app.
+* `ProductExportEventListener` reset `generatedAt`, `nextGenerationAt` and `isRunning` with one `update()` per written export. It now resets all written exports in a single `update()`, so a listener on `product_export.written` receives one event carrying every reset export instead of one event per export.
+
+The written values, their order and the resulting database state are unchanged; only the number of write calls and therefore of dispatched write events differs. If your subscriber assumed one result per event, iterate `$event->getResults()` (or `$event->getIds()`) instead of reading the first entry.
+
 ### Deprecated XML configuration
 
 Loading Symfony configuration from XML files is deprecated for Shopware bundles, plugins, and the project-level `config/` directory of an installation, and will stop working with Shopware 6.8, because Symfony 8 removes XML configuration support entirely. This covers service definitions (`Resources/config/services.xml`, `services_test.xml`, `config/services.xml`), route definitions (`Resources/config/routes.xml`, `routes_<env>.xml`, `routes_overwrite.xml`, and any XML file below a `routes/` config directory), and package configuration (`packages/**/*.xml`). Symfony already logs a runtime deprecation for every loaded XML file since Symfony 7.4; Shopware now additionally reports which file — and for bundles and plugins, which bundle — is affected. Shopware-specific XML formats such as `config.xml`, `custom-fields.xml`, or app manifests are not affected.

--- a/phpstan-baseline.php
+++ b/phpstan-baseline.php
@@ -34,18 +34,6 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
     'rawMessage' => 'Construct empty() is not allowed. Use more strict comparison.',
     'identifier' => 'empty.notAllowed',
-    'count' => 1,
-    'path' => __DIR__ . '/src/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Entity/ProductCrossSellingSerializer.php',
-];
-$ignoreErrors[] = [
-    'rawMessage' => 'Construct empty() is not allowed. Use more strict comparison.',
-    'identifier' => 'empty.notAllowed',
-    'count' => 6,
-    'path' => __DIR__ . '/src/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Entity/ProductSerializer.php',
-];
-$ignoreErrors[] = [
-    'rawMessage' => 'Construct empty() is not allowed. Use more strict comparison.',
-    'identifier' => 'empty.notAllowed',
     'count' => 3,
     'path' => __DIR__ . '/src/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Entity/PromotionIndividualCodeSerializer.php',
 ];
@@ -192,12 +180,6 @@ $ignoreErrors[] = [
     'identifier' => 'shopware.domainException',
     'count' => 1,
     'path' => __DIR__ . '/src/Core/Content/Rule/DataAbstractionLayer/RulePayloadUpdater.php',
-];
-$ignoreErrors[] = [
-    'rawMessage' => 'Construct empty() is not allowed. Use more strict comparison.',
-    'identifier' => 'empty.notAllowed',
-    'count' => 1,
-    'path' => __DIR__ . '/src/Core/Content/Seo/SeoUrlPersister.php',
 ];
 $ignoreErrors[] = [
     'rawMessage' => 'Throwing new exceptions within classes are not allowed. Please use domain exception pattern. See https://github.com/shopware/platform/blob/v6.4.20.0/adr/2022-02-24-domain-exceptions.md',

--- a/src/Administration/Framework/App/Subscriber/SystemLanguageChangedSubscriber.php
+++ b/src/Administration/Framework/App/Subscriber/SystemLanguageChangedSubscriber.php
@@ -63,9 +63,9 @@ readonly class SystemLanguageChangedSubscriber implements EventSubscriberInterfa
         $previousLocale = $this->getLocale($event->previousLocaleCode, $context);
         $newLocale = $this->getLocale($event->newLocaleCode, $context);
 
-        foreach ($appsWithSnippets as $appId) {
-            $updates = [];
+        $updates = [];
 
+        foreach ($appsWithSnippets as $appId) {
             // Reassign the snippet that was previously associated with the new locale to the previous locale
             $snippetForPreviousLocale = $this->snippetForLocale($snippets, $appId, $newLocale);
             if ($snippetForPreviousLocale) {
@@ -83,9 +83,14 @@ readonly class SystemLanguageChangedSubscriber implements EventSubscriberInterfa
                     'localeId' => $newLocale->getId(),
                 ];
             }
-
-            $this->snippetRepository->update($updates, $context);
         }
+
+        if ($updates === []) {
+            return;
+        }
+
+        // one write for every app instead of one per app
+        $this->snippetRepository->update($updates, $context);
     }
 
     private function getLocale(string $code, Context $context): LocaleEntity

--- a/src/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Entity/ProductCrossSellingSerializer.php
+++ b/src/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Entity/ProductCrossSellingSerializer.php
@@ -12,7 +12,6 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\PartialEntity;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsAnyFilter;
-use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\Struct;
 
@@ -114,22 +113,22 @@ class ProductCrossSellingSerializer extends EntitySerializer
             return $assignedProducts;
         }
 
-        // Read the existing assignments of the record in one query. Every entry belongs to the cross selling of
-        // the record, so this matches the same rows the per assignment lookups did, and only the product id is
-        // loaded instead of the whole entity.
+        // Read the existing assignments in one query, loading only the two keys next to the id. Today every entry
+        // carries the cross selling of the record, so this reads the same rows the per assignment lookups did, but
+        // the result is matched by the full key pair so that a mixed set stays correct.
         $criteria = new Criteria();
-        $criteria->addFilter(new EqualsFilter('crossSellingId', $assignedProducts[array_key_first($assignedProducts)]['crossSellingId']));
+        $criteria->addFilter(new EqualsAnyFilter('crossSellingId', array_column($assignedProducts, 'crossSellingId')));
         $criteria->addFilter(new EqualsAnyFilter('productId', array_column($assignedProducts, 'productId')));
-        $criteria->addFields(['productId']);
+        $criteria->addFields(['crossSellingId', 'productId']);
 
         $existing = [];
         foreach ($this->assignedProductsRepository->search($criteria, $context)->getEntities() as $entity) {
             \assert($entity instanceof PartialEntity);
-            $existing[(string) $entity->get('productId')] = (string) $entity->get('id');
+            $existing[(string) $entity->get('crossSellingId')][(string) $entity->get('productId')] = (string) $entity->get('id');
         }
 
         foreach ($assignedProducts as $i => $assignedProduct) {
-            $id = $existing[$assignedProduct['productId']] ?? null;
+            $id = $existing[$assignedProduct['crossSellingId']][$assignedProduct['productId']] ?? null;
 
             if ($id) {
                 $assignedProduct['id'] = $id;

--- a/src/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Entity/ProductCrossSellingSerializer.php
+++ b/src/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Entity/ProductCrossSellingSerializer.php
@@ -12,6 +12,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\PartialEntity;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsAnyFilter;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\Struct;
 
@@ -87,7 +88,7 @@ class ProductCrossSellingSerializer extends EntitySerializer
         }
 
         if ($crossSellingId) {
-            $assignedProducts = $this->findAssignedProductsIds($assignedProducts);
+            $assignedProducts = $this->findAssignedProductsIds((string) $crossSellingId, $assignedProducts);
         }
 
         $deserialized['assignedProducts'] = $assignedProducts;
@@ -101,11 +102,14 @@ class ProductCrossSellingSerializer extends EntitySerializer
     }
 
     /**
+     * All assignments of a record belong to the same cross selling, so it is passed explicitly instead of being
+     * read back out of the entries.
+     *
      * @param list<array{productId: string, crossSellingId: string, position: int}> $assignedProducts
      *
      * @return array<array{productId: string, crossSellingId: string, position: int, id?: string}>
      */
-    private function findAssignedProductsIds(array $assignedProducts): array
+    private function findAssignedProductsIds(string $crossSellingId, array $assignedProducts): array
     {
         $context = Context::createDefaultContext();
 
@@ -113,22 +117,20 @@ class ProductCrossSellingSerializer extends EntitySerializer
             return $assignedProducts;
         }
 
-        // Read the existing assignments in one query, loading only the two keys next to the id. Today every entry
-        // carries the cross selling of the record, so this reads the same rows the per assignment lookups did, but
-        // the result is matched by the full key pair so that a mixed set stays correct.
+        // Read the existing assignments in one query, loading only the product id next to the id of the assignment
         $criteria = new Criteria();
-        $criteria->addFilter(new EqualsAnyFilter('crossSellingId', array_column($assignedProducts, 'crossSellingId')));
+        $criteria->addFilter(new EqualsFilter('crossSellingId', $crossSellingId));
         $criteria->addFilter(new EqualsAnyFilter('productId', array_column($assignedProducts, 'productId')));
-        $criteria->addFields(['crossSellingId', 'productId']);
+        $criteria->addFields(['productId']);
 
         $existing = [];
         foreach ($this->assignedProductsRepository->search($criteria, $context)->getEntities() as $entity) {
             \assert($entity instanceof PartialEntity);
-            $existing[(string) $entity->get('crossSellingId')][(string) $entity->get('productId')] = (string) $entity->get('id');
+            $existing[(string) $entity->get('productId')] = (string) $entity->get('id');
         }
 
         foreach ($assignedProducts as $i => $assignedProduct) {
-            $id = $existing[$assignedProduct['crossSellingId']][$assignedProduct['productId']] ?? null;
+            $id = $existing[$assignedProduct['productId']] ?? null;
 
             if ($id) {
                 $assignedProduct['id'] = $id;

--- a/src/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Entity/ProductCrossSellingSerializer.php
+++ b/src/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Entity/ProductCrossSellingSerializer.php
@@ -66,7 +66,9 @@ class ProductCrossSellingSerializer extends EntitySerializer
         $deserialized = parent::deserialize($config, $definition, $entity);
         $deserialized = \is_array($deserialized) ? $deserialized : iterator_to_array($deserialized);
 
-        if (empty($deserialized['assignedProducts'])) {
+        $assignedProductIds = $deserialized['assignedProducts'] ?? null;
+
+        if ($assignedProductIds === null || $assignedProductIds === '' || $assignedProductIds === []) {
             return $deserialized;
         }
 

--- a/src/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Entity/ProductCrossSellingSerializer.php
+++ b/src/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Entity/ProductCrossSellingSerializer.php
@@ -9,8 +9,10 @@ use Shopware\Core\Content\Product\Aggregate\ProductCrossSellingAssignedProducts\
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\DataAbstractionLayer\PartialEntity;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsAnyFilter;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\Struct;
 
@@ -112,19 +114,22 @@ class ProductCrossSellingSerializer extends EntitySerializer
             return $assignedProducts;
         }
 
-        // Read the existing assignments in one query. The filters describe a superset, so only the exact cross
-        // selling and product combinations below are used.
+        // Read the existing assignments of the record in one query. Every entry belongs to the cross selling of
+        // the record, so this matches the same rows the per assignment lookups did, and only the product id is
+        // loaded instead of the whole entity.
         $criteria = new Criteria();
-        $criteria->addFilter(new EqualsAnyFilter('crossSellingId', array_column($assignedProducts, 'crossSellingId')));
+        $criteria->addFilter(new EqualsFilter('crossSellingId', $assignedProducts[array_key_first($assignedProducts)]['crossSellingId']));
         $criteria->addFilter(new EqualsAnyFilter('productId', array_column($assignedProducts, 'productId')));
+        $criteria->addFields(['productId']);
 
         $existing = [];
         foreach ($this->assignedProductsRepository->search($criteria, $context)->getEntities() as $entity) {
-            $existing[$entity->getCrossSellingId()][$entity->getProductId()] = $entity->getId();
+            \assert($entity instanceof PartialEntity);
+            $existing[(string) $entity->get('productId')] = (string) $entity->get('id');
         }
 
         foreach ($assignedProducts as $i => $assignedProduct) {
-            $id = $existing[$assignedProduct['crossSellingId']][$assignedProduct['productId']] ?? null;
+            $id = $existing[$assignedProduct['productId']] ?? null;
 
             if ($id) {
                 $assignedProduct['id'] = $id;

--- a/src/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Entity/ProductCrossSellingSerializer.php
+++ b/src/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Entity/ProductCrossSellingSerializer.php
@@ -10,7 +10,7 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
-use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsAnyFilter;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\Struct;
 
@@ -106,12 +106,23 @@ class ProductCrossSellingSerializer extends EntitySerializer
     {
         $context = Context::createDefaultContext();
 
-        foreach ($assignedProducts as $i => $assignedProduct) {
-            $criteria = new Criteria();
-            $criteria->addFilter(new EqualsFilter('crossSellingId', $assignedProduct['crossSellingId']));
-            $criteria->addFilter(new EqualsFilter('productId', $assignedProduct['productId']));
+        if ($assignedProducts === []) {
+            return $assignedProducts;
+        }
 
-            $id = $this->assignedProductsRepository->searchIds($criteria, $context)->firstId();
+        // Read the existing assignments in one query. The filters describe a superset, so only the exact cross
+        // selling and product combinations below are used.
+        $criteria = new Criteria();
+        $criteria->addFilter(new EqualsAnyFilter('crossSellingId', array_column($assignedProducts, 'crossSellingId')));
+        $criteria->addFilter(new EqualsAnyFilter('productId', array_column($assignedProducts, 'productId')));
+
+        $existing = [];
+        foreach ($this->assignedProductsRepository->search($criteria, $context)->getEntities() as $entity) {
+            $existing[$entity->getCrossSellingId()][$entity->getProductId()] = $entity->getId();
+        }
+
+        foreach ($assignedProducts as $i => $assignedProduct) {
+            $id = $existing[$assignedProduct['crossSellingId']][$assignedProduct['productId']] ?? null;
 
             if ($id) {
                 $assignedProduct['id'] = $id;

--- a/src/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Entity/ProductSerializer.php
+++ b/src/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Entity/ProductSerializer.php
@@ -138,7 +138,10 @@ class ProductSerializer extends EntitySerializer
         }
 
         if ($visibilities !== []) {
-            yield 'visibilities' => $this->findVisibilityIds($visibilities, $context);
+            // without a product id there is nothing to match existing visibilities against
+            yield 'visibilities' => $productId
+                ? $this->findVisibilityIds((string) $productId, $visibilities, $context)
+                : $visibilities;
         }
 
         try {
@@ -162,46 +165,34 @@ class ProductSerializer extends EntitySerializer
     }
 
     /**
+     * All visibilities of a record belong to the same product, so it is passed explicitly instead of being read
+     * back out of the entries.
+     *
      * @param array<array<string, mixed>> $visibilities
      *
      * @return array<array<string, mixed>>
      */
-    private function findVisibilityIds(array $visibilities, Context $context): array
+    private function findVisibilityIds(string $productId, array $visibilities, Context $context): array
     {
-        $productIds = [];
-        $salesChannelIds = [];
-        foreach ($visibilities as $visibility) {
-            if (!isset($visibility['productId'])) {
-                continue;
-            }
-
-            $productIds[$visibility['productId']] = true;
-            $salesChannelIds[$visibility['salesChannelId']] = true;
-        }
-
-        if ($productIds === []) {
+        if ($visibilities === []) {
             return $visibilities;
         }
 
         // Read the existing visibilities of the whole record in one query, loading only the sales channel next to
         // the id instead of the whole entity.
         $criteria = new Criteria();
-        $criteria->addFilter(new EqualsAnyFilter('productId', array_keys($productIds)));
-        $criteria->addFilter(new EqualsAnyFilter('salesChannelId', array_keys($salesChannelIds)));
-        $criteria->addFields(['productId', 'salesChannelId']);
+        $criteria->addFilter(new EqualsFilter('productId', $productId));
+        $criteria->addFilter(new EqualsAnyFilter('salesChannelId', array_column($visibilities, 'salesChannelId')));
+        $criteria->addFields(['salesChannelId']);
 
         $existing = [];
         foreach ($this->visibilityRepository->search($criteria, $context)->getEntities() as $entity) {
             \assert($entity instanceof PartialEntity);
-            $existing[(string) $entity->get('productId')][(string) $entity->get('salesChannelId')] = (string) $entity->get('id');
+            $existing[(string) $entity->get('salesChannelId')] = (string) $entity->get('id');
         }
 
         foreach ($visibilities as $i => $visibility) {
-            if (!isset($visibility['productId'])) {
-                continue;
-            }
-
-            $id = $existing[$visibility['productId']][$visibility['salesChannelId']] ?? null;
+            $id = $existing[$visibility['salesChannelId']] ?? null;
 
             if ($id) {
                 $visibility['id'] = $id;

--- a/src/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Entity/ProductSerializer.php
+++ b/src/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Entity/ProductSerializer.php
@@ -17,6 +17,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\ManyToOneAssociationField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\OneToManyAssociationField;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsAnyFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\MultiFilter;
 use Shopware\Core\Framework\Feature;
@@ -166,16 +167,38 @@ class ProductSerializer extends EntitySerializer
      */
     private function findVisibilityIds(array $visibilities, Context $context): array
     {
+        $productIds = [];
+        $salesChannelIds = [];
+        foreach ($visibilities as $visibility) {
+            if (!isset($visibility['productId'])) {
+                continue;
+            }
+
+            $productIds[$visibility['productId']] = true;
+            $salesChannelIds[$visibility['salesChannelId']] = true;
+        }
+
+        if ($productIds === []) {
+            return $visibilities;
+        }
+
+        // Read the existing visibilities of the whole record in one query. The filters describe a superset, so only
+        // the exact product and sales channel combinations below are used.
+        $criteria = new Criteria();
+        $criteria->addFilter(new EqualsAnyFilter('productId', array_keys($productIds)));
+        $criteria->addFilter(new EqualsAnyFilter('salesChannelId', array_keys($salesChannelIds)));
+
+        $existing = [];
+        foreach ($this->visibilityRepository->search($criteria, $context)->getEntities() as $entity) {
+            $existing[$entity->getProductId()][$entity->getSalesChannelId()] = $entity->getId();
+        }
+
         foreach ($visibilities as $i => $visibility) {
             if (!isset($visibility['productId'])) {
                 continue;
             }
 
-            $criteria = new Criteria();
-            $criteria->addFilter(new EqualsFilter('productId', $visibility['productId']));
-            $criteria->addFilter(new EqualsFilter('salesChannelId', $visibility['salesChannelId']));
-
-            $id = $this->visibilityRepository->searchIds($criteria, $context)->firstId();
+            $id = $existing[$visibility['productId']][$visibility['salesChannelId']] ?? null;
 
             if ($id) {
                 $visibility['id'] = $id;
@@ -252,6 +275,22 @@ class ProductSerializer extends EntitySerializer
      */
     private function findConfiguratorSettings(string $parentId, array $options, Context $context): array
     {
+        $optionIds = array_values(array_filter(array_column($options, 'id')));
+
+        if ($optionIds === []) {
+            return [];
+        }
+
+        // Read the existing settings of all options in one query instead of one per option
+        $criteria = new Criteria();
+        $criteria->addFilter(new EqualsFilter('productId', $parentId));
+        $criteria->addFilter(new EqualsAnyFilter('optionId', $optionIds));
+
+        $existing = [];
+        foreach ($this->productConfiguratorSettingRepository->search($criteria, $context)->getEntities() as $entity) {
+            $existing[$entity->getOptionId()] = $entity->getId();
+        }
+
         $configuratorSettings = [];
 
         foreach ($options as $option) {
@@ -266,14 +305,8 @@ class ProductSerializer extends EntitySerializer
                 ],
             ];
 
-            $criteria = new Criteria();
-            $criteria->addFilter(new EqualsFilter('productId', $parentId));
-            $criteria->addFilter(new EqualsFilter('optionId', $option['id']));
-
-            $id = $this->productConfiguratorSettingRepository->searchIds($criteria, $context)->firstId();
-
-            if ($id) {
-                $configuratorSetting['id'] = $id;
+            if (isset($existing[$option['id']])) {
+                $configuratorSetting['id'] = $existing[$option['id']];
             }
 
             $configuratorSettings[] = $configuratorSetting;

--- a/src/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Entity/ProductSerializer.php
+++ b/src/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Entity/ProductSerializer.php
@@ -350,6 +350,8 @@ class ProductSerializer extends EntitySerializer
         $mediaDefinition = $mediaField->getReferenceDefinition();
         $mediaSerializer = $this->serializerRegistry->getEntity($mediaDefinition->getEntityName());
 
+        // First pass: deserialize every url, so the media ids of the whole record are known
+        $mediaIds = [];
         foreach ($urls as $url) {
             $deserializedMedia = $mediaSerializer->deserialize($config, $mediaDefinition, [
                 'url' => $url,
@@ -360,27 +362,35 @@ class ProductSerializer extends EntitySerializer
                 throw $deserializedMedia['_error'];
             }
 
-            $productMedia = [
+            $productMedias[] = [
                 'media' => $deserializedMedia,
             ];
 
-            if (!isset($deserialized['id'])) {
-                $productMedias[] = $productMedia;
-
-                continue;
+            if (isset($deserializedMedia['id'])) {
+                $mediaIds[] = $deserializedMedia['id'];
             }
+        }
 
-            $criteria = new Criteria();
-            $criteria->addFilter(new EqualsFilter('productId', $deserialized['id']));
-            $criteria->addFilter(new EqualsFilter('media.id', $deserializedMedia['id']));
+        if (!isset($deserialized['id']) || $mediaIds === []) {
+            return $productMedias;
+        }
 
-            $productMediaId = $this->productMediaRepository->searchIds($criteria, $context)->firstId();
+        // Second pass: read the existing product media of all of them in one query and carry over their ids
+        $criteria = new Criteria();
+        $criteria->addFilter(new EqualsFilter('productId', $deserialized['id']));
+        $criteria->addFilter(new EqualsAnyFilter('media.id', $mediaIds));
+
+        $existing = [];
+        foreach ($this->productMediaRepository->search($criteria, $context)->getEntities() as $productMediaEntity) {
+            $existing[$productMediaEntity->getMediaId()] = $productMediaEntity->getId();
+        }
+
+        foreach ($productMedias as $i => $productMedia) {
+            $productMediaId = $existing[$productMedia['media']['id'] ?? ''] ?? null;
 
             if ($productMediaId) {
-                $productMedia['id'] = $productMediaId;
+                $productMedias[$i]['id'] = $productMediaId;
             }
-
-            $productMedias[] = $productMedia;
         }
 
         return $productMedias;

--- a/src/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Entity/ProductSerializer.php
+++ b/src/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Entity/ProductSerializer.php
@@ -150,7 +150,7 @@ class ProductSerializer extends EntitySerializer
             yield 'cover' => $this->findCoverProductMediaId($deserialized['id'], $deserialized['cover'], $context);
         }
 
-        if (!empty($deserialized['parentId']) && !empty($deserialized['options'])) {
+        if (($deserialized['parentId'] ?? '') !== '' && ($deserialized['options'] ?? []) !== []) {
             yield 'configuratorSettings' => $this->findConfiguratorSettings($deserialized['parentId'], $deserialized['options'], $context);
         }
     }
@@ -294,7 +294,7 @@ class ProductSerializer extends EntitySerializer
         $configuratorSettings = [];
 
         foreach ($options as $option) {
-            if (empty($option['id'])) {
+            if (($option['id'] ?? '') === '') {
                 continue;
             }
 
@@ -328,7 +328,7 @@ class ProductSerializer extends EntitySerializer
         array $deserialized,
         Context $context
     ): array {
-        if (empty($entity['media'])) {
+        if (($entity['media'] ?? '') === '') {
             return [];
         }
 
@@ -405,7 +405,7 @@ class ProductSerializer extends EntitySerializer
         $urls = [];
         $coverUrl = null;
 
-        if ($productMedias !== [] && !empty($entity['cover'])) {
+        if ($productMedias !== [] && ($entity['cover'] ?? null) !== null) {
             $coverMedia = $entity['cover'] instanceof ProductMediaEntity
                 ? $entity['cover']->jsonSerialize()
                 : $entity['cover'];
@@ -419,7 +419,7 @@ class ProductSerializer extends EntitySerializer
                 ? $productMedia->jsonSerialize()
                 : $productMedia;
 
-            if (empty($productMedia['media'])) {
+            if (($productMedia['media'] ?? null) === null) {
                 continue;
             }
 

--- a/src/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Entity/ProductSerializer.php
+++ b/src/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Entity/ProductSerializer.php
@@ -16,6 +16,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\ManyToOneAssociationField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\OneToManyAssociationField;
+use Shopware\Core\Framework\DataAbstractionLayer\PartialEntity;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsAnyFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
@@ -182,15 +183,17 @@ class ProductSerializer extends EntitySerializer
             return $visibilities;
         }
 
-        // Read the existing visibilities of the whole record in one query. The filters describe a superset, so only
-        // the exact product and sales channel combinations below are used.
+        // Read the existing visibilities of the whole record in one query, loading only the sales channel next to
+        // the id instead of the whole entity.
         $criteria = new Criteria();
         $criteria->addFilter(new EqualsAnyFilter('productId', array_keys($productIds)));
         $criteria->addFilter(new EqualsAnyFilter('salesChannelId', array_keys($salesChannelIds)));
+        $criteria->addFields(['productId', 'salesChannelId']);
 
         $existing = [];
         foreach ($this->visibilityRepository->search($criteria, $context)->getEntities() as $entity) {
-            $existing[$entity->getProductId()][$entity->getSalesChannelId()] = $entity->getId();
+            \assert($entity instanceof PartialEntity);
+            $existing[(string) $entity->get('productId')][(string) $entity->get('salesChannelId')] = (string) $entity->get('id');
         }
 
         foreach ($visibilities as $i => $visibility) {
@@ -285,10 +288,12 @@ class ProductSerializer extends EntitySerializer
         $criteria = new Criteria();
         $criteria->addFilter(new EqualsFilter('productId', $parentId));
         $criteria->addFilter(new EqualsAnyFilter('optionId', $optionIds));
+        $criteria->addFields(['optionId']);
 
         $existing = [];
         foreach ($this->productConfiguratorSettingRepository->search($criteria, $context)->getEntities() as $entity) {
-            $existing[$entity->getOptionId()] = $entity->getId();
+            \assert($entity instanceof PartialEntity);
+            $existing[(string) $entity->get('optionId')] = (string) $entity->get('id');
         }
 
         $configuratorSettings = [];
@@ -379,10 +384,12 @@ class ProductSerializer extends EntitySerializer
         $criteria = new Criteria();
         $criteria->addFilter(new EqualsFilter('productId', $deserialized['id']));
         $criteria->addFilter(new EqualsAnyFilter('media.id', $mediaIds));
+        $criteria->addFields(['mediaId']);
 
         $existing = [];
         foreach ($this->productMediaRepository->search($criteria, $context)->getEntities() as $productMediaEntity) {
-            $existing[$productMediaEntity->getMediaId()] = $productMediaEntity->getId();
+            \assert($productMediaEntity instanceof PartialEntity);
+            $existing[(string) $productMediaEntity->get('mediaId')] = (string) $productMediaEntity->get('id');
         }
 
         foreach ($productMedias as $i => $productMedia) {

--- a/src/Core/Content/Media/DataAbstractionLayer/MediaFolderIndexer.php
+++ b/src/Core/Content/Media/DataAbstractionLayer/MediaFolderIndexer.php
@@ -109,21 +109,23 @@ class MediaFolderIndexer extends EntityIndexer
             $this->connection->prepare('UPDATE media_folder SET media_folder_configuration_id = :configId WHERE id = :id')
         );
 
+        // Load the parent configuration of every folder of the message in a single query instead of one per folder
+        $parentConfigurationIds = $this->connection->fetchAllKeyValue(
+            'SELECT LOWER(HEX(child.id)) as id,
+                   LOWER(HEX(parent.media_folder_configuration_id)) AS parent_configuration_id
+            FROM media_folder child
+                LEFT JOIN media_folder as parent
+                    ON parent.id = child.parent_id
+            WHERE child.id IN (:ids)
+                AND child.media_folder_configuration_id != parent.media_folder_configuration_id
+                AND child.use_parent_configuration = 1',
+            ['ids' => Uuid::fromHexToBytesList($ids)],
+            ['ids' => ArrayParameterType::BINARY]
+        );
+
         $children = [];
         foreach ($ids as $id) {
-            $folder = $this->connection->fetchAssociative(
-                'SELECT LOWER(HEX(child.id)) as id,
-                       LOWER(HEX(parent.media_folder_configuration_id)) AS parent_configuration_id
-                FROM media_folder child
-                    LEFT JOIN media_folder as parent
-                        ON parent.id = child.parent_id
-                WHERE child.id = :id
-                    AND child.media_folder_configuration_id != parent.media_folder_configuration_id
-                    AND child.use_parent_configuration = 1',
-                ['id' => Uuid::fromHexToBytes($id)]
-            );
-
-            if ($folder === false) {
+            if (!isset($parentConfigurationIds[$id])) {
                 continue;
             }
 
@@ -132,7 +134,7 @@ class MediaFolderIndexer extends EntityIndexer
             foreach (array_merge([$id], $children) as $folderId) {
                 $update->execute([
                     'id' => Uuid::fromHexToBytes($folderId),
-                    'configId' => Uuid::fromHexToBytes($folder['parent_configuration_id']),
+                    'configId' => Uuid::fromHexToBytes($parentConfigurationIds[$id]),
                 ]);
             }
         }

--- a/src/Core/Content/ProductExport/EventListener/ProductExportEventListener.php
+++ b/src/Core/Content/ProductExport/EventListener/ProductExportEventListener.php
@@ -40,32 +40,35 @@ class ProductExportEventListener implements EventSubscriberInterface
 
     public function afterWrite(EntityWrittenEvent $event): void
     {
+        $ids = [];
         foreach ($event->getResults()->only(EntityWriteResult::OPERATION_INSERT, EntityWriteResult::OPERATION_UPDATE) as $writeResult) {
             if (!$this->productExportWritten($writeResult)) {
                 continue;
             }
 
             $primaryKey = $writeResult->getPrimaryKey();
-            $primaryKey = \is_array($primaryKey) ? $primaryKey['id'] : $primaryKey;
+            $ids[] = \is_array($primaryKey) ? $primaryKey['id'] : $primaryKey;
+        }
 
-            $this->productExportRepository->update(
-                [
-                    [
-                        'id' => $primaryKey,
-                        'generatedAt' => null,
-                        'nextGenerationAt' => null,
-                        // Reset stuck runs when a user/admin edits the export
-                        'isRunning' => false,
-                    ],
-                ],
-                $event->getContext()
-            );
+        if ($ids === []) {
+            return;
+        }
 
-            $productExport = $this->productExportRepository->search(new Criteria([$primaryKey]), $event->getContext())->getEntities()->first();
-            if (!$productExport) {
-                continue;
-            }
+        // reset and reload all written exports at once instead of one round-trip pair per export
+        $this->productExportRepository->update(
+            array_map(static fn (string $id): array => [
+                'id' => $id,
+                'generatedAt' => null,
+                'nextGenerationAt' => null,
+                // Reset stuck runs when a user/admin edits the export
+                'isRunning' => false,
+            ], $ids),
+            $event->getContext()
+        );
 
+        $productExports = $this->productExportRepository->search(new Criteria($ids), $event->getContext())->getEntities();
+
+        foreach ($productExports as $productExport) {
             $filePath = $this->productExportFileHandler->getFilePath($productExport);
             if ($this->fileSystem->fileExists($filePath)) {
                 $this->fileSystem->delete($filePath);

--- a/src/Core/Content/Seo/SeoUrlPersister.php
+++ b/src/Core/Content/Seo/SeoUrlPersister.php
@@ -245,6 +245,15 @@ class SeoUrlPersister
     }
 
     /**
+     * Identifies the group a seo url competes in for the canonical flag: the same foreign key, sales channel and
+     * route always resolve to a single canonical seo url.
+     */
+    private function canonicalGroup(string $foreignKey, string $salesChannelId, string $routeName): string
+    {
+        return $foreignKey . "\0" . $salesChannelId . "\0" . $routeName;
+    }
+
+    /**
      * @param array<string> $seoPathInfos
      *
      * @return array<array<string, mixed>>
@@ -283,34 +292,62 @@ class SeoUrlPersister
 
         $languageId = Uuid::fromHexToBytes($languageId);
 
-        $ids = [];
+        // A seo url without a sales channel can never match `sales_channel_id = :salesChannelId`, so it is skipped
+        // here just as the per-url lookup skipped it before.
+        $wanted = [];
         foreach ($seoUrls as $seoUrl) {
-            $id = $this->connection->fetchOne(
-                'SELECT id
-                 FROM seo_url
-                 WHERE language_id = :languageId
-                   AND foreign_key = :foreignKey
-                   AND sales_channel_id = :salesChannelId
-                   AND route_name = :routeName
-                   AND is_canonical IS NULL AND is_deleted = 0
-                 ORDER BY created_at ASC
-                 LIMIT 1',
-                [
-                    'languageId' => $languageId,
-                    'foreignKey' => $seoUrl['foreignKey'],
-                    'salesChannelId' => $seoUrl['salesChannelId'],
-                    'routeName' => (string) $seoUrl['routeName'],
-                ]
-            );
-
-            if ($id !== false) {
-                $ids[] = $id;
+            if ($seoUrl['salesChannelId'] === null) {
+                continue;
             }
+
+            $wanted[$this->canonicalGroup($seoUrl['foreignKey'], $seoUrl['salesChannelId'], (string) $seoUrl['routeName'])] = true;
+        }
+
+        if ($wanted === []) {
+            return;
+        }
+
+        // Load the candidates of all groups in a single query, ordered so that the earliest created seo url of a
+        // group is the first row seen for it, instead of running one `LIMIT 1` lookup per seo url.
+        $candidates = $this->connection->fetchAllAssociative(
+            'SELECT id, foreign_key, sales_channel_id, route_name
+             FROM seo_url
+             WHERE language_id = :languageId
+               AND foreign_key IN (:foreignKeys)
+               AND sales_channel_id IN (:salesChannelIds)
+               AND route_name IN (:routeNames)
+               AND is_canonical IS NULL AND is_deleted = 0
+             ORDER BY created_at ASC',
+            [
+                'languageId' => $languageId,
+                'foreignKeys' => array_column($seoUrls, 'foreignKey'),
+                'salesChannelIds' => array_values(array_filter(array_column($seoUrls, 'salesChannelId'))),
+                'routeNames' => array_map('strval', array_column($seoUrls, 'routeName')),
+            ],
+            [
+                'foreignKeys' => ArrayParameterType::BINARY,
+                'salesChannelIds' => ArrayParameterType::BINARY,
+                'routeNames' => ArrayParameterType::STRING,
+            ]
+        );
+
+        $ids = [];
+        foreach ($candidates as $candidate) {
+            $group = $this->canonicalGroup($candidate['foreign_key'], $candidate['sales_channel_id'], (string) $candidate['route_name']);
+
+            if (!isset($wanted[$group])) {
+                continue;
+            }
+
+            // the first row of a group is its earliest created seo url
+            $ids[$group] ??= $candidate['id'];
         }
 
         if ($ids === []) {
             return;
         }
+
+        $ids = array_values($ids);
 
         $this->connection->executeStatement(
             'UPDATE seo_url SET is_canonical = 1, is_modified = 1 WHERE id IN (:ids)',

--- a/src/Core/Content/Seo/SeoUrlPersister.php
+++ b/src/Core/Content/Seo/SeoUrlPersister.php
@@ -103,7 +103,7 @@ class SeoUrlPersister
 
             $updatedFks[] = $fk;
 
-            if (!empty($seoUrl['error'])) {
+            if (($seoUrl['error'] ?? null) !== null) {
                 continue;
             }
             $existing = $canonicals[$fk][$salesChannelId] ?? null;

--- a/src/Core/Framework/App/Lifecycle/Update/AppUpdater.php
+++ b/src/Core/Framework/App/Lifecycle/Update/AppUpdater.php
@@ -36,6 +36,16 @@ class AppUpdater extends AbstractAppUpdater
         $extensions = $this->extensionDataProvider->getInstalledExtensions($context, true);
         $extensions = $extensions->filterByType(ExtensionStruct::EXTENSION_TYPE_APP);
 
+        $localIds = array_values(array_filter(array_map(
+            static fn (ExtensionStruct $extension): ?string => $extension->getLocalId(),
+            $extensions->getElements()
+        )));
+
+        // read every installed app once instead of one query per extension
+        $localApps = $localIds === []
+            ? new AppCollection()
+            : $this->appRepo->search(new Criteria($localIds), $context)->getEntities();
+
         $outdatedApps = [];
 
         foreach ($extensions as $extension) {
@@ -43,7 +53,7 @@ class AppUpdater extends AbstractAppUpdater
             if (!$id) {
                 continue;
             }
-            $localApp = $this->appRepo->search(new Criteria([$id]), $context)->getEntities()->first();
+            $localApp = $localApps->get($id);
             if ($localApp === null) {
                 continue;
             }

--- a/src/Core/System/CustomField/CustomFieldSetPersister.php
+++ b/src/Core/System/CustomField/CustomFieldSetPersister.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Core\System\CustomField;
 
+use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\Connection;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
@@ -67,6 +68,16 @@ class CustomFieldSetPersister
         $obsoleteRelations = [];
         $obsoleteFields = [];
 
+        // Read the relations and fields of all known sets up front instead of two queries per set
+        $relationsBySet = $this->fetchGroupedBySet(
+            'SELECT LOWER(HEX(set_id)) AS setId, entity_name AS `key`, id FROM custom_field_set_relation WHERE set_id IN (:ids)',
+            array_values($existingCustomFieldSets)
+        );
+        $fieldsBySet = $this->fetchGroupedBySet(
+            'SELECT LOWER(HEX(set_id)) AS setId, name AS `key`, id FROM custom_field WHERE set_id IN (:ids)',
+            array_values($existingCustomFieldSets)
+        );
+
         foreach ($customFields->getCustomFieldSets() as $customFieldSet) {
             if (!\array_key_exists($customFieldSet->getName(), $existingCustomFieldSets)) {
                 $existingRelations = $existingFields = [];
@@ -82,18 +93,8 @@ class CustomFieldSetPersister
 
             $customFieldSetId = $existingCustomFieldSets[$customFieldSet->getName()];
 
-            $existingRelations = Uuid::fromBytesToHexList(
-                $this->connection->fetchAllKeyValue(
-                    'SELECT entity_name, id FROM custom_field_set_relation WHERE set_id = :setId',
-                    ['setId' => Uuid::fromHexToBytes($customFieldSetId)]
-                )
-            );
-            $existingFields = Uuid::fromBytesToHexList(
-                $this->connection->fetchAllKeyValue(
-                    'SELECT name, id FROM custom_field WHERE set_id = :setId',
-                    ['setId' => Uuid::fromHexToBytes($customFieldSetId)]
-                )
-            );
+            $existingRelations = $relationsBySet[$customFieldSetId] ?? [];
+            $existingFields = $fieldsBySet[$customFieldSetId] ?? [];
             $entityData = $customFieldSet->toEntityArray($appId, $existingRelations, $existingFields, $customFieldSetId);
             if ($extensionName !== null) {
                 $entityData['extensionName'] = $extensionName;
@@ -156,6 +157,33 @@ class CustomFieldSetPersister
         }
 
         return $existingCustomFieldSets;
+    }
+
+    /**
+     * Reads rows of `setId`, `key` and `id` for all given custom field set ids at once.
+     *
+     * @param list<string> $customFieldSetIds
+     *
+     * @return array<string, array<string, string>> the hex ids, keyed by custom field set id and row key
+     */
+    private function fetchGroupedBySet(string $query, array $customFieldSetIds): array
+    {
+        if ($customFieldSetIds === []) {
+            return [];
+        }
+
+        $grouped = [];
+        $rows = $this->connection->fetchAllAssociative(
+            $query,
+            ['ids' => Uuid::fromHexToBytesList($customFieldSetIds)],
+            ['ids' => ArrayParameterType::BINARY]
+        );
+
+        foreach ($rows as $row) {
+            $grouped[(string) $row['setId']][(string) $row['key']] = Uuid::fromBytesToHex((string) $row['id']);
+        }
+
+        return $grouped;
     }
 
     /**

--- a/src/Storefront/Checkout/Customer/CustomerGroupSubscriber.php
+++ b/src/Storefront/Checkout/Customer/CustomerGroupSubscriber.php
@@ -141,6 +141,9 @@ class CustomerGroupSubscriber implements EventSubscriberInterface
         $groups = $this->customerGroupRepository->search($criteria, $context)->getEntities();
         $buildUrls = [];
 
+        // Resolve the active languages of every registration sales channel in one query instead of one per channel
+        $activeLanguages = $this->findActiveLanguages($groups, $context);
+
         foreach ($groups as $group) {
             if ($group->getRegistrationSalesChannels() === null) {
                 continue;
@@ -156,13 +159,9 @@ class CustomerGroupSubscriber implements EventSubscriberInterface
                 }
 
                 $languageIds = $registrationSalesChannel->getLanguages()->getIds();
-                $languageCriteria = new Criteria($languageIds);
-                $languageCriteria->addFilter(new EqualsFilter('active', true));
-
-                $languageCollection = $this->languageRepository->search($languageCriteria, $context)->getEntities();
 
                 foreach ($languageIds as $languageId) {
-                    $language = $languageCollection->get($languageId);
+                    $language = $activeLanguages->get($languageId);
                     if (!$language) {
                         continue;
                     }
@@ -209,6 +208,30 @@ class CustomerGroupSubscriber implements EventSubscriberInterface
                 $config['salesChannel']
             );
         }
+    }
+
+    /**
+     * The active languages of every registration sales channel of the given groups, in one query.
+     */
+    private function findActiveLanguages(CustomerGroupCollection $groups, Context $context): LanguageCollection
+    {
+        $languageIds = [];
+        foreach ($groups as $group) {
+            foreach ($group->getRegistrationSalesChannels() ?? [] as $registrationSalesChannel) {
+                foreach ($registrationSalesChannel->getLanguages()?->getIds() ?? [] as $languageId) {
+                    $languageIds[$languageId] = true;
+                }
+            }
+        }
+
+        if ($languageIds === []) {
+            return new LanguageCollection();
+        }
+
+        $criteria = new Criteria(array_keys($languageIds));
+        $criteria->addFilter(new EqualsFilter('active', true));
+
+        return $this->languageRepository->search($criteria, $context)->getEntities();
     }
 
     private function getTranslatedTitle(?CustomerGroupTranslationCollection $translations, LanguageEntity $language): string

--- a/src/Storefront/Theme/ThemeLifecycleService.php
+++ b/src/Storefront/Theme/ThemeLifecycleService.php
@@ -16,6 +16,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Entity;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsAnyFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\Validation\RestrictDeleteViolationException;
 use Shopware\Core\Framework\Deprecation\BCChange\BecomesFinal;
@@ -416,6 +417,10 @@ class ThemeLifecycleService
         }
 
         if (\array_key_exists('fields', $baseConfig)) {
+            // Resolve which media file names already exist in one query instead of one per configuration field.
+            // The set covers every media field of the configuration, so it is a superset of the names looked up below.
+            $existingFileNames = $this->findExistingMediaFileNames($baseConfig['fields'], $context);
+
             foreach ($baseConfig['fields'] as $key => $field) {
                 if ($this->hasNewMedia($field) === false) {
                     continue;
@@ -440,9 +445,7 @@ class ThemeLifecycleService
                         continue;
                     }
 
-                    $criteriaMedia = new Criteria();
-                    $criteriaMedia->addFilter(new EqualsFilter('fileName', basename($path)));
-                    if ($this->mediaRepository->searchIds($criteriaMedia, $context)->getTotal() > 0) {
+                    if (isset($existingFileNames[basename($path)])) {
                         continue;
                     }
 
@@ -640,6 +643,39 @@ class ThemeLifecycleService
         return $currentThemeConfig->getTechnicalName() !== $parentConfig->getTechnicalName()
             && \in_array('@' . $parentConfig->getTechnicalName(), $currentThemeConfig->getStyleFiles()->getFilepaths(), true)
         ;
+    }
+
+    /**
+     * The file names of the given media configuration fields that already exist as media.
+     *
+     * @param array<int|string, mixed> $fields
+     *
+     * @return array<string, true>
+     */
+    private function findExistingMediaFileNames(array $fields, Context $context): array
+    {
+        $fileNames = [];
+        foreach ($fields as $field) {
+            if (!\is_array($field) || $this->hasNewMedia($field) === false) {
+                continue;
+            }
+
+            $fileNames[basename((string) $field['value'])] = true;
+        }
+
+        if ($fileNames === []) {
+            return [];
+        }
+
+        $criteria = new Criteria();
+        $criteria->addFilter(new EqualsAnyFilter('fileName', array_keys($fileNames)));
+
+        $existing = [];
+        foreach ($this->mediaRepository->search($criteria, $context)->getEntities() as $media) {
+            $existing[(string) $media->getFileName()] = true;
+        }
+
+        return $existing;
     }
 
     /**

--- a/src/Storefront/Theme/ThemeLifecycleService.php
+++ b/src/Storefront/Theme/ThemeLifecycleService.php
@@ -15,6 +15,7 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Entity;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\DataAbstractionLayer\PartialEntity;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsAnyFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
@@ -669,10 +670,12 @@ class ThemeLifecycleService
 
         $criteria = new Criteria();
         $criteria->addFilter(new EqualsAnyFilter('fileName', array_keys($fileNames)));
+        $criteria->addFields(['fileName']);
 
         $existing = [];
         foreach ($this->mediaRepository->search($criteria, $context)->getEntities() as $media) {
-            $existing[(string) $media->getFileName()] = true;
+            \assert($media instanceof PartialEntity);
+            $existing[(string) $media->get('fileName')] = true;
         }
 
         return $existing;

--- a/tests/unit/Administration/Framework/App/Subscriber/SystemLanguageChangedSubscriberTest.php
+++ b/tests/unit/Administration/Framework/App/Subscriber/SystemLanguageChangedSubscriberTest.php
@@ -144,6 +144,9 @@ class SystemLanguageChangedSubscriberTest extends TestCase
             $newLocale->getCode(),
         ));
 
+        // the snippets of all apps are written in a single update
+        static::assertCount(1, $snippetRepository->updates);
+
         static::assertSame([
             'id' => $snippetOneToUpdate->getId(),
             'localeId' => $previousLocale->getId(),
@@ -152,7 +155,7 @@ class SystemLanguageChangedSubscriberTest extends TestCase
         static::assertSame([
             'id' => $snippetTwoToUpdate->getId(),
             'localeId' => $previousLocale->getId(),
-        ], $snippetRepository->updates[1][0]);
+        ], $snippetRepository->updates[0][1]);
     }
 
     #[DataProvider('localeCodes')]
@@ -164,8 +167,8 @@ class SystemLanguageChangedSubscriberTest extends TestCase
         ]);
 
         $snippetRepository = new StaticEntityRepository([new AppAdministrationSnippetCollection([
-            $this->createSnippet('app-one-id', $previousLocale->getId()),
-            $this->createSnippet('app-two-id', $previousLocale->getId()),
+            $snippetOneToUpdate = $this->createSnippet('app-one-id', $previousLocale->getId()),
+            $snippetTwoToUpdate = $this->createSnippet('app-two-id', $previousLocale->getId()),
         ])]);
 
         $subscriber = new SystemLanguageChangedSubscriber(
@@ -179,7 +182,12 @@ class SystemLanguageChangedSubscriberTest extends TestCase
             $newLocale->getCode(),
         ));
 
-        static::assertCount(2, $snippetRepository->updates);
+        // one update carrying the snippet of both apps, not one update per app
+        static::assertCount(1, $snippetRepository->updates);
+        static::assertSame([
+            ['id' => $snippetOneToUpdate->getId(), 'localeId' => $newLocale->getId()],
+            ['id' => $snippetTwoToUpdate->getId(), 'localeId' => $newLocale->getId()],
+        ], $snippetRepository->updates[0]);
     }
 
     public static function localeCodes(): \Generator

--- a/tests/unit/Administration/Framework/App/Subscriber/SystemLanguageChangedSubscriberTest.php
+++ b/tests/unit/Administration/Framework/App/Subscriber/SystemLanguageChangedSubscriberTest.php
@@ -198,6 +198,32 @@ class SystemLanguageChangedSubscriberTest extends TestCase
         yield ['fr-FR'];
     }
 
+    public function testWithoutSnippetsForEitherLocaleNothingIsWritten(): void
+    {
+        $localeRepository = new StaticEntityRepository([
+            new LocaleCollection([$previousLocale = $this->createLocale('en-GB')]),
+            new LocaleCollection([$newLocale = $this->createLocale('de-AT')]),
+        ]);
+
+        // the app has snippets, but none for the previous or the new locale
+        $snippetRepository = new StaticEntityRepository([new AppAdministrationSnippetCollection([
+            $this->createSnippet('app-one-id', 'other-locale-id'),
+        ])]);
+
+        $subscriber = new SystemLanguageChangedSubscriber(
+            $localeRepository,
+            $snippetRepository
+        );
+
+        $subscriber->onSystemLanguageChanged(new SystemLanguageChangeEvent(
+            'previous-language-id',
+            $previousLocale->getCode(),
+            $newLocale->getCode(),
+        ));
+
+        static::assertSame([], $snippetRepository->updates);
+    }
+
     private function createLocale(string $code): LocaleEntity
     {
         return (new LocaleEntity())->assign([

--- a/tests/unit/Core/Content/Seo/SeoUrlPersisterTest.php
+++ b/tests/unit/Core/Content/Seo/SeoUrlPersisterTest.php
@@ -312,6 +312,61 @@ class SeoUrlPersisterTest extends TestCase
         );
     }
 
+    public function testInuseSeoPathsWithoutCandidatesAreNotMarkedCanonical(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $seoUrlPersister = $this->createSeoUrlPersister($connection);
+
+        $seoUrls = [
+            [
+                'languageId' => Uuid::randomHex(),
+                'foreignKey' => Uuid::randomHex(),
+                'salesChannelId' => Uuid::randomHex(),
+                'routeName' => 'test-route',
+                'pathInfo' => 'path1',
+                'seoPathInfo' => 'path1',
+            ],
+        ];
+
+        $inUse = [
+            [
+                'id' => 'id1',
+                'languageId' => Uuid::randomHex(),
+                'salesChannelId' => Uuid::randomBytes(),
+                'foreignKey' => Uuid::randomBytes(),
+                'routeName' => 'test-route',
+            ],
+        ];
+
+        // the only candidate belongs to another group, so no seo url becomes canonical
+        $candidates = [
+            [
+                'id' => Uuid::randomBytes(),
+                'foreign_key' => Uuid::randomBytes(),
+                'sales_channel_id' => $inUse[0]['salesChannelId'],
+                'route_name' => 'test-route',
+            ],
+        ];
+
+        $connection->expects($this->exactly(2))
+            ->method('fetchAllAssociative')
+            ->willReturnOnConsecutiveCalls($inUse, $candidates);
+
+        $connection->expects($this->never())
+            ->method('executeStatement');
+
+        $seoChannel = new SalesChannelEntity();
+        $seoChannel->setId(Uuid::randomHex());
+
+        $seoUrlPersister->updateSeoUrls(
+            Context::createDefaultContext(),
+            'test-route',
+            ['foreignKey' => Uuid::randomHex()],
+            $seoUrls,
+            $seoChannel
+        );
+    }
+
     /**
      * Runs an update for one entity that already has a canonical SEO URL and returns every value that was
      * written to the database, so a test can check whether a row carrying a given `seo_path_info` was

--- a/tests/unit/Core/Content/Seo/SeoUrlPersisterTest.php
+++ b/tests/unit/Core/Content/Seo/SeoUrlPersisterTest.php
@@ -244,28 +244,51 @@ class SeoUrlPersisterTest extends TestCase
         $id2 = Uuid::randomBytes();
         $expectedIds = [$id1, $id2];
 
-        $connection->expects($this->once())
-            ->method('fetchAllAssociative')
-            ->willReturn([
-                [
-                    'id' => 'id1',
-                    'languageId' => Uuid::randomHex(),
-                    'salesChannelId' => Uuid::randomHex(),
-                    'foreignKey' => Uuid::randomHex(),
-                    'routeName' => 'test-route',
-                ],
-                [
-                    'id' => 'id2',
-                    'languageId' => Uuid::randomHex(),
-                    'salesChannelId' => Uuid::randomHex(),
-                    'foreignKey' => Uuid::randomHex(),
-                    'routeName' => 'test-route',
-                ],
-            ]);
+        $inUse = [
+            [
+                'id' => 'id1',
+                'languageId' => Uuid::randomHex(),
+                'salesChannelId' => Uuid::randomBytes(),
+                'foreignKey' => Uuid::randomBytes(),
+                'routeName' => 'test-route',
+            ],
+            [
+                'id' => 'id2',
+                'languageId' => Uuid::randomHex(),
+                'salesChannelId' => Uuid::randomBytes(),
+                'foreignKey' => Uuid::randomBytes(),
+                'routeName' => 'test-route',
+            ],
+        ];
+
+        // the earliest created candidate of each group wins, so the second row of group one must be ignored
+        $candidates = [
+            [
+                'id' => $id1,
+                'foreign_key' => $inUse[0]['foreignKey'],
+                'sales_channel_id' => $inUse[0]['salesChannelId'],
+                'route_name' => 'test-route',
+            ],
+            [
+                'id' => Uuid::randomBytes(),
+                'foreign_key' => $inUse[0]['foreignKey'],
+                'sales_channel_id' => $inUse[0]['salesChannelId'],
+                'route_name' => 'test-route',
+            ],
+            [
+                'id' => $id2,
+                'foreign_key' => $inUse[1]['foreignKey'],
+                'sales_channel_id' => $inUse[1]['salesChannelId'],
+                'route_name' => 'test-route',
+            ],
+        ];
 
         $connection->expects($this->exactly(2))
-            ->method('fetchOne')
-            ->willReturnOnConsecutiveCalls($id1, $id2);
+            ->method('fetchAllAssociative')
+            ->willReturnOnConsecutiveCalls($inUse, $candidates);
+
+        $connection->expects($this->never())
+            ->method('fetchOne');
 
         $connection->expects($this->once())
             ->method('executeStatement')

--- a/tests/unit/Core/Framework/App/Lifecycle/Update/AppUpdaterTest.php
+++ b/tests/unit/Core/Framework/App/Lifecycle/Update/AppUpdaterTest.php
@@ -1,0 +1,112 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\App\Lifecycle\Update;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\App\AppCollection;
+use Shopware\Core\Framework\App\AppEntity;
+use Shopware\Core\Framework\App\Lifecycle\Update\AppUpdater;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Store\Services\AbstractExtensionDataProvider;
+use Shopware\Core\Framework\Store\Services\AbstractStoreAppLifecycleService;
+use Shopware\Core\Framework\Store\Services\ExtensionDownloader;
+use Shopware\Core\Framework\Store\Struct\ExtensionCollection;
+use Shopware\Core\Framework\Store\Struct\ExtensionStruct;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\Test\Stub\DataAbstractionLayer\StaticEntityRepository;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+#[CoversClass(AppUpdater::class)]
+class AppUpdaterTest extends TestCase
+{
+    public function testUpdatesOutdatedAppsAndReadsEveryInstalledAppWithOneSearch(): void
+    {
+        $outdatedId = Uuid::randomHex();
+        $upToDateId = Uuid::randomHex();
+
+        $extensions = new ExtensionCollection([
+            $this->createExtension('OutdatedApp', $outdatedId, '2.0.0'),
+            $this->createExtension('UpToDateApp', $upToDateId, '1.0.0'),
+            // an extension that was never installed locally has no id and is skipped
+            $this->createExtension('NotInstalledApp', null, '3.0.0'),
+        ]);
+
+        /** @var StaticEntityRepository<AppCollection> $appRepo */
+        $appRepo = new StaticEntityRepository([
+            new AppCollection([
+                $this->createApp($outdatedId, '1.0.0'),
+                $this->createApp($upToDateId, '1.0.0'),
+            ]),
+        ]);
+
+        $downloader = $this->createMock(ExtensionDownloader::class);
+        $downloader->expects($this->once())->method('download')->with('OutdatedApp');
+
+        $appLifecycle = $this->createMock(AbstractStoreAppLifecycleService::class);
+        $appLifecycle->expects($this->once())->method('updateExtension')->with('OutdatedApp', false);
+
+        $this->createUpdater($extensions, $appRepo, $downloader, $appLifecycle)
+            ->updateApps(Context::createDefaultContext());
+
+        // the single prepared search was consumed, so all apps were read at once
+        static::assertSame([], $appRepo->searches);
+    }
+
+    public function testWithoutLocallyInstalledExtensionsNothingIsRead(): void
+    {
+        $extensions = new ExtensionCollection([$this->createExtension('NotInstalledApp', null, '3.0.0')]);
+
+        /** @var StaticEntityRepository<AppCollection> $appRepo */
+        $appRepo = new StaticEntityRepository([]);
+
+        $downloader = $this->createMock(ExtensionDownloader::class);
+        $downloader->expects($this->never())->method('download');
+
+        $appLifecycle = $this->createMock(AbstractStoreAppLifecycleService::class);
+        $appLifecycle->expects($this->never())->method('updateExtension');
+
+        $this->createUpdater($extensions, $appRepo, $downloader, $appLifecycle)
+            ->updateApps(Context::createDefaultContext());
+    }
+
+    /**
+     * @param StaticEntityRepository<AppCollection> $appRepo
+     */
+    private function createUpdater(
+        ExtensionCollection $extensions,
+        StaticEntityRepository $appRepo,
+        ExtensionDownloader $downloader,
+        AbstractStoreAppLifecycleService $appLifecycle
+    ): AppUpdater {
+        $dataProvider = $this->createMock(AbstractExtensionDataProvider::class);
+        $dataProvider->method('getInstalledExtensions')->willReturn($extensions);
+
+        return new AppUpdater($dataProvider, $appRepo, $downloader, $appLifecycle);
+    }
+
+    private function createExtension(string $name, ?string $localId, string $latestVersion): ExtensionStruct
+    {
+        return (new ExtensionStruct())->assign([
+            'name' => $name,
+            'label' => $name,
+            'type' => ExtensionStruct::EXTENSION_TYPE_APP,
+            'localId' => $localId,
+            'latestVersion' => $latestVersion,
+        ]);
+    }
+
+    private function createApp(string $id, string $version): AppEntity
+    {
+        $app = new AppEntity();
+        $app->setUniqueIdentifier($id);
+        $app->setId($id);
+        $app->setVersion($version);
+
+        return $app;
+    }
+}

--- a/tests/unit/Core/System/CustomField/CustomFieldSetPersisterTest.php
+++ b/tests/unit/Core/System/CustomField/CustomFieldSetPersisterTest.php
@@ -156,23 +156,19 @@ class CustomFieldSetPersisterTest extends TestCase
 
         $fixture = $this->loadFixtureSingleSet();
 
-        $this->connection->method('fetchAllKeyValue')->willReturnCallback(
+        // existing set lookup by extension_name (plugin behavior), keyed by binary id, value is the name
+        $this->connection->method('fetchAllKeyValue')->willReturn([Uuid::fromHexToBytes($setId) => 'test_set']);
+
+        // the relations and fields of all known sets are read in one query each, grouped by set id
+        $this->connection->method('fetchAllAssociative')->willReturnCallback(
             function (string $sql) use ($setId, $obsoleteRelationId, $obsoleteFieldId): array {
-                if (str_contains($sql, 'FROM custom_field_set ')) {
-                    // existing set lookup by extension_name (plugin behavior),
-                    // keyed by binary id, value is the name
-                    return [Uuid::fromHexToBytes($setId) => 'test_set'];
-                }
-
                 if (str_contains($sql, 'FROM custom_field_set_relation')) {
-                    // keyed by entity_name, value is the binary id; this relation is
-                    // no longer defined in the XML -> obsolete
-                    return ['obsolete_entity' => Uuid::fromHexToBytes($obsoleteRelationId)];
+                    // this relation is no longer defined in the XML -> obsolete
+                    return [['setId' => $setId, 'key' => 'obsolete_entity', 'id' => Uuid::fromHexToBytes($obsoleteRelationId)]];
                 }
 
-                // keyed by field name, value is the binary id; this field is
-                // no longer defined in the XML -> obsolete
-                return ['obsolete_field' => Uuid::fromHexToBytes($obsoleteFieldId)];
+                // this field is no longer defined in the XML -> obsolete
+                return [['setId' => $setId, 'key' => 'obsolete_field', 'id' => Uuid::fromHexToBytes($obsoleteFieldId)]];
             }
         );
 


### PR DESCRIPTION
### 1. Why is this change necessary?

Each of these places ran one query per processed record instead of one query for all of them, so the number of database round-trips grew with the amount of data. They are the batchable findings of the `NoQueryInLoopRule` static analysis rule (#18922), which reports queries executed inside a loop.

The import serializers were the worst of them, because the cost is per *sub-value* of a record rather than per record: `deserialize()` runs once per CSV row and issued a `searchIds()` per visibility, per media url and per variant option of that row. A product with three sales channel visibilities, four images and three options cost about ten queries for that single row.

Those lookups only fire for a record that already carries an id, so they hit re-imports and syncs of existing products rather than a first import of new ones. The variant lookup is the exception: it keys off the parent product and fires either way.

### 2. What does this change do, exactly?

Every change loads the data for all records of a run before the loop, or writes all records at once, and keeps the resulting values and database state identical.

**Reads that scaled with the number of records**

* `MediaFolderIndexer::handle()` read the parent configuration of each folder of an indexing message with its own `SELECT`; they are now read for the whole message in one query.
* `SeoUrlPersister::updateCanonicalSeoUrls()` ran one `ORDER BY created_at ASC LIMIT 1` lookup per seo url to find the earliest candidate of its group. The candidates of all groups are now read in one ordered query, where the first row of a group is that group's earliest seo url. A seo url without a sales channel could never match `sales_channel_id = :salesChannelId` and is still skipped.
* `ProductSerializer` and `ProductCrossSellingSerializer` looked up every existing visibility, configurator setting, product media and cross selling assignment separately; each now reads the existing rows of the whole record in one query and matches them in PHP. `convertMediaStringToArray()` deserializes all urls first, so the media ids of the record are known before the lookup.
* `AppUpdater::updateApps()` read every installed app with its own `search()`; they are now read once and looked up by id.
* `CustomFieldSetPersister` read the relations and fields of each custom field set with two queries per set; both are now read for all sets in one query each.
* `CustomerGroupSubscriber::createUrls()` searched the active languages once per registration sales channel; they are now resolved for all channels before the loop.
* `ThemeLifecycleService::updateMediaInConfiguration()` checked with one query per configuration field whether a media file name exists; the names of all media fields are now resolved once.

**Writes that scaled with the number of records**

* `SystemLanguageChangedSubscriber` wrote its snippet payload per app and now writes all apps in one `update()`.
* `ProductExportEventListener` reset and re-read every written export separately and now resets all of them in one `update()` and reads them back in one `search()`.

A listener on `snippet.written` or `product_export.written` therefore receives one event carrying every record instead of one event per record, which is documented in `RELEASE_INFO-6.7.md`.

**Only the keys each lookup needs are loaded.** The batched lookups replaced `searchIds()` with `search()`, which would read whole entities where the previous code only read ids. They use partial field loading (`Criteria::addFields()`), so a lookup reads the id plus the one or two keys it matches on.

**The constant side of a lookup is passed explicitly.** `findAssignedProductsIds()` and `findVisibilityIds()` used to collect the cross selling and the product out of the entries they were given, which only works because every entry of a record carries the same one. Both now take it as a parameter, so the invariant is part of the signature instead of an assumption about the caller, and the lookup filters a single value. This matches `findConfiguratorSettings()`, which already took its parent product that way.

**Boyscouting.** The three files of this change set that carried baselined PHPStan errors — all of them `empty.notAllowed` — now compare against the value the surrounding code actually handles, and their baseline entries are removed.

**Deliberately not included.** Four sites the rule also reports are not batchable and are better left alone than churned:

* `SearchConfigLoader::load()` — the loop `return`s on the first language of the chain that has a config, so it already performs one query in practice and at most three. Batching it would read config for languages that are never used.
* `ProductCategoryPathsSubscriber` — a hierarchical walk where each level's `parentId` comes from the previous query, and it already caches resolved paths in memory for the whole import.
* `PrimaryKeyResolver::handleManyToManyAssociations()` — one query per many-to-many *field* of the definition, already covering all values of that field with one `OR` filter.
* `MediaFolderIndexer::fetchChildren()` — a second, recursive per folder query in the same loop that the rule does not see because it sits behind a helper. It is left as it is because `$children` is assigned rather than merged in that loop, so the following `treeUpdater->batchUpdate()` only ever receives the children of the last folder. That looks like a defect, but changing it changes behaviour and does not belong in a performance change.

The per record primary key lookup of `PrimaryKeyResolver` is batched separately, because it needs the import to announce a window of rows rather than a local change.

### 3. Describe each step to reproduce the issue or behaviour.

1. Enable the SQL logger and import a CSV of products that carry visibilities, variant options, images and cross selling assignments, using a file whose rows already exist (or an `updateBy` mapping), so the id lookups run.
2. Before this change the query log contains one `SELECT` per visibility, per option, per image and per assigned product of every row; after it, one per record for each of those lookups.
3. The imported products and their visibilities, configurator settings, media and cross selling assignments are identical, which the existing `ProductSerializerTest`, `ProductCrossSellingSerializerTest` and `ImportExportTest` integration tests assert.
4. The same holds for a media folder reindex, SEO URL generation and a theme refresh, covered by their existing integration tests.

### 4. Please link to the relevant issues (if any).

relates #18922

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [x] I have written or adjusted the documentation and agent skills according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
