### PR TITLE
ci: upload junit reports from blue-green and update integration jobs

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -240,7 +240,17 @@ jobs:
 
       - name: Run integration tests
         if: inputs.profile == 'nightly'
-        run: php -d memory_limit=-1 vendor/bin/phpunit --testsuite "integration" --stop-on-error --stop-on-failure
+        run: php -d memory_limit=-1 vendor/bin/phpunit --log-junit junit.xml --testsuite "integration" --stop-on-error --stop-on-failure
+
+      - name: Upload junit report for the failure tracking issue
+        if: failure() && github.event_name == 'schedule'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: junit-phpunit-blue-green-67-68
+          path: junit.xml
+          # a job that fails before PHPUnit reports (setup, crash) has no junit.xml
+          if-no-files-found: ignore
+          overwrite: true
 
       - name: Install Shopware in previous major version
         if: inputs.profile != 'nightly'
@@ -329,7 +339,17 @@ jobs:
 
       - name: Run integration tests in previous major version
         if: inputs.profile == 'nightly'
-        run: php -d memory_limit=-1 vendor/bin/phpunit --testsuite "integration" --stop-on-error --stop-on-failure
+        run: php -d memory_limit=-1 vendor/bin/phpunit --log-junit junit.xml --testsuite "integration" --stop-on-error --stop-on-failure
+
+      - name: Upload junit report for the failure tracking issue
+        if: failure() && github.event_name == 'schedule'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: junit-phpunit-blue-green-66-67
+          path: junit.xml
+          # a job that fails before PHPUnit reports (setup, crash) has no junit.xml
+          if-no-files-found: ignore
+          overwrite: true
 
       - name: Run blue-green check
         if: inputs.profile != 'nightly'
@@ -404,7 +424,17 @@ jobs:
         run: bin/console dal:refresh:index
 
       - name: Run integration tests
-        run: php -d memory_limit=-1 vendor/bin/phpunit --testsuite "integration" --stop-on-error --stop-on-failure
+        run: php -d memory_limit=-1 vendor/bin/phpunit --log-junit junit.xml --testsuite "integration" --stop-on-error --stop-on-failure
+
+      - name: Upload junit report for the failure tracking issue
+        if: failure() && github.event_name == 'schedule'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: junit-phpunit-update-66-67
+          path: junit.xml
+          # a job that fails before PHPUnit reports (setup, crash) has no junit.xml
+          if-no-files-found: ignore
+          overwrite: true
 
   # this allows us to specify just one required job/check
   # this is not practical with matrix jobs directly, because you've to specify all permutations


### PR DESCRIPTION
### 1. Why is this change necessary?

The blue-green and update jobs invoke PHPUnit directly without `--log-junit`, so failed nightly runs produce no `junit-phpunit-*` artifact. The nightly tracking issue then reports "Failing tests: 0 / no junit reports" and the agentic triage has nothing to cluster — the blue-green regression from #18290 stayed invisible in #19091 for five nightlies.

### 2. What does this change do, exactly?

Adds `--log-junit junit.xml` to the PHPUnit invocations of the `blue-green-67-68`, `blue-green-66-67`, and `update-66-67` jobs and uploads the report on scheduled failures, mirroring the artifact naming and upload conditions of the sharded phpunit jobs.

### 3. Describe each step to reproduce the issue or behaviour.

Let a nightly blue-green integration test fail: the run's tracking issue update shows "No junit reports were produced" instead of the failing tests.

### 4. Please link to the relevant issues (if any).

- relates #19091

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
