### PR TITLE
ci: fail fast when the acceptance browser install hangs

### DIFF
--- a/.github/actions/ats/action.yaml
+++ b/.github/actions/ats/action.yaml
@@ -176,7 +176,7 @@ runs:
       with:
         working-directory: ${{ inputs.directory }}
         # A stalled apt mirror hangs without failing, so the retry loop never fires; time each attempt out so it can retry (normal runtime is ~2 minutes).
-        command: timeout 5m bash -c 'sudo apt-get update --allow-releaseinfo-change && npx playwright install --with-deps chromium'
+        command: timeout 10m bash -c 'sudo apt-get update --allow-releaseinfo-change && npx playwright install --with-deps chromium'
 
     - name: Run your tests
       shell: bash

--- a/.github/actions/ats/action.yaml
+++ b/.github/actions/ats/action.yaml
@@ -175,7 +175,8 @@ runs:
       uses: shopware/github-actions/npm-ci-retry@main
       with:
         working-directory: ${{ inputs.directory }}
-        command: sudo apt-get update --allow-releaseinfo-change && npx playwright install --with-deps chromium
+        # A stalled apt mirror hangs without failing, so the retry loop never fires; time each attempt out so it can retry (normal runtime is ~2 minutes).
+        command: timeout 5m bash -c 'sudo apt-get update --allow-releaseinfo-change && npx playwright install --with-deps chromium'
 
     - name: Run your tests
       shell: bash

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -58,6 +58,8 @@ jobs:
 
   acceptance:
     runs-on: ubuntu-24.04
+    # Shards finish in under 20 minutes; without a cap a single hung step holds the job for GitHub's 6-hour default.
+    timeout-minutes: 40
     needs: generate-acceptance-matrix
     strategy: ${{ fromJson(needs.generate-acceptance-matrix.outputs.matrix) }}
     steps:


### PR DESCRIPTION
### 1. Why is this change necessary?

In the nightly run from 2026-08-18, the acceptance shard `acceptance (Platform, 8.2, 1, 3, true)` hung for six hours in the "Install Playwright Browsers" step and was only stopped by GitHub's default 6-hour job timeout: https://github.com/shopware/shopware/actions/runs/32088516085/job/95565979181

The job log shows `apt-get update` stalling after the runner's Azure apt mirror became unhealthy (repeated `Ign:` lines, last output at 01:35:49, cancellation at 07:32:01). Because the stalled command never *failed*, the 3-attempt retry loop in `npm-ci-retry` never fired, and because the `acceptance` job sets no `timeout-minutes`, the hung shard held the whole nightly run open for six hours. All sibling shards finished in 6–15 minutes.

### 2. What does this change do, exactly?

Two guards, at the two layers involved:

- **`.github/actions/ats/action.yaml`**: wraps the browser-install command in `timeout 10m`, so a stalled attempt fails fast and the existing retry loop in `npm-ci-retry` gets a chance to re-run it. Normal runtime of the command is ~2 minutes; the generous headroom avoids killing slow-but-working installs against mirrors/CDNs we do not own (see review discussion). This covers every consumer of the composite action (`acceptance`, `acceptance-tests-changed`, `visual-tests`).
- **`.github/workflows/acceptance.yml`**: adds `timeout-minutes: 40` to the `acceptance` job as a backstop against any other hang. Worst observed shard duration over the recent runs is 18 minutes; the cap leaves >2× headroom.

No test-execution behaviour changes; a healthy run is unaffected.

`composer lint:actions` passes. The acceptance run on this PR exercises the modified install step on every shard.

### 3. Describe each step to reproduce the issue or behaviour.

1. Let a nightly `acceptance` shard run on a runner whose apt mirror stalls mid-download during `apt-get update` (see the linked job above).
2. Without this change: the step hangs until GitHub kills the job after 6 hours; the retry loop never triggers.
3. With this change: the attempt is killed after 10 minutes, retried up to 3 times, and the job fails in ~30 minutes instead of 6 hours if the mirror stays broken.

### 4. Please link to the relevant issues (if any).

None — root cause analysis of the hung job linked above.

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
