### PR TITLE
fix(storefront): invalidate domain cache after theme assignment

### DIFF
--- a/src/Storefront/Framework/Routing/CachedDomainLoaderInvalidator.php
+++ b/src/Storefront/Framework/Routing/CachedDomainLoaderInvalidator.php
@@ -6,6 +6,7 @@ use Shopware\Core\Framework\Adapter\Cache\CacheInvalidator;
 use Shopware\Core\Framework\DataAbstractionLayer\Event\EntityWrittenContainerEvent;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelDefinition;
+use Shopware\Storefront\Theme\Aggregate\ThemeSalesChannelDefinition;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 /**
@@ -35,11 +36,14 @@ class CachedDomainLoaderInvalidator implements EventSubscriberInterface
 
     public function invalidate(EntityWrittenContainerEvent $event): void
     {
-        if ($event->getEventByEntityName(SalesChannelDefinition::ENTITY_NAME)) {
-            $this->logger->invalidate([
-                CachedDomainLoader::CACHE_KEY,
-                CachedDomainLoader::DOMAIN_COLLECTION_CACHE_KEY,
-            ], true);
+        if (!$event->getEventByEntityName(SalesChannelDefinition::ENTITY_NAME)
+            && !$event->getEventByEntityName(ThemeSalesChannelDefinition::ENTITY_NAME)) {
+            return;
         }
+
+        $this->logger->invalidate([
+            CachedDomainLoader::CACHE_KEY,
+            CachedDomainLoader::DOMAIN_COLLECTION_CACHE_KEY,
+        ], true);
     }
 }

--- a/tests/unit/Storefront/Framework/Routing/CachedDomainLoaderInvalidatorTest.php
+++ b/tests/unit/Storefront/Framework/Routing/CachedDomainLoaderInvalidatorTest.php
@@ -13,6 +13,7 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelDefinition;
 use Shopware\Storefront\Framework\Routing\CachedDomainLoader;
 use Shopware\Storefront\Framework\Routing\CachedDomainLoaderInvalidator;
+use Shopware\Storefront\Theme\Aggregate\ThemeSalesChannelDefinition;
 use Shopware\Tests\Unit\Storefront\Theme\MockedCacheInvalidator;
 
 /**
@@ -37,6 +38,30 @@ class CachedDomainLoaderInvalidatorTest extends TestCase
         $event = new EntityWrittenContainerEvent(
             $context,
             new NestedEventCollection([new EntityWrittenEvent(SalesChannelDefinition::ENTITY_NAME, [], $context)]),
+            []
+        );
+
+        $mockedInvalidator = new MockedCacheInvalidator();
+
+        $invalidationSubscriber = new CachedDomainLoaderInvalidator(
+            $mockedInvalidator
+        );
+
+        $invalidationSubscriber->invalidate($event);
+
+        static::assertSame(
+            [CachedDomainLoader::CACHE_KEY, CachedDomainLoader::DOMAIN_COLLECTION_CACHE_KEY],
+            $mockedInvalidator->getForceInvalidatedTags()
+        );
+    }
+
+    public function testInvalidateIsCalledForThemeSalesChannelWrittenEvent(): void
+    {
+        $context = Context::createDefaultContext();
+
+        $event = new EntityWrittenContainerEvent(
+            $context,
+            new NestedEventCollection([new EntityWrittenEvent(ThemeSalesChannelDefinition::ENTITY_NAME, [], $context)]),
             []
         );
 


### PR DESCRIPTION
### 1. Why is this change necessary?

The storefront domain cache contains the `theme_sales_channel` mapping, but it is currently invalidated only when the sales channel itself is written. Assigning or replacing a theme updates only the mapping, so a request that cached the sales channel beforehand can continue to use an absent or outdated theme.

In production, this can cause a newly assigned theme not to take effect immediately. A previously unassigned sales channel can render without its theme JavaScript; a theme replacement can continue to resolve the old theme asset path until the cache is cleared. This can leave storefront plugins uninitialised or serve stale theme assets.

### 2. What does this change do, exactly?

Invalidates the cached domain lookup whenever `theme_sales_channel` is written, alongside existing sales-channel invalidation.

### 3. Describe each step to reproduce the issue or behaviour.

1. Request a storefront sales channel before it has a theme assignment, which caches the domain lookup without a theme.
2. Assign the Storefront theme to that sales channel.
3. Request the storefront again without clearing the domain cache.
4. Before this change, the request can still have no theme ID and therefore no theme JavaScript.

The ATS exposed this with durable, worker-specific sales channels: the first readiness request could cache the channel before the fixture assigned its theme. Later pages had no theme script tags, so the PluginManager did not initialise listing filters and the ProductFilter tests became flaky.

### 4. Please link to the relevant issues (if any).

- Relates to #19078

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Not needed: this restores cache correctness without changing a public contract.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them