### PR TITLE
perf(core): prune non-PHP subtrees from PHPStan's directory walk

### DIFF
--- a/phpstan-paths.php
+++ b/phpstan-paths.php
@@ -2,21 +2,26 @@
 
 /**
  * Replaces `paths: [src, tests]`: PHPStan walks all paths before applying excludePaths
- * (https://github.com/phpstan/phpstan/issues/1978), so `src` would drag in the ~190k files
- * under the administration/storefront frontend roots (src/<Bundle>/Resources/app — Vue/JS
- * sources and node_modules, no PHP). This lists src and tests with those roots left out.
+ * (https://github.com/phpstan/phpstan/issues/1978), so `src` and `tests` would drag in the
+ * ~200k files under the frontend roots, Twig templates and npm installs, none holding PHP.
+ * This lists both trees with only the PHP-bearing parts left in.
  */
 
 // a directory is analysed whole; a loose file only if it is PHP
 $analysable = static fn (string $path): bool => is_dir($path) || str_ends_with($path, '.php');
 
-$paths = [__DIR__ . '/tests'];
+// tests, minus the acceptance suite.
+$paths = [];
+
+foreach (glob(__DIR__ . '/tests/*') as $path) {
+    if ($path !== __DIR__ . '/tests/acceptance' && $analysable($path)) {
+        $paths[] = $path;
+    }
+}
 
 foreach (glob(__DIR__ . '/src/*') as $bundle) {
-    $frontendRoot = $bundle . '/Resources/app';
-
-    // bundles without a frontend root (src/Core, src/Elasticsearch) are analysed whole
-    if (!is_dir($frontendRoot)) {
+    // bundles without a `Resources/` dir (src/Core) are analysed whole
+    if (!is_dir($bundle . '/Resources')) {
         $paths[] = $bundle;
 
         continue;
@@ -29,11 +34,9 @@ foreach (glob(__DIR__ . '/src/*') as $bundle) {
         }
     }
 
-    // `Resources/` entries, minus the app/ frontend root
-    foreach (glob($bundle . '/Resources/*') as $path) {
-        if ($path !== $frontendRoot && $analysable($path)) {
-            $paths[] = $path;
-        }
+    // `Resources/config` holds the only PHP under `Resources/`: routes and package config.
+    if (is_dir($bundle . '/Resources/config')) {
+        $paths[] = $bundle . '/Resources/config';
     }
 }
 

--- a/src/Core/DevOps/StaticAnalyze/PHPStan/Rules/ServiceDefinitionRule.php
+++ b/src/Core/DevOps/StaticAnalyze/PHPStan/Rules/ServiceDefinitionRule.php
@@ -208,7 +208,22 @@ class ServiceDefinitionRule implements Rule
         }
 
         $files = [];
-        $iterator = new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($srcDir, \FilesystemIterator::SKIP_DOTS));
+
+        // both filters below only match `/DependencyInjection/` or `/Resources/config/`, so
+        // the frontend roots pruned here cannot contribute a service definition
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveCallbackFilterIterator(
+                new \RecursiveDirectoryIterator($srcDir, \FilesystemIterator::SKIP_DOTS),
+                static function (\SplFileInfo $current): bool {
+                    if (!$current->isDir()) {
+                        return true;
+                    }
+
+                    return $current->getFilename() !== 'node_modules'
+                        && !str_ends_with($current->getPathname(), '/Resources/app');
+                }
+            )
+        );
 
         foreach ($iterator as $file) {
             if (!$file instanceof \SplFileInfo || !$file->isFile()) {


### PR DESCRIPTION
### 1. Why is this change necessary?

PHPStan walks every configured path before applying `excludePaths` ([phpstan/phpstan#1978](https://github.com/phpstan/phpstan/issues/1978)), so directories holding no PHP still get enumerated on every run. `phpstan-paths.php` already pruned `src/<Bundle>/Resources/app` for that reason, but two subtrees its pattern could not reach were still walked:

- `tests/acceptance/node_modules` (~31k files), because `tests` was listed wholesale.
- `src/Storefront/Resources/views/components/node_modules` (~52k files) — the symlink the storefront's `postinstall` hook creates, reachable because `Resources/views` was itself a listed path.

Separately, `ServiceDefinitionRule` builds its own `RecursiveDirectoryIterator` over `src/`, so it re-walked the frontend roots regardless of the configured paths.

The symlink is gitignored and only exists after an npm install, so this cost lands on local development rather than CI.

### 2. What does this change do, exactly?

`phpstan-paths.php`:

- lists `tests/*` and leaves out `tests/acceptance`.
- lists each bundle's entries except `Resources/`, plus `Resources/config` — the only part of `Resources/` that holds PHP (`routes.php`, `routes_dev.php`, `packages/shopware.php`).

`ServiceDefinitionRule::getFiles()` wraps its iterator in a `RecursiveCallbackFilterIterator` that prunes `node_modules` and `Resources/app`. Both of the rule's filters only match paths under `/DependencyInjection/` or `/Resources/config/`, so pruning cannot change which files it collects.

Measured on a single-file run, the filesystem syscalls (`openat`, `newfstatat`, `getdents64`) drop from 910,828 to 251,213. Those under `node_modules` drop from 482,620 to 38.

The set of analysed PHP files goes from 11,394 to 11,392. Both dropped files sit inside a `node_modules` install; nothing is added.

### 3. Describe each step to reproduce the issue or behaviour.

1. `composer install && composer init:js` — the storefront `postinstall` hook creates the `Resources/views/components/node_modules` symlink.
2. Count the filesystem syscalls PHPStan makes to analyse one file:

   ```
   strace -f -e trace=openat,newfstatat,getdents64 -o trace.txt \
     vendor/bin/phpstan analyse --no-progress src/Core/Framework/App/Hmac/QuerySigner.php
   wc -l trace.txt
   grep -c node_modules trace.txt
   ```

3. On `trunk` the trace holds ~910k lines, ~482k of them under `node_modules`. With this change, ~251k and 38.

### 4. Please link to the relevant issues (if any).

- Upstream cause: https://github.com/phpstan/phpstan/issues/1978
- Follows up #17421, which introduced the computed paths.

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change — no behavioural change to assert: the analysed file set and the rule's collected file set are both unchanged. `tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/ServiceDefinitionRuleTest.php` and `tests/devops/Core/Framework/ServiceDefinitionTest.php` pass.
- [x] I have updated developer-facing release notes if this change is **relevant** for external developers — not relevant, static-analysis tooling only.
- [x] I have written or adjusted the documentation and agent skills according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
