### PR TITLE
test: cover the Twig escape-cache worker reset via ServicesResetter

### DIFF
--- a/tests/integration/Core/Framework/Adapter/Twig/TwigEscapeCacheResetTest.php
+++ b/tests/integration/Core/Framework/Adapter/Twig/TwigEscapeCacheResetTest.php
@@ -11,14 +11,8 @@ use Twig\Environment;
 use Twig\Runtime\EscaperRuntime;
 
 /**
- * Regression guard for the escape-cache memory leak in long-running workers (issue #19272).
- *
- * The bug was not that the reset logic was wrong, but that Symfony's ServicesResetter never ran it:
- * the reset-carrying service was never initialized, so `initialized(...)` stayed false and the reset
- * was skipped. A unit test that calls `reset()` directly cannot catch that, because it bypasses the
- * one broken link. This test drives the real `services_resetter` from a booted container, exactly as
- * a worker runtime does between requests, so it fails on the unfixed code and passes once the reset
- * hangs off the always-initialized `twig` service.
+ * Drives the real `services_resetter` (not `reset()` directly), so it fails unless the reset actually
+ * runs on the initialized `twig` service between requests. Regression guard for issue #19272.
  *
  * @internal
  */
@@ -34,15 +28,13 @@ class TwigEscapeCacheResetTest extends TestCase
         CachedEscaperRuntime::resetEscapeCache();
 
         try {
-            // Render once so the `twig` service is initialized. The fix hangs the reset off `twig`,
-            // and ServicesResetter only resets services that a request already initialized.
+            // Render so ServicesResetter has an initialized `twig` service to reset.
             $twig = $container->get('twig');
             static::assertInstanceOf(Environment::class, $twig);
             $twig->createTemplate('{{ "warmup"|escape }}')->render([]);
-            static::assertTrue($container->initialized('twig'), 'a render must initialize the twig service');
+            static::assertTrue($container->initialized('twig'));
 
-            // Warm the static cache under an isolated escaper strategy, and prove it really is a cache:
-            // the inner escaper runs once, the second identical escape is served from the cache.
+            // Warm the cache: a second identical escape is a hit, so the inner escaper runs only once.
             $callCount = 0;
             $escaper = new EscaperRuntime();
             $escaper->setEscaper('test', static function (string $value) use (&$callCount): string {
@@ -54,21 +46,16 @@ class TwigEscapeCacheResetTest extends TestCase
             CachedEscaperRuntime::escape($escaper, 'foo', 'test');
             $callsWhileWarm = $callCount;
 
-            // The exact reset a long-running runtime (RoadRunner, FrankenPHP, Swoole) fires between requests.
+            // What a worker fires between requests.
             $resetter = $container->get('services_resetter');
             static::assertInstanceOf(ServicesResetter::class, $resetter);
             $resetter->reset();
 
-            // If the reset actually ran, the cache is empty and the next identical escape is a miss.
-            // On the unfixed code the cache survives the reset and the inner escaper is not called again.
+            // Cache cleared, so this is a miss and the inner escaper runs again.
             CachedEscaperRuntime::escape($escaper, 'foo', 'test');
 
-            static::assertSame(1, $callsWhileWarm, 'the escape cache should be warm before the reset (one inner call for two identical escapes)');
-            static::assertSame(
-                2,
-                $callCount,
-                'ServicesResetter must clear the escape cache between requests, otherwise it grows unbounded in worker mode'
-            );
+            static::assertSame(1, $callsWhileWarm);
+            static::assertSame(2, $callCount, 'ServicesResetter must clear the escape cache, else it grows unbounded in worker mode');
         } finally {
             CachedEscaperRuntime::resetEscapeCache();
         }

--- a/tests/integration/Core/Framework/Adapter/Twig/TwigEscapeCacheResetTest.php
+++ b/tests/integration/Core/Framework/Adapter/Twig/TwigEscapeCacheResetTest.php
@@ -11,8 +11,7 @@ use Twig\Environment;
 use Twig\Runtime\EscaperRuntime;
 
 /**
- * Drives the real `services_resetter` (not `reset()` directly), so it fails unless the reset actually
- * runs on the initialized `twig` service between requests. Regression guard for issue #19272.
+ * Drives the real `services_resetter` (not `reset()` directly), so it fails unless the reset actually runs.
  *
  * @internal
  */

--- a/tests/integration/Core/Framework/Adapter/Twig/TwigEscapeCacheResetTest.php
+++ b/tests/integration/Core/Framework/Adapter/Twig/TwigEscapeCacheResetTest.php
@@ -1,0 +1,76 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Integration\Core\Framework\Adapter\Twig;
+
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Adapter\Twig\Runtime\CachedEscaperRuntime;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
+use Symfony\Component\HttpKernel\DependencyInjection\ServicesResetter;
+use Twig\Environment;
+use Twig\Runtime\EscaperRuntime;
+
+/**
+ * Regression guard for the escape-cache memory leak in long-running workers (issue #19272).
+ *
+ * The bug was not that the reset logic was wrong, but that Symfony's ServicesResetter never ran it:
+ * the reset-carrying service was never initialized, so `initialized(...)` stayed false and the reset
+ * was skipped. A unit test that calls `reset()` directly cannot catch that, because it bypasses the
+ * one broken link. This test drives the real `services_resetter` from a booted container, exactly as
+ * a worker runtime does between requests, so it fails on the unfixed code and passes once the reset
+ * hangs off the always-initialized `twig` service.
+ *
+ * @internal
+ */
+#[Package('framework')]
+class TwigEscapeCacheResetTest extends TestCase
+{
+    use KernelTestBehaviour;
+
+    public function testServicesResetterClearsEscapeCacheBetweenRequests(): void
+    {
+        $container = $this->getContainer();
+
+        CachedEscaperRuntime::resetEscapeCache();
+
+        try {
+            // Render once so the `twig` service is initialized. The fix hangs the reset off `twig`,
+            // and ServicesResetter only resets services that a request already initialized.
+            $twig = $container->get('twig');
+            static::assertInstanceOf(Environment::class, $twig);
+            $twig->createTemplate('{{ "warmup"|escape }}')->render([]);
+            static::assertTrue($container->initialized('twig'), 'a render must initialize the twig service');
+
+            // Warm the static cache under an isolated escaper strategy, and prove it really is a cache:
+            // the inner escaper runs once, the second identical escape is served from the cache.
+            $callCount = 0;
+            $escaper = new EscaperRuntime();
+            $escaper->setEscaper('test', static function (string $value) use (&$callCount): string {
+                ++$callCount;
+
+                return $value;
+            });
+            CachedEscaperRuntime::escape($escaper, 'foo', 'test');
+            CachedEscaperRuntime::escape($escaper, 'foo', 'test');
+            $callsWhileWarm = $callCount;
+
+            // The exact reset a long-running runtime (RoadRunner, FrankenPHP, Swoole) fires between requests.
+            $resetter = $container->get('services_resetter');
+            static::assertInstanceOf(ServicesResetter::class, $resetter);
+            $resetter->reset();
+
+            // If the reset actually ran, the cache is empty and the next identical escape is a miss.
+            // On the unfixed code the cache survives the reset and the inner escaper is not called again.
+            CachedEscaperRuntime::escape($escaper, 'foo', 'test');
+
+            static::assertSame(1, $callsWhileWarm, 'the escape cache should be warm before the reset (one inner call for two identical escapes)');
+            static::assertSame(
+                2,
+                $callCount,
+                'ServicesResetter must clear the escape cache between requests, otherwise it grows unbounded in worker mode'
+            );
+        } finally {
+            CachedEscaperRuntime::resetEscapeCache();
+        }
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?

The escape-cache fix has no test that fails without it. A direct `reset()` unit test passes on the unfixed code, because the real bug is that `ServicesResetter` never ran the reset.

### 2. What does this change do, exactly?

Adds an integration test that renders through the container (initializing `twig`), warms the escape cache, runs the real `services_resetter->reset()`, and asserts the cache was cleared. Red without the fix, green with it.

### 3. Describe each step to reproduce the issue or behaviour.

`docker compose exec web vendor/bin/phpunit tests/integration/Core/Framework/Adapter/Twig/TwigEscapeCacheResetTest.php`

### 4. Please link to the relevant issues (if any).

relates #19272

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under "Upcoming" for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
