### PR TITLE
ci: demo pending codeowners status (do not merge)

### DIFF
--- a/.github/pending-status-demo.md
+++ b/.github/pending-status-demo.md
@@ -1,0 +1,5 @@
+# Temporary demo file
+
+Exists only so this pull request touches a path with a required code owner.
+The PR demonstrates the pending `codeowners/approvals` status for its base
+branch and will be closed unmerged.


### PR DESCRIPTION
Demonstrates the pending `codeowners/approvals` status from #19340: this PR targets that branch, and `pull_request_target` runs the workflow and composite action from the base branch, so the patched status reporter evaluates this PR.

Temporary, will be closed unmerged.


This demo does not show you cannot merge because it's a derived branch and the button merge differs (squash & merge) from original branch (which is the same behaviour actually)

Look more for the status 'pending' rather than 'failure'