### PR TITLE
fix(administration): fix CMS select field overflow

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/base/sw-chart-card/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/base/sw-chart-card/index.js
@@ -84,11 +84,46 @@ export default {
         hasHeaderLink() {
             return !!this.$slots['header-link'];
         },
+
+        rangeOptions() {
+            return this.availableRanges.map((range, index) => {
+                const vnode = this.$slots['range-option']?.({
+                    range,
+                    index,
+                });
+
+                return {
+                    value: range,
+                    label: this.extractSlotText(vnode) || range,
+                };
+            });
+        },
     },
 
     methods: {
         dispatchRangeUpdate() {
             this.$emit('sw-chart-card-range-update', this.selectedRange);
+        },
+
+        extractSlotText(vnodes) {
+            if (!Array.isArray(vnodes)) {
+                return '';
+            }
+
+            return vnodes
+                .map((vnode) => {
+                    if (typeof vnode === 'string' || typeof vnode === 'number') {
+                        return String(vnode);
+                    }
+
+                    if (Array.isArray(vnode.children)) {
+                        return this.extractSlotText(vnode.children);
+                    }
+
+                    return typeof vnode.children === 'string' ? vnode.children : '';
+                })
+                .join('')
+                .trim();
         },
     },
 };

--- a/src/Administration/Resources/app/administration/src/app/component/base/sw-chart-card/sw-chart-card.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/base/sw-chart-card/sw-chart-card.html.twig
@@ -39,25 +39,23 @@
             {% endblock %}
 
             {% block sw_chart_card_header_range_select %}
-            <sw-select-field-deprecated
-                v-model:value="selectedRange"
+            <mt-select
+                v-model="selectedRange"
                 name="sw-field--selectedRange"
-                size="small"
-                @update:value="dispatchRangeUpdate"
+                small
+                :options="rangeOptions"
+                hide-clearable-button
+                @update:model-value="dispatchRangeUpdate"
             >
                 {% block sw_chart_card_header_range_select_options %}
-                <option
-                    v-for="(range, index) in availableRanges"
-                    :key="range"
-                    :value="range"
-                >
+                <template #result-label-property="{ index, item }">
                     <slot
                         name="range-option"
-                        v-bind="{ index, range }"
+                        v-bind="{ index, range: item.value }"
                     ></slot>
-                </option>
+                </template>
                 {% endblock %}
-            </sw-select-field-deprecated>
+            </mt-select>
             {% endblock %}
         </div>
     </template>

--- a/src/Administration/Resources/app/administration/src/app/component/base/sw-chart-card/sw-chart-card.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/base/sw-chart-card/sw-chart-card.spec.js
@@ -3,6 +3,7 @@
  */
 
 import { mount } from '@vue/test-utils';
+import { h } from 'vue';
 
 const extendedRanges = [
     {
@@ -33,23 +34,45 @@ const extendedRanges = [
 const defaultRangeIndex = 1;
 const defaultRange = extendedRanges[defaultRangeIndex];
 
-async function createWrapper(additionalProps = {}) {
+async function createWrapper(additionalProps = {}, additionalOptions = {}) {
     return mount(await wrapTestComponent('sw-chart-card', { sync: true }), {
         props: {
             positionIdentifier: 'sw-chart-card__statistics-count',
             defaultRangeIndex,
             ...additionalProps,
         },
+        ...additionalOptions,
         global: {
             stubs: {
                 'mt-card': {
-                    template: '<div class="mt-card" :is-loading="isLoading"><slot /><slot name="title"></slot></div>',
+                    template:
+                        '<div class="mt-card" :is-loading="isLoading"><slot /><slot name="title"></slot><slot name="headerRight"></slot></div>',
                     props: [
                         'helpText',
                         'isLoading',
                     ],
                 },
-                'sw-select-field-deprecated': true,
+                'mt-select': {
+                    name: 'mt-select',
+                    props: [
+                        'modelValue',
+                        'options',
+                    ],
+                    template: `
+                        <div class="mt-select">
+                            <div
+                                v-for="(option, index) in options"
+                                :key="index"
+                                class="mt-select-option"
+                            >
+                                <slot
+                                    name="result-label-property"
+                                    v-bind="{ item: option, index }"
+                                />
+                            </div>
+                        </div>
+                    `,
+                },
                 'sw-chart': true,
             },
         },
@@ -61,6 +84,86 @@ describe('src/app/component/base/sw-chart-card', () => {
         const wrapper = await createWrapper();
 
         expect(wrapper.vm.hasHeaderLink).toBeFalsy();
+    });
+
+    it('maps the legacy range-option slot to mt-select option labels', async () => {
+        const wrapper = await createWrapper(
+            {
+                availableRanges: [
+                    '30Days',
+                    '14Days',
+                    '7Days',
+                    '24Hours',
+                    'yesterday',
+                ],
+            },
+            {
+                slots: {
+                    'range-option': ({ range }) => h('span', `Range ${range}`),
+                },
+            },
+        );
+
+        expect(wrapper.getComponent({ name: 'mt-select' }).props('options')).toEqual([
+            { value: '30Days', label: 'Range 30Days' },
+            { value: '14Days', label: 'Range 14Days' },
+            { value: '7Days', label: 'Range 7Days' },
+            { value: '24Hours', label: 'Range 24Hours' },
+            { value: 'yesterday', label: 'Range yesterday' },
+        ]);
+    });
+
+    it('forwards the option value to the legacy range-option slot', async () => {
+        const wrapper = await createWrapper(
+            {
+                availableRanges: [
+                    '30Days',
+                    '14Days',
+                ],
+            },
+            {
+                slots: {
+                    'range-option': ({ range }) => h('span', `Legacy ${range}`),
+                },
+            },
+        );
+
+        expect(wrapper.findAll('.mt-select-option').map((option) => option.text())).toEqual([
+            'Legacy 30Days',
+            'Legacy 14Days',
+        ]);
+    });
+
+    it('falls back to the range as option label when the legacy slot is not used', async () => {
+        const wrapper = await createWrapper({
+            availableRanges: [
+                '30Days',
+                '14Days',
+                '7Days',
+                '24Hours',
+                'yesterday',
+            ],
+        });
+
+        expect(wrapper.getComponent({ name: 'mt-select' }).props('options')).toEqual(
+            [
+                '30Days',
+                '14Days',
+                '7Days',
+                '24Hours',
+                'yesterday',
+            ].map((range) => ({ value: range, label: range })),
+        );
+    });
+
+    it('updates the selected range through mt-select', async () => {
+        const wrapper = await createWrapper();
+        const select = wrapper.getComponent({ name: 'mt-select' });
+
+        await select.vm.$emit('update:model-value', '7Days');
+
+        expect(wrapper.vm.selectedRange).toBe('7Days');
+        expect(wrapper.emitted('sw-chart-card-range-update')).toEqual([['7Days']]);
     });
 
     it('should set the correct range in the dropdown by default', async () => {

--- a/src/Administration/Resources/app/administration/src/app/component/form/field-base/sw-block-field/sw-block-field.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/form/field-base/sw-block-field/sw-block-field.scss
@@ -7,6 +7,12 @@
         height: 48px;
     }
 
+    &.sw-select {
+        .sw-block-field__block {
+            overflow: hidden;
+        }
+    }
+
     .sw-field--select__options .mt-icon {
         margin-bottom: 5px;
     }

--- a/src/Administration/Resources/app/administration/src/module/sw-dashboard/component/sw-dashboard-statistics/sw-dashboard-statistics.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-dashboard/component/sw-dashboard-statistics/sw-dashboard-statistics.spec.js
@@ -223,9 +223,15 @@ describe('module/sw-dashboard/component/sw-dashboard-statistics', () => {
         wrapper = await createWrapper(['order.viewer']);
         await flushPromises();
 
-        const dateRanges = wrapper.get('#sw-field--selectedRange').findAll('option');
+        const dateRanges = wrapper.getComponent({ name: 'mt-select' }).props('options');
 
-        expect(dateRanges.at(dateRanges.length - 2).text()).toBe('["sw-dashboard.monthStats.dateRanges.72Hours"]');
-        expect(dateRanges.at(dateRanges.length - 1).text()).toBe('["sw-dashboard.monthStats.dateRanges.90Days"]');
+        expect(dateRanges.at(dateRanges.length - 2)).toEqual({
+            value: '72Hours',
+            label: '["sw-dashboard.monthStats.dateRanges.72Hours"]',
+        });
+        expect(dateRanges.at(dateRanges.length - 1)).toEqual({
+            value: '90Days',
+            label: '["sw-dashboard.monthStats.dateRanges.90Days"]',
+        });
     });
 });


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

CMS select fields could render incorrectly depending on lazy-loaded stylesheet order. `sw-select-base.scss` could override `sw-block-field`'s clipping rule because both selectors had equal specificity.

### 2. What does this change do, exactly?

- Increases the specificity of the `sw-block-field` overflow rule for select fields, making it independent of stylesheet load order.
- Replaces the deprecated chart-card select with `mt-select`, removing the Dashboard path that lazy-loaded the legacy select styling.

### 3. Describe each step to reproduce the issue or behaviour.

1. Open the Dashboard so its chart range select lazy-loads `sw-block-field.scss`.
2. Open CMS and edit a select field, causing `sw-select-base.scss` to load afterwards.
3. The later `overflow: visible` rule overrides `sw-block-field`'s `overflow: hidden`, breaking the select-field layout.

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

- closes #19022
- closes #15730

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
