### PR TITLE
fix(storefront): use existing required-fields snippet on guest conversion

### DIFF
--- a/src/Storefront/Resources/views/storefront/page/account/convert.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/account/convert.html.twig
@@ -83,7 +83,7 @@
 
             {% block component_account_guest_conversion_required_fields %}
             <p class="account-guest-conversion__required-info">
-                {{ 'general.requiredFields'|trans|sw_sanitize }}
+                {{ 'global.default.noteRequiredFields'|trans|sw_sanitize }}
             </p>
             {% endblock %}
 


### PR DESCRIPTION
### 1. Why is this change necessary?

The guest account conversion page prints the raw snippet key `general.requiredFields`, because that key was removed and consolidated into `global.default.noteRequiredFields` by #17651.

### 2. What does this change do, exactly?

Points `convert.html.twig` at `global.default.noteRequiredFields` snippet.

### 3. Describe each step to reproduce the issue or behaviour.

Place an order as a guest, convert the guest account from the finish page.

### 4. Please link to the relevant issues (if any).

- closes #19315

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
