### PR TITLE
fix(core): signal deprecated class constructors

### DIFF
--- a/src/Core/Content/Flow/Events/BeforeLoadStorableFlowDataEvent.php
+++ b/src/Core/Content/Flow/Events/BeforeLoadStorableFlowDataEvent.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Core\Content\Flow\Events;
 
+use Shopware\Core\Content\Shared\MailFlow\Event\MailFlowDataCriteriaEvent;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Event\GenericEvent;
@@ -21,6 +22,10 @@ class BeforeLoadStorableFlowDataEvent extends Event implements ShopwareEvent, Ge
         private readonly Criteria $criteria,
         private readonly Context $context,
     ) {
+        Feature::triggerDeprecationOrThrow(
+            'v6.8.0.0',
+            Feature::deprecatedClassMessage(self::class, 'v6.8.0.0', MailFlowDataCriteriaEvent::class)
+        );
     }
 
     public function getName(): string

--- a/src/Core/Content/MailTemplate/Exception/SalesChannelNotFoundException.php
+++ b/src/Core/Content/MailTemplate/Exception/SalesChannelNotFoundException.php
@@ -17,6 +17,11 @@ class SalesChannelNotFoundException extends ShopwareHttpException
 {
     public function __construct(string $salesChannelId)
     {
+        Feature::triggerDeprecationOrThrow(
+            'v6.8.0.0',
+            Feature::deprecatedClassMessage(self::class, 'v6.8.0.0'),
+        );
+
         parent::__construct(
             'Sales channel with id "{{ salesChannelId }}" was not found.',
             ['salesChannelId' => $salesChannelId]

--- a/src/Core/Content/Product/DataAbstractionLayer/UpdatedStates.php
+++ b/src/Core/Content/Product/DataAbstractionLayer/UpdatedStates.php
@@ -23,6 +23,10 @@ final class UpdatedStates extends Struct
         private readonly array $oldStates,
         private array $newStates
     ) {
+        Feature::triggerDeprecationOrThrow(
+            'v6.8.0.0',
+            Feature::deprecatedClassMessage(self::class, 'v6.8.0.0')
+        );
     }
 
     public function getId(): string

--- a/src/Core/Content/Product/Events/ProductStatesBeforeChangeEvent.php
+++ b/src/Core/Content/Product/Events/ProductStatesBeforeChangeEvent.php
@@ -22,6 +22,10 @@ class ProductStatesBeforeChangeEvent extends Event implements ShopwareEvent
         protected array $updatedStates,
         protected Context $context
     ) {
+        Feature::triggerDeprecationOrThrow(
+            'v6.8.0.0',
+            Feature::deprecatedClassMessage(self::class, 'v6.8.0.0')
+        );
     }
 
     /**

--- a/src/Core/Content/Product/Events/ProductStatesChangedEvent.php
+++ b/src/Core/Content/Product/Events/ProductStatesChangedEvent.php
@@ -22,6 +22,10 @@ class ProductStatesChangedEvent extends Event implements ShopwareEvent
         protected array $updatedStates,
         protected Context $context
     ) {
+        Feature::triggerDeprecationOrThrow(
+            'v6.8.0.0',
+            Feature::deprecatedClassMessage(self::class, 'v6.8.0.0')
+        );
     }
 
     /**

--- a/src/Core/System/NumberRange/Exception/IncrementStorageNotFoundException.php
+++ b/src/Core/System/NumberRange/Exception/IncrementStorageNotFoundException.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Core\System\NumberRange\Exception;
 
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\NumberRange\NumberRangeException;
 use Symfony\Component\HttpFoundation\Response;
@@ -21,6 +22,11 @@ class IncrementStorageNotFoundException extends NumberRangeException
         string $configuredStorage,
         array $availableStorages = []
     ) {
+        Feature::triggerDeprecationOrThrow(
+            'v6.8.0.0',
+            Feature::deprecatedClassMessage(self::class, 'v6.8.0.0', NumberRangeException::class)
+        );
+
         parent::__construct(
             Response::HTTP_INTERNAL_SERVER_ERROR,
             self::INCREMENT_STORAGE_NOT_FOUND,

--- a/src/Core/System/NumberRange/Exception/NoConfigurationException.php
+++ b/src/Core/System/NumberRange/Exception/NoConfigurationException.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Core\System\NumberRange\Exception;
 
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\NumberRange\NumberRangeException;
 use Symfony\Component\HttpFoundation\Response;
@@ -18,6 +19,11 @@ class NoConfigurationException extends NumberRangeException
         string $entityName,
         ?string $salesChannelId = null
     ) {
+        Feature::triggerDeprecationOrThrow(
+            'v6.8.0.0',
+            Feature::deprecatedClassMessage(self::class, 'v6.8.0.0', NumberRangeException::class)
+        );
+
         parent::__construct(
             Response::HTTP_BAD_REQUEST,
             self::NO_CONFIGURATION_FOR_ENTITY,

--- a/src/Storefront/Page/Account/Order/AccountOrderDetailPageLoadedEvent.php
+++ b/src/Storefront/Page/Account/Order/AccountOrderDetailPageLoadedEvent.php
@@ -19,6 +19,11 @@ class AccountOrderDetailPageLoadedEvent extends PageLoadedEvent
         SalesChannelContext $salesChannelContext,
         Request $request,
     ) {
+        Feature::triggerDeprecationOrThrow(
+            'v6.8.0.0',
+            Feature::deprecatedClassMessage(self::class, 'v6.8.0.0')
+        );
+
         parent::__construct($salesChannelContext, $request);
     }
 

--- a/src/Storefront/Page/Account/Order/AccountOrderDetailPageLoadedHook.php
+++ b/src/Storefront/Page/Account/Order/AccountOrderDetailPageLoadedHook.php
@@ -32,6 +32,11 @@ class AccountOrderDetailPageLoadedHook extends PageLoadedHook
         private readonly AccountOrderDetailPage $page,
         SalesChannelContext $context
     ) {
+        Feature::triggerDeprecationOrThrow(
+            'v6.8.0.0',
+            Feature::deprecatedClassMessage(self::class, 'v6.8.0.0')
+        );
+
         parent::__construct($context->getContext());
         $this->salesChannelContext = $context;
     }

--- a/src/Storefront/Theme/Exception/ThemeAssignmentException.php
+++ b/src/Storefront/Theme/Exception/ThemeAssignmentException.php
@@ -25,6 +25,8 @@ class ThemeAssignmentException extends ShopwareHttpException
         private readonly array $assignedSalesChannels,
         ?\Throwable $e = null
     ) {
+        Feature::triggerDeprecationOrThrow('v6.8.0.0', Feature::deprecatedClassMessage(self::class, 'v6.8.0.0', ThemeException::class));
+
         $parameters = ['themeName' => $themeName];
         $message = 'Unable to deactivate or uninstall theme "{{ themeName }}".';
         $message .= ' Remove the following assignments between theme and sales channel assignments: {{ assignments }}.';

--- a/src/Storefront/Theme/Message/DeleteThemeFilesMessage.php
+++ b/src/Storefront/Theme/Message/DeleteThemeFilesMessage.php
@@ -23,6 +23,10 @@ class DeleteThemeFilesMessage implements AsyncMessageInterface
         private readonly string $salesChannelId,
         private readonly string $themeId
     ) {
+        Feature::triggerDeprecationOrThrow(
+            'v6.8.0.0',
+            Feature::deprecatedClassMessage(self::class, 'v6.8.0.0')
+        );
     }
 
     public function getThemePath(): string


### PR DESCRIPTION
### 1. Why is this change necessary?

Enabling the deprecated-method runtime-signal rule in #19043 also checks constructors of deprecated public classes. Those constructors must emit the existing deprecation so extension code receives an actionable signal.

### 2. What does this change do, exactly?

Adds runtime deprecation handling to the constructors of the remaining public deprecated events, value objects, exceptions, hooks, and messages.

### 3. Describe each step to reproduce the issue or behaviour.

1. Enable the v6.8 feature flag.
2. Construct one of the deprecated public classes.
3. A v6.8 deprecation is signaled.

### 4. Please link to the relevant issues (if any).

Required before #19043 can be merged, as it enables the enforcing PHPStan rules.

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to RELEASE_INFO-6.<major>.md under Upcoming for informational changes, including the consequences of the change and how it affects external developers.
  - Add an UPGRADE section in UPGRADE-6.<next-major>.md for breaking changes (what/why/impact/how to adapt).
  - See the Documenting a Release Process guide for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them