### PR TITLE
fix(administration): preserve snippet translations on deep links

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-settings-snippet/page/sw-settings-snippet-list/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-snippet/page/sw-settings-snippet-list/index.js
@@ -92,10 +92,6 @@ export default {
             criteria.addFilter(Criteria.equalsAny('id', this.queryIds));
             criteria.addSorting(Criteria.sort('name', 'ASC'));
 
-            if (this.term) {
-                criteria.setTerm(this.term);
-            }
-
             return criteria;
         },
 

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-snippet/page/sw-settings-snippet-list/sw-settings-snippet-list.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-snippet/page/sw-settings-snippet-list/sw-settings-snippet-list.spec.js
@@ -67,7 +67,19 @@ describe('module/sw-settings-snippet/page/sw-settings-snippet-list', () => {
         jest.restoreAllMocks();
     });
 
-    async function createWrapper(privileges = []) {
+    async function createWrapper(
+        privileges = [],
+        query = {},
+        getCustomList = jest.fn(() => Promise.resolve(getSnippets())),
+    ) {
+        const snippetSetSearch = jest.fn((criteria) => {
+            if (criteria.term) {
+                return Promise.resolve([]);
+            }
+
+            return Promise.resolve(getSnippetSets());
+        });
+
         wrapper = mount(
             await wrapTestComponent('sw-settings-snippet-list', {
                 sync: true,
@@ -77,9 +89,7 @@ describe('module/sw-settings-snippet/page/sw-settings-snippet-list', () => {
                     renderStubDefaultSlot: true,
                     provide: {
                         repositoryFactory: {
-                            create: () => ({
-                                search: () => Promise.resolve(getSnippetSets()),
-                            }),
+                            create: () => ({ search: snippetSetSearch }),
                         },
                         acl: {
                             can: (identifier) => {
@@ -100,9 +110,7 @@ describe('module/sw-settings-snippet/page/sw-settings-snippet-list', () => {
                             getAuthors: () => {
                                 return Promise.resolve({ data: [] });
                             },
-                            getCustomList: () => {
-                                return Promise.resolve(getSnippets());
-                            },
+                            getCustomList,
                         },
                         snippetService: {
                             save: () => Promise.resolve(),
@@ -120,6 +128,7 @@ describe('module/sw-settings-snippet/page/sw-settings-snippet-list', () => {
                             },
                             query: {
                                 ids: 'a2f95068665e4498ae98a2318a7963df',
+                                ...query,
                             },
                         },
                     },
@@ -158,6 +167,30 @@ describe('module/sw-settings-snippet/page/sw-settings-snippet-list', () => {
 
         return wrapper;
     }
+
+    it('should display translation columns when opening a filtered view through a deep link', async () => {
+        const getCustomList = jest.fn(() => Promise.resolve(getSnippets()));
+        const wrapper = await createWrapper([], { term: 'account' }, getCustomList);
+
+        await flushPromises();
+
+        expect(getCustomList).toHaveBeenCalledWith(
+            expect.any(Number),
+            expect.any(Number),
+            expect.objectContaining({
+                term: 'account',
+            }),
+            expect.any(Object),
+        );
+
+        expect(wrapper.vm.columns).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({
+                    property: 'a2f95068665e4498ae98a2318a7963df',
+                }),
+            ]),
+        );
+    });
 
     it.each([
         [


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

Opening a filtered snippet deep link does not display the translation columns.

### 2. What does this change do, exactly?

Stops applying the snippet search term to the snippet-set lookup. The term remains applied to the snippet results, while the snippet set is loaded by its ID.

### 3. Describe each step to reproduce the issue or behaviour.

1. Open the Administration and navigate to Snippets.
2. Open a snippet set.
3. Enter a search term.
4. Copy the URL and open it in a new tab.
5. Observe that the translation columns are missing.

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

- closes #15728

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
