### PR TITLE
feat(administration): convert the component-coupled mixins to composables in the sfc codemod

### DIFF
--- a/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/TECHNICAL_README.md
+++ b/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/TECHNICAL_README.md
@@ -66,7 +66,8 @@ Examples:
 | Case | Status |
 | --- | --- |
 | Normal Options API component | `fully-migrated` |
-| Component with `mixins` | `partially-migrated`, script stays Options API |
+| Component with a registered mixin | `fully-migrated`, the mixin becomes a composable |
+| Component with an unregistered mixin | `partially-migrated`, script stays Options API |
 | Component using `Shopware.Component.extend()` | `partially-migrated`, script stays Options API |
 | Component with `render()` | `not-migratable` |
 | Template with `{% extends ... %}` | `not-migratable` |
@@ -213,7 +214,7 @@ flowchart TD
     C -- yes --> E[Detect blockers]
     E --> F{render function?}
     F -- yes --> D
-    F -- no --> G{mixins, extend, unsupported inject?}
+    F -- no --> G{unresolved mixin, extend, unsupported inject?}
     G -- yes --> H[Options API backoff]
     G -- no --> I[Build CompositionScriptState]
     I --> J[Emit script setup]
@@ -249,7 +250,7 @@ inside the SFC.
 | Feature | Handling |
 | --- | --- |
 | `render()` | Hard blocker. No SFC is generated. |
-| `mixins` | Soft blocker. Generates a plain Options API `<script>`. |
+| A mixin with no registry entry | Soft blocker. Generates a plain Options API `<script>`. |
 | `Shopware.Component.extend()` | Soft blocker. Generates a plain Options API `<script>`. |
 | Unsupported `inject` shape | Soft blocker. Generates a plain Options API `<script>`. |
 
@@ -321,6 +322,78 @@ const {
 
 Returning values under `public` is important. It exposes them to the template
 and to Shopware's Composition API extension system.
+
+## Mixins To Composables
+
+`script-transformer/composable-registry.ts` is the single declarative layer that
+maps a `this.<member>` access onto an imported composable call. It covers both
+Vue globals (`$router`, `$t`, …) and mixins.
+
+A mixin descriptor names the mixin, the composable to import, and every member
+the mixin put on `this`:
+
+```ts
+const salutationDescriptor: ComposableDescriptor = {
+    id: 'salutation',
+    trigger: { type: 'mixin', mixinNames: ['salutation'], unmappedMembers: ['salutationFilter'] },
+    import: { source: 'src/app/composables/use-salutation', name: 'useSalutation' },
+    declarationStyle: 'destructure',
+    members: methodMembers(['salutation']),
+};
+```
+
+Each member declares how it is read back:
+
+| Member kind | Rewrite of `this.<member>` |
+| --- | --- |
+| `method` | `<binding>(…)` |
+| `value` | `<binding>` |
+| `ref` | `<binding>.value` — the mixin's `data()` entries and computeds |
+
+Conversion is all-or-nothing per component: a mixin without a registry entry
+keeps the whole component on the Options API backoff. So do
+`unmappedMembers` (members the composable does not provide) and
+`internallyReferencedMembers` (members the composable calls itself, where a
+component override would silently stop taking effect).
+
+### Instance Dependencies
+
+Some mixins reach into the component instance in ways a plain composable cannot:
+they emit events, read a prop, or call a method the host is expected to override.
+The descriptor declares those, and the codemod passes them in one options
+argument:
+
+```ts
+instanceDependencies: {
+    emits: [{ option: 'onFolderChange', event: 'media-folder-change' }],
+    props: [{ option: 'item', prop: 'item' }],
+    callbacks: [{ option: 'selectableItems', member: 'selectableItems' }],
+}
+```
+
+which generates:
+
+```js
+const emit = defineEmits(['media-folder-change']);
+
+const { clearSelection } = useMediaGridListener({
+    onFolderChange: (...args) => emit('media-folder-change', ...args),
+    item: () => props.item,
+    selectableItems: () => selectableItems.value,
+});
+```
+
+| Dependency | Generated value | Backoff when |
+| --- | --- | --- |
+| `emits` | A callback forwarding to `emit`; the event joins `defineEmits`. | The component declares object-form `emits`, which cannot be merged. |
+| `props` | `() => props.<prop>` | The component does not declare the prop. |
+| `callbacks` | A getter for the component member. | The generated setup has no binding for that member. |
+
+Callback and prop values are getters so the read happens when the composable
+calls them, not while the declaration is emitted. The callback member's binding
+comes from the `createExtendableSetup()` destructure below the composable
+declaration, so a composable that invoked such a callback during setup itself
+would read it too early.
 
 ## Why `createExtendableSetup()` Is Used
 
@@ -422,6 +495,7 @@ timing does not map cleanly to generated setup code.
 | `script-transformer/emit-composition-api-script.ts` | Emits the generated `<script setup>`. |
 | `script-transformer/build-options-api-backoff.ts` | Emits plain Options API script for soft blockers. |
 | `script-transformer/rewrite-this.ts` | Rewrites known `this.*` references. |
+| `script-transformer/composable-registry.ts` | Maps globals and mixins onto composable calls. |
 | `script-transformer/extract-*.ts` | Focused extractors for Options API sections. |
 | `__fixtures__/` | Input examples used by tests. |
 | `__snapshots__/` | Expected generated output snapshots. |

--- a/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/TECHNICAL_README.md
+++ b/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/TECHNICAL_README.md
@@ -395,6 +395,34 @@ comes from the `createExtendableSetup()` destructure below the composable
 declaration, so a composable that invoked such a callback during setup itself
 would read it too early.
 
+### Mixin-Declared Props
+
+A mixin can also declare props of its own, which every component using it
+inherited. `providedProps` carries them over:
+
+```ts
+providedProps: [{ name: 'condition', definition: '{ type: Object, required: true }' }],
+```
+
+They are merged into the component's `defineProps` literal — a spread would not
+be statically analysable — and registered as prop names, so `this.condition`
+still rewrites to `props.condition`. A component prop of the same name wins,
+mirroring Vue's option merge. Unlike the instance dependencies above, these are
+contributed by every resolved mixin, used or not, because the Options API
+declared them the same way.
+
+### Mixin Names Behind A Constant
+
+Some components pass the mixin name as an imported constant rather than a string
+literal. The value lives in another module, which the transformer never reads, so
+the descriptor registers the export instead:
+
+```ts
+nameConstants: [{ source: 'src/app/mixin/rule-between-operator.mixin', exportName: 'RULE_BETWEEN_OPERATOR_MIXIN_NAME' }],
+```
+
+An unregistered constant stays an unresolved mixin and backs the component off.
+
 ## Why `createExtendableSetup()` Is Used
 
 Shopware plugins can override Administration components. After moving a

--- a/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/script-transformer/build-composition-api-script.ts
+++ b/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/script-transformer/build-composition-api-script.ts
@@ -23,9 +23,6 @@ export function buildCompositionApiScript(
         script: emitCompositionApiScript(state),
         publicNames: state.publicNames,
         manualMigrationReasons: [...new Set(state.manualMigrationReasons)],
-        backoffReasons: state.templateBindingCollisions.map(
-            (member) =>
-                `mixins: template reads '${member}' but its composable binding collides with an existing name and cannot be renamed in the template`,
-        ),
+        backoffReasons: [...new Set(state.backoffReasons)],
     };
 }

--- a/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/script-transformer/composable-registry.ts
+++ b/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/script-transformer/composable-registry.ts
@@ -35,6 +35,12 @@ export interface ComposableMemberBinding {
     sourceKey?: string;
 }
 
+/** A module export holding a mixin's registered name, for `getByName(CONSTANT)` calls. */
+export interface ComposableMixinNameConstant {
+    source: string;
+    exportName: string;
+}
+
 export type ComposableTrigger =
     // A global fires whenever any of its member keys is accessed via `this`.
     | { type: 'global' }
@@ -49,6 +55,7 @@ export type ComposableTrigger =
           mixinNames: readonly string[];
           unmappedMembers?: readonly string[];
           internallyReferencedMembers?: readonly string[];
+          nameConstants?: readonly ComposableMixinNameConstant[];
       };
 
 /** An event the mixin emitted on the host component via `this.$emit`. */
@@ -86,6 +93,17 @@ export interface ComposableInstanceDependencies {
     callbacks?: readonly ComposableCallbackDependency[];
 }
 
+/**
+ * A prop the mixin declared on every component that used it. The composable
+ * cannot declare props, so the codemod merges these into the component's own
+ * `defineProps` instead.
+ */
+export interface ComposableProvidedProp {
+    name: string;
+    /** Source text of the prop definition, e.g. `{ type: Object, required: true }`. */
+    definition: string;
+}
+
 export interface ComposableDescriptor {
     id: string;
     trigger: ComposableTrigger;
@@ -96,6 +114,7 @@ export interface ComposableDescriptor {
     /** key = the `this.<key>` access this descriptor answers. */
     members: Record<string, ComposableMemberBinding>;
     instanceDependencies?: ComposableInstanceDependencies;
+    providedProps?: readonly ComposableProvidedProp[];
 }
 
 // --- Globals -----------------------------------------------------------------
@@ -481,6 +500,111 @@ const mediaGridListenerDescriptor: ComposableDescriptor = {
     },
 };
 
+const extensionErrorDescriptor: ComposableDescriptor = {
+    id: 'sw-extension-error',
+    trigger: { type: 'mixin', mixinNames: ['sw-extension-error'] },
+    import: { source: 'src/module/sw-extension/composables/use-extension-error', name: 'useExtensionError' },
+    declarationStyle: 'destructure',
+    members: methodMembers(['showExtensionErrors']),
+};
+
+const ruleBetweenOperatorDescriptor: ComposableDescriptor = {
+    id: 'rule-between-operator',
+    trigger: {
+        type: 'mixin',
+        mixinNames: ['rule-between-operator'],
+        // Every consumer passes the name as this constant rather than a literal.
+        nameConstants: [
+            { source: 'src/app/mixin/rule-between-operator.mixin', exportName: 'RULE_BETWEEN_OPERATOR_MIXIN_NAME' },
+        ],
+    },
+    import: { source: 'src/app/composables/use-rule-between-operator', name: 'useRuleBetweenOperator' },
+    declarationStyle: 'destructure',
+    instanceDependencies: {
+        props: [{ option: 'condition', prop: 'condition' }],
+        callbacks: [{ option: 'ensureValueExist', member: 'ensureValueExist' }],
+    },
+    members: refMembers([
+        'isBetween',
+        'betweenValue',
+    ]),
+};
+
+const validationDescriptor: ComposableDescriptor = {
+    id: 'validation',
+    trigger: {
+        type: 'mixin',
+        mixinNames: ['validation'],
+        internallyReferencedMembers: ['validateRule'],
+        // `isValid` read the host's current value under whichever of
+        // currentValue/value/selections existed; the composable cannot resolve
+        // that name, so a component reading it must back off.
+        unmappedMembers: ['isValid'],
+    },
+    import: { source: 'src/app/composables/use-validation', name: 'useValidation' },
+    declarationStyle: 'destructure',
+    instanceDependencies: {
+        props: [{ option: 'validation', prop: 'validation' }],
+    },
+    providedProps: [
+        {
+            name: 'validation',
+            definition: '{ type: [String, Array, Object, Boolean], required: false, default: null }',
+        },
+    ],
+    members: {
+        validationService: { ident: ident('validationService'), kind: 'value', sourceKey: 'validationService' },
+        ...methodMembers([
+            'validate',
+            'validateRule',
+        ]),
+    },
+};
+
+const ruleContainerDescriptor: ComposableDescriptor = {
+    id: 'ruleContainer',
+    trigger: {
+        type: 'mixin',
+        mixinNames: ['ruleContainer'],
+        // nextPosition reads childAssociationField, and the placeholder watcher
+        // reads nextPosition, inside the composable.
+        internallyReferencedMembers: [
+            'childAssociationField',
+            'nextPosition',
+        ],
+    },
+    import: { source: 'src/app/composables/use-rule-container', name: 'useRuleContainer' },
+    declarationStyle: 'destructure',
+    instanceDependencies: {
+        props: [
+            { option: 'condition', prop: 'condition' },
+            { option: 'level', prop: 'level' },
+            { option: 'disabled', prop: 'disabled' },
+        ],
+        // The mixin watched nextPosition and called the host's onAddPlaceholder.
+        callbacks: [{ option: 'onAddPlaceholder', member: 'onAddPlaceholder' }],
+    },
+    providedProps: [
+        { name: 'condition', definition: '{ type: Object, required: true }' },
+        { name: 'parentCondition', definition: '{ type: Object, required: false, default: null }' },
+        { name: 'level', definition: '{ type: Number, required: true }' },
+        { name: 'disabled', definition: '{ type: Boolean, required: false, default: false }' },
+    ],
+    members: {
+        ...refMembers([
+            'conditionDataProviderService',
+            'childAssociationField',
+            'containerRowClass',
+            'nextPosition',
+        ]),
+        ...methodMembers([
+            'createCondition',
+            'insertNodeIntoTree',
+            'removeNodeFromTree',
+        ]),
+    },
+};
+
 export const MIXIN_DESCRIPTORS: readonly ComposableDescriptor[] = [
     notificationDescriptor,
     placeholderDescriptor,
@@ -494,6 +618,10 @@ export const MIXIN_DESCRIPTORS: readonly ComposableDescriptor[] = [
     mediaSidebarModalDescriptor,
     videoCoverDescriptor,
     mediaGridListenerDescriptor,
+    extensionErrorDescriptor,
+    ruleBetweenOperatorDescriptor,
+    validationDescriptor,
+    ruleContainerDescriptor,
 ];
 
 export const COMPOSABLE_REGISTRY: readonly ComposableDescriptor[] = [
@@ -515,5 +643,16 @@ export function globalThisKeys(): string[] {
 export function findMixinDescriptorByName(name: string): ComposableDescriptor | undefined {
     return MIXIN_DESCRIPTORS.find(
         (descriptor) => descriptor.trigger.type === 'mixin' && descriptor.trigger.mixinNames.includes(name),
+    );
+}
+
+/** The mixin descriptor whose name is exported as `<exportName>` from `<source>`. */
+export function findMixinDescriptorByNameConstant(source: string, exportName: string): ComposableDescriptor | undefined {
+    return MIXIN_DESCRIPTORS.find(
+        (descriptor) =>
+            descriptor.trigger.type === 'mixin' &&
+            (descriptor.trigger.nameConstants ?? []).some(
+                (constant) => constant.source === source && constant.exportName === exportName,
+            ),
     );
 }

--- a/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/script-transformer/composable-registry.ts
+++ b/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/script-transformer/composable-registry.ts
@@ -51,6 +51,41 @@ export type ComposableTrigger =
           internallyReferencedMembers?: readonly string[];
       };
 
+/** An event the mixin emitted on the host component via `this.$emit`. */
+export interface ComposableEmitDependency {
+    /** Property name on the composable's options argument. */
+    option: string;
+    /** The event the generated callback forwards to `emit`. */
+    event: string;
+}
+
+/** A prop the mixin read from the host component. */
+export interface ComposablePropDependency {
+    option: string;
+    /** The prop the component must declare; passed as a getter so reads stay reactive. */
+    prop: string;
+}
+
+/** A member the mixin expected the host component to define (an overridable). */
+export interface ComposableCallbackDependency {
+    option: string;
+    /** The component member the generated callback reads. */
+    member: string;
+}
+
+/**
+ * What a mixin needs from the component instance. A composable has no `$emit`,
+ * no props and no overridable members, so a mixin that uses any of them can only
+ * become a composable if the descriptor declares what to hand over. The codemod
+ * passes every declared dependency in one options argument:
+ * `useVideoCover({ item: () => props.item })`.
+ */
+export interface ComposableInstanceDependencies {
+    emits?: readonly ComposableEmitDependency[];
+    props?: readonly ComposablePropDependency[];
+    callbacks?: readonly ComposableCallbackDependency[];
+}
+
 export interface ComposableDescriptor {
     id: string;
     trigger: ComposableTrigger;
@@ -60,6 +95,7 @@ export interface ComposableDescriptor {
     binding?: IdentifierToken;
     /** key = the `this.<key>` access this descriptor answers. */
     members: Record<string, ComposableMemberBinding>;
+    instanceDependencies?: ComposableInstanceDependencies;
 }
 
 // --- Globals -----------------------------------------------------------------
@@ -133,6 +169,15 @@ function methodMembers(names: readonly string[]): Record<string, ComposableMembe
     return Object.fromEntries(
         names.map((name) => [name, { ident: ident(name), kind: 'method' as const, sourceKey: name }]),
     );
+}
+
+/**
+ * Build a destructured-members map for members the composable returns as refs —
+ * the mixin's `data()` entries and computeds. Reads and writes are rewritten to
+ * `<binding>.value`.
+ */
+function refMembers(names: readonly string[]): Record<string, ComposableMemberBinding> {
+    return Object.fromEntries(names.map((name) => [name, { ident: ident(name), kind: 'ref' as const, sourceKey: name }]));
 }
 
 const notificationDescriptor: ComposableDescriptor = {
@@ -259,6 +304,183 @@ const userSettingsDescriptor: ComposableDescriptor = {
     members: methodMembers(['getUserSettingsEntity', 'getUserSettings', 'saveUserSettings', 'userGridSettingsCriteria']),
 };
 
+const cmsStateDescriptor: ComposableDescriptor = {
+    id: 'cms-state',
+    trigger: {
+        type: 'mixin',
+        mixinNames: ['cms-state'],
+        // The store-backed computeds and contentEntity feed each other inside the
+        // composable, so a component override of one would not take effect.
+        internallyReferencedMembers: [
+            'cmsPageState',
+            'category',
+            'product',
+            'landingPage',
+            'contentEntity',
+            'getSlotConfigForLanguage',
+        ],
+    },
+    import: { source: 'src/module/sw-cms/composables/use-cms-state', name: 'useCmsState' },
+    declarationStyle: 'destructure',
+    members: {
+        ...refMembers([
+            'cmsPageState',
+            'selectedBlock',
+            'selectedSection',
+            'currentDeviceView',
+            'isSystemDefaultLanguage',
+            'category',
+            'product',
+            'landingPage',
+            'contentEntity',
+            'inheritedSlotConfig',
+        ]),
+        ...methodMembers(['getSlotConfigForLanguage']),
+    },
+};
+
+const mediaSidebarModalDescriptor: ComposableDescriptor = {
+    id: 'media-sidebar-modal',
+    trigger: {
+        type: 'mixin',
+        mixinNames: ['media-sidebar-modal-mixin'],
+        // The delete/dissolve/move handlers close their own modal first.
+        internallyReferencedMembers: [
+            'closeModalDelete',
+            'closeFolderDissolve',
+            'closeModalMove',
+        ],
+    },
+    import: { source: 'src/module/sw-media/composables/use-media-sidebar-modal', name: 'useMediaSidebarModal' },
+    declarationStyle: 'destructure',
+    instanceDependencies: {
+        emits: [
+            { option: 'onItemsDelete', event: 'media-sidebar-items-delete' },
+            { option: 'onFolderItemsDissolve', event: 'media-sidebar-folder-items-dissolve' },
+            { option: 'onItemsMove', event: 'media-sidebar-items-move' },
+        ],
+    },
+    members: {
+        ...refMembers([
+            'showModalReplace',
+            'showModalDelete',
+            'showFolderSettings',
+            'showFolderDissolve',
+            'showModalMove',
+        ]),
+        ...methodMembers([
+            'openModalReplace',
+            'closeModalReplace',
+            'openModalDelete',
+            'closeModalDelete',
+            'openFolderSettings',
+            'closeFolderSettings',
+            'openFolderDissolve',
+            'closeFolderDissolve',
+            'openModalMove',
+            'closeModalMove',
+            'deleteSelectedItems',
+            'onFolderDissolved',
+            'onFolderMoved',
+        ]),
+    },
+};
+
+const videoCoverDescriptor: ComposableDescriptor = {
+    id: 'video-cover',
+    trigger: {
+        type: 'mixin',
+        mixinNames: ['video-cover'],
+        // The cover computeds and persist flow call these helpers internally.
+        internallyReferencedMembers: [
+            'showCoverSelectionModal',
+            'isVideoMedia',
+            'isVideo',
+            'isImage',
+            'getCoverMediaId',
+            'closeCoverSelectionModal',
+            'persistCoverMedia',
+        ],
+    },
+    import: { source: 'src/module/sw-media/composables/use-video-cover', name: 'useVideoCover' },
+    declarationStyle: 'destructure',
+    instanceDependencies: {
+        props: [{ option: 'item', prop: 'item' }],
+    },
+    members: {
+        ...refMembers([
+            'showCoverSelectionModal',
+            'isVideoMedia',
+            'hasVideoCover',
+        ]),
+        ...methodMembers([
+            'openCoverSelectionModal',
+            'closeCoverSelectionModal',
+            'onCoverSelectionChange',
+            'persistCoverMedia',
+            'isImage',
+            'isVideo',
+            'removeVideoCover',
+            'getCoverMediaId',
+        ]),
+    },
+};
+
+const mediaGridListenerDescriptor: ComposableDescriptor = {
+    id: 'media-grid-listener',
+    trigger: {
+        type: 'mixin',
+        mixinNames: ['media-grid-listener'],
+        internallyReferencedMembers: [
+            'selectedItems',
+            'listSelectionStartItem',
+            'isListSelect',
+            'isItemSelected',
+            'navigateToFolder',
+            'handleMediaItemClicked',
+            'handleMediaGridItemSelected',
+            'handleMediaGridItemUnselected',
+        ],
+        // The mixin's underscore-prefixed selection internals stay private to the
+        // composable, so a component that calls one directly must back off.
+        unmappedMembers: [
+            '_singleSelect',
+            '_startListSelect',
+            '_handleSelection',
+            '_removeItemFromSelection',
+            '_addItemToSelection',
+            '_handleShiftSelect',
+            '_findSelectionIndices',
+        ],
+    },
+    import: { source: 'src/module/sw-media/composables/use-media-grid-listener', name: 'useMediaGridListener' },
+    declarationStyle: 'destructure',
+    instanceDependencies: {
+        emits: [{ option: 'onFolderChange', event: 'media-folder-change' }],
+        // The mixin declared an empty `selectableItems` computed purely so the host
+        // could override it; the composable takes it as a callback instead.
+        callbacks: [{ option: 'selectableItems', member: 'selectableItems' }],
+    },
+    members: {
+        ...refMembers([
+            'selectedItems',
+            'listSelectionStartItem',
+            'mediaItemSelectionHandler',
+            'isListSelect',
+        ]),
+        ...methodMembers([
+            'isItemSelected',
+            'showItemSelected',
+            'clearSelection',
+            'navigateToFolder',
+            'showDetails',
+            'handleMediaItemClicked',
+            'handleMediaGridItemSelected',
+            'handleMediaGridItemUnselected',
+        ]),
+    },
+};
+
 export const MIXIN_DESCRIPTORS: readonly ComposableDescriptor[] = [
     notificationDescriptor,
     placeholderDescriptor,
@@ -268,6 +490,10 @@ export const MIXIN_DESCRIPTORS: readonly ComposableDescriptor[] = [
     positionDescriptor,
     notificationTranslationDescriptor,
     userSettingsDescriptor,
+    cmsStateDescriptor,
+    mediaSidebarModalDescriptor,
+    videoCoverDescriptor,
+    mediaGridListenerDescriptor,
 ];
 
 export const COMPOSABLE_REGISTRY: readonly ComposableDescriptor[] = [

--- a/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/script-transformer/composition-script-state.ts
+++ b/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/script-transformer/composition-script-state.ts
@@ -43,7 +43,7 @@ import type {
     UsedComposables,
     WatchProp,
 } from './types';
-import type { ComposableDescriptor } from './composable-registry';
+import type { ComposableDescriptor, ComposableProvidedProp } from './composable-registry';
 import { GLOBAL_DESCRIPTORS } from './composable-registry';
 import { collectComponentMemberNames } from './extract-mixins';
 
@@ -125,10 +125,21 @@ export function collectCompositionScriptState(
     // no non-equivalent defineProps/defineEmits leaks; methods that depended on
     // the dropped members then surface as unresolved `this.<name>` follow-ups.
     const propsIssue = analyzePropsShape(optionsObj, moduleLocalNames);
-    const propsText = propsIssue && !propsIssue.backoff ? null : extractPropsText(optionsObj);
+    const ownPropsText = propsIssue && !propsIssue.backoff ? null : extractPropsText(optionsObj);
     if (propsIssue && !propsIssue.backoff) {
         pushManualMigration(manualMigrationReasons, todoComments, 'props', propsIssue.reason);
     }
+
+    // A mixin declared its props on every component that used it, so they are
+    // merged in regardless of whether the composable itself ends up being used.
+    // A component prop of the same name wins, mirroring Vue's option merge.
+    const ownPropNames = ownPropsText ? extractPropNamesFromText(optionsObj) : [];
+    const providedProps = collectProvidedProps(mixinDescriptors, new Set(ownPropNames));
+    const propsText = mergeProvidedProps(ownPropsText, providedProps);
+    const propNames = new Set([
+        ...ownPropNames,
+        ...providedProps.map(({ name }) => name),
+    ]);
 
     const emitsIssue = analyzeEmitsShape(optionsObj, moduleLocalNames);
     const emitsDefinition =
@@ -137,7 +148,7 @@ export function collectCompositionScriptState(
         pushManualMigration(manualMigrationReasons, todoComments, 'emits', emitsIssue.reason);
     }
 
-    const supportedMembers = collectSupportedCompositionMembers(optionsObj, propsText, composableMembers);
+    const supportedMembers = collectSupportedCompositionMembers(optionsObj, propNames, composableMembers);
     manualMigrationReasons.push(...supportedMembers.manualMigrationReasons);
     todoComments.push(...supportedMembers.todoComments);
 
@@ -148,7 +159,6 @@ export function collectCompositionScriptState(
         supportedMethodProps,
         supportedWatchProps,
         unsupportedWatchEntries,
-        propNames,
         dataNames,
         computedNames,
         methodNames,
@@ -296,7 +306,7 @@ function collectTemplateBindingCollisions(
 
 function collectSupportedCompositionMembers(
     optionsObj: ObjectLiteralExpression,
-    propsText: string | null,
+    propNames: Set<string>,
     composableMembers: Map<string, ComposableMemberRewrite>,
 ): SupportedCompositionMembers {
     const { injectProps, unsupportedEntries: unsupportedInjectEntries } = extractInjectProps(optionsObj);
@@ -353,8 +363,6 @@ function collectSupportedCompositionMembers(
         todoComments,
     );
     collectUnsupportedEntries(unsupportedMethodEntries, 'methods', 'method', manualMigrationReasons, todoComments);
-
-    const propNames = new Set(propsText ? extractPropNamesFromText(optionsObj) : []);
 
     // Dropping a member can turn a `this.<member>` reference inside another
     // member into an unresolved access, and removing duplicates can do the same.
@@ -890,6 +898,48 @@ function collectActiveGlobalComposables(usedComposables: UsedComposables): Activ
         memberKeys: Object.keys(descriptor.members),
         argumentEntries: [],
     }));
+}
+
+/** The mixin-declared props to add, first descriptor wins on a name clash. */
+function collectProvidedProps(
+    mixinDescriptors: ComposableDescriptor[],
+    ownPropNames: Set<string>,
+): ComposableProvidedProp[] {
+    const byName = new Map<string, ComposableProvidedProp>();
+
+    for (const descriptor of mixinDescriptors) {
+        for (const providedProp of descriptor.providedProps ?? []) {
+            if (ownPropNames.has(providedProp.name) || byName.has(providedProp.name)) {
+                continue;
+            }
+
+            byName.set(providedProp.name, providedProp);
+        }
+    }
+
+    return [...byName.values()];
+}
+
+/**
+ * Appends the mixin-declared props to the component's own `defineProps` object
+ * literal. `defineProps` is a compiler macro, so the entries have to end up in
+ * one literal — a spread would not be statically analysable.
+ */
+function mergeProvidedProps(propsText: string | null, providedProps: ComposableProvidedProp[]): string | null {
+    if (providedProps.length === 0) {
+        return propsText;
+    }
+
+    const entries = providedProps.map(({ name, definition }) => `    ${name}: ${definition},`).join('\n');
+    const inner = propsText === null ? '' : propsText.trim().slice(1, -1);
+    if (inner.trim() === '') {
+        return `{\n${entries}\n}`;
+    }
+
+    const body = inner.includes('\n') ? inner.replace(/^\r?\n/, '').trimEnd() : `    ${inner.trim()}`;
+    const separator = body.endsWith(',') ? '' : ',';
+
+    return `{\n${body}${separator}\n${entries}\n}`;
 }
 
 /**

--- a/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/script-transformer/composition-script-state.ts
+++ b/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/script-transformer/composition-script-state.ts
@@ -15,7 +15,10 @@ import { extractInjectProps } from './extract-inject';
 import { analyzeUnsupportedLifecycleHooks, extractLifecycleHooks } from './extract-lifecycle';
 import { extractMethodProps } from './extract-methods';
 import { extractWatchProps } from './extract-watch';
-import { isDefined, isSafeIdentifier, sanitizeTodoCommentText } from './helpers';
+import { buildPropertyAccess, isDefined, isSafeIdentifier, sanitizeTodoCommentText } from './helpers';
+import { identTemplate } from './identifier-template';
+import { emitIdent } from './identifiers';
+import { quoteJsString } from '../string-literals';
 import {
     collectEmittedEventNames,
     collectThisRefNames,
@@ -28,6 +31,7 @@ import type {
     ActiveComposable,
     CodeSnippet,
     ComponentRegistration,
+    ComposableArgument,
     ComposableMemberRewrite,
     ComputedProp,
     DataProp,
@@ -69,8 +73,8 @@ export interface CompositionScriptState {
     propNames: Set<string>;
     injectNames: Set<string>;
     manualMigrationReasons: string[];
-    /** Template-read composable members whose binding would be renamed on collision. */
-    templateBindingCollisions: string[];
+    /** Reasons the generated setup cannot be used at all — force the Options-API backoff. */
+    backoffReasons: string[];
     existingBindingNames: Set<string>;
 }
 
@@ -156,10 +160,18 @@ export function collectCompositionScriptState(
 
     const allSnippets = collectSetupSnippets(supportedMembers, lifecycleHooks);
 
+    const backoffReasons: string[] = [];
     const usedComposables = detectUsedComposables(allSnippets, supportedMembers.supportedWatchProps);
     const activeComposables = [
         ...collectActiveGlobalComposables(usedComposables),
-        ...collectActiveMixinComposables(mixinDescriptors, allSnippets, ownMemberNames, templateReferences),
+        ...collectActiveMixinComposables(
+            mixinDescriptors,
+            allSnippets,
+            ownMemberNames,
+            templateReferences,
+            ctx,
+            backoffReasons,
+        ),
     ];
     const templateRefNames = collectThisRefNames(allSnippets);
 
@@ -168,10 +180,25 @@ export function collectCompositionScriptState(
     }
     collectPlaceholderApiReasons(allSnippets, manualMigrationReasons, todoComments);
 
-    const effectiveEmitsKeys =
-        emitsDefinition.keys.length > 0 || emitsDefinition.objectText !== null
-            ? emitsDefinition.keys
-            : collectEmittedEventNames(allSnippets);
+    // Events a converted mixin used to emit through the component instance are
+    // now emitted by the callbacks the codemod passes in, so they must join the
+    // component's own defineEmits declaration.
+    const mixinEmitEvents = activeComposables.flatMap(({ descriptor }) =>
+        (descriptor.instanceDependencies?.emits ?? []).map(({ event }) => event),
+    );
+    if (mixinEmitEvents.length > 0 && emitsDefinition.objectText !== null) {
+        backoffReasons.push(
+            `mixins: object-form 'emits' cannot be merged with the mixin events ${mixinEmitEvents.map((event) => `'${event}'`).join(', ')}`,
+        );
+    }
+    const effectiveEmitsKeys = [
+        ...new Set([
+            ...(emitsDefinition.keys.length > 0 || emitsDefinition.objectText !== null
+                ? emitsDefinition.keys
+                : collectEmittedEventNames(allSnippets)),
+            ...mixinEmitEvents,
+        ]),
+    ];
 
     const regularHooks = lifecycleHooks.filter((h) => h.compositionName !== null);
     const vueImports = collectVueImports(supportedMembers, templateRefNames, usedComposables, regularHooks, allSnippets);
@@ -202,15 +229,20 @@ export function collectCompositionScriptState(
     }
 
     const existingBindingNames = collectExistingBindingNames(sourceFile);
-    const templateBindingCollisions = collectTemplateBindingCollisions(
-        activeComposables,
-        templateReferences,
-        new Set([
-            ...existingBindingNames,
-            ...publicNames,
-            ...templateRefNames,
-            'props',
-        ]),
+    backoffReasons.push(
+        ...collectTemplateBindingCollisions(
+            activeComposables,
+            templateReferences,
+            new Set([
+                ...existingBindingNames,
+                ...publicNames,
+                ...templateRefNames,
+                'props',
+            ]),
+        ).map(
+            (member) =>
+                `mixins: template reads '${member}' but its composable binding collides with an existing name and cannot be renamed in the template`,
+        ),
     );
 
     return {
@@ -239,7 +271,7 @@ export function collectCompositionScriptState(
         propNames,
         injectNames,
         manualMigrationReasons,
-        templateBindingCollisions,
+        backoffReasons,
         existingBindingNames,
     };
 }
@@ -856,7 +888,84 @@ function collectActiveGlobalComposables(usedComposables: UsedComposables): Activ
     return GLOBAL_DESCRIPTORS.filter((descriptor) => activeById[descriptor.id]).map((descriptor) => ({
         descriptor,
         memberKeys: Object.keys(descriptor.members),
+        argumentEntries: [],
     }));
+}
+
+/**
+ * Turns a descriptor's declared instance dependencies into the `option: value`
+ * entries of the composable's options argument. A dependency the generated setup
+ * cannot satisfy is a backoff reason, not a silent omission — the composable
+ * would otherwise run without the emit, prop, or override the mixin relied on.
+ */
+function resolveInstanceDependencies(
+    descriptor: ComposableDescriptor,
+    ctx: RewriteContext,
+    backoffReasons: string[],
+): ComposableArgument[] {
+    const dependencies = descriptor.instanceDependencies;
+    if (!dependencies) {
+        return [];
+    }
+
+    const argumentEntries: ComposableArgument[] = [];
+
+    for (const { option, event } of dependencies.emits ?? []) {
+        argumentEntries.push({
+            option,
+            valueSnippet: identTemplate`(...args) => ${emitIdent}(${quoteJsString(event)}, ...args)`,
+        });
+    }
+
+    for (const { option, prop } of dependencies.props ?? []) {
+        if (!ctx.propNames.has(prop)) {
+            backoffReasons.push(
+                `mixins: the '${descriptor.id}' composable needs the '${prop}' prop, which the component does not declare`,
+            );
+            continue;
+        }
+
+        argumentEntries.push({ option, valueSnippet: `() => ${buildPropertyAccess('props', prop)}` });
+    }
+
+    for (const { option, member } of dependencies.callbacks ?? []) {
+        const valueSnippet = buildCallbackSnippet(member, ctx);
+        if (valueSnippet === null) {
+            backoffReasons.push(
+                `mixins: the '${descriptor.id}' composable needs the component member '${member}', which the generated setup does not declare`,
+            );
+            continue;
+        }
+
+        argumentEntries.push({ option, valueSnippet });
+    }
+
+    return argumentEntries;
+}
+
+/**
+ * Reads an overridable component member through a getter. The binding lives in
+ * the `createExtendableSetup` destructure that follows the composable
+ * declaration, so the read must stay deferred.
+ */
+function buildCallbackSnippet(member: string, ctx: RewriteContext): string | null {
+    if (ctx.propNames.has(member)) {
+        return `() => ${buildPropertyAccess('props', member)}`;
+    }
+
+    if (ctx.dataNames.has(member) || ctx.computedNames.has(member)) {
+        return `() => ${member}.value`;
+    }
+
+    if (ctx.methodNames.has(member)) {
+        return `(...args) => ${member}(...args)`;
+    }
+
+    if (ctx.injectNames.has(member)) {
+        return `() => ${member}`;
+    }
+
+    return null;
 }
 
 /**
@@ -894,6 +1003,8 @@ function collectActiveMixinComposables(
     snippets: CodeSnippet[],
     ownMemberNames: Set<string>,
     templateReferences: Set<string>,
+    ctx: RewriteContext,
+    backoffReasons: string[],
 ): ActiveComposable[] {
     // A member counts as used when accessed via `this` in the script or read as
     // a binding in the template (e.g. `placeholder(...)` in a `{{ }}`), so a
@@ -907,7 +1018,11 @@ function collectActiveMixinComposables(
                     (hasDirectThisPropertyUsage(snippets, key) || templateReferences.has(key)),
             ),
         }))
-        .filter((active) => active.memberKeys.length > 0);
+        .filter((active) => active.memberKeys.length > 0)
+        .map((active) => ({
+            ...active,
+            argumentEntries: resolveInstanceDependencies(active.descriptor, ctx, backoffReasons),
+        }));
 }
 
 function collectVueImports(

--- a/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/script-transformer/emit-composition-api-script.ts
+++ b/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/script-transformer/emit-composition-api-script.ts
@@ -2,9 +2,14 @@ import type { CompositionScriptState } from './composition-script-state';
 import { emitCreateExtendableSetup } from './emit-create-extendable-setup';
 import { emitIdent } from './identifiers';
 import type { ComposableDescriptor } from './composable-registry';
-import type { ActiveComposable } from './types';
-import { IDENTIFIER_TEMPLATE_MARKER, identTemplate, renderIdentifierTemplates } from './identifier-template';
-import type { IdentifierTemplate, IdentifierToken, ScriptLine } from './identifier-template';
+import type { ActiveComposable, ComposableArgument } from './types';
+import {
+    IDENTIFIER_TEMPLATE_MARKER,
+    identTemplate,
+    isIdentifierTemplate,
+    renderIdentifierTemplates,
+} from './identifier-template';
+import type { IdentifierTemplate, IdentifierToken, ScriptLine, ScriptSnippet } from './identifier-template';
 
 export function emitCompositionApiScript(state: CompositionScriptState): string {
     const lines: ScriptLine[] = [];
@@ -107,14 +112,42 @@ function emitComposableDeclarations(lines: ScriptLine[], state: CompositionScrip
 }
 
 function buildComposableDeclaration(active: ActiveComposable): ScriptLine {
-    const { descriptor, memberKeys } = active;
+    const { descriptor, memberKeys, argumentEntries } = active;
 
     if (descriptor.declarationStyle === 'whole') {
         // `binding` is always set for whole descriptors.
-        return identTemplate`const ${descriptor.binding as IdentifierToken} = ${descriptor.import.name}();`;
+        return identTemplate`const ${descriptor.binding as IdentifierToken} = ${descriptor.import.name}(${buildArgumentsSnippet(argumentEntries)});`;
     }
 
-    return createDestructureDeclarationTemplate(descriptor, memberKeys);
+    return createDestructureDeclarationTemplate(descriptor, memberKeys, argumentEntries);
+}
+
+/**
+ * Renders the composable's single options argument, e.g.
+ * `{ item: () => props.item }`, or an empty string when the descriptor declares
+ * no instance dependencies.
+ */
+function buildArgumentsSnippet(argumentEntries: ComposableArgument[]): ScriptSnippet {
+    if (argumentEntries.length === 0) {
+        return '';
+    }
+
+    return {
+        [IDENTIFIER_TEMPLATE_MARKER]: true,
+        getIdentifierTokens(): IdentifierToken[] {
+            return argumentEntries.flatMap(({ valueSnippet }) =>
+                isIdentifierTemplate(valueSnippet) ? valueSnippet.getIdentifierTokens() : [],
+            );
+        },
+        render(resolve: (token: IdentifierToken) => string): string {
+            const entries = argumentEntries.map(
+                ({ option, valueSnippet }) =>
+                    `    ${option}: ${isIdentifierTemplate(valueSnippet) ? valueSnippet.render(resolve) : valueSnippet},`,
+            );
+
+            return `{\n${entries.join('\n')}\n}`;
+        },
+    };
 }
 
 function emitTemplateRefs(lines: ScriptLine[], state: CompositionScriptState): void {
@@ -140,7 +173,11 @@ function collectTakenNames(state: CompositionScriptState): Set<string> {
  * binding renders as its source key, or `sourceKey: renamed` when the identifier
  * resolver had to rename it to avoid a collision.
  */
-function createDestructureDeclarationTemplate(descriptor: ComposableDescriptor, memberKeys: string[]): IdentifierTemplate {
+function createDestructureDeclarationTemplate(
+    descriptor: ComposableDescriptor,
+    memberKeys: string[],
+    argumentEntries: ComposableArgument[],
+): IdentifierTemplate {
     const usedKeys = new Set(memberKeys);
     const seen = new Set<IdentifierToken>();
     const entries: { ident: IdentifierToken; sourceKey: string }[] = [];
@@ -152,10 +189,15 @@ function createDestructureDeclarationTemplate(descriptor: ComposableDescriptor, 
         entries.push({ ident: member.ident, sourceKey: member.sourceKey ?? '' });
     }
 
+    const argumentsSnippet = buildArgumentsSnippet(argumentEntries);
+
     return {
         [IDENTIFIER_TEMPLATE_MARKER]: true,
         getIdentifierTokens(): IdentifierToken[] {
-            return entries.map((entry) => entry.ident);
+            return [
+                ...entries.map((entry) => entry.ident),
+                ...(isIdentifierTemplate(argumentsSnippet) ? argumentsSnippet.getIdentifierTokens() : []),
+            ];
         },
         render(resolve: (token: IdentifierToken) => string): string {
             const parts = entries.map(({ ident, sourceKey }) => {
@@ -163,8 +205,9 @@ function createDestructureDeclarationTemplate(descriptor: ComposableDescriptor, 
 
                 return resolved === sourceKey ? sourceKey : `${sourceKey}: ${resolved}`;
             });
+            const args = isIdentifierTemplate(argumentsSnippet) ? argumentsSnippet.render(resolve) : argumentsSnippet;
 
-            return `const { ${parts.join(', ')} } = ${descriptor.import.name}();`;
+            return `const { ${parts.join(', ')} } = ${descriptor.import.name}(${args});`;
         },
     };
 }

--- a/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/script-transformer/extract-mixins.ts
+++ b/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/script-transformer/extract-mixins.ts
@@ -1,7 +1,7 @@
 import type { Expression, ObjectLiteralExpression, SourceFile } from 'ts-morph';
 import { Node, SyntaxKind } from 'ts-morph';
 import type { ComposableDescriptor } from './composable-registry';
-import { findMixinDescriptorByName } from './composable-registry';
+import { findMixinDescriptorByName, findMixinDescriptorByNameConstant } from './composable-registry';
 import { extractPropNamesFromText } from './extract-component-options';
 import { extractDataProps } from './extract-data';
 import { extractInjectProps } from './extract-inject';
@@ -151,6 +151,20 @@ function resolveMixinElement(element: Expression, sourceFile: SourceFile): Compo
             return resolveMixinName(name);
         }
 
+        // `getByName(MIXIN_NAME_CONSTANT)`: the value lives in another module, so
+        // it can only be resolved through a descriptor that registers the export.
+        const constantArgument = extractGetByNameIdentifierArgument(element);
+        if (constantArgument) {
+            const imported = resolveImportedIdentifier(constantArgument, sourceFile);
+            const descriptor = imported
+                ? findMixinDescriptorByNameConstant(imported.moduleSpecifier, imported.importedName)
+                : undefined;
+
+            if (descriptor) {
+                return descriptor;
+            }
+        }
+
         // Factory form `getByName('base')(<arg>)`: the base mixin drives resolution
         // and `<arg>` is a factory parameter, not a mixin name. Report the base so
         // the reason is not mistaken for the argument (e.g. a bare 'salutation').
@@ -186,32 +200,52 @@ function resolveMixinName(name: string): ComposableDescriptor | string {
 
 /** Extracts the string name from `*.getByName('name')`, or undefined. */
 function extractGetByNameArgument(call: import('ts-morph').CallExpression): string | undefined {
+    const argument = getByNameArgument(call);
+
+    return argument && Node.isStringLiteral(argument) ? argument.getLiteralValue() : undefined;
+}
+
+/** Extracts the identifier from `*.getByName(NAME)`, or undefined. */
+function extractGetByNameIdentifierArgument(
+    call: import('ts-morph').CallExpression,
+): import('ts-morph').Identifier | undefined {
+    const argument = getByNameArgument(call);
+
+    return argument && Node.isIdentifier(argument) ? argument : undefined;
+}
+
+function getByNameArgument(call: import('ts-morph').CallExpression): Expression | undefined {
     const expression = call.getExpression();
     if (!Node.isPropertyAccessExpression(expression) || expression.getName() !== 'getByName') {
         return undefined;
     }
 
-    const argument = call.getArguments()[0];
-    if (argument && Node.isStringLiteral(argument)) {
-        return argument.getLiteralValue();
-    }
-
-    return undefined;
+    return call.getArguments()[0]?.asKind(SyntaxKind.StringLiteral) ?? call.getArguments()[0]?.asKind(SyntaxKind.Identifier);
 }
 
 /** Resolves the module specifier an imported identifier was imported from. */
 function resolveImportedIdentifierModule(identifier: import('ts-morph').Identifier, sourceFile: SourceFile): string | undefined {
+    return resolveImportedIdentifier(identifier, sourceFile)?.moduleSpecifier;
+}
+
+/** Resolves an identifier to the module it was imported from and its exported name. */
+function resolveImportedIdentifier(
+    identifier: import('ts-morph').Identifier,
+    sourceFile: SourceFile,
+): { moduleSpecifier: string; importedName: string } | undefined {
     const name = identifier.getText();
 
     for (const importDeclaration of sourceFile.getImportDeclarations()) {
+        const moduleSpecifier = importDeclaration.getModuleSpecifierValue();
+
         if (importDeclaration.getDefaultImport()?.getText() === name) {
-            return importDeclaration.getModuleSpecifierValue();
+            return { moduleSpecifier, importedName: 'default' };
         }
 
         for (const namedImport of importDeclaration.getNamedImports()) {
             const localName = namedImport.getAliasNode()?.getText() ?? namedImport.getName();
             if (localName === name) {
-                return importDeclaration.getModuleSpecifierValue();
+                return { moduleSpecifier, importedName: namedImport.getName() };
             }
         }
     }

--- a/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/script-transformer/rewrite-this.ts
+++ b/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/script-transformer/rewrite-this.ts
@@ -2,8 +2,8 @@ import type { Node as TsNode, PropertyAccessExpression } from 'ts-morph';
 import { Node, SyntaxKind } from 'ts-morph';
 import { emitIdent, routeIdent } from './identifiers';
 import { findGlobalDescriptorByThisKey } from './composable-registry';
-import { createIdentifierTemplate, identTemplate, isIdentifierToken } from './identifier-template';
-import type { IdentifierTemplateValue, IdentifierToken, ScriptSnippet } from './identifier-template';
+import { createIdentifierTemplate, identTemplate, isIdentifierTemplate, isIdentifierToken } from './identifier-template';
+import type { IdentifierTemplate, IdentifierTemplateValue, IdentifierToken, ScriptSnippet } from './identifier-template';
 import type { CodeSnippet, RewriteContext, RewriteSnippetKind, UsedComposables, WatchProp } from './types';
 import {
     createWrappedSnippetSource,
@@ -270,7 +270,7 @@ export function rewriteThisInBody(bodyText: string, ctx: RewriteContext, kind: R
         lastReplacedStart = start;
     }
 
-    if (!acceptedReplacements.some(({ replacement }) => isIdentifierToken(replacement))) {
+    if (!acceptedReplacements.some(({ replacement }) => isIdentifierToken(replacement) || isIdentifierTemplate(replacement))) {
         let result = bodyText;
 
         for (const { start, end, replacement } of acceptedReplacements) {
@@ -301,7 +301,10 @@ export function rewriteThisInBody(bodyText: string, ctx: RewriteContext, kind: R
     return createIdentifierTemplate(parts);
 }
 
-function buildThisReplacement(node: PropertyAccessExpression, ctx: RewriteContext): string | IdentifierToken | null {
+function buildThisReplacement(
+    node: PropertyAccessExpression,
+    ctx: RewriteContext,
+): string | IdentifierToken | IdentifierTemplate | null {
     const refName = getThisRefName(node);
 
     if (refName) {
@@ -369,9 +372,10 @@ function buildThisReplacement(node: PropertyAccessExpression, ctx: RewriteContex
     // component-declared member of the same name wins (Vue override semantics).
     const composableMember = ctx.composableMembers.get(name);
     if (composableMember) {
-        // Every mapped mixin member is a method or plain value, so the bare binding
-        // is used as-is; none are reactive refs that would need a `.value` suffix.
-        return composableMember.binding;
+        // `ref` members mirror the mixin's data entries and computeds, so both
+        // reads and writes go through `.value`; methods and plain values use the
+        // bare binding.
+        return composableMember.kind === 'ref' ? identTemplate`${composableMember.binding}.value` : composableMember.binding;
     }
 
     // Unknown `this.<name>` is left unrewritten here; findUnsupportedThisUsage

--- a/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/script-transformer/types.ts
+++ b/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/script-transformer/types.ts
@@ -1,7 +1,13 @@
 import type { CallExpression, ObjectLiteralExpression } from 'ts-morph';
 import type { MigrationStatus } from '../types';
 import type { ComposableDescriptor, ComposableMemberKind } from './composable-registry';
-import type { IdentifierToken } from './identifier-template';
+import type { IdentifierToken, ScriptSnippet } from './identifier-template';
+
+/** One `option: <expression>` entry of a composable call's options argument. */
+export interface ComposableArgument {
+    option: string;
+    valueSnippet: ScriptSnippet;
+}
 
 /**
  * A composable the component actually uses, together with the `this.<key>`
@@ -11,6 +17,8 @@ import type { IdentifierToken } from './identifier-template';
 export interface ActiveComposable {
     descriptor: ComposableDescriptor;
     memberKeys: string[];
+    /** Resolved instance dependencies, emitted as the composable's options argument. */
+    argumentEntries: ComposableArgument[];
 }
 
 export interface TransformScriptResult {

--- a/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/transform-script.spec.ts
+++ b/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/transform-script.spec.ts
@@ -806,6 +806,142 @@ describe('scripts/codemods/sfc-migration/transform-script', () => {
     });
 
     // -------------------------------------------------------------------------
+    describe('sw-extension-error mixin: converts without any instance dependency', () => {
+        it('imports the composable and rewrites showExtensionErrors', () => {
+            const result = transformScript(
+                `Shopware.Component.register('sw-demo', {
+                    template,
+                    mixins: [Shopware.Mixin.getByName('sw-extension-error')],
+                    methods: {
+                        onError(error) { this.showExtensionErrors(error); },
+                    },
+                });`,
+            );
+
+            expect(result.status).toBe('fully-migratable');
+            expect(result.script).toContain(
+                "import { useExtensionError } from 'src/module/sw-extension/composables/use-extension-error';",
+            );
+            expect(result.script).toContain('const { showExtensionErrors } = useExtensionError();');
+        });
+    });
+
+    // -------------------------------------------------------------------------
+    describe('rule-between-operator mixin: passes the condition prop and the host callback', () => {
+        it('converts a condition component that declares condition and ensureValueExist', () => {
+            const result = transformScript(
+                `Shopware.Component.register('sw-demo', {
+                    template,
+                    mixins: [Shopware.Mixin.getByName('rule-between-operator')],
+                    props: { condition: { type: Object, required: true } },
+                    methods: {
+                        ensureValueExist() { if (!this.condition.value) { this.condition.value = {}; } },
+                    },
+                });`,
+                new Set([
+                    'isBetween',
+                    'betweenValue',
+                ]),
+            );
+
+            expect(result.status).toBe('fully-migratable');
+            expect(result.script).toContain('const { isBetween, betweenValue } = useRuleBetweenOperator({');
+            expect(result.script).toContain('condition: () => props.condition,');
+            expect(result.script).toContain('ensureValueExist: (...args) => ensureValueExist(...args),');
+        });
+
+        it('resolves the mixin name passed as the registered exported constant', () => {
+            const result = transformScript(
+                `import { RULE_BETWEEN_OPERATOR_MIXIN_NAME } from 'src/app/mixin/rule-between-operator.mixin';
+
+                Shopware.Component.register('sw-demo', {
+                    template,
+                    mixins: [Shopware.Mixin.getByName(RULE_BETWEEN_OPERATOR_MIXIN_NAME)],
+                    props: { condition: { type: Object, required: true } },
+                    methods: {
+                        ensureValueExist() { this.condition.value = this.condition.value || {}; },
+                    },
+                });`,
+                new Set(['isBetween']),
+            );
+
+            expect(result.status).toBe('fully-migratable');
+            expect(result.script).toContain('useRuleBetweenOperator({');
+        });
+
+        it('backs off for a constant no descriptor registers', () => {
+            const result = transformScript(
+                `import { SOME_MIXIN_NAME } from 'src/app/mixin/other.mixin';
+
+                Shopware.Component.register('sw-demo', {
+                    template,
+                    mixins: [Shopware.Mixin.getByName(SOME_MIXIN_NAME)],
+                });`,
+            );
+
+            expect(result.status).toBe('partially-migratable');
+            expect(result.blockers.some((b) => b.includes('unrecognised mixin call'))).toBe(true);
+        });
+    });
+
+    // -------------------------------------------------------------------------
+    describe('mixin-declared props: merges them into the component defineProps', () => {
+        it('adds the validation prop the mixin used to declare', () => {
+            const result = transformScript(
+                `Shopware.Component.register('sw-demo', {
+                    template,
+                    mixins: [Shopware.Mixin.getByName('validation')],
+                    props: { label: { type: String, required: false, default: '' } },
+                    methods: {
+                        check(value) { return this.validate(value); },
+                    },
+                });`,
+            );
+
+            expect(result.status).toBe('fully-migratable');
+            expect(result.script).toContain("label: { type: String, required: false, default: '' },");
+            expect(result.script).toContain('validation: { type: [String, Array, Object, Boolean], required: false, default: null },');
+            expect(result.script).toContain('validation: () => props.validation,');
+        });
+
+        it('emits a props object for a component that declared none', () => {
+            const result = transformScript(
+                `Shopware.Component.register('sw-demo', {
+                    template,
+                    mixins: [Shopware.Mixin.getByName('ruleContainer')],
+                    methods: {
+                        onAddPlaceholder() { this.insertNodeIntoTree(this.condition, this.nextPosition); },
+                    },
+                });`,
+            );
+
+            expect(result.status).toBe('fully-migratable');
+            expect(result.script).toContain('condition: { type: Object, required: true },');
+            expect(result.script).toContain('level: { type: Number, required: true },');
+            expect(result.script).toContain('onAddPlaceholder: (...args) => onAddPlaceholder(...args),');
+            // The mixin props feed the rewrite, so `this.condition` resolves.
+            expect(result.script).toContain('insertNodeIntoTree(props.condition, nextPosition.value)');
+        });
+
+        it('keeps the component prop when it declares one of the same name', () => {
+            const result = transformScript(
+                `Shopware.Component.register('sw-demo', {
+                    template,
+                    mixins: [Shopware.Mixin.getByName('ruleContainer')],
+                    props: { condition: { type: Object, required: false, default: null } },
+                    methods: {
+                        onAddPlaceholder() { this.insertNodeIntoTree(this.condition, this.nextPosition); },
+                    },
+                });`,
+            );
+
+            expect(result.status).toBe('fully-migratable');
+            expect(result.script).toContain('condition: { type: Object, required: false, default: null },');
+            expect(result.script).not.toContain('condition: { type: Object, required: true },');
+        });
+    });
+
+    // -------------------------------------------------------------------------
     describe('render-component: detects render() as a hard blocker and marks as not-migratable', () => {
         let result: ReturnType<typeof transformScript>;
 

--- a/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/transform-script.spec.ts
+++ b/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/transform-script.spec.ts
@@ -631,6 +631,181 @@ describe('scripts/codemods/sfc-migration/transform-script', () => {
     });
 
     // -------------------------------------------------------------------------
+    describe('cms-state mixin: converts the store-backed computeds to composable refs', () => {
+        let result: ReturnType<typeof transformScript>;
+
+        beforeAll(() => {
+            result = transformScript(
+                `Shopware.Component.register('sw-demo', {
+                    template,
+                    mixins: [Shopware.Mixin.getByName('cms-state')],
+                    computed: {
+                        hasOverrides() { return !Shopware.Utils.types.isEmpty(this.contentEntity?.slotConfig); },
+                    },
+                    methods: {
+                        reset() { this.selectedBlock = null; },
+                        view() { return this.currentDeviceView; },
+                    },
+                });`,
+            );
+        });
+
+        it('reports status fully-migratable with no blockers', () => {
+            expect(result.status).toBe('fully-migratable');
+            expect(result.blockers).toEqual([]);
+        });
+
+        it('imports the composable without an options argument — it needs nothing from the instance', () => {
+            expect(result.script).toContain("import { useCmsState } from 'src/module/sw-cms/composables/use-cms-state';");
+            expect(result.script).toContain('const { selectedBlock, currentDeviceView, contentEntity } = useCmsState();');
+        });
+
+        it('rewrites reads and writes of ref members through .value', () => {
+            expect(result.script).toContain('contentEntity.value?.slotConfig');
+            expect(result.script).toContain('selectedBlock.value = null;');
+            expect(result.script).toContain('return currentDeviceView.value;');
+            expect(result.script).not.toMatch(/\bthis\./);
+        });
+    });
+
+    // -------------------------------------------------------------------------
+    describe('mixin instance dependency `emits`: wires the mixin events to defineEmits', () => {
+        it('merges the mixin events with the component emits and passes emit callbacks', () => {
+            const result = transformScript(
+                `Shopware.Component.register('sw-demo', {
+                    template,
+                    emits: ['media-item-selection-remove'],
+                    mixins: [Shopware.Mixin.getByName('media-sidebar-modal-mixin')],
+                    methods: {
+                        onDelete(ids) { this.deleteSelectedItems(ids); },
+                    },
+                });`,
+            );
+
+            expect(result.status).toBe('fully-migratable');
+            expect(result.script).toContain(
+                "const emit = defineEmits(['media-item-selection-remove', 'media-sidebar-items-delete', 'media-sidebar-folder-items-dissolve', 'media-sidebar-items-move']);",
+            );
+            expect(result.script).toContain("onItemsDelete: (...args) => emit('media-sidebar-items-delete', ...args),");
+            expect(result.script).toContain('} = useMediaSidebarModal({');
+        });
+
+        it('backs off when the component declares object-form emits that cannot be merged', () => {
+            const result = transformScript(
+                `Shopware.Component.register('sw-demo', {
+                    template,
+                    emits: { 'media-item-selection-remove': null },
+                    mixins: [Shopware.Mixin.getByName('media-sidebar-modal-mixin')],
+                    methods: {
+                        onDelete(ids) { this.deleteSelectedItems(ids); },
+                    },
+                });`,
+            );
+
+            expect(result.status).toBe('partially-migratable');
+            expect(result.scriptType).toBe('options');
+            expect(result.blockers.some((b) => b.includes("object-form 'emits' cannot be merged"))).toBe(true);
+        });
+    });
+
+    // -------------------------------------------------------------------------
+    describe('mixin instance dependency `props`: passes the required prop as a getter', () => {
+        it('converts a component that declares the prop the mixin reads', () => {
+            const result = transformScript(
+                `Shopware.Component.register('sw-demo', {
+                    template,
+                    mixins: [Shopware.Mixin.getByName('video-cover')],
+                    props: { item: { type: Object, required: true } },
+                    methods: {
+                        open() { this.openCoverSelectionModal(); },
+                    },
+                });`,
+            );
+
+            expect(result.status).toBe('fully-migratable');
+            expect(result.script).toContain('} = useVideoCover({');
+            expect(result.script).toContain('item: () => props.item,');
+        });
+
+        it('backs off when the component does not declare the required prop', () => {
+            const result = transformScript(
+                `Shopware.Component.register('sw-demo', {
+                    template,
+                    mixins: [Shopware.Mixin.getByName('video-cover')],
+                    methods: {
+                        open() { this.openCoverSelectionModal(); },
+                    },
+                });`,
+            );
+
+            expect(result.status).toBe('partially-migratable');
+            expect(result.scriptType).toBe('options');
+            expect(result.blockers).toContain(
+                "mixins: the 'video-cover' composable needs the 'item' prop, which the component does not declare",
+            );
+        });
+    });
+
+    // -------------------------------------------------------------------------
+    describe('mixin instance dependency `callbacks`: passes the overridable member as a getter', () => {
+        it('converts a component that declares the member the mixin expects it to override', () => {
+            const result = transformScript(
+                `Shopware.Component.register('sw-demo', {
+                    template,
+                    mixins: [Shopware.Mixin.getByName('media-grid-listener')],
+                    computed: {
+                        selectableItems() { return []; },
+                    },
+                    methods: {
+                        reset() { this.clearSelection(); },
+                    },
+                });`,
+            );
+
+            expect(result.status).toBe('fully-migratable');
+            expect(result.script).toContain('selectableItems: () => selectableItems.value,');
+            expect(result.script).toContain("onFolderChange: (...args) => emit('media-folder-change', ...args),");
+        });
+
+        it('backs off when the component does not declare the overridable member', () => {
+            const result = transformScript(
+                `Shopware.Component.register('sw-demo', {
+                    template,
+                    mixins: [Shopware.Mixin.getByName('media-grid-listener')],
+                    methods: {
+                        reset() { this.clearSelection(); },
+                    },
+                });`,
+            );
+
+            expect(result.status).toBe('partially-migratable');
+            expect(result.scriptType).toBe('options');
+            expect(result.blockers).toContain(
+                "mixins: the 'media-grid-listener' composable needs the component member 'selectableItems', which the generated setup does not declare",
+            );
+        });
+
+        it('backs off when the component calls a selection internal the composable keeps private', () => {
+            const result = transformScript(
+                `Shopware.Component.register('sw-demo', {
+                    template,
+                    mixins: [Shopware.Mixin.getByName('media-grid-listener')],
+                    computed: {
+                        selectableItems() { return []; },
+                    },
+                    methods: {
+                        pick(item) { this._singleSelect(item); },
+                    },
+                });`,
+            );
+
+            expect(result.status).toBe('partially-migratable');
+            expect(result.scriptType).toBe('options');
+            expect(result.blockers.some((b) => b.includes("reads '_singleSelect'"))).toBe(true);
+        });
+    });
+
+    // -------------------------------------------------------------------------
     describe('render-component: detects render() as a hard blocker and marks as not-migratable', () => {
         let result: ReturnType<typeof transformScript>;
 

--- a/src/Administration/Resources/app/administration/src/app/composables/use-rule-between-operator.spec.ts
+++ b/src/Administration/Resources/app/administration/src/app/composables/use-rule-between-operator.spec.ts
@@ -1,0 +1,76 @@
+/**
+ * @sw-package fundamentals@after-sales
+ */
+import { useRuleBetweenOperator } from './use-rule-between-operator';
+
+interface TestCondition {
+    value?: { operator?: string; renderedFieldValue?: unknown } | null;
+}
+
+function createComposable(condition: TestCondition | null) {
+    const ensureValueExist = jest.fn();
+
+    return {
+        ensureValueExist,
+        condition,
+        composable: useRuleBetweenOperator({ condition: () => condition, ensureValueExist }),
+    };
+}
+
+describe('src/app/composables/use-rule-between-operator', () => {
+    it('is only between for the between operator', () => {
+        expect(createComposable({ value: { operator: 'between' } }).composable.isBetween.value).toBe(true);
+        expect(createComposable({ value: { operator: 'gte' } }).composable.isBetween.value).toBe(false);
+        expect(createComposable({}).composable.isBetween.value).toBe(false);
+        expect(createComposable(null).composable.isBetween.value).toBe(false);
+    });
+
+    it('reads the from/to pair off the rendered field value', () => {
+        const { composable } = createComposable({
+            value: { operator: 'between', renderedFieldValue: { from: '2026-01-01', to: '2026-02-01' } },
+        });
+
+        expect(composable.betweenValue.value).toEqual({ from: '2026-01-01', to: '2026-02-01' });
+    });
+
+    it.each([
+        [
+            'a missing value',
+            {},
+        ],
+        [
+            'null',
+            { value: { renderedFieldValue: null } },
+        ],
+        [
+            'an array',
+            { value: { renderedFieldValue: [] } },
+        ],
+    ])('falls back to an empty pair for %s', (_name, condition) => {
+        const { composable } = createComposable(condition);
+
+        expect(composable.betweenValue.value).toEqual({ from: null, to: null });
+    });
+
+    it('fills in the missing half of a partial pair', () => {
+        const { composable } = createComposable({ value: { renderedFieldValue: { from: '2026-01-01' } } });
+
+        expect(composable.betweenValue.value).toEqual({ from: '2026-01-01', to: null });
+    });
+
+    it('lets the caller create the value before writing the pair back', () => {
+        const condition: TestCondition = {};
+        const ensureValueExist = jest.fn(() => {
+            condition.value = { operator: 'between' };
+        });
+        const composable = useRuleBetweenOperator({ condition: () => condition, ensureValueExist });
+
+        composable.betweenValue.value = { from: '2026-01-01', to: '2026-02-01' };
+
+        expect(ensureValueExist).toHaveBeenCalledTimes(1);
+        expect(condition.value).toEqual({
+            operator: 'between',
+            renderedFieldValue: { from: '2026-01-01', to: '2026-02-01' },
+        });
+    });
+});

--- a/src/Administration/Resources/app/administration/src/app/composables/use-rule-between-operator.ts
+++ b/src/Administration/Resources/app/administration/src/app/composables/use-rule-between-operator.ts
@@ -1,0 +1,81 @@
+/**
+ * @sw-package fundamentals@after-sales
+ */
+import { computed } from 'vue';
+import type { ComputedRef, WritableComputedRef } from 'vue';
+
+/** @private */
+export type BetweenValue = {
+    from: string | null;
+    to: string | null;
+};
+
+interface RuleCondition {
+    value?: {
+        operator?: string;
+        renderedFieldValue?: unknown;
+        [key: string]: unknown;
+    } | null;
+}
+
+/**
+ * The mixin read `this.condition` and called the host's `ensureValueExist()`
+ * before writing to it. Both are passed in, because a composable has neither.
+ *
+ * @private
+ */
+export interface UseRuleBetweenOperatorOptions {
+    condition: () => RuleCondition | null | undefined;
+    ensureValueExist: () => void;
+}
+
+/** @private */
+export interface UseRuleBetweenOperatorReturn {
+    isBetween: ComputedRef<boolean>;
+    betweenValue: WritableComputedRef<BetweenValue>;
+}
+
+/**
+ * Composable alternative to the `rule-between-operator` mixin: renders a
+ * condition's `between` operator as a from/to pair on a date or datetime field.
+ *
+ * Keep this and `src/app/mixin/rule-between-operator.mixin.ts` in sync —
+ * change both together.
+ *
+ * @private
+ */
+export function useRuleBetweenOperator(options: UseRuleBetweenOperatorOptions): UseRuleBetweenOperatorReturn {
+    const isBetween = computed(() => options.condition()?.value?.operator === 'between');
+
+    const betweenValue = computed<BetweenValue>({
+        get: () => {
+            const raw: unknown = options.condition()?.value?.renderedFieldValue;
+
+            if (raw === null || typeof raw !== 'object' || Array.isArray(raw)) {
+                return { from: null, to: null };
+            }
+
+            const value = raw as Partial<BetweenValue>;
+
+            return {
+                from: value.from ?? null,
+                to: value.to ?? null,
+            };
+        },
+        set: (value: BetweenValue) => {
+            options.ensureValueExist();
+
+            const condition = options.condition();
+            if (!condition) {
+                return;
+            }
+
+            condition.value = {
+                ...condition.value,
+                renderedFieldValue: value,
+            };
+        },
+    });
+
+    return { isBetween, betweenValue };
+}

--- a/src/Administration/Resources/app/administration/src/app/composables/use-rule-container.spec.ts
+++ b/src/Administration/Resources/app/administration/src/app/composables/use-rule-container.spec.ts
@@ -1,0 +1,107 @@
+/**
+ * @sw-package framework
+ */
+import { mount } from '@vue/test-utils';
+import { computed, nextTick, reactive } from 'vue';
+import { useRuleContainer } from './use-rule-container';
+import type { RuleConditionNode, UseRuleContainerOptions, UseRuleContainerReturn } from './use-rule-container';
+
+const conditionDataProviderService = { getPlaceholderData: () => ({}) };
+
+function createComposable(options: Partial<UseRuleContainerOptions> & { condition: () => RuleConditionNode }) {
+    const onAddPlaceholder = options.onAddPlaceholder ?? jest.fn();
+    let composable: UseRuleContainerReturn | undefined;
+
+    mount(
+        {
+            template: '<div></div>',
+            setup() {
+                composable = useRuleContainer({
+                    level: () => 0,
+                    disabled: () => false,
+                    ...options,
+                    onAddPlaceholder,
+                });
+
+                return {};
+            },
+        },
+        {
+            global: {
+                provide: {
+                    conditionDataProviderService: computed(() => conditionDataProviderService),
+                    childAssociationField: computed(() => 'children'),
+                    createCondition: jest.fn(),
+                    insertNodeIntoTree: jest.fn(),
+                    removeNodeFromTree: jest.fn(),
+                },
+            },
+        },
+    );
+
+    return { onAddPlaceholder, composable: composable as UseRuleContainerReturn };
+}
+
+describe('src/app/composables/use-rule-container', () => {
+    it('unwraps the refs sw-condition-tree provides', () => {
+        const { composable } = createComposable({ condition: () => ({}) });
+
+        expect(composable.childAssociationField.value).toBe('children');
+        expect(composable.conditionDataProviderService.value).toBe(conditionDataProviderService);
+    });
+
+    it.each([
+        [
+            0,
+            'container-condition-level__is--even',
+        ],
+        [
+            1,
+            'container-condition-level__is--odd',
+        ],
+        [
+            2,
+            'container-condition-level__is--even',
+        ],
+    ])('marks level %s as %s', (level, expectedClass) => {
+        const { composable } = createComposable({ condition: () => ({}), level: () => level });
+
+        expect(composable.containerRowClass.value).toEqual({ 'is--disabled': false, [expectedClass]: true });
+    });
+
+    it('reports the disabled state on the row class', () => {
+        const { composable } = createComposable({ condition: () => ({}), disabled: () => true });
+
+        expect(composable.containerRowClass.value['is--disabled']).toBe(true);
+    });
+
+    it('counts the children of the provided association field as the next position', () => {
+        const { composable } = createComposable({
+            condition: () => ({
+                children: [
+                    {},
+                    {},
+                ],
+            }),
+        });
+
+        expect(composable.nextPosition.value).toBe(2);
+    });
+
+    it('reports position 0 for a container without children', () => {
+        expect(createComposable({ condition: () => ({}) }).composable.nextPosition.value).toBe(0);
+        expect(createComposable({ condition: () => ({ children: [] }) }).composable.nextPosition.value).toBe(0);
+    });
+
+    it('asks the caller for a placeholder once the last child is gone', async () => {
+        const condition = reactive<RuleConditionNode>({ children: [{}] });
+        const { onAddPlaceholder } = createComposable({ condition: () => condition });
+
+        expect(onAddPlaceholder).not.toHaveBeenCalled();
+
+        (condition.children as unknown[]).pop();
+        await nextTick();
+
+        expect(onAddPlaceholder).toHaveBeenCalledTimes(1);
+    });
+});

--- a/src/Administration/Resources/app/administration/src/app/composables/use-rule-container.ts
+++ b/src/Administration/Resources/app/administration/src/app/composables/use-rule-container.ts
@@ -1,0 +1,106 @@
+/**
+ * @sw-package framework
+ */
+import { computed, inject, unref, watch } from 'vue';
+import type { ComputedRef } from 'vue';
+
+/** @private */
+export interface RuleConditionNode {
+    id?: string;
+    [key: string]: unknown;
+}
+
+/** @private */
+export interface ContainerRowClass {
+    'is--disabled': boolean;
+    'container-condition-level__is--odd'?: boolean;
+    'container-condition-level__is--even'?: boolean;
+}
+
+/**
+ * The mixin declared the `condition`, `level` and `disabled` props itself and
+ * watched `nextPosition` to call the host's `onAddPlaceholder()`. The props are
+ * passed in as getters and the watcher callback as an option, because a
+ * composable can declare neither.
+ *
+ * @private
+ */
+export interface UseRuleContainerOptions {
+    condition: () => RuleConditionNode;
+    level: () => number;
+    disabled: () => boolean;
+    onAddPlaceholder: () => void;
+}
+
+/** @private */
+export interface UseRuleContainerReturn {
+    conditionDataProviderService: ComputedRef<unknown>;
+    childAssociationField: ComputedRef<string>;
+    createCondition: (conditionData: unknown, parentId: string | null, position: number) => RuleConditionNode;
+    insertNodeIntoTree: (parentCondition: RuleConditionNode, childToInsert: RuleConditionNode) => void;
+    removeNodeFromTree: (parentCondition: RuleConditionNode, childToRemove: RuleConditionNode) => void;
+    containerRowClass: ComputedRef<ContainerRowClass>;
+    nextPosition: ComputedRef<number>;
+}
+
+/**
+ * Composable alternative to the `ruleContainer` mixin: the shared state of a
+ * condition container inside `sw-condition-tree`.
+ *
+ * `sw-condition-tree` provides `childAssociationField` and
+ * `conditionDataProviderService` as computed refs. The Options API unwrapped
+ * them on the instance proxy; here they stay refs and are returned as such.
+ *
+ * Keep this and `src/app/mixin/rule-container.mixin.ts` in sync —
+ * change both together.
+ *
+ * @private
+ */
+export function useRuleContainer(options: UseRuleContainerOptions): UseRuleContainerReturn {
+    const injectedDataProviderService = inject<unknown>('conditionDataProviderService');
+    const injectedChildAssociationField = inject<string | ComputedRef<string>>('childAssociationField', '');
+    const createCondition = inject<UseRuleContainerReturn['createCondition']>('createCondition');
+    const insertNodeIntoTree = inject<UseRuleContainerReturn['insertNodeIntoTree']>('insertNodeIntoTree');
+    const removeNodeFromTree = inject<UseRuleContainerReturn['removeNodeFromTree']>('removeNodeFromTree');
+
+    const conditionDataProviderService = computed(() => unref(injectedDataProviderService));
+    const childAssociationField = computed(() => unref(injectedChildAssociationField));
+
+    const containerRowClass = computed<ContainerRowClass>(() => {
+        const classes: ContainerRowClass = {
+            'is--disabled': options.disabled(),
+        };
+
+        const level = options.level() % 2 ? 'container-condition-level__is--odd' : 'container-condition-level__is--even';
+
+        classes[level] = true;
+
+        return classes;
+    });
+
+    const nextPosition = computed(() => {
+        const children = options.condition()[childAssociationField.value] as { length: number } | undefined;
+
+        if (children && children.length > 0) {
+            return children.length;
+        }
+
+        return 0;
+    });
+
+    watch(nextPosition, () => {
+        if (nextPosition.value === 0) {
+            options.onAddPlaceholder();
+        }
+    });
+
+    return {
+        conditionDataProviderService,
+        childAssociationField,
+        createCondition: createCondition as UseRuleContainerReturn['createCondition'],
+        insertNodeIntoTree: insertNodeIntoTree as UseRuleContainerReturn['insertNodeIntoTree'],
+        removeNodeFromTree: removeNodeFromTree as UseRuleContainerReturn['removeNodeFromTree'],
+        containerRowClass,
+        nextPosition,
+    };
+}

--- a/src/Administration/Resources/app/administration/src/app/composables/use-validation.spec.ts
+++ b/src/Administration/Resources/app/administration/src/app/composables/use-validation.spec.ts
@@ -1,0 +1,73 @@
+/**
+ * @sw-package framework
+ */
+import { mount } from '@vue/test-utils';
+import { useValidation } from './use-validation';
+import type { UseValidationReturn, ValidationRules } from './use-validation';
+
+const validationService = {
+    required: (value: unknown) => !!value,
+    email: (value: unknown) => typeof value === 'string' && value.includes('@'),
+};
+
+function createComposable(validation: ValidationRules, service: unknown = validationService): UseValidationReturn {
+    let composable: UseValidationReturn | undefined;
+
+    mount(
+        {
+            template: '<div></div>',
+            setup() {
+                composable = useValidation({ validation: () => validation });
+
+                return {};
+            },
+        },
+        { global: { provide: { validationService: service } } },
+    );
+
+    return composable as UseValidationReturn;
+}
+
+describe('src/app/composables/use-validation', () => {
+    it('returns a boolean rule as-is', () => {
+        expect(createComposable(true).validate('')).toBe(true);
+        expect(createComposable(false).validate('anything')).toBe(false);
+    });
+
+    it('runs a single rule name against the injected validation service', () => {
+        const { validate } = createComposable('required');
+
+        expect(validate('value')).toBe(true);
+        expect(validate('')).toBe(false);
+    });
+
+    it('splits a comma-separated rule list and requires every rule to pass', () => {
+        const { validate } = createComposable('required,email');
+
+        expect(validate('user@example.com')).toBe(true);
+        expect(validate('user')).toBe(false);
+    });
+
+    it('accepts an array of rules and booleans', () => {
+        expect(createComposable(['required']).validate('value')).toBe(true);
+        expect(
+            createComposable([
+                'required',
+                'email',
+            ]).validate('value'),
+        ).toBe(false);
+        expect(createComposable([false]).validate('value')).toBe(false);
+        expect(createComposable([{ nested: true }] as unknown as ValidationRules).validate('value')).toBe(false);
+    });
+
+    it('fails a rule the validation service does not know', () => {
+        expect(createComposable('unknownRule').validate('value')).toBe(false);
+    });
+
+    it('fails every rule when no validation service was provided', () => {
+        const { validate, validationService: injected } = createComposable('required', null);
+
+        expect(injected).toBeNull();
+        expect(validate('value')).toBe(false);
+    });
+});

--- a/src/Administration/Resources/app/administration/src/app/composables/use-validation.ts
+++ b/src/Administration/Resources/app/administration/src/app/composables/use-validation.ts
@@ -1,0 +1,88 @@
+/**
+ * @sw-package framework
+ */
+import { inject } from 'vue';
+
+/** @private */
+export type ValidationRules = string | boolean | Array<string | boolean> | Record<string, unknown> | null;
+
+type ValidationService = Record<string, (value: unknown) => boolean> | null;
+
+/**
+ * The mixin declared the `validation` prop itself; the composable takes it as a
+ * getter so the rules stay reactive.
+ *
+ * @private
+ */
+export interface UseValidationOptions {
+    validation: () => ValidationRules;
+}
+
+/** @private */
+export interface UseValidationReturn {
+    validationService: ValidationService;
+    validate: (value: unknown) => boolean;
+    validateRule: (value: unknown, rule: string) => boolean;
+}
+
+/**
+ * Composable alternative to the `validation` mixin: runs a field value against
+ * the rules of the `validation` prop.
+ *
+ * The mixin also exposed an `isValid` computed that read the host's current
+ * value under whichever of `currentValue`, `value` or `selections` existed. That
+ * name is not knowable up front, so the composable leaves it out — call
+ * `validate(...)` with the value instead.
+ *
+ * Keep this and `src/app/mixin/validation.mixin.ts` in sync — change both together.
+ *
+ * @private
+ */
+export function useValidation(options: UseValidationOptions): UseValidationReturn {
+    const validationService = inject<ValidationService>('validationService', null);
+
+    function validateRule(value: unknown, rule: string): boolean {
+        if (typeof validationService?.[rule] === 'undefined') {
+            return false;
+        }
+
+        return validationService[rule](value);
+    }
+
+    function validate(value: unknown): boolean {
+        let validation = options.validation();
+        let valid = true;
+
+        if (Shopware.Utils.types.isBoolean(validation)) {
+            return validation;
+        }
+
+        if (Shopware.Utils.types.isString(validation)) {
+            const validationList = validation.split(',');
+
+            if (validationList.length > 1) {
+                validation = validationList;
+            } else {
+                valid = validateRule(value, validation);
+            }
+        }
+
+        if (Shopware.Utils.types.isArray(validation)) {
+            valid = validation.every((validationRule) => {
+                if (Shopware.Utils.types.isBoolean(validationRule)) {
+                    return validationRule;
+                }
+
+                if (Shopware.Utils.types.isString(validationRule)) {
+                    return validateRule(value, validationRule.trim());
+                }
+
+                return false;
+            });
+        }
+
+        return valid;
+    }
+
+    return { validationService, validate, validateRule };
+}

--- a/src/Administration/Resources/app/administration/src/app/mixin/rule-between-operator.mixin.ts
+++ b/src/Administration/Resources/app/administration/src/app/mixin/rule-between-operator.mixin.ts
@@ -17,6 +17,8 @@ type BetweenValue = {
  * Adds `isBetween` and `betweenValue` to a condition component so
  * it can render a two picker ui for the `between` operator on a date / datetime
  * field.
+ *
+ * Duplicated in `src/app/composables/use-rule-between-operator`; change both together.
  */
 export default Shopware.Mixin.register(
     RULE_BETWEEN_OPERATOR_MIXIN_NAME,

--- a/src/Administration/Resources/app/administration/src/app/mixin/rule-container.mixin.ts
+++ b/src/Administration/Resources/app/administration/src/app/mixin/rule-container.mixin.ts
@@ -6,6 +6,8 @@ import { defineComponent } from 'vue';
 
 /**
  * @private
+ *
+ * Duplicated in `src/app/composables/use-rule-container`; change both together.
  */
 export default Shopware.Mixin.register(
     'ruleContainer',

--- a/src/Administration/Resources/app/administration/src/app/mixin/validation.mixin.ts
+++ b/src/Administration/Resources/app/administration/src/app/mixin/validation.mixin.ts
@@ -6,6 +6,8 @@ import { defineComponent } from 'vue';
  * @sw-package framework
  *
  * @module app/mixin/validation
+ *
+ * Duplicated in `src/app/composables/use-validation`; change both together.
  */
 export default Shopware.Mixin.register(
     'validation',

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/composables/use-cms-state.spec.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/composables/use-cms-state.spec.ts
@@ -1,0 +1,140 @@
+/**
+ * @sw-package discovery
+ */
+import { useRoute } from 'vue-router';
+import { setupCmsEnvironment } from 'src/module/sw-cms/test-utils';
+import { useCmsState } from './use-cms-state';
+
+jest.mock('vue-router', () => {
+    const actual: object = jest.requireActual('vue-router');
+
+    return { ...actual, useRoute: jest.fn(() => ({ name: '' })) };
+});
+
+const useRouteMock = useRoute as unknown as jest.Mock;
+
+function onRoute(name: string): void {
+    useRouteMock.mockReturnValue({ name });
+}
+
+describe('src/module/sw-cms/composables/use-cms-state', () => {
+    let initialLanguageId: string | null;
+    let initialLanguage: { name: string; parentId?: string } | null;
+
+    beforeAll(async () => {
+        await setupCmsEnvironment();
+    });
+
+    beforeEach(() => {
+        onRoute('');
+        initialLanguageId = Shopware.Store.get('context').api.languageId;
+        initialLanguage = Shopware.Store.get('context').api.language;
+    });
+
+    afterEach(() => {
+        Shopware.Store.get('cmsPage').resetCmsPageState();
+        Shopware.Store.get('context').api.languageId = initialLanguageId;
+        Shopware.Store.get('context').api.language = initialLanguage;
+    });
+
+    it('reads and writes the selection through the shared cms page store', () => {
+        const { selectedBlock, selectedSection, currentDeviceView, isSystemDefaultLanguage } = useCmsState();
+        const store = Shopware.Store.get('cmsPage');
+
+        const block = { id: 'block-1234' } as Entity<'cms_block'>;
+        selectedBlock.value = block;
+        expect(selectedBlock.value).toEqual(block);
+        expect(store.selectedBlock).toEqual(block);
+
+        const section = { id: 'section-1234' } as Entity<'cms_section'>;
+        selectedSection.value = section;
+        expect(selectedSection.value).toEqual(section);
+        expect(store.selectedSection).toEqual(section);
+
+        expect(currentDeviceView.value).toBe('desktop');
+        store.setCurrentCmsDeviceView('mobile');
+        expect(currentDeviceView.value).toBe('mobile');
+
+        expect(isSystemDefaultLanguage.value).toBe(true);
+        store.setIsSystemDefaultLanguage(false);
+        expect(isSystemDefaultLanguage.value).toBe(false);
+    });
+
+    it('resolves the content entity from the current route', () => {
+        onRoute('sw.category.detail.cms');
+        const category = { id: 'category-1', name: 'Test Category', translations: [] };
+        Shopware.Store.get('swCategoryDetail').category = category as never;
+
+        const { contentEntity } = useCmsState();
+
+        expect(contentEntity.value).toMatchObject(category);
+    });
+
+    it('returns no content entity outside the category, product and landing page routes', () => {
+        const { contentEntity } = useCmsState();
+
+        expect(contentEntity.value).toBeNull();
+    });
+
+    it('prefers the parent translation slotConfig for inherited overrides', () => {
+        onRoute('sw.category.detail.cms');
+        const inheritedSlotConfig = { 'slot-id': { content: { value: 'inherited' } } };
+
+        Shopware.Store.get('swCategoryDetail').category = {
+            translations: [
+                {
+                    languageId: 'parent-language-id',
+                    slotConfig: inheritedSlotConfig,
+                },
+            ],
+        } as never;
+        Shopware.Store.get('context').api.languageId = 'child-language-id';
+        Shopware.Store.get('context').api.language = { parentId: 'parent-language-id' } as never;
+
+        const { inheritedSlotConfig: resolved } = useCmsState();
+
+        expect(resolved.value).toStrictEqual(inheritedSlotConfig);
+    });
+
+    it('keeps parent-language fields when the child slot overrides only one of them', () => {
+        onRoute('sw.category.detail.cms');
+
+        Shopware.Store.get('swCategoryDetail').category = {
+            slotConfig: {
+                'slot-id': { content: { value: 'child content' } },
+            },
+            translations: [
+                {
+                    languageId: 'parent-language-id',
+                    slotConfig: {
+                        'slot-id': {
+                            content: { value: 'parent content' },
+                            media: { value: 'parent media' },
+                        },
+                    },
+                },
+            ],
+        } as never;
+        Shopware.Store.get('context').api.languageId = 'child-language-id';
+        Shopware.Store.get('context').api.language = { parentId: 'parent-language-id' } as never;
+
+        const { inheritedSlotConfig } = useCmsState();
+
+        expect(inheritedSlotConfig.value).toStrictEqual({
+            'slot-id': {
+                content: { value: 'child content' },
+                media: { value: 'parent media' },
+            },
+        });
+    });
+
+    it('returns no slot config for a language the content entity has no translation for', () => {
+        onRoute('sw.category.detail.cms');
+        Shopware.Store.get('swCategoryDetail').category = { translations: [] } as never;
+
+        const { getSlotConfigForLanguage } = useCmsState();
+
+        expect(getSlotConfigForLanguage('unknown-language-id')).toBeNull();
+        expect(getSlotConfigForLanguage(null)).toBeNull();
+    });
+});

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/composables/use-cms-state.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/composables/use-cms-state.ts
@@ -1,0 +1,180 @@
+/**
+ * @sw-package discovery
+ */
+import { computed } from 'vue';
+import type { ComputedRef, WritableComputedRef } from 'vue';
+import { useRoute } from 'vue-router';
+import '../store/cms-page.store';
+import type { CmsSlotConfig } from '../service/cms.service';
+
+const { cloneDeep } = Shopware.Utils.object;
+
+type SlotConfigMap = {
+    [slotId: string]: CmsSlotConfig;
+};
+
+/** @private */
+export type CmsContentEntity<T extends keyof EntitySchema.Entities> = Entity<T> & {
+    slotConfig?: SlotConfigMap;
+    translations?: Array<{
+        languageId: string;
+        slotConfig?: SlotConfigMap;
+    }>;
+};
+
+/** @private */
+export type AnyCmsContentEntity =
+    | CmsContentEntity<'category'>
+    | CmsContentEntity<'product'>
+    | CmsContentEntity<'landing_page'>;
+
+/** @private */
+export interface UseCmsStateReturn {
+    cmsPageState: ComputedRef<PiniaRootState['cmsPage']>;
+    selectedBlock: WritableComputedRef<Entity<'cms_block'> | null>;
+    selectedSection: WritableComputedRef<Entity<'cms_section'> | null>;
+    currentDeviceView: ComputedRef<PiniaRootState['cmsPage']['currentCmsDeviceView']>;
+    isSystemDefaultLanguage: ComputedRef<boolean>;
+    category: ComputedRef<CmsContentEntity<'category'> | null>;
+    product: ComputedRef<CmsContentEntity<'product'> | null>;
+    landingPage: ComputedRef<CmsContentEntity<'landing_page'> | null>;
+    contentEntity: ComputedRef<AnyCmsContentEntity | null>;
+    inheritedSlotConfig: ComputedRef<SlotConfigMap | null>;
+    getSlotConfigForLanguage: (languageId?: string | null) => SlotConfigMap | null;
+}
+
+/**
+ * Composable alternative to the `cms-state` mixin: exposes the CMS page store and
+ * the slot config of the entity the current route edits. The mixin read the route
+ * from `this.$route`; here it comes from `useRoute()`, so the composable needs
+ * nothing from the component instance.
+ *
+ * Keep this and `src/module/sw-cms/mixin/sw-cms-state.mixin.ts` in sync — change both together.
+ *
+ * @private
+ */
+export function useCmsState(): UseCmsStateReturn {
+    const route = useRoute();
+
+    const cmsPageState = computed(() => Shopware.Store.get('cmsPage'));
+
+    const selectedBlock = computed({
+        get: () => cmsPageState.value.selectedBlock,
+        set: (block: Entity<'cms_block'>) => cmsPageState.value.setSelectedBlock(block),
+    });
+
+    const selectedSection = computed({
+        get: () => cmsPageState.value.selectedSection,
+        set: (section: Entity<'cms_section'>) => cmsPageState.value.setSelectedSection(section),
+    });
+
+    const currentDeviceView = computed(() => cmsPageState.value.currentCmsDeviceView);
+
+    const isSystemDefaultLanguage = computed(() => cmsPageState.value.isSystemDefaultLanguage);
+
+    const category = computed(() => {
+        try {
+            return (Shopware.Store.get('swCategoryDetail')?.category as CmsContentEntity<'category'>) ?? null;
+        } catch {
+            return null;
+        }
+    });
+
+    const product = computed(() => {
+        try {
+            return (Shopware.Store.get('swProductDetail')?.product as CmsContentEntity<'product'>) ?? null;
+        } catch {
+            return null;
+        }
+    });
+
+    const landingPage = computed(() => {
+        try {
+            return (Shopware.Store.get('swCategoryDetail')?.landingPage as CmsContentEntity<'landing_page'>) ?? null;
+        } catch {
+            return null;
+        }
+    });
+
+    const contentEntity = computed<AnyCmsContentEntity | null>(() => {
+        const name = route.name?.toString() || '';
+
+        if (name.startsWith('sw.category.landingPageDetail')) {
+            return landingPage.value;
+        }
+
+        if (name.startsWith('sw.category.')) {
+            return category.value;
+        }
+
+        if (name.startsWith('sw.product.')) {
+            return product.value;
+        }
+
+        return null;
+    });
+
+    function getSlotConfigForLanguage(languageId?: string | null): SlotConfigMap | null {
+        if (!languageId) {
+            return null;
+        }
+
+        if (languageId === Shopware.Store.get('context').api.languageId) {
+            return contentEntity.value?.slotConfig ?? null;
+        }
+
+        const translation = contentEntity.value?.translations?.find((entityTranslation) => {
+            return entityTranslation.languageId === languageId;
+        });
+
+        return translation?.slotConfig ?? null;
+    }
+
+    const inheritedSlotConfig = computed<SlotConfigMap | null>(() => {
+        const currentLanguageId = Shopware.Store.get('context').api.languageId;
+        const parentLanguageId = Shopware.Store.get('context').api.language?.parentId;
+
+        const currentSlotConfig = getSlotConfigForLanguage(currentLanguageId);
+        const parentSlotConfig = parentLanguageId ? getSlotConfigForLanguage(parentLanguageId) : null;
+
+        if (!currentSlotConfig && !parentSlotConfig) {
+            return null;
+        }
+
+        /**
+         * Merge field-by-field within each slot so a partial child-language override
+         * does not shadow parent-language fields on the same slot.
+         */
+        const merged: SlotConfigMap = {};
+
+        for (const [
+            slotId,
+            fields,
+        ] of Object.entries(parentSlotConfig ?? {})) {
+            merged[slotId] = { ...fields };
+        }
+
+        for (const [
+            slotId,
+            fields,
+        ] of Object.entries(currentSlotConfig ?? {})) {
+            merged[slotId] = { ...(merged[slotId] ?? {}), ...fields };
+        }
+
+        return cloneDeep(merged);
+    });
+
+    return {
+        cmsPageState,
+        selectedBlock,
+        selectedSection,
+        currentDeviceView,
+        isSystemDefaultLanguage,
+        category,
+        product,
+        landingPage,
+        contentEntity,
+        inheritedSlotConfig,
+        getSlotConfigForLanguage,
+    };
+}

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/mixin/sw-cms-state.mixin.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/mixin/sw-cms-state.mixin.ts
@@ -1,25 +1,15 @@
 import { defineComponent } from 'vue';
 import '../store/cms-page.store';
 import type { CmsSlotConfig } from '../service/cms.service';
+import type { CmsContentEntity } from '../composables/use-cms-state';
 
 const { cloneDeep } = Shopware.Utils.object;
 
-type WithSlotConfig = {
-    slotConfig?: {
-        [slotId: string]: CmsSlotConfig;
-    };
-    translations?: Array<{
-        languageId: string;
-        slotConfig?: {
-            [slotId: string]: CmsSlotConfig;
-        };
-    }>;
-};
-
-type ContentEntity<T extends keyof EntitySchema.Entities> = Entity<T> & WithSlotConfig;
 /**
  * @private
  * @sw-package discovery
+ *
+ * Duplicated in `src/module/sw-cms/composables/use-cms-state`; change both together.
  */
 export default Shopware.Mixin.register(
     'cms-state',
@@ -59,7 +49,7 @@ export default Shopware.Mixin.register(
 
             category() {
                 try {
-                    return Shopware.Store.get('swCategoryDetail')?.category as ContentEntity<'category'>;
+                    return Shopware.Store.get('swCategoryDetail')?.category as CmsContentEntity<'category'>;
                 } catch {
                     return null;
                 }
@@ -67,7 +57,7 @@ export default Shopware.Mixin.register(
 
             product() {
                 try {
-                    return Shopware.Store.get('swProductDetail')?.product as ContentEntity<'product'>;
+                    return Shopware.Store.get('swProductDetail')?.product as CmsContentEntity<'product'>;
                 } catch {
                     return null;
                 }
@@ -75,7 +65,7 @@ export default Shopware.Mixin.register(
 
             landingPage() {
                 try {
-                    return Shopware.Store.get('swCategoryDetail')?.landingPage as ContentEntity<'landing_page'>;
+                    return Shopware.Store.get('swCategoryDetail')?.landingPage as CmsContentEntity<'landing_page'>;
                 } catch {
                     return null;
                 }

--- a/src/Administration/Resources/app/administration/src/module/sw-extension/composables/use-extension-error.spec.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension/composables/use-extension-error.spec.ts
@@ -1,0 +1,58 @@
+/**
+ * @sw-package checkout
+ */
+import { useNotification } from 'src/app/composables/use-notification';
+import { useExtensionError } from './use-extension-error';
+
+jest.mock('vue-i18n', () => {
+    const actual: object = jest.requireActual('vue-i18n');
+
+    return { ...actual, useI18n: () => ({ t: (key: string) => `translated:${key}` }) };
+});
+
+jest.mock('src/app/composables/use-notification', () => ({
+    useNotification: jest.fn(),
+}));
+
+describe('src/module/sw-extension/composables/use-extension-error', () => {
+    const createNotificationError = jest.fn();
+    const handleErrorResponse = jest.fn().mockReturnValue([]);
+
+    beforeEach(() => {
+        (useNotification as jest.Mock).mockReturnValue({ createNotificationError });
+        jest.spyOn(Shopware, 'Service').mockImplementation(() => ({ handleErrorResponse }) as never);
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+        jest.clearAllMocks();
+    });
+
+    it('hands the error service a translator instead of a component instance', () => {
+        const errorResponse = { response: { data: { errors: [] } } };
+
+        useExtensionError().showExtensionErrors(errorResponse);
+
+        expect(handleErrorResponse).toHaveBeenCalledTimes(1);
+        const [
+            passedResponse,
+            translator,
+        ] = handleErrorResponse.mock.calls[0] as [unknown, { $t: (key: string) => string }];
+
+        expect(passedResponse).toBe(errorResponse);
+        expect(translator.$t('sw-extension.error')).toBe('translated:sw-extension.error');
+    });
+
+    it('raises one error notification per handled error', () => {
+        handleErrorResponse.mockReturnValueOnce([
+            { title: 'first', message: 'one' },
+            { title: 'second', message: 'two' },
+        ]);
+
+        useExtensionError().showExtensionErrors({});
+
+        expect(createNotificationError).toHaveBeenCalledTimes(2);
+        expect(createNotificationError).toHaveBeenNthCalledWith(1, { title: 'first', message: 'one' });
+        expect(createNotificationError).toHaveBeenNthCalledWith(2, { title: 'second', message: 'two' });
+    });
+});

--- a/src/Administration/Resources/app/administration/src/module/sw-extension/composables/use-extension-error.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension/composables/use-extension-error.ts
@@ -1,0 +1,44 @@
+/**
+ * @sw-package checkout
+ */
+import { useI18n } from 'vue-i18n';
+import { useNotification } from 'src/app/composables/use-notification';
+import type { NotificationType } from 'src/app/store/notification.store';
+
+interface ExtensionErrorService {
+    handleErrorResponse: (errorResponse: unknown, translator: { $t: unknown }) => NotificationType[];
+}
+
+/** @private */
+export interface UseExtensionErrorReturn {
+    showExtensionErrors: (errorResponse: unknown) => void;
+}
+
+/**
+ * Composable alternative to the `sw-extension-error` mixin: turns an extension
+ * API error response into notifications. The mixin handed its own component
+ * instance to `extensionErrorService`, which uses it only as a translator, so the
+ * composable hands over `useI18n()`'s `t` under the same key instead.
+ *
+ * Keep this and `src/module/sw-extension/mixin/sw-extension-error.mixin.js` in sync —
+ * change both together.
+ *
+ * @private
+ */
+export function useExtensionError(): UseExtensionErrorReturn {
+    const { t } = useI18n();
+    const { createNotificationError } = useNotification();
+
+    function showExtensionErrors(errorResponse: unknown): void {
+        // `extensionErrorService` is registered in the DI container but missing from its type map.
+        const errorService = Shopware.Service(
+            'extensionErrorService' as keyof ServiceContainer,
+        ) as unknown as ExtensionErrorService;
+
+        errorService.handleErrorResponse(errorResponse, { $t: t }).forEach((notification) => {
+            createNotificationError(notification);
+        });
+    }
+
+    return { showExtensionErrors };
+}

--- a/src/Administration/Resources/app/administration/src/module/sw-extension/mixin/sw-extension-error.mixin.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension/mixin/sw-extension-error.mixin.js
@@ -3,6 +3,8 @@ import { defineComponent } from 'vue';
 /**
  * @sw-package checkout
  * @private
+ *
+ * Duplicated in `src/module/sw-extension/composables/use-extension-error`; change both together.
  */
 export default Shopware.Mixin.register(
     'sw-extension-error',

--- a/src/Administration/Resources/app/administration/src/module/sw-media/composables/use-media-grid-listener.spec.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-media/composables/use-media-grid-listener.spec.ts
@@ -1,0 +1,135 @@
+/**
+ * @sw-package discovery
+ */
+import { reactive } from 'vue';
+import { useMediaGridListener } from './use-media-grid-listener';
+import type { MediaGridItem } from './use-media-grid-listener';
+
+/**
+ * The selection compares items by identity, and the composable holds them in a
+ * deeply reactive ref. Real grid items already come from a reactive entity
+ * collection, so the test items have to be reactive too — otherwise every read
+ * would hand back a fresh proxy of a plain object.
+ */
+function createItem(id: string, entityName = 'media'): MediaGridItem {
+    return reactive({ id, getEntityName: () => entityName });
+}
+
+function createComposable(items: MediaGridItem[]) {
+    const onFolderChange = jest.fn();
+
+    return {
+        onFolderChange,
+        composable: useMediaGridListener({ selectableItems: () => items, onFolderChange }),
+    };
+}
+
+function click(item: MediaGridItem, modifiers: Partial<MouseEvent> = {}) {
+    return { originalDomEvent: modifiers as MouseEvent, item };
+}
+
+describe('src/module/sw-media/composables/use-media-grid-listener', () => {
+    it('selects a single item on a plain click', () => {
+        const items = [
+            createItem('a'),
+            createItem('b'),
+        ];
+        const { composable } = createComposable(items);
+
+        composable.handleMediaItemClicked(click(items[0]));
+
+        expect(composable.selectedItems.value).toEqual([items[0]]);
+        expect(composable.isListSelect.value).toBe(false);
+        expect(composable.showItemSelected(items[0])).toBe(true);
+        expect(composable.showItemSelected(items[1])).toBe(false);
+    });
+
+    it('reports the folder change instead of emitting it itself', () => {
+        const folder = createItem('folder-1', 'media_folder');
+        const { onFolderChange, composable } = createComposable([folder]);
+
+        composable.showDetails(folder);
+
+        expect(onFolderChange).toHaveBeenCalledWith('folder-1');
+    });
+
+    it('adds and removes items with a ctrl click', () => {
+        const items = [
+            createItem('a'),
+            createItem('b'),
+        ];
+        const { composable } = createComposable(items);
+
+        composable.handleMediaItemClicked(click(items[0], { ctrlKey: true }));
+        composable.handleMediaItemClicked(click(items[1], { ctrlKey: true }));
+        expect(composable.selectedItems.value).toEqual(items);
+
+        composable.handleMediaItemClicked(click(items[1], { ctrlKey: true }));
+        expect(composable.selectedItems.value).toEqual([items[0]]);
+    });
+
+    it('selects the range between the start item and the shift-clicked item', () => {
+        const items = [
+            createItem('a'),
+            createItem('b'),
+            createItem('c'),
+            createItem('d'),
+        ];
+        const { composable } = createComposable(items);
+
+        composable.handleMediaItemClicked(click(items[1]));
+        composable.handleMediaItemClicked(click(items[3], { shiftKey: true }));
+
+        expect(composable.selectedItems.value).toEqual(items.slice(1, 4));
+    });
+
+    it('takes the selectable items from the caller, not from its own state', () => {
+        const items = [
+            createItem('a'),
+            createItem('b'),
+            createItem('c'),
+        ];
+        const selectable: MediaGridItem[] = [];
+        const composable = useMediaGridListener({
+            selectableItems: () => selectable,
+            onFolderChange: jest.fn(),
+        });
+
+        composable.handleMediaItemClicked(click(items[0]));
+        selectable.push(...items);
+        composable.handleMediaItemClicked(click(items[2], { shiftKey: true }));
+
+        expect(composable.selectedItems.value).toEqual(items);
+    });
+
+    it('clears the selection and the list selection start', () => {
+        const items = [
+            createItem('a'),
+            createItem('b'),
+        ];
+        const { composable } = createComposable(items);
+
+        composable.handleMediaGridItemSelected(click(items[0]));
+        composable.handleMediaGridItemSelected(click(items[1]));
+        expect(composable.isListSelect.value).toBe(true);
+
+        composable.clearSelection();
+
+        expect(composable.selectedItems.value).toEqual([]);
+        expect(composable.listSelectionStartItem.value).toBeNull();
+    });
+
+    it('unselects an item through the selection handler map', () => {
+        const items = [
+            createItem('a'),
+            createItem('b'),
+        ];
+        const { composable } = createComposable(items);
+
+        composable.handleMediaGridItemSelected(click(items[0]));
+        composable.handleMediaGridItemSelected(click(items[1]));
+        composable.mediaItemSelectionHandler.value['media-item-selection-remove'](click(items[0]));
+
+        expect(composable.selectedItems.value).toEqual([items[1]]);
+    });
+});

--- a/src/Administration/Resources/app/administration/src/module/sw-media/composables/use-media-grid-listener.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-media/composables/use-media-grid-listener.ts
@@ -1,0 +1,227 @@
+/**
+ * @sw-package discovery
+ */
+import { computed, ref } from 'vue';
+import type { ComputedRef, Ref } from 'vue';
+
+/** @private */
+export interface MediaGridItem {
+    id: string;
+    getEntityName: () => string;
+}
+
+/** @private */
+export interface MediaGridItemEvent {
+    originalDomEvent: MouseEvent;
+    item: MediaGridItem;
+}
+
+/**
+ * What the mixin took from the host component: the `media-folder-change` event it
+ * emitted, and the `selectableItems` computed every consumer had to override.
+ *
+ * @private
+ */
+export interface UseMediaGridListenerOptions {
+    selectableItems: () => MediaGridItem[];
+    onFolderChange: (folderId: string) => void;
+}
+
+/** @private */
+export interface UseMediaGridListenerReturn {
+    selectedItems: Ref<MediaGridItem[]>;
+    listSelectionStartItem: Ref<MediaGridItem | null>;
+    mediaItemSelectionHandler: ComputedRef<{ [event: string]: (payload: MediaGridItemEvent) => void }>;
+    isListSelect: ComputedRef<boolean>;
+    isItemSelected: (itemToCompare: MediaGridItem) => boolean;
+    showItemSelected: (item: MediaGridItem) => boolean;
+    clearSelection: () => void;
+    navigateToFolder: (payload: { item: MediaGridItem }) => void;
+    showDetails: (gridItem: MediaGridItem) => void;
+    handleMediaItemClicked: (payload: MediaGridItemEvent) => void;
+    handleMediaGridItemSelected: (payload: MediaGridItemEvent) => void;
+    handleMediaGridItemUnselected: (payload: { item: MediaGridItem }) => void;
+}
+
+/**
+ * Composable alternative to the `media-grid-listener` mixin: owns click, ctrl and
+ * shift selection of media grid items. The mixin emitted `media-folder-change` and
+ * declared an empty `selectableItems` computed for the host to override; a
+ * composable can do neither, so both are passed in as options.
+ *
+ * Keep this and `src/module/sw-media/mixin/media-grid-listener.mixin.js` in sync —
+ * change both together.
+ *
+ * @private
+ */
+export function useMediaGridListener(options: UseMediaGridListenerOptions): UseMediaGridListenerReturn {
+    const selectedItems = ref<MediaGridItem[]>([]);
+    const listSelectionStartItem = ref<MediaGridItem | null>(null);
+
+    const isListSelect = computed(() => listSelectionStartItem.value !== null);
+
+    function isItemSelected(itemToCompare: MediaGridItem): boolean {
+        const findIndex = selectedItems.value.findIndex((item) => {
+            return item === itemToCompare;
+        });
+
+        return findIndex > -1;
+    }
+
+    function showItemSelected(item: MediaGridItem): boolean {
+        return isItemSelected(item);
+    }
+
+    function clearSelection(): void {
+        selectedItems.value = [];
+        listSelectionStartItem.value = null;
+    }
+
+    function navigateToFolder({ item }: { item: MediaGridItem }): void {
+        options.onFolderChange(item.id);
+    }
+
+    function startListSelect(item: MediaGridItem): void {
+        selectedItems.value = [item];
+        listSelectionStartItem.value = item;
+    }
+
+    function singleSelect(item: MediaGridItem): void {
+        if (item.getEntityName() === 'media_folder') {
+            navigateToFolder({ item });
+        }
+
+        selectedItems.value = [item];
+        listSelectionStartItem.value = null;
+    }
+
+    function removeItemFromSelection(item: MediaGridItem): void {
+        selectedItems.value = selectedItems.value.filter((currentSelected) => {
+            return currentSelected !== item;
+        });
+
+        if (listSelectionStartItem.value === item) {
+            listSelectionStartItem.value = selectedItems.value[0] || null;
+        }
+    }
+
+    function addItemToSelection(item: MediaGridItem): void {
+        if (!isListSelect.value) {
+            if (selectedItems.value.length === 1) {
+                startListSelect(selectedItems.value[0]);
+                addItemToSelection(item);
+                return;
+            }
+
+            startListSelect(item);
+            return;
+        }
+
+        if (!isItemSelected(item)) {
+            selectedItems.value.push(item);
+        }
+    }
+
+    function findSelectionIndices(first: MediaGridItem | null, second: MediaGridItem): { start: number; end: number } {
+        const selectable = options.selectableItems();
+
+        const firstIndex = selectable.findIndex((selectableItem) => {
+            return first === selectableItem;
+        });
+
+        const secondIndex = selectable.findIndex((selectableItem) => {
+            return second === selectableItem;
+        });
+
+        return {
+            start: Math.min(firstIndex, secondIndex),
+            end: Math.max(firstIndex, secondIndex),
+        };
+    }
+
+    function handleShiftSelect(item: MediaGridItem): void {
+        if (!isListSelect.value) {
+            if (selectedItems.value.length === 1) {
+                startListSelect(selectedItems.value[0]);
+                handleShiftSelect(item);
+                return;
+            }
+
+            startListSelect(item);
+            return;
+        }
+
+        if (item === listSelectionStartItem.value) {
+            startListSelect(item);
+            return;
+        }
+
+        const indices = findSelectionIndices(listSelectionStartItem.value, item);
+        const selectable = options.selectableItems();
+
+        selectedItems.value = selectable.slice(indices.start, indices.end + 1);
+        listSelectionStartItem.value = selectable[indices.start];
+    }
+
+    function handleSelection(item: MediaGridItem): void {
+        if (isItemSelected(item)) {
+            removeItemFromSelection(item);
+            return;
+        }
+
+        addItemToSelection(item);
+    }
+
+    function showDetails(gridItem: MediaGridItem): void {
+        singleSelect(gridItem);
+    }
+
+    function handleMediaItemClicked({ originalDomEvent, item }: MediaGridItemEvent): void {
+        if (originalDomEvent.shiftKey) {
+            handleShiftSelect(item);
+            return;
+        }
+
+        if (isListSelect.value || originalDomEvent.ctrlKey || originalDomEvent.metaKey) {
+            handleSelection(item);
+            return;
+        }
+
+        singleSelect(item);
+    }
+
+    function handleMediaGridItemSelected({ originalDomEvent, item }: MediaGridItemEvent): void {
+        if (originalDomEvent.shiftKey) {
+            handleShiftSelect(item);
+            return;
+        }
+
+        addItemToSelection(item);
+    }
+
+    function handleMediaGridItemUnselected({ item }: { item: MediaGridItem }): void {
+        removeItemFromSelection(item);
+    }
+
+    const mediaItemSelectionHandler = computed(() => ({
+        'media-item-click': handleMediaItemClicked,
+        'media-item-selection-add': handleMediaGridItemSelected,
+        'media-item-selection-remove': handleMediaGridItemUnselected,
+        'media-item-play': handleMediaItemClicked,
+    }));
+
+    return {
+        selectedItems,
+        listSelectionStartItem,
+        mediaItemSelectionHandler,
+        isListSelect,
+        isItemSelected,
+        showItemSelected,
+        clearSelection,
+        navigateToFolder,
+        showDetails,
+        handleMediaItemClicked,
+        handleMediaGridItemSelected,
+        handleMediaGridItemUnselected,
+    };
+}

--- a/src/Administration/Resources/app/administration/src/module/sw-media/composables/use-media-sidebar-modal.spec.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-media/composables/use-media-sidebar-modal.spec.ts
@@ -1,0 +1,108 @@
+/**
+ * @sw-package discovery
+ */
+import { nextTick } from 'vue';
+import { useMediaSidebarModal } from './use-media-sidebar-modal';
+
+function createComposable(
+    privileges: string[] = [
+        'media.editor',
+        'media.deleter',
+    ],
+) {
+    jest.spyOn(Shopware, 'Service').mockImplementation(
+        () =>
+            ({
+                can: (privilege: string) => privileges.includes(privilege),
+            }) as never,
+    );
+
+    const options = {
+        onItemsDelete: jest.fn(),
+        onFolderItemsDissolve: jest.fn(),
+        onItemsMove: jest.fn(),
+    };
+
+    return { options, composable: useMediaSidebarModal(options) };
+}
+
+describe('src/module/sw-media/composables/use-media-sidebar-modal', () => {
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    it.each([
+        [
+            'openModalReplace',
+            'showModalReplace',
+            'media.editor',
+        ],
+        [
+            'openModalDelete',
+            'showModalDelete',
+            'media.deleter',
+        ],
+        [
+            'openFolderDissolve',
+            'showFolderDissolve',
+            'media.editor',
+        ],
+        [
+            'openModalMove',
+            'showModalMove',
+            'media.editor',
+        ],
+    ] as const)('%s opens %s only with the %s privilege', (open, flag, privilege) => {
+        const denied = createComposable([]).composable;
+        denied[open]();
+        expect(denied[flag].value).toBe(false);
+
+        const granted = createComposable([privilege]).composable;
+        granted[open]();
+        expect(granted[flag].value).toBe(true);
+    });
+
+    it('opens the folder settings without an acl check', () => {
+        const { composable } = createComposable([]);
+
+        composable.openFolderSettings();
+        expect(composable.showFolderSettings.value).toBe(true);
+
+        composable.closeFolderSettings();
+        expect(composable.showFolderSettings.value).toBe(false);
+    });
+
+    it.each([
+        [
+            'deleteSelectedItems',
+            'showModalDelete',
+            'openModalDelete',
+            'onItemsDelete',
+        ],
+        [
+            'onFolderDissolved',
+            'showFolderDissolve',
+            'openFolderDissolve',
+            'onFolderItemsDissolve',
+        ],
+        [
+            'onFolderMoved',
+            'showModalMove',
+            'openModalMove',
+            'onItemsMove',
+        ],
+    ] as const)('%s closes %s and forwards the payload on the next tick', async (handler, flag, open, callback) => {
+        const { options, composable } = createComposable();
+        const payload = { mediaIds: ['media-1'] };
+
+        composable[open]();
+        composable[handler](payload);
+
+        expect(composable[flag].value).toBe(false);
+        expect(options[callback]).not.toHaveBeenCalled();
+
+        await nextTick();
+
+        expect(options[callback]).toHaveBeenCalledWith(payload);
+    });
+});

--- a/src/Administration/Resources/app/administration/src/module/sw-media/composables/use-media-sidebar-modal.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-media/composables/use-media-sidebar-modal.ts
@@ -1,0 +1,162 @@
+/**
+ * @sw-package discovery
+ */
+import { nextTick, ref } from 'vue';
+import type { Ref } from 'vue';
+
+/**
+ * Callbacks for the three events the mixin emitted on the host component.
+ *
+ * @private
+ */
+export interface UseMediaSidebarModalOptions {
+    onItemsDelete: (ids: unknown) => void;
+    onFolderItemsDissolve: (ids: unknown) => void;
+    onItemsMove: (ids: unknown) => void;
+}
+
+/** @private */
+export interface UseMediaSidebarModalReturn {
+    showModalReplace: Ref<boolean>;
+    showModalDelete: Ref<boolean>;
+    showFolderSettings: Ref<boolean>;
+    showFolderDissolve: Ref<boolean>;
+    showModalMove: Ref<boolean>;
+    openModalReplace: () => void;
+    closeModalReplace: () => void;
+    openModalDelete: () => void;
+    closeModalDelete: () => void;
+    openFolderSettings: () => void;
+    closeFolderSettings: () => void;
+    openFolderDissolve: () => void;
+    closeFolderDissolve: () => void;
+    openModalMove: () => void;
+    closeModalMove: () => void;
+    deleteSelectedItems: (ids: unknown) => void;
+    onFolderDissolved: (ids: unknown) => void;
+    onFolderMoved: (ids: unknown) => void;
+}
+
+/**
+ * Composable alternative to the `media-sidebar-modal-mixin`: owns the open/close
+ * state of the media sidebar modals. The mixin injected `acl` and emitted three
+ * events on the host component; here `acl` comes from `Shopware.Service` and the
+ * events are passed in as callbacks, because a composable has no `$emit`.
+ *
+ * Keep this and `src/module/sw-media/mixin/media-sidebar-modal.mixin.js` in sync —
+ * change both together.
+ *
+ * @private
+ */
+export function useMediaSidebarModal(options: UseMediaSidebarModalOptions): UseMediaSidebarModalReturn {
+    const showModalReplace = ref(false);
+    const showModalDelete = ref(false);
+    const showFolderSettings = ref(false);
+    const showFolderDissolve = ref(false);
+    const showModalMove = ref(false);
+
+    function acl(): { can: (privilege: string) => boolean } {
+        return Shopware.Service('acl');
+    }
+
+    function openModalReplace(): void {
+        if (!acl().can('media.editor')) {
+            return;
+        }
+
+        showModalReplace.value = true;
+    }
+
+    function closeModalReplace(): void {
+        showModalReplace.value = false;
+    }
+
+    function openModalDelete(): void {
+        if (!acl().can('media.deleter')) {
+            return;
+        }
+
+        showModalDelete.value = true;
+    }
+
+    function closeModalDelete(): void {
+        showModalDelete.value = false;
+    }
+
+    function openFolderSettings(): void {
+        showFolderSettings.value = true;
+    }
+
+    function closeFolderSettings(): void {
+        showFolderSettings.value = false;
+    }
+
+    function openFolderDissolve(): void {
+        if (!acl().can('media.editor')) {
+            return;
+        }
+
+        showFolderDissolve.value = true;
+    }
+
+    function closeFolderDissolve(): void {
+        showFolderDissolve.value = false;
+    }
+
+    function openModalMove(): void {
+        if (!acl().can('media.editor')) {
+            return;
+        }
+
+        showModalMove.value = true;
+    }
+
+    function closeModalMove(): void {
+        showModalMove.value = false;
+    }
+
+    function deleteSelectedItems(ids: unknown): void {
+        closeModalDelete();
+
+        void nextTick(() => {
+            options.onItemsDelete(ids);
+        });
+    }
+
+    function onFolderDissolved(ids: unknown): void {
+        closeFolderDissolve();
+
+        void nextTick(() => {
+            options.onFolderItemsDissolve(ids);
+        });
+    }
+
+    function onFolderMoved(ids: unknown): void {
+        closeModalMove();
+
+        void nextTick(() => {
+            options.onItemsMove(ids);
+        });
+    }
+
+    return {
+        showModalReplace,
+        showModalDelete,
+        showFolderSettings,
+        showFolderDissolve,
+        showModalMove,
+        openModalReplace,
+        closeModalReplace,
+        openModalDelete,
+        closeModalDelete,
+        openFolderSettings,
+        closeFolderSettings,
+        openFolderDissolve,
+        closeFolderDissolve,
+        openModalMove,
+        closeModalMove,
+        deleteSelectedItems,
+        onFolderDissolved,
+        onFolderMoved,
+    };
+}

--- a/src/Administration/Resources/app/administration/src/module/sw-media/composables/use-video-cover.spec.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-media/composables/use-video-cover.spec.ts
@@ -1,0 +1,125 @@
+/**
+ * @sw-package discovery
+ */
+import { useNotification } from 'src/app/composables/use-notification';
+import { useVideoCover } from './use-video-cover';
+import type { VideoCoverMediaItem } from './use-video-cover';
+
+jest.mock('vue-i18n', () => {
+    const actual: object = jest.requireActual('vue-i18n');
+
+    return { ...actual, useI18n: () => ({ t: (key: string) => key }) };
+});
+
+jest.mock('src/app/composables/use-notification', () => ({
+    useNotification: jest.fn(),
+}));
+
+const createNotificationSuccess = jest.fn();
+const createNotificationError = jest.fn();
+const assignVideoCover = jest.fn().mockResolvedValue(undefined);
+
+function createComposable(item: VideoCoverMediaItem | null, canEdit = true) {
+    (useNotification as jest.Mock).mockReturnValue({ createNotificationSuccess, createNotificationError });
+
+    jest.spyOn(Shopware, 'Service').mockImplementation(
+        (name?: string) => (name === 'acl' ? { can: () => canEdit } : { assignVideoCover }) as never,
+    );
+
+    return useVideoCover({ item: () => item });
+}
+
+const videoItem: VideoCoverMediaItem = {
+    id: 'media-1',
+    mediaType: { name: 'VIDEO' },
+    metaData: { video: { coverMediaId: null } },
+};
+
+describe('src/module/sw-media/composables/use-video-cover', () => {
+    afterEach(() => {
+        jest.restoreAllMocks();
+        jest.clearAllMocks();
+    });
+
+    it('detects video items and their cover from the item getter', () => {
+        const composable = createComposable({ ...videoItem, metaData: { video: { coverMediaId: 'cover-1' } } });
+
+        expect(composable.isVideoMedia.value).toBe(true);
+        expect(composable.hasVideoCover.value).toBe(true);
+    });
+
+    it('falls back to the mime type when no media type is set', () => {
+        const composable = createComposable({ mimeType: 'video/mp4' });
+
+        expect(composable.isVideoMedia.value).toBe(true);
+        expect(composable.isImage({ mimeType: 'image/png' })).toBe(true);
+        expect(composable.isImage({ mimeType: 'video/mp4' })).toBe(false);
+    });
+
+    it('opens the cover selection modal only for media editors', () => {
+        const denied = createComposable(videoItem, false);
+        denied.openCoverSelectionModal();
+        expect(denied.showCoverSelectionModal.value).toBe(false);
+
+        const granted = createComposable(videoItem);
+        granted.openCoverSelectionModal();
+        expect(granted.showCoverSelectionModal.value).toBe(true);
+    });
+
+    it('assigns the selected cover and reports success', async () => {
+        const item = { ...videoItem };
+        const composable = createComposable(item);
+
+        await composable.onCoverSelectionChange([{ id: 'cover-1', mediaType: { name: 'IMAGE' } }]);
+
+        expect(assignVideoCover).toHaveBeenCalledWith('media-1', 'cover-1');
+        expect(createNotificationSuccess).toHaveBeenCalledWith({
+            message: 'global.sw-media-media-item.notification.coverSaveSuccess.message',
+        });
+        expect(composable.showCoverSelectionModal.value).toBe(false);
+        expect(item.isLoading).toBe(false);
+    });
+
+    it('rejects a non-image selection without touching the media service', async () => {
+        const composable = createComposable(videoItem);
+
+        await composable.onCoverSelectionChange([{ id: 'other-video', mediaType: { name: 'VIDEO' } }]);
+
+        expect(assignVideoCover).not.toHaveBeenCalled();
+        expect(createNotificationError).toHaveBeenCalledWith({
+            message: 'global.sw-media-media-item.notification.coverSelectionInvalid.message',
+        });
+    });
+
+    it('removes the cover and reports the remove message', async () => {
+        const composable = createComposable(videoItem);
+
+        await composable.removeVideoCover();
+
+        expect(assignVideoCover).toHaveBeenCalledWith('media-1', null);
+        expect(createNotificationSuccess).toHaveBeenCalledWith({
+            message: 'global.sw-media-media-item.notification.coverRemoveSuccess.message',
+        });
+    });
+
+    it('reports an error and stops loading when the media service fails', async () => {
+        const item = { ...videoItem };
+        const composable = createComposable(item);
+        assignVideoCover.mockRejectedValueOnce(new Error('nope'));
+
+        await composable.persistCoverMedia('cover-1');
+
+        expect(createNotificationError).toHaveBeenCalledWith({
+            message: 'global.sw-media-media-item.notification.coverSaveError.message',
+        });
+        expect(item.isLoading).toBe(false);
+    });
+
+    it('does nothing for an item that is not a video', async () => {
+        const composable = createComposable({ id: 'media-1', mediaType: { name: 'IMAGE' } });
+
+        await composable.persistCoverMedia('cover-1');
+
+        expect(assignVideoCover).not.toHaveBeenCalled();
+    });
+});

--- a/src/Administration/Resources/app/administration/src/module/sw-media/composables/use-video-cover.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-media/composables/use-video-cover.ts
@@ -1,0 +1,175 @@
+/**
+ * @sw-package discovery
+ */
+import { computed, ref } from 'vue';
+import type { ComputedRef, Ref } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { useNotification } from 'src/app/composables/use-notification';
+
+interface VideoCoverMediaService {
+    assignVideoCover: (mediaId: string, coverMediaId: string | null) => Promise<unknown>;
+}
+
+/** @private */
+export interface VideoCoverMediaItem {
+    id?: string;
+    isLoading?: boolean;
+    mediaType?: { name?: string };
+    mimeType?: string;
+    metaData?: { video?: { coverMediaId?: string | null } };
+}
+
+/**
+ * The mixin read the media item from the host component's `item` prop. The
+ * composable takes it as a getter so it stays reactive.
+ *
+ * @private
+ */
+export interface UseVideoCoverOptions {
+    item: () => VideoCoverMediaItem | null | undefined;
+}
+
+/** @private */
+export interface UseVideoCoverReturn {
+    showCoverSelectionModal: Ref<boolean>;
+    isVideoMedia: ComputedRef<boolean>;
+    hasVideoCover: ComputedRef<boolean>;
+    openCoverSelectionModal: () => void;
+    closeCoverSelectionModal: () => void;
+    onCoverSelectionChange: (selection: VideoCoverMediaItem[]) => Promise<void>;
+    persistCoverMedia: (coverMediaId: string | null) => Promise<void>;
+    isImage: (media?: VideoCoverMediaItem | null) => boolean;
+    isVideo: (item?: VideoCoverMediaItem | null) => boolean;
+    removeVideoCover: () => Promise<void>;
+    getCoverMediaId: (item?: VideoCoverMediaItem | null) => string | null;
+}
+
+/**
+ * Composable alternative to the `video-cover` mixin: assigns and removes the
+ * cover image of a video media item. The mixin injected `mediaService`/`acl` and
+ * read `this.item`; here the services come from `Shopware.Service` and the item
+ * is passed in as a getter, because a composable has no component instance.
+ *
+ * Keep this and `src/module/sw-media/mixin/video-cover.mixin.js` in sync —
+ * change both together.
+ *
+ * @private
+ */
+export function useVideoCover(options: UseVideoCoverOptions): UseVideoCoverReturn {
+    const { t } = useI18n();
+    const { createNotificationSuccess, createNotificationError } = useNotification();
+
+    const showCoverSelectionModal = ref(false);
+
+    function acl(): { can: (privilege: string) => boolean } {
+        return Shopware.Service('acl');
+    }
+
+    function mediaService(): VideoCoverMediaService {
+        // `mediaService` is registered in the DI container but missing from its type map.
+        return Shopware.Service('mediaService' as keyof ServiceContainer) as unknown as VideoCoverMediaService;
+    }
+
+    function isImage(media?: VideoCoverMediaItem | null): boolean {
+        const typeName = media?.mediaType?.name;
+
+        if (typeName) {
+            return typeName === 'IMAGE';
+        }
+
+        return media?.mimeType?.startsWith('image/') ?? false;
+    }
+
+    function isVideo(item?: VideoCoverMediaItem | null): boolean {
+        const typeName = item?.mediaType?.name;
+
+        if (typeName) {
+            return typeName === 'VIDEO';
+        }
+
+        return item?.mimeType?.startsWith('video/') ?? false;
+    }
+
+    function getCoverMediaId(item?: VideoCoverMediaItem | null): string | null {
+        return item?.metaData?.video?.coverMediaId ?? null;
+    }
+
+    const isVideoMedia = computed(() => isVideo(options.item()));
+
+    const hasVideoCover = computed(() => getCoverMediaId(options.item()) !== null);
+
+    function openCoverSelectionModal(): void {
+        if (!acl().can('media.editor')) {
+            return;
+        }
+
+        showCoverSelectionModal.value = true;
+    }
+
+    function closeCoverSelectionModal(): void {
+        showCoverSelectionModal.value = false;
+    }
+
+    async function persistCoverMedia(coverMediaId: string | null): Promise<void> {
+        const item = options.item();
+
+        if (!isVideoMedia.value || !item?.id) {
+            return;
+        }
+
+        item.isLoading = true;
+
+        try {
+            await mediaService().assignVideoCover(item.id, coverMediaId);
+
+            const snippetKey = coverMediaId
+                ? 'global.sw-media-media-item.notification.coverSaveSuccess.message'
+                : 'global.sw-media-media-item.notification.coverRemoveSuccess.message';
+
+            createNotificationSuccess({
+                message: t(snippetKey),
+            });
+
+            Shopware.Utils.EventBus.emit('sw-media-library-item-updated', item.id);
+        } catch {
+            createNotificationError({
+                message: t('global.sw-media-media-item.notification.coverSaveError.message'),
+            });
+        } finally {
+            item.isLoading = false;
+        }
+    }
+
+    async function onCoverSelectionChange(selection: VideoCoverMediaItem[]): Promise<void> {
+        const [media] = selection;
+        closeCoverSelectionModal();
+
+        if (!media || !isImage(media)) {
+            createNotificationError({
+                message: t('global.sw-media-media-item.notification.coverSelectionInvalid.message'),
+            });
+
+            return;
+        }
+
+        await persistCoverMedia(media.id ?? null);
+    }
+
+    async function removeVideoCover(): Promise<void> {
+        await persistCoverMedia(null);
+    }
+
+    return {
+        showCoverSelectionModal,
+        isVideoMedia,
+        hasVideoCover,
+        openCoverSelectionModal,
+        closeCoverSelectionModal,
+        onCoverSelectionChange,
+        persistCoverMedia,
+        isImage,
+        isVideo,
+        removeVideoCover,
+        getCoverMediaId,
+    };
+}

--- a/src/Administration/Resources/app/administration/src/module/sw-media/mixin/media-grid-listener.mixin.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-media/mixin/media-grid-listener.mixin.js
@@ -6,6 +6,8 @@ const { Mixin } = Shopware;
  * usage:
  *   - override selectableItems computed property and return array of entities that can be selected
  * @sw-package discovery
+ *
+ * Duplicated in `src/module/sw-media/composables/use-media-grid-listener`; change both together.
  */
 Mixin.register('media-grid-listener', {
     emits: ['media-folder-change'],

--- a/src/Administration/Resources/app/administration/src/module/sw-media/mixin/media-sidebar-modal.mixin.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-media/mixin/media-sidebar-modal.mixin.js
@@ -1,5 +1,7 @@
 /**
  * @sw-package discovery
+ *
+ * Duplicated in `src/module/sw-media/composables/use-media-sidebar-modal`; change both together.
  */
 Shopware.Mixin.register('media-sidebar-modal-mixin', {
     inject: [

--- a/src/Administration/Resources/app/administration/src/module/sw-media/mixin/video-cover.mixin.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-media/mixin/video-cover.mixin.js
@@ -1,5 +1,7 @@
 /**
  * @sw-package discovery
+ *
+ * Duplicated in `src/module/sw-media/composables/use-video-cover`; change both together.
  */
 Shopware.Mixin.register('video-cover', {
     inject: [


### PR DESCRIPTION
### 1. Why is this change necessary?

Stacked on #18356 — please review that one first.

#18356 converted the **self-contained** mixins: everything they touch comes from `Shopware.*` globals or plain arguments, so a composable is a drop-in. The next tier cannot be expressed that way. Those mixins reach into the component instance, and a composable has no instance:

- **`$emit`** — `media-sidebar-modal-mixin` and `media-grid-listener` emit events on the host.
- **props read reactively** — `video-cover` reads `this.item`, `rule-between-operator` reads `this.condition`.
- **overridable members** — `media-grid-listener` calls `selectableItems`, `rule-between-operator` calls `ensureValueExist()`, `ruleContainer` calls `onAddPlaceholder()`. The mixin *calls* them; the component *defines* them.
- **props the mixin itself declares** — `validation` declares `validation`, `ruleContainer` declares `condition` / `parentCondition` / `level` / `disabled`. Every component using them inherited those props.
- **`data()` entries and computeds** — the descriptor could only rewrite `this.<member>` to a bare binding. A mixin's reactive state needs `.value`.

Without all of that the codemod can only report an unresolved mixin and keep the whole component on the Options-API backoff:

```
~  partially-migrated  [mixins: no composable registered for mixin 'ruleContainer']
~  partially-migrated  [mixins: no composable registered for mixin 'cms-state']
~  partially-migrated  [mixins: no composable registered for mixin 'media-sidebar-modal-mixin']
```

This is also the prerequisite layer for the two large follow-ups. `sw-cms-element.mixin.ts` opens with

```js
mixins: [Mixin.getByName('cms-state')],
```

so #19338 (35 components) cannot start before `useCmsState` exists, and it needs the mixin-declared props and prop getters added here. #19336 (`listing`, 36 components) needs the `ref` member kind for its 12 `data()` refs and the callback mechanism for its abstract `getList()`.

### 2. What does this change do, exactly?

Extends the composable descriptor so it can declare what a mixin needs from the instance, and wires it in one options argument:

- **`instanceDependencies.emits`** — generates `(...args) => emit('<event>', ...args)` and merges the event into the component's `defineEmits`.
- **`instanceDependencies.props`** — passes `() => props.<name>`, so reads stay reactive.
- **`instanceDependencies.callbacks`** — passes a getter for the component member the mixin expected the host to override.
- **`providedProps`** — merges the props the mixin declared into the component's `defineProps` literal (a spread would not be statically analysable) and registers the names, so `this.<prop>` still rewrites.
- **`ComposableMemberKind: 'ref'`** — a mixin's `data()` entries and computeds now rewrite through `.value`, reads and writes alike.
- **`nameConstants`** — matches the module export a component may pass to `Mixin.getByName(...)` instead of a string literal. The value lives in a module the transformer never reads, so it can only be matched, not resolved.

A dependency the generated setup cannot satisfy is a **backoff reason**, not a silent omission — the component keeps the Options-API script rather than running a composable without the emit, prop or override it relied on:

```
~  partially-migrated  [mixins: the 'rule-between-operator' composable needs the 'condition' prop, which the component does not declare]
```

Eight composables use the model. Each mirrors its mixin and is duplicated rather than delegating, matching #18356; the mixins stay for legacy Options API components.

| Composable | Mechanism it exercises |
| --- | --- |
| `useCmsState` | `ref` members (store-backed computeds, incl. writable `selectedBlock` / `selectedSection`) |
| `useMediaSidebarModal` | `emits` |
| `useVideoCover` | `props` |
| `useMediaGridListener` | `emits` + `callbacks` |
| `useRuleContainer` | `props` + `callbacks` + `providedProps` |
| `useValidation` | `props` + `providedProps` |
| `useRuleBetweenOperator` | `props` + `callbacks` + `nameConstants` |
| `useExtensionError` | none — drop-in |

`sw-extension-error` was expected to need `getCurrentInstance()`. It does not: the mixin passed `this` to `extensionErrorService`, which only ever calls `translator.$t(...)`, so the composable passes `{ $t: t }` from `useI18n()`.

**nit: `useValidation` drops the mixin's `isValid` computed.** The mixin reads the host's value under whichever name exists:

```js
isValid() {
    const value = this.currentValue || this.value || this.selections;
    return this.validate(value);
}
```

A descriptor can name one fixed member, not "whichever of these three this component happens to declare". It is listed under `unmappedMembers`, so any component reading `isValid` backs off instead of silently losing it. Impact is zero — both components that use the mixin (`sw-text-field-deprecated`, `sw-vector-field`) never read it, and `validate(value)` is exposed for callers that need it.

**nit: a callback option reads a binding declared below it.** `selectableItems: () => selectableItems.value` closes over the `createExtendableSetup()` destructure that follows the composable declaration. Deferring the read is correct for event handlers and watchers, which is every current use. A composable that invoked such a callback during its own setup would hit the temporal dead zone and throw loudly. Documented in `TECHNICAL_README.md`.

**nit: `ruleContainer` returns two injects as refs.** `sw-condition-tree` provides `childAssociationField` and `conditionDataProviderService` as `computed(...)`. The Options API unwrapped them on the instance proxy; `inject()` in a composable does not, so they are returned as refs and rewrite to `.value`.

### 3. Describe each step to reproduce the issue or behaviour.

```bash
cd src/Administration/Resources/app/administration
npm run codemod:sfc-migration -- --dry-run src
```

Before this branch, on top of #18356: **412** fully migrated. After: **416**, with no component regressing from fully to partially migrated.

Newly fully migrated:

```
✓  fully-migrated  ./src/app/component/rule/sw-condition-and-container/sw-condition-and-container.vue
✓  fully-migrated  ./src/app/component/rule/sw-condition-or-container/sw-condition-or-container.vue
✓  fully-migrated  ./src/module/sw-extension/component/sw-ratings/sw-extension-ratings-card/sw-extension-ratings-card.vue
✓  fully-migrated  ./src/module/sw-media/component/sidebar/sw-media-quickinfo-multiple/sw-media-quickinfo-multiple.vue
```

`sw-media-quickinfo-multiple` now generates:

```js
const emit = defineEmits(['media-item-selection-remove', 'media-sidebar-items-delete', 'media-sidebar-folder-items-dissolve', 'media-sidebar-items-move']);

const { showModalDelete, deleteSelectedItems } = useMediaSidebarModal({
    onItemsDelete: (...args) => emit('media-sidebar-items-delete', ...args),
    onFolderItemsDissolve: (...args) => emit('media-sidebar-folder-items-dissolve', ...args),
    onItemsMove: (...args) => emit('media-sidebar-items-move', ...args),
});
```

The remaining consumers of these eight mixins report the reason they back off. Most are unrelated to mixins (`mapPropertyErrors` spreads, `$super`, `provide`, dynamic `this[key]`); five components redeclare a `data()` entry the mixin already gives them, and three inherit `condition` / `ensureValueExist` from `sw-condition-base` via `Shopware.Component.extend`, which the single-file transformer cannot see.

Tests:

```bash
npx jest --config jest.config.js --collectCoverage=false scripts/codemods src/app/composables src/module/sw-cms/composables src/module/sw-media/composables src/module/sw-extension/composables
```

### 4. Please link to the relevant issues (if any).

- closes #19331
- relates #17213
- relates #19336
- relates #19338

closes #19331

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [x] I have written or adjusted the documentation and agent skills according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
