### PR TITLE
fix: Add counter to client side

### DIFF
--- a/src/Storefront/Resources/views/components/Sw/Product/Listing.js
+++ b/src/Storefront/Resources/views/components/Sw/Product/Listing.js
@@ -21,6 +21,7 @@ export default class ProductListing extends ShopwareComponent {
         this.debouncedLoad = this.debounce(async () => {
             const productGrid = this.el.querySelector('.sw-product-listing__grid');
             const pagination = this.el.querySelector('.sw-product-listing__pagination');
+            const resultCounter = this.el.querySelector('.sw-filter-panel__counter');
             productGrid.classList.add('is--loading');
 
             const location = new URL(window.location);
@@ -33,9 +34,15 @@ export default class ProductListing extends ShopwareComponent {
             const doc = this.domParser.parseFromString(html, 'text/html');
             const grid = doc.querySelector('.sw-product-listing__grid');
             const pagi = doc.querySelector('.sw-product-listing__pagination');
+            const counter = doc.querySelector('.sw-filter-panel__counter');
 
             productGrid.replaceWith(grid);
             pagination.replaceWith(pagi);
+
+            if (resultCounter && counter) {
+                resultCounter.replaceWith(counter);
+            }
+
             productGrid.classList.remove('is--loading');
         }, 200);
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
In the content-system product listing, applying or removing a filter, changing the sorting or paginating updates the listing via a background request instead of a page reload. The result counter in the filter panel (listing.resultCount, e.g. "2030 Items") is not part of what gets swapped in, so it keeps showing the number from the initial page load. It only becomes correct after a manual page refresh, which makes the count read as wrong for the entire filtered session.

### 2. What does this change do, exactly?
`Sw/Product/Listing.js` now also replaces `.sw-filter-panel__counter` with the counter from the fetched document, alongside the existing grid and pagination swaps

The swap is guarded because the filter panel is optional: a layout can override the listing's filters-panel slot or leave it without a panel, in which case either lookup returns null and replaceWith would throw and abort the whole refresh.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
