### PR TITLE
feat: Remove service dashboard banner

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-dashboard/page/sw-dashboard-index/sw-dashboard-index.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-dashboard/page/sw-dashboard-index/sw-dashboard-index.html.twig
@@ -26,8 +26,6 @@
             {% endblock %}
             {% endblock %}
 
-            <sw-settings-services-dashboard-banner />
-
             <sw-extension-component-section
                 position-identifier="sw-dashboard__before-content"
                 class="sw-dashboard__before-content"

--- a/src/Administration/Resources/app/administration/src/module/sw-dashboard/page/sw-dashboard-index/sw-dashboard-index.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-dashboard/page/sw-dashboard-index/sw-dashboard-index.spec.js
@@ -23,7 +23,6 @@ async function createWrapper(privileges = []) {
                 'sw-error-summary': true,
                 'sw-context-menu-item': true,
                 'sw-context-button': true,
-                'sw-settings-services-dashboard-banner': true,
             },
             mocks: {
                 $t: jest.fn().mockImplementation((snippetPath, placeholders) => {

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-services/component/sw-settings-services-dashboard-banner/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-services/component/sw-settings-services-dashboard-banner/index.ts
@@ -2,6 +2,7 @@ import template from './sw-settings-services-dashboard-banner.html.twig';
 import './sw-settings-services-dashboard-banner.scss';
 
 /**
+ * @deprecated tag:v6.8.0 - Will be removed, the services banner is no longer shown on the dashboard.
  * @sw-package framework
  * @private
  */

--- a/tests/acceptance/tests/Settings/ShopwareServices.spec.ts
+++ b/tests/acceptance/tests/Settings/ShopwareServices.spec.ts
@@ -43,44 +43,6 @@ test.describe('Shopware Services', () => {
         }
     });
 
-    test(
-        'As a merchant, I want to see an advertisement banner for Shopware Services on the dashboard.',
-        { tag: '@Settings' },
-        async ({ ShopAdmin, AdminDashboard, AdminShopwareServices, InstanceMeta }) => {
-            test.skip(satisfies(InstanceMeta.version, '<6.7.1'), 'Feature not available until version 6.7.1.0');
-
-            await ShopAdmin.goesTo(AdminDashboard.url());
-            await ShopAdmin.expects(AdminDashboard.shopwareServicesAdvertisementBanner).toBeVisible();
-            await ShopAdmin.expects(AdminDashboard.shopwareServicesAdvertisementBanner).toContainText(
-                'Introducing Shopware Services',
-            );
-            await ShopAdmin.expects(AdminDashboard.shopwareServicesExploreNowButton).toBeVisible();
-            await AdminDashboard.shopwareServicesExploreNowButton.click();
-            await ShopAdmin.expects(AdminShopwareServices.header).toBeVisible();
-        },
-    );
-
-    test(
-        'As a merchant, I want to hide the advertisement banner for Shopware Services on the dashboard.',
-        { tag: '@Settings' },
-        async ({ ShopAdmin, AdminDashboard, AdminSettingsListing, CheckVisibilityOfServicesBanner, InstanceMeta }) => {
-            test.skip(satisfies(InstanceMeta.version, '<6.7.1'), 'Feature not available until version 6.7.1.0');
-
-            await ShopAdmin.goesTo(AdminDashboard.url());
-            await ShopAdmin.expects(AdminDashboard.shopwareServicesAdvertisementBanner).toBeVisible();
-            await AdminDashboard.shopwareServicesAdvertisementBannerCloseButton.click();
-            await ShopAdmin.expects(AdminDashboard.shopwareServicesAdvertisementBanner).not.toBeVisible();
-            await ShopAdmin.goesTo(AdminSettingsListing.url());
-            await ShopAdmin.expects(AdminSettingsListing.shopwareServicesLink).toBeVisible();
-            await ShopAdmin.goesTo(AdminDashboard.url());
-            await ShopAdmin.expects(AdminDashboard.shopwareServicesAdvertisementBanner).not.toBeVisible();
-
-            await test.step('Verify the visibility of the services banner for another admin user', async () => {
-                await ShopAdmin.attemptsTo(CheckVisibilityOfServicesBanner());
-            });
-        },
-    );
-
     // eslint-disable-next-line playwright/no-skipped-test
     test.skip(
         'As a merchant, I want to fully deactivate the Shopware Services feature.',
@@ -141,6 +103,10 @@ test.describe('Shopware Services', () => {
         { tag: '@Settings' },
         async ({ ShopAdmin, TestDataService, CheckAccessToShopwareServices, InstanceMeta }) => {
             test.skip(satisfies(InstanceMeta.version, '<6.7.1'), 'Feature not available until version 6.7.1.0');
+            // The `CheckAccessToShopwareServices` task enters the services page through the dashboard
+            // advertisement banner, which was removed from the dashboard. Re-enable once the task in
+            // @shopware-ag/acceptance-test-suite navigates to `sw.settings.services.index` directly.
+            test.skip(true, 'Task depends on the removed services dashboard banner.');
 
             await test.step('Verify insufficient permissions prevent access to services.', async () => {
                 let aclRole;


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
Remove this banner in core since service banners are added in Copilot, Recommendation service

### 2. What does this change do, exactly?
- Remove `<sw-settings-services-dashboard-banner />` in src/Administration/Resources/app/administration/src/module/sw-dashboard/page/sw-dashboard-index/sw-dashboard-index.html.twig
- Deprecated `sw-settings-services-dashboard-banner ` component

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
