### PR TITLE
test: use CoversNothing for coverage-excluded Checkout DTOs

### DIFF
--- a/tests/unit/Core/Checkout/Cart/Event/BeforeCartMergeEventTest.php
+++ b/tests/unit/Core/Checkout/Cart/Event/BeforeCartMergeEventTest.php
@@ -2,7 +2,7 @@
 
 namespace Shopware\Tests\Unit\Core\Checkout\Cart\Event;
 
-use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\Cart\Cart;
 use Shopware\Core\Checkout\Cart\Event\BeforeCartMergeEvent;
@@ -15,7 +15,7 @@ use Shopware\Core\System\SalesChannel\SalesChannelContext;
  * @internal
  */
 #[Package('checkout')]
-#[CoversClass(BeforeCartMergeEvent::class)]
+#[CoversNothing]
 class BeforeCartMergeEventTest extends TestCase
 {
     public function testReturnsCorrectProperties(): void

--- a/tests/unit/Core/Checkout/Cart/Event/CartBeforeSerializationEventTest.php
+++ b/tests/unit/Core/Checkout/Cart/Event/CartBeforeSerializationEventTest.php
@@ -2,7 +2,7 @@
 
 namespace Shopware\Tests\Unit\Core\Checkout\Cart\Event;
 
-use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\Cart\Cart;
 use Shopware\Core\Checkout\Cart\Event\CartBeforeSerializationEvent;
@@ -12,7 +12,7 @@ use Shopware\Core\Framework\Log\Package;
  * @internal
  */
 #[Package('checkout')]
-#[CoversClass(CartBeforeSerializationEvent::class)]
+#[CoversNothing]
 class CartBeforeSerializationEventTest extends TestCase
 {
     public function testConstructor(): void

--- a/tests/unit/Core/Checkout/Cart/Event/CartContextHashEventTest.php
+++ b/tests/unit/Core/Checkout/Cart/Event/CartContextHashEventTest.php
@@ -2,7 +2,7 @@
 
 namespace Shopware\Tests\Unit\Core\Checkout\Cart\Event;
 
-use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\Cart\Cart;
 use Shopware\Core\Checkout\Cart\CartContextHashStruct;
@@ -15,7 +15,7 @@ use Shopware\Core\Test\Generator;
  * @internal
  */
 #[Package('checkout')]
-#[CoversClass(CartContextHashEvent::class)]
+#[CoversNothing]
 class CartContextHashEventTest extends TestCase
 {
     public SalesChannelContext $salesChannelContext;

--- a/tests/unit/Core/Checkout/Cart/Event/SalesChannelContextAssembledEventTest.php
+++ b/tests/unit/Core/Checkout/Cart/Event/SalesChannelContextAssembledEventTest.php
@@ -2,7 +2,7 @@
 
 namespace Shopware\Tests\Unit\Core\Checkout\Cart\Event;
 
-use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\Cart\Event\SalesChannelContextAssembledEvent;
 use Shopware\Core\Checkout\Order\OrderEntity;
@@ -13,7 +13,7 @@ use Shopware\Core\Test\Generator;
  * @internal
  */
 #[Package('checkout')]
-#[CoversClass(SalesChannelContextAssembledEvent::class)]
+#[CoversNothing]
 class SalesChannelContextAssembledEventTest extends TestCase
 {
     public function testConstruct(): void

--- a/tests/unit/Core/Checkout/Cart/LineItem/Group/LineItemGroupDefinitionTest.php
+++ b/tests/unit/Core/Checkout/Cart/LineItem/Group/LineItemGroupDefinitionTest.php
@@ -2,7 +2,7 @@
 
 namespace Shopware\Tests\Unit\Core\Checkout\Cart\LineItem\Group;
 
-use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\Cart\LineItem\Group\LineItemGroupDefinition;
@@ -15,7 +15,7 @@ use Shopware\Tests\Unit\Core\Checkout\Cart\LineItem\Group\Helpers\Traits\RulesTe
  * @internal
  */
 #[Package('checkout')]
-#[CoversClass(LineItemGroupDefinition::class)]
+#[CoversNothing]
 class LineItemGroupDefinitionTest extends TestCase
 {
     use RulesTestFixtureBehaviour;

--- a/tests/unit/Core/Checkout/Cart/LineItem/LineItemFlatCollectionTest.php
+++ b/tests/unit/Core/Checkout/Cart/LineItem/LineItemFlatCollectionTest.php
@@ -2,7 +2,7 @@
 
 namespace Shopware\Tests\Unit\Core\Checkout\Cart\LineItem;
 
-use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\Cart\CartException;
 use Shopware\Core\Checkout\Cart\LineItem\LineItem;
@@ -13,7 +13,7 @@ use Shopware\Core\Framework\Log\Package;
  * @internal
  */
 #[Package('checkout')]
-#[CoversClass(LineItemFlatCollection::class)]
+#[CoversNothing]
 class LineItemFlatCollectionTest extends TestCase
 {
     /**

--- a/tests/unit/Core/Checkout/Cart/Promotion/Aggregate/PromotionSetGroup/PromotionSetGroupEntityTest.php
+++ b/tests/unit/Core/Checkout/Cart/Promotion/Aggregate/PromotionSetGroup/PromotionSetGroupEntityTest.php
@@ -2,7 +2,7 @@
 
 namespace Shopware\Tests\Unit\Core\Checkout\Cart\Promotion\Aggregate\PromotionSetGroup;
 
-use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\Promotion\Aggregate\PromotionSetGroup\PromotionSetGroupEntity;
@@ -14,7 +14,7 @@ use Shopware\Core\Framework\Log\Package;
  * @internal
  */
 #[Package('checkout')]
-#[CoversClass(PromotionSetGroupEntity::class)]
+#[CoversNothing]
 class PromotionSetGroupEntityTest extends TestCase
 {
     private const KEY_PACKAGER_COUNT = 'PACKAGER_COUNT';

--- a/tests/unit/Core/Checkout/Customer/Event/CustomerBeforeLoginEventTest.php
+++ b/tests/unit/Core/Checkout/Customer/Event/CustomerBeforeLoginEventTest.php
@@ -2,7 +2,7 @@
 
 namespace Shopware\Tests\Unit\Core\Checkout\Customer\Event;
 
-use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\Customer\Event\CustomerBeforeLoginEvent;
 use Shopware\Core\Content\Flow\Dispatching\StorableFlow;
@@ -15,7 +15,7 @@ use Shopware\Core\System\SalesChannel\SalesChannelContext;
  * @internal
  */
 #[Package('checkout')]
-#[CoversClass(CustomerBeforeLoginEvent::class)]
+#[CoversNothing]
 class CustomerBeforeLoginEventTest extends TestCase
 {
     public function testRestoreScalarValuesCorrectly(): void

--- a/tests/unit/Core/Checkout/Customer/Event/CustomerLoginEventTest.php
+++ b/tests/unit/Core/Checkout/Customer/Event/CustomerLoginEventTest.php
@@ -2,7 +2,7 @@
 
 namespace Shopware\Tests\Unit\Core\Checkout\Customer\Event;
 
-use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\Customer\CustomerEntity;
 use Shopware\Core\Checkout\Customer\Event\CustomerLoginEvent;
@@ -16,7 +16,7 @@ use Shopware\Core\System\SalesChannel\SalesChannelContext;
  * @internal
  */
 #[Package('checkout')]
-#[CoversClass(CustomerLoginEvent::class)]
+#[CoversNothing]
 class CustomerLoginEventTest extends TestCase
 {
     public function testRestoreScalarValuesCorrectly(): void

--- a/tests/unit/Core/Checkout/Customer/SalesChannel/SalesChannelCustomerAddressCollectionTest.php
+++ b/tests/unit/Core/Checkout/Customer/SalesChannel/SalesChannelCustomerAddressCollectionTest.php
@@ -2,7 +2,7 @@
 
 namespace Shopware\Tests\Unit\Core\Checkout\Customer\SalesChannel;
 
-use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\Customer\SalesChannel\SalesChannelCustomerAddressCollection;
 use Shopware\Core\Checkout\Customer\SalesChannel\SalesChannelCustomerAddressEntity;
@@ -13,7 +13,7 @@ use Shopware\Core\Framework\Uuid\Uuid;
  * @internal
  */
 #[Package('checkout')]
-#[CoversClass(SalesChannelCustomerAddressCollection::class)]
+#[CoversNothing]
 class SalesChannelCustomerAddressCollectionTest extends TestCase
 {
     public function testGetApiAliasReturnsUniqueAlias(): void

--- a/tests/unit/Core/Checkout/Customer/SalesChannel/SalesChannelCustomerAddressDefinitionTest.php
+++ b/tests/unit/Core/Checkout/Customer/SalesChannel/SalesChannelCustomerAddressDefinitionTest.php
@@ -2,7 +2,7 @@
 
 namespace Shopware\Tests\Unit\Core\Checkout\Customer\SalesChannel;
 
-use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\Customer\SalesChannel\SalesChannelCustomerAddressDefinition;
 use Shopware\Core\Framework\DataAbstractionLayer\Dbal\EntityWriteGateway;
@@ -20,7 +20,7 @@ use Symfony\Component\Validator\Validator\ValidatorInterface;
  * @internal
  */
 #[Package('checkout')]
-#[CoversClass(SalesChannelCustomerAddressDefinition::class)]
+#[CoversNothing]
 class SalesChannelCustomerAddressDefinitionTest extends TestCase
 {
     public function testProcessCriteria(): void

--- a/tests/unit/Core/Checkout/Gateway/Command/Struct/CheckoutGatewayPayloadStructTest.php
+++ b/tests/unit/Core/Checkout/Gateway/Command/Struct/CheckoutGatewayPayloadStructTest.php
@@ -2,7 +2,7 @@
 
 namespace Shopware\Tests\Unit\Core\Checkout\Gateway\Command\Struct;
 
-use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\Cart\Cart;
 use Shopware\Core\Checkout\Gateway\Command\Struct\CheckoutGatewayPayloadStruct;
@@ -15,7 +15,7 @@ use Shopware\Core\Test\Generator;
  * @internal
  */
 #[Package('checkout')]
-#[CoversClass(CheckoutGatewayPayloadStruct::class)]
+#[CoversNothing]
 class CheckoutGatewayPayloadStructTest extends TestCase
 {
     public function testConstruct(): void

--- a/tests/unit/Core/Checkout/Order/Aggregate/OrderLineItemDownload/OrderLineItemDownloadCollectionTest.php
+++ b/tests/unit/Core/Checkout/Order/Aggregate/OrderLineItemDownload/OrderLineItemDownloadCollectionTest.php
@@ -2,7 +2,7 @@
 
 namespace Shopware\Tests\Unit\Core\Checkout\Order\Aggregate\OrderLineItemDownload;
 
-use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\Order\Aggregate\OrderLineItemDownload\OrderLineItemDownloadCollection;
 use Shopware\Core\Checkout\Order\Aggregate\OrderLineItemDownload\OrderLineItemDownloadEntity;
@@ -13,7 +13,7 @@ use Shopware\Core\Framework\Uuid\Uuid;
  * @internal
  */
 #[Package('checkout')]
-#[CoversClass(OrderLineItemDownloadCollection::class)]
+#[CoversNothing]
 class OrderLineItemDownloadCollectionTest extends TestCase
 {
     public function testFilterByOrderLineItemId(): void

--- a/tests/unit/Core/Checkout/Payment/Cart/PaymentTransactionStructTest.php
+++ b/tests/unit/Core/Checkout/Payment/Cart/PaymentTransactionStructTest.php
@@ -2,7 +2,7 @@
 
 namespace Shopware\Tests\Unit\Core\Checkout\Payment\Cart;
 
-use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\Payment\Cart\PaymentTransactionStruct;
 use Shopware\Core\Checkout\Payment\Cart\Recurring\RecurringDataStruct;
@@ -12,7 +12,7 @@ use Shopware\Core\Framework\Log\Package;
  * @internal
  */
 #[Package('checkout')]
-#[CoversClass(PaymentTransactionStruct::class)]
+#[CoversNothing]
 class PaymentTransactionStructTest extends TestCase
 {
     public function testGetters(): void

--- a/tests/unit/Core/Checkout/Payment/Cart/Recurring/RecurringDataStructTest.php
+++ b/tests/unit/Core/Checkout/Payment/Cart/Recurring/RecurringDataStructTest.php
@@ -2,7 +2,7 @@
 
 namespace Shopware\Tests\Unit\Core\Checkout\Payment\Cart\Recurring;
 
-use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\Payment\Cart\Recurring\RecurringDataStruct;
 use Shopware\Core\Framework\Log\Package;
@@ -14,7 +14,7 @@ use Shopware\Core\Test\Annotation\DisabledFeatures;
  * @deprecated tag:v6.8.0 - Will be removed
  */
 #[Package('checkout')]
-#[CoversClass(RecurringDataStruct::class)]
+#[CoversNothing]
 class RecurringDataStructTest extends TestCase
 {
     #[DisabledFeatures(['v6.8.0.0'])]

--- a/tests/unit/Core/Checkout/Payment/Cart/RefundPaymentTransactionStructTest.php
+++ b/tests/unit/Core/Checkout/Payment/Cart/RefundPaymentTransactionStructTest.php
@@ -2,7 +2,7 @@
 
 namespace Shopware\Tests\Unit\Core\Checkout\Payment\Cart;
 
-use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\Payment\Cart\RefundPaymentTransactionStruct;
 use Shopware\Core\Framework\Log\Package;
@@ -11,7 +11,7 @@ use Shopware\Core\Framework\Log\Package;
  * @internal
  */
 #[Package('checkout')]
-#[CoversClass(RefundPaymentTransactionStruct::class)]
+#[CoversNothing]
 class RefundPaymentTransactionStructTest extends TestCase
 {
     public function testGetters(): void

--- a/tests/unit/Core/Checkout/Payment/Event/FinalizePaymentOrderTransactionCriteriaEventTest.php
+++ b/tests/unit/Core/Checkout/Payment/Event/FinalizePaymentOrderTransactionCriteriaEventTest.php
@@ -2,7 +2,7 @@
 
 namespace Shopware\Tests\Unit\Core\Checkout\Payment\Event;
 
-use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\Payment\Event\FinalizePaymentOrderTransactionCriteriaEvent;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
@@ -14,7 +14,7 @@ use Shopware\Core\Test\Generator;
  * @internal
  */
 #[Package('checkout')]
-#[CoversClass(FinalizePaymentOrderTransactionCriteriaEvent::class)]
+#[CoversNothing]
 class FinalizePaymentOrderTransactionCriteriaEventTest extends TestCase
 {
     public function testEvent(): void

--- a/tests/unit/Core/Checkout/Payment/Event/PayPaymentOrderCriteriaEventTest.php
+++ b/tests/unit/Core/Checkout/Payment/Event/PayPaymentOrderCriteriaEventTest.php
@@ -2,7 +2,7 @@
 
 namespace Shopware\Tests\Unit\Core\Checkout\Payment\Event;
 
-use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\Payment\Event\PayPaymentOrderCriteriaEvent;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
@@ -14,7 +14,7 @@ use Shopware\Core\Test\Generator;
  * @internal
  */
 #[Package('checkout')]
-#[CoversClass(PayPaymentOrderCriteriaEvent::class)]
+#[CoversNothing]
 class PayPaymentOrderCriteriaEventTest extends TestCase
 {
     public function testEvent(): void


### PR DESCRIPTION
### 1. Why is this change necessary?

Part of #18344, near-term slice for the Checkout domain. `phpunit.xml.dist` excludes `*Event.php`, `*Struct.php`, `*Collection.php`, `*Definition.php`, `*Entity.php` under `src/Core/Checkout` from the coverage source, because those are boilerplate DTOs. Under PHPUnit 12 a test that declares `#[CoversClass]` on an excluded class emits `... is not a valid target for code coverage`. These 18 classes are genuinely logic-free (verified: no control flow, ternary, match, or array computation), so keeping them out of the coverage source is the intended policy; the tests just should not claim to cover them. This has no coverage-score impact.

### 2. What does this change do, exactly?

- Converts `#[CoversClass(...)]` to `#[CoversNothing]` in the 18 Checkout DTO tests whose target is a suffix-excluded, no-logic class (cart/customer/payment events, structs, collections, definitions, and two aggregate entities). The tests keep exercising the DTO contract; they simply no longer attribute coverage to a class that is deliberately excluded.

This is distinct from #19216: there the excluded classes had real logic and dedicated tests, so the exclude was narrowed to count their coverage. Here the classes are boilerplate, so they stay excluded and the covers attribute is dropped.

### 3. Describe each step to reproduce the issue or behaviour.

1. Run the unit suite under PHPUnit 12 (the preview arm).
2. Before: each `#[CoversClass]` on a Checkout DTO emits a `not a valid target for code coverage` warning.
3. After: none; those tests declare `#[CoversNothing]`, which has no target.

### 4. Please link to the relevant issues (if any).

- relates #18344

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
