### PR TITLE
fix(npm): ignore extract-zip audit for Node 20 packages

### DIFF
--- a/src/Administration/Resources/app/administration/scripts/runNpmAudit.ts
+++ b/src/Administration/Resources/app/administration/scripts/runNpmAudit.ts
@@ -31,10 +31,6 @@ runNpmAudit({
         'https://github.com/advisories/GHSA-gcfj-64vw-6mp9', // axios v0 inherited proxy use, legacy admin HTTP client kept for extension compatibility until v6.8 axios v1 migration
         'https://github.com/advisories/GHSA-hcpx-6fm6-wx23', // axios v0 form serializer maxDepth bypass, legacy admin HTTP client kept for extension compatibility until v6.8 axios v1 migration
         'https://github.com/advisories/GHSA-7q8q-rj6j-mhjq', // axios v0 nested option prototype pollution, legacy admin HTTP client kept for extension compatibility until v6.8 axios v1 migration
-        'https://github.com/advisories/GHSA-rgw5-rvv9-x895', // brace-expansion DoS via unbounded intermediate arrays, high severity, transitive devDep, no fix in the pinned tree
-        'https://github.com/advisories/GHSA-7p8r-x3mc-p8w7', // fast-uri host confusion via backslash authority introducer, high severity, transitive devDep, no fix in the pinned tree
-        'https://github.com/advisories/GHSA-mwp4-54f8-5fhr', // ip-address leading-zero octet SSRF/trust-boundary bypass, high severity, transitive devDep, no fix in the pinned tree
-        'https://github.com/advisories/GHSA-4xrf-jv44-h6hh', // ip-address CIDR-suffix special-use bypass, moderate severity, transitive devDep, no fix in the pinned tree
-        'https://github.com/advisories/GHSA-22jq-vg5j-6vgg', // ip-address IPv4-mapped/NAT64 misclassification bypass, moderate severity, transitive devDep, no fix in the pinned tree
+        'https://github.com/advisories/GHSA-jmr9-qjv8-65gv', // extract-zip symlink traversal via Puppeteer browser downloads, devDep only; fixed Puppeteer requires Node 22.12+ while this package still supports Node 20
     ],
 });

--- a/tests/acceptance/scripts/runNpmAudit.ts
+++ b/tests/acceptance/scripts/runNpmAudit.ts
@@ -25,5 +25,7 @@ import { runNpmAudit } from '../../../.github/bin/js/run-npm-audit.ts';
  * - GHSA-7c78-jf6q-g5cm by pinning tmp to 0.2.7
  */
 runNpmAudit({
-    ignoredGHSAs: [],
+    ignoredGHSAs: [
+        'https://github.com/advisories/GHSA-jmr9-qjv8-65gv', // extract-zip symlink traversal via Lighthouse/Puppeteer browser downloads, test-only; fixed Lighthouse requires Node 22.19+ while this package still supports Node 20
+    ],
 });


### PR DESCRIPTION
### 1. Why is this change necessary?

The scheduled npm audit fails for Administration Main and Tests Acceptance because `extract-zip` is reported via Puppeteer/Lighthouse browser download dependencies. Direct package upgrades are not compatible with the current Node 20 support because the fixed Puppeteer/Lighthouse releases require Node 22.12+ or 22.19+.

### 2. What does this change do, exactly?

Adds explicit `GHSA-jmr9-qjv8-65gv` ignore entries to the affected package audit wrappers with comments explaining the Node compatibility constraint, and removes stale Administration ignore entries no longer present in audit output.

### 3. Describe each step to reproduce the issue or behaviour.

1. Run the scheduled npm audit workflow on `trunk`.
2. Observe the `extract-zip` advisory in Administration Main and Tests Acceptance.

### 4. Please link to the relevant issues (if any).

- closes #19280

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
