### PR TITLE
feat(storefront): add merchant listing data to product JSON-LD

### DIFF
--- a/src/Storefront/Resources/views/storefront/layout/structured-data/json-ld-product.html.twig
+++ b/src/Storefront/Resources/views/storefront/layout/structured-data/json-ld-product.html.twig
@@ -107,10 +107,21 @@
             seller: sellerData
         } %}
 
-        {% if page.product.deliveryTime %}
-            {% set offersData = offersData|merge({
-                shippingDetails: {
-                    '@type': 'OfferShippingDetails',
+        {% if page.product.deliveryTime or page.product.shippingFree %}
+            {% set shippingDetails = {'@type': 'OfferShippingDetails'} %}
+
+            {% if page.product.shippingFree %}
+                {% set shippingDetails = shippingDetails|merge({
+                    shippingRate: {
+                        '@type': 'MonetaryAmount',
+                        value: 0,
+                        currency: context.currency.isoCode
+                    }
+                }) %}
+            {% endif %}
+
+            {% if page.product.deliveryTime %}
+                {% set shippingDetails = shippingDetails|merge({
                     deliveryTime: {
                         '@type': 'ShippingDeliveryTime',
                         handlingTime: {
@@ -120,8 +131,10 @@
                             unitCode: 'DAY'
                         }
                     }
-                }
-            }) %}
+                }) %}
+            {% endif %}
+
+            {% set offersData = offersData|merge({shippingDetails}) %}
         {% endif %}
     {% endif %}
 

--- a/src/Storefront/Resources/views/storefront/layout/structured-data/json-ld-product.html.twig
+++ b/src/Storefront/Resources/views/storefront/layout/structured-data/json-ld-product.html.twig
@@ -125,6 +125,18 @@
         {% endif %}
     {% endif %}
 
+    {% set revocationPageId = config('core.basicInformation.revocationPage') %}
+    {% if revocationPageId %}
+        {% set returnPolicyUrl = url('frontend.cms.page.full', { id: revocationPageId }) %}
+
+        {% set offersData = offersData|merge({
+            hasMerchantReturnPolicy: {
+                '@type': 'MerchantReturnPolicy',
+                url: returnPolicyUrl
+            }
+        }) %}
+    {% endif %}
+
     {# Build main product data structure #}
     {% set productData = {
         '@context': 'https://schema.org',


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

Improve the product JSON-LD output for Google merchant listings by exposing return-policy and free-shipping information that is already available in the core Storefront product context.

The implementation is intentionally limited to data that has a clear, stable core representation.

### 2. What does this change do, exactly?

- Adds `hasMerchantReturnPolicy` when a return-policy page is configured.
- Adds a zero-value `shippingRate` when the product is marked as shipping-free. Products do not contain a general shipping price; all other shipping costs are calculated dynamically in the cart based on the customer, destination, shipping method, and cart contents.

The following ACs are intentionally not included:

- `shippingDestination`: the product’s `shippingFree` flag applies to all countries enabled for the sales channel, while the actual country is selected during checkout. Emitting one country would be incorrect. Enumerating every enabled country would require an additional DAL query on every uncached product-page request, even though the country list is not product-specific and does not materially change the product’s JSON-LD. The additional query and payload size are in my opinion disproportionate for this use case.
- `priceValidUntil`: core products do not have a general offer-valid-until value. Advanced or commercial pricing rules may provide customer-specific prices, but those prices are not meaningful in JSON-LD because crawlers and LLMs typically access the storefront without an authenticated customer context. This should not be introduced as a core assumption.
- Organization company data: the corresponding `core.basicInformation` fields currently belong to the experimental `DOCUMENT_GENERATION_REWORK` feature and are primarily document-related. Exposing them as a new public Storefront page-data contract should be considered once that feature is finalized.

### 3. Describe each step to reproduce the issue or behaviour.

1. Enable `JSON_LD_DATA`.
2. Configure a return-policy page in the sales-channel basic information.
3. Mark a product as shipping-free.
4. Open the product detail page and inspect the `Product` JSON-LD.
5. Verify that the return policy and zero shipping rate are present.

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

- closes #19080

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
