### PR TITLE
fix: Use correct limit fallback for defining offset on API calls

### DIFF
--- a/src/Core/Framework/DataAbstractionLayer/Search/RequestCriteriaBuilder.php
+++ b/src/Core/Framework/DataAbstractionLayer/Search/RequestCriteriaBuilder.php
@@ -161,7 +161,7 @@ class RequestCriteriaBuilder
             }
 
             if (isset($payload['page'])) {
-                $this->setPage($payload, $criteria, $searchException);
+                $this->setPage($payload['page'], $criteria, $searchException);
             }
         }
 
@@ -379,30 +379,30 @@ class RequestCriteriaBuilder
     }
 
     /**
-     * @param array{page: int|numeric-string, limit?: int|numeric-string, ...} $payload
+     * @param int|numeric-string $page
      */
-    private function setPage(array $payload, Criteria $criteria, SearchRequestException $searchRequestException): void
+    private function setPage(mixed $page, Criteria $criteria, SearchRequestException $searchRequestException): void
     {
-        if ($payload['page'] === '') {
+        if ($page === '') {
             $searchRequestException->add(new InvalidPageQueryException('(empty)'), '/page');
 
             return;
         }
 
-        if (!is_numeric($payload['page'])) {
-            $searchRequestException->add(new InvalidPageQueryException($payload['page']), '/page');
+        if (!is_numeric($page)) {
+            $searchRequestException->add(new InvalidPageQueryException($page), '/page');
 
             return;
         }
 
-        $page = (int) $payload['page'];
-        $limit = (int) ($payload['limit'] ?? 0);
-
+        $page = (int) $page;
         if ($page <= 0) {
             $searchRequestException->add(new InvalidPageQueryException($page), '/page');
 
             return;
         }
+
+        $limit = $criteria->getLimit();
 
         $offset = $limit * ($page - 1);
         $criteria->setOffset($offset);

--- a/src/Core/Framework/DataAbstractionLayer/Search/RequestCriteriaBuilder.php
+++ b/src/Core/Framework/DataAbstractionLayer/Search/RequestCriteriaBuilder.php
@@ -402,7 +402,7 @@ class RequestCriteriaBuilder
             return;
         }
 
-        $limit = $criteria->getLimit();
+        $limit = $criteria->getLimit() ?? 0;
 
         $offset = $limit * ($page - 1);
         $criteria->setOffset($offset);

--- a/tests/unit/Core/Framework/DataAbstractionLayer/Search/RequestCriteriaBuilderTest.php
+++ b/tests/unit/Core/Framework/DataAbstractionLayer/Search/RequestCriteriaBuilderTest.php
@@ -645,6 +645,30 @@ class RequestCriteriaBuilderTest extends TestCase
         static::assertSame($expectedLimit, $criteria->getLimit());
     }
 
+    public function testPageOffsetUsesFallbackLimitWhenRequestHasNoLimit(): void
+    {
+        $aggregationParser = new AggregationParser();
+        $maxLimit = 500;
+
+        $builder = new RequestCriteriaBuilder(
+            $aggregationParser,
+            new ApiCriteriaValidator($this->staticDefinitionRegistry),
+            new CriteriaArrayConverter($aggregationParser),
+            new CompressedCriteriaDecoder(),
+            $maxLimit
+        );
+
+        $criteria = $builder->fromArray(
+            ['page' => 2],
+            new Criteria(),
+            $this->staticDefinitionRegistry->get(ProductDefinition::class),
+            Context::createDefaultContext()
+        );
+
+        static::assertSame($maxLimit, $criteria->getLimit());
+        static::assertSame($maxLimit, $criteria->getOffset());
+    }
+
     public static function providerPaging(): \Generator
     {
         yield 'offset correctly calculated' => [


### PR DESCRIPTION
### 1. Why is this change necessary?

Successor of https://github.com/shopware/shopware/pull/18677 to adjust with small improvement.
So big thanks to @amenk :blue_heart:

### 2. What does this change do, exactly?

Consider the already defined limit from the criteria instead of using the plain payload.

### 3. Describe each step to reproduce the issue or behaviour.

See issue

### 4. Please link to the relevant issues (if any).

closes: https://github.com/shopware/shopware/issues/18652

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
