### PR TITLE
fix(administration): calculate bulk edit net prices per product tax rate

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-price-field/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-price-field/index.js
@@ -104,6 +104,12 @@ export default {
             default: false,
         },
 
+        netDisabled: {
+            type: Boolean,
+            required: false,
+            default: false,
+        },
+
         grossLabel: {
             type: String,
             required: false,
@@ -265,7 +271,7 @@ export default {
 
     methods: {
         onLockSwitch() {
-            if (this.isDisabled) {
+            if (this.isDisabled || this.netDisabled) {
                 return;
             }
             this.priceForCurrency.linked = !this.priceForCurrency.linked;

--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-price-field/sw-price-field.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-price-field/sw-price-field.html.twig
@@ -46,7 +46,7 @@
             class="sw-price-field__lock"
             :class="{
                 'is--locked': priceForCurrency.linked,
-                'is--disabled': isDisabled
+                'is--disabled': isDisabled || netDisabled
             }"
             :aria-label="$t('global.sw-price-field.toggleLinkedCurrency')"
             :aria-pressed="priceForCurrency.linked"
@@ -78,7 +78,7 @@
             :min="0"
             :digits="20"
             :error="netError"
-            :disabled="isInherited || disabled"
+            :disabled="isInherited || disabled || netDisabled"
             :name="netFieldName"
             v-bind="attributesWithoutListeners"
             @update:model-value="onPriceNetInputChange"

--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-price-field/sw-price-field.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-price-field/sw-price-field.spec.js
@@ -126,6 +126,24 @@ describe('components/form/sw-price-field', () => {
         expect(wrapper.find('.sw-price-field--disabled').exists()).toBeTruthy();
     });
 
+    it('should only disable the net field when netDisabled is set', async () => {
+        const wrapper = await setup({ netDisabled: true });
+
+        expect(wrapper.find('.sw-price-field__gross input').attributes('disabled')).toBeUndefined();
+        expect(wrapper.find('.sw-price-field__net input').attributes('disabled')).toBeDefined();
+    });
+
+    it('should not allow to unlink the price when netDisabled is set', async () => {
+        const wrapper = await setup({ value: [{ ...euroPrice, currencyId: currency.id }], netDisabled: true });
+        const lock = wrapper.find('.sw-price-field__lock');
+
+        expect(lock.classes()).toContain('is--disabled');
+
+        await lock.trigger('click');
+
+        expect(wrapper.vm.priceForCurrency.linked).toBe(true);
+    });
+
     it('should calculate price based on default price', async () => {
         const wrapper = await setup({ value: [euroPrice] });
 

--- a/src/Administration/Resources/app/administration/src/module/sw-bulk-edit/page/sw-bulk-edit-product/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-bulk-edit/page/sw-bulk-edit-product/index.js
@@ -143,6 +143,7 @@ export default {
                 .addAssociation('options.group');
 
             criteria
+                .addAssociation('tax')
                 .addAssociation('cover')
                 .addAssociation('categories')
                 .addAssociation('visibilities.salesChannel')
@@ -237,6 +238,13 @@ export default {
         },
 
         pricesFormFields() {
+            // Without a single tax rate for all selected products the price fields cannot convert
+            // between gross and net, so only the gross value can be entered.
+            const netProps = {
+                netDisabled: !this.taxRate?.id,
+                netHelpText: this.taxRate?.id ? null : this.$t('sw-bulk-edit.product.prices.netHelpTextMixedTaxRates'),
+            };
+
             const fields = [
                 {
                     name: 'taxId',
@@ -261,6 +269,7 @@ export default {
                             : this.$t('sw-bulk-edit.product.prices.price.changeLabel'),
                         placeholder: this.$t('sw-bulk-edit.product.prices.price.placeholderPrice'),
                         disabled: this.isChild ? this.bulkEditProduct?.isPriceInherited?.isInherited : false,
+                        ...netProps,
                     },
                 },
                 {
@@ -275,6 +284,7 @@ export default {
                             : this.$t('sw-bulk-edit.product.prices.purchasePrices.changeLabel'),
                         placeholder: this.$t('sw-bulk-edit.product.prices.purchasePrices.placeholderPurchasePrices'),
                         disabled: this.isChild ? this.bulkEditProduct?.isPriceInherited?.isInherited : false,
+                        ...netProps,
                     },
                 },
                 {
@@ -289,6 +299,7 @@ export default {
                             : this.$t('sw-bulk-edit.product.prices.listPrice.changeLabel'),
                         placeholder: this.$t('sw-bulk-edit.product.prices.listPrice.placeholderListPrice'),
                         disabled: this.isChild ? this.bulkEditProduct?.isPriceInherited?.isInherited : false,
+                        ...netProps,
                     },
                 },
                 {
@@ -303,6 +314,7 @@ export default {
                             : this.$t('sw-bulk-edit.product.prices.regulationPrice.changeLabel'),
                         placeholder: this.$t('sw-bulk-edit.product.prices.regulationPrice.placeholderRegulationPrice'),
                         disabled: this.isChild ? this.bulkEditProduct?.isPriceInherited?.isInherited : false,
+                        ...netProps,
                     },
                 },
             ];
@@ -1071,8 +1083,42 @@ export default {
 
         loadTaxes() {
             return this.taxRepository.search(this.taxCriteria).then((taxes) => {
-                this.taxRate = this.isChild ? this.parentProduct?.tax : taxes[0];
                 Shopware.Store.get('swProductDetail').setTaxes(taxes);
+
+                if (this.isChild) {
+                    this.taxRate = this.parentProduct?.tax;
+
+                    return null;
+                }
+
+                return this.loadSelectedTaxRate(taxes);
+            });
+        },
+
+        /**
+         * The gross/net conversion of the price fields needs a single tax rate, but every selected product
+         * can use its own one. Only preselect a rate when all selected products share the same tax, otherwise
+         * the net prices are calculated per product when the changes are applied.
+         */
+        loadSelectedTaxRate(taxes) {
+            if (!this.selectedIds.length) {
+                return null;
+            }
+
+            const criteria = new Criteria(1, 1);
+            criteria.addFilter(Criteria.equalsAny('id', this.selectedIds));
+            criteria.addAggregation(Criteria.terms('taxIds', 'taxId', null, null, null));
+
+            return this.productRepository.search(criteria).then((result) => {
+                const buckets = result.aggregations?.taxIds?.buckets ?? [];
+
+                if (buckets.length !== 1) {
+                    this.taxRate = {};
+
+                    return;
+                }
+
+                this.taxRate = taxes.find((tax) => tax.id === buckets[0].key) ?? {};
             });
         },
 
@@ -1189,7 +1235,6 @@ export default {
         onProcessData() {
             let hasListPrice = false;
             let hasRegulationPrice = false;
-            let hasPriceChange = false;
 
             Object.keys(this.bulkEditProduct).forEach((key) => {
                 const bulkEditField = cloneDeep(this.bulkEditProduct[key]);
@@ -1199,25 +1244,14 @@ export default {
 
                 if (key === 'listPrice') {
                     hasListPrice = true;
-                    hasPriceChange = true;
 
                     return;
                 }
 
                 if (key === 'regulationPrice') {
                     hasRegulationPrice = true;
-                    hasPriceChange = true;
 
                     return;
-                }
-
-                if (
-                    [
-                        'price',
-                        'purchasePrices',
-                    ].includes(key)
-                ) {
-                    hasPriceChange = true;
                 }
 
                 let bulkEditValue = this.product[key];
@@ -1282,14 +1316,6 @@ export default {
 
                 this.bulkEditSelected.push(change);
             });
-
-            if (hasPriceChange && !this.bulkEditProduct.taxId?.isChanged && this.taxRate?.id) {
-                this.bulkEditSelected.push({
-                    field: 'taxId',
-                    type: 'overwrite',
-                    value: this.taxRate.id,
-                });
-            }
 
             if (hasListPrice) {
                 this.processListPrice();

--- a/src/Administration/Resources/app/administration/src/module/sw-bulk-edit/page/sw-bulk-edit-product/sw-bulk-edit-product.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-bulk-edit/page/sw-bulk-edit-product/sw-bulk-edit-product.spec.js
@@ -24,6 +24,7 @@ describe('src/module/sw-bulk-edit/page/sw-bulk-edit-product', () => {
             productRepositoryMock: undefined,
             templateType: 'default',
             options: [],
+            taxIdBuckets: undefined,
         },
     ) {
         const productEntity = productEntityOverride === undefined ? { metaTitle: 'test' } : productEntityOverride;
@@ -270,10 +271,6 @@ describe('src/module/sw-bulk-edit/page/sw-bulk-edit-product', () => {
                             }
 
                             if (entity === 'product') {
-                                if (customMocks.productRepositoryMock) {
-                                    return customMocks.productRepositoryMock;
-                                }
-
                                 return {
                                     create: () => ({
                                         isNew: () => true,
@@ -286,6 +283,17 @@ describe('src/module/sw-bulk-edit/page/sw-bulk-edit-product', () => {
 
                                         return Promise.resolve(productEntity);
                                     },
+                                    search: () =>
+                                        Promise.resolve({
+                                            aggregations: {
+                                                taxIds: {
+                                                    buckets: customMocks.taxIdBuckets ?? [
+                                                        { key: 'rate1' },
+                                                    ],
+                                                },
+                                            },
+                                        }),
+                                    ...customMocks.productRepositoryMock,
                                 };
                             }
 
@@ -690,7 +698,7 @@ describe('src/module/sw-bulk-edit/page/sw-bulk-edit-product', () => {
         expect(wrapper.vm.bulkEditProduct.price.value).toBeTruthy();
     });
 
-    it('should add default taxId when price is changed without selecting tax change', async () => {
+    it('should not change the taxId when price is changed without selecting tax change', async () => {
         const wrapper = await createWrapper({}, { name: 'sw.bulk.edit.product', params: { parentId: 'null' } });
 
         await flushPromises();
@@ -704,10 +712,52 @@ describe('src/module/sw-bulk-edit/page/sw-bulk-edit-product', () => {
 
         wrapper.vm.onProcessData();
 
-        const taxChangeField = wrapper.vm.bulkEditSelected.find((field) => field.field === 'taxId');
-        expect(taxChangeField).toBeDefined();
-        expect(taxChangeField.type).toBe('overwrite');
-        expect(taxChangeField.value).toBe('rate1');
+        expect(wrapper.vm.bulkEditSelected.find((field) => field.field === 'taxId')).toBeUndefined();
+    });
+
+    it('should use the tax rate shared by all selected products for the price calculation', async () => {
+        const wrapper = await createWrapper({}, { name: 'sw.bulk.edit.product', params: { parentId: 'null' } });
+
+        await flushPromises();
+
+        expect(wrapper.vm.taxRate).toEqual(
+            expect.objectContaining({
+                id: 'rate1',
+                taxRate: 19,
+            }),
+        );
+
+        wrapper.vm.pricesFormFields
+            .filter((field) => field.config.componentName === 'sw-price-field')
+            .forEach((field) => {
+                expect(field.config.netDisabled).toBe(false);
+                expect(field.config.netHelpText).toBeNull();
+            });
+    });
+
+    it('should not preselect a tax rate when the selected products use different tax rates', async () => {
+        const wrapper = await createWrapper(
+            {},
+            { name: 'sw.bulk.edit.product', params: { parentId: 'null' } },
+            {
+                taxIdBuckets: [
+                    { key: 'rate1' },
+                    { key: 'rate2' },
+                ],
+            },
+        );
+
+        await flushPromises();
+
+        expect(wrapper.vm.taxRate).toEqual({});
+
+        // Without a single tax rate no net value can be entered, only a gross value.
+        wrapper.vm.pricesFormFields
+            .filter((field) => field.config.componentName === 'sw-price-field')
+            .forEach((field) => {
+                expect(field.config.netDisabled).toBe(true);
+                expect(field.config.netHelpText).toBe('sw-bulk-edit.product.prices.netHelpTextMixedTaxRates');
+            });
     });
 
     it('should be getting the list price when the price field is exists', async () => {
@@ -1311,6 +1361,14 @@ describe('src/module/sw-bulk-edit/page/sw-bulk-edit-product', () => {
         await wrapper.vm.getParentProduct();
 
         expect(wrapper.vm.parentProduct).toStrictEqual({});
+    });
+
+    it('should load the tax of the parent product to calculate variant prices', async () => {
+        const wrapper = await createWrapper();
+
+        await flushPromises();
+
+        expect(wrapper.vm.productCriteria.hasAssociation('tax')).toBe(true);
     });
 
     it('should get parent product successful', async () => {

--- a/src/Administration/Resources/app/administration/src/module/sw-bulk-edit/service/handler/bulk-edit-product.handler.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-bulk-edit/service/handler/bulk-edit-product.handler.js
@@ -41,6 +41,10 @@ class BulkEditProductHandler extends BulkEditBaseHandler {
         if (price || purchasePrices) {
             updatedPricePayload = this.updatePriceDirectly(price, purchasePrices, updatedPricePayload);
 
+            if (!taxId) {
+                updatedPricePayload = await this.recalculateNetPrices(updatedPricePayload, price, purchasePrices);
+            }
+
             payload = payload.filter((change) => change.field !== 'price' && change.field !== 'purchasePrices');
         }
 
@@ -276,6 +280,82 @@ class BulkEditProductHandler extends BulkEditBaseHandler {
         });
 
         return payload.concat(calculatedProductPrices);
+    }
+
+    /**
+     * The net values of the entered prices are calculated in the administration with a single tax rate,
+     * but each product can use a different one. Recalculate the net value of every linked price with the
+     * tax rate of the product it belongs to, so the tax rate of the products stays untouched.
+     */
+    async recalculateNetPrices(pricePayload, inputPrice, inputPurchasePrices) {
+        // One group per tax rate and price type, each holding the price to recalculate per product
+        const groups = new Map();
+
+        const addPrice = (taxId, type, productId, enteredPrice, price) => {
+            // Only prices the user entered a gross value for are recalculated, every other price was
+            // restored from the database by `formatPrice` and has to stay untouched.
+            if (enteredPrice?.gross == null || price?.gross == null || !price.linked) {
+                return;
+            }
+
+            const key = `${taxId}.${type}`;
+
+            if (!groups.has(key)) {
+                groups.set(key, { taxId, prices: new Map() });
+            }
+
+            groups.get(key).prices.set(productId, price);
+        };
+
+        pricePayload.forEach(({ id, price, purchasePrices }) => {
+            const taxId = this.products.find((product) => product.id === id)?.taxId;
+
+            if (!taxId) {
+                return;
+            }
+
+            if (inputPrice) {
+                const currentPrice = price?.find((item) => item.currencyId === inputPrice[0].currencyId);
+
+                addPrice(taxId, 'price', id, inputPrice[0], currentPrice);
+                addPrice(taxId, 'listPrice', id, inputPrice[0].listPrice, currentPrice?.listPrice);
+                addPrice(taxId, 'regulationPrice', id, inputPrice[0].regulationPrice, currentPrice?.regulationPrice);
+            }
+
+            if (inputPurchasePrices) {
+                const currentPurchasePrice = purchasePrices?.find(
+                    (item) => item.currencyId === inputPurchasePrices[0].currencyId,
+                );
+
+                addPrice(taxId, 'purchasePrices', id, inputPurchasePrices[0], currentPurchasePrice);
+            }
+        });
+
+        await Promise.all(
+            Array.from(groups.values()).map(async ({ taxId, prices }) => {
+                const grossPrices = {};
+
+                prices.forEach((price, productId) => {
+                    grossPrices[productId] = [this.getRecalculatePrice(price)];
+                });
+
+                const calculatedPrices = await this.calculatePrices(taxId, grossPrices);
+
+                prices.forEach((price, productId) => {
+                    const calculatedPrice = calculatedPrices[productId]?.[price.currencyId];
+
+                    if (!calculatedPrice) {
+                        return;
+                    }
+
+                    const net = price.gross - this.getTax(calculatedPrice.calculatedTaxes);
+
+                    price.net = parseFloat(net.toPrecision(14));
+                });
+            }),
+        );
+
+        return pricePayload;
     }
 
     updatePrice(inputPrice, dbPrices) {

--- a/src/Administration/Resources/app/administration/src/module/sw-bulk-edit/service/handler/bulk-edit-product.handler.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-bulk-edit/service/handler/bulk-edit-product.handler.spec.js
@@ -118,9 +118,29 @@ describe('module/sw-bulk-edit/service/handler/bulk-edit-product.handler', () => 
         handler.products = [
             {
                 id: 'product_1',
+                taxId: 'tax_19',
                 price: [originalBasePrice],
             },
         ];
+        handler.calculatePriceService = {
+            calculatePrices: jest.fn((taxId, prices) => {
+                const calculated = {};
+
+                Object.keys(prices).forEach((productId) => {
+                    const { price, currencyId: priceCurrencyId } = prices[productId][0];
+
+                    calculated[productId] = {
+                        [priceCurrencyId]: {
+                            calculatedTaxes: [
+                                { tax: price - price / 1.19 },
+                            ],
+                        },
+                    };
+                });
+
+                return Promise.resolve(calculated);
+            }),
+        };
 
         const syncSpy = jest.spyOn(handler.syncService, 'sync').mockResolvedValue({ data: [] });
 
@@ -147,10 +167,13 @@ describe('module/sw-bulk-edit/service/handler/bulk-edit-product.handler', () => 
         const syncPayload = syncSpy.mock.calls[0][0];
         const productPayload = syncPayload['upsert-product'].payload[0];
 
+        // The base price was not entered, so it stays exactly as it is stored, even though the
+        // entered list price is recalculated with the tax rate of the product.
         expect(productPayload.price[0].gross).toBe(50);
         expect(productPayload.price[0].net).toBe(42.02);
         expect(productPayload.price[0].linked).toBe(true);
         expect(productPayload.price[0].listPrice.gross).toBe(100);
+        expect(productPayload.price[0].listPrice.net).toBe(84.033613445378);
     });
 
     it('should preserve base price fields (gross/net/linked) when only regulationPrice is changed', async () => {
@@ -201,6 +224,117 @@ describe('module/sw-bulk-edit/service/handler/bulk-edit-product.handler', () => 
         expect(productPayload.price[0].net).toBe(63.03);
         expect(productPayload.price[0].linked).toBe(true);
         expect(productPayload.price[0].regulationPrice.gross).toBe(150);
+    });
+
+    it('should recalculate the net price with the tax rate of each product', async () => {
+        const currencyId = 'b7d2554b0ce847cd82f3ac9bd1c0dfca';
+        const handler = getBulkEditProductHandler();
+
+        handler.getProducts = jest.fn().mockResolvedValue(undefined);
+        handler.products = [
+            {
+                id: 'product_1',
+                taxId: 'tax_19',
+                price: [
+                    { currencyId, gross: 5, net: 4.2, linked: true },
+                ],
+            },
+            {
+                id: 'product_2',
+                taxId: 'tax_0',
+                price: [
+                    { currencyId, gross: 5, net: 5, linked: true },
+                ],
+            },
+        ];
+        handler.calculatePriceService = {
+            calculatePrices: jest.fn((taxId, prices) => {
+                const taxRate = taxId === 'tax_19' ? 0.19 : 0;
+                const calculated = {};
+
+                Object.keys(prices).forEach((productId) => {
+                    const { price, currencyId: priceCurrencyId } = prices[productId][0];
+
+                    calculated[productId] = {
+                        [priceCurrencyId]: {
+                            calculatedTaxes: [
+                                { tax: price - price / (1 + taxRate) },
+                            ],
+                        },
+                    };
+                });
+
+                return Promise.resolve(calculated);
+            }),
+        };
+
+        const syncSpy = jest.spyOn(handler.syncService, 'sync').mockResolvedValue({ data: [] });
+
+        await handler.bulkEdit(
+            [
+                'product_1',
+                'product_2',
+            ],
+            [
+                {
+                    field: 'price',
+                    type: 'overwrite',
+                    value: [
+                        { currencyId, gross: 11.9, net: 11.9, linked: true },
+                    ],
+                },
+            ],
+        );
+
+        expect(syncSpy.mock.calls[0][0]['upsert-product'].payload).toEqual([
+            {
+                id: 'product_1',
+                price: [
+                    { currencyId, gross: 11.9, net: 10, linked: true },
+                ],
+            },
+            {
+                id: 'product_2',
+                price: [
+                    { currencyId, gross: 11.9, net: 11.9, linked: true },
+                ],
+            },
+        ]);
+    });
+
+    it('should not recalculate the net price when the price is not linked', async () => {
+        const currencyId = 'b7d2554b0ce847cd82f3ac9bd1c0dfca';
+        const handler = getBulkEditProductHandler();
+
+        handler.getProducts = jest.fn().mockResolvedValue(undefined);
+        handler.products = [
+            {
+                id: 'product_1',
+                taxId: 'tax_19',
+                price: [
+                    { currencyId, gross: 5, net: 4.2, linked: true },
+                ],
+            },
+        ];
+        handler.calculatePriceService = { calculatePrices: jest.fn() };
+
+        const syncSpy = jest.spyOn(handler.syncService, 'sync').mockResolvedValue({ data: [] });
+
+        await handler.bulkEdit(
+            ['product_1'],
+            [
+                {
+                    field: 'price',
+                    type: 'overwrite',
+                    value: [
+                        { currencyId, gross: 11.9, net: 9, linked: false },
+                    ],
+                },
+            ],
+        );
+
+        expect(handler.calculatePriceService.calculatePrices).not.toHaveBeenCalled();
+        expect(syncSpy.mock.calls[0][0]['upsert-product'].payload[0].price[0].net).toBe(9);
     });
 
     describe('test buildBulkSyncPayload', () => {

--- a/src/Administration/Resources/app/administration/src/module/sw-bulk-edit/snippet/de.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-bulk-edit/snippet/de.json
@@ -46,6 +46,7 @@
       },
       "prices": {
         "cardTitle": "Preise",
+        "netHelpTextMixedTaxRates": "Die ausgewählten Produkte verwenden unterschiedliche Steuersätze. Gib einen Bruttopreis ein, der Nettopreis wird für jedes Produkt mit dessen eigenem Steuersatz berechnet. Um einen Nettopreis einzugeben, wähle oben einen Steuersatz aus.",
         "taxRate": {
           "changeLabel": "Ändern: Steuersatz",
           "placeholderTax": "Steuersatz auswählen ..."

--- a/src/Administration/Resources/app/administration/src/module/sw-bulk-edit/snippet/en.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-bulk-edit/snippet/en.json
@@ -46,6 +46,7 @@
       },
       "prices": {
         "cardTitle": "Prices",
+        "netHelpTextMixedTaxRates": "The selected products use different tax rates. Enter a gross price, the net price is calculated for each product with its own tax rate. To enter a net price, select a tax rate above.",
         "taxRate": {
           "changeLabel": "Change: Tax rate",
           "placeholderTax": "Select tax rate..."


### PR DESCRIPTION
### 1. Why is this change necessary?

Entering a gross price in the product bulk edit stored the entered value as the net price as soon as a 0% tax rate existed in the shop, and it silently replaced the tax rate of every selected product.

The price fields converted gross to net with `taxes[0]`, sorted by `tax.position`. That column defaults to `0` and only taxes named "Standard rate"/"Reduced rate"/"Reduced rate 2" ever received a position, so any newly created tax rate sorts first. With a 0% rate first, no tax was deducted. On installs where the default rates share position `0` the winner depends on the database order, which is why the issue appears sporadically. Since #15784 a price change additionally wrote that arbitrary rate to all selected products to keep gross and net consistent, so bulk editing a price moved products to the wrong tax rate.

### 2. What does this change do, exactly?

- The net value of every linked price (price, purchase price, list price, cheapest price) is recalculated per product with the tax rate that product uses, grouped by tax rate. Prices the user did not enter a gross value for, and unlinked prices, stay untouched.
- The tax rate is only written when it was explicitly selected in the bulk edit.
- The price fields preselect a tax rate only when all selected products share one. Otherwise no single net value can be derived, so the net input and the lock are disabled and a help text explains that a gross price is expected. Selecting a tax rate enables the net input again.
- `sw-price-field` gained a `netDisabled` prop for that, and the bulk edit loads the `tax` association of the parent product so variants keep using the inherited rate.

### 3. Describe each step to reproduce the issue or behaviour.

1. Create a tax rate with a value of 0% in the administration.
2. Open the product listing and select one or more products that use the standard tax rate.
3. Start the bulk edit and go to the price section.
4. Enter a gross price of 11.90 and observe the calculated net price.
5. Apply the changes and open one of the products.

Before: the net price field showed 11.90, the products were saved with the 0% tax rate and a net price of 11.90. Now: the net price field shows 10, and the products keep their tax rate with a net price of 10.

### 4. Please link to the relevant issues (if any).

- closes #17392
- closes #14308

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [x] I have written or adjusted the documentation and agent skills according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
