### PR TITLE
fix: reset google recaptcha v2 after failed form submission

### DIFF
--- a/src/Storefront/Resources/app/storefront/src/plugin/captcha/google-re-captcha/google-re-captcha-base.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/captcha/google-re-captcha/google-re-captcha-base.plugin.js
@@ -60,6 +60,15 @@ export default class GoogleReCaptchaBasePlugin extends Plugin {
     }
 
     /**
+     * Resets the captcha after the form was submitted via AJAX. Concrete captcha versions
+     * override this to clear their widget state. Versions that already request a fresh token on
+     * every submit (e.g. reCAPTCHA v3) do not need to reset.
+     */
+    resetGreCaptcha() {
+        // handle by child plugin
+    }
+
+    /**
      * tries to get the closest form
      *
      * @returns {HTMLElement|boolean}
@@ -78,6 +87,33 @@ export default class GoogleReCaptchaBasePlugin extends Plugin {
 
     _registerEvents() {
         this._form.addEventListener('submit', this._onFormSubmitCallback.bind(this), { capture: true });
+
+        // Once the form's AJAX submission returns, the round-trip is complete and any captcha
+        // token that was sent has been consumed. Re-enable submitting and reset the captcha so a
+        // single-use token is never sent twice. This matters when the form stays on screen after
+        // a server-side validation error: the `_captcha` route flag validates (and consumes) the
+        // token before the remaining fields are validated, so a failed field validation would
+        // otherwise leave a stale token behind that fails on the next submission.
+        this._onFormAjaxResponseCallback = this._onFormAjaxResponse.bind(this);
+        this._form.addEventListener('onFormResponse', this._onFormAjaxResponseCallback);
+        this._form.addEventListener('onAfterAjaxSubmit', this._onFormAjaxResponseCallback);
+    }
+
+    /**
+     * Handles the completion of an AJAX form submission emitted by the form handler plugins.
+     *
+     * @private
+     */
+    _onFormAjaxResponse() {
+        this._formSubmitting = false;
+        this.resetGreCaptcha();
+    }
+
+    destroy() {
+        if (this._form && this._onFormAjaxResponseCallback) {
+            this._form.removeEventListener('onFormResponse', this._onFormAjaxResponseCallback);
+            this._form.removeEventListener('onAfterAjaxSubmit', this._onFormAjaxResponseCallback);
+        }
     }
 
     _submitInvisibleForm() {

--- a/src/Storefront/Resources/app/storefront/src/plugin/captcha/google-re-captcha/google-re-captcha-v2.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/captcha/google-re-captcha/google-re-captcha-v2.plugin.js
@@ -43,6 +43,26 @@ export default class GoogleReCaptchaV2Plugin extends GoogleReCaptchaBasePlugin
         };
     }
 
+    /**
+     * Resets the reCAPTCHA v2 widget so a fresh challenge has to be solved before the next
+     * submission. The cached token and hidden input are cleared as well, so the invisible
+     * variant requests a new token via `execute()` instead of reusing the consumed one, and the
+     * visible variant requires the checkbox to be solved again.
+     */
+    resetGreCaptcha() {
+        if (this.grecaptchaWidgetId === null) {
+            return;
+        }
+
+        this.grecaptcha.reset(this.grecaptchaWidgetId);
+        this.currentToken = null;
+        this.grecaptchaInput.value = '';
+
+        if (!this.options.invisible && this.grecaptchaContainerIframe) {
+            this.grecaptchaContainerIframe.classList.remove(this.options.grecaptchaIframeHasErrorClassSelector);
+        }
+    }
+
     onFormSubmit() {
         if (this.options.invisible) {
             if (this.grecaptchaWidgetId === null) {

--- a/src/Storefront/Resources/app/storefront/test/plugin/captcha/google-re-captcha/google-re-captcha-base.plugin.test.js
+++ b/src/Storefront/Resources/app/storefront/test/plugin/captcha/google-re-captcha/google-re-captcha-base.plugin.test.js
@@ -374,6 +374,50 @@ describe('GoogleReCaptchaBasePlugin tests', () => {
         });
     });
 
+    describe('AJAX response handling', () => {
+        beforeEach(() => {
+            googleReCaptchaBasePlugin._executeGoogleReCaptchaInitialization();
+        });
+
+        test('_onFormAjaxResponse re-enables submitting and resets the captcha', () => {
+            googleReCaptchaBasePlugin._formSubmitting = true;
+            const resetSpy = jest.spyOn(googleReCaptchaBasePlugin, 'resetGreCaptcha');
+
+            googleReCaptchaBasePlugin._onFormAjaxResponse();
+
+            expect(googleReCaptchaBasePlugin._formSubmitting).toBe(false);
+            expect(resetSpy).toHaveBeenCalledTimes(1);
+        });
+
+        test.each([
+            'onFormResponse',
+            'onAfterAjaxSubmit',
+        ])('resets the captcha when the form emits "%s"', (eventName) => {
+            googleReCaptchaBasePlugin._formSubmitting = true;
+            const resetSpy = jest.spyOn(googleReCaptchaBasePlugin, 'resetGreCaptcha');
+
+            googleReCaptchaBasePlugin._form.dispatchEvent(new CustomEvent(eventName));
+
+            expect(googleReCaptchaBasePlugin._formSubmitting).toBe(false);
+            expect(resetSpy).toHaveBeenCalledTimes(1);
+        });
+
+        test('base resetGreCaptcha is a no-op that does not throw', () => {
+            expect(() => googleReCaptchaBasePlugin.resetGreCaptcha()).not.toThrow();
+        });
+
+        test('destroy removes the response listeners', () => {
+            const resetSpy = jest.spyOn(googleReCaptchaBasePlugin, 'resetGreCaptcha');
+            const form = googleReCaptchaBasePlugin._form;
+
+            googleReCaptchaBasePlugin.destroy();
+            form.dispatchEvent(new CustomEvent('onFormResponse'));
+            form.dispatchEvent(new CustomEvent('onAfterAjaxSubmit'));
+
+            expect(resetSpy).not.toHaveBeenCalled();
+        });
+    });
+
     describe('_submitInvisibleForm validation', () => {
         beforeEach(() => {
             googleReCaptchaBasePlugin._executeGoogleReCaptchaInitialization();

--- a/src/Storefront/Resources/app/storefront/test/plugin/captcha/google-re-captcha/google-re-captcha-v2.plugin.test.js
+++ b/src/Storefront/Resources/app/storefront/test/plugin/captcha/google-re-captcha/google-re-captcha-v2.plugin.test.js
@@ -224,6 +224,56 @@ describe('GoogleReCaptchaV2Plugin tests', () => {
         });
     });
 
+    describe('captcha reset after form submission', () => {
+        test('resets the visible widget, clears token and input and removes the error class', () => {
+            googleReCaptchav2Plugin.options.invisible = false;
+            googleReCaptchav2Plugin.grecaptchaWidgetId = 'mockWidgetId';
+            googleReCaptchav2Plugin.currentToken = 'consumed-token';
+            googleReCaptchav2Plugin.grecaptchaInput.value = 'consumed-token';
+            googleReCaptchav2Plugin.grecaptchaContainerIframe = mockIframe;
+            mockIframe.classList.add('has-error');
+
+            googleReCaptchav2Plugin.resetGreCaptcha();
+
+            expect(window.grecaptcha.reset).toHaveBeenCalledWith('mockWidgetId');
+            expect(googleReCaptchav2Plugin.currentToken).toBeNull();
+            expect(googleReCaptchav2Plugin.grecaptchaInput.value).toBe('');
+            expect(mockIframe.classList.contains('has-error')).toBe(false);
+        });
+
+        test('resets the invisible widget without touching the iframe error class', () => {
+            googleReCaptchav2Plugin.options.invisible = true;
+            googleReCaptchav2Plugin.grecaptchaWidgetId = 'mockWidgetId';
+            googleReCaptchav2Plugin.currentToken = 'consumed-token';
+            googleReCaptchav2Plugin.grecaptchaInput.value = 'consumed-token';
+
+            googleReCaptchav2Plugin.resetGreCaptcha();
+
+            expect(window.grecaptcha.reset).toHaveBeenCalledWith('mockWidgetId');
+            expect(googleReCaptchav2Plugin.currentToken).toBeNull();
+            expect(googleReCaptchav2Plugin.grecaptchaInput.value).toBe('');
+        });
+
+        test('does nothing when the widget was not rendered yet', () => {
+            googleReCaptchav2Plugin.grecaptchaWidgetId = null;
+
+            googleReCaptchav2Plugin.resetGreCaptcha();
+
+            expect(window.grecaptcha.reset).not.toHaveBeenCalled();
+        });
+
+        test('resets the captcha when the form emits an AJAX response', () => {
+            googleReCaptchav2Plugin.grecaptchaInput.value = 'consumed-token';
+            googleReCaptchav2Plugin.currentToken = 'consumed-token';
+
+            mockElement.dispatchEvent(new CustomEvent('onFormResponse'));
+
+            expect(window.grecaptcha.reset).toHaveBeenCalledWith('mockWidgetId');
+            expect(googleReCaptchav2Plugin.currentToken).toBeNull();
+            expect(googleReCaptchav2Plugin.grecaptchaInput.value).toBe('');
+        });
+    });
+
     test('provides correct captcha info', () => {
         const info = googleReCaptchav2Plugin.getGreCaptchaInfo();
 


### PR DESCRIPTION
### 1. Why is this change necessary?

When a form protected by the `_captcha` route flag (e.g. the CMS contact form) is submitted via AJAX with Google reCAPTCHA v2 enabled and the server returns a validation error, the form stays on screen but the captcha is never reset. Because the `_captcha` listener validates — and thereby consumes — the single-use token *before* the controller validates the remaining fields, the retry re-sends the already consumed token. Google rejects it as a duplicate, so the form can never be submitted again without a full page reload.

### 2. What does this change do, exactly?

`GoogleReCaptchaBasePlugin` now listens for the form's AJAX response events (`onFormResponse` from `FormCmsHandler` and `onAfterAjaxSubmit` from `FormAjaxSubmitPlugin`). When the round-trip completes it:

  - clears `_formSubmitting`, so the form can be submitted again, and
  - calls a new overridable `resetGreCaptcha()` method.

`GoogleReCaptchaV2Plugin` overrides `resetGreCaptcha()` to reset the widget and clear the cached `currentToken` and the hidden input, so the visible variant  requires the checkbox to be solved again and the invisible variant requests a fresh token via `execute()` instead of reusing the consumed one. reCAPTCHA v3 needs no override because it already requests a fresh token on every submit. Listeners are removed in a new `destroy()`.

Resetting after every completed submission is safe: on success the form is replaced, so the reset only takes effect when the form stays on screen after an error.

### 3. Describe each step to reproduce the issue or behaviour.

  1. Enable Google reCAPTCHA v2 in Basic Information.
  2. Open a CMS page with a contact form (or any `_captcha`-protected AJAX form).
  3. Enter an invalid email address (e.g. `.@test.example`).
  4. Solve the captcha and submit the form.
  5. The form returns a validation error and stays on screen.
  6. Correct the email to a valid address and submit again without reloading.

Before: the second submission fails (duplicate captcha token), or on the visible variant is blocked entirely.

After: the captcha is reset, the user solves it again, and the form submits successfully.

  ### 4. Please link to the relevant issues (if any).

- closes #14879

### 5. Checklist

  - [x] I have written tests and verified that they fail without my change
  - [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
    - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
    - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
    - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
  - [ ] This change has comments for package types, values, functions, and non-obvious lines of code
  - [x] I have read the contribution requirements and fulfilled them

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * CAPTCHA widgets now reset automatically after AJAX form submissions.
  * Submission controls are re-enabled after form responses.
  * CAPTCHA tokens, hidden fields, and visible error states are cleared to support repeat submissions.
  * Reset handling safely skips widgets that have not yet been rendered.

* **Tests**
  * Added coverage for CAPTCHA reset behavior, submission-state recovery, event handling, and cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->