### PR TITLE
test: resolve opaque mock uses and fix the remaining phpunit 12 notices

### DIFF
--- a/src/Core/DevOps/StaticAnalyze/PHPStan/Rules/Tests/NoCreateMockWithoutExpectationsRule.php
+++ b/src/Core/DevOps/StaticAnalyze/PHPStan/Rules/Tests/NoCreateMockWithoutExpectationsRule.php
@@ -431,6 +431,7 @@ class NoCreateMockWithoutExpectationsRule implements Rule
      * @param array<Node> $stmts
      * @param array<string, ClassMethod> $ownMethods
      * @param list<int> $extraHarmless spl_object_ids of Variable nodes to accept
+     * @param array<string, true> $visited guards against recursive helpers and alias chains
      */
     private function variableIsNeverExpected(array $stmts, string $name, array $ownMethods, array $extraHarmless = [], array $visited = []): bool
     {

--- a/src/Core/DevOps/StaticAnalyze/PHPStan/Rules/Tests/NoCreateMockWithoutExpectationsRule.php
+++ b/src/Core/DevOps/StaticAnalyze/PHPStan/Rules/Tests/NoCreateMockWithoutExpectationsRule.php
@@ -5,7 +5,9 @@ namespace Shopware\Core\DevOps\StaticAnalyze\PHPStan\Rules\Tests;
 use PhpParser\Node;
 use PhpParser\Node\Arg;
 use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\Array_;
 use PhpParser\Node\Expr\Assign;
+use PhpParser\Node\Expr\AssignOp\Coalesce as CoalesceAssign;
 use PhpParser\Node\Expr\BinaryOp\Coalesce;
 use PhpParser\Node\Expr\ClassConstFetch;
 use PhpParser\Node\Expr\MethodCall;
@@ -82,6 +84,22 @@ class NoCreateMockWithoutExpectationsRule implements Rule
      * ClassMethod attribute carrying the ancestor file an inherited method was parsed from.
      */
     private const SOURCE_FILE = 'noCreateMockRuleSourceFile';
+
+    /**
+     * Methods of PHPUnit's double-configuration chain whose arguments are consumed as data (method names,
+     * matchers, return values) — they can never configure an expectation on a double passed into them.
+     *
+     * @var list<string>
+     */
+    private const DOUBLE_CONFIGURATION_METHODS = [
+        'method',
+        'with',
+        'willReturn',
+        'willReturnMap',
+        'willReturnOnConsecutiveCalls',
+        'willReturnArgument',
+        'willThrowException',
+    ];
 
     public function __construct(private readonly Parser $parser)
     {
@@ -414,13 +432,14 @@ class NoCreateMockWithoutExpectationsRule implements Rule
      * @param array<string, ClassMethod> $ownMethods
      * @param list<int> $extraHarmless spl_object_ids of Variable nodes to accept
      */
-    private function variableIsNeverExpected(array $stmts, string $name, array $ownMethods, array $extraHarmless = []): bool
+    private function variableIsNeverExpected(array $stmts, string $name, array $ownMethods, array $extraHarmless = [], array $visited = []): bool
     {
         return $this->referenceIsNeverExpected(
             $stmts,
             static fn (Node $node): bool => $node instanceof Variable && $node->name === $name,
             $ownMethods,
             $extraHarmless,
+            $visited,
         );
     }
 
@@ -478,6 +497,59 @@ class NoCreateMockWithoutExpectationsRule implements Rule
                 foreach ($this->passedThrough($arg->value, $isReference) as $occurrence) {
                     $harmless[spl_object_id($occurrence)] = true;
                 }
+            }
+        }
+
+        // arguments of PHPUnit's double-configuration chain — `$other->method(...)`, `->with($ref)`,
+        // `->willReturnMap([[..., $ref]])` — are consumed as data; the stubbing machinery never
+        // configures an expectation on a double passed there.
+        foreach ($finder->findInstanceOf($stmts, MethodCall::class) as $call) {
+            if (!$call->name instanceof Identifier || !\in_array($call->name->name, self::DOUBLE_CONFIGURATION_METHODS, true)) {
+                continue;
+            }
+
+            foreach ($call->getArgs() as $arg) {
+                foreach ($this->passedThrough($arg->value, $isReference) as $occurrence) {
+                    $harmless[spl_object_id($occurrence)] = true;
+                }
+            }
+        }
+
+        // `$ref = $ref ?? <default>` / `$ref ??= <default>` self-defaulting keeps the double flowing
+        // through the same reference, whose other uses this analysis already tracks. `$alias = $ref`
+        // (incl. behind `??`/ternary defaulting) is followed into the alias, which must itself stay clean.
+        foreach ($finder->findInstanceOf($stmts, Assign::class) as $assign) {
+            if ($isReference($assign->var)) {
+                if ($assign->expr instanceof Coalesce && $isReference($assign->expr->left)) {
+                    $harmless[spl_object_id($assign->var)] = true;
+                    $harmless[spl_object_id($assign->expr->left)] = true;
+                }
+
+                continue; // any other re-assignment of the reference stays unclassified
+            }
+
+            if (!$assign->var instanceof Variable || !\is_string($assign->var->name)) {
+                continue;
+            }
+
+            $occurrences = $this->passedThrough($assign->expr, $isReference);
+            $aliasKey = 'alias$' . $assign->var->name;
+            if ($occurrences === [] || isset($visited[$aliasKey])) {
+                continue;
+            }
+
+            if (!$this->variableIsNeverExpected($stmts, $assign->var->name, $ownMethods, [spl_object_id($assign->var)], [...$visited, $aliasKey => true])) {
+                continue;
+            }
+
+            foreach ($occurrences as $occurrence) {
+                $harmless[spl_object_id($occurrence)] = true;
+            }
+        }
+
+        foreach ($finder->findInstanceOf($stmts, CoalesceAssign::class) as $assign) {
+            if ($isReference($assign->var)) {
+                $harmless[spl_object_id($assign->var)] = true;
             }
         }
 
@@ -677,14 +749,21 @@ class NoCreateMockWithoutExpectationsRule implements Rule
                 }
             }
 
+            // Every method assigning `$this->$name = createMock(...)`. A test owns an instance — and can
+            // trigger the notice — when setUp, the test itself, or a fixture helper it calls creates one.
+            $creators = [];
+            foreach ($methods as $method) {
+                if ($this->methodCreatesProperty($finder, $method, $name)) {
+                    $creators[mb_strtolower($method->name->name)] = true;
+                }
+            }
+
             $coveredBySetUp = $setUp !== null && $this->coversProperty('setup', $expectors, $callGraph);
-            $createdInSetUp = $setUp !== null && $this->methodCreatesProperty($finder, $setUp, $name);
+            $createdInSetUp = $setUp !== null && $this->coversProperty('setup', $creators, $callGraph);
 
             $bare = [];
             foreach ($testMethods as $test) {
-                // For a setUp-created (shared) mock every test owns an instance; otherwise only the tests
-                // that create it themselves are relevant.
-                if (!$createdInSetUp && !$this->methodCreatesProperty($finder, $test, $name)) {
+                if (!$createdInSetUp && !$this->coversProperty(mb_strtolower($test->name->name), $creators, $callGraph)) {
                     continue;
                 }
 
@@ -736,13 +815,13 @@ class NoCreateMockWithoutExpectationsRule implements Rule
     }
 
     /**
-     * True when $methodName — or any own method it transitively calls — is one of the $expectors, i.e. the
-     * property provably carries an expectation by the time a test that runs this method finishes.
+     * True when $methodName — or any own method it transitively calls — is one of the $targets: the methods
+     * that directly `->expects()` the property (coverage walk), or the ones that create it (ownership walk).
      *
-     * @param array<string, true> $expectors lowercased names of methods with a direct ->expects() on the property
+     * @param array<string, true> $targets lowercased method names
      * @param array<string, list<string>> $callGraph
      */
-    private function coversProperty(string $methodName, array $expectors, array $callGraph): bool
+    private function coversProperty(string $methodName, array $targets, array $callGraph): bool
     {
         $queue = [$methodName];
         $visited = [];
@@ -753,7 +832,7 @@ class NoCreateMockWithoutExpectationsRule implements Rule
             }
             $visited[$current] = true;
 
-            if (isset($expectors[$current])) {
+            if (isset($targets[$current])) {
                 return true;
             }
 
@@ -788,9 +867,10 @@ class NoCreateMockWithoutExpectationsRule implements Rule
 
     /**
      * True when some helper method uses `$this->$name` in a way that could configure an expectation out of
-     * view: anything that is neither stub configuration, forwarding, an inherited-assertion read, nor a
-     * direct `->expects()` on the property itself. The direct `->expects()` is not hidden — the per-test
-     * coverage walk ({@see self::coversProperty()}) attributes it to the tests that call the helper.
+     * view: anything that is neither stub configuration, forwarding, an inherited-assertion read, a direct
+     * `->expects()` on the property, nor its creating assignment. The direct `->expects()` and the creation
+     * are not hidden — the per-test coverage and ownership walks ({@see self::coversProperty()}) attribute
+     * them to the tests that call the helper.
      *
      * @param array<ClassMethod> $helperMethods
      * @param array<string, ClassMethod> $ownMethods
@@ -805,14 +885,19 @@ class NoCreateMockWithoutExpectationsRule implements Rule
                 continue;
             }
 
-            $sanctionedExpects = [];
+            $sanctioned = [];
             foreach ($finder->findInstanceOf($stmts, MethodCall::class) as $call) {
                 if ($this->isExpectsCall($call) && $isReference($call->var)) {
-                    $sanctionedExpects[] = spl_object_id($call->var);
+                    $sanctioned[] = spl_object_id($call->var);
+                }
+            }
+            foreach ($finder->findInstanceOf($stmts, Assign::class) as $assign) {
+                if ($isReference($assign->var) && $this->isCreateMockCall($assign->expr)) {
+                    $sanctioned[] = spl_object_id($assign->var);
                 }
             }
 
-            if (!$this->referenceIsNeverExpected($stmts, $isReference, $ownMethods, $sanctionedExpects)) {
+            if (!$this->referenceIsNeverExpected($stmts, $isReference, $ownMethods, $sanctioned)) {
                 return true;
             }
         }
@@ -1061,8 +1146,10 @@ class NoCreateMockWithoutExpectationsRule implements Rule
     }
 
     /**
-     * The reference occurrences that $expr passes on unchanged — the bare reference, or one behind the
-     * defaulting wrappers fixture helpers use (`$param ?? $this->shared`, `$param ?: $fallback`). Occurrences
+     * The reference occurrences that $expr passes on unchanged — the bare reference, one behind the
+     * defaulting wrappers fixture helpers use (`$param ?? $this->shared`, `$param ?: $fallback`), or one
+     * wrapped in an array literal (`[$ref]`, `['key' => $ref]`; a receiver can only get at the element
+     * through an access this analysis leaves unclassified, so wrapping loses no soundness). Occurrences
      * anywhere else in $expr are not passed on unchanged and are left for the caller to reject.
      *
      * @param callable(Node): bool $isReference
@@ -1084,6 +1171,19 @@ class NoCreateMockWithoutExpectationsRule implements Rule
                 ...$this->passedThrough($expr->if ?? $expr->cond, $isReference),
                 ...$this->passedThrough($expr->else, $isReference),
             ];
+        }
+
+        if ($expr instanceof Array_) {
+            $occurrences = [];
+            foreach ($expr->items as $item) {
+                if ($item->byRef || $item->unpack) {
+                    continue;
+                }
+
+                $occurrences = [...$occurrences, ...$this->passedThrough($item->value, $isReference)];
+            }
+
+            return $occurrences;
         }
 
         return [];

--- a/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/NoCreateMockWithoutExpectationsRuleTest.php
+++ b/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/NoCreateMockWithoutExpectationsRuleTest.php
@@ -106,6 +106,38 @@ class NoCreateMockWithoutExpectationsRuleTest extends RuleTestCase
         ]);
     }
 
+    public function testOpaqueUses(): void
+    {
+        $this->analyse([__DIR__ . '/data/NoCreateMockWithoutExpectationsRule/OpaqueUseCases.php'], [
+            [
+                \sprintf(NoCreateMockWithoutExpectationsRule::ERROR_MIXED, 'OpaqueDependency::class', 'testBare()'),
+                31, // embedded in another double's willReturnMap() by the helper: data, not a hidden expectation
+            ],
+            [
+                \sprintf(NoCreateMockWithoutExpectationsRule::ERROR_STUB, 'OpaqueLocator::class', 'OpaqueLocator::class'),
+                32, // the locator double itself is only ever stub-configured
+            ],
+            [
+                \sprintf(NoCreateMockWithoutExpectationsRule::ERROR_MIXED, 'OpaqueDependency::class', 'testBare()'),
+                83, // created inside the fixture helper: the tests reaching it own an instance
+            ],
+            [
+                \sprintf(NoCreateMockWithoutExpectationsRule::ERROR_MIXED, 'OpaqueDependency::class', 'testBare()'),
+                100, // forwarded into the SUT constructor wrapped in an array literal
+            ],
+            [
+                \sprintf(NoCreateMockWithoutExpectationsRule::ERROR_STUB, 'OpaqueDependency::class', 'OpaqueDependency::class'),
+                130, // helper re-binds its parameter with `$dep = $dep ?? <stub>` before the SUT constructor
+            ],
+            [
+                \sprintf(NoCreateMockWithoutExpectationsRule::ERROR_STUB, 'OpaqueDependency::class', 'OpaqueDependency::class'),
+                155, // aliased into a clean local that only forwards into the SUT constructor
+            ],
+            // NOT flagged: 182 (the alias itself is ->expects()-ed — conservative skip),
+            // and testNotOwning() at 83 (it never reaches the creating helper)
+        ]);
+    }
+
     public function testHelperReturnedMocks(): void
     {
         $this->analyse([__DIR__ . '/data/NoCreateMockWithoutExpectationsRule/HelperReturnCases.php'], [

--- a/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/data/NoCreateMockWithoutExpectationsRule/OpaqueUseCases.php
+++ b/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/data/NoCreateMockWithoutExpectationsRule/OpaqueUseCases.php
@@ -1,0 +1,253 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\DevOps\StaticAnalyse\PHPStan\Rules\data\NoCreateMockWithoutExpectationsRule;
+
+use PHPUnit\Framework\TestCase;
+
+interface OpaqueDependency
+{
+    public function value(): string;
+}
+
+interface OpaqueLocator
+{
+    public function get(string $key): OpaqueDependency;
+}
+
+/**
+ * @internal
+ *
+ * The helper embeds the property in another double's willReturnMap() — data consumption, not a hidden
+ * expectation. FLAGGED as mixed, naming testBare().
+ */
+class WillReturnMapEmbeddedPropertyCases extends TestCase
+{
+    private OpaqueDependency $dependency;
+
+    private OpaqueLocator $locator;
+
+    protected function setUp(): void
+    {
+        $this->dependency = $this->createMock(OpaqueDependency::class);
+        $this->locator = $this->createMock(OpaqueLocator::class);
+    }
+
+    public function testCovered(): void
+    {
+        $this->dependency->expects($this->once())->method('value')->willReturn('a');
+        static::assertSame('a', $this->createSut()->lookup());
+    }
+
+    public function testBare(): void
+    {
+        static::assertSame('', $this->createSut()->lookup());
+    }
+
+    private function createSut(): OpaqueLocatorSut
+    {
+        $this->locator->method('get')->willReturnMap([['key', $this->dependency]]);
+
+        return new OpaqueLocatorSut($this->locator);
+    }
+}
+
+/**
+ * @internal
+ *
+ * The property is created inside a fixture helper instead of setUp(): the tests reaching that helper own
+ * an instance. FLAGGED as mixed, naming testBare() — testNotOwning never creates the double and stays out.
+ */
+class HelperCreatedPropertyCases extends TestCase
+{
+    private OpaqueDependency $dependency;
+
+    public function testCovered(): void
+    {
+        $sut = $this->createSut();
+        $this->dependency->expects($this->once())->method('value')->willReturn('a');
+        static::assertSame('a', $sut->run());
+    }
+
+    public function testBare(): void
+    {
+        static::assertSame('', $this->createSut()->run());
+    }
+
+    public function testNotOwning(): void
+    {
+        static::assertTrue(true);
+    }
+
+    private function createSut(): OpaqueSut
+    {
+        $this->dependency = $this->createMock(OpaqueDependency::class);
+
+        return new OpaqueSut($this->dependency);
+    }
+}
+
+/**
+ * @internal
+ *
+ * The property reaches the SUT constructor wrapped in an array literal. FLAGGED as mixed, naming testBare().
+ */
+class ArrayWrappedPropertyCases extends TestCase
+{
+    private OpaqueDependency $dependency;
+
+    protected function setUp(): void
+    {
+        $this->dependency = $this->createMock(OpaqueDependency::class);
+    }
+
+    public function testCovered(): void
+    {
+        $this->dependency->expects($this->once())->method('value')->willReturn('a');
+        static::assertSame('a', $this->createSut()->first());
+    }
+
+    public function testBare(): void
+    {
+        static::assertSame('', $this->createSut()->first());
+    }
+
+    private function createSut(): OpaqueCollectionSut
+    {
+        return new OpaqueCollectionSut(['dep' => $this->dependency]);
+    }
+}
+
+/**
+ * @internal
+ *
+ * The fixture helper re-binds its parameter with `$dep = $dep ?? <fresh stub>` before forwarding it into
+ * the SUT — the double still only flows into production code. FLAGGED as stub.
+ */
+class SelfDefaultingParamCases extends TestCase
+{
+    public function testOne(): void
+    {
+        $dependency = $this->createMock(OpaqueDependency::class);
+        $dependency->method('value')->willReturn('a');
+
+        static::assertSame('a', $this->createSut($dependency)->run());
+    }
+
+    private function createSut(?OpaqueDependency $dependency = null): OpaqueSut
+    {
+        $dependency = $dependency ?? static::createStub(OpaqueDependency::class);
+
+        return new OpaqueSut($dependency);
+    }
+}
+
+/**
+ * @internal
+ *
+ * A helper aliases the property into a local that stays clean (constructor forwarding only). FLAGGED as stub.
+ */
+class AliasFollowedPropertyCases extends TestCase
+{
+    private OpaqueDependency $dependency;
+
+    protected function setUp(): void
+    {
+        $this->dependency = $this->createMock(OpaqueDependency::class);
+    }
+
+    public function testOne(): void
+    {
+        static::assertSame('', $this->createSut()->run());
+    }
+
+    private function createSut(): OpaqueSut
+    {
+        $dependency = $this->dependency;
+
+        return new OpaqueSut($dependency);
+    }
+}
+
+/**
+ * @internal
+ *
+ * The alias itself gets ->expects()-ed — the property must keep its conservative skip. NOT flagged.
+ */
+class AliasExpectedPropertyCases extends TestCase
+{
+    private OpaqueDependency $dependency;
+
+    protected function setUp(): void
+    {
+        $this->dependency = $this->createMock(OpaqueDependency::class);
+    }
+
+    public function testOne(): void
+    {
+        $this->configureAlias();
+        static::assertSame('a', $this->dependency->value());
+    }
+
+    public function testTwo(): void
+    {
+        static::assertSame('', $this->dependency->value());
+    }
+
+    private function configureAlias(): void
+    {
+        $dependency = $this->dependency;
+        $dependency->expects($this->once())->method('value')->willReturn('a');
+    }
+}
+
+/**
+ * @internal
+ */
+class OpaqueSut
+{
+    public function __construct(private readonly OpaqueDependency $dependency)
+    {
+    }
+
+    public function run(): string
+    {
+        return $this->dependency->value();
+    }
+}
+
+/**
+ * @internal
+ */
+class OpaqueLocatorSut
+{
+    public function __construct(private readonly OpaqueLocator $locator)
+    {
+    }
+
+    public function lookup(): string
+    {
+        return $this->locator->get('key')->value();
+    }
+}
+
+/**
+ * @internal
+ */
+class OpaqueCollectionSut
+{
+    /**
+     * @param array<string, OpaqueDependency> $dependencies
+     */
+    public function __construct(private readonly array $dependencies)
+    {
+    }
+
+    public function first(): string
+    {
+        foreach ($this->dependencies as $dependency) {
+            return $dependency->value();
+        }
+
+        return '';
+    }
+}

--- a/tests/unit/Core/Content/Cms/DataResolver/CmsSlotsDataResolverTest.php
+++ b/tests/unit/Core/Content/Cms/DataResolver/CmsSlotsDataResolverTest.php
@@ -46,12 +46,12 @@ class CmsSlotsDataResolverTest extends TestCase
 
     private TextCmsElementResolver&MockObject $textResolver;
 
-    private DefinitionInstanceRegistry&MockObject $registry;
+    private DefinitionInstanceRegistry&Stub $registry;
 
     /**
-     * @var SalesChannelRepository<SalesChannelProductCollection>&MockObject
+     * @var SalesChannelRepository<SalesChannelProductCollection>&Stub
      */
-    private SalesChannelRepository&MockObject $productRepository;
+    private SalesChannelRepository&Stub $productRepository;
 
     private EventDispatcher&Stub $dispatcher;
 
@@ -62,8 +62,8 @@ class CmsSlotsDataResolverTest extends TestCase
         $this->formResolver = $this->createMock(FormCmsElementResolver::class);
         $this->htmlResolver = $this->createMock(HtmlCmsElementResolver::class);
         $this->textResolver = $this->createMock(TextCmsElementResolver::class);
-        $this->registry = $this->createMock(DefinitionInstanceRegistry::class);
-        $this->productRepository = $this->createMock(SalesChannelRepository::class);
+        $this->registry = static::createStub(DefinitionInstanceRegistry::class);
+        $this->productRepository = static::createStub(SalesChannelRepository::class);
         $this->dispatcher = static::createStub(EventDispatcher::class);
         $this->extensions = new ExtensionDispatcher($this->dispatcher);
     }
@@ -129,6 +129,8 @@ class CmsSlotsDataResolverTest extends TestCase
 
         $this->formResolver->method('getType')->willReturn('form');
         $this->formResolver->expects($this->once())->method('enrich');
+        $this->htmlResolver->expects($this->never())->method('enrich');
+        $this->textResolver->expects($this->never())->method('enrich');
 
         $criteria = new Criteria(['id-1', 'id-2']);
         $criteriaCollection = new CriteriaCollection();
@@ -200,6 +202,8 @@ class CmsSlotsDataResolverTest extends TestCase
 
         $this->formResolver->method('getType')->willReturn('form');
         $this->formResolver->method('collect')->willReturn($collection);
+        $this->htmlResolver->expects($this->never())->method('enrich');
+        $this->textResolver->expects($this->never())->method('enrich');
 
         $context = Generator::generateSalesChannelContext();
         $resolverContext = new ResolverContext($context, new Request());

--- a/tests/unit/Core/Content/ImportExport/Service/DownloadServiceTest.php
+++ b/tests/unit/Core/Content/ImportExport/Service/DownloadServiceTest.php
@@ -112,7 +112,7 @@ class DownloadServiceTest extends TestCase
             static::assertIsResource($stream);
             fwrite($stream, 'test');
             rewind($stream);
-            $fileSystem->method('readStream')->willReturn($stream);
+            $fileSystem->expects($this->once())->method('readStream')->willReturn($stream);
             $expectedResponse->headers->set(DownloadResponseGenerator::X_SENDFILE_DOWNLOAD_STRATEGY, 'php://memory');
         } else {
             $fileSystem->expects($this->never())->method('readStream');

--- a/tests/unit/Core/Content/ImportExport/Strategy/Import/BatchImportStrategyTest.php
+++ b/tests/unit/Core/Content/ImportExport/Strategy/Import/BatchImportStrategyTest.php
@@ -39,6 +39,9 @@ class BatchImportStrategyTest extends ImportStrategyTestCase
         $progress = new Progress('logId', Progress::STATE_PROGRESS);
         $config = new Config([], [], []);
 
+        $this->repository->expects($this->never())->method('upsert');
+        $this->eventDispatcher->expects($this->never())->method('dispatch');
+
         $result = $this->strategy->import(['some' => 'data'], [], $config, $progress, $context);
 
         static::assertSame([], $result->results);

--- a/tests/unit/Core/Content/ImportExport/Strategy/Import/OneByOneImportStrategyTest.php
+++ b/tests/unit/Core/Content/ImportExport/Strategy/Import/OneByOneImportStrategyTest.php
@@ -96,6 +96,9 @@ class OneByOneImportStrategyTest extends ImportStrategyTestCase
         $config = new Config([], [], []);
         $progress = new Progress('logId', Progress::STATE_PROGRESS);
 
+        $this->repository->expects($this->never())->method('upsert');
+        $this->eventDispatcher->expects($this->never())->method('dispatch');
+
         $result = $this->strategy->commit($config, $progress, Context::createDefaultContext());
 
         static::assertSame([], $result->results);

--- a/tests/unit/Core/Content/Product/Cms/ProductSlider/ProductStreamProcessorTest.php
+++ b/tests/unit/Core/Content/Product/Cms/ProductSlider/ProductStreamProcessorTest.php
@@ -4,6 +4,7 @@ namespace Shopware\Tests\Unit\Core\Content\Product\Cms\ProductSlider;
 
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Rule\InvocationOrder;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Shopware\Core\Content\Cms\DataResolver\CriteriaCollection;
@@ -58,7 +59,6 @@ class ProductStreamProcessorTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->productStreamBuilder = $this->createMock(ProductStreamBuilder::class);
         $this->configureProductStreamBuilder();
 
         $this->productRepository = $this->createMock(SalesChannelRepository::class);
@@ -95,6 +95,7 @@ class ProductStreamProcessorTest extends TestCase
 
         $this->config->add($config);
 
+        $this->configureProductStreamBuilder(enrichCriteriaCalls: $this->once());
         $this->productRepository->expects($this->never())->method('search');
         $this->logger->expects($this->never())->method('warning');
 
@@ -128,7 +129,7 @@ class ProductStreamProcessorTest extends TestCase
         $slot = $this->getSlot();
         $resolverContext = $this->getResolverContext();
 
-        $this->configureProductStreamBuilder(false);
+        $this->configureProductStreamBuilder(false, $this->once());
 
         $config = new FieldConfig('products', FieldConfig::SOURCE_PRODUCT_STREAM, 'product-stream-1');
 
@@ -157,6 +158,7 @@ class ProductStreamProcessorTest extends TestCase
         $config = new FieldConfig('products', FieldConfig::SOURCE_PRODUCT_STREAM, 'product-stream-1');
         $this->config->add($config);
 
+        $this->configureProductStreamBuilder(enrichCriteriaCalls: $this->once());
         $this->productRepository->expects($this->never())->method('search');
         $this->logger->expects($this->never())->method('warning');
 
@@ -256,6 +258,7 @@ class ProductStreamProcessorTest extends TestCase
         $this->config->add($productsConfig);
         $this->config->add($sortingConfig);
 
+        $this->configureProductStreamBuilder(enrichCriteriaCalls: $this->once());
         $this->productRepository->expects($this->never())->method('search');
         $this->eventDispatcher->expects($this->once())->method('dispatch');
         $this->logger->expects($this->never())->method('warning');
@@ -413,13 +416,14 @@ class ProductStreamProcessorTest extends TestCase
         return new ProductStreamProcessor($this->productStreamBuilder, $this->productRepository, $this->eventDispatcher, $this->logger);
     }
 
-    private function configureProductStreamBuilder(bool $displayAsGroup = true): void
+    private function configureProductStreamBuilder(bool $displayAsGroup = true, ?InvocationOrder $enrichCriteriaCalls = null): void
     {
         $this->productStreamBuilder = $this->createMock(ProductStreamBuilder::class);
 
         $filter = $this->getFilter();
 
-        $this->productStreamBuilder->method('enrichCriteria')
+        $this->productStreamBuilder->expects($enrichCriteriaCalls ?? $this->never())
+            ->method('enrichCriteria')
             ->willReturnCallback(static function (Criteria $criteria, mixed ...$_) use ($displayAsGroup, $filter): void {
                 $criteria->addFilter($filter);
 

--- a/tests/unit/Core/Content/ProductExport/ScheduledTask/ProductExportPartialGenerationHandlerTest.php
+++ b/tests/unit/Core/Content/ProductExport/ScheduledTask/ProductExportPartialGenerationHandlerTest.php
@@ -130,7 +130,7 @@ class ProductExportPartialGenerationHandlerTest extends TestCase
         $salesChannelContextService
             ->expects($this->once())
             ->method('get')
-            ->willReturn($this->createConfiguredMock(SalesChannelContext::class, [
+            ->willReturn(static::createConfiguredStub(SalesChannelContext::class, [
                 'getContext' => $this->context,
             ]));
 
@@ -279,7 +279,7 @@ class ProductExportPartialGenerationHandlerTest extends TestCase
         $salesChannel->setId($salesChannelId);
         $salesChannel->setTypeId(Defaults::SALES_CHANNEL_TYPE_STOREFRONT);
 
-        return $this->createConfiguredMock(SalesChannelContext::class, [
+        return static::createConfiguredStub(SalesChannelContext::class, [
             'getSalesChannel' => $salesChannel,
             'getContext' => $context,
         ]);

--- a/tests/unit/Core/Content/Seo/SeoUrlGeneratorTest.php
+++ b/tests/unit/Core/Content/Seo/SeoUrlGeneratorTest.php
@@ -63,17 +63,17 @@ class SeoUrlGeneratorTest extends TestCase
             new EntityCollection(),
         ], $this->createTestDefinition());
 
-        $parser = $this->createMock(TwigVariableParser::class);
+        $parser = static::createStub(TwigVariableParser::class);
         $parser->method('parse')->willReturn([]);
 
         $twig = $this->createTwigEnvironment();
 
-        $router = $this->createMock(RouterInterface::class);
+        $router = static::createStub(RouterInterface::class);
         $router->method('generate')->willReturn('/base/path-info');
 
         $request = Request::create('/base/path-info');
         $request->server->set('SCRIPT_NAME', '/base/index.php');
-        $requestStack = $this->createMock(RequestStack::class);
+        $requestStack = static::createStub(RequestStack::class);
         $requestStack->method('getMainRequest')->willReturn($request);
 
         $config = new SeoUrlRouteConfig($this->createTestDefinition(), ProductPageSeoUrlRoute::ROUTE_NAME, '  seo-path  ', true);
@@ -111,12 +111,12 @@ class SeoUrlGeneratorTest extends TestCase
             new EntityCollection(),
         ], $this->createTestDefinition());
 
-        $parser = $this->createMock(TwigVariableParser::class);
+        $parser = static::createStub(TwigVariableParser::class);
         $parser->method('parse')->willReturn([]);
 
         $twig = $this->createTwigEnvironment();
 
-        $router = $this->createMock(RouterInterface::class);
+        $router = static::createStub(RouterInterface::class);
         $router->method('generate')->willReturn('/path-info');
 
         $route = static::createStub(SeoUrlRouteInterface::class);
@@ -142,7 +142,7 @@ class SeoUrlGeneratorTest extends TestCase
     {
         $entityRepository = new StaticEntityRepository([], $this->createTestDefinition());
 
-        $parser = $this->createMock(TwigVariableParser::class);
+        $parser = static::createStub(TwigVariableParser::class);
         $twig = $this->createTwigEnvironment();
 
         $logger = $this->createMock(LoggerInterface::class);
@@ -168,7 +168,7 @@ class SeoUrlGeneratorTest extends TestCase
     {
         $entityRepository = new StaticEntityRepository([], $this->createTestDefinition());
 
-        $parser = $this->createMock(TwigVariableParser::class);
+        $parser = static::createStub(TwigVariableParser::class);
         $twig = $this->createTwigEnvironment();
 
         $route = static::createStub(SeoUrlRouteInterface::class);
@@ -193,7 +193,7 @@ class SeoUrlGeneratorTest extends TestCase
             new EntityCollection(),
         ], $this->createTestDefinition());
 
-        $parser = $this->createMock(TwigVariableParser::class);
+        $parser = static::createStub(TwigVariableParser::class);
         $parser->method('parse')->willReturn([]);
 
         $twig = $this->createTwigEnvironment(strict: true);
@@ -201,7 +201,7 @@ class SeoUrlGeneratorTest extends TestCase
         $logger = $this->createMock(LoggerInterface::class);
         $logger->expects($this->once())->method('warning');
 
-        $router = $this->createMock(RouterInterface::class);
+        $router = static::createStub(RouterInterface::class);
         $router->method('generate')->willReturn('/path-info');
 
         $route = static::createStub(SeoUrlRouteInterface::class);
@@ -230,12 +230,12 @@ class SeoUrlGeneratorTest extends TestCase
             new EntityCollection(),
         ], $this->createTestDefinition());
 
-        $parser = $this->createMock(TwigVariableParser::class);
+        $parser = static::createStub(TwigVariableParser::class);
         $parser->method('parse')->willReturn([]);
 
         $twig = $this->createTwigEnvironment(strict: true);
 
-        $router = $this->createMock(RouterInterface::class);
+        $router = static::createStub(RouterInterface::class);
         $router->method('generate')->willReturn('/path-info');
 
         $route = static::createStub(SeoUrlRouteInterface::class);
@@ -261,10 +261,10 @@ class SeoUrlGeneratorTest extends TestCase
         $entityRepository = new StaticEntityRepository([
             new EntityCollection([$entity]),
         ], $this->createTestDefinition());
-        $parser = $this->createMock(TwigVariableParser::class);
+        $parser = static::createStub(TwigVariableParser::class);
         $parser->method('parse')->willThrowException(new \Exception('broken parser'));
         $twig = $this->createTwigEnvironment(true);
-        $router = $this->createMock(RouterInterface::class);
+        $router = static::createStub(RouterInterface::class);
         $requestStack = new RequestStack();
         $generator = $this->createGenerator([self::TEST_ENTITY_NAME => $entityRepository], $twig, $parser, null, $router, $requestStack);
         $this->expectException(InvalidTemplateException::class);
@@ -278,10 +278,10 @@ class SeoUrlGeneratorTest extends TestCase
             new EntityCollection([$entity]),
             new EntityCollection(),
         ], $this->createTestDefinition());
-        $parser = $this->createMock(TwigVariableParser::class);
+        $parser = static::createStub(TwigVariableParser::class);
         $parser->method('parse')->willReturn(['testRuntime']);
         $twig = $this->createTwigEnvironment();
-        $router = $this->createMock(RouterInterface::class);
+        $router = static::createStub(RouterInterface::class);
         $requestStack = new RequestStack();
         $generator = $this->createGenerator([self::TEST_ENTITY_NAME => $entityRepository], $twig, $parser, null, $router, $requestStack);
         $route = static::createStub(SeoUrlRouteInterface::class);

--- a/tests/unit/Core/Content/Sitemap/Provider/CategoryUrlProviderTest.php
+++ b/tests/unit/Core/Content/Sitemap/Provider/CategoryUrlProviderTest.php
@@ -52,7 +52,7 @@ class CategoryUrlProviderTest extends TestCase
 
     private int $categoryResultIncrement;
 
-    private (QueryBuilder&MockObject)|null $queryBuilder = null;
+    private (QueryBuilder&Stub)|null $queryBuilder = null;
 
     protected function setUp(): void
     {
@@ -273,7 +273,7 @@ class CategoryUrlProviderTest extends TestCase
         $this->entityRouteResolver->method('getRouteNameForEntityName')->willReturn('frontend.navigation.page');
         $this->entityRouteResolver->method('generateUrl')->willReturn('category/2/detail');
 
-        $this->queryBuilder = $this->createMock(QueryBuilder::class);
+        $this->queryBuilder = static::createStub(QueryBuilder::class);
         $this->queryBuilder->method('executeQuery')->willReturn($categoryQueryResult);
 
         $query = static::createStub(IterableQuery::class);

--- a/tests/unit/Core/Framework/Adapter/Cache/Http/CacheHeadersServiceTest.php
+++ b/tests/unit/Core/Framework/Adapter/Cache/Http/CacheHeadersServiceTest.php
@@ -63,7 +63,7 @@ class CacheHeadersServiceTest extends TestCase
     public function testGenerateCashHashWithItemsInCart(?CustomerEntity $customer, Cart $cart, bool $hasCookie, ?string $hashName = null): void
     {
         $salesChannelContext = $this->createMock(SalesChannelContext::class);
-        $salesChannelContext->method('getCustomer')->willReturn($customer);
+        $salesChannelContext->expects($this->atLeastOnce())->method('getCustomer')->willReturn($customer);
         if ($customer !== null) {
             $salesChannelContext->expects($this->once())
                 ->method('getRuleIdsByAreas')

--- a/tests/unit/Core/Framework/Adapter/Twig/Extension/BuildBreadcrumbExtensionTest.php
+++ b/tests/unit/Core/Framework/Adapter/Twig/Extension/BuildBreadcrumbExtensionTest.php
@@ -57,7 +57,7 @@ class BuildBreadcrumbExtensionTest extends TestCase
     {
         $salesChannelContext = Generator::generateSalesChannelContext();
 
-        $categoryBreadcrumbBuilder = $this->createMock(CategoryBreadcrumbBuilder::class);
+        $categoryBreadcrumbBuilder = static::createStub(CategoryBreadcrumbBuilder::class);
         $categoryBreadcrumbBuilder->method('build')->willReturn([]);
 
         $breadCrumb = $this->getBuildBreadcrumbExtension($categoryBreadcrumbBuilder)
@@ -73,7 +73,7 @@ class BuildBreadcrumbExtensionTest extends TestCase
         $categoryId = Uuid::randomHex();
         $notConsideredCategoryId = Uuid::randomHex();
 
-        $categoryBreadcrumbBuilder = $this->createMock(CategoryBreadcrumbBuilder::class);
+        $categoryBreadcrumbBuilder = static::createStub(CategoryBreadcrumbBuilder::class);
         $categoryBreadcrumbBuilder->method('build')->willReturn([$categoryId => 'Home', $notConsideredCategoryId => 'Not considered']);
 
         $breadCrumb = $this->getBuildBreadcrumbExtension($categoryBreadcrumbBuilder, $categoryId)
@@ -124,7 +124,7 @@ class BuildBreadcrumbExtensionTest extends TestCase
         $categoryId = Uuid::randomHex();
         $notConsideredCategoryId = Uuid::randomHex();
 
-        $categoryBreadcrumbBuilder = $this->createMock(CategoryBreadcrumbBuilder::class);
+        $categoryBreadcrumbBuilder = static::createStub(CategoryBreadcrumbBuilder::class);
         $categoryBreadcrumbBuilder->method('build')->willReturn([$categoryId => 'Home', $notConsideredCategoryId => 'Not considered']);
 
         $breadCrumb = $this->getBuildBreadcrumbExtension($categoryBreadcrumbBuilder, $categoryId)

--- a/tests/unit/Core/Framework/Adapter/Twig/TwigEnvironmentTest.php
+++ b/tests/unit/Core/Framework/Adapter/Twig/TwigEnvironmentTest.php
@@ -99,7 +99,7 @@ TWIG;
             ->setConstructorArgs([new ArrayLoader(['test' => ''])])
             ->onlyMethods(['render'])
             ->getMock();
-        $twig->method('render')->willThrowException($exception);
+        $twig->expects($this->once())->method('render')->willThrowException($exception);
         $this->getCoreExtension($twig)->setTimezone('UTC');
 
         static::expectExceptionObject($exception);
@@ -186,7 +186,7 @@ TWIG;
             ->setConstructorArgs([new ArrayLoader()])
             ->onlyMethods(['hasExtension'])
             ->getMock();
-        $twig->method('hasExtension')->willReturn(false);
+        $twig->expects($this->atLeastOnce())->method('hasExtension')->willReturn(false);
         $this->getCoreExtension($twig)->setTimezone('UTC');
 
         $twig->overrideTimezone('Europe/Berlin');

--- a/tests/unit/Core/Framework/Api/Controller/HealthCheckControllerTest.php
+++ b/tests/unit/Core/Framework/Api/Controller/HealthCheckControllerTest.php
@@ -32,7 +32,10 @@ class HealthCheckControllerTest extends TestCase
 
     public function testCheck(): void
     {
-        $response = $this->createHealthCheckController()->check(Context::createDefaultContext());
+        $controller = $this->createHealthCheckController();
+        $this->systemChecker->expects($this->never())->method('check');
+
+        $response = $controller->check(Context::createDefaultContext());
 
         static::assertSame(Response::HTTP_OK, $response->getStatusCode());
         static::assertFalse($response->isCacheable());
@@ -82,7 +85,10 @@ class HealthCheckControllerTest extends TestCase
 
     public function testEventIsDispatched(): void
     {
-        $response = $this->createHealthCheckController()->check(Context::createDefaultContext());
+        $controller = $this->createHealthCheckController();
+        $this->systemChecker->expects($this->never())->method('check');
+
+        $response = $controller->check(Context::createDefaultContext());
 
         static::assertCount(1, $this->eventDispatcher->getEvents());
         static::assertInstanceOf(HealthCheckEvent::class, $this->eventDispatcher->getEvents()[0]);
@@ -98,6 +104,8 @@ class HealthCheckControllerTest extends TestCase
         ?string $validBearer = null
     ): void {
         $controller = $this->createHealthCheckController($staticToken, $validBearer);
+        $this->systemChecker->expects($expectedOAuthServerException ? $this->never() : $this->once())
+            ->method('check');
         $request = Request::create('');
         if ($headerValue !== null) {
             $request->headers->set(HealthCheckController::HEADER_AUTHORIZATION, $headerValue);

--- a/tests/unit/Core/Framework/DataAbstractionLayer/FieldSerializer/IntFieldSerializerTest.php
+++ b/tests/unit/Core/Framework/DataAbstractionLayer/FieldSerializer/IntFieldSerializerTest.php
@@ -42,7 +42,7 @@ class IntFieldSerializerTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->definitionInstanceRegistry = $this->createMock(DefinitionInstanceRegistry::class);
+        $this->definitionInstanceRegistry = static::createStub(DefinitionInstanceRegistry::class);
         $validator = new RecursiveValidator(
             new ExecutionContextFactory(static::createStub(TranslatorInterface::class)),
             new BlackHoleMetadataFactory(),

--- a/tests/unit/Core/Framework/Mcp/Controller/McpToolListControllerTest.php
+++ b/tests/unit/Core/Framework/Mcp/Controller/McpToolListControllerTest.php
@@ -104,7 +104,7 @@ class McpToolListControllerTest extends TestCase
     {
         $page = new Page([self::makeTool('MyApp-my-tool')], null);
 
-        $provider = $this->createMock(AppMcpPrivilegeProvider::class);
+        $provider = static::createStub(AppMcpPrivilegeProvider::class);
         $provider->method('getAppToolPrivileges')->willReturn([
             'MyApp-my-tool' => ['product:read', 'order:read'],
         ]);

--- a/tests/unit/Core/Framework/Mcp/Tool/EntityDeleteToolTest.php
+++ b/tests/unit/Core/Framework/Mcp/Tool/EntityDeleteToolTest.php
@@ -108,7 +108,7 @@ class EntityDeleteToolTest extends TestCase
         $events->method('getEvents')->willReturn(new NestedEventCollection([$writtenEvent]));
 
         $repository = $this->createMock(EntityRepository::class);
-        $repository->method('delete')->willReturn($events);
+        $repository->expects($this->once())->method('delete')->willReturn($events);
 
         $tool = $this->createTool($repository, $connection);
         $result = $this->decode(($tool)('product', '["abc"]', true));
@@ -126,7 +126,7 @@ class EntityDeleteToolTest extends TestCase
         $connection->expects($this->once())->method('rollBack');
 
         $repository = $this->createMock(EntityRepository::class);
-        $repository->method('delete')->willThrowException(new \RuntimeException('FK constraint'));
+        $repository->expects($this->once())->method('delete')->willThrowException(new \RuntimeException('FK constraint'));
 
         $tool = $this->createTool($repository, $connection);
         $result = $this->decode(($tool)('product', '["abc"]', true));
@@ -145,7 +145,7 @@ class EntityDeleteToolTest extends TestCase
         $events->method('getEvents')->willReturn(new NestedEventCollection());
 
         $repository = $this->createMock(EntityRepository::class);
-        $repository->method('delete')->willReturn($events);
+        $repository->expects($this->once())->method('delete')->willReturn($events);
 
         $tool = $this->createTool($repository, $connection);
         $result = $this->decode(($tool)('product', '["abc123"]', false));

--- a/tests/unit/Core/Framework/Mcp/Tool/EntityUpsertToolTest.php
+++ b/tests/unit/Core/Framework/Mcp/Tool/EntityUpsertToolTest.php
@@ -175,7 +175,7 @@ class EntityUpsertToolTest extends TestCase
         $events->method('getEvents')->willReturn(new NestedEventCollection([$writtenEvent]));
 
         $repository = $this->createMock(EntityRepository::class);
-        $repository->method('upsert')->willReturn($events);
+        $repository->expects($this->once())->method('upsert')->willReturn($events);
 
         $tool = $this->createTool($repository, $connection);
         $result = $this->decode(($tool)('product', '[{"name": "Test"}]', true));
@@ -193,7 +193,7 @@ class EntityUpsertToolTest extends TestCase
         $connection->expects($this->once())->method('rollBack');
 
         $repository = $this->createMock(EntityRepository::class);
-        $repository->method('upsert')->willThrowException(new \RuntimeException('Constraint violation'));
+        $repository->expects($this->once())->method('upsert')->willThrowException(new \RuntimeException('Constraint violation'));
 
         $tool = $this->createTool($repository, $connection);
         $result = $this->decode(($tool)('product', '[{"name": "Test"}]', true));
@@ -212,7 +212,7 @@ class EntityUpsertToolTest extends TestCase
         $events->method('getEvents')->willReturn(new NestedEventCollection());
 
         $repository = $this->createMock(EntityRepository::class);
-        $repository->method('upsert')->willReturn($events);
+        $repository->expects($this->once())->method('upsert')->willReturn($events);
 
         $tool = $this->createTool($repository, $connection);
         $result = $this->decode(($tool)('product', '{"name": "Test"}', false));

--- a/tests/unit/Core/Framework/MessageQueue/Telemetry/MessengerQueueDepthCollectorTest.php
+++ b/tests/unit/Core/Framework/MessageQueue/Telemetry/MessengerQueueDepthCollectorTest.php
@@ -80,7 +80,7 @@ class MessengerQueueDepthCollectorTest extends TestCase
 
     public function testFailingTransportIsLoggedAndDoesNotStopTheOthers(): void
     {
-        $failing = $this->createMockForIntersectionOfInterfaces([MessageCountAwareInterface::class, ReceiverInterface::class]);
+        $failing = static::createStubForIntersectionOfInterfaces([MessageCountAwareInterface::class, ReceiverInterface::class]);
         $failing->method('getMessageCount')->willThrowException(new \RuntimeException('broker down'));
 
         $logger = $this->createMock(LoggerInterface::class);

--- a/tests/unit/Core/Framework/Plugin/PluginLifecycleServiceTest.php
+++ b/tests/unit/Core/Framework/Plugin/PluginLifecycleServiceTest.php
@@ -192,6 +192,8 @@ class PluginLifecycleServiceTest extends TestCase
 
         $pluginEntityMock->setUpgradeVersion('9999999');
 
+        $this->pluginMock->expects($this->once())->method('install');
+
         $this->pluginLifecycleService->installPlugin($pluginEntityMock, $context);
 
         static::assertNotNull($pluginEntityMock->getUpgradedAt());
@@ -231,6 +233,8 @@ class PluginLifecycleServiceTest extends TestCase
         $context = Context::createDefaultContext();
 
         $this->kernelPluginCollectionMock->method('get')->willReturnMap([[Plugin::class, $this->pluginMock]]);
+
+        $this->pluginMock->expects($this->never())->method('install');
 
         $this->pluginLifecycleService->installPlugin($pluginEntityMock, $context);
 
@@ -329,6 +333,8 @@ class PluginLifecycleServiceTest extends TestCase
         $pluginEntityMock->setInstalledAt(new \DateTime());
         $pluginEntityMock->setActive(false);
 
+        $this->pluginMock->expects($this->once())->method('uninstall');
+
         $customFieldSetPersister = $this->createMock(CustomFieldSetPersister::class);
         $customFieldSetPersister->expects($this->once())
             ->method('sync')
@@ -348,6 +354,8 @@ class PluginLifecycleServiceTest extends TestCase
         $pluginEntityMock = $this->getPluginEntityMock();
         $context = Context::createDefaultContext();
 
+        $this->pluginMock->expects($this->never())->method('uninstall');
+
         $this->expectException(PluginNotInstalledException::class);
 
         $this->pluginLifecycleService->uninstallPlugin($pluginEntityMock, $context);
@@ -362,6 +370,8 @@ class PluginLifecycleServiceTest extends TestCase
         $pluginEntityMock->setActive(true);
 
         $this->cacheItemPoolInterfaceMock->method('getItem')->willReturn(new CacheItem());
+
+        $this->pluginMock->expects($this->once())->method('update');
 
         $this->pluginLifecycleService->updatePlugin($pluginEntityMock, $context);
 
@@ -407,6 +417,8 @@ class PluginLifecycleServiceTest extends TestCase
         $pluginEntityMock = $this->getPluginEntityMock();
         $context = Context::createDefaultContext();
 
+        $this->pluginMock->expects($this->never())->method('update');
+
         $this->expectException(PluginNotInstalledException::class);
 
         $this->pluginLifecycleService->updatePlugin($pluginEntityMock, $context);
@@ -436,6 +448,8 @@ class PluginLifecycleServiceTest extends TestCase
         $plugin->setComposerName('swag/mock-plugin');
         $plugin->setPath('custom/plugins/mock-plugin');
 
+        $this->pluginMock->expects($this->once())->method('executeComposerCommands');
+
         $commandExecutor = $this->createMock(CommandExecutor::class);
         $commandExecutor->expects($this->once())->method('remove');
         $this->pluginLifecycleService = $this->createService(commandExecutor: $commandExecutor);
@@ -451,6 +465,8 @@ class PluginLifecycleServiceTest extends TestCase
 
         $plugin->setInstalledAt(new \DateTime());
         $plugin->setActive(false);
+
+        $this->pluginMock->expects($this->once())->method('update');
 
         $customFieldSetPersister = $this->createMock(CustomFieldSetPersister::class);
         $customFieldSetPersister->expects($this->once())
@@ -506,8 +522,8 @@ class PluginLifecycleServiceTest extends TestCase
         $plugin->setComposerName('swag/mock-plugin');
         $plugin->setPath('custom/plugins/mock-plugin');
 
-        $this->pluginMock->method('rebuildContainer')->willReturn(true);
-        $this->pluginMock->method('executeComposerCommands')->willReturn(true);
+        $this->pluginMock->expects($this->once())->method('rebuildContainer')->willReturn(true);
+        $this->pluginMock->expects($this->once())->method('executeComposerCommands')->willReturn(true);
         $kernel = static::createStub(Kernel::class);
         $kernel->method('getContainer')->willReturn($this->container);
         $this->container->set('kernel', $kernel);
@@ -533,6 +549,8 @@ class PluginLifecycleServiceTest extends TestCase
         $plugin->setManagedByComposer(true);
         $plugin->setComposerName('swag/mock-plugin');
         $plugin->setPath('vendor/shopware/mock-plugin');
+
+        $this->pluginMock->expects($this->once())->method('executeComposerCommands');
 
         $commandExecutor = $this->createMock(CommandExecutor::class);
         $commandExecutor->expects($this->never())->method('remove');
@@ -605,6 +623,8 @@ class PluginLifecycleServiceTest extends TestCase
 
         $this->cacheItemPoolInterfaceMock->method('getItem')->willReturn(new CacheItem());
 
+        $this->pluginMock->expects($this->once())->method('activate');
+
         $pluginRepo = $this->createMock(EntityRepository::class);
         $this->pluginLifecycleService = $this->createService(pluginRepo: $pluginRepo);
 
@@ -661,6 +681,8 @@ class PluginLifecycleServiceTest extends TestCase
         $pluginEntityMock = $this->getPluginEntityMock();
         $context = Context::createDefaultContext();
 
+        $this->pluginMock->expects($this->never())->method('activate');
+
         $this->expectException(PluginNotInstalledException::class);
 
         $this->pluginLifecycleService->activatePlugin($pluginEntityMock, $context);
@@ -673,6 +695,8 @@ class PluginLifecycleServiceTest extends TestCase
         $pluginEntityMock->setActive(true);
         $context = Context::createDefaultContext();
         $this->cacheItemPoolInterfaceMock->method('getItem')->willReturn(new CacheItem());
+
+        $this->pluginMock->expects($this->never())->method('activate');
 
         $this->pluginLifecycleService->activatePlugin($pluginEntityMock, $context);
         static::assertCount(0, $this->eventDispatcher->getEvents());
@@ -694,6 +718,8 @@ class PluginLifecycleServiceTest extends TestCase
         $kernelMock->method('getContainer')->willReturn($containerMock);
 
         $kernelMock->expects($this->once())->method('reboot');
+
+        $this->pluginMock->expects($this->once())->method('rebuildContainer');
 
         $this->container->set('kernel', $kernelMock);
         $this->container->set(KernelPluginLoader::class, new FakeKernelPluginLoader(
@@ -725,6 +751,8 @@ class PluginLifecycleServiceTest extends TestCase
         $kernelMock->method('getContainer')->willReturn($containerMock);
 
         $this->container->set('kernel', $kernelMock);
+
+        $this->pluginMock->expects($this->never())->method('activate');
 
         $this->expectExceptionObject(PluginException::invalidContainerParameter('kernel.plugin_dir', 'string'));
 
@@ -762,6 +790,8 @@ class PluginLifecycleServiceTest extends TestCase
             ]
         ));
 
+        $this->pluginMock->expects($this->never())->method('activate');
+
         $this->expectExceptionObject(new \RuntimeException('Failed to reboot the kernel'));
 
         $this->pluginLifecycleService->activatePlugin($pluginEntityMock, $context);
@@ -794,6 +824,8 @@ class PluginLifecycleServiceTest extends TestCase
         $pluginEntityMock = $this->getPluginEntityMock();
         $context = Context::createDefaultContext();
 
+        $this->pluginMock->expects($this->never())->method('deactivate');
+
         $this->expectException(PluginNotInstalledException::class);
 
         $this->pluginLifecycleService->deactivatePlugin($pluginEntityMock, $context);
@@ -806,6 +838,8 @@ class PluginLifecycleServiceTest extends TestCase
         $pluginEntityMock->setActive(false);
         $context = Context::createDefaultContext();
         $this->cacheItemPoolInterfaceMock->method('getItem')->willReturn(new CacheItem());
+
+        $this->pluginMock->expects($this->never())->method('deactivate');
 
         $this->expectException(PluginNotActivatedException::class);
 
@@ -827,6 +861,8 @@ class PluginLifecycleServiceTest extends TestCase
             ->expects($this->once())
             ->method('resolveActiveDependants')->willReturn([$this->pluginMock]);
         $this->pluginLifecycleService = $this->createService(requirementsValidator: $requirementsValidator);
+
+        $this->pluginMock->expects($this->never())->method('deactivate');
 
         $this->expectException(PluginHasActiveDependantsException::class);
 
@@ -857,6 +893,8 @@ class PluginLifecycleServiceTest extends TestCase
             ]
         ));
 
+        $this->pluginMock->expects($this->once())->method('deactivate');
+
         $this->pluginLifecycleService->deactivatePlugin($pluginEntityMock, $context);
 
         static::assertCount(2, $this->eventDispatcher->getEvents());
@@ -871,6 +909,8 @@ class PluginLifecycleServiceTest extends TestCase
 
         $this->pluginRepoMock->method('update')->willThrowException(new \Exception('failed update'));
 
+        $this->pluginMock->expects($this->once())->method('deactivate');
+
         $this->expectExceptionObject(new \Exception('failed update'));
 
         $this->pluginLifecycleService->deactivatePlugin($pluginEntityMock, $context);
@@ -883,6 +923,8 @@ class PluginLifecycleServiceTest extends TestCase
         $context = Context::createDefaultContext();
 
         $this->kernelPluginCollectionMock->method('get')->willReturn(null);
+
+        $this->pluginMock->expects($this->never())->method('install');
 
         $this->expectException(PluginBaseClassNotFoundException::class);
 
@@ -916,6 +958,9 @@ class PluginLifecycleServiceTest extends TestCase
 
         $this->kernelPluginCollectionMock->method('get')->willReturn(null);
 
+        // the lifecycle installs the local plugin stub above, never the shared plugin mock
+        $this->pluginMock->expects($this->never())->method('install');
+
         $this->pluginLifecycleService->installPlugin($pluginEntityMock, $context);
     }
 
@@ -929,6 +974,8 @@ class PluginLifecycleServiceTest extends TestCase
         $this->container->set(Plugin::class, $this->pluginMock);
 
         $this->cacheItemPoolInterfaceMock->method('getItem')->willReturn(new CacheItem());
+
+        $this->pluginMock->expects($this->once())->method('deactivate');
 
         $this->pluginLifecycleService->deactivatePlugin($pluginEntityMock, $context);
 
@@ -946,6 +993,8 @@ class PluginLifecycleServiceTest extends TestCase
 
         $this->cacheItemPoolInterfaceMock->method('getItem')->willReturn(new CacheItem());
 
+        $this->pluginMock->expects($this->never())->method('deactivate');
+
         $this->expectExceptionObject(PluginException::wrongBaseClass(Plugin::class));
 
         $this->pluginLifecycleService->deactivatePlugin($pluginEntityMock, $context);
@@ -962,6 +1011,8 @@ class PluginLifecycleServiceTest extends TestCase
 
         $this->cacheItemPoolInterfaceMock->method('getItem')->willReturn(new CacheItem());
 
+        $this->pluginMock->expects($this->once())->method('deactivate');
+
         $this->pluginLifecycleService->deactivatePlugin($pluginEntityMock, $context);
 
         static::assertCount(2, $this->eventDispatcher->getEvents());
@@ -969,6 +1020,8 @@ class PluginLifecycleServiceTest extends TestCase
 
     public function testOnResponseWithoutPluginMarkedForDelete(): void
     {
+        $this->pluginMock->expects($this->never())->method('executeComposerCommands');
+
         $commandExecutor = $this->createMock(CommandExecutor::class);
         $commandExecutor->expects($this->never())->method('remove');
         $pluginService = $this->createMock(PluginService::class);
@@ -981,6 +1034,8 @@ class PluginLifecycleServiceTest extends TestCase
     public function testOnResponseWithPluginMarkedForDelete(): void
     {
         $context = Context::createDefaultContext();
+
+        $this->pluginMock->expects($this->never())->method('executeComposerCommands');
 
         $commandExecutor = $this->createMock(CommandExecutor::class);
         $commandExecutor->expects($this->once())
@@ -1031,6 +1086,8 @@ class PluginLifecycleServiceTest extends TestCase
                 ],
             ]
         ));
+
+        $this->pluginMock->expects($this->once())->method('activate');
 
         $sessionMock = $this->createMock(SessionInterface::class);
         $sessionMock->expects($this->once())->method('isStarted')->willReturn(true);

--- a/tests/unit/Core/Framework/Plugin/Util/AssetServiceTest.php
+++ b/tests/unit/Core/Framework/Plugin/Util/AssetServiceTest.php
@@ -207,6 +207,7 @@ class AssetServiceTest extends TestCase
 
         $kernel = $this->createMock(KernelInterface::class);
         $kernel
+            ->expects($this->atLeastOnce())
             ->method('getBundle')
             ->willThrowException(new \InvalidArgumentException('foo'));
 
@@ -238,6 +239,7 @@ class AssetServiceTest extends TestCase
     {
         $kernel = $this->createMock(KernelInterface::class);
         $kernel
+            ->expects($this->atLeastOnce())
             ->method('getBundle')
             ->with('ExampleBundle')
             ->willThrowException(new \InvalidArgumentException());
@@ -365,6 +367,7 @@ class AssetServiceTest extends TestCase
         ksort($manifest);
         $kernel = $this->createMock(KernelInterface::class);
         $kernel
+            ->expects($this->atLeastOnce())
             ->method('getBundle')
             ->with('AdministrationBundle')
             ->willReturn(new Administration());
@@ -450,6 +453,7 @@ class AssetServiceTest extends TestCase
     {
         $kernel = $this->createMock(KernelInterface::class);
         $kernel
+            ->expects($this->atLeastOnce())
             ->method('getBundle')
             ->with('AdministrationBundle')
             ->willReturn(new Administration());

--- a/tests/unit/Core/Framework/Sso/TokenService/ExternalTokenServiceTest.php
+++ b/tests/unit/Core/Framework/Sso/TokenService/ExternalTokenServiceTest.php
@@ -93,6 +93,8 @@ class ExternalTokenServiceTest extends TestCase
 
         if ($withEmptyConfig) {
             $config = [];
+            $responseInterface->expects($this->never())->method('getContent');
+            $client->expects($this->never())->method('request');
         } else {
             $responseInterface->expects($this->once())->method('getContent');
             $client->expects($this->once())->method('request');

--- a/tests/unit/Core/Framework/Store/Api/ExtensionStoreActionsControllerTest.php
+++ b/tests/unit/Core/Framework/Store/Api/ExtensionStoreActionsControllerTest.php
@@ -3,7 +3,6 @@
 namespace Shopware\Tests\Unit\Core\Framework\Store\Api;
 
 use PHPUnit\Framework\Attributes\CoversClass;
-use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Log\Package;
@@ -80,10 +79,7 @@ class ExtensionStoreActionsControllerTest extends TestCase
 
     public function testUploadExtensionsWithInvalidFileAndDeleteFileException(): void
     {
-        $fileSystemMock = $this->createFileSystemMock();
-        if (!$fileSystemMock instanceof MockObject) {
-            static::fail('Filesystem mock is not a mock object');
-        }
+        $fileSystemMock = $this->createMock(Filesystem::class);
 
         $fileSystemMock->expects($this->once())
             ->method('remove')
@@ -373,6 +369,8 @@ class ExtensionStoreActionsControllerTest extends TestCase
 
         if ($expectCallRemove) {
             $fileSystem->expects($this->once())->method('remove');
+        } else {
+            $fileSystem->expects($this->never())->method('remove');
         }
 
         return $fileSystem;

--- a/tests/unit/Core/Installer/Controller/DatabaseConfigurationControllerTest.php
+++ b/tests/unit/Core/Installer/Controller/DatabaseConfigurationControllerTest.php
@@ -346,6 +346,7 @@ class DatabaseConfigurationControllerTest extends TestCase
         $this->translator->expects($this->never())->method('trans');
         $this->blueGreenDeploymentService->expects($this->never())->method('setEnvironmentVariable');
         $this->router->expects($this->never())->method('generate');
+        $this->twig->expects($this->never())->method('render');
 
         $request = Request::create('/installer/database-information', 'POST');
 
@@ -365,6 +366,7 @@ class DatabaseConfigurationControllerTest extends TestCase
     {
         $this->blueGreenDeploymentService->expects($this->never())->method('setEnvironmentVariable');
         $this->router->expects($this->never())->method('generate');
+        $this->twig->expects($this->never())->method('render');
 
         $request = Request::create('/installer/database-information', 'POST');
 
@@ -390,6 +392,7 @@ class DatabaseConfigurationControllerTest extends TestCase
         $this->translator->expects($this->never())->method('trans');
         $this->blueGreenDeploymentService->expects($this->never())->method('setEnvironmentVariable');
         $this->router->expects($this->never())->method('generate');
+        $this->twig->expects($this->never())->method('render');
 
         $request = Request::create('/installer/database-information', 'POST');
 

--- a/tests/unit/Core/Installer/Controller/DatabaseImportControllerTest.php
+++ b/tests/unit/Core/Installer/Controller/DatabaseImportControllerTest.php
@@ -115,6 +115,7 @@ class DatabaseImportControllerTest extends TestCase
     {
         $this->databaseMigrator->expects($this->never())->method('migrate');
         $this->router->expects($this->never())->method('generate');
+        $this->twig->expects($this->never())->method('render');
 
         $session = new Session(new MockArraySessionStorage());
         $request = Request::create('/installer/database-import');
@@ -131,6 +132,7 @@ class DatabaseImportControllerTest extends TestCase
     public function testDatabaseMigrateWithoutOffset(): void
     {
         $this->router->expects($this->never())->method('generate');
+        $this->twig->expects($this->never())->method('render');
 
         $connection = static::createStub(Connection::class);
         $this->connectionFactory->method('getConnection')
@@ -161,6 +163,7 @@ class DatabaseImportControllerTest extends TestCase
     public function testDatabaseMigrateWillReportException(): void
     {
         $this->router->expects($this->never())->method('generate');
+        $this->twig->expects($this->never())->method('render');
 
         $connection = static::createStub(Connection::class);
         $this->connectionFactory->method('getConnection')

--- a/tests/unit/Core/Installer/Controller/TranslationControllerTest.php
+++ b/tests/unit/Core/Installer/Controller/TranslationControllerTest.php
@@ -50,6 +50,8 @@ class TranslationControllerTest extends TestCase
 
     public function testRunWithSuccessfulTranslation(): void
     {
+        $this->twig->expects($this->never())->method('render');
+
         $session = new Session(new MockArraySessionStorage());
         $session->set('SELECTED_LANGUAGES', ['en-GB', 'de-DE']);
         $request = Request::create('/installer/translation/run', 'POST');
@@ -73,6 +75,8 @@ class TranslationControllerTest extends TestCase
 
     public function testRunResponseStructure(): void
     {
+        $this->twig->expects($this->never())->method('render');
+
         $session = new Session(new MockArraySessionStorage());
         $session->set('SELECTED_LANGUAGES', ['en-GB']);
         $request = Request::create('/installer/translation/run', 'POST');
@@ -94,6 +98,8 @@ class TranslationControllerTest extends TestCase
 
     public function testRunSessionHandling(): void
     {
+        $this->twig->expects($this->never())->method('render');
+
         $session = new Session(new MockArraySessionStorage());
         $session->set('SELECTED_LANGUAGES', ['en-GB', 'de-DE', 'fr-FR']);
         $request = Request::create('/installer/translation/run', 'POST');
@@ -109,6 +115,8 @@ class TranslationControllerTest extends TestCase
 
     public function testRunWithEmptyLocales(): void
     {
+        $this->twig->expects($this->never())->method('render');
+
         $session = new Session(new MockArraySessionStorage());
         $session->set('SELECTED_LANGUAGES', []);
         $request = Request::create('/installer/translation/run', 'POST');

--- a/tests/unit/Core/Service/LifecycleManagerTest.php
+++ b/tests/unit/Core/Service/LifecycleManagerTest.php
@@ -80,6 +80,8 @@ class LifecycleManagerTest extends TestCase
             ->method('revoke');
         $this->client->expects($this->never())
             ->method('getAll');
+        $this->serviceConsentRequirement->expects($this->never())
+            ->method('isSatisfied');
 
         $manager = $this->createManager($this->createAppRepository());
 
@@ -106,6 +108,8 @@ class LifecycleManagerTest extends TestCase
             ->method('reconcile');
         $this->client->expects($this->never())
             ->method('getAll');
+        $this->serviceConsentRequirement->expects($this->never())
+            ->method('isSatisfied');
 
         $this->createManager($this->createAppRepository())->disable($this->context);
     }
@@ -124,6 +128,8 @@ class LifecycleManagerTest extends TestCase
             ->method('revoke');
         $this->client->expects($this->never())
             ->method('getAll');
+        $this->serviceConsentRequirement->expects($this->never())
+            ->method('isSatisfied');
 
         $manager = $this->createManager($this->createAppRepository());
 
@@ -294,6 +300,8 @@ class LifecycleManagerTest extends TestCase
             ->method('reconcile');
         $this->permissionsService->expects($this->never())
             ->method('revoke');
+        $this->serviceConsentRequirement->expects($this->never())
+            ->method('isSatisfied');
 
         $manager = $this->createManager($this->createAppRepository($services));
 
@@ -319,6 +327,8 @@ class LifecycleManagerTest extends TestCase
             ->method('set');
         $this->permissionsService->expects($this->never())
             ->method('revoke');
+        $this->serviceConsentRequirement->expects($this->never())
+            ->method('isSatisfied');
 
         $manager = $this->createManager($this->createAppRepository());
 
@@ -339,6 +349,8 @@ class LifecycleManagerTest extends TestCase
             ->method('revoke');
         $this->client->expects($this->never())
             ->method('getAll');
+        $this->serviceConsentRequirement->expects($this->never())
+            ->method('isSatisfied');
 
         $manager = $this->createManager($this->createAppRepository(), enabled: 'false');
 
@@ -364,6 +376,8 @@ class LifecycleManagerTest extends TestCase
             ->method('revoke');
         $this->client->expects($this->never())
             ->method('getAll');
+        $this->serviceConsentRequirement->expects($this->never())
+            ->method('isSatisfied');
 
         $manager = new LifecycleManager(
             $envEnabled,

--- a/tests/unit/Core/Service/ServiceLifecycleTest.php
+++ b/tests/unit/Core/Service/ServiceLifecycleTest.php
@@ -64,7 +64,7 @@ class ServiceLifecycleTest extends TestCase
 
     private Client&Stub $registryClient;
 
-    private ServiceClient&MockObject $serviceClient;
+    private ServiceClient&Stub $serviceClient;
 
     private ServiceClientFactory&Stub $serviceClientFactory;
 
@@ -79,7 +79,7 @@ class ServiceLifecycleTest extends TestCase
         $this->eventDispatcher = $this->createMock(EventDispatcherInterface::class);
         $this->requirementsValidator = $this->createMock(RequirementsValidator::class);
         $this->registryClient = static::createStub(Client::class);
-        $this->serviceClient = $this->createMock(ServiceClient::class);
+        $this->serviceClient = static::createStub(ServiceClient::class);
         $this->serviceClientFactory = static::createStub(ServiceClientFactory::class);
     }
 

--- a/tests/unit/Core/System/SalesChannel/Context/SalesChannelContextRequestRestorerTest.php
+++ b/tests/unit/Core/System/SalesChannel/Context/SalesChannelContextRequestRestorerTest.php
@@ -53,7 +53,7 @@ class SalesChannelContextRequestRestorerTest extends TestCase
 
     public function testItLoadsAndStoresContextFromSalesChannelRequestAttributes(): void
     {
-        $context = $this->createMock(SalesChannelContext::class);
+        $context = static::createStub(SalesChannelContext::class);
         $request = new Request();
         $request->attributes->set(PlatformRequest::ATTRIBUTE_SALES_CHANNEL_ID, TestDefaults::SALES_CHANNEL);
         $request->attributes->set(SalesChannelRequest::ATTRIBUTE_DOMAIN_CURRENCY_ID, Defaults::CURRENCY);

--- a/tests/unit/Core/System/Snippet/SnippetServiceTest.php
+++ b/tests/unit/Core/System/Snippet/SnippetServiceTest.php
@@ -358,6 +358,8 @@ class SnippetServiceTest extends TestCase
             },
         ]);
 
+        $this->connection->expects($this->never())->method('fetchOne');
+
         $service = $this->createSnippetService(
             snippetRepository: $snippetRepository,
             snippetSetRepository: $snippetSetRepository,
@@ -453,6 +455,8 @@ class SnippetServiceTest extends TestCase
 
         $snippetSetRepository = new StaticEntityRepository([$snippetSetCollection]);
         $snippetRepository = new StaticEntityRepository([new SnippetCollection()]);
+
+        $this->connection->expects($this->never())->method('fetchOne');
 
         $service = $this->createSnippetService(
             snippetRepository: $snippetRepository,

--- a/tests/unit/Core/System/StateMachine/StateMachineRegistryTest.php
+++ b/tests/unit/Core/System/StateMachine/StateMachineRegistryTest.php
@@ -107,7 +107,8 @@ class StateMachineRegistryTest extends TestCase
 
         // The history entry is written first inside the transaction; if it fails, the state must not be
         // updated, so no entity-written events are dispatched for a state change that never commits.
-        $fixture->historyRepository->method('create')
+        $fixture->historyRepository->expects($this->once())
+            ->method('create')
             ->willThrowException(new \RuntimeException('history write failed'));
 
         $fixture->entityRepository->expects($this->never())


### PR DESCRIPTION
### 1. Why is this change necessary?

TLDR; no rules can catch it all, but this add some narrowing when possible and cleanup for the rest


After #19153, the PHPUnit 12 preview arm (PR #17226) still emits 130 "no expectations were configured for the mock object" notices from 25 unit-test files. A classification of every remaining notice against the rule's skip branches showed that four of the hiding patterns are provable after all, and the rest (expectations inside untaken branches, trait fixture helpers, mock factories other than `createMock`, doubles handed to external calls) are enumerable from the run log even though no static rule can safely flag them.

### 2. What does this change do, exactly?

Rule (first commit), four analysability extensions to `NoCreateMockWithoutExpectationsRule`:

- Array literals pass references through: `new Sut(['dep' => $this->dep])` is constructor forwarding; a receiver can only get at the element through an access the analysis leaves unclassified, so no soundness is lost.
- Arguments of PHPUnit's double-configuration chain (`method`, `with`, `willReturn`, `willReturnMap`, ...) are consumed as data; embedding a double in another double's `willReturnMap([[..., $this->dep]])` no longer hides it.
- Self-defaulting re-binding (`$dep = $dep ?? <stub>`, `$dep ??= <stub>`) keeps the double flowing through the tracked reference, and `$alias = $ref` is followed into the alias, which must itself stay clean.
- A property created inside a fixture helper is a creation site, not a hidden use: ownership is walked over the call graph like coverage, so the tests reaching the creating helper are the ones that can trigger the notice.

Sweep (second commit): all 130 remaining notices fixed, across 29 files (the 25 classified ones plus four already-swept files where the extensions exposed additional bare tests). 30 findings the extended rule now reports (with the bare test methods listed), plus the statically unprovable rest fixed from the run-log classification: expectations pinned per data-provider row where a branch decides (`ExtensionStoreActionsControllerTest`, `HealthCheckControllerTest`, `ExternalTokenServiceTest`), trait-fixture doubles pinned in the Installer controller tests, `createConfiguredMock`/`createMockForIntersectionOfInterfaces` converted to their stub factories, and pure value providers upgraded to real expectations or `createStub()` per the established policy (no `->with()`, no `any()`, no opt-out attributes).

### 3. Describe each step to reproduce the issue or behaviour.

1. Run the unit suite with PHPUnit 12 and `--display-phpunit-notices` (the preview arm of PR #17226).
2. Before: 130 notices from doubles the rule cannot reason about; `composer phpstan` is silent.
3. After: PHPStan flags the four newly provable shapes (30 findings, all fixed here), and the swept files no longer emit notices.

### 4. Please link to the relevant issues (if any).

- relates #19153

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
