### PR TITLE
ci: grant the release gate the permissions its nested workflows need

### DIFF
--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -18,9 +18,14 @@ concurrency:
   group: release-gate-${{ github.ref }}
   cancel-in-progress: true
 
+# Union of what the called workflows declare. A nested job requesting more than is
+# granted here fails the whole run at startup, even when its own `if` would skip it.
 permissions:
+  actions: read
   contents: read
   id-token: write
+  pull-requests: read
+  security-events: write
 
 jobs:
   acceptance:

--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -18,8 +18,6 @@ concurrency:
   group: release-gate-${{ github.ref }}
   cancel-in-progress: true
 
-# Union of what the called workflows declare. A nested job requesting more than is
-# granted here fails the whole run at startup, even when its own `if` would skip it.
 permissions:
   actions: read
   contents: read


### PR DESCRIPTION
### 1. Why is this change necessary?

Every run of the release gate since #17750 ended in a startup failure: the `permissions:` block caps the workflows it calls, and three of their jobs request more than it grants.

### 2. What does this change do, exactly?

Grants `actions: read`, `pull-requests: read` and `security-events: write` in addition to the existing two.

### 3. Describe each step to reproduce the issue or behaviour.

[Run 31078564361](https://github.com/shopware/shopware/actions/runs/31078564361): `startup_failure`, no jobs. With this change the run starts: [run 31182696516](https://github.com/shopware/shopware/actions/runs/31182696516).

### 4. Please link to the relevant issues (if any).

- relates #17750

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
