### PR TITLE
fix(administration): cart price initialization in shipping method price matrix settings (backport: 6.6.x)

### DIFF
--- a/changelog/_unreleased/2025-09-17-fix-cart-price-initialization-in-shipping-method-price-matrix.md
+++ b/changelog/_unreleased/2025-09-17-fix-cart-price-initialization-in-shipping-method-price-matrix.md
@@ -1,0 +1,7 @@
+---
+title: Fix cart price initialization in shipping method price matrix settings
+author: Chuc Le
+issue: 12430
+---
+# Administration
+* Changed `sw-settings-shipping-detail` and `sw-settings-shipping-price-matrix` components to initialize cart `quantityStart` at 0

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-shipping/component/sw-settings-shipping-price-matrices/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-shipping/component/sw-settings-shipping-price-matrices/index.js
@@ -77,7 +77,7 @@ export default {
         onAddNewPriceGroup() {
             const newShippingPrice = this.shippingPriceRepository.create(Context.api);
             newShippingPrice.shippingMethodId = this.shippingMethod.id;
-            newShippingPrice.quantityStart = 1;
+            newShippingPrice.quantityStart = 0;
             newShippingPrice.ruleId = null;
 
             // Create a flagged as new price matrix, if there is already an unrestricted.

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-shipping/component/sw-settings-shipping-price-matrices/sw-settings-shipping-price-matrices.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-shipping/component/sw-settings-shipping-price-matrices/sw-settings-shipping-price-matrices.spec.js
@@ -1,5 +1,6 @@
 import { mount } from '@vue/test-utils';
 import state from 'src/module/sw-settings-shipping/page/sw-settings-shipping-detail/state';
+import EntityCollection from 'src/core/data/entity-collection.data';
 
 /**
  * @sw-package checkout
@@ -337,6 +338,17 @@ describe('module/sw-settings-shipping/component/sw-settings-shipping-price-matri
         wrapper.vm.onAddNewPriceGroup();
 
         expect(Object.keys(wrapper.vm.shippingPriceGroups)).toContain('null');
+    });
+
+    it('should set quantityStart to 0 when creating a new price group', async () => {
+        const wrapper = await createWrapper();
+        const shippingMethod = {
+            prices: new EntityCollection(),
+        };
+        wrapper.vm.$data.shippingMethod = shippingMethod;
+
+        wrapper.vm.onAddNewPriceGroup();
+        expect(shippingMethod.prices[0].quantityStart).toBe(0);
     });
 
     it('should show all rules with matching prices', async () => {

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-shipping/page/sw-settings-shipping-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-shipping/page/sw-settings-shipping-detail/index.js
@@ -195,7 +195,7 @@ export default {
                 const shippingMethod = this.shippingMethodRepository.create();
                 const shippingMethodPrice = this.shippingMethodPricesRepository.create();
                 shippingMethodPrice.calculation = 1;
-                shippingMethodPrice.quantityStart = 1;
+                shippingMethodPrice.quantityStart = 0;
                 shippingMethodPrice.shippingMethodId = shippingMethod.id;
                 shippingMethodPrice.ruleId = null;
                 shippingMethod.prices.add(shippingMethodPrice);

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-shipping/page/sw-settings-shipping-detail/sw-settings-shipping-detail.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-shipping/page/sw-settings-shipping-detail/sw-settings-shipping-detail.spec.js
@@ -225,4 +225,9 @@ describe('module/sw-settings-shipping/page/sw-settings-shipping-detail', () => {
         wrapper.vm.loadEntityData();
         expect(spy).toHaveBeenCalled();
     });
+
+    it('should initialize shipping price with quantityStart=0 after creating component', async () => {
+        const wrapper = await createWrapper([]);
+        expect(wrapper.vm.shippingMethod.quantityStart).toBe(0);
+    });
 });


### PR DESCRIPTION
### 1. Why is this change necessary?

The Administration initialises a new shipping price matrix with `quantityStart = 1`, which blocks checkout for carts below 1.00 when pricing by Cart price, Weight or Volume. Fixed on trunk in #12560 but never backported to 6.6.

### 2. What does this change do, exactly?

Cherry-pick of `6bc814ee6c3`, changing the initial `quantityStart` from `1` to `0` in `sw-settings-shipping-price-matrices` and `sw-settings-shipping-detail`. The only conflict was the spec import block, since 6.6 still uses the Vuex `state` module; existing price matrices are not migrated.

### 3. Describe each step to reproduce the issue or behaviour.

Settings → Shipping → Add shipping method → "Add price matrix" → select "Cart price". The "Cart price from" column shows `1` instead of `0` (reproduced on 6.6.10.18).

### 4. Please link to the relevant issues (if any).

- closes #19002
- Backport of #12560

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
