### PR TITLE
test: align migration suite package attributes with the migrated domains

### DIFF
--- a/src/Core/Migration/V6_6/Migration1712309989DropLanguageLocaleUnique.php
+++ b/src/Core/Migration/V6_6/Migration1712309989DropLanguageLocaleUnique.php
@@ -9,7 +9,7 @@ use Shopware\Core\Framework\Migration\MigrationStep;
 /**
  * @internal
  */
-#[Package('framework')]
+#[Package('fundamentals@discovery')]
 class Migration1712309989DropLanguageLocaleUnique extends MigrationStep
 {
     public function getCreationTimestamp(): int

--- a/src/Core/Migration/V6_7/Migration1752219159AddLanguageActive.php
+++ b/src/Core/Migration/V6_7/Migration1752219159AddLanguageActive.php
@@ -10,7 +10,7 @@ use Shopware\Core\Framework\Util\Database\TableHelper;
 /**
  * @internal
  */
-#[Package('framework')]
+#[Package('fundamentals@discovery')]
 class Migration1752219159AddLanguageActive extends MigrationStep
 {
     public function getCreationTimestamp(): int

--- a/src/Core/Migration/V6_7/Migration1752750086AddIndexToOrderLineItemCreateAndUpdate.php
+++ b/src/Core/Migration/V6_7/Migration1752750086AddIndexToOrderLineItemCreateAndUpdate.php
@@ -10,7 +10,7 @@ use Shopware\Core\Framework\Util\Database\TableHelper;
 /**
  * @internal
  */
-#[Package('framework')]
+#[Package('checkout')]
 class Migration1752750086AddIndexToOrderLineItemCreateAndUpdate extends MigrationStep
 {
     public function getCreationTimestamp(): int

--- a/src/Core/Migration/V6_7/Migration1752750171AddIndexToOrderAddressCreateAndUpdate.php
+++ b/src/Core/Migration/V6_7/Migration1752750171AddIndexToOrderAddressCreateAndUpdate.php
@@ -10,7 +10,7 @@ use Shopware\Core\Framework\Util\Database\TableHelper;
 /**
  * @internal
  */
-#[Package('framework')]
+#[Package('checkout')]
 class Migration1752750171AddIndexToOrderAddressCreateAndUpdate extends MigrationStep
 {
     public function getCreationTimestamp(): int

--- a/src/Core/Migration/V6_7/Migration1752750234AddIndexToOrderTransactionCreateAndUpdate.php
+++ b/src/Core/Migration/V6_7/Migration1752750234AddIndexToOrderTransactionCreateAndUpdate.php
@@ -10,7 +10,7 @@ use Shopware\Core\Framework\Util\Database\TableHelper;
 /**
  * @internal
  */
-#[Package('framework')]
+#[Package('checkout')]
 class Migration1752750234AddIndexToOrderTransactionCreateAndUpdate extends MigrationStep
 {
     public function getCreationTimestamp(): int

--- a/src/Core/Migration/V6_7/Migration1756296414UpdateSnippetSetBaseFiles.php
+++ b/src/Core/Migration/V6_7/Migration1756296414UpdateSnippetSetBaseFiles.php
@@ -9,7 +9,7 @@ use Shopware\Core\Framework\Migration\MigrationStep;
 /**
  * @internal
  */
-#[Package('framework')]
+#[Package('discovery')]
 class Migration1756296414UpdateSnippetSetBaseFiles extends MigrationStep
 {
     public function getCreationTimestamp(): int

--- a/src/Core/Migration/V6_7/Migration1763377575SendEmailAfterPasswordChangeFlow.php
+++ b/src/Core/Migration/V6_7/Migration1763377575SendEmailAfterPasswordChangeFlow.php
@@ -14,7 +14,7 @@ use Shopware\Core\Framework\Uuid\Uuid;
 /**
  * @internal
  */
-#[Package('framework')]
+#[Package('after-sales')]
 class Migration1763377575SendEmailAfterPasswordChangeFlow extends MigrationStep
 {
     public function getCreationTimestamp(): int

--- a/src/Core/Migration/V6_7/Migration1773225412AddZugferdEmbeddedCancellationInvoice.php
+++ b/src/Core/Migration/V6_7/Migration1773225412AddZugferdEmbeddedCancellationInvoice.php
@@ -14,7 +14,7 @@ use Shopware\Core\Migration\Traits\Translations;
 /**
  * @internal
  */
-#[Package('framework')]
+#[Package('after-sales')]
 class Migration1773225412AddZugferdEmbeddedCancellationInvoice extends MigrationStep
 {
     use ImportTranslationsTrait;

--- a/src/Core/Migration/V6_7/Migration1774359918ProductPriceQuantityRangeMinValues.php
+++ b/src/Core/Migration/V6_7/Migration1774359918ProductPriceQuantityRangeMinValues.php
@@ -9,7 +9,7 @@ use Shopware\Core\Framework\Migration\MigrationStep;
 /**
  * @internal
  */
-#[Package('framework')]
+#[Package('inventory')]
 class Migration1774359918ProductPriceQuantityRangeMinValues extends MigrationStep
 {
     public function getCreationTimestamp(): int

--- a/src/Core/Migration/V6_7/Migration1778146739AddSalesChannelTrackingCustomerPrivilege.php
+++ b/src/Core/Migration/V6_7/Migration1778146739AddSalesChannelTrackingCustomerPrivilege.php
@@ -9,7 +9,7 @@ use Shopware\Core\Framework\Migration\MigrationStep;
 /**
  * @internal
  */
-#[Package('framework')]
+#[Package('discovery')]
 class Migration1778146739AddSalesChannelTrackingCustomerPrivilege extends MigrationStep
 {
     final public const NEW_PRIVILEGES = [

--- a/src/Core/Migration/V6_8/Migration1755497870RemoveLabelTranslationOfImportExportProfile.php
+++ b/src/Core/Migration/V6_8/Migration1755497870RemoveLabelTranslationOfImportExportProfile.php
@@ -9,7 +9,7 @@ use Shopware\Core\Framework\Migration\MigrationStep;
 /**
  * @internal
  */
-#[Package('framework')]
+#[Package('fundamentals@after-sales')]
 class Migration1755497870RemoveLabelTranslationOfImportExportProfile extends MigrationStep
 {
     public function getCreationTimestamp(): int

--- a/tests/migration/Core/V6_6/Migration1712309989DropLanguageLocaleUniqueTest.php
+++ b/tests/migration/Core/V6_6/Migration1712309989DropLanguageLocaleUniqueTest.php
@@ -15,7 +15,7 @@ use Shopware\Core\System\Language\LanguageDefinition;
 /**
  * @internal
  */
-#[Package('checkout')]
+#[Package('fundamentals@discovery')]
 #[CoversClass(Migration1712309989DropLanguageLocaleUnique::class)]
 class Migration1712309989DropLanguageLocaleUniqueTest extends TestCase
 {

--- a/tests/migration/Core/V6_6/Migration1727768690UpdateDefaultEnglishPlainMailFooterTest.php
+++ b/tests/migration/Core/V6_6/Migration1727768690UpdateDefaultEnglishPlainMailFooterTest.php
@@ -15,7 +15,7 @@ use Shopware\Core\Migration\V6_6\Migration1727768690UpdateDefaultEnglishPlainMai
 /**
  * @internal
  */
-#[Package('framework')]
+#[Package('after-sales')]
 #[CoversClass(Migration1727768690UpdateDefaultEnglishPlainMailFooter::class)]
 class Migration1727768690UpdateDefaultEnglishPlainMailFooterTest extends TestCase
 {

--- a/tests/migration/Core/V6_6/Migration1733323215AddHashToAppTemplateTest.php
+++ b/tests/migration/Core/V6_6/Migration1733323215AddHashToAppTemplateTest.php
@@ -13,7 +13,7 @@ use Shopware\Core\Migration\V6_6\Migration1733323215AddHashToAppTemplate;
 /**
  * @internal
  */
-#[Package('checkout')]
+#[Package('framework')]
 #[CoversClass(Migration1733323215AddHashToAppTemplate::class)]
 class Migration1733323215AddHashToAppTemplateTest extends TestCase
 {

--- a/tests/migration/Core/V6_7/Migration1743151679AddContextGatewayUrlTest.php
+++ b/tests/migration/Core/V6_7/Migration1743151679AddContextGatewayUrlTest.php
@@ -14,7 +14,7 @@ use Shopware\Core\Migration\V6_7\Migration1743151679AddContextGatewayUrl;
 /**
  * @internal
  */
-#[Package('framework')]
+#[Package('checkout')]
 #[CoversClass(Migration1696515133AddCheckoutGatewayUrl::class)]
 class Migration1743151679AddContextGatewayUrlTest extends TestCase
 {

--- a/tests/migration/Core/V6_7/Migration1748326970UpdateMailTemplatesForAccessibilityTest.php
+++ b/tests/migration/Core/V6_7/Migration1748326970UpdateMailTemplatesForAccessibilityTest.php
@@ -13,7 +13,7 @@ use Shopware\Core\Migration\V6_7\Migration1748326970UpdateMailTemplatesForAccess
 /**
  * @internal
  */
-#[Package('framework')]
+#[Package('after-sales')]
 #[CoversClass(Migration1748326970UpdateMailTemplatesForAccessibility::class)]
 class Migration1748326970UpdateMailTemplatesForAccessibilityTest extends TestCase
 {

--- a/tests/migration/Core/V6_7/Migration1754892246FixWordingMistakeInEmailTemplatesTest.php
+++ b/tests/migration/Core/V6_7/Migration1754892246FixWordingMistakeInEmailTemplatesTest.php
@@ -13,7 +13,7 @@ use Shopware\Core\Migration\V6_7\Migration1754892246FixWordingMistakeInEmailTemp
 /**
  * @internal
  */
-#[Package('framework')]
+#[Package('after-sales')]
 #[CoversClass(Migration1754892246FixWordingMistakeInEmailTemplates::class)]
 class Migration1754892246FixWordingMistakeInEmailTemplatesTest extends TestCase
 {

--- a/tests/migration/Core/V6_7/Migration1763377575SendEmailAfterPasswordChangeFlowTest.php
+++ b/tests/migration/Core/V6_7/Migration1763377575SendEmailAfterPasswordChangeFlowTest.php
@@ -15,7 +15,7 @@ use Shopware\Core\Migration\V6_7\Migration1763377575SendEmailAfterPasswordChange
 /**
  * @internal
  */
-#[Package('checkout')]
+#[Package('after-sales')]
 #[CoversClass(Migration1763377575SendEmailAfterPasswordChangeFlow::class)]
 class Migration1763377575SendEmailAfterPasswordChangeFlowTest extends TestCase
 {

--- a/tests/migration/Core/V6_7/Migration1774359918ProductPriceQuantityRangeMinValuesTest.php
+++ b/tests/migration/Core/V6_7/Migration1774359918ProductPriceQuantityRangeMinValuesTest.php
@@ -16,7 +16,7 @@ use Shopware\Core\Migration\V6_7\Migration1774359918ProductPriceQuantityRangeMin
 /**
  * @internal
  */
-#[Package('data-services')]
+#[Package('inventory')]
 #[CoversClass(Migration1774359918ProductPriceQuantityRangeMinValues::class)]
 class Migration1774359918ProductPriceQuantityRangeMinValuesTest extends TestCase
 {


### PR DESCRIPTION
### 1. Why is this change necessary?

Migration tests and the migrations they cover disagree on their `#[Package]` value. For migrations the test side is often the correct one: many migrations carry `framework` although they migrate feature-domain tables, so failing nightly migration tests are routed to the wrong team.

### 2. What does this change do, exactly?

Attribute lines only, resolved per case against the owner of the migrated table (the `#[Package]` of the table's entity definition):

- 11 migrations move from `framework` to the domain whose table they migrate: 3x order index migrations to `checkout`; language migrations (`DropLanguageLocaleUnique`, `AddLanguageActive`) to `fundamentals@discovery`; `UpdateSnippetSetBaseFiles` and `AddSalesChannelTrackingCustomerPrivilege` to `discovery`; `AddZugferdEmbeddedCancellationInvoice` and `SendEmailAfterPasswordChangeFlow` to `after-sales`; `RemoveLabelTranslationOfImportExportProfile` to `fundamentals@after-sales`; `ProductPriceQuantityRangeMinValues` to `inventory`.
- 8 migration tests get the matching value where they disagreed with the entity owner (mail template migrations to `after-sales`, `AddHashToAppTemplate` to `framework`, and the cases above).

Once aligned, `Shopware\Tests\Migration\` is added to the `coversPackageMatchNamespaces` rollout list of the enforcement rule (#19394).

### 3. Describe each step to reproduce the issue or behaviour.

Attribute-only changes, no behaviour and no schema changes. For each touched migration, compare its `#[Package]` with the `#[Package]` of the entity definition owning the migrated table.

### 4. Please link to the relevant issues (if any).

- relates #18473

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
