### PR TITLE
feat(framework): allow authorizers to decide webhook event delivery

### DIFF
--- a/src/Core/Framework/DependencyInjection/webhook.php
+++ b/src/Core/Framework/DependencyInjection/webhook.php
@@ -146,6 +146,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             param('shopware.admin_worker.enable_admin_worker'),
             service(WebhookDeliveryService::class),
             service(WebhookOutboxStore::class),
+            tagged_iterator('shopware.webhook.authorizer'),
         ]);
 
     $services->set(WebhookCacheClearer::class)

--- a/src/Core/Framework/Webhook/HookableAuthorizer.php
+++ b/src/Core/Framework/Webhook/HookableAuthorizer.php
@@ -1,0 +1,26 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\Webhook;
+
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * Decides which recipients may receive an event, in place of the event's own privilege check.
+ *
+ * Authorizers are registered with the 'shopware.webhook.authorizer' tag. For each dispatched event
+ * the WebhookManager uses the first authorizer that supports() it; if no authorizer supports the
+ * event, the default Hookable::isAllowed() check applies.
+ *
+ * This exists because Hookable::isAllowed() only sees the app id and its privileges, which is not
+ * enough to restrict an event to a class of recipient, for example to services only. An authorizer
+ * receives the whole Webhook, so it can decide on the recipient's source type, url or version.
+ *
+ * @internal
+ */
+#[Package('framework')]
+interface HookableAuthorizer
+{
+    public function supports(Hookable $event): bool;
+
+    public function isAllowed(Hookable $event, Webhook $webhook, AclPrivilegeCollection $permissions): bool;
+}

--- a/src/Core/Framework/Webhook/Service/WebhookManager.php
+++ b/src/Core/Framework/Webhook/Service/WebhookManager.php
@@ -20,6 +20,7 @@ use Shopware\Core\Framework\Webhook\AclPrivilegeCollection;
 use Shopware\Core\Framework\Webhook\Hookable;
 use Shopware\Core\Framework\Webhook\Hookable\HookableEntityWrittenEvent;
 use Shopware\Core\Framework\Webhook\Hookable\HookableEventFactory;
+use Shopware\Core\Framework\Webhook\HookableAuthorizer;
 use Shopware\Core\Framework\Webhook\Message\WebhookEventMessage;
 use Shopware\Core\Framework\Webhook\Outbox\DeliveryResponse;
 use Shopware\Core\Framework\Webhook\Outbox\OutboxEntry;
@@ -46,6 +47,9 @@ class WebhookManager implements ResetInterface
      */
     private array $privileges = [];
 
+    /**
+     * @param iterable<HookableAuthorizer> $hookableAuthorizers
+     */
     public function __construct(
         private readonly WebhookLoader $webhookLoader,
         private readonly HookableEventFactory $eventFactory,
@@ -58,6 +62,7 @@ class WebhookManager implements ResetInterface
         private readonly bool $isAdminWorkerEnabled,
         private readonly WebhookDeliveryService $webhookDeliveryService,
         private readonly WebhookOutboxStore $webhookOutboxStore,
+        private readonly iterable $hookableAuthorizers,
     ) {
     }
 
@@ -331,6 +336,12 @@ class WebhookManager implements ResetInterface
         }
 
         $privileges = $this->privileges[$event->getName()][$webhook->appAclRoleId] ?? new AclPrivilegeCollection([]);
+
+        foreach ($this->hookableAuthorizers as $authorizer) {
+            if ($authorizer->supports($event)) {
+                return $authorizer->isAllowed($event, $webhook, $privileges);
+            }
+        }
 
         return $event->isAllowed($webhook->appId, $privileges);
     }

--- a/tests/integration/Core/Framework/Webhook/Command/WebhookDrainToAsyncCommandTest.php
+++ b/tests/integration/Core/Framework/Webhook/Command/WebhookDrainToAsyncCommandTest.php
@@ -318,6 +318,7 @@ class WebhookDrainToAsyncCommandTest extends TestCase
             false,
             $deliveryService,
             static::getContainer()->get(WebhookOutboxStore::class),
+            [],
         );
     }
 

--- a/tests/integration/Core/Framework/Webhook/Service/WebhookManagerTest.php
+++ b/tests/integration/Core/Framework/Webhook/Service/WebhookManagerTest.php
@@ -1610,6 +1610,7 @@ class WebhookManagerTest extends TestCase
             $adminWorkerEnabled,
             static::getContainer()->get(WebhookDeliveryService::class),
             static::getContainer()->get(WebhookOutboxStore::class),
+            [],
         );
     }
 

--- a/tests/integration/Core/Framework/Webhook/WebhookDispatchEndToEndTest.php
+++ b/tests/integration/Core/Framework/Webhook/WebhookDispatchEndToEndTest.php
@@ -940,6 +940,7 @@ class WebhookDispatchEndToEndTest extends TestCase
             $isAdminWorkerEnabled,
             $deliveryService,
             static::getContainer()->get(WebhookOutboxStore::class),
+            [],
         );
     }
 

--- a/tests/unit/Core/Framework/Webhook/Service/WebhookManagerTest.php
+++ b/tests/unit/Core/Framework/Webhook/Service/WebhookManagerTest.php
@@ -27,6 +27,7 @@ use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\Framework\Webhook\AclPrivilegeCollection;
 use Shopware\Core\Framework\Webhook\Hookable\HookableEntityWrittenEvent;
 use Shopware\Core\Framework\Webhook\Hookable\HookableEventFactory;
+use Shopware\Core\Framework\Webhook\HookableAuthorizer;
 use Shopware\Core\Framework\Webhook\Message\WebhookEventMessage;
 use Shopware\Core\Framework\Webhook\Outbox\DeliveryResponse;
 use Shopware\Core\Framework\Webhook\Outbox\OutboxEntry;
@@ -245,6 +246,58 @@ class WebhookManagerTest extends TestCase
         $this->getWebhookManager(false)->dispatch($event);
         $messages = $this->bus->getMessages();
         static::assertEmpty($messages);
+    }
+
+    public function testAnAuthorizerCanAllowAnEventTheAppHasNoPrivilegeFor(): void
+    {
+        $event = $this->prepareHookableEvent();
+        $this->prepareWebhook('product.written', true, []);
+
+        $this->webhookOutboxStore->expects($this->never())->method('recordOutboxEntry');
+
+        $this->getWebhookManager(false, [$this->authorizer(true)])->dispatch($event);
+
+        static::assertCount(1, $this->bus->getMessages());
+    }
+
+    public function testAnAuthorizerCanDenyAnEventTheAppHasThePrivilegeFor(): void
+    {
+        $event = $this->prepareHookableEvent();
+        $this->prepareWebhook('product.written', true, ['product:read']);
+
+        $this->webhookOutboxStore->expects($this->never())->method('recordOutboxEntry');
+
+        $this->getWebhookManager(false, [$this->authorizer(false)])->dispatch($event);
+
+        static::assertEmpty($this->bus->getMessages());
+    }
+
+    public function testAnAuthorizerThatDoesNotSupportTheEventLeavesThePrivilegeCheckInPlace(): void
+    {
+        $event = $this->prepareHookableEvent();
+        $this->prepareWebhook('product.written', true, []);
+
+        $unsupporting = static::createStub(HookableAuthorizer::class);
+        $unsupporting->method('supports')->willReturn(false);
+        $unsupporting->method('isAllowed')->willReturn(true);
+
+        $this->webhookOutboxStore->expects($this->never())->method('recordOutboxEntry');
+
+        $this->getWebhookManager(false, [$unsupporting])->dispatch($event);
+
+        static::assertEmpty($this->bus->getMessages());
+    }
+
+    public function testTheFirstSupportingAuthorizerDecides(): void
+    {
+        $event = $this->prepareHookableEvent();
+        $this->prepareWebhook('product.written', true, ['product:read']);
+
+        $this->webhookOutboxStore->expects($this->never())->method('recordOutboxEntry');
+
+        $this->getWebhookManager(false, [$this->authorizer(false), $this->authorizer(true)])->dispatch($event);
+
+        static::assertEmpty($this->bus->getMessages());
     }
 
     public function testWebhookCacheKeepsInactiveAppStateUntilCleared(): void
@@ -547,7 +600,19 @@ class WebhookManagerTest extends TestCase
         return $webhook;
     }
 
-    private function getWebhookManager(bool $isAdminWorkerEnabled): WebhookManager
+    private function authorizer(bool $allows): HookableAuthorizer
+    {
+        $authorizer = static::createStub(HookableAuthorizer::class);
+        $authorizer->method('supports')->willReturn(true);
+        $authorizer->method('isAllowed')->willReturn($allows);
+
+        return $authorizer;
+    }
+
+    /**
+     * @param list<HookableAuthorizer> $hookableAuthorizers
+     */
+    private function getWebhookManager(bool $isAdminWorkerEnabled, array $hookableAuthorizers = []): WebhookManager
     {
         $appPayloadServiceHelper = static::createStub(AppPayloadServiceHelper::class);
         $appPayloadServiceHelper->method('buildSource')->willReturn(new Source('https://example.com', 'foobar', '0.0.0'));
@@ -570,6 +635,7 @@ class WebhookManagerTest extends TestCase
             $isAdminWorkerEnabled,
             $deliveryService,
             $this->webhookOutboxStore,
+            $hookableAuthorizers,
         );
     }
 


### PR DESCRIPTION
### 1. Why is this change necessary?

`Hookable::isAllowed()` only sees the recipient app id and its privileges. That cannot express a restriction on the class of recipient, for example delivering an event to services only.

### 2. What does this change do, exactly?

Adds a `HookableAuthorizer` interface, registered with the `shopware.webhook.authorizer` tag. For each dispatched event `WebhookManager` uses the first authorizer that supports it, in place of the event own privilege check. When none supports the event, `Hookable::isAllowed()` applies as before.

An authorizer receives the whole `Webhook`, so it can decide on the recipient source type, url or version.

The interface is `@internal` and no authorizer ships here, so delivery behaviour is unchanged.

### 3. Describe each step to reproduce the issue or behaviour.

No behaviour change to reproduce. The unit tests cover the seam: an authorizer allowing an event the app has no privilege for, denying one it does have, a non-supporting authorizer leaving the privilege check in place, and the first supporting authorizer winning.

### 4. Please link to the relevant issues (if any).

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers: not relevant, the interface is `@internal` and behaviour is unchanged
- [x] I have written or adjusted the documentation and agent skills according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them