### PR TITLE
test(acceptance): wait for cancel order modal focus

### DIFF
--- a/tests/acceptance/tests/Account/CancelOrder.spec.ts
+++ b/tests/acceptance/tests/Account/CancelOrder.spec.ts
@@ -28,6 +28,7 @@ test(
         await ShopCustomer.expects(orderItemLocators.orderStatus).toContainText('Open');
         await ShopCustomer.presses(orderItemLocators.orderActionsButton);
         await ShopCustomer.presses(orderItemLocators.orderCancelButton);
+        await ShopCustomer.expects(StorefrontAccountOrder.dialogOrderCancel).toBeFocused();
         await ShopCustomer.presses(StorefrontAccountOrder.dialogOrderCancelButton);
         await ShopCustomer.goesTo(StorefrontAccountOrder.url());
         await ShopCustomer.expects(orderItemLocators.orderShippingStatus).toContainText('Open');
@@ -64,6 +65,7 @@ test(
         await ShopCustomer.presses(orderItemLocators.orderActionsButton);
         await ShopCustomer.presses(orderItemLocators.orderChangePaymentMethodButton);
         await ShopCustomer.presses(StorefrontCheckoutOrderEdit.orderCancelButton);
+        await ShopCustomer.expects(StorefrontCheckoutOrderEdit.dialogOrderCancel).toBeFocused();
         await ShopCustomer.presses(StorefrontCheckoutOrderEdit.dialogOrderCancelButton);
         await ShopCustomer.goesTo(StorefrontAccountOrder.url());
         await ShopCustomer.expects(orderItemLocators.orderShippingStatus).toContainText('Open');


### PR DESCRIPTION
### 1. Why is this change necessary?

The CancelOrder acceptance flows submit the modal immediately after opening it. Bootstrap activates the modal focus trap only after its fade transition finishes, while the ATS `presses()` action first requires the target button to receive focus. This race caused the recurring CancelOrder retries.

### 2. What does this change do, exactly?

Wait for the cancellation dialog itself to receive Bootstrap focus before pressing its confirmation button in the two affected storefront flows.

### 3. Describe each step to reproduce the issue or behaviour.

1. Run the Platform acceptance suite under CI load.
2. Open an order cancellation dialog from either account orders or checkout order edit.
3. The immediate confirmation action can run before the modal focus trap is active; retries report the confirmation button as inactive.

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them