### PR TITLE
fix(administration): synchronize cache indexer selection

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -4,10 +4,6 @@
 
 ## API
 
-### Cache information includes registered indexers
-
-`GET /api/_action/cache_info` now returns an `indexers` map containing the registered normal-refresh indexers and their optional child updaters. Administration clients can use this metadata when offering cache-index refresh controls; post-update-only indexers are excluded.
-
 ## Core
 
 ### Backward compatible invalid locales

--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -4,6 +4,10 @@
 
 ## API
 
+### Cache information includes registered indexers
+
+`GET /api/_action/cache_info` now returns an `indexers` map containing the registered normal-refresh indexers and their optional child updaters. Administration clients can use this metadata when offering cache-index refresh controls; post-update-only indexers are excluded.
+
 ## Core
 
 ### Backward compatible invalid locales

--- a/changelog/_unreleased/2026-08-14-synchronize-cache-indexer-selection.md
+++ b/changelog/_unreleased/2026-08-14-synchronize-cache-indexer-selection.md
@@ -1,0 +1,9 @@
+---
+title: Cache indexer selection uses registered indexers
+issue: 18673
+---
+# API
+* Added an `indexers` map to `GET /api/_action/cache_info` with registered normal-refresh indexers and their optional child updaters. Post-update-only indexers are excluded.
+___
+# Administration
+* Changed cache index selection to use the indexers returned by the cache-info API. Child updaters can only be selected in skip mode; only mode sends parent indexers exclusively.

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-cache/page/sw-settings-cache-index/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-cache/page/sw-settings-cache-index/index.js
@@ -37,54 +37,6 @@ export default {
             },
             indexingMethod: 'skip',
             indexerSelection: [],
-            indexers: {
-                'category.indexer': [
-                    'category.child-count',
-                    'category.tree',
-                    'category.breadcrumb',
-                    'category.seo-url',
-                ],
-                'customer.indexer': [
-                    'customer.many-to-many-id-field',
-                ],
-                'landing_page.indexer': [
-                    'landing_page.many-to-many-id-field',
-                    'landing_page.seo-url',
-                ],
-                'media.indexer': [],
-                'media_folder.indexer': [
-                    'media_folder.child-count',
-                ],
-                'media_folder_configuration.indexer': [],
-                'payment_method.indexer': [],
-                'product.indexer': [
-                    'product.inheritance',
-                    'product.stock',
-                    'product.variant-listing',
-                    'product.child-count',
-                    'product.many-to-many-id-field',
-                    'product.category-denormalizer',
-                    'product.cheapest-price',
-                    'product.rating-average',
-                    'product.stream',
-                    'product.search-keyword',
-                    'product.seo-url',
-                ],
-                'product_stream.indexer': [],
-                'product_stream_mapping.indexer': [],
-                'promotion.indexer': [
-                    'promotion.exclusion',
-                    'promotion.redemption',
-                ],
-                'rule.indexer': [
-                    'rule.payload',
-                ],
-                'sales_channel.indexer': [
-                    'sales_channel.many-to-many',
-                ],
-                'flow.indexer': [],
-                'newsletter_recipient.indexer': [],
-            },
         };
     },
 
@@ -124,6 +76,22 @@ export default {
             }
 
             return this.cacheInfo.cacheAdapter;
+        },
+
+        indexers() {
+            return this.cacheInfo?.indexers ?? {};
+        },
+    },
+
+    watch: {
+        indexingMethod(value) {
+            if (value !== 'only') {
+                return;
+            }
+
+            this.indexerSelection = this.indexerSelection.filter((selection) =>
+                Object.prototype.hasOwnProperty.call(this.indexers, selection),
+            );
         },
     },
 
@@ -251,29 +219,15 @@ export default {
             }
         },
 
+        clearIndexerSelection() {
+            this.indexerSelection = [];
+        },
+
         createOnlySelection(only) {
-            // eslint-disable-next-line no-restricted-syntax
-            for (const [
-                indexerName,
-                updaters,
-            ] of Object.entries(this.indexers)) {
+            for (const indexerName of Object.keys(this.indexers)) {
                 if (this.indexerSelection.indexOf(indexerName) > -1) {
                     only.push(indexerName);
                 }
-
-                const selectedUpdaters = [];
-                // eslint-disable-next-line no-restricted-syntax
-                for (const updater of updaters) {
-                    if (this.indexerSelection.indexOf(updater) > -1) {
-                        selectedUpdaters.push(updater);
-                    }
-                }
-
-                if (selectedUpdaters.length > 0) {
-                    only.push(indexerName);
-                }
-
-                only.push(...selectedUpdaters);
             }
         },
 

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-cache/page/sw-settings-cache-index/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-cache/page/sw-settings-cache-index/index.js
@@ -224,6 +224,7 @@ export default {
         },
 
         createOnlySelection(only) {
+            // eslint-disable-next-line no-restricted-syntax
             for (const indexerName of Object.keys(this.indexers)) {
                 if (this.indexerSelection.indexOf(indexerName) > -1) {
                     only.push(indexerName);

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-cache/page/sw-settings-cache-index/sw-settings-cache-index.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-cache/page/sw-settings-cache-index/sw-settings-cache-index.html.twig
@@ -202,6 +202,7 @@
                             class="sw-settings-cache__indexers-select"
                             :label="indexingMethod === 'skip' ? $tc('sw-settings-cache.section.indexesSkipSelectLabel') : $tc('sw-settings-cache.section.indexesOnlySelectLabel')"
                             :disabled="processes.updateIndexes"
+                            @clear="clearIndexerSelection"
                         >
                             <template #sw-select-selection>
                                 <sw-label
@@ -248,8 +249,7 @@
                                                             :label="updater"
                                                             :name="updater"
                                                             size="small"
-                                                            :disabled="indexerSelection.includes(indexer)"
-                                                            @click.prevent
+                                                            :disabled="indexingMethod === 'only' || indexerSelection.includes(indexer)"
                                                             @update:value="changeSelection($event, updater)"
                                                         />
                                                     </li>

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-cache/page/sw-settings-cache-index/sw-settings-cache-index.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-cache/page/sw-settings-cache-index/sw-settings-cache-index.spec.js
@@ -8,6 +8,9 @@ const cacheInfo = {
         httpCache: true,
         environment: 'dev',
         cacheAdapter: 'fooBar',
+        indexers: {
+            'category.indexer': ['category.tree'],
+        },
     },
 };
 
@@ -105,6 +108,17 @@ describe('module/sw-settings-cache/page/sw-settings-cache-index', () => {
         expect(mock).toHaveBeenCalledTimes(1);
     });
 
+    it('should clear the selected indexers', async () => {
+        const wrapper = await createWrapper();
+        await flushPromises();
+
+        wrapper.vm.changeSelection(true, 'category.indexer');
+
+        await wrapper.findComponent('.sw-settings-cache__indexers-select').vm.$emit('clear');
+
+        expect(wrapper.vm.indexerSelection).toEqual([]);
+    });
+
     it('should send different values for skip and only on reindex', async () => {
         const indexMock = jest.fn(() => Promise.resolve());
 
@@ -128,16 +142,12 @@ describe('module/sw-settings-cache/page/sw-settings-cache-index', () => {
         const methodSelect = wrapper.find('select[name="indexingMethod"]');
         await methodSelect.setValue('only');
 
+        wrapper.vm.changeSelection(true, 'category.indexer');
+
         await button.trigger('click');
         await flushPromises();
 
         expect(indexMock).toHaveBeenCalledTimes(2);
-        expect(indexMock).toHaveBeenCalledWith(
-            [],
-            [
-                'category.indexer',
-                'category.tree',
-            ],
-        );
+        expect(indexMock).toHaveBeenCalledWith([], ['category.indexer']);
     });
 });

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/AdminApi/paths/cache_info.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/AdminApi/paths/cache_info.json
@@ -16,6 +16,12 @@
                         "content": {
                             "application\/json": {
                                 "schema": {
+                                    "required": [
+                                        "environment",
+                                        "httpCache",
+                                        "cacheAdapter",
+                                        "indexers"
+                                    ],
                                     "properties": {
                                         "environment": {
                                             "description": "The active environment.",
@@ -28,6 +34,16 @@
                                         "cacheAdapter": {
                                             "description": "The active cache adapter.",
                                             "type": "string"
+                                        },
+                                        "indexers": {
+                                            "description": "Normal-refresh indexers and their optional child updaters.",
+                                            "type": "object",
+                                            "additionalProperties": {
+                                                "type": "array",
+                                                "items": {
+                                                    "type": "string"
+                                                }
+                                            }
                                         }
                                     },
                                     "type": "object"

--- a/src/Core/Framework/Api/Controller/CacheController.php
+++ b/src/Core/Framework/Api/Controller/CacheController.php
@@ -37,6 +37,7 @@ class CacheController extends AbstractController
             'environment' => $this->getParameter('kernel.environment'),
             'httpCache' => $this->container->get('parameter_bag')->has('shopware.http.cache.enabled') && $this->getParameter('shopware.http.cache.enabled'),
             'cacheAdapter' => $this->getUsedCache($this->adapter),
+            'indexers' => $this->indexerRegistry->getIndexers(),
         ]);
     }
 
@@ -45,8 +46,8 @@ class CacheController extends AbstractController
     {
         $data = $dataBag->all();
 
-        $skip = !empty($data['skip']) && \is_array($data['skip']) ? array_values($data['skip']) : [];
-        $only = !empty($data['only']) && \is_array($data['only']) ? array_values($data['only']) : [];
+        $skip = isset($data['skip']) && \is_array($data['skip']) && $data['skip'] !== [] ? array_values($data['skip']) : [];
+        $only = isset($data['only']) && \is_array($data['only']) && $data['only'] !== [] ? array_values($data['only']) : [];
 
         $this->indexerRegistry->sendFullIndexingMessage($skip, $only);
 

--- a/src/Core/Framework/DataAbstractionLayer/Indexing/EntityIndexerRegistry.php
+++ b/src/Core/Framework/DataAbstractionLayer/Indexing/EntityIndexerRegistry.php
@@ -212,6 +212,24 @@ class EntityIndexerRegistry
         return $this->getIndexer($name) !== null;
     }
 
+    /**
+     * @return array<string, list<string>>
+     */
+    public function getIndexers(): array
+    {
+        $indexers = [];
+
+        foreach ($this->indexer as $indexer) {
+            if ($indexer instanceof PostUpdateIndexer) {
+                continue;
+            }
+
+            $indexers[$indexer->getName()] = $indexer->getOptions();
+        }
+
+        return $indexers;
+    }
+
     public function getIndexer(string $name): ?EntityIndexer
     {
         foreach ($this->indexer as $indexer) {

--- a/tests/integration/Core/Framework/Api/Controller/CacheControllerTest.php
+++ b/tests/integration/Core/Framework/Api/Controller/CacheControllerTest.php
@@ -76,6 +76,11 @@ class CacheControllerTest extends TestCase
         static::assertIsBool($decodedContent['httpCache']);
         static::assertArrayHasKey('cacheAdapter', $decodedContent);
         static::assertSame('CacheDecorator', $decodedContent['cacheAdapter']);
+        static::assertArrayHasKey('indexers', $decodedContent);
+        static::assertIsArray($decodedContent['indexers']);
+        static::assertArrayHasKey('category.indexer', $decodedContent['indexers']);
+        static::assertContains('category.tree', $decodedContent['indexers']['category.indexer']);
+        static::assertArrayNotHasKey('product.description_teaser.indexer', $decodedContent['indexers']);
     }
 
     public function testCacheIndexEndpoint(): void

--- a/tests/unit/Core/Framework/DataAbstractionLayer/Indexing/EntityIndexerRegistryTest.php
+++ b/tests/unit/Core/Framework/DataAbstractionLayer/Indexing/EntityIndexerRegistryTest.php
@@ -11,6 +11,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Indexing\EntityIndexer;
 use Shopware\Core\Framework\DataAbstractionLayer\Indexing\EntityIndexerRegistry;
 use Shopware\Core\Framework\DataAbstractionLayer\Indexing\EntityIndexingMessage;
 use Shopware\Core\Framework\DataAbstractionLayer\Indexing\MessageQueue\FullEntityIndexerMessage;
+use Shopware\Core\Framework\DataAbstractionLayer\Indexing\PostUpdateIndexer;
 use Shopware\Core\Framework\Event\ProgressFinishedEvent;
 use Shopware\Core\Framework\Event\ProgressStartedEvent;
 use Shopware\Core\Framework\Struct\ArrayEntity;
@@ -103,6 +104,24 @@ class EntityIndexerRegistryTest extends TestCase
         $this->indexerMock2->expects($this->atLeastOnce())->method('iterate');
 
         $this->registry->index(false, $skip, $only);
+    }
+
+    public function testGetIndexersReturnsNormalIndexersAndOptions(): void
+    {
+        $normalIndexer = static::createStub(EntityIndexer::class);
+        $normalIndexer->method('getName')->willReturn('normal.indexer');
+        $normalIndexer->method('getOptions')->willReturn(['normal.option']);
+
+        $postUpdateIndexer = static::createStub(PostUpdateIndexer::class);
+        $postUpdateIndexer->method('getName')->willReturn('post-update.indexer');
+
+        $registry = new EntityIndexerRegistry(
+            [$normalIndexer, $postUpdateIndexer],
+            $this->messageBusMock,
+            $this->dispatcherMock,
+        );
+
+        static::assertSame(['normal.indexer' => ['normal.option']], $registry->getIndexers());
     }
 
     public function testRefreshMethod(): void


### PR DESCRIPTION
### 1. Why is this change necessary?

The Administration cache/index selector uses a hard-coded indexer list that can drift from registered DAL indexers. It also permits selecting child updaters in `only` mode, although the backend only supports parent indexers there.

### 2. What does this change do, exactly?

- Exposes normal-refresh indexers and their child options through the existing cache-info API.
- Builds the Administration selector from that API response.
- Excludes post-update-only indexers and limits `only` mode to parent indexers.
- Restores the selector's clear button.

### 3. Describe each step to reproduce the issue or behaviour.

1. Open Settings → System → Caches & indexes.
2. Compare selector entries with the services tagged `shopware.entity_indexer`.
3. Switch to `only` mode and select an indexer.
4. Verify that the request contains only parent indexer names.

### 4. Please link to the relevant issues (if any).

- Backport of #19270
- fixes #18673

### 5. Checklist

- [x] I have written tests
- [x] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
