### PR TITLE
feat: component section ordering

### DIFF
--- a/src/Administration/Framework/Api/Subscriber/AdminInfoConfigBundlesSubscriber.php
+++ b/src/Administration/Framework/Api/Subscriber/AdminInfoConfigBundlesSubscriber.php
@@ -52,6 +52,7 @@ readonly class AdminInfoConfigBundlesSubscriber implements EventSubscriberInterf
      *     active: bool,
      *     integrationId: string,
      *     baseUrl: string,
+     *     sourceType: string,
      *     version: string,
      *     permissions: array<string, list<string>>
      * }>
@@ -89,6 +90,7 @@ readonly class AdminInfoConfigBundlesSubscriber implements EventSubscriberInterf
                 'active' => (bool) $app['active'],
                 'integrationId' => $app['integrationId'],
                 'type' => 'app',
+                'sourceType' => $app['sourceType'],
                 'baseUrl' => $app['baseUrl'],
                 'permissions' => $app['privileges'],
                 'version' => $app['version'],

--- a/src/Administration/Framework/App/ActiveAdminAppLoader.php
+++ b/src/Administration/Framework/App/ActiveAdminAppLoader.php
@@ -16,17 +16,18 @@ readonly class ActiveAdminAppLoader
     }
 
     /**
-     * @return list<array{name: string, active: int, integrationId: string, baseUrl: string, version: string, privileges: array<string, list<string>>}>
+     * @return list<array{name: string, active: int, integrationId: string, baseUrl: string, version: string, sourceType: string, privileges: array<string, list<string>>}>
      */
     public function getActiveAdminApps(): array
     {
-        /** @var list<array{name: string, active: int, integrationId: string, baseUrl: string, version: string, privileges: ?string}> $apps */
+        /** @var list<array{name: string, active: int, integrationId: string, baseUrl: string, version: string, sourceType: string, privileges: ?string}> $apps */
         $apps = $this->connection->fetchAllAssociative('SELECT
     app.name,
     app.active,
     LOWER(HEX(app.integration_id)) as integrationId,
     app.base_app_url as baseUrl,
     app.version,
+    app.source_type as sourceType,
     ar.privileges as privileges
 FROM app
 LEFT JOIN acl_role ar on app.acl_role_id = ar.id

--- a/src/Administration/Resources/app/administration/src/app/component/extension-api/sw-extension-component-section/index.ts
+++ b/src/Administration/Resources/app/administration/src/app/component/extension-api/sw-extension-component-section/index.ts
@@ -54,7 +54,9 @@ export default Shopware.Component.wrapComponentConfig({
 
     computed: {
         componentSections(): ComponentSectionEntry[] {
-            const sections = Shopware.Store.get('extensionComponentSections').identifier[this.positionIdentifier] ?? [];
+            const sections = this.sortSections(
+                Shopware.Store.get('extensionComponentSections').identifier[this.positionIdentifier] ?? [],
+            );
             if (sections.length && this.deprecated) {
                 sections.forEach((section) => {
                     const debugArgs = [
@@ -98,6 +100,33 @@ export default Shopware.Component.wrapComponentConfig({
     },
 
     methods: {
+        /**
+         * Sorts the sections for this position identifier:
+         * 1. Sections registered by services (`sourceType === 'service'`) always render above app sections.
+         * 2. Within each group, ascending `priority` (1 = topmost). Entries without a valid `priority`
+         *    render below those that set one (unset sorts last).
+         * 3. Ties (equal `priority`, or both unset) keep their original registration order. The sort is
+         *    stable, so returning `0` preserves the array index — no extension is favoured by name.
+         */
+        sortSections(sections: ComponentSectionEntry[]): ComponentSectionEntry[] {
+            const extensionsState = Shopware.Store.get('extensions').extensionsState;
+
+            const isService = (entry: ComponentSectionEntry): boolean =>
+                extensionsState[entry.extensionName]?.sourceType === 'service';
+
+            // Unset priorities sort last so explicitly prioritized entries always win their group.
+            const priorityOf = (entry: ComponentSectionEntry): number => entry.priority ?? Number.MAX_SAFE_INTEGER;
+
+            return [...sections].sort((a, b) => {
+                const serviceDiff = Number(isService(b)) - Number(isService(a));
+                if (serviceDiff !== 0) {
+                    return serviceDiff;
+                }
+
+                return priorityOf(a) - priorityOf(b);
+            });
+        },
+
         setActiveTab(name: string) {
             this.activeTabName = name;
         },

--- a/src/Administration/Resources/app/administration/src/app/component/extension-api/sw-extension-component-section/index.ts
+++ b/src/Administration/Resources/app/administration/src/app/component/extension-api/sw-extension-component-section/index.ts
@@ -103,9 +103,9 @@ export default Shopware.Component.wrapComponentConfig({
         /**
          * Sorts the sections for this position identifier:
          * 1. Sections registered by services (`sourceType === 'service'`) always render above app sections.
-         * 2. Within each group, ascending `position` (1 = topmost). Entries without a valid `position`
+         * 2. Within each group, ascending `priority` (1 = topmost). Entries without a valid `priority`
          *    render below those that set one (unset sorts last).
-         * 3. Ties (equal `position`, or both unset) keep their original registration order. The sort is
+         * 3. Ties (equal `priority`, or both unset) keep their original registration order. The sort is
          *    stable, so returning `0` preserves the array index — no extension is favoured by name.
          */
         sortSections(sections: ComponentSectionEntry[]): ComponentSectionEntry[] {
@@ -114,8 +114,8 @@ export default Shopware.Component.wrapComponentConfig({
             const isService = (entry: ComponentSectionEntry): boolean =>
                 extensionsState[entry.extensionName]?.sourceType === 'service';
 
-            // Unset positions sort last so explicitly positioned entries always win their group.
-            const positionOf = (entry: ComponentSectionEntry): number => entry.position ?? Number.MAX_SAFE_INTEGER;
+            // Unset priorities sort last so explicitly prioritized entries always win their group.
+            const priorityOf = (entry: ComponentSectionEntry): number => entry.priority ?? Number.MAX_SAFE_INTEGER;
 
             return [...sections].sort((a, b) => {
                 const serviceDiff = Number(isService(b)) - Number(isService(a));
@@ -123,7 +123,7 @@ export default Shopware.Component.wrapComponentConfig({
                     return serviceDiff;
                 }
 
-                return positionOf(a) - positionOf(b);
+                return priorityOf(a) - priorityOf(b);
             });
         },
 

--- a/src/Administration/Resources/app/administration/src/app/component/extension-api/sw-extension-component-section/index.ts
+++ b/src/Administration/Resources/app/administration/src/app/component/extension-api/sw-extension-component-section/index.ts
@@ -54,7 +54,9 @@ export default Shopware.Component.wrapComponentConfig({
 
     computed: {
         componentSections(): ComponentSectionEntry[] {
-            const sections = Shopware.Store.get('extensionComponentSections').identifier[this.positionIdentifier] ?? [];
+            const sections = this.sortSections(
+                Shopware.Store.get('extensionComponentSections').identifier[this.positionIdentifier] ?? [],
+            );
             if (sections.length && this.deprecated) {
                 sections.forEach((section) => {
                     const debugArgs = [
@@ -98,6 +100,33 @@ export default Shopware.Component.wrapComponentConfig({
     },
 
     methods: {
+        /**
+         * Sorts the sections for this position identifier:
+         * 1. Sections registered by services (`sourceType === 'service'`) always render above app sections.
+         * 2. Within each group, ascending `position` (1 = topmost). Entries without a valid `position`
+         *    render below those that set one (unset sorts last).
+         * 3. Ties (equal `position`, or both unset) keep their original registration order. The sort is
+         *    stable, so returning `0` preserves the array index — no extension is favoured by name.
+         */
+        sortSections(sections: ComponentSectionEntry[]): ComponentSectionEntry[] {
+            const extensionsState = Shopware.Store.get('extensions').extensionsState;
+
+            const isService = (entry: ComponentSectionEntry): boolean =>
+                extensionsState[entry.extensionName]?.sourceType === 'service';
+
+            // Unset positions sort last so explicitly positioned entries always win their group.
+            const positionOf = (entry: ComponentSectionEntry): number => entry.position ?? Number.MAX_SAFE_INTEGER;
+
+            return [...sections].sort((a, b) => {
+                const serviceDiff = Number(isService(b)) - Number(isService(a));
+                if (serviceDiff !== 0) {
+                    return serviceDiff;
+                }
+
+                return positionOf(a) - positionOf(b);
+            });
+        },
+
         setActiveTab(name: string) {
             this.activeTabName = name;
         },

--- a/src/Administration/Resources/app/administration/src/app/component/extension-api/sw-extension-component-section/sw-extension-component-section.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/extension-api/sw-extension-component-section/sw-extension-component-section.spec.js
@@ -234,4 +234,184 @@ describe('src/app/component/extension-api/sw-extension-component-section', () =>
             process.env = restoreEnv;
         }
     });
+
+    describe('section ordering', () => {
+        function registerExtension(name, sourceType) {
+            Shopware.Store.get('extensions').addExtension({
+                name,
+                baseUrl: `https://example.com/${name}`,
+                permissions: {},
+                type: 'app',
+                sourceType,
+                active: true,
+            });
+        }
+
+        function addSection(extensionName, priority) {
+            Shopware.Store.get('extensionComponentSections').addSection({
+                component: 'card',
+                positionId: 'test-position',
+                props: { title: extensionName, locationId: extensionName },
+                extensionName,
+                priority,
+            });
+        }
+
+        const orderedNames = () => wrapper.vm.componentSections.map((section) => section.extensionName);
+
+        beforeEach(() => {
+            Shopware.Store.get('extensions').extensionsState = {};
+        });
+
+        it('renders service sections above app sections regardless of registration order', async () => {
+            registerExtension('AppExtension', 'local');
+            registerExtension('ServiceExtension', 'service');
+
+            // App registers first (wins the race today), service second.
+            addSection('AppExtension');
+            addSection('ServiceExtension');
+
+            wrapper = await createWrapper();
+            await flushPromises();
+
+            expect(orderedNames()).toEqual([
+                'ServiceExtension',
+                'AppExtension',
+            ]);
+        });
+
+        it('orders by ascending priority within the same group', async () => {
+            registerExtension('AppA', 'local');
+            registerExtension('AppB', 'local');
+            registerExtension('AppC', 'local');
+
+            addSection('AppB', 20);
+            addSection('AppC', 30);
+            addSection('AppA', 10);
+
+            wrapper = await createWrapper();
+            await flushPromises();
+
+            expect(orderedNames()).toEqual([
+                'AppA',
+                'AppB',
+                'AppC',
+            ]);
+        });
+
+        it('renders entries without a priority below those that set one', async () => {
+            registerExtension('AppUnset', 'local');
+            registerExtension('AppPositioned', 'local');
+
+            addSection('AppUnset');
+            addSection('AppPositioned', 999);
+
+            wrapper = await createWrapper();
+            await flushPromises();
+
+            expect(orderedNames()).toEqual([
+                'AppPositioned',
+                'AppUnset',
+            ]);
+        });
+
+        it('keeps registration order for entries with an unset priority (no name bias)', async () => {
+            registerExtension('Charlie', 'local');
+            registerExtension('Alpha', 'local');
+            registerExtension('Bravo', 'local');
+
+            // No priority on any → all unset → ties keep their registration order, not alphabetical.
+            addSection('Charlie');
+            addSection('Alpha');
+            addSection('Bravo');
+
+            wrapper = await createWrapper();
+            await flushPromises();
+
+            expect(orderedNames()).toEqual([
+                'Charlie',
+                'Alpha',
+                'Bravo',
+            ]);
+        });
+
+        it('keeps registration order for entries sharing the same priority', async () => {
+            registerExtension('First', 'local');
+            registerExtension('Second', 'local');
+
+            addSection('Second', 10);
+            addSection('First', 10);
+
+            wrapper = await createWrapper();
+            await flushPromises();
+
+            // Equal priority → stable sort preserves insertion order (Second was registered first).
+            expect(orderedNames()).toEqual([
+                'Second',
+                'First',
+            ]);
+        });
+
+        it('keeps services on top even when an app has a lower priority', async () => {
+            registerExtension('ServiceExtension', 'service');
+            registerExtension('AppExtension', 'local');
+
+            addSection('ServiceExtension', 100);
+            addSection('AppExtension', 1);
+
+            wrapper = await createWrapper();
+            await flushPromises();
+
+            expect(orderedNames()).toEqual([
+                'ServiceExtension',
+                'AppExtension',
+            ]);
+        });
+
+        it('treats sections whose extension is unknown as non-services', async () => {
+            registerExtension('ServiceExtension', 'service');
+
+            addSection('ServiceExtension');
+            addSection('UnknownExtension');
+
+            wrapper = await createWrapper();
+            await flushPromises();
+
+            expect(orderedNames()).toEqual([
+                'ServiceExtension',
+                'UnknownExtension',
+            ]);
+        });
+
+        it('orders distinct priorities deterministically regardless of registration order', async () => {
+            registerExtension('AppA', 'local');
+            registerExtension('AppB', 'local');
+            registerExtension('ServiceZ', 'service');
+
+            addSection('AppB', 20);
+            addSection('ServiceZ', 50);
+            addSection('AppA', 5);
+
+            wrapper = await createWrapper();
+            await flushPromises();
+
+            const firstRun = orderedNames();
+
+            // Re-register in a different order to simulate a page refresh.
+            Shopware.Store.get('extensionComponentSections').identifier = {};
+            addSection('AppA', 5);
+            addSection('ServiceZ', 50);
+            addSection('AppB', 20);
+            await flushPromises();
+
+            // Service first, then apps by ascending priority — identical both runs because
+            // every entry has a distinct priority (no reliance on registration order).
+            expect(firstRun).toEqual([
+                'ServiceZ',
+                'AppA',
+                'AppB',
+            ]);
+            expect(orderedNames()).toEqual(firstRun);
+        });
+    });
 });

--- a/src/Administration/Resources/app/administration/src/app/component/extension-api/sw-extension-component-section/sw-extension-component-section.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/extension-api/sw-extension-component-section/sw-extension-component-section.spec.js
@@ -234,4 +234,184 @@ describe('src/app/component/extension-api/sw-extension-component-section', () =>
             process.env = restoreEnv;
         }
     });
+
+    describe('section ordering', () => {
+        function registerExtension(name, sourceType) {
+            Shopware.Store.get('extensions').addExtension({
+                name,
+                baseUrl: `https://example.com/${name}`,
+                permissions: {},
+                type: 'app',
+                sourceType,
+                active: true,
+            });
+        }
+
+        function addSection(extensionName, position) {
+            Shopware.Store.get('extensionComponentSections').addSection({
+                component: 'card',
+                positionId: 'test-position',
+                props: { title: extensionName, locationId: extensionName },
+                extensionName,
+                position,
+            });
+        }
+
+        const orderedNames = () => wrapper.vm.componentSections.map((section) => section.extensionName);
+
+        beforeEach(() => {
+            Shopware.Store.get('extensions').extensionsState = {};
+        });
+
+        it('renders service sections above app sections regardless of registration order', async () => {
+            registerExtension('AppExtension', 'local');
+            registerExtension('ServiceExtension', 'service');
+
+            // App registers first (wins the race today), service second.
+            addSection('AppExtension');
+            addSection('ServiceExtension');
+
+            wrapper = await createWrapper();
+            await flushPromises();
+
+            expect(orderedNames()).toEqual([
+                'ServiceExtension',
+                'AppExtension',
+            ]);
+        });
+
+        it('orders by ascending position within the same group', async () => {
+            registerExtension('AppA', 'local');
+            registerExtension('AppB', 'local');
+            registerExtension('AppC', 'local');
+
+            addSection('AppB', 20);
+            addSection('AppC', 30);
+            addSection('AppA', 10);
+
+            wrapper = await createWrapper();
+            await flushPromises();
+
+            expect(orderedNames()).toEqual([
+                'AppA',
+                'AppB',
+                'AppC',
+            ]);
+        });
+
+        it('renders entries without a position below those that set one', async () => {
+            registerExtension('AppUnset', 'local');
+            registerExtension('AppPositioned', 'local');
+
+            addSection('AppUnset');
+            addSection('AppPositioned', 999);
+
+            wrapper = await createWrapper();
+            await flushPromises();
+
+            expect(orderedNames()).toEqual([
+                'AppPositioned',
+                'AppUnset',
+            ]);
+        });
+
+        it('keeps registration order for entries with an unset position (no name bias)', async () => {
+            registerExtension('Charlie', 'local');
+            registerExtension('Alpha', 'local');
+            registerExtension('Bravo', 'local');
+
+            // No position on any → all unset → ties keep their registration order, not alphabetical.
+            addSection('Charlie');
+            addSection('Alpha');
+            addSection('Bravo');
+
+            wrapper = await createWrapper();
+            await flushPromises();
+
+            expect(orderedNames()).toEqual([
+                'Charlie',
+                'Alpha',
+                'Bravo',
+            ]);
+        });
+
+        it('keeps registration order for entries sharing the same position', async () => {
+            registerExtension('First', 'local');
+            registerExtension('Second', 'local');
+
+            addSection('Second', 10);
+            addSection('First', 10);
+
+            wrapper = await createWrapper();
+            await flushPromises();
+
+            // Equal position → stable sort preserves insertion order (Second was registered first).
+            expect(orderedNames()).toEqual([
+                'Second',
+                'First',
+            ]);
+        });
+
+        it('keeps services on top even when an app has a lower position', async () => {
+            registerExtension('ServiceExtension', 'service');
+            registerExtension('AppExtension', 'local');
+
+            addSection('ServiceExtension', 100);
+            addSection('AppExtension', 1);
+
+            wrapper = await createWrapper();
+            await flushPromises();
+
+            expect(orderedNames()).toEqual([
+                'ServiceExtension',
+                'AppExtension',
+            ]);
+        });
+
+        it('treats sections whose extension is unknown as non-services', async () => {
+            registerExtension('ServiceExtension', 'service');
+
+            addSection('ServiceExtension');
+            addSection('UnknownExtension');
+
+            wrapper = await createWrapper();
+            await flushPromises();
+
+            expect(orderedNames()).toEqual([
+                'ServiceExtension',
+                'UnknownExtension',
+            ]);
+        });
+
+        it('orders distinct positions deterministically regardless of registration order', async () => {
+            registerExtension('AppA', 'local');
+            registerExtension('AppB', 'local');
+            registerExtension('ServiceZ', 'service');
+
+            addSection('AppB', 20);
+            addSection('ServiceZ', 50);
+            addSection('AppA', 5);
+
+            wrapper = await createWrapper();
+            await flushPromises();
+
+            const firstRun = orderedNames();
+
+            // Re-register in a different order to simulate a page refresh.
+            Shopware.Store.get('extensionComponentSections').identifier = {};
+            addSection('AppA', 5);
+            addSection('ServiceZ', 50);
+            addSection('AppB', 20);
+            await flushPromises();
+
+            // Service first, then apps by ascending position — identical both runs because
+            // every entry has a distinct position (no reliance on registration order).
+            expect(firstRun).toEqual([
+                'ServiceZ',
+                'AppA',
+                'AppB',
+            ]);
+            expect(orderedNames()).toEqual(firstRun);
+        });
+    });
 });

--- a/src/Administration/Resources/app/administration/src/app/component/extension-api/sw-extension-component-section/sw-extension-component-section.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/extension-api/sw-extension-component-section/sw-extension-component-section.spec.js
@@ -247,13 +247,13 @@ describe('src/app/component/extension-api/sw-extension-component-section', () =>
             });
         }
 
-        function addSection(extensionName, position) {
+        function addSection(extensionName, priority) {
             Shopware.Store.get('extensionComponentSections').addSection({
                 component: 'card',
                 positionId: 'test-position',
                 props: { title: extensionName, locationId: extensionName },
                 extensionName,
-                position,
+                priority,
             });
         }
 
@@ -280,7 +280,7 @@ describe('src/app/component/extension-api/sw-extension-component-section', () =>
             ]);
         });
 
-        it('orders by ascending position within the same group', async () => {
+        it('orders by ascending priority within the same group', async () => {
             registerExtension('AppA', 'local');
             registerExtension('AppB', 'local');
             registerExtension('AppC', 'local');
@@ -299,7 +299,7 @@ describe('src/app/component/extension-api/sw-extension-component-section', () =>
             ]);
         });
 
-        it('renders entries without a position below those that set one', async () => {
+        it('renders entries without a priority below those that set one', async () => {
             registerExtension('AppUnset', 'local');
             registerExtension('AppPositioned', 'local');
 
@@ -315,12 +315,12 @@ describe('src/app/component/extension-api/sw-extension-component-section', () =>
             ]);
         });
 
-        it('keeps registration order for entries with an unset position (no name bias)', async () => {
+        it('keeps registration order for entries with an unset priority (no name bias)', async () => {
             registerExtension('Charlie', 'local');
             registerExtension('Alpha', 'local');
             registerExtension('Bravo', 'local');
 
-            // No position on any → all unset → ties keep their registration order, not alphabetical.
+            // No priority on any → all unset → ties keep their registration order, not alphabetical.
             addSection('Charlie');
             addSection('Alpha');
             addSection('Bravo');
@@ -335,7 +335,7 @@ describe('src/app/component/extension-api/sw-extension-component-section', () =>
             ]);
         });
 
-        it('keeps registration order for entries sharing the same position', async () => {
+        it('keeps registration order for entries sharing the same priority', async () => {
             registerExtension('First', 'local');
             registerExtension('Second', 'local');
 
@@ -345,14 +345,14 @@ describe('src/app/component/extension-api/sw-extension-component-section', () =>
             wrapper = await createWrapper();
             await flushPromises();
 
-            // Equal position → stable sort preserves insertion order (Second was registered first).
+            // Equal priority → stable sort preserves insertion order (Second was registered first).
             expect(orderedNames()).toEqual([
                 'Second',
                 'First',
             ]);
         });
 
-        it('keeps services on top even when an app has a lower position', async () => {
+        it('keeps services on top even when an app has a lower priority', async () => {
             registerExtension('ServiceExtension', 'service');
             registerExtension('AppExtension', 'local');
 
@@ -383,7 +383,7 @@ describe('src/app/component/extension-api/sw-extension-component-section', () =>
             ]);
         });
 
-        it('orders distinct positions deterministically regardless of registration order', async () => {
+        it('orders distinct priorities deterministically regardless of registration order', async () => {
             registerExtension('AppA', 'local');
             registerExtension('AppB', 'local');
             registerExtension('ServiceZ', 'service');
@@ -404,8 +404,8 @@ describe('src/app/component/extension-api/sw-extension-component-section', () =>
             addSection('AppB', 20);
             await flushPromises();
 
-            // Service first, then apps by ascending position — identical both runs because
-            // every entry has a distinct position (no reliance on registration order).
+            // Service first, then apps by ascending priority — identical both runs because
+            // every entry has a distinct priority (no reliance on registration order).
             expect(firstRun).toEqual([
                 'ServiceZ',
                 'AppA',

--- a/src/Administration/Resources/app/administration/src/app/store/extension-component-sections.store.spec.ts
+++ b/src/Administration/Resources/app/administration/src/app/store/extension-component-sections.store.spec.ts
@@ -134,5 +134,38 @@ describe('extension-component-sections.store', () => {
                 extensionName: 'TestExtension2',
             });
         });
+
+        it('stores a valid priority (1 or higher)', () => {
+            store.addSection({
+                component: 'card',
+                positionId: 'test-position',
+                props: { locationId: 'test-location' },
+                extensionName: 'TestExtension',
+                priority: 5,
+            });
+
+            expect(store.identifier['test-position'][0].priority).toBe(5);
+        });
+
+        it.each([
+            [
+                'a negative',
+                -5,
+            ],
+            [
+                'a zero',
+                0,
+            ],
+        ])('ignores %s priority, storing it as unset', (_label, invalidPriority) => {
+            store.addSection({
+                component: 'card',
+                positionId: 'test-position',
+                props: { locationId: 'test-location' },
+                extensionName: 'TestExtension',
+                priority: invalidPriority,
+            });
+
+            expect(store.identifier['test-position'][0].priority).toBeUndefined();
+        });
     });
 });

--- a/src/Administration/Resources/app/administration/src/app/store/extension-component-sections.store.spec.ts
+++ b/src/Administration/Resources/app/administration/src/app/store/extension-component-sections.store.spec.ts
@@ -135,16 +135,16 @@ describe('extension-component-sections.store', () => {
             });
         });
 
-        it('stores a valid position (1 or higher)', () => {
+        it('stores a valid priority (1 or higher)', () => {
             store.addSection({
                 component: 'card',
                 positionId: 'test-position',
                 props: { locationId: 'test-location' },
                 extensionName: 'TestExtension',
-                position: 5,
+                priority: 5,
             });
 
-            expect(store.identifier['test-position'][0].position).toBe(5);
+            expect(store.identifier['test-position'][0].priority).toBe(5);
         });
 
         it.each([
@@ -156,16 +156,16 @@ describe('extension-component-sections.store', () => {
                 'a zero',
                 0,
             ],
-        ])('ignores %s position, storing it as unset', (_label, invalidPosition) => {
+        ])('ignores %s priority, storing it as unset', (_label, invalidPriority) => {
             store.addSection({
                 component: 'card',
                 positionId: 'test-position',
                 props: { locationId: 'test-location' },
                 extensionName: 'TestExtension',
-                position: invalidPosition,
+                priority: invalidPriority,
             });
 
-            expect(store.identifier['test-position'][0].position).toBeUndefined();
+            expect(store.identifier['test-position'][0].priority).toBeUndefined();
         });
     });
 });

--- a/src/Administration/Resources/app/administration/src/app/store/extension-component-sections.store.spec.ts
+++ b/src/Administration/Resources/app/administration/src/app/store/extension-component-sections.store.spec.ts
@@ -134,5 +134,38 @@ describe('extension-component-sections.store', () => {
                 extensionName: 'TestExtension2',
             });
         });
+
+        it('stores a valid position (1 or higher)', () => {
+            store.addSection({
+                component: 'card',
+                positionId: 'test-position',
+                props: { locationId: 'test-location' },
+                extensionName: 'TestExtension',
+                position: 5,
+            });
+
+            expect(store.identifier['test-position'][0].position).toBe(5);
+        });
+
+        it.each([
+            [
+                'a negative',
+                -5,
+            ],
+            [
+                'a zero',
+                0,
+            ],
+        ])('ignores %s position, storing it as unset', (_label, invalidPosition) => {
+            store.addSection({
+                component: 'card',
+                positionId: 'test-position',
+                props: { locationId: 'test-location' },
+                extensionName: 'TestExtension',
+                position: invalidPosition,
+            });
+
+            expect(store.identifier['test-position'][0].position).toBeUndefined();
+        });
     });
 });

--- a/src/Administration/Resources/app/administration/src/app/store/extension-component-sections.store.ts
+++ b/src/Administration/Resources/app/administration/src/app/store/extension-component-sections.store.ts
@@ -7,6 +7,7 @@ import { reactive } from 'vue';
 // eslint-disable-next-line sw-deprecation-rules/private-feature-declarations
 export type ComponentSectionEntry = Omit<uiComponentSectionRenderer, 'responseType' | 'positionId'> & {
     extensionName: string;
+    priority?: number;
 };
 
 interface ExtensionComponentSectionsState {
@@ -29,9 +30,14 @@ const ExtensionComponentSectionsStore = Shopware.Store.register({
             src,
             props,
             extensionName,
-        }: Omit<uiComponentSectionRenderer, 'responseType'> & { extensionName: string }) {
+            priority,
+        }: Omit<uiComponentSectionRenderer, 'responseType'> & { extensionName: string; priority?: number }) {
             if (!this.identifier[positionId]) {
                 this.identifier[positionId] = reactive([]);
+            }
+
+            if (typeof priority === 'number' && priority < 1) {
+                priority = undefined;
             }
 
             this.identifier[positionId].push({
@@ -39,6 +45,7 @@ const ExtensionComponentSectionsStore = Shopware.Store.register({
                 src,
                 props,
                 extensionName,
+                priority,
             });
         },
     },

--- a/src/Administration/Resources/app/administration/src/app/store/extension-component-sections.store.ts
+++ b/src/Administration/Resources/app/administration/src/app/store/extension-component-sections.store.ts
@@ -7,6 +7,7 @@ import { reactive } from 'vue';
 // eslint-disable-next-line sw-deprecation-rules/private-feature-declarations
 export type ComponentSectionEntry = Omit<uiComponentSectionRenderer, 'responseType' | 'positionId'> & {
     extensionName: string;
+    position?: number;
 };
 
 interface ExtensionComponentSectionsState {
@@ -29,9 +30,14 @@ const ExtensionComponentSectionsStore = Shopware.Store.register({
             src,
             props,
             extensionName,
-        }: Omit<uiComponentSectionRenderer, 'responseType'> & { extensionName: string }) {
+            position,
+        }: Omit<uiComponentSectionRenderer, 'responseType'> & { extensionName: string; position?: number }) {
             if (!this.identifier[positionId]) {
                 this.identifier[positionId] = reactive([]);
+            }
+
+            if (typeof position === 'number' && position < 1) {
+                position = undefined;
             }
 
             this.identifier[positionId].push({
@@ -39,6 +45,7 @@ const ExtensionComponentSectionsStore = Shopware.Store.register({
                 src,
                 props,
                 extensionName,
+                position,
             });
         },
     },

--- a/src/Administration/Resources/app/administration/src/app/store/extension-component-sections.store.ts
+++ b/src/Administration/Resources/app/administration/src/app/store/extension-component-sections.store.ts
@@ -7,7 +7,7 @@ import { reactive } from 'vue';
 // eslint-disable-next-line sw-deprecation-rules/private-feature-declarations
 export type ComponentSectionEntry = Omit<uiComponentSectionRenderer, 'responseType' | 'positionId'> & {
     extensionName: string;
-    position?: number;
+    priority?: number;
 };
 
 interface ExtensionComponentSectionsState {
@@ -30,14 +30,14 @@ const ExtensionComponentSectionsStore = Shopware.Store.register({
             src,
             props,
             extensionName,
-            position,
-        }: Omit<uiComponentSectionRenderer, 'responseType'> & { extensionName: string; position?: number }) {
+            priority,
+        }: Omit<uiComponentSectionRenderer, 'responseType'> & { extensionName: string; priority?: number }) {
             if (!this.identifier[positionId]) {
                 this.identifier[positionId] = reactive([]);
             }
 
-            if (typeof position === 'number' && position < 1) {
-                position = undefined;
+            if (typeof priority === 'number' && priority < 1) {
+                priority = undefined;
             }
 
             this.identifier[positionId].push({
@@ -45,7 +45,7 @@ const ExtensionComponentSectionsStore = Shopware.Store.register({
                 src,
                 props,
                 extensionName,
-                position,
+                priority,
             });
         },
     },

--- a/src/Administration/Resources/app/administration/src/app/store/extensions.store.spec.ts
+++ b/src/Administration/Resources/app/administration/src/app/store/extensions.store.spec.ts
@@ -23,6 +23,7 @@ describe('extensions.store', () => {
             permissions: {},
             version: '1.0.0',
             type: 'app',
+            sourceType: undefined,
             integrationId: '123',
             active: true,
         });
@@ -33,6 +34,7 @@ describe('extensions.store', () => {
             permissions: {},
             version: '1.0.0',
             type: 'app',
+            sourceType: undefined,
             integrationId: '123',
             active: true,
         });
@@ -76,6 +78,7 @@ describe('extensions.store', () => {
                 permissions: {},
                 version: '1.0.0',
                 type: 'app',
+                sourceType: undefined,
                 integrationId: '123',
                 active: true,
             },

--- a/src/Administration/Resources/app/administration/src/app/store/extensions.store.ts
+++ b/src/Administration/Resources/app/administration/src/app/store/extensions.store.ts
@@ -14,6 +14,7 @@ export interface Extension {
     permissions: privileges;
     version?: string;
     type: 'app' | 'plugin';
+    sourceType?: string;
     integrationId?: string;
     active?: boolean;
 }
@@ -33,7 +34,7 @@ const extensions = Shopware.Store.register({
     }),
 
     actions: {
-        addExtension({ name, baseUrl, permissions, version, type, integrationId, active }: Extension) {
+        addExtension({ name, baseUrl, permissions, version, type, sourceType, integrationId, active }: Extension) {
             if (!this.extensionsState[name]) {
                 this.extensionsState[name] = {
                     name,
@@ -41,6 +42,7 @@ const extensions = Shopware.Store.register({
                     permissions,
                     version,
                     type,
+                    sourceType,
                     integrationId,
                     active,
                 };

--- a/src/Administration/Resources/app/administration/src/core/application.ts
+++ b/src/Administration/Resources/app/administration/src/core/application.ts
@@ -17,6 +17,7 @@ interface bundlesSinglePluginResponse {
     html?: string;
     baseUrl?: null | string;
     type?: 'app' | 'plugin';
+    sourceType?: string;
     version?: string;
     // Properties below this line are only available for apps
     integrationId?: string;
@@ -691,6 +692,7 @@ class ApplicationBootstrapper {
                     bundleVersion: bundle.version,
                     iframeSrc: bundle.baseUrl,
                     bundleType: bundle.type,
+                    sourceType: bundle.sourceType,
                 });
             },
         );
@@ -808,6 +810,7 @@ class ApplicationBootstrapper {
         iframeSrc,
         bundleVersion,
         bundleType,
+        sourceType,
     }: {
         active?: boolean;
         integrationId?: string;
@@ -815,6 +818,7 @@ class ApplicationBootstrapper {
         iframeSrc: string;
         bundleVersion?: string;
         bundleType?: 'app' | 'plugin';
+        sourceType?: string;
     }): void {
         const bundles = Shopware.Context.app.config.bundles;
         let permissions = null;
@@ -830,6 +834,7 @@ class ApplicationBootstrapper {
             baseUrl: string;
             version?: string;
             type: 'app' | 'plugin';
+            sourceType?: string;
             permissions: Record<string, unknown>;
         } = {
             active,
@@ -838,6 +843,7 @@ class ApplicationBootstrapper {
             baseUrl: iframeSrc,
             version: bundleVersion,
             type: bundleType ?? 'plugin',
+            sourceType,
             permissions: {},
         };
 

--- a/tests/integration/Core/Framework/Api/Controller/InfoControllerTest.php
+++ b/tests/integration/Core/Framework/Api/Controller/InfoControllerTest.php
@@ -241,6 +241,7 @@ class InfoControllerTest extends TestCase
             'active' => true,
             'integrationId' => $ids->get('integration'),
             'type' => 'app',
+            'sourceType' => 'local',
             'baseUrl' => 'https://example.com',
             'permissions' => [
                 'create' => ['user'],
@@ -288,6 +289,71 @@ class InfoControllerTest extends TestCase
         static::assertArrayHasKey('PHPUnit', $bundles);
         static::assertIsArray($bundles['PHPUnit']);
         static::assertSame($bundle, $bundles['PHPUnit']);
+    }
+
+    public function testGetConfigWithServiceSourceType(): void
+    {
+        $ids = new IdsCollection();
+        $appRepository = static::getContainer()->get('app.repository');
+        $appRepository->create([
+            [
+                'name' => 'PHPUnitService',
+                'path' => '/foo/bar',
+                'active' => true,
+                'configurable' => false,
+                'version' => '1.0.0',
+                'label' => 'PHPUnitService',
+                'sourceType' => 'service',
+                // Service apps are self-managed; this excludes them from the automatic script
+                // refresh (ScriptLifecycleHandler::refresh) which would otherwise try to resolve
+                // the service filesystem and fail without a full source config.
+                'selfManaged' => true,
+                'integration' => [
+                    'id' => $ids->create('integration'),
+                    'label' => 'foo',
+                    'accessKey' => '123',
+                    'secretAccessKey' => '456',
+                ],
+                'aclRole' => [
+                    'name' => 'PHPUnitServiceRole',
+                    'privileges' => [
+                        'user:read',
+                    ],
+                ],
+                'baseAppUrl' => 'https://example.com',
+            ],
+        ], Context::createDefaultContext());
+
+        $bundle = [
+            'active' => true,
+            'integrationId' => $ids->get('integration'),
+            'type' => 'app',
+            'sourceType' => 'service',
+            'baseUrl' => 'https://example.com',
+            'permissions' => [
+                'read' => ['user'],
+            ],
+            'version' => '1.0.0',
+            'name' => 'PHPUnitService',
+        ];
+
+        $url = '/api/_info/config';
+        $client = $this->getBrowser();
+        $client->request(Request::METHOD_GET, $url);
+
+        $content = $client->getResponse()->getContent();
+        static::assertNotFalse($content);
+        static::assertJson($content);
+
+        $decodedResponse = json_decode($content, true, 512, \JSON_THROW_ON_ERROR);
+
+        static::assertSame(Response::HTTP_OK, $client->getResponse()->getStatusCode());
+
+        $bundles = $decodedResponse['bundles'];
+        static::assertIsArray($bundles);
+        static::assertArrayHasKey('PHPUnitService', $bundles);
+        static::assertIsArray($bundles['PHPUnitService']);
+        static::assertSame($bundle, $bundles['PHPUnitService']);
     }
 
     public function testGetShopwareVersion(): void

--- a/tests/integration/Core/Framework/Api/Controller/InfoControllerTest.php
+++ b/tests/integration/Core/Framework/Api/Controller/InfoControllerTest.php
@@ -241,6 +241,7 @@ class InfoControllerTest extends TestCase
             'active' => true,
             'integrationId' => $ids->get('integration'),
             'type' => 'app',
+            'sourceType' => 'local',
             'baseUrl' => 'https://example.com',
             'permissions' => [
                 'create' => ['user'],

--- a/tests/unit/Administration/Framework/Api/Subscriber/AdminInfoConfigBundlesSubscriberTest.php
+++ b/tests/unit/Administration/Framework/Api/Subscriber/AdminInfoConfigBundlesSubscriberTest.php
@@ -150,6 +150,7 @@ class AdminInfoConfigBundlesSubscriberTest extends TestCase
                 'integrationId' => 'abc',
                 'baseUrl' => 'https://app.test',
                 'version' => '1.0.0',
+                'sourceType' => 'service',
                 'privileges' => ['read' => ['product']],
             ],
         ]);
@@ -158,6 +159,7 @@ class AdminInfoConfigBundlesSubscriberTest extends TestCase
 
         static::assertArrayHasKey('AcmeApp', $bundles);
         static::assertSame('app', $bundles['AcmeApp']['type']);
+        static::assertSame('service', $bundles['AcmeApp']['sourceType']);
         static::assertSame('https://app.test', $bundles['AcmeApp']['baseUrl']);
         static::assertTrue($bundles['AcmeApp']['active']);
         static::assertSame(['read' => ['product']], $bundles['AcmeApp']['permissions']);


### PR DESCRIPTION
### 1. Why is this change necessary?

Multiple apps and services can register UI into the same `sw-extension-component-section` position identifier (for example the dashboard's topmost injectable slot `sw-dashboard__before-content`). Sections were rendered in **arrival order**, and because each extension's iframe boots and posts its `uiComponentSectionRenderer` message asynchronously, the resulting order was **non-deterministic** — it changed between page refreshes. There was also no way for a first-party **service** to reliably render above third-party **apps** in a shared slot.

### 2. What does this change do, exactly?

- Adds an optional `priority` to component-section entries and sorts them deterministically in `sw-extension-component-section`:
  1. Sections registered by services (`sourceType === 'service'`) always render above app sections.
  2. Within each group, ascending `priority` (`1` = topmost). Entries without a valid `priority` render below those that set one.
  3. Ties (equal `priority`, or both unset) keep their original registration order. The sort is stable, so no extension is favoured by name.
- `addSection` treats a `priority` below `1` (`0` or negative) as invalid and stores it as unset.
- Surfaces the app `sourceType` to the Administration so services can be distinguished from apps: `ActiveAdminAppLoader` / `AdminInfoConfigBundlesSubscriber` (backend) → `application.ts` → `extensions` store.
- The matching optional `priority` on the SDK message type is added separately in `@shopware-ag/meteor-admin-sdk`. The runtime already forwards the field, so this PR only consumes it; until that SDK release ships, apps cannot set `priority` in a typed way, and behaviour for existing extensions is unchanged.

### 3. Describe each step to reproduce the issue or behaviour.

1. Install two extensions that both register a component into the same slot (e.g. `sw-dashboard__before-content`) via `ui.componentSection.add`.
2. Open the dashboard and refresh the page several times.
   - Before: the two sections swap order randomly between refreshes.
   - After: the order is stable — services first, then ascending `priority`, then registration order for ties.
3. Give one extension `priority: 1` and the other `priority: 2` and confirm the order is now fixed regardless of which one loads first.

### 4. Please link to the relevant issues (if any).

- relates to https://github.com/shopware/services-roadmap/issues/621
- depends on https://github.com/shopware/meteor/pull/1318 (adds the `priority` field to `@shopware-ag/meteor-admin-sdk`)

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
