### PR TITLE
fix(storefront): refresh static theme configuration values

### DIFF
--- a/src/Storefront/Theme/ThemeService.php
+++ b/src/Storefront/Theme/ThemeService.php
@@ -88,7 +88,9 @@ class ThemeService implements ResetInterface
             $context
         );
 
-        // refresh the runtime config only if not using the StaticFileConfigLoader (no database)
+        // Refresh the runtime config values when the static file loader is used.
+        // The static file loader is only used for the compiled theme configuration;
+        // the resolved values are still stored in the runtime config table.
         if (!$this->configLoader instanceof StaticFileConfigLoader) {
             $importMap = null;
             if ($this->themeCompiler instanceof ThemeCompiler) {
@@ -107,6 +109,8 @@ class ThemeService implements ResetInterface
                 $configurationCollection,
                 $importMap,
             );
+        } else {
+            $this->themeRuntimeConfigService->refreshConfigValues($themeId, $context);
         }
     }
 

--- a/tests/unit/Storefront/Theme/ThemeServiceTest.php
+++ b/tests/unit/Storefront/Theme/ThemeServiceTest.php
@@ -200,6 +200,41 @@ class ThemeServiceTest extends TestCase
         $this->getThemeService(themeCompiler: $themeCompiler)->compileTheme(TestDefaults::SALES_CHANNEL, $themeId, $this->context);
     }
 
+    public function testCompileThemeRefreshesConfigValuesWithStaticFileConfigLoader(): void
+    {
+        $themeId = Uuid::randomHex();
+        $fs = new Filesystem(new InMemoryFilesystemAdapter());
+        $fs->write(
+            \sprintf('theme-config/%s.json', $themeId),
+            json_encode([
+                'styleFiles' => [],
+                'scriptFiles' => [],
+            ], \JSON_THROW_ON_ERROR)
+        );
+        $configLoader = new StaticFileConfigLoader($fs);
+
+        $themeCompiler = $this->createMock(ThemeCompiler::class);
+        $themeCompiler->expects($this->once())->method('compileTheme')->with(
+            TestDefaults::SALES_CHANNEL,
+            $themeId,
+            static::anything(),
+            static::anything(),
+            true,
+            $this->context
+        );
+        $themeCompiler->expects($this->never())->method('buildComponentImportMap');
+
+        $runtimeConfigService = $this->createMock(ThemeRuntimeConfigService::class);
+        $runtimeConfigService->expects($this->once())->method('refreshConfigValues')->with($themeId, $this->context);
+        $runtimeConfigService->expects($this->never())->method('refreshRuntimeConfig');
+
+        $this->getThemeService(
+            themeCompiler: $themeCompiler,
+            configLoader: $configLoader,
+            runtimeConfigService: $runtimeConfigService,
+        )->compileTheme(TestDefaults::SALES_CHANNEL, $themeId, $this->context);
+    }
+
     public function testCompileThemeAsyncSkipHeader(): void
     {
         $themeId = Uuid::randomHex();


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

Saving a theme configuration with `StaticFileConfigLoader` leaves the storefront runtime configuration stale until `theme:refresh` runs.

### 2. What does this change do, exactly?

Refreshes resolved runtime configuration values after compiling a theme with `StaticFileConfigLoader`.

### 3. Describe each step to reproduce the issue or behaviour.

1. Configure `StaticFileConfigLoader`.
2. Assign an inheriting theme plugin to a sales channel.
3. Change and save a theme configuration value, such as a logo.
4. Observe that the storefront still uses the previous value until `theme:refresh` runs.

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

- closes #16779

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
