### PR TITLE
ci: make release-content verification testable and exit-free

### DIFF
--- a/.github/bin/verify-release-content.php
+++ b/.github/bin/verify-release-content.php
@@ -1,286 +1,86 @@
-<?php
+<?php declare(strict_types=1);
 
-declare(strict_types=1);
+use Shopware\Core\DevOps\Release\ProcessGitReader;
+use Shopware\Core\DevOps\Release\ReleaseContentVerifier;
+use Shopware\Core\DevOps\Release\ReleaseSummaryRenderer;
 
-// Verifies that every feature heading documented in trunk's RELEASE_INFO for the given
-// version prefix is also present on the release branch, and that the commit which
-// introduced it on trunk is reachable from that branch.
-//
-// The release branch defaults to "<version-prefix>.x" and is always compared via its remote
-// ref (origin/<branch>), so the result does not depend on which branch is currently checked out.
+// Thin CLI wrapper around the release-content verification. All logic lives in
+// Shopware\Core\DevOps\Release\* (unit-tested); this script only handles argv, wiring and output.
 //
 // Usage: php verify-release-content.php <version-prefix> [release-branch]
 // Example: php verify-release-content.php 6.7.11
 // Example: php verify-release-content.php 6.7.11 6.7.11.x
 //
-// Exit codes:
-//   0 — all entries verified (warnings may still be printed)
-//   1 — one or more entries are missing from the release branch
+// The verdict is NOT signalled through the exit code. It is written to GITHUB_OUTPUT as
+// state=success|failure plus a one-line description, and the workflow publishes it as the
+// `release-content/verify` commit status. Missing entries keep the job green on purpose — the
+// commit status is the gate. An operational error (bad usage, refs not fetched) throws, so a red
+// job always means the verification itself could not run.
 
-const TRUNK_REF = 'origin/trunk';
+require __DIR__ . '/../../vendor/autoload.php';
 
-$versionPrefix = $_SERVER['argv'][1] ?? '';
-if ($versionPrefix === '') {
-    fwrite(\STDERR, "Usage: {$_SERVER['argv'][0]} <version-prefix>\n");
-    fwrite(\STDERR, "Example: {$_SERVER['argv'][0]} 6.7.11\n");
-    exit(1);
-}
+// Operational errors (bad usage, refs not fetched) are thrown, not exited. An uncaught exception
+// leaves with a non-zero status, so the job turns red without this script ever calling exit().
 
-$majorMinor = implode('.', \array_slice(explode('.', $versionPrefix), 0, 2));
-$releaseInfoFile = "RELEASE_INFO-{$majorMinor}.md";
+(static function (): void {
+    $trunkRef = 'origin/trunk';
 
-// The release branch to verify. Defaults to "<prefix>.x" (e.g. 6.7.12 → 6.7.12.x); an optional
-// second argument overrides it. We compare against the remote ref, independent of the checkout.
-$targetBranch = $_SERVER['argv'][2] ?? ($versionPrefix . '.x');
-$branchRef = 'origin/' . $targetBranch;
-
-if (!refExists(TRUNK_REF)) {
-    fwrite(\STDERR, 'ERROR: ' . TRUNK_REF . " not found — fetch it first (git fetch origin trunk).\n");
-    exit(1);
-}
-if (!refExists($branchRef)) {
-    fwrite(\STDERR, "ERROR: release branch {$branchRef} not found — fetch it first (git fetch origin {$targetBranch}).\n");
-    exit(1);
-}
-
-// When running in GitHub Actions, build a base URL so commit SHAs can be rendered as links.
-$commitUrlBase = '';
-$server = getenv('GITHUB_SERVER_URL');
-$repo = getenv('GITHUB_REPOSITORY');
-if (\is_string($server) && $server !== '' && \is_string($repo) && $repo !== '') {
-    $commitUrlBase = rtrim($server, '/') . '/' . $repo . '/commit';
-}
-
-echo "Verifying RELEASE_INFO for {$versionPrefix}.*\n";
-echo '  trunk  : ' . TRUNK_REF . "\n";
-echo "  branch : {$branchRef}\n";
-echo "  file   : {$releaseInfoFile}\n\n";
-
-// Trunk is the authoritative source for what is supposed to be in the release.
-// The release branch is what actually shipped (or will ship).
-$trunkContent = (string) shell_exec(sprintf('git show %s', escapeshellarg(TRUNK_REF . ':' . $releaseInfoFile)));
-$trunkHeadings = extractHeadings($trunkContent, $versionPrefix);
-$branchContent = (string) shell_exec(sprintf('git show %s', escapeshellarg($branchRef . ':' . $releaseInfoFile)));
-$branchHeadings = extractHeadings($branchContent, $versionPrefix);
-
-if (!$trunkHeadings) {
-    echo "No entries found for {$versionPrefix}.* in trunk's {$releaseInfoFile} — nothing to verify.\n";
-    exit(0);
-}
-
-/** @var list<array{heading: string, sha: string}> $missing */
-$missing = [];
-/** @var list<array{heading: string, sha: string, note: string}> $warnings */
-$warnings = [];
-$confirmed = 0;
-
-foreach ($trunkHeadings as $heading) {
-    // Check 1 — text: is the heading present in the release branch's copy of the file?
-    // If it's missing here, the RELEASE_INFO update was never merged or cherry-picked into the branch.
-    $textPresent = \in_array($heading, $branchHeadings, true);
-
-    // Check 2 — commit: find the trunk commit that introduced this heading via pickaxe search (-S),
-    // then verify it is a direct ancestor of the release branch.
-    // This confirms the full PR (docs + code) landed in the branch, not just the text.
-    $introducingCommit = findIntroducingCommit($heading, $releaseInfoFile);
-    $commitReachable = false;
-    $docsOnly = false;
-
-    if ($introducingCommit !== '') {
-        $commitReachable = isAncestor($introducingCommit, $branchRef);
-
-        // Check 3 — docs-only: if the introducing commit only touched RELEASE_INFO and nothing else,
-        // it was a standalone documentation update decoupled from the feature code. In that case the
-        // reachability check tells us nothing about the actual feature — flag it for manual review.
-        $changed = trim((string) shell_exec(sprintf('git diff-tree --no-commit-id -r --name-only %s', escapeshellarg($introducingCommit))));
-        $changedFiles = array_values(array_filter(explode("\n", $changed), static fn (string $l): bool => $l !== ''));
-        $docsOnly = \count($changedFiles) === 1 && $changedFiles[0] === $releaseInfoFile;
+    $versionPrefix = $_SERVER['argv'][1] ?? '';
+    if (!\is_string($versionPrefix) || $versionPrefix === '') {
+        throw new RuntimeException(\sprintf('Usage: %s <version-prefix> [release-branch]', $_SERVER['argv'][0]));
     }
 
-    if ($textPresent && $commitReachable && !$docsOnly) {
-        ++$confirmed; // heading and feature code landed together and are reachable
-    } elseif (!$textPresent && !$commitReachable) {
-        $missing[] = ['heading' => $heading, 'sha' => $introducingCommit];
-    } elseif ($textPresent && !$commitReachable) {
-        $warnings[] = ['heading' => $heading, 'sha' => $introducingCommit, 'note' => 'RELEASE_INFO present but trunk commit not in branch — verify cherry-pick includes feature code'];
-    } elseif (!$textPresent && $commitReachable) {
-        $warnings[] = ['heading' => $heading, 'sha' => $introducingCommit, 'note' => 'code commit present but RELEASE_INFO entry missing from branch'];
-    } elseif ($docsOnly) {
-        $warnings[] = ['heading' => $heading, 'sha' => $introducingCommit, 'note' => 'RELEASE_INFO was updated in a docs-only commit — feature code commit is unknown, verify manually'];
+    $majorMinor = implode('.', \array_slice(explode('.', $versionPrefix), 0, 2));
+    $releaseInfoFile = "RELEASE_INFO-{$majorMinor}.md";
+
+    // The release branch to verify. Defaults to "<prefix>.x" (e.g. 6.7.12 → 6.7.12.x); an optional
+    // second argument overrides it. We compare against the remote ref, independent of the checkout.
+    $targetBranch = $_SERVER['argv'][2] ?? ($versionPrefix . '.x');
+    \assert(\is_string($targetBranch));
+    $branchRef = 'origin/' . $targetBranch;
+
+    $git = new ProcessGitReader();
+
+    if (!$git->refExists($trunkRef)) {
+        throw new RuntimeException($trunkRef . ' not found — fetch it first (git fetch origin trunk).');
     }
-}
-
-$total = \count($trunkHeadings);
-
-// Order entries by the introducing commit hash so log and summary are stable and grouped by commit.
-$byCommit = static fn (array $a, array $b): int => strcmp($a['sha'], $b['sha']);
-usort($missing, $byCommit);
-usort($warnings, $byCommit);
-
-// ── Console log (visible in the Actions job log) ────────────────────────────────
-if ($warnings) {
-    echo 'WARN: ' . \count($warnings) . " of {$total} entries need manual verification:\n\n";
-    foreach ($warnings as $w) {
-        echo "  ? {$w['heading']} [" . commitRef($w['sha'], $commitUrlBase) . "] {$w['note']}\n";
+    if (!$git->refExists($branchRef)) {
+        throw new RuntimeException("release branch {$branchRef} not found — fetch it first (git fetch origin {$targetBranch}).");
     }
-    echo "\n";
-}
 
-if ($missing) {
-    echo 'MISSING: ' . \count($missing) . " of {$total} entries documented on trunk are absent from this release branch:\n\n";
-    foreach ($missing as $m) {
-        echo "  x {$m['heading']} [" . commitRef($m['sha'], $commitUrlBase) . "]\n";
+    // When running in GitHub Actions, build a base URL so commit SHAs can be rendered as links.
+    $commitUrlBase = '';
+    $server = getenv('GITHUB_SERVER_URL');
+    $repo = getenv('GITHUB_REPOSITORY');
+    if (\is_string($server) && $server !== '' && \is_string($repo) && $repo !== '') {
+        $commitUrlBase = rtrim($server, '/') . '/' . $repo . '/commit';
     }
-    echo "\n";
-}
 
-// ── Job summary: rendered Markdown with real commit links (always written) ──────
-$summaryFile = getenv('GITHUB_STEP_SUMMARY');
-if (\is_string($summaryFile) && $summaryFile !== '') {
-    file_put_contents(
-        $summaryFile,
-        renderSummary($versionPrefix, $branchRef, $releaseInfoFile, $total, $confirmed, $missing, $warnings, $commitUrlBase),
-        \FILE_APPEND
-    );
-}
+    echo "Verifying RELEASE_INFO for {$versionPrefix}.*\n";
+    echo "  trunk  : {$trunkRef}\n";
+    echo "  branch : {$branchRef}\n";
+    echo "  file   : {$releaseInfoFile}\n\n";
 
-if ($missing) {
-    echo "These features were documented in {$releaseInfoFile} on trunk but have not been merged into this release branch.\n";
-    exit(1);
-}
+    $result = (new ReleaseContentVerifier($git))->verify($versionPrefix, $trunkRef, $branchRef, $releaseInfoFile);
+    $renderer = new ReleaseSummaryRenderer($commitUrlBase);
 
-$ok = $total - \count($warnings);
-echo "OK: {$ok} of {$total} entries confirmed present. " . \count($warnings) . " need manual verification (see above).\n";
+    if ($result->total === 0) {
+        echo "No entries found for {$versionPrefix}.* in trunk's {$releaseInfoFile} — nothing to verify.\n";
+    } else {
+        echo $renderer->consoleReport($result, $releaseInfoFile);
 
-/**
- * Collects every "### " heading that appears under a "# <version-prefix>.*" section.
- *
- * @return list<string>
- */
-function extractHeadings(string $content, string $versionPrefix): array
-{
-    $escapedPrefix = preg_quote($versionPrefix, '/');
-    $inSection = false;
-    $headings = [];
-
-    foreach (explode("\n", $content) as $line) {
-        // "# 6.7.11.0" → enter the section for this version prefix.
-        if (preg_match('/^#[[:space:]]+' . $escapedPrefix . '\./', $line) === 1) {
-            $inSection = true;
-            continue;
-        }
-        // Any other top-level "# " heading closes the section.
-        if ($inSection && preg_match('/^#[[:space:]]/', $line) === 1) {
-            $inSection = false;
-            continue;
-        }
-        if ($inSection && preg_match('/^###[[:space:]]/', $line) === 1) {
-            $headings[] = $line;
+        // Job summary: rendered Markdown with real commit links (written whenever GitHub provides the file).
+        $summaryFile = getenv('GITHUB_STEP_SUMMARY');
+        if (\is_string($summaryFile) && $summaryFile !== '') {
+            file_put_contents($summaryFile, $renderer->markdownSummary($versionPrefix, $branchRef, $releaseInfoFile, $result), \FILE_APPEND);
         }
     }
 
-    return $headings;
-}
-
-// Returns the most recent trunk commit that changed the count of the given string in the
-// given file (i.e. the commit that introduced or last re-added it), or '' if none.
-function findIntroducingCommit(string $heading, string $file): string
-{
-    return trim((string) shell_exec(sprintf(
-        'git log %s --format=%s --max-count=1 -S %s -- %s',
-        escapeshellarg(TRUNK_REF),
-        escapeshellarg('%H'),
-        escapeshellarg($heading),
-        escapeshellarg($file)
-    )));
-}
-
-// True when $commit is a direct ancestor of the given ref.
-function isAncestor(string $commit, string $ref): bool
-{
-    exec(sprintf('git merge-base --is-ancestor %s %s 2>/dev/null', escapeshellarg($commit), escapeshellarg($ref)), $output, $code);
-
-    return $code === 0;
-}
-
-// True when the given git ref resolves to a commit (e.g. it has been fetched).
-function refExists(string $ref): bool
-{
-    exec(sprintf('git rev-parse --verify --quiet %s 2>/dev/null', escapeshellarg($ref)), $output, $code);
-
-    return $code === 0;
-}
-
-// Commit reference for the log: short SHA locally, "short (full-url)" inside GitHub Actions.
-function commitRef(string $sha, string $base): string
-{
-    if ($sha === '') {
-        return 'unknown';
+    // Deliver the verdict as step outputs so the workflow can publish the commit status.
+    $outputFile = getenv('GITHUB_OUTPUT');
+    if (\is_string($outputFile) && $outputFile !== '') {
+        $state = $result->hasMissing() ? 'failure' : 'success';
+        $description = $renderer->commitStatusDescription($result, $versionPrefix, $targetBranch);
+        file_put_contents($outputFile, "state={$state}\ndescription={$description}\n", \FILE_APPEND);
     }
-
-    $short = substr($sha, 0, 8);
-
-    return $base !== '' ? sprintf('%s (%s/%s)', $short, $base, $sha) : $short;
-}
-
-// Commit reference as a Markdown link for the job summary (code span when unknown).
-function commitMd(string $sha, string $base): string
-{
-    if ($sha === '') {
-        return '`unknown`';
-    }
-
-    $short = substr($sha, 0, 8);
-
-    return $base !== '' ? sprintf('[`%s`](%s/%s)', $short, $base, $sha) : sprintf('`%s`', $short);
-}
-
-// Strip the leading "### " from a heading and escape pipes for Markdown table cells.
-function mdTitle(string $heading): string
-{
-    return str_replace('|', '\\|', (string) preg_replace('/^###[[:space:]]+/', '', $heading));
-}
-
-/**
- * @param list<array{heading: string, sha: string}>               $missing
- * @param list<array{heading: string, sha: string, note: string}> $warnings
- */
-function renderSummary(string $versionPrefix, string $branch, string $file, int $total, int $confirmed, array $missing, array $warnings, string $base): string
-{
-    $lines = [];
-    $lines[] = "## Release content verification — `{$versionPrefix}.*`";
-    $lines[] = '';
-    $lines[] = sprintf('**%d** confirmed · **%d** warning(s) · **%d** missing (of %d)', $confirmed, \count($warnings), \count($missing), $total);
-    $lines[] = '';
-    $lines[] = "- branch: `{$branch}`";
-    $lines[] = "- file: `{$file}`";
-    $lines[] = '';
-
-    if ($missing) {
-        $lines[] = '### ❌ Missing from this release branch';
-        $lines[] = '';
-        $lines[] = '| Entry | Trunk commit |';
-        $lines[] = '| --- | --- |';
-        foreach ($missing as $m) {
-            $lines[] = sprintf('| %s | %s |', mdTitle($m['heading']), commitMd($m['sha'], $base));
-        }
-        $lines[] = '';
-    }
-
-    if ($warnings) {
-        $lines[] = '### ⚠️ Needs manual verification';
-        $lines[] = '';
-        $lines[] = '| Entry | Trunk commit | Note |';
-        $lines[] = '| --- | --- | --- |';
-        foreach ($warnings as $w) {
-            $lines[] = sprintf('| %s | %s | %s |', mdTitle($w['heading']), commitMd($w['sha'], $base), $w['note']);
-        }
-        $lines[] = '';
-    }
-
-    if (!$missing && !$warnings) {
-        $lines[] = "✅ All {$total} documented entries are present and traceable.";
-    }
-
-    return implode("\n", $lines) . "\n";
-}
+})();

--- a/.github/bin/verify-release-content.php
+++ b/.github/bin/verify-release-content.php
@@ -3,6 +3,7 @@
 use Shopware\Core\DevOps\Release\ProcessGitReader;
 use Shopware\Core\DevOps\Release\ReleaseContentVerifier;
 use Shopware\Core\DevOps\Release\ReleaseSummaryRenderer;
+use Symfony\Component\Filesystem\Filesystem;
 
 // Thin CLI wrapper around the release-content verification. All logic lives in
 // Shopware\Core\DevOps\Release\* (unit-tested); this script only handles argv, wiring and output.
@@ -63,6 +64,7 @@ require __DIR__ . '/../../vendor/autoload.php';
 
     $result = (new ReleaseContentVerifier($git))->verify($versionPrefix, $trunkRef, $branchRef, $releaseInfoFile);
     $renderer = new ReleaseSummaryRenderer($commitUrlBase);
+    $filesystem = new Filesystem();
 
     if ($result->total === 0) {
         echo "No entries found for {$versionPrefix}.* in trunk's {$releaseInfoFile} — nothing to verify.\n";
@@ -72,7 +74,7 @@ require __DIR__ . '/../../vendor/autoload.php';
         // Job summary: rendered Markdown with real commit links (written whenever GitHub provides the file).
         $summaryFile = getenv('GITHUB_STEP_SUMMARY');
         if (\is_string($summaryFile) && $summaryFile !== '') {
-            file_put_contents($summaryFile, $renderer->markdownSummary($versionPrefix, $branchRef, $releaseInfoFile, $result), \FILE_APPEND);
+            $filesystem->appendToFile($summaryFile, $renderer->markdownSummary($versionPrefix, $branchRef, $releaseInfoFile, $result));
         }
     }
 
@@ -81,6 +83,6 @@ require __DIR__ . '/../../vendor/autoload.php';
     if (\is_string($outputFile) && $outputFile !== '') {
         $state = $result->hasMissing() ? 'failure' : 'success';
         $description = $renderer->commitStatusDescription($result, $versionPrefix, $targetBranch);
-        file_put_contents($outputFile, "state={$state}\ndescription={$description}\n", \FILE_APPEND);
+        $filesystem->appendToFile($outputFile, "state={$state}\ndescription={$description}\n");
     }
 })();

--- a/.github/workflows/verify-release-content.yml
+++ b/.github/workflows/verify-release-content.yml
@@ -1,4 +1,8 @@
 name: Verify release content
+# The verdict is delivered through the `release-content/verify` commit status on the release branch
+# head, not through the job result — block on that status; the job stays green by design. A red job
+# here means the verification itself could not run (operational error), so pipeline monitoring only
+# surfaces real CI problems.
 
 on:
   push:
@@ -9,6 +13,10 @@ on:
       version_prefix:
         description: 'Version prefix to verify (e.g. 6.7.11). Derived from branch name when omitted.'
         required: false
+
+permissions:
+  contents: read
+  statuses: write
 
 jobs:
   verify:
@@ -36,4 +44,26 @@ jobs:
         run: git fetch origin trunk "${{ steps.version.outputs.prefix }}.x"
 
       - name: Verify release content
+        id: verify
+        # The script never fails on a verdict; it writes state/description to GITHUB_OUTPUT. A non-zero
+        # exit here is an operational error (bad usage, refs not fetched) and must stay a job failure.
         run: php .github/bin/verify-release-content.php "${{ steps.version.outputs.prefix }}"
+
+      - name: Report verdict as commit status
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        env:
+          # Written by verify-release-content.php via GITHUB_OUTPUT. An empty state means the script
+          # produced no verdict — createCommitStatus then rejects the call and fails this job, which is
+          # the guard we want.
+          STATE: ${{ steps.verify.outputs.state }}
+          DESCRIPTION: ${{ steps.verify.outputs.description }}
+        with:
+          script: |
+            await github.rest.repos.createCommitStatus({
+              ...context.repo,
+              sha: context.sha,
+              state: process.env.STATE,
+              context: 'release-content/verify',
+              description: process.env.DESCRIPTION,
+              target_url: `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+            })

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -96,6 +96,7 @@
             <directory suffix=".php">src/Core/Content/Cms/DataResolver/ResolverContext/</directory>
             <directory suffix=".php">src/Core/Content/Cms/Extension/</directory>
             <directory suffix=".php">src/Core/DevOps/StaticAnalyze</directory>
+            <directory suffix=".php">src/Core/DevOps/Release</directory>
             <directory suffix=".php">src/Core/Framework/Telemetry/Metrics/Metric</directory>
 
             <directory suffix="Definition.php">src/Storefront/Checkout</directory>

--- a/src/Core/DevOps/Release/GitReader.php
+++ b/src/Core/DevOps/Release/GitReader.php
@@ -1,0 +1,45 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\DevOps\Release;
+
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * Read-only git access used by the release-content verification. Abstracting it behind an
+ * interface keeps {@see ReleaseContentVerifier} free of subprocess calls, so its logic can be
+ * unit-tested against an in-memory fake instead of a real repository.
+ *
+ * @internal
+ */
+#[Package('framework')]
+interface GitReader
+{
+    /**
+     * Content of $path at $ref (e.g. "origin/trunk"), or an empty string when the ref or file
+     * does not exist.
+     */
+    public function showFile(string $ref, string $path): string;
+
+    /**
+     * True when $ref resolves to a commit (i.e. it has been fetched).
+     */
+    public function refExists(string $ref): bool;
+
+    /**
+     * Most recent commit on $ref that changed the number of occurrences of $needle in $path
+     * (pickaxe search), or an empty string when none is found.
+     */
+    public function findIntroducingCommit(string $ref, string $needle, string $path): string;
+
+    /**
+     * True when $commit is a direct ancestor of $ref.
+     */
+    public function isAncestor(string $commit, string $ref): bool;
+
+    /**
+     * Paths changed by $commit.
+     *
+     * @return list<string>
+     */
+    public function changedFiles(string $commit): array;
+}

--- a/src/Core/DevOps/Release/ProcessGitReader.php
+++ b/src/Core/DevOps/Release/ProcessGitReader.php
@@ -1,0 +1,77 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\DevOps\Release;
+
+use Shopware\Core\Framework\Log\Package;
+use Symfony\Component\Process\Process;
+
+/**
+ * {@see GitReader} backed by the git binary via Symfony Process. Commands are passed as argument
+ * lists (never a shell string), so there is no shell interpolation to escape and no shell_exec/exec.
+ *
+ * @internal
+ *
+ * @see \Shopware\Tests\Integration\Core\DevOps\Release\ProcessGitReaderTest
+ */
+#[Package('framework')]
+class ProcessGitReader implements GitReader
+{
+    /**
+     * @param string|null $workingDirectory directory the git commands run in; null uses the current
+     *                                      working directory (the checked-out repository in CI)
+     */
+    public function __construct(
+        private readonly ?string $workingDirectory = null,
+    ) {
+    }
+
+    public function showFile(string $ref, string $path): string
+    {
+        // git show exits non-zero when the ref or file is absent; callers treat '' as "not present".
+        return $this->output(['git', 'show', $ref . ':' . $path]);
+    }
+
+    public function refExists(string $ref): bool
+    {
+        return $this->succeeds(['git', 'rev-parse', '--verify', '--quiet', $ref]);
+    }
+
+    public function findIntroducingCommit(string $ref, string $needle, string $path): string
+    {
+        return trim($this->output(['git', 'log', $ref, '--format=%H', '--max-count=1', '-S', $needle, '--', $path]));
+    }
+
+    public function isAncestor(string $commit, string $ref): bool
+    {
+        return $this->succeeds(['git', 'merge-base', '--is-ancestor', $commit, $ref]);
+    }
+
+    public function changedFiles(string $commit): array
+    {
+        $output = trim($this->output(['git', 'diff-tree', '--no-commit-id', '-r', '--name-only', $commit]));
+
+        return array_values(array_filter(explode("\n", $output), static fn (string $line): bool => $line !== ''));
+    }
+
+    /**
+     * @param list<string> $command
+     */
+    private function output(array $command): string
+    {
+        $process = new Process($command, $this->workingDirectory);
+        $process->run();
+
+        return $process->isSuccessful() ? $process->getOutput() : '';
+    }
+
+    /**
+     * @param list<string> $command
+     */
+    private function succeeds(array $command): bool
+    {
+        $process = new Process($command, $this->workingDirectory);
+        $process->run();
+
+        return $process->isSuccessful();
+    }
+}

--- a/src/Core/DevOps/Release/ReleaseContentVerifier.php
+++ b/src/Core/DevOps/Release/ReleaseContentVerifier.php
@@ -1,0 +1,117 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\DevOps\Release;
+
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * Verifies that every feature heading documented in trunk's RELEASE_INFO for a version prefix is
+ * also present on the release branch, and that the commit which introduced it on trunk is reachable
+ * from that branch.
+ *
+ * Per documented heading three checks are combined:
+ *  1. text     — is the heading present in the branch's copy of the file?
+ *  2. commit   — is the trunk commit that introduced the heading an ancestor of the branch?
+ *  3. docs-only — did that commit touch only RELEASE_INFO (so reachability says nothing about the
+ *                 feature code)?
+ *
+ * @internal
+ */
+#[Package('framework')]
+class ReleaseContentVerifier
+{
+    public const NOTE_TEXT_WITHOUT_COMMIT = 'RELEASE_INFO present but trunk commit not in branch — verify cherry-pick includes feature code';
+    public const NOTE_COMMIT_WITHOUT_TEXT = 'code commit present but RELEASE_INFO entry missing from branch';
+    public const NOTE_DOCS_ONLY = 'RELEASE_INFO was updated in a docs-only commit — feature code commit is unknown, verify manually';
+
+    public function __construct(
+        private readonly GitReader $git,
+    ) {
+    }
+
+    public function verify(string $versionPrefix, string $trunkRef, string $branchRef, string $releaseInfoFile): VerificationResult
+    {
+        // Trunk is the authoritative source for what is supposed to be in the release; the branch is
+        // what actually shipped (or will ship).
+        $trunkHeadings = self::extractHeadings($this->git->showFile($trunkRef, $releaseInfoFile), $versionPrefix);
+        $branchHeadings = self::extractHeadings($this->git->showFile($branchRef, $releaseInfoFile), $versionPrefix);
+
+        /** @var list<array{heading: string, sha: string}> $missing */
+        $missing = [];
+        /** @var list<array{heading: string, sha: string, note: string}> $warnings */
+        $warnings = [];
+        $confirmed = 0;
+
+        foreach ($trunkHeadings as $heading) {
+            $textPresent = \in_array($heading, $branchHeadings, true);
+
+            $introducingCommit = $this->git->findIntroducingCommit($trunkRef, $heading, $releaseInfoFile);
+            $commitReachable = false;
+            $docsOnly = false;
+
+            if ($introducingCommit !== '') {
+                $commitReachable = $this->git->isAncestor($introducingCommit, $branchRef);
+
+                $changedFiles = $this->git->changedFiles($introducingCommit);
+                $docsOnly = \count($changedFiles) === 1 && $changedFiles[0] === $releaseInfoFile;
+            }
+
+            if ($textPresent && $commitReachable) {
+                if ($docsOnly) {
+                    // Heading and reachable commit, but the commit only touched RELEASE_INFO — reachability
+                    // says nothing about the feature code, so flag it for manual review.
+                    $warnings[] = ['heading' => $heading, 'sha' => $introducingCommit, 'note' => self::NOTE_DOCS_ONLY];
+                } else {
+                    ++$confirmed; // heading and feature code landed together and are reachable
+                }
+            } elseif (!$textPresent && !$commitReachable) {
+                $missing[] = ['heading' => $heading, 'sha' => $introducingCommit];
+            } elseif ($textPresent) {
+                // heading present but the introducing commit is not an ancestor of the branch
+                $warnings[] = ['heading' => $heading, 'sha' => $introducingCommit, 'note' => self::NOTE_TEXT_WITHOUT_COMMIT];
+            } else {
+                // introducing commit reachable but the heading text is missing from the branch
+                $warnings[] = ['heading' => $heading, 'sha' => $introducingCommit, 'note' => self::NOTE_COMMIT_WITHOUT_TEXT];
+            }
+        }
+
+        // Order entries by the introducing commit hash so log and summary are stable and grouped by commit.
+        $byCommit = static fn (array $a, array $b): int => strcmp($a['sha'], $b['sha']);
+        usort($missing, $byCommit);
+        usort($warnings, $byCommit);
+
+        return new VerificationResult(\count($trunkHeadings), $confirmed, $missing, $warnings);
+    }
+
+    /**
+     * Collects every "### " heading that appears under a "# <version-prefix>.*" section.
+     *
+     * @return list<string>
+     */
+    public static function extractHeadings(string $content, string $versionPrefix): array
+    {
+        $escapedPrefix = preg_quote($versionPrefix, '/');
+        $inSection = false;
+        $headings = [];
+
+        foreach (explode("\n", $content) as $line) {
+            // "# 6.7.11.0" → enter the section for this version prefix.
+            if (preg_match('/^#[[:space:]]+' . $escapedPrefix . '\./', $line) === 1) {
+                $inSection = true;
+
+                continue;
+            }
+            // Any other top-level "# " heading closes the section.
+            if ($inSection && preg_match('/^#[[:space:]]/', $line) === 1) {
+                $inSection = false;
+
+                continue;
+            }
+            if ($inSection && preg_match('/^###[[:space:]]/', $line) === 1) {
+                $headings[] = $line;
+            }
+        }
+
+        return $headings;
+    }
+}

--- a/src/Core/DevOps/Release/ReleaseSummaryRenderer.php
+++ b/src/Core/DevOps/Release/ReleaseSummaryRenderer.php
@@ -1,0 +1,147 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\DevOps\Release;
+
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * Turns a {@see VerificationResult} into the two report surfaces the CI job shows: the plain-text
+ * console log and the Markdown job summary. Kept separate from the verifier so the formatting can be
+ * unit-tested without running git.
+ *
+ * @internal
+ */
+#[Package('framework')]
+class ReleaseSummaryRenderer
+{
+    /**
+     * @param string $commitUrlBase base URL for commit links (e.g. "https://github.com/owner/repo/commit");
+     *                              empty when running outside GitHub Actions, which falls back to short SHAs
+     */
+    public function __construct(
+        private readonly string $commitUrlBase = '',
+    ) {
+    }
+
+    public function consoleReport(VerificationResult $result, string $releaseInfoFile): string
+    {
+        $report = '';
+
+        if ($result->warnings !== []) {
+            $report .= 'WARN: ' . \count($result->warnings) . " of {$result->total} entries need manual verification:\n\n";
+            foreach ($result->warnings as $warning) {
+                $report .= "  ? {$warning['heading']} [" . $this->commitRef($warning['sha']) . "] {$warning['note']}\n";
+            }
+            $report .= "\n";
+        }
+
+        if ($result->missing !== []) {
+            $report .= 'MISSING: ' . \count($result->missing) . " of {$result->total} entries documented on trunk are absent from this release branch:\n\n";
+            foreach ($result->missing as $missing) {
+                $report .= "  x {$missing['heading']} [" . $this->commitRef($missing['sha']) . "]\n";
+            }
+            $report .= "\n";
+        }
+
+        if ($result->hasMissing()) {
+            return $report . "These features were documented in {$releaseInfoFile} on trunk but have not been merged into this release branch.\n";
+        }
+
+        $ok = $result->total - \count($result->warnings);
+
+        return $report . "OK: {$ok} of {$result->total} entries confirmed present. " . \count($result->warnings) . " need manual verification (see above).\n";
+    }
+
+    public function markdownSummary(string $versionPrefix, string $branchRef, string $releaseInfoFile, VerificationResult $result): string
+    {
+        $lines = [];
+        $lines[] = "## Release content verification — `{$versionPrefix}.*`";
+        $lines[] = '';
+        $lines[] = \sprintf('**%d** confirmed · **%d** warning(s) · **%d** missing (of %d)', $result->confirmed, \count($result->warnings), \count($result->missing), $result->total);
+        $lines[] = '';
+        $lines[] = "- branch: `{$branchRef}`";
+        $lines[] = "- file: `{$releaseInfoFile}`";
+        $lines[] = '';
+
+        if ($result->missing !== []) {
+            $lines[] = '### ❌ Missing from this release branch';
+            $lines[] = '';
+            $lines[] = '| Entry | Trunk commit |';
+            $lines[] = '| --- | --- |';
+            foreach ($result->missing as $missing) {
+                $lines[] = \sprintf('| %s | %s |', $this->mdTitle($missing['heading']), $this->commitMd($missing['sha']));
+            }
+            $lines[] = '';
+        }
+
+        if ($result->warnings !== []) {
+            $lines[] = '### ⚠️ Needs manual verification';
+            $lines[] = '';
+            $lines[] = '| Entry | Trunk commit | Note |';
+            $lines[] = '| --- | --- | --- |';
+            foreach ($result->warnings as $warning) {
+                $lines[] = \sprintf('| %s | %s | %s |', $this->mdTitle($warning['heading']), $this->commitMd($warning['sha']), $warning['note']);
+            }
+            $lines[] = '';
+        }
+
+        if ($result->missing === [] && $result->warnings === []) {
+            $lines[] = "✅ All {$result->total} documented entries are present and traceable.";
+        }
+
+        return implode("\n", $lines) . "\n";
+    }
+
+    /**
+     * One-line verdict for the `release-content/verify` commit status (the GitHub status description
+     * limit is 140 characters, so this stays a short summary).
+     */
+    public function commitStatusDescription(VerificationResult $result, string $versionPrefix, string $targetBranch): string
+    {
+        if ($result->total === 0) {
+            return "no entries for {$versionPrefix}.* on trunk — nothing to verify";
+        }
+
+        if ($result->hasMissing()) {
+            return \sprintf('%d of %d documented entries missing from %s', \count($result->missing), $result->total, $targetBranch);
+        }
+
+        return \sprintf('%d of %d entries confirmed, %d need manual verification', $result->confirmed, $result->total, \count($result->warnings));
+    }
+
+    /**
+     * Commit reference for the console log: short SHA locally, "short (full-url)" inside GitHub Actions.
+     */
+    private function commitRef(string $sha): string
+    {
+        if ($sha === '') {
+            return 'unknown';
+        }
+
+        $short = substr($sha, 0, 8);
+
+        return $this->commitUrlBase !== '' ? \sprintf('%s (%s/%s)', $short, $this->commitUrlBase, $sha) : $short;
+    }
+
+    /**
+     * Commit reference as a Markdown link for the job summary (code span when unknown).
+     */
+    private function commitMd(string $sha): string
+    {
+        if ($sha === '') {
+            return '`unknown`';
+        }
+
+        $short = substr($sha, 0, 8);
+
+        return $this->commitUrlBase !== '' ? \sprintf('[`%s`](%s/%s)', $short, $this->commitUrlBase, $sha) : \sprintf('`%s`', $short);
+    }
+
+    /**
+     * Strip the leading "### " from a heading and escape pipes for Markdown table cells.
+     */
+    private function mdTitle(string $heading): string
+    {
+        return str_replace('|', '\\|', (string) preg_replace('/^###[[:space:]]+/', '', $heading));
+    }
+}

--- a/src/Core/DevOps/Release/VerificationResult.php
+++ b/src/Core/DevOps/Release/VerificationResult.php
@@ -1,0 +1,36 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\DevOps\Release;
+
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * Outcome of a {@see ReleaseContentVerifier} run: how many documented headings were confirmed,
+ * which are missing from the release branch, and which need manual verification. The verifier
+ * returns this instead of writing output or setting an exit code, so callers decide how to report.
+ *
+ * @internal
+ *
+ * @phpstan-type MissingEntry array{heading: string, sha: string}
+ * @phpstan-type WarningEntry array{heading: string, sha: string, note: string}
+ */
+#[Package('framework')]
+class VerificationResult
+{
+    /**
+     * @param list<MissingEntry> $missing
+     * @param list<WarningEntry> $warnings
+     */
+    public function __construct(
+        public readonly int $total,
+        public readonly int $confirmed,
+        public readonly array $missing,
+        public readonly array $warnings,
+    ) {
+    }
+
+    public function hasMissing(): bool
+    {
+        return $this->missing !== [];
+    }
+}

--- a/tests/devops/Core/DevOps/Release/FakeGitReader.php
+++ b/tests/devops/Core/DevOps/Release/FakeGitReader.php
@@ -1,0 +1,57 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\DevOps\Core\DevOps\Release;
+
+use Shopware\Core\DevOps\Release\GitReader;
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * In-memory {@see GitReader} for the release-content verifier tests: every answer is configured up
+ * front, so scenarios read as data instead of subprocess plumbing.
+ *
+ * @internal
+ */
+#[Package('framework')]
+class FakeGitReader implements GitReader
+{
+    /**
+     * @param array<string, string> $files "<ref>:<path>" => file content
+     * @param array<string, string> $introducing heading => introducing commit sha on trunk
+     * @param list<string> $existingRefs refs that resolve to a commit
+     * @param list<string> $ancestors commits reachable from the release branch
+     * @param array<string, list<string>> $changedFiles sha => files that commit changed
+     */
+    public function __construct(
+        private readonly array $files = [],
+        private readonly array $introducing = [],
+        private readonly array $existingRefs = [],
+        private readonly array $ancestors = [],
+        private readonly array $changedFiles = [],
+    ) {
+    }
+
+    public function showFile(string $ref, string $path): string
+    {
+        return $this->files[$ref . ':' . $path] ?? '';
+    }
+
+    public function refExists(string $ref): bool
+    {
+        return \in_array($ref, $this->existingRefs, true);
+    }
+
+    public function findIntroducingCommit(string $ref, string $needle, string $path): string
+    {
+        return $this->introducing[$needle] ?? '';
+    }
+
+    public function isAncestor(string $commit, string $ref): bool
+    {
+        return \in_array($commit, $this->ancestors, true);
+    }
+
+    public function changedFiles(string $commit): array
+    {
+        return $this->changedFiles[$commit] ?? [];
+    }
+}

--- a/tests/devops/Core/DevOps/Release/ReleaseContentVerifierTest.php
+++ b/tests/devops/Core/DevOps/Release/ReleaseContentVerifierTest.php
@@ -1,0 +1,186 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\DevOps\Core\DevOps\Release;
+
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\DevOps\Release\ReleaseContentVerifier;
+use Shopware\Core\DevOps\Release\VerificationResult;
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+class ReleaseContentVerifierTest extends TestCase
+{
+    private const VERSION = '6.7.11';
+    private const FILE = 'RELEASE_INFO-6.7.md';
+    private const TRUNK = 'origin/trunk';
+    private const BRANCH = 'origin/6.7.11.x';
+
+    public function testHeadingWithReachableFeatureCommitIsConfirmed(): void
+    {
+        $content = $this->releaseInfo('### Feature A');
+
+        $git = new FakeGitReader(
+            files: [self::TRUNK . ':' . self::FILE => $content, self::BRANCH . ':' . self::FILE => $content],
+            introducing: ['### Feature A' => 'aaaa1111'],
+            ancestors: ['aaaa1111'],
+            changedFiles: ['aaaa1111' => [self::FILE, 'src/Feature.php']],
+        );
+
+        $result = $this->verify($git);
+
+        static::assertSame(1, $result->total);
+        static::assertSame(1, $result->confirmed);
+        static::assertSame([], $result->missing);
+        static::assertSame([], $result->warnings);
+        static::assertFalse($result->hasMissing());
+    }
+
+    public function testHeadingAbsentFromBranchWithUnreachableCommitIsMissing(): void
+    {
+        $git = new FakeGitReader(
+            files: [
+                self::TRUNK . ':' . self::FILE => $this->releaseInfo('### Feature A'),
+                self::BRANCH . ':' . self::FILE => $this->releaseInfo(),
+            ],
+            introducing: ['### Feature A' => 'aaaa1111'],
+            // not an ancestor of the branch
+            changedFiles: ['aaaa1111' => [self::FILE, 'src/Feature.php']],
+        );
+
+        $result = $this->verify($git);
+
+        static::assertSame(1, $result->total);
+        static::assertSame(0, $result->confirmed);
+        static::assertTrue($result->hasMissing());
+        static::assertSame([['heading' => '### Feature A', 'sha' => 'aaaa1111']], $result->missing);
+    }
+
+    public function testHeadingPresentButCommitNotReachableIsWarned(): void
+    {
+        $content = $this->releaseInfo('### Feature A');
+
+        $git = new FakeGitReader(
+            files: [self::TRUNK . ':' . self::FILE => $content, self::BRANCH . ':' . self::FILE => $content],
+            introducing: ['### Feature A' => 'aaaa1111'],
+            // commit exists but is not an ancestor of the branch
+            changedFiles: ['aaaa1111' => [self::FILE, 'src/Feature.php']],
+        );
+
+        $result = $this->verify($git);
+
+        static::assertSame([], $result->missing);
+        static::assertSame(
+            [['heading' => '### Feature A', 'sha' => 'aaaa1111', 'note' => ReleaseContentVerifier::NOTE_TEXT_WITHOUT_COMMIT]],
+            $result->warnings,
+        );
+    }
+
+    public function testCommitReachableButHeadingMissingFromBranchIsWarned(): void
+    {
+        $git = new FakeGitReader(
+            files: [
+                self::TRUNK . ':' . self::FILE => $this->releaseInfo('### Feature A'),
+                self::BRANCH . ':' . self::FILE => $this->releaseInfo(),
+            ],
+            introducing: ['### Feature A' => 'aaaa1111'],
+            ancestors: ['aaaa1111'],
+            changedFiles: ['aaaa1111' => [self::FILE, 'src/Feature.php']],
+        );
+
+        $result = $this->verify($git);
+
+        static::assertSame(
+            [['heading' => '### Feature A', 'sha' => 'aaaa1111', 'note' => ReleaseContentVerifier::NOTE_COMMIT_WITHOUT_TEXT]],
+            $result->warnings,
+        );
+    }
+
+    public function testDocsOnlyIntroducingCommitIsWarned(): void
+    {
+        $content = $this->releaseInfo('### Feature A');
+
+        $git = new FakeGitReader(
+            files: [self::TRUNK . ':' . self::FILE => $content, self::BRANCH . ':' . self::FILE => $content],
+            introducing: ['### Feature A' => 'aaaa1111'],
+            ancestors: ['aaaa1111'],
+            // the introducing commit touched only RELEASE_INFO
+            changedFiles: ['aaaa1111' => [self::FILE]],
+        );
+
+        $result = $this->verify($git);
+
+        static::assertSame(0, $result->confirmed);
+        static::assertSame(
+            [['heading' => '### Feature A', 'sha' => 'aaaa1111', 'note' => ReleaseContentVerifier::NOTE_DOCS_ONLY]],
+            $result->warnings,
+        );
+    }
+
+    public function testNoHeadingsOnTrunkYieldsNothingToVerify(): void
+    {
+        $git = new FakeGitReader(
+            files: [self::TRUNK . ':' . self::FILE => "# 6.7.11.0\n\nno feature headings here\n"],
+        );
+
+        $result = $this->verify($git);
+
+        static::assertSame(0, $result->total);
+        static::assertSame([], $result->missing);
+        static::assertSame([], $result->warnings);
+    }
+
+    public function testEntriesAreSortedByIntroducingCommit(): void
+    {
+        $content = $this->releaseInfo('### Feature Z', '### Feature A');
+
+        $git = new FakeGitReader(
+            files: [self::TRUNK . ':' . self::FILE => $content, self::BRANCH . ':' . self::FILE => $this->releaseInfo()],
+            introducing: ['### Feature Z' => 'zzzz9999', '### Feature A' => 'aaaa1111'],
+            changedFiles: ['zzzz9999' => [self::FILE, 'src/Z.php'], 'aaaa1111' => [self::FILE, 'src/A.php']],
+        );
+
+        $result = $this->verify($git);
+
+        static::assertSame(['aaaa1111', 'zzzz9999'], array_column($result->missing, 'sha'));
+    }
+
+    public function testExtractHeadingsCollectsThirdLevelHeadingsWithinTheVersionSection(): void
+    {
+        $content = "# 6.7.11.0\n\n### Feature A\nbody\n#### deeper\n## other\n### Feature B\n";
+
+        static::assertSame(
+            ['### Feature A', '### Feature B'],
+            ReleaseContentVerifier::extractHeadings($content, self::VERSION),
+        );
+    }
+
+    public function testExtractHeadingsStopsAtTheNextTopLevelSection(): void
+    {
+        $content = "# 6.7.11.0\n### In section\n# 6.8.0.0\n### Other version\n";
+
+        static::assertSame(['### In section'], ReleaseContentVerifier::extractHeadings($content, self::VERSION));
+    }
+
+    public function testExtractHeadingsSpansMultipleSectionsSharingThePrefix(): void
+    {
+        $content = "# 6.7.11.0\n### First patch\n# 6.7.11.1\n### Second patch\n";
+
+        static::assertSame(
+            ['### First patch', '### Second patch'],
+            ReleaseContentVerifier::extractHeadings($content, self::VERSION),
+        );
+    }
+
+    private function releaseInfo(string ...$headings): string
+    {
+        return "# 6.7.11.0\n\n" . implode("\n", array_map(static fn (string $h): string => $h . "\nsome description\n", $headings));
+    }
+
+    private function verify(FakeGitReader $git): VerificationResult
+    {
+        return (new ReleaseContentVerifier($git))->verify(self::VERSION, self::TRUNK, self::BRANCH, self::FILE);
+    }
+}

--- a/tests/devops/Core/DevOps/Release/ReleaseSummaryRendererTest.php
+++ b/tests/devops/Core/DevOps/Release/ReleaseSummaryRendererTest.php
@@ -1,0 +1,119 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\DevOps\Core\DevOps\Release;
+
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\DevOps\Release\ReleaseContentVerifier;
+use Shopware\Core\DevOps\Release\ReleaseSummaryRenderer;
+use Shopware\Core\DevOps\Release\VerificationResult;
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+class ReleaseSummaryRendererTest extends TestCase
+{
+    private const URL_BASE = 'https://github.com/shopware/shopware/commit';
+
+    public function testConsoleReportForAllConfirmedShowsOnlyTheOkLine(): void
+    {
+        $report = (new ReleaseSummaryRenderer())->consoleReport(new VerificationResult(3, 3, [], []), 'RELEASE_INFO-6.7.md');
+
+        static::assertStringContainsString('OK: 3 of 3 entries confirmed present. 0 need manual verification', $report);
+        static::assertStringNotContainsString('WARN', $report);
+        static::assertStringNotContainsString('MISSING', $report);
+    }
+
+    public function testConsoleReportRendersWarningsWithLinkedCommitAndKeepsTheOkLine(): void
+    {
+        $result = new VerificationResult(2, 1, [], [
+            ['heading' => '### Feature A', 'sha' => 'aaaa11112222', 'note' => ReleaseContentVerifier::NOTE_DOCS_ONLY],
+        ]);
+
+        $report = (new ReleaseSummaryRenderer(self::URL_BASE))->consoleReport($result, 'RELEASE_INFO-6.7.md');
+
+        static::assertStringContainsString('WARN: 1 of 2 entries need manual verification:', $report);
+        static::assertStringContainsString('? ### Feature A [aaaa1111 (' . self::URL_BASE . '/aaaa11112222)] ' . ReleaseContentVerifier::NOTE_DOCS_ONLY, $report);
+        static::assertStringContainsString('OK: 1 of 2 entries confirmed present. 1 need manual verification', $report);
+    }
+
+    public function testConsoleReportForMissingShowsTheFailureEpilogueAndNoOkLine(): void
+    {
+        $result = new VerificationResult(1, 0, [['heading' => '### Feature A', 'sha' => '']], []);
+
+        $report = (new ReleaseSummaryRenderer())->consoleReport($result, 'RELEASE_INFO-6.7.md');
+
+        static::assertStringContainsString('MISSING: 1 of 1 entries documented on trunk are absent', $report);
+        // unknown sha renders as "unknown", and without a URL base there is no link
+        static::assertStringContainsString('x ### Feature A [unknown]', $report);
+        static::assertStringContainsString('These features were documented in RELEASE_INFO-6.7.md on trunk', $report);
+        static::assertStringNotContainsString('OK:', $report);
+    }
+
+    public function testMarkdownSummaryForCleanRunShowsTheSuccessLine(): void
+    {
+        $markdown = (new ReleaseSummaryRenderer())->markdownSummary(
+            '6.7.11',
+            'origin/6.7.11.x',
+            'RELEASE_INFO-6.7.md',
+            new VerificationResult(2, 2, [], []),
+        );
+
+        static::assertStringContainsString('## Release content verification — `6.7.11.*`', $markdown);
+        static::assertStringContainsString('**2** confirmed · **0** warning(s) · **0** missing (of 2)', $markdown);
+        static::assertStringContainsString('✅ All 2 documented entries are present and traceable.', $markdown);
+    }
+
+    public function testMarkdownSummaryRendersMissingTableWithLinkedCommitAndEscapedPipes(): void
+    {
+        $result = new VerificationResult(1, 0, [['heading' => '### Feature | A', 'sha' => 'aaaa11112222']], []);
+
+        $markdown = (new ReleaseSummaryRenderer(self::URL_BASE))->markdownSummary('6.7.11', 'origin/6.7.11.x', 'RELEASE_INFO-6.7.md', $result);
+
+        static::assertStringContainsString('### ❌ Missing from this release branch', $markdown);
+        static::assertStringContainsString('| Feature \\| A | [`aaaa1111`](' . self::URL_BASE . '/aaaa11112222) |', $markdown);
+    }
+
+    public function testMarkdownSummaryRendersUnknownCommitAsCodeSpanWithoutUrlBase(): void
+    {
+        $result = new VerificationResult(1, 0, [], [
+            ['heading' => '### Feature A', 'sha' => '', 'note' => ReleaseContentVerifier::NOTE_TEXT_WITHOUT_COMMIT],
+        ]);
+
+        $markdown = (new ReleaseSummaryRenderer())->markdownSummary('6.7.11', 'origin/6.7.11.x', 'RELEASE_INFO-6.7.md', $result);
+
+        static::assertStringContainsString('### ⚠️ Needs manual verification', $markdown);
+        static::assertStringContainsString('| Feature A | `unknown` | ' . ReleaseContentVerifier::NOTE_TEXT_WITHOUT_COMMIT . ' |', $markdown);
+    }
+
+    public function testCommitStatusDescriptionForNothingToVerify(): void
+    {
+        $description = (new ReleaseSummaryRenderer())->commitStatusDescription(new VerificationResult(0, 0, [], []), '6.7.11', '6.7.11.x');
+
+        static::assertSame('no entries for 6.7.11.* on trunk — nothing to verify', $description);
+    }
+
+    public function testCommitStatusDescriptionForMissingEntries(): void
+    {
+        $result = new VerificationResult(3, 1, [
+            ['heading' => '### A', 'sha' => 'aaaa'],
+            ['heading' => '### B', 'sha' => 'bbbb'],
+        ], []);
+
+        $description = (new ReleaseSummaryRenderer())->commitStatusDescription($result, '6.7.11', '6.7.11.x');
+
+        static::assertSame('2 of 3 documented entries missing from 6.7.11.x', $description);
+    }
+
+    public function testCommitStatusDescriptionForConfirmedRun(): void
+    {
+        $result = new VerificationResult(4, 3, [], [
+            ['heading' => '### A', 'sha' => 'aaaa', 'note' => ReleaseContentVerifier::NOTE_DOCS_ONLY],
+        ]);
+
+        $description = (new ReleaseSummaryRenderer())->commitStatusDescription($result, '6.7.11', '6.7.11.x');
+
+        static::assertSame('3 of 4 entries confirmed, 1 need manual verification', $description);
+    }
+}

--- a/tests/integration/Core/DevOps/Release/ProcessGitReaderTest.php
+++ b/tests/integration/Core/DevOps/Release/ProcessGitReaderTest.php
@@ -1,0 +1,117 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Integration\Core\DevOps\Release;
+
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\DevOps\Release\ProcessGitReader;
+use Shopware\Core\Framework\Log\Package;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Process\Process;
+
+/**
+ * Exercises {@see ProcessGitReader} against a real throwaway git repository, since its whole job is
+ * to shell out to the git binary.
+ *
+ * @internal
+ */
+#[Package('framework')]
+class ProcessGitReaderTest extends TestCase
+{
+    private string $repository;
+
+    private Filesystem $filesystem;
+
+    private ProcessGitReader $reader;
+
+    private string $firstCommit;
+
+    private string $secondCommit;
+
+    protected function setUp(): void
+    {
+        $this->filesystem = new Filesystem();
+        $this->repository = sys_get_temp_dir() . '/sw-git-reader-' . bin2hex(random_bytes(6));
+        $this->filesystem->mkdir($this->repository);
+
+        $this->git(['git', '-c', 'init.defaultBranch=main', 'init']);
+
+        // Root commit, so the commits under test have a parent and `git diff-tree` reports their changes.
+        $this->filesystem->dumpFile($this->repository . '/README.md', "init\n");
+        $this->commit('init');
+
+        $this->filesystem->dumpFile($this->repository . '/RELEASE_INFO-6.7.md', "# 6.7.11.0\n\n### Feature A\n");
+        $this->firstCommit = $this->commit('add release info');
+
+        $this->filesystem->dumpFile($this->repository . '/RELEASE_INFO-6.7.md', "# 6.7.11.0\n\n### Feature A\n### Feature B\n");
+        $this->filesystem->dumpFile($this->repository . '/src/Feature.php', "<?php\n");
+        $this->secondCommit = $this->commit('add feature B and code');
+
+        // A release branch that stops at the first commit, so the second commit is not reachable from it.
+        $this->git(['git', 'branch', 'release', $this->firstCommit]);
+
+        $this->reader = new ProcessGitReader($this->repository);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->filesystem->remove($this->repository);
+    }
+
+    public function testRefExists(): void
+    {
+        static::assertTrue($this->reader->refExists('main'));
+        static::assertTrue($this->reader->refExists('release'));
+        static::assertFalse($this->reader->refExists('does-not-exist'));
+    }
+
+    public function testShowFileReturnsContentAtRefAndEmptyForMissingPath(): void
+    {
+        static::assertStringContainsString('### Feature B', $this->reader->showFile('main', 'RELEASE_INFO-6.7.md'));
+        static::assertStringNotContainsString('### Feature B', $this->reader->showFile('release', 'RELEASE_INFO-6.7.md'));
+        static::assertSame('', $this->reader->showFile('main', 'does/not/exist.md'));
+    }
+
+    public function testFindIntroducingCommitLocatesThePickaxeMatch(): void
+    {
+        static::assertSame($this->secondCommit, $this->reader->findIntroducingCommit('main', '### Feature B', 'RELEASE_INFO-6.7.md'));
+        static::assertSame('', $this->reader->findIntroducingCommit('main', '### Never written', 'RELEASE_INFO-6.7.md'));
+    }
+
+    public function testIsAncestor(): void
+    {
+        static::assertTrue($this->reader->isAncestor($this->firstCommit, 'main'));
+        static::assertTrue($this->reader->isAncestor($this->firstCommit, 'release'));
+        static::assertFalse($this->reader->isAncestor($this->secondCommit, 'release'));
+    }
+
+    public function testChangedFiles(): void
+    {
+        static::assertSame(['RELEASE_INFO-6.7.md'], $this->reader->changedFiles($this->firstCommit));
+        static::assertSame(['RELEASE_INFO-6.7.md', 'src/Feature.php'], $this->reader->changedFiles($this->secondCommit));
+    }
+
+    private function commit(string $message): string
+    {
+        $this->git(['git', 'add', '-A']);
+        $this->git([
+            'git',
+            '-c', 'user.email=test@example.com',
+            '-c', 'user.name=Test',
+            '-c', 'commit.gpgsign=false',
+            'commit', '-m', $message,
+        ]);
+
+        return trim($this->git(['git', 'rev-parse', 'HEAD']));
+    }
+
+    /**
+     * @param list<string> $command
+     */
+    private function git(array $command): string
+    {
+        $process = new Process($command, $this->repository);
+        $process->mustRun();
+
+        return $process->getOutput();
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?

TLDR; counter proposal of https://github.com/shopware/shopware/pull/19232

The release-content verification script mixed git subprocess calls, console output, and process exit codes in one procedural file, so its logic could not be unit tested. It also signalled its verdict through the exit code, which made a documented-but-missing entry look like a broken pipeline instead of an expected finding.

### 2. What does this change do, exactly?

Splits the script into focused, unit-tested services under `src/Core/DevOps/Release/`:

- `GitReader` (interface) and `ProcessGitReader` (Symfony Process, argument arrays) replace the raw `shell_exec`/`exec` git calls, so there is no shell string to escape and the git access can be faked in tests.
- `ReleaseContentVerifier` holds the verification logic and returns a `VerificationResult` value object. It never writes output or sets an exit code.
- `ReleaseSummaryRenderer` produces the console log, the Markdown job summary, and the one-line commit-status description.

`.github/bin/verify-release-content.php` becomes a thin wrapper that wires the services and delivers the outcome. The verdict is no longer an exit code: it is written to `GITHUB_OUTPUT` as `state`/`description` and published as the `release-content/verify` commit status, so a missing entry keeps the job green and the status is the gate. Operational errors (bad usage, refs not fetched) throw, so a red job always means the verification itself could not run.

Coverage:

- Unit tests (devops suite) cover the verifier verdict branches, heading extraction, sorting, and the renderer output, driven by an in-memory `GitReader` fake.
- An integration test exercises `ProcessGitReader` against a throwaway git repository, since its job is to shell out to git.
- `src/Core/DevOps/Release` is excluded from the unit-coverage source, matching the existing treatment of `src/Core/DevOps/StaticAnalyze`.

### 3. Describe each step to reproduce the issue or behaviour.

1. On a release branch (or via `workflow_dispatch`), the "Verify release content" workflow runs `php .github/bin/verify-release-content.php <prefix>`.
2. The script compares `origin/trunk` against `origin/<prefix>.x` and writes `state`/`description` to `GITHUB_OUTPUT`.
3. The workflow publishes the `release-content/verify` commit status from those outputs. Missing entries report a failing status while the job stays green; an unfetched ref or bad usage fails the job.

### 4. Please link to the relevant issues (if any).



### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under "Upcoming" for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
