### PR TITLE
ci: run stale PR management only in the public repository

### DIFF
--- a/.github/workflows/manage-stale-prs.yml
+++ b/.github/workflows/manage-stale-prs.yml
@@ -7,6 +7,8 @@ on:
 
 jobs:
   manage-stale-prs:
+    # Acts on the whole shopware organization, so it must run exactly once.
+    if: github.repository == 'shopware/shopware'
     runs-on: ubuntu-24.04
     permissions:
       id-token: write

--- a/.github/workflows/manage-stale-prs.yml
+++ b/.github/workflows/manage-stale-prs.yml
@@ -7,7 +7,6 @@ on:
 
 jobs:
   manage-stale-prs:
-    # Acts on the whole shopware organization, so it must run exactly once.
     if: github.repository == 'shopware/shopware'
     runs-on: ubuntu-24.04
     permissions:


### PR DESCRIPTION
### 1. Why is this change necessary?

The workflow is mirrored to `shopware/shopware-private`, where the scheduled job fails every day and would otherwise handle the same organization-wide pull requests a second time.

### 2. What does this change do, exactly?

Adds `if: github.repository == 'shopware/shopware'` to the job.

### 3. Describe each step to reproduce the issue or behaviour.

Every scheduled run of "Manage stale pull requests" in `shopware/shopware-private` fails in the `Checkout` step.

### 4. Please link to the relevant issues (if any).

- relates #19041

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
