### PR TITLE
chore(inventory): hoist loop-invariant lookups out of loops

### DIFF
--- a/src/Core/Content/ProductExport/ScheduledTask/ProductExportGenerateTaskHandler.php
+++ b/src/Core/Content/ProductExport/ScheduledTask/ProductExportGenerateTaskHandler.php
@@ -41,14 +41,14 @@ final class ProductExportGenerateTaskHandler extends ScheduledTaskHandler
 
     public function run(): void
     {
+        $now = $this->clock->now();
+
         foreach ($this->fetchSalesChannelIds() as $salesChannelId) {
             $productExports = $this->fetchProductExports($salesChannelId);
 
             if ($productExports === []) {
                 continue;
             }
-
-            $now = $this->clock->now();
 
             foreach ($productExports as $productExport) {
                 if (!$this->shouldBeRun($productExport, $now)) {

--- a/src/Elasticsearch/Framework/ElasticsearchFieldBuilder.php
+++ b/src/Elasticsearch/Framework/ElasticsearchFieldBuilder.php
@@ -138,8 +138,10 @@ class ElasticsearchFieldBuilder
 
         $customFields = [];
 
+        $cfMapping = $this->getCustomFieldsMapping($entity, $context);
+
         foreach (array_keys($languages) as $languageId) {
-            $customFields[$languageId] = $this->getCustomFieldsMapping($entity, $context);
+            $customFields[$languageId] = $cfMapping;
         }
 
         return ['properties' => $customFields];


### PR DESCRIPTION
### 1. Why is this change necessary?

Two `inventory` loops recompute a value per iteration.

Part of #19187, which splits the cleanup per `#[Package]` so each domain team reviews its own files.

### 2. What does this change do, exactly?

- `ElasticsearchFieldBuilder::customFields()` built the same custom field mapping once per language; it is now built once and reused, which also removes one `getCustomFieldTypes()` lookup per language.
- `ProductExportGenerateTaskHandler::run()` takes `$now` once per run instead of once per sales channel.

**The second one is not a pure movement.** An export whose interval elapses while earlier sales channels are still being queried is now picked up by the next scheduled run rather than the current one. The upside is that a single run evaluates every export against the same timestamp. Happy to drop this hunk if the trade-off is not wanted.

### 3. Describe each step to reproduce the issue or behaviour.

No user-facing behaviour changes for the Elasticsearch mapping. For the scheduled task, the timing nuance above is the only observable difference.

### 4. Please link to the relevant issues (if any).

relates #19187

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
