### PR TITLE
chore(after-sales): hoist container lookups out of the mail flow test loop

### DIFF
--- a/tests/integration/Core/Content/Flow/SendMailActionTest.php
+++ b/tests/integration/Core/Content/Flow/SendMailActionTest.php
@@ -796,29 +796,37 @@ class SendMailActionTest extends TestCase
 
         $sequencesConfig = $this->createFlowSequencesConfig($mailTemplateId, $documentTypes);
 
+        $transportDecorator = new MailerTransportDecorator(
+            $this->createMock(TransportInterface::class),
+            static::getContainer()->get(MailAttachmentsBuilder::class),
+            static::getContainer()->get('shopware.filesystem.public'),
+            $this->documentRepository
+        );
+
+        $logger = static::getContainer()->get('logger');
+        $eventDispatcher = static::getContainer()->get('event_dispatcher');
+        $mailTemplateTypeRepository = static::getContainer()->get('mail_template_type.repository');
+        $translator = static::getContainer()->get(Translator::class);
+        $languageLocaleCodeProvider = static::getContainer()->get(LanguageLocaleCodeProvider::class);
+        $jsonEntityEncoder = static::getContainer()->get(JsonEntityEncoder::class);
+        $definitionInstanceRegistry = static::getContainer()->get(DefinitionInstanceRegistry::class);
+
         foreach ($sequencesConfig as $config) {
             $flow->setConfig($config);
-
-            $transportDecorator = new MailerTransportDecorator(
-                $this->createMock(TransportInterface::class),
-                static::getContainer()->get(MailAttachmentsBuilder::class),
-                static::getContainer()->get('shopware.filesystem.public'),
-                $this->documentRepository
-            );
 
             $mailService = new TestEmailService(static::getContainer()->get(MailFactory::class), $transportDecorator);
 
             $sendMailAction = new SendMailAction(
                 $mailService,
                 $this->mailTemplateRepository,
-                static::getContainer()->get('logger'),
-                static::getContainer()->get('event_dispatcher'),
-                static::getContainer()->get('mail_template_type.repository'),
-                static::getContainer()->get(Translator::class),
+                $logger,
+                $eventDispatcher,
+                $mailTemplateTypeRepository,
+                $translator,
                 $this->connection,
-                static::getContainer()->get(LanguageLocaleCodeProvider::class),
-                static::getContainer()->get(JsonEntityEncoder::class),
-                static::getContainer()->get(DefinitionInstanceRegistry::class),
+                $languageLocaleCodeProvider,
+                $jsonEntityEncoder,
+                $definitionInstanceRegistry,
                 true
             );
 


### PR DESCRIPTION
### 1. Why is this change necessary?

`SendMailActionTest` resolves the mailer transport and seven container services on every flow sequence it iterates.

Part of #19187, which splits the cleanup per `#[Package]` so each domain team reviews its own files.

### 2. What does this change do, exactly?

Moves the transport decorator and the container lookups in `testNumberOfDocumentAttachmentsInCaseFlowSequencesAttachDifferentDocumentTypes()` in front of the loop. A fresh `TestEmailService` is still created per iteration because it records the sent mail; `MailerTransportDecorator` only holds readonly dependencies, so sharing it is safe.

### 3. Describe each step to reproduce the issue or behaviour.

Run `tests/integration/Core/Content/Flow/SendMailActionTest.php`; the attachment and "marked as sent" assertions are unchanged.

### 4. Please link to the relevant issues (if any).

relates #19187

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
