### PR TITLE
fix: newsletter discount promotions for newly registered customers (backport 6.6.x)

### DIFF
--- a/src/Core/Checkout/Customer/SalesChannel/RegisterRoute.php
+++ b/src/Core/Checkout/Customer/SalesChannel/RegisterRoute.php
@@ -20,6 +20,7 @@ use Shopware\Core\Checkout\Customer\Validation\Constraint\CustomerEmailUnique;
 use Shopware\Core\Checkout\Customer\Validation\Constraint\CustomerVatIdentification;
 use Shopware\Core\Checkout\Customer\Validation\Constraint\CustomerZipCode;
 use Shopware\Core\Checkout\Order\SalesChannel\OrderService;
+use Shopware\Core\Content\Newsletter\DataAbstractionLayer\Indexing\CustomerNewsletterSalesChannelsUpdater;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Indexing\EntityIndexerRegistry;
@@ -88,6 +89,7 @@ class RegisterRoute extends AbstractRegisterRoute
         private readonly SalesChannelContextServiceInterface $contextService,
         private readonly StoreApiCustomFieldMapper $customFieldMapper,
         private readonly EntityRepository $salutationRepository,
+        private readonly CustomerNewsletterSalesChannelsUpdater $customerNewsletterSalesChannelsUpdater,
     ) {
     }
 
@@ -196,6 +198,7 @@ class RegisterRoute extends AbstractRegisterRoute
         $writeContext->addState(EntityIndexerRegistry::USE_INDEXING_QUEUE);
 
         $this->customerRepository->create([$customer], $writeContext);
+        $this->customerNewsletterSalesChannelsUpdater->update([$customer['id']], true);
 
         $criteria = new Criteria([$customer['id']]);
 

--- a/src/Core/Checkout/DependencyInjection/customer.xml
+++ b/src/Core/Checkout/DependencyInjection/customer.xml
@@ -257,6 +257,7 @@
             <argument type="service" id="Shopware\Core\System\SalesChannel\Context\SalesChannelContextService"/>
             <argument type="service" id="Shopware\Core\System\SalesChannel\StoreApiCustomFieldMapper"/>
             <argument type="service" id="salutation.repository"/>
+            <argument type="service" id="Shopware\Core\Content\Newsletter\DataAbstractionLayer\Indexing\CustomerNewsletterSalesChannelsUpdater"/>
         </service>
 
         <service id="Shopware\Core\Checkout\Customer\SalesChannel\RegisterConfirmRoute" public="true">

--- a/tests/integration/Core/Checkout/Customer/SalesChannel/RegisterRouteTest.php
+++ b/tests/integration/Core/Checkout/Customer/SalesChannel/RegisterRouteTest.php
@@ -13,7 +13,9 @@ use Shopware\Core\Checkout\Customer\Event\CustomerConfirmRegisterUrlEvent;
 use Shopware\Core\Checkout\Customer\Event\CustomerDoubleOptInRegistrationEvent;
 use Shopware\Core\Checkout\Customer\Event\CustomerRegisterEvent;
 use Shopware\Core\Checkout\Customer\Rule\CustomerLoggedInRule;
+use Shopware\Core\Checkout\Customer\Rule\IsNewsletterRecipientRule;
 use Shopware\Core\Checkout\Customer\SalesChannel\RegisterRoute;
+use Shopware\Core\Content\Newsletter\SalesChannel\NewsletterSubscribeRoute;
 use Shopware\Core\Content\Product\Aggregate\ProductVisibility\ProductVisibilityDefinition;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
@@ -160,6 +162,46 @@ class RegisterRouteTest extends TestCase
 
         static::assertNotNull($ruleIds, 'Register event was not dispatched');
         static::assertContains($ids->get('rule'), $ruleIds, 'Context was not reloaded');
+    }
+
+    public function testRegisterEventWithNewsletterRecipientRule(): void
+    {
+        $ids = new IdsCollection();
+
+        static::getContainer()->get('newsletter_recipient.repository')->create([
+            [
+                'id' => $ids->create('newsletter-recipient'),
+                'email' => 'teg-reg@example.com',
+                'salesChannelId' => $this->ids->get('sales-channel'),
+                'status' => NewsletterSubscribeRoute::STATUS_DIRECT,
+                'hash' => Uuid::randomHex(),
+            ],
+        ], Context::createDefaultContext());
+
+        $rule = [
+            'id' => $ids->create('rule'),
+            'name' => 'Test newsletter recipient rule',
+            'priority' => 1,
+            'conditions' => [
+                ['type' => (new IsNewsletterRecipientRule())->getName(), 'value' => ['isNewsletterRecipient' => true]],
+            ],
+        ];
+
+        static::getContainer()->get('rule.repository')->create([$rule], Context::createDefaultContext());
+
+        $ruleIds = null;
+        static::getContainer()->get('event_dispatcher')->addListener(CustomerRegisterEvent::class, static function (CustomerRegisterEvent $event) use (&$ruleIds): void {
+            $ruleIds = $event->getSalesChannelContext()->getRuleIds();
+        });
+
+        $this->browser->request('POST', '/store-api/account/register', [], [], ['CONTENT_TYPE' => 'application/json'], json_encode($this->getRegistrationData(), \JSON_THROW_ON_ERROR));
+
+        $response = json_decode((string) $this->browser->getResponse()->getContent(), true, 512, \JSON_THROW_ON_ERROR);
+
+        static::assertArrayHasKey('apiAlias', $response, \print_r($response, true));
+        static::assertSame('customer', $response['apiAlias']);
+        static::assertNotNull($ruleIds, 'Register event was not dispatched');
+        static::assertContains($ids->get('rule'), $ruleIds, 'Newsletter recipient rule was not available in the refreshed context');
     }
 
     #[DataProvider('customerBoundToSalesChannelProvider')]

--- a/tests/unit/Core/Checkout/Customer/SalesChannel/RegisterRouteTest.php
+++ b/tests/unit/Core/Checkout/Customer/SalesChannel/RegisterRouteTest.php
@@ -14,6 +14,7 @@ use Shopware\Core\Checkout\Customer\Event\CustomerDoubleOptInRegistrationEvent;
 use Shopware\Core\Checkout\Customer\SalesChannel\RegisterRoute;
 use Shopware\Core\Checkout\Customer\Validation\Constraint\CustomerVatIdentification;
 use Shopware\Core\Checkout\Customer\Validation\Constraint\CustomerZipCode;
+use Shopware\Core\Content\Newsletter\DataAbstractionLayer\Indexing\CustomerNewsletterSalesChannelsUpdater;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Event\EntityWrittenContainerEvent;
@@ -102,6 +103,7 @@ class RegisterRouteTest extends TestCase
             $this->createMock(SalesChannelContextService::class),
             $this->createMock(StoreApiCustomFieldMapper::class),
             $this->createMock(EntityRepository::class),
+            $this->createMock(CustomerNewsletterSalesChannelsUpdater::class),
         );
 
         $data = [
@@ -173,6 +175,7 @@ class RegisterRouteTest extends TestCase
             $this->createMock(SalesChannelContextService::class),
             $this->createMock(StoreApiCustomFieldMapper::class),
             $this->createMock(EntityRepository::class),
+            $this->createMock(CustomerNewsletterSalesChannelsUpdater::class),
         );
 
         $data = [
@@ -250,6 +253,7 @@ class RegisterRouteTest extends TestCase
             $this->createMock(SalesChannelContextService::class),
             $this->createMock(StoreApiCustomFieldMapper::class),
             $this->createMock(EntityRepository::class),
+            $this->createMock(CustomerNewsletterSalesChannelsUpdater::class),
         );
 
         $data = [
@@ -323,6 +327,7 @@ class RegisterRouteTest extends TestCase
             $this->createMock(SalesChannelContextService::class),
             $this->createMock(StoreApiCustomFieldMapper::class),
             $this->createMock(EntityRepository::class),
+            $this->createMock(CustomerNewsletterSalesChannelsUpdater::class),
         );
 
         $data = [
@@ -391,6 +396,7 @@ class RegisterRouteTest extends TestCase
             $this->createMock(SalesChannelContextService::class),
             $customFieldMapper,
             $this->createMock(EntityRepository::class),
+            $this->createMock(CustomerNewsletterSalesChannelsUpdater::class),
         );
 
         $data = [
@@ -458,6 +464,7 @@ class RegisterRouteTest extends TestCase
             $this->createMock(SalesChannelContextService::class),
             $this->createMock(StoreApiCustomFieldMapper::class),
             $salutationRepository,
+            $this->createMock(CustomerNewsletterSalesChannelsUpdater::class),
         );
 
         $data = [
@@ -529,6 +536,7 @@ class RegisterRouteTest extends TestCase
             $this->createMock(SalesChannelContextService::class),
             $this->createMock(StoreApiCustomFieldMapper::class),
             $salutationRepository,
+            $this->createMock(CustomerNewsletterSalesChannelsUpdater::class),
         );
 
         $data = [
@@ -605,6 +613,7 @@ class RegisterRouteTest extends TestCase
             $this->createMock(SalesChannelContextService::class),
             $this->createMock(StoreApiCustomFieldMapper::class),
             $this->createMock(EntityRepository::class),
+            $this->createMock(CustomerNewsletterSalesChannelsUpdater::class),
         );
 
         $data = [
@@ -679,6 +688,7 @@ class RegisterRouteTest extends TestCase
             $this->createMock(SalesChannelContextService::class),
             $this->createMock(StoreApiCustomFieldMapper::class),
             $this->createMock(EntityRepository::class),
+            $this->createMock(CustomerNewsletterSalesChannelsUpdater::class),
         );
 
         $data = [
@@ -805,6 +815,7 @@ class RegisterRouteTest extends TestCase
             $this->createMock(SalesChannelContextService::class),
             $this->createMock(StoreApiCustomFieldMapper::class),
             $this->createMock(EntityRepository::class),
+            $this->createMock(CustomerNewsletterSalesChannelsUpdater::class),
         );
 
         $salesChannelContext = $this->createMock(SalesChannelContext::class);
@@ -911,6 +922,7 @@ class RegisterRouteTest extends TestCase
             $this->createMock(SalesChannelContextService::class),
             $this->createMock(StoreApiCustomFieldMapper::class),
             $this->createMock(EntityRepository::class),
+            $this->createMock(CustomerNewsletterSalesChannelsUpdater::class),
         );
 
         $salesChannelContext = $this->createMock(SalesChannelContext::class);
@@ -980,6 +992,69 @@ class RegisterRouteTest extends TestCase
         );
     }
 
+    public function testUpdatesNewsletterSalesChannelIdsBeforeCustomerIsLoaded(): void
+    {
+        $customerEntity = new CustomerEntity();
+        $customerEntity->setDoubleOptInRegistration(false);
+        $customerEntity->setId('customer-1');
+        $customerEntity->setGuest(false);
+
+        $result = new EntitySearchResult(
+            CustomerDefinition::ENTITY_NAME,
+            1,
+            new CustomerCollection([$customerEntity]),
+            null,
+            new Criteria(),
+            Context::createDefaultContext()
+        );
+
+        $createdCustomerId = null;
+        $calls = [];
+
+        $customerRepository = $this->createMock(EntityRepository::class);
+        $customerRepository->method('getDefinition')->willReturn(new CustomerDefinition());
+        $customerRepository
+            ->expects($this->once())
+            ->method('create')
+            ->willReturnCallback(static function (array $create) use (&$createdCustomerId, &$calls) {
+                $calls[] = 'create';
+                $createdCustomerId = $create[0]['id'];
+
+                return new EntityWrittenContainerEvent(Context::createDefaultContext(), new NestedEventCollection([]), []);
+            });
+        $customerRepository
+            ->expects($this->once())
+            ->method('search')
+            ->willReturnCallback(static function () use (&$calls, $result) {
+                static::assertSame(['create', 'update'], $calls);
+
+                return $result;
+            });
+
+        $customerNewsletterSalesChannelsUpdater = $this->createMock(CustomerNewsletterSalesChannelsUpdater::class);
+        $customerNewsletterSalesChannelsUpdater
+            ->expects($this->once())
+            ->method('update')
+            ->willReturnCallback(static function (array $ids, bool $reverseUpdate) use (&$createdCustomerId, &$calls): void {
+                $calls[] = 'update';
+
+                static::assertNotNull($createdCustomerId);
+                static::assertSame([$createdCustomerId], $ids);
+                static::assertTrue($reverseUpdate);
+            });
+
+        $registerRoute = $this->createRegisterRoute(
+            customerRepository: $customerRepository,
+            customerNewsletterSalesChannelsUpdater: $customerNewsletterSalesChannelsUpdater
+        );
+
+        $registerRoute->register(
+            new RequestDataBag($this->createRegistrationData()),
+            Generator::generateSalesChannelContext(),
+            false
+        );
+    }
+
     /**
      * @return StaticEntityRepository<CustomerCollection>
      */
@@ -1010,7 +1085,8 @@ class RegisterRouteTest extends TestCase
         ?StoreApiCustomFieldMapper $customFieldMapper = null,
         ?EntityRepository $salutationRepository = null,
         ?StaticSystemConfigService $systemConfigService = null,
-        EntityRepository|StaticEntityRepository|null $customerRepository = null
+        EntityRepository|StaticEntityRepository|null $customerRepository = null,
+        ?CustomerNewsletterSalesChannelsUpdater $customerNewsletterSalesChannelsUpdater = null
     ): RegisterRoute {
         $dataValidator ??= $this->createMock(DataValidator::class);
         $eventDispatcher ??= new EventDispatcher();
@@ -1024,6 +1100,7 @@ class RegisterRouteTest extends TestCase
             'core.systemWideLoginRegistration.isCustomerBoundToSalesChannel' => true,
         ]);
         $customerRepository ??= $this->createCustomerRepository();
+        $customerNewsletterSalesChannelsUpdater ??= $this->createMock(CustomerNewsletterSalesChannelsUpdater::class);
 
         return new RegisterRoute(
             $eventDispatcher,
@@ -1039,6 +1116,7 @@ class RegisterRouteTest extends TestCase
             $this->createMock(SalesChannelContextService::class),
             $customFieldMapper,
             $salutationRepository,
+            $customerNewsletterSalesChannelsUpdater,
         );
     }
 


### PR DESCRIPTION
**Backport:** https://github.com/shopware/shopware/pull/17545

The automatic backport ([workflow run](https://github.com/shopware/shopware/actions/runs/31172927859)) failed with a `modify/delete` conflict, because trunk has migrated the Checkout DI to PHP (`customer.php`) while 6.6.x is still on XML (`customer.xml`). This is the manual equivalent.

---

### 1. Why is this change necessary?

When a discount for newsletter recipients is configured, that should be applied automatically and a customer that is already a newsletter recipient registers via checkout the discount is only applied after reload. If a user goes directly to checkout the discount is not applied.

### 2. What does this change do, exactly?

Add `CustomerNewsletterSalesChannelsUpdater::update` to `RegisterRoute` to immediately update newly built SalesChannelContext after register with newsletter recipient info.

Differences to the trunk change, caused by branch divergence:

- The service argument is added to `customer.xml` instead of `customer.php`.
- The new dependency is appended to the `RegisterRoute` constructor, which on 6.6.x has no `$passwordValidationFactory`, `$doubleOptInService`, or `$clock` parameters. The constructor is `@internal`, so this is not a public API change.
- The unit test constructs `RegisterRoute` inline at 11 further call sites that trunk has already refactored into the `createRegisterRoute()` helper; all of them get the new argument.

### 3. Describe each step to reproduce the issue or behaviour.

- Create a discount with rule "Newsletter recipient = true".
- Register for newsletter with email address
- Fill cart and go to checkout (not logged-in, no account registered yet)
- Register a new account (real account or guest makes no difference)
- Go to confirm page
- Discount is not applied
- Reload page
- Discount is applied

### 4. Please link to the relevant issues (if any).
fixes https://github.com/shopware/shopware/issues/16782

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
