### PR TITLE
ci: stop crashing when milestone-label.ts is absent on this base

### DIFF
--- a/.github/workflows/milestone.yml
+++ b/.github/workflows/milestone.yml
@@ -127,7 +127,15 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.base.sha }}
           sparse-checkout: .github/bin/js
-      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+      - id: rule
+        run: |
+          if [ -f .github/bin/js/milestone-label.ts ]; then
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::notice::No milestone label rule on ${{ github.event.pull_request.base.ref }}, nothing to fix."
+          fi
+      - if: steps.rule.outputs.present == 'true'
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
             const { reconcileMilestoneLabel } = await import('${{ github.workspace }}/.github/bin/js/milestone-label.ts')
@@ -142,7 +150,15 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           sparse-checkout: .github/bin/js
-      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+      - id: rule
+        run: |
+          if [ -f .github/bin/js/milestone-label.ts ]; then
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::notice::No milestone label rule on the default branch of this repository, nothing to reconcile."
+          fi
+      - if: steps.rule.outputs.present == 'true'
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         env:
           # Set the repository variable to "false" to let it actually relabel.
           DRY_RUN: ${{ vars.MILESTONE_RECONCILE_DRY_RUN || 'true' }}
@@ -160,9 +176,18 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.pull_request.base.sha }}
-      - shell: bash
+      - id: automation
+        run: |
+          if [ -f .github/bin/js/package.json ]; then
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::notice::No .github/bin/js/package.json on ${{ github.event.pull_request.base.ref }}, nothing to set."
+          fi
+      - if: steps.automation.outputs.present == 'true'
+        shell: bash
         run: npm ci --prefix .github/bin/js/
       - name: Set milestone
+        if: steps.automation.outputs.present == 'true'
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # 9
         with:
           script: |


### PR DESCRIPTION
### 1. Why is this change necessary?

Workflow files only ever exist on the default branch. `fix_milestone_label_on_base_change` and `reconcile_milestone_labels` import `.github/bin/js/milestone-label.ts` unconditionally, so any PR based on a branch without it crashes with `ERR_MODULE_NOT_FOUND` — hit on shopware-private#317, a private-only patch branch with no counterpart in `shopware/shopware` to sync from. `milestone-check.yml` already tolerates this; these two didn't.

### 2. What does this change do, exactly?

Same presence guard as `milestone-check.yml`: check the file exists before importing it, `::notice` and skip otherwise. `set_milestone` predates the module and hits the same gap for a different reason (`npm ci` with no `package.json`), so it gets the same treatment.

### 3. Describe each step to reproduce the issue or behaviour.

Edit a PR's base (or open one) against a branch without `.github/bin/js/`: the job used to crash, now skips with a notice.

### 4. Please link to the relevant issues (if any).

Fixes shopware-private#317's CI failure.

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
