### PR TITLE
test: align Content, Administration and Elasticsearch unit test package attributes with the covered classes

### DIFF
--- a/tests/unit/Administration/Controller/AdministrationControllerTest.php
+++ b/tests/unit/Administration/Controller/AdministrationControllerTest.php
@@ -54,7 +54,7 @@ use Twig\Environment;
 /**
  * @internal
  */
-#[Package('checkout')]
+#[Package('framework')]
 #[CoversClass(AdministrationController::class)]
 class AdministrationControllerTest extends TestCase
 {

--- a/tests/unit/Administration/Snippet/CachedSnippetFinderTest.php
+++ b/tests/unit/Administration/Snippet/CachedSnippetFinderTest.php
@@ -14,7 +14,7 @@ use Symfony\Component\Cache\CacheItem;
 /**
  * @internal
  */
-#[Package('framework')]
+#[Package('discovery')]
 #[CoversClass(CachedSnippetFinder::class)]
 class CachedSnippetFinderTest extends TestCase
 {

--- a/tests/unit/Core/Content/Category/Tree/CategoryTreePathResolverTest.php
+++ b/tests/unit/Core/Content/Category/Tree/CategoryTreePathResolverTest.php
@@ -11,7 +11,7 @@ use Shopware\Core\Framework\Log\Package;
 /**
  * @internal
  */
-#[Package('framework')]
+#[Package('discovery')]
 #[CoversClass(CategoryTreePathResolver::class)]
 class CategoryTreePathResolverTest extends TestCase
 {

--- a/tests/unit/Core/Content/Media/Infrastructure/Path/BanMediaUrlTest.php
+++ b/tests/unit/Core/Content/Media/Infrastructure/Path/BanMediaUrlTest.php
@@ -17,7 +17,7 @@ use Shopware\Core\Test\Stub\Framework\IdsCollection;
 /**
  * @internal
  */
-#[Package('framework')]
+#[Package('discovery')]
 #[CoversClass(BanMediaUrl::class)]
 class BanMediaUrlTest extends TestCase
 {

--- a/tests/unit/Core/Content/Media/SalesChannel/MediaRouteTest.php
+++ b/tests/unit/Core/Content/Media/SalesChannel/MediaRouteTest.php
@@ -21,7 +21,7 @@ use Symfony\Component\HttpFoundation\Request;
 /**
  * @internal
  */
-#[Package('framework')]
+#[Package('discovery')]
 #[CoversClass(MediaRoute::class)]
 class MediaRouteTest extends TestCase
 {

--- a/tests/unit/Core/Content/Product/SalesChannel/Review/ProductReviewsWidgetLoadedHookTest.php
+++ b/tests/unit/Core/Content/Product/SalesChannel/Review/ProductReviewsWidgetLoadedHookTest.php
@@ -30,7 +30,7 @@ use Symfony\Component\HttpFoundation\Request;
 /**
  * @internal
  */
-#[Package('inventory')]
+#[Package('after-sales')]
 #[CoversClass(ProductReviewsWidgetLoadedHook::class)]
 class ProductReviewsWidgetLoadedHookTest extends TestCase
 {

--- a/tests/unit/Core/Content/Product/SalesChannel/Sorting/ProductSortingEntityTest.php
+++ b/tests/unit/Core/Content/Product/SalesChannel/Sorting/ProductSortingEntityTest.php
@@ -12,7 +12,7 @@ use Shopware\Core\Framework\Log\Package;
 /**
  * @internal
  */
-#[Package('framework')]
+#[Package('inventory')]
 #[CoversClass(ProductSortingEntity::class)]
 class ProductSortingEntityTest extends TestCase
 {

--- a/tests/unit/Core/Content/Seo/ConfiguredEntitySeoUrlRouteTest.php
+++ b/tests/unit/Core/Content/Seo/ConfiguredEntitySeoUrlRouteTest.php
@@ -19,7 +19,7 @@ use Shopware\Core\System\SalesChannel\SalesChannelEntity;
 /**
  * @internal
  */
-#[Package('inventory')]
+#[Package('discovery')]
 #[CoversClass(ConfiguredEntitySeoUrlRoute::class)]
 class ConfiguredEntitySeoUrlRouteTest extends TestCase
 {

--- a/tests/unit/Core/Content/Seo/SeoUrlRoute/SeoUrlRouteConfigTest.php
+++ b/tests/unit/Core/Content/Seo/SeoUrlRoute/SeoUrlRouteConfigTest.php
@@ -12,7 +12,7 @@ use Shopware\Core\Framework\Log\Package;
 /**
  * @internal
  */
-#[Package('discovery')]
+#[Package('inventory')]
 #[CoversClass(SeoUrlRouteConfig::class)]
 class SeoUrlRouteConfigTest extends TestCase
 {

--- a/tests/unit/Elasticsearch/Product/ProductSearchQueryBuilderTest.php
+++ b/tests/unit/Elasticsearch/Product/ProductSearchQueryBuilderTest.php
@@ -49,7 +49,7 @@ use Symfony\Component\Validator\Validator\ValidatorInterface;
 /**
  * @internal
  */
-#[Package('inventory')]
+#[Package('framework')]
 #[CoversClass(AbstractProductSearchQueryBuilder::class)]
 #[CoversClass(ProductSearchQueryBuilder::class)]
 class ProductSearchQueryBuilderTest extends TestCase


### PR DESCRIPTION
### 1. Why is this change necessary?

The `#[Package]` attribute of several tests differs from the ownership of the code they cover, so failing tests are routed to the wrong domain team.

### 2. What does this change do, exactly?

Sets the `#[Package]` value of 10 unit tests under Content, Administration and Elasticsearch to the value of their covered class. Attribute lines only.

Once this suite is aligned, its namespace is added to the `coversPackageMatchNamespaces` rollout list of the enforcement rule (#19394), which keeps the values in sync from then on.

### 3. Describe each step to reproduce the issue or behaviour.

Attribute-only changes, no behaviour. Compare each test's `#[Package]` value with the `#[Package]` of its `CoversClass` target.

### 4. Please link to the relevant issues (if any).

- relates #18473

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
