### PR TITLE
fix: ux gallery nav arrows and 3d object click

### DIFF
--- a/src/Storefront/Resources/app/storefront/src/main.js
+++ b/src/Storefront/Resources/app/storefront/src/main.js
@@ -113,6 +113,10 @@ PluginManager.register('AlertAria', AlertAriaPlugin, '[data-alert-aria]'); // Pl
 /**
  * @experimental stableVersion:v6.8.0 feature:SPATIAL_BASES
  */
+PluginManager.register('SpatialBaseViewer', () => import('src/plugin/spatial/spatial-base-viewer.plugin'), '[data-spatial-base-viewer]');
+/**
+ * @experimental stableVersion:v6.8.0 feature:SPATIAL_BASES
+ */
 PluginManager.register('SpatialGallerySliderViewer', () => import('src/plugin/spatial/spatial-gallery-slider-viewer.plugin'), '[data-spatial-gallery-slider-viewer]');
 /**
  * @experimental stableVersion:v6.8.0 feature:SPATIAL_BASES

--- a/src/Storefront/Resources/views/components/Sw/Button/Button.stories.json
+++ b/src/Storefront/Resources/views/components/Sw/Button/Button.stories.json
@@ -4,22 +4,38 @@
         "server": {
             "id": "Sw:Button"
         },
-        "template": "<twig:Sw:Button text=\"Click me!\" variant=\"primary\" icon=\"cart\" />"
+        "template": "<twig:Sw:Button text=\"Click me!\" variant=\"primary\" />"
     },
     "argTypes": {
         "text": { "control": "text" },
         "variant": {
-          "control": "select",
-          "options": ["primary", "secondary"]
+            "control": "select",
+            "options": ["primary", "secondary", "light", "dark", "danger", "warning", "success", "info", "buy", "link", "inline", "filter"]
+        },
+        "iconOnly": { "control": "boolean" },
+        "outline": { "control": "boolean" },
+        "size": {
+            "control": "select",
+            "options": ["sm", "lg"]
         }
-      },
+    },
     "stories": [
         {
             "name": "Button",
             "args": {
                 "text": "Click me!",
                 "variant": "primary",
-                "icon": ""
+                "iconOnly": false
+            }
+        },
+        {
+            "name": "Icon only",
+            "parameters": {
+                "template": "<twig:Sw:Button variant=\"light\" :iconOnly=\"true\" aria-label=\"Previous\"><twig:Sw:Icon name=\"arrow-head-left\" size=\"sm\" /></twig:Sw:Button>"
+            },
+            "args": {
+                "variant": "light",
+                "iconOnly": true
             }
         }
     ]

--- a/src/Storefront/Resources/views/components/Sw/Button/index.html.twig
+++ b/src/Storefront/Resources/views/components/Sw/Button/index.html.twig
@@ -1,5 +1,5 @@
 {% props
-    icon = null,
+    iconOnly = false,
     variant = 'primary',
     outline = false,
     size = null,
@@ -18,6 +18,9 @@
         size: {
             sm: 'btn-sm',
             lg: 'btn-lg',
+        },
+        iconOnly: {
+            true: 'btn-icon',
         },
     },
     compoundVariants: [{
@@ -87,6 +90,11 @@
     }],
 }) %}
 
-<button {{ attributes.defaults({ class: buttonCVA.apply({ variant, outline, size }) }) }}>
+{% set attributeDefaults = {
+    class: buttonCVA.apply({ variant, outline, size, iconOnly }),
+    type: 'button',
+} %}
+
+<button {{ attributes.defaults(attributeDefaults) }}>
     {% block content %}{{ text }}{% endblock %}
 </button>

--- a/src/Storefront/Resources/views/components/Sw/Button/index.scss
+++ b/src/Storefront/Resources/views/components/Sw/Button/index.scss
@@ -1,8 +1,31 @@
 .sw-button {
     --bs-btn-disabled-color: var(--btn-link-disabled-color);
-    --bs-btn-focus-box-shadow: 0 0 0 0.125rem var(--bs-white), 0 0 0 var(--bs-focus-ring-width) var(--bs-focus-ring-color);
+    --bs-btn-focus-box-shadow:
+        0 0 0 0.125rem var(--bs-white), 0 0 0 var(--bs-focus-ring-width) var(--bs-focus-ring-color);
     overflow: hidden;
     text-overflow: ellipsis;
+}
+
+/**
+ * Square icon-only button via the `iconOnly` prop (`btn-icon` class).
+ * Override `--sw-btn-icon-size` when a different footprint is needed.
+ */
+.btn-icon {
+    --bs-btn-padding-x: 0;
+    --bs-btn-padding-y: 0;
+    --sw-btn-icon-size: 2.5rem;
+
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: var(--sw-btn-icon-size);
+    height: var(--sw-btn-icon-size);
+    line-height: 1;
+}
+
+.btn-icon .sw-icon > svg,
+.btn-icon .icon > svg {
+    top: 0;
 }
 
 .btn-buy {

--- a/src/Storefront/Resources/views/components/Sw/Media/Gallery.html.twig
+++ b/src/Storefront/Resources/views/components/Sw/Media/Gallery.html.twig
@@ -21,6 +21,7 @@
     maxHeight = null,
     thumbnailSize = 70,
     thumbnailNavigationPosition = 'left',
+    thumbnailNavShowsMediaOnHover = true,
     showNavigationArrows = true,
     showMagnifier = true,
     useSchemaMarkup = false,
@@ -58,6 +59,7 @@
     showNavigationArrows,
     showFullScreenGallery,
     isLightbox,
+    thumbnailNavShowsMediaOnHover,
     counterDeviderLabel: 'component.cms.mediaGallery.counterDeviderLabel'|trans|striptags,
 } %}
 
@@ -113,21 +115,23 @@
         </div>
 
         {% if showNavigationArrows and not singleMedia %}
-            <button
-                type="button"
-                class="sw-media-gallery__nav-button is--backward btn btn-light"
+            <twig:Sw:Button
+                class="sw-media-gallery__nav-button is--backward"
+                variant="light"
+                :iconOnly="true"
                 aria-label="{{ 'component.cms.mediaGallery.previousMedia'|trans|striptags }}"
             >
                 <twig:Sw:Icon name="arrow-head-left" size="sm" />
-            </button>
+            </twig:Sw:Button>
 
-            <button
-                type="button"
-                class="sw-media-gallery__nav-button is--forward btn btn-light"
+            <twig:Sw:Button
+                class="sw-media-gallery__nav-button is--forward"
+                variant="light"
+                :iconOnly="true"
                 aria-label="{{ 'component.cms.mediaGallery.nextMedia'|trans|striptags }}"
             >
                 <twig:Sw:Icon name="arrow-head-right" size="sm" />
-            </button>
+            </twig:Sw:Button>
         {% endif %}
 
         {% if not singleMedia %}

--- a/src/Storefront/Resources/views/components/Sw/Media/Gallery.js
+++ b/src/Storefront/Resources/views/components/Sw/Media/Gallery.js
@@ -296,26 +296,48 @@ export default class MediaGallery extends ShopwareComponent {
         }
 
         this.thumbnailNavInner.addEventListener('scroll', this.updateThumbnailNavScrollArrows.bind(this));
-        this.thumbnailNavScrollFordwardBtn.addEventListener('click', this.scrollForwardThumbnailNav.bind(this));
-        this.thumbnailNavScrollBackBtn.addEventListener('click', this.scrollBackwardThumbnailNav.bind(this));
+        this.thumbnailNavScrollFordwardBtn.addEventListener('click', this.scrollThumbnailNavForward.bind(this));
+        this.thumbnailNavScrollBackBtn.addEventListener('click', this.scrollThumbnailNavBackward.bind(this));
 
         this.updateThumbnailNavScrollArrows();
     }
 
-    scrollForwardThumbnailNav() {
-        this.thumbnailNavInner.scrollBy({ top: this.thumbnailNavInner.clientHeight / 2, behavior: 'smooth' });
+    isThumbnailNavHorizontal() {
+        return this.options.thumbnailNavigationPosition === 'bottom';
     }
 
-    scrollBackwardThumbnailNav() {
-        this.thumbnailNavInner.scrollBy({ top: -(this.thumbnailNavInner.clientHeight / 2), behavior: 'smooth' });
+    getThumbnailNavScrollDistance() {
+        if (this.isThumbnailNavHorizontal()) {
+            return this.thumbnailNavInner.clientWidth / 2;
+        }
+
+        return this.thumbnailNavInner.clientHeight / 2;
+    }
+
+    scrollThumbnailNavForward() {
+        this.scrollThumbnailNavBy(this.getThumbnailNavScrollDistance());
+    }
+
+    scrollThumbnailNavBackward() {
+        this.scrollThumbnailNavBy(-this.getThumbnailNavScrollDistance());
+    }
+
+    scrollThumbnailNavBy(amount) {
+        this.thumbnailNavInner.scrollBy({
+            left: this.isThumbnailNavHorizontal() ? amount : 0,
+            top: this.isThumbnailNavHorizontal() ? 0 : amount,
+            behavior: 'smooth',
+        });
     }
 
     updateThumbnailNavScrollArrows() {
-        const canScrollUp = this.thumbnailNavInner.scrollTop > 0;
-        const canScrollDown = this.thumbnailNavInner.scrollTop + this.thumbnailNavInner.clientHeight < this.thumbnailNavInner.scrollHeight - 1;
+        const isHorizontal = this.isThumbnailNavHorizontal();
+        const scrollPos = isHorizontal ? this.thumbnailNavInner.scrollLeft : this.thumbnailNavInner.scrollTop;
+        const clientSize = isHorizontal ? this.thumbnailNavInner.clientWidth : this.thumbnailNavInner.clientHeight;
+        const scrollSize = isHorizontal ? this.thumbnailNavInner.scrollWidth : this.thumbnailNavInner.scrollHeight;
 
-        this.thumbnailNavScrollBackBtn.toggleAttribute('hidden', !canScrollUp);
-        this.thumbnailNavScrollFordwardBtn.toggleAttribute('hidden', !canScrollDown);
+        this.thumbnailNavScrollBackBtn.toggleAttribute('hidden', scrollPos <= 0);
+        this.thumbnailNavScrollFordwardBtn.toggleAttribute('hidden', scrollPos + clientSize >= scrollSize - 1);
     }
 
     destroy() {

--- a/src/Storefront/Resources/views/components/Sw/Media/Gallery.scss
+++ b/src/Storefront/Resources/views/components/Sw/Media/Gallery.scss
@@ -24,10 +24,10 @@
     .sw-media-gallery__thumbnail-nav {
         order: 2;
     }
+}
 
-    .sw-media-gallery__previews-wrapper {
-        min-height: 0;
-    }
+.sw-media-gallery__previews-wrapper {
+    min-height: 0;
 }
 
 .sw-media-gallery--display-mode-fixed-height {
@@ -79,10 +79,6 @@
 
     position: absolute;
     z-index: 1;
-    width: 40px;
-    height: 40px;
-    padding: 0;
-    line-height: 1;
     top: 50%;
     transform: translateY(-50%);
 
@@ -93,6 +89,11 @@
     &.is--forward {
         right: 0;
     }
+}
+
+/* Higher specificity than `.btn-icon` so desktop hide wins over icon-button display */
+.sw-media-gallery__nav-button.sw-button {
+    display: none;
 }
 
 .sw-media-gallery__preview-item-badge {
@@ -114,10 +115,6 @@
     }
 }
 
-.sw-media-gallery__nav-button {
-    display: none;
-}
-
 @include media-breakpoint-down(md) {
     .sw-media-gallery__thumbnail-nav {
         display: none;
@@ -127,8 +124,8 @@
         grid-template-columns: 100%;
     }
 
-    .sw-media-gallery__nav-button {
-        display: block;
+    .sw-media-gallery__nav-button.sw-button {
+        display: inline-flex;
     }
 }
 

--- a/src/Storefront/Resources/views/components/Sw/Media/GalleryLightbox.html.twig
+++ b/src/Storefront/Resources/views/components/Sw/Media/GalleryLightbox.html.twig
@@ -29,13 +29,15 @@
             {{ 'component.cms.mediaGallery.lightboxTitle'|trans|striptags }}
         </h2>
 
-        <button
-            type="button"
-            class="sw-media-gallery-lightbox__close-btn btn btn-light"
+        <twig:Sw:Button
+            class="sw-media-gallery-lightbox__close-btn"
+            variant="light"
+            :iconOnly="true"
             data-bs-dismiss="modal"
-            aria-label="{{ 'global.default.close'|trans|striptags }}">
+            aria-label="{{ 'global.default.close'|trans|striptags }}"
+        >
             <twig:Sw:Icon name="x" size="sm" />
-        </button>
+        </twig:Sw:Button>
 
         <div class="sw-media-gallery-lightbox__content">
             <twig:Sw:Media:Gallery

--- a/src/Storefront/Resources/views/components/Sw/Media/GalleryLightbox.scss
+++ b/src/Storefront/Resources/views/components/Sw/Media/GalleryLightbox.scss
@@ -61,10 +61,7 @@
 .sw-media-gallery-lightbox__close-btn {
     --bs-btn-border-color: var(--bs-gray-300);
     position: absolute;
-    padding: 0;
     top: var(--sw-media-gallery-lightbox-padding);
     right: var(--sw-media-gallery-lightbox-padding);
-    width: 40px;
-    height: 40px;
     z-index: 1;
 }

--- a/src/Storefront/Resources/views/components/Sw/Media/Spatial.js
+++ b/src/Storefront/Resources/views/components/Sw/Media/Spatial.js
@@ -1,8 +1,18 @@
 export default class MediaSpatial extends ShopwareComponent {
+    static options = {
+        dragClickThreshold: 10,
+    };
+
     init() {
         this.spatialBaseViewerInstance = null;
         this.canvasElement = this.el.querySelector('[data-spatial-base-viewer]');
         this.loaderElement = this.el.querySelector('.sw-media-spatial__loader');
+
+        this.pointerDown = false;
+        this.pixelsMoved = 0;
+        this.lightboxTrigger = this.el.closest('[data-bs-toggle="modal"]');
+
+        this.initSuppressClickAfterDrag();
 
         this.initializeObserver({
             childList: true,
@@ -39,9 +49,62 @@ export default class MediaSpatial extends ShopwareComponent {
         this.observer.observe(this.el);
     }
 
+    /**
+     * Dragging the 3D model ends with a click that would open the lightbox
+     * (data-bs-toggle="modal"). Bootstrap listens for that click on document in the
+     * capture phase, so stopPropagation on the canvas is too late. Instead, briefly
+     * remove the toggle attribute after a drag so the unintended click is ignored.
+     */
+    initSuppressClickAfterDrag() {
+        if (!this.canvasElement || !this.lightboxTrigger) {
+            return;
+        }
+
+        this.onPointerDown = () => {
+            this.pointerDown = true;
+            this.pixelsMoved = 0;
+        };
+
+        this.onPointerMove = () => {
+            if (this.pointerDown) {
+                this.pixelsMoved += 1;
+            }
+        };
+
+        this.onPointerUp = () => {
+            this.pointerDown = false;
+
+            if (this.pixelsMoved <= this.options.dragClickThreshold) {
+                return;
+            }
+
+            this.lightboxTrigger.removeAttribute('data-bs-toggle');
+
+            setTimeout(() => {
+                this.lightboxTrigger.setAttribute('data-bs-toggle', 'modal');
+                this.pixelsMoved = 0;
+            }, 0);
+        };
+
+        this.canvasElement.addEventListener('pointerdown', this.onPointerDown);
+        this.canvasElement.addEventListener('pointermove', this.onPointerMove);
+        this.canvasElement.addEventListener('pointerup', this.onPointerUp);
+    }
+
     destroy() {
         if (this.observer) {
             this.observer.disconnect();
+        }
+
+        if (this.canvasElement) {
+            this.canvasElement.removeEventListener('pointerdown', this.onPointerDown);
+            this.canvasElement.removeEventListener('pointermove', this.onPointerMove);
+            this.canvasElement.removeEventListener('pointerup', this.onPointerUp);
+        }
+
+        // Ensure the trigger is restored if the component is destroyed mid-drag
+        if (this.lightboxTrigger && !this.lightboxTrigger.hasAttribute('data-bs-toggle')) {
+            this.lightboxTrigger.setAttribute('data-bs-toggle', 'modal');
         }
     }
 }

--- a/src/Storefront/Resources/views/components/Sw/Media/ThumbnailNav.html.twig
+++ b/src/Storefront/Resources/views/components/Sw/Media/ThumbnailNav.html.twig
@@ -27,17 +27,15 @@
 {% set scrollBackwardText = isHorizontal ? 'component.cms.mediaGallery.thumbnailNavScrollLeft'|trans : 'component.cms.mediaGallery.thumbnailNavScrollUp'|trans %}
 
 <div {{ attributes.defaults(defaultAttributes) }}>
-    <button
-        type="button" 
-        class="sw-thumbnail-nav__scroll-control is--backward btn btn-light"
+    <twig:Sw:Button
+        class="sw-thumbnail-nav__scroll-control is--backward"
+        variant="light"
+        :iconOnly="true"
         aria-label="{{ scrollBackwardText|striptags }}"
         hidden="hidden"
     >
-        <twig:Sw:Icon 
-            :name="scrollBackwardIcon" 
-            size="sm" 
-        />
-    </button>
+        <twig:Sw:Icon :name="scrollBackwardIcon" size="sm" />
+    </twig:Sw:Button>
     <nav
         class="sw-thumbnail-nav__inner" 
         aria-label="{{ 'component.cms.mediaGallery.thumbnailNavAriaLabel'|trans|striptags }}"
@@ -61,15 +59,13 @@
             </button>
         {% endfor %}
     </nav>
-    <button
-        type="button" 
-        class="sw-thumbnail-nav__scroll-control is--forward btn btn-light"
+    <twig:Sw:Button
+        class="sw-thumbnail-nav__scroll-control is--forward"
+        variant="light"
+        :iconOnly="true"
         aria-label="{{ scrollForwardText|striptags }}"
         hidden="hidden"
     >
-        <twig:Sw:Icon 
-            :name="scrollForwardIcon" 
-            size="sm" 
-        />
-    </button>
+        <twig:Sw:Icon :name="scrollForwardIcon" size="sm" />
+    </twig:Sw:Button>
 </div>

--- a/src/Storefront/Resources/views/components/Sw/Media/ThumbnailNav.scss
+++ b/src/Storefront/Resources/views/components/Sw/Media/ThumbnailNav.scss
@@ -49,20 +49,18 @@
     }
 
     &:focus-visible {
-        outline: var(--sw-thumbnail-nav-thumbnail-border-width) solid var(--sw-thumbnail-nav-thumbnail-hover-border-color);
-        outline-offset: calc(var(--sw-thumbnail-nav-thumbnail-border-width) * -2);
+        outline: 0;
+        box-shadow: inset 0 0 0 var(--sw-thumbnail-nav-thumbnail-border-width) var(--sw-thumbnail-nav-thumbnail-hover-border-color);
         border-color: var(--bs-primary-border-subtle);
     }
 }
 
 .sw-thumbnail-nav__scroll-control {
     --bs-btn-border-color: var(--bs-gray-300);
+    --sw-btn-icon-size: var(--sw-thumbnail-nav-scroll-control-size);
+
     position: absolute;
     z-index: 1;
-    width: var(--sw-thumbnail-nav-scroll-control-size);
-    height: var(--sw-thumbnail-nav-scroll-control-size);
-    padding: 0;
-    line-height: 1;
     left: 50%;
     transform: translateX(-50%);
 
@@ -80,10 +78,14 @@
  */
 .sw-thumbnail-nav--horizontal {
     width: 100%;
+    height: auto;
+    min-width: 0;
 
     .sw-thumbnail-nav__inner {
         width: 100%;
+        min-width: 0;
         height: auto;
+        inset: auto;
         flex-direction: row;
         overflow-y: hidden;
         overflow-x: auto;
@@ -92,15 +94,16 @@
 
     .sw-thumbnail-nav__scroll-control {
         top: 50%;
+        bottom: auto;
         transform: translateY(-50%);
         left: auto;
-    }
 
-    .sw-thumbnail-nav__scroll-control.is--forward {
-        right: 0;
-    }
+        &.is--forward {
+            right: 0;
+        }
 
-    .sw-thumbnail-nav__scroll-control.is--backward {
-        left: 0;
+        &.is--backward {
+            left: 0;
+        }
     }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?

* Gallery nav controls still used hard-coded buttons
* Dragging 3D object ended in an accidental lightbox open
* Horizontal thumbnail nav scroll direction did not show/hide the nav controls properly

### 2. What does this change do, exactly?

* Adds an iconOnly (btn-icon) variant to Sw:Button and switches gallery / thumbnail / lightbox icon controls to it (icon stays in the default slot).
* Fixes thumbnail nav scroll controls for horizontal layout.
* Prevents 3D model drag from opening the lightbox on click release

### 3. Describe each step to reproduce the issue or behaviour.

* Open a PDP with multiple media and thumbnail nav set to bottom → scroll arrows should move horizontally.
* Resize to mobile → gallery prev/next icon buttons should show and work.
* Open a product with a 3D model → drag to rotate; releasing should not open the lightbox. A plain click still should.

### 4. Please link to the relevant issues (if any).
- closes https://github.com/shopware/shopware/issues/15288