### PR TITLE
test(acceptance): serialize order cancellation scenarios

### DIFF
--- a/tests/acceptance/tests/Account/CancelOrder.spec.ts
+++ b/tests/acceptance/tests/Account/CancelOrder.spec.ts
@@ -1,5 +1,8 @@
 import { test } from '@fixtures/AcceptanceTest';
 
+test.describe('Order cancellation', () => {
+    test.describe.configure({ mode: 'serial' });
+
 test(
     'Customers are able to cancel orders in storefront account.',
     {
@@ -127,3 +130,4 @@ test(
         await ShopCustomer.expects(orderItemLocators.orderCancelButton).not.toBeVisible();
     },
 );
+});


### PR DESCRIPTION
### 1. Why is this change necessary?

The cancel-order scenarios update the same global `core.cart.enableOrderRefunds` system configuration while Playwright executes the file in parallel. One scenario can change the setting before another renders its conditional cancellation controls, making its expected dialog absent.

### 2. What does this change do, exactly?

Runs the four `CancelOrder` scenarios serially. The remainder of the acceptance suite keeps its normal parallel execution.

### 3. Describe each step to reproduce the issue or behaviour.

1. Run the Platform acceptance suite with multiple workers.
2. Execute the cancel-order scenarios, which set `core.cart.enableOrderRefunds` to conflicting values.
3. A scenario can render an order page without its expected cancellation control or modal.

### 4. Please link to the relevant issues (if any).

No issue.

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them