### PR TITLE
fix(cms): Fix broken Image in cms img blocks

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image/config/config.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image/config/config.spec.js
@@ -157,6 +157,41 @@ describe('src/module/sw-cms/elements/image/config', () => {
         expect(wrapper.vm.element.config.minHeight.value).toBe('');
     });
 
+    it('should use the media entity as preview source when element data holds one', async () => {
+        const wrapper = await createWrapper();
+        const media = {
+            id: 'media-id',
+            url: 'http://shop.example/media/preview.png',
+        };
+
+        wrapper.vm.element.data.media = media;
+        await wrapper.vm.$nextTick();
+
+        expect(wrapper.vm.previewSource).toStrictEqual(media);
+    });
+
+    it('should use the config value as preview source for a static media source', async () => {
+        const wrapper = await createWrapper();
+
+        wrapper.vm.element.config.media.value = 'media-id';
+        await wrapper.vm.$nextTick();
+
+        expect(wrapper.vm.previewSource).toBe('media-id');
+    });
+
+    it('should build an asset url as preview source for a default media source', async () => {
+        const wrapper = await createWrapper();
+
+        wrapper.vm.element.config.media.source = 'default';
+        wrapper.vm.element.config.media.value = Shopware.Constants.CMS.MEDIA.previewMountain;
+        await wrapper.vm.$nextTick();
+
+        const previewSource = wrapper.vm.previewSource;
+
+        expect(previewSource).toBeInstanceOf(URL);
+        expect(previewSource.pathname).toContain('administration/administration/static/img/cms/preview_mountain_large.webp');
+    });
+
     it('should change the isDecorative value', async () => {
         const wrapper = await createWrapper();
         const isDecorativeSwitch = wrapper.find('.sw-cms-el-config-image__is-decorative input');

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image/config/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image/config/index.js
@@ -1,7 +1,7 @@
 import template from './sw-cms-el-config-image.html.twig';
 import './sw-cms-el-config-image.scss';
 
-const { Mixin } = Shopware;
+const { Mixin, Filter } = Shopware;
 
 /**
  * @private
@@ -39,7 +39,26 @@ export default {
                 return this.element.data.media;
             }
 
-            return this.element.config.media.value;
+            const elemConfig = this.element.config.media;
+
+            /**
+             * A default source holds an asset path instead of a media id. Returning it as a URL
+             * lets the media preview render it directly instead of querying the media API with it.
+             */
+            if (elemConfig.source === 'default' && elemConfig.value) {
+                const fileName = elemConfig.value.slice(elemConfig.value.lastIndexOf('/') + 1);
+
+                return new URL(
+                    this.assetFilter(`administration/administration/static/img/cms/${fileName}`),
+                    window.location.origin,
+                );
+            }
+
+            return elemConfig.value;
+        },
+
+        assetFilter() {
+            return Filter.getByName('asset');
         },
 
         displayModeOptions() {


### PR DESCRIPTION
fixes #10105

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

- New image blocks initialise their media config with `source: 'default'` and an asset path instead of a media id
- The element config panel passes this path unmodified to the media preview, which treats it as a media entity id and fires a failing `GET /api/media/bundles/administration/...`
- While the request is in flight, the preview shows a broken-file icon instead of the default preview image — permanently on setups where assets are served from a CDN or subfolder

### 2. What does this change do, exactly?

- `previewSource` in `sw-cms-el-config-image` now handles the `default` media source and returns the asset URL as a `URL` instance
- `sw-media-preview-v2` renders URL sources directly without querying the media API — no failing request, no broken icon
- Static sources and media entities from element data behave as before; all three variants are covered by Jest tests

### 3. Describe each step to reproduce the issue or behaviour.

1. Create a new shopping experience layout
2. Drag the "Image" block from the sidebar onto the stage
3. Click the freshly dropped image element to open its config panel
4. The media upload preview shows a broken-file icon instead of the default mountain image; the network tab shows a failing `GET /api/media/bundles/administration/...` request


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
