### PR TITLE
feat(administration): scaffold-assisted migration of the listing mixin to a useListing composable

### DIFF
--- a/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/README.md
+++ b/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/README.md
@@ -79,7 +79,7 @@ Each component is classified into one of three states:
 | Status               | Meaning                                                                                           | Output                                         |
 | -------------------- | ------------------------------------------------------------------------------------------------- | ---------------------------------------------- |
 | `fully-migrated`     | Full `<script setup>` with `createExtendableSetup`                                                | `.vue` file written                            |
-| `partially-migrated` | Soft blocker found (mixins, `Shopware.Component.extend()`) — Options API kept in plain `<script>` | `.vue` file written, manual follow-up required |
+| `partially-migrated` | Either `<script setup>` with TODOs for the parts that need a human, or — for a soft blocker such as an unregistered mixin or `Shopware.Component.extend()` — the Options API kept in a plain `<script>` | `.vue` file written, manual follow-up required |
 | `not-migratable`     | Hard blocker found (`render()`) — cannot be automatically converted                               | No file written                                |
 
 ## Programmatic API

--- a/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/TECHNICAL_README.md
+++ b/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/TECHNICAL_README.md
@@ -67,6 +67,7 @@ Examples:
 | --- | --- |
 | Normal Options API component | `fully-migrated` |
 | Component with a registered mixin | `fully-migrated`, the mixin becomes a composable |
+| Component with a scaffold-only mixin (`listing`) | `partially-migrated`, `<script setup>` plus a verification TODO |
 | Component with an unregistered mixin | `partially-migrated`, script stays Options API |
 | Component using `Shopware.Component.extend()` | `partially-migrated`, script stays Options API |
 | Component with `render()` | `not-migratable` |
@@ -389,6 +390,9 @@ const { clearSelection } = useMediaGridListener({
 | `props` | `() => props.<prop>` | The component does not declare the prop. |
 | `callbacks` | A getter for the component member. | The generated setup has no binding for that member. |
 
+A callback marked `optional: true` is dropped instead of backing off, for a member
+the mixin declared a default for and only invited the component to override.
+
 Callback and prop values are getters so the read happens when the composable
 calls them, not while the declaration is emitted. The callback member's binding
 comes from the `createExtendableSetup()` destructure below the composable
@@ -422,6 +426,60 @@ nameConstants: [{ source: 'src/app/mixin/rule-between-operator.mixin', exportNam
 ```
 
 An unregistered constant stays an unresolved mixin and backs the component off.
+
+### Scaffolded Mixins
+
+A mixin like `listing` is not a helper. It owns state, lifecycle and route
+handling, and drives an abstract `getList()` that each component implements. The
+composable can own everything except that inversion of control, so the codemod
+produces a reviewed draft rather than a finished component. Three descriptor
+fields describe that shape:
+
+```ts
+alwaysActive: true,
+configKeys: ['page', 'limit', 'sortBy', ...],
+manualVerification: 'the listing mixin was scaffolded, not fully migrated: …',
+instanceDependencies: {
+    callbacks: [
+        { option: 'getList', member: 'getList' },
+        { option: 'filters', member: 'filters', optional: true },
+    ],
+},
+```
+
+which generates:
+
+```js
+const { page, limit, total, sortBy, sortDirection, term, onPageChange } = useListing({
+    getList: (...args) => getList(...args),
+    sortBy: 'name',
+    searchConfigEntity: 'product',
+});
+```
+
+| Field | Effect |
+| --- | --- |
+| `alwaysActive` | Declares the composable even when no member is read. Dropping it would drop the whole listing lifecycle, not just an unused import. |
+| `configKeys` | Mixin `data()` fields a component was allowed to re-declare in its own `data()` purely to set their initial value. |
+| `manualVerification` | Emits a leading TODO and keeps the result `partially-migrated`. |
+
+Config keys exist because Vue merged the mixin's `data()` and the component's
+`data()` into one property. The composable owns that state, so the component's
+initializer has to reach it as an option — leaving it as a local `ref` would
+create a second, disconnected copy that the composable's watchers never see. The
+entry is therefore removed from the generated `data` refs, does not shadow the
+composable member, and is emitted as an option instead.
+
+Two shapes back the component off rather than guess: a config key declared as
+anything but a `data()` entry (a prop, computed, method or inject), and a
+`data()` initializer that reads `this` — a composable option is evaluated before
+any setup binding exists.
+
+The `getList` callback is passed as `(...args) => getList(...args)` so the read
+stays deferred: the component's `getList` is declared in the
+`createExtendableSetup()` destructure below the composable call. `useListing`
+therefore runs its first load in `onMounted`, not during setup. That timing
+change is the main thing the verification TODO asks a human to check.
 
 ## Why `createExtendableSetup()` Is Used
 

--- a/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/__fixtures__/listing-mixin-component.html.twig
+++ b/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/__fixtures__/listing-mixin-component.html.twig
@@ -1,0 +1,19 @@
+{% block sw_listing_demo %}
+    <div class="sw-listing-demo">
+        <sw-search-bar :search-term="term" @search="onSearch" />
+
+        <sw-data-grid
+            :items="products"
+            :is-loading="isLoading"
+            @column-sort="onSortColumn"
+            @delete-item="onDeleteProduct"
+        />
+
+        <sw-pagination
+            :page="page"
+            :limit="limit"
+            :total="total"
+            @page-change="onPageChange"
+        />
+    </div>
+{% endblock %}

--- a/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/__fixtures__/listing-mixin-component.index.js
+++ b/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/__fixtures__/listing-mixin-component.index.js
@@ -1,0 +1,58 @@
+import template from './listing-mixin-component.html.twig';
+
+const { Criteria } = Shopware.Data;
+
+Shopware.Component.register('sw-listing-demo', {
+    template,
+
+    inject: ['repositoryFactory'],
+
+    mixins: [
+        Shopware.Mixin.getByName('listing'),
+    ],
+
+    data() {
+        return {
+            products: null,
+            isLoading: false,
+            sortBy: 'name',
+            searchConfigEntity: 'product',
+            storeKey: 'grid.filter.product',
+            filterCriteria: [],
+        };
+    },
+
+    computed: {
+        productRepository() {
+            return this.repositoryFactory.create('product');
+        },
+
+        filters() {
+            return [
+                { name: 'term', active: false },
+            ];
+        },
+    },
+
+    methods: {
+        async getList() {
+            this.isLoading = true;
+
+            const criteria = new Criteria(this.page, this.limit);
+            criteria.setTerm(this.term);
+            criteria.addSorting(Criteria.sort(this.sortBy, this.sortDirection));
+
+            const items = await this.productRepository.search(criteria);
+
+            this.total = items.total;
+            this.products = items;
+            this.isLoading = false;
+        },
+
+        onDeleteProduct(id) {
+            return this.productRepository.delete(id).then(() => {
+                this.getList();
+            });
+        },
+    },
+});

--- a/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/__snapshots__/generate-sfc.spec.ts.snap
+++ b/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/__snapshots__/generate-sfc.spec.ts.snap
@@ -123,6 +123,113 @@ const {
 </script>"
 `;
 
+exports[`scripts/codemods/sfc-migration/generate-sfc listing-mixin-component: scaffolded listing page — useListing() owns the state and calls back into getList matches the complete scaffolded SFC output snapshot 1`] = `
+"<template>
+<sw-block name="sw_listing_demo" :data="$dataScope">
+    <div class="sw-listing-demo">
+        <sw-search-bar :search-term="term" @search="onSearch" />
+
+        <sw-data-grid
+            :items="products"
+            :is-loading="isLoading"
+            @column-sort="onSortColumn"
+            @delete-item="onDeleteProduct"
+        />
+
+        <sw-pagination
+            :page="page"
+            :limit="limit"
+            :total="total"
+            @page-change="onPageChange"
+        />
+    </div>
+</sw-block>
+
+</template>
+
+<script setup>
+// TODO: verify the 'listing' migration: the 'listing' mixin was scaffolded, not fully migrated: check that getList() reads and writes the composable's state, that the listing fields moved to useListing() options are configuration and not local state, and that moving the initial load from created() to onMounted() did not change behaviour
+
+const { Criteria } = Shopware.Data;
+
+const props = defineProps({});
+
+import { createExtendableSetup } from 'src/app/adapter/composition-extension-system';
+import { ref, computed, inject } from 'vue';
+import { useListing } from 'src/app/composables/use-listing';
+
+const { page, limit, total, sortBy, sortDirection, term, onPageChange, onSearch, onSortColumn } = useListing({
+    getList: (...args) => getList(...args),
+    filters: () => filters.value,
+    sortBy: 'name',
+    searchConfigEntity: 'product',
+    storeKey: 'grid.filter.product',
+    filterCriteria: [],
+});
+
+const {
+    repositoryFactory,
+    products,
+    isLoading,
+    productRepository,
+    filters,
+    getList,
+    onDeleteProduct,
+} = createExtendableSetup(
+    {
+        name: 'sw-listing-demo',
+        props,
+    },
+    () => {
+        const repositoryFactory = inject('repositoryFactory');
+
+        const products = ref(null);
+        const isLoading = ref(false);
+
+        const productRepository = computed(() => {
+            return repositoryFactory.create('product');
+        });
+        const filters = computed(() => {
+            return [
+                { name: 'term', active: false },
+            ];
+        });
+
+        const getList = async () => {
+            isLoading.value = true;
+
+                        const criteria = new Criteria(page.value, limit.value);
+                        criteria.setTerm(term.value);
+                        criteria.addSorting(Criteria.sort(sortBy.value, sortDirection.value));
+
+                        const items = await productRepository.value.search(criteria);
+
+                        total.value = items.total;
+                        products.value = items;
+                        isLoading.value = false;
+        };
+        const onDeleteProduct = (id) => {
+            return productRepository.value.delete(id).then(() => {
+                getList();
+            });
+        };
+
+        return {
+            public: {
+                repositoryFactory,
+                products,
+                isLoading,
+                productRepository,
+                filters,
+                getList,
+                onDeleteProduct,
+            },
+        };
+    },
+);
+</script>"
+`;
+
 exports[`scripts/codemods/sfc-migration/generate-sfc mixin-component: partially migrated SFC — template converted, script kept as Options API without createExtendableSetup matches the complete partially-migrated SFC output snapshot 1`] = `
 "<template>
 <div class="sw-mixin-list"></div>

--- a/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/generate-sfc.spec.ts
+++ b/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/generate-sfc.spec.ts
@@ -176,6 +176,66 @@ describe('scripts/codemods/sfc-migration/generate-sfc', () => {
         });
     });
 
+    describe('listing-mixin-component: scaffolded listing page — useListing() owns the state and calls back into getList', () => {
+        let result: ReturnType<typeof mergeComponentFiles>;
+
+        beforeAll(() => {
+            result = mergeComponentFiles(
+                readFixture('listing-mixin-component.html.twig'),
+                readFixture('listing-mixin-component.index.js'),
+            );
+        });
+
+        it('reports status partially-migrated with the listing verification as its only blocker', () => {
+            expect(result.status).toBe('partially-migrated');
+            expect(result.blockers).toEqual([
+                expect.stringContaining("the 'listing' mixin was scaffolded"),
+            ]);
+        });
+
+        it('produces a <script setup> block instead of the Options API backoff', () => {
+            expect(result.sfc).toContain('<script setup>');
+        });
+
+        it('leads with a TODO naming the checks the codemod cannot make', () => {
+            expect(result.sfc).toContain("// TODO: verify the 'listing' migration:");
+        });
+
+        it('hands the component getList and its own filters to useListing', () => {
+            expect(result.sfc).toContain("import { useListing } from 'src/app/composables/use-listing';");
+            expect(result.sfc).toContain('getList: (...args) => getList(...args),');
+            expect(result.sfc).toContain('filters: () => filters.value,');
+        });
+
+        it('routes the listing fields the component set in data() into the useListing options', () => {
+            expect(result.sfc).toContain("sortBy: 'name',");
+            expect(result.sfc).toContain("searchConfigEntity: 'product',");
+            expect(result.sfc).toContain("storeKey: 'grid.filter.product',");
+            expect(result.sfc).toContain('filterCriteria: [],');
+            // The composable owns that state, so no second ref is declared for it.
+            expect(result.sfc).not.toContain("const sortBy = ref('name');");
+        });
+
+        it('destructures the listing state under the names the template already uses', () => {
+            expect(result.sfc).toMatch(/const \{[^}]*\bpage\b[^}]*\blimit\b[^}]*\btotal\b[^}]*\} = useListing\(/);
+        });
+
+        it('rewrites the listing fields getList reads and writes to the composable refs', () => {
+            expect(result.sfc).toContain('new Criteria(page.value, limit.value)');
+            expect(result.sfc).toContain('total.value = items.total;');
+            expect(result.sfc).not.toContain('this.total');
+        });
+
+        it('rewrites the component calling its own getList', () => {
+            expect(result.sfc).toContain('getList();');
+            expect(result.sfc).not.toContain('this.getList');
+        });
+
+        it('matches the complete scaffolded SFC output snapshot', () => {
+            expect(result.sfc).toMatchSnapshot();
+        });
+    });
+
     describe('manual-follow-up partials: generated setup scripts stay wrapped in <script setup>', () => {
         it('keeps <script setup> for partially-migratable setup output', () => {
             const result = mergeComponentFiles(

--- a/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/script-transformer/composable-registry.ts
+++ b/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/script-transformer/composable-registry.ts
@@ -78,6 +78,11 @@ export interface ComposableCallbackDependency {
     option: string;
     /** The component member the generated callback reads. */
     member: string;
+    /**
+     * Drop the entry when the component defines no such member, instead of
+     * backing off. For overridables the mixin declared a default for.
+     */
+    optional?: boolean;
 }
 
 /**
@@ -115,6 +120,26 @@ export interface ComposableDescriptor {
     members: Record<string, ComposableMemberBinding>;
     instanceDependencies?: ComposableInstanceDependencies;
     providedProps?: readonly ComposableProvidedProp[];
+    /**
+     * Mixin `data()` fields a component was allowed to re-declare in its own
+     * `data()` purely to configure the mixin — Vue merged both declarations into
+     * one property. The composable owns that state, so the component's
+     * initializer is handed to it as an option instead of becoming a second,
+     * disconnected ref. A component that declares one of these as anything but a
+     * static `data()` entry backs off.
+     */
+    configKeys?: readonly string[];
+    /**
+     * Declare the composable even when no member is read. Set it for a composable
+     * that drives the component through a callback: dropping it would drop the
+     * whole listing lifecycle, not just an unused import.
+     */
+    alwaysActive?: boolean;
+    /**
+     * What a human has to check on the generated component. Set it for a mixin
+     * the codemod can only scaffold; the result is marked partially-migrated.
+     */
+    manualVerification?: string;
 }
 
 // --- Globals -----------------------------------------------------------------
@@ -605,6 +630,103 @@ const ruleContainerDescriptor: ComposableDescriptor = {
     },
 };
 
+const listingDescriptor: ComposableDescriptor = {
+    id: 'listing',
+    trigger: {
+        type: 'mixin',
+        mixinNames: ['listing'],
+        // The route handling, the initial load and `addQueryScores` call these
+        // themselves, so a component override would not reach the composable.
+        internallyReferencedMembers: [
+            'updateData',
+            'updateRoute',
+            'resetListing',
+            'parseBooleanQueryParams',
+            'isValidTerm',
+            'selectionArray',
+        ],
+        // The mixin injected both for its own use. The composable resolves the
+        // search ranking service itself and never needed `feature`, so a
+        // component that inherited either through the mixin must back off.
+        unmappedMembers: [
+            'searchRankingService',
+            'feature',
+        ],
+    },
+    import: { source: 'src/app/composables/use-listing', name: 'useListing' },
+    declarationStyle: 'destructure',
+    alwaysActive: true,
+    manualVerification:
+        "the 'listing' mixin was scaffolded, not fully migrated: check that getList() reads and writes the composable's state, that the listing fields moved to useListing() options are configuration and not local state, and that moving the initial load from created() to onMounted() did not change behaviour",
+    instanceDependencies: {
+        // The mixin called an abstract `getList()` the component implemented, and
+        // read a `filters` computed it invited the component to override.
+        callbacks: [
+            { option: 'getList', member: 'getList' },
+            { option: 'filters', member: 'filters', optional: true },
+        ],
+    },
+    configKeys: [
+        'page',
+        'limit',
+        'total',
+        'sortBy',
+        'sortDirection',
+        'naturalSorting',
+        'selection',
+        'term',
+        'disableRouteParams',
+        'searchConfigEntity',
+        'entitySearchable',
+        'freshSearchTerm',
+        'storeKey',
+        'filterCriteria',
+    ],
+    members: {
+        ...refMembers([
+            'page',
+            'limit',
+            'total',
+            'sortBy',
+            'sortDirection',
+            'naturalSorting',
+            'selection',
+            'term',
+            'disableRouteParams',
+            'searchConfigEntity',
+            'entitySearchable',
+            'freshSearchTerm',
+            'previousRouteName',
+            'storeKey',
+            'filterCriteria',
+            'maxPage',
+            'routeName',
+            'selectionArray',
+            'selectionCount',
+            'filters',
+            'searchRankingFields',
+            'currentSortBy',
+        ]),
+        ...methodMembers([
+            'updateData',
+            'updateRoute',
+            'resetListing',
+            'getMainListingParams',
+            'updateSelection',
+            'onPageChange',
+            'onSearch',
+            'onSwitchFilter',
+            'onSort',
+            'onSortColumn',
+            'onRefresh',
+            'isValidTerm',
+            'addQueryScores',
+            'parseBooleanQueryParams',
+            'updateCriteria',
+        ]),
+    },
+};
+
 export const MIXIN_DESCRIPTORS: readonly ComposableDescriptor[] = [
     notificationDescriptor,
     placeholderDescriptor,
@@ -622,12 +744,18 @@ export const MIXIN_DESCRIPTORS: readonly ComposableDescriptor[] = [
     ruleBetweenOperatorDescriptor,
     validationDescriptor,
     ruleContainerDescriptor,
+    listingDescriptor,
 ];
 
 export const COMPOSABLE_REGISTRY: readonly ComposableDescriptor[] = [
     ...GLOBAL_DESCRIPTORS,
     ...MIXIN_DESCRIPTORS,
 ];
+
+/** Every member the given descriptors treat as configuration rather than as component state. */
+export function collectConfigKeys(descriptors: readonly ComposableDescriptor[]): Set<string> {
+    return new Set(descriptors.flatMap((descriptor) => descriptor.configKeys ?? []));
+}
 
 /** The global descriptor that answers a given `this.<key>` access, if any. */
 export function findGlobalDescriptorByThisKey(key: string): ComposableDescriptor | undefined {

--- a/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/script-transformer/composition-script-state.ts
+++ b/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/script-transformer/composition-script-state.ts
@@ -44,7 +44,7 @@ import type {
     WatchProp,
 } from './types';
 import type { ComposableDescriptor, ComposableProvidedProp } from './composable-registry';
-import { GLOBAL_DESCRIPTORS } from './composable-registry';
+import { collectConfigKeys, GLOBAL_DESCRIPTORS } from './composable-registry';
 import { collectComponentMemberNames } from './extract-mixins';
 
 export interface CompositionScriptState {
@@ -107,11 +107,17 @@ export function collectCompositionScriptState(
     mixinDescriptors: ComposableDescriptor[] = [],
     templateReferences: Set<string> = new Set(),
 ): CompositionScriptState {
+    // A config key's `data()` entry initializes composable state instead of
+    // declaring component state, so it neither shadows the composable member nor
+    // becomes a local ref.
+    const configKeyNames = collectConfigKeys(mixinDescriptors);
+    const configValues = collectConfigValues(optionsObj, configKeyNames);
+
     // All names the component declares, including members later dropped as
     // unsupported. A same-name component member shadows the composable member
     // (Vue override semantics), so a dropped override must not silently fall back
     // to the composable's version.
-    const ownMemberNames = collectComponentMemberNames(optionsObj);
+    const ownMemberNames = collectComponentMemberNames(optionsObj, configKeyNames);
     const composableMembers = buildComposableMemberMap(mixinDescriptors, ownMemberNames);
     let lifecycleHooks = extractLifecycleHooks(optionsObj);
     const inheritAttrs = extractInheritAttrs(optionsObj);
@@ -148,7 +154,7 @@ export function collectCompositionScriptState(
         pushManualMigration(manualMigrationReasons, todoComments, 'emits', emitsIssue.reason);
     }
 
-    const supportedMembers = collectSupportedCompositionMembers(optionsObj, propNames, composableMembers);
+    const supportedMembers = collectSupportedCompositionMembers(optionsObj, propNames, composableMembers, configKeyNames);
     manualMigrationReasons.push(...supportedMembers.manualMigrationReasons);
     todoComments.push(...supportedMembers.todoComments);
 
@@ -180,10 +186,22 @@ export function collectCompositionScriptState(
             ownMemberNames,
             templateReferences,
             ctx,
+            configValues,
             backoffReasons,
         ),
     ];
     const templateRefNames = collectThisRefNames(allSnippets);
+
+    // Reporting a scaffold as fully migrated would hide the wiring a human still
+    // has to check.
+    for (const { descriptor } of activeComposables) {
+        if (descriptor.manualVerification) {
+            manualMigrationReasons.push(descriptor.manualVerification);
+            todoComments.push(
+                `// TODO: verify the '${descriptor.id}' migration: ${sanitizeTodoCommentText(descriptor.manualVerification)}`,
+            );
+        }
+    }
 
     if (hasDirectThisPropertyUsage(allSnippets, '$store')) {
         manualMigrationReasons.push('$store usage requires manual migration to the appropriate Pinia store or composable');
@@ -308,9 +326,11 @@ function collectSupportedCompositionMembers(
     optionsObj: ObjectLiteralExpression,
     propNames: Set<string>,
     composableMembers: Map<string, ComposableMemberRewrite>,
+    configKeyNames: Set<string>,
 ): SupportedCompositionMembers {
     const { injectProps, unsupportedEntries: unsupportedInjectEntries } = extractInjectProps(optionsObj);
-    const { dataProps, unsupportedEntries: unsupportedDataEntries } = extractDataProps(optionsObj);
+    const { dataProps: allDataProps, unsupportedEntries: unsupportedDataEntries } = extractDataProps(optionsObj);
+    const dataProps = allDataProps.filter(({ name }) => !configKeyNames.has(name));
     const { computedProps, unsupportedEntries: unsupportedComputedEntries } = extractComputedProps(optionsObj);
     const { watchProps, unsupportedEntries } = extractWatchProps(optionsObj);
     const unsupportedWatchEntries = [...unsupportedEntries];
@@ -951,6 +971,34 @@ function mergeProvidedProps(propsText: string | null, providedProps: ComposableP
 function resolveInstanceDependencies(
     descriptor: ComposableDescriptor,
     ctx: RewriteContext,
+    configValues: Map<string, string>,
+    backoffReasons: string[],
+): ComposableArgument[] {
+    const argumentEntries: ComposableArgument[] = [
+        ...resolveDeclaredDependencies(descriptor, ctx, backoffReasons),
+        ...(descriptor.configKeys ?? [])
+            .filter((key) => configValues.has(key))
+            .map((key) => ({ option: key, valueSnippet: configValues.get(key) as string })),
+    ];
+
+    return argumentEntries;
+}
+
+/** The `data()` entries that configure a composable rather than declaring component state. */
+function collectConfigValues(optionsObj: ObjectLiteralExpression, configKeyNames: Set<string>): Map<string, string> {
+    return new Map(
+        extractDataProps(optionsObj)
+            .dataProps.filter(({ name }) => configKeyNames.has(name))
+            .map(({ name, valueText }) => [
+                name,
+                valueText,
+            ]),
+    );
+}
+
+function resolveDeclaredDependencies(
+    descriptor: ComposableDescriptor,
+    ctx: RewriteContext,
     backoffReasons: string[],
 ): ComposableArgument[] {
     const dependencies = descriptor.instanceDependencies;
@@ -978,12 +1026,14 @@ function resolveInstanceDependencies(
         argumentEntries.push({ option, valueSnippet: `() => ${buildPropertyAccess('props', prop)}` });
     }
 
-    for (const { option, member } of dependencies.callbacks ?? []) {
+    for (const { option, member, optional } of dependencies.callbacks ?? []) {
         const valueSnippet = buildCallbackSnippet(member, ctx);
         if (valueSnippet === null) {
-            backoffReasons.push(
-                `mixins: the '${descriptor.id}' composable needs the component member '${member}', which the generated setup does not declare`,
-            );
+            if (!optional) {
+                backoffReasons.push(
+                    `mixins: the '${descriptor.id}' composable needs the component member '${member}', which the generated setup does not declare`,
+                );
+            }
             continue;
         }
 
@@ -1054,6 +1104,7 @@ function collectActiveMixinComposables(
     ownMemberNames: Set<string>,
     templateReferences: Set<string>,
     ctx: RewriteContext,
+    configValues: Map<string, string>,
     backoffReasons: string[],
 ): ActiveComposable[] {
     // A member counts as used when accessed via `this` in the script or read as
@@ -1068,10 +1119,10 @@ function collectActiveMixinComposables(
                     (hasDirectThisPropertyUsage(snippets, key) || templateReferences.has(key)),
             ),
         }))
-        .filter((active) => active.memberKeys.length > 0)
+        .filter((active) => active.memberKeys.length > 0 || active.descriptor.alwaysActive)
         .map((active) => ({
             ...active,
-            argumentEntries: resolveInstanceDependencies(active.descriptor, ctx, backoffReasons),
+            argumentEntries: resolveInstanceDependencies(active.descriptor, ctx, configValues, backoffReasons),
         }));
 }
 

--- a/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/script-transformer/emit-composition-api-script.ts
+++ b/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/script-transformer/emit-composition-api-script.ts
@@ -207,6 +207,12 @@ function createDestructureDeclarationTemplate(
             });
             const args = isIdentifierTemplate(argumentsSnippet) ? argumentsSnippet.render(resolve) : argumentsSnippet;
 
+            // An always-active composable can be declared without any member
+            // being read; it still has to run for its lifecycle and watchers.
+            if (parts.length === 0) {
+                return `${descriptor.import.name}(${args});`;
+            }
+
             return `const { ${parts.join(', ')} } = ${descriptor.import.name}(${args});`;
         },
     };

--- a/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/script-transformer/extract-mixins.ts
+++ b/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/script-transformer/extract-mixins.ts
@@ -1,7 +1,7 @@
 import type { Expression, ObjectLiteralExpression, SourceFile } from 'ts-morph';
 import { Node, SyntaxKind } from 'ts-morph';
 import type { ComposableDescriptor } from './composable-registry';
-import { findMixinDescriptorByName, findMixinDescriptorByNameConstant } from './composable-registry';
+import { collectConfigKeys, findMixinDescriptorByName, findMixinDescriptorByNameConstant } from './composable-registry';
 import { extractPropNamesFromText } from './extract-component-options';
 import { extractDataProps } from './extract-data';
 import { extractInjectProps } from './extract-inject';
@@ -56,12 +56,14 @@ export function resolveComponentMixins(
         }
     }
 
-    const ownMemberNames = collectComponentMemberNames(optionsObj);
+    const ownMemberNames = collectComponentMemberNames(optionsObj, collectConfigKeys(descriptors));
     for (const descriptor of descriptors) {
         const trigger = descriptor.trigger;
         if (trigger.type !== 'mixin') {
             continue;
         }
+
+        unresolved.push(...collectConfigKeyIssues(descriptor, optionsObj));
 
         // Overriding a leaf member is fine — the component's version wins and the
         // composable member is simply dropped. Only a member the composable calls
@@ -93,8 +95,53 @@ export function resolveComponentMixins(
     return { hasMixins: true, descriptors, unresolved };
 }
 
-/** Names the component binds via its own `methods`, `computed`, `props`, `data`, or `inject`. */
-export function collectComponentMemberNames(optionsObj: ObjectLiteralExpression): Set<string> {
+/**
+ * A config key's `data()` entry only sets the initial value of state the
+ * composable owns. Declaring it anywhere else, or from an initializer that reads
+ * the instance, cannot be expressed as a plain option, so the component backs off.
+ */
+function collectConfigKeyIssues(descriptor: ComposableDescriptor, optionsObj: ObjectLiteralExpression): string[] {
+    const configKeys = descriptor.configKeys ?? [];
+    if (configKeys.length === 0) {
+        return [];
+    }
+
+    const dataProps = extractDataProps(optionsObj).dataProps;
+    const dataPropsByName = new Map(dataProps.map((prop) => [prop.name, prop]));
+    const nonDataMemberNames = collectComponentMemberNames(optionsObj, new Set(dataPropsByName.keys()));
+
+    return configKeys.flatMap((key) => {
+        if (nonDataMemberNames.has(key)) {
+            return [
+                `mixins: component declares '${key}' from the '${descriptor.id}' mixin outside of data(), which the composable cannot take as configuration`,
+            ];
+        }
+
+        const dataProp = dataPropsByName.get(key);
+        if (dataProp && readsInstance(dataProp.valueText)) {
+            return [
+                `mixins: the '${key}' data entry configuring the '${descriptor.id}' mixin reads the component instance`,
+            ];
+        }
+
+        return [];
+    });
+}
+
+/** Whether an expression reads `this`, and therefore cannot be emitted as a composable option. */
+function readsInstance(valueText: string): boolean {
+    return /\bthis\b/u.test(valueText);
+}
+
+/**
+ * Names the component binds via its own `methods`, `computed`, `props`, `data`, or
+ * `inject`. `excludedDataNames` drops `data()` entries that are not component state
+ * — config keys, whose value is handed to a composable instead.
+ */
+export function collectComponentMemberNames(
+    optionsObj: ObjectLiteralExpression,
+    excludedDataNames: Set<string> = new Set(),
+): Set<string> {
     const names = new Set<string>();
 
     for (const option of [
@@ -124,7 +171,9 @@ export function collectComponentMemberNames(optionsObj: ObjectLiteralExpression)
     // one of them shadows is overridden just like a method would be. Mirror the
     // override set used when the composable members are emitted.
     extractPropNamesFromText(optionsObj).forEach((name) => names.add(name));
-    extractDataProps(optionsObj).dataProps.forEach((prop) => names.add(prop.name));
+    extractDataProps(optionsObj)
+        .dataProps.filter((prop) => !excludedDataNames.has(prop.name))
+        .forEach((prop) => names.add(prop.name));
     extractInjectProps(optionsObj).injectProps.forEach((prop) => names.add(prop.localName));
 
     return names;

--- a/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/transform-script.spec.ts
+++ b/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/transform-script.spec.ts
@@ -375,12 +375,96 @@ describe('scripts/codemods/sfc-migration/transform-script', () => {
             const result = transformScript(
                 `Shopware.Component.register('sw-demo', {
                     template,
-                    mixins: ['listing'],
+                    mixins: ['form-field'],
                 });`,
             );
 
             expect(result.status).toBe('partially-migratable');
-            expect(result.blockers).toContain("mixins: no composable registered for mixin 'listing'");
+            expect(result.blockers).toContain("mixins: no composable registered for mixin 'form-field'");
+        });
+    });
+
+    // -------------------------------------------------------------------------
+    describe('listing mixin: scaffolded via config keys, an IoC callback, and a verification marker', () => {
+        function listingComponent(body: string): string {
+            return `Shopware.Component.register('sw-listing-demo', {
+                template,
+                mixins: [Shopware.Mixin.getByName('listing')],
+                ${body}
+            });`;
+        }
+
+        it('keeps the result partial and names the checks the codemod cannot make', () => {
+            const result = transformScript(listingComponent(`methods: { getList() { this.total = 0; } }`));
+
+            expect(result.scriptType).toBe('setup');
+            expect(result.status).toBe('partially-migratable');
+            expect(result.blockers).toEqual([
+                expect.stringContaining("the 'listing' mixin was scaffolded"),
+            ]);
+        });
+
+        it('declares useListing even when the component reads none of its members', () => {
+            const result = transformScript(listingComponent(`methods: { getList() { return 1; } }`));
+
+            expect(result.script).toContain('useListing({');
+            expect(result.script).not.toContain('} = useListing(');
+        });
+
+        it('omits the optional filters callback when the component does not override it', () => {
+            const result = transformScript(listingComponent(`methods: { getList() { this.total = 0; } }`));
+
+            expect(result.script).toContain('getList: (...args) => getList(...args),');
+            expect(result.script).not.toContain('filters:');
+        });
+
+        it('backs off when the component defines no getList', () => {
+            const result = transformScript(listingComponent(`data() { return { items: [] }; }`));
+
+            expect(result.scriptType).toBe('options');
+            expect(result.blockers).toContain(
+                "mixins: the 'listing' composable needs the component member 'getList', which the generated setup does not declare",
+            );
+        });
+
+        it('backs off when a listing field is declared outside data()', () => {
+            const result = transformScript(
+                listingComponent(`props: { storeKey: { type: String, required: true } }, methods: { getList() {} }`),
+            );
+
+            expect(result.scriptType).toBe('options');
+            expect(result.blockers).toContain(
+                "mixins: component declares 'storeKey' from the 'listing' mixin outside of data(), which the composable cannot take as configuration",
+            );
+        });
+
+        it('backs off when a listing field is initialized from the instance', () => {
+            const result = transformScript(
+                listingComponent(`data() { return { limit: this.defaultLimit }; }, methods: { getList() {} }`),
+            );
+
+            expect(result.scriptType).toBe('options');
+            expect(result.blockers).toContain(
+                "mixins: the 'limit' data entry configuring the 'listing' mixin reads the component instance",
+            );
+        });
+
+        it('backs off when the component overrides a member useListing calls itself', () => {
+            const result = transformScript(listingComponent(`methods: { getList() {}, updateRoute() {} }`));
+
+            expect(result.scriptType).toBe('options');
+            expect(result.blockers).toContain("mixins: component redefines 'updateRoute' from the 'listing' mixin");
+        });
+
+        it('backs off when the component reads a member the mixin only injected', () => {
+            const result = transformScript(
+                listingComponent(`methods: { getList() { this.searchRankingService.isValidTerm('x'); } }`),
+            );
+
+            expect(result.scriptType).toBe('options');
+            expect(result.blockers).toContain(
+                "mixins: reads 'searchRankingService' from the 'listing' mixin, which the composable does not provide",
+            );
         });
     });
 

--- a/src/Administration/Resources/app/administration/src/app/composables/use-listing.spec.ts
+++ b/src/Administration/Resources/app/administration/src/app/composables/use-listing.spec.ts
@@ -1,0 +1,332 @@
+/**
+ * @sw-package framework
+ */
+import { flushPromises, mount } from '@vue/test-utils';
+import { createRouter, createWebHashHistory } from 'vue-router';
+import type { RouteLocationRaw, Router } from 'vue-router';
+import { useListing } from './use-listing';
+import type { UseListingOptions, UseListingReturn } from './use-listing';
+
+const searchRankingService = {
+    isValidTerm: jest.fn((term: string) => term.trim().length >= 1),
+    getSearchFieldsByEntity: jest.fn(),
+    buildSearchQueriesForEntity: jest.fn(),
+};
+
+interface MountResult {
+    listing: UseListingReturn;
+    getList: jest.Mock;
+    router: Router;
+}
+
+async function mountListing(
+    options: Partial<UseListingOptions> = {},
+    initialRoute: RouteLocationRaw = { name: 'sw.product.index' },
+): Promise<MountResult> {
+    const getList = (options.getList as jest.Mock | undefined) ?? jest.fn();
+    let listing: UseListingReturn | undefined;
+
+    const router = createRouter({
+        routes: [
+            {
+                name: 'sw.product.index',
+                path: '/sw/product/index',
+                component: {
+                    template: '<div class="sw-product-index"></div>',
+                    setup() {
+                        listing = useListing({ ...options, getList });
+
+                        return {};
+                    },
+                },
+            },
+            {
+                name: 'sw.product.detail',
+                path: '/sw/product/detail',
+                component: { template: '<div></div>' },
+            },
+            {
+                name: 'sw.bulk.edit.product',
+                path: '/sw/bulk/edit/product',
+                component: { template: '<div></div>' },
+            },
+        ],
+        history: createWebHashHistory(),
+    });
+
+    await router.push(initialRoute);
+
+    mount({ template: '<router-view />' }, { global: { plugins: [router] } });
+    await flushPromises();
+
+    return { listing: listing as UseListingReturn, getList, router };
+}
+
+describe('src/app/composables/use-listing', () => {
+    beforeEach(() => {
+        jest.spyOn(Shopware, 'Service').mockImplementation(((name: string) =>
+            name === 'searchRankingService' ? searchRankingService : undefined) as typeof Shopware.Service);
+
+        Shopware.Store.get('shopwareApps').selectedIds = [];
+        Shopware.Store.get('swBulkEdit').selectedIds = [];
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    it('starts from the listing defaults', async () => {
+        const { listing } = await mountListing();
+
+        expect(listing.page.value).toBe(1);
+        expect(listing.limit.value).toBe(25);
+        expect(listing.total.value).toBe(0);
+        expect(listing.sortBy.value).toBeNull();
+        expect(listing.sortDirection.value).toBe('ASC');
+        expect(listing.naturalSorting.value).toBe(false);
+        expect(listing.term.value).toBeUndefined();
+        expect(listing.disableRouteParams.value).toBe(false);
+        expect(listing.filters.value).toEqual([]);
+    });
+
+    it('takes the initial state from the given options', async () => {
+        const { listing } = await mountListing({
+            limit: 10,
+            sortBy: 'position',
+            sortDirection: 'DESC',
+            searchConfigEntity: 'product',
+            storeKey: 'grid.filter.product',
+            filterCriteria: ['stored'],
+        });
+
+        expect(listing.limit.value).toBe(10);
+        expect(listing.sortBy.value).toBe('position');
+        expect(listing.sortDirection.value).toBe('DESC');
+        expect(listing.searchConfigEntity.value).toBe('product');
+        expect(listing.storeKey.value).toBe('grid.filter.product');
+        expect(listing.filterCriteria.value).toEqual(['stored']);
+    });
+
+    it('writes the listing state into the route when the route has no query yet', async () => {
+        const { router, getList } = await mountListing();
+
+        expect(router.currentRoute.value.query).toEqual({
+            limit: '25',
+            page: '1',
+            sortBy: null,
+            sortDirection: 'ASC',
+            naturalSorting: false,
+        });
+        expect(getList).toHaveBeenCalled();
+    });
+
+    it('reads page, limit and sorting from the route query on mount', async () => {
+        const { listing, getList } = await mountListing({}, {
+            name: 'sw.product.index',
+            query: { page: '3', limit: '50', sortBy: 'name', sortDirection: 'DESC', naturalSorting: 'true' },
+        } as RouteLocationRaw);
+
+        expect(listing.page.value).toBe(3);
+        expect(listing.limit.value).toBe(50);
+        expect(listing.sortBy.value).toBe('name');
+        expect(listing.sortDirection.value).toBe('DESC');
+        expect(listing.naturalSorting.value).toBe(true);
+        expect(getList).toHaveBeenCalledTimes(1);
+    });
+
+    it('loads without touching the route when route params are disabled', async () => {
+        const { listing, router, getList } = await mountListing({ disableRouteParams: true });
+
+        expect(getList).toHaveBeenCalledTimes(1);
+        expect(router.currentRoute.value.query).toEqual({});
+
+        listing.onSearch('shirt');
+        expect(listing.page.value).toBe(1);
+        expect(listing.term.value).toBe('shirt');
+        expect(getList).toHaveBeenCalledTimes(2);
+        expect(router.currentRoute.value.query).toEqual({});
+    });
+
+    it('derives the page count from the total and the limit', async () => {
+        const { listing } = await mountListing({ limit: 10 });
+
+        listing.total.value = 42;
+
+        expect(listing.maxPage.value).toBe(5);
+    });
+
+    it('publishes the selection to the app and bulk edit stores', async () => {
+        const { listing } = await mountListing();
+
+        listing.updateSelection({ 'id-1': {}, 'id-2': {} });
+        await flushPromises();
+
+        expect(listing.selectionArray.value).toHaveLength(2);
+        expect(listing.selectionCount.value).toBe(2);
+        expect(Shopware.Store.get('shopwareApps').selectedIds).toEqual([
+            'id-1',
+            'id-2',
+        ]);
+        expect(Shopware.Store.get('swBulkEdit').selectedIds).toEqual([
+            'id-1',
+            'id-2',
+        ]);
+    });
+
+    it('suspends the current sorting while a fresh search term is set', async () => {
+        const { listing } = await mountListing({ sortBy: 'name' });
+
+        listing.term.value = 'shirt';
+        await flushPromises();
+
+        expect(listing.freshSearchTerm.value).toBe(true);
+        expect(listing.currentSortBy.value).toBeNull();
+
+        listing.sortBy.value = 'price';
+        await flushPromises();
+
+        expect(listing.freshSearchTerm.value).toBe(false);
+        expect(listing.currentSortBy.value).toBe('price');
+    });
+
+    it('pushes the search term and the first page into the route', async () => {
+        const { listing, router } = await mountListing();
+
+        listing.onSearch('shirt');
+        await flushPromises();
+
+        expect(router.currentRoute.value.query).toMatchObject({ term: 'shirt', page: '1' });
+    });
+
+    it('toggles the sort direction when the same column is sorted twice', async () => {
+        const { listing, router } = await mountListing({ sortBy: 'name' });
+
+        listing.onSortColumn({ dataIndex: 'name', naturalSorting: false });
+        await flushPromises();
+        expect(router.currentRoute.value.query.sortDirection).toBe('DESC');
+
+        listing.sortDirection.value = 'DESC';
+        listing.onSortColumn({ dataIndex: 'name', naturalSorting: false });
+        await flushPromises();
+        expect(router.currentRoute.value.query.sortDirection).toBe('ASC');
+    });
+
+    it('reloads the list on refresh and on a sorting change', async () => {
+        const { listing, getList } = await mountListing();
+        const callsAfterMount = getList.mock.calls.length;
+
+        listing.onRefresh();
+        expect(getList).toHaveBeenCalledTimes(callsAfterMount + 1);
+
+        listing.onSort({ sortBy: 'name', sortDirection: 'DESC' });
+        expect(getList).toHaveBeenCalledTimes(callsAfterMount + 2);
+    });
+
+    it('stores new filter criteria and goes back to the first page', async () => {
+        const { listing, router } = await mountListing();
+        const criteria = [{ field: 'active' }];
+
+        listing.page.value = 4;
+        listing.updateCriteria(criteria);
+        await flushPromises();
+
+        expect(listing.page.value).toBe(1);
+        expect(listing.filterCriteria.value).toStrictEqual(criteria);
+        expect(router.currentRoute.value.query.page).toBe('1');
+    });
+
+    it('drops the filter criteria when the stored filter query parameter changes', async () => {
+        const { listing, router } = await mountListing({
+            storeKey: 'grid.filter.product',
+            filterCriteria: [{ field: 'active' }],
+        });
+
+        await router.push({
+            name: 'sw.product.index',
+            query: { ...router.currentRoute.value.query, 'grid.filter.product': 'changed' },
+        });
+        await flushPromises();
+
+        expect(listing.filterCriteria.value).toEqual([]);
+    });
+
+    it('toggles a filter provided by the component and returns to the first page', async () => {
+        const filters = [{ name: 'term', active: false }];
+        const { listing } = await mountListing({ filters: () => filters });
+
+        listing.page.value = 3;
+        listing.onSwitchFilter(filters[0], 0);
+
+        expect(filters[0].active).toBe(true);
+        expect(listing.page.value).toBe(1);
+    });
+
+    it('clears the store selections when leaving for a regular route', async () => {
+        const { listing, router } = await mountListing();
+
+        listing.updateSelection({ 'id-1': {} });
+        await flushPromises();
+
+        await router.push({ name: 'sw.product.detail' });
+        await flushPromises();
+
+        expect(Shopware.Store.get('shopwareApps').selectedIds).toEqual([]);
+        expect(Shopware.Store.get('swBulkEdit').selectedIds).toEqual([]);
+    });
+
+    it('keeps the store selections when leaving for a bulk edit route', async () => {
+        const { listing, router } = await mountListing();
+
+        listing.updateSelection({ 'id-1': {} });
+        await flushPromises();
+
+        await router.push({ name: 'sw.bulk.edit.product' });
+        await flushPromises();
+
+        expect(Shopware.Store.get('shopwareApps').selectedIds).toEqual(['id-1']);
+        expect(Shopware.Store.get('swBulkEdit').selectedIds).toEqual(['id-1']);
+    });
+
+    it('reports the listing parameters from the route, or from the state when disabled', async () => {
+        const { listing } = await mountListing({}, {
+            name: 'sw.product.index',
+            query: { page: '2', limit: '10' },
+        } as RouteLocationRaw);
+
+        expect(listing.getMainListingParams()).toMatchObject({ page: '2', limit: '10' });
+
+        listing.disableRouteParams.value = true;
+
+        expect(listing.getMainListingParams()).toMatchObject({ page: 2, limit: 10 });
+    });
+
+    it('scores the search query with the fields configured for the entity', async () => {
+        const scoredCriteria = { scored: true };
+        searchRankingService.getSearchFieldsByEntity.mockResolvedValue({ name: 500 });
+        searchRankingService.buildSearchQueriesForEntity.mockReturnValue(scoredCriteria);
+
+        const { listing } = await mountListing({ searchConfigEntity: 'product' });
+        const originalCriteria = { original: true } as never;
+
+        await expect(listing.addQueryScores('shirt', originalCriteria)).resolves.toBe(scoredCriteria);
+        expect(listing.entitySearchable.value).toBe(true);
+    });
+
+    it('marks the entity as not searchable when it has no ranking fields', async () => {
+        searchRankingService.getSearchFieldsByEntity.mockResolvedValue({});
+
+        const { listing } = await mountListing({ searchConfigEntity: 'product' });
+        const originalCriteria = { original: true } as never;
+
+        await expect(listing.addQueryScores('shirt', originalCriteria)).resolves.toBe(originalCriteria);
+        expect(listing.entitySearchable.value).toBe(false);
+    });
+
+    it('leaves the criteria untouched without a search config entity', async () => {
+        const { listing } = await mountListing();
+        const originalCriteria = { original: true } as never;
+
+        await expect(listing.addQueryScores('shirt', originalCriteria)).resolves.toBe(originalCriteria);
+        expect(listing.searchRankingFields.value).toEqual({});
+    });
+});

--- a/src/Administration/Resources/app/administration/src/app/composables/use-listing.ts
+++ b/src/Administration/Resources/app/administration/src/app/composables/use-listing.ts
@@ -1,0 +1,488 @@
+/**
+ * @sw-package framework
+ */
+import { computed, onMounted, ref, watch } from 'vue';
+import { onBeforeRouteLeave, useRoute, useRouter } from 'vue-router';
+import type { ComputedRef, Ref } from 'vue';
+import type { LocationQuery, RouteLocationNamedRaw, RouteLocationNormalizedLoaded } from 'vue-router';
+import type Criteria from '@shopware-ag/meteor-admin-sdk/es/data/Criteria';
+
+/* The listing contract predates typing; several values cross untyped service boundaries */
+/* eslint-disable @typescript-eslint/no-unsafe-call,@typescript-eslint/no-unsafe-member-access,@typescript-eslint/no-unsafe-return,@typescript-eslint/no-explicit-any */
+
+/** @private */
+export interface ListingFilter {
+    active: boolean;
+    [key: string]: any;
+}
+
+/** @private */
+export interface ListingParams {
+    limit?: unknown;
+    page?: unknown;
+    term?: unknown;
+    sortBy?: unknown;
+    sortDirection?: unknown;
+    naturalSorting?: unknown;
+}
+
+/**
+ * The mixin drove an abstract `getList()` the component implemented, and read a
+ * `filters` computed the component was invited to override. A composable can
+ * declare neither, so both are handed in as callbacks. Every other option is the
+ * initial value of a listing field — the component used to set those in its own
+ * `data()`, where Vue merged them into the mixin's state.
+ *
+ * @private
+ */
+export interface UseListingOptions {
+    getList: () => void | Promise<void>;
+    filters?: () => ListingFilter[];
+    page?: number;
+    limit?: number;
+    total?: number;
+    sortBy?: string | null;
+    sortDirection?: string;
+    naturalSorting?: boolean;
+    selection?: Record<string, any>;
+    term?: string;
+    disableRouteParams?: boolean;
+    searchConfigEntity?: string | null;
+    entitySearchable?: boolean;
+    freshSearchTerm?: boolean;
+    storeKey?: string;
+    filterCriteria?: any[];
+}
+
+/** @private */
+export interface UseListingReturn {
+    page: Ref<number>;
+    limit: Ref<number>;
+    total: Ref<number>;
+    sortBy: Ref<string | null>;
+    sortDirection: Ref<string>;
+    naturalSorting: Ref<boolean>;
+    selection: Ref<Record<string, any>>;
+    term: Ref<string | undefined>;
+    disableRouteParams: Ref<boolean>;
+    searchConfigEntity: Ref<string | null>;
+    entitySearchable: Ref<boolean>;
+    freshSearchTerm: Ref<boolean>;
+    previousRouteName: Ref<string>;
+    storeKey: Ref<string | undefined>;
+    filterCriteria: Ref<any[]>;
+    maxPage: ComputedRef<number>;
+    routeName: ComputedRef<unknown>;
+    selectionArray: ComputedRef<any[]>;
+    selectionCount: ComputedRef<number>;
+    filters: ComputedRef<ListingFilter[]>;
+    searchRankingFields: ComputedRef<unknown>;
+    currentSortBy: ComputedRef<string | null>;
+    updateData: (customData: ListingParams) => void;
+    updateRoute: (customQuery: ListingParams, queryExtension?: Record<string, unknown>) => void;
+    resetListing: () => void;
+    getMainListingParams: () => ListingParams;
+    updateSelection: (selection: Record<string, any>) => void;
+    onPageChange: (opts: { page: number; limit: number }) => void;
+    onSearch: (value: string | undefined) => void;
+    onSwitchFilter: (filter: any, filterIndex: number) => void;
+    onSort: (sorting: { sortBy: string; sortDirection: string }) => void;
+    onSortColumn: (column: { dataIndex: string; naturalSorting: boolean }) => void;
+    onRefresh: () => void;
+    isValidTerm: (term: string) => boolean;
+    addQueryScores: (term: string, originalCriteria: Criteria) => Promise<Criteria>;
+    parseBooleanQueryParams: (query: LocationQuery) => void;
+    updateCriteria: (criteria: any[]) => void;
+}
+
+/**
+ * Composable alternative to the `listing` mixin: owns the pagination, sorting,
+ * search and selection state of a list page, keeps it in sync with the route,
+ * and calls back into the component to load the actual data.
+ *
+ * The mixin's `created()` loaded the first page before the component rendered.
+ * Here the initial load runs `onMounted`, because `getList` is a callback the
+ * component can only close over after this call has returned. Components that
+ * relied on the pre-render load need to be verified.
+ *
+ * Keep this and `src/app/mixin/listing.mixin.ts` in sync — change both together.
+ *
+ * @private
+ */
+export function useListing(options: UseListingOptions): UseListingReturn {
+    const route = useRoute();
+    const router = useRouter();
+
+    // The route object keeps its identity across navigations, so a watcher only
+    // sees distinct `to`/`from` values when it watches a snapshot of it.
+    const routeSnapshot = (): RouteLocationNormalizedLoaded => ({
+        ...route,
+        params: { ...route.params },
+        query: { ...route.query },
+    });
+
+    const page = ref(options.page ?? 1);
+    const limit = ref(options.limit ?? 25);
+    const total = ref(options.total ?? 0);
+    const sortBy = ref<string | null>(options.sortBy ?? null);
+    const sortDirection = ref(options.sortDirection ?? 'ASC');
+    const naturalSorting = ref(options.naturalSorting ?? false);
+    const selection = ref<Record<string, any>>(options.selection ?? []);
+    const term = ref<string | undefined>(options.term);
+    const disableRouteParams = ref(options.disableRouteParams ?? false);
+    const searchConfigEntity = ref<string | null>(options.searchConfigEntity ?? null);
+    const entitySearchable = ref(options.entitySearchable ?? true);
+    const freshSearchTerm = ref(options.freshSearchTerm ?? false);
+    const previousRouteName = ref('');
+    const storeKey = ref(options.storeKey);
+    const filterCriteria = ref<any[]>(options.filterCriteria ?? []);
+
+    function searchRankingService(): any {
+        return Shopware.Service('searchRankingService');
+    }
+
+    const maxPage = computed(() => Math.ceil(total.value / limit.value));
+
+    const routeName = computed(() => route.name);
+
+    const selectionArray = computed(() => Object.values(selection.value));
+
+    const selectionCount = computed(() => selectionArray.value.length);
+
+    const filters = computed(() => options.filters?.() ?? []);
+
+    const searchRankingFields = computed(() => {
+        if (!searchConfigEntity.value) {
+            return {};
+        }
+
+        return searchRankingService().getSearchFieldsByEntity(searchConfigEntity.value);
+    });
+
+    const currentSortBy = computed(() => (freshSearchTerm.value ? null : sortBy.value));
+
+    function updateData(customData: ListingParams): void {
+        page.value = parseInt(customData.page as string, 10) || page.value;
+        limit.value = parseInt(customData.limit as string, 10) || limit.value;
+        term.value = (customData.term as string | undefined) ?? term.value;
+        sortBy.value = (customData.sortBy as string) || sortBy.value;
+        sortDirection.value = (customData.sortDirection as string) || sortDirection.value;
+        naturalSorting.value = (customData.naturalSorting as boolean) || naturalSorting.value;
+    }
+
+    function updateRoute(customQuery: ListingParams, queryExtension: Record<string, unknown> = {}): void {
+        const query = customQuery || route.query;
+        const routeQuery = route.query;
+
+        const targetRoute = {
+            name: route.name,
+            params: route.params,
+            query: {
+                limit: query.limit || limit.value,
+                page: query.page || page.value,
+                term: query.term || term.value,
+                sortBy: query.sortBy || sortBy.value,
+                sortDirection: query.sortDirection || sortDirection.value,
+                naturalSorting: query.naturalSorting || naturalSorting.value,
+                ...queryExtension,
+            },
+        };
+
+        // Writing the initial state into an empty query must not add a history entry.
+        if (Shopware.Utils.types.isEmpty(routeQuery)) {
+            void router.replace(targetRoute as unknown as RouteLocationNamedRaw);
+        } else {
+            void router.push(targetRoute as unknown as RouteLocationNamedRaw);
+        }
+    }
+
+    function resetListing(): void {
+        updateRoute({
+            // @ts-expect-error - mirrors the mixin: `name` and `query` are ignored by updateRoute
+            name: route.name,
+            query: {
+                limit: limit.value,
+                page: page.value,
+                term: term.value,
+                sortBy: sortBy.value,
+                sortDirection: sortDirection.value,
+                naturalSorting: naturalSorting.value,
+            },
+        });
+    }
+
+    function getMainListingParams(): ListingParams {
+        if (disableRouteParams.value) {
+            return {
+                limit: limit.value,
+                page: page.value,
+                term: term.value,
+                sortBy: sortBy.value,
+                sortDirection: sortDirection.value,
+                naturalSorting: naturalSorting.value,
+            };
+        }
+
+        const query = route.query;
+
+        return {
+            limit: query.limit,
+            page: query.page,
+            term: query.term,
+            sortBy: query.sortBy || sortBy.value,
+            sortDirection: query.sortDirection || sortDirection.value,
+            naturalSorting: query.naturalSorting || naturalSorting.value,
+        };
+    }
+
+    function updateSelection(newSelection: Record<string, any>): void {
+        selection.value = newSelection;
+    }
+
+    function onPageChange(opts: { page: number; limit: number }): void {
+        page.value = opts.page;
+        limit.value = opts.limit;
+
+        if (disableRouteParams.value) {
+            void options.getList();
+            return;
+        }
+
+        updateRoute({ page: page.value });
+    }
+
+    function onSearch(value: string | undefined): void {
+        term.value = value;
+
+        if (disableRouteParams.value) {
+            page.value = 1;
+            void options.getList();
+            return;
+        }
+
+        updateRoute({ term: term.value, page: 1 });
+    }
+
+    function onSwitchFilter(filter: any, filterIndex: number): void {
+        filters.value[filterIndex].active = !filters.value[filterIndex].active;
+
+        page.value = 1;
+    }
+
+    function onSort({
+        sortBy: newSortBy,
+        sortDirection: newSortDirection,
+    }: {
+        sortBy: string;
+        sortDirection: string;
+    }): void {
+        if (disableRouteParams.value) {
+            updateData({ sortBy: newSortBy, sortDirection: newSortDirection });
+        } else {
+            updateRoute({ sortBy: newSortBy, sortDirection: newSortDirection });
+        }
+
+        void options.getList();
+    }
+
+    function onSortColumn(column: { dataIndex: string; naturalSorting: boolean }): void {
+        if (disableRouteParams.value) {
+            if (sortBy.value === column.dataIndex) {
+                sortDirection.value = sortDirection.value === 'ASC' ? 'DESC' : 'ASC';
+            } else {
+                sortDirection.value = 'ASC';
+                sortBy.value = column.dataIndex;
+            }
+
+            void options.getList();
+            return;
+        }
+
+        if (sortBy.value === column.dataIndex) {
+            updateRoute({ sortDirection: sortDirection.value === 'ASC' ? 'DESC' : 'ASC' });
+        } else {
+            naturalSorting.value = column.naturalSorting;
+            updateRoute({
+                sortBy: column.dataIndex,
+                sortDirection: 'ASC',
+                naturalSorting: column.naturalSorting,
+            });
+        }
+    }
+
+    function onRefresh(): void {
+        void options.getList();
+    }
+
+    function isValidTerm(searchTerm: string): boolean {
+        return searchRankingService().isValidTerm(searchTerm);
+    }
+
+    async function addQueryScores(searchTerm: string, originalCriteria: Criteria): Promise<Criteria> {
+        entitySearchable.value = true;
+
+        if (!searchConfigEntity.value || !isValidTerm(searchTerm)) {
+            return originalCriteria;
+        }
+
+        const rankingFields = (await searchRankingService().getSearchFieldsByEntity(searchConfigEntity.value)) as Record<
+            string,
+            unknown
+        > | null;
+
+        if (!rankingFields || Object.keys(rankingFields).length < 1) {
+            entitySearchable.value = false;
+            return originalCriteria;
+        }
+
+        return searchRankingService().buildSearchQueriesForEntity(rankingFields, searchTerm, originalCriteria);
+    }
+
+    /**
+     * Parses all string representations of boolean values to actual boolean values.
+     * Only works on root level of the query object.
+     */
+    function parseBooleanQueryParams(query: LocationQuery): void {
+        Object.keys(query).forEach((key) => {
+            if (String(query[key]).toLowerCase() === 'true') {
+                // @ts-expect-error - the parsed value intentionally leaves the LocationQuery type
+                query[key] = true;
+            } else if (String(query[key]).toLowerCase() === 'false') {
+                // @ts-expect-error - the parsed value intentionally leaves the LocationQuery type
+                query[key] = false;
+            }
+        });
+    }
+
+    /**
+     * Update filter criteria and reset pagination to page 1.
+     * This method is called when filters are changed via sw-sidebar-filter-panel.
+     */
+    function updateCriteria(criteria: any[]): void {
+        page.value = 1;
+        filterCriteria.value = criteria;
+
+        if (disableRouteParams.value) {
+            void options.getList();
+            return;
+        }
+
+        updateRoute({ page: 1 });
+    }
+
+    watch(routeSnapshot, (newRoute, oldRoute) => {
+        if (disableRouteParams.value || oldRoute.name !== newRoute.name) {
+            return;
+        }
+
+        const query = route.query;
+
+        if (Shopware.Utils.types.isEmpty(query)) {
+            resetListing();
+        }
+
+        parseBooleanQueryParams(query);
+        updateData(query);
+
+        if (
+            storeKey.value !== undefined &&
+            newRoute.query[storeKey.value] !== oldRoute.query[storeKey.value] &&
+            filterCriteria.value?.length
+        ) {
+            filterCriteria.value = [];
+            return;
+        }
+
+        void options.getList();
+    });
+
+    watch(selection, () => {
+        Shopware.Store.get('shopwareApps').selectedIds = Object.keys(selection.value);
+        Shopware.Store.get('swBulkEdit').selectedIds = Object.keys(selection.value);
+    });
+
+    watch(term, (newValue) => {
+        freshSearchTerm.value = !!newValue?.length;
+    });
+
+    watch(sortBy, () => {
+        freshSearchTerm.value = false;
+    });
+
+    watch(sortDirection, () => {
+        freshSearchTerm.value = false;
+    });
+
+    // The first load runs here, not during setup: `options.getList` closes over
+    // bindings the caller can only declare after this call has returned.
+    onMounted(() => {
+        previousRouteName.value = route.name as string;
+
+        if (disableRouteParams.value) {
+            void options.getList();
+            return;
+        }
+
+        const actualQueryParameters: LocationQuery = route.query;
+
+        if (Shopware.Utils.types.isEmpty(actualQueryParameters)) {
+            resetListing();
+        } else {
+            parseBooleanQueryParams(actualQueryParameters);
+            updateData(actualQueryParameters);
+            void options.getList();
+        }
+    });
+
+    onBeforeRouteLeave((to) => {
+        const targetRouteName = typeof to !== 'string' && 'name' in to ? to.name : undefined;
+
+        // Routes from the `sw-bulk-edit` module are generated under `sw.bulk.edit.*`.
+        if (typeof targetRouteName === 'string' && targetRouteName.startsWith('sw.bulk.edit.')) {
+            return;
+        }
+
+        Shopware.Store.get('shopwareApps').selectedIds = [];
+        Shopware.Store.get('swBulkEdit').selectedIds = [];
+    });
+
+    return {
+        page,
+        limit,
+        total,
+        sortBy,
+        sortDirection,
+        naturalSorting,
+        selection,
+        term,
+        disableRouteParams,
+        searchConfigEntity,
+        entitySearchable,
+        freshSearchTerm,
+        previousRouteName,
+        storeKey,
+        filterCriteria,
+        maxPage,
+        routeName,
+        selectionArray,
+        selectionCount,
+        filters,
+        searchRankingFields,
+        currentSortBy,
+        updateData,
+        updateRoute,
+        resetListing,
+        getMainListingParams,
+        updateSelection,
+        onPageChange,
+        onSearch,
+        onSwitchFilter,
+        onSort,
+        onSortColumn,
+        onRefresh,
+        isValidTerm,
+        addQueryScores,
+        parseBooleanQueryParams,
+        updateCriteria,
+    };
+}

--- a/src/Administration/Resources/app/administration/src/app/mixin/listing.mixin.ts
+++ b/src/Administration/Resources/app/administration/src/app/mixin/listing.mixin.ts
@@ -15,6 +15,8 @@ export {};
 
 /**
  * @private
+ *
+ * Duplicated in `src/app/composables/use-listing`; change both together.
  */
 export default Shopware.Mixin.register(
     'listing',


### PR DESCRIPTION
### 1. Why is this change necessary?

`listing` is the single biggest blocker left for the SFC codemod — 34 components are held back only by it. But unlike `notification` or `placeholder` it is not a helper mixin, it is an abstract controller:

- it owns 13 `data()` fields, 7 computeds, 5 watchers, `created()` and `beforeRouteLeave`
- it **calls** `this.getList()`; the component **defines** it

That last point is inversion of control, not a value we can hand in, so the all-or-nothing "mixin becomes a composable" path the codemod uses today does not apply. Two things make a naive port silently wrong:

**a) The initial load cannot run during setup.** `useListing()` is declared above `createExtendableSetup()`, so the component's `getList` does not exist yet:

```js
const { page, limit, total } = useListing({
    getList: (...args) => getList(...args),   // getList is declared 20 lines below
});
```

Calling it eagerly (as `created()` did) hits a TDZ error. The composable defers to `onMounted`.

**b) A listing field the component re-declares would end up as two disconnected refs.** Vue merged the mixin's `data()` and the component's `data()` into *one* property. Half the listing pages do this:

```js
data() {
    return {
        sortBy: 'name',          // <- overrides the mixin's `sortBy: null`
        storeKey: 'grid.filter.rule',
        filterCriteria: [],
    };
},
```

Emitting `const sortBy = ref('name')` next to `const { sortBy } = useListing()` compiles, renders, and is wrong: the composable's watchers and `updateData()` write the ref nobody reads.

### 2. What does this change do, exactly?

Adds `useListing` and teaches the descriptor model to scaffold — produce a reviewed draft, never a "done" component.

**`src/app/composables/use-listing.ts`** owns the state, the computeds, the route watcher, `onBeforeRouteLeave` and all 15 methods. It takes `{ getList, filters?, ...config }`. `storeKey` and `filterCriteria` become composable state too — the mixin read and wrote both on the host through `@ts-expect-error`; owning them keeps the listing contract in one place.

**Four new descriptor fields:**

- `configKeys` — a listing field set in the component's own `data()` is routed into `useListing({ sortBy: 'name' })` and dropped from the generated refs, so there is exactly one ref. This is the fix for (b).
- `alwaysActive` — declare the composable even when no member is read; dropping it would drop the whole listing lifecycle, not just an unused import.
- `callbacks: [{ optional: true }]` — for `filters`, which the mixin declared a default for and only invited the component to override.
- `manualVerification` — emits a leading TODO and keeps the result `partially-migrated`.

Generated output:

```js
// TODO: verify the 'listing' migration: … check that getList() reads and writes the composable's
// state, that the listing fields moved to useListing() options are configuration and not local
// state, and that moving the initial load from created() to onMounted() did not change behaviour

const { page, limit, total, sortBy, sortDirection, term, onPageChange, onSearch } = useListing({
    getList: (...args) => getList(...args),
    filters: () => filters.value,
    sortBy: 'name',
    searchConfigEntity: 'product',
});
```

Two shapes back off instead of guessing: a config key declared as anything but a `data()` entry (a prop, computed, method or inject), and a `data()` initializer that reads `this`.

**nit: `feature` and `searchRankingService` back the whole component off.** The mixin injected both; `useListing` resolves the ranking service itself and never needed `feature`, so they are registered as `unmappedMembers`. Two components (`sw-mail-template-list`, `sw-mail-header-footer-list`) inherit `this.feature` through the mixin and therefore stay on the Options API backoff. Declaring their own `inject: ['feature']` would migrate them, but that is a production edit and belongs to the rollout, not to the codemod.

### 3. Describe each step to reproduce the issue or behaviour.

Dry-run the codemod over every listing component:

```bash
cd src/Administration/Resources/app/administration
grep -rl "Mixin.getByName('listing')" src --include=index.js \
  | xargs -n1 dirname \
  | while read d; do npm run --silent codemod:sfc-migration -- "$d"; done
```

**Result on the 38 listing components in this repository: 21 now produce a `<script setup>` scaffold** (before: 0 — every one of them backed off with `mixins: no composable registered for mixin 'listing'`).

The remaining 17 are **not** listing-specific:

| Reason | Count |
|---|---|
| Template reads `total`/`term`/`page`, shadowed by an inner-scope binding in the same file | 6 |
| The component's own `getList` reads an undeclared `this.<x>` (e.g. `sw-settings-tax-list` writes `this.selectedDefaultRate`, which does not exist) | 4 |
| Reads `this.feature` | 2 |
| `storeKey` declared as a prop (`sw-entity-advanced-selection-modal`) | 1 |
| Broken twig / `orphaned cross-block v-else` | 2 |
| Component uses `index.ts`; the runner only globs `index.js` | 2 |

Spot-check a generated scaffold:

```bash
cp -r src/module/sw-settings-rule/page/sw-settings-rule-list /tmp/spike-rule-list
npm run codemod:sfc-migration -- --write /tmp/spike-rule-list
```

`this.total = items.total` → `total.value = items.total`, `this.getList()` → `getList()`, and the template's `page`/`limit`/`total` bindings keep their names.

Tests:

```bash
npx jest --config jest.config.js --collectCoverage=false src/app/composables/use-listing.spec.ts scripts/codemods/sfc-migration
```

### 4. Please link to the relevant issues (if any).

- closes #19336
- relates #19331

Stacked on #19350 — please review that one first.

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [x] I have written or adjusted the documentation and agent skills according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
