### PR TITLE
fix(administration): resolve inherited product tax rate correctly

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-product/page/sw-product-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/page/sw-product-detail/index.js
@@ -949,7 +949,14 @@ export default {
 
                     Shopware.Store.get('swProductDetail').parentProduct = parent;
                 })
-                .then(() => {
+                .catch(() => {
+                    // Without releasing the loading state the whole detail page stays in a
+                    // loading state forever, which hides the inheritance aware fields.
+                    this.createNotificationError({
+                        message: this.$t('sw-product.detail.messageParentProductNotFound'),
+                    });
+                })
+                .finally(() => {
                     Shopware.Store.get('swProductDetail').setLoading([
                         'parentProduct',
                         false,

--- a/src/Administration/Resources/app/administration/src/module/sw-product/page/sw-product-detail/store.spec.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/page/sw-product-detail/store.spec.ts
@@ -6,10 +6,25 @@ import { createPinia, setActivePinia } from 'pinia';
 const taxes = [
     { id: 'tax-0', name: '0%', taxRate: 0, position: 1 },
     { id: 'tax-19', name: '19%', taxRate: 19, position: 2 },
-] as EntitySchema.tax[];
+] as unknown as EntitySchema.tax[];
 
 function getStore() {
     return Shopware.Store.get('swProductDetail');
+}
+
+// The product entities are reduced to the properties the tax rate handling reads, so the
+// scenario of each test stays visible. They are cast through `unknown` because a full
+// product entity is not needed to describe the behaviour under test.
+function setProduct(product: Record<string, unknown>) {
+    const store = getStore();
+
+    store.product = product as unknown as typeof store.product;
+}
+
+function setParentProduct(parentProduct: Record<string, unknown>) {
+    const store = getStore();
+
+    store.parentProduct = parentProduct as unknown as typeof store.parentProduct;
 }
 
 describe('sw-product-detail.store', () => {
@@ -20,21 +35,19 @@ describe('sw-product-detail.store', () => {
 
     describe('setTaxes', () => {
         it('assigns the first tax rate to a root product without a tax rate', () => {
-            const store = getStore();
-            store.product = { id: 'product-id', taxId: null } as EntitySchema.product;
+            setProduct({ id: 'product-id', taxId: null });
 
-            store.setTaxes(taxes);
+            getStore().setTaxes(taxes);
 
-            expect(store.product.taxId).toBe('tax-0');
+            expect(getStore().product.taxId).toBe('tax-0');
         });
 
         it('keeps the tax rate of a root product that already has one', () => {
-            const store = getStore();
-            store.product = { id: 'product-id', taxId: 'tax-19' } as EntitySchema.product;
+            setProduct({ id: 'product-id', taxId: 'tax-19' });
 
-            store.setTaxes(taxes);
+            getStore().setTaxes(taxes);
 
-            expect(store.product.taxId).toBe('tax-19');
+            expect(getStore().product.taxId).toBe('tax-19');
         });
 
         // A variant inherits the tax rate of its parent, so its own taxId is null. The taxes
@@ -42,49 +55,44 @@ describe('sw-product-detail.store', () => {
         // product is still being fetched. The variant must not be treated as a root product
         // in that window, otherwise it silently loses its inheritance.
         it('does not assign a tax rate to a variant while its parent product is still loading', () => {
-            const store = getStore();
-            store.product = { id: 'variant-id', parentId: 'parent-id', taxId: null } as EntitySchema.product;
-            store.parentProduct = {} as EntitySchema.product;
+            setProduct({ id: 'variant-id', parentId: 'parent-id', taxId: null });
+            setParentProduct({});
 
-            store.setTaxes(taxes);
+            getStore().setTaxes(taxes);
 
-            expect(store.product.taxId).toBeNull();
+            expect(getStore().product.taxId).toBeNull();
         });
     });
 
     describe('productTaxRate', () => {
         it('returns the tax rate of the product', () => {
-            const store = getStore();
-            store.taxes = taxes;
-            store.product = { id: 'product-id', taxId: 'tax-19' } as EntitySchema.product;
+            getStore().taxes = taxes;
+            setProduct({ id: 'product-id', taxId: 'tax-19' });
 
-            expect(store.productTaxRate).toEqual(taxes[1]);
+            expect(getStore().productTaxRate).toEqual(taxes[1]);
         });
 
         it('returns the inherited tax rate of the parent product', () => {
-            const store = getStore();
-            store.taxes = taxes;
-            store.product = { id: 'variant-id', parentId: 'parent-id', taxId: null } as EntitySchema.product;
-            store.parentProduct = { id: 'parent-id', taxId: 'tax-19' } as EntitySchema.product;
+            getStore().taxes = taxes;
+            setProduct({ id: 'variant-id', parentId: 'parent-id', taxId: null });
+            setParentProduct({ id: 'parent-id', taxId: 'tax-19' });
 
-            expect(store.productTaxRate).toEqual(taxes[1]);
+            expect(getStore().productTaxRate).toEqual(taxes[1]);
         });
 
         it('returns an empty object when neither the product nor its parent has a tax rate', () => {
-            const store = getStore();
-            store.taxes = taxes;
-            store.product = { id: 'variant-id', parentId: 'parent-id', taxId: null } as EntitySchema.product;
-            store.parentProduct = {} as EntitySchema.product;
+            getStore().taxes = taxes;
+            setProduct({ id: 'variant-id', parentId: 'parent-id', taxId: null });
+            setParentProduct({});
 
-            expect(store.productTaxRate).toEqual({});
+            expect(getStore().productTaxRate).toEqual({});
         });
 
         it('returns an empty object when the tax rate is unknown', () => {
-            const store = getStore();
-            store.taxes = taxes;
-            store.product = { id: 'product-id', taxId: 'deleted-tax' } as EntitySchema.product;
+            getStore().taxes = taxes;
+            setProduct({ id: 'product-id', taxId: 'deleted-tax' });
 
-            expect(store.productTaxRate).toEqual({});
+            expect(getStore().productTaxRate).toEqual({});
         });
     });
 });

--- a/src/Administration/Resources/app/administration/src/module/sw-product/page/sw-product-detail/store.spec.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/page/sw-product-detail/store.spec.ts
@@ -1,0 +1,90 @@
+/**
+ * @sw-package inventory
+ */
+import { createPinia, setActivePinia } from 'pinia';
+
+const taxes = [
+    { id: 'tax-0', name: '0%', taxRate: 0, position: 1 },
+    { id: 'tax-19', name: '19%', taxRate: 19, position: 2 },
+] as EntitySchema.tax[];
+
+function getStore() {
+    return Shopware.Store.get('swProductDetail');
+}
+
+describe('sw-product-detail.store', () => {
+    beforeEach(() => {
+        setActivePinia(createPinia());
+        getStore().$reset();
+    });
+
+    describe('setTaxes', () => {
+        it('assigns the first tax rate to a root product without a tax rate', () => {
+            const store = getStore();
+            store.product = { id: 'product-id', taxId: null } as EntitySchema.product;
+
+            store.setTaxes(taxes);
+
+            expect(store.product.taxId).toBe('tax-0');
+        });
+
+        it('keeps the tax rate of a root product that already has one', () => {
+            const store = getStore();
+            store.product = { id: 'product-id', taxId: 'tax-19' } as EntitySchema.product;
+
+            store.setTaxes(taxes);
+
+            expect(store.product.taxId).toBe('tax-19');
+        });
+
+        // A variant inherits the tax rate of its parent, so its own taxId is null. The taxes
+        // are loaded in parallel to the product, therefore they can arrive while the parent
+        // product is still being fetched. The variant must not be treated as a root product
+        // in that window, otherwise it silently loses its inheritance.
+        it('does not assign a tax rate to a variant while its parent product is still loading', () => {
+            const store = getStore();
+            store.product = { id: 'variant-id', parentId: 'parent-id', taxId: null } as EntitySchema.product;
+            store.parentProduct = {} as EntitySchema.product;
+
+            store.setTaxes(taxes);
+
+            expect(store.product.taxId).toBeNull();
+        });
+    });
+
+    describe('productTaxRate', () => {
+        it('returns the tax rate of the product', () => {
+            const store = getStore();
+            store.taxes = taxes;
+            store.product = { id: 'product-id', taxId: 'tax-19' } as EntitySchema.product;
+
+            expect(store.productTaxRate).toEqual(taxes[1]);
+        });
+
+        it('returns the inherited tax rate of the parent product', () => {
+            const store = getStore();
+            store.taxes = taxes;
+            store.product = { id: 'variant-id', parentId: 'parent-id', taxId: null } as EntitySchema.product;
+            store.parentProduct = { id: 'parent-id', taxId: 'tax-19' } as EntitySchema.product;
+
+            expect(store.productTaxRate).toEqual(taxes[1]);
+        });
+
+        it('returns an empty object when neither the product nor its parent has a tax rate', () => {
+            const store = getStore();
+            store.taxes = taxes;
+            store.product = { id: 'variant-id', parentId: 'parent-id', taxId: null } as EntitySchema.product;
+            store.parentProduct = {} as EntitySchema.product;
+
+            expect(store.productTaxRate).toEqual({});
+        });
+
+        it('returns an empty object when the tax rate is unknown', () => {
+            const store = getStore();
+            store.taxes = taxes;
+            store.product = { id: 'product-id', taxId: 'deleted-tax' } as EntitySchema.product;
+
+            expect(store.productTaxRate).toEqual({});
+        });
+    });
+});

--- a/src/Administration/Resources/app/administration/src/module/sw-product/page/sw-product-detail/store.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/page/sw-product-detail/store.ts
@@ -134,23 +134,14 @@ const swProductDetail = Shopware.Store.register({
         },
 
         productTaxRate(state): EntitySchema.tax | object {
-            if (!state.taxes) {
+            // a child product without its own tax rate inherits the one of its parent
+            const taxId = state.product.taxId ?? state.parentProduct.taxId;
+
+            if (!state.taxes || !taxId) {
                 return {};
             }
 
-            return (
-                state.taxes.find((tax) => {
-                    if (!state.product.taxId) {
-                        if (!state.parentProduct.taxId) {
-                            return {};
-                        }
-
-                        return tax.id === state.parentProduct.taxId;
-                    }
-
-                    return tax.id === state.product.taxId;
-                }) ?? {}
-            );
+            return state.taxes.find((tax) => tax.id === taxId) ?? {};
         },
 
         isChild(state): boolean {

--- a/src/Administration/Resources/app/administration/src/module/sw-product/page/sw-product-detail/sw-product-detail.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/page/sw-product-detail/sw-product-detail.spec.js
@@ -1320,4 +1320,37 @@ describe('module/sw-product/page/sw-product-detail', () => {
         await flushPromises();
         expect(store.parentProduct).toEqual({});
     });
+
+    it('should release the loading state when the parent product cannot be loaded', async () => {
+        await wrapper.unmount();
+
+        wrapper = await createWrapper(
+            () => Promise.resolve([]),
+            (id) => {
+                if (id === 'parent-456') {
+                    return Promise.reject(new Error('parent product is not reachable'));
+                }
+
+                return Promise.resolve({ variation: [] });
+            },
+        );
+        await flushPromises();
+
+        const store = Shopware.Store.get('swProductDetail');
+        wrapper.vm.createNotificationError = jest.fn();
+
+        store.product = { id: 'variant-123', parentId: 'parent-456' };
+        store.parentProduct = {};
+
+        await wrapper.vm.loadParentProduct();
+        await flushPromises();
+
+        expect(wrapper.vm.createNotificationError).toHaveBeenCalledWith({
+            message: 'sw-product.detail.messageParentProductNotFound',
+        });
+        // the detail page must not stay in a loading state, otherwise all
+        // inheritance aware fields stay hidden until the page is reloaded
+        expect(store.loading.parentProduct).toBe(false);
+        expect(store.isLoading).toBe(false);
+    });
 });

--- a/src/Administration/Resources/app/administration/src/module/sw-product/snippet/de.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/snippet/de.json
@@ -300,6 +300,7 @@
       "messageUploadSuccess": "{count} von {total} Dateien erfolgreich gespeichert.",
       "messageSaveWarning": "Keine Änderung vorgenommen.",
       "messageProductNotFound": "Das Produkt konnte nicht gefunden werden. Es wurde möglicherweise gelöscht.",
+      "messageParentProductNotFound": "Das Hauptprodukt konnte nicht geladen werden. Vererbte Werte sind möglicherweise unvollständig.",
       "errorMinMaxPurchase": "Produkt konnte nicht gespeichert werden, die minimale Bestellmenge überschreitet die Maximalabnahme."
     },
     "mediaForm": {

--- a/src/Administration/Resources/app/administration/src/module/sw-product/snippet/en.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/snippet/en.json
@@ -300,6 +300,7 @@
       "messageUploadSuccess": "{count} of {total} files saved.",
       "messageSaveWarning": "No changes detected.",
       "messageProductNotFound": "The product could not be found. It may have been deleted.",
+      "messageParentProductNotFound": "The main product could not be loaded. Inherited values may be incomplete.",
       "errorMinMaxPurchase": "Could not save product, the min purchase quantity is larger than max purchase quantity."
     },
     "mediaForm": {


### PR DESCRIPTION
### 1. Why is this change necessary?

Follow-up to #14596, which fixed tax rate inheritance for variants in the product detail page. That fix is correct and is not changed here. While verifying it against `trunk` and `v6.7.11.1`, two defects turned up in the same code path, and the race it fixed had no test guarding it.

`loadParentProduct` releases the `parentProduct` loading state in a `then` callback and has no rejection handling. If the request for the parent product fails, the loading state is never released, `isLoading` stays `true`, and every inheritance aware field of a variant stays hidden until the page is reloaded.

`productTaxRate` passes a callback to `Array.prototype.find` that returns an empty object when neither the product nor its parent has a tax rate. An empty object is truthy, so `find` matches the **first** tax rate of the list instead of returning no match. The consumers of the getter are guarded by `isLoading`, so this is not reachable while the parent product is being loaded. It becomes reachable exactly in the state the first fix above makes renderable: a variant whose parent product could not be loaded would show an arbitrary tax rate, for example `0%`, instead of none.

### 2. What does this change do, exactly?

* `loadParentProduct` handles a failing request, informs the user that inherited values may be incomplete, and releases the loading state in `finally`, so the detail page always leaves the loading state.
* `productTaxRate` resolves the effective tax id once, preferring the product's own tax id and falling back to the one of the parent product, and then looks it up. It returns an empty object when no tax id applies or when the tax rate is unknown.
* Adds `store.spec.ts` for the `swProductDetail` store covering `setTaxes` and `productTaxRate`. It pins the behaviour that a variant must not receive a default tax rate while its parent product is still loading, which is the race that caused #12974 and which had no test.

### 3. Describe each step to reproduce the issue or behaviour.

For `loadParentProduct`:

1. Open a variant in the administration and let the request for its parent product fail.
2. Before this change the detail page stays in a loading state permanently and the tax rate field is not rendered at all.

For `productTaxRate`:

1. Set `taxes` on the `swProductDetail` store, set a product with `taxId: null` and a `parentProduct` without a tax id, which is the state left behind by the failing request above.
2. Read `productTaxRate`. Before this change it returns the first tax rate of the list, for example `0%`, instead of an empty object.

### 4. Please link to the relevant issues (if any).

- relates #12974
- relates #14596

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
