### PR TITLE
fix(storefront): key pinch zoom persistence on the end input type

### DIFF
--- a/src/Storefront/Resources/app/storefront/src/plugin/image-zoom/image-zoom.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/image-zoom/image-zoom.plugin.js
@@ -155,7 +155,7 @@ export default class ImageZoomPlugin extends Plugin {
             this._panStartTransform = new Vector3(this._storedTransform.x, this._storedTransform.y, this._storedTransform.z);
         });
         this._hammer.on('pan panend pancancel', event => this._onPan(event));
-        this._hammer.on('pinch pinchmove', event => this._onPinch(event));
+        this._hammer.on('pinch pinchmove pinchend pinchcancel', event => this._onPinch(event));
         this._hammer.on('doubletap', event => this._onDoubleTap(event));
 
         this.el.addEventListener('wheel', event => this._onMouseWheel(event), false);

--- a/src/Storefront/Resources/app/storefront/src/plugin/image-zoom/image-zoom.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/image-zoom/image-zoom.plugin.js
@@ -155,7 +155,7 @@ export default class ImageZoomPlugin extends Plugin {
             this._panStartTransform = new Vector3(this._storedTransform.x, this._storedTransform.y, this._storedTransform.z);
         });
         this._hammer.on('pan panend pancancel', event => this._onPan(event));
-        this._hammer.on('pinch pinchmove pinchend pinchcancel', event => this._onPinch(event));
+        this._hammer.on('pinch pinchmove', event => this._onPinch(event));
         this._hammer.on('doubletap', event => this._onDoubleTap(event));
 
         this.el.addEventListener('wheel', event => this._onMouseWheel(event), false);
@@ -226,9 +226,16 @@ export default class ImageZoomPlugin extends Plugin {
             const y = this._storedTransform.y + deltaY;
             const z = this._storedTransform.z * event.scale;
 
+            // Hammer only sets isFinal once every pointer is a changed pointer, so releasing
+            // a pinch — where the two fingers never lift in the same frame — leaves it false
+            // and the reached zoom level would never be stored. The END/CANCEL input type is
+            // the reliable end-of-gesture signal for multi-pointer recognisers.
+            const isGestureEnd = Boolean(event.isFinal)
+                || Boolean(event.eventType & (Hammer.INPUT_END | Hammer.INPUT_CANCEL));
+
             this._transform = new Vector3(x, y, z);
             this._unsetTransition();
-            this._updateTransform(event.isFinal);
+            this._updateTransform(isGestureEnd);
             this._setCursor('move');
         }
 

--- a/src/Storefront/Resources/app/storefront/test/plugin/image-zoom/image-zoom.plugin.test.js
+++ b/src/Storefront/Resources/app/storefront/test/plugin/image-zoom/image-zoom.plugin.test.js
@@ -1,0 +1,58 @@
+import ImageZoomPlugin from 'src/plugin/image-zoom/image-zoom.plugin';
+
+/**
+ * @package discovery
+ */
+describe('ImageZoomPlugin tests', () => {
+    let plugin = undefined;
+
+    function defineSize(element, width, height) {
+        Object.defineProperty(element, 'offsetWidth', { value: width, configurable: true });
+        Object.defineProperty(element, 'offsetHeight', { value: height, configurable: true });
+    }
+
+    beforeEach(() => {
+        document.body.innerHTML = `
+            <div data-image-zoom-modal="true">
+                <div class="zoom-modal-actions">
+                    <button class="js-image-zoom-out">Zoom Out</button>
+                    <button class="js-image-zoom-reset">Reset</button>
+                    <button class="js-image-zoom-in">Zoom In</button>
+                </div>
+                <div class="tns-slide-active">
+                    <div class="image-zoom-container" data-image-zoom="true">
+                        <img src="#" alt="Test" class="js-image-zoom-element">
+                    </div>
+                </div>
+            </div>
+        `;
+
+        const container = document.querySelector('[data-image-zoom="true"]');
+        const image = container.querySelector('.js-image-zoom-element');
+
+        // jsdom reports every layout box as 0, which makes _getMaxZoomValue() return 1
+        // and clamp away any zoom the assertions depend on.
+        defineSize(container, 100, 100);
+        defineSize(image, 100, 100);
+        Object.defineProperty(image, 'naturalWidth', { value: 400, configurable: true });
+        Object.defineProperty(image, 'naturalHeight', { value: 400, configurable: true });
+
+        plugin = new ImageZoomPlugin(container);
+    });
+
+    it('persists the pinched zoom level when the gesture ends', () => {
+        expect(plugin._storedTransform.z).toBe(1);
+
+        plugin._hammer.emit('pinchend', { isFinal: true, scale: 2, deltaX: 0, deltaY: 0 });
+
+        expect(plugin._storedTransform.z).toBe(2);
+    });
+
+    it('persists the pinched zoom level when the gesture is cancelled', () => {
+        expect(plugin._storedTransform.z).toBe(1);
+
+        plugin._hammer.emit('pinchcancel', { isFinal: true, scale: 3, deltaX: 0, deltaY: 0 });
+
+        expect(plugin._storedTransform.z).toBe(3);
+    });
+});

--- a/src/Storefront/Resources/app/storefront/test/plugin/image-zoom/image-zoom.plugin.test.js
+++ b/src/Storefront/Resources/app/storefront/test/plugin/image-zoom/image-zoom.plugin.test.js
@@ -1,7 +1,8 @@
 import ImageZoomPlugin from 'src/plugin/image-zoom/image-zoom.plugin';
+import Hammer from 'hammerjs';
 
 /**
- * @package discovery
+ * @package storefront
  */
 describe('ImageZoomPlugin tests', () => {
     let plugin = undefined;
@@ -9,6 +10,14 @@ describe('ImageZoomPlugin tests', () => {
     function defineSize(element, width, height) {
         Object.defineProperty(element, 'offsetWidth', { value: width, configurable: true });
         Object.defineProperty(element, 'offsetHeight', { value: height, configurable: true });
+    }
+
+    /**
+     * Mirrors what Hammer delivers when a pinch ends: the END input type, but isFinal
+     * false, because the two fingers never lift within the same frame.
+     */
+    function pinchEvent(eventType, scale) {
+        return { eventType, scale, isFinal: false, deltaX: 0, deltaY: 0 };
     }
 
     beforeEach(() => {
@@ -43,7 +52,7 @@ describe('ImageZoomPlugin tests', () => {
     it('persists the pinched zoom level when the gesture ends', () => {
         expect(plugin._storedTransform.z).toBe(1);
 
-        plugin._hammer.emit('pinchend', { isFinal: true, scale: 2, deltaX: 0, deltaY: 0 });
+        plugin._hammer.emit('pinch', pinchEvent(Hammer.INPUT_END, 2));
 
         expect(plugin._storedTransform.z).toBe(2);
     });
@@ -51,8 +60,15 @@ describe('ImageZoomPlugin tests', () => {
     it('persists the pinched zoom level when the gesture is cancelled', () => {
         expect(plugin._storedTransform.z).toBe(1);
 
-        plugin._hammer.emit('pinchcancel', { isFinal: true, scale: 3, deltaX: 0, deltaY: 0 });
+        plugin._hammer.emit('pinch', pinchEvent(Hammer.INPUT_CANCEL, 3));
 
         expect(plugin._storedTransform.z).toBe(3);
+    });
+
+    it('does not persist while the gesture is still running', () => {
+        plugin._hammer.emit('pinch', pinchEvent(Hammer.INPUT_MOVE, 2));
+
+        expect(plugin._transform.z).toBe(2);
+        expect(plugin._storedTransform.z).toBe(1);
     });
 });

--- a/src/Storefront/Resources/app/storefront/test/plugin/image-zoom/image-zoom.plugin.test.js
+++ b/src/Storefront/Resources/app/storefront/test/plugin/image-zoom/image-zoom.plugin.test.js
@@ -2,7 +2,7 @@ import ImageZoomPlugin from 'src/plugin/image-zoom/image-zoom.plugin';
 import Hammer from 'hammerjs';
 
 /**
- * @package storefront
+ * @package discovery
  */
 describe('ImageZoomPlugin tests', () => {
     let plugin = undefined;


### PR DESCRIPTION
### 1. Why is this change necessary?

Pinch-to-zoom in the storefront image gallery does not keep the new zoom level on a touch device. While both fingers are on the screen the image scales with the gesture, but as soon as they are released it snaps back to the zoom level from before the gesture — in both directions. Zooming with the `+` / `−` controls is unaffected.

### 2. What does this change do, exactly?

`_onPinch()` passed `event.isFinal` to `_updateTransform()` to decide whether the reached zoom level is stored. On a pinch that flag is never set. From `hammer.js`, `computeInputData()`:

```js
isFinal = eventType & (INPUT_END | INPUT_CANCEL)
          && (pointersLen - changedPointersLen === 0)
```

Releasing a pinch lifts one of the two fingers first, so `pointersLen` 2 minus `changedPointersLen` 1 is never 0 and `isFinal` stays `false`. The transform is therefore never written to `_storedTransform`, and the next render recomputes from the pre-gesture value. `_onPan()` is unaffected because a single pointer always satisfies the condition.

The end of the gesture is now derived from the `END` / `CANCEL` input type, which is the reliable signal for a multi-pointer recogniser. No event binding changes — the END input already arrives through the registered `pinch` event.

Adds `test/plugin/image-zoom/image-zoom.plugin.test.js`; the plugin had no spec before. The assertions use the event shape Hammer actually emits (`eventType: Hammer.INPUT_END`, `isFinal: false`) and fail against the unfixed handler. Note that jsdom reports every layout box as `0`, which makes `_getMaxZoomValue()` return `1` and clamp away the zoom the assertions depend on, so the test defines `offsetWidth` / `naturalWidth` explicitly.

### 3. Describe each step to reproduce the issue or behaviour.

1. Open a product detail page on a touch device (or a device-emulating browser with touch events enabled).
2. Tap a product image to open the zoom modal.
3. Pinch to zoom in, then lift both fingers.

Before: the image returns to the previous zoom level. After: the zoom level reached with the gesture is kept.

Verified in Chromium against a running storefront by dispatching a real two-finger gesture over CDP with the pan recogniser disabled, so only the pinch path can persist: unfixed handler does not store the transform, the fixed handler does. The `pinchend` binding first tried here was refuted the same way — it adds a handler call but no persist, because the event carries `isFinal: false`.

Confirmed on a physical iPhone in Safari against a locally built storefront: the zoom level reached with the gesture is kept after both fingers are lifted.

### 4. Please link to the relevant issues (if any).

- closes #19178
- relates #11992 — the same plugin, reported via Customer Support. The pinch-persistence half is covered here; that issue additionally reports missing horizontal scrolling after a strong button zoom, which is the pan/clamp path and is **not** addressed by this change.

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have updated developer-facing release notes if this change is **relevant** for external developers — n/a: narrow bug fix restoring intended behaviour, no external contract, no configuration or API change
- [x] I have written or adjusted the documentation and agent skills according to my changes — n/a: no documented behaviour changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them

