### PR TITLE
fix: allow changing the sales channel default language while removing the previous one

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -95,6 +95,12 @@ Send the header with an authenticated Admin API request, where the behaviour is 
 
 The Store API OpenAPI schema previously documented item prices and cart totals as one `CalculatedPrice` component, which marked the cart-level fields `netPrice`, `positionPrice`, `rawTotal`, and `taxStatus` as required on item prices such as `product.calculatedPrice` and `lineItem.price`. The schema now contains a dedicated `CartPrice` component used for `cart.price` and `order.price`, while `CalculatedPrice` only documents the fields item prices actually contain. The `taxStatus` enum also includes the previously missing `gross` value. API responses are unchanged; only clients generated from the schema are affected and now match the actual payloads.
 
+### Sales channel language list validation compares against the incoming default language
+
+Assigning a new `languageId` to a sales channel and removing the previous default language from its `languages` list in the same write is now accepted. It previously failed with `SYSTEM__CANNOT_DELETE_DEFAULT_LANGUAGE_ID`, and the two steps had to be sent as separate requests.
+
+Removing the language that the same write assigns as the new default is now rejected with that error code instead of being applied. Such a write previously succeeded and left the sales channel with a default language that was missing from its language list.
+
 ## Core
 
 ### E-invoice line positions state the correct price base quantity

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/page/sw-sales-channel-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/page/sw-sales-channel-detail/index.js
@@ -222,7 +222,10 @@ export default {
         },
 
         salesChannelRepository() {
-            return this.repositoryFactory.create('sales_channel');
+            // Sync keeps removed language mappings and the new languageId in one write, so the
+            // default language validation sees the post-write state instead of rejecting the
+            // removal of the previous default.
+            return this.repositoryFactory.create('sales_channel', null, { useSync: true });
         },
 
         salesChannelAnalyticsRepository() {

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/page/sw-sales-channel-detail/sw-sales-channel-detail.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/page/sw-sales-channel-detail/sw-sales-channel-detail.spec.js
@@ -8,6 +8,7 @@ import { mount } from '@vue/test-utils';
 
 const mockSave = jest.fn(() => Promise.resolve());
 const mockGet = jest.fn();
+const mockCreateRepository = jest.fn();
 const mockGetSystemConfig = jest.fn(() => Promise.resolve([]));
 const mockGetSystemConfigValues = jest.fn(() => Promise.resolve({}));
 
@@ -143,13 +144,17 @@ async function createWrapper(optionsOrLegacyArg = { id: '1a2b3c4d' }) {
             },
             provide: {
                 repositoryFactory: {
-                    create: () => ({
-                        create: () => ({}),
-                        get: mockGet,
-                        search: () => Promise.resolve([]),
-                        delete: () => Promise.resolve(),
-                        save: mockSave,
-                    }),
+                    create: (...args) => {
+                        mockCreateRepository(...args);
+
+                        return {
+                            create: () => ({}),
+                            get: mockGet,
+                            search: () => Promise.resolve([]),
+                            delete: () => Promise.resolve(),
+                            save: mockSave,
+                        };
+                    },
                 },
                 exportTemplateService: {
                     getProductExportTemplateRegistry: () => ({}),
@@ -182,6 +187,7 @@ describe('src/module/sw-sales-channel/page/sw-sales-channel-detail', () => {
         global.activeAclRoles = [];
         mockSave.mockClear();
         mockGet.mockClear();
+        mockCreateRepository.mockClear();
         mockGetSystemConfig.mockClear();
         mockGetSystemConfigValues.mockClear();
         Shopware.Store.get('error').resetApiErrors();
@@ -448,6 +454,13 @@ describe('src/module/sw-sales-channel/page/sw-sales-channel-detail', () => {
         await flushPromises();
 
         expect(wrapper.vm.isProductExportChannel).toBe(false);
+    });
+
+    it('should create the sales channel repository with sync enabled', async () => {
+        await createWrapper();
+        await flushPromises();
+
+        expect(mockCreateRepository).toHaveBeenCalledWith('sales_channel', null, { useSync: true });
     });
 
     it('should save without reloading entity data when saveOnLanguageChange is called', async () => {

--- a/src/Core/System/SalesChannel/Validation/SalesChannelValidator.php
+++ b/src/Core/System/SalesChannel/Validation/SalesChannelValidator.php
@@ -169,8 +169,9 @@ class SalesChannelValidator implements EventSubscriberInterface
                 }
             }
 
-            if ($salesChannelData->deletions !== [] && $this->isInvalidDeleteCase($salesChannelData)) {
-                $deletions[$salesChannelId] = $salesChannelData->currentDefault;
+            $deletedDefault = $this->findDeletedDefaultLanguageId($salesChannelData);
+            if ($deletedDefault !== null) {
+                $deletions[$salesChannelId] = $deletedDefault;
             }
 
             if ($salesChannelData->updateId !== null && $this->isInvalidUpdateCase($salesChannelData)) {
@@ -210,15 +211,18 @@ class SalesChannelValidator implements EventSubscriberInterface
     }
 
     /**
-     * @phpstan-assert-if-true !null $salesChannelData->currentDefault
+     * Compares the deletions against the default language in effect after this write rather than the stored
+     * one, so that assigning a new default and removing the previous one in a single write stays valid.
      */
-    private function isInvalidDeleteCase(SalesChannelData $salesChannelData): bool
+    private function findDeletedDefaultLanguageId(SalesChannelData $salesChannelData): ?string
     {
-        if ($salesChannelData->currentDefault === null) {
-            return false;
+        $default = $salesChannelData->updateId ?? $salesChannelData->newDefault ?? $salesChannelData->currentDefault;
+
+        if ($default === null || !\in_array($default, $salesChannelData->deletions, true)) {
+            return null;
         }
 
-        return \in_array($salesChannelData->currentDefault, $salesChannelData->deletions, true);
+        return $default;
     }
 
     /**

--- a/tests/integration/Core/System/SalesChannel/Validation/SalesChannelValidatorTest.php
+++ b/tests/integration/Core/System/SalesChannel/Validation/SalesChannelValidatorTest.php
@@ -6,6 +6,9 @@ use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Defaults;
+use Shopware\Core\Framework\Api\Sync\SyncBehavior;
+use Shopware\Core\Framework\Api\Sync\SyncOperation;
+use Shopware\Core\Framework\Api\Sync\SyncService;
 use Shopware\Core\Framework\Api\Util\AccessKeyHelper;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Entity;
@@ -17,7 +20,9 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\Framework\Validation\WriteConstraintViolationException;
+use Shopware\Core\System\SalesChannel\Aggregate\SalesChannelLanguage\SalesChannelLanguageDefinition;
 use Shopware\Core\System\SalesChannel\SalesChannelCollection;
+use Shopware\Core\System\SalesChannel\SalesChannelDefinition;
 use Shopware\Core\Test\TestDefaults;
 use Symfony\Component\Validator\ConstraintViolation;
 use Symfony\Component\Validator\ConstraintViolationList;
@@ -312,6 +317,36 @@ class SalesChannelValidatorTest extends TestCase
 
             throw $e;
         }
+    }
+
+    public function testChangingTheDefaultLanguageAndRemovingThePreviousDefaultInOneWrite(): void
+    {
+        $id = Uuid::randomHex();
+        $newDefaultId = $this->getDeDeLanguageId();
+        $context = Context::createDefaultContext();
+
+        $this->getSalesChannelRepository()->create([
+            $this->getSalesChannelData($id, Defaults::LANGUAGE_SYSTEM, [Defaults::LANGUAGE_SYSTEM, $newDefaultId]),
+        ], $context);
+
+        static::getContainer()->get(SyncService::class)->sync([
+            new SyncOperation('write', SalesChannelDefinition::ENTITY_NAME, SyncOperation::ACTION_UPSERT, [
+                ['id' => $id, 'languageId' => $newDefaultId],
+            ]),
+            new SyncOperation('delete', SalesChannelLanguageDefinition::ENTITY_NAME, SyncOperation::ACTION_DELETE, [
+                ['salesChannelId' => $id, 'languageId' => Defaults::LANGUAGE_SYSTEM],
+            ]),
+        ], $context, new SyncBehavior());
+
+        $criteria = new Criteria([$id]);
+        $criteria->addAssociation('languages');
+
+        $salesChannel = $this->getSalesChannelRepository()->search($criteria, $context)->getEntities()->first();
+
+        static::assertNotNull($salesChannel);
+        static::assertSame($newDefaultId, $salesChannel->getLanguageId());
+        static::assertNotNull($salesChannel->getLanguages());
+        static::assertSame([$newDefaultId], array_values($salesChannel->getLanguages()->getIds()));
     }
 
     public function testDeletingSalesChannelWillNotBeValidated(): void

--- a/tests/unit/Core/System/SalesChannel/Validation/SalesChannelValidatorTest.php
+++ b/tests/unit/Core/System/SalesChannel/Validation/SalesChannelValidatorTest.php
@@ -9,7 +9,9 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\Write\Command\DeleteCommand;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\Command\InsertCommand;
+use Shopware\Core\Framework\DataAbstractionLayer\Write\Command\UpdateCommand;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\EntityExistence;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\EntityWriteGatewayInterface;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\Validation\PreWriteValidationEvent;
@@ -148,6 +150,74 @@ class SalesChannelValidatorTest extends TestCase
         static::assertCount(0, $event->getExceptions()->getExceptions());
     }
 
+    public function testDeletingThePreviousDefaultLanguageSucceedsWhenTheSameWriteSetsANewDefault(): void
+    {
+        $salesChannelId = Uuid::randomHex();
+        $previousDefaultId = Uuid::randomHex();
+        $newDefaultId = Uuid::randomHex();
+
+        $event = new PreWriteValidationEvent(
+            WriteContext::createFromContext(Context::createDefaultContext()),
+            [
+                $this->updateDefaultLanguageCommand($salesChannelId, $newDefaultId),
+                $this->deleteLanguageCommand($salesChannelId, $previousDefaultId),
+            ]
+        );
+
+        $connection = $this->connectionWithLanguageState($salesChannelId, $previousDefaultId, [$previousDefaultId, $newDefaultId]);
+
+        (new SalesChannelValidator($connection))->handleSalesChannelLanguageIds($event);
+
+        static::assertCount(0, $event->getExceptions()->getExceptions());
+    }
+
+    public function testDeletingTheNewDefaultLanguageFails(): void
+    {
+        $salesChannelId = Uuid::randomHex();
+        $previousDefaultId = Uuid::randomHex();
+        $newDefaultId = Uuid::randomHex();
+
+        $event = new PreWriteValidationEvent(
+            WriteContext::createFromContext(Context::createDefaultContext()),
+            [
+                $this->updateDefaultLanguageCommand($salesChannelId, $newDefaultId),
+                $this->deleteLanguageCommand($salesChannelId, $newDefaultId),
+            ]
+        );
+
+        $connection = $this->connectionWithLanguageState($salesChannelId, $previousDefaultId, [$previousDefaultId, $newDefaultId]);
+
+        (new SalesChannelValidator($connection))->handleSalesChannelLanguageIds($event);
+
+        static::assertCount(1, $event->getExceptions()->getExceptions());
+        $exception = $event->getExceptions()->getExceptions()[0];
+        static::assertInstanceOf(WriteConstraintViolationException::class, $exception);
+        static::assertSame('SYSTEM__CANNOT_DELETE_DEFAULT_LANGUAGE_ID', $exception->getViolations()->get(0)->getCode());
+    }
+
+    public function testDeletingTheDefaultLanguageFailsWhenTheWriteKeepsThatDefault(): void
+    {
+        $salesChannelId = Uuid::randomHex();
+        $defaultId = Uuid::randomHex();
+        $secondLanguageId = Uuid::randomHex();
+
+        $event = new PreWriteValidationEvent(
+            WriteContext::createFromContext(Context::createDefaultContext()),
+            [
+                $this->deleteLanguageCommand($salesChannelId, $defaultId),
+            ]
+        );
+
+        $connection = $this->connectionWithLanguageState($salesChannelId, $defaultId, [$defaultId, $secondLanguageId]);
+
+        (new SalesChannelValidator($connection))->handleSalesChannelLanguageIds($event);
+
+        static::assertCount(1, $event->getExceptions()->getExceptions());
+        $exception = $event->getExceptions()->getExceptions()[0];
+        static::assertInstanceOf(WriteConstraintViolationException::class, $exception);
+        static::assertSame('SYSTEM__CANNOT_DELETE_DEFAULT_LANGUAGE_ID', $exception->getViolations()->get(0)->getCode());
+    }
+
     /**
      * @return iterable<string, array{string}>
      */
@@ -157,5 +227,48 @@ class SalesChannelValidatorTest extends TestCase
         yield 'api' => [Defaults::SALES_CHANNEL_TYPE_API];
         yield 'product comparison' => [Defaults::SALES_CHANNEL_TYPE_PRODUCT_COMPARISON];
         yield 'agentic commerce' => [Defaults::SALES_CHANNEL_TYPE_AGENTIC_COMMERCE];
+    }
+
+    private function updateDefaultLanguageCommand(string $salesChannelId, string $languageId): UpdateCommand
+    {
+        return new UpdateCommand(
+            $this->definitionRegistry->getByEntityName(SalesChannelDefinition::ENTITY_NAME),
+            ['language_id' => Uuid::fromHexToBytes($languageId)],
+            ['id' => Uuid::fromHexToBytes($salesChannelId)],
+            static::createStub(EntityExistence::class),
+            '/0'
+        );
+    }
+
+    private function deleteLanguageCommand(string $salesChannelId, string $languageId): DeleteCommand
+    {
+        return new DeleteCommand(
+            $this->definitionRegistry->getByEntityName(SalesChannelLanguageDefinition::ENTITY_NAME),
+            [
+                'sales_channel_id' => Uuid::fromHexToBytes($salesChannelId),
+                'language_id' => Uuid::fromHexToBytes($languageId),
+            ],
+            static::createStub(EntityExistence::class)
+        );
+    }
+
+    /**
+     * @param list<string> $assignedLanguageIds
+     */
+    private function connectionWithLanguageState(string $salesChannelId, string $currentDefaultId, array $assignedLanguageIds): Connection
+    {
+        $states = [];
+        foreach ($assignedLanguageIds as $languageId) {
+            $states[] = [
+                'sales_channel_id' => $salesChannelId,
+                'current_default' => $currentDefaultId,
+                'language_id' => $languageId,
+            ];
+        }
+
+        $connection = static::createStub(Connection::class);
+        $connection->method('fetchAllAssociative')->willReturn($states);
+
+        return $connection;
     }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?

Changing a sales channel's default language and removing the previous default in one save fails with `SYSTEM__CANNOT_DELETE_DEFAULT_LANGUAGE_ID`. Merchants have to save twice: once to switch the default, once to remove the old language.

Two independent defects cause this, and both need fixing — either one alone leaves the reported scenario broken.

`SalesChannelValidator` compared the removed language against the default currently stored in the database instead of the default the write is about to assign. The same comparison also *accepted* removing the language that a write assigns as the new default, which left `sales_channel.language_id` pointing at a language no longer present in `sales_channel_language`. No database constraint prevents that state.

The Administration never gave the validator a chance either: `sw-sales-channel-detail` used a plain repository, so `Repository.saveWithRest()` sent each removed language as its own `DELETE` request *before* the `PATCH` that assigns the new default. Every deletion was therefore validated in isolation, against the still-current default.

### 2. What does this change do, exactly?

`SalesChannelValidator::isInvalidDeleteCase()` is replaced by `findDeletedDefaultLanguageId()`, which resolves the default in effect *after* the write (`updateId ?? newDefault ?? currentDefault`) and reports the deletion only when it removes that language. `isInvalidUpdateCase()` already guarantees the incoming default is present in the resulting language list, so the delete check no longer needs to consult the stored default. The now-incorrect `@phpstan-assert-if-true` annotation is dropped, since the method returns the offending id directly.

`sw-sales-channel-detail` creates its repository with `useSync: true`, matching `sw-product-detail`. `saveWithSync()` batches the language deletions and the entity update into one `_action/sync` request, so both arrive in a single `PreWriteValidationEvent`. This also makes the save atomic; previously a failing `PATCH` after successful deletions left the sales channel half-saved.

One combination becomes stricter: removing and re-adding the incoming default in the same sync batch is now rejected. Its previous acceptance depended on command ordering that is not guaranteed.

The PHP tests were verified to fail without the validator change — reverting it makes the new integration test fail with the error from the issue.

### 3. Describe each step to reproduce the issue or behaviour.

1. Open a sales channel whose default language is German and whose language list is German and English.
2. Set the default language to English.
3. Remove German from the language list.
4. Save once.

Before: the save fails with "The Sales Channel could not be saved. Please check your entries.", and the API responds `400` with `SYSTEM__CANNOT_DELETE_DEFAULT_LANGUAGE_ID`.

After: the save succeeds, English is the default language and German is gone from the list.

Removing the default language *without* assigning a new one is still rejected, as before.

### 4. Please link to the relevant issues (if any).

- closes #6247
- Jira issue: https://shopware.atlassian.net/browse/NEXT-40289

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
