### PR TITLE
fix(framework): default missing S3 file sizes to zero

### DIFF
--- a/src/Core/Framework/Adapter/Filesystem/Adapter/AsyncAwsS3WriteBatchAdapter.php
+++ b/src/Core/Framework/Adapter/Filesystem/Adapter/AsyncAwsS3WriteBatchAdapter.php
@@ -6,6 +6,8 @@ use AsyncAws\Core\Result;
 use AsyncAws\S3\S3Client;
 use League\Flysystem\AsyncAwsS3\AsyncAwsS3Adapter;
 use League\Flysystem\AsyncAwsS3\PortableVisibilityConverter;
+use League\Flysystem\FileAttributes;
+use League\Flysystem\UnableToRetrieveMetadata;
 use Shopware\Core\Framework\Adapter\Filesystem\Plugin\CopyBatchInput;
 use Shopware\Core\Framework\Adapter\Filesystem\Plugin\WriteBatchInterface;
 use Shopware\Core\Framework\Log\Package;
@@ -17,6 +19,22 @@ class AsyncAwsS3WriteBatchAdapter extends AsyncAwsS3Adapter implements WriteBatc
      * @var int<1, max>
      */
     public int $batchSize = 250;
+
+    public function fileSize(string $path): FileAttributes
+    {
+        try {
+            return parent::fileSize($path);
+        } catch (UnableToRetrieveMetadata $exception) {
+            // Fetch failures include a reason or a previous exception. An empty response from a successful HEAD request
+            // reaches AsyncAwsS3Adapter::fileSize()'s null check without either, which happens with empty objects behind
+            // some S3-compatible storage proxies. See https://github.com/shopware/shopware/issues/18497.
+            if ($exception->reason() !== '' || $exception->getPrevious() !== null) {
+                throw $exception;
+            }
+
+            return new FileAttributes($path, 0);
+        }
+    }
 
     public function writeBatch(CopyBatchInput ...$files): void
     {

--- a/tests/unit/Core/Framework/Adapter/Filesystem/Adapter/AsyncAwsS3WriteBatchAdapterTest.php
+++ b/tests/unit/Core/Framework/Adapter/Filesystem/Adapter/AsyncAwsS3WriteBatchAdapterTest.php
@@ -3,9 +3,12 @@
 namespace Shopware\Tests\Unit\Core\Framework\Adapter\Filesystem\Adapter;
 
 use AsyncAws\Core\Test\ResultMockFactory;
+use AsyncAws\S3\Result\HeadObjectOutput;
 use AsyncAws\S3\Result\PutObjectOutput;
 use AsyncAws\S3\S3Client;
 use League\Flysystem\AsyncAwsS3\PortableVisibilityConverter;
+use League\Flysystem\FileAttributes;
+use League\Flysystem\UnableToRetrieveMetadata;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Adapter\Filesystem\Adapter\AsyncAwsS3WriteBatchAdapter;
@@ -20,6 +23,41 @@ use Symfony\Component\Filesystem\Filesystem;
 #[CoversClass(AsyncAwsS3WriteBatchAdapter::class)]
 class AsyncAwsS3WriteBatchAdapterTest extends TestCase
 {
+    public function testFileSizeDefaultsToZeroWhenHeadResponseHasNoContentLength(): void
+    {
+        $s3Client = $this->createMock(S3Client::class);
+        $s3Client
+            ->expects($this->once())
+            ->method('headObject')
+            ->with(['Bucket' => 'test', 'Key' => 'directory/test.txt'])
+            ->willReturn(ResultMockFactory::create(HeadObjectOutput::class));
+
+        $adapter = new AsyncAwsS3WriteBatchAdapter($s3Client, 'test');
+
+        static::assertSame(0, $adapter->fileSize('directory/test.txt')->fileSize());
+    }
+
+    public function testFileSizeRethrowsMetadataExceptionWhenHeadRequestFails(): void
+    {
+        $headException = new \RuntimeException();
+        $s3Client = $this->createMock(S3Client::class);
+        $s3Client
+            ->expects($this->once())
+            ->method('headObject')
+            ->willThrowException($headException);
+
+        $adapter = new AsyncAwsS3WriteBatchAdapter($s3Client, 'test');
+
+        $this->expectExceptionObject(UnableToRetrieveMetadata::create(
+            'directory/test.txt',
+            FileAttributes::ATTRIBUTE_FILE_SIZE,
+            '',
+            $headException
+        ));
+
+        $adapter->fileSize('directory/test.txt');
+    }
+
     public function testS3(): void
     {
         $fs = new Filesystem();


### PR DESCRIPTION
### 1. Why is this change necessary?

Some S3-compatible storage proxies omit `Content-Length` for empty objects on successful `HEAD` requests. Flysystem then treats the file size as unavailable, which prevents Shopware from creating empty Import/Export files.

### 2. What does this change do, exactly?

The Shopware S3 adapter treats a successful metadata response without a file size as a zero-byte file. Metadata requests that fail still throw their original exception.

### 3. Describe each step to reproduce the issue or behaviour.

1. Configure Shopware's private filesystem with an S3-compatible storage proxy that omits `Content-Length: 0` on `HEAD` requests.
2. Start an export or an import that creates an invalid-records file.
3. Shopware creates an empty object and requests its size; previously, this failed with `UnableToRetrieveMetadata`.

### 4. Please link to the relevant issues (if any).

- relates #18497

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [x] I have written or adjusted the documentation and agent skills according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
