### PR TITLE
fix(framework): resolve js-yaml audit failures

### DIFF
--- a/src/Administration/Resources/app/administration/package-lock.json
+++ b/src/Administration/Resources/app/administration/package-lock.json
@@ -20428,9 +20428,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "funding": [
         {
           "type": "github",

--- a/src/Administration/Resources/app/administration/package-lock.json
+++ b/src/Administration/Resources/app/administration/package-lock.json
@@ -38,7 +38,7 @@
         "date-fns": "2.30.0",
         "date-fns-tz": "2.0.1",
         "debug": "4.4.3",
-        "dompurify": "3.4.12",
+        "dompurify": "3.4.13",
         "eslint-plugin-listeners": "1.5.1",
         "flatpickr": "4.6.13",
         "fs-extra": "11.3.0",
@@ -12926,9 +12926,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.12",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
-      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
+      "version": "3.4.13",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.13.tgz",
+      "integrity": "sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -21994,9 +21994,9 @@
       "license": "ISC"
     },
     "node_modules/nanoid": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.0.tgz",
-      "integrity": "sha512-zDAl/llz8Ue/EblwSYwdxGBYfj46IM1dhjVi8dyp9LQffoIGxJEAHj2oeZ4uNcgycSRcQ83CnfcZqEJzVDLcDw==",
+      "version": "5.1.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.16.tgz",
+      "integrity": "sha512-kVrnsrJqMR8+oLJnGEmSWw9BivK5mt7H3FZatVRjrc5wGqFYuBxX1yG7+A7Gi5AefkX6t/oCkizcQgpu0cY1dQ==",
       "funding": [
         {
           "type": "github",
@@ -23434,9 +23434,9 @@
       "license": "MIT"
     },
     "node_modules/postcss/node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",

--- a/src/Administration/Resources/app/administration/package.json
+++ b/src/Administration/Resources/app/administration/package.json
@@ -254,7 +254,7 @@
     "glob": "12.0.0",
     "immutable": "4.3.9",
     "js-cookie": "3.0.8",
-    "js-yaml": "4.3.0",
+    "js-yaml": "4.3.1",
     "svgo": "3.3.4",
     "vue": "3.5.22",
     "markdown-it": "14.2.0",

--- a/src/Administration/Resources/app/administration/package.json
+++ b/src/Administration/Resources/app/administration/package.json
@@ -83,7 +83,7 @@
     "date-fns": "2.30.0",
     "date-fns-tz": "2.0.1",
     "debug": "4.4.3",
-    "dompurify": "3.4.12",
+    "dompurify": "3.4.13",
     "eslint-plugin-listeners": "1.5.1",
     "flatpickr": "4.6.13",
     "fs-extra": "11.3.0",
@@ -259,6 +259,8 @@
     "vue": "3.5.22",
     "markdown-it": "14.2.0",
     "micromatch": "4.0.8",
+    "nanoid@^3.3.16": "3.3.18",
+    "nanoid@^5.0.7": "5.1.16",
     "ws": "8.21.0",
     "lighthouse": {
       "ws": "7.5.11"

--- a/src/Storefront/Resources/app/storefront/package-lock.json
+++ b/src/Storefront/Resources/app/storefront/package-lock.json
@@ -2360,9 +2360,9 @@
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -13608,9 +13608,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "funding": [
         {
           "type": "github",

--- a/src/Storefront/Resources/app/storefront/package-lock.json
+++ b/src/Storefront/Resources/app/storefront/package-lock.json
@@ -14468,9 +14468,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",

--- a/src/Storefront/Resources/app/storefront/package.json
+++ b/src/Storefront/Resources/app/storefront/package.json
@@ -117,6 +117,7 @@
     "qs": "6.15.2",
     "express": "4.22.2",
     "minimatch": "10.2.5",
+    "nanoid": "3.3.18",
     "brace-expansion": "5.0.9",
     "serialize-javascript": "7.0.5",
     "test-exclude": "8.0.0",

--- a/tests/acceptance/package-lock.json
+++ b/tests/acceptance/package-lock.json
@@ -4357,9 +4357,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",

--- a/tests/acceptance/package-lock.json
+++ b/tests/acceptance/package-lock.json
@@ -3829,9 +3829,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {

--- a/tests/acceptance/package.json
+++ b/tests/acceptance/package.json
@@ -52,7 +52,7 @@
     "picomatch@2": "2.3.2",
     "picomatch@4": "4.0.4",
     "form-data": "4.0.6",
-    "js-yaml": "4.3.0",
+    "js-yaml": "4.3.1",
     "tmp": "0.2.7"
   }
 }

--- a/tests/acceptance/package.json
+++ b/tests/acceptance/package.json
@@ -41,6 +41,7 @@
   "overrides": {
     "follow-redirects": "1.16.0",
     "minimatch": "10.2.5",
+    "nanoid": "3.3.18",
     "brace-expansion": "5.0.9",
     "basic-ftp": "^5.3.1",
     "flatted": "3.4.2",

--- a/tests/acceptance/scripts/runNpmAudit.ts
+++ b/tests/acceptance/scripts/runNpmAudit.ts
@@ -20,7 +20,8 @@ import { runNpmAudit } from '../../../.github/bin/js/run-npm-audit.ts';
  * dependency tree:
  * - GHSA-8988-4f7v-96qf by pinning lighthouse to 12.6.1
  * - GHSA-hmw2-7cc7-3qxx by pinning form-data to 4.0.6
- * - GHSA-h67p-54hq-rp68 by pinning js-yaml to 4.2.0
+ * - GHSA-h67p-54hq-rp68 and GHSA-5p4m-2wfm-xmqj by pinning js-yaml to 4.3.1
+ * - GHSA-28wg-ghj8-5hjv and GHSA-2v37-7h3g-55p8 by pinning nanoid to 3.3.18
  * - GHSA-7c78-jf6q-g5cm by pinning tmp to 0.2.7
  */
 runNpmAudit({


### PR DESCRIPTION
### 1. Why is this change necessary?

The scheduled npm audits fail because `js-yaml` versions affected by GHSA-5p4m-2wfm-xmqj are locked in Administration, Storefront, and acceptance tests.

### 2. What does this change do, exactly?

It updates the affected `js-yaml` lockfile entries to `4.3.1` and the nested Storefront `3.x` entry to `3.15.1`, including the direct overrides where present.

### 3. Describe each step to reproduce the issue or behaviour.

Run the nightly npm audit checks for Administration, Storefront, and acceptance tests on `trunk`.

### 4. Please link to the relevant issues (if any).

- closes #19098

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
