### PR TITLE
test: align System and Maintenance unit test package attributes with the covered classes

### DIFF
--- a/tests/unit/Core/Maintenance/SalesChannel/Command/SalesChannelListCommandTest.php
+++ b/tests/unit/Core/Maintenance/SalesChannel/Command/SalesChannelListCommandTest.php
@@ -17,7 +17,7 @@ use Symfony\Component\Console\Tester\CommandTester;
 /**
  * @internal
  */
-#[Package('framework')]
+#[Package('discovery')]
 #[CoversClass(SalesChannelListCommand::class)]
 class SalesChannelListCommandTest extends TestCase
 {

--- a/tests/unit/Core/System/Currency/CurrencyFormatterTest.php
+++ b/tests/unit/Core/System/Currency/CurrencyFormatterTest.php
@@ -19,7 +19,7 @@ use Shopware\Core\System\Locale\LanguageLocaleCodeProvider;
 /**
  * @internal
  */
-#[Package('fundamentals@discovery')]
+#[Package('fundamentals@framework')]
 #[CoversClass(CurrencyFormatter::class)]
 class CurrencyFormatterTest extends TestCase
 {

--- a/tests/unit/Core/System/Currency/Rule/CurrencyRuleTest.php
+++ b/tests/unit/Core/System/Currency/Rule/CurrencyRuleTest.php
@@ -24,7 +24,7 @@ use Symfony\Component\Validator\Validation;
 /**
  * @internal
  */
-#[Package('fundamentals@discovery')]
+#[Package('fundamentals@after-sales')]
 #[CoversClass(CurrencyRule::class)]
 class CurrencyRuleTest extends TestCase
 {

--- a/tests/unit/Core/System/SalesChannel/Api/StructEncoderTest.php
+++ b/tests/unit/Core/System/SalesChannel/Api/StructEncoderTest.php
@@ -41,7 +41,7 @@ use Symfony\Component\Validator\Validator\ValidatorInterface;
 /**
  * @internal
  */
-#[Package('discovery')]
+#[Package('framework')]
 #[CoversClass(StructEncoder::class)]
 class StructEncoderTest extends TestCase
 {

--- a/tests/unit/Core/System/SalesChannel/Context/BaseSalesChannelContextFactoryTest.php
+++ b/tests/unit/Core/System/SalesChannel/Context/BaseSalesChannelContextFactoryTest.php
@@ -57,7 +57,7 @@ use Shopware\Core\Test\TestDefaults;
  *
  * @phpstan-import-type ContextOptions from BaseSalesChannelContextFactory
  */
-#[Package('discovery')]
+#[Package('framework')]
 #[CoversClass(BaseSalesChannelContextFactory::class)]
 class BaseSalesChannelContextFactoryTest extends TestCase
 {

--- a/tests/unit/Core/System/SalesChannel/Context/CartRestorerTest.php
+++ b/tests/unit/Core/System/SalesChannel/Context/CartRestorerTest.php
@@ -22,7 +22,7 @@ use Symfony\Component\HttpFoundation\RequestStack;
 /**
  * @internal
  */
-#[Package('discovery')]
+#[Package('framework')]
 #[CoversClass(CartRestorer::class)]
 class CartRestorerTest extends TestCase
 {

--- a/tests/unit/Core/System/SalesChannel/Context/SalesChannelContextServiceTest.php
+++ b/tests/unit/Core/System/SalesChannel/Context/SalesChannelContextServiceTest.php
@@ -33,7 +33,7 @@ use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
 /**
  * @internal
  */
-#[Package('discovery')]
+#[Package('framework')]
 #[CoversClass(SalesChannelContextService::class)]
 class SalesChannelContextServiceTest extends TestCase
 {

--- a/tests/unit/Core/System/SalesChannel/ContextTokenResponseTest.php
+++ b/tests/unit/Core/System/SalesChannel/ContextTokenResponseTest.php
@@ -11,7 +11,7 @@ use Shopware\Core\System\SalesChannel\ContextTokenResponse;
 /**
  * @internal
  */
-#[Package('discovery')]
+#[Package('framework')]
 #[CoversClass(ContextTokenResponse::class)]
 class ContextTokenResponseTest extends TestCase
 {

--- a/tests/unit/Core/System/SalesChannel/Event/SalesChannelContextCreatedEventTest.php
+++ b/tests/unit/Core/System/SalesChannel/Event/SalesChannelContextCreatedEventTest.php
@@ -12,7 +12,7 @@ use Shopware\Core\System\SalesChannel\SalesChannelContext;
 /**
  * @internal
  */
-#[Package('discovery')]
+#[Package('framework')]
 #[CoversClass(SalesChannelContextCreatedEvent::class)]
 class SalesChannelContextCreatedEventTest extends TestCase
 {

--- a/tests/unit/Core/System/SalesChannel/Rule/SalesChannelRuleTest.php
+++ b/tests/unit/Core/System/SalesChannel/Rule/SalesChannelRuleTest.php
@@ -19,7 +19,7 @@ use Shopware\Core\Test\Generator;
 /**
  * @internal
  */
-#[Package('discovery')]
+#[Package('fundamentals@after-sales')]
 #[CoversClass(SalesChannelRule::class)]
 class SalesChannelRuleTest extends TestCase
 {

--- a/tests/unit/Core/System/SalesChannel/SalesChannelContextTest.php
+++ b/tests/unit/Core/System/SalesChannel/SalesChannelContextTest.php
@@ -16,7 +16,7 @@ use Shopware\Core\Test\Generator;
 /**
  * @internal
  */
-#[Package('discovery')]
+#[Package('framework')]
 #[CoversClass(SalesChannelContext::class)]
 class SalesChannelContextTest extends TestCase
 {

--- a/tests/unit/Core/System/SalesChannel/StoreApiCustomFieldMapperTest.php
+++ b/tests/unit/Core/System/SalesChannel/StoreApiCustomFieldMapperTest.php
@@ -15,7 +15,7 @@ use Shopware\Core\System\SalesChannel\StoreApiCustomFieldMapper;
 /**
  * @internal
  */
-#[Package('discovery')]
+#[Package('framework')]
 #[CoversClass(StoreApiCustomFieldMapper::class)]
 class StoreApiCustomFieldMapperTest extends TestCase
 {


### PR DESCRIPTION
### 1. Why is this change necessary?

The `#[Package]` attribute of several tests differs from the ownership of the code they cover, so failing tests are routed to the wrong domain team.

### 2. What does this change do, exactly?

Sets the `#[Package]` value of 12 System and Maintenance unit tests to the value of their covered class. Attribute lines only.

Once this suite is aligned, its namespace is added to the `coversPackageMatchNamespaces` rollout list of the enforcement rule (#19394), which keeps the values in sync from then on.

### 3. Describe each step to reproduce the issue or behaviour.

Attribute-only changes, no behaviour. Compare each test's `#[Package]` value with the `#[Package]` of its `CoversClass` target.

### 4. Please link to the relevant issues (if any).

- relates #18473

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
