### PR TITLE
fix(checkout): enforce ACL on sales channel proxy routes

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -10,9 +10,9 @@ Rule Builder and Flow Builder are now reachable from a dedicated top-level "Auto
 
 ### Order recalculation and conversion endpoints now require ACL privileges
 
-Ten admin endpoints that previously only required authentication now enforce ACL privileges. Requests with tokens lacking the privilege receive a `403` with `FRAMEWORK__MISSING_PRIVILEGE_ERROR`:
+Thirteen admin checkout endpoints that previously only required authentication now enforce ACL privileges. Requests with tokens lacking the privilege receive a `403` with `FRAMEWORK__MISSING_PRIVILEGE_ERROR`:
 
-* `POST /api/_action/order/{orderId}/recalculate`, `/product/{productId}`, `/creditItem`, `/lineItem`, `/promotion-item`, `/toggleAutomaticPromotions` and `/applyAutomaticPromotions` require `order:update`.
+* `POST /api/_action/order/{orderId}/recalculate`, `/product/{productId}`, `/creditItem`, `/lineItem`, `/promotion-item`, `/toggleAutomaticPromotions` and `/applyAutomaticPromotions`, plus `PATCH /api/_proxy/modify-shipping-costs`, `/api/_proxy/disable-automatic-promotions` and `/api/_proxy/enable-automatic-promotions`, require `order:update`.
 * `POST /api/_action/order-address/{orderAddressId}/customer-address/{customerAddressId}` and `POST /api/_action/order/{orderId}/order-address` require `order_address:update`.
 * `POST /api/_action/order/{orderId}/convert-to-cart/` requires `order:read`.
 

--- a/src/Core/Framework/Api/Controller/SalesChannelProxyController.php
+++ b/src/Core/Framework/Api/Controller/SalesChannelProxyController.php
@@ -201,6 +201,7 @@ class SalesChannelProxyController extends AbstractController
     #[Route(
         path: '/api/_proxy/modify-shipping-costs',
         name: 'api.proxy.modify-shipping-costs',
+        defaults: [PlatformRequest::ATTRIBUTE_ACL => ['order:update']],
         methods: [Request::METHOD_PATCH]
     )]
     public function modifyShippingCosts(Request $request, Context $context): JsonResponse
@@ -225,6 +226,7 @@ class SalesChannelProxyController extends AbstractController
     #[Route(
         path: '/api/_proxy/disable-automatic-promotions',
         name: 'api.proxy.disable-automatic-promotions',
+        defaults: [PlatformRequest::ATTRIBUTE_ACL => ['order:update']],
         methods: [Request::METHOD_PATCH]
     )]
     public function disableAutomaticPromotions(Request $request): JsonResponse
@@ -245,6 +247,7 @@ class SalesChannelProxyController extends AbstractController
     #[Route(
         path: '/api/_proxy/enable-automatic-promotions',
         name: 'api.proxy.enable-automatic-promotions',
+        defaults: [PlatformRequest::ATTRIBUTE_ACL => ['order:update']],
         methods: [Request::METHOD_PATCH]
     )]
     public function enableAutomaticPromotions(Request $request): JsonResponse

--- a/tests/integration/Core/Framework/Api/Controller/SalesChannelProxyControllerTest.php
+++ b/tests/integration/Core/Framework/Api/Controller/SalesChannelProxyControllerTest.php
@@ -3,6 +3,7 @@
 namespace Shopware\Tests\Integration\Core\Framework\Api\Controller;
 
 use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\Cart\CartPersister;
 use Shopware\Core\Checkout\Cart\LineItem\LineItem;
@@ -13,6 +14,7 @@ use Shopware\Core\Checkout\Shipping\ShippingMethodEntity;
 use Shopware\Core\Content\Product\Cart\ProductCartProcessor;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Api\EventListener\Acl\CreditOrderLineItemListener;
+use Shopware\Core\Framework\Api\Exception\MissingPrivilegeException;
 use Shopware\Core\Framework\Api\Util\AccessKeyHelper;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
@@ -80,6 +82,48 @@ class SalesChannelProxyControllerTest extends TestCase
         $eventDispatcher = new EventDispatcher();
         $this->contextPersister = new SalesChannelContextPersister($this->connection, $eventDispatcher, static::getContainer()->get(CartPersister::class), new NativeClock());
         $this->ids = new IdsCollection();
+    }
+
+    #[DataProvider('checkoutProxyRoutesProvider')]
+    public function testCheckoutProxyRoutesRequireOrderUpdatePrivilege(string $path, array $payload): void
+    {
+        $browser = $this->getBrowser(true, [], []);
+        $browser->jsonRequest('PATCH', $path, $payload, [
+            'HTTP_SW_CONTEXT_TOKEN' => Uuid::randomHex(),
+        ]);
+
+        $content = (string) $browser->getResponse()->getContent();
+        $response = json_decode($content, true, 512, \JSON_THROW_ON_ERROR);
+
+        static::assertSame(Response::HTTP_FORBIDDEN, $browser->getResponse()->getStatusCode(), $content);
+        static::assertSame(MissingPrivilegeException::MISSING_PRIVILEGE_ERROR, $response['errors'][0]['code'] ?? null, $content);
+    }
+
+    /**
+     * @return \Generator<string, array{string, array<string, mixed>}>
+     */
+    public static function checkoutProxyRoutesProvider(): \Generator
+    {
+        yield 'modify shipping costs' => [
+            '/api/_proxy/modify-shipping-costs',
+            [
+                'salesChannelId' => Uuid::randomHex(),
+                'shippingCosts' => [
+                    'unitPrice' => 1,
+                    'totalPrice' => 1,
+                ],
+            ],
+        ];
+
+        yield 'disable automatic promotions' => [
+            '/api/_proxy/disable-automatic-promotions',
+            ['salesChannelId' => Uuid::randomHex()],
+        ];
+
+        yield 'enable automatic promotions' => [
+            '/api/_proxy/enable-automatic-promotions',
+            ['salesChannelId' => Uuid::randomHex()],
+        ];
     }
 
     public function testProxyWithInvalidSalesChannelId(): void

--- a/tests/integration/Core/Framework/Api/Controller/SalesChannelProxyControllerTest.php
+++ b/tests/integration/Core/Framework/Api/Controller/SalesChannelProxyControllerTest.php
@@ -84,6 +84,9 @@ class SalesChannelProxyControllerTest extends TestCase
         $this->ids = new IdsCollection();
     }
 
+    /**
+     * @param array<string, mixed> $payload
+     */
     #[DataProvider('checkoutProxyRoutesProvider')]
     public function testCheckoutProxyRoutesRequireOrderUpdatePrivilege(string $path, array $payload): void
     {


### PR DESCRIPTION
### 1. Why is this change necessary?

Three Administration sales-channel proxy endpoints mutate checkout state without enforcing an ACL privilege. An authenticated API client without the required order permissions can therefore reach these state-changing actions.

### 2. What does this change do, exactly?

The following endpoints now require the existing `order:update` privilege:

- `PATCH /api/_proxy/modify-shipping-costs`
- `PATCH /api/_proxy/disable-automatic-promotions`
- `PATCH /api/_proxy/enable-automatic-promotions`

The integration test covers all three routes through a data provider and verifies the standard missing-privilege response. The upcoming 6.7 release information records the changed ACL requirement.

### 3. Describe each step to reproduce the issue or behaviour.

1. Authenticate an Admin API client without `order:update`.
2. Send a PATCH request to any of the three endpoints above.
3. Observe that the request is rejected with HTTP 403 and `FRAMEWORK__MISSING_PRIVILEGE_ERROR`.

### 4. Please link to the relevant issues (if any).

None.

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have updated developer-facing release notes if this change is relevant for external developers
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them