### PR TITLE
fix(core): split Store API CartPrice schema from CalculatedPrice

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -80,6 +80,10 @@ The `sw-expect-packages` header is no longer evaluated on API endpoints that do 
 
 Send the header with an authenticated Admin API request, where the behaviour is unchanged: a violated constraint still returns `417` with `FRAMEWORK__API_EXPECTATION_FAILED` and the installed version. Clients that set the header as a default on their HTTP client must remove it from unauthenticated calls — most importantly from the token request, which otherwise fails before the token is issued. Requests that do not send the header are unaffected.
 
+### Store API schema documents cart totals as a separate `CartPrice` component
+
+The Store API OpenAPI schema previously documented item prices and cart totals as one `CalculatedPrice` component, which marked the cart-level fields `netPrice`, `positionPrice`, `rawTotal`, and `taxStatus` as required on item prices such as `product.calculatedPrice` and `lineItem.price`. The schema now contains a dedicated `CartPrice` component used for `cart.price` and `order.price`, while `CalculatedPrice` only documents the fields item prices actually contain. The `taxStatus` enum also includes the previously missing `gross` value. API responses are unchanged; only clients generated from the schema are affected and now match the actual payloads.
+
 ## Core
 
 ### GARAN commercial guarantee label and EU legal guarantee notice

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/components/schemas/Cart.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/components/schemas/Cart.json
@@ -16,7 +16,7 @@
                         "type": "string"
                     },
                     "price": {
-                        "$ref": "#/components/schemas/CalculatedPrice"
+                        "$ref": "#/components/schemas/CartPrice"
                     },
                     "lineItems": {
                         "description": "All items within the cart",

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/components/schemas/CartPrice.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/components/schemas/CartPrice.json
@@ -4,18 +4,25 @@
     "paths": [],
     "components": {
         "schemas": {
-            "CalculatedPrice": {
+            "CartPrice": {
                 "type": "object",
-                "description": "Represents the calculated price of an item, including taxes and optional reference, list and regulation prices.",
+                "description": "Represents the total calculated price of a cart or order, including taxes and the tax status.",
                 "properties": {
-                    "unitPrice": {
-                        "type": "number"
-                    },
-                    "quantity": {
+                    "netPrice": {
                         "type": "number"
                     },
                     "totalPrice": {
                         "type": "number"
+                    },
+                    "positionPrice": {
+                        "type": "number"
+                    },
+                    "rawTotal": {
+                        "type": "number"
+                    },
+                    "taxStatus": {
+                        "type": "string",
+                        "enum": ["gross", "net", "tax-free"]
                     },
                     "calculatedTaxes": {
                         "type": "array",
@@ -39,49 +46,6 @@
                             "required": ["apiAlias", "tax", "taxRate", "price"]
                         }
                     },
-                    "referencePrice": {
-                        "oneOf": [
-                            {
-                                "$ref": "#/components/schemas/CartPriceReference"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ]
-                    },
-                    "listPrice": {
-                        "oneOf": [
-                            {
-                                "$ref": "#/components/schemas/CartListPrice"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ]
-                    },
-                    "regulationPrice": {
-                        "oneOf": [
-                            {
-                                "type": "object",
-                                "properties": {
-                                    "price": {
-                                        "type": "number"
-                                    },
-                                    "apiAlias": {
-                                        "type": "string",
-                                        "const": "cart_regulation_price"
-                                    }
-                                }
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ]
-                    },
-                    "apiAlias": {
-                        "type": "string",
-                        "const": "calculated_price"
-                    },
                     "taxRules": {
                         "type": "array",
                         "description": "Currently active tax rules and/or rates",
@@ -97,17 +61,20 @@
                                 }
                             }
                         }
+                    },
+                    "apiAlias": {
+                        "type": "string",
+                        "const": "cart_price"
                     }
                 },
                 "required": [
                     "apiAlias",
-                    "regulationPrice",
-                    "listPrice",
-                    "referencePrice",
-                    "calculatedTaxes",
+                    "netPrice",
                     "totalPrice",
-                    "quantity",
-                    "unitPrice",
+                    "positionPrice",
+                    "rawTotal",
+                    "taxStatus",
+                    "calculatedTaxes",
                     "taxRules"
                 ]
             }

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/components/schemas/Order.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/components/schemas/Order.json
@@ -83,42 +83,8 @@
                         "readOnly": true
                     },
                     "price": {
-                        "required": [
-                            "netPrice",
-                            "totalPrice",
-                            "positionPrice",
-                            "rawTotal",
-                            "taxStatus"
-                        ],
-                        "properties": {
-                            "netPrice": {
-                                "type": "number",
-                                "format": "float"
-                            },
-                            "totalPrice": {
-                                "type": "number",
-                                "format": "float"
-                            },
-                            "calculatedTaxes": {
-                                "type": "object"
-                            },
-                            "taxRules": {
-                                "type": "object"
-                            },
-                            "positionPrice": {
-                                "type": "number",
-                                "format": "float"
-                            },
-                            "rawTotal": {
-                                "type": "number",
-                                "format": "float"
-                            },
-                            "taxStatus": {
-                                "type": "string"
-                            }
-                        },
                         "type": "object",
-                        "$ref": "#/components/schemas/CalculatedPrice"
+                        "$ref": "#/components/schemas/CartPrice"
                     },
                     "amountTotal": {
                         "description": "Gross price of the order.",


### PR DESCRIPTION
### 1. Why is this change necessary?

The Store API OpenAPI schema documented one `CalculatedPrice` component that mixed the fields of three PHP structs: `CalculatedPrice`, `CartPrice` (`netPrice`, `positionPrice`, `rawTotal`, `taxStatus`), and `CalculatedCheapestPrice` (`hasRange`, `variantId`). The cart-level fields and `hasRange` were marked as required, so typed clients generated from the schema expect fields on item prices such as `product.calculatedPrice` and `lineItem.price` that the API never returns there. The `taxStatus` enum was also missing the valid `gross` value, and the documented `apiAlias` for cart prices was wrong (`calculated_price` instead of `cart_price`).

### 2. What does this change do, exactly?

- Reduces the `CalculatedPrice` component to the fields of `Shopware\Core\Checkout\Cart\Price\Struct\CalculatedPrice`: `unitPrice`, `totalPrice`, `quantity`, `calculatedTaxes`, `taxRules`, `referencePrice`, `listPrice`, `regulationPrice`, `apiAlias`
- Adds a new `CartPrice` component matching `Shopware\Core\Checkout\Cart\Price\Struct\CartPrice`, with the full `taxStatus` enum (`gross`, `net`, `tax-free`) and `apiAlias` const `cart_price`
- Points `cart.price` and `order.price` at `CartPrice` — both are `CartPrice` structs in PHP; `Order.json` previously combined inline properties with the wrong `CalculatedPrice` `$ref`
- Leaves all other `CalculatedPrice` references unchanged, as they are backed by the PHP `CalculatedPrice` struct: `cart.transactions[].amount`, `cartDelivery.shippingCosts`, `cartDeliveryPosition.price`, `product.calculatedPrice(s)`, and the checkout shipping-cost responses
- Adds a `RELEASE_INFO-6.7.md` entry

API responses are unchanged; only the generated schema and clients generated from it are affected, which now match the actual payloads.

### 3. Describe each step to reproduce the issue or behaviour.

1. Fetch the Store API OpenAPI schema from `/store-api/_info/openapi3.json`
2. Inspect `components.schemas.CalculatedPrice`: it requires `netPrice`, `positionPrice`, `rawTotal`, `taxStatus`, and `hasRange`
3. Compare with an actual `product.calculatedPrice` or `lineItem.price` payload — none of these fields are present
4. Compare with an actual `cart.price` payload — its `apiAlias` is `cart_price` and its `taxStatus` can be `gross`, neither of which the schema declared

### 4. Please link to the relevant issues (if any).

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them