### PR TITLE
feat(elasticsearch): prune outdated admin and storefront indices

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -130,7 +130,7 @@ Two additions:
 * `bin/console es:admin:index:cleanup` lists the admin indices without an alias and deletes them after confirmation. Aliased indices are kept. The command fails when admin Elasticsearch is disabled.
 * A new `shopware.elasticsearch.cleanup.indices` scheduled task deletes outdated storefront and admin indices once a day. It runs when Elasticsearch or admin Elasticsearch is enabled.
 
-An index that is currently being built has no alias either, so the scheduled task needs two more conditions: it skips every index listed in `elasticsearch_index_task` or `admin_elasticsearch_index_task`, and it only deletes indices created longer ago than `elasticsearch.index_cleanup_minimum_age` (86400 seconds by default, `SHOPWARE_ES_INDEX_CLEANUP_MINIMUM_AGE`). Raise that value when a full indexing run can take longer than the threshold. An index whose creation date cannot be read is never deleted by the task.
+An index that is currently being built has no alias either, so the scheduled task needs two more conditions: it skips every index listed in `elasticsearch_index_task` or `admin_elasticsearch_index_task`, and it only deletes indices created longer ago than `elasticsearch.index_cleanup_minimum_age` (one week by default, `SHOPWARE_ES_INDEX_CLEANUP_MINIMUM_AGE` in seconds). The default is deliberately generous because deleting an index cannot be undone; lower it when outdated indices take up too much disk, and raise it when a full indexing run can take longer than a week. An index whose creation date cannot be read is never deleted by the task.
 
 `es:index:cleanup` itself is unchanged.
 

--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -121,6 +121,23 @@ The new `shopware.cdn.path_cache_buster` setting defaults to `true`, preserving 
 
 When updating an Elasticsearch/OpenSearch mapping references an analyzer/normalizer that the live index's analysis settings do not define (for example after an update introduced a new analyzer), `putMapping` fails with `analyzer [...] has not been configured in mappings`. Analysis settings are fixed at index creation and cannot be added to a live index, so this is now handled like the other unrecoverable mapping errors: the affected entity is scheduled for a reindex into a freshly created index, which rebuilds it with the current analysis settings instead of leaving the outdated mapping in place.
 
+### Outdated Elasticsearch indices are removed automatically
+
+Indices that no longer serve an alias were only removable by hand, and `es:index:cleanup` never covered the admin search indices at all — it builds its search pattern from the storefront index prefix (`sw_<entity>_*`), which never matches an admin index (`sw-admin-<name>_<timestamp>`), and it talks to the storefront client rather than the admin one. Admin indices are normally cleaned up when the alias is swapped at the end of an indexing run, so leftovers came from runs that were aborted before that point and then stayed until `es:admin:reset` deleted every admin index, including the live ones.
+
+Two additions close this:
+
+* `bin/console es:admin:index:cleanup` lists the admin indices without an alias and deletes them after confirmation, leaving the aliased indices in place. It fails when admin Elasticsearch is disabled.
+* A new `shopware.elasticsearch.cleanup.indices` scheduled task deletes outdated storefront and admin indices once a day. It runs when either Elasticsearch or admin Elasticsearch is enabled.
+
+The scheduled task applies two guards the interactive commands do not need, because an index that is currently being built also has no alias: it skips indices that an entry in `elasticsearch_index_task` or `admin_elasticsearch_index_task` still writes to, and it only deletes indices older than `elasticsearch.index_cleanup_minimum_age` (default 86400 seconds, override with `SHOPWARE_ES_INDEX_CLEANUP_MINIMUM_AGE`). Raise the value if a full indexing run can take longer than the threshold. Indices whose creation date cannot be read are never deleted by the task.
+
+`es:index:cleanup` is unchanged and still deletes every storefront index without an alias after confirmation, regardless of age.
+
+### Admin index alias swap no longer stops at the first missing alias
+
+`AdminSearchRegistry` swapped aliases in a loop that returned instead of continuing when an alias did not exist yet. Every entity after that one kept its previous index and left the newly built index behind without an alias. Each entity's alias is now swapped independently.
+
 ### Built-in translation system configurable via `shopware.translation`
 
 The built-in translation system's configuration (previously only editable by decorating `AbstractTranslationConfigLoader`) can now be overridden through the standard Symfony configuration in `config/packages`. Add a `shopware.translation` section to override individual options; any option left unset falls back to the shipped defaults in `translation.yaml`:

--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -123,20 +123,16 @@ When updating an Elasticsearch/OpenSearch mapping references an analyzer/normali
 
 ### Outdated Elasticsearch indices are removed automatically
 
-Indices that no longer serve an alias were only removable by hand, and `es:index:cleanup` never covered the admin search indices at all — it builds its search pattern from the storefront index prefix (`sw_<entity>_*`), which never matches an admin index (`sw-admin-<name>_<timestamp>`), and it talks to the storefront client rather than the admin one. Admin indices are normally cleaned up when the alias is swapped at the end of an indexing run, so leftovers came from runs that were aborted before that point and then stayed until `es:admin:reset` deleted every admin index, including the live ones.
+An index that no longer serves an alias could only be removed by hand, and `es:index:cleanup` never covered the admin search indices: it builds its pattern from the storefront index prefix (`sw_<entity>_*`), which never matches an admin index (`sw-admin-<name>_<timestamp>`), and it uses the storefront client instead of the admin one. Removing a leftover admin index therefore meant running `es:admin:reset`, which deletes every admin index including the live ones.
 
-Two additions close this:
+Two additions:
 
-* `bin/console es:admin:index:cleanup` lists the admin indices without an alias and deletes them after confirmation, leaving the aliased indices in place. It fails when admin Elasticsearch is disabled.
-* A new `shopware.elasticsearch.cleanup.indices` scheduled task deletes outdated storefront and admin indices once a day. It runs when either Elasticsearch or admin Elasticsearch is enabled.
+* `bin/console es:admin:index:cleanup` lists the admin indices without an alias and deletes them after confirmation. Aliased indices are kept. The command fails when admin Elasticsearch is disabled.
+* A new `shopware.elasticsearch.cleanup.indices` scheduled task deletes outdated storefront and admin indices once a day. It runs when Elasticsearch or admin Elasticsearch is enabled.
 
-The scheduled task applies two guards the interactive commands do not need, because an index that is currently being built also has no alias: it skips indices that an entry in `elasticsearch_index_task` or `admin_elasticsearch_index_task` still writes to, and it only deletes indices older than `elasticsearch.index_cleanup_minimum_age` (default 86400 seconds, override with `SHOPWARE_ES_INDEX_CLEANUP_MINIMUM_AGE`). Raise the value if a full indexing run can take longer than the threshold. Indices whose creation date cannot be read are never deleted by the task.
+An index that is currently being built has no alias either, so the scheduled task needs two more conditions: it skips every index listed in `elasticsearch_index_task` or `admin_elasticsearch_index_task`, and it only deletes indices created longer ago than `elasticsearch.index_cleanup_minimum_age` (86400 seconds by default, `SHOPWARE_ES_INDEX_CLEANUP_MINIMUM_AGE`). Raise that value when a full indexing run can take longer than the threshold. An index whose creation date cannot be read is never deleted by the task.
 
-`es:index:cleanup` is unchanged and still deletes every storefront index without an alias after confirmation, regardless of age.
-
-### Admin index alias swap no longer stops at the first missing alias
-
-`AdminSearchRegistry` swapped aliases in a loop that returned instead of continuing when an alias did not exist yet. Every entity after that one kept its previous index and left the newly built index behind without an alias. Each entity's alias is now swapped independently.
+`es:index:cleanup` itself is unchanged.
 
 ### Built-in translation system configurable via `shopware.translation`
 

--- a/src/Elasticsearch/Admin/AdminElasticsearchOutdatedIndexDetector.php
+++ b/src/Elasticsearch/Admin/AdminElasticsearchOutdatedIndexDetector.php
@@ -1,0 +1,78 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Elasticsearch\Admin;
+
+use OpenSearch\Client;
+use Shopware\Core\Framework\Log\Package;
+
+#[Package('inventory')]
+class AdminElasticsearchOutdatedIndexDetector
+{
+    /**
+     * @internal
+     */
+    public function __construct(
+        private readonly Client $client,
+        private readonly AdminElasticsearchHelper $adminEsHelper
+    ) {
+    }
+
+    /**
+     * @return array<string>
+     */
+    public function get(): array
+    {
+        return $this->collect(null);
+    }
+
+    /**
+     * Restricts the result to indices that were created before the given point in time. An index that is currently
+     * being built carries no alias either, so an age threshold is what separates a leftover from a running indexing
+     * run for unattended callers.
+     *
+     * @return array<string>
+     */
+    public function getOutdated(\DateTimeInterface $createdBefore): array
+    {
+        return $this->collect($createdBefore);
+    }
+
+    /**
+     * @return array<string>
+     */
+    private function collect(?\DateTimeInterface $createdBefore): array
+    {
+        $allIndices = $this->client->indices()->get(['index' => $this->adminEsHelper->getPrefix() . '*']);
+
+        $indicesToBeDeleted = [];
+        foreach ($allIndices as $index) {
+            if (\count($index['aliases']) > 0) {
+                continue;
+            }
+
+            if ($createdBefore !== null && !$this->isCreatedBefore($index, $createdBefore)) {
+                continue;
+            }
+
+            $indicesToBeDeleted[] = $index['settings']['index']['provided_name'];
+        }
+
+        return $indicesToBeDeleted;
+    }
+
+    /**
+     * @param array{aliases: array<string>, settings: array<mixed>} $index
+     */
+    private function isCreatedBefore(array $index, \DateTimeInterface $createdBefore): bool
+    {
+        $creationDate = (int) ($index['settings']['index']['creation_date'] ?? 0);
+
+        // creation_date is epoch milliseconds. A missing value is treated as "too young to touch" so an index we
+        // cannot date is never deleted unattended.
+        if ($creationDate === 0) {
+            return false;
+        }
+
+        return $creationDate < $createdBefore->getTimestamp() * 1000;
+    }
+}

--- a/src/Elasticsearch/DependencyInjection/Configuration.php
+++ b/src/Elasticsearch/DependencyInjection/Configuration.php
@@ -23,7 +23,7 @@ class Configuration implements ConfigurationInterface
                 ->scalarNode('hosts')->end()
                 ->scalarNode('index_prefix')->end()
                 ->scalarNode('throw_exception')->end()
-                ->integerNode('index_cleanup_minimum_age')->defaultValue(86400)->end()
+                ->integerNode('index_cleanup_minimum_age')->defaultValue(604800)->end()
                 ->arrayNode('ssl')
                     ->children()
                         ->scalarNode('cert_path')->end()

--- a/src/Elasticsearch/DependencyInjection/Configuration.php
+++ b/src/Elasticsearch/DependencyInjection/Configuration.php
@@ -23,6 +23,7 @@ class Configuration implements ConfigurationInterface
                 ->scalarNode('hosts')->end()
                 ->scalarNode('index_prefix')->end()
                 ->scalarNode('throw_exception')->end()
+                ->integerNode('index_cleanup_minimum_age')->defaultValue(86400)->end()
                 ->arrayNode('ssl')
                     ->children()
                         ->scalarNode('cert_path')->end()

--- a/src/Elasticsearch/DependencyInjection/services.php
+++ b/src/Elasticsearch/DependencyInjection/services.php
@@ -24,6 +24,7 @@ use Shopware\Elasticsearch\AbstractFieldQueryBuilder;
 use Shopware\Elasticsearch\AbstractTokenQueryBuilder;
 use Shopware\Elasticsearch\Admin\AdminElasticsearchEntitySearcher;
 use Shopware\Elasticsearch\Admin\AdminElasticsearchHelper;
+use Shopware\Elasticsearch\Admin\AdminElasticsearchOutdatedIndexDetector;
 use Shopware\Elasticsearch\Admin\AdminSearchController;
 use Shopware\Elasticsearch\Admin\AdminSearcher;
 use Shopware\Elasticsearch\Admin\AdminSearchRegistry;
@@ -47,6 +48,7 @@ use Shopware\Elasticsearch\Admin\Subscriber\RefreshIndexSubscriber;
 use Shopware\Elasticsearch\ExplainFieldQueryBuilder;
 use Shopware\Elasticsearch\FieldQueryBuilder;
 use Shopware\Elasticsearch\Framework\ClientFactory;
+use Shopware\Elasticsearch\Framework\Command\ElasticsearchAdminCleanIndicesCommand;
 use Shopware\Elasticsearch\Framework\Command\ElasticsearchAdminIndexingCommand;
 use Shopware\Elasticsearch\Framework\Command\ElasticsearchAdminResetCommand;
 use Shopware\Elasticsearch\Framework\Command\ElasticsearchAdminTestCommand;
@@ -74,6 +76,8 @@ use Shopware\Elasticsearch\Framework\ElasticsearchLanguageProvider;
 use Shopware\Elasticsearch\Framework\ElasticsearchOutdatedIndexDetector;
 use Shopware\Elasticsearch\Framework\ElasticsearchRegistry;
 use Shopware\Elasticsearch\Framework\ElasticsearchStagingHandler;
+use Shopware\Elasticsearch\Framework\Indexing\CleanupIndicesTask;
+use Shopware\Elasticsearch\Framework\Indexing\CleanupIndicesTaskHandler;
 use Shopware\Elasticsearch\Framework\Indexing\CreateAliasTask;
 use Shopware\Elasticsearch\Framework\Indexing\CreateAliasTaskHandler;
 use Shopware\Elasticsearch\Framework\Indexing\ElasticsearchIndexer;
@@ -350,6 +354,25 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $services->set(CreateAliasTask::class)
         ->tag('shopware.scheduled.task');
 
+    $services->set(CleanupIndicesTaskHandler::class)
+        ->args([
+            service('scheduled_task.repository'),
+            service('shopware.elasticsearch.logger'),
+            service(Client::class),
+            service('admin.openSearch.client'),
+            service(Connection::class),
+            service(ElasticsearchOutdatedIndexDetector::class),
+            service(AdminElasticsearchOutdatedIndexDetector::class),
+            service(AdminElasticsearchHelper::class),
+            service(ClockInterface::class),
+            param('elasticsearch.enabled'),
+            param('elasticsearch.index_cleanup_minimum_age'),
+        ])
+        ->tag('messenger.message_handler');
+
+    $services->set(CleanupIndicesTask::class)
+        ->tag('shopware.scheduled.task');
+
     $services->set(ElasticsearchRegistry::class)
         ->args([
             tagged_iterator('shopware.es.definition'),
@@ -472,6 +495,14 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         ])
         ->tag('console.command');
 
+    $services->set(ElasticsearchAdminCleanIndicesCommand::class)
+        ->args([
+            service('admin.openSearch.client'),
+            service(AdminElasticsearchOutdatedIndexDetector::class),
+            service(AdminElasticsearchHelper::class),
+        ])
+        ->tag('console.command');
+
     $services->set(ElasticsearchAdminIndexingCommand::class)
         ->args([
             service(AdminSearchRegistry::class),
@@ -581,6 +612,12 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             param('kernel.environment'),
             param('elasticsearch.administration.throw_exception'),
             service('shopware.elasticsearch.logger'),
+        ]);
+
+    $services->set(AdminElasticsearchOutdatedIndexDetector::class)
+        ->args([
+            service('admin.openSearch.client'),
+            service(AdminElasticsearchHelper::class),
         ]);
 
     $services->set(AdminSearchController::class)

--- a/src/Elasticsearch/Framework/Command/ElasticsearchAdminCleanIndicesCommand.php
+++ b/src/Elasticsearch/Framework/Command/ElasticsearchAdminCleanIndicesCommand.php
@@ -1,0 +1,72 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Elasticsearch\Framework\Command;
+
+use OpenSearch\Client;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Elasticsearch\Admin\AdminElasticsearchHelper;
+use Shopware\Elasticsearch\Admin\AdminElasticsearchOutdatedIndexDetector;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * @internal
+ */
+#[Package('inventory')]
+#[AsCommand(
+    name: 'es:admin:index:cleanup',
+    description: 'Clean outdated admin indices',
+)]
+class ElasticsearchAdminCleanIndicesCommand extends Command
+{
+    /**
+     * @internal
+     */
+    public function __construct(
+        private readonly Client $client,
+        private readonly AdminElasticsearchOutdatedIndexDetector $outdatedIndexDetector,
+        private readonly AdminElasticsearchHelper $adminEsHelper
+    ) {
+        parent::__construct();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        if ($this->adminEsHelper->isEnabled() !== true) {
+            $io->error('Admin elasticsearch is not enabled');
+
+            return self::FAILURE;
+        }
+
+        $indices = $this->outdatedIndexDetector->get();
+
+        if ($indices === []) {
+            $io->writeln('No indices to be deleted.');
+
+            return self::SUCCESS;
+        }
+
+        $io->table(['Indices to be deleted:'], array_map(static fn (string $name) => [$name], $indices));
+
+        $confirm = $io->confirm(\sprintf('Delete these %d indices?', \count($indices)));
+
+        if (!$confirm) {
+            $io->caution('Deletion aborted.');
+
+            return self::SUCCESS;
+        }
+
+        foreach ($indices as $index) {
+            $this->client->indices()->delete(['index' => $index]);
+        }
+
+        $io->writeln('Indices deleted.');
+
+        return self::SUCCESS;
+    }
+}

--- a/src/Elasticsearch/Framework/ElasticsearchOutdatedIndexDetector.php
+++ b/src/Elasticsearch/Framework/ElasticsearchOutdatedIndexDetector.php
@@ -42,6 +42,36 @@ class ElasticsearchOutdatedIndexDetector
     }
 
     /**
+     * Restricts the result to indices that were created before the given point in time. An index that is currently
+     * being built carries no alias either, so an age threshold is what separates a leftover from a running indexing
+     * run for unattended callers.
+     *
+     * @return array<string>
+     */
+    public function getOutdated(\DateTimeInterface $createdBefore): array
+    {
+        $indicesToBeDeleted = [];
+
+        foreach ($this->getAllIndices() as $index) {
+            if (\count($index['aliases']) > 0) {
+                continue;
+            }
+
+            $creationDate = (int) ($index['settings']['index']['creation_date'] ?? 0);
+
+            // creation_date is epoch milliseconds. A missing value is treated as "too young to touch" so an index we
+            // cannot date is never deleted unattended.
+            if ($creationDate === 0 || $creationDate >= $createdBefore->getTimestamp() * 1000) {
+                continue;
+            }
+
+            $indicesToBeDeleted[] = $index['settings']['index']['provided_name'];
+        }
+
+        return $indicesToBeDeleted;
+    }
+
+    /**
      * @return array<string>
      */
     public function getAllUsedIndices(): array

--- a/src/Elasticsearch/Framework/Indexing/CleanupIndicesTask.php
+++ b/src/Elasticsearch/Framework/Indexing/CleanupIndicesTask.php
@@ -1,0 +1,31 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Elasticsearch\Framework\Indexing;
+
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTask;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
+
+#[Package('framework')]
+class CleanupIndicesTask extends ScheduledTask
+{
+    public static function getTaskName(): string
+    {
+        return 'shopware.elasticsearch.cleanup.indices';
+    }
+
+    public static function getDefaultInterval(): int
+    {
+        return self::DAILY;
+    }
+
+    public static function shouldRun(ParameterBagInterface $bag): bool
+    {
+        return (bool) $bag->get('elasticsearch.enabled') || (bool) $bag->get('elasticsearch.administration.enabled');
+    }
+
+    public static function shouldRescheduleOnFailure(): bool
+    {
+        return true;
+    }
+}

--- a/src/Elasticsearch/Framework/Indexing/CleanupIndicesTaskHandler.php
+++ b/src/Elasticsearch/Framework/Indexing/CleanupIndicesTaskHandler.php
@@ -1,0 +1,82 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Elasticsearch\Framework\Indexing;
+
+use Doctrine\DBAL\Connection;
+use OpenSearch\Client;
+use Psr\Clock\ClockInterface;
+use Psr\Log\LoggerInterface;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTaskCollection;
+use Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTaskHandler;
+use Shopware\Elasticsearch\Admin\AdminElasticsearchHelper;
+use Shopware\Elasticsearch\Admin\AdminElasticsearchOutdatedIndexDetector;
+use Shopware\Elasticsearch\Framework\ElasticsearchOutdatedIndexDetector;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+
+/**
+ * Deletes indices that no longer serve an alias. "No alias" alone is not enough to call an index outdated: a full
+ * reindex only moves the alias once it finished, so its target looks identical to a leftover for the whole run. This
+ * handler therefore deletes an index only when it is old enough and is not the write target of a recorded indexing
+ * task.
+ *
+ * @internal
+ */
+#[Package('framework')]
+#[AsMessageHandler(handles: CleanupIndicesTask::class)]
+final class CleanupIndicesTaskHandler extends ScheduledTaskHandler
+{
+    /**
+     * @param EntityRepository<ScheduledTaskCollection> $scheduledTaskRepository
+     */
+    public function __construct(
+        EntityRepository $scheduledTaskRepository,
+        LoggerInterface $logger,
+        private readonly Client $client,
+        private readonly Client $adminClient,
+        private readonly Connection $connection,
+        private readonly ElasticsearchOutdatedIndexDetector $detector,
+        private readonly AdminElasticsearchOutdatedIndexDetector $adminDetector,
+        private readonly AdminElasticsearchHelper $adminEsHelper,
+        private readonly ClockInterface $clock,
+        private readonly bool $elasticsearchEnabled,
+        private readonly int $minimumAge,
+    ) {
+        parent::__construct($scheduledTaskRepository, $logger);
+    }
+
+    public function run(): void
+    {
+        $createdBefore = $this->clock->now()->sub(new \DateInterval(\sprintf('PT%dS', $this->minimumAge)));
+
+        if ($this->elasticsearchEnabled) {
+            $this->delete(
+                $this->client,
+                $this->detector->getOutdated($createdBefore),
+                $this->connection->fetchFirstColumn('SELECT `index` FROM elasticsearch_index_task')
+            );
+        }
+
+        if ($this->adminEsHelper->isEnabled()) {
+            $this->delete(
+                $this->adminClient,
+                $this->adminDetector->getOutdated($createdBefore),
+                $this->connection->fetchFirstColumn('SELECT `index` FROM admin_elasticsearch_index_task')
+            );
+        }
+    }
+
+    /**
+     * @param array<string> $outdated
+     * @param array<mixed> $inFlight indices a recorded indexing task still writes to
+     */
+    private function delete(Client $client, array $outdated, array $inFlight): void
+    {
+        foreach (array_diff($outdated, $inFlight) as $index) {
+            $client->indices()->delete(['index' => $index]);
+
+            $this->exceptionLogger->info(\sprintf('Deleted outdated elasticsearch index "%s".', $index));
+        }
+    }
+}

--- a/src/Elasticsearch/Resources/config/packages/elasticsearch.yaml
+++ b/src/Elasticsearch/Resources/config/packages/elasticsearch.yaml
@@ -7,7 +7,8 @@ elasticsearch:
     throw_exception: "%env(string:SHOPWARE_ES_THROW_EXCEPTION)%"
     # Minimum age in seconds an index without an alias must reach before the cleanup scheduled task deletes it.
     # A running reindex writes to an index that carries no alias yet, so this threshold must stay comfortably
-    # above the duration of a full indexing run. Applies to both storefront and admin indices.
+    # above the duration of a full indexing run. It defaults to a week because deleting an index is not
+    # reversible, while keeping a few outdated ones only costs disk. Applies to storefront and admin indices.
     index_cleanup_minimum_age: "%env(int:SHOPWARE_ES_INDEX_CLEANUP_MINIMUM_AGE)%"
     # Injects sw_dimension_normalize into the technical-term chains so
     # "5 x 70"/"5×70" collapse to one token. See SEARCH_ARCHITECTURE.md §4.
@@ -303,7 +304,7 @@ parameters:
     env(OPENSEARCH_URL): ""
     env(SHOPWARE_ES_INDEX_PREFIX): "sw"
     env(SHOPWARE_ES_THROW_EXCEPTION): "1"
-    env(SHOPWARE_ES_INDEX_CLEANUP_MINIMUM_AGE): "86400"
+    env(SHOPWARE_ES_INDEX_CLEANUP_MINIMUM_AGE): "604800"
     env(SHOPWARE_ADMIN_ES_ENABLED): ""
     env(ADMIN_OPENSEARCH_URL): ""
     env(SHOPWARE_ADMIN_ES_INDEX_PREFIX): "sw-admin"

--- a/src/Elasticsearch/Resources/config/packages/elasticsearch.yaml
+++ b/src/Elasticsearch/Resources/config/packages/elasticsearch.yaml
@@ -5,6 +5,10 @@ elasticsearch:
     hosts: "%env(string:OPENSEARCH_URL)%"
     index_prefix: "%env(string:SHOPWARE_ES_INDEX_PREFIX)%"
     throw_exception: "%env(string:SHOPWARE_ES_THROW_EXCEPTION)%"
+    # Minimum age in seconds an index without an alias must reach before the cleanup scheduled task deletes it.
+    # A running reindex writes to an index that carries no alias yet, so this threshold must stay comfortably
+    # above the duration of a full indexing run. Applies to both storefront and admin indices.
+    index_cleanup_minimum_age: "%env(int:SHOPWARE_ES_INDEX_CLEANUP_MINIMUM_AGE)%"
     # Injects sw_dimension_normalize into the technical-term chains so
     # "5 x 70"/"5×70" collapse to one token. See SEARCH_ARCHITECTURE.md §4.
     # Toggling requires a full reindex.
@@ -299,6 +303,7 @@ parameters:
     env(OPENSEARCH_URL): ""
     env(SHOPWARE_ES_INDEX_PREFIX): "sw"
     env(SHOPWARE_ES_THROW_EXCEPTION): "1"
+    env(SHOPWARE_ES_INDEX_CLEANUP_MINIMUM_AGE): "86400"
     env(SHOPWARE_ADMIN_ES_ENABLED): ""
     env(ADMIN_OPENSEARCH_URL): ""
     env(SHOPWARE_ADMIN_ES_INDEX_PREFIX): "sw-admin"

--- a/tests/unit/Elasticsearch/Admin/AdminElasticsearchOutdatedIndexDetectorTest.php
+++ b/tests/unit/Elasticsearch/Admin/AdminElasticsearchOutdatedIndexDetectorTest.php
@@ -1,0 +1,108 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Elasticsearch\Admin;
+
+use OpenSearch\Client;
+use OpenSearch\Namespaces\IndicesNamespace;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Elasticsearch\Admin\AdminElasticsearchHelper;
+use Shopware\Elasticsearch\Admin\AdminElasticsearchOutdatedIndexDetector;
+
+/**
+ * @internal
+ */
+#[Package('inventory')]
+#[CoversClass(AdminElasticsearchOutdatedIndexDetector::class)]
+class AdminElasticsearchOutdatedIndexDetectorTest extends TestCase
+{
+    private const THRESHOLD = '2026-08-11 12:00:00';
+
+    public function testGetReturnsOnlyIndicesWithoutAlias(): void
+    {
+        $detector = $this->createDetector([
+            'sw-admin-product_1000' => $this->index('sw-admin-product_1000', ['sw-admin-product'], '2020-01-01 00:00:00'),
+            'sw-admin-product_2000' => $this->index('sw-admin-product_2000', [], '2020-01-01 00:00:00'),
+        ]);
+
+        static::assertSame(['sw-admin-product_2000'], $detector->get());
+    }
+
+    public function testGetIgnoresTheAgeOfAnIndex(): void
+    {
+        $detector = $this->createDetector([
+            'sw-admin-product_2000' => $this->index('sw-admin-product_2000', [], '2026-08-12 11:59:00'),
+        ]);
+
+        static::assertSame(['sw-admin-product_2000'], $detector->get());
+    }
+
+    public function testGetOutdatedKeepsIndicesCreatedAfterTheThreshold(): void
+    {
+        $detector = $this->createDetector([
+            'sw-admin-product_1000' => $this->index('sw-admin-product_1000', [], '2026-08-10 12:00:00'),
+            'sw-admin-product_2000' => $this->index('sw-admin-product_2000', [], '2026-08-12 11:59:00'),
+        ]);
+
+        static::assertSame(['sw-admin-product_1000'], $detector->getOutdated(new \DateTimeImmutable(self::THRESHOLD)));
+    }
+
+    public function testGetOutdatedKeepsIndicesWithoutCreationDate(): void
+    {
+        $index = $this->index('sw-admin-product_1000', [], '2020-01-01 00:00:00');
+        unset($index['settings']['index']['creation_date']);
+
+        $detector = $this->createDetector(['sw-admin-product_1000' => $index]);
+
+        static::assertSame([], $detector->getOutdated(new \DateTimeImmutable(self::THRESHOLD)));
+    }
+
+    public function testGetOutdatedKeepsAliasedIndicesRegardlessOfAge(): void
+    {
+        $detector = $this->createDetector([
+            'sw-admin-product_1000' => $this->index('sw-admin-product_1000', ['sw-admin-product'], '2020-01-01 00:00:00'),
+        ]);
+
+        static::assertSame([], $detector->getOutdated(new \DateTimeImmutable(self::THRESHOLD)));
+    }
+
+    /**
+     * @param array<string, array{aliases: array<string>, settings: array<mixed>}> $indices
+     */
+    private function createDetector(array $indices): AdminElasticsearchOutdatedIndexDetector
+    {
+        $indicesNamespace = $this->createMock(IndicesNamespace::class);
+        $indicesNamespace
+            ->expects($this->once())
+            ->method('get')
+            ->with(['index' => 'sw-admin*'])
+            ->willReturn($indices);
+
+        $client = static::createStub(Client::class);
+        $client->method('indices')->willReturn($indicesNamespace);
+
+        $helper = static::createStub(AdminElasticsearchHelper::class);
+        $helper->method('getPrefix')->willReturn('sw-admin');
+
+        return new AdminElasticsearchOutdatedIndexDetector($client, $helper);
+    }
+
+    /**
+     * @param array<string> $aliases
+     *
+     * @return array{aliases: array<string>, settings: array<mixed>}
+     */
+    private function index(string $name, array $aliases, string $createdAt): array
+    {
+        return [
+            'aliases' => $aliases,
+            'settings' => [
+                'index' => [
+                    'provided_name' => $name,
+                    'creation_date' => (string) ((new \DateTimeImmutable($createdAt))->getTimestamp() * 1000),
+                ],
+            ],
+        ];
+    }
+}

--- a/tests/unit/Elasticsearch/Framework/Command/ElasticsearchAdminCleanIndicesCommandTest.php
+++ b/tests/unit/Elasticsearch/Framework/Command/ElasticsearchAdminCleanIndicesCommandTest.php
@@ -1,0 +1,135 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Elasticsearch\Framework\Command;
+
+use OpenSearch\Client;
+use OpenSearch\Namespaces\IndicesNamespace;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\MockObject\Stub;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Elasticsearch\Admin\AdminElasticsearchHelper;
+use Shopware\Elasticsearch\Admin\AdminElasticsearchOutdatedIndexDetector;
+use Shopware\Elasticsearch\Framework\Command\ElasticsearchAdminCleanIndicesCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+
+/**
+ * @internal
+ */
+#[Package('inventory')]
+#[CoversClass(ElasticsearchAdminCleanIndicesCommand::class)]
+class ElasticsearchAdminCleanIndicesCommandTest extends TestCase
+{
+    private IndicesNamespace&Stub $indices;
+
+    private Client&Stub $client;
+
+    protected function setUp(): void
+    {
+        $this->indices = static::createStub(IndicesNamespace::class);
+        $this->client = static::createStub(Client::class);
+        $this->client->method('indices')->willReturn($this->indices);
+    }
+
+    public function testExecuteWithAdminEsNotEnabled(): void
+    {
+        $detector = $this->createMock(AdminElasticsearchOutdatedIndexDetector::class);
+        $detector->expects($this->never())->method('get');
+
+        $commandTester = new CommandTester($this->createCommand($detector, false));
+        $commandTester->execute([]);
+
+        static::assertSame(Command::FAILURE, $commandTester->getStatusCode());
+        static::assertStringContainsString('Admin elasticsearch is not enabled', $commandTester->getDisplay());
+    }
+
+    public function testExecuteWithoutOutdatedIndices(): void
+    {
+        $commandTester = new CommandTester($this->createCommand($this->createDetector([])));
+        $commandTester->execute([]);
+
+        static::assertSame(Command::SUCCESS, $commandTester->getStatusCode());
+        static::assertStringContainsString('No indices to be deleted.', $commandTester->getDisplay());
+    }
+
+    public function testExecuteAbortsWithoutConfirmation(): void
+    {
+        $indices = $this->createMock(IndicesNamespace::class);
+        $indices->expects($this->never())->method('delete');
+
+        $client = static::createStub(Client::class);
+        $client->method('indices')->willReturn($indices);
+
+        $command = new ElasticsearchAdminCleanIndicesCommand(
+            $client,
+            $this->createDetector(['sw-admin-product_1000']),
+            $this->createHelper(true)
+        );
+
+        $commandTester = new CommandTester($command);
+        $commandTester->setInputs(['no']);
+        $commandTester->execute([]);
+
+        static::assertSame(Command::SUCCESS, $commandTester->getStatusCode());
+        static::assertStringContainsString('Deletion aborted.', $commandTester->getDisplay());
+    }
+
+    public function testExecuteDeletesConfirmedIndices(): void
+    {
+        $deleted = [];
+
+        $indices = $this->createMock(IndicesNamespace::class);
+        $indices
+            ->expects($this->exactly(2))
+            ->method('delete')
+            ->willReturnCallback(function (array $arguments) use (&$deleted): array {
+                $deleted[] = $arguments['index'];
+
+                return [];
+            });
+
+        $client = static::createStub(Client::class);
+        $client->method('indices')->willReturn($indices);
+
+        $command = new ElasticsearchAdminCleanIndicesCommand(
+            $client,
+            $this->createDetector(['sw-admin-product_1000', 'sw-admin-order_1000']),
+            $this->createHelper(true)
+        );
+
+        $commandTester = new CommandTester($command);
+        $commandTester->setInputs(['yes']);
+        $commandTester->execute([]);
+
+        static::assertSame(Command::SUCCESS, $commandTester->getStatusCode());
+        static::assertSame(['sw-admin-product_1000', 'sw-admin-order_1000'], $deleted);
+        static::assertStringContainsString('Indices deleted.', $commandTester->getDisplay());
+    }
+
+    private function createCommand(
+        AdminElasticsearchOutdatedIndexDetector $detector,
+        bool $enabled = true
+    ): ElasticsearchAdminCleanIndicesCommand {
+        return new ElasticsearchAdminCleanIndicesCommand($this->client, $detector, $this->createHelper($enabled));
+    }
+
+    /**
+     * @param array<string> $outdated
+     */
+    private function createDetector(array $outdated): AdminElasticsearchOutdatedIndexDetector
+    {
+        $detector = static::createStub(AdminElasticsearchOutdatedIndexDetector::class);
+        $detector->method('get')->willReturn($outdated);
+
+        return $detector;
+    }
+
+    private function createHelper(bool $enabled): AdminElasticsearchHelper
+    {
+        $helper = static::createStub(AdminElasticsearchHelper::class);
+        $helper->method('isEnabled')->willReturn($enabled);
+
+        return $helper;
+    }
+}

--- a/tests/unit/Elasticsearch/Framework/ElasticsearchOutdatedIndexDetectorTest.php
+++ b/tests/unit/Elasticsearch/Framework/ElasticsearchOutdatedIndexDetectorTest.php
@@ -79,6 +79,34 @@ class ElasticsearchOutdatedIndexDetectorTest extends TestCase
         static::assertCount(2, $detector->getAllUsedIndices());
     }
 
+    public function testGetOutdatedOnlyReturnsIndicesOlderThanTheThreshold(): void
+    {
+        $threshold = new \DateTimeImmutable('2026-08-11 12:00:00');
+
+        $indices = static::createStub(IndicesNamespace::class);
+        $indices
+            ->method('get')
+            ->willReturn([
+                'aliased' => $this->index('sw_product_1000', ['sw_product'], '2020-01-01 00:00:00'),
+                'old' => $this->index('sw_product_2000', [], '2026-08-10 12:00:00'),
+                'young' => $this->index('sw_product_3000', [], '2026-08-12 11:59:00'),
+                'undated' => [
+                    'aliases' => [],
+                    'settings' => ['index' => ['provided_name' => 'sw_product_4000']],
+                ],
+            ]);
+
+        $client = static::createStub(Client::class);
+        $client->method('indices')->willReturn($indices);
+
+        $registry = static::createStub(ElasticsearchRegistry::class);
+        $registry->method('getDefinitions')->willReturn([static::createStub(ElasticsearchProductDefinition::class)]);
+
+        $detector = new ElasticsearchOutdatedIndexDetector($client, $registry, static::createStub(ElasticsearchHelper::class));
+
+        static::assertSame(['sw_product_2000'], $detector->getOutdated($threshold));
+    }
+
     public function testDoesNothingWithoutIndices(): void
     {
         $indices = $this->createMock(IndicesNamespace::class);
@@ -96,5 +124,23 @@ class ElasticsearchOutdatedIndexDetectorTest extends TestCase
 
         $detector = new ElasticsearchOutdatedIndexDetector($client, $registry, $esHelper);
         static::assertEmpty($detector->get());
+    }
+
+    /**
+     * @param array<string> $aliases
+     *
+     * @return array{aliases: array<string>, settings: array<mixed>}
+     */
+    private function index(string $name, array $aliases, string $createdAt): array
+    {
+        return [
+            'aliases' => $aliases,
+            'settings' => [
+                'index' => [
+                    'provided_name' => $name,
+                    'creation_date' => (string) ((new \DateTimeImmutable($createdAt))->getTimestamp() * 1000),
+                ],
+            ],
+        ];
     }
 }

--- a/tests/unit/Elasticsearch/Framework/Indexing/CleanupIndicesTaskHandlerTest.php
+++ b/tests/unit/Elasticsearch/Framework/Indexing/CleanupIndicesTaskHandlerTest.php
@@ -1,0 +1,185 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Elasticsearch\Framework\Indexing;
+
+use Doctrine\DBAL\Connection;
+use OpenSearch\Client;
+use OpenSearch\Namespaces\IndicesNamespace;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTaskCollection;
+use Shopware\Core\Test\Stub\DataAbstractionLayer\StaticEntityRepository;
+use Shopware\Elasticsearch\Admin\AdminElasticsearchHelper;
+use Shopware\Elasticsearch\Admin\AdminElasticsearchOutdatedIndexDetector;
+use Shopware\Elasticsearch\Framework\ElasticsearchOutdatedIndexDetector;
+use Shopware\Elasticsearch\Framework\Indexing\CleanupIndicesTaskHandler;
+use Symfony\Component\Clock\MockClock;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+#[CoversClass(CleanupIndicesTaskHandler::class)]
+class CleanupIndicesTaskHandlerTest extends TestCase
+{
+    private const NOW = '2026-08-12 12:00:00';
+
+    /**
+     * @var array<string>
+     */
+    private array $deleted = [];
+
+    /**
+     * @var array<string>
+     */
+    private array $adminDeleted = [];
+
+    protected function setUp(): void
+    {
+        $this->deleted = [];
+        $this->adminDeleted = [];
+    }
+
+    public function testDeletesOutdatedStorefrontIndicesButNotInFlightOnes(): void
+    {
+        $handler = $this->createHandler(
+            outdated: ['sw_product_1000', 'sw_product_2000'],
+            inFlight: [['sw_product_2000']],
+        );
+
+        $handler->run();
+
+        static::assertSame(['sw_product_1000'], $this->deleted);
+    }
+
+    public function testDeletesOutdatedAdminIndicesButNotInFlightOnes(): void
+    {
+        $handler = $this->createHandler(
+            adminOutdated: ['sw-admin-product_1000', 'sw-admin-product_2000'],
+            inFlight: [[], ['sw-admin-product_2000']],
+            adminEnabled: true,
+        );
+
+        $handler->run();
+
+        static::assertSame(['sw-admin-product_1000'], $this->adminDeleted);
+    }
+
+    public function testDoesNotTouchStorefrontIndicesWhenElasticsearchIsDisabled(): void
+    {
+        $handler = $this->createHandler(
+            outdated: ['sw_product_1000'],
+            adminOutdated: ['sw-admin-product_1000'],
+            inFlight: [[]],
+            elasticsearchEnabled: false,
+            adminEnabled: true,
+        );
+
+        $handler->run();
+
+        static::assertSame([], $this->deleted);
+        static::assertSame(['sw-admin-product_1000'], $this->adminDeleted);
+    }
+
+    public function testDoesNotTouchAdminIndicesWhenAdminElasticsearchIsDisabled(): void
+    {
+        $handler = $this->createHandler(
+            outdated: ['sw_product_1000'],
+            adminOutdated: ['sw-admin-product_1000'],
+            inFlight: [[]],
+            adminEnabled: false,
+        );
+
+        $handler->run();
+
+        static::assertSame(['sw_product_1000'], $this->deleted);
+        static::assertSame([], $this->adminDeleted);
+    }
+
+    public function testSubtractsTheConfiguredMinimumAgeFromTheCurrentTime(): void
+    {
+        $captured = null;
+
+        $detector = $this->createMock(ElasticsearchOutdatedIndexDetector::class);
+        $detector
+            ->method('getOutdated')
+            ->willReturnCallback(static function (\DateTimeInterface $createdBefore) use (&$captured): array {
+                $captured = $createdBefore;
+
+                return [];
+            });
+
+        $handler = $this->createHandler(detector: $detector, minimumAge: 7200);
+
+        $handler->run();
+
+        static::assertInstanceOf(\DateTimeInterface::class, $captured);
+        static::assertSame(
+            (new \DateTimeImmutable(self::NOW))->getTimestamp() - 7200,
+            $captured->getTimestamp()
+        );
+    }
+
+    /**
+     * @param array<string> $outdated
+     * @param array<string> $adminOutdated
+     * @param array<array<string>> $inFlight consecutive results of the indexing task lookups
+     */
+    private function createHandler(
+        array $outdated = [],
+        array $adminOutdated = [],
+        array $inFlight = [[]],
+        bool $elasticsearchEnabled = true,
+        bool $adminEnabled = false,
+        int $minimumAge = 86400,
+        ?ElasticsearchOutdatedIndexDetector $detector = null,
+    ): CleanupIndicesTaskHandler {
+        if ($detector === null) {
+            $detector = static::createStub(ElasticsearchOutdatedIndexDetector::class);
+            $detector->method('getOutdated')->willReturn($outdated);
+        }
+
+        $adminDetector = static::createStub(AdminElasticsearchOutdatedIndexDetector::class);
+        $adminDetector->method('getOutdated')->willReturn($adminOutdated);
+
+        $adminEsHelper = static::createStub(AdminElasticsearchHelper::class);
+        $adminEsHelper->method('isEnabled')->willReturn($adminEnabled);
+
+        $connection = static::createStub(Connection::class);
+        $connection->method('fetchFirstColumn')->willReturnOnConsecutiveCalls(...array_values($inFlight));
+
+        return new CleanupIndicesTaskHandler(
+            StaticEntityRepository::of(ScheduledTaskCollection::class, []),
+            new NullLogger(),
+            $this->createClient($this->deleted),
+            $this->createClient($this->adminDeleted),
+            $connection,
+            $detector,
+            $adminDetector,
+            $adminEsHelper,
+            new MockClock(self::NOW),
+            $elasticsearchEnabled,
+            $minimumAge,
+        );
+    }
+
+    /**
+     * @param array<string> $deleted
+     */
+    private function createClient(array &$deleted): Client
+    {
+        $indices = static::createStub(IndicesNamespace::class);
+        $indices->method('delete')->willReturnCallback(static function (array $arguments) use (&$deleted): array {
+            $deleted[] = $arguments['index'];
+
+            return [];
+        });
+
+        $client = static::createStub(Client::class);
+        $client->method('indices')->willReturn($indices);
+
+        return $client;
+    }
+}

--- a/tests/unit/Elasticsearch/Framework/Indexing/CleanupIndicesTaskTest.php
+++ b/tests/unit/Elasticsearch/Framework/Indexing/CleanupIndicesTaskTest.php
@@ -1,0 +1,45 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Elasticsearch\Framework\Indexing;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Elasticsearch\Framework\Indexing\CleanupIndicesTask;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+#[CoversClass(CleanupIndicesTask::class)]
+class CleanupIndicesTaskTest extends TestCase
+{
+    public function testTaskMetadata(): void
+    {
+        static::assertSame('shopware.elasticsearch.cleanup.indices', CleanupIndicesTask::getTaskName());
+        // ScheduledTask::DAILY is protected; assert the resolved value (one day in seconds).
+        static::assertSame(86400, CleanupIndicesTask::getDefaultInterval());
+        static::assertTrue(CleanupIndicesTask::shouldRescheduleOnFailure());
+    }
+
+    public function testRunsWhenEitherElasticsearchIsEnabled(): void
+    {
+        static::assertTrue(CleanupIndicesTask::shouldRun($this->bag(true, false)));
+        static::assertTrue(CleanupIndicesTask::shouldRun($this->bag(false, true)));
+        static::assertTrue(CleanupIndicesTask::shouldRun($this->bag(true, true)));
+    }
+
+    public function testDoesNotRunWhenBothAreDisabled(): void
+    {
+        static::assertFalse(CleanupIndicesTask::shouldRun($this->bag(false, false)));
+    }
+
+    private function bag(bool $elasticsearch, bool $administration): ParameterBag
+    {
+        return new ParameterBag([
+            'elasticsearch.enabled' => $elasticsearch,
+            'elasticsearch.administration.enabled' => $administration,
+        ]);
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?

`es:index:cleanup` deletes indices that no longer serve an alias, but it never sees the admin search indices. It builds its search pattern from the storefront index prefix (`sw_<entity>_*`), which never matches an admin index (`sw-admin-<name>_<timestamp>`), and it talks to the storefront client instead of the admin one.

The only way to remove a leftover admin index today is `es:admin:reset`, which deletes every admin index including the live ones, so admin search is down until a full reindex finishes.

Both commands also have to be run by hand, so leftovers pile up until the cluster hits its shard limit and refuses to create new indices.

### 2. What does this change do, exactly?

- Adds `bin/console es:admin:index:cleanup`. It lists the admin indices without an alias and deletes them after confirmation, leaving the aliased ones in place. It fails when admin Elasticsearch is disabled.
- Adds a daily `shopware.elasticsearch.cleanup.indices` scheduled task that removes outdated storefront and admin indices without being asked.

An index that is still being built has no alias either, so the scheduled task cannot use that alone. It also skips indices that an entry in `elasticsearch_index_task` or `admin_elasticsearch_index_task` still writes to, and only deletes indices older than `elasticsearch.index_cleanup_minimum_age` (default 24 hours, `SHOPWARE_ES_INDEX_CLEANUP_MINIMUM_AGE`). An index whose creation date cannot be read is never deleted.

`es:index:cleanup` itself is unchanged.

### 3. Describe each step to reproduce the issue or behaviour.

1. Enable admin Elasticsearch and run `bin/console es:admin:index`.
2. Run it a second time and stop it with Ctrl+C while it is queueing, so the alias swap never happens.
3. `curl "$OPENSEARCH_URL/_cat/indices/sw-admin*"` shows an index without an alias.
4. `bin/console es:index:cleanup` reports nothing to delete.
5. With this change, `bin/console es:admin:index:cleanup` lists and deletes it.

### 4. Please link to the relevant issues (if any).

relates #19264

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have updated developer-facing release notes if this change is **relevant** for external developers
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
