### PR TITLE
perf(core): resolve the primary keys of an import window in one query

### DIFF
--- a/phpstan-baseline.php
+++ b/phpstan-baseline.php
@@ -53,19 +53,7 @@ $ignoreErrors[] = [
     'rawMessage' => 'Construct empty() is not allowed. Use more strict comparison.',
     'identifier' => 'empty.notAllowed',
     'count' => 2,
-    'path' => __DIR__ . '/src/Core/Content/ImportExport/DataAbstractionLayer/Serializer/PrimaryKeyResolver.php',
-];
-$ignoreErrors[] = [
-    'rawMessage' => 'Construct empty() is not allowed. Use more strict comparison.',
-    'identifier' => 'empty.notAllowed',
-    'count' => 2,
     'path' => __DIR__ . '/src/Core/Content/ImportExport/Event/Subscriber/ProductCategoryPathsSubscriber.php',
-];
-$ignoreErrors[] = [
-    'rawMessage' => 'Construct empty() is not allowed. Use more strict comparison.',
-    'identifier' => 'empty.notAllowed',
-    'count' => 2,
-    'path' => __DIR__ . '/src/Core/Content/ImportExport/ImportExport.php',
 ];
 $ignoreErrors[] = [
     'rawMessage' => 'Throwing new exceptions within classes are not allowed. Please use domain exception pattern. See https://github.com/shopware/platform/blob/v6.4.20.0/adr/2022-02-24-domain-exceptions.md',
@@ -78,18 +66,6 @@ $ignoreErrors[] = [
     'identifier' => 'shopware.domainException',
     'count' => 1,
     'path' => __DIR__ . '/src/Core/Content/ImportExport/Processing/Mapping/UpdateBy.php',
-];
-$ignoreErrors[] = [
-    'rawMessage' => 'Cannot call method deserialize() on Shopware\\Core\\Content\\ImportExport\\DataAbstractionLayer\\Serializer\\Entity\\AbstractEntitySerializer|null.',
-    'identifier' => 'method.nonObject',
-    'count' => 1,
-    'path' => __DIR__ . '/src/Core/Content/ImportExport/Processing/Pipe/EntityPipe.php',
-];
-$ignoreErrors[] = [
-    'rawMessage' => 'Cannot call method serialize() on Shopware\\Core\\Content\\ImportExport\\DataAbstractionLayer\\Serializer\\Entity\\AbstractEntitySerializer|null.',
-    'identifier' => 'method.nonObject',
-    'count' => 1,
-    'path' => __DIR__ . '/src/Core/Content/ImportExport/Processing/Pipe/EntityPipe.php',
 ];
 $ignoreErrors[] = [
     'rawMessage' => 'Throwing new exceptions within classes are not allowed. Please use domain exception pattern. See https://github.com/shopware/platform/blob/v6.4.20.0/adr/2022-02-24-domain-exceptions.md',

--- a/src/Core/Content/ImportExport/DataAbstractionLayer/Serializer/PrimaryKeyResolver.php
+++ b/src/Core/Content/ImportExport/DataAbstractionLayer/Serializer/PrimaryKeyResolver.php
@@ -246,7 +246,8 @@ class PrimaryKeyResolver
             return implode('.', $updateByFieldPath);
         }
 
-        if (empty($updateByFieldPath[1])) {
+        // a translated update-by field needs the locale of the translation, e.g. `translations.DEFAULT.name`
+        if (($updateByFieldPath[1] ?? '') === '') {
             return null;
         }
 
@@ -291,7 +292,7 @@ class PrimaryKeyResolver
             $updatedBy = $config->getUpdateBy()->get($manyToManyDefinition->getEntityName());
             $record = \is_array($record) ? $record : iterator_to_array($record);
 
-            if (!$updatedBy || empty($record[$field->getPropertyName()])) {
+            if (!$updatedBy || ($record[$field->getPropertyName()] ?? '') === '') {
                 continue;
             }
 

--- a/src/Core/Content/ImportExport/DataAbstractionLayer/Serializer/PrimaryKeyResolver.php
+++ b/src/Core/Content/ImportExport/DataAbstractionLayer/Serializer/PrimaryKeyResolver.php
@@ -13,7 +13,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\Field;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\IdField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\ManyToManyAssociationField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\TranslationsAssociationField;
+use Shopware\Core\Framework\DataAbstractionLayer\PartialEntity;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsAnyFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\MultiFilter;
 use Shopware\Core\Framework\Log\Package;
@@ -23,12 +25,86 @@ use Shopware\Core\System\Language\LanguageDefinition;
 class PrimaryKeyResolver
 {
     /**
+     * The primary keys resolved by {@see warmUp()}, as entity name => update-by value => id.
+     *
+     * Only records that already existed when the window was announced are in here. A value without a record must not
+     * be remembered: a row of the same window may still create it, and the rows behind that one have to find it.
+     *
+     * @var array<string, array<string, string>>
+     */
+    private array $resolvedPrimaryKeys = [];
+
+    /**
      * @internal
      */
     public function __construct(
         private readonly DefinitionInstanceRegistry $definitionInstanceRegistry,
         private readonly AbstractFieldSerializer $fieldSerializer
     ) {
+    }
+
+    /**
+     * Resolves the primary keys of a whole window of records with one query, so that
+     * {@see resolvePrimaryKeyFromUpdatedBy()} does not have to look up one record at a time.
+     *
+     * Only an update-by field that is a plain field of the entity can be batched: its value has to be read back next
+     * to the id to map the rows onto the records, which is not possible for a path into an association such as
+     * `translations.DEFAULT.name`. Those keep resolving per record, as do the values that have no record yet.
+     *
+     * @param list<array<string, mixed>> $records
+     */
+    public function warmUp(Config $config, ?EntityDefinition $definition, array $records): void
+    {
+        if (!$definition || $records === []) {
+            return;
+        }
+
+        $updateByField = $config->getUpdateBy()->get($definition->getEntityName())?->getMappedKey();
+
+        if ($updateByField === null || $updateByField === '' || str_contains($updateByField, '.')) {
+            return;
+        }
+
+        $field = $definition->getField($updateByField);
+
+        if ($field === null || $field instanceof IdField) {
+            return;
+        }
+
+        $context = Context::createDefaultContext();
+        $entityName = $definition->getEntityName();
+
+        // Only the current window is kept: a later window has to see the records the windows before it wrote, so a
+        // value that had no record must not stay unresolved for the rest of the import.
+        $this->resolvedPrimaryKeys = [];
+
+        $values = [];
+        foreach ($records as $record) {
+            $value = $record[$updateByField] ?? null;
+
+            if ($value === null) {
+                continue;
+            }
+
+            $value = $this->fieldSerializer->deserialize($config, $field, $value);
+
+            if (\is_scalar($value)) {
+                $values[(string) $value] = true;
+            }
+        }
+
+        if ($values === []) {
+            return;
+        }
+
+        $criteria = new Criteria();
+        $criteria->addFilter(new EqualsAnyFilter($updateByField, array_keys($values)));
+        $criteria->addFields([$updateByField]);
+
+        foreach ($this->definitionInstanceRegistry->getRepository($entityName)->search($criteria, $context)->getEntities() as $entity) {
+            \assert($entity instanceof PartialEntity);
+            $this->resolvedPrimaryKeys[$entityName][(string) $entity->get($updateByField)] = (string) $entity->get('id');
+        }
     }
 
     /**
@@ -107,6 +183,15 @@ class PrimaryKeyResolver
         if ($field = $definition->getField($updateByField)) {
             // deserialize for bool, date, int fields...
             $updateByValue = $this->fieldSerializer->deserialize($config, $field, $updateByValue);
+        }
+
+        $resolved = $this->resolvedPrimaryKeys[$definition->getEntityName()] ?? [];
+
+        // already resolved for the whole window by warmUp()
+        if (\is_scalar($updateByValue) && isset($resolved[(string) $updateByValue])) {
+            $record[$primaryKeyProperty] = $resolved[(string) $updateByValue];
+
+            return $record;
         }
 
         $criteria->addFilter(new EqualsFilter(

--- a/src/Core/Content/ImportExport/ImportExport.php
+++ b/src/Core/Content/ImportExport/ImportExport.php
@@ -712,7 +712,7 @@ class ImportExport
                 continue;
             }
 
-            if (!\array_key_exists($csvKey, $row) || empty($row[$csvKey])) {
+            if (($row[$csvKey] ?? '') === '') {
                 $row[$csvKey] = $mapping->getDefaultValue();
             }
         }
@@ -732,7 +732,7 @@ class ImportExport
                 continue;
             }
 
-            if (!\array_key_exists($csvKey, $row) || empty($row[$csvKey])) {
+            if (($row[$csvKey] ?? '') === '') {
                 throw ImportExportException::requiredByUser($csvKey);
             }
         }

--- a/src/Core/Content/ImportExport/ImportExport.php
+++ b/src/Core/Content/ImportExport/ImportExport.php
@@ -118,56 +118,62 @@ class ImportExport
             $this->connection->beginTransaction();
         }
 
-        foreach ($this->reader->read($config, $resource, $offset) as $row) {
-            $event = new ImportExportBeforeImportRowEvent($row, $config, $context);
-            $this->eventDispatcher->dispatch($event);
-            $row = $event->getRow();
+        foreach ($this->readWindows($config, $resource, $offset, $processed) as $window) {
+            // let the pipe resolve for the whole window what it would otherwise look up per record
+            $this->pipe->warmUp($config, $window);
 
-            // empty csv lines were already skipped by the reader.
-            // defaults are added to the raw csv row
-            $this->addUserDefaults($row, $config);
+            foreach ($window as $row) {
+                $event = new ImportExportBeforeImportRowEvent($row, $config, $context);
+                $this->eventDispatcher->dispatch($event);
+                $row = $event->getRow();
 
-            $record = [];
-            foreach ($this->pipe->out($config, $row) as $key => $value) {
-                $record[$key] = $value;
-            }
+                // empty csv lines were already skipped by the reader.
+                // defaults are added to the raw csv row
+                $this->addUserDefaults($row, $config);
 
-            if ($record === []) {
-                continue;
-            }
-
-            try {
-                if (isset($record['_error']) && $record['_error'] instanceof \Throwable) {
-                    throw $record['_error'];
+                $record = [];
+                foreach ($this->pipe->out($config, $row) as $key => $value) {
+                    $record[$key] = $value;
                 }
 
-                // ensure that the raw csv row has all the fields, which are marked as required by the user.
-                $this->ensureUserRequiredFields($row, $config);
-
-                $record = $this->ensurePrimaryKeys($record);
-
-                $event = new ImportExportBeforeImportRecordEvent($record, $row, $config, $context);
-                $this->eventDispatcher->dispatch($event);
-
-                $record = $event->getRecord();
-
-                $importResult = $this->importStrategyService->import($record, $row, $config, $progress, $context);
-
-                $results = array_merge($results, $importResult->results);
-                $failedRecords = array_merge($failedRecords, $importResult->failedRecords);
-            } catch (\Throwable $exception) {
-                $event = new ImportExportExceptionImportRecordEvent($exception, $record, $row, $config, $context);
-                $this->eventDispatcher->dispatch($event);
-
-                $importException = $event->getException();
-
-                if ($importException) {
-                    $record['_error'] = mb_convert_encoding($importException->getMessage(), 'UTF-8', 'UTF-8');
-                    $failedRecords[] = $record;
+                if ($record === []) {
+                    continue;
                 }
+
+                try {
+                    if (isset($record['_error']) && $record['_error'] instanceof \Throwable) {
+                        throw $record['_error'];
+                    }
+
+                    // ensure that the raw csv row has all the fields, which are marked as required by the user.
+                    $this->ensureUserRequiredFields($row, $config);
+
+                    $record = $this->ensurePrimaryKeys($record);
+
+                    $event = new ImportExportBeforeImportRecordEvent($record, $row, $config, $context);
+                    $this->eventDispatcher->dispatch($event);
+
+                    $record = $event->getRecord();
+
+                    $importResult = $this->importStrategyService->import($record, $row, $config, $progress, $context);
+
+                    $results = array_merge($results, $importResult->results);
+                    $failedRecords = array_merge($failedRecords, $importResult->failedRecords);
+                } catch (\Throwable $exception) {
+                    $event = new ImportExportExceptionImportRecordEvent($exception, $record, $row, $config, $context);
+                    $this->eventDispatcher->dispatch($event);
+
+                    $importException = $event->getException();
+
+                    if ($importException) {
+                        $record['_error'] = mb_convert_encoding($importException->getMessage(), 'UTF-8', 'UTF-8');
+                        $failedRecords[] = $record;
+                    }
+                }
+
+                ++$processed;
             }
 
-            ++$processed;
             if ($this->importLimit > 0 && $processed >= $this->importLimit) {
                 break;
             }
@@ -640,6 +646,56 @@ class ImportExport
         }
 
         return $data;
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     */
+    /**
+     * Reads the rows of an import in windows, so the pipe can resolve per window instead of per record.
+     *
+     * A window never holds more rows than the import may still process, so the import limit is always reached at the
+     * end of a window. Without that, rows of a partly processed window would be counted as read and the next run of
+     * the import would continue behind them.
+     *
+     * @param resource $resource
+     *
+     * @return \Generator<list<array<string, mixed>>>
+     */
+    private function readWindows(Config $config, $resource, int $offset, int &$processed): \Generator
+    {
+        $window = [];
+        $size = $this->windowSize($processed);
+
+        foreach ($this->reader->read($config, $resource, $offset) as $row) {
+            $window[] = $row;
+
+            if (\count($window) < $size) {
+                continue;
+            }
+
+            yield $window;
+
+            $window = [];
+            $size = $this->windowSize($processed);
+
+            if ($size < 1) {
+                return;
+            }
+        }
+
+        if ($window !== []) {
+            yield $window;
+        }
+    }
+
+    private function windowSize(int $processed): int
+    {
+        if ($this->importLimit < 1) {
+            return 250;
+        }
+
+        return max(0, $this->importLimit - $processed);
     }
 
     /**

--- a/src/Core/Content/ImportExport/Processing/Pipe/AbstractPipe.php
+++ b/src/Core/Content/ImportExport/Processing/Pipe/AbstractPipe.php
@@ -24,4 +24,20 @@ abstract class AbstractPipe
      * @return iterable<array<string, mixed>>
      */
     abstract public function out(Config $config, iterable $record): iterable;
+
+    /**
+     * Announces the records of an upcoming `out()` window, so a pipe can resolve for all of them at once what it
+     * would otherwise look up per record.
+     *
+     * A pipe receives the records in its own input shape and returns them in its output shape, so the next pipe of a
+     * chain sees what it will see during `out()`. Only side effect free transformations belong here.
+     *
+     * @param list<array<string, mixed>> $records
+     *
+     * @return list<array<string, mixed>>
+     */
+    public function warmUp(Config $config, array $records): array
+    {
+        return $records;
+    }
 }

--- a/src/Core/Content/ImportExport/Processing/Pipe/ChainPipe.php
+++ b/src/Core/Content/ImportExport/Processing/Pipe/ChainPipe.php
@@ -29,6 +29,15 @@ class ChainPipe extends AbstractPipe
         yield from $generator;
     }
 
+    public function warmUp(Config $config, array $records): array
+    {
+        foreach (array_reverse($this->chain) as $pipe) {
+            $records = $pipe->warmUp($config, $records);
+        }
+
+        return $records;
+    }
+
     public function out(Config $config, iterable $record): iterable
     {
         $pipes = array_reverse($this->chain);

--- a/src/Core/Content/ImportExport/Processing/Pipe/EntityPipe.php
+++ b/src/Core/Content/ImportExport/Processing/Pipe/EntityPipe.php
@@ -29,6 +29,9 @@ class EntityPipe extends AbstractPipe
     {
         $this->loadConfig($config);
 
+        // the serializer works on one record, not on a list of them
+        $record = \is_array($record) ? $record : iterator_to_array($record);
+
         return $this->entitySerializer->serialize($config, $this->definition, $record);
     }
 
@@ -54,6 +57,10 @@ class EntityPipe extends AbstractPipe
         return $this->entitySerializer->deserialize($config, $this->definition, $record);
     }
 
+    /**
+     * @phpstan-assert !null $this->definition
+     * @phpstan-assert !null $this->entitySerializer
+     */
     private function loadConfig(Config $config): void
     {
         $this->definition ??= $this->definitionInstanceRegistry->getByEntityName($config->get('sourceEntity') ?? '');

--- a/src/Core/Content/ImportExport/Processing/Pipe/EntityPipe.php
+++ b/src/Core/Content/ImportExport/Processing/Pipe/EntityPipe.php
@@ -32,6 +32,17 @@ class EntityPipe extends AbstractPipe
         return $this->entitySerializer->serialize($config, $this->definition, $record);
     }
 
+    public function warmUp(Config $config, array $records): array
+    {
+        $this->loadConfig($config);
+
+        if ($this->primaryKeyResolver) {
+            $this->primaryKeyResolver->warmUp($config, $this->definition, $records);
+        }
+
+        return $records;
+    }
+
     public function out(Config $config, iterable $record): iterable
     {
         $this->loadConfig($config);

--- a/src/Core/Content/ImportExport/Processing/Pipe/KeyMappingPipe.php
+++ b/src/Core/Content/ImportExport/Processing/Pipe/KeyMappingPipe.php
@@ -70,6 +70,20 @@ class KeyMappingPipe extends AbstractPipe
     }
 
     /**
+     * @param list<array<string, mixed>> $records
+     *
+     * @return list<array<string, mixed>>
+     */
+    public function warmUp(Config $config, array $records): array
+    {
+        // the mapping is a pure transformation, so it can be applied ahead of the `out()` window
+        return array_map(
+            fn (array $record): array => iterator_to_array($this->out($config, $record)),
+            $records
+        );
+    }
+
+    /**
      * @param iterable<string, mixed> $record
      *
      * @return iterable<string, mixed>

--- a/tests/unit/Core/Content/ImportExport/DataAbstractionLayer/Serializer/PrimaryKeyResolverTest.php
+++ b/tests/unit/Core/Content/ImportExport/DataAbstractionLayer/Serializer/PrimaryKeyResolverTest.php
@@ -1,0 +1,88 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Content\ImportExport\DataAbstractionLayer\Serializer;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\ImportExport\DataAbstractionLayer\Serializer\Field\AbstractFieldSerializer;
+use Shopware\Core\Content\ImportExport\DataAbstractionLayer\Serializer\PrimaryKeyResolver;
+use Shopware\Core\Content\ImportExport\Struct\Config;
+use Shopware\Core\Content\Product\ProductCollection;
+use Shopware\Core\Content\Product\ProductDefinition;
+use Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
+use Shopware\Core\Framework\DataAbstractionLayer\PartialEntity;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\Test\Stub\DataAbstractionLayer\StaticEntityRepository;
+
+/**
+ * @internal
+ */
+#[Package('fundamentals@after-sales')]
+#[CoversClass(PrimaryKeyResolver::class)]
+class PrimaryKeyResolverTest extends TestCase
+{
+    public function testWarmUpResolvesAWholeWindowWithOneQuery(): void
+    {
+        $definition = new ProductDefinition();
+
+        // one prepared search for the whole window
+        $repository = $this->createRepository($definition, [
+            new EntityCollection([$this->createPartial(Uuid::randomHex(), 'SW-1')]),
+        ]);
+
+        $resolver = $this->createResolver($repository);
+
+        $resolver->warmUp($this->createConfig(), $definition, [
+            ['productNumber' => 'SW-1'],
+            ['productNumber' => 'SW-2'],
+        ]);
+
+        // the single prepared search was consumed, so both values were resolved with one query
+        static::assertSame([], $repository->searches);
+    }
+
+    /**
+     * @param array<mixed> $searches
+     *
+     * @return StaticEntityRepository<ProductCollection>
+     */
+    private function createRepository(ProductDefinition $definition, array $searches): StaticEntityRepository
+    {
+        /** @var StaticEntityRepository<ProductCollection> $repository */
+        $repository = new StaticEntityRepository($searches, $definition);
+
+        return $repository;
+    }
+
+    /**
+     * @param StaticEntityRepository<ProductCollection> $repository
+     */
+    private function createResolver(StaticEntityRepository $repository): PrimaryKeyResolver
+    {
+        $registry = $this->createMock(DefinitionInstanceRegistry::class);
+        $registry->method('getRepository')->willReturn($repository);
+
+        $fieldSerializer = $this->createMock(AbstractFieldSerializer::class);
+        $fieldSerializer->method('deserialize')->willReturnCallback(
+            static fn (Config $config, $field, $value) => $value
+        );
+
+        return new PrimaryKeyResolver($registry, $fieldSerializer);
+    }
+
+    private function createPartial(string $id, string $productNumber): PartialEntity
+    {
+        $entity = new PartialEntity();
+        $entity->assign(['id' => $id, 'productNumber' => $productNumber]);
+        $entity->setUniqueIdentifier($id);
+
+        return $entity;
+    }
+
+    private function createConfig(): Config
+    {
+        return new Config([], [], [['entityName' => ProductDefinition::ENTITY_NAME, 'mappedKey' => 'productNumber']]);
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?

`PrimaryKeyResolver` resolves the primary key of an imported row from the configured `updateBy` field, for example the product number. It did that with one query per row, so an import of 10,000 products issued 10,000 lookups on top of the writes.

This is the one N+1 of the import that #18934 could not remove locally: the serializer pipeline is record at a time, so nothing inside it can see the other rows.

### 2. What does this change do, exactly?

The import reads its rows in windows and announces each window to the pipe before processing it.

* `AbstractPipe::warmUp()` receives the records in the pipe's own input shape and returns them in its output shape, so the next pipe of a chain sees what it will see during `out()`. The default implementation returns the records unchanged, so a pipe that does not need it is unaffected.
* `KeyMappingPipe` applies its mapping, which is a pure transformation, so the resolver receives the records with their entity keys.
* `EntityPipe` hands the window to `PrimaryKeyResolver::warmUp()`, which resolves the primary keys of all values with a single query and keeps them for the window.
* `PrimaryKeyResolver::resolvePrimaryKey()` takes the id from that window instead of querying, and falls back to its previous per record lookup whenever the window has no answer.

**Window size.** A window never holds more rows than the import may still process, so the import limit is always reached at the end of a window. Without that, the rows of a partly processed window would count as read and the next run of the import would resume behind them, silently skipping them.

**Two deliberate limits.**

* Only an `updateBy` field that is a plain field of the entity is batched. Its value has to be read back next to the id to map the rows onto the records, which is not possible for a path into an association such as `translations.DEFAULT.name`. Those keep resolving per record.
* A value without a record is not remembered. A row of the same window may still create that record, and the rows behind it have to find it. Caching the miss broke exactly that case, which `ImportExportTest::testImportProductsWithUpdateByMapping` covers.

Everything else about the import is unchanged: the per row events, the error handling per record, the dry run transaction, the offset the progress reports, and the order in which rows are processed.

### 3. Describe each step to reproduce the issue or behaviour.

1. Create an import profile for products that maps `updateBy` to the product number.
2. Import a CSV whose rows all refer to existing products, with the SQL logger enabled.
3. Before this change the log contains one `SELECT ... FROM product WHERE product_number = ?` per row; after it, one `SELECT ... WHERE product_number IN (...)` per window, and rows whose product does not exist yet still fall back to their own lookup.
4. The imported products are identical, and the import resumes at the same offset when it is split over several runs.

### 4. Please link to the relevant issues (if any).

relates #18922
relates #18934

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  <!-- `ImportExport`, `AbstractPipe` and `PrimaryKeyResolver` are internal, and `warmUp()` has a default implementation, so no plugin contract changes. -->
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [x] I have written or adjusted the documentation and agent skills according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
