### PR TITLE
feat(media): Add force removal of thumbnails option

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -100,6 +100,17 @@ The Store API OpenAPI schema previously documented item prices and cart totals a
 ### Plugins can customize version cleanup
 
 Plugins can subscribe to the new `CleanupVersionEvent` to protect version records from scheduled cleanup. The event provides the cleanup cutoff through `getCleanupTime()`, allowing plugins to apply retention rules consistently with the scheduled cleanup task.
+### Force thumbnail regeneration and deletion via `--force`
+
+The `media:generate-thumbnails` command now accepts a `--force` (`-f`) option that regenerates thumbnails for all configured sizes even when a thumbnail already exists — for example after changing the thumbnail quality or sizes of a media folder. The option works with both synchronous and `--async` execution. Previously, existing thumbnails were always skipped.
+
+Note that regenerated thumbnails are written to the same physical path, so their URLs do not change: browsers and CDNs may keep serving the previously cached files until their cache expires or is invalidated manually.
+
+The `media:delete-local-thumbnails` command also accepts a new `--force` (`-f`) option that deletes all thumbnail records and files even when remote thumbnails are disabled — previously the command refused to run in that case. The command now removes the whole physical thumbnail directory, which also cleans up orphaned files without a database record (e.g. left behind after their media was uploaded again), and prints a summary of deleted and orphaned files. Note that the storefront is missing thumbnails until they are regenerated; prefer `media:generate-thumbnails --force` to replace them without such a gap.
+
+A new `--orphans` (`-o`) option deletes only those orphaned files. Referenced thumbnails and their records are kept, so this cleanup is safe in every setup and works regardless of the remote thumbnail configuration.
+
+`ThumbnailService::updateThumbnails()` accepts a matching optional `$force` argument; classes overriding this method must add the parameter with Shopware 6.8 (see `UPGRADE-6.8.md`).
 
 ### GARAN commercial guarantee label and EU legal guarantee notice
 

--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -106,9 +106,9 @@ The `media:generate-thumbnails` command now accepts a `--force` (`-f`) option th
 
 Note that regenerated thumbnails are written to the same physical path, so their URLs do not change: browsers and CDNs may keep serving the previously cached files until their cache expires or is invalidated manually.
 
-The `media:delete-local-thumbnails` command also accepts a new `--force` (`-f`) option that deletes all thumbnail records and files even when remote thumbnails are disabled — previously the command refused to run in that case. The command now removes the whole physical thumbnail directory, which also cleans up orphaned files without a database record (e.g. left behind after their media was uploaded again), and prints a summary of deleted and orphaned files. Note that the storefront is missing thumbnails until they are regenerated; prefer `media:generate-thumbnails --force` to replace them without such a gap.
+The `media:delete-local-thumbnails` command also accepts a new `--force` (`-f`) option that deletes all thumbnail records and files even when remote thumbnails are disabled — previously the command refused to run in that case. The command now removes the whole physical thumbnail directory, which also cleans up orphaned files without a database record (e.g. left behind after their media was uploaded again), and prints the number of deleted files. Note that the storefront is missing thumbnails until they are regenerated; prefer `media:generate-thumbnails --force` to replace them without such a gap.
 
-A new `--orphans` (`-o`) option deletes only those orphaned files. Referenced thumbnails and their records are kept, so this cleanup is safe in every setup and works regardless of the remote thumbnail configuration.
+A new `--orphans` (`-o`) option deletes only those orphaned files. Referenced thumbnails and their records are kept, so this cleanup is safe in every setup and works regardless of the remote thumbnail configuration. The two options cannot be combined.
 
 `ThumbnailService::updateThumbnails()` accepts a matching optional `$force` argument; classes overriding this method must add the parameter with Shopware 6.8 (see `UPGRADE-6.8.md`).
 

--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -82,6 +82,14 @@ Send the header with an authenticated Admin API request, where the behaviour is 
 
 ## Core
 
+### Force thumbnail regeneration and deletion via `--force`
+
+The `media:generate-thumbnails` command now accepts a `--force` (`-f`) option that regenerates thumbnails for all configured sizes even when a thumbnail already exists — for example after changing the thumbnail quality or sizes of a media folder. The option works with both synchronous and `--async` execution. Previously, existing thumbnails were always skipped.
+
+The `media:delete-local-thumbnails` command also accepts a new `--force` (`-f`) option that deletes all thumbnail records and files even when remote thumbnails are disabled — previously the command refused to run in that case. Note that the storefront is missing thumbnails until they are regenerated; prefer `media:generate-thumbnails --force` to replace them without such a gap.
+
+`ThumbnailService::updateThumbnails()` accepts a matching optional `$force` argument; classes overriding this method must add the parameter with Shopware 6.8 (see `UPGRADE-6.8.md`).
+
 ### GARAN commercial guarantee label and EU legal guarantee notice
 
 - Products get a new `guaranteeMonths` field for an optional commercial durability guarantee beyond the statutory two years (must be empty, or a half-year value greater than 24 months).

--- a/UPGRADE-6.8.md
+++ b/UPGRADE-6.8.md
@@ -339,6 +339,22 @@ return static function (RoutingConfigurator $routes): void {
 
 XML package configuration below `Resources/config/packages/` can be migrated to YAML or PHP. YAML configuration (`services.yaml`, `routes.yaml`, package YAML files) remains supported.
 
+## `ThumbnailService::updateThumbnails()` received a new optional `$force` parameter
+
+`Shopware\Core\Content\Media\Thumbnail\ThumbnailService::updateThumbnails()` received a new optional parameter `bool $force = false` that regenerates thumbnails for all configured sizes even when a thumbnail already exists. Call sites are not affected. Classes overriding this method had to add the parameter to keep a compatible signature:
+
+Before:
+
+```php
+public function updateThumbnails(MediaEntity $media, Context $context, bool $strict): int
+```
+
+After:
+
+```php
+public function updateThumbnails(MediaEntity $media, Context $context, bool $strict, bool $force = false): int
+```
+
 ## Landing page slot config must not be null
 
 `LandingPageEntity::setSlotConfig()` and `LandingPageTranslationEntity::setSlotConfig()` no longer accept `null` for their `$slotConfig` argument. Pass the slot configuration array when writing a landing page or its translation.

--- a/UPGRADE-6.8.md
+++ b/UPGRADE-6.8.md
@@ -327,6 +327,22 @@ return static function (RoutingConfigurator $routes): void {
 
 XML package configuration below `Resources/config/packages/` can be migrated to YAML or PHP. YAML configuration (`services.yaml`, `routes.yaml`, package YAML files) remains supported.
 
+## `ThumbnailService::updateThumbnails()` received a new optional `$force` parameter
+
+`Shopware\Core\Content\Media\Thumbnail\ThumbnailService::updateThumbnails()` received a new optional parameter `bool $force = false` that regenerates thumbnails for all configured sizes even when a thumbnail already exists. Call sites are not affected. Classes overriding this method had to add the parameter to keep a compatible signature:
+
+Before:
+
+```php
+public function updateThumbnails(MediaEntity $media, Context $context, bool $strict): int
+```
+
+After:
+
+```php
+public function updateThumbnails(MediaEntity $media, Context $context, bool $strict, bool $force = false): int
+```
+
 ## Landing page slot config must not be null
 
 `LandingPageEntity::setSlotConfig()` and `LandingPageTranslationEntity::setSlotConfig()` no longer accept `null` for their `$slotConfig` argument. Pass the slot configuration array when writing a landing page or its translation.

--- a/src/Core/Content/DependencyInjection/media.php
+++ b/src/Core/Content/DependencyInjection/media.php
@@ -268,6 +268,8 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         ->args([
             service(Connection::class),
             service('media_thumbnail.repository'),
+            service('shopware.filesystem.public'),
+            service('shopware.filesystem.private'),
             param('shopware.media.remote_thumbnails.enable'),
         ])
         ->tag('console.command');

--- a/src/Core/Content/Media/Commands/DeleteThumbnailsCommand.php
+++ b/src/Core/Content/Media/Commands/DeleteThumbnailsCommand.php
@@ -63,9 +63,16 @@ class DeleteThumbnailsCommand extends Command
     {
         $io = new SymfonyStyle($input, $output);
 
-        $orphansOnly = $input->getOption('orphans') && !$input->getOption('force');
+        $force = (bool) $input->getOption('force');
+        $orphansOnly = (bool) $input->getOption('orphans');
 
-        if (!$this->remoteThumbnailsEnable && !$input->getOption('force') && !$orphansOnly) {
+        if ($force && $orphansOnly) {
+            $io->error('The options --force and --orphans cannot be combined: --force deletes all thumbnail files including orphaned ones, while --orphans only deletes orphaned files.');
+
+            return self::INVALID;
+        }
+
+        if (!$this->remoteThumbnailsEnable && !$force && !$orphansOnly) {
             $io->comment('Deleting thumbnails is only supported when remote thumbnail is enabled. Use the --force option to delete them anyway, --orphans to only delete files without a database record, or "media:generate-thumbnails --force" to regenerate them in place.');
 
             return self::FAILURE;
@@ -73,24 +80,31 @@ class DeleteThumbnailsCommand extends Command
 
         $thumbnails = $this->connection->fetchAllKeyValue('SELECT LOWER(HEX(`id`)) as id, `path` FROM `media_thumbnail`');
 
-        $orphaned = $this->findOrphanedThumbnailFiles(array_values(array_filter($thumbnails)));
-
         if ($orphansOnly) {
-            $this->deleteOrphanedThumbnailFiles($io, $orphaned, \count($thumbnails));
+            $deletedCount = $this->deleteOrphanedThumbnailFiles(array_values(array_filter($thumbnails)));
+
+            $io->table(
+                ['Action', 'Number of thumbnail files'],
+                [
+                    ['Deleted (orphaned)', $deletedCount],
+                    ['Kept (referenced)', \count($thumbnails)],
+                ]
+            );
 
             $io->success('Successfully deleted all orphaned thumbnail files.');
 
             return self::SUCCESS;
         }
 
+        $fileCount = $this->countThumbnailFiles();
+
         $this->deleteThumbnails(array_keys($thumbnails));
         $this->deleteThumbnailFiles();
 
         $io->table(
-            ['Deleted', 'Number of thumbnail files'],
+            ['Action', 'Number of thumbnail files'],
             [
-                ['Referenced', \count($thumbnails)],
-                ['Orphaned', \count($orphaned)],
+                ['Deleted', $fileCount],
             ]
         );
 
@@ -113,44 +127,40 @@ class DeleteThumbnailsCommand extends Command
 
     /**
      * Orphaned files have no database record anymore, e.g. because they were left behind under an
-     * outdated cache buster path after their media was uploaded again.
+     * outdated cache buster path after their media was uploaded again. Files are deleted while
+     * iterating, so the tree is walked once and never materialized in memory.
      *
      * @param list<string> $recordPaths
-     *
-     * @return list<array{FilesystemOperator, string}>
      */
-    private function findOrphanedThumbnailFiles(array $recordPaths): array
+    private function deleteOrphanedThumbnailFiles(array $recordPaths): int
     {
         $recordPaths = array_flip($recordPaths);
 
-        $orphaned = [];
+        $deleted = 0;
         foreach ([$this->filesystemPublic, $this->filesystemPrivate] as $filesystem) {
             foreach ($filesystem->listContents('thumbnail', true) as $item) {
                 if ($item->isFile() && !isset($recordPaths[$item->path()])) {
-                    $orphaned[] = [$filesystem, $item->path()];
+                    $filesystem->delete($item->path());
+                    ++$deleted;
                 }
             }
         }
 
-        return $orphaned;
+        return $deleted;
     }
 
-    /**
-     * @param list<array{FilesystemOperator, string}> $orphaned
-     */
-    private function deleteOrphanedThumbnailFiles(SymfonyStyle $io, array $orphaned, int $keptCount): void
+    private function countThumbnailFiles(): int
     {
-        foreach ($orphaned as [$filesystem, $path]) {
-            $filesystem->delete($path);
+        $count = 0;
+        foreach ([$this->filesystemPublic, $this->filesystemPrivate] as $filesystem) {
+            foreach ($filesystem->listContents('thumbnail', true) as $item) {
+                if ($item->isFile()) {
+                    ++$count;
+                }
+            }
         }
 
-        $io->table(
-            ['Action', 'Number of thumbnail files'],
-            [
-                ['Deleted (orphaned)', \count($orphaned)],
-                ['Kept (referenced)', $keptCount],
-            ]
-        );
+        return $count;
     }
 
     /**

--- a/src/Core/Content/Media/Commands/DeleteThumbnailsCommand.php
+++ b/src/Core/Content/Media/Commands/DeleteThumbnailsCommand.php
@@ -3,6 +3,7 @@
 namespace Shopware\Core\Content\Media\Commands;
 
 use Doctrine\DBAL\Connection;
+use League\Flysystem\FilesystemOperator;
 use Shopware\Core\Content\Media\Aggregate\MediaThumbnail\MediaThumbnailCollection;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
@@ -10,13 +11,14 @@ use Shopware\Core\Framework\Log\Package;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
 #[Package('discovery')]
 #[AsCommand(
     name: 'media:delete-local-thumbnails',
-    description: 'Deletes all physical media thumbnails when remote thumbnails is enabled.',
+    description: 'Deletes all media thumbnail records and physical thumbnail files.',
 )]
 class DeleteThumbnailsCommand extends Command
 {
@@ -28,9 +30,30 @@ class DeleteThumbnailsCommand extends Command
     public function __construct(
         private readonly Connection $connection,
         private readonly EntityRepository $thumbnailRepository,
+        private readonly FilesystemOperator $filesystemPublic,
+        private readonly FilesystemOperator $filesystemPrivate,
         private readonly bool $remoteThumbnailsEnable = false
     ) {
         parent::__construct();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure(): void
+    {
+        $this->addOption(
+            'force',
+            'f',
+            InputOption::VALUE_NONE,
+            'Delete thumbnails even when remote thumbnails are disabled. The storefront will be missing thumbnails until they are regenerated'
+        );
+        $this->addOption(
+            'orphans',
+            'o',
+            InputOption::VALUE_NONE,
+            'Only delete orphaned thumbnail files without a database record. Referenced thumbnails are kept, so this is safe in every setup'
+        );
     }
 
     /**
@@ -40,25 +63,102 @@ class DeleteThumbnailsCommand extends Command
     {
         $io = new SymfonyStyle($input, $output);
 
-        if (!$this->remoteThumbnailsEnable) {
-            $io->comment('Deleting thumbnails is only supported when remote thumbnail is enabled.');
+        $orphansOnly = $input->getOption('orphans') && !$input->getOption('force');
+
+        if (!$this->remoteThumbnailsEnable && !$input->getOption('force') && !$orphansOnly) {
+            $io->comment('Deleting thumbnails is only supported when remote thumbnail is enabled. Use the --force option to delete them anyway, --orphans to only delete files without a database record, or "media:generate-thumbnails --force" to regenerate them in place.');
 
             return self::FAILURE;
         }
 
-        $this->deleteThumbnails();
+        $thumbnails = $this->connection->fetchAllKeyValue('SELECT LOWER(HEX(`id`)) as id, `path` FROM `media_thumbnail`');
+
+        $orphaned = $this->findOrphanedThumbnailFiles(array_values(array_filter($thumbnails)));
+
+        if ($orphansOnly) {
+            $this->deleteOrphanedThumbnailFiles($io, $orphaned, \count($thumbnails));
+
+            $io->success('Successfully deleted all orphaned thumbnail files.');
+
+            return self::SUCCESS;
+        }
+
+        $this->deleteThumbnails(array_keys($thumbnails));
+        $this->deleteThumbnailFiles();
+
+        $io->table(
+            ['Deleted', 'Number of thumbnail files'],
+            [
+                ['Referenced', \count($thumbnails)],
+                ['Orphaned', \count($orphaned)],
+            ]
+        );
 
         $io->success('Successfully deleted all thumbnails records and thumbnails files.');
 
         return self::SUCCESS;
     }
 
-    private function deleteThumbnails(): void
+    /**
+     * @param list<string> $thumbnailIds
+     */
+    private function deleteThumbnails(array $thumbnailIds): void
     {
-        $thumbnailIds = $this->connection->fetchAllAssociative('SELECT LOWER(HEX(`id`)) as id FROM `media_thumbnail`');
+        $ids = array_map(static fn (string $id) => ['id' => $id], $thumbnailIds);
 
-        $this->thumbnailRepository->delete($thumbnailIds, Context::createCLIContext());
+        $this->thumbnailRepository->delete($ids, Context::createCLIContext());
 
         $this->connection->executeStatement('UPDATE `media` SET `thumbnails_ro` = NULL;');
+    }
+
+    /**
+     * Orphaned files have no database record anymore, e.g. because they were left behind under an
+     * outdated cache buster path after their media was uploaded again.
+     *
+     * @param list<string> $recordPaths
+     *
+     * @return list<array{FilesystemOperator, string}>
+     */
+    private function findOrphanedThumbnailFiles(array $recordPaths): array
+    {
+        $recordPaths = array_flip($recordPaths);
+
+        $orphaned = [];
+        foreach ([$this->filesystemPublic, $this->filesystemPrivate] as $filesystem) {
+            foreach ($filesystem->listContents('thumbnail', true) as $item) {
+                if ($item->isFile() && !isset($recordPaths[$item->path()])) {
+                    $orphaned[] = [$filesystem, $item->path()];
+                }
+            }
+        }
+
+        return $orphaned;
+    }
+
+    /**
+     * @param list<array{FilesystemOperator, string}> $orphaned
+     */
+    private function deleteOrphanedThumbnailFiles(SymfonyStyle $io, array $orphaned, int $keptCount): void
+    {
+        foreach ($orphaned as [$filesystem, $path]) {
+            $filesystem->delete($path);
+        }
+
+        $io->table(
+            ['Action', 'Number of thumbnail files'],
+            [
+                ['Deleted (orphaned)', \count($orphaned)],
+                ['Kept (referenced)', $keptCount],
+            ]
+        );
+    }
+
+    /**
+     * Removes the whole physical thumbnail directory to also catch orphaned files.
+     */
+    private function deleteThumbnailFiles(): void
+    {
+        $this->filesystemPublic->deleteDirectory('thumbnail');
+        $this->filesystemPrivate->deleteDirectory('thumbnail');
     }
 }

--- a/src/Core/Content/Media/Commands/DeleteThumbnailsCommand.php
+++ b/src/Core/Content/Media/Commands/DeleteThumbnailsCommand.php
@@ -10,13 +10,14 @@ use Shopware\Core\Framework\Log\Package;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
 #[Package('discovery')]
 #[AsCommand(
     name: 'media:delete-local-thumbnails',
-    description: 'Deletes all physical media thumbnails when remote thumbnails is enabled.',
+    description: 'Deletes all media thumbnail records and physical thumbnail files.',
 )]
 class DeleteThumbnailsCommand extends Command
 {
@@ -36,12 +37,25 @@ class DeleteThumbnailsCommand extends Command
     /**
      * {@inheritdoc}
      */
+    protected function configure(): void
+    {
+        $this->addOption(
+            'force',
+            'f',
+            InputOption::VALUE_NONE,
+            'Delete thumbnails even when remote thumbnails are disabled. The storefront will be missing thumbnails until they are regenerated'
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $io = new SymfonyStyle($input, $output);
 
-        if (!$this->remoteThumbnailsEnable) {
-            $io->comment('Deleting thumbnails is only supported when remote thumbnail is enabled.');
+        if (!$this->remoteThumbnailsEnable && !$input->getOption('force')) {
+            $io->comment('Deleting thumbnails is only supported when remote thumbnail is enabled. Use the --force option to delete them anyway, or "media:generate-thumbnails --force" to regenerate them in place.');
 
             return self::FAILURE;
         }

--- a/src/Core/Content/Media/Commands/GenerateThumbnailsCommand.php
+++ b/src/Core/Content/Media/Commands/GenerateThumbnailsCommand.php
@@ -40,6 +40,8 @@ class GenerateThumbnailsCommand extends Command
 
     private bool $isStrict;
 
+    private bool $isForce;
+
     /**
      * @internal
      *
@@ -80,6 +82,12 @@ class GenerateThumbnailsCommand extends Command
                 InputOption::VALUE_NONE,
                 'Additionally checks that physical files for existing thumbnails are present'
             )
+            ->addOption(
+                'force',
+                'f',
+                InputOption::VALUE_NONE,
+                'Regenerates thumbnails for all configured sizes even when a thumbnail already exists, e.g. after changing the thumbnail quality'
+            )
         ;
     }
 
@@ -118,6 +126,7 @@ class GenerateThumbnailsCommand extends Command
         $this->batchSize = $this->getBatchSizeFromInput($input);
         $this->isAsync = $input->getOption('async');
         $this->isStrict = $input->getOption('strict');
+        $this->isForce = $input->getOption('force');
     }
 
     private function getBatchSizeFromInput(InputInterface $input): int
@@ -165,7 +174,7 @@ class GenerateThumbnailsCommand extends Command
         while (($result = $iterator->fetch()) !== null) {
             foreach ($result->getEntities() as $media) {
                 try {
-                    if ($this->thumbnailService->updateThumbnails($media, $context, $this->isStrict) > 0) {
+                    if ($this->thumbnailService->updateThumbnails($media, $context, $this->isStrict, $this->isForce) > 0) {
                         ++$generated;
                     } else {
                         ++$skipped;
@@ -246,6 +255,7 @@ class GenerateThumbnailsCommand extends Command
         while (($result = $mediaIterator->fetch()) !== null) {
             $msg = new UpdateThumbnailsMessage();
             $msg->setStrict($this->isStrict);
+            $msg->setForce($this->isForce);
             $msg->setMediaIds($result->getEntities()->getIds());
             $msg->setContext($context);
 

--- a/src/Core/Content/Media/Message/GenerateThumbnailsHandler.php
+++ b/src/Core/Content/Media/Message/GenerateThumbnailsHandler.php
@@ -48,7 +48,7 @@ final readonly class GenerateThumbnailsHandler
         if ($msg instanceof UpdateThumbnailsMessage) {
             foreach ($entities as $media) {
                 try {
-                    $this->thumbnailService->updateThumbnails($media, $context, $msg->isStrict());
+                    $this->thumbnailService->updateThumbnails($media, $context, $msg->isStrict(), $msg->isForce());
                 } catch (\Throwable $e) {
                     $this->logger->error('Thumbnail generation failed for media {mediaId}', [
                         'mediaId' => $media->getId(),

--- a/src/Core/Content/Media/Message/UpdateThumbnailsMessage.php
+++ b/src/Core/Content/Media/Message/UpdateThumbnailsMessage.php
@@ -12,6 +12,8 @@ class UpdateThumbnailsMessage extends GenerateThumbnailsMessage
 {
     private bool $strict = false;
 
+    private bool $force = false;
+
     public function isStrict(): bool
     {
         return $this->strict;
@@ -20,5 +22,15 @@ class UpdateThumbnailsMessage extends GenerateThumbnailsMessage
     public function setStrict(bool $isStrict): void
     {
         $this->strict = $isStrict;
+    }
+
+    public function isForce(): bool
+    {
+        return $this->force;
+    }
+
+    public function setForce(bool $isForce): void
+    {
+        $this->force = $isForce;
     }
 }

--- a/src/Core/Content/Media/Subscriber/MediaDeletionSubscriber.php
+++ b/src/Core/Content/Media/Subscriber/MediaDeletionSubscriber.php
@@ -34,6 +34,12 @@ class MediaDeletionSubscriber implements EventSubscriberInterface
     final public const SYNCHRONE_FILE_DELETE = 'synchrone-file-delete';
 
     /**
+     * Context state that suppresses the physical file deletion entirely, for callers
+     * that overwrite or clean up the affected files themselves after the transaction.
+     */
+    final public const SKIP_FILE_DELETE = 'skip-file-delete';
+
+    /**
      * @internal
      *
      * @param EntityRepository<MediaThumbnailCollection> $thumbnailRepository
@@ -223,7 +229,7 @@ class MediaDeletionSubscriber implements EventSubscriberInterface
      */
     private function performFileDelete(Context $context, array $paths, string $visibility): void
     {
-        if (\count($paths) <= 0) {
+        if (\count($paths) <= 0 || $context->hasState(self::SKIP_FILE_DELETE)) {
             return;
         }
 

--- a/src/Core/Content/Media/Thumbnail/ThumbnailService.php
+++ b/src/Core/Content/Media/Thumbnail/ThumbnailService.php
@@ -28,6 +28,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Indexing\EntityIndexer;
 use Shopware\Core\Framework\DataAbstractionLayer\Indexing\EntityIndexerRegistry;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Deprecation\BCChange\NewOptionalParameter;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
@@ -142,8 +143,12 @@ class ThumbnailService
     /**
      * @throws MediaException
      */
-    public function updateThumbnails(MediaEntity $media, Context $context, bool $strict): int
+    #[NewOptionalParameter(version: 'v6.8.0', parameterName: 'force', parameterType: 'bool', defaultValue: false, description: 'Regenerates thumbnails for all configured sizes even when a thumbnail already exists.')]
+    public function updateThumbnails(MediaEntity $media, Context $context, bool $strict/* , bool $force = false */): int
     {
+        /** @deprecated tag:v6.8.0 - Remove next line as $force will become part of the method signature */
+        $force = (bool) (\func_get_args()[3] ?? false);
+
         if ($this->remoteThumbnailsEnable) {
             throw MediaException::thumbnailGenerationDisabled();
         }
@@ -178,20 +183,22 @@ class ThumbnailService
         $toBeCreatedSizes = new MediaThumbnailSizeCollection($config->getMediaThumbnailSizes()->getElements());
         $toBeDeletedThumbnails = new MediaThumbnailCollection($media->getThumbnails()->getElements());
 
-        foreach ($toBeCreatedSizes as $thumbnailSize) {
-            foreach ($toBeDeletedThumbnails as $thumbnail) {
-                if ($thumbnailSize->getId() !== $thumbnail->getMediaThumbnailSizeId()) {
-                    continue;
+        if (!$force) {
+            foreach ($toBeCreatedSizes as $thumbnailSize) {
+                foreach ($toBeDeletedThumbnails as $thumbnail) {
+                    if ($thumbnailSize->getId() !== $thumbnail->getMediaThumbnailSizeId()) {
+                        continue;
+                    }
+
+                    if ($strict === true && !$this->getFileSystem($media)->fileExists($thumbnail->getPath())) {
+                        continue;
+                    }
+
+                    $toBeDeletedThumbnails->remove($thumbnail->getId());
+                    $toBeCreatedSizes->remove($thumbnailSize->getId());
+
+                    continue 2;
                 }
-
-                if ($strict === true && !$this->getFileSystem($media)->fileExists($thumbnail->getPath())) {
-                    continue;
-                }
-
-                $toBeDeletedThumbnails->remove($thumbnail->getId());
-                $toBeCreatedSizes->remove($thumbnailSize->getId());
-
-                continue 2;
             }
         }
 

--- a/src/Core/Content/Media/Thumbnail/ThumbnailService.php
+++ b/src/Core/Content/Media/Thumbnail/ThumbnailService.php
@@ -204,17 +204,32 @@ class ThumbnailService
 
         $delete = \array_values(\array_map(static fn (string $id) => ['id' => $id], $toBeDeletedThumbnails->getIds()));
 
-        $update = RetryableTransaction::transactional($this->connection, function () use ($delete, $media, $config, $context, $toBeCreatedSizes): array {
-            return $context->state(function () use ($delete, $media, $config, $context, $toBeCreatedSizes): array {
+        $toBeDeletedPaths = [];
+        foreach ($toBeDeletedThumbnails as $thumbnail) {
+            $path = $thumbnail->getPath();
+            if (!MediaUploadService::isExternalUrl($path)) {
+                $toBeDeletedPaths[] = $path;
+            }
+        }
+
+        /**
+         * The physical files are deleted after the transaction has been committed, so a failed
+         * regeneration rolls back to the previous thumbnails instead of leaving records without files.
+         */
+        $update = RetryableTransaction::transactional($this->connection, function () use ($delete, $media, $config, $context, $toBeCreatedSizes, $toBeDeletedPaths): array {
+            return $context->state(function () use ($delete, $media, $config, $context, $toBeCreatedSizes, $toBeDeletedPaths): array {
                 $this->thumbnailRepository->delete($delete, $context);
 
-                $updated = $this->generateAndSave($media, $config, $context, $toBeCreatedSizes);
+                $updated = $this->generateAndSave($media, $config, $context, $toBeCreatedSizes, $toBeDeletedPaths);
 
                 $this->indexer->handle(new MediaIndexingMessage([$media->getId()]));
 
                 return $updated;
-            }, EntityIndexerRegistry::DISABLE_INDEXING, MediaDeletionSubscriber::SYNCHRONE_FILE_DELETE);
+            }, EntityIndexerRegistry::DISABLE_INDEXING, MediaDeletionSubscriber::SKIP_FILE_DELETE);
         });
+
+        /** @var list<array{id:string, mediaId:string, mediaThumbnailSizeId:string, width:int, height:int}> $update */
+        $this->deleteStaleThumbnailFiles($media, $toBeDeletedPaths, $update);
 
         return \count($update);
     }
@@ -229,9 +244,53 @@ class ThumbnailService
     }
 
     /**
+     * Deletes files of replaced thumbnails whose path is no longer referenced. Regenerated
+     * thumbnails of an unchanged size overwrite their previous file in place, so only paths
+     * of dropped sizes remain to be cleaned up.
+     *
+     * @param list<string> $oldPaths
+     * @param list<array{id:string, mediaId:string, mediaThumbnailSizeId:string, width:int, height:int}> $updated
+     */
+    private function deleteStaleThumbnailFiles(MediaEntity $media, array $oldPaths, array $updated): void
+    {
+        if ($oldPaths === []) {
+            return;
+        }
+
+        $ids = \array_column($updated, 'id');
+
+        $newPaths = [];
+        if ($ids !== []) {
+            $newPaths = $this->connection->fetchFirstColumn(
+                <<<'SQL'
+                SELECT `path`
+                FROM `media_thumbnail`
+                WHERE `id` IN (:ids)
+                SQL,
+                ['ids' => Uuid::fromHexToBytesList($ids)],
+                ['ids' => ArrayParameterType::BINARY]
+            );
+        }
+
+        $fileSystem = $this->getFileSystem($media);
+        foreach (\array_diff($oldPaths, $newPaths) as $stalePath) {
+            try {
+                $fileSystem->delete($stalePath);
+            } catch (\Throwable $e) {
+                $this->logger->error('Could not delete stale thumbnail file {path}', [
+                    'path' => $stalePath,
+                    'exception' => $e,
+                ]);
+            }
+        }
+    }
+
+    /**
+     * @param list<string> $preservePaths Paths of previous thumbnails which are overwritten in place and must survive a failed generation
+     *
      * @return list<array{id:string, mediaId:string, mediaThumbnailSizeId:string, width:int, height:int}>
      */
-    private function generateAndSave(MediaEntity $media, MediaFolderConfigurationEntity $config, Context $context, ?MediaThumbnailSizeCollection $sizes): array
+    private function generateAndSave(MediaEntity $media, MediaFolderConfigurationEntity $config, Context $context, ?MediaThumbnailSizeCollection $sizes, array $preservePaths = []): array
     {
         if ($sizes === null || $sizes->count() === 0) {
             return [];
@@ -323,6 +382,10 @@ class ThumbnailService
         } catch (\Throwable $e) {
             $fileSystem = $this->getFileSystem($media);
             foreach ($writtenPaths as $writtenPath) {
+                if (\in_array($writtenPath, $preservePaths, true)) {
+                    continue;
+                }
+
                 try {
                     $fileSystem->delete($writtenPath);
                 } catch (\Throwable) {

--- a/tests/unit/Core/Content/Media/Commands/DeleteThumbnailsCommandTest.php
+++ b/tests/unit/Core/Content/Media/Commands/DeleteThumbnailsCommandTest.php
@@ -13,6 +13,7 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Uuid\Uuid;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Tester\CommandTester;
 
 /**
@@ -92,9 +93,31 @@ class DeleteThumbnailsCommandTest extends TestCase
         $commandTester->assertCommandIsSuccessful();
 
         $display = $commandTester->getDisplay();
-        static::assertMatchesRegularExpression('/Referenced\s+1\b/', $display);
-        static::assertMatchesRegularExpression('/Orphaned\s+2\b/', $display);
+        static::assertMatchesRegularExpression('/Deleted\s+3\b/', $display);
         static::assertStringContainsString('Successfully deleted all thumbnails records and thumbnails files.', $display);
+    }
+
+    public function testExecuteFailsWhenForceAndOrphansAreCombined(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection->expects($this->never())->method('fetchAllKeyValue');
+
+        $command = new DeleteThumbnailsCommand(
+            $connection,
+            static::createStub(EntityRepository::class),
+            static::createStub(FilesystemOperator::class),
+            static::createStub(FilesystemOperator::class),
+            false
+        );
+
+        $commandTester = new CommandTester($command);
+
+        static::assertSame(Command::INVALID, $commandTester->execute([
+            '--force' => true,
+            '--orphans' => true,
+        ]));
+
+        static::assertStringContainsStringIgnoringLineEndings('The options --force and --orphans cannot be combined', $commandTester->getDisplay());
     }
 
     public function testExecuteWithOrphansOptionOnlyDeletesOrphanedFiles(): void

--- a/tests/unit/Core/Content/Media/Commands/DeleteThumbnailsCommandTest.php
+++ b/tests/unit/Core/Content/Media/Commands/DeleteThumbnailsCommandTest.php
@@ -3,6 +3,9 @@
 namespace Shopware\Tests\Unit\Core\Content\Media\Commands;
 
 use Doctrine\DBAL\Connection;
+use League\Flysystem\DirectoryListing;
+use League\Flysystem\FileAttributes;
+use League\Flysystem\FilesystemOperator;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Media\Commands\DeleteThumbnailsCommand;
@@ -24,6 +27,8 @@ class DeleteThumbnailsCommandTest extends TestCase
         $command = new DeleteThumbnailsCommand(
             static::createStub(Connection::class),
             static::createStub(EntityRepository::class),
+            static::createStub(FilesystemOperator::class),
+            static::createStub(FilesystemOperator::class),
             false
         );
 
@@ -34,27 +39,154 @@ class DeleteThumbnailsCommandTest extends TestCase
         static::assertStringContainsStringIgnoringLineEndings('// Deleting thumbnails is only supported when remote thumbnail is enabled.', trim($commandTester->getDisplay()));
     }
 
-    public function testExecuteWithRemoteThumbnailsEnabled(): void
+    public function testExecuteWithRemoteThumbnailsDisabledAndForce(): void
     {
         $connection = $this->createMock(Connection::class);
         $thumbnailRepository = $this->createMock(EntityRepository::class);
-        $command = new DeleteThumbnailsCommand($connection, $thumbnailRepository, true);
+        $filesystemPublic = $this->createMock(FilesystemOperator::class);
+        $filesystemPrivate = $this->createMock(FilesystemOperator::class);
+        $command = new DeleteThumbnailsCommand($connection, $thumbnailRepository, $filesystemPublic, $filesystemPrivate, false);
 
         $commandTester = new CommandTester($command);
         $commandTester->setInputs(['yes']);
 
-        $thumbnailIds = [
-            ['id' => Uuid::randomHex()],
-            ['id' => Uuid::randomHex()],
-        ];
+        $thumbnailId = Uuid::randomHex();
+        $thumbnailPath = 'thumbnail/aa/bb/cc/1786525629/test_100x100.png';
         $connection->expects($this->once())
-            ->method('fetchAllAssociative')
-            ->with('SELECT LOWER(HEX(`id`)) as id FROM `media_thumbnail`')
-            ->willReturn($thumbnailIds);
+            ->method('fetchAllKeyValue')
+            ->with('SELECT LOWER(HEX(`id`)) as id, `path` FROM `media_thumbnail`')
+            ->willReturn([$thumbnailId => $thumbnailPath]);
+
+        $filesystemPublic->expects($this->once())
+            ->method('listContents')
+            ->with('thumbnail', true)
+            ->willReturn(new DirectoryListing([
+                new FileAttributes($thumbnailPath),
+                new FileAttributes('thumbnail/dd/ee/ff/1776341071/orphan_100x100.png'),
+                new FileAttributes('thumbnail/dd/ee/ff/1779799284/orphan_100x100.png'),
+            ]));
+
+        $filesystemPrivate->expects($this->once())
+            ->method('listContents')
+            ->with('thumbnail', true)
+            ->willReturn(new DirectoryListing([]));
 
         $thumbnailRepository->expects($this->once())
             ->method('delete')
-            ->with($thumbnailIds, static::isInstanceOf(Context::class));
+            ->with([['id' => $thumbnailId]], static::isInstanceOf(Context::class));
+
+        $connection->expects($this->once())
+            ->method('executeStatement')
+            ->with('UPDATE `media` SET `thumbnails_ro` = NULL;');
+
+        $filesystemPublic->expects($this->once())
+            ->method('deleteDirectory')
+            ->with('thumbnail');
+
+        $filesystemPrivate->expects($this->once())
+            ->method('deleteDirectory')
+            ->with('thumbnail');
+
+        $commandTester->execute(['--force' => true]);
+
+        $commandTester->assertCommandIsSuccessful();
+
+        $display = $commandTester->getDisplay();
+        static::assertMatchesRegularExpression('/Referenced\s+1\b/', $display);
+        static::assertMatchesRegularExpression('/Orphaned\s+2\b/', $display);
+        static::assertStringContainsString('Successfully deleted all thumbnails records and thumbnails files.', $display);
+    }
+
+    public function testExecuteWithOrphansOptionOnlyDeletesOrphanedFiles(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $thumbnailRepository = $this->createMock(EntityRepository::class);
+        $filesystemPublic = $this->createMock(FilesystemOperator::class);
+        $filesystemPrivate = $this->createMock(FilesystemOperator::class);
+        $command = new DeleteThumbnailsCommand($connection, $thumbnailRepository, $filesystemPublic, $filesystemPrivate, false);
+
+        $commandTester = new CommandTester($command);
+
+        $thumbnailPath = 'thumbnail/aa/bb/cc/1786525629/test_100x100.png';
+        $orphanedPaths = [
+            'thumbnail/dd/ee/ff/1776341071/orphan_100x100.png',
+            'thumbnail/dd/ee/ff/1779799284/orphan_100x100.png',
+        ];
+        $connection->expects($this->once())
+            ->method('fetchAllKeyValue')
+            ->with('SELECT LOWER(HEX(`id`)) as id, `path` FROM `media_thumbnail`')
+            ->willReturn([Uuid::randomHex() => $thumbnailPath]);
+
+        $filesystemPublic->expects($this->once())
+            ->method('listContents')
+            ->with('thumbnail', true)
+            ->willReturn(new DirectoryListing([
+                new FileAttributes($thumbnailPath),
+                new FileAttributes($orphanedPaths[0]),
+                new FileAttributes($orphanedPaths[1]),
+            ]));
+
+        $filesystemPrivate->expects($this->once())
+            ->method('listContents')
+            ->with('thumbnail', true)
+            ->willReturn(new DirectoryListing([]));
+
+        $deletedPaths = [];
+        $filesystemPublic->expects($this->exactly(2))
+            ->method('delete')
+            ->willReturnCallback(function (string $path) use (&$deletedPaths): void {
+                $deletedPaths[] = $path;
+            });
+
+        $filesystemPublic->expects($this->never())->method('deleteDirectory');
+        $filesystemPrivate->expects($this->never())->method('deleteDirectory');
+        $filesystemPrivate->expects($this->never())->method('delete');
+        $thumbnailRepository->expects($this->never())->method('delete');
+        $connection->expects($this->never())->method('executeStatement');
+
+        $commandTester->execute(['--orphans' => true]);
+
+        $commandTester->assertCommandIsSuccessful();
+
+        static::assertSame($orphanedPaths, $deletedPaths);
+
+        $display = $commandTester->getDisplay();
+        static::assertMatchesRegularExpression('/Deleted \(orphaned\)\s+2\b/', $display);
+        static::assertMatchesRegularExpression('/Kept \(referenced\)\s+1\b/', $display);
+        static::assertStringContainsString('Successfully deleted all orphaned thumbnail files.', $display);
+    }
+
+    public function testExecuteWithRemoteThumbnailsEnabled(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $thumbnailRepository = $this->createMock(EntityRepository::class);
+        $filesystemPublic = static::createStub(FilesystemOperator::class);
+        $filesystemPrivate = static::createStub(FilesystemOperator::class);
+        $filesystemPublic->method('listContents')->willReturn(new DirectoryListing([]));
+        $filesystemPrivate->method('listContents')->willReturn(new DirectoryListing([]));
+        $command = new DeleteThumbnailsCommand(
+            $connection,
+            $thumbnailRepository,
+            $filesystemPublic,
+            $filesystemPrivate,
+            true
+        );
+
+        $commandTester = new CommandTester($command);
+        $commandTester->setInputs(['yes']);
+
+        $thumbnails = [
+            Uuid::randomHex() => 'thumbnail/aa/bb/cc/1786525629/test_100x100.png',
+            Uuid::randomHex() => 'thumbnail/aa/bb/cc/1786525629/test_200x200.png',
+        ];
+        $connection->expects($this->once())
+            ->method('fetchAllKeyValue')
+            ->with('SELECT LOWER(HEX(`id`)) as id, `path` FROM `media_thumbnail`')
+            ->willReturn($thumbnails);
+
+        $thumbnailRepository->expects($this->once())
+            ->method('delete')
+            ->with(array_map(static fn (string $id) => ['id' => $id], array_keys($thumbnails)), static::isInstanceOf(Context::class));
 
         $connection->expects($this->once())
             ->method('executeStatement')

--- a/tests/unit/Core/Content/Media/Commands/DeleteThumbnailsCommandTest.php
+++ b/tests/unit/Core/Content/Media/Commands/DeleteThumbnailsCommandTest.php
@@ -34,6 +34,38 @@ class DeleteThumbnailsCommandTest extends TestCase
         static::assertStringContainsStringIgnoringLineEndings('// Deleting thumbnails is only supported when remote thumbnail is enabled.', trim($commandTester->getDisplay()));
     }
 
+    public function testExecuteWithRemoteThumbnailsDisabledAndForce(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $thumbnailRepository = $this->createMock(EntityRepository::class);
+        $command = new DeleteThumbnailsCommand($connection, $thumbnailRepository, false);
+
+        $commandTester = new CommandTester($command);
+        $commandTester->setInputs(['yes']);
+
+        $thumbnailIds = [
+            ['id' => Uuid::randomHex()],
+        ];
+        $connection->expects($this->once())
+            ->method('fetchAllAssociative')
+            ->with('SELECT LOWER(HEX(`id`)) as id FROM `media_thumbnail`')
+            ->willReturn($thumbnailIds);
+
+        $thumbnailRepository->expects($this->once())
+            ->method('delete')
+            ->with($thumbnailIds, static::isInstanceOf(Context::class));
+
+        $connection->expects($this->once())
+            ->method('executeStatement')
+            ->with('UPDATE `media` SET `thumbnails_ro` = NULL;');
+
+        $commandTester->execute(['--force' => true]);
+
+        $commandTester->assertCommandIsSuccessful();
+
+        static::assertStringContainsString('Successfully deleted all thumbnails records and thumbnails files.', $commandTester->getDisplay());
+    }
+
     public function testExecuteWithRemoteThumbnailsEnabled(): void
     {
         $connection = $this->createMock(Connection::class);

--- a/tests/unit/Core/Content/Media/Commands/GenerateThumbnailsCommandTest.php
+++ b/tests/unit/Core/Content/Media/Commands/GenerateThumbnailsCommandTest.php
@@ -94,6 +94,66 @@ class GenerateThumbnailsCommandTest extends TestCase
         static::assertTrue($message->isStrict());
     }
 
+    #[TestDox('The force option is forwarded to the thumbnail service')]
+    public function testForwardsForceOptionSynchronously(): void
+    {
+        $media = $this->createMediaEntity();
+
+        $mediaRepository = new StaticEntityRepository([
+            [$media->getId()],
+            new MediaCollection([$media]),
+            new MediaCollection(),
+        ], new TestEntityDefinition());
+
+        $thumbnailService = $this->createMock(ThumbnailService::class);
+        $thumbnailService
+            ->expects($this->once())
+            ->method('updateThumbnails')
+            ->with($media, static::anything(), false, true)
+            ->willReturn(1);
+
+        $commandTester = new CommandTester(new GenerateThumbnailsCommand(
+            $thumbnailService,
+            $mediaRepository,
+            $this->createFolderRepository(),
+            new CollectingMessageBus()
+        ));
+
+        static::assertSame(Command::SUCCESS, $commandTester->execute(['--force' => true]));
+    }
+
+    #[TestDox('The force option is forwarded to queued batch jobs')]
+    public function testForwardsForceOptionToBatchJobs(): void
+    {
+        $media = $this->createMediaEntity();
+
+        $mediaRepository = new StaticEntityRepository([
+            new MediaCollection([$media]),
+            new MediaCollection(),
+        ], new TestEntityDefinition());
+
+        $messageBus = new CollectingMessageBus();
+
+        $commandTester = new CommandTester(new GenerateThumbnailsCommand(
+            static::createStub(ThumbnailService::class),
+            $mediaRepository,
+            $this->createFolderRepository(),
+            $messageBus
+        ));
+
+        static::assertSame(Command::SUCCESS, $commandTester->execute([
+            '--async' => true,
+            '--force' => true,
+        ]));
+
+        $messages = $messageBus->getMessages();
+        static::assertCount(1, $messages);
+        $message = $messages[0]->getMessage();
+        static::assertInstanceOf(UpdateThumbnailsMessage::class, $message);
+        static::assertTrue($message->isForce());
+        static::assertFalse($message->isStrict());
+    }
+
     #[TestDox('Thumbnail generation is skipped when remote thumbnails are enabled')]
     public function testFailsWhenRemoteThumbnailsAreEnabled(): void
     {

--- a/tests/unit/Core/Content/Media/Message/GenerateThumbnailsHandlerTest.php
+++ b/tests/unit/Core/Content/Media/Message/GenerateThumbnailsHandlerTest.php
@@ -62,4 +62,29 @@ class GenerateThumbnailsHandlerTest extends TestCase
 
         static::assertSame([$failingId, $succeedingId], $handledIds);
     }
+
+    public function testUpdateThumbnailsForwardsStrictAndForceFlags(): void
+    {
+        $mediaId = Uuid::randomHex();
+        $media = new MediaEntity();
+        $media->setId($mediaId);
+
+        $mediaRepository = new StaticEntityRepository([new MediaCollection([$media])]);
+
+        $thumbnailService = $this->createMock(ThumbnailService::class);
+        $thumbnailService->expects($this->once())
+            ->method('updateThumbnails')
+            ->with($media, static::anything(), true, true)
+            ->willReturn(1);
+
+        $handler = new GenerateThumbnailsHandler($thumbnailService, $mediaRepository, static::createStub(LoggerInterface::class));
+
+        $message = new UpdateThumbnailsMessage();
+        $message->setMediaIds([$mediaId]);
+        $message->setStrict(true);
+        $message->setForce(true);
+        $message->setContext(Context::createDefaultContext());
+
+        $handler($message);
+    }
 }

--- a/tests/unit/Core/Content/Media/Subscriber/MediaDeletionSubscriberTest.php
+++ b/tests/unit/Core/Content/Media/Subscriber/MediaDeletionSubscriberTest.php
@@ -242,6 +242,32 @@ class MediaDeletionSubscriberTest extends TestCase
         static::assertFalse($this->filesystemPublic->fileExists('media/image.jpg'));
     }
 
+    public function testThumbnailDeletionSkipsFileDeleteWhenSkipStateSet(): void
+    {
+        $thumbId = $this->ids->get('thumb-1');
+        $media = new MediaEntity();
+        $media->setId($this->ids->get('media-1'));
+        $media->setPrivate(false);
+
+        $thumbnail = new MediaThumbnailEntity();
+        $thumbnail->setId($thumbId);
+        $thumbnail->setPath('thumbnail/thumbnail.jpg');
+        $thumbnail->setMedia($media);
+
+        $this->thumbnailRepository->addSearch(new MediaThumbnailCollection([$thumbnail]));
+
+        $this->filesystemPublic->write('thumbnail/thumbnail.jpg', 'content');
+
+        $context = Context::createDefaultContext();
+        $context->addState(MediaDeletionSubscriber::SKIP_FILE_DELETE);
+
+        $event = $this->createDeleteEvent(MediaThumbnailDefinition::ENTITY_NAME, $thumbId, $context);
+        $this->createMediaDeletionSubscriber()->beforeDelete($event);
+
+        static::assertEmpty($this->messageBus->getMessages());
+        static::assertTrue($this->filesystemPublic->fileExists('thumbnail/thumbnail.jpg'));
+    }
+
     public function testThumbnailDeletionDispatchesDeleteMessageForPublicThumbnail(): void
     {
         $thumbId = $this->ids->get('thumb-1');

--- a/tests/unit/Core/Content/Media/Thumbnail/ThumbnailServiceTest.php
+++ b/tests/unit/Core/Content/Media/Thumbnail/ThumbnailServiceTest.php
@@ -378,7 +378,7 @@ class ThumbnailServiceTest extends TestCase
                 static::assertInstanceOf(MediaThumbnailSizeCollection::class, $staticVars['toBeCreatedSizes']);
                 static::assertCount(1, $staticVars['toBeCreatedSizes']->getElements());
 
-                return [['id' => 'new-media-thumbnail-id']];
+                return [['id' => Uuid::randomHex()]];
             });
 
         $thumbnailService = $this->createThumbnailService(connection: $connection);

--- a/tests/unit/Core/Content/Media/Thumbnail/ThumbnailServiceTest.php
+++ b/tests/unit/Core/Content/Media/Thumbnail/ThumbnailServiceTest.php
@@ -355,6 +355,39 @@ class ThumbnailServiceTest extends TestCase
         static::assertSame(0, $actual);
     }
 
+    public function testUpdateThumbnailsWithForceRegeneratesExistingThumbnails(): void
+    {
+        // Use the same mediaThumbnailSizeId, without force nothing would be regenerated
+        $mediaThumbnailEntity = $this->createMediaThumbnailEntity('abc');
+        $mediaFolderEntity = $this->createMediaFolderEntity('abc');
+
+        $mediaEntity = $this->createMediaEntity($mediaThumbnailEntity, $mediaFolderEntity);
+        $mediaThumbnailEntity->setMedia($mediaEntity);
+
+        $connection = $this->createMock(Connection::class);
+        $connection->expects($this->once())
+            ->method('transactional')
+            ->willReturnCallback(function (\Closure $func) use ($mediaEntity, $mediaFolderEntity) {
+                $reflection = new \ReflectionFunction($func);
+                $staticVars = $reflection->getStaticVariables();
+
+                static::assertSame([['id' => 'media-thumbnail-id-1']], $staticVars['delete']);
+                static::assertSame($mediaEntity, $staticVars['media']);
+                static::assertSame($mediaFolderEntity->getConfiguration(), $staticVars['config']);
+                static::assertSame($this->context, $staticVars['context']);
+                static::assertInstanceOf(MediaThumbnailSizeCollection::class, $staticVars['toBeCreatedSizes']);
+                static::assertCount(1, $staticVars['toBeCreatedSizes']->getElements());
+
+                return [['id' => 'new-media-thumbnail-id']];
+            });
+
+        $thumbnailService = $this->createThumbnailService(connection: $connection);
+
+        $actual = $thumbnailService->updateThumbnails($mediaEntity, $this->context, false, true);
+
+        static::assertSame(1, $actual);
+    }
+
     public function testDeleteThumbnailsExecutesRepository(): void
     {
         $expected = [


### PR DESCRIPTION
fixes #12967

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

Existing thumbnails are never regenerated by `media:generate-thumbnails` — sizes that already have a thumbnail are always skipped. And `media:delete-local-thumbnails` refuses to run unless remote thumbnails are enabled. So after changing the thumbnail quality or size configuration, there is no way to refresh local thumbnails at all (e.g. in PaaS setups with S3 buckets). See #12967.

### 2. What does this change do, exactly?

- Adds a `--force` (`-f`) option to `media:generate-thumbnails` that regenerates thumbnails for all configured sizes even when a thumbnail already exists, replacing them in place without a delete-then-regenerate gap. Works for both synchronous and `--async` execution (`UpdateThumbnailsMessage` carries a new `force` flag).
- Adds a `--force` (`-f`) option to `media:delete-local-thumbnails` that deletes all thumbnail records and files even when remote thumbnails are disabled, as suggested in the issue.
- Adds a new optional `$force` parameter to `ThumbnailService::updateThumbnails()`, announced via `#[NewOptionalParameter]` for v6.8.0; when set, the existing-thumbnail matching is skipped and deletion plus regeneration run within the existing per-media transaction.
- The error message of `media:delete-local-thumbnails` without `--force` now points to both new options.

### 3. Describe each step to reproduce the issue or behaviour.

1. Upload an image to a media folder with thumbnail generation enabled and run `bin/console media:generate-thumbnails`.
2. Change the thumbnail quality in the media folder settings.
3. Run `bin/console media:generate-thumbnails` again → the media is reported as "Skipped", the thumbnail files keep the old quality.
4. Run `bin/console media:delete-local-thumbnails` → fails with "Deleting thumbnails is only supported when remote thumbnail is enabled."
5. With this change, run `bin/console media:generate-thumbnails --force` → the thumbnails are regenerated with the new quality; alternatively `bin/console media:delete-local-thumbnails --force` deletes them.



### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
