### PR TITLE
fix(framework): allow users to change their timezone

### DIFF
--- a/src/Core/Framework/Api/Controller/UserController.php
+++ b/src/Core/Framework/Api/Controller/UserController.php
@@ -95,7 +95,7 @@ class UserController extends AbstractController
             throw ApiException::userNotLoggedIn();
         }
 
-        $allowedChanges = ['firstName', 'lastName', 'username', 'localeId', 'email', 'avatarMedia', 'avatarId', 'password'];
+        $allowedChanges = ['firstName', 'lastName', 'username', 'localeId', 'email', 'avatarMedia', 'avatarId', 'password', 'timeZone'];
 
         if (array_diff(array_keys($request->request->all()), $allowedChanges) !== []) {
             throw ApiException::missingPrivileges(['user:update']);

--- a/tests/unit/Core/Framework/Api/Controller/UserControllerTest.php
+++ b/tests/unit/Core/Framework/Api/Controller/UserControllerTest.php
@@ -13,7 +13,9 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Sso\SsoService;
+use Shopware\Core\System\User\UserCollection;
 use Shopware\Core\System\User\UserDefinition;
+use Shopware\Core\Test\Stub\DataAbstractionLayer\StaticEntityRepository;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -66,26 +68,19 @@ class UserControllerTest extends TestCase
         $userId = 'test-user-id';
         $context = Context::createDefaultContext(new AdminApiSource($userId));
         $request = Request::create('/', Request::METHOD_PATCH, ['timeZone' => 'Europe/Berlin']);
-        $responseFactory = static::createStub(ResponseFactoryInterface::class);
+        $userDefinition = new UserDefinition();
+        $userRepository = StaticEntityRepository::of(UserCollection::class, [], $userDefinition);
+        $responseFactory = $this->createMock(ResponseFactoryInterface::class);
         $response = new Response();
-
-        $controller = $this->getMockBuilder(UserController::class)
-            ->setConstructorArgs([
-                static::createStub(EntityRepository::class),
-                static::createStub(EntityRepository::class),
-                static::createStub(EntityRepository::class),
-                static::createStub(EntityRepository::class),
-                static::createStub(UserDefinition::class),
-                static::createStub(SsoService::class),
-            ])
-            ->onlyMethods(['upsertUser'])
-            ->getMock();
-        $controller->expects($this->once())
-            ->method('upsertUser')
-            ->with($userId, $request, $context, $responseFactory)
+        $responseFactory->expects($this->once())
+            ->method('createRedirectResponse')
+            ->with($userDefinition, $userId, $request, $context)
             ->willReturn($response);
 
+        $controller = $this->createController(userRepository: $userRepository, userDefinition: $userDefinition);
+
         static::assertSame($response, $controller->updateMe($context, $request, $responseFactory));
+        static::assertSame('Europe/Berlin', $userRepository->upserts[0][0]['timeZone']);
     }
 
     public function testUpdateMeRejectsFieldsOutsideTheSelfProfileAllowlist(): void
@@ -99,14 +94,17 @@ class UserControllerTest extends TestCase
         $controller->updateMe($context, $request, static::createStub(ResponseFactoryInterface::class));
     }
 
-    private function createController(?SsoService $ssoService = null): UserController
-    {
+    private function createController(
+        ?SsoService $ssoService = null,
+        ?EntityRepository $userRepository = null,
+        ?UserDefinition $userDefinition = null,
+    ): UserController {
         return new UserController(
+            $userRepository ?? static::createStub(EntityRepository::class),
             static::createStub(EntityRepository::class),
             static::createStub(EntityRepository::class),
             static::createStub(EntityRepository::class),
-            static::createStub(EntityRepository::class),
-            static::createStub(UserDefinition::class),
+            $userDefinition ?? static::createStub(UserDefinition::class),
             $ssoService ?? static::createStub(SsoService::class),
         );
     }

--- a/tests/unit/Core/Framework/Api/Controller/UserControllerTest.php
+++ b/tests/unit/Core/Framework/Api/Controller/UserControllerTest.php
@@ -8,11 +8,13 @@ use Shopware\Core\Framework\Api\ApiException;
 use Shopware\Core\Framework\Api\Context\AdminApiSource;
 use Shopware\Core\Framework\Api\Context\ShopApiSource;
 use Shopware\Core\Framework\Api\Controller\UserController;
+use Shopware\Core\Framework\Api\Response\ResponseFactoryInterface;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Sso\SsoService;
 use Shopware\Core\System\User\UserDefinition;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
@@ -57,6 +59,44 @@ class UserControllerTest extends TestCase
         $context = Context::createDefaultContext(new AdminApiSource(null));
 
         $controller->logout($context);
+    }
+
+    public function testUpdateMeAllowsChangingTimezone(): void
+    {
+        $userId = 'test-user-id';
+        $context = Context::createDefaultContext(new AdminApiSource($userId));
+        $request = Request::create('/', Request::METHOD_PATCH, ['timeZone' => 'Europe/Berlin']);
+        $responseFactory = static::createStub(ResponseFactoryInterface::class);
+        $response = new Response();
+
+        $controller = $this->getMockBuilder(UserController::class)
+            ->setConstructorArgs([
+                static::createStub(EntityRepository::class),
+                static::createStub(EntityRepository::class),
+                static::createStub(EntityRepository::class),
+                static::createStub(EntityRepository::class),
+                static::createStub(UserDefinition::class),
+                static::createStub(SsoService::class),
+            ])
+            ->onlyMethods(['upsertUser'])
+            ->getMock();
+        $controller->expects($this->once())
+            ->method('upsertUser')
+            ->with($userId, $request, $context, $responseFactory)
+            ->willReturn($response);
+
+        static::assertSame($response, $controller->updateMe($context, $request, $responseFactory));
+    }
+
+    public function testUpdateMeRejectsFieldsOutsideTheSelfProfileAllowlist(): void
+    {
+        static::expectExceptionObject(ApiException::missingPrivileges(['user:update']));
+
+        $controller = $this->createController();
+        $context = Context::createDefaultContext(new AdminApiSource('test-user-id'));
+        $request = Request::create('/', Request::METHOD_PATCH, ['title' => 'Dr.']);
+
+        $controller->updateMe($context, $request, static::createStub(ResponseFactoryInterface::class));
     }
 
     private function createController(?SsoService $ssoService = null): UserController

--- a/tests/unit/Core/Framework/Api/Controller/UserControllerTest.php
+++ b/tests/unit/Core/Framework/Api/Controller/UserControllerTest.php
@@ -94,6 +94,9 @@ class UserControllerTest extends TestCase
         $controller->updateMe($context, $request, static::createStub(ResponseFactoryInterface::class));
     }
 
+    /**
+     * @param EntityRepository<UserCollection>|null $userRepository
+     */
     private function createController(
         ?SsoService $ssoService = null,
         ?EntityRepository $userRepository = null,


### PR DESCRIPTION
### 1. Why is this change necessary?

Users with the profile-update permission cannot save a timezone change from their profile settings. The self-profile endpoint rejects the field before the user update is processed.

### 2. What does this change do, exactly?

Allow `timeZone` in the self-profile update allowlist and add unit coverage for accepting it while continuing to reject fields outside the allowlist.

#### Before

https://www.loom.com/share/eb87df945a504e8588da70220361f7d6

#### after

https://www.loom.com/share/226681bb5fcc4a6c8c9677e8c91bb9df

### 3. Describe each step to reproduce the issue or behaviour.

1. Create a non-admin permission role with the profile update permission.
2. Assign it to a user and open the profile settings.
3. Change the timezone and save.
4. The request is rejected with a misleading missing `user:update` privilege error.

### 4. Please link to the relevant issues (if any).

- closes #18594

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this is relevant for external developers
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them