### PR TITLE
test: isolate Documents test with a dedicated customer

### DIFF
--- a/tests/acceptance/tests/Settings/Documents.spec.ts
+++ b/tests/acceptance/tests/Settings/Documents.spec.ts
@@ -6,7 +6,6 @@ test(
     async ({
         ShopAdmin,
         TestDataService,
-        DefaultSalesChannel,
         AdminDocumentListing,
         AdminDocumentDetail,
         AdminOrderDetail,
@@ -17,8 +16,9 @@ test(
         CreateDocument,
     }) => {
         const product = await TestDataService.createBasicProduct();
+        const customer = await TestDataService.createCustomer();
 
-        const order = await TestDataService.createOrder([{ product, quantity: 1 }], DefaultSalesChannel.customer);
+        const order = await TestDataService.createOrder([{ product, quantity: 1 }], customer);
 
         await test.step('Go to documents settings page and activate documents in customer accounts', async () => {
             await ShopAdmin.goesTo(AdminDocumentListing.url());
@@ -52,7 +52,7 @@ test(
         });
 
         await test.step('Log into customer account and check the order document', async () => {
-            await ShopCustomer.attemptsTo(Login());
+            await ShopCustomer.attemptsTo(Login(customer));
             await ShopCustomer.goesTo(StorefrontAccountOrder.url());
 
             await ShopCustomer.expects(StorefrontAccountOrder.orderExpandButton).toBeVisible();


### PR DESCRIPTION
## Problem
```
Error: expect(locator).toBeVisible() failed
Locator: locator('.order-item-detail')
Error: strict mode violation: locator('.order-item-detail') resolved to 2 elements
```

The test creates a single order and then asserts on the storefront account order list, expecting exactly one order. However, it reused `DefaultSalesChannel.customer`, which is a **worker-scoped** fixture. When another test in the same worker placed an order for that customer (e.g. a real checkout, order number 10000), the account listed two orders and `.order-item-detail` matched twice → strict-mode violation.

## Fix

Create a dedicated customer via `TestDataService.createCustomer()` and use it for both the order and the login. This is more robust than matching by order number, which would break once the account order list paginates.
