### PR TITLE
fix(storefront): resolve component SCSS imports without the postinstall symlink

### DIFF
--- a/src/Storefront/Resources/app/storefront/build/vite/build-components.js
+++ b/src/Storefront/Resources/app/storefront/build/vite/build-components.js
@@ -78,6 +78,25 @@ function getNpmInstallCommand(storefrontAppDir, env = process.env) {
     };
 }
 
+/**
+ * SCSS load paths for a component build: the extension's own vendor first, then core Storefront
+ * vendor and scss, then both node_modules directories.
+ *
+ * The node_modules entries matter because a bare specifier such as `bootstrap/scss/functions`
+ * otherwise resolves only through the `views/components/node_modules` symlink, which exists solely
+ * after the storefront's postinstall hook has run. Load paths are what sass supports for this, so
+ * the build must not depend on that symlink.
+ */
+function getScssLoadPaths(storefrontAppDir, coreStorefrontAppDir) {
+    return [
+        path.join(storefrontAppDir, 'vendor'),
+        path.join(coreStorefrontAppDir, 'vendor'),
+        path.join(coreStorefrontAppDir, 'src/scss'),
+        path.join(storefrontAppDir, 'node_modules'),
+        path.join(coreStorefrontAppDir, 'node_modules'),
+    ];
+}
+
 function shouldInstallNpmDependencies(storefrontAppDir, env = process.env) {
     if (env.FORCE_COMPONENT_DEP_INSTALL === '1') {
         return true;
@@ -338,17 +357,7 @@ async function main() {
         // Core Storefront's app/storefront directory — used as vendor fallback for extensions.
         const coreStorefrontAppDir = path.join(scriptDir, '../..');
 
-        // SCSS load paths: extension's own vendor first, then core Storefront vendor + scss.
-        const scssLoadPaths = [
-            path.join(storefrontAppDir, 'vendor'),
-            path.join(coreStorefrontAppDir, 'vendor'),
-            path.join(coreStorefrontAppDir, 'src/scss'),
-            // Bare specifiers such as `bootstrap/scss/functions` otherwise resolve only through the
-            // views/components/node_modules symlink, which exists solely after the storefront's
-            // postinstall hook has run.
-            path.join(storefrontAppDir, 'node_modules'),
-            path.join(coreStorefrontAppDir, 'node_modules'),
-        ];
+        const scssLoadPaths = getScssLoadPaths(storefrontAppDir, coreStorefrontAppDir);
 
         // Build the combined entry map.
         // For extensions the entry name carries the namespace prefix so the
@@ -480,6 +489,7 @@ module.exports = {
     componentMapPlugin,
     extensionNodeModulesPlugin,
     getNpmInstallCommand,
+    getScssLoadPaths,
     main,
     shouldInstallNpmDependencies,
     shouldAllowInstallScripts,

--- a/src/Storefront/Resources/app/storefront/build/vite/build-components.js
+++ b/src/Storefront/Resources/app/storefront/build/vite/build-components.js
@@ -343,6 +343,11 @@ async function main() {
             path.join(storefrontAppDir, 'vendor'),
             path.join(coreStorefrontAppDir, 'vendor'),
             path.join(coreStorefrontAppDir, 'src/scss'),
+            // Bare specifiers such as `bootstrap/scss/functions` otherwise resolve only through the
+            // views/components/node_modules symlink, which exists solely after the storefront's
+            // postinstall hook has run.
+            path.join(storefrontAppDir, 'node_modules'),
+            path.join(coreStorefrontAppDir, 'node_modules'),
         ];
 
         // Build the combined entry map.

--- a/src/Storefront/Resources/app/storefront/build/vite/build-components.test.ts
+++ b/src/Storefront/Resources/app/storefront/build/vite/build-components.test.ts
@@ -34,10 +34,10 @@ describe('build-components scss load paths', () => {
         const loadPaths = getScssLoadPaths(extensionDir, coreDir);
 
         expect(loadPaths.indexOf(path.join(extensionDir, 'vendor'))).toBeLessThan(
-            loadPaths.indexOf(path.join(extensionDir, 'node_modules'))
+            loadPaths.indexOf(path.join(extensionDir, 'node_modules')),
         );
         expect(loadPaths.indexOf(path.join(coreDir, 'vendor'))).toBeLessThan(
-            loadPaths.indexOf(path.join(coreDir, 'node_modules'))
+            loadPaths.indexOf(path.join(coreDir, 'node_modules')),
         );
     });
 });

--- a/src/Storefront/Resources/app/storefront/build/vite/build-components.test.ts
+++ b/src/Storefront/Resources/app/storefront/build/vite/build-components.test.ts
@@ -6,17 +6,41 @@ import { createRequire } from 'node:module';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 const require = createRequire(import.meta.url);
-const { getNpmInstallCommand, shouldAllowInstallScripts, shouldInstallNpmDependencies } = require('./build-components.js') as {
+const { getNpmInstallCommand, getScssLoadPaths, shouldAllowInstallScripts, shouldInstallNpmDependencies } = require('./build-components.js') as {
     getNpmInstallCommand: (
         storefrontAppDir: string,
         env?: Record<string, string | undefined>
     ) => { cmd: string; args: string[]; scriptsAllowed: boolean };
+    getScssLoadPaths: (storefrontAppDir: string, coreStorefrontAppDir: string) => string[];
     shouldAllowInstallScripts: (env?: Record<string, string | undefined>) => boolean;
     shouldInstallNpmDependencies: (
         storefrontAppDir: string,
         env?: Record<string, string | undefined>
     ) => boolean;
 };
+
+describe('build-components scss load paths', () => {
+    const extensionDir = path.join('/ext', 'Resources', 'app', 'storefront');
+    const coreDir = path.join('/core', 'Resources', 'app', 'storefront');
+
+    it('includes both node_modules directories so bare imports do not need the postinstall symlink', () => {
+        const loadPaths = getScssLoadPaths(extensionDir, coreDir);
+
+        expect(loadPaths).toContain(path.join(extensionDir, 'node_modules'));
+        expect(loadPaths).toContain(path.join(coreDir, 'node_modules'));
+    });
+
+    it('keeps vendor ahead of node_modules so a vendored copy still wins', () => {
+        const loadPaths = getScssLoadPaths(extensionDir, coreDir);
+
+        expect(loadPaths.indexOf(path.join(extensionDir, 'vendor'))).toBeLessThan(
+            loadPaths.indexOf(path.join(extensionDir, 'node_modules'))
+        );
+        expect(loadPaths.indexOf(path.join(coreDir, 'vendor'))).toBeLessThan(
+            loadPaths.indexOf(path.join(coreDir, 'node_modules'))
+        );
+    });
+});
 
 describe('build-components npm install policy', () => {
     let fixtureRoot: string;

--- a/src/Storefront/Resources/app/storefront/build/vite/component-config-factory.ts
+++ b/src/Storefront/Resources/app/storefront/build/vite/component-config-factory.ts
@@ -126,6 +126,11 @@ export async function createComponentBuildConfig(options: ComponentBuildConfigOp
         path.join(storefrontAppDir, 'vendor'),
         path.join(coreStorefrontAppDir, 'vendor'),
         path.join(coreStorefrontAppDir, 'src/scss'),
+        // Bare specifiers such as `bootstrap/scss/functions` otherwise resolve only through the
+        // views/components/node_modules symlink, which exists solely after the storefront's
+        // postinstall hook has run.
+        path.join(storefrontAppDir, 'node_modules'),
+        path.join(coreStorefrontAppDir, 'node_modules'),
     ];
 
     const pluginStack: Plugin[] = [

--- a/src/Storefront/Resources/app/storefront/vite.components.config.mts
+++ b/src/Storefront/Resources/app/storefront/vite.components.config.mts
@@ -31,6 +31,10 @@ const projectRoot = process.env.PROJECT_ROOT
 const scssLoadPaths = [
     path.resolve(import.meta.dirname, 'vendor'),
     path.resolve(import.meta.dirname, 'src/scss'),
+    // Bare specifiers such as `bootstrap/scss/functions` otherwise resolve only through the
+    // views/components/node_modules symlink, which exists solely after the storefront's
+    // postinstall hook has run.
+    path.resolve(import.meta.dirname, 'node_modules'),
 ];
 
 const storefrontViteOrigin = process.env.STOREFRONT_VITE_ORIGIN;


### PR DESCRIPTION
### 1. Why is this change necessary?

Four CI jobs on `feat/experience-studio` fail before they run anything — `Jest Storefront`, `Vitest Storefront Components`, `lint` and `storefront-check` all abort inside "Setup Shopware":

```
Build failed with 4 errors:
Error: [sass] Error: Can't find stylesheet to import.
1 │ @import 'bootstrap/scss/functions';
  views/components/Sw/Grid/Container.scss 1:9  root stylesheet
  views/components/Sw/Content/Page.scss   1:9  root stylesheet
```

Component SCSS resolves bare specifiers like `bootstrap/scss/functions` only through the `views/components/node_modules` symlink. That symlink is created by `build/link-component-node-modules.js`, which runs from the storefront's `postinstall` hook — so wherever the hook has not run, every component with a bare SCSS import breaks the build.

The declared SCSS load paths contain `vendor/` and `src/scss/` but not `node_modules`, so sass has no supported way to find the package on its own.

### 2. What does this change do, exactly?

Adds the storefront `node_modules` directories to the SCSS load paths in all three places that declare them:

- `build/vite/build-components.js`
- `build/vite/component-config-factory.ts`
- `vite.components.config.mts`

Load paths are the mechanism sass supports for resolving package imports, so component SCSS no longer depends on a symlink being present. The existing entries keep their precedence — `vendor/` still wins over `node_modules`.

### 3. Describe each step to reproduce the issue or behaviour.

```bash
mv src/Storefront/Resources/views/components/node_modules /tmp/
cd src/Storefront/Resources/app/storefront && npm run build:components
```

Before this change the build exits 1 and reports `Can't find stylesheet to import` for `Sw/Content/Page.scss`, `Sw/Grid/Column.scss`, `Sw/Grid/Container.scss` and `Sw/Media/Gallery.scss`. With the change it exits 0.

Restore the symlink afterwards and the build still succeeds, so the existing resolution path is unaffected.

Moving `app/storefront/vendor/bootstrap` aside instead of the symlink does **not** reproduce the failure, which rules out the `copy-to-vendor` step as the cause.

`composer storefront:components:unit` passes with the change (8 files, 48 tests).

### 4. Please link to the relevant issues (if any).

Blocks #19156

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [x] I have written or adjusted the documentation and agent skills according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
