### PR TITLE
fix(migration): preserve sales channels when deleting analytics

### DIFF
--- a/src/Core/Migration/V6_7/Migration1786447612FixSalesChannelAnalyticsConstraint.php
+++ b/src/Core/Migration/V6_7/Migration1786447612FixSalesChannelAnalyticsConstraint.php
@@ -1,0 +1,33 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Migration\V6_7;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Migration\MigrationStep;
+
+/**
+ * @internal
+ */
+#[Package('discovery')]
+class Migration1786447612FixSalesChannelAnalyticsConstraint extends MigrationStep
+{
+    public function getCreationTimestamp(): int
+    {
+        return 1786447612;
+    }
+
+    public function update(Connection $connection): void
+    {
+        /** @phpstan-ignore shopware.dropStatement (FK is directly added again so dropping the FK is no issue for blue green) */
+        $this->dropForeignKeyIfExists($connection, 'sales_channel', 'fk.sales_channel.analytics_id');
+
+        $connection->executeStatement('
+            ALTER TABLE `sales_channel`
+            ADD CONSTRAINT `fk.sales_channel.analytics_id`
+            FOREIGN KEY (`analytics_id`)
+            REFERENCES `sales_channel_analytics` (`id`)
+            ON DELETE SET NULL ON UPDATE CASCADE;
+        ');
+    }
+}

--- a/tests/migration/Core/V6_7/Migration1786447612FixSalesChannelAnalyticsConstraintTest.php
+++ b/tests/migration/Core/V6_7/Migration1786447612FixSalesChannelAnalyticsConstraintTest.php
@@ -1,0 +1,77 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Migration\Core\V6_7;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Schema\ForeignKeyConstraint\ReferentialAction;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
+use Shopware\Core\Framework\Util\Database\TableHelper;
+use Shopware\Core\Migration\V6_7\Migration1786447612FixSalesChannelAnalyticsConstraint;
+use Shopware\Core\System\SalesChannel\SalesChannelDefinition;
+
+/**
+ * @internal
+ */
+#[Package('discovery')]
+#[CoversClass(Migration1786447612FixSalesChannelAnalyticsConstraint::class)]
+class Migration1786447612FixSalesChannelAnalyticsConstraintTest extends TestCase
+{
+    private const FOREIGN_KEY_NAME = 'fk.sales_channel.analytics_id';
+
+    private Connection $connection;
+
+    protected function setUp(): void
+    {
+        $this->connection = KernelLifecycleManager::getConnection();
+    }
+
+    public function testGetCreationTimestamp(): void
+    {
+        static::assertSame(1786447612, (new Migration1786447612FixSalesChannelAnalyticsConstraint())->getCreationTimestamp());
+    }
+
+    public function testMigration(): void
+    {
+        $this->resetAnalyticsForeignKey();
+
+        $foreignKeyBefore = TableHelper::getForeignKeyOfTable(
+            $this->connection,
+            SalesChannelDefinition::ENTITY_NAME,
+            self::FOREIGN_KEY_NAME
+        );
+        static::assertSame(ReferentialAction::CASCADE->value, $foreignKeyBefore->onDeleteAction);
+
+        $migration = new Migration1786447612FixSalesChannelAnalyticsConstraint();
+        $migration->update($this->connection);
+        $migration->update($this->connection);
+
+        $foreignKeyAfter = TableHelper::getForeignKeyOfTable(
+            $this->connection,
+            SalesChannelDefinition::ENTITY_NAME,
+            self::FOREIGN_KEY_NAME
+        );
+        static::assertSame(ReferentialAction::SET_NULL->value, $foreignKeyAfter->onDeleteAction);
+    }
+
+    private function resetAnalyticsForeignKey(): void
+    {
+        try {
+            $this->connection->executeStatement(\sprintf('
+                ALTER TABLE `sales_channel`
+                DROP FOREIGN KEY `%s`;
+            ', self::FOREIGN_KEY_NAME));
+        } catch (\Throwable) {
+        }
+
+        $this->connection->executeStatement(\sprintf('
+            ALTER TABLE `sales_channel`
+            ADD CONSTRAINT `%s`
+            FOREIGN KEY (`analytics_id`)
+            REFERENCES `sales_channel_analytics` (`id`)
+            ON DELETE CASCADE ON UPDATE CASCADE;
+        ', self::FOREIGN_KEY_NAME));
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?

The sales-channel analytics foreign key currently cascades deletion from `sales_channel_analytics` to its owning `sales_channel`. Deleting analytics configuration must not delete the sales channel.

### 2. What does this change do, exactly?

Adds an idempotent migration that replaces `fk.sales_channel.analytics_id` with a constraint using `ON DELETE SET NULL`.

### 3. Describe each step to reproduce the issue or behaviour.

1. Create a sales channel with analytics configured.
2. Delete the linked `sales_channel_analytics` record.
3. Before this change, the sales channel is deleted through the foreign-key cascade.
4. After the migration, the sales channel remains and its `analytics_id` is set to `NULL`.

### 4. Please link to the relevant issues (if any).

No existing GitHub issue found for this foreign-key behaviour.

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Not needed: this restores the intended persistence behaviour and does not require an external developer action.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them