### PR TITLE
test: unskip FlowBuilderCreate for SaaS instances

### DIFF
--- a/tests/acceptance/tests/Settings/FlowBuilderCreate.spec.ts
+++ b/tests/acceptance/tests/Settings/FlowBuilderCreate.spec.ts
@@ -10,17 +10,7 @@ test(
             description: 'https://github.com/shopware/shopware/issues/15749',
         },
     },
-    async ({
-        ShopAdmin,
-        AdminFlowBuilderListing,
-        AdminFlowBuilderDetail,
-        IdProvider,
-        TestDataService,
-        CreateFlow,
-        InstanceMeta,
-    }) => {
-        test.skip(InstanceMeta.isSaaS, 'Test is skipped in SaaS due to flakiness');
-
+    async ({ ShopAdmin, AdminFlowBuilderListing, AdminFlowBuilderDetail, IdProvider, TestDataService, CreateFlow }) => {
         const uniqueId = IdProvider.getIdPair().uuid;
         const tagName = `Test tag - ${uniqueId}`;
         const flowName = `Test flow - ${uniqueId}`;


### PR DESCRIPTION
### 1. Why is this change necessary?
FlowBuilderCreate test was skipped due to flakiness in SaaS

### 2. What does this change do, exactly?
Undo the skip, as the flakiness couldn't be reproduced in current SaaS environments with latest ATS. Though a potential improvement to make the create flow tasks more robust was found and implemented here: https://github.com/shopware/acceptance-test-suite/pull/680

### 3. Describe each step to reproduce the issue or behaviour.
N/A

### 4. Please link to the relevant issues (if any).

- closes #15749

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
