### PR TITLE
test(checkout): stabilize CheckoutWithDigitalProduct on major

### DIFF
--- a/tests/acceptance/tasks/ShopCustomer/Account/DownloadDigitalProductFromOrder.ts
+++ b/tests/acceptance/tasks/ShopCustomer/Account/DownloadDigitalProductFromOrder.ts
@@ -1,4 +1,4 @@
-import { test as base, expect } from '@playwright/test';
+import { test as base } from '@playwright/test';
 import type { FixtureTypes, Task } from '@fixtures/AcceptanceTest';
 
 export const DownloadDigitalProductFromOrderAndExpectContentToBe = base.extend<
@@ -8,15 +8,20 @@ export const DownloadDigitalProductFromOrderAndExpectContentToBe = base.extend<
     DownloadDigitalProductFromOrderAndExpectContentToBe: async ({ ShopCustomer, StorefrontAccountOrder }, use) => {
         const task = (contentOfFile: string) => {
             return async function DownloadDigitalProductFromOrder() {
-                // TODO: Migrate to StorefrontAccountOrder.orderExpandButton.click(); when https://github.com/shopware/acceptance-test-suite/pull/126 is released.
-                await ShopCustomer.presses(StorefrontAccountOrder.page.locator('.order-hide-btn').first());
+                // On 6.8 the download grant runs after the paid request, so refresh the order
+                // details until the Download link appears.
+                await ShopCustomer.expects(async () => {
+                    await StorefrontAccountOrder.page.reload();
+                    await ShopCustomer.expects(StorefrontAccountOrder.orderExpandButton).toBeVisible();
+                    await ShopCustomer.presses(StorefrontAccountOrder.orderExpandButton);
+                    await ShopCustomer.expects(StorefrontAccountOrder.digitalProductDownloadButton).toBeVisible();
+                }).toPass({ intervals: [500], timeout: 30_000 });
 
                 const [newTab] = await Promise.all([
                     StorefrontAccountOrder.page.waitForEvent('popup'),
-                    await ShopCustomer.presses(StorefrontAccountOrder.digitalProductDownloadButton),
+                    ShopCustomer.presses(StorefrontAccountOrder.digitalProductDownloadButton),
                 ]);
-                const tabContent = await newTab.content();
-                expect(tabContent).toContain(contentOfFile);
+                ShopCustomer.expects(await newTab.content()).toContain(contentOfFile);
             };
         };
 

--- a/tests/acceptance/tests/Checkout/CheckoutWithDigitalProduct.spec.ts
+++ b/tests/acceptance/tests/Checkout/CheckoutWithDigitalProduct.spec.ts
@@ -56,6 +56,18 @@ test(
         });
 
         await test.step('Verify that customer can access the digital product.', async () => {
+            // As of 6.8 (feature FLOW_EXECUTION_AFTER_BUSINESS_PROCESS) the "grant download access"
+            // flow runs AFTER the paid request instead of inline, so the Download link (rendered
+            // only once access is granted) may be absent right after checkout. Reload the order
+            // overview and open the details until the link shows up, otherwise the download step
+            // times out (see nightly-major failures).
+            await ShopCustomer.expects(async () => {
+                await ShopCustomer.goesTo(StorefrontAccountOrder.url());
+                await ShopCustomer.presses(StorefrontAccountOrder.orderExpandButton);
+                await ShopCustomer.expects(StorefrontAccountOrder.digitalProductDownloadButton).toBeVisible();
+            }).toPass({ timeout: 30_000 });
+
+            // Reload once more so the download task opens the order details from a clean state.
             await ShopCustomer.goesTo(StorefrontAccountOrder.url());
 
             // Download the digital product and check if the content is equal to what was uploaded.


### PR DESCRIPTION
### 1. Why is this change necessary?

`Checkout/CheckoutWithDigitalProduct.spec.ts` fails deterministically on the **nightly-major** acceptance run (it fails on the same commit every night, e.g. runs on Aug 8/9/10). It is not the rule-condition issue fixed in #18932 — that fix is present. Under `FEATURE_ALL=major` the feature `FLOW_EXECUTION_AFTER_BUSINESS_PROCESS` makes flows run **after** the triggering request instead of inline, so the "Deliver ordered product downloads" flow that sets `order_line_item_download.accessGranted` has not necessarily run when the `state/paid` transition returns. The test marks the order paid and immediately reads the storefront, so the `Download` link (rendered only once access is granted) can be missing → the download step hits the 60s timeout.

### 2. What does this change do, exactly?

In the verification step, before downloading, it reloads the order overview and opens the details until the `Download` link is available (`ShopCustomer.expects(...).toPass()`), then performs the download. This makes the storefront read wait for the deferred grant instead of racing it. No production code changes.

### 3. Describe each step to reproduce the issue or behaviour.

Run the spec on the major arm (`FEATURE_ALL=major`): the order is marked paid, the storefront account order is opened immediately, and the `Download` link is not yet rendered → `Test timeout of 60000ms exceeded` at the download step. It does not reproduce on the non-major arm (flows run inline) nor on a fast local machine where the `state/paid` request blocks until `kernel.terminate` completes the grant. The `major-acceptance` label is set on this PR so CI runs the major arm that actually exercises this.

### 4. Please link to the relevant issues (if any).

closes #18172
