### PR TITLE
chore: deprecate legacy document domain

### DIFF
--- a/src/Core/Checkout/Document/Aggregate/DocumentBaseConfig/DocumentBaseConfigCollection.php
+++ b/src/Core/Checkout/Document/Aggregate/DocumentBaseConfig/DocumentBaseConfigCollection.php
@@ -3,6 +3,7 @@
 namespace Shopware\Core\Checkout\Document\Aggregate\DocumentBaseConfig;
 
 use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
+use Shopware\Core\Framework\Deprecation\BCChange\NamespaceChange;
 use Shopware\Core\Framework\Log\Package;
 
 /**
@@ -11,6 +12,7 @@ use Shopware\Core\Framework\Log\Package;
  * @codeCoverageIgnore
  */
 #[Package('after-sales')]
+#[NamespaceChange(version: 'v6.9.0', newLocation: 'Shopware\Core\Checkout\DocumentV2\Aggregate\DocumentBaseConfig\DocumentBaseConfigCollection')]
 class DocumentBaseConfigCollection extends EntityCollection
 {
     public function getApiAlias(): string

--- a/src/Core/Checkout/Document/Aggregate/DocumentBaseConfig/DocumentBaseConfigDefinition.php
+++ b/src/Core/Checkout/Document/Aggregate/DocumentBaseConfig/DocumentBaseConfigDefinition.php
@@ -22,6 +22,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\ManyToOneAssociationField
 use Shopware\Core\Framework\DataAbstractionLayer\Field\OneToManyAssociationField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\StringField;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
+use Shopware\Core\Framework\Deprecation\BCChange\NamespaceChange;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\NumberRange\DataAbstractionLayer\NumberRangeField;
 
@@ -29,6 +30,7 @@ use Shopware\Core\System\NumberRange\DataAbstractionLayer\NumberRangeField;
  * @codeCoverageIgnore
  */
 #[Package('after-sales')]
+#[NamespaceChange(version: 'v6.9.0', newLocation: 'Shopware\Core\Checkout\DocumentV2\Aggregate\DocumentBaseConfig\DocumentBaseConfigDefinition')]
 class DocumentBaseConfigDefinition extends EntityDefinition
 {
     final public const ENTITY_NAME = 'document_base_config';

--- a/src/Core/Checkout/Document/Aggregate/DocumentBaseConfig/DocumentBaseConfigEntity.php
+++ b/src/Core/Checkout/Document/Aggregate/DocumentBaseConfig/DocumentBaseConfigEntity.php
@@ -8,12 +8,14 @@ use Shopware\Core\Content\Media\MediaEntity;
 use Shopware\Core\Framework\DataAbstractionLayer\Entity;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityCustomFieldsTrait;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityIdTrait;
+use Shopware\Core\Framework\Deprecation\BCChange\NamespaceChange;
 use Shopware\Core\Framework\Log\Package;
 
 /**
  * @codeCoverageIgnore
  */
 #[Package('after-sales')]
+#[NamespaceChange(version: 'v6.9.0', newLocation: 'Shopware\Core\Checkout\DocumentV2\Aggregate\DocumentBaseConfig\DocumentBaseConfigEntity')]
 class DocumentBaseConfigEntity extends Entity
 {
     use EntityCustomFieldsTrait;

--- a/src/Core/Checkout/Document/Aggregate/DocumentBaseConfig/DocumentBaseConfigValidator.php
+++ b/src/Core/Checkout/Document/Aggregate/DocumentBaseConfig/DocumentBaseConfigValidator.php
@@ -12,6 +12,8 @@ use Symfony\Component\Validator\ConstraintViolationList;
 
 /**
  * @internal
+ *
+ * @deprecated tag:v6.9.0 reason:remove-subscriber - Will be removed.
  */
 #[Package('after-sales')]
 class DocumentBaseConfigValidator implements EventSubscriberInterface

--- a/src/Core/Checkout/Document/Aggregate/DocumentBaseConfigSalesChannel/DocumentBaseConfigSalesChannelCollection.php
+++ b/src/Core/Checkout/Document/Aggregate/DocumentBaseConfigSalesChannel/DocumentBaseConfigSalesChannelCollection.php
@@ -3,6 +3,7 @@
 namespace Shopware\Core\Checkout\Document\Aggregate\DocumentBaseConfigSalesChannel;
 
 use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
+use Shopware\Core\Framework\Deprecation\BCChange\NamespaceChange;
 use Shopware\Core\Framework\Log\Package;
 
 /**
@@ -11,6 +12,7 @@ use Shopware\Core\Framework\Log\Package;
  * @codeCoverageIgnore
  */
 #[Package('after-sales')]
+#[NamespaceChange(version: 'v6.9.0', newLocation: 'Shopware\Core\Checkout\DocumentV2\Aggregate\DocumentBaseConfigSalesChannel\DocumentBaseConfigSalesChannelCollection')]
 class DocumentBaseConfigSalesChannelCollection extends EntityCollection
 {
     public function getApiAlias(): string

--- a/src/Core/Checkout/Document/Aggregate/DocumentBaseConfigSalesChannel/DocumentBaseConfigSalesChannelDefinition.php
+++ b/src/Core/Checkout/Document/Aggregate/DocumentBaseConfigSalesChannel/DocumentBaseConfigSalesChannelDefinition.php
@@ -12,6 +12,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\Required;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\IdField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\ManyToOneAssociationField;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
+use Shopware\Core\Framework\Deprecation\BCChange\NamespaceChange;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelDefinition;
 
@@ -19,6 +20,7 @@ use Shopware\Core\System\SalesChannel\SalesChannelDefinition;
  * @codeCoverageIgnore
  */
 #[Package('after-sales')]
+#[NamespaceChange(version: 'v6.9.0', newLocation: 'Shopware\Core\Checkout\DocumentV2\Aggregate\DocumentBaseConfigSalesChannel\DocumentBaseConfigSalesChannelDefinition')]
 class DocumentBaseConfigSalesChannelDefinition extends EntityDefinition
 {
     final public const ENTITY_NAME = 'document_base_config_sales_channel';

--- a/src/Core/Checkout/Document/Aggregate/DocumentBaseConfigSalesChannel/DocumentBaseConfigSalesChannelEntity.php
+++ b/src/Core/Checkout/Document/Aggregate/DocumentBaseConfigSalesChannel/DocumentBaseConfigSalesChannelEntity.php
@@ -6,6 +6,7 @@ use Shopware\Core\Checkout\Document\Aggregate\DocumentBaseConfig\DocumentBaseCon
 use Shopware\Core\Checkout\Document\Aggregate\DocumentType\DocumentTypeEntity;
 use Shopware\Core\Framework\DataAbstractionLayer\Entity;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityIdTrait;
+use Shopware\Core\Framework\Deprecation\BCChange\NamespaceChange;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelEntity;
 
@@ -13,6 +14,7 @@ use Shopware\Core\System\SalesChannel\SalesChannelEntity;
  * @codeCoverageIgnore
  */
 #[Package('after-sales')]
+#[NamespaceChange(version: 'v6.9.0', newLocation: 'Shopware\Core\Checkout\DocumentV2\Aggregate\DocumentBaseConfigSalesChannel\DocumentBaseConfigSalesChannelEntity')]
 class DocumentBaseConfigSalesChannelEntity extends Entity
 {
     use EntityIdTrait;

--- a/src/Core/Checkout/Document/Aggregate/DocumentType/DocumentTypeCollection.php
+++ b/src/Core/Checkout/Document/Aggregate/DocumentType/DocumentTypeCollection.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Core\Checkout\Document\Aggregate\DocumentType;
 
+use Shopware\Core\Checkout\DocumentV2\Type\DocumentTypeRegistry;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
 use Shopware\Core\Framework\Log\Package;
 
@@ -9,6 +10,8 @@ use Shopware\Core\Framework\Log\Package;
  * @extends EntityCollection<DocumentTypeEntity>
  *
  * @codeCoverageIgnore
+ *
+ * @deprecated tag:v6.9.0 reason:remove-entity - Will be removed. Document types are code registered in {@link DocumentTypeRegistry} instead.
  */
 #[Package('after-sales')]
 class DocumentTypeCollection extends EntityCollection

--- a/src/Core/Checkout/Document/Aggregate/DocumentType/DocumentTypeDefinition.php
+++ b/src/Core/Checkout/Document/Aggregate/DocumentType/DocumentTypeDefinition.php
@@ -22,6 +22,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @codeCoverageIgnore
+ *
+ * @deprecated tag:v6.9.0 reason:remove-entity - Will be removed. Document types are code registered in {@link DocumentTypeRegistry} instead.
  */
 #[Package('after-sales')]
 class DocumentTypeDefinition extends EntityDefinition

--- a/src/Core/Checkout/Document/Aggregate/DocumentType/DocumentTypeEntity.php
+++ b/src/Core/Checkout/Document/Aggregate/DocumentType/DocumentTypeEntity.php
@@ -13,6 +13,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @codeCoverageIgnore
+ *
+ * @deprecated tag:v6.9.0 reason:remove-entity - Will be removed. Document types are code registered in {@link DocumentTypeRegistry} instead.
  */
 #[Package('after-sales')]
 class DocumentTypeEntity extends Entity

--- a/src/Core/Checkout/Document/Aggregate/DocumentTypeTranslation/DocumentTypeTranslationCollection.php
+++ b/src/Core/Checkout/Document/Aggregate/DocumentTypeTranslation/DocumentTypeTranslationCollection.php
@@ -9,6 +9,8 @@ use Shopware\Core\Framework\Log\Package;
  * @extends EntityCollection<DocumentTypeTranslationEntity>
  *
  * @codeCoverageIgnore
+ *
+ * @deprecated tag:v6.9.0 reason:remove-entity - Will be removed. Document types are code registered in {@link DocumentTypeRegistry} instead.
  */
 #[Package('after-sales')]
 class DocumentTypeTranslationCollection extends EntityCollection

--- a/src/Core/Checkout/Document/Aggregate/DocumentTypeTranslation/DocumentTypeTranslationDefinition.php
+++ b/src/Core/Checkout/Document/Aggregate/DocumentTypeTranslation/DocumentTypeTranslationDefinition.php
@@ -13,6 +13,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @codeCoverageIgnore
+ *
+ * @deprecated tag:v6.9.0 reason:remove-entity - Will be removed. Document types are code registered in {@link DocumentTypeRegistry} instead.
  */
 #[Package('after-sales')]
 class DocumentTypeTranslationDefinition extends EntityTranslationDefinition

--- a/src/Core/Checkout/Document/Aggregate/DocumentTypeTranslation/DocumentTypeTranslationEntity.php
+++ b/src/Core/Checkout/Document/Aggregate/DocumentTypeTranslation/DocumentTypeTranslationEntity.php
@@ -9,6 +9,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @codeCoverageIgnore
+ *
+ * @deprecated tag:v6.9.0 reason:remove-entity - Will be removed. Document types are code registered in {@link DocumentTypeRegistry} instead.
  */
 #[Package('after-sales')]
 class DocumentTypeTranslationEntity extends TranslationEntity

--- a/src/Core/Checkout/Document/Api/DocumentTypeTechnicalNameFkResolver.php
+++ b/src/Core/Checkout/Document/Api/DocumentTypeTechnicalNameFkResolver.php
@@ -6,10 +6,13 @@ use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\Connection;
 use Shopware\Core\Framework\Api\Sync\AbstractFkResolver;
 use Shopware\Core\Framework\Api\Sync\FkReference;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 
 /**
  * @internal
+ *
+ * @deprecated tag:v6.9.0 - reason:remove-fk-resolver - Will be removed.
  */
 #[Package('framework')]
 class DocumentTypeTechnicalNameFkResolver extends AbstractFkResolver
@@ -30,6 +33,8 @@ class DocumentTypeTechnicalNameFkResolver extends AbstractFkResolver
      */
     public function resolve(array $map): array
     {
+        Feature::triggerDeprecationOrThrow('v6.9.0.0', 'DocumentTypeTechnicalNameFkResolver is deprecated and will be removed with document generation v1.');
+
         $names = \array_map(static fn ($id) => $id->value, $map);
 
         $names = \array_filter(\array_unique($names));

--- a/src/Core/Checkout/Document/Controller/DocumentController.php
+++ b/src/Core/Checkout/Document/Controller/DocumentController.php
@@ -7,9 +7,11 @@ use Shopware\Core\Checkout\Document\Service\DocumentGenerator;
 use Shopware\Core\Checkout\Document\Service\DocumentMerger;
 use Shopware\Core\Checkout\Document\Service\PdfRenderer;
 use Shopware\Core\Checkout\Document\Struct\DocumentGenerateOperation;
+use Shopware\Core\Checkout\DocumentV2\Controller\DocumentV2Controller;
 use Shopware\Core\Content\Media\Exception\IllegalFileNameException;
 use Shopware\Core\Content\Media\Util\PathHelper;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Routing\ApiRouteScope;
 use Shopware\Core\PlatformRequest;
@@ -20,6 +22,9 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
 
+/**
+ * @deprecated tag:v6.9.0 reason:remove-route - Will be removed. Use {@link DocumentV2Controller} instead.
+ */
 #[Package('after-sales')]
 #[Route(defaults: [PlatformRequest::ATTRIBUTE_ROUTE_SCOPE => [ApiRouteScope::ID]])]
 class DocumentController extends AbstractController
@@ -44,7 +49,7 @@ class DocumentController extends AbstractController
         $download = $request->query->getBoolean('download');
         $fileType = $request->query->getString('fileType', PdfRenderer::FILE_EXTENSION);
 
-        $generatedDocument = $this->documentGenerator->readDocument($documentId, $context, $deepLinkCode, $fileType);
+        $generatedDocument = Feature::silent('v6.9.0.0', fn () => $this->documentGenerator->readDocument($documentId, $context, $deepLinkCode, $fileType));
 
         if ($generatedDocument === null) {
             return new JsonResponse(null, JsonResponse::HTTP_NO_CONTENT);
@@ -80,7 +85,7 @@ class DocumentController extends AbstractController
 
         $operation = new DocumentGenerateOperation($orderId, $fileType, $config, $referencedDocumentId, false, true);
 
-        $generatedDocument = $this->documentGenerator->preview($documentTypeName, $operation, $deepLinkCode, $context);
+        $generatedDocument = Feature::silent('v6.9.0.0', fn () => $this->documentGenerator->preview($documentTypeName, $operation, $deepLinkCode, $context));
 
         return $this->createResponse(
             $generatedDocument->getName(),
@@ -105,7 +110,7 @@ class DocumentController extends AbstractController
         }
 
         $download = $request->query->getBoolean('download', true);
-        $combinedDocument = $this->documentMerger->merge($documentIds, $context);
+        $combinedDocument = Feature::silent('v6.9.0.0', fn () => $this->documentMerger->merge($documentIds, $context));
 
         if ($combinedDocument === null) {
             return new JsonResponse(null, JsonResponse::HTTP_NO_CONTENT);

--- a/src/Core/Checkout/Document/DocumentCollection.php
+++ b/src/Core/Checkout/Document/DocumentCollection.php
@@ -3,6 +3,7 @@
 namespace Shopware\Core\Checkout\Document;
 
 use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
+use Shopware\Core\Framework\Deprecation\BCChange\NamespaceChange;
 use Shopware\Core\Framework\Log\Package;
 
 /**
@@ -11,6 +12,7 @@ use Shopware\Core\Framework\Log\Package;
  * @codeCoverageIgnore
  */
 #[Package('after-sales')]
+#[NamespaceChange(version: 'v6.9.0', newLocation: 'Shopware\Core\Checkout\DocumentV2\DocumentCollection')]
 class DocumentCollection extends EntityCollection
 {
     public function getApiAlias(): string

--- a/src/Core/Checkout/Document/DocumentConfiguration.php
+++ b/src/Core/Checkout/Document/DocumentConfiguration.php
@@ -2,6 +2,9 @@
 
 namespace Shopware\Core\Checkout\Document;
 
+use Shopware\Core\Checkout\DocumentV2\Config\DocumentCompanyInfo;
+use Shopware\Core\Checkout\DocumentV2\Config\DocumentConfig;
+use Shopware\Core\Checkout\DocumentV2\Config\DocumentDisplayOptions;
 use Shopware\Core\Content\Media\MediaEntity;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\Struct;
@@ -9,6 +12,8 @@ use Shopware\Core\System\Country\CountryEntity;
 
 /**
  * @codeCoverageIgnore
+ *
+ * @deprecated tag:v6.9.0 reason:remove-getter-setter - Will be removed. Use {@link DocumentConfig}, {@link DocumentCompanyInfo} and {@link DocumentDisplayOptions} instead.
  */
 #[Package('after-sales')]
 #[\AllowDynamicProperties]

--- a/src/Core/Checkout/Document/DocumentConfigurationFactory.php
+++ b/src/Core/Checkout/Document/DocumentConfigurationFactory.php
@@ -3,16 +3,18 @@
 namespace Shopware\Core\Checkout\Document;
 
 use Shopware\Core\Checkout\Document\Aggregate\DocumentBaseConfig\DocumentBaseConfigEntity;
-use Shopware\Core\Framework\DataAbstractionLayer\Entity;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\Struct;
 
+/**
+ * @deprecated tag:v6.9.0 - Will be removed.
+ */
 #[Package('after-sales')]
 class DocumentConfigurationFactory
 {
     private function __construct()
     {
-        // Factory is Static
     }
 
     /**
@@ -20,6 +22,8 @@ class DocumentConfigurationFactory
      */
     public static function createConfiguration(array $specificConfig, ?DocumentBaseConfigEntity ...$configs): DocumentConfiguration
     {
+        Feature::triggerDeprecationOrThrow('v6.9.0.0', 'DocumentConfigurationFactory is removed with document generation v1.');
+
         $configs = array_filter($configs);
         $documentConfiguration = new DocumentConfiguration();
         foreach ($configs as $config) {
@@ -34,6 +38,8 @@ class DocumentConfigurationFactory
      */
     public static function mergeConfiguration(DocumentConfiguration $baseConfig, DocumentBaseConfigEntity|DocumentConfiguration|array $additionalConfig): DocumentConfiguration
     {
+        Feature::triggerDeprecationOrThrow('v6.9.0.0', 'DocumentConfigurationFactory is removed with document generation v1.');
+
         $additionalConfigArray = [];
         if (\is_array($additionalConfig)) {
             $additionalConfigArray = $additionalConfig;

--- a/src/Core/Checkout/Document/DocumentDefinition.php
+++ b/src/Core/Checkout/Document/DocumentDefinition.php
@@ -21,6 +21,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\OneToManyAssociationField
 use Shopware\Core\Framework\DataAbstractionLayer\Field\ReferenceVersionField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\StringField;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
+use Shopware\Core\Framework\Deprecation\BCChange\NamespaceChange;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\NumberRange\DataAbstractionLayer\NumberRangeField;
 
@@ -28,6 +29,7 @@ use Shopware\Core\System\NumberRange\DataAbstractionLayer\NumberRangeField;
  * @codeCoverageIgnore
  */
 #[Package('after-sales')]
+#[NamespaceChange(version: 'v6.9.0', newLocation: 'Shopware\Core\Checkout\DocumentV2\DocumentDefinition')]
 class DocumentDefinition extends EntityDefinition
 {
     final public const ENTITY_NAME = 'document';

--- a/src/Core/Checkout/Document/DocumentEntity.php
+++ b/src/Core/Checkout/Document/DocumentEntity.php
@@ -9,12 +9,14 @@ use Shopware\Core\Content\Media\MediaEntity;
 use Shopware\Core\Framework\DataAbstractionLayer\Entity;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityCustomFieldsTrait;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityIdTrait;
+use Shopware\Core\Framework\Deprecation\BCChange\NamespaceChange;
 use Shopware\Core\Framework\Log\Package;
 
 /**
  * @codeCoverageIgnore
  */
 #[Package('after-sales')]
+#[NamespaceChange(version: 'v6.9.0', newLocation: 'Shopware\Core\Checkout\DocumentV2\DocumentEntity')]
 class DocumentEntity extends Entity
 {
     use EntityCustomFieldsTrait;

--- a/src/Core/Checkout/Document/DocumentEvents.php
+++ b/src/Core/Checkout/Document/DocumentEvents.php
@@ -8,6 +8,9 @@ use Shopware\Core\Checkout\Document\Renderer\InvoiceRenderer;
 use Shopware\Core\Checkout\Document\Renderer\StornoRenderer;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @deprecated tag:v6.9.0 - Will be removed.
+ */
 #[Package('after-sales')]
 class DocumentEvents
 {

--- a/src/Core/Checkout/Document/DocumentException.php
+++ b/src/Core/Checkout/Document/DocumentException.php
@@ -4,6 +4,7 @@ namespace Shopware\Core\Checkout\Document;
 
 use Shopware\Core\Checkout\Cart\CartException;
 use Shopware\Core\Checkout\Cart\Exception\CustomerNotLoggedInException;
+use Shopware\Core\Checkout\DocumentV2\DocumentV2Exception;
 use Shopware\Core\Checkout\Order\Exception\GuestNotAuthenticatedException;
 use Shopware\Core\Checkout\Order\Exception\WrongGuestCredentialsException;
 use Shopware\Core\Framework\Feature;
@@ -12,6 +13,8 @@ use Shopware\Core\Framework\Log\Package;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
+ * @deprecated tag:v6.9.0 reason:remove-exception - Will be removed. Document generation will throw {@link DocumentV2Exception} instead.
+ *
  * @codeCoverageIgnore
  */
 #[Package('after-sales')]

--- a/src/Core/Checkout/Document/DocumentGenerationResult.php
+++ b/src/Core/Checkout/Document/DocumentGenerationResult.php
@@ -2,12 +2,15 @@
 
 namespace Shopware\Core\Checkout\Document;
 
+use Shopware\Core\Checkout\DocumentV2\Struct\RenderResult;
 use Shopware\Core\Framework\Api\EventListener\ErrorResponseFactory;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\Struct;
 
 /**
  * @final
+ *
+ * @deprecated tag:v6.9.0 reason:remove-getter-setter - Will be removed. Use {@link RenderResult} instead.
  */
 #[Package('after-sales')]
 class DocumentGenerationResult extends Struct

--- a/src/Core/Checkout/Document/DocumentGenerator/Counter.php
+++ b/src/Core/Checkout/Document/DocumentGenerator/Counter.php
@@ -2,8 +2,12 @@
 
 namespace Shopware\Core\Checkout\Document\DocumentGenerator;
 
+use Shopware\Core\Checkout\DocumentV2\Template\PaginationCounter;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @deprecated tag:v6.9.0 reason:remove-getter-setter - Will be removed. Use {@link PaginationCounter} instead.
+ */
 #[Package('after-sales')]
 class Counter
 {

--- a/src/Core/Checkout/Document/DocumentGeneratorController.php
+++ b/src/Core/Checkout/Document/DocumentGeneratorController.php
@@ -5,7 +5,9 @@ namespace Shopware\Core\Checkout\Document;
 use Shopware\Core\Checkout\Document\Service\DocumentGenerator;
 use Shopware\Core\Checkout\Document\Service\PdfRenderer;
 use Shopware\Core\Checkout\Document\Struct\DocumentGenerateOperation;
+use Shopware\Core\Checkout\DocumentV2\Controller\DocumentV2Controller;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Routing\ApiRouteScope;
 use Shopware\Core\Framework\Validation\Constraint\Uuid;
@@ -21,6 +23,9 @@ use Symfony\Component\Validator\Constraints\Choice;
 use Symfony\Component\Validator\Constraints\NotBlank;
 use Symfony\Component\Validator\Constraints\Type;
 
+/**
+ * @deprecated tag:v6.9.0 reason:remove-route - Will be removed. Use {@link DocumentV2Controller} instead.
+ */
 #[Package('after-sales')]
 #[Route(defaults: [PlatformRequest::ATTRIBUTE_ROUTE_SCOPE => [ApiRouteScope::ID]])]
 class DocumentGeneratorController extends AbstractController
@@ -80,7 +85,7 @@ class DocumentGeneratorController extends AbstractController
             );
         }
 
-        return new JsonResponse($this->documentGenerator->generate($documentTypeName, $operations, $context));
+        return new JsonResponse(Feature::silent('v6.9.0.0', fn () => $this->documentGenerator->generate($documentTypeName, $operations, $context)));
     }
 
     #[Route(
@@ -91,11 +96,11 @@ class DocumentGeneratorController extends AbstractController
     )]
     public function uploadToDocument(Request $request, string $documentId, Context $context): JsonResponse
     {
-        $documentIdStruct = $this->documentGenerator->upload(
+        $documentIdStruct = Feature::silent('v6.9.0.0', fn () => $this->documentGenerator->upload(
             $documentId,
             $context,
             $request
-        );
+        ));
 
         return new JsonResponse(
             [

--- a/src/Core/Checkout/Document/DocumentIdCollection.php
+++ b/src/Core/Checkout/Document/DocumentIdCollection.php
@@ -8,6 +8,8 @@ use Shopware\Core\Framework\Struct\Collection;
 /**
  * @extends Collection<DocumentIdStruct>
  *
+ * @deprecated tag:v6.9.0 reason:remove-getter-setter - Will be removed.
+ *
  * @codeCoverageIgnore
  */
 #[Package('after-sales')]

--- a/src/Core/Checkout/Document/DocumentIdStruct.php
+++ b/src/Core/Checkout/Document/DocumentIdStruct.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Struct\Struct;
 
 /**
  * @codeCoverageIgnore
+ *
+ * @deprecated tag:v6.9.0 reason:remove-getter-setter - Will be removed.
  */
 #[Package('after-sales')]
 class DocumentIdStruct extends Struct

--- a/src/Core/Checkout/Document/Event/CreditNoteOrdersEvent.php
+++ b/src/Core/Checkout/Document/Event/CreditNoteOrdersEvent.php
@@ -6,6 +6,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @codeCoverageIgnore
+ *
+ * @deprecated tag:v6.9.0 - Will be removed.
  */
 #[Package('after-sales')]
 final class CreditNoteOrdersEvent extends DocumentOrderEvent

--- a/src/Core/Checkout/Document/Event/DeliveryNoteOrdersEvent.php
+++ b/src/Core/Checkout/Document/Event/DeliveryNoteOrdersEvent.php
@@ -6,6 +6,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @codeCoverageIgnore
+ *
+ * @deprecated tag:v6.9.0 - Will be removed.
  */
 #[Package('after-sales')]
 final class DeliveryNoteOrdersEvent extends DocumentOrderEvent

--- a/src/Core/Checkout/Document/Event/DocumentOrderCriteriaEvent.php
+++ b/src/Core/Checkout/Document/Event/DocumentOrderCriteriaEvent.php
@@ -12,6 +12,8 @@ use Symfony\Contracts\EventDispatcher\Event;
 
 /**
  * @codeCoverageIgnore
+ *
+ * @deprecated tag:v6.9.0 reason:remove-getter-setter - Will be removed.
  */
 #[Package('after-sales')]
 final class DocumentOrderCriteriaEvent extends Event implements GenericEvent

--- a/src/Core/Checkout/Document/Event/DocumentOrderEvent.php
+++ b/src/Core/Checkout/Document/Event/DocumentOrderEvent.php
@@ -10,6 +10,8 @@ use Symfony\Contracts\EventDispatcher\Event;
 
 /**
  * @codeCoverageIgnore
+ *
+ * @deprecated tag:v6.9.0 reason:remove-getter-setter - Will be removed.
  */
 #[Package('after-sales')]
 abstract class DocumentOrderEvent extends Event

--- a/src/Core/Checkout/Document/Event/DocumentTemplateRendererParameterEvent.php
+++ b/src/Core/Checkout/Document/Event/DocumentTemplateRendererParameterEvent.php
@@ -8,6 +8,8 @@ use Symfony\Contracts\EventDispatcher\Event;
 
 /**
  * @codeCoverageIgnore
+ *
+ * @deprecated tag:v6.9.0 reason:remove-getter-setter - Will be removed.
  */
 #[Package('after-sales')]
 class DocumentTemplateRendererParameterEvent extends Event

--- a/src/Core/Checkout/Document/Event/InvoiceOrdersEvent.php
+++ b/src/Core/Checkout/Document/Event/InvoiceOrdersEvent.php
@@ -6,6 +6,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @codeCoverageIgnore
+ *
+ * @deprecated tag:v6.9.0 - Will be removed.
  */
 #[Package('after-sales')]
 final class InvoiceOrdersEvent extends DocumentOrderEvent

--- a/src/Core/Checkout/Document/Event/StornoOrdersEvent.php
+++ b/src/Core/Checkout/Document/Event/StornoOrdersEvent.php
@@ -6,6 +6,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @codeCoverageIgnore
+ *
+ * @deprecated tag:v6.9.0 - Will be removed.
  */
 #[Package('after-sales')]
 final class StornoOrdersEvent extends DocumentOrderEvent

--- a/src/Core/Checkout/Document/Event/ZugferdCancellationInvoiceOrdersEvent.php
+++ b/src/Core/Checkout/Document/Event/ZugferdCancellationInvoiceOrdersEvent.php
@@ -6,6 +6,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @codeCoverageIgnore
+ *
+ * @deprecated tag:v6.9.0 - Will be removed.
  */
 #[Package('after-sales')]
 class ZugferdCancellationInvoiceOrdersEvent extends DocumentOrderEvent

--- a/src/Core/Checkout/Document/Event/ZugferdCreditNoteOrdersEvent.php
+++ b/src/Core/Checkout/Document/Event/ZugferdCreditNoteOrdersEvent.php
@@ -6,6 +6,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @codeCoverageIgnore
+ *
+ * @deprecated tag:v6.9.0 - Will be removed.
  */
 #[Package('after-sales')]
 class ZugferdCreditNoteOrdersEvent extends DocumentOrderEvent

--- a/src/Core/Checkout/Document/Extension/HtmlRendererExtension.php
+++ b/src/Core/Checkout/Document/Extension/HtmlRendererExtension.php
@@ -4,6 +4,7 @@ namespace Shopware\Core\Checkout\Document\Extension;
 
 use Shopware\Core\Checkout\Document\Renderer\RenderedDocument;
 use Shopware\Core\Framework\Extensions\Extension;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 
 /**
@@ -16,6 +17,8 @@ use Shopware\Core\Framework\Log\Package;
  * @codeCoverageIgnore
  *
  * @extends Extension<string>
+ *
+ * @deprecated tag:v6.9.0 - Will be removed.
  */
 #[Package('checkout')]
 final class HtmlRendererExtension extends Extension
@@ -27,5 +30,6 @@ final class HtmlRendererExtension extends Extension
      */
     public function __construct(public readonly RenderedDocument $document)
     {
+        Feature::triggerDeprecationOrThrow('v6.9.0.0', 'HtmlRendererExtension is deprecated and will be removed with document generation v1.');
     }
 }

--- a/src/Core/Checkout/Document/Extension/PdfRendererExtension.php
+++ b/src/Core/Checkout/Document/Extension/PdfRendererExtension.php
@@ -4,6 +4,7 @@ namespace Shopware\Core\Checkout\Document\Extension;
 
 use Shopware\Core\Checkout\Document\Renderer\RenderedDocument;
 use Shopware\Core\Framework\Extensions\Extension;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 
 /**
@@ -16,6 +17,8 @@ use Shopware\Core\Framework\Log\Package;
  * @codeCoverageIgnore
  *
  * @extends Extension<string>
+ *
+ * @deprecated tag:v6.9.0 - Will be removed.
  */
 #[Package('after-sales')]
 final class PdfRendererExtension extends Extension
@@ -27,5 +30,6 @@ final class PdfRendererExtension extends Extension
      */
     public function __construct(public readonly RenderedDocument $document)
     {
+        Feature::triggerDeprecationOrThrow('v6.9.0.0', 'PdfRendererExtension is deprecated and will be removed with document generation v1.');
     }
 }

--- a/src/Core/Checkout/Document/FileGenerator/FileGeneratorInterface.php
+++ b/src/Core/Checkout/Document/FileGenerator/FileGeneratorInterface.php
@@ -3,8 +3,12 @@
 namespace Shopware\Core\Checkout\Document\FileGenerator;
 
 use Shopware\Core\Checkout\Document\Renderer\RenderedDocument;
+use Shopware\Core\Checkout\DocumentV2\Renderer\AbstractDocumentRenderer;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @deprecated tag:v6.9.0 reason:remove-interface - Will be removed. Register a {@link AbstractDocumentRenderer} instead.
+ */
 #[Package('after-sales')]
 interface FileGeneratorInterface
 {

--- a/src/Core/Checkout/Document/FileGenerator/FileTypes.php
+++ b/src/Core/Checkout/Document/FileGenerator/FileTypes.php
@@ -2,8 +2,12 @@
 
 namespace Shopware\Core\Checkout\Document\FileGenerator;
 
+use Shopware\Core\Checkout\DocumentV2\DocumentFormat;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @deprecated tag:v6.9.0 - Will be removed. Document generation v2 resolves formats via {@link DocumentFormat} instead.
+ */
 #[Package('after-sales')]
 class FileTypes
 {

--- a/src/Core/Checkout/Document/Renderer/AbstractDocumentRenderer.php
+++ b/src/Core/Checkout/Document/Renderer/AbstractDocumentRenderer.php
@@ -15,6 +15,9 @@ use Shopware\Core\Framework\Uuid\Uuid;
 use Symfony\Component\Validator\Constraints\NotBlank;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 
+/**
+ * @deprecated tag:v6.9.0 reason:remove-decorator - Will be removed. Register a {@link \Shopware\Core\Checkout\DocumentV2\Renderer\AbstractDocumentRenderer} instead
+ */
 #[Package('after-sales')]
 abstract class AbstractDocumentRenderer
 {

--- a/src/Core/Checkout/Document/Renderer/CreditNoteRenderer.php
+++ b/src/Core/Checkout/Document/Renderer/CreditNoteRenderer.php
@@ -14,6 +14,7 @@ use Shopware\Core\Checkout\Document\Service\DocumentConfigLoader;
 use Shopware\Core\Checkout\Document\Service\DocumentFileRendererRegistry;
 use Shopware\Core\Checkout\Document\Service\ReferenceInvoiceLoader;
 use Shopware\Core\Checkout\Document\Struct\DocumentGenerateOperation;
+use Shopware\Core\Checkout\DocumentV2\Generation\DocumentGenerator;
 use Shopware\Core\Checkout\Order\Aggregate\OrderLineItem\OrderLineItemCollection;
 use Shopware\Core\Checkout\Order\Aggregate\OrderLineItem\OrderLineItemEntity;
 use Shopware\Core\Checkout\Order\OrderCollection;
@@ -29,6 +30,9 @@ use Shopware\Core\System\NumberRange\ValueGenerator\NumberRangeValueGeneratorInt
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
+/**
+ * @deprecated tag:v6.9.0 reason:remove-decorator - Will be removed. Use {@link DocumentGenerator} instead.
+ */
 #[Package('after-sales')]
 final class CreditNoteRenderer extends AbstractDocumentRenderer
 {

--- a/src/Core/Checkout/Document/Renderer/DeliveryNoteRenderer.php
+++ b/src/Core/Checkout/Document/Renderer/DeliveryNoteRenderer.php
@@ -10,6 +10,7 @@ use Shopware\Core\Checkout\Document\Event\DocumentOrderCriteriaEvent;
 use Shopware\Core\Checkout\Document\Service\DocumentConfigLoader;
 use Shopware\Core\Checkout\Document\Service\DocumentFileRendererRegistry;
 use Shopware\Core\Checkout\Document\Struct\DocumentGenerateOperation;
+use Shopware\Core\Checkout\DocumentV2\Generation\DocumentGenerator;
 use Shopware\Core\Checkout\Order\OrderCollection;
 use Shopware\Core\Checkout\Order\OrderEntity;
 use Shopware\Core\Defaults;
@@ -21,6 +22,9 @@ use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
 use Shopware\Core\System\NumberRange\ValueGenerator\NumberRangeValueGeneratorInterface;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
+/**
+ * @deprecated tag:v6.9.0 reason:remove-decorator - Will be removed. Use {@link DocumentGenerator} instead.
+ */
 #[Package('after-sales')]
 final class DeliveryNoteRenderer extends AbstractDocumentRenderer
 {

--- a/src/Core/Checkout/Document/Renderer/DocumentRendererConfig.php
+++ b/src/Core/Checkout/Document/Renderer/DocumentRendererConfig.php
@@ -4,6 +4,9 @@ namespace Shopware\Core\Checkout\Document\Renderer;
 
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @deprecated tag:v6.9.0 reason:remove-getter-setter - Will be removed.
+ */
 #[Package('after-sales')]
 final class DocumentRendererConfig
 {

--- a/src/Core/Checkout/Document/Renderer/DocumentRendererRegistry.php
+++ b/src/Core/Checkout/Document/Renderer/DocumentRendererRegistry.php
@@ -5,8 +5,12 @@ namespace Shopware\Core\Checkout\Document\Renderer;
 use Shopware\Core\Checkout\Document\DocumentException;
 use Shopware\Core\Checkout\Document\Struct\DocumentGenerateOperation;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @deprecated tag:v6.9.0 - Will be removed.
+ */
 #[Package('after-sales')]
 final class DocumentRendererRegistry
 {
@@ -24,6 +28,8 @@ final class DocumentRendererRegistry
      */
     public function render(string $documentType, array $operations, Context $context, DocumentRendererConfig $rendererConfig): RendererResult
     {
+        Feature::triggerDeprecationOrThrow('v6.9.0.0', 'DocumentRendererRegistry is deprecated and will be removed with document generation v1.');
+
         foreach ($this->documentRenderers as $documentRenderer) {
             if ($documentRenderer->supports() !== $documentType) {
                 continue;

--- a/src/Core/Checkout/Document/Renderer/InvoiceRenderer.php
+++ b/src/Core/Checkout/Document/Renderer/InvoiceRenderer.php
@@ -10,6 +10,7 @@ use Shopware\Core\Checkout\Document\Event\InvoiceOrdersEvent;
 use Shopware\Core\Checkout\Document\Service\DocumentConfigLoader;
 use Shopware\Core\Checkout\Document\Service\DocumentFileRendererRegistry;
 use Shopware\Core\Checkout\Document\Struct\DocumentGenerateOperation;
+use Shopware\Core\Checkout\DocumentV2\Generation\DocumentGenerator;
 use Shopware\Core\Checkout\Order\OrderCollection;
 use Shopware\Core\Checkout\Order\OrderEntity;
 use Shopware\Core\Defaults;
@@ -21,6 +22,9 @@ use Shopware\Core\System\NumberRange\ValueGenerator\NumberRangeValueGeneratorInt
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
+/**
+ * @deprecated tag:v6.9.0 reason:remove-decorator - Will be removed. Use {@link DocumentGenerator} instead.
+ */
 #[Package('after-sales')]
 final class InvoiceRenderer extends AbstractDocumentRenderer
 {

--- a/src/Core/Checkout/Document/Renderer/OrderDocumentCriteriaFactory.php
+++ b/src/Core/Checkout/Document/Renderer/OrderDocumentCriteriaFactory.php
@@ -8,6 +8,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Sorting\FieldSorting;
 use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @deprecated tag:v6.9.0 - Will be removed.
+ */
 #[Package('after-sales')]
 final class OrderDocumentCriteriaFactory
 {
@@ -23,6 +26,8 @@ final class OrderDocumentCriteriaFactory
      */
     public static function create(array $ids, string $deepLinkCode = '', ?string $documentType = null): Criteria
     {
+        Feature::triggerDeprecationOrThrow('v6.9.0.0', 'OrderDocumentCriteriaFactory is deprecated and will be removed with document generation v1.');
+
         $criteria = new Criteria($ids);
 
         $criteria->addAssociations([

--- a/src/Core/Checkout/Document/Renderer/RenderedDocument.php
+++ b/src/Core/Checkout/Document/Renderer/RenderedDocument.php
@@ -5,10 +5,12 @@ namespace Shopware\Core\Checkout\Document\Renderer;
 use Shopware\Core\Checkout\Document\Service\PdfRenderer;
 use Shopware\Core\Checkout\Order\OrderEntity;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Deprecation\BCChange\NamespaceChange;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\Struct;
 
 #[Package('after-sales')]
+#[NamespaceChange(version: 'v6.9.0', newLocation: 'Shopware\Core\Checkout\DocumentV2\Struct\RenderedDocument')]
 final class RenderedDocument extends Struct
 {
     private string $template = '';

--- a/src/Core/Checkout/Document/Renderer/RendererResult.php
+++ b/src/Core/Checkout/Document/Renderer/RendererResult.php
@@ -2,9 +2,13 @@
 
 namespace Shopware\Core\Checkout\Document\Renderer;
 
+use Shopware\Core\Checkout\DocumentV2\Struct\RenderResult;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\Struct;
 
+/**
+ * @deprecated tag:v6.9.0 reason:remove-getter-setter - Will be removed. Use {@link RenderResult} instead.
+ */
 #[Package('after-sales')]
 final class RendererResult extends Struct
 {

--- a/src/Core/Checkout/Document/Renderer/StornoRenderer.php
+++ b/src/Core/Checkout/Document/Renderer/StornoRenderer.php
@@ -12,6 +12,7 @@ use Shopware\Core\Checkout\Document\Service\DocumentConfigLoader;
 use Shopware\Core\Checkout\Document\Service\DocumentFileRendererRegistry;
 use Shopware\Core\Checkout\Document\Service\ReferenceInvoiceLoader;
 use Shopware\Core\Checkout\Document\Struct\DocumentGenerateOperation;
+use Shopware\Core\Checkout\DocumentV2\Generation\DocumentGenerator;
 use Shopware\Core\Checkout\Order\OrderCollection;
 use Shopware\Core\Checkout\Order\OrderEntity;
 use Shopware\Core\Defaults;
@@ -23,6 +24,9 @@ use Shopware\Core\System\NumberRange\ValueGenerator\NumberRangeValueGeneratorInt
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
+/**
+ * @deprecated tag:v6.9.0 reason:remove-decorator - Will be removed. Use {@link DocumentGenerator} instead.
+ */
 #[Package('after-sales')]
 final class StornoRenderer extends AbstractDocumentRenderer
 {

--- a/src/Core/Checkout/Document/Renderer/ZugferdCancellationInvoiceRenderer.php
+++ b/src/Core/Checkout/Document/Renderer/ZugferdCancellationInvoiceRenderer.php
@@ -14,6 +14,7 @@ use Shopware\Core\Checkout\Document\Service\DocumentConfigLoader;
 use Shopware\Core\Checkout\Document\Service\ReferenceInvoiceLoader;
 use Shopware\Core\Checkout\Document\Struct\DocumentGenerateOperation;
 use Shopware\Core\Checkout\Document\Zugferd\ZugferdBuilder;
+use Shopware\Core\Checkout\DocumentV2\Generation\DocumentGenerator;
 use Shopware\Core\Checkout\Order\Aggregate\OrderLineItem\OrderLineItemCollection;
 use Shopware\Core\Checkout\Order\OrderCollection;
 use Shopware\Core\Checkout\Order\OrderEntity;
@@ -25,6 +26,9 @@ use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
 use Shopware\Core\System\NumberRange\ValueGenerator\NumberRangeValueGeneratorInterface;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
+/**
+ * @deprecated tag:v6.9.0 reason:remove-decorator - Will be removed. Use {@link DocumentGenerator} instead.
+ */
 #[Package('after-sales')]
 class ZugferdCancellationInvoiceRenderer extends AbstractDocumentRenderer
 {

--- a/src/Core/Checkout/Document/Renderer/ZugferdCreditNoteRenderer.php
+++ b/src/Core/Checkout/Document/Renderer/ZugferdCreditNoteRenderer.php
@@ -16,6 +16,7 @@ use Shopware\Core\Checkout\Document\Service\DocumentConfigLoader;
 use Shopware\Core\Checkout\Document\Service\ReferenceInvoiceLoader;
 use Shopware\Core\Checkout\Document\Struct\DocumentGenerateOperation;
 use Shopware\Core\Checkout\Document\Zugferd\ZugferdBuilder;
+use Shopware\Core\Checkout\DocumentV2\Generation\DocumentGenerator;
 use Shopware\Core\Checkout\Order\Aggregate\OrderDelivery\OrderDeliveryCollection;
 use Shopware\Core\Checkout\Order\Aggregate\OrderLineItem\OrderLineItemCollection;
 use Shopware\Core\Checkout\Order\Aggregate\OrderLineItem\OrderLineItemEntity;
@@ -31,6 +32,9 @@ use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\NumberRange\ValueGenerator\NumberRangeValueGeneratorInterface;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
+/**
+ * @deprecated tag:v6.9.0 reason:remove-decorator - Will be removed. Use {@link DocumentGenerator} instead.
+ */
 #[Package('after-sales')]
 final class ZugferdCreditNoteRenderer extends AbstractDocumentRenderer
 {

--- a/src/Core/Checkout/Document/Renderer/ZugferdEmbeddedCancellationInvoiceRenderer.php
+++ b/src/Core/Checkout/Document/Renderer/ZugferdEmbeddedCancellationInvoiceRenderer.php
@@ -3,10 +3,14 @@
 namespace Shopware\Core\Checkout\Document\Renderer;
 
 use Shopware\Core\Checkout\Document\Service\ZugferdEmbeddedService;
+use Shopware\Core\Checkout\DocumentV2\Generation\DocumentGenerator;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
 
+/**
+ * @deprecated tag:v6.9.0 reason:remove-decorator - Will be removed. Use {@link DocumentGenerator} instead.
+ */
 #[Package('after-sales')]
 class ZugferdEmbeddedCancellationInvoiceRenderer extends AbstractDocumentRenderer
 {

--- a/src/Core/Checkout/Document/Renderer/ZugferdEmbeddedCreditNoteRenderer.php
+++ b/src/Core/Checkout/Document/Renderer/ZugferdEmbeddedCreditNoteRenderer.php
@@ -3,10 +3,14 @@
 namespace Shopware\Core\Checkout\Document\Renderer;
 
 use Shopware\Core\Checkout\Document\Service\ZugferdEmbeddedService;
+use Shopware\Core\Checkout\DocumentV2\Generation\DocumentGenerator;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
 
+/**
+ * @deprecated tag:v6.9.0 reason:remove-decorator - Will be removed. Use {@link DocumentGenerator} instead.
+ */
 #[Package('after-sales')]
 class ZugferdEmbeddedCreditNoteRenderer extends AbstractDocumentRenderer
 {

--- a/src/Core/Checkout/Document/Renderer/ZugferdEmbeddedRenderer.php
+++ b/src/Core/Checkout/Document/Renderer/ZugferdEmbeddedRenderer.php
@@ -3,10 +3,14 @@
 namespace Shopware\Core\Checkout\Document\Renderer;
 
 use Shopware\Core\Checkout\Document\Service\ZugferdEmbeddedService;
+use Shopware\Core\Checkout\DocumentV2\Generation\DocumentGenerator;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
 
+/**
+ * @deprecated tag:v6.9.0 reason:remove-decorator - Will be removed. Use {@link DocumentGenerator} instead.
+ */
 #[Package('after-sales')]
 class ZugferdEmbeddedRenderer extends AbstractDocumentRenderer
 {

--- a/src/Core/Checkout/Document/Renderer/ZugferdRenderer.php
+++ b/src/Core/Checkout/Document/Renderer/ZugferdRenderer.php
@@ -11,6 +11,7 @@ use Shopware\Core\Checkout\Document\Service\DocumentConfigLoader;
 use Shopware\Core\Checkout\Document\Struct\DocumentGenerateOperation;
 use Shopware\Core\Checkout\Document\Zugferd\ZugferdBuilder;
 use Shopware\Core\Checkout\Document\Zugferd\ZugferdInvoiceOrdersEvent;
+use Shopware\Core\Checkout\DocumentV2\Generation\DocumentGenerator;
 use Shopware\Core\Checkout\Order\OrderCollection;
 use Shopware\Core\Checkout\Order\OrderEntity;
 use Shopware\Core\Defaults;
@@ -21,6 +22,9 @@ use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
 use Shopware\Core\System\NumberRange\ValueGenerator\NumberRangeValueGeneratorInterface;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
+/**
+ * @deprecated tag:v6.9.0 reason:remove-decorator - Will be removed. Use {@link DocumentGenerator} instead.
+ */
 #[Package('after-sales')]
 class ZugferdRenderer extends AbstractDocumentRenderer
 {

--- a/src/Core/Checkout/Document/SalesChannel/AbstractDocumentRoute.php
+++ b/src/Core/Checkout/Document/SalesChannel/AbstractDocumentRoute.php
@@ -10,6 +10,8 @@ use Symfony\Component\HttpFoundation\Response;
 
 /**
  * This route is used to get the generated document from a documentId
+ *
+ * @deprecated tag:v6.9.0 reason:remove-route - Will be removed. A DocumentV2 download route will replace it.
  */
 #[Package('after-sales')]
 abstract class AbstractDocumentRoute

--- a/src/Core/Checkout/Document/SalesChannel/DocumentRoute.php
+++ b/src/Core/Checkout/Document/SalesChannel/DocumentRoute.php
@@ -31,6 +31,9 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
 
+/**
+ * @deprecated tag:v6.9.0 reason:remove-route - Will be removed. A DocumentV2 download route will replace it.
+ */
 #[Package('after-sales')]
 #[Route(defaults: [PlatformRequest::ATTRIBUTE_ROUTE_SCOPE => [StoreApiRouteScope::ID]])]
 final class DocumentRoute extends AbstractDocumentRoute
@@ -326,12 +329,12 @@ final class DocumentRoute extends AbstractDocumentRoute
         $document = null;
 
         foreach ($fileTypes as $fileType) {
-            $document = $this->documentGenerator->readDocument(
+            $document = Feature::silent('v6.9.0.0', fn () => $this->documentGenerator->readDocument(
                 $documentId,
                 $context,
                 $deepLinkCode,
                 $fileType
-            );
+            ));
 
             if ($document !== null) {
                 break;

--- a/src/Core/Checkout/Document/Service/AbstractDocumentTypeRenderer.php
+++ b/src/Core/Checkout/Document/Service/AbstractDocumentTypeRenderer.php
@@ -2,9 +2,13 @@
 
 namespace Shopware\Core\Checkout\Document\Service;
 
+use Shopware\Core\Checkout\Document\Renderer\AbstractDocumentRenderer;
 use Shopware\Core\Checkout\Document\Renderer\RenderedDocument;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @deprecated tag:v6.9.0 reason:remove-decorator - Will be removed. Use {@link AbstractDocumentRenderer} instead
+ */
 #[Package('after-sales')]
 abstract class AbstractDocumentTypeRenderer
 {

--- a/src/Core/Checkout/Document/Service/DocumentConfigLoader.php
+++ b/src/Core/Checkout/Document/Service/DocumentConfigLoader.php
@@ -18,6 +18,9 @@ use Shopware\Core\System\Country\CountryCollection;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Contracts\Service\ResetInterface;
 
+/**
+ * @deprecated tag:v6.9.0 reason:remove-subscriber - Will be removed.
+ */
 #[Package('after-sales')]
 final class DocumentConfigLoader implements EventSubscriberInterface, ResetInterface
 {

--- a/src/Core/Checkout/Document/Service/DocumentFileRendererRegistry.php
+++ b/src/Core/Checkout/Document/Service/DocumentFileRendererRegistry.php
@@ -4,8 +4,12 @@ namespace Shopware\Core\Checkout\Document\Service;
 
 use Shopware\Core\Checkout\Document\DocumentException;
 use Shopware\Core\Checkout\Document\Renderer\RenderedDocument;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @deprecated tag:v6.9.0 - Will be removed.
+ */
 #[Package('after-sales')]
 class DocumentFileRendererRegistry
 {
@@ -20,6 +24,8 @@ class DocumentFileRendererRegistry
 
     public function render(RenderedDocument $document): string
     {
+        Feature::triggerDeprecationOrThrow('v6.9.0.0', 'DocumentFileRendererRegistry is deprecated and will be removed with document generation v1.');
+
         $renderers = $this->renderers instanceof \Traversable ? iterator_to_array($this->renderers) : $this->renderers;
         $renderer = $renderers[$document->getFileExtension()] ?? null;
 

--- a/src/Core/Checkout/Document/Service/DocumentGenerator.php
+++ b/src/Core/Checkout/Document/Service/DocumentGenerator.php
@@ -25,6 +25,7 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Util\Random;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -32,6 +33,8 @@ use Symfony\Component\HttpFoundation\Request;
 
 /**
  * @final
+ *
+ * @deprecated tag:v6.9.0 - Will be removed. Use {@link \Shopware\Core\Checkout\DocumentV2\Generation\DocumentGenerator} instead.
  */
 #[Package('after-sales')]
 class DocumentGenerator
@@ -57,6 +60,8 @@ class DocumentGenerator
         string $deepLinkCode = '',
         ?string $fileType = PdfRenderer::FILE_EXTENSION
     ): ?RenderedDocument {
+        Feature::triggerDeprecationOrThrow('v6.9.0.0', 'DocumentGenerator is deprecated and will be removed. Use the Shopware\Core\Checkout\DocumentV2\Generation\DocumentGenerator instead.');
+
         $criteria = (new Criteria([$documentId]))
             ->addAssociations([
                 'documentMediaFile',
@@ -95,6 +100,8 @@ class DocumentGenerator
 
     public function preview(string $documentType, DocumentGenerateOperation $operation, string $deepLinkCode, Context $context): RenderedDocument
     {
+        Feature::triggerDeprecationOrThrow('v6.9.0.0', 'DocumentGenerator is deprecated and will be removed. Use the Shopware\Core\Checkout\DocumentV2\Generation\DocumentGenerator instead.');
+
         $config = new DocumentRendererConfig();
         $config->deepLinkCode = $deepLinkCode;
 
@@ -118,6 +125,8 @@ class DocumentGenerator
      */
     public function generate(string $documentType, array $operations, Context $context): DocumentGenerationResult
     {
+        Feature::triggerDeprecationOrThrow('v6.9.0.0', 'DocumentGenerator is deprecated and will be removed. Use the Shopware\Core\Checkout\DocumentV2\Generation\DocumentGenerator instead.');
+
         $documentTypeId = $this->getDocumentTypeByName($documentType);
 
         if ($documentTypeId === null) {
@@ -179,6 +188,8 @@ class DocumentGenerator
 
     public function upload(string $documentId, Context $context, Request $uploadedFileRequest): DocumentIdStruct
     {
+        Feature::triggerDeprecationOrThrow('v6.9.0.0', 'DocumentGenerator is deprecated and will be removed. Use the Shopware\Core\Checkout\DocumentV2\Generation\DocumentGenerator instead.');
+
         $criteria = (new Criteria([$documentId]))
             ->addAssociation('documentMediaFile');
 

--- a/src/Core/Checkout/Document/Service/DocumentMerger.php
+++ b/src/Core/Checkout/Document/Service/DocumentMerger.php
@@ -15,11 +15,15 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Sorting\FieldSorting;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Util\Random;
 use Symfony\Component\Filesystem\Exception\IOException;
 use Symfony\Component\Filesystem\Filesystem;
 
+/**
+ * @deprecated tag:v6.9.0 - Will be removed.
+ */
 #[Package('after-sales')]
 final class DocumentMerger
 {
@@ -49,6 +53,8 @@ final class DocumentMerger
      */
     public function merge(array $documentIds, Context $context): ?RenderedDocument
     {
+        Feature::triggerDeprecationOrThrow('v6.9.0.0', 'DocumentMerger is deprecated and will be removed with document generation v1.');
+
         if ($documentIds === []) {
             return null;
         }

--- a/src/Core/Checkout/Document/Service/HtmlRenderer.php
+++ b/src/Core/Checkout/Document/Service/HtmlRenderer.php
@@ -12,6 +12,9 @@ use Shopware\Core\Framework\Extensions\ExtensionDispatcher;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
 
+/**
+ * @deprecated tag:v6.9.0 reason:remove-decorator - Will be removed. Use {@link \Shopware\Core\Checkout\DocumentV2\Generation\DocumentGenerator} instead.
+ */
 #[Package('after-sales')]
 class HtmlRenderer extends AbstractDocumentTypeRenderer
 {

--- a/src/Core/Checkout/Document/Service/PdfRenderer.php
+++ b/src/Core/Checkout/Document/Service/PdfRenderer.php
@@ -16,6 +16,9 @@ use Shopware\Core\Framework\Extensions\ExtensionDispatcher;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
 
+/**
+ * @deprecated tag:v6.9.0 reason:remove-decorator - Will be removed. Use {@link \Shopware\Core\Checkout\DocumentV2\Generation\DocumentGenerator} instead.
+ */
 #[Package('after-sales')]
 class PdfRenderer extends AbstractDocumentTypeRenderer
 {

--- a/src/Core/Checkout/Document/Service/ReferenceInvoiceLoader.php
+++ b/src/Core/Checkout/Document/Service/ReferenceInvoiceLoader.php
@@ -8,6 +8,7 @@ use Shopware\Core\Checkout\Document\Renderer\InvoiceRenderer;
 use Shopware\Core\Checkout\Document\Renderer\ZugferdEmbeddedRenderer;
 use Shopware\Core\Checkout\Document\Renderer\ZugferdRenderer;
 use Shopware\Core\Defaults;
+use Shopware\Core\Framework\Deprecation\BCChange\NamespaceChange;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Uuid\Uuid;
 
@@ -15,6 +16,7 @@ use Shopware\Core\Framework\Uuid\Uuid;
  * @internal - Fetch the $referenceDocumentId if set, otherwise fetch the latest document
  */
 #[Package('after-sales')]
+#[NamespaceChange(version: 'v6.9.0', newLocation: 'Shopware\Core\Checkout\DocumentV2\Service\ReferenceInvoiceLoader')]
 final readonly class ReferenceInvoiceLoader
 {
     /**

--- a/src/Core/Checkout/Document/Service/ZugferdEmbeddedService.php
+++ b/src/Core/Checkout/Document/Service/ZugferdEmbeddedService.php
@@ -11,10 +11,13 @@ use Shopware\Core\Checkout\Document\Renderer\RenderedDocument;
 use Shopware\Core\Checkout\Document\Renderer\RendererResult;
 use Shopware\Core\Checkout\Document\Struct\DocumentGenerateOperation;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 
 /**
  * @internal
+ *
+ * @deprecated tag:v6.9.0 - Will be removed.
  */
 #[Package('after-sales')]
 final class ZugferdEmbeddedService
@@ -38,6 +41,8 @@ final class ZugferdEmbeddedService
         AbstractDocumentRenderer $zugferdRenderer,
         string $shopwareVersion,
     ): RendererResult {
+        Feature::triggerDeprecationOrThrow('v6.9.0.0', 'ZugferdEmbeddedService is deprecated and will be removed with document generation v1.');
+
         $this->setSuccessDocumentNumbers($baseDocument->getSuccess(), $operations);
 
         $renderResult = new RendererResult();
@@ -104,6 +109,8 @@ final class ZugferdEmbeddedService
      */
     public function setSuccessDocumentNumbers(array $successes, array $operations): void
     {
+        Feature::triggerDeprecationOrThrow('v6.9.0.0', 'ZugferdEmbeddedService is deprecated and will be removed with document generation v1.');
+
         foreach ($successes as $orderId => $document) {
             $operation = $operations[$orderId] ?? null;
 

--- a/src/Core/Checkout/Document/Struct/DocumentGenerateOperation.php
+++ b/src/Core/Checkout/Document/Struct/DocumentGenerateOperation.php
@@ -3,10 +3,14 @@
 namespace Shopware\Core\Checkout\Document\Struct;
 
 use Shopware\Core\Checkout\Document\Service\PdfRenderer;
+use Shopware\Core\Checkout\DocumentV2\Generation\DocumentGenerationRequest;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\Struct;
 
+/**
+ * @deprecated tag:v6.9.0 reason:remove-getter-setter - Will be removed. Use {@link DocumentGenerationRequest} instead.
+ */
 #[Package('after-sales')]
 final class DocumentGenerateOperation extends Struct
 {

--- a/src/Core/Checkout/Document/Subscriber/DocumentDeleteSubscriber.php
+++ b/src/Core/Checkout/Document/Subscriber/DocumentDeleteSubscriber.php
@@ -18,6 +18,8 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 /**
  * @internal
+ *
+ * @deprecated tag:v6.9.0 reason:remove-subscriber - Will be removed without replacement.
  */
 #[Package('after-sales')]
 class DocumentDeleteSubscriber implements EventSubscriberInterface

--- a/src/Core/Checkout/Document/Twig/DocumentTemplateRenderer.php
+++ b/src/Core/Checkout/Document/Twig/DocumentTemplateRenderer.php
@@ -8,6 +8,7 @@ use Shopware\Core\Framework\Adapter\Translation\AbstractTranslator;
 use Shopware\Core\Framework\Adapter\Twig\TemplateFinder;
 use Shopware\Core\Framework\Adapter\Twig\TwigEnvironment;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SalesChannel\Context\AbstractSalesChannelContextFactory;
@@ -17,6 +18,9 @@ use Twig\Error\LoaderError;
 use Twig\Error\RuntimeError;
 use Twig\Error\SyntaxError;
 
+/**
+ * @deprecated tag:v6.9.0 - Will be removed. Use {@link \Shopware\Core\Checkout\DocumentV2\Template\DocumentTemplateRenderer} instead.
+ */
 #[Package('after-sales')]
 class DocumentTemplateRenderer
 {
@@ -47,6 +51,8 @@ class DocumentTemplateRenderer
         ?string $languageId = null,
         ?string $locale = null
     ): string {
+        Feature::triggerDeprecationOrThrow('v6.9.0.0', 'DocumentTemplateRenderer is deprecated and will be removed with document generation v1.');
+
         $salesChannelContext = null;
 
         // If parameters for specific language setting provided, inject to translator

--- a/src/Core/Checkout/Document/Zugferd/ZugferdBuilder.php
+++ b/src/Core/Checkout/Document/Zugferd/ZugferdBuilder.php
@@ -21,6 +21,9 @@ use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
+/**
+ * @deprecated tag:v6.9.0 - Will be removed.
+ */
 #[Package('after-sales')]
 class ZugferdBuilder
 {
@@ -40,6 +43,8 @@ class ZugferdBuilder
         DocumentConfiguration $config,
         Context $context,
     ): string {
+        Feature::triggerDeprecationOrThrow('v6.9.0.0', 'ZugferdBuilder is deprecated and will be removed with document generation v1.');
+
         return $this->build($order, $config, $context, ZugferdInvoiceType::INVOICE);
     }
 
@@ -53,11 +58,15 @@ class ZugferdBuilder
         string $documentType,
         ?array $invoiceReference = null,
     ): string {
+        Feature::triggerDeprecationOrThrow('v6.9.0.0', 'ZugferdBuilder is deprecated and will be removed with document generation v1.');
+
         return $this->build($order, $config, $context, $documentType, $invoiceReference);
     }
 
     protected function addLineItems(ZugferdDocument $document, ?OrderLineItemCollection $lineItems, string $parentPosition = ''): self
     {
+        Feature::triggerDeprecationOrThrow('v6.9.0.0', 'ZugferdBuilder is deprecated and will be removed with document generation v1.');
+
         if (!$lineItems) {
             return $this;
         }
@@ -72,6 +81,8 @@ class ZugferdBuilder
 
     protected function matchByType(ZugferdDocument $document, OrderLineItemEntity $lineItem, string $parentPosition = ''): void
     {
+        Feature::triggerDeprecationOrThrow('v6.9.0.0', 'ZugferdBuilder is deprecated and will be removed with document generation v1.');
+
         match ($lineItem->getType()) {
             LineItem::PRODUCT_LINE_ITEM_TYPE, LineItem::CUSTOM_LINE_ITEM_TYPE => $document->withProductLineItem($lineItem, $parentPosition),
             LineItem::PROMOTION_LINE_ITEM_TYPE => $document->withDiscountItem($lineItem),

--- a/src/Core/Checkout/Document/Zugferd/ZugferdDocument.php
+++ b/src/Core/Checkout/Document/Zugferd/ZugferdDocument.php
@@ -34,6 +34,9 @@ use Shopware\Core\Framework\Util\FloatComparator;
 use Shopware\Core\System\SalesChannel\SalesChannelDefinition;
 use Symfony\Component\Clock\Clock;
 
+/**
+ * @deprecated tag:v6.9.0 reason:remove-getter-setter - Will be removed.
+ */
 #[Package('after-sales')]
 class ZugferdDocument
 {

--- a/src/Core/Checkout/Document/Zugferd/ZugferdInvoiceGeneratedEvent.php
+++ b/src/Core/Checkout/Document/Zugferd/ZugferdInvoiceGeneratedEvent.php
@@ -10,6 +10,8 @@ use Symfony\Contracts\EventDispatcher\Event;
 
 /**
  * @codeCoverageIgnore
+ *
+ * @deprecated tag:v6.9.0 reason:remove-getter-setter - Will be removed.
  */
 #[Package('after-sales')]
 class ZugferdInvoiceGeneratedEvent extends Event

--- a/src/Core/Checkout/Document/Zugferd/ZugferdInvoiceItemAddedEvent.php
+++ b/src/Core/Checkout/Document/Zugferd/ZugferdInvoiceItemAddedEvent.php
@@ -8,6 +8,8 @@ use Symfony\Contracts\EventDispatcher\Event;
 
 /**
  * @codeCoverageIgnore
+ *
+ * @deprecated tag:v6.9.0 reason:remove-getter-setter - Will be removed.
  */
 #[Package('after-sales')]
 class ZugferdInvoiceItemAddedEvent extends Event

--- a/src/Core/Checkout/Document/Zugferd/ZugferdInvoiceOrdersEvent.php
+++ b/src/Core/Checkout/Document/Zugferd/ZugferdInvoiceOrdersEvent.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @codeCoverageIgnore
+ *
+ * @deprecated tag:v6.9.0 - Will be removed.
  */
 #[Package('after-sales')]
 final class ZugferdInvoiceOrdersEvent extends DocumentOrderEvent

--- a/src/Core/Checkout/DocumentV2/Aggregate/DocumentFile/DocumentFileCollection.php
+++ b/src/Core/Checkout/DocumentV2/Aggregate/DocumentFile/DocumentFileCollection.php
@@ -6,7 +6,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
 use Shopware\Core\Framework\Log\Package;
 
 /**
- * @internal
+ * @experimental stableVersion:v6.8.0 feature:DOCUMENT_GENERATION_REWORK
  *
  * @extends EntityCollection<DocumentFileEntity>
  *

--- a/src/Core/Checkout/DocumentV2/Aggregate/DocumentFile/DocumentFileDefinition.php
+++ b/src/Core/Checkout/DocumentV2/Aggregate/DocumentFile/DocumentFileDefinition.php
@@ -24,7 +24,7 @@ use Shopware\Core\Framework\Log\Package;
  * for HTML and PDF output for the same document number. Intermediate dependency formats that
  * only exist during rendering are not stored here.
  *
- * @internal
+ * @experimental stableVersion:v6.8.0 feature:DOCUMENT_GENERATION_REWORK
  *
  * @codeCoverageIgnore
  */

--- a/src/Core/Checkout/DocumentV2/Aggregate/DocumentFile/DocumentFileEntity.php
+++ b/src/Core/Checkout/DocumentV2/Aggregate/DocumentFile/DocumentFileEntity.php
@@ -9,7 +9,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityIdTrait;
 use Shopware\Core\Framework\Log\Package;
 
 /**
- * @internal
+ * @experimental stableVersion:v6.8.0 feature:DOCUMENT_GENERATION_REWORK
  *
  * @codeCoverageIgnore
  */

--- a/src/Core/Checkout/DocumentV2/Config/DocumentCompanyInfo.php
+++ b/src/Core/Checkout/DocumentV2/Config/DocumentCompanyInfo.php
@@ -8,7 +8,7 @@ use Shopware\Core\System\Country\CountryEntity;
 /**
  * @codeCoverageIgnore
  *
- * @internal
+ * @experimental stableVersion:v6.8.0 feature:DOCUMENT_GENERATION_REWORK
  */
 #[Package('after-sales')]
 final readonly class DocumentCompanyInfo

--- a/src/Core/Checkout/DocumentV2/Config/DocumentConfig.php
+++ b/src/Core/Checkout/DocumentV2/Config/DocumentConfig.php
@@ -6,7 +6,7 @@ use Shopware\Core\Content\Media\MediaEntity;
 use Shopware\Core\Framework\Log\Package;
 
 /**
- * @internal
+ * @experimental stableVersion:v6.8.0 feature:DOCUMENT_GENERATION_REWORK
  */
 #[Package('after-sales')]
 final readonly class DocumentConfig

--- a/src/Core/Checkout/DocumentV2/Config/DocumentConfigLoader.php
+++ b/src/Core/Checkout/DocumentV2/Config/DocumentConfigLoader.php
@@ -65,8 +65,6 @@ final class DocumentConfigLoader implements EventSubscriberInterface, ResetInter
     private array $bundles = [];
 
     /**
-     * @internal
-     *
      * @param EntityRepository<DocumentBaseConfigCollection> $documentConfigRepository
      * @param EntityRepository<CountryCollection> $countryRepository
      * @param EntityRepository<MediaCollection> $mediaRepository

--- a/src/Core/Checkout/DocumentV2/Config/DocumentDisplayOptions.php
+++ b/src/Core/Checkout/DocumentV2/Config/DocumentDisplayOptions.php
@@ -11,7 +11,7 @@ use Shopware\Core\Migration\V6_4\Migration1610439375AddEUStatesAsDefaultForIntra
  * Backed by the merchants `document_base_config.config` JSON; built by
  * {@see DocumentConfigLoader} and shared across renderers.
  *
- * @internal
+ * @experimental stableVersion:v6.8.0 feature:DOCUMENT_GENERATION_REWORK
  *
  * @codeCoverageIgnore
  */

--- a/src/Core/Checkout/DocumentV2/Controller/DocumentV2Controller.php
+++ b/src/Core/Checkout/DocumentV2/Controller/DocumentV2Controller.php
@@ -38,11 +38,11 @@ use Symfony\Component\HttpKernel\Attribute\MapRequestPayload;
 use Symfony\Component\Routing\Attribute\Route;
 
 /**
- * @internal
+ * @experimental stableVersion:v6.8.0 feature:DOCUMENT_GENERATION_REWORK
  */
 #[Package('after-sales')]
 #[Route(defaults: [PlatformRequest::ATTRIBUTE_ROUTE_SCOPE => [ApiRouteScope::ID]])]
-final class DocumentV2Controller extends AbstractController
+class DocumentV2Controller extends AbstractController
 {
     /**
      * @internal

--- a/src/Core/Checkout/DocumentV2/DocumentFormat.php
+++ b/src/Core/Checkout/DocumentV2/DocumentFormat.php
@@ -5,7 +5,7 @@ namespace Shopware\Core\Checkout\DocumentV2;
 use Shopware\Core\Framework\Log\Package;
 
 /**
- * @internal
+ * @experimental stableVersion:v6.8.0 feature:DOCUMENT_GENERATION_REWORK
  *
  * @codeCoverageIgnore
  */

--- a/src/Core/Checkout/DocumentV2/DocumentSourceEntity.php
+++ b/src/Core/Checkout/DocumentV2/DocumentSourceEntity.php
@@ -8,7 +8,7 @@ use Shopware\Core\System\Language\LanguageEntity;
 /**
  * Contract for entities that documents can be generated from.
  *
- * @internal
+ * @experimental stableVersion:v6.8.0 feature:DOCUMENT_GENERATION_REWORK
  */
 #[Package('after-sales')]
 interface DocumentSourceEntity

--- a/src/Core/Checkout/DocumentV2/DocumentV2Exception.php
+++ b/src/Core/Checkout/DocumentV2/DocumentV2Exception.php
@@ -7,7 +7,7 @@ use Shopware\Core\Framework\Log\Package;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
- * @internal
+ * @experimental stableVersion:v6.8.0 feature:DOCUMENT_GENERATION_REWORK
  *
  * @codeCoverageIgnore
  */

--- a/src/Core/Checkout/DocumentV2/Generation/DocumentGenerationRequest.php
+++ b/src/Core/Checkout/DocumentV2/Generation/DocumentGenerationRequest.php
@@ -9,7 +9,7 @@ use Shopware\Core\Framework\Log\Package;
 use Symfony\Component\Clock\Clock;
 
 /**
- * @internal
+ * @experimental stableVersion:v6.8.0 feature:DOCUMENT_GENERATION_REWORK
  */
 #[Package('after-sales')]
 final readonly class DocumentGenerationRequest

--- a/src/Core/Checkout/DocumentV2/Generation/DocumentGenerator.php
+++ b/src/Core/Checkout/DocumentV2/Generation/DocumentGenerator.php
@@ -25,12 +25,16 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Log\Package;
 
 /**
- * @internal
+ * @final
+ *
+ * @experimental stableVersion:v6.8.0 feature:DOCUMENT_GENERATION_REWORK
  */
 #[Package('after-sales')]
-final readonly class DocumentGenerator
+readonly class DocumentGenerator
 {
     /**
+     * @internal
+     *
      * @param EntityRepository<OrderCollection> $orderRepository
      */
     public function __construct(

--- a/src/Core/Checkout/DocumentV2/Provider/AbstractDocumentDataProvider.php
+++ b/src/Core/Checkout/DocumentV2/Provider/AbstractDocumentDataProvider.php
@@ -14,7 +14,7 @@ use Shopware\Core\Framework\Log\Package;
  * Each matching provider is called once per generation request. Its output is stored in the
  * RenderInput so multiple renderers can reuse the same prepared data.
  *
- * @internal
+ * @experimental stableVersion:v6.8.0 feature:DOCUMENT_GENERATION_REWORK
  *
  * @codeCoverageIgnore
  */

--- a/src/Core/Checkout/DocumentV2/Provider/CancellationInvoiceDataProvider.php
+++ b/src/Core/Checkout/DocumentV2/Provider/CancellationInvoiceDataProvider.php
@@ -16,7 +16,7 @@ use Shopware\Core\Framework\Log\Package;
 #[Package('after-sales')]
 final readonly class CancellationInvoiceDataProvider extends AbstractDocumentDataProvider implements RendersReferencedSnapshot
 {
-    final public const KEY = 'storno';
+    final public const KEY = DocumentDataProviderKey::CANCELLATION_INVOICE;
 
     public function __construct(
         private InvoiceDataProvider $invoiceDataProvider,
@@ -25,7 +25,7 @@ final readonly class CancellationInvoiceDataProvider extends AbstractDocumentDat
 
     public function getKey(): string
     {
-        return self::KEY;
+        return self::KEY->value;
     }
 
     public function supports(string $documentType): bool

--- a/src/Core/Checkout/DocumentV2/Provider/CreditNoteDataProvider.php
+++ b/src/Core/Checkout/DocumentV2/Provider/CreditNoteDataProvider.php
@@ -19,7 +19,7 @@ use Shopware\Core\Framework\Log\Package;
 #[Package('after-sales')]
 final readonly class CreditNoteDataProvider extends AbstractDocumentDataProvider implements ReferencesDocument
 {
-    final public const KEY = 'credit_note';
+    final public const KEY = DocumentDataProviderKey::CREDIT_NOTE;
 
     public function __construct(
         private InvoiceDataProvider $invoiceDataProvider,
@@ -29,7 +29,7 @@ final readonly class CreditNoteDataProvider extends AbstractDocumentDataProvider
 
     public function getKey(): string
     {
-        return self::KEY;
+        return self::KEY->value;
     }
 
     public function supports(string $documentType): bool

--- a/src/Core/Checkout/DocumentV2/Provider/DeliveryNoteDataProvider.php
+++ b/src/Core/Checkout/DocumentV2/Provider/DeliveryNoteDataProvider.php
@@ -17,11 +17,11 @@ use Shopware\Core\Framework\Log\Package;
 #[Package('after-sales')]
 final readonly class DeliveryNoteDataProvider extends AbstractDocumentDataProvider
 {
-    final public const KEY = 'delivery_note';
+    final public const KEY = DocumentDataProviderKey::DELIVERY_NOTE;
 
     public function getKey(): string
     {
-        return self::KEY;
+        return self::KEY->value;
     }
 
     public function supports(string $documentType): bool

--- a/src/Core/Checkout/DocumentV2/Provider/DocumentDataProviderKey.php
+++ b/src/Core/Checkout/DocumentV2/Provider/DocumentDataProviderKey.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-namespace Shopware\Core\Checkout\DocumentV2;
+namespace Shopware\Core\Checkout\DocumentV2\Provider;
 
 use Shopware\Core\Framework\Log\Package;
 
@@ -10,8 +10,9 @@ use Shopware\Core\Framework\Log\Package;
  * @codeCoverageIgnore
  */
 #[Package('after-sales')]
-enum DocumentType: string
+enum DocumentDataProviderKey: string
 {
+    case META = 'meta';
     case INVOICE = 'invoice';
     case DELIVERY_NOTE = 'delivery_note';
     case CREDIT_NOTE = 'credit_note';

--- a/src/Core/Checkout/DocumentV2/Provider/DocumentMetaProvider.php
+++ b/src/Core/Checkout/DocumentV2/Provider/DocumentMetaProvider.php
@@ -18,7 +18,7 @@ use Shopware\Core\Framework\Log\Package;
 #[Package('after-sales')]
 final readonly class DocumentMetaProvider extends AbstractDocumentDataProvider
 {
-    final public const KEY = 'meta';
+    final public const KEY = DocumentDataProviderKey::META;
 
     public function __construct(
         private DocumentConfigLoader $documentConfigLoader,
@@ -27,7 +27,7 @@ final readonly class DocumentMetaProvider extends AbstractDocumentDataProvider
 
     public function getKey(): string
     {
-        return self::KEY;
+        return self::KEY->value;
     }
 
     public function supports(string $documentType): bool

--- a/src/Core/Checkout/DocumentV2/Provider/InvoiceDataProvider.php
+++ b/src/Core/Checkout/DocumentV2/Provider/InvoiceDataProvider.php
@@ -32,7 +32,7 @@ use Symfony\Component\Validator\Validator\ValidatorInterface;
 #[Package('after-sales')]
 final readonly class InvoiceDataProvider extends AbstractDocumentDataProvider
 {
-    final public const KEY = 'invoice';
+    final public const KEY = DocumentDataProviderKey::INVOICE;
 
     public function __construct(
         private DocumentConfigLoader $documentConfigLoader,
@@ -43,7 +43,7 @@ final readonly class InvoiceDataProvider extends AbstractDocumentDataProvider
 
     public function getKey(): string
     {
-        return self::KEY;
+        return self::KEY->value;
     }
 
     public function supports(string $documentType): bool

--- a/src/Core/Checkout/DocumentV2/Provider/ReferencesDocument.php
+++ b/src/Core/Checkout/DocumentV2/Provider/ReferencesDocument.php
@@ -10,7 +10,7 @@ use Shopware\Core\Framework\Log\Package;
  * The generation pipeline resolves the referenced document, fills
  * ProviderInput::$resolvedReference and persists the resolved reference id.
  *
- * @internal
+ * @experimental stableVersion:v6.8.0 feature:DOCUMENT_GENERATION_REWORK
  */
 #[Package('after-sales')]
 interface ReferencesDocument

--- a/src/Core/Checkout/DocumentV2/Provider/RenderData/DocumentMetaRenderData.php
+++ b/src/Core/Checkout/DocumentV2/Provider/RenderData/DocumentMetaRenderData.php
@@ -13,7 +13,7 @@ use Shopware\Core\Framework\Log\Package;
  * info, display options and document identity. Provided once per generation run by
  * {@see \Shopware\Core\Checkout\DocumentV2\Provider\DocumentMetaProvider}
  *
- * @internal
+ * @experimental stableVersion:v6.8.0 feature:DOCUMENT_GENERATION_REWORK
  *
  * @codeCoverageIgnore
  */

--- a/src/Core/Checkout/DocumentV2/Provider/RendersReferencedSnapshot.php
+++ b/src/Core/Checkout/DocumentV2/Provider/RendersReferencedSnapshot.php
@@ -11,7 +11,7 @@ use Shopware\Core\Framework\Log\Package;
  * The generation pipeline loads the order at the referenced document's snapshot instead of
  * creating a new version, in preview too.
  *
- * @internal
+ * @experimental stableVersion:v6.8.0 feature:DOCUMENT_GENERATION_REWORK
  */
 #[Package('after-sales')]
 interface RendersReferencedSnapshot extends ReferencesDocument

--- a/src/Core/Checkout/DocumentV2/Renderer/AbstractDocumentRenderer.php
+++ b/src/Core/Checkout/DocumentV2/Renderer/AbstractDocumentRenderer.php
@@ -15,7 +15,7 @@ use Shopware\Core\Framework\Log\Package;
  * Renderers can depend on other formats and consume their output from RenderState, which makes
  * chained generation flows like HTML -> PDF -> embedded PDF explicit in code.
  *
- * @internal
+ * @experimental stableVersion:v6.8.0 feature:DOCUMENT_GENERATION_REWORK
  *
  * @codeCoverageIgnore
  */

--- a/src/Core/Checkout/DocumentV2/Renderer/HtmlRenderer.php
+++ b/src/Core/Checkout/DocumentV2/Renderer/HtmlRenderer.php
@@ -47,12 +47,12 @@ final readonly class HtmlRenderer extends AbstractDocumentRenderer
     public function renderToString(RenderInput $input, RenderState $state, Context $context): RenderResult
     {
         $meta = $input->requireData(
-            DocumentMetaProvider::KEY,
+            DocumentMetaProvider::KEY->value,
             DocumentMetaRenderData::class,
         );
 
         $typeData = $input->getAllData();
-        unset($typeData[DocumentMetaProvider::KEY]);
+        unset($typeData[DocumentMetaProvider::KEY->value]);
 
         $configuration = new TemplateContext($meta, $typeData);
 

--- a/src/Core/Checkout/DocumentV2/Renderer/PdfRenderer.php
+++ b/src/Core/Checkout/DocumentV2/Renderer/PdfRenderer.php
@@ -55,7 +55,7 @@ final readonly class PdfRenderer extends AbstractDocumentRenderer
         $html = $state->require(DocumentFormat::HTML->value)->content;
 
         $meta = $input->requireData(
-            DocumentMetaProvider::KEY,
+            DocumentMetaProvider::KEY->value,
             DocumentMetaRenderData::class,
         );
 

--- a/src/Core/Checkout/DocumentV2/Renderer/ZugferdEmbeddedPdfRenderer.php
+++ b/src/Core/Checkout/DocumentV2/Renderer/ZugferdEmbeddedPdfRenderer.php
@@ -53,7 +53,7 @@ final readonly class ZugferdEmbeddedPdfRenderer extends AbstractDocumentRenderer
     public function renderToString(RenderInput $input, RenderState $state, Context $context): RenderResult
     {
         $meta = $input->requireData(
-            DocumentMetaProvider::KEY,
+            DocumentMetaProvider::KEY->value,
             DocumentMetaRenderData::class,
         );
 

--- a/src/Core/Checkout/DocumentV2/Renderer/ZugferdXmlRenderer.php
+++ b/src/Core/Checkout/DocumentV2/Renderer/ZugferdXmlRenderer.php
@@ -48,7 +48,7 @@ final readonly class ZugferdXmlRenderer extends AbstractDocumentRenderer
     public function renderToString(RenderInput $input, RenderState $state, Context $context): RenderResult
     {
         $meta = $input->requireData(
-            DocumentMetaProvider::KEY,
+            DocumentMetaProvider::KEY->value,
             DocumentMetaRenderData::class,
         );
 

--- a/src/Core/Checkout/DocumentV2/Struct/AbstractRenderData.php
+++ b/src/Core/Checkout/DocumentV2/Struct/AbstractRenderData.php
@@ -11,7 +11,7 @@ use Shopware\Core\Framework\Log\Package;
  * input instead of reaching back into the data loading layer. The base holds no state: shared data
  * lives in {@see \Shopware\Core\Checkout\DocumentV2\Provider\RenderData\DocumentMetaRenderData}
  *
- * @internal
+ * @experimental stableVersion:v6.8.0 feature:DOCUMENT_GENERATION_REWORK
  *
  * @codeCoverageIgnore
  *

--- a/src/Core/Checkout/DocumentV2/Struct/ProviderInput.php
+++ b/src/Core/Checkout/DocumentV2/Struct/ProviderInput.php
@@ -9,7 +9,7 @@ use Shopware\Core\Framework\Log\Package;
 /**
  * Shared input handed to all data providers during one generation run.
  *
- * @internal
+ * @experimental stableVersion:v6.8.0 feature:DOCUMENT_GENERATION_REWORK
  *
  * @codeCoverageIgnore
  */

--- a/src/Core/Checkout/DocumentV2/Struct/ReferencedDocument.php
+++ b/src/Core/Checkout/DocumentV2/Struct/ReferencedDocument.php
@@ -7,7 +7,7 @@ use Shopware\Core\Framework\Log\Package;
 /**
  * The document another document references, resolved by the generation pipeline.
  *
- * @internal
+ * @experimental stableVersion:v6.8.0 feature:DOCUMENT_GENERATION_REWORK
  *
  * @codeCoverageIgnore
  */

--- a/src/Core/Checkout/DocumentV2/Struct/RenderInput.php
+++ b/src/Core/Checkout/DocumentV2/Struct/RenderInput.php
@@ -12,7 +12,7 @@ use Shopware\Core\Framework\Log\Package;
  * It bundles the order snapshot, the final document number and all provider DTOs so renderers
  * can consume prepared data without reloading or recalculating it.
  *
- * @internal
+ * @experimental stableVersion:v6.8.0 feature:DOCUMENT_GENERATION_REWORK
  */
 #[Package('after-sales')]
 final readonly class RenderInput

--- a/src/Core/Checkout/DocumentV2/Struct/RenderResult.php
+++ b/src/Core/Checkout/DocumentV2/Struct/RenderResult.php
@@ -10,7 +10,7 @@ use Shopware\Core\Framework\Log\Package;
  * It contains both the binary or textual content and the metadata needed by the renderer to
  * create the final persisted file artifact.
  *
- * @internal
+ * @experimental stableVersion:v6.8.0 feature:DOCUMENT_GENERATION_REWORK
  *
  * @codeCoverageIgnore
  */

--- a/src/Core/Checkout/DocumentV2/Struct/RenderState.php
+++ b/src/Core/Checkout/DocumentV2/Struct/RenderState.php
@@ -12,7 +12,7 @@ use Shopware\Core\Framework\Log\Package;
  * reuse already rendered formats without persisting every intermediate artifact.
  * Renderers must declare every format they read from this state as a dependency.
  *
- * @internal
+ * @experimental stableVersion:v6.8.0 feature:DOCUMENT_GENERATION_REWORK
  */
 #[Package('after-sales')]
 final class RenderState

--- a/src/Core/Checkout/DocumentV2/Subscriber/DocumentBaseConfigSyncSubscriber.php
+++ b/src/Core/Checkout/DocumentV2/Subscriber/DocumentBaseConfigSyncSubscriber.php
@@ -22,7 +22,7 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
  * @internal
  */
 #[Package('after-sales')]
-class DocumentBaseConfigSyncSubscriber implements EventSubscriberInterface
+final readonly class DocumentBaseConfigSyncSubscriber implements EventSubscriberInterface
 {
     final public const DOCUMENT_CONFIG_MIGRATION_MAP = [
         'pageSize' => [
@@ -67,7 +67,7 @@ class DocumentBaseConfigSyncSubscriber implements EventSubscriberInterface
      * @internal
      */
     public function __construct(
-        private readonly Connection $connection,
+        private Connection $connection,
     ) {
     }
 

--- a/src/Core/Checkout/DocumentV2/Template/DocumentTemplateRenderer.php
+++ b/src/Core/Checkout/DocumentV2/Template/DocumentTemplateRenderer.php
@@ -20,11 +20,14 @@ use Shopware\Core\System\SalesChannel\Context\SalesChannelContextService;
  * Renderers pass only the view path, the {@see RenderInput} and any format-specific extras
  * (e.g. an HTML pagination counter or PDF configuration).
  *
- * @internal
+ * @experimental stableVersion:v6.8.0 feature:DOCUMENT_GENERATION_REWORK
  */
 #[Package('after-sales')]
 final readonly class DocumentTemplateRenderer
 {
+    /**
+     * @internal
+     */
     public function __construct(
         private TemplateFinder $templateFinder,
         private TwigEnvironment $twig,

--- a/src/Core/Checkout/DocumentV2/Template/PaginationCounter.php
+++ b/src/Core/Checkout/DocumentV2/Template/PaginationCounter.php
@@ -16,7 +16,7 @@ use Shopware\Core\Framework\Log\Package;
  * @internal
  */
 #[Package('after-sales')]
-class PaginationCounter
+final class PaginationCounter
 {
     private int $counter = 0;
 

--- a/src/Core/Checkout/DocumentV2/Type/AbstractDocumentType.php
+++ b/src/Core/Checkout/DocumentV2/Type/AbstractDocumentType.php
@@ -5,7 +5,7 @@ namespace Shopware\Core\Checkout\DocumentV2\Type;
 use Shopware\Core\Framework\Log\Package;
 
 /**
- * @internal
+ * @experimental stableVersion:v6.8.0 feature:DOCUMENT_GENERATION_REWORK
  *
  * @codeCoverageIgnore
  */

--- a/src/Core/Content/Flow/Dispatching/Action/GenerateDocumentAction.php
+++ b/src/Core/Content/Flow/Dispatching/Action/GenerateDocumentAction.php
@@ -110,7 +110,7 @@ class GenerateDocumentAction extends FlowAction implements DelayableAction
 
         $operation = new DocumentGenerateOperation($orderId, $fileType, $config, null, $static);
 
-        $result = $this->documentGenerator->generate($documentType, [$orderId => $operation], $context);
+        $result = Feature::silent('v6.9.0.0', fn () => $this->documentGenerator->generate($documentType, [$orderId => $operation], $context));
 
         foreach ($result->getErrors() as $error) {
             $this->logger->error($error->getMessage());

--- a/src/Core/Content/Mail/Service/MailAttachmentsBuilder.php
+++ b/src/Core/Content/Mail/Service/MailAttachmentsBuilder.php
@@ -18,6 +18,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Sorting\FieldSorting;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Util\Hasher;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -184,7 +185,7 @@ class MailAttachmentsBuilder
      */
     private function buildLegacyAttachment(string $documentId, Context $context): array
     {
-        $document = $this->documentGenerator->readDocument($documentId, $context, fileType: null);
+        $document = Feature::silent('v6.9.0.0', fn () => $this->documentGenerator->readDocument($documentId, $context, fileType: null));
 
         if ($document === null) {
             return [];

--- a/src/Core/DevOps/StaticAnalyze/PHPStan/Rules/Deprecation/BCChangeAttributeUsageRule.php
+++ b/src/Core/DevOps/StaticAnalyze/PHPStan/Rules/Deprecation/BCChangeAttributeUsageRule.php
@@ -23,6 +23,7 @@ use Shopware\Core\Framework\Deprecation\BCChange\BecomesInternal;
 use Shopware\Core\Framework\Deprecation\BCChange\CallSiteCompatibilityChange;
 use Shopware\Core\Framework\Deprecation\BCChange\ExceptionChange;
 use Shopware\Core\Framework\Deprecation\BCChange\ExtenderCompatibilityChange;
+use Shopware\Core\Framework\Deprecation\BCChange\NamespaceChange;
 use Shopware\Core\Framework\Deprecation\BCChange\NewOptionalParameter;
 use Shopware\Core\Framework\Deprecation\BCChange\NewRequiredParameter;
 use Shopware\Core\Framework\Deprecation\BCChange\ParameterDefaultValueChange;
@@ -215,6 +216,23 @@ class BCChangeAttributeUsageRule implements Rule
 
         if ($attribute->getName() === BecomesInternal::class && $this->isMarkedInternal($class->getDocComment())) {
             return [$this->error($line, \sprintf('BecomesInternal on "%s": the class is already @internal.', $symbol))];
+        }
+
+        if ($attribute->getName() === NamespaceChange::class) {
+            $newLocation = $this->argument($attribute, 'newLocation', 1);
+
+            if (\is_string($newLocation) && $newLocation !== '') {
+                $newShortName = substr((string) strrchr('\\' . $newLocation, '\\'), 1);
+
+                if ($newShortName !== $symbol) {
+                    return [$this->error($line, \sprintf(
+                        'NamespaceChange on "%s": newLocation "%s" must be the fully qualified class name ending in "%s". A namespace move keeps the class name.',
+                        $symbol,
+                        $newLocation,
+                        $symbol
+                    ))];
+                }
+            }
         }
 
         return [];

--- a/src/Core/DevOps/StaticAnalyze/PHPStan/Rules/Deprecation/DeprecatedMethodsThrowDeprecationRule.php
+++ b/src/Core/DevOps/StaticAnalyze/PHPStan/Rules/Deprecation/DeprecatedMethodsThrowDeprecationRule.php
@@ -53,6 +53,8 @@ class DeprecatedMethodsThrowDeprecationRule implements Rule
         'reason:factory-for-deprecation',
         // Rules still need to be called for rule evaluation, therefore they do not trigger deprecations.
         'reason:remove-rule',
+        // Sync FK resolvers are matched by getName() across all resolvers, so that method must stay silent.
+        'reason:remove-fk-resolver',
     ];
 
     public function __construct(private readonly ServiceMap $serviceMap)

--- a/src/Core/DevOps/StaticAnalyze/PHPStan/tagged-service-contracts.php
+++ b/src/Core/DevOps/StaticAnalyze/PHPStan/tagged-service-contracts.php
@@ -11,6 +11,9 @@ use Shopware\Core\Checkout\Cart\TaxProvider\AbstractTaxProvider;
 use Shopware\Core\Checkout\Customer\Password\LegacyEncoder\LegacyEncoderInterface;
 use Shopware\Core\Checkout\Document\Renderer\AbstractDocumentRenderer;
 use Shopware\Core\Checkout\Document\Service\AbstractDocumentTypeRenderer;
+use Shopware\Core\Checkout\DocumentV2\Provider\AbstractDocumentDataProvider;
+use Shopware\Core\Checkout\DocumentV2\Renderer\AbstractDocumentRenderer as AbstractDocumentV2Renderer;
+use Shopware\Core\Checkout\DocumentV2\Type\AbstractDocumentType;
 use Shopware\Core\Checkout\Gateway\Command\Handler\AbstractCheckoutGatewayCommandHandler;
 use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AbstractPaymentHandler;
 use Shopware\Core\Checkout\Promotion\Cart\Discount\Filter\FilterPickerInterface;
@@ -89,6 +92,9 @@ return [
             'shopware.cms.product_slider.processor' => AbstractProductSliderProcessor::class,
             'shopware.dal.exception_handler' => ExceptionHandlerInterface::class,
             'shopware.demodata_generator' => DemodataGeneratorInterface::class,
+            'shopware.document_v2.provider' => AbstractDocumentDataProvider::class,
+            'shopware.document_v2.renderer' => AbstractDocumentV2Renderer::class,
+            'shopware.document_v2.type' => AbstractDocumentType::class,
             'shopware.elastic.admin-searcher-index' => AbstractAdminIndexer::class,
             'shopware.entity.definition' => EntityDefinition::class,
             'shopware.entity.hookable' => [EntityDefinition::class, Entity::class],

--- a/src/Core/Framework/Deprecation/BCChange/NamespaceChange.php
+++ b/src/Core/Framework/Deprecation/BCChange/NamespaceChange.php
@@ -1,0 +1,27 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\Deprecation\BCChange;
+
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * @internal
+ *
+ * Signals that the class keeps working unchanged but relocates to a different fully-qualified
+ * name in the given version, for example when it moves into another namespace.
+ *
+ * Any third-party reference to the current name — calling, extending, or type-hinting — must be
+ * updated to the new location before the change happens. The new class does not exist yet, so
+ * `$newLocation` is given as a plain FQCN string rather than a `::class` constant.
+ */
+#[Package('framework')]
+#[\Attribute(\Attribute::TARGET_CLASS)]
+final class NamespaceChange implements CallSiteCompatibilityChange, ExtenderCompatibilityChange
+{
+    public function __construct(
+        public readonly string $version,
+        public readonly string $newLocation,
+        public readonly ?string $description = null,
+    ) {
+    }
+}

--- a/src/Core/Framework/Resources/config/packages/feature.yaml
+++ b/src/Core/Framework/Resources/config/packages/feature.yaml
@@ -17,6 +17,10 @@ shopware:
         default: false
         major: true
         toggleable: false
+      - name: v6.9.0.0
+        default: false
+        major: true
+        toggleable: false
       - name: DISABLE_VUE_COMPAT
         default: true
         major: true
@@ -37,10 +41,10 @@ shopware:
         toggleable: true
         description: "Execute flows after the main unit of work has concluded. Will become the default for next major 6.8"
       - name: DOCUMENT_GENERATION_REWORK
-        default: false
+        default: false # ""default: true" in v6.8.0.0
         major: true
         toggleable: true
-        description: "Experimental! Enable the new document generation implementation and its accompanying UI changes."
+        description: "Experimental! Enable the new document generation implementation and its accompanying UI changes. Will become enabled by default with the next major 6.8"
       - name: PERFORMANCE_TWEAKS
         default: false
         major: true

--- a/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/BCChangeAttributeUsageRuleTest.php
+++ b/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/BCChangeAttributeUsageRuleTest.php
@@ -22,107 +22,111 @@ class BCChangeAttributeUsageRuleTest extends RuleTestCase
         $this->analyse([__DIR__ . '/data/BCChangeAttributeUsageRule/BCChangeAttributeUsage.php'], [
             [
                 'BecomesFinal on "AlreadyFinalClass": the class is already final.',
-                21,
+                22,
             ],
             [
                 'BecomesInternal on "WrongVersionFormatClass": version "6.8.0" must match the format "v6.8.0".',
-                26,
+                27,
             ],
             [
                 'BecomesInternal on "AlreadyInternalClass": the class is already @internal.',
-                34,
+                35,
             ],
             [
                 'NewOptionalParameter on "MethodLevelViolations::leadingDollar()": parameter name "$states" must be given without the leading "$".',
-                41,
+                42,
             ],
             [
                 'NewOptionalParameter on "MethodLevelViolations::alreadyExistingParameter()": parameter "existing" already exists.',
-                46,
+                47,
             ],
             [
                 'ParameterNameChange on "MethodLevelViolations::missingParameter()": parameter "missing" does not exist.',
-                51,
+                52,
             ],
             [
                 'BecomesAbstract on "MethodLevelViolations::alreadyAbstract()": the method is already abstract.',
-                56,
+                57,
             ],
             [
                 'VisibilityChange on "MethodLevelViolations::alreadyProtected()": announced visibility "protected" is not narrower than the current visibility.',
-                59,
+                60,
             ],
             [
                 'ReturnTypeNarrowing on "SealedClass::narrowingOnFinalClass()": the class is final, so no extenders can exist. Apply the announced change directly instead of announcing it.',
-                87,
+                88,
             ],
             [
                 'NewOptionalParameter on "SoftSealedClass::newParameterOnSoftFinalClass()": the class is final, so no extenders can exist. Apply the announced change directly instead of announcing it.',
-                104,
+                105,
             ],
             [
                 'ParameterTypeWidening on "ClassWithFinalMethod::wideningOnFinalMethod()": the method is final, so no extenders can exist. Apply the announced change directly instead of announcing it.',
-                112,
+                113,
             ],
             [
                 'ParameterTypeNarrowing on "RuntimeDetectableViolations::narrowingWithoutTrigger()": the legacy usage is detectable at runtime, but the method does not call "Feature::triggerDeprecationOrThrow". Trigger a deprecation when the method is used in a way that breaks with the announced change.',
-                120,
+                121,
             ],
             [
                 'BecomesAbstract on "RuntimeDetectableViolations::becomesAbstractWithoutTrigger()": the legacy usage is detectable at runtime, but the method does not call "Feature::triggerDeprecationOrThrow". Trigger a deprecation when the method is used in a way that breaks with the announced change.',
-                125,
+                126,
             ],
             [
                 'ParameterRemoval on "RuntimeDetectableViolations::removalWithoutTrigger()": the legacy usage is detectable at runtime, but the method does not call "Feature::triggerDeprecationOrThrow". Trigger a deprecation when the method is used in a way that breaks with the announced change.',
-                130,
+                131,
             ],
             [
                 'NewRequiredParameter on "NewRequiredParameterCases::requiredAlreadyExists()": parameter "existing" already exists.',
-                146,
+                147,
             ],
             [
                 'NewRequiredParameter on "NewRequiredParameterCases::requiredWithoutTrigger()": the legacy usage is detectable at runtime, but the method does not call "Feature::triggerDeprecationOrThrow". Trigger a deprecation when the method is used in a way that breaks with the announced change.',
-                152,
+                153,
             ],
             [
                 'ExceptionChange on "ExceptionChangeCases::narrowingIsCovered()": every announced exception is already covered by the current "@throws" contract. Throwing narrower exceptions is not a BC change; apply it directly instead of announcing it.',
-                206,
+                207,
             ],
             [
                 'ExceptionChange on "ExceptionChangeCases::unchangedIsCovered()": every announced exception is already covered by the current "@throws" contract. Throwing narrower exceptions is not a BC change; apply it directly instead of announcing it.',
-                214,
+                215,
             ],
             [
                 'ExceptionChange on "ExceptionChangeCases::notAThrowable()": announced class "ArrayObject" is not a Throwable.',
-                222,
+                223,
             ],
             [
                 'ExceptionChange on "ExceptionChangeCases::unresolvableExceptionClass()": announced exception "UnimportedException" is not a resolvable class. Reference exception classes via ::class.',
-                230,
+                231,
             ],
             [
                 'ParameterDefaultValueChange on "ParameterDefaultValueChangeCases::missingParameter()": parameter "missing" does not exist.',
-                246,
+                247,
             ],
             [
                 'ParameterDefaultValueChange on "ParameterDefaultValueChangeCases::requiredParameter()": parameter "required" has no current default value.',
-                251,
+                252,
             ],
             [
                 'ParameterDefaultValueChange on "ParameterDefaultValueChangeCases::unchangedDefault()": announced default value for parameter "value" is already current.',
-                256,
+                257,
             ],
             [
                 'ParameterRemoval on "ParameterRemovalCases::requiredParameter()": parameter "required" is required. Removing a required parameter is not actionable before the major release; introduce a new method or factory with the future signature and deprecate the old method instead.',
-                274,
+                275,
             ],
             [
                 'ParameterRemoval on "ParameterRemovalCases::leadingDollar()": parameter name "$optional" must be given without the leading "$".',
-                287,
+                288,
             ],
             [
                 'ParameterRemoval on "ParameterRemovalCases::leadingDollar()": parameter "$optional" does not exist.',
-                287,
+                288,
+            ],
+            [
+                'NamespaceChange on "NamespaceChangeWithWrongLocation": newLocation "Shopware\Core\Some\Other\Location" must be the fully qualified class name ending in "NamespaceChangeWithWrongLocation". A namespace move keeps the class name.',
+                302,
             ],
         ]);
     }

--- a/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/data/BCChangeAttributeUsageRule/BCChangeAttributeUsage.php
+++ b/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/data/BCChangeAttributeUsageRule/BCChangeAttributeUsage.php
@@ -6,6 +6,7 @@ use Shopware\Core\Framework\Deprecation\BCChange\BecomesAbstract;
 use Shopware\Core\Framework\Deprecation\BCChange\BecomesFinal;
 use Shopware\Core\Framework\Deprecation\BCChange\BecomesInternal;
 use Shopware\Core\Framework\Deprecation\BCChange\ExceptionChange;
+use Shopware\Core\Framework\Deprecation\BCChange\NamespaceChange;
 use Shopware\Core\Framework\Deprecation\BCChange\NewOptionalParameter;
 use Shopware\Core\Framework\Deprecation\BCChange\NewRequiredParameter;
 use Shopware\Core\Framework\Deprecation\BCChange\ParameterDefaultValueChange;
@@ -296,4 +297,14 @@ class ParameterRemovalCases
             Feature::triggerDeprecationOrThrow('v6.8.0.0', 'Passing a non-default value for $legacy is deprecated');
         }
     }
+}
+
+#[NamespaceChange(version: 'v6.8.0', newLocation: 'Shopware\Core\Some\Other\Location')]
+class NamespaceChangeWithWrongLocation
+{
+}
+
+#[NamespaceChange(version: 'v6.8.0', newLocation: 'Shopware\Core\Some\Other\NamespaceChangeWithCorrectLocation')]
+class NamespaceChangeWithCorrectLocation
+{
 }

--- a/tests/integration/Core/Checkout/Document/DocumentControllerTest.php
+++ b/tests/integration/Core/Checkout/Document/DocumentControllerTest.php
@@ -30,6 +30,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Pricing\CashRoundingConfig;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\AdminApiTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\CountryAddToSalesChannelTestBehaviour;
@@ -69,6 +70,8 @@ class DocumentControllerTest extends TestCase
 
     protected function setUp(): void
     {
+        Feature::skipTestIfActive('v6.9.0.0', $this); // tested class will be removed
+
         parent::setUp();
 
         $this->connection = static::getContainer()->get(Connection::class);

--- a/tests/integration/Core/Checkout/Document/DocumentGeneratorControllerTest.php
+++ b/tests/integration/Core/Checkout/Document/DocumentGeneratorControllerTest.php
@@ -29,6 +29,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Pricing\CashRoundingConfig;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\AdminApiTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\CountryAddToSalesChannelTestBehaviour;
@@ -66,6 +67,8 @@ class DocumentGeneratorControllerTest extends TestCase
 
     protected function setUp(): void
     {
+        Feature::skipTestIfActive('v6.9.0.0', $this); // tested class will be removed
+
         parent::setUp();
 
         $this->connection = static::getContainer()->get(Connection::class);

--- a/tests/integration/Core/Checkout/Document/Renderer/CreditNoteRendererTest.php
+++ b/tests/integration/Core/Checkout/Document/Renderer/CreditNoteRendererTest.php
@@ -38,6 +38,7 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\VersionManager;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\WriteContext;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Rule\Collector\RuleConditionRegistry;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -84,6 +85,8 @@ class CreditNoteRendererTest extends TestCase
 
     protected function setUp(): void
     {
+        Feature::skipTestIfActive('v6.9.0.0', $this); // tested class will be removed
+
         parent::setUp();
 
         $this->context = Context::createDefaultContext();

--- a/tests/integration/Core/Checkout/Document/Renderer/DeliveryNoteRendererTest.php
+++ b/tests/integration/Core/Checkout/Document/Renderer/DeliveryNoteRendererTest.php
@@ -21,6 +21,7 @@ use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Adapter\Translation\Translator;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\Framework\Validation\DataBag\RequestDataBag;
@@ -56,6 +57,8 @@ class DeliveryNoteRendererTest extends TestCase
 
     protected function setUp(): void
     {
+        Feature::skipTestIfActive('v6.9.0.0', $this); // tested class will be removed
+
         parent::setUp();
 
         $this->context = Context::createDefaultContext();

--- a/tests/integration/Core/Checkout/Document/Renderer/InvoiceRendererTest.php
+++ b/tests/integration/Core/Checkout/Document/Renderer/InvoiceRendererTest.php
@@ -59,6 +59,8 @@ class InvoiceRendererTest extends TestCase
 
     protected function setUp(): void
     {
+        Feature::skipTestIfActive('v6.9.0.0', $this);
+
         $this->context = Context::createDefaultContext();
 
         $priceRuleId = Uuid::randomHex();

--- a/tests/integration/Core/Checkout/Document/Renderer/StornoRendererTest.php
+++ b/tests/integration/Core/Checkout/Document/Renderer/StornoRendererTest.php
@@ -26,6 +26,7 @@ use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Adapter\Translation\Translator;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\Framework\Validation\DataBag\RequestDataBag;
@@ -63,6 +64,8 @@ class StornoRendererTest extends TestCase
 
     protected function setUp(): void
     {
+        Feature::skipTestIfActive('v6.9.0.0', $this); // tested class will be removed
+
         parent::setUp();
 
         $this->context = Context::createDefaultContext();

--- a/tests/integration/Core/Checkout/Document/Renderer/ZugferdCancellationInvoiceRendererTest.php
+++ b/tests/integration/Core/Checkout/Document/Renderer/ZugferdCancellationInvoiceRendererTest.php
@@ -13,6 +13,7 @@ use Shopware\Core\Checkout\Document\Renderer\ZugferdCancellationInvoiceRenderer;
 use Shopware\Core\Checkout\Document\Service\DocumentGenerator;
 use Shopware\Core\Checkout\Document\Struct\DocumentGenerateOperation;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SalesChannel\Context\SalesChannelContextFactory;
@@ -43,6 +44,8 @@ class ZugferdCancellationInvoiceRendererTest extends TestCase
 
     protected function setUp(): void
     {
+        Feature::skipTestIfActive('v6.9.0.0', $this); // tested class will be removed
+
         $this->context = Context::createDefaultContext();
 
         $priceRuleId = Uuid::randomHex();

--- a/tests/integration/Core/Checkout/Document/Renderer/ZugferdCreditNoteRendererTest.php
+++ b/tests/integration/Core/Checkout/Document/Renderer/ZugferdCreditNoteRendererTest.php
@@ -58,6 +58,8 @@ class ZugferdCreditNoteRendererTest extends TestCase
 
     protected function setUp(): void
     {
+        Feature::skipTestIfActive('v6.9.0.0', $this); // tested class will be removed
+
         $this->context = Context::createDefaultContext();
 
         $priceRuleId = Uuid::randomHex();

--- a/tests/integration/Core/Checkout/Document/Renderer/ZugferdRendererTest.php
+++ b/tests/integration/Core/Checkout/Document/Renderer/ZugferdRendererTest.php
@@ -9,6 +9,7 @@ use Shopware\Core\Checkout\Document\Renderer\RenderedDocument;
 use Shopware\Core\Checkout\Document\Renderer\ZugferdRenderer;
 use Shopware\Core\Checkout\Document\Struct\DocumentGenerateOperation;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SalesChannel\Context\SalesChannelContextFactory;
@@ -35,6 +36,8 @@ class ZugferdRendererTest extends TestCase
 
     protected function setUp(): void
     {
+        Feature::skipTestIfActive('v6.9.0.0', $this); // tested class will be removed
+
         $this->context = Context::createDefaultContext();
 
         $priceRuleId = Uuid::randomHex();

--- a/tests/integration/Core/Checkout/Document/SalesChannel/DocumentRouteTest.php
+++ b/tests/integration/Core/Checkout/Document/SalesChannel/DocumentRouteTest.php
@@ -70,6 +70,8 @@ class DocumentRouteTest extends TestCase
 
     protected function setUp(): void
     {
+        Feature::skipTestIfActive('v6.9.0.0', $this); // tested class will be removed
+
         $this->ids = new IdsCollection();
 
         $this->documentGenerator = static::getContainer()->get(DocumentGenerator::class);

--- a/tests/integration/Core/Checkout/Document/Service/DocumentConfigLoaderTest.php
+++ b/tests/integration/Core/Checkout/Document/Service/DocumentConfigLoaderTest.php
@@ -9,6 +9,7 @@ use Shopware\Core\Checkout\Document\Renderer\InvoiceRenderer;
 use Shopware\Core\Checkout\Document\Service\DocumentConfigLoader;
 use Shopware\Core\Content\Media\MediaEntity;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\DatabaseTransactionBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -37,6 +38,8 @@ class DocumentConfigLoaderTest extends TestCase
 
     protected function setUp(): void
     {
+        Feature::skipTestIfActive('v6.9.0.0', $this);
+
         parent::setUp();
 
         $this->context = Context::createDefaultContext();

--- a/tests/integration/Core/Checkout/Document/Service/DocumentGeneratorTest.php
+++ b/tests/integration/Core/Checkout/Document/Service/DocumentGeneratorTest.php
@@ -33,6 +33,7 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Util\Random;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -68,6 +69,8 @@ class DocumentGeneratorTest extends TestCase
 
     protected function setUp(): void
     {
+        Feature::skipTestIfActive('v6.9.0.0', $this);
+
         parent::setUp();
 
         $this->context = Context::createDefaultContext();

--- a/tests/integration/Core/Checkout/Document/Service/DocumentMergerTest.php
+++ b/tests/integration/Core/Checkout/Document/Service/DocumentMergerTest.php
@@ -22,6 +22,7 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Util\Random;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -60,6 +61,8 @@ class DocumentMergerTest extends TestCase
 
     protected function setUp(): void
     {
+        Feature::skipTestIfActive('v6.9.0.0', $this);
+
         parent::setUp();
 
         $this->context = Context::createDefaultContext();

--- a/tests/integration/Core/Checkout/Document/Service/PdfRendererTest.php
+++ b/tests/integration/Core/Checkout/Document/Service/PdfRendererTest.php
@@ -12,6 +12,7 @@ use Shopware\Core\Checkout\Document\Service\DocumentGenerator;
 use Shopware\Core\Checkout\Document\Service\PdfRenderer;
 use Shopware\Core\Checkout\Document\Struct\DocumentGenerateOperation;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SalesChannel\Context\SalesChannelContextFactory;
@@ -40,6 +41,8 @@ class PdfRendererTest extends TestCase
 
     protected function setUp(): void
     {
+        Feature::skipTestIfActive('v6.9.0.0', $this);
+
         parent::setUp();
 
         $this->context = Context::createDefaultContext();

--- a/tests/integration/Core/Checkout/Document/Service/ReferenceInvoiceLoaderTest.php
+++ b/tests/integration/Core/Checkout/Document/Service/ReferenceInvoiceLoaderTest.php
@@ -10,6 +10,7 @@ use Shopware\Core\Checkout\Document\Renderer\ZugferdRenderer;
 use Shopware\Core\Checkout\Document\Service\ReferenceInvoiceLoader;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SalesChannel\Context\SalesChannelContextFactory;
@@ -36,6 +37,8 @@ class ReferenceInvoiceLoaderTest extends TestCase
 
     protected function setUp(): void
     {
+        Feature::skipTestIfActive('v6.9.0.0', $this); // tested class will be removed
+
         parent::setUp();
 
         $this->referenceInvoiceLoader = static::getContainer()->get(ReferenceInvoiceLoader::class);

--- a/tests/integration/Core/Checkout/Document/Subscriber/DocumentDeleteSubscriberTest.php
+++ b/tests/integration/Core/Checkout/Document/Subscriber/DocumentDeleteSubscriberTest.php
@@ -21,6 +21,7 @@ use Shopware\Core\Framework\Api\Controller\SyncController;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Event\EntityDeleteEvent;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\AdminApiTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\DatabaseTransactionBehaviour;
@@ -63,6 +64,8 @@ class DocumentDeleteSubscriberTest extends TestCase
 
     protected function setUp(): void
     {
+        Feature::skipTestIfActive('v6.9.0.0', $this); // tested class will be removed
+
         parent::setUp();
 
         $this->context = Context::createDefaultContext();

--- a/tests/integration/Core/Checkout/DocumentV2/Renderer/DocumentRendererSnapshotTest.php
+++ b/tests/integration/Core/Checkout/DocumentV2/Renderer/DocumentRendererSnapshotTest.php
@@ -331,14 +331,14 @@ class DocumentRendererSnapshotTest extends TestCase
         $companyCountry = $withoutCompanyCountry ? new CountryEntity() : $this->companyCountry;
 
         $data = [
-            DocumentMetaProvider::KEY => $this->buildMeta($companyCountry, $itemsPerPage),
+            DocumentMetaProvider::KEY->value => $this->buildMeta($companyCountry, $itemsPerPage),
         ];
 
         $data += match ($documentType) {
-            DocumentType::INVOICE => [InvoiceDataProvider::KEY => $this->buildInvoiceRenderData($order)],
-            DocumentType::CANCELLATION_INVOICE => [CancellationInvoiceDataProvider::KEY => $this->buildCancellationInvoiceRenderData($order)],
-            DocumentType::CREDIT_NOTE => [CreditNoteDataProvider::KEY => $this->buildCreditNoteRenderData($order)],
-            DocumentType::DELIVERY_NOTE => [DeliveryNoteDataProvider::KEY => $this->buildDeliveryNoteRenderData()],
+            DocumentType::INVOICE => [InvoiceDataProvider::KEY->value => $this->buildInvoiceRenderData($order)],
+            DocumentType::CANCELLATION_INVOICE => [CancellationInvoiceDataProvider::KEY->value => $this->buildCancellationInvoiceRenderData($order)],
+            DocumentType::CREDIT_NOTE => [CreditNoteDataProvider::KEY->value => $this->buildCreditNoteRenderData($order)],
+            DocumentType::DELIVERY_NOTE => [DeliveryNoteDataProvider::KEY->value => $this->buildDeliveryNoteRenderData()],
         };
 
         return $data;

--- a/tests/integration/Core/Checkout/Order/SalesChannel/OrderRouteTest.php
+++ b/tests/integration/Core/Checkout/Order/SalesChannel/OrderRouteTest.php
@@ -14,6 +14,10 @@ use Shopware\Core\Checkout\Document\FileGenerator\FileTypes;
 use Shopware\Core\Checkout\Document\Renderer\DeliveryNoteRenderer;
 use Shopware\Core\Checkout\Document\Service\DocumentGenerator;
 use Shopware\Core\Checkout\Document\Struct\DocumentGenerateOperation;
+use Shopware\Core\Checkout\DocumentV2\DocumentFormat;
+use Shopware\Core\Checkout\DocumentV2\Generation\DocumentGenerationRequest;
+use Shopware\Core\Checkout\DocumentV2\Generation\DocumentGenerator as DocumentV2Generator;
+use Shopware\Core\Checkout\DocumentV2\Provider\DeliveryNoteDataProvider;
 use Shopware\Core\Checkout\Order\Aggregate\OrderDelivery\OrderDeliveryStates;
 use Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionStates;
 use Shopware\Core\Checkout\Order\OrderCollection;
@@ -28,6 +32,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Pricing\CashRoundingConfig;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\RequestCriteriaBuilder;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\MailTemplateTestBehaviour;
@@ -43,6 +48,7 @@ use Shopware\Core\Test\Integration\Traits\Promotion\PromotionIntegrationTestBeha
 use Shopware\Core\Test\Integration\Traits\Promotion\PromotionTestFixtureBehaviour;
 use Shopware\Core\Test\TestDefaults;
 use Shopware\Storefront\Controller\AccountOrderController;
+use Shopware\Tests\Integration\Core\Checkout\DocumentV2\DocumentV2Trait;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -53,11 +59,14 @@ use Symfony\Component\HttpFoundation\Response;
 #[Group('store-api')]
 class OrderRouteTest extends TestCase
 {
+    use DocumentV2Trait;
     use IntegrationTestBehaviour;
     use MailTemplateTestBehaviour;
     use PromotionIntegrationTestBehaviour;
     use PromotionTestFixtureBehaviour;
-    use SalesChannelApiTestBehaviour;
+    use SalesChannelApiTestBehaviour {
+        SalesChannelApiTestBehaviour::createCustomer insteadof DocumentV2Trait;
+    }
 
     private KernelBrowser $browser;
 
@@ -694,6 +703,27 @@ class OrderRouteTest extends TestCase
     {
         $criteria = new Criteria();
         $criteria->addFilter(new EqualsFilter('technicalName', DeliveryNoteRenderer::TYPE));
+
+        if (Feature::isActive('v6.9.0.0')) {
+            $this->context = Context::createDefaultContext();
+            $this->seedDemoBaseConfig(DeliveryNoteDataProvider::KEY->value);
+
+            $documentId = static::getContainer()->get(DocumentV2Generator::class)->generate(
+                new DocumentGenerationRequest($orderId, DeliveryNoteDataProvider::KEY->value, [DocumentFormat::PDF], '1001'),
+                Context::createDefaultContext(),
+            )->getId();
+
+            // v2 has no displayInCustomerAccount input, set it on the row so the store api filter matches v1.
+            static::getContainer()->get('document.repository')->update([
+                [
+                    'id' => $documentId,
+                    'sent' => $sent,
+                    'config' => ['documentNumber' => '1001', 'displayInCustomerAccount' => $showInCustomerAccount],
+                ],
+            ], Context::createDefaultContext());
+
+            return;
+        }
 
         $operation = new DocumentGenerateOperation(
             $orderId,

--- a/tests/integration/Core/Checkout/Order/SalesChannel/OrderRouteTest.php
+++ b/tests/integration/Core/Checkout/Order/SalesChannel/OrderRouteTest.php
@@ -48,7 +48,6 @@ use Shopware\Core\Test\Integration\Traits\Promotion\PromotionIntegrationTestBeha
 use Shopware\Core\Test\Integration\Traits\Promotion\PromotionTestFixtureBehaviour;
 use Shopware\Core\Test\TestDefaults;
 use Shopware\Storefront\Controller\AccountOrderController;
-use Shopware\Tests\Integration\Core\Checkout\DocumentV2\DocumentV2Trait;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -59,14 +58,11 @@ use Symfony\Component\HttpFoundation\Response;
 #[Group('store-api')]
 class OrderRouteTest extends TestCase
 {
-    use DocumentV2Trait;
     use IntegrationTestBehaviour;
     use MailTemplateTestBehaviour;
     use PromotionIntegrationTestBehaviour;
     use PromotionTestFixtureBehaviour;
-    use SalesChannelApiTestBehaviour {
-        SalesChannelApiTestBehaviour::createCustomer insteadof DocumentV2Trait;
-    }
+    use SalesChannelApiTestBehaviour;
 
     private KernelBrowser $browser;
 
@@ -705,11 +701,10 @@ class OrderRouteTest extends TestCase
         $criteria->addFilter(new EqualsFilter('technicalName', DeliveryNoteRenderer::TYPE));
 
         if (Feature::isActive('v6.9.0.0')) {
-            $this->context = Context::createDefaultContext();
-            $this->seedDemoBaseConfig(DeliveryNoteDataProvider::KEY->value);
+            $this->seedDocumentBaseConfig(DeliveryNoteDataProvider::KEY->value);
 
             $documentId = static::getContainer()->get(DocumentV2Generator::class)->generate(
-                new DocumentGenerationRequest($orderId, DeliveryNoteDataProvider::KEY->value, [DocumentFormat::PDF], '1001'),
+                new DocumentGenerationRequest($orderId, DeliveryNoteDataProvider::KEY->value, [DocumentFormat::PDF], '1001', deliveryDate: '2026-05-05T12:00:00+00:00'),
                 Context::createDefaultContext(),
             )->getId();
 
@@ -742,6 +737,27 @@ class OrderRouteTest extends TestCase
                 'sent' => $sent,
             ],
         ], Context::createDefaultContext());
+    }
+
+    private function seedDocumentBaseConfig(string $documentType): void
+    {
+        $context = Context::createDefaultContext();
+
+        $companyCountryId = static::getContainer()->get('country.repository')
+            ->searchIds((new Criteria())->addFilter(new EqualsFilter('iso', 'DE'))->setLimit(1), $context)
+            ->firstId();
+
+        $documentTypeId = static::getContainer()->get('document_type.repository')
+            ->searchIds((new Criteria())->addFilter(new EqualsFilter('technicalName', $documentType)), $context)
+            ->firstId();
+
+        static::getContainer()->get('document_base_config.repository')->upsert([[
+            'id' => Uuid::randomHex(),
+            'name' => 'test',
+            'typeId' => $documentTypeId,
+            'documentTypeId' => $documentTypeId,
+            'config' => ['companyCountryId' => $companyCountryId],
+        ]], $context);
     }
 
     private function handleMailSentEvent(MailSentEvent $event): void

--- a/tests/integration/Core/Content/Flow/SendMailActionTest.php
+++ b/tests/integration/Core/Content/Flow/SendMailActionTest.php
@@ -19,6 +19,9 @@ use Shopware\Core\Checkout\Document\Renderer\DeliveryNoteRenderer;
 use Shopware\Core\Checkout\Document\Renderer\InvoiceRenderer;
 use Shopware\Core\Checkout\Document\Service\DocumentGenerator;
 use Shopware\Core\Checkout\Document\Struct\DocumentGenerateOperation;
+use Shopware\Core\Checkout\DocumentV2\DocumentFormat;
+use Shopware\Core\Checkout\DocumentV2\Generation\DocumentGenerationRequest;
+use Shopware\Core\Checkout\DocumentV2\Generation\DocumentGenerator as DocumentV2Generator;
 use Shopware\Core\Checkout\Order\Event\OrderStateMachineStateChangeEvent;
 use Shopware\Core\Checkout\Order\OrderCollection;
 use Shopware\Core\Checkout\Order\OrderEntity;
@@ -61,6 +64,7 @@ use Shopware\Core\System\Locale\LanguageLocaleCodeProvider;
 use Shopware\Core\System\StateMachine\Loader\InitialStateIdLoader;
 use Shopware\Core\Test\Generator;
 use Shopware\Core\Test\TestDefaults;
+use Shopware\Tests\Integration\Core\Checkout\DocumentV2\DocumentV2Trait;
 use Symfony\Component\Mailer\Transport\TransportInterface;
 use Symfony\Component\Mime\Email;
 use Symfony\Component\Mime\Part\DataPart;
@@ -71,6 +75,7 @@ use Symfony\Component\Mime\Part\DataPart;
 #[Package('after-sales')]
 class SendMailActionTest extends TestCase
 {
+    use DocumentV2Trait;
     use IntegrationTestBehaviour;
 
     /**
@@ -1129,10 +1134,21 @@ class SendMailActionTest extends TestCase
 
     private function createDocumentWithFile(string $orderId, Context $context, string $documentType = InvoiceRenderer::TYPE): string
     {
-        $documentGenerator = static::getContainer()->get(DocumentGenerator::class);
+        if (Feature::isActive('v6.9.0.0')) {
+            $this->context = $context;
+            $this->seedDemoBaseConfig($documentType);
 
-        $operation = new DocumentGenerateOperation($orderId, FileTypes::PDF, []);
-        $document = $documentGenerator->generate($documentType, [$orderId => $operation], $context)->getSuccess()->first();
+            return static::getContainer()->get(DocumentV2Generator::class)->generate(
+                new DocumentGenerationRequest($orderId, $documentType, [DocumentFormat::PDF]),
+                $context,
+            )->getId();
+        }
+
+        $document = Feature::silent('v6.9.0.0', static fn () => static::getContainer()->get(DocumentGenerator::class)->generate(
+            $documentType,
+            [$orderId => new DocumentGenerateOperation($orderId, FileTypes::PDF, [])],
+            $context,
+        )->getSuccess()->first());
 
         static::assertNotNull($document);
 

--- a/tests/integration/Core/Content/Flow/SendMailActionTest.php
+++ b/tests/integration/Core/Content/Flow/SendMailActionTest.php
@@ -1139,7 +1139,7 @@ class SendMailActionTest extends TestCase
             $this->seedDemoBaseConfig($documentType);
 
             return static::getContainer()->get(DocumentV2Generator::class)->generate(
-                new DocumentGenerationRequest($orderId, $documentType, [DocumentFormat::PDF]),
+                new DocumentGenerationRequest($orderId, $documentType, [DocumentFormat::PDF], deliveryDate: self::DOCUMENT_DATE),
                 $context,
             )->getId();
         }

--- a/tests/integration/Core/Content/MailTemplate/Api/MailActionControllerTest.php
+++ b/tests/integration/Core/Content/MailTemplate/Api/MailActionControllerTest.php
@@ -356,7 +356,7 @@ class MailActionControllerTest extends TestCase
             $this->seedDemoBaseConfig($documentType);
 
             return static::getContainer()->get(DocumentV2Generator::class)->generate(
-                new DocumentGenerationRequest($orderId, $documentType, [DocumentFormat::PDF]),
+                new DocumentGenerationRequest($orderId, $documentType, [DocumentFormat::PDF], deliveryDate: self::DOCUMENT_DATE),
                 $context,
             )->getId();
         }

--- a/tests/integration/Core/Content/MailTemplate/Api/MailActionControllerTest.php
+++ b/tests/integration/Core/Content/MailTemplate/Api/MailActionControllerTest.php
@@ -12,6 +12,9 @@ use Shopware\Core\Checkout\Document\FileGenerator\FileTypes;
 use Shopware\Core\Checkout\Document\Renderer\InvoiceRenderer;
 use Shopware\Core\Checkout\Document\Service\DocumentGenerator;
 use Shopware\Core\Checkout\Document\Struct\DocumentGenerateOperation;
+use Shopware\Core\Checkout\DocumentV2\DocumentFormat;
+use Shopware\Core\Checkout\DocumentV2\Generation\DocumentGenerationRequest;
+use Shopware\Core\Checkout\DocumentV2\Generation\DocumentGenerator as DocumentV2Generator;
 use Shopware\Core\Checkout\Order\OrderDefinition;
 use Shopware\Core\Checkout\Order\OrderEntity;
 use Shopware\Core\Checkout\Order\OrderStates;
@@ -25,6 +28,7 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Pricing\CashRoundingConfig;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\Serializer\StructNormalizer;
 use Shopware\Core\Framework\Test\TestCaseBase\AdminApiTestBehaviour;
@@ -35,6 +39,7 @@ use Shopware\Core\System\SalesChannel\SalesChannelDefinition;
 use Shopware\Core\System\SalesChannel\SalesChannelEntity;
 use Shopware\Core\System\StateMachine\Loader\InitialStateIdLoader;
 use Shopware\Core\Test\TestDefaults;
+use Shopware\Tests\Integration\Core\Checkout\DocumentV2\DocumentV2Trait;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Serializer\Encoder\JsonEncoder;
 use Symfony\Component\Serializer\Serializer;
@@ -46,6 +51,7 @@ use Symfony\Component\Serializer\Serializer;
 class MailActionControllerTest extends TestCase
 {
     use AdminApiTestBehaviour;
+    use DocumentV2Trait;
     use IntegrationTestBehaviour;
 
     public function testSendSuccess(): void
@@ -345,10 +351,21 @@ class MailActionControllerTest extends TestCase
 
     private function createDocumentWithFile(string $orderId, Context $context, string $documentType = InvoiceRenderer::TYPE): string
     {
-        $documentGenerator = static::getContainer()->get(DocumentGenerator::class);
+        if (Feature::isActive('v6.9.0.0')) {
+            $this->context = $context;
+            $this->seedDemoBaseConfig($documentType);
 
-        $operation = new DocumentGenerateOperation($orderId, FileTypes::PDF, []);
-        $document = $documentGenerator->generate($documentType, [$orderId => $operation], $context)->getSuccess()->first();
+            return static::getContainer()->get(DocumentV2Generator::class)->generate(
+                new DocumentGenerationRequest($orderId, $documentType, [DocumentFormat::PDF]),
+                $context,
+            )->getId();
+        }
+
+        $document = Feature::silent('v6.9.0.0', static fn () => static::getContainer()->get(DocumentGenerator::class)->generate(
+            $documentType,
+            [$orderId => new DocumentGenerateOperation($orderId, FileTypes::PDF, [])],
+            $context,
+        )->getSuccess()->first());
 
         static::assertNotNull($document);
 

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Dbal/FieldResolver/ManyToOneAssociationFieldResolverTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Dbal/FieldResolver/ManyToOneAssociationFieldResolverTest.php
@@ -8,6 +8,10 @@ use Shopware\Core\Checkout\Document\Aggregate\DocumentType\DocumentTypeDefinitio
 use Shopware\Core\Checkout\Document\DocumentCollection;
 use Shopware\Core\Checkout\Document\DocumentDefinition;
 use Shopware\Core\Checkout\Document\DocumentEntity;
+use Shopware\Core\Checkout\DocumentV2\DocumentFormat;
+use Shopware\Core\Checkout\DocumentV2\DocumentType;
+use Shopware\Core\Checkout\DocumentV2\Generation\DocumentGenerationRequest;
+use Shopware\Core\Checkout\DocumentV2\Generation\DocumentGenerator as DocumentV2Generator;
 use Shopware\Core\Checkout\Order\OrderCollection;
 use Shopware\Core\Checkout\Order\OrderDefinition;
 use Shopware\Core\Checkout\Order\OrderEntity;
@@ -22,6 +26,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -31,7 +36,7 @@ use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\Test\Stub\Doctrine\QueryBuilderDataExtractor;
 use Shopware\Core\Test\Stub\Framework\IdsCollection;
 use Shopware\Core\Test\TestDefaults;
-use Shopware\Tests\Integration\Core\Checkout\Document\DocumentTrait;
+use Shopware\Tests\Integration\Core\Checkout\DocumentV2\DocumentV2Trait;
 
 /**
  * @internal
@@ -39,7 +44,7 @@ use Shopware\Tests\Integration\Core\Checkout\Document\DocumentTrait;
 #[Package('framework')]
 class ManyToOneAssociationFieldResolverTest extends TestCase
 {
-    use DocumentTrait;
+    use DocumentV2Trait;
     use KernelTestBehaviour;
 
     protected ManyToOneAssociationFieldResolver $resolver;
@@ -228,7 +233,16 @@ class ManyToOneAssociationFieldResolverTest extends TestCase
         static::assertInstanceOf(OrderEntity::class, $order);
 
         // 2. Generate a document attached to the order
-        $this->createDocument('invoice', $orderId, [], $this->context);
+        if (Feature::isActive('v6.9.0.0')) {
+            $this->seedDemoBaseConfig(DocumentType::INVOICE->value);
+
+            static::getContainer()->get(DocumentV2Generator::class)->generate(
+                new DocumentGenerationRequest($orderId, DocumentType::INVOICE, [DocumentFormat::PDF]),
+                $this->context,
+            );
+        } else {
+            Feature::silent('v6.9.0.0', fn () => $this->createDocument('invoice', $orderId, [], $this->context));
+        }
 
         // 3. Set created order version to be lexicographically smaller than the live version
         $this->connection->executeStatement(

--- a/tests/integration/Storefront/Controller/DocumentControllerTest.php
+++ b/tests/integration/Storefront/Controller/DocumentControllerTest.php
@@ -71,6 +71,8 @@ class DocumentControllerTest extends TestCase
 
     protected function setUp(): void
     {
+        Feature::skipTestIfActive('v6.9.0.0', $this); // tested class will be removed
+
         parent::setUp();
 
         $this->documentGenerator = static::getContainer()->get(DocumentGenerator::class);

--- a/tests/unit/Core/Checkout/Document/Api/DocumentTypeTechnicalNameFkResolverTest.php
+++ b/tests/unit/Core/Checkout/Document/Api/DocumentTypeTechnicalNameFkResolverTest.php
@@ -7,6 +7,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\Document\Api\DocumentTypeTechnicalNameFkResolver;
 use Shopware\Core\Framework\Api\Sync\FkReference;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 
 /**
@@ -16,6 +17,11 @@ use Shopware\Core\Framework\Log\Package;
 #[CoversClass(DocumentTypeTechnicalNameFkResolver::class)]
 class DocumentTypeTechnicalNameFkResolverTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        Feature::skipTestIfActive('v6.9.0.0', $this); // tested class will be removed
+    }
+
     public function testGetName(): void
     {
         static::assertSame('document_type.technical_name', DocumentTypeTechnicalNameFkResolver::getName());

--- a/tests/unit/Core/Checkout/Document/DocumentConfigurationFactoryTest.php
+++ b/tests/unit/Core/Checkout/Document/DocumentConfigurationFactoryTest.php
@@ -6,6 +6,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\Document\DocumentConfiguration;
 use Shopware\Core\Checkout\Document\DocumentConfigurationFactory;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\Country\CountryEntity;
 
@@ -16,6 +17,11 @@ use Shopware\Core\System\Country\CountryEntity;
 #[CoversClass(DocumentConfigurationFactory::class)]
 class DocumentConfigurationFactoryTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        Feature::skipTestIfActive('v6.9.0.0', $this); // tested class will be removed
+    }
+
     public function testMergeConfigurationConvertsArrayToEntityObjectAndUseSetterMethod(): void
     {
         $baseConfig = new DocumentConfiguration();

--- a/tests/unit/Core/Checkout/Document/Renderer/CreditNoteRendererTest.php
+++ b/tests/unit/Core/Checkout/Document/Renderer/CreditNoteRendererTest.php
@@ -31,6 +31,7 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\Language\LanguageEntity;
@@ -48,6 +49,11 @@ use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 class CreditNoteRendererTest extends TestCase
 {
     private const ORDER_ID = '01995837666372fc8eb01ca3aa815ee1';
+
+    protected function setUp(): void
+    {
+        Feature::skipTestIfActive('v6.9.0.0', $this); // tested class will be removed
+    }
 
     /**
      * @param array<int, string> $creditItemIds

--- a/tests/unit/Core/Checkout/Document/Renderer/DeliveryNoteRendererTest.php
+++ b/tests/unit/Core/Checkout/Document/Renderer/DeliveryNoteRendererTest.php
@@ -18,6 +18,7 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\Language\LanguageEntity;
@@ -33,6 +34,11 @@ use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 #[CoversClass(DeliveryNoteRenderer::class)]
 class DeliveryNoteRendererTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        Feature::skipTestIfActive('v6.9.0.0', $this); // tested class will be removed
+    }
+
     public function testRenderCreatesNewOrderVersion(): void
     {
         $context = Context::createDefaultContext();

--- a/tests/unit/Core/Checkout/Document/Renderer/InvoiceRendererTest.php
+++ b/tests/unit/Core/Checkout/Document/Renderer/InvoiceRendererTest.php
@@ -33,6 +33,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
 use Shopware\Core\Framework\DataAbstractionLayer\TaxFreeConfig;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\Country\CountryEntity;
@@ -57,6 +58,11 @@ use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 class InvoiceRendererTest extends TestCase
 {
     private const COUNTRY_ID = 'country-id';
+
+    protected function setUp(): void
+    {
+        Feature::skipTestIfActive('v6.9.0.0', $this); // tested class will be removed
+    }
 
     /**
      * @param OrderSettings $orderSettings

--- a/tests/unit/Core/Checkout/Document/Renderer/OrderDocumentCriteriaFactoryTest.php
+++ b/tests/unit/Core/Checkout/Document/Renderer/OrderDocumentCriteriaFactoryTest.php
@@ -6,6 +6,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\Document\Renderer\OrderDocumentCriteriaFactory;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\Test\Annotation\DisabledFeatures;
@@ -17,6 +18,11 @@ use Shopware\Core\Test\Annotation\DisabledFeatures;
 #[CoversClass(OrderDocumentCriteriaFactory::class)]
 class OrderDocumentCriteriaFactoryTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        Feature::skipTestIfActive('v6.9.0.0', $this); // tested class will be removed
+    }
+
     public function testCreate(): void
     {
         $id = Uuid::randomHex();

--- a/tests/unit/Core/Checkout/Document/Renderer/ZugferdCancellationInvoiceRendererTest.php
+++ b/tests/unit/Core/Checkout/Document/Renderer/ZugferdCancellationInvoiceRendererTest.php
@@ -24,6 +24,7 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\NumberRange\ValueGenerator\NumberRangeValueGeneratorInterface;
@@ -39,6 +40,11 @@ use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 class ZugferdCancellationInvoiceRendererTest extends TestCase
 {
     private const ORDER_ID = '0192b305fddb7347be83a311a82f0649';
+
+    protected function setUp(): void
+    {
+        Feature::skipTestIfActive('v6.9.0.0', $this); // tested class will be removed
+    }
 
     public function testSupports(): void
     {

--- a/tests/unit/Core/Checkout/Document/Renderer/ZugferdCreditNoteRendererTest.php
+++ b/tests/unit/Core/Checkout/Document/Renderer/ZugferdCreditNoteRendererTest.php
@@ -29,6 +29,7 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\NumberRange\ValueGenerator\NumberRangeValueGeneratorInterface;
@@ -46,6 +47,11 @@ class ZugferdCreditNoteRendererTest extends TestCase
     private const ORDER_ID = '0192b305fddb7347be83a311a82f0649';
 
     private const INVOICE_ID = '01995837666372fc8eb01ca3aa815ee2';
+
+    protected function setUp(): void
+    {
+        Feature::skipTestIfActive('v6.9.0.0', $this); // tested class will be removed
+    }
 
     /**
      * @param array<int, string> $creditItemIds

--- a/tests/unit/Core/Checkout/Document/Renderer/ZugferdEmbeddedCancellationInvoiceRendererTest.php
+++ b/tests/unit/Core/Checkout/Document/Renderer/ZugferdEmbeddedCancellationInvoiceRendererTest.php
@@ -12,6 +12,7 @@ use Shopware\Core\Checkout\Document\Renderer\ZugferdEmbeddedCancellationInvoiceR
 use Shopware\Core\Checkout\Document\Service\ZugferdEmbeddedService;
 use Shopware\Core\Checkout\Document\Struct\DocumentGenerateOperation;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 
 /**
@@ -21,6 +22,11 @@ use Shopware\Core\Framework\Log\Package;
 #[CoversClass(ZugferdEmbeddedCancellationInvoiceRenderer::class)]
 class ZugferdEmbeddedCancellationInvoiceRendererTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        Feature::skipTestIfActive('v6.9.0.0', $this); // tested class will be removed
+    }
+
     public function testSupports(): void
     {
         $renderer = new ZugferdEmbeddedCancellationInvoiceRenderer(

--- a/tests/unit/Core/Checkout/Document/Renderer/ZugferdEmbeddedCreditNoteRendererTest.php
+++ b/tests/unit/Core/Checkout/Document/Renderer/ZugferdEmbeddedCreditNoteRendererTest.php
@@ -12,6 +12,7 @@ use Shopware\Core\Checkout\Document\Renderer\ZugferdEmbeddedCreditNoteRenderer;
 use Shopware\Core\Checkout\Document\Service\ZugferdEmbeddedService;
 use Shopware\Core\Checkout\Document\Struct\DocumentGenerateOperation;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 
 /**
@@ -21,6 +22,11 @@ use Shopware\Core\Framework\Log\Package;
 #[CoversClass(ZugferdEmbeddedCreditNoteRenderer::class)]
 class ZugferdEmbeddedCreditNoteRendererTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        Feature::skipTestIfActive('v6.9.0.0', $this); // tested class will be removed
+    }
+
     public function testSupports(): void
     {
         $renderer = new ZugferdEmbeddedCreditNoteRenderer(

--- a/tests/unit/Core/Checkout/Document/Renderer/ZugferdEmbeddedRendererTest.php
+++ b/tests/unit/Core/Checkout/Document/Renderer/ZugferdEmbeddedRendererTest.php
@@ -12,6 +12,7 @@ use Shopware\Core\Checkout\Document\Renderer\ZugferdEmbeddedRenderer;
 use Shopware\Core\Checkout\Document\Service\ZugferdEmbeddedService;
 use Shopware\Core\Checkout\Document\Struct\DocumentGenerateOperation;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 
 /**
@@ -21,6 +22,11 @@ use Shopware\Core\Framework\Log\Package;
 #[CoversClass(ZugferdEmbeddedRenderer::class)]
 class ZugferdEmbeddedRendererTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        Feature::skipTestIfActive('v6.9.0.0', $this); // tested class will be removed
+    }
+
     public function testSupports(): void
     {
         $renderer = new ZugferdEmbeddedRenderer(

--- a/tests/unit/Core/Checkout/Document/Renderer/ZugferdRendererTest.php
+++ b/tests/unit/Core/Checkout/Document/Renderer/ZugferdRendererTest.php
@@ -19,6 +19,7 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\NumberRange\ValueGenerator\NumberRangeValueGeneratorInterface;
@@ -33,6 +34,11 @@ use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 class ZugferdRendererTest extends TestCase
 {
     private const ORDER_ID = '0192b305fddb7347be83a311a82f0649';
+
+    protected function setUp(): void
+    {
+        Feature::skipTestIfActive('v6.9.0.0', $this); // tested class will be removed
+    }
 
     public function testSupports(): void
     {

--- a/tests/unit/Core/Checkout/Document/SalesChannel/DocumentRouteTest.php
+++ b/tests/unit/Core/Checkout/Document/SalesChannel/DocumentRouteTest.php
@@ -53,6 +53,11 @@ class DocumentRouteTest extends TestCase
         ZugferdRenderer::FILE_EXTENSION => ZugferdRenderer::FILE_CONTENT_TYPE,
     ];
 
+    protected function setUp(): void
+    {
+        Feature::skipTestIfActive('v6.9.0.0', $this); // tested class will be removed
+    }
+
     public function testDownloadWithDocumentNotFound(): void
     {
         $generator = static::createStub(DocumentGenerator::class);

--- a/tests/unit/Core/Checkout/Document/Service/DocumentConfigLoaderTest.php
+++ b/tests/unit/Core/Checkout/Document/Service/DocumentConfigLoaderTest.php
@@ -35,6 +35,8 @@ class DocumentConfigLoaderTest extends TestCase
 
     protected function setUp(): void
     {
+        Feature::skipTestIfActive('v6.9.0.0', $this); // tested class will be removed
+
         $this->ids = new IdsCollection();
     }
 

--- a/tests/unit/Core/Checkout/Document/Service/DocumentFileRendererRegistryTest.php
+++ b/tests/unit/Core/Checkout/Document/Service/DocumentFileRendererRegistryTest.php
@@ -11,6 +11,7 @@ use Shopware\Core\Checkout\Document\Service\DocumentFileRendererRegistry;
 use Shopware\Core\Checkout\Document\Service\HtmlRenderer;
 use Shopware\Core\Checkout\Order\OrderEntity;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\Language\LanguageEntity;
@@ -23,6 +24,11 @@ use Shopware\Core\System\Locale\LocaleEntity;
 #[CoversClass(DocumentFileRendererRegistry::class)]
 class DocumentFileRendererRegistryTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        Feature::skipTestIfActive('v6.9.0.0', $this); // tested class will be removed
+    }
+
     #[DataProvider('documentTypeRendererProvider')]
     public function testRender(RenderedDocument $document, \Closure $expectsClosure): void
     {

--- a/tests/unit/Core/Checkout/Document/Service/DocumentGeneratorTest.php
+++ b/tests/unit/Core/Checkout/Document/Service/DocumentGeneratorTest.php
@@ -32,6 +32,7 @@ use Shopware\Core\Content\Media\MediaService;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\Test\Stub\DataAbstractionLayer\StaticEntityRepository;
@@ -44,6 +45,11 @@ use Symfony\Component\Clock\NativeClock;
 #[CoversClass(DocumentGenerator::class)]
 class DocumentGeneratorTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        Feature::skipTestIfActive('v6.9.0.0', $this); // tested class will be removed
+    }
+
     #[DataProvider('readDataProvider')]
     public function testReadDocument(string $fileType, RenderedDocument $resultRenderer, \Closure $expectClosure): void
     {

--- a/tests/unit/Core/Checkout/Document/Service/DocumentMergerTest.php
+++ b/tests/unit/Core/Checkout/Document/Service/DocumentMergerTest.php
@@ -22,6 +22,7 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\Test\Stub\DataAbstractionLayer\StaticEntityRepository;
@@ -36,6 +37,11 @@ use Symfony\Component\Filesystem\Filesystem;
 class DocumentMergerTest extends TestCase
 {
     public const PDF_CONTENT = 'PDF content for testing';
+
+    protected function setUp(): void
+    {
+        Feature::skipTestIfActive('v6.9.0.0', $this); // tested class will be removed
+    }
 
     public function testMergeOneDocument(): void
     {

--- a/tests/unit/Core/Checkout/Document/Service/HtmlRendererTest.php
+++ b/tests/unit/Core/Checkout/Document/Service/HtmlRendererTest.php
@@ -13,6 +13,7 @@ use Shopware\Core\Checkout\Document\Twig\DocumentTemplateRenderer;
 use Shopware\Core\Checkout\Order\OrderEntity;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Extensions\ExtensionDispatcher;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseHelper\CallableClass;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -27,6 +28,11 @@ use Symfony\Component\EventDispatcher\EventDispatcher;
 #[CoversClass(HtmlRenderer::class)]
 class HtmlRendererTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        Feature::skipTestIfActive('v6.9.0.0', $this); // tested class will be removed
+    }
+
     public function testGetContentType(): void
     {
         $htmlRenderer = new HtmlRenderer(static::createStub(DocumentTemplateRenderer::class), '', new ExtensionDispatcher(new EventDispatcher()));

--- a/tests/unit/Core/Checkout/Document/Service/PdfRendererTest.php
+++ b/tests/unit/Core/Checkout/Document/Service/PdfRendererTest.php
@@ -13,6 +13,7 @@ use Shopware\Core\Checkout\Document\Twig\DocumentTemplateRenderer;
 use Shopware\Core\Checkout\Order\OrderEntity;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Extensions\ExtensionDispatcher;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseHelper\CallableClass;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -27,6 +28,11 @@ use Symfony\Component\EventDispatcher\EventDispatcher;
 #[CoversClass(PdfRenderer::class)]
 class PdfRendererTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        Feature::skipTestIfActive('v6.9.0.0', $this); // tested class will be removed
+    }
+
     public function testGetContentType(): void
     {
         $pdfRenderer = new PdfRenderer(

--- a/tests/unit/Core/Checkout/Document/Service/ZugferdEmbeddedServiceTest.php
+++ b/tests/unit/Core/Checkout/Document/Service/ZugferdEmbeddedServiceTest.php
@@ -12,6 +12,7 @@ use Shopware\Core\Checkout\Document\Renderer\RendererResult;
 use Shopware\Core\Checkout\Document\Service\ZugferdEmbeddedService;
 use Shopware\Core\Checkout\Document\Struct\DocumentGenerateOperation;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 
 /**
@@ -25,6 +26,8 @@ class ZugferdEmbeddedServiceTest extends TestCase
 
     protected function setUp(): void
     {
+        Feature::skipTestIfActive('v6.9.0.0', $this); // tested class will be removed
+
         $this->service = new ZugferdEmbeddedService();
     }
 

--- a/tests/unit/Core/Checkout/Document/Subscriber/DocumentDeleteSubscriberTest.php
+++ b/tests/unit/Core/Checkout/Document/Subscriber/DocumentDeleteSubscriberTest.php
@@ -20,6 +20,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\Command\DeleteCommand;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\EntityExistence;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\WriteContext;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\Test\Stub\DataAbstractionLayer\StaticEntityRepository;
@@ -31,6 +32,11 @@ use Shopware\Core\Test\Stub\DataAbstractionLayer\StaticEntityRepository;
 #[CoversClass(DocumentDeleteSubscriber::class)]
 class DocumentDeleteSubscriberTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        Feature::skipTestIfActive('v6.9.0.0', $this); // tested class will be removed
+    }
+
     public function testBeforeDeleteDeletesMediaFilesOnSuccess(): void
     {
         $documentId = Uuid::randomBytes();

--- a/tests/unit/Core/Checkout/Document/Twig/DocumentTemplateRendererTest.php
+++ b/tests/unit/Core/Checkout/Document/Twig/DocumentTemplateRendererTest.php
@@ -11,6 +11,7 @@ use Shopware\Core\Framework\Adapter\Translation\Translator;
 use Shopware\Core\Framework\Adapter\Twig\TemplateFinder;
 use Shopware\Core\Framework\Adapter\Twig\TwigEnvironment;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SalesChannel\Context\AbstractSalesChannelContextFactory;
@@ -30,6 +31,11 @@ use Twig\Loader\ArrayLoader;
 class DocumentTemplateRendererTest extends TestCase
 {
     private static bool $rendererParameterEventCalled = false;
+
+    protected function setUp(): void
+    {
+        Feature::skipTestIfActive('v6.9.0.0', $this); // tested class will be removed
+    }
 
     public function testDocumentTemplateRendererParameterEventIsDispatched(): void
     {

--- a/tests/unit/Core/Checkout/Document/Zugferd/ZugferdBuilderTest.php
+++ b/tests/unit/Core/Checkout/Document/Zugferd/ZugferdBuilderTest.php
@@ -28,6 +28,7 @@ use Shopware\Core\Checkout\Order\Aggregate\OrderLineItem\OrderLineItemCollection
 use Shopware\Core\Checkout\Order\Aggregate\OrderLineItem\OrderLineItemEntity;
 use Shopware\Core\Checkout\Order\OrderEntity;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\Country\Aggregate\CountryState\CountryStateEntity;
@@ -50,6 +51,11 @@ class ZugferdBuilderTest extends TestCase
     private int $position = 0;
 
     private float $totalAmount = 0.0;
+
+    protected function setUp(): void
+    {
+        Feature::skipTestIfActive('v6.9.0.0', $this); // tested class will be removed
+    }
 
     protected function tearDown(): void
     {

--- a/tests/unit/Core/Checkout/DocumentV2/Renderer/HtmlRendererTest.php
+++ b/tests/unit/Core/Checkout/DocumentV2/Renderer/HtmlRendererTest.php
@@ -90,8 +90,8 @@ class HtmlRendererTest extends TestCase
             $meta->documentNumber,
             $this->createOrder(),
             [
-                DocumentMetaProvider::KEY => $meta,
-                InvoiceDataProvider::KEY => $renderData,
+                DocumentMetaProvider::KEY->value => $meta,
+                InvoiceDataProvider::KEY->value => $renderData,
             ],
         );
 
@@ -130,7 +130,7 @@ class HtmlRendererTest extends TestCase
                 DocumentType::CREDIT_NOTE->value,
                 '12345',
                 $this->createOrder(),
-                [DocumentMetaProvider::KEY => $this->createMeta()],
+                [DocumentMetaProvider::KEY->value => $this->createMeta()],
             ),
             new RenderState(),
             Context::createDefaultContext(),
@@ -151,7 +151,7 @@ class HtmlRendererTest extends TestCase
                 '../invoice',
                 '12345',
                 $this->createOrder(),
-                [InvoiceDataProvider::KEY => $this->createRenderData()],
+                [InvoiceDataProvider::KEY->value => $this->createRenderData()],
             ),
             new RenderState(),
             Context::createDefaultContext(),
@@ -173,7 +173,7 @@ class HtmlRendererTest extends TestCase
         );
 
         $this->expectExceptionObject(
-            DocumentV2Exception::unknownRenderData(DocumentMetaProvider::KEY, DocumentMetaRenderData::class),
+            DocumentV2Exception::unknownRenderData(DocumentMetaProvider::KEY->value, DocumentMetaRenderData::class),
         );
 
         $renderer->renderToString(

--- a/tests/unit/Core/Checkout/DocumentV2/Renderer/PdfRendererTest.php
+++ b/tests/unit/Core/Checkout/DocumentV2/Renderer/PdfRendererTest.php
@@ -117,7 +117,7 @@ class PdfRendererTest extends TestCase
         );
 
         $this->expectExceptionObject(
-            DocumentV2Exception::unknownRenderData(DocumentMetaProvider::KEY, DocumentMetaRenderData::class),
+            DocumentV2Exception::unknownRenderData(DocumentMetaProvider::KEY->value, DocumentMetaRenderData::class),
         );
 
         $renderer->renderToString($input, $state, Context::createDefaultContext());
@@ -193,7 +193,7 @@ class PdfRendererTest extends TestCase
             DocumentType::INVOICE->value,
             $meta->documentNumber,
             $this->createOrder(),
-            [DocumentMetaProvider::KEY => $meta],
+            [DocumentMetaProvider::KEY->value => $meta],
         );
     }
 

--- a/tests/unit/Core/Checkout/DocumentV2/Renderer/ZugferdEmbeddedPdfRendererTest.php
+++ b/tests/unit/Core/Checkout/DocumentV2/Renderer/ZugferdEmbeddedPdfRendererTest.php
@@ -47,7 +47,7 @@ class ZugferdEmbeddedPdfRendererTest extends TestCase
         $input = new RenderInput(DocumentType::INVOICE->value, '12345', $this->createOrder(), []);
 
         $this->expectExceptionObject(
-            DocumentV2Exception::unknownRenderData(DocumentMetaProvider::KEY, DocumentMetaRenderData::class),
+            DocumentV2Exception::unknownRenderData(DocumentMetaProvider::KEY->value, DocumentMetaRenderData::class),
         );
 
         $renderer->renderToString($input, new RenderState(), Context::createDefaultContext());
@@ -104,7 +104,7 @@ class ZugferdEmbeddedPdfRendererTest extends TestCase
             DocumentType::INVOICE->value,
             '12345',
             $this->createOrder(),
-            [DocumentMetaProvider::KEY => $this->createMeta()],
+            [DocumentMetaProvider::KEY->value => $this->createMeta()],
         );
     }
 

--- a/tests/unit/Core/Checkout/DocumentV2/Renderer/ZugferdXmlRendererTest.php
+++ b/tests/unit/Core/Checkout/DocumentV2/Renderer/ZugferdXmlRendererTest.php
@@ -138,7 +138,7 @@ class ZugferdXmlRendererTest extends TestCase
                 '12345',
                 $this->createOrder(),
                 [
-                    DocumentMetaProvider::KEY => $this->createMeta(),
+                    DocumentMetaProvider::KEY->value => $this->createMeta(),
                     DocumentType::CREDIT_NOTE->value => $this->createRenderData(),
                 ],
             ),
@@ -161,7 +161,7 @@ class ZugferdXmlRendererTest extends TestCase
                 '../invoice',
                 '12345',
                 $this->createOrder(),
-                [InvoiceDataProvider::KEY => $this->createRenderData()],
+                [InvoiceDataProvider::KEY->value => $this->createRenderData()],
             ),
             new RenderState(),
             Context::createDefaultContext(),
@@ -183,7 +183,7 @@ class ZugferdXmlRendererTest extends TestCase
         );
 
         $this->expectExceptionObject(
-            DocumentV2Exception::unknownRenderData(DocumentMetaProvider::KEY, DocumentMetaRenderData::class),
+            DocumentV2Exception::unknownRenderData(DocumentMetaProvider::KEY->value, DocumentMetaRenderData::class),
         );
 
         $renderer->renderToString(
@@ -224,8 +224,8 @@ class ZugferdXmlRendererTest extends TestCase
             '12345',
             $this->createOrder(),
             [
-                DocumentMetaProvider::KEY => $meta,
-                InvoiceDataProvider::KEY => $data,
+                DocumentMetaProvider::KEY->value => $meta,
+                InvoiceDataProvider::KEY->value => $data,
             ],
         );
     }


### PR DESCRIPTION
part of https://github.com/shopware/shopware/issues/16151

Important ADR that is explaining the migration strategy: [2026-08-05-document-generation-v1-to-v2-migration-strategy.md](https://github.com/shopware/shopware/blob/trunk/adr/2026-08-05-document-generation-v1-to-v2-migration-strategy.md)

### Changes

#### framework

- added `v6.9.0.0` feature flag to `feature.yaml`
- added `NamespaceChange` annotation for signaling namespace relocation
- added `reason:remove-fk-resolver` as phpstan deprecation reason for childs of `AbstractFkResolver`

#### after-sales

- deprecated all replaced code of document domain for deletion in `6.9`
- deprecated all adopted code of document domain for relocation to document v2 domain
- deprecated `document_type` table for removal in `6.9` (migration will follow)
- added `@experimental` flag for all future public code of document v2

### Important follow ups

To not make this bigger then it is anyway, I will follow up with ([ref](https://github.com/shopware/shopware/issues/16151#issuecomment-5323953350)):

- upgrade documentation & release infos for all breaks & migration to document v2
- admin deprecations
- db backfill migration
- db migration for `document_type` removal