### PR TITLE
test: skipping FlowBuilderTemplate test for SaaS due to valid failure

### DIFF
--- a/tests/acceptance/tests/Settings/FlowBuilderTemplates.spec.ts
+++ b/tests/acceptance/tests/Settings/FlowBuilderTemplates.spec.ts
@@ -3,11 +3,11 @@ import { getFlowId, compareFlowTemplateWithFlow } from '@shopware-ag/acceptance-
 
 test(
     'As an admin, I want to create new flows from templates, so that I can easily create new ones based on the default flows.',
-    { 
+    {
         tag: '@Flow',
         annotation: {
             type: 'issue',
-            description: 'https://github.com/shopware/shopware/issues/19378',      
+            description: 'https://github.com/shopware/shopware/issues/19378',
         },
     },
     async ({
@@ -19,8 +19,11 @@ test(
         AdminApiContext,
         InstanceMeta,
     }) => {
-        test.skip(InstanceMeta.isSaaS, 'Test is skipped in SaaS due to search issue with Advanced Search. See https://github.com/shopware/shopware/issues/19378 ');
-        
+        test.skip(
+            InstanceMeta.isSaaS,
+            'Test is skipped in SaaS due to search issue with Advanced Search. See https://github.com/shopware/shopware/issues/19378 ',
+        );
+
         const flowTemplateName = 'Order placed';
         const flowTemplateSingleTerms = flowTemplateName.split(' ');
         const flowTemplateSearchTerm = flowTemplateSingleTerms[flowTemplateSingleTerms.length - 2];

--- a/tests/acceptance/tests/Settings/FlowBuilderTemplates.spec.ts
+++ b/tests/acceptance/tests/Settings/FlowBuilderTemplates.spec.ts
@@ -17,6 +17,7 @@ test(
         AdminFlowBuilderDetail,
         IdProvider,
         AdminApiContext,
+        InstanceMeta
     }) => {
         test.skip(InstanceMeta.isSaaS, 'Test is skipped in SaaS due to search issue with Advanced Search. See https://github.com/shopware/shopware/issues/19378 ');
         

--- a/tests/acceptance/tests/Settings/FlowBuilderTemplates.spec.ts
+++ b/tests/acceptance/tests/Settings/FlowBuilderTemplates.spec.ts
@@ -3,7 +3,13 @@ import { getFlowId, compareFlowTemplateWithFlow } from '@shopware-ag/acceptance-
 
 test(
     'As an admin, I want to create new flows from templates, so that I can easily create new ones based on the default flows.',
-    { tag: '@Flow' },
+    { 
+        tag: '@Flow',
+        annotation: {
+            type: 'issue',
+            description: 'https://github.com/shopware/shopware/issues/19378',      
+        },
+    },
     async ({
         ShopAdmin,
         AdminFlowBuilderTemplates,
@@ -12,6 +18,8 @@ test(
         IdProvider,
         AdminApiContext,
     }) => {
+        test.skip(InstanceMeta.isSaaS, 'Test is skipped in SaaS due to search issue with Advanced Search. See https://github.com/shopware/shopware/issues/19378 ');
+        
         const flowTemplateName = 'Order placed';
         const flowTemplateSingleTerms = flowTemplateName.split(' ');
         const flowTemplateSearchTerm = flowTemplateSingleTerms[flowTemplateSingleTerms.length - 2];

--- a/tests/acceptance/tests/Settings/FlowBuilderTemplates.spec.ts
+++ b/tests/acceptance/tests/Settings/FlowBuilderTemplates.spec.ts
@@ -17,7 +17,7 @@ test(
         AdminFlowBuilderDetail,
         IdProvider,
         AdminApiContext,
-        InstanceMeta
+        InstanceMeta,
     }) => {
         test.skip(InstanceMeta.isSaaS, 'Test is skipped in SaaS due to search issue with Advanced Search. See https://github.com/shopware/shopware/issues/19378 ');
         


### PR DESCRIPTION
skipping Test due valid failure in SaaS/Commercial

### 1. Why is this change necessary?
The Flow Builder Template test fails validly in SaaS due to a misbehaviour with Advanced Search within Flows und Rules

### 2. What does this change do, exactly?
It skips the flow builder template test as long as https://github.com/shopware/shopware/issues/19378 isn't fixed

### 3. Describe each step to reproduce the issue or behaviour.
See https://github.com/shopware/shopware/issues/19378

### 4. Please link to the relevant issues (if any).
https://github.com/shopware/shopware/issues/19378

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
