### PR TITLE
fix(framework): allow users to change their timezone (backport: 6.6.x)

### DIFF
--- a/src/Core/Framework/Api/Controller/UserController.php
+++ b/src/Core/Framework/Api/Controller/UserController.php
@@ -72,7 +72,7 @@ class UserController extends AbstractController
             throw ApiException::userNotLoggedIn();
         }
 
-        $allowedChanges = ['firstName', 'lastName', 'username', 'localeId', 'email', 'avatarMedia', 'avatarId', 'password'];
+        $allowedChanges = ['firstName', 'lastName', 'username', 'localeId', 'email', 'avatarMedia', 'avatarId', 'password', 'timeZone'];
 
         if (!empty(array_diff(array_keys($request->request->all()), $allowedChanges))) {
             throw ApiException::missingPrivileges(['user:update']);

--- a/tests/unit/Core/Framework/Api/Controller/UserControllerTest.php
+++ b/tests/unit/Core/Framework/Api/Controller/UserControllerTest.php
@@ -1,0 +1,54 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\Api\Controller;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Api\Context\AdminApiSource;
+use Shopware\Core\Framework\Api\Controller\UserController;
+use Shopware\Core\Framework\Api\Response\ResponseFactoryInterface;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\System\User\UserDefinition;
+use Shopware\Core\Test\Stub\DataAbstractionLayer\StaticEntityRepository;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * @internal
+ */
+#[Package('fundamentals@framework')]
+#[CoversClass(UserController::class)]
+class UserControllerTest extends TestCase
+{
+    public function testUpdateMeAllowsChangingTimezone(): void
+    {
+        $userId = 'test-user-id';
+        $context = Context::createDefaultContext(new AdminApiSource($userId));
+        $request = Request::create('/', Request::METHOD_PATCH, ['timeZone' => 'Europe/Berlin']);
+        $userDefinition = new UserDefinition();
+        $userRepository = new StaticEntityRepository([], $userDefinition);
+        $responseFactory = $this->createMock(ResponseFactoryInterface::class);
+        $response = new Response(null, Response::HTTP_NO_CONTENT);
+        $responseFactory->expects($this->once())
+            ->method('createRedirectResponse')
+            ->with($userDefinition, $userId, $request, $context)
+            ->willReturn($response);
+
+        $controller = $this->createController(userRepository: $userRepository, userDefinition: $userDefinition);
+
+        static::assertSame(Response::HTTP_NO_CONTENT, $controller->updateMe($context, $request, $responseFactory)->getStatusCode());
+    }
+
+    private function createController(?EntityRepository $userRepository = null, ?UserDefinition $userDefinition = null): UserController
+    {
+        return new UserController(
+            $userRepository ?? static::createStub(EntityRepository::class),
+            static::createStub(EntityRepository::class),
+            static::createStub(EntityRepository::class),
+            static::createStub(EntityRepository::class),
+            $userDefinition ?? static::createStub(UserDefinition::class),
+        );
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?

The 6.6 profile endpoint rejects `timeZone` for non-admin users before processing their self-profile update, despite the field being editable in Administration.

### 2. What does this change do, exactly?

Allows `timeZone` in the self-profile update allowlist and adds focused unit coverage for the 6.6 controller.

### 3. Describe each step to reproduce the issue or behaviour.

1. Assign a non-admin user a role with the profile-update permission.
2. Open the user profile in Administration.
3. Change the timezone and save.
4. The request is rejected with a missing `user:update` privilege error.

### 4. Please link to the relevant issues (if any).

- Backport of #19334
- relates #18594

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a changelog file with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.