### PR TITLE
test(administration): cover label, help text and inheritance in the field renderers

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-form-field-renderer/sw-form-field-renderer.spec/renderer-label-help-text-inheritance.helper.ts
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-form-field-renderer/sw-form-field-renderer.spec/renderer-label-help-text-inheritance.helper.ts
@@ -1,0 +1,533 @@
+/**
+ * @sw-package framework
+ */
+
+/* eslint-disable sw-deprecation-rules/private-feature-declarations */
+
+import { mount, type DOMWrapper, type VueWrapper } from '@vue/test-utils';
+import MtCheckbox from '@shopware-ag/meteor-component-library/dist/esm/MtCheckbox';
+import MtColorpicker from '@shopware-ag/meteor-component-library/dist/esm/MtColorpicker';
+import MtDatepicker from '@shopware-ag/meteor-component-library/dist/esm/MtDatepicker';
+import MtEmailField from '@shopware-ag/meteor-component-library/dist/esm/MtEmailField';
+import MtNumberField from '@shopware-ag/meteor-component-library/dist/esm/MtNumberField';
+import MtPasswordField from '@shopware-ag/meteor-component-library/dist/esm/MtPasswordField';
+import MtSelect from '@shopware-ag/meteor-component-library/dist/esm/MtSelect';
+import MtSwitch from '@shopware-ag/meteor-component-library/dist/esm/MtSwitch';
+import MtTextField from '@shopware-ag/meteor-component-library/dist/esm/MtTextField';
+import MtTextarea from '@shopware-ag/meteor-component-library/dist/esm/MtTextarea';
+import MtUnitField from '@shopware-ag/meteor-component-library/dist/esm/MtUnitField';
+import MtUrlField from '@shopware-ag/meteor-component-library/dist/esm/MtUrlField';
+interface FormFieldConfig {
+    componentName?: string;
+    type?: string;
+    entity?: string;
+    snippet?: string;
+    currency?: { id: string; factor: number };
+    label?: { 'en-GB': string };
+    helpText?: { 'en-GB': string };
+    options?: Array<{ id: string; name: string; value?: string }>;
+}
+
+export interface FormFieldDefinition {
+    name?: string;
+    type: string;
+    config?: FormFieldConfig;
+}
+
+export type RendererField = FormFieldDefinition & {
+    name: string;
+    config: FormFieldConfig & {
+        label: { 'en-GB': string };
+        helpText: { 'en-GB': string };
+        options: Array<{ id: string; name: string; value?: string }>;
+    };
+};
+
+type TestWrapper = DOMWrapper<Element> | VueWrapper;
+// `GlobalMountOptions` is not exported by @vue/test-utils, so derive the `global` option type from mount.
+type MountGlobal = NonNullable<NonNullable<Parameters<typeof mount>[1]>['global']>;
+
+type SystemConfigWrapper = VueWrapper<{
+    actualConfigData: Record<string, Record<string, unknown>>;
+    currentSalesChannelId: string | null;
+    $nextTick: () => Promise<void>;
+}>;
+
+const HEADLESS_SALES_CHANNEL_ID = 'headless-sales-channel-id';
+export function buildRendererFields(fields: FormFieldDefinition[]): RendererField[] {
+    return fields.map(
+        (field, index) =>
+            ({
+                ...field,
+                name: `renderer_field_${index}`,
+                config: {
+                    ...(field.config ?? {}),
+                    ...getAdditionalFieldConfig(field),
+                    label: { 'en-GB': `Renderer label ${index}` },
+                    helpText: { 'en-GB': `Renderer help text ${index}` },
+                    options: [
+                        { id: 'first', value: 'first', name: 'First option' },
+                        { id: 'second', value: 'second', name: 'Second option' },
+                    ],
+                    ...(field.config?.componentName === 'sw-snippet-field' ? { snippet: 'renderer.snippet' } : {}),
+                },
+            }) as RendererField,
+    );
+}
+
+function getAdditionalFieldConfig(field: FormFieldDefinition): Partial<FormFieldConfig> {
+    const componentName = field.config?.componentName;
+
+    if (
+        field.type?.includes('entity') ||
+        [
+            'sw-entity-multi-id-select',
+            'sw-entity-multi-select',
+            'sw-entity-single-select',
+        ].includes(componentName ?? '')
+    ) {
+        return { entity: 'product' };
+    }
+
+    if (componentName === 'sw-price-field') {
+        return { currency: { id: Shopware.Context.app.systemCurrencyId ?? '', factor: 1 } };
+    }
+
+    return {};
+}
+
+async function createGlobalConfig(
+    additionalStubs: Record<string, unknown> = {},
+    additionalProvide: Record<string, unknown> = {},
+) {
+    const stubs: Record<string, unknown> = {
+        ...meteorFieldComponents(),
+        ...(await shopwareFieldComponents()),
+        ...supportComponents(),
+        'sw-help-text': await wrapTestComponent('sw-help-text', { sync: true }),
+        'sw-inheritance-switch': await wrapTestComponent('sw-inheritance-switch', { sync: true }),
+        ...additionalStubs,
+    };
+
+    return {
+        directives: {
+            tooltip: {},
+            popover: {},
+        },
+        mocks: {
+            $t: (key: string) => key,
+        },
+        renderStubDefaultSlot: true,
+        stubs,
+        provide: {
+            repositoryFactory: {
+                create: () => ({
+                    get: () => Promise.resolve({ id: 'currency-id', factor: 1 }),
+                    search: () => Promise.resolve([]),
+                }),
+            },
+            validationService: {},
+            mediaService: {},
+            snippetSetService: {
+                getCustomList: () => Promise.resolve({ total: 0, data: {} }),
+            },
+            ...additionalProvide,
+        },
+    } as unknown as MountGlobal;
+}
+
+function meteorFieldComponents() {
+    return {
+        'mt-checkbox': MtCheckbox,
+        'mt-colorpicker': MtColorpicker,
+        'mt-datepicker': MtDatepicker,
+        'mt-email-field': MtEmailField,
+        'mt-number-field': MtNumberField,
+        'mt-password-field': MtPasswordField,
+        'mt-select': MtSelect,
+        'mt-switch': MtSwitch,
+        'mt-text-field': MtTextField,
+        'mt-textarea': MtTextarea,
+        'mt-unit-field': MtUnitField,
+        'mt-url-field': MtUrlField,
+    };
+}
+
+async function shopwareFieldComponents() {
+    return Object.fromEntries(
+        await Promise.all(
+            [
+                'sw-checkbox-field',
+                'sw-colorpicker',
+                'sw-compact-colorpicker',
+                'sw-datepicker',
+                'sw-email-field',
+                'sw-entity-multi-id-select',
+                'sw-entity-multi-select',
+                'sw-entity-single-select',
+                'sw-media-field',
+                'sw-multi-select',
+                'sw-number-field',
+                'sw-password-field',
+                'sw-price-field',
+                'sw-radio-field',
+                'sw-select-field',
+                'sw-single-select',
+                'sw-snippet-field',
+                'sw-switch-field',
+                'sw-tagged-field',
+                'sw-text-editor',
+                'sw-text-field',
+                'sw-textarea-field',
+                'sw-url-field',
+            ].map(async (componentName) => [
+                componentName,
+                await wrapTestComponent(componentName, { sync: true }),
+            ]),
+        ),
+    ) as Record<string, unknown>;
+}
+
+function supportComponents() {
+    return {
+        'mt-banner': true,
+        'sw-base-field': wrapShopwareBaseField(),
+        'sw-block-field': wrapShopwareBlockField(),
+        'mt-card': {
+            template: '<section><slot></slot><slot name="toolbar"></slot></section>',
+        },
+        'mt-floating-ui': true,
+        'mt-icon': true,
+        'mt-skeleton-bar': true,
+        'router-link': true,
+        'sw-ai-copilot-badge': true,
+        'sw-context-button': true,
+        'sw-context-menu-item': true,
+        'sw-contextual-field': true,
+        'sw-field-copyable': true,
+        'sw-field-error': true,
+        'sw-highlight-text': true,
+        'sw-loader': true,
+        'sw-media-base-item': true,
+        'sw-media-media-item': true,
+        'sw-media-modal-delete': true,
+        'sw-media-modal-move': true,
+        'sw-media-modal-replace': true,
+        'sw-media-modal-v2': true,
+        'sw-media-preview-v2': true,
+        'sw-media-upload-v2': true,
+        'sw-pagination': true,
+        'sw-popover': true,
+        'sw-product-variant-info': true,
+        'sw-select-base': wrapSelectBase(),
+        'sw-select-result': true,
+        'sw-select-result-list': true,
+        'sw-select-selection-list': true,
+        'sw-simple-search-field': true,
+        'sw-skeleton': true,
+        'sw-skeleton-bar': true,
+        'sw-text-editor-toolbar': true,
+        'sw-upload-listener': true,
+    };
+}
+
+function createSystemConfigService(fields: RendererField[]) {
+    return {
+        getConfig: () =>
+            Promise.resolve([
+                {
+                    title: { 'en-GB': 'Renderer card' },
+                    elements: fields,
+                },
+            ]),
+        getValues: (domain: string, salesChannelId: string | null) =>
+            Promise.resolve(salesChannelId === null ? createDefaultFieldValueMap(fields) : {}),
+    };
+}
+
+function createDefaultFieldValueMap(fields: RendererField[]) {
+    return Object.fromEntries(
+        fields.map((field) => [
+            field.name,
+            getFieldValue(field),
+        ]),
+    );
+}
+
+function getFieldValue(field: RendererField) {
+    const componentName = field.config.componentName;
+
+    if (
+        [
+            'multi-select',
+            'tagged',
+        ].includes(field.type) ||
+        componentName === 'sw-tagged-field'
+    ) {
+        return [];
+    }
+
+    if (
+        [
+            'sw-entity-multi-id-select',
+            'sw-entity-multi-select',
+            'sw-multi-select',
+        ].includes(componentName ?? '')
+    ) {
+        return [];
+    }
+
+    if (
+        [
+            'bool',
+            'checkbox',
+            'switch',
+            'mt-checkbox',
+            'mt-switch',
+            'sw-checkbox-field',
+            'sw-switch-field',
+        ].includes(field.type) ||
+        [
+            'mt-checkbox',
+            'mt-switch',
+            'sw-checkbox-field',
+            'sw-switch-field',
+        ].includes(componentName ?? '')
+    ) {
+        return false;
+    }
+
+    if (
+        [
+            'float',
+            'int',
+            'number',
+            'mt-number-field',
+            'sw-number-field',
+        ].includes(field.type) ||
+        [
+            'mt-number-field',
+            'sw-number-field',
+        ].includes(componentName ?? '')
+    ) {
+        return 1;
+    }
+
+    if (field.type === 'price' || componentName === 'sw-price-field') {
+        return [
+            {
+                currencyId: Shopware.Context.app.systemCurrencyId,
+                gross: 1,
+                net: 1,
+                linked: true,
+            },
+        ];
+    }
+
+    return '';
+}
+
+function fieldDebugMessage(field: RendererField, wrapper: TestWrapper) {
+    return `${field.name} ${field.type} ${field.config?.componentName ?? ''}\n${wrapper.html()}`;
+}
+
+export function customFieldSelector(field: RendererField) {
+    return `.sw-form-field-renderer-field__${field.name}`;
+}
+
+export function systemConfigSelector(field: RendererField) {
+    return `.sw-system-config--field-${Shopware.Utils.string.kebabCase(field.name)}`;
+}
+
+export function expectOneLabelAndHelpText(wrapper: TestWrapper, field: RendererField) {
+    const message = fieldDebugMessage(field, wrapper);
+
+    expect(findFieldLabels(wrapper, field), message).toHaveLength(1);
+    expect(findFieldHelpTexts(wrapper), message).toHaveLength(1);
+}
+
+export function expectInheritanceSwitches(wrapper: TestWrapper, field: RendererField, count: number) {
+    expect(
+        wrapper.findAll('.sw-inheritance-switch, .mt-inheritance-switch'),
+        fieldDebugMessage(field, wrapper),
+    ).toHaveLength(count);
+}
+
+export async function mountFormFieldRenderer(field: RendererField, props = {}) {
+    ensureInnerTextSupport();
+
+    return mount(await wrapTestComponent('sw-form-field-renderer', { sync: true }), {
+        props: {
+            type: field.type,
+            config: field.config,
+            value: getFieldValue(field),
+            ...props,
+        },
+        global: await createGlobalConfig(),
+    });
+}
+
+export async function mountCustomFieldSetRenderer(fields: RendererField[], { hasParent }: { hasParent: boolean }) {
+    ensureInnerTextSupport();
+
+    return mount(await wrapTestComponent('sw-custom-field-set-renderer', { sync: true }), {
+        props: {
+            sets: [
+                {
+                    id: 'renderer-set',
+                    name: 'renderer_set',
+                    config: {
+                        label: { 'en-GB': 'Renderer set' },
+                    },
+                    customFields: fields,
+                },
+            ],
+            entity: {
+                id: 'entity-id',
+                customFields: createDefaultFieldValueMap(fields),
+                getEntityName: () => 'product',
+            },
+            parentEntity: hasParent
+                ? {
+                      id: 'parent-id',
+                      translated: {
+                          customFields: createDefaultFieldValueMap(fields),
+                      },
+                  }
+                : null,
+        },
+        global: await createGlobalConfig({
+            'sw-form-field-renderer': await wrapTestComponent('sw-form-field-renderer', { sync: true }),
+            'sw-inherit-wrapper': await wrapTestComponent('sw-inherit-wrapper', { sync: true }),
+            'sw-tabs': tabsStub(),
+            'sw-tabs-item': true,
+        }),
+    });
+}
+
+export async function mountSystemConfig(fields: RendererField[]): Promise<SystemConfigWrapper> {
+    ensureInnerTextSupport();
+
+    const wrapper = mount(await wrapTestComponent('sw-system-config', { sync: true }), {
+        props: {
+            domain: 'Renderer.config',
+            salesChannelId: null,
+            salesChannelSwitchable: false,
+        },
+        global: await createGlobalConfig(
+            {
+                'sw-form-field-renderer': await wrapTestComponent('sw-form-field-renderer', { sync: true }),
+                'sw-inherit-wrapper': await wrapTestComponent('sw-inherit-wrapper', { sync: true }),
+            },
+            {
+                systemConfigApiService: createSystemConfigService(fields),
+            },
+        ),
+    });
+
+    return wrapper as unknown as SystemConfigWrapper;
+}
+
+function tabsStub() {
+    return {
+        template: '<div><slot :active="defaultItem"></slot><slot name="content" :active="defaultItem"></slot></div>',
+        props: ['defaultItem'],
+        methods: {
+            mountedComponent() {},
+            setActiveItem() {},
+        },
+    };
+}
+
+export async function switchSystemConfigToSalesChannel(wrapper: SystemConfigWrapper) {
+    wrapper.vm.actualConfigData[HEADLESS_SALES_CHANNEL_ID] = {};
+    wrapper.vm.currentSalesChannelId = HEADLESS_SALES_CHANNEL_ID;
+
+    await wrapper.vm.$nextTick();
+}
+
+function findFieldLabels(wrapper: TestWrapper, field: RendererField) {
+    return wrapper.findAll('label').filter((label) => label.text().trim() === field.config.label['en-GB']);
+}
+
+function findFieldHelpTexts(wrapper: TestWrapper) {
+    return wrapper.findAll('.sw-field__help-text, .sw-inherit-wrapper__help-text, .mt-help-text');
+}
+
+function ensureInnerTextSupport() {
+    if ('innerText' in HTMLElement.prototype) {
+        return;
+    }
+
+    Object.defineProperty(HTMLElement.prototype, 'innerText', {
+        get(this: HTMLElement): string {
+            return this.textContent ?? '';
+        },
+        set(this: HTMLElement, value: string) {
+            this.textContent = value;
+        },
+    });
+}
+
+function wrapShopwareBaseField() {
+    return {
+        template: `
+            <div class="sw-field" v-bind="$attrs">
+                <div v-if="$attrs.label || $attrs.helpText || $attrs.isInheritanceField" class="sw-field__label">
+                    <sw-inheritance-switch
+                        v-if="$attrs.isInheritanceField || $attrs.mapInheritance?.isInheritField"
+                        class="sw-field__inheritance-icon"
+                        :is-inherited="$attrs.isInherited || $attrs.mapInheritance?.isInherited"
+                    />
+                    <label v-if="$attrs.label">{{ $attrs.label }}</label>
+                    <sw-help-text
+                        v-if="$attrs.helpText"
+                        class="sw-field__help-text"
+                        :text="$attrs.helpText"
+                    />
+                </div>
+                <slot name="sw-field-input" v-bind="{ identification: 'field', error: null, disabled: false }"></slot>
+                <slot name="hint"></slot>
+            </div>
+        `,
+    };
+}
+
+function wrapShopwareBlockField() {
+    return {
+        template: `
+            <sw-base-field class="sw-block-field" v-bind="$attrs">
+                <template #sw-field-input="slotProps">
+                    <slot name="sw-field-input" v-bind="slotProps"></slot>
+                </template>
+                <template #label>
+                    <slot name="label"></slot>
+                </template>
+                <template #hint>
+                    <slot name="hint"></slot>
+                </template>
+            </sw-base-field>
+        `,
+    };
+}
+
+function wrapSelectBase() {
+    return {
+        template: `
+            <sw-block-field class="sw-select" v-bind="$attrs">
+                <template #sw-field-input="slotProps">
+                    <div class="sw-select__selection">
+                        <slot name="sw-select-selection" v-bind="slotProps"></slot>
+                    </div>
+                    <slot name="results-list" v-bind="{ collapse: () => {} }"></slot>
+                </template>
+                <template #label>
+                    <slot name="label"></slot>
+                </template>
+                <template #hint>
+                    <slot name="hint"></slot>
+                </template>
+            </sw-block-field>
+        `,
+    };
+}

--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-form-field-renderer/sw-form-field-renderer.spec/renderer-label-help-text-inheritance.spec.ts
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-form-field-renderer/sw-form-field-renderer.spec/renderer-label-help-text-inheritance.spec.ts
@@ -1,0 +1,205 @@
+/**
+ * @sw-package framework
+ */
+
+import {
+    type FormFieldDefinition,
+    buildRendererFields,
+    customFieldSelector,
+    expectInheritanceSwitches,
+    expectOneLabelAndHelpText,
+    mountCustomFieldSetRenderer,
+    mountFormFieldRenderer,
+    mountSystemConfig,
+    switchSystemConfigToSalesChannel,
+    systemConfigSelector,
+} from './renderer-label-help-text-inheritance.helper';
+
+type LabelHelpContract = 'simple' | 'composite' | 'rich';
+
+/**
+ * How the rendered input component decides to show an inheritance switch:
+ * - `switch-prop`: only when `isInheritanceField` is set (mt-switch).
+ * - `inherited-value`: whenever `inheritedValue` is not null (mt-checkbox). sw-system-config always
+ *   passes one, so those fields show the switch even while no sales channel is selected.
+ * - `none`: never — the component has no inheritance support (mt-datepicker) or the field is not inheritable.
+ */
+type InheritanceContract = 'switch-prop' | 'inherited-value' | 'none';
+
+type TestedFieldDefinition = FormFieldDefinition & {
+    labelHelp: LabelHelpContract;
+    inheritance: InheritanceContract;
+};
+
+const TESTED_FIELD_DEFINITIONS: TestedFieldDefinition[] = [
+    { type: 'bool', labelHelp: 'simple', inheritance: 'switch-prop' },
+    { type: 'checkbox', labelHelp: 'simple', inheritance: 'inherited-value' },
+    { type: 'colorpicker', labelHelp: 'simple', inheritance: 'none' },
+    { type: 'date', labelHelp: 'simple', inheritance: 'none' },
+    { type: 'datetime', labelHelp: 'simple', inheritance: 'none' },
+    { type: 'email', labelHelp: 'simple', inheritance: 'none' },
+    { type: 'float', labelHelp: 'simple', inheritance: 'none' },
+    { type: 'int', labelHelp: 'simple', inheritance: 'none' },
+    { type: 'multi-select', labelHelp: 'simple', inheritance: 'none' },
+    { type: 'number', labelHelp: 'simple', inheritance: 'none' },
+    { type: 'password', labelHelp: 'simple', inheritance: 'none' },
+    { type: 'price', labelHelp: 'composite', inheritance: 'none' },
+    { type: 'radio', labelHelp: 'simple', inheritance: 'none' },
+    { type: 'single-select', labelHelp: 'simple', inheritance: 'none' },
+    { type: 'string', labelHelp: 'simple', inheritance: 'none' },
+    { type: 'switch', labelHelp: 'simple', inheritance: 'switch-prop' },
+    { type: 'tagged', labelHelp: 'simple', inheritance: 'none' },
+    { type: 'text', labelHelp: 'simple', inheritance: 'none' },
+    { type: 'text-editor', labelHelp: 'rich', inheritance: 'none' },
+    { type: 'textarea', labelHelp: 'simple', inheritance: 'none' },
+    { type: 'time', labelHelp: 'simple', inheritance: 'none' },
+    { type: 'url', labelHelp: 'simple', inheritance: 'none' },
+    { type: 'text', config: { componentName: 'mt-checkbox' }, labelHelp: 'simple', inheritance: 'inherited-value' },
+    { type: 'text', config: { componentName: 'mt-email-field' }, labelHelp: 'simple', inheritance: 'none' },
+    { type: 'text', config: { componentName: 'mt-number-field' }, labelHelp: 'simple', inheritance: 'none' },
+    { type: 'text', config: { componentName: 'mt-password-field' }, labelHelp: 'simple', inheritance: 'none' },
+    { type: 'text', config: { componentName: 'mt-select' }, labelHelp: 'simple', inheritance: 'none' },
+    { type: 'text', config: { componentName: 'mt-switch' }, labelHelp: 'simple', inheritance: 'switch-prop' },
+    { type: 'text', config: { componentName: 'mt-text-field' }, labelHelp: 'simple', inheritance: 'none' },
+    { type: 'text', config: { componentName: 'mt-textarea' }, labelHelp: 'simple', inheritance: 'none' },
+    { type: 'text', config: { componentName: 'mt-url-field' }, labelHelp: 'simple', inheritance: 'none' },
+    { type: 'text', config: { componentName: 'sw-checkbox-field' }, labelHelp: 'simple', inheritance: 'inherited-value' },
+    { type: 'text', config: { componentName: 'sw-colorpicker' }, labelHelp: 'simple', inheritance: 'none' },
+    { type: 'text', config: { componentName: 'sw-datepicker' }, labelHelp: 'simple', inheritance: 'none' },
+    { type: 'text', config: { componentName: 'sw-email-field' }, labelHelp: 'simple', inheritance: 'none' },
+    { type: 'text', config: { componentName: 'sw-number-field' }, labelHelp: 'simple', inheritance: 'none' },
+    { type: 'text', config: { componentName: 'sw-password-field' }, labelHelp: 'simple', inheritance: 'none' },
+    { type: 'text', config: { componentName: 'sw-price-field' }, labelHelp: 'composite', inheritance: 'none' },
+    { type: 'text', config: { componentName: 'sw-radio-field' }, labelHelp: 'simple', inheritance: 'none' },
+    { type: 'text', config: { componentName: 'sw-select-field' }, labelHelp: 'simple', inheritance: 'none' },
+    { type: 'text', config: { componentName: 'sw-snippet-field' }, labelHelp: 'simple', inheritance: 'none' },
+    { type: 'text', config: { componentName: 'sw-switch-field' }, labelHelp: 'simple', inheritance: 'switch-prop' },
+    { type: 'text', config: { componentName: 'sw-tagged-field' }, labelHelp: 'simple', inheritance: 'none' },
+    { type: 'text', config: { componentName: 'sw-text-editor' }, labelHelp: 'rich', inheritance: 'none' },
+    { type: 'text', config: { componentName: 'sw-text-field' }, labelHelp: 'simple', inheritance: 'none' },
+    { type: 'text', config: { componentName: 'sw-textarea-field' }, labelHelp: 'simple', inheritance: 'none' },
+    { type: 'text', config: { componentName: 'sw-url-field' }, labelHelp: 'simple', inheritance: 'none' },
+];
+
+const SIMPLE_LABEL_HELP_DEFINITIONS = TESTED_FIELD_DEFINITIONS.filter((field) => field.labelHelp === 'simple');
+const INHERITANCE_DEFINITIONS = TESTED_FIELD_DEFINITIONS.filter((field) => field.inheritance !== 'none');
+const INHERITANCE_CONTRACTS = INHERITANCE_DEFINITIONS.map((field) => field.inheritance);
+
+const FORM_FIELD_RENDERER_LABEL_FIELDS = buildRendererFields(removeTestMetadata(SIMPLE_LABEL_HELP_DEFINITIONS));
+const FORM_FIELD_RENDERER_INHERITANCE_FIELDS = buildRendererFields(removeTestMetadata(INHERITANCE_DEFINITIONS));
+const SIMPLE_LABEL_HELP_FIELDS = buildRendererFields(removeTestMetadata(SIMPLE_LABEL_HELP_DEFINITIONS));
+const INHERITANCE_FIELDS = buildRendererFields(removeTestMetadata(INHERITANCE_DEFINITIONS));
+
+function removeTestMetadata(fields: TestedFieldDefinition[]): FormFieldDefinition[] {
+    return fields.map(({ type, config }) => ({ type, config }));
+}
+
+describe('components/form/sw-form-field-renderer label, help text, and inheritance rendering', () => {
+    it.each(FORM_FIELD_RENDERER_LABEL_FIELDS)(
+        'renders one label and one help text for $type $config.componentName',
+        async (field) => {
+            expect.hasAssertions();
+
+            const wrapper = await mountFormFieldRenderer(field);
+
+            expectOneLabelAndHelpText(wrapper, field);
+            expectInheritanceSwitches(wrapper, field, 0);
+        },
+    );
+
+    it.each(FORM_FIELD_RENDERER_INHERITANCE_FIELDS)(
+        'renders one inheritance switch when inheritance is enabled for $type $config.componentName',
+        async (field) => {
+            expect.hasAssertions();
+
+            const wrapper = await mountFormFieldRenderer(field, {
+                isInheritanceField: true,
+                isInherited: true,
+            });
+
+            expectInheritanceSwitches(wrapper, field, 1);
+        },
+    );
+
+    it.each(FORM_FIELD_RENDERER_INHERITANCE_FIELDS)(
+        'renders no inheritance switch when inheritance is disabled for $type $config.componentName',
+        async (field) => {
+            expect.hasAssertions();
+
+            const wrapper = await mountFormFieldRenderer(field, {
+                isInheritanceField: false,
+                isInherited: false,
+            });
+
+            expectInheritanceSwitches(wrapper, field, 0);
+        },
+    );
+});
+
+describe('components/form/sw-custom-field-set-renderer label, help text, and inheritance rendering', () => {
+    it('renders one label and one help text for each simple custom field', async () => {
+        expect.hasAssertions();
+
+        const wrapper = await mountCustomFieldSetRenderer(SIMPLE_LABEL_HELP_FIELDS, { hasParent: false });
+        await flushPromises();
+
+        SIMPLE_LABEL_HELP_FIELDS.forEach((field) => {
+            expectOneLabelAndHelpText(wrapper.find(customFieldSelector(field)), field);
+        });
+    });
+
+    it.each([
+        { hasParent: true, expectedCount: 1 },
+        { hasParent: false, expectedCount: 0 },
+    ])(
+        'renders $expectedCount inheritance switch for each custom field when hasParent is $hasParent',
+        async ({ hasParent, expectedCount }) => {
+            expect.hasAssertions();
+
+            const wrapper = await mountCustomFieldSetRenderer(INHERITANCE_FIELDS, { hasParent });
+            await flushPromises();
+
+            INHERITANCE_FIELDS.forEach((field) => {
+                expectInheritanceSwitches(wrapper.find(customFieldSelector(field)), field, expectedCount);
+            });
+        },
+    );
+});
+
+describe('src/module/sw-settings/component/sw-system-config label, help text, and inheritance rendering', () => {
+    it('renders one label and one help text for each simple system config field', async () => {
+        expect.hasAssertions();
+
+        const wrapper = await mountSystemConfig(SIMPLE_LABEL_HELP_FIELDS);
+        await flushPromises();
+
+        SIMPLE_LABEL_HELP_FIELDS.forEach((field) => {
+            expectOneLabelAndHelpText(wrapper.find(systemConfigSelector(field)), field);
+        });
+    });
+
+    it('renders one inheritance switch for each system config field when a sales channel is selected', async () => {
+        expect.hasAssertions();
+
+        const wrapper = await mountSystemConfig(INHERITANCE_FIELDS);
+        await flushPromises();
+        await switchSystemConfigToSalesChannel(wrapper);
+
+        INHERITANCE_FIELDS.forEach((field) => {
+            expectInheritanceSwitches(wrapper.find(systemConfigSelector(field)), field, 1);
+        });
+    });
+
+    it('renders an inheritance switch without a sales channel only for inherited-value fields', async () => {
+        expect.hasAssertions();
+
+        const wrapper = await mountSystemConfig(INHERITANCE_FIELDS);
+        await flushPromises();
+
+        INHERITANCE_FIELDS.forEach((field, index) => {
+            const expectedCount = INHERITANCE_CONTRACTS[index] === 'inherited-value' ? 1 : 0;
+
+            expectInheritanceSwitches(wrapper.find(systemConfigSelector(field)), field, expectedCount);
+        });
+    });
+});


### PR DESCRIPTION
### 1. Why is this change necessary?

Three components decide where a field's label, help text and inheritance switch end up: `sw-form-field-renderer`, `sw-custom-field-set-renderer` and `sw-system-config`. That decision differs per field type *and* per component name, and nothing pinned it. A change in any of the three can duplicate a label or drop an inheritance switch for a subset of the ~46 supported type/component combinations without a single test turning red.

Writing the spec surfaced two behaviours that are not obvious from the code:

**`mt-datepicker` has no inheritance support at all.** The props fall through to the DOM as plain attributes:

```html
<div class="mt-datepicker__wrapper" isinheritancefield="true" isinherited="true" type="date">
```

So `date`, `datetime`, `time` and `sw-datepicker` never render a switch — even though `sw-datepicker` is otherwise treated as inheritance-capable.

**`mt-checkbox` derives inheritance from `inheritedValue`, not from `isInheritanceField`:**

```js
isInheritanceField() {
    if (this.$attrs.isInheritanceField) {
        return true;
    }
    return this.inheritedValue !== null;
}
```

`sw-system-config` always passes an `inheritedValue`, so checkbox fields show the inheritance switch while no sales channel is selected.

### 2. What does this change do, exactly?

Adds a table-driven spec over every supported field type and component name, mounted through all three renderers. Test-only, no production change.

**nit:** the second finding is locked in as expected behaviour. An inheritance switch on a default-scope checkbox looks wrong in the UI, but it comes from the meteor component and exists on `trunk` today, so changing it is a separate production fix.

### 3. Describe each step to reproduce the issue or behaviour.

From `src/Administration/Resources/app/administration`:

```sh
npx jest --config jest.config.js --collectCoverage=false src/app/component/form/sw-form-field-renderer/
FEATURE_ALL=major npx jest --config jest.config.js --collectCoverage=false src/app/component/form/sw-form-field-renderer/
```

68 tests pass in both modes.

### 4. Please link to the relevant issues (if any).

- relates #16586 — that refactor centralises exactly this logic into `isFieldHandlingInheritanceItself()` and `isFieldHandlingLabelAndHelpText()`. This spec pins the current behaviour first, so the refactor can show what it changes.

### 5. Checklist

- [x] I have written tests and verified that they fail without my change — characterisation coverage for existing behaviour, so there is no production change to remove; verified instead by asserting the rendered output of every combination in both flag modes
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
