### PR TITLE
test: fix flaky acceptance test FlowValidation 

### DIFF
--- a/tests/acceptance/tasks/ShopAdmin/FlowBuilder/WaitForFlowValidationSideEffects.ts
+++ b/tests/acceptance/tasks/ShopAdmin/FlowBuilder/WaitForFlowValidationSideEffects.ts
@@ -30,8 +30,10 @@ export const WaitForFlowValidationSideEffects = base.extend<{ WaitForFlowValidat
                     const { data: orders } = await orderResponse.json();
                     ShopAdmin.expects(orders).toHaveLength(1);
 
-                    const expectTechnicalName = (technicalName: string) => ShopAdmin.expects.objectContaining({ technicalName });
-                    const expectEntityInState = (technicalName: string) => ShopAdmin.expects.objectContaining({
+                    const expectTechnicalName = (technicalName: string) =>
+                        ShopAdmin.expects.objectContaining({ technicalName });
+                    const expectEntityInState = (technicalName: string) =>
+                        ShopAdmin.expects.objectContaining({
                             stateMachineState: expectTechnicalName(technicalName),
                         });
 

--- a/tests/acceptance/tasks/ShopAdmin/FlowBuilder/WaitForFlowValidationSideEffects.ts
+++ b/tests/acceptance/tasks/ShopAdmin/FlowBuilder/WaitForFlowValidationSideEffects.ts
@@ -1,0 +1,53 @@
+import { test as base } from '@shopware-ag/acceptance-test-suite';
+import type { FixtureTypes, Task } from '@shopware-ag/acceptance-test-suite';
+
+export const WaitForFlowValidationSideEffects = base.extend<{ WaitForFlowValidationSideEffects: Task }, FixtureTypes>({
+    WaitForFlowValidationSideEffects: async ({ ShopAdmin, AdminApiContext }, use) => {
+        const task = (config) => {
+            return async function WaitForFlowValidationSideEffects() {
+                // Buffered flows run on Kernel TERMINATE after the process response — wait for persisted side-effects.
+                await ShopAdmin.expects(async () => {
+                    const orderResponse = await AdminApiContext.post('search/order', {
+                        data: {
+                            ids: [config.orderId],
+                            associations: {
+                                stateMachineState: {},
+                                transactions: {
+                                    associations: {
+                                        stateMachineState: {},
+                                    },
+                                },
+                                deliveries: {
+                                    associations: {
+                                        stateMachineState: {},
+                                    },
+                                },
+                            },
+                        },
+                    });
+                    ShopAdmin.expects(orderResponse.ok()).toBeTruthy();
+
+                    const { data: orders } = await orderResponse.json();
+                    ShopAdmin.expects(orders).toHaveLength(1);
+
+                    const expectTechnicalName = (technicalName: string) => ShopAdmin.expects.objectContaining({ technicalName });
+                    const expectEntityInState = (technicalName: string) => ShopAdmin.expects.objectContaining({
+                            stateMachineState: expectTechnicalName(technicalName),
+                        });
+
+                    ShopAdmin.expects(orders[0]).toEqual(
+                        ShopAdmin.expects.objectContaining({
+                            stateMachineState: expectTechnicalName('in_progress'),
+                            transactions: ShopAdmin.expects.arrayContaining([expectEntityInState('paid')]),
+                            deliveries: ShopAdmin.expects.arrayContaining([
+                                expectEntityInState('shipped_partially'),
+                            ]),
+                        }),
+                    );
+                }).toPass();
+            };
+        };
+
+        await use(task);
+    },
+});

--- a/tests/acceptance/tasks/ShopAdminTasks.ts
+++ b/tests/acceptance/tasks/ShopAdminTasks.ts
@@ -45,6 +45,7 @@ import { CreateRuleBillingCountry } from '@tasks/ShopAdmin/RuleBuilder/CreateRul
  * Flows
  */
 import { CreateFlowForValidation } from '@tasks/ShopAdmin/FlowBuilder/CreateFlowForValidation';
+import { WaitForFlowValidationSideEffects } from '@tasks/ShopAdmin/FlowBuilder/WaitForFlowValidationSideEffects';
 
 export const test = mergeTests(
     GenerateVariants,
@@ -57,4 +58,5 @@ export const test = mergeTests(
     CreateDocument,
     CreateRuleBillingCountry,
     CreateFlowForValidation,
+    WaitForFlowValidationSideEffects,
 );

--- a/tests/acceptance/tests/Settings/FlowValidation.spec.ts
+++ b/tests/acceptance/tests/Settings/FlowValidation.spec.ts
@@ -36,7 +36,6 @@ test(
 
         const order = await TestDataService.createOrder([{ product, quantity: 1 }], customer);
         TestDataService.addCreatedRecord('order', order.id);
-
         const ruleConfig = { ruleId: IdProvider.getIdPair().uuid, countryId: countryId };
         await ShopAdmin.attemptsTo(CreateRuleBillingCountry(ruleConfig));
 

--- a/tests/acceptance/tests/Settings/FlowValidation.spec.ts
+++ b/tests/acceptance/tests/Settings/FlowValidation.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@fixtures/AcceptanceTest';
-import { getCountryId, getSalutationId } from '@shopware-ag/acceptance-test-suite';
+import { getCountryId, getSalutationId, setOrderStatus } from '@shopware-ag/acceptance-test-suite';
 
 test(
     'As an admin user, I want that certain actions get executed based on the flow, so that I can automate the processes.',
@@ -13,6 +13,7 @@ test(
         AdminCustomerDetail,
         CreateRuleBillingCountry,
         CreateFlowForValidation,
+        WaitForFlowValidationSideEffects,
     }) => {
         // Test data setup
         const tagTrue = await TestDataService.createTag('Santa?');
@@ -41,10 +42,16 @@ test(
 
         const flowConfig = { flowId: IdProvider.getIdPair().uuid, ruleId: ruleConfig.ruleId, tagTrue, tagFalse };
         await ShopAdmin.attemptsTo(CreateFlowForValidation(flowConfig));
+        // Ensure flow-loader cache sees the newly created flow before we trigger it.
+        await TestDataService.clearCaches();
 
         await test.step('Set the order status to "in progress" to trigger the flow.', async () => {
-            const orderState = await AdminApiContext.post(`./_action/order/${order.id}/state/process`);
+            const orderState = await setOrderStatus(order.id, 'process', AdminApiContext);
             expect(orderState.ok()).toBeTruthy();
+        });
+
+        await test.step('Wait until flow side-effects are persisted via Admin API.', async () => {
+            await ShopAdmin.attemptsTo(WaitForFlowValidationSideEffects({ orderId: order.id }));
         });
 
         await test.step('Validate order state and customer tag via UI', async () => {


### PR DESCRIPTION


### 1. Why is this change necessary?
`FlowValidation.spec.ts` was flaky (especially on SaaS): after `POST …/state/process`, the Admin UI often still showed payment **Open** instead of **Paid**.

Flow Builder actions run after the HTTP response (`KernelEvents::TERMINATE` / buffered flows). The old test opened Admin and asserted UI immediately, so it raced that async work. A change is needed so we only assert UI after flow side-effects are persisted.

### 2. What does this change do, exactly?

1. Clears delayed cache after creating the flow so it is loadable before process.
2. Triggers the flow via setOrderStatus(…, 'process').
3. Adds task WaitForFlowValidationSideEffects that retries Admin API search/order with .toPass() until:
- order in_progress
- transaction paid
- delivery shipped_partially

4. Only then runs the existing UI checks (order statuses + customer tag).

### 3. Describe each step to reproduce the issue or behaviour.
Run `tests/acceptance/tests/Settings/FlowValidation.spec.ts` (Platform; more often SaaS).

### 4. Please link to the relevant issues (if any).
- relates #18867



### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
