### PR TITLE
fix(administration): synchronize cache indexer selection

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -8,6 +8,10 @@ Rule Builder and Flow Builder are now reachable from a dedicated top-level "Auto
 
 ## API
 
+### Cache information includes registered indexers
+
+`GET /api/_action/cache_info` now returns an `indexers` map containing the registered normal-refresh indexers and their optional child updaters. Administration clients can use this metadata when offering cache-index refresh controls; post-update-only indexers are excluded.
+
 ### Order recalculation and conversion endpoints now require ACL privileges
 
 Thirteen admin checkout endpoints that previously only required authentication now enforce ACL privileges. Requests with tokens lacking the privilege receive a `403` with `FRAMEWORK__MISSING_PRIVILEGE_ERROR`:

--- a/phpstan-baseline.php
+++ b/phpstan-baseline.php
@@ -248,12 +248,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/src/Core/Framework/Api/Controller/ApiController.php',
 ];
 $ignoreErrors[] = [
-    'rawMessage' => 'Construct empty() is not allowed. Use more strict comparison.',
-    'identifier' => 'empty.notAllowed',
-    'count' => 2,
-    'path' => __DIR__ . '/src/Core/Framework/Api/Controller/CacheController.php',
-];
-$ignoreErrors[] = [
     'rawMessage' => 'Throwing new exceptions within classes are not allowed. Please use domain exception pattern. See https://github.com/shopware/platform/blob/v6.4.20.0/adr/2022-02-24-domain-exceptions.md',
     'identifier' => 'shopware.domainException',
     'count' => 1,

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-cache/page/sw-settings-cache-index/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-cache/page/sw-settings-cache-index/index.js
@@ -39,54 +39,6 @@ export default {
             },
             indexingMethod: 'skip',
             indexerSelection: [],
-            indexers: {
-                'category.indexer': [
-                    'category.child-count',
-                    'category.tree',
-                    'category.breadcrumb',
-                    'category.seo-url',
-                ],
-                'customer.indexer': [
-                    'customer.many-to-many-id-field',
-                ],
-                'landing_page.indexer': [
-                    'landing_page.many-to-many-id-field',
-                    'landing_page.seo-url',
-                ],
-                'media.indexer': [],
-                'media_folder.indexer': [
-                    'media_folder.child-count',
-                ],
-                'media_folder_configuration.indexer': [],
-                'payment_method.indexer': [],
-                'product.indexer': [
-                    'product.inheritance',
-                    'product.stock',
-                    'product.variant-listing',
-                    'product.child-count',
-                    'product.many-to-many-id-field',
-                    'product.category-denormalizer',
-                    'product.cheapest-price',
-                    'product.rating-average',
-                    'product.stream',
-                    'product.search-keyword',
-                    'product.seo-url',
-                ],
-                'product_stream.indexer': [],
-                'product_stream_mapping.indexer': [],
-                'promotion.indexer': [
-                    'promotion.exclusion',
-                    'promotion.redemption',
-                ],
-                'rule.indexer': [
-                    'rule.payload',
-                ],
-                'sales_channel.indexer': [
-                    'sales_channel.many-to-many',
-                ],
-                'flow.indexer': [],
-                'newsletter_recipient.indexer': [],
-            },
         };
     },
 
@@ -139,6 +91,22 @@ export default {
                     value: 'only',
                 },
             ];
+        },
+
+        indexers() {
+            return this.cacheInfo?.indexers ?? {};
+        },
+    },
+
+    watch: {
+        indexingMethod(value) {
+            if (value !== 'only') {
+                return;
+            }
+
+            this.indexerSelection = this.indexerSelection.filter((selection) =>
+                Object.prototype.hasOwnProperty.call(this.indexers, selection),
+            );
         },
     },
 
@@ -270,26 +238,10 @@ export default {
         },
 
         createOnlySelection(only) {
-            for (const [
-                indexerName,
-                updaters,
-            ] of Object.entries(this.indexers)) {
+            for (const indexerName of Object.keys(this.indexers)) {
                 if (this.indexerSelection.indexOf(indexerName) > -1) {
                     only.push(indexerName);
                 }
-
-                const selectedUpdaters = [];
-                for (const updater of updaters) {
-                    if (this.indexerSelection.indexOf(updater) > -1) {
-                        selectedUpdaters.push(updater);
-                    }
-                }
-
-                if (selectedUpdaters.length > 0) {
-                    only.push(indexerName);
-                }
-
-                only.push(...selectedUpdaters);
             }
         },
     },

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-cache/page/sw-settings-cache-index/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-cache/page/sw-settings-cache-index/index.js
@@ -237,6 +237,10 @@ export default {
             }
         },
 
+        clearIndexerSelection() {
+            this.indexerSelection = [];
+        },
+
         createOnlySelection(only) {
             for (const indexerName of Object.keys(this.indexers)) {
                 if (this.indexerSelection.indexOf(indexerName) > -1) {

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-cache/page/sw-settings-cache-index/sw-settings-cache-index.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-cache/page/sw-settings-cache-index/sw-settings-cache-index.html.twig
@@ -225,7 +225,7 @@
                                                             :label="updater"
                                                             :name="updater"
                                                             size="small"
-                                                            :disabled="indexerSelection.includes(indexer)"
+                                                            :disabled="indexingMethod === 'only' || indexerSelection.includes(indexer)"
                                                             @update:checked="changeSelection($event, updater)"
                                                         />
                                                     </li>

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-cache/page/sw-settings-cache-index/sw-settings-cache-index.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-cache/page/sw-settings-cache-index/sw-settings-cache-index.html.twig
@@ -176,6 +176,7 @@
                             class="sw-settings-cache__indexers-select"
                             :label="indexingMethod === 'skip' ? $t('sw-settings-cache.section.indexesSkipSelectLabel') : $t('sw-settings-cache.section.indexesOnlySelectLabel')"
                             :disabled="processes.updateIndexes"
+                            @clear="clearIndexerSelection"
                         >
                             <template #sw-select-selection>
                                 <sw-label

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-cache/page/sw-settings-cache-index/sw-settings-cache-index.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-cache/page/sw-settings-cache-index/sw-settings-cache-index.spec.js
@@ -123,6 +123,8 @@ describe('module/sw-settings-cache/page/sw-settings-cache-index', () => {
 
         await selectMtSelectOptionByText(wrapper, 'sw-settings-cache.section.indexingModeOptionOnlyLabel');
 
+        wrapper.vm.changeSelection(true, 'category.indexer');
+
         await button.trigger('click');
         await flushPromises();
 

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-cache/page/sw-settings-cache-index/sw-settings-cache-index.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-cache/page/sw-settings-cache-index/sw-settings-cache-index.spec.js
@@ -101,6 +101,17 @@ describe('module/sw-settings-cache/page/sw-settings-cache-index', () => {
         expect(mock).toHaveBeenCalledTimes(1);
     });
 
+    it('should clear the selected indexers', async () => {
+        const wrapper = await createWrapper();
+        await flushPromises();
+
+        wrapper.vm.changeSelection(true, 'category.indexer');
+
+        await wrapper.findComponent('.sw-settings-cache__indexers-select').vm.$emit('clear');
+
+        expect(wrapper.vm.indexerSelection).toEqual([]);
+    });
+
     it('should send different values for skip and only on reindex', async () => {
         const indexMock = jest.fn(() => Promise.resolve());
 

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-cache/page/sw-settings-cache-index/sw-settings-cache-index.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-cache/page/sw-settings-cache-index/sw-settings-cache-index.spec.js
@@ -9,6 +9,9 @@ const cacheInfo = {
         httpCache: true,
         environment: 'dev',
         cacheAdapter: 'fooBar',
+        indexers: {
+            'category.indexer': ['category.tree'],
+        },
     },
 };
 
@@ -124,12 +127,6 @@ describe('module/sw-settings-cache/page/sw-settings-cache-index', () => {
         await flushPromises();
 
         expect(indexMock).toHaveBeenCalledTimes(2);
-        expect(indexMock).toHaveBeenCalledWith(
-            [],
-            [
-                'category.indexer',
-                'category.tree',
-            ],
-        );
+        expect(indexMock).toHaveBeenCalledWith([], ['category.indexer']);
     });
 });

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/AdminApi/paths/cache_info.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/AdminApi/paths/cache_info.json
@@ -16,6 +16,12 @@
                         "content": {
                             "application\/json": {
                                 "schema": {
+                                    "required": [
+                                        "environment",
+                                        "httpCache",
+                                        "cacheAdapter",
+                                        "indexers"
+                                    ],
                                     "properties": {
                                         "environment": {
                                             "description": "The active environment.",

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/AdminApi/paths/cache_info.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/AdminApi/paths/cache_info.json
@@ -28,6 +28,16 @@
                                         "cacheAdapter": {
                                             "description": "The active cache adapter.",
                                             "type": "string"
+                                        },
+                                        "indexers": {
+                                            "description": "Normal-refresh indexers and their optional child updaters.",
+                                            "type": "object",
+                                            "additionalProperties": {
+                                                "type": "array",
+                                                "items": {
+                                                    "type": "string"
+                                                }
+                                            }
                                         }
                                     },
                                     "type": "object"

--- a/src/Core/Framework/Api/Controller/CacheController.php
+++ b/src/Core/Framework/Api/Controller/CacheController.php
@@ -62,8 +62,8 @@ class CacheController extends AbstractController
     {
         $data = $dataBag->all();
 
-        $skip = !empty($data['skip']) && \is_array($data['skip']) ? array_values($data['skip']) : [];
-        $only = !empty($data['only']) && \is_array($data['only']) ? array_values($data['only']) : [];
+        $skip = isset($data['skip']) && \is_array($data['skip']) && $data['skip'] !== [] ? array_values($data['skip']) : [];
+        $only = isset($data['only']) && \is_array($data['only']) && $data['only'] !== [] ? array_values($data['only']) : [];
 
         $this->indexerRegistry->sendFullIndexingMessage($skip, $only);
 

--- a/src/Core/Framework/Api/Controller/CacheController.php
+++ b/src/Core/Framework/Api/Controller/CacheController.php
@@ -48,6 +48,7 @@ class CacheController extends AbstractController
             'environment' => $this->getParameter('kernel.environment'),
             'httpCache' => $this->container->get('parameter_bag')->has('shopware.http.cache.enabled') && $this->getParameter('shopware.http.cache.enabled'),
             'cacheAdapter' => $this->getUsedCache($this->adapter),
+            'indexers' => $this->indexerRegistry->getIndexers(),
         ]);
     }
 

--- a/src/Core/Framework/DataAbstractionLayer/Indexing/EntityIndexerRegistry.php
+++ b/src/Core/Framework/DataAbstractionLayer/Indexing/EntityIndexerRegistry.php
@@ -242,6 +242,24 @@ class EntityIndexerRegistry
         return $this->getIndexer($name) !== null;
     }
 
+    /**
+     * @return array<string, list<string>>
+     */
+    public function getIndexers(): array
+    {
+        $indexers = [];
+
+        foreach ($this->indexer as $indexer) {
+            if ($indexer instanceof PostUpdateIndexer) {
+                continue;
+            }
+
+            $indexers[$indexer->getName()] = $indexer->getOptions();
+        }
+
+        return $indexers;
+    }
+
     public function getIndexer(string $name): ?EntityIndexer
     {
         foreach ($this->indexer as $indexer) {

--- a/tests/integration/Core/Framework/Api/Controller/CacheControllerTest.php
+++ b/tests/integration/Core/Framework/Api/Controller/CacheControllerTest.php
@@ -76,9 +76,10 @@ class CacheControllerTest extends TestCase
         static::assertArrayHasKey('cacheAdapter', $decodedContent);
         static::assertSame('Filesystem', $decodedContent['cacheAdapter']);
         static::assertArrayHasKey('indexers', $decodedContent);
+        static::assertIsArray($decodedContent['indexers']);
         static::assertArrayHasKey('category.indexer', $decodedContent['indexers']);
         static::assertContains('category.tree', $decodedContent['indexers']['category.indexer']);
-        static::assertNotContains('product.description_teaser.indexer', array_keys($decodedContent['indexers']));
+        static::assertArrayNotHasKey('product.description_teaser.indexer', $decodedContent['indexers']);
     }
 
     public function testCacheIndexEndpoint(): void

--- a/tests/integration/Core/Framework/Api/Controller/CacheControllerTest.php
+++ b/tests/integration/Core/Framework/Api/Controller/CacheControllerTest.php
@@ -75,6 +75,10 @@ class CacheControllerTest extends TestCase
         static::assertIsBool($decodedContent['httpCache']);
         static::assertArrayHasKey('cacheAdapter', $decodedContent);
         static::assertSame('Filesystem', $decodedContent['cacheAdapter']);
+        static::assertArrayHasKey('indexers', $decodedContent);
+        static::assertArrayHasKey('category.indexer', $decodedContent['indexers']);
+        static::assertContains('category.tree', $decodedContent['indexers']['category.indexer']);
+        static::assertNotContains('product.description_teaser.indexer', array_keys($decodedContent['indexers']));
     }
 
     public function testCacheIndexEndpoint(): void

--- a/tests/unit/Core/Framework/DataAbstractionLayer/Indexing/EntityIndexerRegistryTest.php
+++ b/tests/unit/Core/Framework/DataAbstractionLayer/Indexing/EntityIndexerRegistryTest.php
@@ -11,6 +11,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Indexing\EntityIndexer;
 use Shopware\Core\Framework\DataAbstractionLayer\Indexing\EntityIndexerRegistry;
 use Shopware\Core\Framework\DataAbstractionLayer\Indexing\EntityIndexingMessage;
 use Shopware\Core\Framework\DataAbstractionLayer\Indexing\MessageQueue\FullEntityIndexerMessage;
+use Shopware\Core\Framework\DataAbstractionLayer\Indexing\PostUpdateIndexer;
 use Shopware\Core\Framework\DataAbstractionLayer\Indexing\Telemetry\IndexerMetricsInstrumentor;
 use Shopware\Core\Framework\Event\ProgressFinishedEvent;
 use Shopware\Core\Framework\Event\ProgressStartedEvent;
@@ -108,6 +109,25 @@ class EntityIndexerRegistryTest extends TestCase
 
         $registry = new EntityIndexerRegistry([$indexer1, $indexer2], $this->messageBusMock, $this->dispatcherMock, $this->instrumentorStub);
         $registry->index(false, $skip, $only);
+    }
+
+    public function testGetIndexersReturnsNormalIndexersAndOptions(): void
+    {
+        $normalIndexer = static::createStub(EntityIndexer::class);
+        $normalIndexer->method('getName')->willReturn('normal.indexer');
+        $normalIndexer->method('getOptions')->willReturn(['normal.option']);
+
+        $postUpdateIndexer = static::createStub(PostUpdateIndexer::class);
+        $postUpdateIndexer->method('getName')->willReturn('post-update.indexer');
+
+        $registry = new EntityIndexerRegistry(
+            [$normalIndexer, $postUpdateIndexer],
+            $this->messageBusMock,
+            $this->dispatcherMock,
+            $this->instrumentorStub,
+        );
+
+        static::assertSame(['normal.indexer' => ['normal.option']], $registry->getIndexers());
     }
 
     public function testRefreshMethod(): void


### PR DESCRIPTION
### 1. Why is this change necessary?

The Administration cache/index selector uses a hard-coded indexer list that drifts from the registered DAL indexers. It omits valid core and extension indexers, includes removed options, and exposes child updater selection in `only` mode even though the backend only supports parent indexers there.

### 2. What does this change do, exactly?

- Exposes registered normal-refresh indexers and their child options through the existing `cache_info` API.
- Excludes post-update-only indexers from that metadata.
- Builds the Administration selector from the API response, so extension indexers are included automatically.
- Keeps child options available for `skip` mode only; `only` mode sends parent indexers only.
- Updates the Admin API schema, release information, and focused tests.
#### Before

* list is hard coded
* only mode allows child, which the backend just ignores
* `x` button to clear multi select is not working
https://www.loom.com/share/6459dd1a36564ea4ba24df67f2e4d1b9

#### After

* List of indexer is dynamically fetched
* child update in  "only" mode is disabled as backend does not support that
* `x` button is working to clear the indexer multi select
https://www.loom.com/share/c746b6c91c574f07adf5489694a760e6

### 3. Describe each step to reproduce the issue or behaviour.

1. Open Settings → System → Caches & indexes.
2. Compare the selector entries with the services tagged `shopware.entity_indexer`.
3. Switch to `only` mode and select an indexer.
4. Verify that the request contains only the selected parent indexer names.

### 4. Please link to the relevant issues (if any).

- fixes #18673

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have updated developer-facing release notes if this change is relevant for external developers
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them