### PR TITLE
fix(inventory): resolve custom field labels in the context language

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -109,6 +109,11 @@ Product specific line item rule conditions (manufacturer, category, tags, proper
 `EntitySearchResult` keeps the `$entity` constructor argument, property, and `getEntity()` method in v6.8.0. Removing the constructor argument would not have provided a forward-compatible migration path: extensions could not construct a result today that also works after the major update. The required call-site changes were therefore disproportionate to the benefit.
 
 The property becomes `readonly`; use the constructor rather than the deprecated `setEntity()` method to provide the entity name. For a non-empty collection, the constructor asserts that the supplied entity name matches the collection's entity name.
+
+### Essential characteristics show custom field labels in the language of the context
+
+The `features` line item payload resolves a custom field's label for the language of the sales channel context instead of always using the system language. Store API consumers and templates that render `features[].label` now receive the translated label. Labels the merchant left empty inherit along the language chain, from the parent language and finally from the system language, the same way translated entity fields resolve. A custom field whose label is empty for every language of the chain is omitted from `features` instead of being rendered without a label.
+
 ### Media path cache busting is configurable
 
 The new `shopware.cdn.path_cache_buster` setting defaults to `true`, preserving timestamped media paths. Set it to `false` to keep paths stable for future media uploads and replacements while retaining `?ts=` query-string cache busting. Configure the CDN to include query strings in its cache key. Existing media paths are not migrated.

--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -109,11 +109,6 @@ Product specific line item rule conditions (manufacturer, category, tags, proper
 `EntitySearchResult` keeps the `$entity` constructor argument, property, and `getEntity()` method in v6.8.0. Removing the constructor argument would not have provided a forward-compatible migration path: extensions could not construct a result today that also works after the major update. The required call-site changes were therefore disproportionate to the benefit.
 
 The property becomes `readonly`; use the constructor rather than the deprecated `setEntity()` method to provide the entity name. For a non-empty collection, the constructor asserts that the supplied entity name matches the collection's entity name.
-
-### Essential characteristics show custom field labels in the language of the context
-
-The `features` line item payload resolves a custom field's label for the language of the sales channel context instead of always using the system language. Store API consumers and templates that render `features[].label` now receive the translated label. Labels the merchant left empty inherit along the language chain, from the parent language and finally from the system language, the same way translated entity fields resolve. A custom field whose label is empty for every language of the chain is omitted from `features` instead of being rendered without a label.
-
 ### Media path cache busting is configurable
 
 The new `shopware.cdn.path_cache_buster` setting defaults to `true`, preserving timestamped media paths. Set it to `false` to keep paths stable for future media uploads and replacements while retaining `?ts=` query-string cache busting. Configure the CDN to include query strings in its cache key. Existing media paths are not migrated.

--- a/src/Core/Content/Product/Cart/ProductFeatureBuilder.php
+++ b/src/Core/Content/Product/Cart/ProductFeatureBuilder.php
@@ -59,7 +59,7 @@ class ProductFeatureBuilder
             }
 
             $lineItem->replacePayload([
-                'features' => $this->buildFeatures($data, $lineItem, $product),
+                'features' => $this->buildFeatures($data, $lineItem, $product, $context),
             ]);
         }
     }
@@ -69,7 +69,7 @@ class ProductFeatureBuilder
      *
      * @return array<int, array{label: string, value: mixed, type: string}>
      */
-    private function buildFeatures(CartDataCollection $data, LineItem $lineItem, SalesChannelProductEntity $product): array
+    private function buildFeatures(CartDataCollection $data, LineItem $lineItem, SalesChannelProductEntity $product, SalesChannelContext $context): array
     {
         $sortedFeatures = $product->getFeatureSet()?->getFeatures();
         if ($sortedFeatures === null) {
@@ -93,7 +93,7 @@ class ProductFeatureBuilder
             }
 
             if ($feature['type'] === ProductFeatureSetDefinition::TYPE_PRODUCT_CUSTOM_FIELD) {
-                $features[] = $this->getCustomField($feature['name'], $data, $product);
+                $features[] = $this->getCustomField($feature['name'], $data, $product, $context);
 
                 continue;
             }
@@ -249,7 +249,7 @@ class ProductFeatureBuilder
      *
      * @return array{label: string, value: array{id: string, type: string, content: mixed}, type: string}|null
      */
-    private function getCustomField(string $name, CartDataCollection $data, SalesChannelProductEntity $product): ?array
+    private function getCustomField(string $name, CartDataCollection $data, SalesChannelProductEntity $product, SalesChannelContext $context): ?array
     {
         $fieldKey = \sprintf('custom-field-%s', $name);
         $translation = $product->getTranslation('customFields');
@@ -267,7 +267,7 @@ class ProductFeatureBuilder
             throw CartException::wrongCartDataType($fieldKey, CustomFieldEntity::class);
         }
 
-        $label = $this->getCustomFieldLabel($customField);
+        $label = $this->getCustomFieldLabel($customField, $context);
         if (!\is_string($label)) {
             return null;
         }
@@ -311,16 +311,25 @@ class ProductFeatureBuilder
     }
 
     /**
-     * Since it's not intended to display custom field labels outside of the admin at the moment,
-     * their labels are indexed by the locale code of the system language (fixed value, not translated).
-     *
-     * @see https://github.com/shopware/shopware/issues/4458
+     * Custom field labels are not translated by the DAL, they are stored inside the field's config,
+     * indexed by locale code. As a label is not required for every language, the language chain of
+     * the context is walked, so a label inherits from the parent language and finally from the
+     * system language, matching how the DAL resolves translated fields.
      */
-    private function getCustomFieldLabel(CustomFieldEntity $customField): ?string
+    private function getCustomFieldLabel(CustomFieldEntity $customField, SalesChannelContext $context): ?string
     {
-        $localeCode = $this->languageLocaleProvider->getLocaleForLanguageId(Defaults::LANGUAGE_SYSTEM);
+        $labels = $customField->getConfig()['label'] ?? null;
 
-        return $customField->getConfig()['label'][$localeCode] ?? null;
+        foreach ($context->getLanguageIdChain() as $languageId) {
+            $localeCode = $this->languageLocaleProvider->getLocaleForLanguageId($languageId);
+            $label = $labels[$localeCode] ?? null;
+
+            if (\is_string($label) && $label !== '') {
+                return $label;
+            }
+        }
+
+        return null;
     }
 
     private function getDataKey(string $id): string

--- a/tests/unit/Core/Content/Product/Cart/ProductFeatureBuilderTest.php
+++ b/tests/unit/Core/Content/Product/Cart/ProductFeatureBuilderTest.php
@@ -3,6 +3,7 @@
 namespace Shopware\Tests\Unit\Core\Content\Product\Cart;
 
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\Cart\LineItem\CartDataCollection;
@@ -19,8 +20,13 @@ use Shopware\Core\Content\Product\SalesChannel\SalesChannelProductEntity;
 use Shopware\Core\Content\Property\Aggregate\PropertyGroupOption\PropertyGroupOptionCollection;
 use Shopware\Core\Content\Property\Aggregate\PropertyGroupOption\PropertyGroupOptionEntity;
 use Shopware\Core\Content\Property\PropertyGroupEntity;
+use Shopware\Core\Defaults;
+use Shopware\Core\Framework\Api\Context\SystemSource;
+use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\System\CustomField\CustomFieldEntity;
+use Shopware\Core\System\CustomField\CustomFieldTypes;
 use Shopware\Core\System\Locale\LanguageLocaleCodeProvider;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\System\Unit\UnitEntity;
@@ -33,6 +39,14 @@ use Shopware\Core\Test\Generator;
 #[CoversClass(ProductFeatureBuilder::class)]
 class ProductFeatureBuilderTest extends TestCase
 {
+    private const LANGUAGE_ID = 'language-id-123';
+
+    private const CHILD_LANGUAGE_ID = 'child-language-id-123';
+
+    private const LANGUAGE_CHAIN = [self::LANGUAGE_ID, Defaults::LANGUAGE_SYSTEM];
+
+    private const CHILD_LANGUAGE_CHAIN = [self::CHILD_LANGUAGE_ID, self::LANGUAGE_ID, Defaults::LANGUAGE_SYSTEM];
+
     private ProductFeatureBuilder $productFeatureBuilder;
 
     /**
@@ -141,5 +155,139 @@ class ProductFeatureBuilderTest extends TestCase
                 'type' => 'referencePrice',
             ],
         ], $lineItem->getPayload()['features']);
+    }
+
+    public function testCustomFieldLabelUsesTheLanguageOfTheContext(): void
+    {
+        $features = $this->buildCustomFieldFeatures([
+            'en-GB' => 'Material',
+            'de-DE' => 'Werkstoff',
+        ]);
+
+        static::assertSame([
+            [
+                'label' => 'Werkstoff',
+                'value' => [
+                    'id' => 'custom-field-id',
+                    'type' => CustomFieldTypes::TEXT,
+                    'content' => 'wood',
+                ],
+                'type' => 'customField',
+            ],
+        ], $features);
+    }
+
+    /**
+     * A child language inherits the label of its parent language before the system language is used.
+     *
+     * @param array<string, string> $labels
+     */
+    #[DataProvider('parentLanguageLabelProvider')]
+    public function testCustomFieldLabelFallsBackToTheParentLanguage(array $labels): void
+    {
+        $features = $this->buildCustomFieldFeatures($labels, self::CHILD_LANGUAGE_CHAIN);
+
+        static::assertSame('Werkstoff', $features[0]['label']);
+    }
+
+    /**
+     * @param array<string, string> $labels
+     */
+    #[DataProvider('missingLabelProvider')]
+    public function testCustomFieldLabelFallsBackToTheSystemLanguage(array $labels): void
+    {
+        $features = $this->buildCustomFieldFeatures($labels);
+
+        static::assertSame('Material', $features[0]['label']);
+    }
+
+    /**
+     * @param array<string, string> $labels
+     */
+    #[DataProvider('skippedLabelProvider')]
+    public function testCustomFieldIsSkippedIfNoLanguageOfTheChainHasALabel(array $labels): void
+    {
+        static::assertSame([], $this->buildCustomFieldFeatures($labels));
+    }
+
+    public function testCustomFieldIsSkippedIfTheSystemLanguageLabelIsEmpty(): void
+    {
+        static::assertSame([], $this->buildCustomFieldFeatures(['en-GB' => ''], [Defaults::LANGUAGE_SYSTEM]));
+    }
+
+    /**
+     * @return iterable<string, array{array<string, string>}>
+     */
+    public static function parentLanguageLabelProvider(): iterable
+    {
+        yield 'no label for the child language' => [['en-GB' => 'Material', 'de-DE' => 'Werkstoff']];
+        yield 'empty label for the child language' => [['en-GB' => 'Material', 'de-DE' => 'Werkstoff', 'de-AT' => '']];
+    }
+
+    /**
+     * @return iterable<string, array{array<string, string>}>
+     */
+    public static function missingLabelProvider(): iterable
+    {
+        yield 'no label for the context language' => [['en-GB' => 'Material']];
+        yield 'empty label for the context language' => [['en-GB' => 'Material', 'de-DE' => '']];
+    }
+
+    /**
+     * @return iterable<string, array{array<string, string>}>
+     */
+    public static function skippedLabelProvider(): iterable
+    {
+        yield 'no label for any language of the chain' => [['fr-FR' => 'Matériau']];
+        yield 'empty system language label' => [['en-GB' => '']];
+    }
+
+    /**
+     * Builds the features of a line item referencing a product with a single custom field feature.
+     * The context defaults to the `de-DE` language chain; the system language is `en-GB` throughout.
+     *
+     * @param array<string, string> $labels
+     * @param non-empty-list<string> $languageIdChain
+     *
+     * @return array<int, array{label: string, value: mixed, type: string}>
+     */
+    private function buildCustomFieldFeatures(array $labels, array $languageIdChain = self::LANGUAGE_CHAIN): array
+    {
+        $this->languageLocaleProvider->method('getLocaleForLanguageId')->willReturnMap([
+            [self::CHILD_LANGUAGE_ID, 'de-AT'],
+            [self::LANGUAGE_ID, 'de-DE'],
+            [Defaults::LANGUAGE_SYSTEM, 'en-GB'],
+        ]);
+
+        $productId = 'product-id-123';
+        $lineItem = new LineItem($productId, LineItem::PRODUCT_LINE_ITEM_TYPE, $productId);
+
+        $product = new SalesChannelProductEntity();
+        $product->setId($productId);
+        $product->setTranslated(['customFields' => ['custom_material' => 'wood']]);
+
+        $featureSet = new ProductFeatureSetEntity();
+        $featureSet->setFeatures([
+            ['name' => 'custom_material', 'id' => 'feature-1', 'type' => ProductFeatureSetDefinition::TYPE_PRODUCT_CUSTOM_FIELD, 'position' => 1],
+        ]);
+        $product->setFeatureSet($featureSet);
+
+        $customField = new CustomFieldEntity();
+        $customField->setId('custom-field-id');
+        $customField->setName('custom_material');
+        $customField->setType(CustomFieldTypes::TEXT);
+        $customField->setConfig(['label' => $labels]);
+
+        $data = new CartDataCollection();
+        $data->set('product-' . $productId, $product);
+        $data->set('custom-field-custom_material', $customField);
+
+        $context = Generator::generateSalesChannelContext(
+            baseContext: new Context(new SystemSource(), languageIdChain: $languageIdChain),
+        );
+
+        $this->productFeatureBuilder->add([$lineItem], $data, $context);
+
+        return $lineItem->getPayload()['features'];
     }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?

When a custom field is displayed via essential characteristics, its label is always rendered in the system default language, even when the storefront runs in another language and the merchant maintained the label for that language.

The label lives in the custom field's `config.label`, indexed by locale code, and `ProductFeatureBuilder` read it with a hardcoded `Defaults::LANGUAGE_SYSTEM` locale. The doc block acknowledged this as a deliberate limitation from a time when custom field labels were not meant to leave the admin, and pointed at #4458, which was closed without the fix. Essential characteristics now render these labels in the storefront, so the limitation has become a bug.

### 2. What does this change do, exactly?

`ProductFeatureBuilder::getCustomFieldLabel()` resolves the label along the language chain of the sales channel context instead of the system language. The chain is `[current, parent?, system]`, so a label inherits from the parent language before it falls back to the system language, matching how the DAL resolves translated fields. `SalesChannelContext` is threaded down through `buildFeatures()` and `getCustomField()`; all three are private, so there is no BC surface.

A label that is empty for every language of the chain now yields no feature entry, instead of an entry with an empty label that the storefront dropped later in Twig via `feature.label is empty`.

### 3. Describe each step to reproduce the issue or behaviour.

1. Add a second language to the sales channel.
2. Create a product custom field and set its label in both languages.
3. Add the custom field to the default essential characteristics template.
4. Create a product and fill the custom field.
5. Put the product in the cart and open the cart in both languages.

Before: both languages show the label of the system default language. After: each language shows its own label.

### 4. Please link to the relevant issues (if any).

- closes #15024
- relates #13711 — that issue asks for the label to additionally be overridable through the snippet system, which is a separate change; this PR only fixes the language resolution.
- relates #4458

This change restores intended behaviour and alters no external contract, so it carries no `RELEASE_INFO` or `UPGRADE` entry.

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [x] I have written or adjusted the documentation and agent skills according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them

