### PR TITLE
fix(docs): code / v-pre

### DIFF
--- a/coding-guidelines/core/ci-workflows.md
+++ b/coding-guidelines/core/ci-workflows.md
@@ -85,7 +85,7 @@ skipped job is visible in the UI, a suppressed failure is not.
   one audit at a time; the remaining audits are disabled there and report a few
   hundred findings between them, so enabling one is its own piece of work.
 - zizmor cannot parse a workflow whose `strategy:` is a dynamic
-  `${{ fromJson(...) }}` matrix, and it *warns and exits 0* rather than failing —
+  <code v-pre>${{ fromJson(...) }}</code> matrix, and it *warns and exits 0* rather than failing —
   an unparsed file is an unaudited file. `zizmor-collection-guard.ts` reconciles
   those warnings against a known list so a new one fails the lint, and so a
   listed file that starts parsing again is reported as a stale entry.


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

Latest change in guidelines broke production build, same as in https://github.com/shopware/shopware/pull/17533


### 2. What does this change do, exactly?

Changes inline code from ticks to `<code v-pre>`


### 3. Describe each step to reproduce the issue or behaviour.

See failures in https://github.com/shopware/developer-portal/actions/workflows/external-healthcheck.yml


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

https://github.com/vuejs/vitepress/issues?q=is%3Aissue%20vue%20interpolation

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfilled them
