### PR TITLE
docs: cover per-branch release note conventions in the release-docs skill

### DIFF
--- a/.agents/skills/shopware-release-docs/SKILL.md
+++ b/.agents/skills/shopware-release-docs/SKILL.md
@@ -26,7 +26,14 @@ Write into the following files, but only if the decision above applies:
   If no, add nothing, however large the change is; a bug fix that restores intended behaviour needs no entry either.
   For deprecations, the old path still works; the entry tells developers what to change before it stops.
   Describe the concrete before and after, and write in past tense, as developers read this only after the next major release.
+  A change that takes effect right away belongs in the release notes only; an `UPGRADE` entry would promise a break that already happened.
 - Public REST/Admin/Store API route additions or changes: add or update the matching OpenAPI JSON schema under `src/Core/Framework/Api/ApiDefinition/Generator/Schema/<AdminApi|StoreApi>/paths`.
+
+Check what the branch you target already does before writing, the convention differs per line and a cherry-pick carries the wrong one with it:
+
+- `trunk` collects entries in the `(upcoming)` section of `RELEASE_INFO-6.<minor>.md`.
+- A release branch such as `6.7.13.1` has no `(upcoming)` section. Add the version heading itself at the top of the file, keeping the descending order, and put the entry under it.
+- The 6.6 line does not use `RELEASE_INFO` at all. Add `changelog/_unreleased/<date>-<slug>.md` with `title:` and `issue:` frontmatter followed by a `# Core` style section; a later release commit folds those files into `CHANGELOG.md`.
 
 ## What To Write
 
@@ -34,8 +41,10 @@ Write from the outside user's perspective: what changed, who is affected, and wh
 
 State the change and its impact, not the reasoning behind it, the internals of how it works, or the history of the problem.
 
+Describe a security fix as an ordinary behaviour change. Do not frame it as an advisory: no attack path, no list of reachable requests, no "expose", "leak", or "other customers" phrasing. `SECURITY.md` routes vulnerabilities to a private process, and release notes reach shops that have not upgraded yet. One sentence of before and after is enough for a reader to decide to patch.
+
 ## Formatting
 
 - Put a blank line before and after every heading, and between paragraphs.
-- Put the entry under the matching category heading of the upcoming version section, and add that heading if it is missing.
+- Put the entry under the matching category heading of the version section you target, and add that heading if it is missing.
 - Keep code snippets to the shortest form a developer can copy.


### PR DESCRIPTION
### 1. Why is this change necessary?

The skill says to add the entry to the `(upcoming)` section of `RELEASE_INFO-6.<minor>.md`. That only holds on `trunk`:

* a release branch such as `6.7.13.1` has no `(upcoming)` section
* the 6.6 line does not use `RELEASE_INFO` at all, it uses `changelog/_unreleased/`

Following it literally puts the entry in the wrong file, and a cherry-pick between lines carries the wrong convention with it — in one case dragging a whole `(upcoming)` section from trunk onto a release branch.

Two more gaps: an `UPGRADE` entry for a change that already takes effect promises a break that has already happened, and nothing said how to word a security fix.

### 2. What does this change do, exactly?

* Documents the convention per target branch: `trunk`, a release branch, and the 6.6 `changelog/_unreleased` files.
* Notes that a change taking effect right away belongs in the release notes only.
* Says a security fix is written as an ordinary behaviour change, not as an advisory — `SECURITY.md` routes vulnerabilities to a private process and release notes reach shops that have not upgraded yet.
* Drops the "upcoming version section" wording from *Formatting*, which contradicted the branch rules.

### 3. Describe each step to reproduce the issue or behaviour.

Documentation only.

### 4. Please link to the relevant issues (if any).

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [x] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
