### PR TITLE
chore(store-api): remove obsolete bc excludes

### DIFF
--- a/.bc-exclude.php
+++ b/.bc-exclude.php
@@ -178,9 +178,5 @@ return [
         preg_quote('CHANGED: Shopware\Core\Content\Seo\SeoUrlRoute\EntitySeoUrlRouteInterface was marked "@internal"', '/'),
         preg_quote('CHANGED: Shopware\Core\Content\Seo\SeoUrlRoute\EntityRouteResolver was marked "@internal"', '/'),
 
-        // Store API schema migration allowlist symbols were added on trunk for
-        // an unreleased migration helper and removed again before release.
-        'REMOVED: Constant Shopware\\\\Core\\\\Framework\\\\Api\\\\(?:Context\\\\Exception\\\\InvalidContextSourceException|ApiException)::API_INVALID_STORE_API_SCHEMA_MIGRATION_ALLOWLIST',
-        preg_quote('REMOVED: Method Shopware\Core\Framework\Api\ApiException::invalidStoreApiSchemaMigrationAllowlist() was removed', '/'),
     ],
 ];


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

PR #19255 removed the unreleased Store API schema migration allowlist, so the temporary BC excludes for those deleted symbols should not remain on trunk.

### 2. What does this change do, exactly?

It removes the obsolete `.bc-exclude.php` entries and comment for the deleted Store API schema migration allowlist exception symbols.

### 3. Describe each step to reproduce the issue or behaviour.

Inspect `.bc-exclude.php` after #19255 and verify that no Store API schema migration allowlist removals are still excluded.

### 4. Please link to the relevant issues (if any).

Follow-up to #19255.
Relates to #18851.

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
