### PR TITLE
feat(elasticsearch): swap admin alias only after indexing finished

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -191,22 +191,22 @@ When updating an Elasticsearch/OpenSearch mapping references an analyzer/normali
 
 The product-specific progress bar is gone, replaced by the remaining document count per entity. Its total came from a live `product` count rather than from the recorded task, so it was only ever an approximation and could not be generalised to other entities.
 
-### Outdated Elasticsearch indices are removed automatically
+### Admin search indices go live only after their indexing run finished
 
-Indices that no longer serve an alias were only removable by hand, and `es:index:cleanup` never covered the admin search indices at all — it builds its search pattern from the storefront index prefix (`sw_<entity>_*`), which never matches an admin index (`sw-admin-<name>_<timestamp>`), and it talks to the storefront client rather than the admin one. Admin indices are normally cleaned up when the alias is swapped at the end of an indexing run, so leftovers came from runs that were aborted before that point and then stayed until `es:admin:reset` deleted every admin index, including the live ones.
+`es:admin:index` swapped each alias to the newly built index immediately after queueing the indexing messages, before a single one had been handled. Admin search was served by an almost empty index for the whole time the queue took to drain, and the previous index was deleted in the same step, so there was nothing to fall back to. The `doc_count` column of `admin_elasticsearch_index_task` was written but never read or decremented, so nothing recorded how far a run had progressed.
 
-Two additions close this:
+The admin indexing lifecycle now works like the storefront one:
 
-* `bin/console es:admin:index:cleanup` lists the admin indices without an alias and deletes them after confirmation, leaving the aliased indices in place. It fails when admin Elasticsearch is disabled.
-* A new `shopware.elasticsearch.cleanup.indices` scheduled task deletes outdated storefront and admin indices once a day. It runs when either Elasticsearch or admin Elasticsearch is enabled.
+* Every indexing message counts its documents off `admin_elasticsearch_index_task.doc_count` after it was written successfully. A failing batch does not count down, so a retried or dead-lettered batch keeps the alias on the previous index instead of promoting an incomplete one.
+* A new `shopware.elasticsearch.admin.create.alias` scheduled task runs every five minutes, promotes indices whose remaining count reached zero, and deletes the index each one replaces. `es:admin:index --no-queue` still swaps within the command, because its messages are handled inline.
+* While a run is in progress an entity has two indices — the one the alias serves and the one being built — and live updates from `AdminSearchRegistry::refresh()` are written to both. Previously they only reached the index being built, so they were invisible in admin search until the swap.
+* Rows of runs that never finished are removed when the entity is indexed again, so a leftover index is no longer recorded as being written to.
 
-The scheduled task applies two guards the interactive commands do not need, because an index that is currently being built also has no alias: it skips indices that an entry in `elasticsearch_index_task` or `admin_elasticsearch_index_task` still writes to, and it only deletes indices older than `elasticsearch.index_cleanup_minimum_age` (default 86400 seconds, override with `SHOPWARE_ES_INDEX_CLEANUP_MINIMUM_AGE`). Raise the value if a full indexing run can take longer than the threshold. Indices whose creation date cannot be read are never deleted by the task.
+Note that promoting an index adds the alias before the index it replaces is deleted, so admin search can briefly see both. That behaviour is unchanged.
 
-`es:index:cleanup` is unchanged and still deletes every storefront index without an alias after confirmation, regardless of age.
+### New `es:admin:status` command
 
-### Admin index alias swap no longer stops at the first missing alias
-
-`AdminSearchRegistry` swapped aliases in a loop that returned instead of continuing when an alias did not exist yet. Every entity after that one kept its previous index and left the newly built index behind without an alias. Each entity's alias is now swapped independently.
+Admin indexing had no status output at all, and the only indirect signal — the `message_queue_stats` entry for `AdminSearchIndexingMessage` — is gone in 6.8. `bin/console es:admin:status` reports the admin cluster health and one row per entity with its index, alias, remaining document count and whether it is live, still indexing, or waiting for its alias swap.
 
 ### Built-in translation system configurable via `shopware.translation`
 

--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -190,6 +190,9 @@ When updating an Elasticsearch/OpenSearch mapping references an analyzer/normali
 `es:status` only looked at the `product` row of `elasticsearch_index_task`, so a running category, manufacturer or custom-entity indexing run was reported as `completed`. It now lists every pending indexing task with its index, alias, remaining document count, and whether it is still indexing or waiting for the alias swap.
 
 The product-specific progress bar is gone, replaced by the remaining document count per entity. Its total came from a live `product` count rather than from the recorded task, so it was only ever an approximation and could not be generalised to other entities.
+### New `es:admin:status` command
+
+Admin indexing had no status output at all, and the only indirect signal — the `message_queue_stats` entry for `AdminSearchIndexingMessage` — is gone in 6.8. `bin/console es:admin:status` reports the admin cluster health and one row per entity with its index, alias, remaining document count and whether it is live, still indexing, or waiting for its alias swap.
 
 ### Admin search indices go live only after their indexing run finished
 

--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -185,31 +185,28 @@ The new `shopware.cdn.path_cache_buster` setting defaults to `true`, preserving 
 
 When updating an Elasticsearch/OpenSearch mapping references an analyzer/normalizer that the live index's analysis settings do not define (for example after an update introduced a new analyzer), `putMapping` fails with `analyzer [...] has not been configured in mappings`. Analysis settings are fixed at index creation and cannot be added to a live index, so this is now handled like the other unrecoverable mapping errors: the affected entity is scheduled for a reindex into a freshly created index, which rebuilds it with the current analysis settings instead of leaving the outdated mapping in place.
 
-### `es:status` reports every indexed entity
-
-`es:status` only looked at the `product` row of `elasticsearch_index_task`, so a running category, manufacturer or custom-entity indexing run was reported as `completed`. It now lists every pending indexing task with its index, alias, remaining document count, and whether it is still indexing or waiting for the alias swap.
-
-The product-specific progress bar is gone, replaced by the remaining document count per entity. Its total came from a live `product` count rather than from the recorded task, so it was only ever an approximation and could not be generalised to other entities.
-### New `es:admin:status` command
-
-Admin indexing had no status output at all, and the only indirect signal — the `message_queue_stats` entry for `AdminSearchIndexingMessage` — is gone in 6.8. `bin/console es:admin:status` reports the admin cluster health and one row per entity with its index, alias, remaining document count and whether it is live, still indexing, or waiting for its alias swap.
-
 ### Admin search indices go live only after their indexing run finished
 
-`es:admin:index` swapped each alias to the newly built index immediately after queueing the indexing messages, before a single one had been handled. Admin search was served by an almost empty index for the whole time the queue took to drain, and the previous index was deleted in the same step, so there was nothing to fall back to. The `doc_count` column of `admin_elasticsearch_index_task` was written but never read or decremented, so nothing recorded how far a run had progressed.
+`es:admin:index` moved each alias to the newly built index right after it queued the indexing messages, before any of them was handled. Admin search was served by an almost empty index for as long as the queue took to drain, and the index it replaced was deleted in the same step, so there was nothing to fall back to. `admin_elasticsearch_index_task.doc_count` recorded the size of a run but was never read or decremented, so nothing knew how far a run had come.
 
-The admin indexing lifecycle now works like the storefront one:
+Admin indexing now follows the same lifecycle as the storefront:
 
-* Every indexing message counts its documents off `admin_elasticsearch_index_task.doc_count` after it was written successfully. A failing batch does not count down, so a retried or dead-lettered batch keeps the alias on the previous index instead of promoting an incomplete one.
-* A new `shopware.elasticsearch.admin.create.alias` scheduled task runs every five minutes, promotes indices whose remaining count reached zero, and deletes the index each one replaces. `es:admin:index --no-queue` still swaps within the command, because its messages are handled inline.
-* While a run is in progress an entity has two indices — the one the alias serves and the one being built — and live updates from `AdminSearchRegistry::refresh()` are written to both. Previously they only reached the index being built, so they were invisible in admin search until the swap.
-* Rows of runs that never finished are removed when the entity is indexed again, so a leftover index is no longer recorded as being written to.
+* Every indexing message subtracts its documents from `admin_elasticsearch_index_task.doc_count` after it was written successfully. A batch that fails does not subtract, so a retried or dead-lettered batch leaves the alias on the previous index instead of promoting an incomplete one.
+* A new `shopware.elasticsearch.admin.create.alias` scheduled task runs every five minutes, moves the alias to indices whose remaining count reached zero, and deletes the index each one replaces. `es:admin:index --no-queue` still swaps inside the command, because it handles its messages inline.
+* While a run is in progress an entity has two indices, the one the alias serves and the one being built, and `AdminSearchRegistry::refresh()` writes live updates to both. They previously only reached the index being built, so they were invisible in admin search until the swap.
+* A row of a run that never finished is removed when the entity is indexed again, so its index is no longer recorded as a write target.
 
-Note that promoting an index adds the alias before the index it replaces is deleted, so admin search can briefly see both. That behaviour is unchanged.
+Moving an alias adds it to the new index before the index it replaces is deleted, so admin search can briefly see both. That is unchanged.
+
+### `es:status` reports every indexed entity
+
+`es:status` only read the `product` row of `elasticsearch_index_task`, so a running category, manufacturer or custom-entity indexing run was reported as `completed`. It now lists every pending indexing task with its index, alias, remaining document count, and whether it is still indexing or waiting for the alias swap.
+
+The product-specific progress bar is replaced by that remaining count. Its total came from a live `product` count instead of from the recorded task, so it was an approximation and could not be generalised to other entities. `ElasticsearchStatusCommand` no longer needs `ConsoleProgressTrait` because of that; the trait and the `getSubscribedEvents()`, `startProgress()`, `advanceProgress()` and `finishProgress()` methods it adds to the command are deprecated and will be removed in 6.8.
 
 ### New `es:admin:status` command
 
-Admin indexing had no status output at all, and the only indirect signal — the `message_queue_stats` entry for `AdminSearchIndexingMessage` — is gone in 6.8. `bin/console es:admin:status` reports the admin cluster health and one row per entity with its index, alias, remaining document count and whether it is live, still indexing, or waiting for its alias swap.
+Admin indexing had no status output, and the only indirect signal, the `message_queue_stats` entry for `AdminSearchIndexingMessage`, is gone in 6.8. `bin/console es:admin:status` reports the admin cluster health plus one row per entity with its index, alias, remaining document count, and whether it is live, still indexing, or waiting for its alias swap.
 
 ### Built-in translation system configurable via `shopware.translation`
 

--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -185,6 +185,29 @@ The new `shopware.cdn.path_cache_buster` setting defaults to `true`, preserving 
 
 When updating an Elasticsearch/OpenSearch mapping references an analyzer/normalizer that the live index's analysis settings do not define (for example after an update introduced a new analyzer), `putMapping` fails with `analyzer [...] has not been configured in mappings`. Analysis settings are fixed at index creation and cannot be added to a live index, so this is now handled like the other unrecoverable mapping errors: the affected entity is scheduled for a reindex into a freshly created index, which rebuilds it with the current analysis settings instead of leaving the outdated mapping in place.
 
+### `es:status` reports every indexed entity
+
+`es:status` only looked at the `product` row of `elasticsearch_index_task`, so a running category, manufacturer or custom-entity indexing run was reported as `completed`. It now lists every pending indexing task with its index, alias, remaining document count, and whether it is still indexing or waiting for the alias swap.
+
+The product-specific progress bar is gone, replaced by the remaining document count per entity. Its total came from a live `product` count rather than from the recorded task, so it was only ever an approximation and could not be generalised to other entities.
+
+### Outdated Elasticsearch indices are removed automatically
+
+Indices that no longer serve an alias were only removable by hand, and `es:index:cleanup` never covered the admin search indices at all — it builds its search pattern from the storefront index prefix (`sw_<entity>_*`), which never matches an admin index (`sw-admin-<name>_<timestamp>`), and it talks to the storefront client rather than the admin one. Admin indices are normally cleaned up when the alias is swapped at the end of an indexing run, so leftovers came from runs that were aborted before that point and then stayed until `es:admin:reset` deleted every admin index, including the live ones.
+
+Two additions close this:
+
+* `bin/console es:admin:index:cleanup` lists the admin indices without an alias and deletes them after confirmation, leaving the aliased indices in place. It fails when admin Elasticsearch is disabled.
+* A new `shopware.elasticsearch.cleanup.indices` scheduled task deletes outdated storefront and admin indices once a day. It runs when either Elasticsearch or admin Elasticsearch is enabled.
+
+The scheduled task applies two guards the interactive commands do not need, because an index that is currently being built also has no alias: it skips indices that an entry in `elasticsearch_index_task` or `admin_elasticsearch_index_task` still writes to, and it only deletes indices older than `elasticsearch.index_cleanup_minimum_age` (default 86400 seconds, override with `SHOPWARE_ES_INDEX_CLEANUP_MINIMUM_AGE`). Raise the value if a full indexing run can take longer than the threshold. Indices whose creation date cannot be read are never deleted by the task.
+
+`es:index:cleanup` is unchanged and still deletes every storefront index without an alias after confirmation, regardless of age.
+
+### Admin index alias swap no longer stops at the first missing alias
+
+`AdminSearchRegistry` swapped aliases in a loop that returned instead of continuing when an alias did not exist yet. Every entity after that one kept its previous index and left the newly built index behind without an alias. Each entity's alias is now swapped independently.
+
 ### Built-in translation system configurable via `shopware.translation`
 
 The built-in translation system's configuration (previously only editable by decorating `AbstractTranslationConfigLoader`) can now be overridden through the standard Symfony configuration in `config/packages`. Add a `shopware.translation` section to override individual options; any option left unset falls back to the shipped defaults in `translation.yaml`:

--- a/UPGRADE-6.8.md
+++ b/UPGRADE-6.8.md
@@ -15,6 +15,9 @@ Nothing is removed from the `Shopware.Component` global — generated component 
 Write native setup SFCs instead. The build-time transform emits these calls for you: a base component (`sw-thing.vue`) keeps its `<script setup>` body and gains a generated `attachOverrides(...)` footer, and an override (`sw-thing.override.vue`) registers its callback through `overrideComponentSetup()`. Extension points are declared with `swDefinePublic({ ... })` in the base and consumed with `swDefineOverride({ ... })` in the override.
 
 See `src/Administration/Resources/app/administration/technical-docs/03-extensibility/07-native-setup-authoring.md` for the authoring rules.
+## `es:status` no longer renders a progress bar
+
+`Shopware\Elasticsearch\Framework\Command\ElasticsearchStatusCommand` stops using `ConsoleProgressTrait`. The `getSubscribedEvents()`, `startProgress()`, `advanceProgress()` and `finishProgress()` methods it provided are removed. The command never registered as an event subscriber, so the methods did nothing; the remaining document count per entity replaces the progress bar.
 
 ## Locale-aware sorting for product property group options
 

--- a/UPGRADE-6.8.md
+++ b/UPGRADE-6.8.md
@@ -17,7 +17,7 @@ Write native setup SFCs instead. The build-time transform emits these calls for 
 See `src/Administration/Resources/app/administration/technical-docs/03-extensibility/07-native-setup-authoring.md` for the authoring rules.
 ## `es:status` no longer renders a progress bar
 
-`Shopware\Elasticsearch\Framework\Command\ElasticsearchStatusCommand` stops using `ConsoleProgressTrait`. The `getSubscribedEvents()`, `startProgress()`, `advanceProgress()` and `finishProgress()` methods it provided are removed. The command never registered as an event subscriber, so the methods did nothing; the remaining document count per entity replaces the progress bar.
+`Shopware\Elasticsearch\Framework\Command\ElasticsearchStatusCommand` stops using `ConsoleProgressTrait`. The `getSubscribedEvents()`, `startProgress()`, `advanceProgress()` and `finishProgress()` methods it provided are removed. The command never registered as an event subscriber, so those methods never ran; the remaining document count per entity replaces the progress bar.
 
 ## Locale-aware sorting for product property group options
 

--- a/src/Elasticsearch/Admin/AdminCreateAliasTask.php
+++ b/src/Elasticsearch/Admin/AdminCreateAliasTask.php
@@ -1,0 +1,31 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Elasticsearch\Admin;
+
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTask;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
+
+#[Package('inventory')]
+class AdminCreateAliasTask extends ScheduledTask
+{
+    public static function getTaskName(): string
+    {
+        return 'shopware.elasticsearch.admin.create.alias';
+    }
+
+    public static function getDefaultInterval(): int
+    {
+        return self::MINUTELY * 5;
+    }
+
+    public static function shouldRun(ParameterBagInterface $bag): bool
+    {
+        return (bool) $bag->get('elasticsearch.administration.enabled');
+    }
+
+    public static function shouldRescheduleOnFailure(): bool
+    {
+        return true;
+    }
+}

--- a/src/Elasticsearch/Admin/AdminCreateAliasTaskHandler.php
+++ b/src/Elasticsearch/Admin/AdminCreateAliasTaskHandler.php
@@ -1,0 +1,47 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Elasticsearch\Admin;
+
+use Psr\Log\LoggerInterface;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTaskCollection;
+use Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTaskHandler;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+
+/**
+ * Promotes admin indices whose indexing run finished to their alias. Queued runs return from
+ * {@see AdminSearchRegistry::iterate()} long before the queue is drained, so the swap cannot happen there.
+ *
+ * @internal
+ */
+#[Package('inventory')]
+#[AsMessageHandler(handles: AdminCreateAliasTask::class)]
+final class AdminCreateAliasTaskHandler extends ScheduledTaskHandler
+{
+    /**
+     * @param EntityRepository<ScheduledTaskCollection> $scheduledTaskRepository
+     */
+    public function __construct(
+        EntityRepository $scheduledTaskRepository,
+        LoggerInterface $logger,
+        private readonly AdminSearchRegistry $registry,
+        private readonly AdminElasticsearchHelper $adminEsHelper,
+    ) {
+        parent::__construct($scheduledTaskRepository, $logger);
+    }
+
+    public function run(): void
+    {
+        if (!$this->adminEsHelper->isEnabled()) {
+            return;
+        }
+
+        try {
+            $this->registry->swapFinishedAliases();
+        } catch (\Throwable $e) {
+            // catch exception - otherwise the task will never be called again
+            $this->adminEsHelper->logAndThrowException($e);
+        }
+    }
+}

--- a/src/Elasticsearch/Admin/AdminSearchIndexingMessage.php
+++ b/src/Elasticsearch/Admin/AdminSearchIndexingMessage.php
@@ -23,7 +23,8 @@ final readonly class AdminSearchIndexingMessage implements AsyncMessageInterface
         private string $indexer,
         private array $indices,
         private array $ids,
-        private array $toRemoveIds = []
+        private array $toRemoveIds = [],
+        private bool $indexingRun = false
     ) {
     }
 
@@ -54,6 +55,16 @@ final readonly class AdminSearchIndexingMessage implements AsyncMessageInterface
     }
 
     /**
+     * Whether this message belongs to a full indexing run. Only those count down the remaining document count of
+     * the {@see \Shopware\Elasticsearch\Admin\AdminCreateAliasTask} that promotes the index; live updates of single
+     * entities must not.
+     */
+    public function isIndexingRun(): bool
+    {
+        return $this->indexingRun;
+    }
+
+    /**
      * @experimental stableVersion:v6.8.0 feature:DEDUPLICATABLE_MESSAGES
      */
     public function deduplicationId(): ?string
@@ -69,6 +80,7 @@ final readonly class AdminSearchIndexingMessage implements AsyncMessageInterface
             $this->indexer,
             $sortedIndices,
             $sortedIds,
+            $this->indexingRun,
         ]);
 
         if ($data === false) {

--- a/src/Elasticsearch/Admin/AdminSearchRegistry.php
+++ b/src/Elasticsearch/Admin/AdminSearchRegistry.php
@@ -117,11 +117,13 @@ class AdminSearchRegistry implements EventSubscriberInterface
             while ($ids = $iterator->fetch()) {
                 $ids = array_values($ids);
 
+                $message = new AdminSearchIndexingMessage($indexer->getEntity(), $indexer->getName(), $indices, $ids, [], true);
+
                 // we provide no queue when the data is sent by the admin
                 if ($indexingBehavior->getNoQueue()) {
-                    $this->__invoke(new AdminSearchIndexingMessage($indexer->getEntity(), $indexer->getName(), $indices, $ids));
+                    $this->__invoke($message);
                 } else {
-                    $this->queue->dispatch(new AdminSearchIndexingMessage($indexer->getEntity(), $indexer->getName(), $indices, $ids));
+                    $this->queue->dispatch($message);
                 }
 
                 $this->dispatcher->dispatch(new ProgressAdvancedEvent(\count($ids)));
@@ -130,7 +132,9 @@ class AdminSearchRegistry implements EventSubscriberInterface
             $this->dispatcher->dispatch(new ProgressFinishedEvent($indexer->getName()));
         }
 
-        $this->swapAlias($indices);
+        // when the messages were handled inline the indices are complete already, so their aliases swap right here.
+        // Queued runs are still being written to and are promoted by AdminCreateAliasTask once they finish.
+        $this->swapFinishedAliases();
     }
 
     public function refresh(EntityWrittenContainerEvent $event): void
@@ -154,9 +158,8 @@ class AdminSearchRegistry implements EventSubscriberInterface
             }
         }
 
-        /** @var array<string, string> $indices */
-        $indices = $this->connection->fetchAllKeyValue('SELECT `alias`, `index` FROM admin_elasticsearch_index_task');
-        if ($indices === []) {
+        $targets = $this->getWriteTargets();
+        if ($targets === []) {
             return;
         }
 
@@ -171,17 +174,63 @@ class AdminSearchRegistry implements EventSubscriberInterface
                 continue;
             }
 
-            $msg = new AdminSearchIndexingMessage($indexer->getEntity(), $indexer->getName(), $indices, $ids, $deletedIds);
+            $alias = $this->adminEsHelper->getIndex($indexer->getName());
 
-            // if the event is triggered from storefront or sales channel API, we dispatch the message to the queue to not slow down the request
-            if ($isSalesChannelSource) {
-                $this->queue->dispatch($msg);
+            // while an indexing run is in progress an entity has two indices: the one the alias currently serves and
+            // the one being built. Both receive the update, otherwise it is either invisible until the alias swaps
+            // or discarded with the index it was written to.
+            foreach ($targets[$alias] ?? [] as $index) {
+                $msg = new AdminSearchIndexingMessage($indexer->getEntity(), $indexer->getName(), [$alias => $index], $ids, $deletedIds);
+
+                // if the event is triggered from storefront or sales channel API, we dispatch the message to the queue to not slow down the request
+                if ($event->getContext()->getSource() instanceof SalesChannelApiSource) {
+                    $this->queue->dispatch($msg);
+
+                    continue;
+                }
+
+                // otherwise we invoke the message handler directly
+                $this->__invoke($msg);
+            }
+        }
+    }
+
+    /**
+     * Promotes every index that finished its indexing run to its alias and removes the index it replaces. Indices
+     * that are still being written to keep a remaining document count above zero and are left alone.
+     */
+    public function swapFinishedAliases(): void
+    {
+        foreach ($this->getFinishedTargets() as $alias => $indices) {
+            if (!$this->client->indices()->existsAlias(['name' => $alias])) {
+                $this->putAlias($indices[0], $alias);
 
                 continue;
             }
 
-            // otherwise we invoke the message handler directly
-            $this->__invoke($msg);
+            $live = array_keys($this->client->indices()->getAlias(['name' => $alias]));
+
+            $finished = array_values(array_diff($indices, $live));
+
+            if ($finished === []) {
+                continue;
+            }
+
+            // two runs can finish before either was promoted; the rows are ordered by index name, whose suffix is
+            // the creation timestamp, so the last one is the newest. The rows of the others are dropped below,
+            // which leaves their indices unused.
+            $newest = $finished[array_key_last($finished)];
+
+            $this->putAlias($newest, $alias);
+
+            foreach ($live as $outdated) {
+                $this->client->indices()->delete(['index' => $outdated]);
+            }
+
+            $this->connection->executeStatement(
+                'DELETE FROM admin_elasticsearch_index_task WHERE `alias` = :alias AND `index` != :index',
+                ['alias' => $alias, 'index' => $newest]
+            );
         }
     }
 
@@ -282,6 +331,52 @@ class AdminSearchRegistry implements EventSubscriberInterface
 
             throw ElasticsearchException::indexingError($errors);
         }
+
+        if (!$message->isIndexingRun()) {
+            return;
+        }
+
+        // counted down only after a successful write, so a failing batch keeps the alias on the previous index
+        // instead of promoting an incomplete one
+        $this->connection->executeStatement(
+            'UPDATE admin_elasticsearch_index_task SET `doc_count` = `doc_count` - :count WHERE `index` = :index',
+            ['count' => \count($ids), 'index' => $indices[$alias]]
+        );
+    }
+
+    /**
+     * @return array<string, list<string>> indices to write to, keyed by alias
+     */
+    private function getWriteTargets(): array
+    {
+        return $this->groupByAlias(
+            $this->connection->fetchAllAssociative('SELECT `alias`, `index` FROM admin_elasticsearch_index_task')
+        );
+    }
+
+    /**
+     * @return array<string, list<string>> indices whose indexing run completed, keyed by alias
+     */
+    private function getFinishedTargets(): array
+    {
+        return $this->groupByAlias(
+            $this->connection->fetchAllAssociative('SELECT `alias`, `index` FROM admin_elasticsearch_index_task WHERE `doc_count` <= 0 ORDER BY `index`')
+        );
+    }
+
+    /**
+     * @param list<array<string, mixed>> $rows
+     *
+     * @return array<string, list<string>>
+     */
+    private function groupByAlias(array $rows): array
+    {
+        $targets = [];
+        foreach ($rows as $row) {
+            $targets[(string) $row['alias']][] = (string) $row['index'];
+        }
+
+        return $targets;
     }
 
     /**
@@ -293,7 +388,6 @@ class AdminSearchRegistry implements EventSubscriberInterface
      */
     private function createIndices(array $entities): array
     {
-        $indexTasks = [];
         $indices = [];
         foreach ($entities as $entityName) {
             $indexer = $this->getIndexer($entityName);
@@ -308,28 +402,22 @@ class AdminSearchRegistry implements EventSubscriberInterface
 
             $this->create($indexer, $index, $alias);
 
+            // rows of earlier runs that never finished are dropped, which leaves their indices unused. Finished
+            // rows stay, so refresh() keeps writing to the index the alias serves until this run is promoted.
+            $this->connection->executeStatement(
+                'DELETE FROM admin_elasticsearch_index_task WHERE `entity` = :entity AND `index` != :index AND `doc_count` > 0',
+                ['entity' => $indexer->getEntity(), 'index' => $index]
+            );
+
             $iterator = $indexer->getIterator();
-            $indexTasks[] = [
+
+            $this->connection->insert('admin_elasticsearch_index_task', [
                 'id' => Uuid::randomBytes(),
                 '`entity`' => $indexer->getEntity(),
                 '`index`' => $index,
                 '`alias`' => $alias,
                 '`doc_count`' => $iterator->fetchCount(),
-            ];
-        }
-
-        if ($indices === []) {
-            return $indices;
-        }
-
-        $this->connection->executeStatement(
-            'DELETE FROM admin_elasticsearch_index_task WHERE `entity` IN (:entities)',
-            ['entities' => $entities],
-            ['entities' => ArrayParameterType::STRING]
-        );
-
-        foreach ($indexTasks as $task) {
-            $this->connection->insert('admin_elasticsearch_index_task', $task);
+            ]);
         }
 
         return $indices;
@@ -351,13 +439,14 @@ class AdminSearchRegistry implements EventSubscriberInterface
 
             $entities[] = $indexer->getEntity();
 
-            $iterator = $indexer->getIterator();
+            // create() attached the alias right away because it did not exist, so this index is live from the start
+            // and has no indexing run to wait for
             $indexTasks[] = [
                 'id' => Uuid::randomBytes(),
                 '`entity`' => $indexer->getEntity(),
                 '`index`' => $index,
                 '`alias`' => $alias,
-                '`doc_count`' => $iterator->fetchCount(),
+                '`doc_count`' => 0,
             ];
         }
 
@@ -426,33 +515,6 @@ class AdminSearchRegistry implements EventSubscriberInterface
         }
 
         $this->putAlias($index, $alias);
-    }
-
-    /**
-     * @param array<string, string> $indices
-     */
-    private function swapAlias(array $indices): void
-    {
-        foreach ($indices as $alias => $index) {
-            if (!$this->client->indices()->existsAlias(['name' => $alias])) {
-                $this->putAlias($index, $alias);
-
-                continue;
-            }
-
-            $current = $this->client->indices()->getAlias(['name' => $alias]);
-
-            if (!isset($current[$index])) {
-                $this->putAlias($index, $alias);
-            }
-
-            unset($current[$index]);
-            $current = array_keys($current);
-
-            foreach ($current as $value) {
-                $this->client->indices()->delete(['index' => $value]);
-            }
-        }
     }
 
     private function putAlias(string $index, string $alias): void

--- a/src/Elasticsearch/Admin/AdminSearchRegistry.php
+++ b/src/Elasticsearch/Admin/AdminSearchRegistry.php
@@ -183,7 +183,7 @@ class AdminSearchRegistry implements EventSubscriberInterface
                 $msg = new AdminSearchIndexingMessage($indexer->getEntity(), $indexer->getName(), [$alias => $index], $ids, $deletedIds);
 
                 // if the event is triggered from storefront or sales channel API, we dispatch the message to the queue to not slow down the request
-                if ($event->getContext()->getSource() instanceof SalesChannelApiSource) {
+                if ($isSalesChannelSource) {
                     $this->queue->dispatch($msg);
 
                     continue;

--- a/src/Elasticsearch/Admin/AdminSearchRegistry.php
+++ b/src/Elasticsearch/Admin/AdminSearchRegistry.php
@@ -203,7 +203,7 @@ class AdminSearchRegistry implements EventSubscriberInterface
     {
         foreach ($this->getFinishedTargets() as $alias => $indices) {
             if (!$this->client->indices()->existsAlias(['name' => $alias])) {
-                $this->putAlias($indices[0], $alias);
+                $this->promote($alias, $this->newest($indices), []);
 
                 continue;
             }
@@ -216,21 +216,7 @@ class AdminSearchRegistry implements EventSubscriberInterface
                 continue;
             }
 
-            // two runs can finish before either was promoted; the rows are ordered by index name, whose suffix is
-            // the creation timestamp, so the last one is the newest. The rows of the others are dropped below,
-            // which leaves their indices unused.
-            $newest = $finished[array_key_last($finished)];
-
-            $this->putAlias($newest, $alias);
-
-            foreach ($live as $outdated) {
-                $this->client->indices()->delete(['index' => $outdated]);
-            }
-
-            $this->connection->executeStatement(
-                'DELETE FROM admin_elasticsearch_index_task WHERE `alias` = :alias AND `index` != :index',
-                ['alias' => $alias, 'index' => $newest]
-            );
+            $this->promote($alias, $this->newest($finished), $live);
         }
     }
 
@@ -270,6 +256,36 @@ class AdminSearchRegistry implements EventSubscriberInterface
                 'body' => $mapping,
             ]);
         }
+    }
+
+    /**
+     * Two runs can finish before either was promoted. The rows are ordered by index name, whose suffix is the
+     * creation timestamp, so the last one is the newest.
+     *
+     * @param non-empty-list<string> $indices
+     */
+    private function newest(array $indices): string
+    {
+        return $indices[array_key_last($indices)];
+    }
+
+    /**
+     * @param array<string> $outdated indices the alias served so far
+     */
+    private function promote(string $alias, string $index, array $outdated): void
+    {
+        $this->putAlias($index, $alias);
+
+        foreach ($outdated as $previous) {
+            $this->client->indices()->delete(['index' => $previous]);
+        }
+
+        // drops the rows of the replaced indices and of any run that finished but lost the promotion, which leaves
+        // those indices unused
+        $this->connection->executeStatement(
+            'DELETE FROM admin_elasticsearch_index_task WHERE `alias` = :alias AND `index` != :index',
+            ['alias' => $alias, 'index' => $index]
+        );
     }
 
     private function isIndexedEntityWritten(EntityWrittenContainerEvent $event): bool
@@ -345,7 +361,7 @@ class AdminSearchRegistry implements EventSubscriberInterface
     }
 
     /**
-     * @return array<string, list<string>> indices to write to, keyed by alias
+     * @return array<string, non-empty-list<string>> indices to write to, keyed by alias
      */
     private function getWriteTargets(): array
     {
@@ -355,7 +371,7 @@ class AdminSearchRegistry implements EventSubscriberInterface
     }
 
     /**
-     * @return array<string, list<string>> indices whose indexing run completed, keyed by alias
+     * @return array<string, non-empty-list<string>> indices whose indexing run completed, keyed by alias
      */
     private function getFinishedTargets(): array
     {
@@ -367,7 +383,7 @@ class AdminSearchRegistry implements EventSubscriberInterface
     /**
      * @param list<array<string, mixed>> $rows
      *
-     * @return array<string, list<string>>
+     * @return array<string, non-empty-list<string>>
      */
     private function groupByAlias(array $rows): array
     {

--- a/src/Elasticsearch/DependencyInjection/services.php
+++ b/src/Elasticsearch/DependencyInjection/services.php
@@ -22,6 +22,8 @@ use Shopware\Core\System\Language\SalesChannelLanguageLoader;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
 use Shopware\Elasticsearch\AbstractFieldQueryBuilder;
 use Shopware\Elasticsearch\AbstractTokenQueryBuilder;
+use Shopware\Elasticsearch\Admin\AdminCreateAliasTask;
+use Shopware\Elasticsearch\Admin\AdminCreateAliasTaskHandler;
 use Shopware\Elasticsearch\Admin\AdminElasticsearchEntitySearcher;
 use Shopware\Elasticsearch\Admin\AdminElasticsearchHelper;
 use Shopware\Elasticsearch\Admin\AdminSearchController;
@@ -49,6 +51,7 @@ use Shopware\Elasticsearch\FieldQueryBuilder;
 use Shopware\Elasticsearch\Framework\ClientFactory;
 use Shopware\Elasticsearch\Framework\Command\ElasticsearchAdminIndexingCommand;
 use Shopware\Elasticsearch\Framework\Command\ElasticsearchAdminResetCommand;
+use Shopware\Elasticsearch\Framework\Command\ElasticsearchAdminStatusCommand;
 use Shopware\Elasticsearch\Framework\Command\ElasticsearchAdminTestCommand;
 use Shopware\Elasticsearch\Framework\Command\ElasticsearchAdminUpdateMappingCommand;
 use Shopware\Elasticsearch\Framework\Command\ElasticsearchCleanIndicesCommand;
@@ -472,6 +475,14 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         ])
         ->tag('console.command');
 
+    $services->set(ElasticsearchAdminStatusCommand::class)
+        ->args([
+            service('admin.openSearch.client'),
+            service(Connection::class),
+            service(AdminElasticsearchHelper::class),
+        ])
+        ->tag('console.command');
+
     $services->set(ElasticsearchAdminIndexingCommand::class)
         ->args([
             service(AdminSearchRegistry::class),
@@ -582,6 +593,18 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             param('elasticsearch.administration.throw_exception'),
             service('shopware.elasticsearch.logger'),
         ]);
+
+    $services->set(AdminCreateAliasTaskHandler::class)
+        ->args([
+            service('scheduled_task.repository'),
+            service('shopware.elasticsearch.logger'),
+            service(AdminSearchRegistry::class),
+            service(AdminElasticsearchHelper::class),
+        ])
+        ->tag('messenger.message_handler');
+
+    $services->set(AdminCreateAliasTask::class)
+        ->tag('shopware.scheduled.task');
 
     $services->set(AdminSearchController::class)
         ->public()

--- a/src/Elasticsearch/DependencyInjection/services.php
+++ b/src/Elasticsearch/DependencyInjection/services.php
@@ -483,6 +483,14 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         ])
         ->tag('console.command');
 
+    $services->set(ElasticsearchAdminStatusCommand::class)
+        ->args([
+            service('admin.openSearch.client'),
+            service(Connection::class),
+            service(AdminElasticsearchHelper::class),
+        ])
+        ->tag('console.command');
+
     $services->set(ElasticsearchAdminIndexingCommand::class)
         ->args([
             service(AdminSearchRegistry::class),

--- a/src/Elasticsearch/DependencyInjection/services.php
+++ b/src/Elasticsearch/DependencyInjection/services.php
@@ -483,14 +483,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         ])
         ->tag('console.command');
 
-    $services->set(ElasticsearchAdminStatusCommand::class)
-        ->args([
-            service('admin.openSearch.client'),
-            service(Connection::class),
-            service(AdminElasticsearchHelper::class),
-        ])
-        ->tag('console.command');
-
     $services->set(ElasticsearchAdminIndexingCommand::class)
         ->args([
             service(AdminSearchRegistry::class),

--- a/src/Elasticsearch/Framework/Command/ElasticsearchAdminStatusCommand.php
+++ b/src/Elasticsearch/Framework/Command/ElasticsearchAdminStatusCommand.php
@@ -1,0 +1,124 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Elasticsearch\Framework\Command;
+
+use Doctrine\DBAL\Connection;
+use OpenSearch\Client;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Elasticsearch\Admin\AdminElasticsearchHelper;
+use Shopware\Elasticsearch\ElasticsearchException;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\Table;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * @internal
+ */
+#[Package('inventory')]
+#[AsCommand(
+    name: 'es:admin:status',
+    description: 'Show the status of the admin elasticsearch indices',
+)]
+class ElasticsearchAdminStatusCommand extends Command
+{
+    /**
+     * @internal
+     */
+    public function __construct(
+        private readonly Client $client,
+        private readonly Connection $connection,
+        private readonly AdminElasticsearchHelper $adminEsHelper
+    ) {
+        parent::__construct();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        if ($this->adminEsHelper->isEnabled() !== true) {
+            $io->error('Admin elasticsearch is not enabled');
+
+            return self::FAILURE;
+        }
+
+        if (!$this->client->ping()) {
+            throw ElasticsearchException::serverNotAvailable();
+        }
+
+        $health = $this->client->cluster()->health();
+
+        $tasks = $this->connection->fetchAllAssociative(
+            'SELECT `entity`, `index`, `alias`, `doc_count` FROM admin_elasticsearch_index_task ORDER BY `entity`'
+        );
+
+        $pending = array_filter($tasks, static fn (array $task) => (int) $task['doc_count'] > 0);
+
+        $table = new Table($output);
+        $table->setHeaders(['Name', 'Status']);
+        $table->addRow(['Cluster Status', $health['status']]);
+        $table->addRow(['Available Nodes', $health['number_of_nodes']]);
+        $table->addRow(['Indexing', $pending === [] ? 'completed' : 'in progress']);
+        $table->render();
+        $output->writeln('');
+
+        if ($tasks === []) {
+            $io->warning('No admin indices have been built yet. Run "bin/console es:admin:index" to create them.');
+
+            return self::SUCCESS;
+        }
+
+        $live = $this->getLiveIndices(array_unique(array_map(static fn (array $task) => (string) $task['alias'], $tasks)));
+
+        $taskTable = new Table($output);
+        $taskTable->setHeaders(['Entity', 'Index', 'Alias', 'Remaining documents', 'Status']);
+
+        foreach ($tasks as $task) {
+            $remaining = (int) $task['doc_count'];
+
+            if ($remaining > 0) {
+                $status = 'indexing';
+            } elseif (\in_array((string) $task['index'], $live, true)) {
+                $status = 'live';
+            } else {
+                $status = 'waiting for alias swap';
+            }
+
+            $taskTable->addRow([
+                $task['entity'],
+                $task['index'],
+                $task['alias'],
+                max($remaining, 0),
+                $status,
+            ]);
+        }
+
+        $taskTable->render();
+        $output->writeln('');
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * @param array<string> $aliases
+     *
+     * @return array<string> indices currently serving one of the given aliases
+     */
+    private function getLiveIndices(array $aliases): array
+    {
+        $live = [];
+
+        foreach ($aliases as $alias) {
+            if (!$this->client->indices()->existsAlias(['name' => $alias])) {
+                continue;
+            }
+
+            $live = array_merge($live, array_keys($this->client->indices()->getAlias(['name' => $alias])));
+        }
+
+        return $live;
+    }
+}

--- a/src/Elasticsearch/Framework/Command/ElasticsearchStatusCommand.php
+++ b/src/Elasticsearch/Framework/Command/ElasticsearchStatusCommand.php
@@ -4,18 +4,13 @@ namespace Shopware\Elasticsearch\Framework\Command;
 
 use Doctrine\DBAL\Connection;
 use OpenSearch\Client;
-use Shopware\Core\Defaults;
-use Shopware\Core\Framework\DataAbstractionLayer\Command\ConsoleProgressTrait;
 use Shopware\Core\Framework\Log\Package;
-use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Elasticsearch\ElasticsearchException;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Console\Style\SymfonyStyle;
 
 #[Package('framework')]
 #[AsCommand(
@@ -24,8 +19,6 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 )]
 class ElasticsearchStatusCommand extends Command
 {
-    use ConsoleProgressTrait;
-
     /**
      * @internal
      */
@@ -49,49 +42,43 @@ class ElasticsearchStatusCommand extends Command
             throw ElasticsearchException::serverNotAvailable();
         }
 
-        $table = new Table($output);
-        $table->setHeaders(['Name', 'Status']);
         $health = $this->client->cluster()->health();
 
+        $tasks = $this->connection->fetchAllAssociative(
+            'SELECT `entity`, `index`, `alias`, `doc_count` FROM elasticsearch_index_task ORDER BY `entity`'
+        );
+
+        $table = new Table($output);
+        $table->setHeaders(['Name', 'Status']);
         $table->addRow(['Cluster Status', $health['status']]);
         $table->addRow(['Available Nodes', $health['number_of_nodes']]);
+        $table->addRow(['Indexing', $tasks === [] ? 'completed' : 'in progress']);
+        $table->render();
+        $output->writeln('');
 
-        $indexTask = $this->connection->fetchAssociative('SELECT * FROM elasticsearch_index_task WHERE entity = "product" LIMIT 1');
-        $totalProducts = (int) $this->connection->fetchOne('SELECT COUNT(*) FROM product WHERE version_id = :liveVersionId AND child_count = 0 OR parent_id IS NOT NULL', ['liveVersionId' => Uuid::fromHexToBytes(Defaults::LIVE_VERSION)]);
-
-        // No entry in key
-        if ($indexTask === false) {
-            $table->addRow(['Indexing', 'completed']);
-            $table->render();
-            $output->writeln('');
-
+        if ($tasks === []) {
             return self::SUCCESS;
         }
 
-        if ((int) $indexTask['doc_count'] > 0) {
-            $table->addRow(['Indexing', 'in progress']);
+        // A row only exists while an index is being built: the alias is swapped and the row removed once the
+        // remaining document count reaches zero.
+        $taskTable = new Table($output);
+        $taskTable->setHeaders(['Entity', 'Index', 'Alias', 'Remaining documents', 'Status']);
 
-            $table->render();
-            $output->writeln('');
+        foreach ($tasks as $task) {
+            $remaining = (int) $task['doc_count'];
 
-            $progressBar = new ProgressBar($output, $totalProducts);
-            $progressBar->advance($totalProducts - $indexTask['doc_count']);
-            $output->writeln('');
-        } else {
-            $table->addRow(['Indexing', 'completed']);
-            $table->render();
-            $output->writeln('');
+            $taskTable->addRow([
+                $task['entity'],
+                $task['index'],
+                $task['alias'],
+                max($remaining, 0),
+                $remaining > 0 ? 'indexing' : 'waiting for alias swap',
+            ]);
         }
 
-        /** @var list<string> $usedIndices */
-        $usedIndices = array_keys($this->client->indices()->getAlias(['name' => $indexTask['alias']]));
-
-        $indexName = $indexTask['index'];
-        \assert(\is_string($indexName));
-        if (!\in_array($indexName, $usedIndices, true)) {
-            $io = new SymfonyStyle($input, $output);
-            $io->warning(\sprintf('Alias will swap at the end of the indexing process from %s to %s', $usedIndices[0], $indexName));
-        }
+        $taskTable->render();
+        $output->writeln('');
 
         return self::SUCCESS;
     }

--- a/src/Elasticsearch/Framework/Command/ElasticsearchStatusCommand.php
+++ b/src/Elasticsearch/Framework/Command/ElasticsearchStatusCommand.php
@@ -4,6 +4,7 @@ namespace Shopware\Elasticsearch\Framework\Command;
 
 use Doctrine\DBAL\Connection;
 use OpenSearch\Client;
+use Shopware\Core\Framework\DataAbstractionLayer\Command\ConsoleProgressTrait;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Elasticsearch\ElasticsearchException;
 use Symfony\Component\Console\Attribute\AsCommand;
@@ -19,6 +20,13 @@ use Symfony\Component\Console\Output\OutputInterface;
 )]
 class ElasticsearchStatusCommand extends Command
 {
+    /**
+     * @deprecated tag:v6.8.0 - The command no longer renders a progress bar, so the trait and the
+     * getSubscribedEvents(), startProgress(), advanceProgress() and finishProgress() methods it provides will be
+     * removed. They are kept for one minor because the class is not internal.
+     */
+    use ConsoleProgressTrait;
+
     /**
      * @internal
      */

--- a/tests/unit/Elasticsearch/Admin/AdminCreateAliasTaskHandlerTest.php
+++ b/tests/unit/Elasticsearch/Admin/AdminCreateAliasTaskHandlerTest.php
@@ -1,0 +1,60 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Elasticsearch\Admin;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTaskCollection;
+use Shopware\Core\Test\Stub\DataAbstractionLayer\StaticEntityRepository;
+use Shopware\Elasticsearch\Admin\AdminCreateAliasTaskHandler;
+use Shopware\Elasticsearch\Admin\AdminElasticsearchHelper;
+use Shopware\Elasticsearch\Admin\AdminSearchRegistry;
+
+/**
+ * @internal
+ */
+#[Package('inventory')]
+#[CoversClass(AdminCreateAliasTaskHandler::class)]
+class AdminCreateAliasTaskHandlerTest extends TestCase
+{
+    public function testSwapsFinishedAliases(): void
+    {
+        $registry = $this->createMock(AdminSearchRegistry::class);
+        $registry->expects($this->once())->method('swapFinishedAliases');
+
+        $this->createHandler($registry, true)->run();
+    }
+
+    public function testDoesNothingWhenAdminElasticsearchIsDisabled(): void
+    {
+        $registry = $this->createMock(AdminSearchRegistry::class);
+        $registry->expects($this->never())->method('swapFinishedAliases');
+
+        $this->createHandler($registry, false)->run();
+    }
+
+    public function testLetsTheHelperDecideWhetherAFailureIsThrown(): void
+    {
+        $exception = new \RuntimeException('cluster unreachable');
+
+        $registry = static::createStub(AdminSearchRegistry::class);
+        $registry->method('swapFinishedAliases')->willThrowException($exception);
+
+        // the helper rethrows in the test environment, which is how the task surfaces a broken cluster
+        $this->expectExceptionObject($exception);
+
+        $this->createHandler($registry, true)->run();
+    }
+
+    private function createHandler(AdminSearchRegistry $registry, bool $enabled): AdminCreateAliasTaskHandler
+    {
+        return new AdminCreateAliasTaskHandler(
+            StaticEntityRepository::of(ScheduledTaskCollection::class, []),
+            new NullLogger(),
+            $registry,
+            new AdminElasticsearchHelper($enabled, false, 'sw-admin', 'test', true, new NullLogger())
+        );
+    }
+}

--- a/tests/unit/Elasticsearch/Admin/AdminCreateAliasTaskTest.php
+++ b/tests/unit/Elasticsearch/Admin/AdminCreateAliasTaskTest.php
@@ -1,0 +1,31 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Elasticsearch\Admin;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Elasticsearch\Admin\AdminCreateAliasTask;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
+
+/**
+ * @internal
+ */
+#[Package('inventory')]
+#[CoversClass(AdminCreateAliasTask::class)]
+class AdminCreateAliasTaskTest extends TestCase
+{
+    public function testTaskMetadata(): void
+    {
+        static::assertSame('shopware.elasticsearch.admin.create.alias', AdminCreateAliasTask::getTaskName());
+        // ScheduledTask::MINUTELY is protected; assert the resolved value (five minutes in seconds).
+        static::assertSame(300, AdminCreateAliasTask::getDefaultInterval());
+        static::assertTrue(AdminCreateAliasTask::shouldRescheduleOnFailure());
+    }
+
+    public function testRunsOnlyWhenAdminElasticsearchIsEnabled(): void
+    {
+        static::assertTrue(AdminCreateAliasTask::shouldRun(new ParameterBag(['elasticsearch.administration.enabled' => true])));
+        static::assertFalse(AdminCreateAliasTask::shouldRun(new ParameterBag(['elasticsearch.administration.enabled' => false])));
+    }
+}

--- a/tests/unit/Elasticsearch/Admin/AdminSearchRegistryTest.php
+++ b/tests/unit/Elasticsearch/Admin/AdminSearchRegistryTest.php
@@ -168,9 +168,10 @@ class AdminSearchRegistryTest extends TestCase
         static::assertSame($this->indexer, $indexer);
     }
 
-    public function testIterateWithExistedAliasWillBeSwap(): void
+    public function testIterateSwapsAliasOfAFinishedIndexingRun(): void
     {
         $this->indexer->method('getName')->willReturn('promotion-listing');
+        $this->indexer->method('getEntity')->willReturn('promotion');
 
         $client = static::createStub(Client::class);
         $indices = $this->createMock(IndicesNamespace::class);
@@ -191,36 +192,81 @@ class AdminSearchRegistryTest extends TestCase
 
         $client->method('indices')->willReturn($indices);
 
-        $searchHelper = new AdminElasticsearchHelper(true, false, 'sw-admin', 'test', true, new NullLogger());
-        $registry = new AdminSearchRegistry(
-            ['promotion' => $this->indexer],
-            static::createStub(Connection::class),
-            static::createStub(MessageBusInterface::class),
-            static::createStub(EventDispatcherInterface::class),
-            $client,
-            $searchHelper,
-            static::createStub(LoggerInterface::class),
-            [],
-            [],
-            'test',
-            new NativeClock()
-        );
+        // the messages were handled inline, so the run has no remaining documents and its index is promoted
+        $connection = static::createStub(Connection::class);
+        $connection->method('fetchAllAssociative')->willReturn([
+            ['alias' => 'sw-admin-promotion-listing', 'index' => 'sw-admin-promotion-listing_67890'],
+        ]);
 
-        $registry->iterate(new AdminIndexingBehavior(false));
+        $registry = $this->createRegistry(['promotion' => $this->indexer], $client, $connection);
+
+        $registry->iterate(new AdminIndexingBehavior(true));
     }
 
-    public function testIterateSwapsRemainingAliasesWhenAnEarlierOneIsMissing(): void
+    public function testIterateLeavesTheAliasAloneWhileDocumentsAreStillPending(): void
     {
         $this->indexer->method('getName')->willReturn('promotion-listing');
         $this->indexer->method('getEntity')->willReturn('promotion');
 
-        $secondIndexer = static::createStub(AbstractAdminIndexer::class);
-        $secondIndexer->method('getName')->willReturn('order-listing');
-        $secondIndexer->method('getEntity')->willReturn('order');
-
         $client = static::createStub(Client::class);
         $indices = $this->createMock(IndicesNamespace::class);
-        // only the second indexer already has an alias, so the first one takes the "alias is missing" branch
+        $indices->method('existsAlias')->willReturn(true);
+        $indices->expects($this->never())->method('delete');
+        $indices->expects($this->never())->method('putAlias');
+
+        $client->method('indices')->willReturn($indices);
+
+        // no row reports zero remaining documents, so AdminCreateAliasTask has to do the swap later
+        $connection = static::createStub(Connection::class);
+        $connection->method('fetchAllAssociative')->willReturn([]);
+
+        $registry = $this->createRegistry(['promotion' => $this->indexer], $client, $connection);
+
+        $registry->iterate(new AdminIndexingBehavior(false));
+    }
+
+    public function testSwapFinishedAliasesPromotesTheNewestOfSeveralFinishedIndices(): void
+    {
+        $client = static::createStub(Client::class);
+        $indices = $this->createMock(IndicesNamespace::class);
+        $indices->method('existsAlias')->willReturn(true);
+        $indices
+            ->method('getAlias')
+            ->willReturn([
+                'sw-admin-promotion-listing_1000' => [
+                    'aliases' => [
+                        'sw-admin-promotion-listing' => [],
+                    ],
+                ],
+            ]);
+        $indices
+            ->expects($this->once())
+            ->method('putAlias')
+            ->with(['index' => 'sw-admin-promotion-listing_3000', 'name' => 'sw-admin-promotion-listing']);
+        $indices
+            ->expects($this->once())
+            ->method('delete')
+            ->with(['index' => 'sw-admin-promotion-listing_1000']);
+
+        $client->method('indices')->willReturn($indices);
+
+        // both runs finished before either was promoted; the rows arrive ordered by index name
+        $connection = static::createStub(Connection::class);
+        $connection->method('fetchAllAssociative')->willReturn([
+            ['alias' => 'sw-admin-promotion-listing', 'index' => 'sw-admin-promotion-listing_2000'],
+            ['alias' => 'sw-admin-promotion-listing', 'index' => 'sw-admin-promotion-listing_3000'],
+        ]);
+
+        $registry = $this->createRegistry(['promotion' => $this->indexer], $client, $connection);
+
+        $registry->swapFinishedAliases();
+    }
+
+    public function testSwapFinishedAliasesContinuesAfterAnAliasThatDoesNotExistYet(): void
+    {
+        $client = static::createStub(Client::class);
+        $indices = $this->createMock(IndicesNamespace::class);
+        // only the second alias exists, so the first one takes the "alias is missing" branch
         $indices
             ->method('existsAlias')
             ->willReturnCallback(static fn (array $arguments): bool => $arguments['name'] === 'sw-admin-order-listing');
@@ -240,22 +286,15 @@ class AdminSearchRegistryTest extends TestCase
 
         $client->method('indices')->willReturn($indices);
 
-        $searchHelper = new AdminElasticsearchHelper(true, false, 'sw-admin', 'test', true, new NullLogger());
-        $registry = new AdminSearchRegistry(
-            ['promotion' => $this->indexer, 'order' => $secondIndexer],
-            static::createStub(Connection::class),
-            static::createStub(MessageBusInterface::class),
-            static::createStub(EventDispatcherInterface::class),
-            $client,
-            $searchHelper,
-            static::createStub(LoggerInterface::class),
-            [],
-            [],
-            'test',
-            new NativeClock()
-        );
+        $connection = static::createStub(Connection::class);
+        $connection->method('fetchAllAssociative')->willReturn([
+            ['alias' => 'sw-admin-promotion-listing', 'index' => 'sw-admin-promotion-listing_67890'],
+            ['alias' => 'sw-admin-order-listing', 'index' => 'sw-admin-order-listing_67890'],
+        ]);
 
-        $registry->iterate(new AdminIndexingBehavior(false));
+        $registry = $this->createRegistry(['promotion' => $this->indexer], $client, $connection);
+
+        $registry->swapFinishedAliases();
     }
 
     /**
@@ -269,14 +308,13 @@ class AdminSearchRegistryTest extends TestCase
         $client = static::createStub(Client::class);
         $indices = $this->createMock(IndicesNamespace::class);
         $indices
-            ->expects($this->exactly(2))
+            ->expects($this->once())
             ->method('existsAlias')
             ->with(['name' => 'sw-admin-promotion-listing']);
 
         $client->method('indices')->willReturn($indices);
 
         $connection = static::createStub(Connection::class);
-        $connection->method('fetchAllKeyValue')->willReturn(['sw-admin-promotion-listing' => 'sw-admin-promotion-listing_12345']);
 
         $searchHelper = new AdminElasticsearchHelper(true, false, 'sw-admin', 'test', true, new NullLogger());
         $registry = new AdminSearchRegistry(
@@ -320,7 +358,7 @@ class AdminSearchRegistryTest extends TestCase
         $client = static::createStub(Client::class);
         $indices = $this->createMock(IndicesNamespace::class);
         $indices
-            ->expects($this->exactly(2))
+            ->expects($this->once())
             ->method('existsAlias')
             ->with(['name' => 'sw-admin-promotion-listing']);
 
@@ -409,7 +447,9 @@ class AdminSearchRegistryTest extends TestCase
         }
 
         $connection = static::createStub(Connection::class);
-        $connection->method('fetchAllKeyValue')->willReturn(['sw-admin-promotion-listing' => 'sw-admin-promotion-listing_12345']);
+        $connection->method('fetchAllAssociative')->willReturn([
+            ['alias' => 'sw-admin-promotion-listing', 'index' => 'sw-admin-promotion-listing_12345'],
+        ]);
 
         $searchHelper = new AdminElasticsearchHelper(true, $refreshIndices, 'sw-admin', 'test', true, new NullLogger());
         $queue = static::createStub(MessageBusInterface::class);
@@ -458,6 +498,142 @@ class AdminSearchRegistryTest extends TestCase
         ]), []));
     }
 
+    public function testInvokeCountsDownTheIndexingTaskOfAnIndexingRun(): void
+    {
+        $this->indexer->method('getName')->willReturn('promotion-listing');
+        $this->indexer->method('getEntity')->willReturn('promotion');
+        $this->indexer->method('fetch')->willReturn([
+            'c1a28776116d4431a2208eb2960ec340' => ['id' => 'c1a28776116d4431a2208eb2960ec340', 'text' => 'a'],
+            'c1a28776116d4431a2208eb2960ec341' => ['id' => 'c1a28776116d4431a2208eb2960ec341', 'text' => 'b'],
+        ]);
+
+        $client = static::createStub(Client::class);
+        $client->method('bulk')->willReturn(['errors' => false, 'items' => []]);
+
+        $statements = [];
+        $connection = static::createStub(Connection::class);
+        $connection
+            ->method('executeStatement')
+            ->willReturnCallback(function (string $sql, array $params = []) use (&$statements): int {
+                $statements[] = $params;
+
+                return 1;
+            });
+
+        $registry = $this->createRegistry(['promotion' => $this->indexer], $client, $connection);
+
+        $registry->__invoke(new AdminSearchIndexingMessage(
+            'promotion',
+            'promotion-listing',
+            ['sw-admin-promotion-listing' => 'sw-admin-promotion-listing_12345'],
+            ['c1a28776116d4431a2208eb2960ec340', 'c1a28776116d4431a2208eb2960ec341'],
+            [],
+            true
+        ));
+
+        static::assertSame(
+            [['count' => 2, 'index' => 'sw-admin-promotion-listing_12345']],
+            $statements
+        );
+    }
+
+    public function testInvokeDoesNotCountDownForLiveUpdates(): void
+    {
+        $this->indexer->method('getName')->willReturn('promotion-listing');
+        $this->indexer->method('getEntity')->willReturn('promotion');
+        $this->indexer->method('fetch')->willReturn([
+            'c1a28776116d4431a2208eb2960ec340' => ['id' => 'c1a28776116d4431a2208eb2960ec340', 'text' => 'a'],
+        ]);
+
+        $client = static::createStub(Client::class);
+        $client->method('bulk')->willReturn(['errors' => false, 'items' => []]);
+
+        $connection = $this->createMock(Connection::class);
+        $connection->expects($this->never())->method('executeStatement');
+
+        $registry = $this->createRegistry(['promotion' => $this->indexer], $client, $connection);
+
+        $registry->__invoke(new AdminSearchIndexingMessage(
+            'promotion',
+            'promotion-listing',
+            ['sw-admin-promotion-listing' => 'sw-admin-promotion-listing_12345'],
+            ['c1a28776116d4431a2208eb2960ec340']
+        ));
+    }
+
+    public function testInvokeDoesNotCountDownWhenTheBulkFailed(): void
+    {
+        $this->indexer->method('getName')->willReturn('promotion-listing');
+        $this->indexer->method('getEntity')->willReturn('promotion');
+        $this->indexer->method('fetch')->willReturn([
+            'c1a28776116d4431a2208eb2960ec340' => ['id' => 'c1a28776116d4431a2208eb2960ec340', 'text' => 'a'],
+        ]);
+
+        $client = static::createStub(Client::class);
+        $client->method('bulk')->willReturn([
+            'errors' => true,
+            'items' => [
+                ['index' => ['_index' => 'sw-admin-promotion-listing_12345', '_id' => 'c1a28776116d4431a2208eb2960ec340', 'status' => 400, 'error' => ['type' => 'mapper_parsing_exception', 'reason' => 'broken']]],
+            ],
+        ]);
+
+        $connection = $this->createMock(Connection::class);
+        $connection->expects($this->never())->method('executeStatement');
+
+        $registry = $this->createRegistry(['promotion' => $this->indexer], $client, $connection);
+
+        $this->expectException(ElasticsearchException::class);
+
+        $registry->__invoke(new AdminSearchIndexingMessage(
+            'promotion',
+            'promotion-listing',
+            ['sw-admin-promotion-listing' => 'sw-admin-promotion-listing_12345'],
+            ['c1a28776116d4431a2208eb2960ec340'],
+            [],
+            true
+        ));
+    }
+
+    public function testRefreshWritesToBothTheLiveAndTheIndexBeingBuilt(): void
+    {
+        $this->indexer->method('getName')->willReturn('promotion-listing');
+        $this->indexer->method('getEntity')->willReturn('promotion');
+        $this->indexer->method('getUpdatedIds')->willReturn(['c1a28776116d4431a2208eb2960ec340']);
+        $this->indexer->method('fetch')->willReturn([
+            'c1a28776116d4431a2208eb2960ec340' => ['id' => 'c1a28776116d4431a2208eb2960ec340', 'text' => 'a'],
+        ]);
+
+        $written = [];
+        $client = $this->createMock(Client::class);
+        $client
+            ->expects($this->exactly(2))
+            ->method('bulk')
+            ->willReturnCallback(function (array $arguments) use (&$written): array {
+                $written[] = $arguments['index'];
+
+                return ['errors' => false, 'items' => []];
+            });
+
+        $connection = static::createStub(Connection::class);
+        $connection->method('fetchAllAssociative')->willReturn([
+            ['alias' => 'sw-admin-promotion-listing', 'index' => 'sw-admin-promotion-listing_12345'],
+            ['alias' => 'sw-admin-promotion-listing', 'index' => 'sw-admin-promotion-listing_67890'],
+        ]);
+
+        $registry = $this->createRegistry(['promotion' => $this->indexer], $client, $connection);
+
+        $registry->refresh(new EntityWrittenContainerEvent(Context::createDefaultContext(), new NestedEventCollection([
+            new EntityWrittenEvent('promotion', [
+                new EntityWriteResult('c1a28776116d4431a2208eb2960ec340', [], 'promotion', EntityWriteResult::OPERATION_INSERT),
+            ], Context::createDefaultContext()),
+        ]), []));
+
+        static::assertSame(
+            ['sw-admin-promotion-listing_12345', 'sw-admin-promotion-listing_67890'],
+            $written
+        );
+    }
+
     public function testRefreshQueuesEveryAffectedIndexerForSalesChannelSources(): void
     {
         $this->indexer->method('getName')->willReturn('promotion-listing');
@@ -470,9 +646,9 @@ class AdminSearchRegistryTest extends TestCase
         $secondIndexer->method('getUpdatedIds')->willReturn(['a1a28776116d4431a2208eb2960ec341']);
 
         $connection = static::createStub(Connection::class);
-        $connection->method('fetchAllKeyValue')->willReturn([
-            'sw-admin-promotion-listing' => 'sw-admin-promotion-listing_12345',
-            'sw-admin-order-listing' => 'sw-admin-order-listing_12345',
+        $connection->method('fetchAllAssociative')->willReturn([
+            ['alias' => 'sw-admin-promotion-listing', 'index' => 'sw-admin-promotion-listing_12345'],
+            ['alias' => 'sw-admin-order-listing', 'index' => 'sw-admin-order-listing_12345'],
         ]);
 
         $dispatched = [];
@@ -803,5 +979,25 @@ class AdminSearchRegistryTest extends TestCase
     {
         yield 'refresh indices' => [true];
         yield 'do not refresh indices' => [false];
+    }
+
+    /**
+     * @param array<string, AbstractAdminIndexer> $indexers
+     */
+    private function createRegistry(array $indexers, Client $client, Connection $connection): AdminSearchRegistry
+    {
+        return new AdminSearchRegistry(
+            $indexers,
+            $connection,
+            static::createStub(MessageBusInterface::class),
+            static::createStub(EventDispatcherInterface::class),
+            $client,
+            new AdminElasticsearchHelper(true, false, 'sw-admin', 'test', true, new NullLogger()),
+            static::createStub(LoggerInterface::class),
+            [],
+            [],
+            'test',
+            new NativeClock()
+        );
     }
 }

--- a/tests/unit/Elasticsearch/Framework/Command/ElasticsearchAdminStatusCommandTest.php
+++ b/tests/unit/Elasticsearch/Framework/Command/ElasticsearchAdminStatusCommandTest.php
@@ -1,0 +1,115 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Elasticsearch\Framework\Command;
+
+use Doctrine\DBAL\Connection;
+use OpenSearch\Client;
+use OpenSearch\Namespaces\ClusterNamespace;
+use OpenSearch\Namespaces\IndicesNamespace;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Elasticsearch\Admin\AdminElasticsearchHelper;
+use Shopware\Elasticsearch\Framework\Command\ElasticsearchAdminStatusCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+
+/**
+ * @internal
+ */
+#[Package('inventory')]
+#[CoversClass(ElasticsearchAdminStatusCommand::class)]
+class ElasticsearchAdminStatusCommandTest extends TestCase
+{
+    public function testFailsWhenAdminElasticsearchIsDisabled(): void
+    {
+        $commandTester = new CommandTester($this->createCommand([], [], false));
+        $commandTester->execute([]);
+
+        static::assertSame(Command::FAILURE, $commandTester->getStatusCode());
+        static::assertStringContainsString('Admin elasticsearch is not enabled', $commandTester->getDisplay());
+    }
+
+    public function testWarnsWhenNoIndexWasBuiltYet(): void
+    {
+        $commandTester = new CommandTester($this->createCommand([], []));
+        $commandTester->execute([]);
+
+        $display = $commandTester->getDisplay();
+
+        static::assertSame(Command::SUCCESS, $commandTester->getStatusCode());
+        static::assertStringContainsString('completed', $display);
+        static::assertStringContainsString('No admin indices have been built yet', $display);
+    }
+
+    public function testReportsRunningIndexingPerEntity(): void
+    {
+        $commandTester = new CommandTester($this->createCommand(
+            [
+                ['entity' => 'order', 'index' => 'sw-admin-order-listing_2000', 'alias' => 'sw-admin-order-listing', 'doc_count' => '42'],
+                ['entity' => 'promotion', 'index' => 'sw-admin-promotion-listing_1000', 'alias' => 'sw-admin-promotion-listing', 'doc_count' => '0'],
+            ],
+            ['sw-admin-promotion-listing' => ['sw-admin-promotion-listing_1000']]
+        ));
+        $commandTester->execute([]);
+
+        $display = $commandTester->getDisplay();
+
+        static::assertSame(Command::SUCCESS, $commandTester->getStatusCode());
+        static::assertStringContainsString('in progress', $display);
+        static::assertStringContainsString('42', $display);
+        static::assertStringContainsString('indexing', $display);
+        static::assertStringContainsString('live', $display);
+    }
+
+    public function testMarksAFinishedIndexAsWaitingForItsAliasSwap(): void
+    {
+        $commandTester = new CommandTester($this->createCommand(
+            [
+                ['entity' => 'promotion', 'index' => 'sw-admin-promotion-listing_1000', 'alias' => 'sw-admin-promotion-listing', 'doc_count' => '0'],
+                ['entity' => 'promotion', 'index' => 'sw-admin-promotion-listing_2000', 'alias' => 'sw-admin-promotion-listing', 'doc_count' => '0'],
+            ],
+            ['sw-admin-promotion-listing' => ['sw-admin-promotion-listing_1000']]
+        ));
+        $commandTester->execute([]);
+
+        $display = $commandTester->getDisplay();
+
+        static::assertStringContainsString('completed', $display);
+        static::assertStringContainsString('live', $display);
+        static::assertStringContainsString('waiting for alias swap', $display);
+    }
+
+    /**
+     * @param list<array{entity: string, index: string, alias: string, doc_count: string}> $tasks
+     * @param array<string, list<string>> $aliases
+     */
+    private function createCommand(array $tasks, array $aliases, bool $enabled = true): ElasticsearchAdminStatusCommand
+    {
+        $cluster = static::createStub(ClusterNamespace::class);
+        $cluster->method('health')->willReturn(['status' => 'green', 'number_of_nodes' => 1]);
+
+        $indices = static::createStub(IndicesNamespace::class);
+        $indices->method('existsAlias')->willReturnCallback(
+            static fn (array $arguments): bool => isset($aliases[$arguments['name']])
+        );
+        $indices->method('getAlias')->willReturnCallback(
+            static fn (array $arguments): array => array_fill_keys($aliases[$arguments['name']] ?? [], ['aliases' => []])
+        );
+
+        $client = static::createStub(Client::class);
+        $client->method('ping')->willReturn(true);
+        $client->method('cluster')->willReturn($cluster);
+        $client->method('indices')->willReturn($indices);
+
+        $connection = static::createStub(Connection::class);
+        $connection->method('fetchAllAssociative')->willReturn($tasks);
+
+        return new ElasticsearchAdminStatusCommand(
+            $client,
+            $connection,
+            new AdminElasticsearchHelper($enabled, false, 'sw-admin', 'test', true, new NullLogger())
+        );
+    }
+}

--- a/tests/unit/Elasticsearch/Framework/Command/ElasticsearchStatusCommandTest.php
+++ b/tests/unit/Elasticsearch/Framework/Command/ElasticsearchStatusCommandTest.php
@@ -1,0 +1,103 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Elasticsearch\Framework\Command;
+
+use Doctrine\DBAL\Connection;
+use OpenSearch\Client;
+use OpenSearch\Namespaces\ClusterNamespace;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Elasticsearch\ElasticsearchException;
+use Shopware\Elasticsearch\Framework\Command\ElasticsearchStatusCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+#[CoversClass(ElasticsearchStatusCommand::class)]
+class ElasticsearchStatusCommandTest extends TestCase
+{
+    public function testThrowsWhenServerIsNotReachable(): void
+    {
+        $client = static::createStub(Client::class);
+        $client->method('ping')->willReturn(false);
+
+        $commandTester = new CommandTester(
+            new ElasticsearchStatusCommand($client, static::createStub(Connection::class))
+        );
+
+        $this->expectExceptionObject(ElasticsearchException::serverNotAvailable());
+
+        $commandTester->execute([]);
+    }
+
+    public function testReportsCompletedWithoutPendingTasks(): void
+    {
+        $commandTester = new CommandTester($this->createCommand([]));
+        $commandTester->execute([]);
+
+        $display = $commandTester->getDisplay();
+
+        static::assertSame(Command::SUCCESS, $commandTester->getStatusCode());
+        static::assertStringContainsString('Cluster Status', $display);
+        static::assertStringContainsString('completed', $display);
+        static::assertStringNotContainsString('Remaining documents', $display);
+    }
+
+    public function testReportsEveryIndexedEntityNotJustProduct(): void
+    {
+        $commandTester = new CommandTester($this->createCommand([
+            ['entity' => 'category', 'index' => 'sw_category_2000', 'alias' => 'sw_category', 'doc_count' => '0'],
+            ['entity' => 'product', 'index' => 'sw_product_2000', 'alias' => 'sw_product', 'doc_count' => '120'],
+        ]));
+        $commandTester->execute([]);
+
+        $display = $commandTester->getDisplay();
+
+        static::assertSame(Command::SUCCESS, $commandTester->getStatusCode());
+        static::assertStringContainsString('in progress', $display);
+
+        static::assertStringContainsString('category', $display);
+        static::assertStringContainsString('sw_category_2000', $display);
+        static::assertStringContainsString('waiting for alias swap', $display);
+
+        static::assertStringContainsString('product', $display);
+        static::assertStringContainsString('sw_product_2000', $display);
+        static::assertStringContainsString('120', $display);
+        static::assertStringContainsString('indexing', $display);
+    }
+
+    public function testNegativeRemainingCountsAreReportedAsZero(): void
+    {
+        $commandTester = new CommandTester($this->createCommand([
+            ['entity' => 'product', 'index' => 'sw_product_2000', 'alias' => 'sw_product', 'doc_count' => '-5'],
+        ]));
+        $commandTester->execute([]);
+
+        $display = $commandTester->getDisplay();
+
+        static::assertStringContainsString('waiting for alias swap', $display);
+        static::assertStringNotContainsString('-5', $display);
+    }
+
+    /**
+     * @param list<array{entity: string, index: string, alias: string, doc_count: string}> $tasks
+     */
+    private function createCommand(array $tasks): ElasticsearchStatusCommand
+    {
+        $cluster = static::createStub(ClusterNamespace::class);
+        $cluster->method('health')->willReturn(['status' => 'green', 'number_of_nodes' => 1]);
+
+        $client = static::createStub(Client::class);
+        $client->method('ping')->willReturn(true);
+        $client->method('cluster')->willReturn($cluster);
+
+        $connection = static::createStub(Connection::class);
+        $connection->method('fetchAllAssociative')->willReturn($tasks);
+
+        return new ElasticsearchStatusCommand($client, $connection);
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?

`es:admin:index` moves each alias to the newly built index right after it queued the indexing messages, before any of them was handled. Admin search is then served by an almost empty index for as long as the queue takes to drain, and the index it replaced is already deleted, so there is nothing to fall back to.

Nothing records how far a run has progressed either. `admin_elasticsearch_index_task.doc_count` is written when the run starts but never read or decremented, and there is no status command for admin indexing. `es:status` cannot help: it only looks at the `product` row of `elasticsearch_index_task`, so even a running category or manufacturer indexing run is reported as `completed`.

### 2. What does this change do, exactly?

Admin indexing gets the same lifecycle the storefront already has:

- Each indexing message counts its documents off `admin_elasticsearch_index_task.doc_count` after it was written successfully. A failing batch does not count down, so the alias stays on the previous index instead of a half-filled one.
- A new `shopware.elasticsearch.admin.create.alias` scheduled task promotes indices whose count reached zero and deletes the index each one replaces. `es:admin:index --no-queue` still swaps inside the command, because its messages are handled inline.
- During a run an entity has two indices, the one the alias serves and the one being built. Live updates go to both. Before they only reached the index being built, so they were invisible in admin search until the swap.

Reporting is fixed alongside it, because the count is what makes it possible:

- `es:status` now lists every pending indexing task instead of only `product`. The product-only progress bar is replaced by the remaining document count, which works for every entity.
- New `bin/console es:admin:status` shows the admin cluster health and one row per entity with its remaining count and whether it is live, still indexing, or waiting for its alias swap.

### 3. Describe each step to reproduce the issue or behaviour.

1. Enable admin Elasticsearch, make sure no message worker is running.
2. Run `bin/console es:admin:index`.
3. Search for a product in the administration.
4. Before: no results, because the alias already points at the index that the queue has not filled yet. After: the previous results, until the queue is drained and the scheduled task promotes the new index.
5. `bin/console es:admin:status` shows the remaining documents while the queue drains.

### 4. Please link to the relevant issues (if any).

relates #19264

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have updated developer-facing release notes if this change is **relevant** for external developers
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
