### PR TITLE
fix(administration): keep shipping price matrix ranges in sync

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-settings-shipping/component/sw-settings-shipping-price-matrix/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-shipping/component/sw-settings-shipping-price-matrix/index.js
@@ -312,17 +312,19 @@ export default {
                 refPrice.quantityEnd = refPrice.quantityStart;
             }
             newShippingPrice.calculation = refPrice.calculation;
-
-            // If the calculation type is "quantity" always increase by one, otherwise use end as start
-            if (this.priceGroup.calculation === 1) {
-                newShippingPrice.quantityStart = refPrice.quantityEnd + 1 > 1 ? refPrice.quantityEnd + 1 : 2;
-            } else {
-                newShippingPrice.quantityStart = refPrice.quantityEnd;
-            }
-
+            newShippingPrice.quantityStart = this.getFollowingQuantityStart(refPrice.quantityEnd);
             newShippingPrice.quantityEnd = null;
 
             this.shippingMethod.prices.push(newShippingPrice);
+        },
+
+        getFollowingQuantityStart(quantityEnd) {
+            // If the calculation type is "quantity" always increase by one, otherwise use end as start
+            if (this.priceGroup.calculation === 1) {
+                return quantityEnd + 1 > 1 ? quantityEnd + 1 : 2;
+            }
+
+            return quantityEnd;
         },
 
         onSaveMainRule(ruleId) {
@@ -491,12 +493,21 @@ export default {
         },
 
         onQuantityEndChange(price) {
-            // when not last price
-            if (this.priceGroup.prices.indexOf(price) + 1 !== this.priceGroup.prices.length) {
+            const priceIndex = this.priceGroup.prices.indexOf(price);
+
+            // when last price, continue the matrix with a new price
+            if (priceIndex + 1 === this.priceGroup.prices.length) {
+                this.onAddNewShippingPrice();
                 return;
             }
 
-            this.onAddNewShippingPrice();
+            if (price.quantityEnd === null || price.quantityEnd === undefined) {
+                return;
+            }
+
+            // The number field of the following price only clamps its displayed value to the new end, it never
+            // writes it back. Move the start along explicitly, otherwise the displayed and the saved value drift.
+            this.priceGroup.prices[priceIndex + 1].quantityStart = this.getFollowingQuantityStart(price.quantityEnd);
         },
 
         updateShowAllPrices() {

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-shipping/component/sw-settings-shipping-price-matrix/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-shipping/component/sw-settings-shipping-price-matrix/index.js
@@ -495,7 +495,6 @@ export default {
         onQuantityEndChange(price) {
             const priceIndex = this.priceGroup.prices.indexOf(price);
 
-            // when last price, continue the matrix with a new price
             if (priceIndex + 1 === this.priceGroup.prices.length) {
                 this.onAddNewShippingPrice();
                 return;
@@ -505,8 +504,6 @@ export default {
                 return;
             }
 
-            // The number field of the following price only clamps its displayed value to the new end, it never
-            // writes it back. Move the start along explicitly, otherwise the displayed and the saved value drift.
             this.priceGroup.prices[priceIndex + 1].quantityStart = this.getFollowingQuantityStart(price.quantityEnd);
         },
 

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-shipping/component/sw-settings-shipping-price-matrix/sw-settings-shipping-price-matrix.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-shipping/component/sw-settings-shipping-price-matrix/sw-settings-shipping-price-matrix.spec.js
@@ -6,7 +6,7 @@ Shopware.State.registerModule('swShippingDetail', state);
 /**
  * @sw-package checkout
  */
-const createWrapper = async () => {
+const createWrapper = async (priceGroupOverride = {}) => {
     return mount(
         await wrapTestComponent('sw-settings-shipping-price-matrix', {
             sync: true,
@@ -75,6 +75,7 @@ const createWrapper = async () => {
                             ],
                         },
                     ],
+                    ...priceGroupOverride,
                 },
             },
         },
@@ -169,6 +170,93 @@ describe('module/sw-settings-shipping/component/sw-settings-shipping-price-matri
         expect(wrapper.vm.showAllPrices).toBeFalsy();
         wrapper.vm.onAddNewShippingPrice();
         expect(wrapper.vm.showAllPrices).toBeTruthy();
+        expect(wrapper.vm.shippingMethod.prices).toHaveLength(length + 1);
+    });
+
+    it.each([
+        [
+            'cart price',
+            2,
+            60,
+        ],
+        [
+            'product quantity',
+            1,
+            61,
+        ],
+    ])('should move the start of the following price when the %s end changes', async (name, calculation, expected) => {
+        const wrapper = await createWrapper({
+            calculation,
+            prices: [
+                {
+                    id: 'priceId1',
+                    quantityStart: 0,
+                    quantityEnd: 40,
+                    calculation,
+                },
+                {
+                    id: 'priceId2',
+                    quantityStart: 40,
+                    quantityEnd: null,
+                    calculation,
+                },
+            ],
+        });
+
+        const [
+            firstPrice,
+            secondPrice,
+        ] = wrapper.vm.priceGroup.prices;
+
+        firstPrice.quantityEnd = 60;
+        wrapper.vm.onQuantityEndChange(firstPrice);
+
+        expect(secondPrice.quantityStart).toBe(expected);
+    });
+
+    it('should not move the start of the following price when its end is emptied', async () => {
+        const wrapper = await createWrapper({
+            calculation: 2,
+            prices: [
+                {
+                    id: 'priceId1',
+                    quantityStart: 0,
+                    quantityEnd: 40,
+                    calculation: 2,
+                },
+                {
+                    id: 'priceId2',
+                    quantityStart: 40,
+                    quantityEnd: null,
+                    calculation: 2,
+                },
+            ],
+        });
+
+        const [
+            firstPrice,
+            secondPrice,
+        ] = wrapper.vm.priceGroup.prices;
+
+        firstPrice.quantityEnd = null;
+        wrapper.vm.onQuantityEndChange(firstPrice);
+
+        expect(secondPrice.quantityStart).toBe(40);
+    });
+
+    it('should add a new price when the end of the last price changes', async () => {
+        const wrapper = await createWrapper();
+
+        if (!wrapper.vm.shippingMethod.hasOwnProperty('prices')) {
+            wrapper.vm.shippingMethod.prices = [];
+        }
+
+        const length = wrapper.vm.shippingMethod.prices.length;
+        const lastPrice = wrapper.vm.priceGroup.prices[wrapper.vm.priceGroup.prices.length - 1];
+
+        lastPrice.quantityEnd = 60;
+        wrapper.vm.onQuantityEndChange(lastPrice);
+
         expect(wrapper.vm.shippingMethod.prices).toHaveLength(length + 1);
     });
 });


### PR DESCRIPTION
### 1. Why is this change necessary?

Changing the end of a price range does not move the start of the following range, so the price matrix shows a range that never gets saved.

### 2. What does this change do, exactly?

`onQuantityEndChange` now writes the new start into the following price, instead of only doing something for the last row.

### 3. Describe each step to reproduce the issue or behaviour.

With two cart price ranges `0-40` and `40-∞`, set the first end to `60`, save and reload: the second row shows `60`, but the database still has `40`.

### 4. Please link to the relevant issues (if any).

closes #18999

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
