### PR TITLE
feat(discovery): allow local filesystem translations

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -566,6 +566,12 @@ The administration media folder settings modal (`sw-media-modal-folder-settings`
 
 ## Hosting & Configuration
 
+### Local translation files and optional automatic updates
+
+The translation system can store downloaded translation files locally instead of on the configured private filesystem. Set `shopware.translation.use_local_filesystem` to `true` and include `var/translation` in the deployed release. Run `translation:download` during the build to populate that directory without creating language or snippet-set records.
+
+The daily translation update task can be disabled with `shopware.translation.scheduled_task.enabled: false`. Use this for immutable deployments that update translation files only during builds. Both options retain their previous behavior by default.
+
 ### Optional `Clear-Site-Data` header on customer logout
 
 On customer logout the storefront can send a [`Clear-Site-Data`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Clear-Site-Data) header, so the browser drops data left over from the session. Disabled by default:

--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -483,6 +483,12 @@ The cookie is only added to the consent manager if at least one of the reference
 
 ## Hosting & Configuration
 
+### Local translation files and optional automatic updates
+
+The translation system can store downloaded translation files locally instead of on the configured private filesystem. Set `shopware.translation.use_local_filesystem` to `true` and include `var/translation` in the deployed release. Run `translation:download` during the build to populate that directory without creating language or snippet-set records.
+
+The daily translation update task can be disabled with `shopware.translation.scheduled_task.enabled: false`. Use this for immutable deployments that update translation files only during builds. Both options retain their previous behavior by default.
+
 ### Optional `Clear-Site-Data` header on customer logout
 
 On customer logout the storefront can send a [`Clear-Site-Data`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Clear-Site-Data) header, so the browser drops data left over from the session. Disabled by default:

--- a/config-schema.json
+++ b/config-schema.json
@@ -63,6 +63,9 @@
                 "sitemap": {
                     "$ref": "#/definitions/sitemap"
                 },
+                "translation": {
+                    "$ref": "#/definitions/translation"
+                },
                 "deployment": {
                     "$ref": "#/definitions/deployment"
                 },
@@ -1539,6 +1542,27 @@
                 }
             },
             "title": "sitemap"
+        },
+        "translation": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "use_local_filesystem": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "scheduled_task": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "default": true
+                        }
+                    }
+                }
+            },
+            "title": "translation"
         },
         "shopware_store": {
             "type": "object",

--- a/phpstan-baseline.php
+++ b/phpstan-baseline.php
@@ -958,12 +958,6 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
     'rawMessage' => 'Construct empty() is not allowed. Use more strict comparison.',
     'identifier' => 'empty.notAllowed',
-    'count' => 2,
-    'path' => __DIR__ . '/src/Core/System/Snippet/Files/SnippetFileLoader.php',
-];
-$ignoreErrors[] = [
-    'rawMessage' => 'Construct empty() is not allowed. Use more strict comparison.',
-    'identifier' => 'empty.notAllowed',
     'count' => 1,
     'path' => __DIR__ . '/src/Core/System/Snippet/Filter/EmptySnippetFilter.php',
 ];

--- a/phpstan-baseline.php
+++ b/phpstan-baseline.php
@@ -982,12 +982,6 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
     'rawMessage' => 'Construct empty() is not allowed. Use more strict comparison.',
     'identifier' => 'empty.notAllowed',
-    'count' => 2,
-    'path' => __DIR__ . '/src/Core/System/Snippet/Files/SnippetFileLoader.php',
-];
-$ignoreErrors[] = [
-    'rawMessage' => 'Construct empty() is not allowed. Use more strict comparison.',
-    'identifier' => 'empty.notAllowed',
     'count' => 1,
     'path' => __DIR__ . '/src/Core/System/Snippet/Filter/EmptySnippetFilter.php',
 ];

--- a/src/Administration/DependencyInjection/services.php
+++ b/src/Administration/DependencyInjection/services.php
@@ -194,7 +194,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         ->args([
             service('kernel'),
             service(Connection::class),
-            service('shopware.filesystem.private'),
+            service('shopware.filesystem.translation'),
             service(TranslationConfig::class),
             service(TranslationLoader::class),
             service(HtmlSanitizer::class),

--- a/src/Core/Framework/DependencyInjection/Configuration.php
+++ b/src/Core/Framework/DependencyInjection/Configuration.php
@@ -1756,6 +1756,13 @@ class Configuration implements ConfigurationInterface
                         ->end()
                     ->end()
                 ->end()
+                ->booleanNode('use_local_filesystem')->defaultFalse()->end()
+                ->arrayNode('scheduled_task')
+                    ->addDefaultsIfNotSet()
+                    ->children()
+                        ->booleanNode('enabled')->defaultTrue()->end()
+                    ->end()
+                ->end()
             ->end();
 
         return $rootNode;

--- a/src/Core/Framework/DependencyInjection/services.php
+++ b/src/Core/Framework/DependencyInjection/services.php
@@ -473,7 +473,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             service(SnippetFilterFactory::class),
             service(ExtensionDispatcher::class),
             service('event_dispatcher'),
-            service('shopware.filesystem.private'),
+            service('shopware.filesystem.translation'),
             service('filesystem'),
         ]);
 
@@ -507,7 +507,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             service(ActiveAppsLoader::class),
             service(TranslationConfig::class),
             service(TranslationLoader::class),
-            service('shopware.filesystem.private'),
+            service('shopware.filesystem.translation'),
             service(SourceResolver::class),
             service('logger'),
         ]);

--- a/src/Core/Framework/DependencyInjection/services.php
+++ b/src/Core/Framework/DependencyInjection/services.php
@@ -474,7 +474,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             service(SnippetFilterFactory::class),
             service(ExtensionDispatcher::class),
             service('event_dispatcher'),
-            service('shopware.filesystem.private'),
+            service('shopware.filesystem.translation'),
             service('filesystem'),
         ]);
 
@@ -508,7 +508,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             service(ActiveAppsLoader::class),
             service(TranslationConfig::class),
             service(TranslationLoader::class),
-            service('shopware.filesystem.private'),
+            service('shopware.filesystem.translation'),
             service(SourceResolver::class),
             service('logger'),
         ]);

--- a/src/Core/Framework/Resources/config/packages/shopware.yaml
+++ b/src/Core/Framework/Resources/config/packages/shopware.yaml
@@ -405,6 +405,11 @@ shopware:
         scheduled_task:
             enabled: true
 
+    translation:
+        use_local_filesystem: false
+        scheduled_task:
+            enabled: true
+
     deployment:
         blue_green: '%env(bool:default:defaults_bool_true:BLUE_GREEN_DEPLOYMENT)%'
         cluster_setup: false

--- a/src/Core/System/DependencyInjection/snippet.php
+++ b/src/Core/System/DependencyInjection/snippet.php
@@ -4,8 +4,11 @@ namespace Shopware\Core\System\DependencyInjection;
 
 use Doctrine\DBAL\Connection;
 use GuzzleHttp\Client;
+use League\Flysystem\FilesystemOperator;
 use Psr\Clock\ClockInterface;
+use Shopware\Core\Framework\Adapter\Filesystem\FilesystemFactory;
 use Shopware\Core\System\Snippet\Aggregate\SnippetSet\SnippetSetDefinition;
+use Shopware\Core\System\Snippet\Command\DownloadTranslationCommand;
 use Shopware\Core\System\Snippet\Command\InstallTranslationCommand;
 use Shopware\Core\System\Snippet\Command\LintTranslationFilesCommand;
 use Shopware\Core\System\Snippet\Command\ListTranslationsCommand;
@@ -16,7 +19,9 @@ use Shopware\Core\System\Snippet\Files\SnippetFileCollection;
 use Shopware\Core\System\Snippet\ScheduledTask\UpdateTranslationsTask;
 use Shopware\Core\System\Snippet\ScheduledTask\UpdateTranslationsTaskHandler;
 use Shopware\Core\System\Snippet\Service\AbstractTranslationConfigLoader;
+use Shopware\Core\System\Snippet\Service\AbstractTranslationLoader;
 use Shopware\Core\System\Snippet\Service\TranslationConfigLoader;
+use Shopware\Core\System\Snippet\Service\TranslationFilesystemFactory;
 use Shopware\Core\System\Snippet\Service\TranslationLoader;
 use Shopware\Core\System\Snippet\Service\TranslationMetadataStore;
 use Shopware\Core\System\Snippet\Service\TranslationRemover;
@@ -94,6 +99,13 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         ])
         ->tag('console.command');
 
+    $services->set(DownloadTranslationCommand::class)
+        ->args([
+            service(AbstractTranslationLoader::class),
+            service(TranslationConfig::class),
+        ])
+        ->tag('console.command');
+
     $services->set(UpdateTranslationCommand::class)
         ->args([
             service(TranslationLoader::class),
@@ -131,7 +143,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
     $services->set(TranslationLoader::class)
         ->args([
-            service('shopware.filesystem.private'),
+            service('shopware.filesystem.translation'),
             service('language.repository'),
             service('locale.repository'),
             service('snippet_set.repository'),
@@ -140,11 +152,13 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             service('event_dispatcher'),
         ]);
 
+    $services->alias(AbstractTranslationLoader::class, TranslationLoader::class);
+
     $services->set(TranslationMetadataStore::class)
         ->args([
             service(TranslationConfig::class),
             service('shopware.translation.client'),
-            service('shopware.filesystem.private'),
+            service('shopware.filesystem.translation'),
             service('cache.object'),
         ]);
 
@@ -156,7 +170,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
     $services->set(TranslationRemover::class)
         ->args([
-            service('shopware.filesystem.private'),
+            service('shopware.filesystem.translation'),
             service(TranslationLoader::class),
             service(TranslationMetadataStore::class),
             service('event_dispatcher'),
@@ -173,6 +187,17 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             service('language.repository'),
         ])
         ->tag('messenger.message_handler');
+
+    $services->set(TranslationFilesystemFactory::class)
+        ->args([
+            service('shopware.filesystem.private'),
+            service(FilesystemFactory::class),
+            param('kernel.project_dir'),
+            param('shopware.translation.use_local_filesystem'),
+        ]);
+
+    $services->set('shopware.filesystem.translation', FilesystemOperator::class)
+        ->factory([service(TranslationFilesystemFactory::class), 'create']);
 
     $services->set(SnippetFileHandler::class)
         ->args([

--- a/src/Core/System/Snippet/Command/DownloadTranslationCommand.php
+++ b/src/Core/System/Snippet/Command/DownloadTranslationCommand.php
@@ -1,0 +1,46 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\System\Snippet\Command;
+
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\System\Snippet\Command\Util\TranslationCommandHelper;
+use Shopware\Core\System\Snippet\Service\AbstractTranslationLoader;
+use Shopware\Core\System\Snippet\Struct\TranslationConfig;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * @internal
+ */
+#[Package('discovery')]
+#[AsCommand(
+    name: 'translation:download',
+    description: 'Downloads all configured translations without creating languages or snippet sets.',
+)]
+class DownloadTranslationCommand extends Command
+{
+    /**
+     * @internal
+     */
+    public function __construct(
+        private readonly AbstractTranslationLoader $translationLoader,
+        private readonly TranslationConfig $config,
+    ) {
+        parent::__construct();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        TranslationCommandHelper::executeLoadWithProgressBar(
+            $this->config->locales,
+            $output,
+            fn (string $locale) => $this->translationLoader->download($locale),
+        );
+
+        $output->write(\PHP_EOL);
+
+        return self::SUCCESS;
+    }
+}

--- a/src/Core/System/Snippet/Files/SnippetFileLoader.php
+++ b/src/Core/System/Snippet/Files/SnippetFileLoader.php
@@ -91,7 +91,7 @@ class SnippetFileLoader implements SnippetFileLoaderInterface
 
             // Check if the path matches the expected structure. If not, the directory was modified and the file should be skipped.
             $validityCheck = \array_intersect_key($pathComponents, array_fill_keys(['locale', 'component'], true));
-            if (\count($validityCheck) !== 2 || empty($pathComponents['locale']) || empty($pathComponents['component'])) {
+            if (\count($validityCheck) !== 2 || $pathComponents['locale'] === '' || $pathComponents['component'] === '') {
                 continue;
             }
 

--- a/src/Core/System/Snippet/Files/SnippetFileLoader.php
+++ b/src/Core/System/Snippet/Files/SnippetFileLoader.php
@@ -4,7 +4,7 @@ namespace Shopware\Core\System\Snippet\Files;
 
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Exception;
-use League\Flysystem\Filesystem;
+use League\Flysystem\FilesystemOperator;
 use League\Flysystem\StorageAttributes;
 use Psr\Log\LoggerInterface;
 use Shopware\Core\Framework\App\ActiveAppsLoader;
@@ -42,7 +42,7 @@ class SnippetFileLoader implements SnippetFileLoaderInterface
         private readonly ActiveAppsLoader $activeAppsLoader,
         private readonly TranslationConfig $config,
         private readonly AbstractTranslationLoader $translationLoader,
-        private readonly Filesystem $translationReader,
+        private readonly FilesystemOperator $translationReader,
         private readonly SourceResolver $sourceResolver,
         private readonly LoggerInterface $logger,
     ) {

--- a/src/Core/System/Snippet/ScheduledTask/UpdateTranslationsTask.php
+++ b/src/Core/System/Snippet/ScheduledTask/UpdateTranslationsTask.php
@@ -4,6 +4,7 @@ namespace Shopware\Core\System\Snippet\ScheduledTask;
 
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTask;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 
 #[Package('discovery')]
 class UpdateTranslationsTask extends ScheduledTask
@@ -16,6 +17,11 @@ class UpdateTranslationsTask extends ScheduledTask
     public static function getDefaultInterval(): int
     {
         return self::DAILY;
+    }
+
+    public static function shouldRun(ParameterBagInterface $bag): bool
+    {
+        return (bool) $bag->get('shopware.translation.scheduled_task.enabled');
     }
 
     public static function shouldRescheduleOnFailure(): bool

--- a/src/Core/System/Snippet/Service/AbstractTranslationLoader.php
+++ b/src/Core/System/Snippet/Service/AbstractTranslationLoader.php
@@ -16,6 +16,11 @@ abstract class AbstractTranslationLoader
 
     abstract public function load(string $locale, Context $context, bool $activate = true): void;
 
+    public function download(string $locale): void
+    {
+        $this->getDecorated()->download($locale);
+    }
+
     /**
      * @deprecated tag:v6.8.0 - reason:becomes-unused - Override `pluginTranslationExistsForLocale()` instead for
      * locale-aware behaviour. This method will be removed.

--- a/src/Core/System/Snippet/Service/TranslationFilesystemFactory.php
+++ b/src/Core/System/Snippet/Service/TranslationFilesystemFactory.php
@@ -1,0 +1,37 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\System\Snippet\Service;
+
+use League\Flysystem\FilesystemOperator;
+use Shopware\Core\Framework\Adapter\Filesystem\FilesystemFactory;
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * @internal
+ */
+#[Package('discovery')]
+class TranslationFilesystemFactory
+{
+    /**
+     * @internal
+     */
+    public function __construct(
+        private readonly FilesystemOperator $privateFilesystem,
+        private readonly FilesystemFactory $filesystemFactory,
+        private readonly string $projectDir,
+        private readonly bool $useLocalFilesystem,
+    ) {
+    }
+
+    public function create(): FilesystemOperator
+    {
+        if (!$this->useLocalFilesystem) {
+            return $this->privateFilesystem;
+        }
+
+        return $this->filesystemFactory->privateFactory([
+            'type' => 'local',
+            'config' => ['root' => $this->projectDir . '/var'],
+        ]);
+    }
+}

--- a/src/Core/System/Snippet/Service/TranslationLoader.php
+++ b/src/Core/System/Snippet/Service/TranslationLoader.php
@@ -4,7 +4,7 @@ namespace Shopware\Core\System\Snippet\Service;
 
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\GuzzleException;
-use League\Flysystem\Filesystem;
+use League\Flysystem\FilesystemOperator;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
@@ -56,7 +56,7 @@ class TranslationLoader extends AbstractTranslationLoader implements ResetInterf
      * @param EntityRepository<SnippetSetCollection> $snippetSetRepository
      */
     public function __construct(
-        private readonly Filesystem $translationWriter,
+        private readonly FilesystemOperator $translationWriter,
         private readonly EntityRepository $languageRepository,
         private readonly EntityRepository $localeRepository,
         private readonly EntityRepository $snippetSetRepository,
@@ -79,16 +79,25 @@ class TranslationLoader extends AbstractTranslationLoader implements ResetInterf
             throw SnippetException::languageDoesNotExist($locale);
         }
 
-        $this->fetchPlatformSnippets($locale);
-        $this->fetchPluginSnippets($locale);
-
-        // new plugin translation directories may have been written, invalidate the memoized lookup
-        $this->reset();
+        $this->download($locale);
 
         $this->createLanguage($language, $context, $activate);
         $this->createSnippetSet($language, $context);
 
         $this->eventDispatcher->dispatch(new TranslationLoadedEvent($locale, $context));
+    }
+
+    public function download(string $locale): void
+    {
+        if (!$this->config->languages->has($locale)) {
+            throw SnippetException::languageDoesNotExist($locale);
+        }
+
+        $this->fetchPlatformSnippets($locale);
+        $this->fetchPluginSnippets($locale);
+
+        // New plugin translation directories may have been written, invalidate the memoized lookup.
+        $this->reset();
     }
 
     public function pluginTranslationExists(Plugin $plugin): bool
@@ -147,7 +156,7 @@ class TranslationLoader extends AbstractTranslationLoader implements ResetInterf
         /** @var ArrayStruct<list<string>> $pluginLocales */
         $pluginLocales = new ArrayStruct();
 
-        foreach ($this->translationWriter->listContents($localesBasePath, Filesystem::LIST_DEEP) as $fsNode) {
+        foreach ($this->translationWriter->listContents($localesBasePath, FilesystemOperator::LIST_DEEP) as $fsNode) {
             if (\preg_match('#(?P<locale>[^/]+)/Plugins/(?P<plugin>[^/]+)#', $fsNode->path(), $matches) !== 1) {
                 continue;
             }

--- a/src/Core/System/Snippet/Service/TranslationMetadataStore.php
+++ b/src/Core/System/Snippet/Service/TranslationMetadataStore.php
@@ -4,8 +4,8 @@ namespace Shopware\Core\System\Snippet\Service;
 
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\GuzzleException;
-use League\Flysystem\Filesystem;
 use League\Flysystem\FilesystemException;
+use League\Flysystem\FilesystemOperator;
 use Psr\Http\Message\ResponseInterface;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\Snippet\DataTransfer\Metadata\MetadataCollection;
@@ -34,7 +34,7 @@ class TranslationMetadataStore
     public function __construct(
         private readonly TranslationConfig $config,
         private readonly ClientInterface $client,
-        private readonly Filesystem $filesystem,
+        private readonly FilesystemOperator $filesystem,
         private readonly CacheInterface $cache,
     ) {
     }

--- a/src/Core/System/Snippet/Service/TranslationRemover.php
+++ b/src/Core/System/Snippet/Service/TranslationRemover.php
@@ -2,7 +2,7 @@
 
 namespace Shopware\Core\System\Snippet\Service;
 
-use League\Flysystem\Filesystem;
+use League\Flysystem\FilesystemOperator;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\Snippet\Event\TranslationRemovedEvent;
 use Shopware\Core\System\Snippet\SnippetException;
@@ -15,7 +15,7 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 readonly class TranslationRemover
 {
     public function __construct(
-        private Filesystem $translationWriter,
+        private FilesystemOperator $translationWriter,
         private AbstractTranslationLoader $translationLoader,
         private TranslationMetadataStore $metadataStore,
         private EventDispatcherInterface $eventDispatcher,

--- a/src/Core/System/Snippet/SnippetService.php
+++ b/src/Core/System/Snippet/SnippetService.php
@@ -48,7 +48,7 @@ class SnippetService
         private readonly SnippetFilterFactory $snippetFilterFactory,
         private readonly ExtensionDispatcher $extensionDispatcher,
         private readonly EventDispatcherInterface $eventDispatcher,
-        private readonly FilesystemOperator $privateFileSystem,
+        private readonly FilesystemOperator $translationFilesystem,
         private readonly Filesystem $localFileSystem,
     ) {
     }
@@ -605,7 +605,7 @@ class SnippetService
     private function decodeSnippetFileJson(AbstractSnippetFile $snippetFile): array
     {
         if ($snippetFile instanceof RemoteSnippetFile) {
-            $content = $this->privateFileSystem->read($snippetFile->getPath());
+            $content = $this->translationFilesystem->read($snippetFile->getPath());
         } else {
             $content = $this->localFileSystem->readFile($snippetFile->getPath());
         }

--- a/tests/integration/Core/System/Snippet/Service/TranslationConfigLoaderTest.php
+++ b/tests/integration/Core/System/Snippet/Service/TranslationConfigLoaderTest.php
@@ -20,6 +20,10 @@ class TranslationConfigLoaderTest extends TestCase
     public function testContainerExposesTranslationConfigParameterWithDefaults(): void
     {
         static::assertSame([
+            'use_local_filesystem' => false,
+            'scheduled_task' => [
+                'enabled' => true,
+            ],
             'repository_url' => null,
             'metadata_url' => null,
             'community_translations_url' => null,

--- a/tests/unit/Core/Framework/DependencyInjection/ConfigurationTest.php
+++ b/tests/unit/Core/Framework/DependencyInjection/ConfigurationTest.php
@@ -78,6 +78,9 @@ class ConfigurationTest extends TestCase
         static::assertInstanceOf(ArrayNodeDefinition::class, $children['excluded_locales']);
         static::assertInstanceOf(ArrayNodeDefinition::class, $children['plugin_mapping']);
         static::assertInstanceOf(ArrayNodeDefinition::class, $children['languages']);
+        static::assertInstanceOf(BooleanNodeDefinition::class, $children['use_local_filesystem']);
+        static::assertInstanceOf(ArrayNodeDefinition::class, $children['scheduled_task']);
+        static::assertInstanceOf(BooleanNodeDefinition::class, $children['scheduled_task']->getChildNodeDefinitions()['enabled']);
     }
 
     public function testTranslationConfigRejectsInvalidListType(): void
@@ -114,6 +117,10 @@ class ConfigurationTest extends TestCase
             'pseudo_locales' => null,
             'plugin_mapping' => null,
             'languages' => null,
+            'use_local_filesystem' => false,
+            'scheduled_task' => [
+                'enabled' => true,
+            ],
         ], $config['translation']);
     }
 

--- a/tests/unit/Core/System/Snippet/Command/DownloadTranslationCommandTest.php
+++ b/tests/unit/Core/System/Snippet/Command/DownloadTranslationCommandTest.php
@@ -1,0 +1,59 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\System\Snippet\Command;
+
+use GuzzleHttp\Psr7\Uri;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\System\Snippet\Command\DownloadTranslationCommand;
+use Shopware\Core\System\Snippet\DataTransfer\Language\LanguageCollection;
+use Shopware\Core\System\Snippet\DataTransfer\PluginMapping\PluginMappingCollection;
+use Shopware\Core\System\Snippet\Service\AbstractTranslationLoader;
+use Shopware\Core\System\Snippet\Struct\TranslationConfig;
+use Symfony\Component\Console\Tester\CommandTester;
+
+/**
+ * @internal
+ */
+#[Package('discovery')]
+#[CoversClass(DownloadTranslationCommand::class)]
+class DownloadTranslationCommandTest extends TestCase
+{
+    /**
+     * @var AbstractTranslationLoader&MockObject
+     */
+    private AbstractTranslationLoader $translationLoader;
+
+    protected function setUp(): void
+    {
+        $this->translationLoader = $this->createMock(AbstractTranslationLoader::class);
+    }
+
+    public function testDownloadsAllConfiguredLocalesWithoutDatabaseActivation(): void
+    {
+        $this->translationLoader->expects($this->exactly(2))
+            ->method('download')
+            ->with(static::callback(
+                static fn (string $locale): bool => \in_array($locale, ['de-DE', 'es-ES'], true)
+            ));
+
+        $tester = new CommandTester(new DownloadTranslationCommand(
+            $this->translationLoader,
+            new TranslationConfig(
+                new Uri('http://localhost:8000'),
+                ['de-DE', 'es-ES'],
+                [],
+                new LanguageCollection(),
+                new PluginMappingCollection(),
+                new Uri('http://localhost:8000/metadata.json'),
+                [],
+            ),
+        ));
+
+        $tester->execute([]);
+
+        $tester->assertCommandIsSuccessful();
+    }
+}

--- a/tests/unit/Core/System/Snippet/ScheduledTask/UpdateTranslationsTaskTest.php
+++ b/tests/unit/Core/System/Snippet/ScheduledTask/UpdateTranslationsTaskTest.php
@@ -6,6 +6,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\Snippet\ScheduledTask\UpdateTranslationsTask;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
 
 /**
  * @internal
@@ -19,5 +20,12 @@ class UpdateTranslationsTaskTest extends TestCase
         static::assertSame('translation.update', UpdateTranslationsTask::getTaskName());
         static::assertSame(86400, UpdateTranslationsTask::getDefaultInterval());
         static::assertTrue(UpdateTranslationsTask::shouldRescheduleOnFailure());
+    }
+
+    public function testTaskDoesNotRunWhenDisabled(): void
+    {
+        static::assertFalse(UpdateTranslationsTask::shouldRun(new ParameterBag([
+            'shopware.translation.scheduled_task.enabled' => false,
+        ])));
     }
 }

--- a/tests/unit/Core/System/Snippet/Service/TranslationFilesystemFactoryTest.php
+++ b/tests/unit/Core/System/Snippet/Service/TranslationFilesystemFactoryTest.php
@@ -1,0 +1,47 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\System\Snippet\Service;
+
+use League\Flysystem\FilesystemOperator;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Adapter\Filesystem\FilesystemFactory;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\System\Snippet\Service\TranslationFilesystemFactory;
+
+/**
+ * @internal
+ */
+#[Package('discovery')]
+#[CoversClass(TranslationFilesystemFactory::class)]
+class TranslationFilesystemFactoryTest extends TestCase
+{
+    public function testUsesPrivateFilesystemByDefault(): void
+    {
+        $privateFilesystem = static::createStub(FilesystemOperator::class);
+        $filesystemFactory = $this->createMock(FilesystemFactory::class);
+        $filesystemFactory->expects($this->never())->method('privateFactory');
+
+        $factory = new TranslationFilesystemFactory($privateFilesystem, $filesystemFactory, '/project', false);
+
+        static::assertSame($privateFilesystem, $factory->create());
+    }
+
+    public function testUsesLocalFilesystemWhenConfigured(): void
+    {
+        $privateFilesystem = static::createStub(FilesystemOperator::class);
+        $localFilesystem = static::createStub(FilesystemOperator::class);
+        $filesystemFactory = $this->createMock(FilesystemFactory::class);
+        $filesystemFactory->expects($this->once())
+            ->method('privateFactory')
+            ->with([
+                'type' => 'local',
+                'config' => ['root' => '/project/var'],
+            ])
+            ->willReturn($localFilesystem);
+
+        $factory = new TranslationFilesystemFactory($privateFilesystem, $filesystemFactory, '/project', true);
+
+        static::assertSame($localFilesystem, $factory->create());
+    }
+}


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

On Shopware SaaS the private filesystem is S3, and the downloaded translation files are the only snippets read over the network — bundle, plugin and app snippets are served from local disk. Building the snippet file collection therefore performs a recursive listing of the entire translation/locale tree, and resolving a locale reads each matching file individually, all as blocking S3 round trips on the request that finds the snippet cache cold. In production we see on the order of 400 S3 calls per freshly deployed shop, paid by its first visitor.
None of that work is dynamic. The translation files are identical for every shop on a given release and change only when we ship new ones, so they belong in the deployment artifact, read from local disk. Two things blocked that: the downloaded translation files were hard-wired to shopware.filesystem.private, and there was no way to fetch them without a database, since translation:install always creates language and snippet_set records.

### 2. What does this change do, exactly?

Three opt-in additions. All default to the current behaviour, so nothing changes for existing setups.

**`shopware.translation.use_local_filesystem`** (default `false`)

Adds `shopware.filesystem.translation`, built by the new `TranslationFilesystemFactory`. When the flag is `false` the factory returns the existing `shopware.filesystem.private` instance, so the wiring is a no-op. When `true` it builds a local Flysystem adapter rooted at `%kernel.project_dir%/var`, so snippets are read from `var/translation/locale/<locale>/` on local disk and the listing plus the per-file reads never leave the machine.

The five translation consumers now take the new service instead of `shopware.filesystem.private`: `TranslationLoader`, `TranslationMetadataStore`, `TranslationRemover`, `SnippetFileLoader` and `SnippetService`. Their type hints were widened from the concrete `League\Flysystem\Filesystem` to `FilesystemOperator` so a factory-created adapter can be injected.

**`bin/console translation:download`**

Downloads the snippet files for all configured locales without creating languages or snippet sets, so it runs during a build with no database available. It is backed by a new `AbstractTranslationLoader::download()`; `TranslationLoader::load()` now delegates its fetch phase to that method, leaving the existing install path unchanged.

**`shopware.translation.scheduled_task.enabled`** (default `true`)

`UpdateTranslationsTask::shouldRun()` reads the parameter. `TaskRegistry` already moves tasks to `STATUS_SKIPPED` when `shouldRun()` returns false, so the daily update can be turned off without deleting the task — appropriate when translation files are provisioned at build time and the runtime filesystem is immutable.

Together these let a deployment run `translation:download` in the build, ship `var/translation` inside the release, and serve every shop's first page load from local disk.

### 3. Describe each step to reproduce the issue or behaviour.

To observe the current behaviour, point `shopware.filesystem.private` at S3, clear the snippet cache and load the storefront: the request performs a recursive listing plus one GetObject per snippet file.

To verify the change, narrow the configured locales so the download stays small — `config/packages/z-test.yaml`:

```yaml
shopware:
    translation:
        use_local_filesystem: true
        languages:
            - { name: 'Deutsch (Österreich)', locale: 'de-AT' }
```

Files are served from local disk

1. bin/console cache:clear
2. bin/console translation:download
3. find var/translation -type f — files are written to var/translation/locale/de-AT/…
4. Clear the snippet cache and load a page in that language; the snippets resolve with no calls to the private filesystem.
5. Set use_local_filesystem: false, bin/console cache:clear, run translation:download again — files go to the private filesystem as before.

Scheduled task toggle

1. Set shopware.translation.scheduled_task.enabled: false, then bin/console cache:clear.
2. bin/console scheduled-task:register
3. SELECT name, status FROM scheduled_task WHERE name = 'translation.update' reports skipped.
4. Set the flag back to true, clear the cache and re-register — the status returns to scheduled.

### 4. Please link to the relevant issues (if any).

https://github.com/shopware/saas/issues/725

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
