### PR TITLE
test: align Framework unit test package attributes with the covered classes

### DIFF
--- a/tests/unit/Core/Framework/App/Checkout/Payload/AppCheckoutGatewayPayloadServiceTest.php
+++ b/tests/unit/Core/Framework/App/Checkout/Payload/AppCheckoutGatewayPayloadServiceTest.php
@@ -26,7 +26,7 @@ use Shopware\Core\Test\Generator;
 /**
  * @internal
  */
-#[Package('checkout')]
+#[Package('framework')]
 #[CoversClass(AppCheckoutGatewayPayloadService::class)]
 class AppCheckoutGatewayPayloadServiceTest extends TestCase
 {

--- a/tests/unit/Core/Framework/App/Payment/Payload/Struct/SourceTest.php
+++ b/tests/unit/Core/Framework/App/Payment/Payload/Struct/SourceTest.php
@@ -10,7 +10,7 @@ use Shopware\Core\Framework\Log\Package;
 /**
  * @internal
  */
-#[Package('checkout')]
+#[Package('framework')]
 #[CoversClass(Source::class)]
 class SourceTest extends TestCase
 {

--- a/tests/unit/Core/Framework/DataAbstractionLayer/FieldSerializer/CreatedByFieldSerializerTest.php
+++ b/tests/unit/Core/Framework/DataAbstractionLayer/FieldSerializer/CreatedByFieldSerializerTest.php
@@ -28,7 +28,7 @@ use Symfony\Component\Validator\Validator\ValidatorInterface;
 /**
  * @internal
  */
-#[Package('checkout')]
+#[Package('framework')]
 #[CoversClass(CreatedByFieldSerializer::class)]
 class CreatedByFieldSerializerTest extends TestCase
 {

--- a/tests/unit/Core/Framework/DataAbstractionLayer/FieldSerializer/UpdatedByFieldSerializerTest.php
+++ b/tests/unit/Core/Framework/DataAbstractionLayer/FieldSerializer/UpdatedByFieldSerializerTest.php
@@ -29,7 +29,7 @@ use Symfony\Component\Validator\Validator\ValidatorInterface;
 /**
  * @internal
  */
-#[Package('checkout')]
+#[Package('framework')]
 #[CoversClass(UpdatedByFieldSerializer::class)]
 class UpdatedByFieldSerializerTest extends TestCase
 {

--- a/tests/unit/Core/Framework/Gateway/Context/Command/Handler/ChangeShippingLocationCommandHandlerTest.php
+++ b/tests/unit/Core/Framework/Gateway/Context/Command/Handler/ChangeShippingLocationCommandHandlerTest.php
@@ -18,7 +18,7 @@ use Shopware\Core\Test\Generator;
 /**
  * @internal
  */
-#[Package('checkout')]
+#[Package('framework')]
 #[CoversClass(ChangeShippingLocationCommandHandler::class)]
 class ChangeShippingLocationCommandHandlerTest extends TestCase
 {

--- a/tests/unit/Core/Framework/Log/Monolog/AnnotatePackageProcessorTest.php
+++ b/tests/unit/Core/Framework/Log/Monolog/AnnotatePackageProcessorTest.php
@@ -23,7 +23,7 @@ use Symfony\Component\Messenger\Exception\HandlerFailedException;
 /**
  * @internal
  */
-#[Package('cause')]
+#[Package('framework')]
 #[CoversClass(AnnotatePackageProcessor::class)]
 class AnnotatePackageProcessorTest extends TestCase
 {
@@ -132,7 +132,7 @@ class AnnotatePackageProcessorTest extends TestCase
         $requestStack->push($request);
 
         $context = [
-            'exception' => new TestException('test'),
+            'exception' => TestCause::createException(),
         ];
 
         $record = new LogRecord(
@@ -171,7 +171,7 @@ class AnnotatePackageProcessorTest extends TestCase
         $requestStack->push($request);
 
         $context = [
-            'exception' => new TestExceptionNoPackage('test'),
+            'exception' => TestCause::createExceptionWithoutPackage(),
         ];
 
         $record = new LogRecord(
@@ -391,8 +391,24 @@ class TestNestedCommand extends Command
  * @internal
  */
 #[Package('cause')]
-class TestCause extends Command
+class TestCause
 {
+    /**
+     * The processor resolves the causing class from the exception's instantiation
+     * site, so exceptions that must be attributed to this fixture are created here.
+     * Deliberately not a Command: the entrypoint detection scans the trace for
+     * Command subclasses and must not match this fixture.
+     */
+    public static function createException(): TestException
+    {
+        return new TestException('test');
+    }
+
+    public static function createExceptionWithoutPackage(): TestExceptionNoPackage
+    {
+        return new TestExceptionNoPackage('test');
+    }
+
     public function throw(\Throwable $exception): never
     {
         throw $exception;

--- a/tests/unit/Core/Framework/Store/Authentication/FrwRequestOptionsProviderTest.php
+++ b/tests/unit/Core/Framework/Store/Authentication/FrwRequestOptionsProviderTest.php
@@ -20,7 +20,7 @@ use Shopware\Core\System\User\Aggregate\UserConfig\UserConfigEntity;
 /**
  * @internal
  */
-#[Package('checkout')]
+#[Package('fundamentals@after-sales')]
 #[CoversClass(FrwRequestOptionsProvider::class)]
 class FrwRequestOptionsProviderTest extends TestCase
 {

--- a/tests/unit/Core/Framework/Store/InAppPurchases/Event/InAppPurchaseChangedEventTest.php
+++ b/tests/unit/Core/Framework/Store/InAppPurchases/Event/InAppPurchaseChangedEventTest.php
@@ -13,7 +13,7 @@ use Shopware\Core\Framework\Webhook\AclPrivilegeCollection;
 /**
  * @internal
  */
-#[Package('checkout')]
+#[Package('framework')]
 #[CoversClass(InAppPurchaseChangedEvent::class)]
 class InAppPurchaseChangedEventTest extends TestCase
 {

--- a/tests/unit/Core/Framework/Store/StoreExceptionTest.php
+++ b/tests/unit/Core/Framework/Store/StoreExceptionTest.php
@@ -16,7 +16,7 @@ use Symfony\Component\HttpFoundation\Response;
 /**
  * @internal
  */
-#[Package('checkout')]
+#[Package('framework')]
 #[CoversClass(StoreException::class)]
 class StoreExceptionTest extends TestCase
 {


### PR DESCRIPTION
### 1. Why is this change necessary?

The `#[Package]` attribute of several Framework unit tests differs from the ownership of the code they cover, so failing tests are routed to the wrong domain team. One test cannot simply be re-valued: `AnnotatePackageProcessorTest` used its own package attribute as test fixture data.

### 2. What does this change do, exactly?

Sets the `#[Package]` value of 8 Framework unit tests to the value of their covered class (attribute lines only), and reworks `AnnotatePackageProcessorTest`, which carried the fake package `cause` because the processor under test resolves the causing class from the exception's instantiation site and two tests instantiated exceptions in the test class body. Those exceptions are now created by factory methods on the existing `TestCause` fixture, so the test class carries its real package. `TestCause` also no longer extends `Command`: the processor's entrypoint detection scans the trace for `Command` subclasses and must not match the fixture.

Once this suite is aligned, its namespace is added to the `coversPackageMatchNamespaces` rollout list of the enforcement rule (#19394), which keeps the values in sync from then on.

### 3. Describe each step to reproduce the issue or behaviour.

Compare each test's `#[Package]` value with the `#[Package]` of its `CoversClass` target. The `AnnotatePackageProcessorTest` rework is covered by its own assertions, which are unchanged.

### 4. Please link to the relevant issues (if any).

- relates #18473

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
