### PR TITLE
fix(checkout): replace deprecated Request::get() usages

### DIFF
--- a/src/Core/Checkout/Order/SalesChannel/OrderRoute.php
+++ b/src/Core/Checkout/Order/SalesChannel/OrderRoute.php
@@ -258,11 +258,14 @@ class OrderRoute extends AbstractOrderRoute
         }
 
         // Verify email and zip code with this order
-        if ($request->get('email', false) && $request->get('zipcode', false)) {
-            $zipCode = $order->getBillingAddress()?->getZipcode();
-            if ($zipCode === null
-                || strtolower($request->get('email')) !== strtolower($orderCustomer->getEmail())
-                || strtoupper($request->get('zipcode')) !== strtoupper($zipCode)) {
+        $email = RequestParamHelper::get($request, 'email', false);
+        $zipcode = RequestParamHelper::get($request, 'zipcode', false);
+
+        if ($email && $zipcode) {
+            $billingZipCode = $order->getBillingAddress()?->getZipcode();
+            if ($billingZipCode === null
+                || strtolower($email) !== strtolower($orderCustomer->getEmail())
+                || strtoupper($zipcode) !== strtoupper($billingZipCode)) {
                 throw OrderException::wrongGuestCredentials();
             }
         } else {

--- a/src/Storefront/Page/Account/Order/AccountOrderDetailPageLoader.php
+++ b/src/Storefront/Page/Account/Order/AccountOrderDetailPageLoader.php
@@ -55,7 +55,7 @@ class AccountOrderDetailPageLoader
             throw CartException::customerNotLoggedIn();
         }
 
-        $orderId = (string) $request->get('id');
+        $orderId = $request->attributes->getString('id', $request->query->getString('id'));
 
         if ($orderId === '') {
             throw RoutingException::missingRequestParameter('id');

--- a/tests/unit/Core/Checkout/Order/SalesChannel/OrderRouteTest.php
+++ b/tests/unit/Core/Checkout/Order/SalesChannel/OrderRouteTest.php
@@ -120,7 +120,7 @@ class OrderRouteTest extends TestCase
      * @param ?class-string<\Throwable> $exception
      */
     #[DataProvider('customerDataProvider')]
-    public function testValidateGuestCustomer(?bool $isGuest, ?string $mail, ?string $postalCode, ?string $exception, bool $login = false): void
+    public function testValidateGuestCustomer(?bool $isGuest, ?string $mail, ?string $postalCode, ?string $exception, bool $login = false, bool $credentialsInQuery = false): void
     {
         if ($exception !== null) {
             $this->expectException($exception);
@@ -198,8 +198,9 @@ class OrderRouteTest extends TestCase
         $criteria->addFilter(new EqualsFilter('deepLinkCode', 'deepLinkCode'));
 
         $request = new Request();
-        $request->request->set('email', $mail);
-        $request->request->set('zipcode', $postalCode);
+        $credentials = $credentialsInQuery ? $request->query : $request->request;
+        $credentials->set('email', $mail);
+        $credentials->set('zipcode', $postalCode);
         $request->request->set('login', $login);
 
         $response = $route->load($request, $context, $criteria);
@@ -211,7 +212,7 @@ class OrderRouteTest extends TestCase
     }
 
     /**
-     * @return iterable<string, array{?bool, ?string, ?string, ?class-string<\Throwable>, 4?: bool}>
+     * @return iterable<string, array{?bool, ?string, ?string, ?class-string<\Throwable>, 4?: bool, 5?: bool}>
      */
     public static function customerDataProvider(): iterable
     {
@@ -225,6 +226,9 @@ class OrderRouteTest extends TestCase
         yield 'valid guest uppercase email' => [true, 'Test@Example.Com', 'AA-345', null];
         yield 'valid guest lowercase postal code' => [true, 'Test@Example.Com', 'aa-345', null];
         yield 'valid guest with login' => [true, 'Test@Example.Com', 'aa-345', null, true];
+        yield 'valid guest with credentials in query' => [true, 'test@example.com', 'AA-345', null, false, true];
+        yield 'wrong e-mail in query' => [true, 'false@example.com', 'AA-345', WrongGuestCredentialsException::class, false, true];
+        yield 'no request e-mail in query' => [true, null, 'AA-345', GuestNotAuthenticatedException::class, false, true];
     }
 
     #[DataProvider('deeplinkFilterProvider')]

--- a/tests/unit/Core/Checkout/Order/SalesChannel/OrderRouteTest.php
+++ b/tests/unit/Core/Checkout/Order/SalesChannel/OrderRouteTest.php
@@ -5,6 +5,7 @@ namespace Shopware\Tests\Unit\Core\Checkout\Order\SalesChannel;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Checkout\Cart\CartException;
 use Shopware\Core\Checkout\Customer\CustomerEntity;
 use Shopware\Core\Checkout\Customer\CustomerException;
 use Shopware\Core\Checkout\Customer\SalesChannel\AccountService;
@@ -34,6 +35,7 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\RateLimiter\RateLimiter;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Shopware\Core\Test\Annotation\DisabledFeatures;
 use Symfony\Component\Clock\NativeClock;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\Request;
@@ -120,104 +122,49 @@ class OrderRouteTest extends TestCase
      * @param ?class-string<\Throwable> $exception
      */
     #[DataProvider('customerDataProvider')]
-    public function testValidateGuestCustomer(?bool $isGuest, ?string $mail, ?string $postalCode, ?string $exception, bool $login = false, bool $credentialsInQuery = false): void
+    public function testValidateGuestCustomer(?bool $isGuest, ?string $mail, ?string $postalCode, ?string $exception, bool $login = false): void
     {
-        if ($exception !== null) {
-            $this->expectException($exception);
-        }
-
-        $orderCustomer = new OrderCustomerEntity();
-        $orderCustomer->setId(Uuid::randomHex());
-        $orderCustomer->setEmail('test@example.com');
-        $orderCustomer->setCustomerId(Uuid::randomHex());
-
-        if ($isGuest !== null) {
-            $customer = new CustomerEntity();
-            $customer->setId($orderCustomer->getId());
-            $customer->setGuest($isGuest);
-
-            $orderCustomer->setCustomer($customer);
-        }
-
-        $billingAddress = new OrderAddressEntity();
-        $billingAddress->setZipcode('AA-345');
-
-        $order = new OrderEntity();
-        $order->setId(Uuid::randomHex());
-        $order->setCreatedAt(new \DateTime());
-        $order->setOrderCustomer($orderCustomer);
-        $order->setBillingAddress($billingAddress);
-
-        $context = static::createStub(SalesChannelContext::class);
-        $context
-            ->method('getCustomer')
-            ->willReturn(null);
-
-        $eventDispatcher = $this->createMock(EventDispatcherInterface::class);
-        $eventDispatcher
-            ->expects($this->once())
-            ->method('dispatch')
-            ->willReturnCallback(static function (object $event): object {
-                static::assertInstanceOf(OrderCriteriaEvent::class, $event);
-
-                return $event;
-            });
-
-        $searchResult = new EntitySearchResult(
-            OrderDefinition::ENTITY_NAME,
-            1,
-            new OrderCollection([$order]),
-            null,
-            new Criteria(),
-            Context::createDefaultContext()
-        );
-
-        $orderRepository = $this->createMock(EntityRepository::class);
-        $orderRepository
-            ->expects($this->once())
-            ->method('search')
-            ->willReturn($searchResult);
-
-        $accountService = $this->createMock(AccountService::class);
-        $accountService->expects($login ? $this->once() : $this->never())
-            ->method('loginById')
-            ->with($orderCustomer->getCustomerId())
-            ->willReturn('newContextToken');
-
-        $route = new OrderRoute(
-            $orderRepository,
-            static::createStub(EntityRepository::class),
-            static::createStub(RateLimiter::class),
-            $eventDispatcher,
-            $accountService,
-            new GuestAuthenticator(),
-            new NativeClock()
-        );
-
-        $criteria = new Criteria();
-        $criteria->addFilter(new EqualsFilter('deepLinkCode', 'deepLinkCode'));
-
-        $request = new Request();
-        $credentials = $credentialsInQuery ? $request->query : $request->request;
-        $credentials->set('email', $mail);
-        $credentials->set('zipcode', $postalCode);
-        $request->request->set('login', $login);
-
-        $response = $route->load($request, $context, $criteria);
-        $responseOrder = $response->getOrders()->getEntities()->first();
-
-        static::assertNotNull($responseOrder);
-        static::assertSame($order->getId(), $responseOrder->getId());
-        static::assertSame($login ? 'newContextToken' : null, $response->headers->get('sw-context-token'));
+        $this->assertGuestOrderAccess($isGuest, $mail, $postalCode, $exception, $login, false);
     }
 
     /**
-     * @return iterable<string, array{?bool, ?string, ?string, ?class-string<\Throwable>, 4?: bool, 5?: bool}>
+     * @deprecated tag:v6.8.0 - remove together with OrderRoute::checkGuestAuth()
+     *
+     * @param ?class-string<\Throwable> $exception
+     */
+    #[DataProvider('legacyCustomerDataProvider')]
+    #[DisabledFeatures(['v6.8.0.0'])]
+    public function testValidateGuestCustomerWithoutGuestAuthenticator(?bool $isGuest, ?string $mail, ?string $postalCode, ?string $exception, bool $login = false, bool $credentialsInQuery = false): void
+    {
+        $this->assertGuestOrderAccess($isGuest, $mail, $postalCode, $exception, $login, $credentialsInQuery);
+    }
+
+    /**
+     * @return iterable<string, array{?bool, ?string, ?string, ?class-string<\Throwable>, 4?: bool}>
      */
     public static function customerDataProvider(): iterable
     {
         yield 'no customer' => [null, 'test@example.com', 'AA-345', CustomerException::class];
         yield 'no guest customer' => [false, 'test@example.com', 'AA-345', CustomerException::class];
+        yield 'no request e-mail' => [true, null, 'AA-345', GuestNotAuthenticatedException::class];
+        yield 'no request postal code' => [true, 'test@example.com', null, GuestNotAuthenticatedException::class];
+        yield 'wrong e-mail' => [true, 'false@example.com', 'AA-345', WrongGuestCredentialsException::class];
+        yield 'wrong postal code' => [true, 'test@example.com', '12345', WrongGuestCredentialsException::class];
+        yield 'valid guest' => [true, 'test@example.com', 'AA-345', null];
+        yield 'valid guest uppercase email' => [true, 'Test@Example.Com', 'AA-345', null];
+        yield 'valid guest lowercase postal code' => [true, 'Test@Example.Com', 'aa-345', null];
+        yield 'valid guest with login' => [true, 'Test@Example.Com', 'aa-345', null, true];
+    }
+
+    /**
+     * @deprecated tag:v6.8.0 - remove together with OrderRoute::checkGuestAuth()
+     *
+     * @return iterable<string, array{?bool, ?string, ?string, ?class-string<\Throwable>, 4?: bool, 5?: bool}>
+     */
+    public static function legacyCustomerDataProvider(): iterable
+    {
+        yield 'no customer' => [null, 'test@example.com', 'AA-345', CartException::class];
+        yield 'no guest customer' => [false, 'test@example.com', 'AA-345', CartException::class];
         yield 'no request e-mail' => [true, null, 'AA-345', GuestNotAuthenticatedException::class];
         yield 'no request postal code' => [true, 'test@example.com', null, GuestNotAuthenticatedException::class];
         yield 'wrong e-mail' => [true, 'false@example.com', 'AA-345', WrongGuestCredentialsException::class];
@@ -341,5 +288,99 @@ class OrderRouteTest extends TestCase
         yield 'order beyond limit' => [31, 30, true];
         yield 'order beyond default, within custom limit' => [40, 60, false];
         yield 'order beyond custom limit' => [61, 60, true];
+    }
+
+    /**
+     * @param ?class-string<\Throwable> $exception
+     */
+    private function assertGuestOrderAccess(?bool $isGuest, ?string $mail, ?string $postalCode, ?string $exception, bool $login, bool $credentialsInQuery): void
+    {
+        if ($exception !== null) {
+            $this->expectException($exception);
+        }
+
+        $orderCustomer = new OrderCustomerEntity();
+        $orderCustomer->setId(Uuid::randomHex());
+        $orderCustomer->setEmail('test@example.com');
+        $orderCustomer->setCustomerId(Uuid::randomHex());
+
+        if ($isGuest !== null) {
+            $customer = new CustomerEntity();
+            $customer->setId($orderCustomer->getId());
+            $customer->setGuest($isGuest);
+
+            $orderCustomer->setCustomer($customer);
+        }
+
+        $billingAddress = new OrderAddressEntity();
+        $billingAddress->setZipcode('AA-345');
+
+        $order = new OrderEntity();
+        $order->setId(Uuid::randomHex());
+        $order->setCreatedAt(new \DateTime());
+        $order->setOrderCustomer($orderCustomer);
+        $order->setBillingAddress($billingAddress);
+
+        $context = static::createStub(SalesChannelContext::class);
+        $context
+            ->method('getCustomer')
+            ->willReturn(null);
+
+        $eventDispatcher = $this->createMock(EventDispatcherInterface::class);
+        $eventDispatcher
+            ->expects($this->once())
+            ->method('dispatch')
+            ->willReturnCallback(static function (object $event): object {
+                static::assertInstanceOf(OrderCriteriaEvent::class, $event);
+
+                return $event;
+            });
+
+        $searchResult = new EntitySearchResult(
+            OrderDefinition::ENTITY_NAME,
+            1,
+            new OrderCollection([$order]),
+            null,
+            new Criteria(),
+            Context::createDefaultContext()
+        );
+
+        $orderRepository = $this->createMock(EntityRepository::class);
+        $orderRepository
+            ->expects($this->once())
+            ->method('search')
+            ->willReturn($searchResult);
+
+        $accountService = $this->createMock(AccountService::class);
+        $accountService->expects($login ? $this->once() : $this->never())
+            ->method('loginById')
+            ->with($orderCustomer->getCustomerId())
+            ->willReturn('newContextToken');
+
+        $route = new OrderRoute(
+            $orderRepository,
+            static::createStub(EntityRepository::class),
+            static::createStub(RateLimiter::class),
+            $eventDispatcher,
+            $accountService,
+            new GuestAuthenticator(),
+            new NativeClock()
+        );
+
+        $criteria = new Criteria();
+        $criteria->addFilter(new EqualsFilter('deepLinkCode', 'deepLinkCode'));
+
+        $request = new Request();
+        $credentials = $credentialsInQuery ? $request->query : $request->request;
+        $credentials->set('email', $mail);
+        $credentials->set('zipcode', $postalCode);
+        $request->request->set('login', $login);
+
+        $response = $route->load($request, $context, $criteria);
+        $responseOrder = $response->getOrders()->getEntities()->first();
+
+        static::assertNotNull($responseOrder);
+        static::assertSame($order->getId(), $responseOrder->getId());
+        static::assertSame($login ? 'newContextToken' : null, $response->headers->get('sw-context-token'));
     }
 }

--- a/tests/unit/Storefront/Page/Account/Order/AccountOrderDetailPageLoaderTest.php
+++ b/tests/unit/Storefront/Page/Account/Order/AccountOrderDetailPageLoaderTest.php
@@ -3,6 +3,7 @@
 namespace Shopware\Tests\Unit\Storefront\Page\Account\Order;
 
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\Order\OrderCollection;
@@ -14,6 +15,7 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Routing\RoutingException;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\Test\Annotation\DisabledFeatures;
 use Shopware\Core\Test\Generator;
@@ -101,6 +103,69 @@ class AccountOrderDetailPageLoaderTest extends TestCase
         $this->expectException(NotFoundHttpException::class);
 
         $this->pageLoader->load(new Request(['id' => Uuid::randomHex()]), Generator::generateSalesChannelContext());
+    }
+
+    #[DataProvider('orderIdRequestProvider')]
+    public function testLoadReadsTheOrderIdFromTheExpectedBag(Request $request, string $expectedOrderId): void
+    {
+        $order = new OrderEntity();
+        $order->setId($expectedOrderId);
+
+        $this->orderRoute
+            ->expects($this->once())
+            ->method('load')
+            ->with(
+                static::anything(),
+                static::anything(),
+                static::callback(static fn (Criteria $criteria) => $criteria->getIds() === [$expectedOrderId]),
+            )
+            ->willReturn($this->orderResponse(new OrderCollection([$order])));
+
+        $page = new Page();
+        $page->setMetaInformation(new MetaInformation());
+
+        $this->genericPageLoader
+            ->expects($this->once())
+            ->method('load')
+            ->willReturn($page);
+
+        $detailPage = $this->pageLoader->load($request, Generator::generateSalesChannelContext());
+
+        static::assertSame($order, $detailPage->getOrder());
+    }
+
+    public function testLoadThrowsWhenTheOrderIdIsMissing(): void
+    {
+        $this->orderRoute
+            ->expects($this->never())
+            ->method('load');
+
+        $this->genericPageLoader
+            ->expects($this->never())
+            ->method('load');
+
+        $this->expectExceptionObject(RoutingException::missingRequestParameter('id'));
+
+        $this->pageLoader->load(new Request(), Generator::generateSalesChannelContext());
+    }
+
+    /**
+     * @return iterable<string, array{Request, string}>
+     */
+    public static function orderIdRequestProvider(): iterable
+    {
+        $attributeId = Uuid::randomHex();
+        $queryId = Uuid::randomHex();
+
+        $fromAttributes = new Request();
+        $fromAttributes->attributes->set('id', $attributeId);
+
+        $fromBothBags = new Request(['id' => $queryId]);
+        $fromBothBags->attributes->set('id', $attributeId);
+
+        yield 'route attribute' => [$fromAttributes, $attributeId];
+        yield 'query fallback' => [new Request(['id' => $queryId]), $queryId];
+        yield 'route attribute takes precedence over query' => [$fromBothBags, $attributeId];
     }
 
     private function orderResponse(OrderCollection $orders): OrderRouteResponse


### PR DESCRIPTION
### 1. Why is this change necessary?

Since Symfony 7.4, `Request::get()` is deprecated in favour of reading `->attributes`, `->query` or `->request` directly.

### 2. What does this change do, exactly?

`OrderRoute::checkGuestAuth()` reads `email` and `zipcode` through `RequestParamHelper::get()`. `AccountOrderDetailPageLoader::load()` reads `id` from the attribute bag with a query fallback, since `widgets.account.order.detail` delivers it as a route parameter.

### 3. Describe each step to reproduce the issue or behaviour.

```bash
APP_ENV=test vendor/bin/phpunit --testsuite integration --filter 'OrderRouteTest::testGetOrderGuest' --display-deprecations
```

Before this change the run reports `Since symfony/http-foundation 7.4: Request::get() is deprecated`; afterwards it is gone. The same applies to `OrderDetailPageTest`, `AccountOrderControllerTest`, `AccountOrderPageLoaderTest::testLogsInGuestById` and `ControllerRateLimiterTest`.

### 4. Please link to the relevant issues (if any).

- closes #17986
- relates #14508

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
