### PR TITLE
test: align Storefront unit test package attributes with the covered classes

### DIFF
--- a/tests/unit/Storefront/Controller/Api/CaptchaControllerTest.php
+++ b/tests/unit/Storefront/Controller/Api/CaptchaControllerTest.php
@@ -11,7 +11,7 @@ use Shopware\Storefront\Framework\Captcha\AbstractCaptcha;
 /**
  * @internal
  */
-#[Package('checkout')]
+#[Package('discovery')]
 #[CoversClass(CaptchaController::class)]
 class CaptchaControllerTest extends TestCase
 {

--- a/tests/unit/Storefront/Controller/SearchControllerTest.php
+++ b/tests/unit/Storefront/Controller/SearchControllerTest.php
@@ -45,7 +45,7 @@ use Twig\Environment;
 /**
  * @internal
  */
-#[Package('discovery')]
+#[Package('inventory')]
 #[CoversClass(SearchController::class)]
 class SearchControllerTest extends TestCase
 {

--- a/tests/unit/Storefront/Controller/StorefrontControllerTest.php
+++ b/tests/unit/Storefront/Controller/StorefrontControllerTest.php
@@ -46,7 +46,7 @@ use Twig\Error\SyntaxError;
 /**
  * @internal
  */
-#[Package('framework')]
+#[Package('discovery')]
 #[CoversClass(StorefrontController::class)]
 class StorefrontControllerTest extends TestCase
 {

--- a/tests/unit/Storefront/DependencyInjection/StorefrontMigrationReplacementCompilerPassTest.php
+++ b/tests/unit/Storefront/DependencyInjection/StorefrontMigrationReplacementCompilerPassTest.php
@@ -12,7 +12,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 /**
  * @internal
  */
-#[Package('framework')]
+#[Package('discovery')]
 #[CoversClass(StorefrontMigrationReplacementCompilerPass::class)]
 class StorefrontMigrationReplacementCompilerPassTest extends TestCase
 {

--- a/tests/unit/Storefront/Event/StorefrontRedirectEventTest.php
+++ b/tests/unit/Storefront/Event/StorefrontRedirectEventTest.php
@@ -11,7 +11,7 @@ use Symfony\Component\HttpFoundation\Response;
 /**
  * @internal
  */
-#[Package('framework')]
+#[Package('discovery')]
 #[CoversClass(StorefrontRedirectEvent::class)]
 class StorefrontRedirectEventTest extends TestCase
 {

--- a/tests/unit/Storefront/Event/Subscriber/CartMergedSubscriberTest.php
+++ b/tests/unit/Storefront/Event/Subscriber/CartMergedSubscriberTest.php
@@ -22,7 +22,7 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 /**
  * @internal
  */
-#[Package('framework')]
+#[Package('checkout')]
 #[CoversClass(CartMergedSubscriber::class)]
 class CartMergedSubscriberTest extends TestCase
 {

--- a/tests/unit/Storefront/Framework/Routing/CachedDomainLoaderTest.php
+++ b/tests/unit/Storefront/Framework/Routing/CachedDomainLoaderTest.php
@@ -14,7 +14,7 @@ use Symfony\Component\Cache\Adapter\ArrayAdapter;
 /**
  * @internal
  */
-#[Package('framework')]
+#[Package('discovery')]
 #[CoversClass(CachedDomainLoader::class)]
 class CachedDomainLoaderTest extends TestCase
 {

--- a/tests/unit/Storefront/Framework/Script/Api/StorefrontScriptResponseFactoryFacadeTest.php
+++ b/tests/unit/Storefront/Framework/Script/Api/StorefrontScriptResponseFactoryFacadeTest.php
@@ -15,7 +15,7 @@ use Symfony\Component\Routing\RouterInterface;
 /**
  * @internal
  */
-#[Package('framework')]
+#[Package('discovery')]
 #[CoversClass(StorefrontScriptResponseFactoryFacade::class)]
 class StorefrontScriptResponseFactoryFacadeTest extends TestCase
 {

--- a/tests/unit/Storefront/Framework/Store/Subscriber/ExtensionThemeDetectionSubscriberTest.php
+++ b/tests/unit/Storefront/Framework/Store/Subscriber/ExtensionThemeDetectionSubscriberTest.php
@@ -23,7 +23,7 @@ use Shopware\Tests\Unit\Storefront\Theme\fixtures\MockStorefront\MockStorefront;
 /**
  * @internal
  */
-#[Package('framework')]
+#[Package('discovery')]
 #[CoversClass(ExtensionThemeDetectionSubscriber::class)]
 class ExtensionThemeDetectionSubscriberTest extends TestCase
 {

--- a/tests/unit/Storefront/Framework/Twig/Extension/UrlEncodingTwigFilterTest.php
+++ b/tests/unit/Storefront/Framework/Twig/Extension/UrlEncodingTwigFilterTest.php
@@ -17,7 +17,7 @@ use Twig\TwigFilter;
 /**
  * @internal
  */
-#[Package('framework')]
+#[Package('discovery')]
 #[CoversClass(UrlEncodingTwigFilter::class)]
 class UrlEncodingTwigFilterTest extends TestCase
 {

--- a/tests/unit/Storefront/Mcp/Tool/ThemeConfigToolTest.php
+++ b/tests/unit/Storefront/Mcp/Tool/ThemeConfigToolTest.php
@@ -18,7 +18,7 @@ use Shopware\Storefront\Theme\ThemeService;
 /**
  * @internal
  */
-#[Package('framework')]
+#[Package('discovery')]
 #[CoversClass(ThemeConfigTool::class)]
 class ThemeConfigToolTest extends TestCase
 {

--- a/tests/unit/Storefront/StorefrontTest.php
+++ b/tests/unit/Storefront/StorefrontTest.php
@@ -23,7 +23,7 @@ use Symfony\Component\DependencyInjection\Extension\Extension;
 /**
  * @internal
  */
-#[Package('framework')]
+#[Package('discovery')]
 #[CoversClass(Storefront::class)]
 class StorefrontTest extends TestCase
 {

--- a/tests/unit/Storefront/Theme/Command/ThemeCompileCommandTest.php
+++ b/tests/unit/Storefront/Theme/Command/ThemeCompileCommandTest.php
@@ -18,7 +18,7 @@ use Symfony\Component\Console\Tester\CommandTester;
 /**
  * @internal
  */
-#[Package('framework')]
+#[Package('discovery')]
 #[CoversClass(ThemeCompileCommand::class)]
 class ThemeCompileCommandTest extends TestCase
 {

--- a/tests/unit/Storefront/Theme/Command/ThemeDumpCommandTest.php
+++ b/tests/unit/Storefront/Theme/Command/ThemeDumpCommandTest.php
@@ -30,7 +30,7 @@ use Symfony\Component\Console\Tester\CommandTester;
 /**
  * @internal
  */
-#[Package('framework')]
+#[Package('discovery')]
 #[CoversClass(ThemeDumpCommand::class)]
 class ThemeDumpCommandTest extends TestCase
 {

--- a/tests/unit/Storefront/Theme/ConfigLoader/DatabaseConfigLoaderTest.php
+++ b/tests/unit/Storefront/Theme/ConfigLoader/DatabaseConfigLoaderTest.php
@@ -22,7 +22,7 @@ use Shopware\Storefront\Theme\ThemeEntity;
 /**
  * @internal
  */
-#[Package('framework')]
+#[Package('discovery')]
 #[CoversClass(DatabaseConfigLoader::class)]
 class DatabaseConfigLoaderTest extends TestCase
 {

--- a/tests/unit/Storefront/Theme/ConfigLoader/StaticFileConfigLoaderTest.php
+++ b/tests/unit/Storefront/Theme/ConfigLoader/StaticFileConfigLoaderTest.php
@@ -16,7 +16,7 @@ use Shopware\Storefront\Theme\ConfigLoader\StaticFileConfigLoader;
 /**
  * @internal
  */
-#[Package('framework')]
+#[Package('discovery')]
 #[CoversClass(StaticFileConfigLoader::class)]
 class StaticFileConfigLoaderTest extends TestCase
 {

--- a/tests/unit/Storefront/Theme/Exception/ThemeAssignmentExceptionTest.php
+++ b/tests/unit/Storefront/Theme/Exception/ThemeAssignmentExceptionTest.php
@@ -15,7 +15,7 @@ use Symfony\Component\HttpFoundation\Response;
  *
  * @deprecated tag:v6.8.0 - reason: the tested class is superseded by ThemeException::themeAssignmentException - to be removed
  */
-#[Package('framework')]
+#[Package('discovery')]
 #[CoversClass(ThemeAssignmentException::class)]
 #[DisabledFeatures(['v6.8.0.0'])]
 class ThemeAssignmentExceptionTest extends TestCase

--- a/tests/unit/Storefront/Theme/Exception/ThemeConfigExceptionTest.php
+++ b/tests/unit/Storefront/Theme/Exception/ThemeConfigExceptionTest.php
@@ -13,7 +13,7 @@ use Symfony\Component\HttpFoundation\Response;
 /**
  * @internal
  */
-#[Package('framework')]
+#[Package('discovery')]
 #[CoversClass(ThemeConfigException::class)]
 class ThemeConfigExceptionTest extends TestCase
 {

--- a/tests/unit/Storefront/Theme/Exception/ThemeExceptionTest.php
+++ b/tests/unit/Storefront/Theme/Exception/ThemeExceptionTest.php
@@ -12,7 +12,7 @@ use Symfony\Component\HttpFoundation\Response;
 /**
  * @internal
  */
-#[Package('framework')]
+#[Package('discovery')]
 #[CoversClass(ThemeException::class)]
 class ThemeExceptionTest extends TestCase
 {

--- a/tests/unit/Storefront/Theme/ThemeRuntimeConfigServiceTest.php
+++ b/tests/unit/Storefront/Theme/ThemeRuntimeConfigServiceTest.php
@@ -24,7 +24,7 @@ use Symfony\Component\Clock\NativeClock;
 /**
  * @internal
  */
-#[Package('framework')]
+#[Package('discovery')]
 #[CoversClass(ThemeRuntimeConfigService::class)]
 class ThemeRuntimeConfigServiceTest extends TestCase
 {

--- a/tests/unit/Storefront/Theme/ThemeRuntimeConfigTest.php
+++ b/tests/unit/Storefront/Theme/ThemeRuntimeConfigTest.php
@@ -10,7 +10,7 @@ use Shopware\Storefront\Theme\ThemeRuntimeConfig;
 /**
  * @internal
  */
-#[Package('framework')]
+#[Package('discovery')]
 #[CoversClass(ThemeRuntimeConfig::class)]
 class ThemeRuntimeConfigTest extends TestCase
 {

--- a/tests/unit/Storefront/Theme/Validator/SCSSValidatorTest.php
+++ b/tests/unit/Storefront/Theme/Validator/SCSSValidatorTest.php
@@ -13,7 +13,7 @@ use Shopware\Storefront\Theme\Validator\SCSSValidator;
 /**
  * @internal
  */
-#[Package('framework')]
+#[Package('discovery')]
 #[CoversClass(SCSSValidator::class)]
 class SCSSValidatorTest extends TestCase
 {


### PR DESCRIPTION
### 1. Why is this change necessary?

The `#[Package]` attribute of several tests differs from the ownership of the code they cover, so failing tests are routed to the wrong domain team.

### 2. What does this change do, exactly?

Sets the `#[Package]` value of 22 Storefront unit tests to the value of their covered class. Attribute lines only.

Once this suite is aligned, its namespace is added to the `coversPackageMatchNamespaces` rollout list of the enforcement rule (#19394), which keeps the values in sync from then on.

### 3. Describe each step to reproduce the issue or behaviour.

Attribute-only changes, no behaviour. Compare each test's `#[Package]` value with the `#[Package]` of its `CoversClass` target.

### 4. Please link to the relevant issues (if any).

- relates #18473

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
