### PR TITLE
ci: report missing codeowner approvals as pending instead of failure

### DIFF
--- a/.github/actions/codeowners-plus-status/action.yaml
+++ b/.github/actions/codeowners-plus-status/action.yaml
@@ -43,10 +43,13 @@ runs:
       with:
         script: |
           const approved = process.env.APPROVED === 'true'
+          // 'pending' blocks the merge exactly like 'failure' for a required
+          // status check, but keeps the commit rollup yellow: missing reviews
+          // are a waiting state, not a broken build.
           await github.rest.repos.createCommitStatus({
             ...context.repo,
             sha: process.env.HEAD_SHA,
-            state: approved ? 'success' : 'failure',
+            state: approved ? 'success' : 'pending',
             context: 'codeowners/approvals',
             description: approved
               ? 'All required code owners approved'


### PR DESCRIPTION
### 1. Why is this change necessary?

The `codeowners/approvals` commit status reports missing code owner approvals as `failure`. That paints the whole commit rollup red although nothing is broken: it is a review gate, not a build result, and it makes genuinely red pipelines harder to spot in the PR list.

`pending` status is enough to prevent merge, and it's actually closer to reality: the status is pending to the review to be accomplished.

### 2. What does this change do, exactly?

Reports the status as `pending` instead of `failure` while approvals are missing. For a required status check, `pending` blocks the merge exactly like `failure`; the merge box still shows the "Approvals from required code owners are still missing" description, and the status flips to `success` on the next `pull_request_review` run as before. No ruleset change is needed.

Known tradeoff: a codeowners-plus tool failure previously showed as a red status and now also shows as `pending`, since the step outcome does not distinguish "approvals missing" from "tool errored". The linked workflow run still exposes the actual error.

### 3. Describe each step to reproduce the issue or behaviour.

Open a pull request touching a path with required code owners. Before their approval the `codeowners/approvals` status is reported as pending (yellow) and the merge stays blocked; after approval the `pull_request_review` trigger re-runs the workflow and the status turns green.

Demo https://github.com/shopware/shopware/pull/19341

### 4. Please link to the relevant issues (if any).

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
