### PR TITLE
test: skip flaky Flow Builder and Media visual tests

### DIFF
--- a/tests/acceptance/tests/Visual/Administration/FlowBuilder.spec.ts
+++ b/tests/acceptance/tests/Visual/Administration/FlowBuilder.spec.ts
@@ -1,28 +1,46 @@
 import { test, setViewport, replaceElements, hideElements, assertScreenshot, FlowConfig } from '@fixtures/AcceptanceTest';
 
-test('Visual: Flow Builder listing', { tag: '@Visual' }, async ({ ShopAdmin, AdminFlowBuilderListing }) => {
-    await test.step('Create a screenshot of the flow listing.', async () => {
-        await ShopAdmin.goesTo(AdminFlowBuilderListing.url());
-        await setViewport(AdminFlowBuilderListing.page, {
-            waitForSelector: AdminFlowBuilderListing.createFlowButton,
+// eslint-disable-next-line playwright/no-skipped-test
+test.skip(
+    'Visual: Flow Builder listing',
+    {
+        tag: '@Visual',
+        annotation: {
+            type: 'issue',
+            description: 'https://github.com/shopware/shopware/issues/19385',
+        },
+    },
+    async ({ ShopAdmin, AdminFlowBuilderListing }) => {
+        await test.step('Create a screenshot of the flow listing.', async () => {
+            await ShopAdmin.goesTo(AdminFlowBuilderListing.url());
+            await setViewport(AdminFlowBuilderListing.page, {
+                waitForSelector: AdminFlowBuilderListing.createFlowButton,
+            });
+            await replaceElements(AdminFlowBuilderListing.page, [AdminFlowBuilderListing.testFlowNameCells]);
+            await AdminFlowBuilderListing.flowTemplatesTab.hover();
+            await assertScreenshot(AdminFlowBuilderListing.page, 'Flow-Builder-Listing-Hover.png');
         });
-        await replaceElements(AdminFlowBuilderListing.page, [AdminFlowBuilderListing.testFlowNameCells]);
-        await AdminFlowBuilderListing.flowTemplatesTab.hover();
-        await assertScreenshot(AdminFlowBuilderListing.page, 'Flow-Builder-Listing-Hover.png');
-    });
 
-    await test.step('Create a screenshot of the flow templates listing.', async () => {
-        await AdminFlowBuilderListing.flowTemplatesTab.click();
-        await setViewport(AdminFlowBuilderListing.page, {
-            waitForSelector: AdminFlowBuilderListing.pagination,
+        await test.step('Create a screenshot of the flow templates listing.', async () => {
+            await AdminFlowBuilderListing.flowTemplatesTab.click();
+            await setViewport(AdminFlowBuilderListing.page, {
+                waitForSelector: AdminFlowBuilderListing.pagination,
+            });
+            await assertScreenshot(AdminFlowBuilderListing.page, 'Flow-Builder-Templates-Listing-Hover.png');
         });
-        await assertScreenshot(AdminFlowBuilderListing.page, 'Flow-Builder-Templates-Listing-Hover.png');
-    });
-});
+    },
+);
 
-test(
+// eslint-disable-next-line playwright/no-skipped-test
+test.skip(
     'Visual: Flow Builder detail page',
-    { tag: '@Visual' },
+    {
+        tag: '@Visual',
+        annotation: {
+            type: 'issue',
+            description: 'https://github.com/shopware/shopware/issues/19385',
+        },
+    },
     async ({ ShopAdmin, TestDataService, IdProvider, AdminFlowBuilderListing, AdminFlowBuilderDetail, CreateFlow }) => {
         const uniqueId = IdProvider.getIdPair().uuid;
         const tagName = `Test tag - ${uniqueId}`;

--- a/tests/acceptance/tests/Visual/Administration/Media.spec.ts
+++ b/tests/acceptance/tests/Visual/Administration/Media.spec.ts
@@ -1,25 +1,36 @@
 import { test, assertScreenshot, setViewport, replaceElementsIndividually } from '@fixtures/AcceptanceTest';
 
-test('Visual: Administration media page', { tag: '@Visual' }, async ({ ShopAdmin, AdminMediaListing }) => {
-    await test.step('Creates a screenshot of the media page.', async () => {
-        await ShopAdmin.goesTo(AdminMediaListing.url());
-        await setViewport(AdminMediaListing.page, {
-            scrollableElementVertical: AdminMediaListing.scrollableElementVertical,
-            additionalHeight: 100,
-            waitForSelector: AdminMediaListing.mediaFolder('Product Media'),
+// eslint-disable-next-line playwright/no-skipped-test
+test.skip(
+    'Visual: Administration media page',
+    {
+        tag: '@Visual',
+        annotation: {
+            type: 'issue',
+            description: 'https://github.com/shopware/shopware/issues/19386',
+        },
+    },
+    async ({ ShopAdmin, AdminMediaListing }) => {
+        await test.step('Creates a screenshot of the media page.', async () => {
+            await ShopAdmin.goesTo(AdminMediaListing.url());
+            await setViewport(AdminMediaListing.page, {
+                scrollableElementVertical: AdminMediaListing.scrollableElementVertical,
+                additionalHeight: 100,
+                waitForSelector: AdminMediaListing.mediaFolder('Product Media'),
+            });
+            await assertScreenshot(AdminMediaListing.page, 'Media-Listing.png');
         });
-        await assertScreenshot(AdminMediaListing.page, 'Media-Listing.png');
-    });
 
-    await test.step('Creates a screenshot of an open media folder.', async () => {
-        await AdminMediaListing.mediaFolder('Product Media').click();
-        await ShopAdmin.expects(AdminMediaListing.emptyState).toBeVisible();
-        await setViewport(AdminMediaListing.page, {
-            scrollableElementVertical: AdminMediaListing.scrollableElementVertical,
+        await test.step('Creates a screenshot of an open media folder.', async () => {
+            await AdminMediaListing.mediaFolder('Product Media').click();
+            await ShopAdmin.expects(AdminMediaListing.emptyState).toBeVisible();
+            await setViewport(AdminMediaListing.page, {
+                scrollableElementVertical: AdminMediaListing.scrollableElementVertical,
+            });
+            await replaceElementsIndividually(AdminMediaListing.page, [
+                { selector: AdminMediaListing.updatedAtDate, replaceWith: '1 January 1970 at 00:01' },
+            ]);
+            await assertScreenshot(AdminMediaListing.page, 'Media-Folder-Open.png');
         });
-        await replaceElementsIndividually(AdminMediaListing.page, [
-            { selector: AdminMediaListing.updatedAtDate, replaceWith: '1 January 1970 at 00:01' },
-        ]);
-        await assertScreenshot(AdminMediaListing.page, 'Media-Folder-Open.png');
-    });
-});
+    },
+);


### PR DESCRIPTION
### 1. Why is this change necessary?

The `Visual: Flow Builder listing`, `Visual: Flow Builder detail page`, and `Visual: Administration media page` tests fail intermittently in CI with screenshot mismatches, e.g. https://github.com/shopware/shopware/actions/runs/31985243606/job/95259013706

### 2. What does this change do, exactly?

Skips the affected tests until the flakiness is fixed.

### 3. Describe each step to reproduce the issue or behaviour.

See the linked issues.

### 4. Please link to the relevant issues (if any).

- relates #19385
- relates #19386

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them