### PR TITLE
fix(store-api): remove schema migration allowlist

### DIFF
--- a/.bc-exclude.php
+++ b/.bc-exclude.php
@@ -177,5 +177,10 @@ return [
         // intended to be internal on release
         preg_quote('CHANGED: Shopware\Core\Content\Seo\SeoUrlRoute\EntitySeoUrlRouteInterface was marked "@internal"', '/'),
         preg_quote('CHANGED: Shopware\Core\Content\Seo\SeoUrlRoute\EntityRouteResolver was marked "@internal"', '/'),
+
+        // Store API schema migration allowlist symbols were added on trunk for
+        // an unreleased migration helper and removed again before release.
+        'REMOVED: Constant Shopware\\\\Core\\\\Framework\\\\Api\\\\(?:Context\\\\Exception\\\\InvalidContextSourceException|ApiException)::API_INVALID_STORE_API_SCHEMA_MIGRATION_ALLOWLIST',
+        preg_quote('REMOVED: Method Shopware\Core\Framework\Api\ApiException::invalidStoreApiSchemaMigrationAllowlist() was removed', '/'),
     ],
 ];

--- a/src/Core/Framework/Api/ApiDefinition/Generator/AllStoreApiSchemaMigrationScopeProvider.php
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/AllStoreApiSchemaMigrationScopeProvider.php
@@ -15,15 +15,11 @@ final class AllStoreApiSchemaMigrationScopeProvider implements StoreApiSchemaMig
 
     private readonly string $schemaPath;
 
-    private readonly string $allowlistPath;
-
     public function __construct(
         private readonly BundleSchemaPathCollection $bundleSchemaPathCollection,
         ?string $schemaPath = null,
-        ?string $allowlistPath = null,
     ) {
         $this->schemaPath = $schemaPath ?? __DIR__ . '/Schema/StoreApi';
-        $this->allowlistPath = $allowlistPath ?? __DIR__ . '/StoreApiPhpGeneratedSchemaAllowlist.json';
     }
 
     public function getScope(): string
@@ -42,11 +38,6 @@ final class AllStoreApiSchemaMigrationScopeProvider implements StoreApiSchemaMig
             [$this->schemaPath],
             $this->bundleSchemaPathCollection->getSchemaPaths(DefinitionService::STORE_API, null),
         ));
-    }
-
-    public function getAllowlistPath(): string
-    {
-        return $this->allowlistPath;
     }
 
     public function includesAllDefinitions(): bool

--- a/src/Core/Framework/Api/ApiDefinition/Generator/CoreStoreApiSchemaMigrationScopeProvider.php
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/CoreStoreApiSchemaMigrationScopeProvider.php
@@ -21,14 +21,10 @@ final class CoreStoreApiSchemaMigrationScopeProvider implements StoreApiSchemaMi
 
     private readonly string $schemaPath;
 
-    private readonly string $allowlistPath;
-
     public function __construct(
         ?string $schemaPath = null,
-        ?string $allowlistPath = null,
     ) {
         $this->schemaPath = $schemaPath ?? __DIR__ . '/Schema/StoreApi';
-        $this->allowlistPath = $allowlistPath ?? __DIR__ . '/StoreApiPhpGeneratedSchemaAllowlist.json';
     }
 
     public function getScope(): string
@@ -44,11 +40,6 @@ final class CoreStoreApiSchemaMigrationScopeProvider implements StoreApiSchemaMi
     public function getSchemaPaths(): array
     {
         return [$this->schemaPath];
-    }
-
-    public function getAllowlistPath(): string
-    {
-        return $this->allowlistPath;
     }
 
     public function includesAllDefinitions(): bool

--- a/src/Core/Framework/Api/ApiDefinition/Generator/StoreApiGenerator.php
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/StoreApiGenerator.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Core\Framework\Api\ApiDefinition\Generator;
 
+use OpenApi\Annotations\Components;
 use OpenApi\Annotations\License;
 use OpenApi\Annotations\OpenApi;
 use OpenApi\Annotations\Parameter;
@@ -80,39 +81,27 @@ class StoreApiGenerator implements ApiDefinitionGeneratorInterface
 
         $loader = new OpenApiFileLoader($schemaPaths);
         $jsonSpec = $loader->loadOpenapiSpecification();
-        $jsonSchemaNames = isset($jsonSpec['components']['schemas']) ? array_keys($jsonSpec['components']['schemas']) : [];
-        $referencedJsonSchemaNames = $this->getReferencedJsonSchemaNames($jsonSpec);
-
-        foreach ($definitions as $definition) {
-            if (!$definition instanceof EntityDefinition) {
-                continue;
-            }
-
-            if (!$this->shouldDefinitionBeIncluded($definition)) {
-                continue;
-            }
-
-            $onlyReference = $this->shouldIncludeReferenceOnly($definition, $forSalesChannel);
-
-            if (\in_array($this->definitionSchemaBuilder->getSchemaName($definition), $jsonSchemaNames, true)) {
-                // A matching JSON component owns the base schema; PHP contributes only dynamic extensions.
-                $schema = $this->definitionSchemaBuilder->getExtensionSchemaByDefinition(
-                    $definition,
-                    $this->getResourceUri($definition),
-                    $forSalesChannel,
-                );
-            } else {
-                if (!\in_array($this->definitionSchemaBuilder->getSchemaName($definition), $referencedJsonSchemaNames, true)) {
-                    continue;
+        $jsonSchemaNames = [];
+        if (isset($jsonSpec['components']['schemas']) && \is_array($jsonSpec['components']['schemas'])) {
+            foreach (array_keys($jsonSpec['components']['schemas']) as $schemaName) {
+                if (\is_string($schemaName)) {
+                    $jsonSchemaNames[] = $schemaName;
                 }
+            }
+        }
+        $generatedSchemas = $this->getGeneratedSchemas($definitions, $jsonSchemaNames, $forSalesChannel);
+        $referencedJsonSchemaNames = $this->getReferencedJsonSchemaNames($jsonSpec, $generatedSchemas['componentSchemas']);
 
-                $schema = $this->definitionSchemaBuilder->getSchemaByDefinition(
-                    $definition,
-                    $this->getResourceUri($definition),
-                    $forSalesChannel,
-                    $onlyReference,
-                    DefinitionService::TYPE_JSON_API,
-                );
+        foreach ($generatedSchemas['definitionSchemas'] as $schemaName => $schema) {
+            if (\in_array($schemaName, $jsonSchemaNames, true)) {
+                // A matching JSON component owns the base schema; PHP contributes only dynamic extensions.
+                $openApi->components->merge(array_values($schema));
+
+                continue;
+            }
+
+            if (!array_intersect(array_keys($schema), $referencedJsonSchemaNames)) {
+                continue;
             }
 
             $openApi->components->merge(array_values($schema));
@@ -262,16 +251,82 @@ class StoreApiGenerator implements ApiDefinitionGeneratorInterface
     }
 
     /**
+     * @param array<string, EntityDefinition> $definitions
+     * @param list<string> $jsonSchemaNames
+     *
+     * @return array{
+     *     definitionSchemas: array<string, array<string, mixed>>,
+     *     componentSchemas: array<string, mixed>
+     * }
+     */
+    private function getGeneratedSchemas(array $definitions, array $jsonSchemaNames, bool $forSalesChannel): array
+    {
+        $definitionSchemas = [];
+
+        foreach ($definitions as $definition) {
+            if (!$definition instanceof EntityDefinition) {
+                continue;
+            }
+
+            if (!$this->shouldDefinitionBeIncluded($definition)) {
+                continue;
+            }
+
+            $schemaName = $this->definitionSchemaBuilder->getSchemaName($definition);
+
+            if (\in_array($schemaName, $jsonSchemaNames, true)) {
+                $definitionSchemas[$schemaName] = $this->definitionSchemaBuilder->getExtensionSchemaByDefinition(
+                    $definition,
+                    $this->getResourceUri($definition),
+                    $forSalesChannel,
+                );
+
+                continue;
+            }
+
+            $definitionSchemas[$schemaName] = $this->definitionSchemaBuilder->getSchemaByDefinition(
+                $definition,
+                $this->getResourceUri($definition),
+                $forSalesChannel,
+                $this->shouldIncludeReferenceOnly($definition, $forSalesChannel),
+                DefinitionService::TYPE_JSON_API,
+            );
+        }
+
+        $openApi = new OpenApi([
+            'openapi' => '3.2.0',
+        ]);
+        $openApi->components = new Components([]);
+
+        foreach ($definitionSchemas as $schema) {
+            $openApi->components->merge(array_values($schema));
+        }
+
+        $data = json_decode($openApi->toJson(), true, 512, \JSON_THROW_ON_ERROR);
+        $componentSchemas = $data['components']['schemas'] ?? [];
+        if (!\is_array($componentSchemas)) {
+            $componentSchemas = [];
+        }
+
+        return [
+            'definitionSchemas' => $definitionSchemas,
+            'componentSchemas' => $componentSchemas,
+        ];
+    }
+
+    /**
      * @param array<string, mixed> $jsonSpec
+     * @param array<string, mixed> $generatedComponentSchemas
      *
      * @return list<string>
      */
-    private function getReferencedJsonSchemaNames(array $jsonSpec): array
+    private function getReferencedJsonSchemaNames(array $jsonSpec, array $generatedComponentSchemas): array
     {
         $componentSchemas = $jsonSpec['components']['schemas'] ?? [];
         if (!\is_array($componentSchemas)) {
             $componentSchemas = [];
         }
+        $componentSchemas = array_replace_recursive($componentSchemas, $generatedComponentSchemas);
 
         $referencedSchemaNames = [];
         $queue = [];

--- a/src/Core/Framework/Api/ApiDefinition/Generator/StoreApiPhpGeneratedSchemaAllowlist.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/StoreApiPhpGeneratedSchemaAllowlist.json
@@ -1,3 +1,0 @@
-{
-    "phpGeneratedStoreApiSchemas": []
-}

--- a/src/Core/Framework/Api/ApiDefinition/Generator/StoreApiSchemaMigrationReport.php
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/StoreApiSchemaMigrationReport.php
@@ -13,39 +13,26 @@ final class StoreApiSchemaMigrationReport implements \JsonSerializable
     /**
      * @param list<string> $jsonOverridesPhpGenerated
      * @param list<string> $phpGeneratedOnly
-     * @param list<string> $phpGeneratedOnlyAllowed
-     * @param list<string> $phpGeneratedOnlyWithoutAllowlist
      * @param list<string> $jsonWithoutPhpGenerated
-     * @param list<string> $allowlistWithoutPhpGeneratedOnlySchema
-     * @param list<string> $allowlistWithoutPhpGeneratedSchema
      */
     public function __construct(
         public readonly array $jsonOverridesPhpGenerated,
         public readonly array $phpGeneratedOnly,
-        public readonly array $phpGeneratedOnlyAllowed,
-        public readonly array $phpGeneratedOnlyWithoutAllowlist,
         public readonly array $jsonWithoutPhpGenerated,
-        public readonly array $allowlistWithoutPhpGeneratedOnlySchema,
-        public readonly array $allowlistWithoutPhpGeneratedSchema,
     ) {
     }
 
     public function hasMismatches(): bool
     {
         return $this->jsonOverridesPhpGenerated !== []
-            || $this->phpGeneratedOnlyWithoutAllowlist !== []
-            || $this->allowlistWithoutPhpGeneratedOnlySchema !== [];
+            || $this->phpGeneratedOnly !== [];
     }
 
     /**
      * @return array{
      *     jsonOverridesPhpGenerated: list<string>,
      *     phpGeneratedOnly: list<string>,
-     *     phpGeneratedOnlyAllowed: list<string>,
-     *     phpGeneratedOnlyWithoutAllowlist: list<string>,
-     *     jsonWithoutPhpGenerated: list<string>,
-     *     allowlistWithoutPhpGeneratedOnlySchema: list<string>,
-     *     allowlistWithoutPhpGeneratedSchema: list<string>
+     *     jsonWithoutPhpGenerated: list<string>
      * }
      */
     public function jsonSerialize(): array
@@ -53,11 +40,7 @@ final class StoreApiSchemaMigrationReport implements \JsonSerializable
         return [
             'jsonOverridesPhpGenerated' => $this->jsonOverridesPhpGenerated,
             'phpGeneratedOnly' => $this->phpGeneratedOnly,
-            'phpGeneratedOnlyAllowed' => $this->phpGeneratedOnlyAllowed,
-            'phpGeneratedOnlyWithoutAllowlist' => $this->phpGeneratedOnlyWithoutAllowlist,
             'jsonWithoutPhpGenerated' => $this->jsonWithoutPhpGenerated,
-            'allowlistWithoutPhpGeneratedOnlySchema' => $this->allowlistWithoutPhpGeneratedOnlySchema,
-            'allowlistWithoutPhpGeneratedSchema' => $this->allowlistWithoutPhpGeneratedSchema,
         ];
     }
 }

--- a/src/Core/Framework/Api/ApiDefinition/Generator/StoreApiSchemaMigrationReporter.php
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/StoreApiSchemaMigrationReporter.php
@@ -2,6 +2,8 @@
 
 namespace Shopware\Core\Framework\Api\ApiDefinition\Generator;
 
+use OpenApi\Annotations\Components;
+use OpenApi\Annotations\OpenApi;
 use Shopware\Core\Framework\Api\ApiDefinition\DefinitionService;
 use Shopware\Core\Framework\Api\ApiDefinition\Generator\OpenApi\OpenApiDefinitionSchemaBuilder;
 use Shopware\Core\Framework\Api\ApiException;
@@ -9,15 +11,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
 use Shopware\Core\Framework\DataAbstractionLayer\MappingEntityDefinition;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\Entity\SalesChannelDefinitionInterface;
-use Symfony\Component\Filesystem\Exception\IOExceptionInterface;
-use Symfony\Component\Filesystem\Filesystem;
 
 /**
  * @internal
- *
- * @phpstan-type StoreApiSchemaMigrationAllowlist array{
- *     phpGeneratedStoreApiSchemas: list<string>
- * }
  */
 #[Package('framework')]
 class StoreApiSchemaMigrationReporter
@@ -30,7 +26,6 @@ class StoreApiSchemaMigrationReporter
     public function __construct(
         private readonly OpenApiDefinitionSchemaBuilder $definitionSchemaBuilder,
         private readonly iterable $scopeProviders,
-        private readonly Filesystem $filesystem = new Filesystem(),
     ) {
     }
 
@@ -40,10 +35,11 @@ class StoreApiSchemaMigrationReporter
     public function report(array $definitions, string $scope = CoreStoreApiSchemaMigrationScopeProvider::SCOPE): StoreApiSchemaMigrationReport
     {
         $scopeProvider = $this->getScopeProvider($scope);
-        $jsonSchemaNames = $this->getJsonSchemaNames($scopeProvider->getSchemaPaths());
-        $referencedJsonSchemaNames = $this->getReferencedJsonSchemaNames($scopeProvider->getSchemaPaths());
-        $phpGeneratedSchemaNames = $this->getPhpGeneratedSchemaNames($definitions, $scopeProvider, $jsonSchemaNames, $referencedJsonSchemaNames);
-        $allowlist = $this->loadAllowlist($scopeProvider->getAllowlistPath());
+        $jsonSpec = $this->loadOpenApiSpecification($scopeProvider->getSchemaPaths());
+        $jsonSchemaNames = $this->getJsonSchemaNames($jsonSpec);
+        $generatedSchemas = $this->getGeneratedSchemas($definitions, $scopeProvider, $jsonSchemaNames);
+        $referencedJsonSchemaNames = $this->getReferencedJsonSchemaNames($jsonSpec, $generatedSchemas['componentSchemas']);
+        $phpGeneratedSchemaNames = $this->getPhpGeneratedSchemaNames($generatedSchemas['definitionSchemas'], $jsonSchemaNames, $referencedJsonSchemaNames);
 
         $jsonOverridesPhpGenerated = array_intersect($jsonSchemaNames, $phpGeneratedSchemaNames);
         $phpGeneratedOnly = array_diff($phpGeneratedSchemaNames, $jsonSchemaNames);
@@ -51,11 +47,7 @@ class StoreApiSchemaMigrationReporter
         return new StoreApiSchemaMigrationReport(
             jsonOverridesPhpGenerated: $this->sortList($jsonOverridesPhpGenerated),
             phpGeneratedOnly: $this->sortList($phpGeneratedOnly),
-            phpGeneratedOnlyAllowed: $this->sortList(array_intersect($phpGeneratedOnly, $allowlist['phpGeneratedStoreApiSchemas'])),
-            phpGeneratedOnlyWithoutAllowlist: $this->sortList(array_diff($phpGeneratedOnly, $allowlist['phpGeneratedStoreApiSchemas'])),
             jsonWithoutPhpGenerated: $this->sortList(array_diff($jsonSchemaNames, $phpGeneratedSchemaNames)),
-            allowlistWithoutPhpGeneratedOnlySchema: $this->sortList(array_diff($allowlist['phpGeneratedStoreApiSchemas'], $phpGeneratedOnly)),
-            allowlistWithoutPhpGeneratedSchema: $this->sortList(array_diff($allowlist['phpGeneratedStoreApiSchemas'], $phpGeneratedSchemaNames)),
         );
     }
 
@@ -73,19 +65,49 @@ class StoreApiSchemaMigrationReporter
     }
 
     /**
-     * @param array<string, EntityDefinition> $definitions
+     * @param array<string, array<string, mixed>> $definitionSchemas
      * @param list<string> $jsonSchemaNames
      * @param list<string> $referencedJsonSchemaNames
      *
      * @return list<string>
      */
     private function getPhpGeneratedSchemaNames(
-        array $definitions,
-        StoreApiSchemaMigrationScopeProviderInterface $scopeProvider,
+        array $definitionSchemas,
         array $jsonSchemaNames,
         array $referencedJsonSchemaNames
     ): array {
         $schemaNames = [];
+
+        foreach ($definitionSchemas as $schemaName => $schema) {
+            if (\in_array($schemaName, $jsonSchemaNames, true)) {
+                continue;
+            }
+
+            if (!array_intersect(array_keys($schema), $referencedJsonSchemaNames)) {
+                continue;
+            }
+
+            array_push($schemaNames, ...array_keys($schema));
+        }
+
+        return $this->sortList($schemaNames);
+    }
+
+    /**
+     * @param array<string, EntityDefinition> $definitions
+     * @param list<string> $jsonSchemaNames
+     *
+     * @return array{
+     *     definitionSchemas: array<string, array<string, mixed>>,
+     *     componentSchemas: array<string, mixed>
+     * }
+     */
+    private function getGeneratedSchemas(
+        array $definitions,
+        StoreApiSchemaMigrationScopeProviderInterface $scopeProvider,
+        array $jsonSchemaNames
+    ): array {
+        $definitionSchemas = [];
 
         ksort($definitions);
 
@@ -97,41 +119,58 @@ class StoreApiSchemaMigrationReporter
             $schemaName = $this->definitionSchemaBuilder->getSchemaName($definition);
 
             if (\in_array($schemaName, $jsonSchemaNames, true)) {
+                $definitionSchemas[$schemaName] = $this->definitionSchemaBuilder->getExtensionSchemaByDefinition(
+                    $definition,
+                    $this->getResourceUri($definition),
+                    true,
+                );
+
                 continue;
             }
 
-            if (!\in_array($schemaName, $referencedJsonSchemaNames, true)) {
-                continue;
-            }
-
-            $schema = $this->definitionSchemaBuilder->getSchemaByDefinition(
+            $definitionSchemas[$schemaName] = $this->definitionSchemaBuilder->getSchemaByDefinition(
                 $definition,
                 $this->getResourceUri($definition),
                 true,
                 $this->shouldIncludeReferenceOnly($definition),
                 DefinitionService::TYPE_JSON_API,
             );
-
-            array_push($schemaNames, ...array_keys($schema));
         }
 
-        return $this->sortList($schemaNames);
+        $openApi = new OpenApi([
+            'openapi' => '3.2.0',
+        ]);
+        $openApi->components = new Components([]);
+
+        foreach ($definitionSchemas as $schema) {
+            $openApi->components->merge(array_values($schema));
+        }
+
+        $data = json_decode($openApi->toJson(), true, 512, \JSON_THROW_ON_ERROR);
+        $componentSchemas = $data['components']['schemas'] ?? [];
+        if (!\is_array($componentSchemas)) {
+            $componentSchemas = [];
+        }
+
+        return [
+            'definitionSchemas' => $definitionSchemas,
+            'componentSchemas' => $componentSchemas,
+        ];
     }
 
     /**
-     * @param list<string> $schemaPaths
+     * @param array<string, mixed> $jsonSpec
+     * @param array<string, mixed> $generatedComponentSchemas
      *
      * @return list<string>
      */
-    private function getReferencedJsonSchemaNames(array $schemaPaths): array
+    private function getReferencedJsonSchemaNames(array $jsonSpec, array $generatedComponentSchemas): array
     {
-        $loader = new OpenApiFileLoader($schemaPaths);
-        $jsonSpec = $loader->loadOpenapiSpecification();
-
         $componentSchemas = $jsonSpec['components']['schemas'] ?? [];
         if (!\is_array($componentSchemas)) {
             $componentSchemas = [];
         }
+        $componentSchemas = array_replace_recursive($componentSchemas, $generatedComponentSchemas);
 
         $referencedSchemaNames = [];
         $queue = [];
@@ -172,15 +211,12 @@ class StoreApiSchemaMigrationReporter
     }
 
     /**
-     * @param list<string> $schemaPaths
+     * @param array<string, mixed> $jsonSpec
      *
      * @return list<string>
      */
-    private function getJsonSchemaNames(array $schemaPaths): array
+    private function getJsonSchemaNames(array $jsonSpec): array
     {
-        $loader = new OpenApiFileLoader($schemaPaths);
-        $jsonSpec = $loader->loadOpenapiSpecification();
-
         if (!isset($jsonSpec['components']['schemas'])) {
             return [];
         }
@@ -201,58 +237,15 @@ class StoreApiSchemaMigrationReporter
     }
 
     /**
-     * @return StoreApiSchemaMigrationAllowlist
-     */
-    private function loadAllowlist(string $allowlistPath): array
-    {
-        if (!$this->filesystem->exists($allowlistPath)) {
-            return [
-                'phpGeneratedStoreApiSchemas' => [],
-            ];
-        }
-
-        try {
-            $contents = $this->filesystem->readFile($allowlistPath);
-        } catch (IOExceptionInterface) {
-            throw ApiException::schemaDefinitionNotReadable($allowlistPath);
-        }
-
-        try {
-            $data = json_decode($contents, true, 512, \JSON_THROW_ON_ERROR);
-        } catch (\JsonException $exception) {
-            throw ApiException::invalidStoreApiSchemaMigrationAllowlist($allowlistPath, 'JSON could not be decoded.', $exception);
-        }
-
-        if (!\is_array($data)) {
-            throw ApiException::invalidStoreApiSchemaMigrationAllowlist($allowlistPath, 'The root value must be an object.');
-        }
-
-        return [
-            'phpGeneratedStoreApiSchemas' => $this->readAllowlistSchemaNames($data, 'phpGeneratedStoreApiSchemas', $allowlistPath),
-        ];
-    }
-
-    /**
-     * @param array<string, mixed> $data
+     * @param list<string> $schemaPaths
      *
-     * @return list<string>
+     * @return array<string, mixed>
      */
-    private function readAllowlistSchemaNames(array $data, string $key, string $allowlistPath): array
+    private function loadOpenApiSpecification(array $schemaPaths): array
     {
-        if (!isset($data[$key]) || !\is_array($data[$key])) {
-            throw ApiException::invalidStoreApiSchemaMigrationAllowlist($allowlistPath, \sprintf('The "%s" list is missing.', $key));
-        }
+        $loader = new OpenApiFileLoader($schemaPaths);
 
-        $schemaNames = [];
-        foreach ($data[$key] as $schemaName) {
-            if (!\is_string($schemaName)) {
-                throw ApiException::invalidStoreApiSchemaMigrationAllowlist($allowlistPath, \sprintf('The "%s" list must contain only schema names.', $key));
-            }
-
-            $schemaNames[] = $schemaName;
-        }
-
-        return $this->sortList($schemaNames);
+        return $loader->loadOpenapiSpecification();
     }
 
     private function shouldDefinitionBeIncluded(EntityDefinition $definition, StoreApiSchemaMigrationScopeProviderInterface $scopeProvider): bool

--- a/src/Core/Framework/Api/ApiDefinition/Generator/StoreApiSchemaMigrationScopeProviderInterface.php
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/StoreApiSchemaMigrationScopeProviderInterface.php
@@ -24,7 +24,5 @@ interface StoreApiSchemaMigrationScopeProviderInterface
      */
     public function getSchemaPaths(): array;
 
-    public function getAllowlistPath(): string;
-
     public function includesAllDefinitions(): bool;
 }

--- a/src/Core/Framework/Api/ApiDefinition/README.md
+++ b/src/Core/Framework/Api/ApiDefinition/README.md
@@ -33,27 +33,25 @@ bin/console framework:store-api:schema-migration-report --scope=core --pretty -
 The report returns named lists, not only counts:
 
 - `jsonOverridesPhpGenerated`: should stay empty. When JSON defines a component, the PHP contribution is reduced to `properties.extensions` and is not treated as PHP base-schema generation.
-- `phpGeneratedOnly`: PHP still generates this schema and there is no JSON schema for it yet. Move these schemas to JSON over time.
+- `phpGeneratedOnly`: PHP still generates this schema and there is no JSON schema for it yet. This is Store API schema debt and fails CI when `--fail-on-mismatch` is used.
 - `jsonWithoutPhpGenerated`: JSON base schemas. They may still receive typed `properties.extensions` fields contributed dynamically by PHP entity extensions.
-- `phpGeneratedOnlyWithoutAllowlist`: PHP-only components that are not accepted by the current allowlist and should fail CI when `--fail-on-mismatch` is used.
-- `allowlistWithoutPhpGenerated*`: stale allowlist entries. Remove these entries when the corresponding migration work makes them obsolete.
 
-JSON/PHP base-schema overlap cannot be allowlisted and always fails `--fail-on-mismatch`.
+JSON/PHP base-schema overlap always fails `--fail-on-mismatch`.
 
-The core allowlist lives in `Generator/StoreApiPhpGeneratedSchemaAllowlist.json`. Core has completed the migration, so this allowlist is now empty and must stay empty. Downstream scopes can use the same migration process in small, domain-coherent batches:
+Core has completed the migration, so `phpGeneratedOnly` must stay empty. Downstream scopes can use the same migration process in small, domain-coherent batches:
 
 1. Capture the current generated StoreAPI component as the compatibility baseline.
 2. Add the explicit JSON component schema and verify that the final generated StoreAPI component stays compatible.
-3. Remove the matching flat-schema entry and, when present, its legacy `*JsonApi` entry from `phpGeneratedStoreApiSchemas`. JSON/PHP base-schema overlap is an error; only typed extension fields may still be contributed by PHP.
+3. Re-run the migration report and remove the component from `phpGeneratedOnly`. JSON/PHP base-schema overlap is an error; only typed extension fields may still be contributed by PHP.
 4. Remove schema-only PHP metadata only when it is no longer needed by Admin API schema generation or runtime DAL/API behavior.
 
 Flags such as `ApiAware`, `Required`, `WriteProtected`, and `Runtime` are not schema-only and must remain on the DAL definition. PHP field descriptions, definition version information, and `IgnoreInOpenapiSchema` are also still used by Admin API generation today, so they cannot be removed as part of a StoreAPI-only component migration without preserving the Admin API schema through another source.
 
 The next metadata-cleanup phase should first preserve the corresponding Admin API schema in JSON or another Admin-specific source, then remove PHP descriptions, version information, and OpenAPI-only flags that have no remaining consumer. Keep runtime and DAL flags unchanged.
 
-JSON-owned Store API components use the flat JSON base schema and receive only typed extension fields from PHP. During the migration, definitions without a matching JSON component generate their legacy flat and `*JsonApi` PHP schemas only when the static Store API path schema references the missing component; both are tracked in `phpGeneratedStoreApiSchemas`. Unreferenced PHP definitions are not Store API schema debt and should not be represented by unused JSON components.
+JSON-owned Store API components use the flat JSON base schema and receive only typed extension fields from PHP. During the migration, definitions without a matching JSON component generate their legacy flat and `*JsonApi` PHP schemas only when the static Store API path schema references the missing component; both are tracked in `phpGeneratedOnly`. Unreferenced PHP definitions are not Store API schema debt and should not be represented by unused JSON components.
 
-Core has reached the target state: `jsonOverridesPhpGenerated` and `phpGeneratedStoreApiSchemas` are empty. All core Store API entity components are JSON-owned, and the legacy PHP-generated `*JsonApi` compatibility schemas are no longer emitted.
+Core has reached the target state: `jsonOverridesPhpGenerated` and `phpGeneratedOnly` are empty. All core Store API entity components are JSON-owned, and the legacy PHP-generated `*JsonApi` compatibility schemas are no longer emitted.
 
 The platform CI runs the check in core scope:
 
@@ -65,7 +63,7 @@ The OpenAPI workflow must install and serve Shopware in the `prod` environment. 
 
 `--scope=core` checks platform entity definitions against the core Framework StoreAPI JSON schema directory only. It intentionally ignores extension PHP definitions and extension schema files, so downstream repositories do not inherit core migration debt. Use `--scope=all` only for local investigation when installed extensions should be included in the report.
 
-Scopes are provided through services implementing `StoreApiSchemaMigrationScopeProviderInterface` and tagged with `shopware.store_api_schema_migration.scope_provider`. Downstream repositories that want to enforce their own migration state should add a dedicated scope provider with extension-owned definition class prefixes, schema paths, and allowlist path instead of copying the reporter, report, or command logic.
+Scopes are provided through services implementing `StoreApiSchemaMigrationScopeProviderInterface` and tagged with `shopware.store_api_schema_migration.scope_provider`. Downstream repositories that want to enforce their own migration state should add a dedicated scope provider with extension-owned definition class prefixes and schema paths instead of copying the reporter, report, or command logic.
 
 ### Using `x-parameter-group` for Reusable Parameters
 

--- a/src/Core/Framework/Api/ApiException.php
+++ b/src/Core/Framework/Api/ApiException.php
@@ -42,7 +42,6 @@ class ApiException extends HttpException
     public const API_NOT_EXISTING_RELATION_EXCEPTION = 'FRAMEWORK__NOT_EXISTING_RELATION_EXCEPTION';
     public const API_UNSUPPORTED_OPERATION_EXCEPTION = 'FRAMEWORK__UNSUPPORTED_OPERATION_EXCEPTION';
     public const API_UNSUPPORTED_STORE_API_SCHEMA_ENDPOINT = 'FRAMEWORK__UNSUPPORTED_STORE_API_SCHEMA_ENDPOINT';
-    public const API_INVALID_STORE_API_SCHEMA_MIGRATION_ALLOWLIST = 'FRAMEWORK__API_INVALID_STORE_API_SCHEMA_MIGRATION_ALLOWLIST';
     public const API_UNSUPPORTED_STORE_API_SCHEMA_MIGRATION_SCOPE = 'FRAMEWORK__API_UNSUPPORTED_STORE_API_SCHEMA_MIGRATION_SCOPE';
     public const API_INVALID_VERSION_ID = 'FRAMEWORK__INVALID_VERSION_ID';
     public const API_TYPE_PARAMETER_INVALID = 'FRAMEWORK__API_TYPE_PARAMETER_INVALID';
@@ -384,17 +383,6 @@ class ApiException extends HttpException
             Response::HTTP_INTERNAL_SERVER_ERROR,
             self::API_INVALID_SCHEMA_DEFINITION_EXCEPTION,
             \sprintf('Failed to parse JSON file "%s": %s', $filename, $exception->getMessage()),
-        );
-    }
-
-    public static function invalidStoreApiSchemaMigrationAllowlist(string $filename, string $message, ?\Throwable $exception = null): self
-    {
-        return new self(
-            Response::HTTP_INTERNAL_SERVER_ERROR,
-            self::API_INVALID_STORE_API_SCHEMA_MIGRATION_ALLOWLIST,
-            'Invalid Store API schema migration allowlist "{{ filename }}": {{ message }}',
-            ['filename' => $filename, 'message' => $message],
-            $exception,
         );
     }
 

--- a/tests/unit/Core/Framework/Api/ApiDefinition/Generator/AllStoreApiSchemaMigrationScopeProviderTest.php
+++ b/tests/unit/Core/Framework/Api/ApiDefinition/Generator/AllStoreApiSchemaMigrationScopeProviderTest.php
@@ -21,7 +21,6 @@ class AllStoreApiSchemaMigrationScopeProviderTest extends TestCase
         $provider = new AllStoreApiSchemaMigrationScopeProvider(
             new BundleSchemaPathCollection([new ShopwareBundleWithName()]),
             '/schema',
-            '/allowlist.json',
         );
 
         static::assertSame('all', $provider->getScope());
@@ -30,7 +29,6 @@ class AllStoreApiSchemaMigrationScopeProviderTest extends TestCase
             '/schema',
             __DIR__ . '/_fixtures/CustomBundleWithApiSchema/Resources/Schema/StoreApi',
         ], $provider->getSchemaPaths());
-        static::assertSame('/allowlist.json', $provider->getAllowlistPath());
         static::assertTrue($provider->includesAllDefinitions());
     }
 }

--- a/tests/unit/Core/Framework/Api/ApiDefinition/Generator/CoreStoreApiSchemaMigrationScopeProviderTest.php
+++ b/tests/unit/Core/Framework/Api/ApiDefinition/Generator/CoreStoreApiSchemaMigrationScopeProviderTest.php
@@ -16,7 +16,7 @@ class CoreStoreApiSchemaMigrationScopeProviderTest extends TestCase
 {
     public function testProvidesCoreScopeConfiguration(): void
     {
-        $provider = new CoreStoreApiSchemaMigrationScopeProvider('/schema', '/allowlist.json');
+        $provider = new CoreStoreApiSchemaMigrationScopeProvider('/schema');
 
         static::assertSame('core', $provider->getScope());
         static::assertSame([
@@ -26,7 +26,6 @@ class CoreStoreApiSchemaMigrationScopeProviderTest extends TestCase
             'Shopware\\Storefront\\',
         ], $provider->getDefinitionClassPrefixes());
         static::assertSame(['/schema'], $provider->getSchemaPaths());
-        static::assertSame('/allowlist.json', $provider->getAllowlistPath());
         static::assertFalse($provider->includesAllDefinitions());
     }
 
@@ -39,9 +38,5 @@ class CoreStoreApiSchemaMigrationScopeProviderTest extends TestCase
         static::assertSame([
             $projectDirectory . '/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi',
         ], $provider->getSchemaPaths());
-        static::assertSame(
-            $projectDirectory . '/src/Core/Framework/Api/ApiDefinition/Generator/StoreApiPhpGeneratedSchemaAllowlist.json',
-            $provider->getAllowlistPath(),
-        );
     }
 }

--- a/tests/unit/Core/Framework/Api/ApiDefinition/Generator/StoreApiGeneratorTest.php
+++ b/tests/unit/Core/Framework/Api/ApiDefinition/Generator/StoreApiGeneratorTest.php
@@ -218,7 +218,40 @@ class StoreApiGeneratorTest extends TestCase
             null
         );
 
+        static::assertArrayNotHasKey('Simple', $schema['components']['schemas'] ?? []);
         static::assertArrayNotHasKey('SimpleJsonApi', $schema['components']['schemas'] ?? []);
+    }
+
+    public function testTransitivelyReferencedPhpGeneratedStoreApiSchemaIsEmitted(): void
+    {
+        $generator = new StoreApiGenerator(
+            new OpenApiSchemaBuilder('0.1.0'),
+            new OpenApiDefinitionSchemaBuilder(),
+            [
+                'Framework' => ['path' => __DIR__ . '/_fixtures/BundleWithPhpGeneratedSchemaReference'],
+            ],
+            new BundleSchemaPathCollection([]),
+        );
+        $definitionRegistry = new StaticDefinitionInstanceRegistry(
+            [
+                DefinitionWithAssociations::class,
+                SimpleDefinition::class,
+                SEOUrlDefinition::class,
+            ],
+            static::createStub(ValidatorInterface::class),
+            static::createStub(EntityWriteGatewayInterface::class)
+        );
+
+        $schema = $generator->generate(
+            $definitionRegistry->getDefinitions(),
+            DefinitionService::STORE_API,
+            DefinitionService::TYPE_JSON_API,
+            null
+        );
+
+        static::assertArrayHasKey('TestEntityWithAssociations', $schema['components']['schemas']);
+        static::assertArrayHasKey('Simple', $schema['components']['schemas']);
+        static::assertArrayNotHasKey('SEOUrl', $schema['components']['schemas']);
     }
 
     public function testJsonOwnedSchemaDoesNotContainJsonApiComponent(): void

--- a/tests/unit/Core/Framework/Api/ApiDefinition/Generator/StoreApiSchemaMigrationReportTest.php
+++ b/tests/unit/Core/Framework/Api/ApiDefinition/Generator/StoreApiSchemaMigrationReportTest.php
@@ -28,6 +28,15 @@ class StoreApiSchemaMigrationReportTest extends TestCase
         static::assertFalse($this->createReport()->hasMismatches());
     }
 
+    public function testDetectsPhpGeneratedOnlySchemasAsMismatches(): void
+    {
+        $report = $this->createReport(
+            phpGeneratedOnly: ['Product'],
+        );
+
+        static::assertTrue($report->hasMismatches());
+    }
+
     public function testSerializesReportBuckets(): void
     {
         $report = $this->createReport(
@@ -38,40 +47,24 @@ class StoreApiSchemaMigrationReportTest extends TestCase
         static::assertSame([
             'jsonOverridesPhpGenerated' => ['JsonOverrideEntity'],
             'phpGeneratedOnly' => ['Product'],
-            'phpGeneratedOnlyAllowed' => [],
-            'phpGeneratedOnlyWithoutAllowlist' => [],
             'jsonWithoutPhpGenerated' => [],
-            'allowlistWithoutPhpGeneratedOnlySchema' => [],
-            'allowlistWithoutPhpGeneratedSchema' => [],
         ], $report->jsonSerialize());
     }
 
     /**
      * @param list<string> $jsonOverridesPhpGenerated
      * @param list<string> $phpGeneratedOnly
-     * @param list<string> $phpGeneratedOnlyAllowed
-     * @param list<string> $phpGeneratedOnlyWithoutAllowlist
      * @param list<string> $jsonWithoutPhpGenerated
-     * @param list<string> $allowlistWithoutPhpGeneratedOnlySchema
-     * @param list<string> $allowlistWithoutPhpGeneratedSchema
      */
     private function createReport(
         array $jsonOverridesPhpGenerated = [],
         array $phpGeneratedOnly = [],
-        array $phpGeneratedOnlyAllowed = [],
-        array $phpGeneratedOnlyWithoutAllowlist = [],
         array $jsonWithoutPhpGenerated = [],
-        array $allowlistWithoutPhpGeneratedOnlySchema = [],
-        array $allowlistWithoutPhpGeneratedSchema = [],
     ): StoreApiSchemaMigrationReport {
         return new StoreApiSchemaMigrationReport(
             jsonOverridesPhpGenerated: $jsonOverridesPhpGenerated,
             phpGeneratedOnly: $phpGeneratedOnly,
-            phpGeneratedOnlyAllowed: $phpGeneratedOnlyAllowed,
-            phpGeneratedOnlyWithoutAllowlist: $phpGeneratedOnlyWithoutAllowlist,
             jsonWithoutPhpGenerated: $jsonWithoutPhpGenerated,
-            allowlistWithoutPhpGeneratedOnlySchema: $allowlistWithoutPhpGeneratedOnlySchema,
-            allowlistWithoutPhpGeneratedSchema: $allowlistWithoutPhpGeneratedSchema,
         );
     }
 }

--- a/tests/unit/Core/Framework/Api/ApiDefinition/Generator/StoreApiSchemaMigrationReporterTest.php
+++ b/tests/unit/Core/Framework/Api/ApiDefinition/Generator/StoreApiSchemaMigrationReporterTest.php
@@ -6,7 +6,6 @@ use OpenApi\Annotations\Schema;
 use PHPUnit\Framework\Attributes\After;
 use PHPUnit\Framework\Attributes\Before;
 use PHPUnit\Framework\Attributes\CoversClass;
-use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Api\Acl\Role\AclRoleDefinition;
 use Shopware\Core\Framework\Api\ApiDefinition\Generator\AllStoreApiSchemaMigrationScopeProvider;
@@ -23,7 +22,6 @@ use Shopware\Core\Test\Stub\DataAbstractionLayer\StaticDefinitionInstanceRegistr
 use Shopware\Tests\Unit\Core\Framework\Api\ApiDefinition\Generator\_extensionFixtures\ExtensionDefinition;
 use Shopware\Tests\Unit\Core\Framework\Api\ApiDefinition\Generator\_fixtures\CustomBundleWithApiSchema\ShopwareBundleWithName;
 use Shopware\Tests\Unit\Core\Framework\Api\ApiDefinition\Generator\_fixtures\SalesChannelSimpleDefinition;
-use Symfony\Component\Filesystem\Exception\IOException;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 
@@ -63,15 +61,65 @@ class StoreApiSchemaMigrationReporterTest extends TestCase
                     ],
                 ],
             ]),
-            allowlistPath: $this->createAllowlistPath(['AclRole']),
         )->report($this->createDefinitions());
 
         static::assertContains('GroupByTest', $report->phpGeneratedOnly);
         static::assertContains('AclRole', $report->phpGeneratedOnly);
-        static::assertContains('AclRole', $report->phpGeneratedOnlyAllowed);
-        static::assertContains('GroupByTest', $report->phpGeneratedOnlyWithoutAllowlist);
         static::assertContains('CalculatedPrice', $report->jsonWithoutPhpGenerated);
         static::assertSame([], $report->jsonOverridesPhpGenerated);
+    }
+
+    public function testReportTracksTransitivelyReferencedPhpGeneratedSchemas(): void
+    {
+        $definitionSchemaBuilder = static::createStub(OpenApiDefinitionSchemaBuilder::class);
+        $definitionSchemaBuilder->method('getSchemaName')->willReturnCallback(static function (EntityDefinition $definition): string {
+            return match ($definition->getEntityName()) {
+                'parent' => 'Parent',
+                'child' => 'Child',
+                'unused' => 'Unused',
+                default => throw new \LogicException('Unexpected definition.'),
+            };
+        });
+        $definitionSchemaBuilder->method('getSchemaByDefinition')->willReturnCallback(static function (EntityDefinition $definition): array {
+            return match ($definition->getEntityName()) {
+                'parent' => [
+                    'Parent' => new Schema([
+                        'schema' => 'Parent',
+                        'ref' => '#/components/schemas/Child',
+                    ]),
+                ],
+                'child' => [
+                    'Child' => new Schema([
+                        'schema' => 'Child',
+                        'type' => 'object',
+                    ]),
+                ],
+                'unused' => [
+                    'Unused' => new Schema([
+                        'schema' => 'Unused',
+                        'type' => 'object',
+                    ]),
+                ],
+                default => throw new \LogicException('Unexpected definition.'),
+            };
+        });
+        $definitionSchemaBuilder->method('getExtensionSchemaByDefinition')->willReturn([]);
+
+        $report = $this->createReporter(
+            definitionSchemaBuilder: $definitionSchemaBuilder,
+            schemaPath: $this->createSchemaPath([
+                'paths' => $this->createPathReferencingSchemas('Parent'),
+                'components' => ['schemas' => []],
+            ]),
+        )->report([
+            'parent' => $this->createDefinition('parent'),
+            'child' => $this->createDefinition('child'),
+            'unused' => $this->createDefinition('unused'),
+        ], AllStoreApiSchemaMigrationScopeProvider::SCOPE);
+
+        static::assertContains('Parent', $report->phpGeneratedOnly);
+        static::assertContains('Child', $report->phpGeneratedOnly);
+        static::assertNotContains('Unused', $report->phpGeneratedOnly);
     }
 
     public function testJsonSchemaWithPhpDefinitionIsTreatedAsJsonOnly(): void
@@ -85,7 +133,6 @@ class StoreApiSchemaMigrationReporterTest extends TestCase
                     ],
                 ],
             ]),
-            allowlistPath: $this->createAllowlistPath(),
         )->report($this->createDefinitions());
 
         static::assertContains('GroupByTest', $report->jsonWithoutPhpGenerated);
@@ -101,7 +148,6 @@ class StoreApiSchemaMigrationReporterTest extends TestCase
                 'paths' => $this->createPathReferencingSchemas('Simple'),
                 'components' => ['schemas' => []],
             ]),
-            allowlistPath: $this->createAllowlistPath(),
         )->report(
             $this->createDefinitions([SalesChannelSimpleDefinition::class]),
             AllStoreApiSchemaMigrationScopeProvider::SCOPE,
@@ -122,14 +168,13 @@ class StoreApiSchemaMigrationReporterTest extends TestCase
         $report = $this->createReporter(
             definitionSchemaBuilder: $definitionSchemaBuilder,
             schemaPath: $this->createSchemaPath([
-                'paths' => $this->createPathReferencingSchemas('DifferentSchema'),
+                'paths' => $this->createPathReferencingSchemas('GroupByTest'),
                 'components' => [
                     'schemas' => [
                         'GroupByTest' => ['type' => 'object'],
                     ],
                 ],
             ]),
-            allowlistPath: $this->createAllowlistPath(),
         )->report([
             'group_by_test' => $this->createDefinition('group_by_test'),
         ], AllStoreApiSchemaMigrationScopeProvider::SCOPE);
@@ -146,7 +191,6 @@ class StoreApiSchemaMigrationReporterTest extends TestCase
                 'paths' => $this->createPathReferencingSchemas('GroupByTest', 'AclRole', 'Extension'),
                 'components' => ['schemas' => []],
             ]),
-            allowlistPath: $this->createAllowlistPath(['AclRole']),
         );
         $definitions = $this->createDefinitions([ExtensionDefinition::class]);
 
@@ -188,7 +232,6 @@ class StoreApiSchemaMigrationReporterTest extends TestCase
         $report = $this->createReporter(
             definitionSchemaBuilder: $definitionSchemaBuilder,
             schemaPath: $this->createSchemaPath(['components' => ['schemas' => []]]),
-            allowlistPath: $this->createAllowlistPath(),
         )->report([
             'example_translation' => $this->createDefinition('example_translation'),
             'version_example' => $this->createDefinition('version_example'),
@@ -201,7 +244,6 @@ class StoreApiSchemaMigrationReporterTest extends TestCase
     {
         $report = $this->createReporter(
             schemaPath: $this->createSchemaPath(['paths' => []]),
-            allowlistPath: $this->createAllowlistPath(),
         )->report([]);
 
         static::assertSame([], $report->jsonWithoutPhpGenerated);
@@ -211,96 +253,22 @@ class StoreApiSchemaMigrationReporterTest extends TestCase
     {
         $report = $this->createReporter(
             schemaPath: $this->createSchemaPath(['components' => ['schemas' => 'invalid']]),
-            allowlistPath: $this->createAllowlistPath(),
         )->report([]);
 
         static::assertSame([], $report->jsonWithoutPhpGenerated);
     }
 
-    public function testReportUsesEmptyAllowlistWhenAllowlistFileDoesNotExist(): void
-    {
-        $report = $this->createReporter(
-            schemaPath: $this->createSchemaPath(['components' => ['schemas' => []]]),
-            allowlistPath: $this->temporaryDirectory . '/missing-allowlist.json',
-        )->report([]);
-
-        static::assertSame([], $report->phpGeneratedOnlyAllowed);
-    }
-
-    #[DataProvider('invalidAllowlistProvider')]
-    public function testReportFailsForInvalidAllowlist(string $contents, string $expectedMessage): void
-    {
-        $allowlistPath = $this->temporaryDirectory . '/allowlist.json';
-        $this->filesystem->dumpFile($allowlistPath, $contents);
-
-        try {
-            $this->createReporter(
-                schemaPath: $this->createSchemaPath(['components' => ['schemas' => []]]),
-                allowlistPath: $allowlistPath,
-            )->report([]);
-
-            static::fail('Expected invalid allowlist exception.');
-        } catch (ApiException $exception) {
-            static::assertStringContainsString($expectedMessage, $exception->getMessage());
-        }
-    }
-
-    public function testReportFailsWhenAllowlistCannotBeRead(): void
-    {
-        $allowlistPath = $this->temporaryDirectory . '/allowlist.json';
-        $filesystem = static::createStub(Filesystem::class);
-        $filesystem->method('exists')->willReturn(true);
-        $filesystem->method('readFile')->willThrowException(new IOException('Could not read file.', 0, null, $allowlistPath));
-
-        $this->expectExceptionObject(ApiException::schemaDefinitionNotReadable($allowlistPath));
-
-        $this->createReporter(
-            filesystem: $filesystem,
-            schemaPath: $this->createSchemaPath(['components' => ['schemas' => []]]),
-            allowlistPath: $allowlistPath,
-        )->report([]);
-    }
-
-    /**
-     * @return iterable<string, array{string, string}>
-     */
-    public static function invalidAllowlistProvider(): iterable
-    {
-        yield 'invalid json' => [
-            '{',
-            'JSON could not be decoded.',
-        ];
-
-        yield 'root value is not an object' => [
-            '"invalid"',
-            'The root value must be an object.',
-        ];
-
-        yield 'missing list' => [
-            '{}',
-            'The "phpGeneratedStoreApiSchemas" list is missing.',
-        ];
-
-        yield 'non-string schema name' => [
-            '{"phpGeneratedStoreApiSchemas":[1]}',
-            'The "phpGeneratedStoreApiSchemas" list must contain only schema names.',
-        ];
-    }
-
     private function createReporter(
         ?BundleSchemaPathCollection $bundleSchemaPathCollection = null,
         ?OpenApiDefinitionSchemaBuilder $definitionSchemaBuilder = null,
-        ?Filesystem $filesystem = null,
         ?string $schemaPath = null,
-        ?string $allowlistPath = null,
     ): StoreApiSchemaMigrationReporter {
         return new StoreApiSchemaMigrationReporter(
             $definitionSchemaBuilder ?? new OpenApiDefinitionSchemaBuilder(),
             [
-                new CoreStoreApiSchemaMigrationScopeProvider($schemaPath, $allowlistPath),
-                new AllStoreApiSchemaMigrationScopeProvider($bundleSchemaPathCollection ?? new BundleSchemaPathCollection([]), $schemaPath, $allowlistPath),
+                new CoreStoreApiSchemaMigrationScopeProvider($schemaPath),
+                new AllStoreApiSchemaMigrationScopeProvider($bundleSchemaPathCollection ?? new BundleSchemaPathCollection([]), $schemaPath),
             ],
-            $filesystem ?? new Filesystem(),
         );
     }
 
@@ -359,19 +327,6 @@ class StoreApiSchemaMigrationReporterTest extends TestCase
                 ],
             ],
         ];
-    }
-
-    /**
-     * @param list<string> $phpGeneratedStoreApiSchemas
-     */
-    private function createAllowlistPath(array $phpGeneratedStoreApiSchemas = []): string
-    {
-        $allowlistPath = $this->temporaryDirectory . '/allowlist-' . bin2hex(random_bytes(4)) . '.json';
-        $this->filesystem->dumpFile($allowlistPath, json_encode([
-            'phpGeneratedStoreApiSchemas' => $phpGeneratedStoreApiSchemas,
-        ], \JSON_THROW_ON_ERROR));
-
-        return $allowlistPath;
     }
 
     /**

--- a/tests/unit/Core/Framework/Api/ApiDefinition/Generator/_fixtures/Api/ApiDefinition/Generator/StoreApiPhpGeneratedSchemaAllowlist.json
+++ b/tests/unit/Core/Framework/Api/ApiDefinition/Generator/_fixtures/Api/ApiDefinition/Generator/StoreApiPhpGeneratedSchemaAllowlist.json
@@ -1,6 +1,0 @@
-{
-    "phpGeneratedStoreApiSchemas": [
-        "Simple",
-        "StalePhpGeneratedOnlyAllowlistEntry"
-    ]
-}

--- a/tests/unit/Core/Framework/Api/ApiDefinition/Generator/_fixtures/BundleWithPhpGeneratedSchemaReference/Api/ApiDefinition/Generator/Schema/StoreApi/paths/test_entity_with_associations.json
+++ b/tests/unit/Core/Framework/Api/ApiDefinition/Generator/_fixtures/BundleWithPhpGeneratedSchemaReference/Api/ApiDefinition/Generator/Schema/StoreApi/paths/test_entity_with_associations.json
@@ -1,0 +1,22 @@
+{
+    "openapi": "3.2.0",
+    "info": [],
+    "paths": {
+        "/test-entity-with-associations": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/TestEntityWithAssociations"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/unit/Core/Framework/Api/Command/StoreApiSchemaMigrationReportCommandTest.php
+++ b/tests/unit/Core/Framework/Api/Command/StoreApiSchemaMigrationReportCommandTest.php
@@ -37,10 +37,10 @@ class StoreApiSchemaMigrationReportCommandTest extends TestCase
         static::assertIsArray($report);
         static::assertArrayHasKey('jsonOverridesPhpGenerated', $report);
         static::assertIsArray($report['jsonOverridesPhpGenerated']);
-        static::assertArrayHasKey('phpGeneratedOnlyWithoutAllowlist', $report);
-        static::assertIsArray($report['phpGeneratedOnlyWithoutAllowlist']);
+        static::assertArrayHasKey('phpGeneratedOnly', $report);
+        static::assertIsArray($report['phpGeneratedOnly']);
         static::assertSame(['JsonOverrideEntity'], $report['jsonOverridesPhpGenerated']);
-        static::assertSame(['TestEntityWithAssociations'], $report['phpGeneratedOnlyWithoutAllowlist']);
+        static::assertSame(['TestEntityWithAssociations'], $report['phpGeneratedOnly']);
     }
 
     public function testCommandCanFailOnMigrationMismatches(): void
@@ -119,12 +119,8 @@ class StoreApiSchemaMigrationReportCommandTest extends TestCase
     {
         return new StoreApiSchemaMigrationReport(
             jsonOverridesPhpGenerated: ['JsonOverrideEntity'],
-            phpGeneratedOnly: [],
-            phpGeneratedOnlyAllowed: [],
-            phpGeneratedOnlyWithoutAllowlist: ['TestEntityWithAssociations'],
+            phpGeneratedOnly: ['TestEntityWithAssociations'],
             jsonWithoutPhpGenerated: [],
-            allowlistWithoutPhpGeneratedOnlySchema: [],
-            allowlistWithoutPhpGeneratedSchema: [],
         );
     }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?

Store API schema migration should fail on remaining PHP-generated schemas directly instead of relying on a file-based allowlist.

### 2. What does this change do, exactly?

It removes the Store API schema migration allowlist, reports `phpGeneratedOnly` as a real mismatch, and keeps only reachable PHP-generated Store API schemas as a temporary compatibility bridge while JSON-owned schemas remain the target state.

### 3. Describe each step to reproduce the issue or behaviour.

Run `bin/console framework:store-api:schema-migration-report --scope=core --fail-on-mismatch --pretty -` and verify that `jsonOverridesPhpGenerated` and `phpGeneratedOnly` are empty.

### 4. Please link to the relevant issues (if any).

Relates to #18851.

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [x] I have written or adjusted the documentation and agent skills according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them