### PR TITLE
fix(checkout): keep delivery positions when editing orders with a shipping discount (backport: 6.6.x)

### DIFF
--- a/changelog/_unreleased/2026-08-13-keep-delivery-positions-when-editing-orders-with-a-shipping-discount.md
+++ b/changelog/_unreleased/2026-08-13-keep-delivery-positions-when-editing-orders-with-a-shipping-discount.md
@@ -1,0 +1,6 @@
+---
+title: Keep delivery positions when editing orders with a shipping discount
+issue: 18971
+---
+# Core
+* Changed `PromotionDeliveryCalculator` to build the shipping discount delivery with its own empty `DeliveryPositionCollection` instead of reusing the positions of the base delivery. Editing an order that contains a shipping-cost discount in the Administration no longer fails the order version merge with a `fk.order_delivery_position.order_delivery_id` foreign key violation.

--- a/src/Core/Checkout/Promotion/Cart/PromotionDeliveryCalculator.php
+++ b/src/Core/Checkout/Promotion/Cart/PromotionDeliveryCalculator.php
@@ -6,6 +6,7 @@ use Shopware\Core\Checkout\Cart\Cart;
 use Shopware\Core\Checkout\Cart\CartException;
 use Shopware\Core\Checkout\Cart\Delivery\Struct\Delivery;
 use Shopware\Core\Checkout\Cart\Delivery\Struct\DeliveryCollection;
+use Shopware\Core\Checkout\Cart\Delivery\Struct\DeliveryPositionCollection;
 use Shopware\Core\Checkout\Cart\LineItem\LineItem;
 use Shopware\Core\Checkout\Cart\LineItem\LineItemCollection;
 use Shopware\Core\Checkout\Cart\Order\IdStruct;
@@ -508,8 +509,9 @@ class PromotionDeliveryCalculator
         $idStruct = $delivery->getExtensionOfType(OrderConverter::ORIGINAL_ADDRESS_ID, IdStruct::class);
         $versionIdStruct = $delivery->getExtensionOfType(OrderConverter::ORIGINAL_ADDRESS_VERSION_ID, IdStruct::class);
 
+        // Own empty positions: never share the base delivery's order_delivery_position rows.
         $delivery = new Delivery(
-            $delivery->getPositions(),
+            new DeliveryPositionCollection(),
             $delivery->getDeliveryDate(),
             $delivery->getShippingMethod(),
             $delivery->getLocation(),

--- a/tests/integration/Core/Checkout/Cart/Order/RecalculationServiceTest.php
+++ b/tests/integration/Core/Checkout/Cart/Order/RecalculationServiceTest.php
@@ -37,6 +37,7 @@ use Shopware\Core\Checkout\Order\OrderDefinition;
 use Shopware\Core\Checkout\Order\OrderEntity;
 use Shopware\Core\Checkout\Order\OrderException;
 use Shopware\Core\Checkout\Promotion\Aggregate\PromotionDiscount\PromotionDiscountEntity;
+use Shopware\Core\Checkout\Promotion\Cart\PromotionItemBuilder;
 use Shopware\Core\Checkout\Promotion\Cart\PromotionProcessor;
 use Shopware\Core\Checkout\Shipping\Aggregate\ShippingMethodPrice\ShippingMethodPriceCollection;
 use Shopware\Core\Checkout\Shipping\Aggregate\ShippingMethodPrice\ShippingMethodPriceEntity;
@@ -792,6 +793,38 @@ class RecalculationServiceTest extends TestCase
         static::assertSame(-0.5, $newPromotionDelivery?->getShippingCosts()->getTotalPrice());
 
         static::assertNotEquals($newPromotionDelivery->getId(), $promotionDelivery->getId());
+    }
+
+    public function testEditOrderWithFreeShippingPromotionKeepsDeliveryPositions(): void
+    {
+        // checkout an order with a 100% shipping discount promotion (shipping delivery + discount delivery)
+        $this->createShippingDiscount(100, 'FREESHIP');
+        $cart = $this->generateDemoCart();
+        $cart->add(static::getContainer()->get(PromotionItemBuilder::class)->buildPlaceholderItem('FREESHIP'));
+        $cart = static::getContainer()->get(Processor::class)->process($cart, $this->salesChannelContext, new CartBehavior());
+        $orderId = $this->persistCart($cart)['orderId'];
+
+        // admin edit: add a product and save (recalculate)
+        $versionContext = $this->context->createWithVersionId($this->createVersionedOrder($orderId));
+        $productId = $this->createProduct('new product', 10.0, 19.0);
+        static::getContainer()->get(RecalculationService::class)->addProductToOrder($orderId, $productId, 1, $versionContext);
+
+        $criteria = (new Criteria([$orderId]))->addAssociation('deliveries.positions');
+        /** @var OrderEntity $order */
+        $order = static::getContainer()->get('order.repository')->search($criteria, $versionContext)->get($orderId);
+
+        $deliveries = $order->getDeliveries();
+        static::assertNotNull($deliveries);
+        static::assertCount(2, $deliveries);
+
+        $shipping = $deliveries->filter(static fn (OrderDeliveryEntity $delivery) => $delivery->getShippingCosts()->getTotalPrice() >= 0)->first();
+        $discount = $deliveries->filter(static fn (OrderDeliveryEntity $delivery) => $delivery->getShippingCosts()->getTotalPrice() < 0)->first();
+        static::assertNotNull($shipping);
+        static::assertNotNull($discount);
+
+        // both initial products plus the newly added one keep a shipping position; the discount delivery has none
+        static::assertCount(3, $shipping->getPositions() ?? []);
+        static::assertCount(0, $discount->getPositions() ?? []);
     }
 
     public function testRecalculationOfPinnedDisabledPromotion(): void


### PR DESCRIPTION
### 1. Why is this change necessary?

Saving an order that contains a shipping-cost discount after adding a line item in the Administration fails, because the version merge hits a `fk.order_delivery_position.order_delivery_id` foreign key violation.

### 2. What does this change do, exactly?

`PromotionDeliveryCalculator::addDiscountDeliveryItem()` reused the base delivery's `DeliveryPositionCollection` for the shipping discount delivery, which is recreated with a fresh id on every recalculation, so those positions were written against a delivery id that does not exist yet. The discount delivery now gets its own empty `DeliveryPositionCollection`.

### 3. Describe each step to reproduce the issue or behaviour.

Create an active promotion with a discount on shipping costs (scope "Delivery") for the Storefront sales channel, give the shipping method a price above 0.00, and place an order using it. Open that order in the Administration, add a custom line item with a price of EUR 0.00, and save.

### 4. Please link to the relevant issues (if any).

- closes #18971
- backport of #18703

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
