### PR TITLE
chore(discovery): hoist loop-invariant lookups out of loops

### DIFF
--- a/src/Core/Content/Cms/DataResolver/CmsSlotsDataResolver.php
+++ b/src/Core/Content/Cms/DataResolver/CmsSlotsDataResolver.php
@@ -175,18 +175,17 @@ class CmsSlotsDataResolver
     private function fetchByCriteria(array $searches, SalesChannelContext $context): array
     {
         $searchResults = [];
+
         foreach ($searches as $definitionClass => $criteriaObjects) {
+            $definition = $this->definitionRegistry->get($definitionClass);
+            $repository = $this->getSalesChannelApiRepository($definition);
+
+            if (!$repository instanceof SalesChannelRepository) {
+                $repository = $this->getApiRepository($definition);
+            }
+
             foreach ($criteriaObjects as $criteriaHash => $criteria) {
-                $definition = $this->definitionRegistry->get($definitionClass);
-
-                $repository = $this->getSalesChannelApiRepository($definition);
-
-                if ($repository) {
-                    $result = $repository->search($criteria, $context);
-                } else {
-                    $repository = $this->getApiRepository($definition);
-                    $result = $repository->search($criteria, $context->getContext());
-                }
+                $result = $repository instanceof SalesChannelRepository ? $repository->search($criteria, $context) : $repository->search($criteria, $context->getContext());
 
                 $searchResults[$definitionClass][$criteriaHash] = $result;
             }

--- a/src/Core/Content/Media/Thumbnail/ThumbnailService.php
+++ b/src/Core/Content/Media/Thumbnail/ThumbnailService.php
@@ -275,6 +275,8 @@ class ThumbnailService
         );
 
         $writtenPaths = [];
+        $fileSystem = $this->getFileSystem($media);
+
         try {
             $event = new MediaPathChangedEvent($context);
 
@@ -289,7 +291,6 @@ class ThumbnailService
                 $this->writeThumbnail($thumbnail, $media, $path, $config->getThumbnailQuality());
                 $writtenPaths[] = $path;
 
-                $fileSystem = $this->getFileSystem($media);
                 if ($imageSize === $thumbnailSize && $fileSystem->fileSize($media->getPath()) < $fileSystem->fileSize($path)) {
                     $fileSystem->write($path, $fileSystem->read($media->getPath()));
                 }

--- a/src/Storefront/Framework/Captcha/CaptchaRouteListener.php
+++ b/src/Storefront/Framework/Captcha/CaptchaRouteListener.php
@@ -59,10 +59,10 @@ readonly class CaptchaRouteListener implements EventSubscriberInterface
         $salesChannelId = $context ? $context->getSalesChannelId() : null;
 
         $activeCaptchas = (array) ($this->systemConfigService->get('core.basicInformation.activeCaptchasV2', $salesChannelId) ?? []);
+        $request = $event->getRequest();
 
         foreach ($this->captchas as $captcha) {
             $captchaConfig = $activeCaptchas[$captcha->getName()] ?? [];
-            $request = $event->getRequest();
             if (
                 $captcha->supports($request, $captchaConfig) && !$captcha->isValid($request, $captchaConfig)
             ) {

--- a/src/Storefront/Theme/Exception/ThemeConfigException.php
+++ b/src/Storefront/Theme/Exception/ThemeConfigException.php
@@ -49,6 +49,8 @@ class ThemeConfigException extends ShopwareHttpException
 
     public function getErrors(bool $withTrace = false): \Generator
     {
+        $errorFactory = new ErrorResponseFactory();
+
         foreach ($this->getExceptions() as $innerException) {
             if ($innerException instanceof ShopwareHttpException) {
                 yield from $innerException->getErrors($withTrace);
@@ -56,7 +58,6 @@ class ThemeConfigException extends ShopwareHttpException
                 continue;
             }
 
-            $errorFactory = new ErrorResponseFactory();
             yield from $errorFactory->getErrorsFromException($innerException, $withTrace);
         }
     }

--- a/src/Storefront/Theme/ThemeCompiler.php
+++ b/src/Storefront/Theme/ThemeCompiler.php
@@ -558,9 +558,11 @@ class ThemeCompiler implements ThemeCompilerInterface
             return [];
         }
 
+        $fs = $this->themeFilesystemResolver->getFilesystemForStorefrontConfig($configuration);
+
         foreach ($configuration->getAssetPaths() as $asset) {
-            if (mb_strpos((string) $asset, '@') === 0) {
-                $name = mb_substr((string) $asset, 1);
+            if (str_starts_with($asset, '@')) {
+                $name = mb_substr($asset, 1);
                 $config = $configurationCollection->getByTechnicalName($name);
                 if (!$config) {
                     throw ThemeException::couldNotFindThemeByName($name);
@@ -571,7 +573,6 @@ class ThemeCompiler implements ThemeCompilerInterface
                 continue;
             }
 
-            $fs = $this->themeFilesystemResolver->getFilesystemForStorefrontConfig($configuration);
             if ($asset[0] !== '/' && $fs->has('Resources', $asset)) {
                 $asset = $fs->path('Resources', $asset);
             }

--- a/src/Storefront/Theme/ThemeFileResolver.php
+++ b/src/Storefront/Theme/ThemeFileResolver.php
@@ -424,12 +424,13 @@ class ThemeFileResolver
 
     private function convertPathsToAbsolute(StorefrontPluginConfiguration $themeConfig, FileCollection $files): void
     {
+        $fs = $this->themeFilesystemResolver->getFilesystemForStorefrontConfig($themeConfig);
+
         foreach ($files->getElements() as $file) {
             if ($this->isInclude($file->getFilepath())) {
                 continue;
             }
 
-            $fs = $this->themeFilesystemResolver->getFilesystemForStorefrontConfig($themeConfig);
             if ($fs->has('Resources', $file->getFilepath())) {
                 $file->setFilepath($fs->realpath('Resources', $file->getFilepath()));
             }

--- a/tests/integration/Core/Content/Media/Thumbnail/ThumbnailServiceTest.php
+++ b/tests/integration/Core/Content/Media/Thumbnail/ThumbnailServiceTest.php
@@ -104,15 +104,15 @@ class ThumbnailServiceTest extends TestCase
         static::assertInstanceOf(MediaThumbnailCollection::class, $thumbnails);
         static::assertCount(2, $thumbnails);
 
+        $folder = $updatedMedia->getMediaFolder();
+        static::assertInstanceOf(MediaFolderEntity::class, $folder);
+        static::assertInstanceOf(MediaFolderConfigurationEntity::class, $folder->getConfiguration());
+
+        $sizes = $folder->getConfiguration()->getMediaThumbnailSizes();
+        static::assertInstanceOf(MediaThumbnailSizeCollection::class, $sizes);
+
         foreach ($thumbnails as $thumbnail) {
             $thumbnailPath = $thumbnail->getPath();
-
-            $folder = $updatedMedia->getMediaFolder();
-            static::assertInstanceOf(MediaFolderEntity::class, $folder);
-            static::assertInstanceOf(MediaFolderConfigurationEntity::class, $folder->getConfiguration());
-
-            $sizes = $folder->getConfiguration()->getMediaThumbnailSizes();
-            static::assertInstanceOf(MediaThumbnailSizeCollection::class, $sizes);
 
             $filtered = $sizes->filter(
                 static fn (MediaThumbnailSizeEntity $size) => $size->getId() === $thumbnail->getMediaThumbnailSizeId()


### PR DESCRIPTION
### 1. Why is this change necessary?

Six `discovery` loops resolve services, repositories or the theme filesystem on every iteration.

Part of #19187, which splits the cleanup per `#[Package]` so each domain team reviews its own files.

### 2. What does this change do, exactly?

- `CmsSlotsDataResolver::fetchByCriteria()` resolved the definition and the repository per criteria object instead of per definition.
- `ThumbnailService::generateAndSave()` resolved the filesystem for the same media entity per thumbnail record.
- `ThemeCompiler::getAssets()` and `ThemeFileResolver::convertPathsToAbsolute()` resolved the theme filesystem per asset and per file.
- `CaptchaRouteListener` read the request per captcha, and `ThemeConfigException::getErrors()` built the error factory per exception.
- The theme asset prefix check now uses `str_starts_with()` instead of `mb_strpos(..., '@') === 0` (review suggestion).

All pure movements. `ThumbnailServiceTest` hoists its folder and size assertions out of the thumbnail loop accordingly.

### 3. Describe each step to reproduce the issue or behaviour.

No user-facing behaviour changes. The existing `Core/Content`, `Storefront` and acceptance suites cover the theme compilation and thumbnail paths.

### 4. Please link to the relevant issues (if any).

relates #19187

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
