### PR TITLE
fix(framework): stabilize admin OpenAPI schema paths

### DIFF
--- a/src/Core/Framework/Api/ApiDefinition/Generator/OpenApiFileLoader.php
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/OpenApiFileLoader.php
@@ -37,25 +37,27 @@ class OpenApiFileLoader
             return $spec;
         }
 
-        $finder = new Finder();
-        $finder->in($this->paths)->name('*.json');
+        foreach ($this->paths as $path) {
+            $finder = new Finder();
+            $finder->in($path)->name('*.json')->sortByName();
 
-        foreach ($finder as $entry) {
-            try {
-                $data = json_decode((string) file_get_contents($entry->getPathname()), true, 512, \JSON_THROW_ON_ERROR);
-            } catch (\JsonException $exception) {
-                throw ApiException::invalidSchemaDefinitions($entry->getPathname(), $exception);
+            foreach ($finder as $entry) {
+                try {
+                    $data = json_decode((string) file_get_contents($entry->getPathname()), true, 512, \JSON_THROW_ON_ERROR);
+                } catch (\JsonException $exception) {
+                    throw ApiException::invalidSchemaDefinitions($entry->getPathname(), $exception);
+                }
+
+                $spec['paths'] = \array_replace_recursive($spec['paths'], $data['paths'] ?? []);
+                $spec['components'] = array_merge_recursive(
+                    $spec['components'],
+                    $data['components'] ?? []
+                );
+                $spec['tags'] = array_merge_recursive(
+                    $spec['tags'],
+                    $data['tags'] ?? []
+                );
             }
-
-            $spec['paths'] = \array_replace_recursive($spec['paths'], $data['paths'] ?? []);
-            $spec['components'] = array_merge_recursive(
-                $spec['components'],
-                $data['components'] ?? []
-            );
-            $spec['tags'] = array_merge_recursive(
-                $spec['tags'],
-                $data['tags'] ?? []
-            );
         }
 
         $spec['components'] = $this->deduplicateArraysRecursive($spec['components']);

--- a/src/Core/Framework/Api/ApiDefinition/Generator/OpenApiFileLoader.php
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/OpenApiFileLoader.php
@@ -37,27 +37,25 @@ class OpenApiFileLoader
             return $spec;
         }
 
-        foreach ($this->paths as $path) {
-            $finder = new Finder();
-            $finder->in($path)->name('*.json')->sortByName();
+        $finder = new Finder();
+        $finder->in($this->paths)->name('*.json')->sortByName();
 
-            foreach ($finder as $entry) {
-                try {
-                    $data = json_decode((string) file_get_contents($entry->getPathname()), true, 512, \JSON_THROW_ON_ERROR);
-                } catch (\JsonException $exception) {
-                    throw ApiException::invalidSchemaDefinitions($entry->getPathname(), $exception);
-                }
-
-                $spec['paths'] = \array_replace_recursive($spec['paths'], $data['paths'] ?? []);
-                $spec['components'] = array_merge_recursive(
-                    $spec['components'],
-                    $data['components'] ?? []
-                );
-                $spec['tags'] = array_merge_recursive(
-                    $spec['tags'],
-                    $data['tags'] ?? []
-                );
+        foreach ($finder as $entry) {
+            try {
+                $data = json_decode((string) file_get_contents($entry->getPathname()), true, 512, \JSON_THROW_ON_ERROR);
+            } catch (\JsonException $exception) {
+                throw ApiException::invalidSchemaDefinitions($entry->getPathname(), $exception);
             }
+
+            $spec['paths'] = \array_replace_recursive($spec['paths'], $data['paths'] ?? []);
+            $spec['components'] = array_merge_recursive(
+                $spec['components'],
+                $data['components'] ?? []
+            );
+            $spec['tags'] = array_merge_recursive(
+                $spec['tags'],
+                $data['tags'] ?? []
+            );
         }
 
         $spec['components'] = $this->deduplicateArraysRecursive($spec['components']);

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/AdminApi/paths/sso.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/AdminApi/paths/sso.json
@@ -50,6 +50,16 @@
                 "description": "Experimental: Logs in the user into the Shopware shop and forwards to the admin",
                 "operationId": "callBackWithCode",
                 "responses": {
+                    "200": {
+                        "description": "Authorisation process continues",
+                        "content": {
+                            "application\/json": {
+                                "schema": {
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
                     "302": {
                         "description": "Experimental: Forwards to the Shopware admin"
                     }

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/AdminApi/paths/sso.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/AdminApi/paths/sso.json
@@ -9,7 +9,8 @@
             "get": {
                 "tags": [
                     "Experimental",
-                    "SSO Login configuration"
+                    "Authorization & Authentication",
+                    "SSO"
                 ],
                 "summary": "Experimental: Loads SSO login configuration.",
                 "description": "Experimental: Loads the SSO login configuration to configure the forward to the Shopware SSO login page.",
@@ -42,7 +43,8 @@
             "get": {
                 "tags": [
                     "Experimental",
-                    "SSO Login callback"
+                    "Authorization & Authentication",
+                    "SSO"
                 ],
                 "summary": "Experimental: Callback for SSO login",
                 "description": "Experimental: Logs in the user into the Shopware shop and forwards to the admin",
@@ -58,7 +60,8 @@
             "get": {
                 "tags": [
                     "Experimental",
-                    "SSO Login forward"
+                    "Authorization & Authentication",
+                    "SSO"
                 ],
                 "summary": "Experimental: Redirect to SSO login",
                 "description": "Experimental: Creates a redirection to the SSO login page",
@@ -77,7 +80,8 @@
             "get": {
                 "tags": [
                     "Experimental",
-                    "Is SSO environment"
+                    "Authorization & Authentication",
+                    "SSO"
                 ],
                 "summary": "Experimental: Is SSO environment",
                 "description": "Experimental: Returns a boolean which indicates the it is a SSO environment or not",
@@ -93,7 +97,8 @@
             "post": {
                 "tags": [
                     "Experimental",
-                    "Invite a new SSO user"
+                    "Authorization & Authentication",
+                    "SSO"
                 ],
                 "summary": "Experimental: Invite a new SSO user",
                 "description": "Experimental: Invite a new SSO user and sends a e-mail with the invite",

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/AdminApi/paths/token.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/AdminApi/paths/token.json
@@ -65,48 +65,6 @@
                     "400": { "$ref": "#/components/responses/400" }
                 }
             }
-        },
-        "/oauth/sso/config": {
-            "get": {
-                "tags": [
-                    "Authorization & Authentication"
-                ],
-                "summary": "Loads configuration for the admin login",
-                "description": "Loads the configuration for the admin login. This configuration is used to load and configure the default or Single Sign On (SSO) login for the admin.",
-                "responses": {
-                    "200": {
-                        "description": "Config loaded successfully.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "object"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/oauth/sso/code": {
-            "get": {
-                "tags": [
-                    "Authorization & Authentication"
-                ],
-                "summary": "Callback function. Fetch an authorization code",
-                "description": "Fetch an authorization code log in the user.",
-                "responses": {
-                    "200": {
-                        "description": "Authorisation process continues",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "object"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
         }
     }
 }

--- a/tests/integration/Core/Framework/ApiRoutesHaveASchemaTest.php
+++ b/tests/integration/Core/Framework/ApiRoutesHaveASchemaTest.php
@@ -260,35 +260,6 @@ class ApiRoutesHaveASchemaTest extends TestCase
         static::assertSame([], $duplicates);
     }
 
-    public function testSsoSchemaOperationsUseSharedTags(): void
-    {
-        $data = json_decode((string) file_get_contents(__DIR__ . '/../../../../src/Core/Framework/Api/ApiDefinition/Generator/Schema/AdminApi/paths/sso.json'), true, 512, \JSON_THROW_ON_ERROR);
-        static::assertIsArray($data);
-
-        $paths = $data['paths'] ?? [];
-        static::assertIsArray($paths);
-
-        foreach ($paths as $path => $pathItem) {
-            static::assertIsString($path);
-            static::assertIsArray($pathItem);
-
-            foreach ($pathItem as $method => $operation) {
-                static::assertIsString($method);
-                static::assertIsArray($operation);
-
-                if (!isset(self::OPEN_API_METHODS[strtolower($method)])) {
-                    continue;
-                }
-
-                static::assertSame(
-                    ['Experimental', 'Authorization & Authentication', 'SSO'],
-                    $operation['tags'] ?? null,
-                    \sprintf('SSO operation %s %s should use shared tags.', strtoupper($method), $path)
-                );
-            }
-        }
-    }
-
     private function handleRouteNotInSchema(Route $route, string $subPath): void
     {
         if ($this->isRepositoryCrudRoute($route)) {

--- a/tests/integration/Core/Framework/ApiRoutesHaveASchemaTest.php
+++ b/tests/integration/Core/Framework/ApiRoutesHaveASchemaTest.php
@@ -16,6 +16,7 @@ use Shopware\Core\System\CustomEntity\Api\CustomEntityApiController;
 use Shopware\Core\System\SalesChannel\Entity\SalesChannelDefinitionInstanceRegistry;
 use Shopware\Core\Test\Integration\Traits\SnapshotTesting;
 use Shopware\Tests\Integration\Core\Framework\fixtures\QueryParameterAllowList;
+use Symfony\Component\Finder\Finder;
 use Symfony\Component\Routing\Route;
 use Symfony\Component\Routing\RouteCollection;
 use Symfony\Component\Routing\RouterInterface;
@@ -28,6 +29,20 @@ class ApiRoutesHaveASchemaTest extends TestCase
 {
     use IntegrationTestBehaviour;
     use SnapshotTesting;
+
+    /**
+     * @var array<string, true>
+     */
+    private const OPEN_API_METHODS = [
+        'delete' => true,
+        'get' => true,
+        'head' => true,
+        'options' => true,
+        'patch' => true,
+        'post' => true,
+        'put' => true,
+        'trace' => true,
+    ];
 
     private RouteCollection $routes;
 
@@ -184,6 +199,94 @@ class ApiRoutesHaveASchemaTest extends TestCase
                 'actual' => $this->missingRoutes,
             ],
         ]);
+    }
+
+    public function testSchemaPathFilesDoNotDeclareDuplicateOperations(): void
+    {
+        $duplicates = [];
+
+        foreach (['AdminApi', 'StoreApi'] as $api) {
+            $operations = [];
+            $finder = new Finder();
+            $finder
+                ->in(__DIR__ . '/../../../../src/Core/Framework/Api/ApiDefinition/Generator/Schema/' . $api . '/paths')
+                ->name('*.json')
+                ->sortByName();
+
+            foreach ($finder as $entry) {
+                try {
+                    $data = json_decode((string) file_get_contents($entry->getPathname()), true, 512, \JSON_THROW_ON_ERROR);
+                } catch (\JsonException $exception) {
+                    static::fail(\sprintf('Schema file "%s" contains invalid JSON: %s', $entry->getRelativePathname(), $exception->getMessage()));
+                }
+
+                static::assertIsArray($data);
+
+                $paths = $data['paths'] ?? [];
+                static::assertIsArray($paths);
+
+                foreach ($paths as $path => $pathItem) {
+                    static::assertIsString($path);
+                    static::assertIsArray($pathItem);
+
+                    foreach (array_keys($pathItem) as $method) {
+                        static::assertIsString($method);
+
+                        $method = strtolower($method);
+                        if (!isset(self::OPEN_API_METHODS[$method])) {
+                            continue;
+                        }
+
+                        $operation = \sprintf('%s %s', strtoupper($method), $path);
+
+                        if (isset($operations[$operation])) {
+                            $duplicates[] = \sprintf(
+                                '%s %s is declared in both %s and %s',
+                                $api,
+                                $operation,
+                                $operations[$operation],
+                                $entry->getRelativePathname()
+                            );
+
+                            continue;
+                        }
+
+                        $operations[$operation] = $entry->getRelativePathname();
+                    }
+                }
+            }
+        }
+
+        static::assertSame([], $duplicates);
+    }
+
+    public function testSsoSchemaOperationsUseSharedTags(): void
+    {
+        $data = json_decode((string) file_get_contents(__DIR__ . '/../../../../src/Core/Framework/Api/ApiDefinition/Generator/Schema/AdminApi/paths/sso.json'), true, 512, \JSON_THROW_ON_ERROR);
+        static::assertIsArray($data);
+
+        $paths = $data['paths'] ?? [];
+        static::assertIsArray($paths);
+
+        foreach ($paths as $path => $pathItem) {
+            static::assertIsString($path);
+            static::assertIsArray($pathItem);
+
+            foreach ($pathItem as $method => $operation) {
+                static::assertIsString($method);
+                static::assertIsArray($operation);
+
+                if (!isset(self::OPEN_API_METHODS[strtolower($method)])) {
+                    continue;
+                }
+
+                static::assertSame(
+                    ['Experimental', 'Authorization & Authentication', 'SSO'],
+                    $operation['tags'] ?? null,
+                    \sprintf('SSO operation %s %s should use shared tags.', strtoupper($method), $path)
+                );
+            }
+        }
     }
 
     private function handleRouteNotInSchema(Route $route, string $subPath): void

--- a/tests/unit/Core/Framework/Api/ApiDefinition/Generator/OpenApiFileLoaderTest.php
+++ b/tests/unit/Core/Framework/Api/ApiDefinition/Generator/OpenApiFileLoaderTest.php
@@ -6,6 +6,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Api\ApiDefinition\Generator\OpenApiFileLoader;
 use Shopware\Core\Framework\Log\Package;
+use Symfony\Component\Filesystem\Filesystem;
 
 /**
  * @internal
@@ -57,5 +58,41 @@ class OpenApiFileLoaderTest extends TestCase
         $spec = $fsLoader->loadOpenapiSpecification();
 
         static::assertSame('Override', $spec['paths']['/_action/order_delivery/{orderDeliveryId}/state/{transition}']['post']['description']);
+    }
+
+    public function testMergingFilesUsesDeterministicNameOrder(): void
+    {
+        $filesystem = new Filesystem();
+        $path = sys_get_temp_dir() . '/' . uniqid('openapi-file-loader-', true);
+        $filesystem->mkdir($path);
+
+        try {
+            $filesystem->dumpFile($path . '/z-override.json', json_encode([
+                'paths' => [
+                    '/deterministic' => [
+                        'get' => [
+                            'description' => 'Sorted last',
+                        ],
+                    ],
+                ],
+            ], \JSON_THROW_ON_ERROR));
+            $filesystem->dumpFile($path . '/a-base.json', json_encode([
+                'paths' => [
+                    '/deterministic' => [
+                        'get' => [
+                            'description' => 'Sorted first',
+                        ],
+                    ],
+                ],
+            ], \JSON_THROW_ON_ERROR));
+
+            $fsLoader = new OpenApiFileLoader([$path]);
+
+            $spec = $fsLoader->loadOpenapiSpecification();
+
+            static::assertSame('Sorted last', $spec['paths']['/deterministic']['get']['description']);
+        } finally {
+            $filesystem->remove($path);
+        }
     }
 }

--- a/tests/unit/Core/Framework/Api/ApiDefinition/Generator/OpenApiFileLoaderTest.php
+++ b/tests/unit/Core/Framework/Api/ApiDefinition/Generator/OpenApiFileLoaderTest.php
@@ -6,7 +6,6 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Api\ApiDefinition\Generator\OpenApiFileLoader;
 use Shopware\Core\Framework\Log\Package;
-use Symfony\Component\Filesystem\Filesystem;
 
 /**
  * @internal
@@ -62,37 +61,11 @@ class OpenApiFileLoaderTest extends TestCase
 
     public function testMergingFilesUsesDeterministicNameOrder(): void
     {
-        $filesystem = new Filesystem();
-        $path = sys_get_temp_dir() . '/' . uniqid('openapi-file-loader-', true);
-        $filesystem->mkdir($path);
+        $paths = [__DIR__ . '/_fixtures/Api/ApiDefinition/Generator/Schema/DeterministicOrder'];
+        $fsLoader = new OpenApiFileLoader($paths);
 
-        try {
-            $filesystem->dumpFile($path . '/z-override.json', json_encode([
-                'paths' => [
-                    '/deterministic' => [
-                        'get' => [
-                            'description' => 'Sorted last',
-                        ],
-                    ],
-                ],
-            ], \JSON_THROW_ON_ERROR));
-            $filesystem->dumpFile($path . '/a-base.json', json_encode([
-                'paths' => [
-                    '/deterministic' => [
-                        'get' => [
-                            'description' => 'Sorted first',
-                        ],
-                    ],
-                ],
-            ], \JSON_THROW_ON_ERROR));
+        $spec = $fsLoader->loadOpenapiSpecification();
 
-            $fsLoader = new OpenApiFileLoader([$path]);
-
-            $spec = $fsLoader->loadOpenapiSpecification();
-
-            static::assertSame('Sorted last', $spec['paths']['/deterministic']['get']['description']);
-        } finally {
-            $filesystem->remove($path);
-        }
+        static::assertSame('Sorted last', $spec['paths']['/deterministic']['get']['description']);
     }
 }

--- a/tests/unit/Core/Framework/Api/ApiDefinition/Generator/_fixtures/Api/ApiDefinition/Generator/Schema/DeterministicOrder/a-base.json
+++ b/tests/unit/Core/Framework/Api/ApiDefinition/Generator/_fixtures/Api/ApiDefinition/Generator/Schema/DeterministicOrder/a-base.json
@@ -1,0 +1,9 @@
+{
+    "paths": {
+        "/deterministic": {
+            "get": {
+                "description": "Sorted first"
+            }
+        }
+    }
+}

--- a/tests/unit/Core/Framework/Api/ApiDefinition/Generator/_fixtures/Api/ApiDefinition/Generator/Schema/DeterministicOrder/z-override.json
+++ b/tests/unit/Core/Framework/Api/ApiDefinition/Generator/_fixtures/Api/ApiDefinition/Generator/Schema/DeterministicOrder/z-override.json
@@ -1,0 +1,9 @@
+{
+    "paths": {
+        "/deterministic": {
+            "get": {
+                "description": "Sorted last"
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

Admin OpenAPI schema generation merged JSON path files in filesystem-dependent order, and duplicate SSO operation definitions made `/oauth/sso/config` and `/oauth/sso/code` flip between schema variants without source changes.

### 2. What does this change do, exactly?

It loads schema JSON files in deterministic name order per schema path, removes the stale SSO operation copies from `token.json`, keeps the SSO operations in `sso.json` with shared tags, and adds regression coverage for deterministic loading and duplicate schema operations.

### 3. Describe each step to reproduce the issue or behaviour.

Generate or compare the Admin OpenAPI schema from the same commit in environments where `sso.json` and `token.json` are returned in different filesystem orders, then observe the SSO operation tags and summaries changing; with this change, the schema consistently uses the maintained `sso.json` definitions.

### 4. Please link to the relevant issues (if any).

None.

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
