### PR TITLE
docs: throwaway test for the release-info section gate

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -534,6 +534,10 @@ Other environments are unrestricted, so local setups and tests can still point a
 
 ## Critical Fixes
 
+### Throwaway entry to test the release-info section gate
+
+This entry is deliberately misfiled in an already-shipped section to prove the `release-info/section` status turns red. This PR is never merged.
+
 ### Store API requests no longer start PHP sessions
 
 Store API requests now remain stateless unless application or extension code explicitly starts a session. Previously, several sales channel and Storefront event subscribers could initialize Symfony's lazy session factory during Store API requests, causing unnecessary session storage growth and potentially taking PHP session locks. Storefront session handling, including customer imitation, remains unchanged.


### PR DESCRIPTION
### 1. Why is this change necessary?

Throwaway PR to verify #19198 on a real run. **Never merge.**

### 2. What does this change do, exactly?

Adds a RELEASE_INFO entry deliberately misfiled in the shipped `6.7.13.0` section, so the `release-info/section` status must turn red once the labeler applies `milestone/6.7.14.0`.

### 3. Describe each step to reproduce the issue or behaviour.

1. Wait for the `release-info/section` status → expected: failure.
2. Add `skip-release-info-check` (or fix the section/label) → expected: status flips to success without a push.

### 4. Please link to the relevant issues (if any).

- relates #19198

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them