### PR TITLE
ci: honor CommonMark fence closing rules in the release info gate

### DIFF
--- a/.github/bin/js/release-info-sections.test.ts
+++ b/.github/bin/js/release-info-sections.test.ts
@@ -113,6 +113,40 @@ test('a version heading quoted inside a code fence does not open a section', () 
     assert.deepEqual(sections, ['6.7.14.0', '6.7.14.0', '6.7.14.0', '6.7.14.0', '6.7.14.0']);
 });
 
+test('an info-string line cannot close a fence, only a bare one can', () => {
+    // Regression: RELEASE_INFO-6.7.md ships an unclosed ```javascript block whose
+    // next marker is a ```js opener. Toggling on every marker flipped the fence
+    // state for the rest of the file, so #19225's misfiled entry passed as green.
+    const sections = sectionByLine([
+        '# 6.7.14.0 (upcoming)', // 1
+        '```javascript', //         2  opened and never closed by its author
+        'code();', //               3
+        '### heading in code', //   4
+        '```js', //                 5  info string: content, not a closer
+        'more();', //               6
+        '```', //                   7  bare: closes the block from line 2
+        '# 6.7.13.0', //            8
+        'entry', //                 9
+    ].join('\n'));
+
+    assert.equal(sections[3], '6.7.14.0');
+    assert.equal(sections[7], '6.7.13.0');
+    assert.equal(sections[8], '6.7.13.0');
+});
+
+test('a closing fence must be at least as long as the opener and use the same character', () => {
+    const sections = sectionByLine([
+        '# 6.7.14.0 (upcoming)', // 1
+        '````', //                  2
+        '```', //                   3  shorter: content
+        '~~~~', //                  4  wrong character: content
+        '`````', //                 5  longer: closes
+        '# 6.7.13.0', //            6
+    ].join('\n'));
+
+    assert.deepEqual(sections.slice(2, 6), ['6.7.14.0', '6.7.14.0', '6.7.14.0', '6.7.13.0']);
+});
+
 test('a PR that does not touch a RELEASE_INFO file is fine', () => {
     const verdict = evaluate([`${MILESTONE_LABEL_PREFIX}6.7.14.0`], [{ filename: 'src/Core/Framework/Api/README.md', patch: '@@ -1 +1 @@\n+x', headContent: 'x' }]);
 

--- a/.github/bin/js/release-info-sections.ts
+++ b/.github/bin/js/release-info-sections.ts
@@ -28,7 +28,7 @@ const RELEASE_INFO_PATTERN = /^RELEASE_INFO-\d+\.\d+\.md$/;
 const VERSION_HEADING_PATTERN = /^# (\d+\.\d+\.\d+\.\d+)\b/;
 
 /** Fenced code blocks may quote `# ...` lines that must not open a section. */
-const FENCE_PATTERN = /^ {0,3}(?:```|~~~)/;
+const FENCE_PATTERN = /^ {0,3}(`{3,}|~{3,})(.*)$/;
 
 const HUNK_HEADER_PATTERN = /^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@/;
 
@@ -68,12 +68,22 @@ export function addedLineNumbers(patch: string): number[] {
 export function sectionByLine(content: string): (string | null)[] {
     const sections: (string | null)[] = [];
     let current: string | null = null;
-    let inFence = false;
+    let fence: string | null = null;
 
     for (const line of content.split('\n')) {
-        if (FENCE_PATTERN.test(line)) {
-            inFence = !inFence;
-        } else if (!inFence) {
+        const marker = FENCE_PATTERN.exec(line);
+        if (fence !== null) {
+            // CommonMark: only a bare fence of the same character and at least the
+            // opening length closes a block — a ```js line inside it is content.
+            // Toggling on every marker misread the whole file once a fence was
+            // left unclosed, which is exactly when parsing must stay right.
+            if (marker && marker[1][0] === fence[0] && marker[1].length >= fence.length && marker[2].trim() === '') {
+                fence = null;
+            }
+        } else if (marker && !(marker[1][0] === '`' && marker[2].includes('`'))) {
+            // A backtick fence's info string may not contain backticks.
+            fence = marker[1];
+        } else {
             current = VERSION_HEADING_PATTERN.exec(line)?.[1] ?? current;
         }
         sections.push(current);

--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -304,6 +304,9 @@ sw.ui.tabs('sw-order-detail').addTabItem({
     label: 'my-plugin.tabTitle',
     componentSectionId: 'my-plugin-tab',
     visible: order.stateMachineState.technicalName === 'open',
+});
+```
+
 ### Administration caches shared user configuration and lookup data
 
 Administration now reuses a generic cache layer for current-user configuration and frequently loaded lookup data such as the system currency, currencies, taxes, active languages, sales channel types, number range ids, and custom field sets. This reduces repeated Admin API requests when multiple Administration components need the same data.


### PR DESCRIPTION
The `release-info/section` gate misparsed fenced code blocks (an info-string line like ```js is not a closer per CommonMark), so #19225's misfiled entry passed as green — this fixes the fence rules in `sectionByLine` and closes the unterminated code block in RELEASE_INFO-6.7.md.