### PR TITLE
fix: media url encoding special characters

### DIFF
--- a/src/Core/Framework/Util/UrlEncoder.php
+++ b/src/Core/Framework/Util/UrlEncoder.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Core\Framework\Util;
 
+use GuzzleHttp\Psr7\Uri;
 use Shopware\Core\Framework\Log\Package;
 
 #[Package('framework')]
@@ -13,33 +14,15 @@ class UrlEncoder
             return null;
         }
 
-        $urlInfo = parse_url($mediaUrl);
-
-        if (!\is_array($urlInfo)) {
+        try {
+            $uri = new Uri($mediaUrl);
+        } catch (\InvalidArgumentException) {
             return null;
         }
 
-        $path = self::encodePathSegments($urlInfo['path'] ?? '');
+        $path = self::encodePathSegments(rawurldecode($uri->getPath()));
 
-        if (isset($urlInfo['query'])) {
-            $path .= "?{$urlInfo['query']}";
-        }
-
-        $encodedPath = '';
-
-        if (isset($urlInfo['scheme'])) {
-            $encodedPath = "{$urlInfo['scheme']}://";
-        }
-
-        if (isset($urlInfo['host'])) {
-            $encodedPath .= "{$urlInfo['host']}";
-        }
-
-        if (isset($urlInfo['port'])) {
-            $encodedPath .= ":{$urlInfo['port']}";
-        }
-
-        return $encodedPath . $path;
+        return (string) $uri->withPath($path)->withFragment('');
     }
 
     public static function encodePathSegments(string $path): string

--- a/src/Storefront/Resources/views/storefront/element/cms-element-video.html.twig
+++ b/src/Storefront/Resources/views/storefront/element/cms-element-video.html.twig
@@ -63,7 +63,7 @@
                                     preload="auto"
                                     {% if ariaLabel is not empty %}aria-label="{{ ariaLabel }}"{% endif %}
                                     {% if mediaTitle is not empty %}title="{{ mediaTitle }}"{% endif %}
-                                    {% if config.showCover.value and element.data.media.extensions.videoCoverMedia %}poster="{{ element.data.media.extensions.videoCoverMedia.url }}"{% endif %}
+                                    {% if config.showCover.value and element.data.media.extensions.videoCoverMedia %}poster="{{ element.data.media.extensions.videoCoverMedia|sw_encode_media_url }}"{% endif %}
                                     {% if config.autoPlay.value and not config.showCover.value %}autoplay{% endif %}
                                     {% if config.muted.value or config.autoPlay.value %}muted{% endif %}
                                     {% if config.loop.value %}loop{% endif %}
@@ -72,7 +72,7 @@
                                 >
                                     {% block element_video_media_sources %}
                                         <source
-                                            src="{{ element.data.media.url|sw_encode_url }}"
+                                            src="{{ element.data.media|sw_encode_media_url }}"
                                             type="{{ element.data.media.mimeType }}"
                                         >
                                     {% endblock %}

--- a/tests/unit/Core/Framework/Util/UrlEncoderTest.php
+++ b/tests/unit/Core/Framework/Util/UrlEncoderTest.php
@@ -3,6 +3,7 @@
 namespace Shopware\Tests\Unit\Core\Framework\Util;
 
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Util\UrlEncoder;
@@ -98,11 +99,127 @@ class UrlEncoderTest extends TestCase
         );
     }
 
+    public function testItReturnsNullForMalformedUrls(): void
+    {
+        static::assertNull(UrlEncoder::encodeUrl('http://shopware.com:notaport/media/file.jpg'));
+    }
+
     public function testItHandlesRelativePaths(): void
     {
         static::assertSame(
             '../media/file%20name.jpg',
             UrlEncoder::encodeUrl('../media/file name.jpg')
+        );
+    }
+
+    /**
+     * `parse_url()` replaces every byte the current libc reports as a control character with `_`.
+     * On platforms where that covers 0x7F-0x9F it destroys the continuation bytes of these
+     * characters, so the encoder must not rebuild the URL from `parse_url()` components.
+     */
+    #[DataProvider('nonAsciiFileNameProvider')]
+    public function testItIdempotentEncodesNonAsciiFileNamesWithoutCorruption(string $url, string $expected): void
+    {
+        static::assertSame($expected, UrlEncoder::encodeUrl($expected));
+        static::assertSame($expected, UrlEncoder::encodeUrl($url));
+    }
+
+    public static function nonAsciiFileNameProvider(): \Generator
+    {
+        yield 'uppercase umlauts and sharp s survive encoding' => [
+            'https://shopware.com/media/Ärmel Öl Übung ß.jpg',
+            'https://shopware.com/media/%C3%84rmel%20%C3%96l%20%C3%9Cbung%20%C3%9F.jpg',
+        ];
+
+        yield 'typographic punctuation and currency signs survive encoding' => [
+            'https://shopware.com/media/Größe – „Zitat“ €.jpg',
+            'https://shopware.com/media/Gr%C3%B6%C3%9Fe%20%E2%80%93%20%E2%80%9EZitat%E2%80%9C%20%E2%82%AC.jpg',
+        ];
+
+        yield 'uppercase accented latin characters survive encoding' => [
+            'https://shopware.com/media/ÀÉÎÕÇ.jpg',
+            'https://shopware.com/media/%C3%80%C3%89%C3%8E%C3%95%C3%87.jpg',
+        ];
+
+        yield 'cyrillic characters survive encoding' => [
+            'https://shopware.com/media/Тест.jpg',
+            'https://shopware.com/media/%D0%A2%D0%B5%D1%81%D1%82.jpg',
+        ];
+
+        yield 'multi byte characters survive encoding' => [
+            'https://shopware.com/media/テスト.jpg',
+            'https://shopware.com/media/%E3%83%86%E3%82%B9%E3%83%88.jpg',
+        ];
+
+        yield 'cache busting query is kept next to an encoded file name' => [
+            'https://shopware.com/media/ab/cd/ef/Ärmel.jpg?ts=1755000000',
+            'https://shopware.com/media/ab/cd/ef/%C3%84rmel.jpg?ts=1755000000',
+        ];
+    }
+
+    #[DataProvider('nonAsciiPathProvider')]
+    public function testEncodePathSegmentsEncodesRawPaths(string $path, string $expected): void
+    {
+        static::assertSame($expected, UrlEncoder::encodePathSegments($path));
+    }
+
+    public static function nonAsciiPathProvider(): \Generator
+    {
+        yield 'uppercase umlauts and sharp s' => [
+            'media/ab/cd/Ärmel Öl ß.jpg',
+            'media/ab/cd/%C3%84rmel%20%C3%96l%20%C3%9F.jpg',
+        ];
+
+        yield 'typographic punctuation and currency signs' => [
+            'media/ab/cd/Größe – €.jpg',
+            'media/ab/cd/Gr%C3%B6%C3%9Fe%20%E2%80%93%20%E2%82%AC.jpg',
+        ];
+
+        yield 'multi byte characters' => [
+            'media/ab/cd/テスト.jpg',
+            'media/ab/cd/%E3%83%86%E3%82%B9%E3%83%88.jpg',
+        ];
+
+        yield 'reserved characters are encoded' => [
+            'media/ab/cd/a+b,c;d=e(f).jpg',
+            'media/ab/cd/a%2Bb%2Cc%3Bd%3De%28f%29.jpg',
+        ];
+    }
+
+    public function testItEncodesPercentSignsThatAreNotAnEscapeSequence(): void
+    {
+        static::assertSame(
+            'https://shopware.com/media/50%25.jpg',
+            UrlEncoder::encodeUrl('https://shopware.com/media/50%.jpg')
+        );
+
+        static::assertSame(
+            'https://shopware.com/media/a%252Gb.jpg',
+            UrlEncoder::encodeUrl('https://shopware.com/media/a%2Gb.jpg')
+        );
+    }
+
+    public function testItKeepsTheAuthorityUntouched(): void
+    {
+        static::assertSame(
+            'https://user:pass@shopware.com:8080/media/%C3%84.jpg',
+            UrlEncoder::encodeUrl('https://user:pass@shopware.com:8080/media/Ä.jpg')
+        );
+    }
+
+    public function testItKeepsProtocolRelativeUrls(): void
+    {
+        static::assertSame(
+            '//shopware.com/media/file%20name.jpg',
+            UrlEncoder::encodeUrl('//shopware.com/media/file name.jpg')
+        );
+    }
+
+    public function testEncodePathSegmentsKeepsNonAsciiCharacters(): void
+    {
+        static::assertSame(
+            'media/foo/%C3%84rmel%20bild.jpg',
+            UrlEncoder::encodePathSegments('media/foo/Ärmel bild.jpg')
         );
     }
 


### PR DESCRIPTION
### 1. Why is this change necessary?

  Media files whose names contain `Ä Ö Ü ß`, uppercase accented letters, typographic punctuation (`– „ “ €`), Cyrillic or CJK characters do not render in the storefront.

  `UrlEncoder::encodeUrl()` rebuilt the URL from `parse_url()` components. `parse_url()` replaces every byte libc's `iscntrl()` reports as a control character with `_` — measured here as `0x01–0x1F`, `0x7F–0x9F`, `0xAD`. `0x80–0x9F` are continuation bytes of those characters, so the file name was corrupted before it was encoded:

  ```
  in : https://host/media/Ärmel Öl Übung ß.jpg
  out: https://host/media/%C3_rmel%20%C3_l%20%C3_bung%20%C3_.jpg
  ```

  Lowercase `äöü é` survive (second byte ≥ `0xA0`), which is why this went unnoticed — the existing test only covered lowercase umlauts.

  The corruption dates back to 2019 but was latent: media paths were force-stripped to ASCII by `/[\x00-\x1F\x7F-\xFF]/`. #16379 correctly narrowed that to control/format characters, so non-ASCII file names now reach the encoder and expose the bug. The `v6.8.0.0` path is unaffected (it uses `encodePathSegments()` and passes the URL through), so
  only the default configuration is broken.

  ### 2. What does this change do, exactly?

  - `UrlEncoder::encodeUrl()` parses with `GuzzleHttp\Psr7\Uri` instead of `parse_url()`. `Uri` percent-encodes before parsing and decodes afterwards, so the control-character replacement never sees a raw `0x80–0x9F` byte. Path encoding still goes through `encodePathSegments()`, so emitted URLs stay byte-identical to before for everything that already worked; fragment is still dropped, malformed URLs still return `null`.
  - `element/cms-element-video.html.twig`: `<source src>` used the non-flag-aware `sw_encode_url` (double-encodes under `v6.8.0.0`) and `poster` was not encoded at all. Both now use `sw_encode_media_url`, matching `utilities/video.html.twig`.

  ### 3. Describe each step to reproduce the issue or behaviour.

  1. Upload a media file named e.g. `Ärmel Öl ß.jpg` to a product and to a CMS page.
  2. Open the product detail page and the CMS page in the storefront.
  3. Before: the image is broken; `src` contains `%C3_rmel` instead of `%C3%84rmel`. After: the image renders.

  Note the corruption depends on libc's `iscntrl()`. It reproduces on macOS/BSD; glibc in the plain `C` locale does not classify `0x80–0x9F` as control, which likely explains why CI never caught it. The fix removes the dependency entirely.

  ### 4. Please link to the relevant issues (if any).

  - closes #19194
  - relates #16379

  ### 5. Checklist

  - [x] I have written tests and verified that they fail without my change
  - [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
    - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
    - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
    - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
  - [ ] I have written or adjusted the documentation and agent skills according to my changes
  - [ ] This change has comments for package types, values, functions, and non-obvious lines of code
  - [x] I have read the contribution requirements and fulfilled them