### PR TITLE
fix(core): allow binary snippet pluralization

### DIFF
--- a/src/Core/System/Snippet/SnippetValidator.php
+++ b/src/Core/System/Snippet/SnippetValidator.php
@@ -254,7 +254,9 @@ readonly class SnippetValidator implements SnippetValidatorInterface
             ];
         }
 
-        $hasInvalidPluralization = !preg_match('/^(\{0\}.+\|)?(\{1\}.+\|)(\[0,inf\[.+)/i', $unformattedSnippet);
+        $hasValidBinaryPluralization = preg_match('/^\{0\}.+\|\{1\}.+$/i', $unformattedSnippet);
+        $hasInvalidPluralization = !$hasValidBinaryPluralization
+            && !preg_match('/^(\{0\}.+\|)?(\{1\}.+\|)(\[0,inf\[.+)/i', $unformattedSnippet);
         $hasInvalidPluralizationRange = str_contains($unformattedSnippet, ']1,inf[');
 
         return [

--- a/tests/unit/Core/System/Snippet/SnippetValidatorTest.php
+++ b/tests/unit/Core/System/Snippet/SnippetValidatorTest.php
@@ -93,6 +93,7 @@ class SnippetValidatorTest extends TestCase
             'noPluralization' => 'Something',
             'somethingValid' => '{1} Singular |[0,Inf[ Plural',
             'somethingValidWith0' => '{0} Zero case | {1} Singular |[0,Inf[ Plural',
+            'binaryPluralization' => '{0} No bundle | {1} Bundle',
             ...$expectedInvalidSnippets,
         ];
 
@@ -106,6 +107,7 @@ class SnippetValidatorTest extends TestCase
         static::assertCount(5, $invalidPluralization);
         static::assertFalse($invalidPluralization->has('somethingValid'));
         static::assertFalse($invalidPluralization->has('somethingValidWith0'));
+        static::assertFalse($invalidPluralization->has('binaryPluralization'));
 
         foreach ($expectedInvalidSnippets as $expectedKey => $expectedValue) {
             static::assertTrue($invalidPluralization->has($expectedKey), "Missing expected key: $expectedKey");


### PR DESCRIPTION
### 1. Why is this change necessary?

The snippet validator rejects valid binary translation selectors such as `{0}...|{1}...`, causing `bin/console snippet:validate` to fail for SwagCommercial.

### 2. What does this change do, exactly?

It accepts explicit `{0}` and `{1}` binary selectors while preserving validation for malformed pluralization and regular selectors without a `[0,Inf[` fallback. A regression test covers the reported form.

### 3. Describe each step to reproduce the issue or behaviour.

1. Install or enable SwagCommercial with its product-bundle snippets.
2. Run `php bin/console snippet:validate`.
3. Observe the `Invalid pluralization found!` error for `detail.skipToBuyBox`.
4. Run the command after this change; the binary selector is no longer reported as invalid.

The focused PHPUnit test was added but could not run in this checkout because the test bootstrap rejects the configured `DATABASE_URL` value `mysql://localhost_test`.

### 4. Please link to the relevant issues (if any).

- closes #19056

### 5. Solution

<img width="1119" height="111" alt="image" src="https://github.com/user-attachments/assets/c5c758c3-90f1-473b-a48f-0a66f7c03b32" />