### PR TITLE
test: narrow DevOps coverage excludes to cover the tested tooling

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -90,7 +90,12 @@
 
             <directory suffix=".php">src/Core/Content/Cms/DataResolver/ResolverContext/</directory>
             <directory suffix=".php">src/Core/Content/Cms/Extension/</directory>
-            <directory suffix=".php">src/Core/DevOps/StaticAnalyze</directory>
+            <!-- Static-analysis tooling; the Danger rules stay covered by their unit tests. -->
+            <directory suffix=".php">src/Core/DevOps/StaticAnalyze/PHPStan</directory>
+            <file>src/Core/DevOps/StaticAnalyze/StaticAnalyzeKernel.php</file>
+            <file>src/Core/DevOps/StaticAnalyze/console-application.php</file>
+            <file>src/Core/DevOps/StaticAnalyze/phpstan-bootstrap.php</file>
+            <file>src/Core/DevOps/StaticAnalyze/print-ignored-errors-by-area.php</file>
             <directory suffix=".php">src/Core/Framework/Telemetry/Metrics/Metric</directory>
 
             <directory suffix="Definition.php">src/Storefront/Checkout</directory>
@@ -131,7 +136,8 @@
 
             <!-- All fixtures, stubs, traits used for tests -->
             <directory suffix=".php">src/Core/Content/Test</directory>
-            <directory suffix=".php">src/Core/DevOps/Test</directory>
+            <!-- Only the test fixtures under DevOps/Test; the tooling classes stay covered by their unit tests. -->
+            <directory suffix=".php">src/Core/DevOps/Test/Environment</directory>
             <directory suffix=".php">src/Core/Framework/Test</directory>
             <directory suffix=".php">src/Core/Migration/Test</directory>
             <directory suffix=".php">src/Core/Migration/Traits</directory>

--- a/src/Core/DevOps/StaticAnalyze/Danger/Rules/MissingPackageAttributeInTests.php
+++ b/src/Core/DevOps/StaticAnalyze/Danger/Rules/MissingPackageAttributeInTests.php
@@ -123,7 +123,7 @@ class MissingPackageAttributeInTests
         foreach ($srcFiles as $srcFile) {
             $package = $this->extractPackage($srcFile->getContents());
             if ($package !== null) {
-                ++$votes[$package];
+                $votes[$package] = ($votes[$package] ?? 0) + 1;
             }
         }
 

--- a/tests/unit/Core/DevOps/StaticAnalyze/PHPStan/Rules/CodeCoverageIgnore/ExemptionResolverTest.php
+++ b/tests/unit/Core/DevOps/StaticAnalyze/PHPStan/Rules/CodeCoverageIgnore/ExemptionResolverTest.php
@@ -7,7 +7,7 @@ use PhpParser\Node\Stmt\Class_;
 use PhpParser\NodeFinder;
 use PhpParser\ParserFactory;
 use PHPStan\Reflection\ReflectionProvider;
-use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\TestDox;
 use PHPUnit\Framework\TestCase;
@@ -18,7 +18,7 @@ use Shopware\Core\Framework\Log\Package;
  * @internal
  */
 #[Package('framework')]
-#[CoversClass(ExemptionResolver::class)]
+#[CoversNothing]
 class ExemptionResolverTest extends TestCase
 {
     private const EXISTING_TEST = 'Shopware\Tests\Integration\Core\Framework\Webhook\Service\WebhookHealthServiceTest';

--- a/tests/unit/Core/DevOps/StaticAnalyze/PHPStan/Rules/CodeCoverageIgnore/LogicDetectorTest.php
+++ b/tests/unit/Core/DevOps/StaticAnalyze/PHPStan/Rules/CodeCoverageIgnore/LogicDetectorTest.php
@@ -5,7 +5,7 @@ namespace Shopware\Tests\Unit\Core\DevOps\StaticAnalyze\PHPStan\Rules\CodeCovera
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\NodeFinder;
 use PhpParser\ParserFactory;
-use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\TestDox;
 use PHPUnit\Framework\TestCase;
@@ -16,7 +16,7 @@ use Shopware\Core\Framework\Log\Package;
  * @internal
  */
 #[Package('framework')]
-#[CoversClass(LogicDetector::class)]
+#[CoversNothing]
 class LogicDetectorTest extends TestCase
 {
     #[TestDox('methodContainsLogic($_dataName)')]

--- a/tests/unit/Core/DevOps/StaticAnalyze/PHPStan/Rules/CodeCoverageIgnore/UseMapTest.php
+++ b/tests/unit/Core/DevOps/StaticAnalyze/PHPStan/Rules/CodeCoverageIgnore/UseMapTest.php
@@ -5,7 +5,7 @@ namespace Shopware\Tests\Unit\Core\DevOps\StaticAnalyze\PHPStan\Rules\CodeCovera
 use PhpParser\Node;
 use PhpParser\Node\Stmt\Namespace_;
 use PhpParser\ParserFactory;
-use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\TestDox;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\DevOps\StaticAnalyze\PHPStan\Rules\CodeCoverageIgnore\UseMap;
@@ -15,7 +15,7 @@ use Shopware\Core\Framework\Log\Package;
  * @internal
  */
 #[Package('framework')]
-#[CoversClass(UseMap::class)]
+#[CoversNothing]
 class UseMapTest extends TestCase
 {
     #[TestDox('fromStmts returns alias to FQCN for regular use statements')]

--- a/tests/unit/Core/Maintenance/System/SystemExceptionTest.php
+++ b/tests/unit/Core/Maintenance/System/SystemExceptionTest.php
@@ -4,8 +4,7 @@ declare(strict_types=1);
 
 namespace Shopware\Tests\Unit\Core\Maintenance\System;
 
-use PHPUnit\Event\Telemetry\System;
-use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Maintenance\MaintenanceException;
@@ -15,7 +14,7 @@ use Symfony\Component\HttpFoundation\Response;
  * @internal
  */
 #[Package('framework')]
-#[CoversClass(System::class)]
+#[CoversNothing]
 class SystemExceptionTest extends TestCase
 {
     public function testConsoleApplicationNotFound(): void


### PR DESCRIPTION
### 1. Why is this change necessary?

Part of #18344. `phpunit.xml.dist` excludes whole directories from the coverage source, and the blanket excludes for `src/Core/DevOps/StaticAnalyze` and `src/Core/DevOps/Test` swept in tooling that has dedicated unit tests (the Danger rules, and the `MakeCoverageTestCommand` / `AnnotationTagTester` helpers). Under PHPUnit 12 their `#[CoversClass]` emits `... is not a valid target for code coverage`. Rather than declare those tests as covering nothing, which discards real coverage, this narrows the excludes so the tested tooling stays in the coverage source.

### 2. What does this change do, exactly?

- Narrows the `src/Core/DevOps/StaticAnalyze` exclude to `src/Core/DevOps/StaticAnalyze/PHPStan` plus its four root scripts, so the Danger rules (all unit-tested) stay covered and keep `#[CoversClass]`. The PHPStan rules and their internals stay excluded as static-analysis tooling.
- Narrows the `src/Core/DevOps/Test` exclude to `src/Core/DevOps/Test/Environment` (the fixtures), so the two tooling classes stay covered and keep `#[CoversClass]`.
- The `CodeCoverageIgnore` helpers stay under the PHPStan exclude, so their tests become `#[CoversNothing]` (consistent with the rest of the PHPStan tooling).
- `SystemExceptionTest` had a stray `use PHPUnit\Event\Telemetry\System;` auto-import with `#[CoversClass(System::class)]` while it actually exercises `MaintenanceException` (itself coverage-ignored). Dropped the import and set `#[CoversNothing]`.
- Fixes an unrelated latent warning surfaced by the Danger rule's own test: `MissingPackageAttributeInTests` incremented an undefined array key (`++$votes[$package]`), now `$votes[$package] = ($votes[$package] ?? 0) + 1`.

Every un-excluded class has a `#[CoversClass]` test, so the coverage source only gains covered code (no score drop). Tests pass (253), PHPStan and cs-fixer clean, and the whole tooling set emits zero `not a valid target` warnings under PHPUnit 12.

### 3. Describe each step to reproduce the issue or behaviour.

1. Run the unit suite under PHPUnit 12 (the preview arm).
2. Before: each `#[CoversClass]` on a DevOps tooling class emits a `not a valid target for code coverage` warning.
3. After: none; the tested tooling is back in the coverage source, the remaining static-analysis internals use `#[CoversNothing]`.

### 4. Please link to the relevant issues (if any).

- relates #18344

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
