### PR TITLE
fix(administration): prevent long default payment names from overlapping

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/component/sw-sales-channel-defaults-select/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/component/sw-sales-channel-defaults-select/index.js
@@ -127,7 +127,7 @@ export default {
         },
 
         singleSelectClass() {
-            return `sw-sales-channel-detail__assign-${this.propertyNameKebabCase}`;
+            return `sw-sales-channel-detail__assign sw-sales-channel-detail__assign-${this.propertyNameKebabCase}`;
         },
 
         defaultsValueError() {

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/component/sw-sales-channel-defaults-select/sw-sales-channel-defaults-select.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/component/sw-sales-channel-defaults-select/sw-sales-channel-defaults-select.scss
@@ -4,3 +4,10 @@
         display: block;
     }
 }
+
+.sw-sales-channel-detail__assign {
+    .sw-block-field__block {
+        height: auto;
+        min-height: var(--scale-size-48);
+    }
+}

--- a/tests/acceptance/tests/SalesChannels/DefaultPaymentMethod.spec.ts
+++ b/tests/acceptance/tests/SalesChannels/DefaultPaymentMethod.spec.ts
@@ -7,64 +7,53 @@ test(
     },
     async ({ ShopAdmin, TestDataService, AdminSalesChannelDetail, DefaultSalesChannel }) => {
         const salesChannelId = DefaultSalesChannel.salesChannel.id;
-        const originalPaymentMethodId = DefaultSalesChannel.salesChannel.paymentMethodId;
         const paymentMethodName = 'PayPal | PayPal Products for Shopware 6';
-        const paymentMethod = await TestDataService.createBasicPaymentMethod({
+        await TestDataService.createBasicPaymentMethod({
             name: paymentMethodName,
         });
 
-        await TestDataService.assignSalesChannelPaymentMethod(salesChannelId, paymentMethod.id);
+        await ShopAdmin.goesTo(AdminSalesChannelDetail.url(salesChannelId));
 
-        const response = await TestDataService.AdminApiClient.patch(`sales-channel/${salesChannelId}`, {
-            data: {
-                paymentMethodId: paymentMethod.id,
-            },
+        const defaultPaymentMethod = AdminSalesChannelDetail.page.locator(
+            '.sw-sales-channel-detail__assign-payment-methods',
+        );
+        const selectedText = defaultPaymentMethod.locator('.sw-entity-single-select__selection-text');
+
+        await defaultPaymentMethod.locator('.sw-select__selection').click();
+        const searchInput = defaultPaymentMethod.locator('.sw-entity-single-select__selection-input');
+        await searchInput.fill(paymentMethodName);
+        await AdminSalesChannelDetail.page
+            .locator('.sw-select-result__result-item-text')
+            .filter({ hasText: paymentMethodName })
+            .click();
+
+        await expect(selectedText).toContainText(paymentMethodName);
+
+        const layout = await defaultPaymentMethod.evaluate((element) => {
+            const label = element.querySelector('.sw-field__label')?.getBoundingClientRect();
+            const block = element.querySelector('.sw-block-field__block')?.getBoundingClientRect();
+            const text = element.querySelector('.sw-entity-single-select__selection-text')?.getBoundingClientRect();
+            const indicator = element.querySelector('.sw-select__selection-indicators')?.getBoundingClientRect();
+
+            if (!label || !block || !text || !indicator) {
+                return null;
+            }
+
+            return {
+                labelIsAboveField: label.bottom <= block.top,
+                textIsInsideField:
+                    text.left >= block.left &&
+                    text.top >= block.top &&
+                    text.right <= block.right &&
+                    text.bottom <= block.bottom,
+                indicatorIsInsideField: indicator.right <= block.right && indicator.bottom <= block.bottom,
+            };
         });
-        expect(response.ok()).toBeTruthy();
 
-        try {
-            await ShopAdmin.goesTo(AdminSalesChannelDetail.url(salesChannelId));
-
-            const defaultPaymentMethod = AdminSalesChannelDetail.page.locator(
-                '.sw-sales-channel-detail__assign-payment-methods',
-            );
-            const selectedText = defaultPaymentMethod.locator('.sw-entity-single-select__selection-text');
-
-            await expect(selectedText).toContainText(paymentMethodName);
-
-            const layout = await defaultPaymentMethod.evaluate((element) => {
-                const label = element.querySelector('.sw-field__label')?.getBoundingClientRect();
-                const block = element.querySelector('.sw-block-field__block')?.getBoundingClientRect();
-                const text = element.querySelector('.sw-entity-single-select__selection-text')?.getBoundingClientRect();
-                const indicator = element.querySelector('.sw-select__selection-indicators')?.getBoundingClientRect();
-
-                if (!label || !block || !text || !indicator) {
-                    return null;
-                }
-
-                return {
-                    labelIsAboveField: label.bottom <= block.top,
-                    textIsInsideField:
-                        text.left >= block.left &&
-                        text.top >= block.top &&
-                        text.right <= block.right &&
-                        text.bottom <= block.bottom,
-                    indicatorIsInsideField: indicator.right <= block.right && indicator.bottom <= block.bottom,
-                };
-            });
-
-            expect(layout).toEqual({
-                labelIsAboveField: true,
-                textIsInsideField: true,
-                indicatorIsInsideField: true,
-            });
-        } finally {
-            const restoreResponse = await TestDataService.AdminApiClient.patch(`sales-channel/${salesChannelId}`, {
-                data: {
-                    paymentMethodId: originalPaymentMethodId,
-                },
-            });
-            expect(restoreResponse.ok()).toBeTruthy();
-        }
+        expect(layout).toEqual({
+            labelIsAboveField: true,
+            textIsInsideField: true,
+            indicatorIsInsideField: true,
+        });
     },
 );

--- a/tests/acceptance/tests/SalesChannels/DefaultPaymentMethod.spec.ts
+++ b/tests/acceptance/tests/SalesChannels/DefaultPaymentMethod.spec.ts
@@ -1,0 +1,70 @@
+import { expect, test } from '@fixtures/AcceptanceTest';
+
+test(
+    'Long default payment method names are displayed without overlapping the field.',
+    {
+        tag: '@SalesChannel',
+    },
+    async ({ ShopAdmin, TestDataService, AdminSalesChannelDetail, DefaultSalesChannel }) => {
+        const salesChannelId = DefaultSalesChannel.salesChannel.id;
+        const originalPaymentMethodId = DefaultSalesChannel.salesChannel.paymentMethodId;
+        const paymentMethodName = 'PayPal | PayPal Products for Shopware 6';
+        const paymentMethod = await TestDataService.createBasicPaymentMethod({
+            name: paymentMethodName,
+        });
+
+        await TestDataService.assignSalesChannelPaymentMethod(salesChannelId, paymentMethod.id);
+
+        const response = await TestDataService.AdminApiClient.patch(`sales-channel/${salesChannelId}`, {
+            data: {
+                paymentMethodId: paymentMethod.id,
+            },
+        });
+        expect(response.ok()).toBeTruthy();
+
+        try {
+            await ShopAdmin.goesTo(AdminSalesChannelDetail.url(salesChannelId));
+
+            const defaultPaymentMethod = AdminSalesChannelDetail.page.locator(
+                '.sw-sales-channel-detail__assign-payment-methods',
+            );
+            const selectedText = defaultPaymentMethod.locator('.sw-entity-single-select__selection-text');
+
+            await expect(selectedText).toContainText(paymentMethodName);
+
+            const layout = await defaultPaymentMethod.evaluate((element) => {
+                const label = element.querySelector('.sw-field__label')?.getBoundingClientRect();
+                const block = element.querySelector('.sw-block-field__block')?.getBoundingClientRect();
+                const text = element.querySelector('.sw-entity-single-select__selection-text')?.getBoundingClientRect();
+                const indicator = element.querySelector('.sw-select__selection-indicators')?.getBoundingClientRect();
+
+                if (!label || !block || !text || !indicator) {
+                    return null;
+                }
+
+                return {
+                    labelIsAboveField: label.bottom <= block.top,
+                    textIsInsideField:
+                        text.left >= block.left &&
+                        text.top >= block.top &&
+                        text.right <= block.right &&
+                        text.bottom <= block.bottom,
+                    indicatorIsInsideField: indicator.right <= block.right && indicator.bottom <= block.bottom,
+                };
+            });
+
+            expect(layout).toEqual({
+                labelIsAboveField: true,
+                textIsInsideField: true,
+                indicatorIsInsideField: true,
+            });
+        } finally {
+            const restoreResponse = await TestDataService.AdminApiClient.patch(`sales-channel/${salesChannelId}`, {
+                data: {
+                    paymentMethodId: originalPaymentMethodId,
+                },
+            });
+            expect(restoreResponse.ok()).toBeTruthy();
+        }
+    },
+);


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

Long default names overlap the field label and select container in the Sales Channel storefront settings.

### 2. What does this change do, exactly?

The default select fields now grow to accommodate wrapped values without overlap. This applies to default payment method, shipping method, currency, language, and country fields.

An acceptance test verifies the payment-method layout programmatically.

Payment methods displayed on one or two lines retain their existing appearance:

<img width="1008" height="418" alt="Bildschirmfoto 2026-08-06 um 09 30 23" src="https://github.com/user-attachments/assets/6eb5c6ab-d65a-46dc-9822-ed9fb35aab78" />
<img width="990" height="408" alt="Bildschirmfoto 2026-08-06 um 09 30 41" src="https://github.com/user-attachments/assets/83a56231-b789-4865-8d03-fe1f49e6b609" />

When the text wraps onto additional lines, the field height adjusts accordingly:

<img width="983" height="439" alt="Bildschirmfoto 2026-08-06 um 09 30 46" src="https://github.com/user-attachments/assets/d3a98912-b7a1-4f2f-8ba6-04b987b1d696" />

### 3. Describe each step to reproduce the issue or behaviour.

1. Open Administration.
2. Go to a Sales Channel’s storefront settings.
3. Assign a payment method with a long name, such as `PayPal | PayPal Products for Shopware 6`.
4. Set it as the default payment method.
5. Observe that the selected text wraps and overlaps the field label or select container.

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

- closes #17376

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
