### PR TITLE
fix(elasticsearch): fall back to DAL search for entities without an admin ES indexer

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -368,6 +368,10 @@ This affects every write path, not just Settings > Shop > SEO:
 - Writes that do not change the stored `template` value do not queue anything: update commands request a DAL change set, so an idempotent Sync API push of an identical template stays inert. Inserts with an empty or `null` template are skipped as well.
 - Extensions and deployment scripts that write `seo_url_template` rows on every install or update will therefore queue a full regeneration pass for the affected route each time. Guard such writes with a value comparison if that is not intended.
 
+### Admin search falls back to the database for entities without an Elasticsearch admin indexer
+
+With Elasticsearch for the Administration enabled, `POST /api/_admin/es-search` silently returned no results for entities that have no admin search indexer, because those entities were dropped from the request. They are now searched over the DAL instead, so an entity registered in the Administration search (`searchTypeService.upsertType()` or a module `defaultSearchConfiguration`) is findable without shipping an indexer. Registering an `AbstractAdminIndexer` for the entity is still the faster option.
+
 ## Administration
 
 ### Admin Worker loads correctly when the Administration is hosted under a base path

--- a/src/Administration/Resources/app/administration/src/app/component/structure/sw-search-bar/sw-search-bar.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/structure/sw-search-bar/sw-search-bar.spec.js
@@ -1481,6 +1481,24 @@ describe('src/app/component/structure/sw-search-bar', () => {
         expect(wrapper.vm.currentSearchType).toBeNull();
     });
 
+    it('should search in the listing when the initial search type is not a registered global search type', async () => {
+        // mirrors an admin ES / Advanced Search instance, where the prop defaults to true
+        wrapper = await createWrapper({
+            initialSearchType: 'flow_template',
+            typeSearchAlwaysInContainer: true,
+        });
+
+        const searchInput = wrapper.find('.sw-search-bar__input');
+        await searchInput.trigger('focus');
+        await searchInput.setValue('Order');
+
+        await swSearchBarComponent.methods.doListSearch.flush();
+        await flushPromises();
+
+        expect(wrapper.emitted('search')).toEqual([['Order']]);
+        expect(spyLoadTypeSearchResults).not.toHaveBeenCalled();
+    });
+
     it('should search global with ES when adminEsEnable is true', async () => {
         Shopware.Context.app.adminEsEnable = true;
         wrapper = await createWrapper(

--- a/src/Administration/Resources/app/administration/src/app/snippet/de.json
+++ b/src/Administration/Resources/app/administration/src/app/snippet/de.json
@@ -1109,6 +1109,7 @@
       "custom-field-set": "Zusatzfeld-Set",
       "store_settings": "Produkt-Sortierung",
       "flow": "Flow | Flows",
+      "flow_template": "Flow-Vorlage | Flow-Vorlagen",
       "module": "Modul",
       "frequently_used": "Häufig verwendete",
       "recently_searched": "Kürzlich gesucht",

--- a/src/Administration/Resources/app/administration/src/app/snippet/en.json
+++ b/src/Administration/Resources/app/administration/src/app/snippet/en.json
@@ -1109,6 +1109,7 @@
       "custom-field-set": "Custom field set",
       "store_settings": "Product sorting",
       "flow": "Flow | Flows",
+      "flow_template": "Flow template | Flow templates",
       "module": "Module",
       "frequently_used": "Frequently used",
       "recently_searched": "Recently searched",

--- a/src/Administration/Resources/app/administration/src/module/sw-flow/page/sw-flow-index/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-flow/page/sw-flow-index/index.ts
@@ -40,6 +40,14 @@ export default Shopware.Component.wrapComponentConfig({
     },
 
     computed: {
+        searchType(): string {
+            if (this.$route.name === 'sw.flow.index.templates') {
+                return 'flow_template';
+            }
+
+            return 'flow';
+        },
+
         flowRepository(): Repository<'flow'> {
             return this.repositoryFactory.create('flow');
         },

--- a/src/Administration/Resources/app/administration/src/module/sw-flow/page/sw-flow-index/sw-flow-index.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-flow/page/sw-flow-index/sw-flow-index.html.twig
@@ -1,7 +1,7 @@
 <sw-page class="sw-flow-list-index">
     <template #search-bar>
         <sw-search-bar
-            initial-search-type="flow"
+            :initial-search-type="searchType"
             :placeholder="$t('sw-flow.general.placeholderSearchBar')"
             :initial-search="term"
             @search="onSearch"

--- a/src/Administration/Resources/app/administration/src/module/sw-flow/page/sw-flow-index/sw-flow-index.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-flow/page/sw-flow-index/sw-flow-index.spec.js
@@ -3,7 +3,7 @@ import { mount } from '@vue/test-utils';
 /**
  * @sw-package after-sales
  */
-async function createWrapper(privileges = []) {
+async function createWrapper(privileges = [], routeName = 'sw.flow.index.flows') {
     return mount(
         await wrapTestComponent('sw-flow-index', {
             sync: true,
@@ -12,6 +12,7 @@ async function createWrapper(privileges = []) {
             global: {
                 mocks: {
                     $route: {
+                        name: routeName,
                         query: {
                             page: 1,
                             limit: 25,
@@ -105,5 +106,17 @@ describe('module/sw-flow/page/sw-flow-index', () => {
         await flushPromises();
 
         expect(wrapper.find('.sw-page__smart-bar-amount').text()).toBe('(20)');
+    });
+
+    it('should search flows on the flows tab', async () => {
+        const wrapper = await createWrapper();
+
+        expect(wrapper.vm.searchType).toBe('flow');
+    });
+
+    it('should search flow templates on the templates tab', async () => {
+        const wrapper = await createWrapper([], 'sw.flow.index.templates');
+
+        expect(wrapper.vm.searchType).toBe('flow_template');
     });
 });

--- a/src/Administration/Resources/app/administration/src/module/sw-flow/view/listing/sw-flow-list-flow-templates/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-flow/view/listing/sw-flow-list-flow-templates/index.ts
@@ -72,8 +72,8 @@ export default Shopware.Component.wrapComponentConfig({
         flowTemplateCriteria(): CriteriaType {
             const criteria = new Criteria(1, 25);
 
-            if (this.searchTerm) {
-                criteria.setTerm(this.searchTerm);
+            if (this.term) {
+                criteria.setTerm(this.term);
             }
 
             criteria

--- a/src/Administration/Resources/app/administration/src/module/sw-flow/view/listing/sw-flow-list-flow-templates/sw-flow-list-flow-templates.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-flow/view/listing/sw-flow-list-flow-templates/sw-flow-list-flow-templates.spec.js
@@ -20,7 +20,7 @@ const flowTemplateRepositorySearchMock = jest.fn((criteria) => {
     return Promise.resolve(new EntityCollection('', '', Context.api, criteria, mockData, 1));
 });
 
-async function createWrapper(privileges = [], props = {}) {
+async function createWrapper(privileges = [], props = {}, routeQuery = {}) {
     return mount(await wrapTestComponent('sw-flow-list-flow-templates', { sync: true }), {
         global: {
             stubs: {
@@ -108,6 +108,7 @@ async function createWrapper(privileges = [], props = {}) {
                     query: {
                         page: 1,
                         limit: 25,
+                        ...routeQuery,
                     },
                     meta: {
                         $module: {
@@ -194,6 +195,13 @@ describe('module/sw-flow/view/listing/sw-flow-list-flow-templates', () => {
                 term: 'test-term',
             }),
         );
+    });
+
+    it('should set the term of the route query to criteria', async () => {
+        await createWrapper([], {}, { term: 'Order' });
+        await flushPromises();
+
+        expect(flowTemplateRepositorySearchMock).toHaveBeenLastCalledWith(expect.objectContaining({ term: 'Order' }));
     });
 
     it('should correctly align table columns', async () => {

--- a/src/Administration/Resources/app/administration/src/module/sw-flow/view/listing/sw-flow-list/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-flow/view/listing/sw-flow-list/index.js
@@ -64,8 +64,8 @@ export default {
         flowCriteria() {
             const criteria = new Criteria(this.page, this.limit);
 
-            if (this.searchTerm) {
-                criteria.setTerm(this.searchTerm);
+            if (this.term) {
+                criteria.setTerm(this.term);
             }
 
             criteria

--- a/src/Administration/Resources/app/administration/src/module/sw-flow/view/listing/sw-flow-list/sw-flow-list.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-flow/view/listing/sw-flow-list/sw-flow-list.spec.js
@@ -30,7 +30,11 @@ const flowData = [
     },
 ];
 
-async function createWrapper(privileges = [], hasSnippetFromApp = false, customFlowData = flowData) {
+let flowSearchMock;
+
+async function createWrapper(privileges = [], hasSnippetFromApp = false, customFlowData = flowData, routeQuery = {}) {
+    flowSearchMock = jest.fn(() => Promise.resolve(customFlowData));
+
     return mount(await wrapTestComponent('sw-flow-list', { sync: true }), {
         global: {
             plugins: [createPinia()],
@@ -76,9 +80,7 @@ async function createWrapper(privileges = [], hasSnippetFromApp = false, customF
             provide: {
                 repositoryFactory: {
                     create: () => ({
-                        search: () => {
-                            return Promise.resolve(customFlowData);
-                        },
+                        search: flowSearchMock,
                         clone: jest.fn(() =>
                             Promise.resolve({
                                 id: '0e6b005ca7a1440b8e87ac3d45ed5c9f',
@@ -108,6 +110,7 @@ async function createWrapper(privileges = [], hasSnippetFromApp = false, customF
                     query: {
                         page: 1,
                         limit: 25,
+                        ...routeQuery,
                     },
                 },
                 $t: (key) => {
@@ -270,5 +273,12 @@ describe('module/sw-flow/view/listing/sw-flow-list', () => {
             name: 'sw.flow.detail',
             params: { id: '0e6b005ca7a1440b8e87ac3d45ed5c9f' },
         });
+    });
+
+    it('should set the term of the route query to criteria', async () => {
+        await createWrapper([], false, flowData, { term: 'Order' });
+        await flushPromises();
+
+        expect(flowSearchMock).toHaveBeenLastCalledWith(expect.objectContaining({ term: 'Order' }));
     });
 });

--- a/src/Elasticsearch/Admin/AdminSearchRegistry.php
+++ b/src/Elasticsearch/Admin/AdminSearchRegistry.php
@@ -41,6 +41,11 @@ class AdminSearchRegistry implements EventSubscriberInterface
     private readonly array $config;
 
     /**
+     * @var array<string, AbstractAdminIndexer>|null
+     */
+    private ?array $indexers = null;
+
+    /**
      * @param iterable<AbstractAdminIndexer> $indexer
      * @param array<string, mixed> $config
      * @param array<string, mixed> $mapping
@@ -495,10 +500,14 @@ class AdminSearchRegistry implements EventSubscriberInterface
      */
     private function getIndexersArray(): array
     {
-        if ($this->indexer instanceof \Traversable) {
-            return iterator_to_array($this->indexer);
+        if ($this->indexers !== null) {
+            return $this->indexers;
         }
 
-        return $this->indexer;
+        $this->indexers = $this->indexer instanceof \Traversable
+            ? iterator_to_array($this->indexer)
+            : $this->indexer;
+
+        return $this->indexers;
     }
 }

--- a/src/Elasticsearch/Admin/AdminSearcher.php
+++ b/src/Elasticsearch/Admin/AdminSearcher.php
@@ -46,28 +46,41 @@ class AdminSearcher
     /**
      * @param array<string> $entities
      *
-     * @return array<string, array{total: int, data: EntityCollection<covariant \Shopware\Core\Framework\DataAbstractionLayer\Entity>, indexer: string, index: string}>
+     * @return array<string, array{total: int, data: EntityCollection<covariant \Shopware\Core\Framework\DataAbstractionLayer\Entity>, indexer?: string, index?: string}>
      */
     public function search(string $term, array $entities, Context $context, int $limit = 5): array
     {
         $indexes = [];
+        $notIndexed = [];
 
-        $term = $this->extractTerm($term);
+        $term = mb_substr(trim($term), 0, $this->termMaxLength);
+        $esTerm = $this->extractTerm($term);
 
         foreach ($entities as $entityName) {
             if (!$context->isAllowed($entityName . ':' . AclRoleDefinition::PRIVILEGE_READ)) {
                 continue;
             }
 
-            try {
-                $indexes = array_merge($indexes, $this->buildSearchPayload($entityName, $term, $limit));
-            } catch (ElasticsearchException) {
+            if (!$this->registry->hasIndexer($entityName)) {
+                $notIndexed[] = $entityName;
+
                 continue;
+            }
+
+            try {
+                $indexes = array_merge($indexes, $this->buildSearchPayload($entityName, $esTerm, $limit));
+            } catch (ElasticsearchException) {
+                $notIndexed[] = $entityName;
             }
         }
 
+        $mapped = [];
+        if ($notIndexed !== []) {
+            $mapped = $this->searchWithoutIndex($notIndexed, $term, $context, $limit);
+        }
+
         if ($indexes === []) {
-            return [];
+            return $mapped;
         }
 
         try {
@@ -75,12 +88,11 @@ class AdminSearcher
         } catch (\Throwable $e) {
             $this->adminEsHelper->logAndThrowException($e);
 
-            return [];
+            return $mapped;
         }
 
         $result = $this->parseResponse($responses);
 
-        $mapped = [];
         foreach ($result as $index => $values) {
             $entityName = $values['hits'][0]['entityName'];
             $indexer = $this->registry->getIndexer($entityName);
@@ -149,6 +161,40 @@ class AdminSearcher
         $ids->addState(ElasticsearchEntitySearcher::RESULT_STATE);
 
         return $ids;
+    }
+
+    /**
+     * @param list<string> $entities
+     *
+     * @return array<string, array{total: int, data: EntityCollection<covariant \Shopware\Core\Framework\DataAbstractionLayer\Entity>}>
+     */
+    private function searchWithoutIndex(array $entities, string $term, Context $context, int $limit): array
+    {
+        $result = [];
+
+        foreach ($entities as $entityName) {
+            if (!$this->definitionInstanceRegistry->has($entityName)) {
+                continue;
+            }
+
+            $criteria = new Criteria();
+            $criteria->setTerm($term);
+            $criteria->setLimit($limit);
+            $criteria->setTotalCountMode(Criteria::TOTAL_COUNT_MODE_EXACT);
+
+            $search = $this->definitionInstanceRegistry->getRepository($entityName)->search($criteria, $context);
+
+            if ($search->getTotal() === 0) {
+                continue;
+            }
+
+            $result[$entityName] = [
+                'total' => $search->getTotal(),
+                'data' => $search->getEntities(),
+            ];
+        }
+
+        return $result;
     }
 
     /**

--- a/src/Elasticsearch/Framework/Command/ElasticsearchAdminTestCommand.php
+++ b/src/Elasticsearch/Framework/Command/ElasticsearchAdminTestCommand.php
@@ -78,7 +78,7 @@ final class ElasticsearchAdminTestCommand extends Command
 
         $rows = [];
         foreach ($result as $data) {
-            $rows[] = [$data['index'], $data['indexer'], $data['total']];
+            $rows[] = [$data['index'] ?? '', $data['indexer'] ?? '', $data['total']];
         }
 
         $this->io->table(['Index', 'Indexer', 'total'], $rows);

--- a/tests/acceptance/tests/Settings/FlowBuilderTemplates.spec.ts
+++ b/tests/acceptance/tests/Settings/FlowBuilderTemplates.spec.ts
@@ -3,13 +3,7 @@ import { getFlowId, compareFlowTemplateWithFlow } from '@shopware-ag/acceptance-
 
 test(
     'As an admin, I want to create new flows from templates, so that I can easily create new ones based on the default flows.',
-    {
-        tag: '@Flow',
-        annotation: {
-            type: 'issue',
-            description: 'https://github.com/shopware/shopware/issues/19378',
-        },
-    },
+    { tag: '@Flow' },
     async ({
         ShopAdmin,
         AdminFlowBuilderTemplates,
@@ -17,13 +11,7 @@ test(
         AdminFlowBuilderDetail,
         IdProvider,
         AdminApiContext,
-        InstanceMeta,
     }) => {
-        test.skip(
-            InstanceMeta.isSaaS,
-            'Test is skipped in SaaS due to search issue with Advanced Search. See https://github.com/shopware/shopware/issues/19378 ',
-        );
-
         const flowTemplateName = 'Order placed';
         const flowTemplateSingleTerms = flowTemplateName.split(' ');
         const flowTemplateSearchTerm = flowTemplateSingleTerms[flowTemplateSingleTerms.length - 2];

--- a/tests/unit/Elasticsearch/Admin/AdminSearchRegistryTest.php
+++ b/tests/unit/Elasticsearch/Admin/AdminSearchRegistryTest.php
@@ -32,6 +32,7 @@ use Shopware\Elasticsearch\Admin\Indexer\AbstractAdminIndexer;
 use Shopware\Elasticsearch\ElasticsearchException;
 use Shopware\Elasticsearch\Framework\AbstractElasticsearchDefinition;
 use Symfony\Component\Clock\NativeClock;
+use Symfony\Component\DependencyInjection\Argument\RewindableGenerator;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Messenger\Envelope;
@@ -77,6 +78,36 @@ class AdminSearchRegistryTest extends TestCase
         $indexers = $registry->getIndexers();
 
         static::assertSame(['promotion' => $this->indexer], $indexers);
+    }
+
+    public function testIndexerLookupIsResolvedOnceFromTheTaggedIterator(): void
+    {
+        $consumed = 0;
+        $indexer = $this->indexer;
+
+        $registry = new AdminSearchRegistry(
+            new RewindableGenerator(static function () use (&$consumed, $indexer): \Generator {
+                ++$consumed;
+
+                yield 'promotion' => $indexer;
+            }, 1),
+            static::createStub(Connection::class),
+            static::createStub(MessageBusInterface::class),
+            static::createStub(EventDispatcherInterface::class),
+            static::createStub(Client::class),
+            new AdminElasticsearchHelper(true, false, 'sw-admin', 'test', true, new NullLogger()),
+            static::createStub(LoggerInterface::class),
+            [],
+            [],
+            'test',
+            new NativeClock()
+        );
+
+        static::assertTrue($registry->hasIndexer('promotion'));
+        static::assertSame($this->indexer, $registry->getIndexer('promotion'));
+        static::assertTrue($registry->hasIndexer('promotion'));
+
+        static::assertSame(1, $consumed);
     }
 
     public function testUpdateMapping(): void

--- a/tests/unit/Elasticsearch/Admin/AdminSearcherTest.php
+++ b/tests/unit/Elasticsearch/Admin/AdminSearcherTest.php
@@ -9,15 +9,22 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
+use Shopware\Core\Content\Flow\FlowCollection;
+use Shopware\Core\Content\Flow\FlowDefinition;
+use Shopware\Core\Content\Flow\FlowEntity;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Dbal\Common\IteratorFactory;
 use Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\SearchRanking;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\Test\Stub\DataAbstractionLayer\StaticEntityRepository;
 use Shopware\Elasticsearch\Admin\AdminElasticsearchHelper;
 use Shopware\Elasticsearch\Admin\AdminSearcher;
 use Shopware\Elasticsearch\Admin\AdminSearchRegistry;
+use Shopware\Elasticsearch\Admin\Indexer\AbstractAdminIndexer;
 use Shopware\Elasticsearch\Admin\Indexer\ProductAdminSearchIndexer;
 use Shopware\Elasticsearch\ElasticsearchException;
 use Shopware\Elasticsearch\Framework\DataAbstractionLayer\AbstractElasticsearchSearchHydrator;
@@ -37,21 +44,24 @@ class AdminSearcherTest extends TestCase
 
     private AdminSearchRegistry&Stub $registry;
 
+    private AbstractAdminIndexer $productIndexer;
+
     protected function setUp(): void
     {
         $this->client = $this->createMock(Client::class);
 
         $this->registry = static::createStub(AdminSearchRegistry::class);
 
-        $indexer = new ProductAdminSearchIndexer(
+        $this->productIndexer = new ProductAdminSearchIndexer(
             static::createStub(Connection::class),
             static::createStub(IteratorFactory::class),
             static::createStub(EntityRepository::class),
             static::createStub(ElasticsearchFieldBuilder::class),
             100
         );
-        $this->registry->method('getIndexers')->willReturn(['product' => $indexer]);
-        $this->registry->method('getIndexer')->willReturn($indexer);
+        $this->registry->method('getIndexers')->willReturn(['product' => $this->productIndexer]);
+        $this->registry->method('hasIndexer')->willReturn(true);
+        $this->registry->method('getIndexer')->willReturn($this->productIndexer);
 
         $searchHelper = new AdminElasticsearchHelper(true, false, 'sw-admin', 'test', true, new NullLogger());
         $this->searcher = new AdminSearcher(
@@ -106,28 +116,93 @@ class AdminSearcherTest extends TestCase
         $this->assertSearchResult($data, 1, 'product-listing', 'sw-admin-product-listing');
     }
 
-    public function testSearchWithUndefinedIndexer(): void
+    public function testSearchWithUndefinedIndexerAndUnknownEntity(): void
     {
-        $this->registry->method('getIndexer')->willThrowException(ElasticsearchException::indexingError(['Indexer for name test not found']));
+        $registry = static::createStub(AdminSearchRegistry::class);
+        $registry->method('hasIndexer')->willReturn(false);
 
         $this->client->expects($this->never())->method('msearch');
 
-        $searchHelper = new AdminElasticsearchHelper(true, false, 'sw-admin', 'test', true, new NullLogger());
-        $searcher = new AdminSearcher(
-            $this->client,
-            $this->registry,
-            $searchHelper,
-            static::createStub(DefinitionInstanceRegistry::class),
-            static::createStub(AbstractElasticsearchSearchHydrator::class),
-            static::createStub(ElasticsearchHelper::class),
-            '5s',
-            20,
-            'query_then_fetch',
-        );
+        $searcher = $this->createSearcher($registry, static::createStub(DefinitionInstanceRegistry::class));
 
         $data = $searcher->search('elasticsearch', ['test'], Context::createDefaultContext());
 
         static::assertEmpty($data);
+    }
+
+    public function testSearchFallsBackToTheDalWhenTheEntityHasNoIndexer(): void
+    {
+        $registry = static::createStub(AdminSearchRegistry::class);
+        $registry->method('hasIndexer')->willReturn(false);
+
+        $this->client->expects($this->never())->method('msearch');
+
+        $flow = new FlowEntity();
+        $flow->setUniqueIdentifier(Uuid::randomHex());
+
+        $searchedCriteria = null;
+        $repository = StaticEntityRepository::of(
+            FlowCollection::class,
+            [
+                function (Criteria $criteria) use (&$searchedCriteria, $flow): FlowCollection {
+                    $searchedCriteria = $criteria;
+
+                    return new FlowCollection([$flow]);
+                },
+            ],
+            new FlowDefinition()
+        );
+
+        $definitionRegistry = static::createStub(DefinitionInstanceRegistry::class);
+        $definitionRegistry->method('has')->willReturn(true);
+        $definitionRegistry->method('getRepository')->willReturn($repository);
+
+        $searcher = $this->createSearcher($registry, $definitionRegistry);
+
+        $data = $searcher->search('Order and placed', ['flow'], Context::createDefaultContext());
+
+        static::assertSame(1, $data['flow']['total']);
+        static::assertSame([$flow], array_values($data['flow']['data']->getElements()));
+
+        static::assertInstanceOf(Criteria::class, $searchedCriteria);
+        // raw term, not the elasticsearch operator syntax where "and" becomes "+"
+        static::assertSame('Order and placed', $searchedCriteria->getTerm());
+        static::assertSame(5, $searchedCriteria->getLimit());
+    }
+
+    public function testSearchFallsBackToTheDalWhenTheIndexerCannotBeResolved(): void
+    {
+        $registry = static::createStub(AdminSearchRegistry::class);
+        $registry->method('hasIndexer')->willReturn(true);
+        $registry->method('getIndexer')->willReturnCallback(function (string $entityName): AbstractAdminIndexer {
+            if ($entityName === 'flow') {
+                throw ElasticsearchException::indexingError(['Indexer for name flow not found']);
+            }
+
+            return $this->productIndexer;
+        });
+
+        $this->client
+            ->expects($this->once())
+            ->method('msearch')
+            ->with($this->getQueryBody('elasticsearch*'))
+            ->willReturn($this->getMockResponse('c1a28776116d4431a2208eb2960ec340 elasticsearch'));
+
+        $flow = new FlowEntity();
+        $flow->setUniqueIdentifier(Uuid::randomHex());
+
+        $definitionRegistry = static::createStub(DefinitionInstanceRegistry::class);
+        $definitionRegistry->method('has')->willReturn(true);
+        $definitionRegistry->method('getRepository')->willReturn(
+            StaticEntityRepository::of(FlowCollection::class, [new FlowCollection([$flow])], new FlowDefinition())
+        );
+
+        $searcher = $this->createSearcher($registry, $definitionRegistry);
+
+        $data = $searcher->search('elasticsearch', ['product', 'flow'], Context::createDefaultContext());
+
+        $this->assertSearchResult($data, 1, 'product-listing', 'sw-admin-product-listing');
+        static::assertSame(1, $data['flow']['total']);
     }
 
     public function testSearchWithNumericTerm(): void
@@ -222,6 +297,21 @@ class AdminSearcherTest extends TestCase
         $this->expectExceptionObject($exception);
 
         $this->searcher->search('elasticsearch', ['product'], Context::createDefaultContext());
+    }
+
+    private function createSearcher(AdminSearchRegistry&Stub $registry, DefinitionInstanceRegistry&Stub $definitionRegistry): AdminSearcher
+    {
+        return new AdminSearcher(
+            $this->client,
+            $registry,
+            new AdminElasticsearchHelper(true, false, 'sw-admin', 'test', true, new NullLogger()),
+            $definitionRegistry,
+            static::createStub(AbstractElasticsearchSearchHydrator::class),
+            static::createStub(ElasticsearchHelper::class),
+            '5s',
+            20,
+            'query_then_fetch',
+        );
     }
 
     /**


### PR DESCRIPTION
This pull request enhances the admin search functionality to ensure that entities without an Elasticsearch indexer are still searchable in the Administration, by falling back to a database (DAL) search. It also updates the return types and test coverage to support this new behavior, and improves the resilience and correctness of the search logic.

**Admin Search Improvements:**

* Entities registered for admin search but lacking an Elasticsearch indexer are now searched using the DAL, ensuring they appear in search results rather than being silently omitted. Results from this fallback do not include `indexer` or `index` keys. [[1]](diffhunk://#diff-819080d3452b5ad5bc86679c15267c543f1920c1f4dae27011f14ccd463ffcdcR297-R302) [[2]](diffhunk://#diff-0fe294a7d08df3e27d0baa510709df3be76d75e2491b52debb6fce75d745dd17L49-L83) [[3]](diffhunk://#diff-0fe294a7d08df3e27d0baa510709df3be76d75e2491b52debb6fce75d745dd17R166-R202)

**Code Robustness and Compatibility:**

* The return type of the `search` method in `AdminSearcher` is updated to mark `indexer` and `index` as optional, reflecting that fallback results may not include these keys.
* The Elasticsearch admin test command is updated to handle missing `index` and `indexer` fields gracefully when displaying results.
