### PR TITLE
test: drive ScaffoldingWriter unit tests with an in-memory filesystem

### DIFF
--- a/src/Core/Framework/Plugin/Command/Scaffolding/ScaffoldingWriter.php
+++ b/src/Core/Framework/Plugin/Command/Scaffolding/ScaffoldingWriter.php
@@ -49,9 +49,9 @@ class ScaffoldingWriter
             return;
         }
 
-        $existing = file_get_contents($file);
+        $existing = $this->filesystem->readFile($file);
 
-        if ($existing === false || str_contains($existing, $content)) {
+        if (str_contains($existing, $content)) {
             return;
         }
 

--- a/src/Core/Test/Stub/Framework/Util/InMemoryUtilFilesystem.php
+++ b/src/Core/Test/Stub/Framework/Util/InMemoryUtilFilesystem.php
@@ -1,0 +1,66 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Test\Stub\Framework\Util;
+
+use Shopware\Core\Framework\Log\Package;
+use Symfony\Component\Filesystem\Exception\IOException;
+use Symfony\Component\Filesystem\Filesystem;
+
+/**
+ * In-memory Symfony {@see Filesystem} double: the write methods a unit test needs, backed by an array, so
+ * filesystem-consuming code can be driven without touching disk. Seed existing files through the constructor
+ * and read the result back with {@see self::dumpedFiles()}.
+ *
+ * @internal
+ */
+#[Package('framework')]
+final class InMemoryUtilFilesystem extends Filesystem
+{
+    /**
+     * @param array<string, string> $files keyed by absolute path
+     */
+    public function __construct(private array $files = [])
+    {
+    }
+
+    /**
+     * @param string|iterable<string> $files
+     */
+    public function exists(string|iterable $files): bool
+    {
+        foreach (\is_iterable($files) ? $files : [$files] as $file) {
+            if (!\array_key_exists($file, $this->files)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    public function readFile(string $filename): string
+    {
+        if (!\array_key_exists($filename, $this->files)) {
+            throw new IOException(\sprintf('Failed to read file "%s": file does not exist.', $filename));
+        }
+
+        return $this->files[$filename];
+    }
+
+    public function dumpFile(string $filename, $content): void
+    {
+        $this->files[$filename] = (string) $content;
+    }
+
+    public function appendToFile(string $filename, $content, bool $lock = false): void
+    {
+        $this->files[$filename] = ($this->files[$filename] ?? '') . $content;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function dumpedFiles(): array
+    {
+        return $this->files;
+    }
+}

--- a/tests/unit/Core/Framework/Plugin/Command/Scaffolding/ScaffoldingWriterTest.php
+++ b/tests/unit/Core/Framework/Plugin/Command/Scaffolding/ScaffoldingWriterTest.php
@@ -9,6 +9,7 @@ use Shopware\Core\Framework\Plugin\Command\Scaffolding\PluginScaffoldConfigurati
 use Shopware\Core\Framework\Plugin\Command\Scaffolding\ScaffoldingWriter;
 use Shopware\Core\Framework\Plugin\Command\Scaffolding\Stub;
 use Shopware\Core\Framework\Plugin\Command\Scaffolding\StubCollection;
+use Shopware\Core\Test\Stub\Framework\Util\InMemoryUtilFilesystem;
 use Symfony\Component\Filesystem\Filesystem;
 
 /**
@@ -52,75 +53,64 @@ class ScaffoldingWriterTest extends TestCase
 
     public function testDoesNotOverwriteExistingFilesAndAppendsAggregateFiles(): void
     {
-        $filesystem = new Filesystem();
-        $directory = sys_get_temp_dir() . '/shopware-scaffolding-' . uniqid('', true);
+        $directory = 'custom/plugins/TestPlugin';
         $servicesFile = $directory . '/src/Resources/config/services.php';
         $composerFile = $directory . '/composer.json';
 
-        try {
-            $filesystem->dumpFile($servicesFile, "<?php\n\nreturn static function (): void {\n    existing();\n};\n");
-            $filesystem->dumpFile($composerFile, '{"version":"custom"}');
+        $filesystem = new InMemoryUtilFilesystem([
+            $servicesFile => "<?php\n\nreturn static function (): void {\n    existing();\n};\n",
+            $composerFile => '{"version":"custom"}',
+        ]);
 
-            (new ScaffoldingWriter($filesystem))->write(
-                new StubCollection([
-                    Stub::append('src/Resources/config/services.php', "\n    generated();\n"),
-                    Stub::raw('composer.json', '{"version":"generated"}'),
-                ]),
-                new PluginScaffoldConfiguration('TestPlugin', 'Test', $directory),
-            );
+        (new ScaffoldingWriter($filesystem))->write(
+            new StubCollection([
+                Stub::append('src/Resources/config/services.php', "\n    generated();\n"),
+                Stub::raw('composer.json', '{"version":"generated"}'),
+            ]),
+            new PluginScaffoldConfiguration('TestPlugin', 'Test', $directory),
+        );
 
-            static::assertStringContainsString('existing();', (string) file_get_contents($servicesFile));
-            static::assertStringContainsString('generated();', (string) file_get_contents($servicesFile));
-            static::assertSame('{"version":"custom"}', file_get_contents($composerFile));
-        } finally {
-            $filesystem->remove($directory);
-        }
+        $files = $filesystem->dumpedFiles();
+        static::assertStringContainsString('existing();', $files[$servicesFile]);
+        static::assertStringContainsString('generated();', $files[$servicesFile]);
+        static::assertSame('{"version":"custom"}', $files[$composerFile]);
     }
 
     public function testAppendsToMissingAndUnterminatedAggregateFiles(): void
     {
-        $filesystem = new Filesystem();
-        $directory = sys_get_temp_dir() . '/shopware-scaffolding-' . uniqid('', true);
-        $existingFile = $directory . '/src/Resources/config/services.php';
+        $directory = 'custom/plugins/TestPlugin';
+        $servicesFile = $directory . '/src/Resources/config/services.php';
+        $routesFile = $directory . '/src/Resources/config/routes.php';
 
-        try {
-            $filesystem->dumpFile($existingFile, "<?php\nexisting();\n");
+        $filesystem = new InMemoryUtilFilesystem([$servicesFile => "<?php\nexisting();\n"]);
 
-            (new ScaffoldingWriter($filesystem))->write(
-                new StubCollection([
-                    Stub::append('src/Resources/config/services.php', "\ngenerated();\n"),
-                    Stub::append('src/Resources/config/routes.php', "generatedRoute();\n"),
-                ]),
-                new PluginScaffoldConfiguration('TestPlugin', 'Test', $directory),
-            );
+        (new ScaffoldingWriter($filesystem))->write(
+            new StubCollection([
+                Stub::append('src/Resources/config/services.php', "\ngenerated();\n"),
+                Stub::append('src/Resources/config/routes.php', "generatedRoute();\n"),
+            ]),
+            new PluginScaffoldConfiguration('TestPlugin', 'Test', $directory),
+        );
 
-            $servicesContent = (string) file_get_contents($existingFile);
-            static::assertStringContainsString('existing();', $servicesContent);
-            static::assertStringContainsString('generated();', $servicesContent);
-            static::assertSame("generatedRoute();\n", file_get_contents($directory . '/src/Resources/config/routes.php'));
-        } finally {
-            $filesystem->remove($directory);
-        }
+        $files = $filesystem->dumpedFiles();
+        static::assertStringContainsString('existing();', $files[$servicesFile]);
+        static::assertStringContainsString('generated();', $files[$servicesFile]);
+        static::assertSame("generatedRoute();\n", $files[$routesFile]);
     }
 
     public function testDoesNotAppendDuplicateAggregateContent(): void
     {
-        $filesystem = new Filesystem();
-        $directory = sys_get_temp_dir() . '/shopware-scaffolding-' . uniqid('', true);
+        $directory = 'custom/plugins/TestPlugin';
         $servicesFile = $directory . '/src/Resources/config/services.php';
         $content = "<?php\nexisting();\ngenerated();\n";
 
-        try {
-            $filesystem->dumpFile($servicesFile, $content);
+        $filesystem = new InMemoryUtilFilesystem([$servicesFile => $content]);
 
-            (new ScaffoldingWriter($filesystem))->write(
-                new StubCollection([Stub::append('src/Resources/config/services.php', "generated();\n")]),
-                new PluginScaffoldConfiguration('TestPlugin', 'Test', $directory),
-            );
+        (new ScaffoldingWriter($filesystem))->write(
+            new StubCollection([Stub::append('src/Resources/config/services.php', "generated();\n")]),
+            new PluginScaffoldConfiguration('TestPlugin', 'Test', $directory),
+        );
 
-            static::assertSame($content, file_get_contents($servicesFile));
-        } finally {
-            $filesystem->remove($directory);
-        }
+        static::assertSame($content, $filesystem->dumpedFiles()[$servicesFile]);
     }
 }


### PR DESCRIPTION
> Demo stacked on #19079 (base is its branch, not trunk). It shows the three `ScaffoldingWriterTest` cases as pure unit tests off the real filesystem, for comparison before deciding whether to fold it in.

### 1. Why is this change necessary?

demo to avoid file / folder states (the tests could be kept, but moved to integration)

### 2. What does this change do, exactly?

use in memory trick to run  in ~37ms with no disk access


### 3. Describe each step to reproduce the issue or behaviour.

1. `vendor/bin/phpunit tests/unit/Core/Framework/Plugin/Command/Scaffolding/ScaffoldingWriterTest.php`.
2. Before: the three appended cases touch a real temp directory.
3. After: they run entirely in memory.

### 4. Please link to the relevant issues (if any).

- relates #19079

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
