### PR TITLE
fix: use dive directly for spatial renderer

### DIFF
--- a/src/Storefront/Resources/app/storefront/src/main.js
+++ b/src/Storefront/Resources/app/storefront/src/main.js
@@ -113,10 +113,6 @@ PluginManager.register('AlertAria', AlertAriaPlugin, '[data-alert-aria]'); // Pl
 /**
  * @experimental stableVersion:v6.8.0 feature:SPATIAL_BASES
  */
-PluginManager.register('SpatialBaseViewer', () => import('src/plugin/spatial/spatial-base-viewer.plugin'), '[data-spatial-base-viewer]');
-/**
- * @experimental stableVersion:v6.8.0 feature:SPATIAL_BASES
- */
 PluginManager.register('SpatialGallerySliderViewer', () => import('src/plugin/spatial/spatial-gallery-slider-viewer.plugin'), '[data-spatial-gallery-slider-viewer]');
 /**
  * @experimental stableVersion:v6.8.0 feature:SPATIAL_BASES

--- a/src/Storefront/Resources/views/components/Sw/Media/Spatial.html.twig
+++ b/src/Storefront/Resources/views/components/Sw/Media/Spatial.html.twig
@@ -12,10 +12,8 @@
     defaultArPlacement = config('core.media.defaultARPlacement'),
 %}
 
-{% set spatialBaseViewerOptions = {
+{% set componentOptions = {
     modelUrl: media.url,
-    lightIntensity: config('core.media.defaultLightIntensity'),
-    sliderPosition: 0,
 } %}
 
 {% set arViewerBaseOptions = {
@@ -64,6 +62,7 @@
 {% if not previewMode %}
     {% set defaultAttributes = defaultAttributes|merge({
         'data-component': 'Sw:Media:Spatial',
+        'data-component-options': componentOptions|json_encode,
     }) %}
 {% endif %}
 
@@ -75,11 +74,7 @@
         />
         <span class="sw-media-spatial__badge badge bg-secondary">3D</span>
     {% else %}
-        <canvas 
-            data-spatial-base-viewer="true" 
-            data-spatial-base-viewer-options='{{ spatialBaseViewerOptions|json_encode }}'
-            class="sw-media-spatial__canvas">
-        </canvas>
+        <canvas class="sw-media-spatial__canvas"></canvas>
 
         {% if media.config.spatial.arReady ?? enableAugmentedReality %}           
            {% set arViewerOptions = arViewerBaseOptions|merge({

--- a/src/Storefront/Resources/views/components/Sw/Media/Spatial.js
+++ b/src/Storefront/Resources/views/components/Sw/Media/Spatial.js
@@ -1,11 +1,14 @@
+import { QuickView } from '@shopware-ag/dive/quickview';
+
 export default class MediaSpatial extends ShopwareComponent {
     static options = {
         dragClickThreshold: 10,
+        modelUrl: null,
     };
 
     init() {
-        this.spatialBaseViewerInstance = null;
-        this.canvasElement = this.el.querySelector('[data-spatial-base-viewer]');
+        this.viewer = null;
+        this.canvasElement = this.el.querySelector('.sw-media-spatial__canvas');
         this.loaderElement = this.el.querySelector('.sw-media-spatial__loader');
 
         this.pointerDown = false;
@@ -14,34 +17,41 @@ export default class MediaSpatial extends ShopwareComponent {
 
         this.initSuppressClickAfterDrag();
 
-        this.initializeObserver({
-            childList: true,
-            attributes: true,
-            subtree: true,
-        });
+        this.initViewer();
     }
 
-    onAttributeUpdate(mutationRecord) {
-        // Wait until SpatialBaseViewer initialized the canvas
-        if (mutationRecord.attributeName === 'data-engine') {
-            this.spatialBaseViewerInstance = window.PluginManager.getPluginInstanceFromElement(this.canvasElement, 'SpatialBaseViewer');
-            this.initVisibilityObserver();
+    /**
+     * Initialize the DIVE QuickView on the canvas. Rendering is not started
+     * automatically, the visibility observer takes care of that.
+     */
+    async initViewer() {
+        if (!this.canvasElement || !this.options.modelUrl) {
+            return;
         }
+
+        this.canvasElement.tabIndex = 0;
+
+        this.viewer = await QuickView(this.options.modelUrl, {
+            autoStart: false,
+            canvas: this.canvasElement,
+        });
+
+        this.initVisibilityObserver();
     }
 
     initVisibilityObserver() {
-        if (!this.spatialBaseViewerInstance) {
+        if (!this.viewer) {
             return;
         }
 
         this.observer = new IntersectionObserver((entries) => {
             entries.forEach((entry) => {
                 if (entry.isIntersecting) {
-                    this.loaderElement.classList.add('d-none');
-                    this.spatialBaseViewerInstance.startRendering();
+                    this.loaderElement?.classList.add('d-none');
+                    this.viewer.start();
                 } else {
-                    this.spatialBaseViewerInstance.stopRendering();
-                    this.loaderElement.classList.remove('d-none');
+                    this.viewer.stop();
+                    this.loaderElement?.classList.remove('d-none');
                 }
             });
         });
@@ -95,6 +105,8 @@ export default class MediaSpatial extends ShopwareComponent {
         if (this.observer) {
             this.observer.disconnect();
         }
+
+        this.viewer?.stop();
 
         if (this.canvasElement) {
             this.canvasElement.removeEventListener('pointerdown', this.onPointerDown);


### PR DESCRIPTION
### 1. Why is this change necessary?

`Sw:Media:Spatial` still partially used the old plugin system to render a 3D object with `SpatialBaseViewer`.

### 2. What does this change do, exactly?

* Remove `SpatialBaseViewer` to be independent from the old PluginSystem.
* Instead, use `@shopware-ag/dive/quickview` directly inside `Spatial.js`.
* Rendering logic remains the same via IntersectionObserver:
   * When in View --> start render
   * When not in view --> stop render

### 3. Describe each step to reproduce the issue or behaviour.

Rendering a 3D object inside `Sw:Media:Gallery` or `Sw:Media` should still work as expected.