### PR TITLE
feat(exp-studio): implement gallery multi media selection

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-experience-studio/component/sw-experience-studio-media-collection-field/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-experience-studio/component/sw-experience-studio-media-collection-field/index.ts
@@ -1,0 +1,126 @@
+import template from './sw-experience-studio-media-collection-field.html.twig';
+import './sw-experience-studio-media-collection-field.scss';
+
+const { Utils } = Shopware;
+
+type MediaListItem = {
+    mediaId: string;
+    url: string;
+    position: number;
+};
+
+/**
+ * @private
+ * @sw-package discovery
+ */
+export default Shopware.Component.wrapComponentConfig({
+    template,
+
+    emits: ['update:value'],
+
+    props: {
+        value: {
+            type: Array as PropType<string[] | null>,
+            required: false,
+            default: null,
+        },
+        label: {
+            type: String,
+            required: false,
+            default: null,
+        },
+        disabled: {
+            type: Boolean,
+            required: false,
+            default: false,
+        },
+    },
+
+    data(): { showMediaModal: boolean; uploadTag: string } {
+        return {
+            showMediaModal: false,
+            uploadTag: Utils.createId(),
+        };
+    },
+
+    computed: {
+        mediaIds(): string[] {
+            return Array.isArray(this.value) ? this.value : [];
+        },
+
+        // Lightweight host object expected by sw-media-list-selection-v2
+        // (only id / isLoading / getEntityName are read).
+        listEntity(): { id: string; isLoading: boolean; getEntityName: () => string } {
+            return {
+                id: this.uploadTag,
+                isLoading: false,
+                getEntityName: () => 'media',
+            };
+        },
+
+        // sw-media-list-selection-item-v2 renders the preview from `mediaId`,
+        // so no hydrated media entity is required here.
+        entityMediaItems(): MediaListItem[] {
+            return this.mediaIds.map((mediaId, position) => ({
+                mediaId,
+                url: mediaId,
+                position,
+            }));
+        },
+    },
+
+    methods: {
+        onOpenMediaModal(): void {
+            if (this.disabled) {
+                return;
+            }
+
+            this.showMediaModal = true;
+        },
+
+        onCloseMediaModal(): void {
+            this.showMediaModal = false;
+        },
+
+        onMediaSelectionChange(selection: Array<{ id: string }>): void {
+            const merged = [...this.mediaIds];
+
+            selection.forEach((media) => {
+                if (!merged.includes(media.id)) {
+                    merged.push(media.id);
+                }
+            });
+
+            this.showMediaModal = false;
+            this.emitValue(merged);
+        },
+
+        onUploadFinish({ targetId }: { targetId: string }): void {
+            if (this.mediaIds.includes(targetId)) {
+                return;
+            }
+
+            this.emitValue([...this.mediaIds, targetId]);
+        },
+
+        onItemRemove(mediaItem: MediaListItem): void {
+            this.emitValue(this.mediaIds.filter((id) => id !== mediaItem.mediaId));
+        },
+
+        onItemSort(dragData: MediaListItem, dropData: MediaListItem): void {
+            if (dragData.position === dropData.position) {
+                return;
+            }
+
+            const ids = [...this.mediaIds];
+            const [moved] = ids.splice(dragData.position, 1);
+            ids.splice(dropData.position, 0, moved);
+
+            this.emitValue(ids);
+        },
+
+        emitValue(ids: string[]): void {
+            this.$emit('update:value', ids.length > 0 ? ids : null);
+        },
+    },
+});

--- a/src/Administration/Resources/app/administration/src/module/sw-experience-studio/component/sw-experience-studio-media-collection-field/sw-experience-studio-media-collection-field.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-experience-studio/component/sw-experience-studio-media-collection-field/sw-experience-studio-media-collection-field.html.twig
@@ -1,0 +1,43 @@
+{% block sw_experience_studio_media_collection_field %}
+<div class="sw-experience-studio-media-collection-field">
+    {% block sw_experience_studio_media_collection_field_label %}
+    <label
+        v-if="label"
+        class="sw-experience-studio-media-collection-field__label"
+    >
+        {{ label }}
+    </label>
+    {% endblock %}
+
+    {% block sw_experience_studio_media_collection_field_selection %}
+    <sw-media-list-selection-v2
+        :entity="listEntity"
+        :entity-media-items="entityMediaItems"
+        :upload-tag="uploadTag"
+        default-folder-name="media"
+        :disabled="disabled"
+        @open-sidebar="onOpenMediaModal"
+        @item-remove="onItemRemove"
+        @item-sort="onItemSort"
+    />
+    {% endblock %}
+
+    {% block sw_experience_studio_media_collection_field_upload_listener %}
+    <sw-upload-listener
+        :upload-tag="uploadTag"
+        auto-upload
+        @media-upload-finish="onUploadFinish"
+    />
+    {% endblock %}
+
+    {% block sw_experience_studio_media_collection_field_modal %}
+    <sw-media-modal-v2
+        v-if="showMediaModal"
+        variant="full"
+        :allow-multi-select="true"
+        @media-modal-selection-change="onMediaSelectionChange"
+        @modal-close="onCloseMediaModal"
+    />
+    {% endblock %}
+</div>
+{% endblock %}

--- a/src/Administration/Resources/app/administration/src/module/sw-experience-studio/component/sw-experience-studio-media-collection-field/sw-experience-studio-media-collection-field.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-experience-studio/component/sw-experience-studio-media-collection-field/sw-experience-studio-media-collection-field.scss
@@ -1,0 +1,11 @@
+.sw-experience-studio-media-collection-field {
+    display: flex;
+    flex-direction: column;
+    gap: var(--mt-spacing-xs);
+
+    &__label {
+        color: var(--color-darkgray-200);
+        font-size: var(--mt-font-size-xs);
+        font-weight: var(--mt-font-weight-medium);
+    }
+}

--- a/src/Administration/Resources/app/administration/src/module/sw-experience-studio/component/sw-experience-studio-media-collection-field/sw-experience-studio-media-collection-field.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-experience-studio/component/sw-experience-studio-media-collection-field/sw-experience-studio-media-collection-field.scss
@@ -1,11 +1,13 @@
 .sw-experience-studio-media-collection-field {
     display: flex;
     flex-direction: column;
-    gap: var(--mt-spacing-xs);
 
-    &__label {
-        color: var(--color-darkgray-200);
-        font-size: var(--mt-font-size-xs);
-        font-weight: var(--mt-font-weight-medium);
+    // More dense appearance for media upload so it fits in the sidebar
+    .sw-media-upload-v2 .sw-media-upload-v2__button {
+        min-width: 0;
+    }
+
+    .sw-media-upload-v2__dropzone.is--multi {
+        padding: var(--scale-size-16);
     }
 }

--- a/src/Administration/Resources/app/administration/src/module/sw-experience-studio/component/sw-experience-studio-settings-fields/sw-experience-studio-settings-fields.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-experience-studio/component/sw-experience-studio-settings-fields/sw-experience-studio-settings-fields.html.twig
@@ -351,6 +351,15 @@
                             @update:value="onUpdateField(field.key, $event)"
                         />
 
+                        <sw-experience-studio-media-collection-field
+                            v-else-if="getControlType(field.property) === 'media-collection'"
+                            v-bind="getControlProps(field.property)"
+                            :label="field.property.title"
+                            :value="getRawPropertyValue(field.key)"
+                            :disabled="!allowEdit || undefined"
+                            @update:value="onUpdateField(field.key, $event)"
+                        />
+
                         <div
                             v-else-if="isInlineTextProperty(field.key, field.property)"
                             class="sw-experience-studio-settings-fields__inline-text-hint"

--- a/src/Administration/Resources/app/administration/src/module/sw-experience-studio/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-experience-studio/index.ts
@@ -97,6 +97,15 @@ Shopware.Component.register(
  * @sw-package discovery
  */
 Shopware.Component.register(
+    'sw-experience-studio-media-collection-field',
+    () => import('./component/sw-experience-studio-media-collection-field'),
+);
+
+/**
+ * @private
+ * @sw-package discovery
+ */
+Shopware.Component.register(
     'sw-experience-studio-element-picker',
     () => import('./component/sw-experience-studio-element-picker'),
 );

--- a/src/Administration/Resources/app/administration/src/module/sw-experience-studio/util/element-settings.util.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-experience-studio/util/element-settings.util.ts
@@ -17,6 +17,7 @@ export type ElementPropertyControlType =
     | 'radio-panel'
     | 'entity'
     | 'media'
+    | 'media-collection'
     | 'richtext'
     | 'text'
     | 'responsive-number'
@@ -44,6 +45,8 @@ const ADMIN_UI_COMPONENT_CONTROL_MAP: Record<string, ElementPropertyControlType>
     'sw-entity-single-select': 'entity',
     'media-field': 'media',
     'sw-media-field': 'media',
+    'media-collection': 'media-collection',
+    'sw-media-list-selection-v2': 'media-collection',
     'responsive-number': 'responsive-number',
     'box-spacing': 'box-spacing',
 };

--- a/src/Core/Framework/ContentSystem/Layout/Type/Definitions/media/gallery.yaml
+++ b/src/Core/Framework/ContentSystem/Layout/Type/Definitions/media/gallery.yaml
@@ -1,0 +1,19 @@
+meta:
+  label: "Gallery"
+  description: "Media gallery element showing multiple images with thumbnail navigation."
+  icon: "regular-image"
+  category: "content"
+  copilot:
+    summary: "Media gallery element."
+    hints:
+      - "Requires one or more media entities."
+
+properties:
+  mediaItems:
+    type: Shopware\Core\Content\Media\MediaCollection
+    required: true
+    title: "Media"
+    description: "The images to be shown in the gallery."
+    resolvedBy: mediaIds
+    adminUI:
+      component: "media-collection"

--- a/src/Core/Framework/ContentSystem/Layout/Type/Definitions/media/gallery.yaml
+++ b/src/Core/Framework/ContentSystem/Layout/Type/Definitions/media/gallery.yaml
@@ -1,7 +1,7 @@
 meta:
   label: "Gallery"
   description: "Media gallery element showing multiple images with thumbnail navigation."
-  icon: "regular-image"
+  icon: "image-text"
   category: "content"
   copilot:
     summary: "Media gallery element."
@@ -17,3 +17,69 @@ properties:
     resolvedBy: mediaIds
     adminUI:
       component: "media-collection"
+
+  displayMode:
+    type: string
+    title: "Display Mode"
+    description: "How the gallery images are sized."
+    default: "auto"
+    enum:
+      - "auto"
+      - "fixedHeight"
+    adminUI:
+      component: "select"
+
+  maxHeight:
+    type: integer
+    required: false
+    title: "Max Height"
+    description: "Maximum image height in px, used in fixed height mode."
+    default: null
+    adminUI:
+      component: "number"
+      visibleWhen:
+        field: "displayMode"
+        equals: "fixedHeight"
+
+  thumbnailSize:
+    type: integer
+    title: "Thumbnail Size"
+    description: "Size of the thumbnails navigation images in px."
+    default: 70
+    adminUI:
+      component: "number"
+
+  thumbnailNavigationPosition:
+    type: string
+    title: "Thumbnail Navigation Position"
+    description: "Position of the thumbnail navigation."
+    default: "left"
+    enum:
+      - "left"
+      - "bottom"
+    adminUI:
+      component: "select"
+
+  showNavigationArrows:
+    type: boolean
+    title: "Show Navigation Arrows"
+    description: "Show the navigation arrows."
+    default: true
+
+  showMagnifier:
+    type: boolean
+    title: "Show Magnifier"
+    description: "Show the magnifier when hovering over the images."
+    default: true
+
+  showFullScreenGallery:
+    type: boolean
+    title: "Show Fullscreen Gallery"
+    description: "Show the fullscreen gallery when clicking on the images."
+    default: true
+
+  autoplayVideos:
+    type: boolean
+    title: "Autoplay Videos"
+    description: "Automatically play videos shown in the gallery."
+    default: true

--- a/src/Storefront/Resources/views/components/Sw/Media/Gallery.html.twig
+++ b/src/Storefront/Resources/views/components/Sw/Media/Gallery.html.twig
@@ -16,7 +16,8 @@
 #}
 
 {% props
-    mediaItems,
+    mediaItems = null,
+    mediaIds = null,
     displayMode = 'auto',
     maxHeight = null,
     thumbnailSize = 70,

--- a/src/Storefront/Resources/views/components/Sw/Media/Gallery.html.twig
+++ b/src/Storefront/Resources/views/components/Sw/Media/Gallery.html.twig
@@ -69,87 +69,95 @@
     'data-component': 'Sw:Media:Gallery',
     'data-component-options': mediaGalleryOptions|json_encode,
     'aria-label': 'component.cms.mediaGallery.ariaLabel'|trans({'%total%': mediaItems|length})|striptags,
+    style: "--sw-media-gallery-thumbnail-size: #{thumbnailSize}px;",
 } %}
 
 {% if displayMode == 'fixedHeight' and maxHeight is not null %}
     {% set defaultAttributes = defaultAttributes|merge({
-        style: "--sw-media-gallery-max-height: #{maxHeight}px;",
+        style: defaultAttributes.style ~ " --sw-media-gallery-max-height: #{maxHeight}px;",
     }) %}
 {% endif %}
 
-<section {{ attributes.defaults(defaultAttributes) }}>
-    {% if mediaItems|length > 1 %}
-        <twig:Sw:Media:ThumbnailNav
-            class="sw-media-gallery__thumbnail-nav"
-            :mediaItems="mediaItems" 
+{% if mediaItems is not null and mediaItems|length > 0 %}
+    <section {{ attributes.defaults(defaultAttributes) }}>
+        {% if mediaItems|length > 1 %}
+            <twig:Sw:Media:ThumbnailNav
+                class="sw-media-gallery__thumbnail-nav"
+                :mediaItems="mediaItems" 
+                :thumbnailSize="thumbnailSize"
+                :isHorizontal="thumbnailNavigationPosition == 'bottom'"
+            />
+        {% endif %}
+
+        <div class="sw-media-gallery__previews-wrapper">
+            <div class="sw-media-gallery__previews">
+                {% for mediaItem in mediaItems %}
+                    <div 
+                        class="sw-media-gallery__preview-item" 
+                        id="sw-media-gallery-preview-{{ loop.index }}"
+                        data-media-id="{{ loop.index }}"
+                        {% if showFullScreenGallery %}
+                            data-bs-toggle="modal"
+                            data-bs-target="#{{ lightboxId }}"
+                            role="button"
+                            tabindex="0"
+                            aria-label="{{ 'component.cms.mediaGallery.openLightboxAriaLabel'|trans({'%index%': loop.index})|striptags }}"
+                            aria-haspopup="dialog"
+                            aria-controls="{{ lightboxId }}"
+                        {% endif %}
+                    >
+                        <twig:Sw:Media 
+                            :media="mediaItem"
+                            :title="null"
+                            class="sw-media-gallery__preview"
+                            :itemprop="useSchemaMarkup ? ('image' ~ (loop.first ? ' primaryImageOfPage' : '')) : null"
+                            :autoplay="autoplayVideos"
+                        />
+                    </div>
+                {% endfor %}
+            </div>
+
+            {% if showNavigationArrows and not singleMedia %}
+                <twig:Sw:Button
+                    class="sw-media-gallery__nav-button is--backward"
+                    variant="light"
+                    :iconOnly="true"
+                    aria-label="{{ 'component.cms.mediaGallery.previousMedia'|trans|striptags }}"
+                >
+                    <twig:Sw:Icon name="arrow-head-left" size="sm" />
+                </twig:Sw:Button>
+
+                <twig:Sw:Button
+                    class="sw-media-gallery__nav-button is--forward"
+                    variant="light"
+                    :iconOnly="true"
+                    aria-label="{{ 'component.cms.mediaGallery.nextMedia'|trans|striptags }}"
+                >
+                    <twig:Sw:Icon name="arrow-head-right" size="sm" />
+                </twig:Sw:Button>
+            {% endif %}
+
+            {% if not singleMedia %}
+                <span class="sw-media-gallery__preview-item-badge badge" aria-live="polite">
+                    <span class="visually-hidden">{{ 'component.cms.mediaGallery.counterLabel'|trans|striptags }} </span> 
+                    <span class="sw-media-galley__counter-info">1 {{ mediaGalleryOptions.counterDeviderLabel }} {{ mediaItems|length }}</span>
+                </span>
+            {% endif %}
+        </div>
+    </section>
+
+    {% if showFullScreenGallery %}
+        <twig:Sw:Media:GalleryLightbox
+            class="sw-media-gallery__lightbox"
+            id="{{ lightboxId }}"
+            :mediaItems="mediaItems"
             :thumbnailSize="thumbnailSize"
-            :isHorizontal="thumbnailNavigationPosition == 'bottom'"
+            :thumbnailNavigationPosition="thumbnailNavigationPosition"
         />
     {% endif %}
-
-    <div class="sw-media-gallery__previews-wrapper">
-        <div class="sw-media-gallery__previews">
-            {% for mediaItem in mediaItems %}
-                <div 
-                    class="sw-media-gallery__preview-item" 
-                    id="sw-media-gallery-preview-{{ loop.index }}"
-                    data-media-id="{{ loop.index }}"
-                    {% if showFullScreenGallery %}
-                        data-bs-toggle="modal"
-                        data-bs-target="#{{ lightboxId }}"
-                        role="button"
-                        tabindex="0"
-                        aria-label="{{ 'component.cms.mediaGallery.openLightboxAriaLabel'|trans({'%index%': loop.index})|striptags }}"
-                        aria-haspopup="dialog"
-                        aria-controls="{{ lightboxId }}"
-                    {% endif %}
-                >
-                    <twig:Sw:Media 
-                        :media="mediaItem"
-                        :title="null"
-                        class="sw-media-gallery__preview"
-                        :itemprop="useSchemaMarkup ? ('image' ~ (loop.first ? ' primaryImageOfPage' : '')) : null"
-                        :autoplay="autoplayVideos"
-                    />
-                </div>
-            {% endfor %}
-        </div>
-
-        {% if showNavigationArrows and not singleMedia %}
-            <twig:Sw:Button
-                class="sw-media-gallery__nav-button is--backward"
-                variant="light"
-                :iconOnly="true"
-                aria-label="{{ 'component.cms.mediaGallery.previousMedia'|trans|striptags }}"
-            >
-                <twig:Sw:Icon name="arrow-head-left" size="sm" />
-            </twig:Sw:Button>
-
-            <twig:Sw:Button
-                class="sw-media-gallery__nav-button is--forward"
-                variant="light"
-                :iconOnly="true"
-                aria-label="{{ 'component.cms.mediaGallery.nextMedia'|trans|striptags }}"
-            >
-                <twig:Sw:Icon name="arrow-head-right" size="sm" />
-            </twig:Sw:Button>
-        {% endif %}
-
-        {% if not singleMedia %}
-            <span class="sw-media-gallery__preview-item-badge badge" aria-live="polite">
-                <span class="visually-hidden">{{ 'component.cms.mediaGallery.counterLabel'|trans|striptags }} </span> 
-                <span class="sw-media-galley__counter-info">1 {{ mediaGalleryOptions.counterDeviderLabel }} {{ mediaItems|length }}</span>
-            </span>
-        {% endif %}
-    </div>
-</section>
-
-{% if showFullScreenGallery %}
-    <twig:Sw:Media:GalleryLightbox
-        class="sw-media-gallery__lightbox"
-        id="{{ lightboxId }}"
-        :mediaItems="mediaItems"
-        :thumbnailSize="thumbnailSize"
-        :thumbnailNavigationPosition="thumbnailNavigationPosition"
+{% else %}
+    {# Render a null media to display a placeholder #}
+    <twig:Sw:Media:Image
+        :media="null"
     />
 {% endif %}


### PR DESCRIPTION
### 1. Why is this change necessary?

* No CMS element with media selection was available for the UX gallery (only the twig component)

### 2. What does this change do, exactly?

* Add a CMS element (yaml)
* Add a new multi media selection component that uses the existing admin media upload
* Modify the component so it fits into the sidebar
* Add the slider prop settings as real admin settings
* Add empty state to the gallery component when no media was selected

<img width="930" height="1266" alt="Screenshot 2026-08-19 at 17 06 25" src="https://github.com/user-attachments/assets/2cdc7c30-1db7-4bdb-bbc8-eea554fe41ed" />

### 3. Describe each step to reproduce the issue or behaviour.

* Go to a experience studio layout
* Place the Gallery element
* Select media
* Test the additional settings

### 4. Please link to the relevant issues (if any).
- closes: #15288