### PR TITLE
ci: disable base64 line wrapping in the sync auth header

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Push to private fork
         run: |
-          git config "http.https://github.com/shopware/shopware-private.git/.extraheader" "AUTHORIZATION: basic $(echo -n "x-access-token:${{ steps.sts-shopware-private.outputs.token }}" | base64)"
+          git config "http.https://github.com/shopware/shopware-private.git/.extraheader" "AUTHORIZATION: basic $(echo -n "x-access-token:${{ steps.sts-shopware-private.outputs.token }}" | base64 -w0)"
           git remote add private https://github.com/shopware/shopware-private.git
           git fetch private
           git push -f private ${{ github.ref }}


### PR DESCRIPTION
Use `base64 -w0` for the sync auth header: GNU base64 wraps at 76 characters, so any token longer than 40 characters gets a newline inside the Authorization header and the push to shopware-private fails with "Failed sending HTTP request".