### PR TITLE
ci: restore the no-stale-review policy (disable codeowners-plus smart dismissal)

### DIFF
--- a/codeowners.toml
+++ b/codeowners.toml
@@ -1,0 +1,7 @@
+# codeowners-plus configuration, read from the repository root (see .github/workflows/codeowner.yml).
+#
+# Keep the long-standing policy of not dismissing reviews on new pushes. codeowners-plus enables
+# "smart dismissal" (dropping a code owner's approval when a later push changes files they own) by
+# default. This repository has deliberately kept review dismissal off for years, so it is turned off
+# here to preserve that policy.
+disable_smart_dismissal = true


### PR DESCRIPTION
### 1. Why is this change necessary?

This repository has deliberately not dismissed reviews on new pushes for years, on both GitHub and GitLab. That policy was silently reverted, not by decision but as a default of the codeowners-plus action, and this change restores it.

### 2. What does this change do, exactly?

Adds a root `codeowners.toml` with `disable_smart_dismissal = true`, so codeowners-plus stops dismissing a code owner's approval when a later push changes files that owner owns.

**The important nuance: nobody appears to have explicitly turned stale dismissal on.** 

The introducing change (commit `210d9a5ad7d`, 2025-10-14) had the opposite purpose: adding non-blocking, optional (`?`) owners, which native GitHub CODEOWNERS cannot express. "Smart dismissal of stale reviews" is simply the default behavior of `multimediallc/codeowners-plus`, on unless a root `codeowners.toml` sets `disable_smart_dismissal = true`. 

No such file was ever committed, so the default took effect silently when the tool was adopted for a different reason, and the history shows no discussion of reintroducing dismissal.

Supporting facts:

- The dismissals (the bot drops the approval with "Changes in owned files since last approval" right after follow-up commits) come from codeowners-plus "smart dismissal", not from branch protection. Native `dismiss_stale_reviews` is still `false` on `trunk`, and GitLab was configured the same way, so the documented policy was intact where it was set.
- The review dismissal therefore came back through a second mechanism that the "we keep dismissal off in branch protection" policy never covered. Turning off smart dismissal returns the behavior to the long-standing agreement.

### 3. Describe each step to reproduce the issue or behaviour.

1. A code owner approves a pull request.
2. A later commit changes files that owner owns.
3. Before this change: the approval is dismissed and a fresh review is required. After this change: the approval is kept.

### 4. Please link to the relevant issues (if any).

Governance note: re-enabling review dismissal is a policy change that has stood unchanged for years and should not move without an explicit decision by @shopware/product-operations (owns the CI governance) and @shopware/framework. This PR restores the prior state and asks both teams to confirm it, so the policy is settled deliberately rather than by a tool default.

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under "Upcoming" for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
