### PR TITLE
fix(checkout): enforce ACL on order recalculation and conversion endpoints (backport 6.6.x)

### DIFF
--- a/changelog/_unreleased/2026-08-07-enforce-acl-on-order-recalculation-and-conversion-endpoints.md
+++ b/changelog/_unreleased/2026-08-07-enforce-acl-on-order-recalculation-and-conversion-endpoints.md
@@ -1,0 +1,8 @@
+---
+title: Order recalculation and conversion endpoints now require ACL privileges
+issue:
+---
+# API
+* Changed the order recalculation endpoints (`recalculate`, `product`, `creditItem`, `lineItem`, `promotion-item`, `toggleAutomaticPromotions`, `applyAutomaticPromotions`) to require the `order:update` privilege. Requests with tokens lacking the privilege now receive a `403` response.
+* Changed the order address endpoints (`order-address`, `customer-address`) to require the `order_address:update` privilege.
+* Changed the `convert-to-cart` endpoint to require the `order:read` privilege.

--- a/src/Core/Checkout/Cart/Order/Api/OrderConverterController.php
+++ b/src/Core/Checkout/Cart/Order/Api/OrderConverterController.php
@@ -11,6 +11,7 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\PlatformRequest;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\Routing\Attribute\Route;
@@ -29,7 +30,7 @@ class OrderConverterController extends AbstractController
     ) {
     }
 
-    #[Route(path: '/api/_action/order/{orderId}/convert-to-cart/', name: 'api.action.order.convert-to-cart', methods: ['POST'])]
+    #[Route(path: '/api/_action/order/{orderId}/convert-to-cart/', name: 'api.action.order.convert-to-cart', defaults: [PlatformRequest::ATTRIBUTE_ACL => ['order:read']], methods: ['POST'])]
     public function convertToCart(string $orderId, Context $context): JsonResponse
     {
         $criteria = (new Criteria([$orderId]))

--- a/src/Core/Checkout/Cart/Order/Api/OrderRecalculationController.php
+++ b/src/Core/Checkout/Cart/Order/Api/OrderRecalculationController.php
@@ -14,6 +14,7 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Routing\RoutingException;
 use Shopware\Core\Framework\Rule\Rule;
+use Shopware\Core\PlatformRequest;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -33,7 +34,7 @@ class OrderRecalculationController extends AbstractController
     ) {
     }
 
-    #[Route(path: '/api/_action/order/{orderId}/recalculate', name: 'api.action.order.recalculate', methods: ['POST'])]
+    #[Route(path: '/api/_action/order/{orderId}/recalculate', name: 'api.action.order.recalculate', defaults: [PlatformRequest::ATTRIBUTE_ACL => ['order:update']], methods: ['POST'])]
     public function recalculateOrder(string $orderId, Context $context): Response
     {
         $errors = $this->recalculationService->recalculate($orderId, $context);
@@ -45,7 +46,7 @@ class OrderRecalculationController extends AbstractController
         return new Response(null, Response::HTTP_NO_CONTENT);
     }
 
-    #[Route(path: '/api/_action/order/{orderId}/product/{productId}', name: 'api.action.order.add-product', methods: ['POST'])]
+    #[Route(path: '/api/_action/order/{orderId}/product/{productId}', name: 'api.action.order.add-product', defaults: [PlatformRequest::ATTRIBUTE_ACL => ['order:update']], methods: ['POST'])]
     public function addProductToOrder(string $orderId, string $productId, Request $request, Context $context): Response
     {
         $quantity = $request->request->getInt('quantity', 1);
@@ -54,7 +55,7 @@ class OrderRecalculationController extends AbstractController
         return new Response(null, Response::HTTP_NO_CONTENT);
     }
 
-    #[Route(path: '/api/_action/order/{orderId}/creditItem', name: 'api.action.order.add-credit-item', methods: ['POST'])]
+    #[Route(path: '/api/_action/order/{orderId}/creditItem', name: 'api.action.order.add-credit-item', defaults: [PlatformRequest::ATTRIBUTE_ACL => ['order:update']], methods: ['POST'])]
     public function addCreditItemToOrder(string $orderId, Request $request, Context $context): Response
     {
         $identifier = (string) $request->request->get('identifier');
@@ -95,7 +96,7 @@ class OrderRecalculationController extends AbstractController
         return new Response(null, Response::HTTP_NO_CONTENT);
     }
 
-    #[Route(path: '/api/_action/order/{orderId}/lineItem', name: 'api.action.order.add-line-item', methods: ['POST'])]
+    #[Route(path: '/api/_action/order/{orderId}/lineItem', name: 'api.action.order.add-line-item', defaults: [PlatformRequest::ATTRIBUTE_ACL => ['order:update']], methods: ['POST'])]
     public function addCustomLineItemToOrder(string $orderId, Request $request, Context $context): Response
     {
         $identifier = (string) $request->request->get('identifier');
@@ -112,7 +113,7 @@ class OrderRecalculationController extends AbstractController
         return new Response(null, Response::HTTP_NO_CONTENT);
     }
 
-    #[Route(path: '/api/_action/order/{orderId}/promotion-item', name: 'api.action.order.add-promotion-item', methods: ['POST'])]
+    #[Route(path: '/api/_action/order/{orderId}/promotion-item', name: 'api.action.order.add-promotion-item', defaults: [PlatformRequest::ATTRIBUTE_ACL => ['order:update']], methods: ['POST'])]
     public function addPromotionItemToOrder(string $orderId, Request $request, Context $context): Response
     {
         $code = (string) $request->request->get('code');
@@ -125,7 +126,7 @@ class OrderRecalculationController extends AbstractController
     /**
      * @deprecated tag:v6.8.0 - Will be removed. Use {@see applyAutomaticPromotions} instead.
      */
-    #[Route(path: '/api/_action/order/{orderId}/toggleAutomaticPromotions', name: 'api.action.order.toggle-automatic-promotions', methods: ['POST'])]
+    #[Route(path: '/api/_action/order/{orderId}/toggleAutomaticPromotions', name: 'api.action.order.toggle-automatic-promotions', defaults: [PlatformRequest::ATTRIBUTE_ACL => ['order:update']], methods: ['POST'])]
     public function toggleAutomaticPromotions(string $orderId, Request $request, Context $context): Response
     {
         $skipAutomaticPromotions = (bool) $request->request->get('skipAutomaticPromotions', true);
@@ -135,7 +136,7 @@ class OrderRecalculationController extends AbstractController
         return new CartResponse($cart);
     }
 
-    #[Route(path: '/api/_action/order/{orderId}/applyAutomaticPromotions', name: 'api.action.order.apply-automatic-promotions', methods: ['POST'])]
+    #[Route(path: '/api/_action/order/{orderId}/applyAutomaticPromotions', name: 'api.action.order.apply-automatic-promotions', defaults: [PlatformRequest::ATTRIBUTE_ACL => ['order:update']], methods: ['POST'])]
     public function applyAutomaticPromotions(string $orderId, Request $request, Context $context): Response
     {
         $errors = $this->recalculationService->applyAutomaticPromotions($orderId, $context);
@@ -143,7 +144,7 @@ class OrderRecalculationController extends AbstractController
         return new JsonResponse(['errors' => $errors]);
     }
 
-    #[Route(path: '/api/_action/order-address/{orderAddressId}/customer-address/{customerAddressId}', name: 'api.action.order.replace-order-address', methods: ['POST'])]
+    #[Route(path: '/api/_action/order-address/{orderAddressId}/customer-address/{customerAddressId}', name: 'api.action.order.replace-order-address', defaults: [PlatformRequest::ATTRIBUTE_ACL => ['order_address:update']], methods: ['POST'])]
     public function replaceOrderAddressWithCustomerAddress(string $orderAddressId, string $customerAddressId, Context $context): JsonResponse
     {
         $this->recalculationService->replaceOrderAddressWithCustomerAddress($orderAddressId, $customerAddressId, $context);
@@ -151,7 +152,7 @@ class OrderRecalculationController extends AbstractController
         return new JsonResponse(null, Response::HTTP_NO_CONTENT);
     }
 
-    #[Route(path: '/api/_action/order/{orderId}/order-address', name: 'api.action.order.update', methods: ['POST'])]
+    #[Route(path: '/api/_action/order/{orderId}/order-address', name: 'api.action.order.update', defaults: [PlatformRequest::ATTRIBUTE_ACL => ['order_address:update']], methods: ['POST'])]
     public function updateOrderAddresses(string $orderId, Request $request, Context $context): JsonResponse
     {
         $mapping = $request->request->all('mapping');

--- a/tests/integration/Core/Checkout/Cart/Order/OrderConverterControllerTest.php
+++ b/tests/integration/Core/Checkout/Cart/Order/OrderConverterControllerTest.php
@@ -1,0 +1,35 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Integration\Core\Checkout\Cart\Order;
+
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Test\TestCaseBase\AdminApiTestBehaviour;
+use Shopware\Core\Framework\Test\TestCaseBase\DatabaseTransactionBehaviour;
+use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * @internal
+ */
+#[Package('checkout')]
+class OrderConverterControllerTest extends TestCase
+{
+    use AdminApiTestBehaviour;
+    use DatabaseTransactionBehaviour;
+    use KernelTestBehaviour;
+
+    public function testConvertToCartIsAllowedForOrderViewer(): void
+    {
+        $browser = $this->getBrowser(true, [], ['order:read']);
+        $browser->jsonRequest('POST', \sprintf('/api/_action/order/%s/convert-to-cart/', Uuid::randomHex()));
+
+        // the order does not exist, but the request must pass the privilege check to get there
+        static::assertSame(
+            Response::HTTP_NOT_FOUND,
+            $browser->getResponse()->getStatusCode(),
+            (string) $browser->getResponse()->getContent()
+        );
+    }
+}

--- a/tests/integration/Core/Checkout/Cart/Order/OrderRecalculationControllerTest.php
+++ b/tests/integration/Core/Checkout/Cart/Order/OrderRecalculationControllerTest.php
@@ -1,0 +1,105 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Integration\Core\Checkout\Cart\Order;
+
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Checkout\Order\OrderCollection;
+use Shopware\Core\Framework\Api\Exception\MissingPrivilegeException;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Test\TestCaseBase\AdminApiTestBehaviour;
+use Shopware\Core\Framework\Test\TestCaseBase\DatabaseTransactionBehaviour;
+use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\Test\Integration\Traits\OrderFixture;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * @internal
+ */
+#[Package('checkout')]
+class OrderRecalculationControllerTest extends TestCase
+{
+    use AdminApiTestBehaviour;
+    use DatabaseTransactionBehaviour;
+    use KernelTestBehaviour;
+    use OrderFixture;
+
+    private Context $context;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->context = Context::createDefaultContext();
+    }
+
+    public function testLineItemIsNotInjectableIntoAnOrderVersion(): void
+    {
+        $orderId = Uuid::randomHex();
+        $versionId = Uuid::randomHex();
+        $marker = 'injected-' . Uuid::randomHex();
+        $this->createOrder($orderId, $versionId);
+
+        // the write sink runs in system scope, so the version context must not become a way around the privilege
+        $browser = $this->getBrowser(true, [], ['order:read']);
+        $browser->setServerParameter('HTTP_SW_VERSION_ID', $versionId);
+        $browser->jsonRequest('POST', \sprintf('/api/_action/order/%s/lineItem', $orderId), [
+            'identifier' => $marker,
+            'type' => 'custom',
+            'quantity' => 1,
+            'label' => $marker,
+            'priceDefinition' => [
+                'type' => 'quantity',
+                'price' => -9999,
+                'quantity' => 1,
+                'taxRules' => [['taxRate' => 0, 'percentage' => 100]],
+            ],
+        ]);
+
+        $content = (string) $browser->getResponse()->getContent();
+        static::assertSame(Response::HTTP_FORBIDDEN, $browser->getResponse()->getStatusCode(), $content);
+        static::assertSame(
+            MissingPrivilegeException::MISSING_PRIVILEGE_ERROR,
+            json_decode($content, true, 512, \JSON_THROW_ON_ERROR)['errors'][0]['code'],
+            $content
+        );
+
+        $lineItemRepository = static::getContainer()->get('order_line_item.repository');
+        static::assertInstanceOf(EntityRepository::class, $lineItemRepository);
+
+        $this->context->assign(['versionId' => $versionId]);
+        $criteria = (new Criteria())->addFilter(new EqualsFilter('identifier', $marker));
+
+        static::assertCount(0, $lineItemRepository->searchIds($criteria, $this->context)->getIds());
+    }
+
+    public function testRecalculateIsAllowedForOrderEditor(): void
+    {
+        $browser = $this->getBrowser(true, [], ['order:read', 'order:update']);
+        $browser->jsonRequest('POST', \sprintf('/api/_action/order/%s/recalculate', Uuid::randomHex()));
+
+        // the order does not exist, but the request must pass the privilege check to get there
+        static::assertSame(
+            Response::HTTP_NOT_FOUND,
+            $browser->getResponse()->getStatusCode(),
+            (string) $browser->getResponse()->getContent()
+        );
+    }
+
+    private function createOrder(string $orderId, string $versionId): void
+    {
+        $orderData = $this->getOrderData($orderId, $this->context)[0];
+
+        $orderData['versionId'] = $versionId;
+        $orderData['orderCustomer']['orderVersionId'] = $versionId;
+
+        /** @var EntityRepository<OrderCollection> $orderRepository */
+        $orderRepository = static::getContainer()->get('order.repository');
+
+        $orderRepository->create([$orderData], $this->context);
+    }
+}

--- a/tests/unit/Core/Checkout/Cart/Order/Api/OrderConverterControllerTest.php
+++ b/tests/unit/Core/Checkout/Cart/Order/Api/OrderConverterControllerTest.php
@@ -1,0 +1,33 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Checkout\Cart\Order\Api;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Checkout\Cart\Order\Api\OrderConverterController;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\PlatformRequest;
+use Symfony\Bundle\FrameworkBundle\Routing\AttributeRouteControllerLoader;
+use Symfony\Component\Routing\Route;
+
+/**
+ * @internal
+ */
+#[Package('checkout')]
+#[CoversClass(OrderConverterController::class)]
+class OrderConverterControllerTest extends TestCase
+{
+    public function testConvertToCartRouteDeclaresOrderReadPrivilege(): void
+    {
+        static::assertSame(['order:read'], $this->loadConvertToCartRoute()->getDefault(PlatformRequest::ATTRIBUTE_ACL));
+    }
+
+    private function loadConvertToCartRoute(): Route
+    {
+        $route = (new AttributeRouteControllerLoader())->load(OrderConverterController::class)->get('api.action.order.convert-to-cart');
+
+        static::assertNotNull($route, \sprintf('Route "api.action.order.convert-to-cart" is not defined on %s', OrderConverterController::class));
+
+        return $route;
+    }
+}

--- a/tests/unit/Core/Checkout/Cart/Order/Api/OrderRecalculationControllerTest.php
+++ b/tests/unit/Core/Checkout/Cart/Order/Api/OrderRecalculationControllerTest.php
@@ -1,0 +1,54 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Checkout\Cart\Order\Api;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Checkout\Cart\Order\Api\OrderRecalculationController;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\PlatformRequest;
+use Symfony\Bundle\FrameworkBundle\Routing\AttributeRouteControllerLoader;
+use Symfony\Component\Routing\Route;
+
+/**
+ * @internal
+ */
+#[Package('checkout')]
+#[CoversClass(OrderRecalculationController::class)]
+class OrderRecalculationControllerTest extends TestCase
+{
+    /**
+     * @param list<string> $expectedPrivileges
+     */
+    #[DataProvider('aclProtectedRouteProvider')]
+    public function testRouteDeclaresPrivilege(string $routeName, array $expectedPrivileges): void
+    {
+        static::assertSame($expectedPrivileges, $this->loadRoute($routeName)->getDefault(PlatformRequest::ATTRIBUTE_ACL));
+    }
+
+    /**
+     * @return \Generator<string, array{0: string, 1: list<string>}>
+     */
+    public static function aclProtectedRouteProvider(): \Generator
+    {
+        yield 'recalculating an order' => ['api.action.order.recalculate', ['order:update']];
+        yield 'adding a product' => ['api.action.order.add-product', ['order:update']];
+        yield 'adding a credit item' => ['api.action.order.add-credit-item', ['order:update']];
+        yield 'adding a custom line item' => ['api.action.order.add-line-item', ['order:update']];
+        yield 'adding a promotion item' => ['api.action.order.add-promotion-item', ['order:update']];
+        yield 'toggling automatic promotions' => ['api.action.order.toggle-automatic-promotions', ['order:update']];
+        yield 'applying automatic promotions' => ['api.action.order.apply-automatic-promotions', ['order:update']];
+        yield 'replacing an order address' => ['api.action.order.replace-order-address', ['order_address:update']];
+        yield 'updating the order addresses' => ['api.action.order.update', ['order_address:update']];
+    }
+
+    private function loadRoute(string $routeName): Route
+    {
+        $route = (new AttributeRouteControllerLoader())->load(OrderRecalculationController::class)->get($routeName);
+
+        static::assertNotNull($route, \sprintf('Route "%s" is not defined on %s', $routeName, OrderRecalculationController::class));
+
+        return $route;
+    }
+}


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
backport https://github.com/shopware/shopware/pull/18968

### 2. What does this change do, exactly?


### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [x] I have written or adjusted the documentation and agent skills according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
