### PR TITLE
fix(core): reset StructEncoder blocked custom fields cache

### DIFF
--- a/phpstan-baseline.php
+++ b/phpstan-baseline.php
@@ -946,12 +946,6 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
     'rawMessage' => 'Construct empty() is not allowed. Use more strict comparison.',
     'identifier' => 'empty.notAllowed',
-    'count' => 1,
-    'path' => __DIR__ . '/src/Core/System/SalesChannel/Api/StructEncoder.php',
-];
-$ignoreErrors[] = [
-    'rawMessage' => 'Construct empty() is not allowed. Use more strict comparison.',
-    'identifier' => 'empty.notAllowed',
     'count' => 2,
     'path' => __DIR__ . '/src/Core/System/SalesChannel/Context/CartRestorer.php',
 ];

--- a/src/Core/System/SalesChannel/Api/StructEncoder.php
+++ b/src/Core/System/SalesChannel/Api/StructEncoder.php
@@ -143,7 +143,7 @@ class StructEncoder implements ResetInterface
             if ($property === 'extensions') {
                 $data[$property] = $this->encodeExtensions($struct, $fields, $value);
 
-                if (empty($data[$property])) {
+                if ($data[$property] === []) {
                     unset($data[$property]);
                 }
 

--- a/src/Core/System/SalesChannel/Api/StructEncoder.php
+++ b/src/Core/System/SalesChannel/Api/StructEncoder.php
@@ -43,7 +43,7 @@ class StructEncoder implements ResetInterface
     public function reset(): void
     {
         $this->protections = [];
-        $this->blockedCustomFields = [];
+        $this->blockedCustomFields = null;
     }
 
     /**

--- a/tests/unit/Core/System/SalesChannel/Api/StructEncoderTest.php
+++ b/tests/unit/Core/System/SalesChannel/Api/StructEncoderTest.php
@@ -226,6 +226,44 @@ class StructEncoderTest extends TestCase
         static::assertEquals($expectedCustomFields, $encoded['translated']['customFields']);
     }
 
+    public function testResetReloadsBlockedCustomFields(): void
+    {
+        $product = new ProductEntity();
+        $product->internalSetEntityData('product', new FieldVisibility([]));
+
+        $product->setName('test');
+        $product->setCustomFields(['visible' => 'test', 'blocked' => 'test']);
+
+        $connection = $this->createMock(Connection::class);
+
+        $connection->expects($this->exactly(2))
+            ->method('fetchAllAssociative')
+            ->willReturn([
+                [
+                    'entity_name' => 'product',
+                    'name' => 'blocked',
+                ],
+            ]);
+
+        $structEncoder = $this->createStructEncoder([SalesChannelProductDefinition::class], $connection);
+
+        $expectedCustomFields = [
+            'visible' => 'test',
+        ];
+
+        $encoded = $structEncoder->encode($product, new ResponseFields());
+
+        static::assertArrayHasKey('customFields', $encoded);
+        static::assertSame($expectedCustomFields, $encoded['customFields']);
+
+        $structEncoder->reset();
+
+        $encoded = $structEncoder->encode($product, new ResponseFields());
+
+        static::assertArrayHasKey('customFields', $encoded);
+        static::assertSame($expectedCustomFields, $encoded['customFields']);
+    }
+
     public function testResponseFieldsEncodeIncludesCorrectly(): void
     {
         $product = new ProductEntity();


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

`StructEncoder` caches custom fields that are not Store API aware. That cache is loaded lazily only when `blockedCustomFields` is `null`. `reset()` currently assigns an empty array, so after a kernel reset the next encode skips the database reload and treats every custom field as allowed.

In long-running PHP workers that reuse the service (FrankenPHP, RoadRunner, Symfony kernel reset), Store API responses after the first request can leak custom fields that should stay hidden.

### 2. What does this change do, exactly?

`reset()` now restores `blockedCustomFields` to `null`, matching the service's initial state. The next `encode()` call fetches the blocked custom fields again and continues to filter them.

A unit test covers encode → reset → encode and asserts the blocked list is reloaded and still applied.

### 3. Describe each step to reproduce the issue or behaviour.

1. Create a product custom field with `storeApiAware` disabled and assign a value on a product.
2. Request that product via the Store API. The first response correctly omits the blocked custom field.
3. Trigger a service reset (`ResetInterface::reset()`, as happens between requests in a long-running worker).
4. Request the same product again via the Store API.
5. The blocked custom field is now present in `customFields`.

### 4. Please link to the relevant issues (if any).

<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
