### PR TITLE
ci: Unblock the BC baseline install from the mcp/sdk advisory

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -191,6 +191,8 @@ jobs:
           set -e
           git remote add bc-checker-upstream https://github.com/shopware/platform.git
           git fetch bc-checker-upstream
+      - name: Unblock the BC baseline install
+        run: composer config --global --json policy.advisories.ignore-id '["PKSA-p9gd-j6gr-6f9t"]'
       - name: BC Checker lastest tag
         if: github.event_name != 'pull_request'
         run: composer run bc-check


### PR DESCRIPTION
### 1. Why is this change necessary?

The trunk merge queue is fully blocked. Every `merge_group` run of `php.yml` fails in `BC Checker lastest tag`, while every `pull_request` run passes — the tag comparison only runs outside pull requests, and on a PR the base is trunk, which already carries `mcp/sdk ^0.7.0`. So a PR goes green and dies once it enters the queue.

The baseline is v6.7.13.0, whose frozen `composer.json` pins `mcp/sdk ^0.6.0`. Advisory `PKSA-p9gd-j6gr-6f9t` (CVE-2026-53965) covers `>=0.5.0 <0.7.1`, so Composer refuses to load the only satisfying version and the patched `0.7.1` is out of range for that tag. Trunk's own dependencies are unaffected and still lock `mcp/sdk v0.7.1`.

### 2. What does this change do, exactly?

Ignores that single advisory ID for the BC check job. The ignore must be global, because `roave/backward-compatibility-check` installs the baseline in a temp directory with the frozen `composer.json` of the tag.

Scoped deliberately: the baseline is installed only to diff API signatures, never shipped. We are also not affected by the vulnerability itself — it lives in `Mcp\Client\Transport\HttpTransport`, and core references no `Mcp\Client` at all.

Remove this step once a 6.7 patch release ships `mcp/sdk ^0.7.1`.

### 3. Describe each step to reproduce the issue or behaviour.

Any merge-queue entry currently reproduces it; see the runs linked in #19326. Verified locally against the baseline tag's exact constraints (`mcp/sdk ^0.6.0` plus `symfony/mcp-bundle ~0.10.0`): resolution fails with the same error, and succeeds with this config applied.

### 4. Please link to the relevant issues (if any).

- relates #19326

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [x] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
