### PR TITLE
test: flag setUp mocks orphaned by per-test re-creation

### DIFF
--- a/src/Core/DevOps/StaticAnalyze/PHPStan/Rules/Tests/NoCreateMockWithoutExpectationsRule.php
+++ b/src/Core/DevOps/StaticAnalyze/PHPStan/Rules/Tests/NoCreateMockWithoutExpectationsRule.php
@@ -52,6 +52,12 @@ use Shopware\Core\Framework\Log\Package;
  * error. The reverse — converting a real mock — is caught for free by phpstan-phpunit (`Stub::expects()` is
  * undefined).
  *
+ * A property created in `setUp()` and re-created via `$this->dep = $this->createMock(...)` inside a test is a
+ * separate trap: the re-assignment replaces the setUp instance before the SUT (built per test) uses it, so the
+ * setUp instance is orphaned and notices with no expectation, regardless of how the re-created instance is
+ * configured. This is reported on the setUp assignment (see {@see self::ERROR_ORPHANED}); the fix is to
+ * configure the setUp instance in place rather than re-create it.
+ *
  * Abstract test classes are analysed through their concrete subclasses instead of on their own: the notice
  * fires per concrete class run, and only there are all call sites of the base fixtures visible. The inherited
  * methods of unit-test ancestors are parsed from their files and merged under the subclass (overrides win, see
@@ -67,6 +73,8 @@ class NoCreateMockWithoutExpectationsRule implements Rule
     public const ERROR_STUB = 'createMock(%s) is only used as a stub (no ->expects() is configured on it). Use createStub(%s) instead, the correct PHPUnit API for a test double without call expectations.';
 
     public const ERROR_MIXED = 'createMock(%s) is a shared mock that is ->expects()-ed in some test methods but left without an expectation in %s, so it triggers the PHPUnit "no expectations" notice there. Do not mix mock and stub usage on one shared double: give it a real expectation (e.g. ->expects($this->never())) in every test, split the test, or use a per-test double.';
+
+    public const ERROR_ORPHANED = 'createMock(%s) is created in setUp() and re-created via `$this->... = $this->createMock(...)` in %s. Re-assigning the property replaces this instance before it is used, so it never receives an expectation and triggers the PHPUnit "no expectations" notice. Configure the setUp instance directly in those tests instead of re-creating it (or move the creation out of setUp).';
 
     /**
      * The domain-by-domain rollout is complete: every unit test suite is covered.
@@ -737,6 +745,28 @@ class NoCreateMockWithoutExpectationsRule implements Rule
 
         $errors = [];
         foreach ($assignments as $name => $propAssignments) {
+            // A property created in setUp() and re-created inside a test replaces the setUp instance
+            // before it is used, orphaning it (it never receives an expectation). Independent of the
+            // property's other usage, so checked before the off-limits bail. Reported on the setUp
+            // assignment, since that is the instance the notice fires on.
+            $setUpAssign = $setUp !== null && !$this->methodExpectsProperty($finder, $setUp, $name)
+                ? $this->propertyCreationAssign($finder, $setUp, $name)
+                : null;
+            if ($setUpAssign !== null) {
+                $reassigners = [];
+                foreach ($testMethods as $test) {
+                    if ($this->propertyCreationAssign($finder, $test, $name) !== null) {
+                        $reassigners[] = $test->name->name . '()';
+                    }
+                }
+
+                if ($reassigners !== []) {
+                    $errors[] = [$setUpAssign, self::ERROR_ORPHANED, implode(', ', $reassigners), $this->sourceFile($setUp)];
+
+                    continue;
+                }
+            }
+
             if ($this->isPropertyOffLimits($finder, $methods, $helperMethods, $ownMethods, $name)) {
                 continue;
             }
@@ -919,13 +949,21 @@ class NoCreateMockWithoutExpectationsRule implements Rule
 
     private function methodCreatesProperty(NodeFinder $finder, ClassMethod $method, string $name): bool
     {
+        return $this->propertyCreationAssign($finder, $method, $name) !== null;
+    }
+
+    /**
+     * The first `$this->$name = $this->createMock(...)` assignment in $method, or null if there is none.
+     */
+    private function propertyCreationAssign(NodeFinder $finder, ClassMethod $method, string $name): ?Assign
+    {
         foreach ($finder->findInstanceOf((array) $method->stmts, Assign::class) as $assign) {
             if ($this->propertyName($assign->var) === $name && $this->isCreateMockCall($assign->expr)) {
-                return true;
+                return $assign;
             }
         }
 
-        return false;
+        return null;
     }
 
     /**

--- a/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/NoCreateMockWithoutExpectationsRuleTest.php
+++ b/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/NoCreateMockWithoutExpectationsRuleTest.php
@@ -80,6 +80,14 @@ class NoCreateMockWithoutExpectationsRuleTest extends RuleTestCase
                 \sprintf(NoCreateMockWithoutExpectationsRule::ERROR_STUB, 'PropertyDependency::class', 'PropertyDependency::class'),
                 228, // helper only stub-configures the property and forwards it into the SUT constructor
             ],
+            [
+                \sprintf(NoCreateMockWithoutExpectationsRule::ERROR_ORPHANED, 'PropertyDependency::class', 'testReCreates()'),
+                282, // setUp instance orphaned by a test re-creating the property
+            ],
+            [
+                \sprintf(NoCreateMockWithoutExpectationsRule::ERROR_ORPHANED, 'PropertyDependency::class', 'testReCreates()'),
+                306, // orphaned only in the re-creating test; the other configures the setUp instance
+            ],
             // NOT flagged: 78 (expected in every test), 106 (->expects()-ed via a helper the test calls),
             // 169 (setUp reaches the ->expects()-ing helper, covering every test),
             // 255 (a helper hands the property to a call the rule cannot resolve)

--- a/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/data/NoCreateMockWithoutExpectationsRule/PropertyCases.php
+++ b/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/data/NoCreateMockWithoutExpectationsRule/PropertyCases.php
@@ -269,6 +269,61 @@ class HelperEscapedPropertyCases extends TestCase
 
 /**
  * @internal
+ *
+ * The property is created in setUp() and re-created in a test, orphaning the setUp instance. FLAGGED as
+ * orphaned on the setUp assignment, naming testReCreates().
+ */
+class ReCreatedPropertyCases extends TestCase
+{
+    private PropertyDependency $dependency;
+
+    protected function setUp(): void
+    {
+        $this->dependency = $this->createMock(PropertyDependency::class);
+    }
+
+    public function testReCreates(): void
+    {
+        $this->dependency = $this->createMock(PropertyDependency::class);
+        $this->dependency->expects($this->once())->method('value')->willReturn('a');
+
+        static::assertSame('a', (new PropertySut($this->dependency))->run());
+    }
+}
+
+/**
+ * @internal
+ *
+ * Re-created in one test, configured on the setUp instance in another. The setUp instance is still orphaned
+ * in the re-creating test. FLAGGED as orphaned, naming only testReCreates().
+ */
+class PartiallyReCreatedPropertyCases extends TestCase
+{
+    private PropertyDependency $dependency;
+
+    protected function setUp(): void
+    {
+        $this->dependency = $this->createMock(PropertyDependency::class);
+    }
+
+    public function testReCreates(): void
+    {
+        $this->dependency = $this->createMock(PropertyDependency::class);
+        $this->dependency->expects($this->once())->method('value')->willReturn('a');
+
+        static::assertSame('a', (new PropertySut($this->dependency))->run());
+    }
+
+    public function testConfiguresSetUpInstance(): void
+    {
+        $this->dependency->expects($this->once())->method('value')->willReturn('b');
+
+        static::assertSame('b', (new PropertySut($this->dependency))->run());
+    }
+}
+
+/**
+ * @internal
  */
 class PropertySut
 {


### PR DESCRIPTION
### 1. Why is this change necessary?

`NoCreateMockWithoutExpectationsRule` tracks whether a mock property is expected, not instance identity. When `setUp()` creates a mock and a test re-creates it with `$this->dep = $this->createMock(...)`, the setUp instance is replaced before the per-test SUT uses it, so it is orphaned and emits the PHPUnit 12 "no expectations" notice while the rule stays silent. The sweep in #19153 introduced exactly this into `AppManagerTest` (30 notices), fixed in the base of this stacked PR.

### 2. What does this change do, exactly?

Adds an `ERROR_ORPHANED` check: a property created in `setUp()` (and not expected there) that a test re-creates is reported on the setUp assignment, naming the re-creating tests. The closure-captured local case is left as a conservative skip.

### 3. Describe each step to reproduce the issue or behaviour.

1. Create a mock property in `setUp()`, then in a test write `$this->prop = $this->createMock(Foo::class); $this->prop->expects(...)`.
2. Before: PHPStan is silent; PHPUnit 12 emits a "no expectations" notice for the orphaned setUp instance.
3. After: PHPStan flags the setUp assignment and names the re-creating tests.

### 4. Please link to the relevant issues (if any).

(none)

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
