### PR TITLE
fix(ci): include scoped commits in release notes

### DIFF
--- a/.github/bin/generate-release-notes.php
+++ b/.github/bin/generate-release-notes.php
@@ -59,8 +59,10 @@ if (!$latestTag) {
 $latestTag = trim($latestTag);
 
 // Get all commits since last release
+// Match conventional feat/fix/refactor/revert commits with an optional scope (for example, "fix:" and "fix(storefront):").
+// Example: https://regex101.com/r/OcDnXj/1
 $commitsRaw = shell_exec(sprintf(
-    'git log @ %s --pretty=format:"%%H %%s" --grep="^feat:\|^fix:\|^refactor:\|^revert:"',
+    'git log @ %s --pretty=format:"%%H %%s" --extended-regexp --grep="^(feat|fix|refactor|revert)(\([^)]*\))?:"',
     escapeshellarg('^' . $latestTag)
 ));
 if (!$commitsRaw) {
@@ -68,8 +70,10 @@ if (!$commitsRaw) {
     exit(1);
 }
 
-$outputContent .= "## What's Changed\n";
+// Keep release notes in conventional commit order while preserving git order within each type.
+$commitsByType = ['feat' => [], 'fix' => [], 'refactor' => [], 'revert' => []];
 foreach (explode("\n", $commitsRaw) as $commit) {
+    preg_match('/^[a-z0-9]+\s(feat|fix|refactor|revert)(?:\([^)]*\))?:/', $commit, $typeMatch);
     if (preg_match('/^([a-z0-9]+)\s(.*)\s\(#(\d+)\)$/', $commit, $m)) {
         $title = $m[2];
         $prNumber = $m[3];
@@ -82,9 +86,16 @@ foreach (explode("\n", $commitsRaw) as $commit) {
             }
         }
         $author = trim(findAuthor($prNumberAuthorCheck) ?? '');
-        $outputContent .= "* $title by @$author [#$prNumber](https://github.com/shopware/shopware/pull/$prNumber)\n";
+        $commitsByType[$typeMatch[1]][] = "* $title by @$author [#$prNumber](https://github.com/shopware/shopware/pull/$prNumber)";
     }
 }
+$outputContent .= "## What's Changed\n";
+$outputContent .= implode("\n", array_merge(
+    $commitsByType['feat'],
+    $commitsByType['fix'],
+    $commitsByType['refactor'],
+    $commitsByType['revert'],
+)) . "\n";
 
 $outputContent .= "\n**Full Changelog**: https://github.com/shopware/shopware/compare/$latestTag...v$version\n\n";
 $outputContent .= "## Get in touch\n";


### PR DESCRIPTION
### 1. Why is this change necessary?

Scoped conventional commits such as `fix(storefront): ...` were excluded from generated release notes because the generator only matched unscoped commit types.

### 2. What does this change do, exactly?

- Matches scoped and unscoped `feat`, `fix`, `refactor`, and `revert` commits.
- Orders the generated “What’s Changed” entries as `feat`, `fix`, `refactor`, then `revert`.
- Preserves git order within each commit type.
- Documents the matching behavior with a regex101 example.

### 3. Describe each step to reproduce the issue or behaviour.

1. Generate release notes for a release containing a commit such as `fix(storefront): ...`.
2. Before this change, the scoped commit is missing from “What’s Changed”.
3. After this change, it is included in the `fix` section/order.

### 4. Please link to the relevant issues (if any).

None.

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is relevant for external developers
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them