### PR TITLE
test: lift the Content coverage suffix excludes and cover the surfaced logic

### DIFF
--- a/phpstan-baseline.php
+++ b/phpstan-baseline.php
@@ -140,12 +140,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/src/Core/Content/Media/TypeDetector/TypeDetector.php',
 ];
 $ignoreErrors[] = [
-    'rawMessage' => 'Method Shopware\\Core\\Content\\Newsletter\\Event\\NewsletterSubscribeUrlEvent::getData() return type has no value type specified in iterable type array.',
-    'identifier' => 'missingType.iterableValue',
-    'count' => 1,
-    'path' => __DIR__ . '/src/Core/Content/Newsletter/Event/NewsletterSubscribeUrlEvent.php',
-];
-$ignoreErrors[] = [
     'rawMessage' => 'Construct empty() is not allowed. Use more strict comparison.',
     'identifier' => 'empty.notAllowed',
     'count' => 1,

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -45,29 +45,23 @@
                  suffix (e.g. Migration...Field, MigrationCollection), which PHPUnit 12 then reports as
                  invalid #[CoversClass] targets. src/Core/Migration and src/Core/Framework/Migration are
                  deliberately NOT listed. -->
-            <directory suffix="Definition.php">src/Core/Content/</directory>
             <directory suffix="Definition.php">src/Core/Framework/</directory>
             <directory suffix="Definition.php">src/Core/System/</directory>
 
-            <directory suffix="Entity.php">src/Core/Content/</directory>
             <directory suffix="Entity.php">src/Core/Framework/</directory>
             <directory suffix="Entity.php">src/Core/System/</directory>
 
-            <directory suffix="Event.php">src/Core/Content/</directory>
             <directory suffix="Event.php">src/Core/Framework/</directory>
             <directory suffix="Event.php">src/Core/Maintenance/</directory>
             <directory suffix="Event.php">src/Core/Service/</directory>
             <directory suffix="Event.php">src/Core/System/</directory>
 
-            <directory suffix="Field.php">src/Core/Content/</directory>
             <directory suffix="Field.php">src/Core/Framework/</directory>
             <directory suffix="Field.php">src/Core/System/</directory>
 
-            <directory suffix="Struct.php">src/Core/Content/</directory>
             <directory suffix="Struct.php">src/Core/Framework/</directory>
             <directory suffix="Struct.php">src/Core/System/</directory>
 
-            <directory suffix="Collection.php">src/Core/Content/</directory>
             <directory suffix="Collection.php">src/Core/Installer/</directory>
             <directory suffix="Collection.php">src/Core/System/</directory>
             <directory suffix="Collection.php">src/Core/Framework/Adapter/</directory>

--- a/src/Core/Content/Flow/Aggregate/FlowSequence/FlowSequenceCollection.php
+++ b/src/Core/Content/Flow/Aggregate/FlowSequence/FlowSequenceCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<FlowSequenceEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('after-sales')]
 class FlowSequenceCollection extends EntityCollection

--- a/src/Core/Content/Flow/Aggregate/FlowSequence/FlowSequenceDefinition.php
+++ b/src/Core/Content/Flow/Aggregate/FlowSequence/FlowSequenceDefinition.php
@@ -23,6 +23,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\StringField;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('after-sales')]
 class FlowSequenceDefinition extends EntityDefinition
 {

--- a/src/Core/Content/Flow/Aggregate/FlowSequence/FlowSequenceEntity.php
+++ b/src/Core/Content/Flow/Aggregate/FlowSequence/FlowSequenceEntity.php
@@ -11,6 +11,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityCustomFieldsTrait;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityIdTrait;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('after-sales')]
 class FlowSequenceEntity extends Entity implements IdAware
 {

--- a/src/Core/Content/Flow/Aggregate/FlowTemplate/FlowTemplateCollection.php
+++ b/src/Core/Content/Flow/Aggregate/FlowTemplate/FlowTemplateCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<FlowTemplateEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('after-sales')]
 class FlowTemplateCollection extends EntityCollection

--- a/src/Core/Content/Flow/Aggregate/FlowTemplate/FlowTemplateDefinition.php
+++ b/src/Core/Content/Flow/Aggregate/FlowTemplate/FlowTemplateDefinition.php
@@ -11,6 +11,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\StringField;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('after-sales')]
 class FlowTemplateDefinition extends EntityDefinition
 {

--- a/src/Core/Content/Flow/Aggregate/FlowTemplate/FlowTemplateEntity.php
+++ b/src/Core/Content/Flow/Aggregate/FlowTemplate/FlowTemplateEntity.php
@@ -6,6 +6,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\Entity;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityIdTrait;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('after-sales')]
 class FlowTemplateEntity extends Entity
 {

--- a/src/Core/Content/Flow/Api/FlowActionDefinition.php
+++ b/src/Core/Content/Flow/Api/FlowActionDefinition.php
@@ -5,6 +5,9 @@ namespace Shopware\Core\Content\Flow\Api;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\Struct;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('after-sales')]
 class FlowActionDefinition extends Struct
 {

--- a/src/Core/Content/Flow/Events/FlowActionCollectorEvent.php
+++ b/src/Core/Content/Flow/Events/FlowActionCollectorEvent.php
@@ -7,6 +7,9 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Event\NestedEvent;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('after-sales')]
 class FlowActionCollectorEvent extends NestedEvent
 {

--- a/src/Core/Content/Flow/Events/FlowIndexerEvent.php
+++ b/src/Core/Content/Flow/Events/FlowIndexerEvent.php
@@ -6,6 +6,9 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Event\NestedEvent;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('after-sales')]
 class FlowIndexerEvent extends NestedEvent
 {

--- a/src/Core/Content/Flow/FlowCollection.php
+++ b/src/Core/Content/Flow/FlowCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<FlowEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('after-sales')]
 class FlowCollection extends EntityCollection

--- a/src/Core/Content/Flow/FlowDefinition.php
+++ b/src/Core/Content/Flow/FlowDefinition.php
@@ -23,6 +23,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\StringField;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('after-sales')]
 class FlowDefinition extends EntityDefinition
 {

--- a/src/Core/Content/Flow/FlowEntity.php
+++ b/src/Core/Content/Flow/FlowEntity.php
@@ -10,6 +10,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityCustomFieldsTrait;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityIdTrait;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('after-sales')]
 class FlowEntity extends Entity
 {

--- a/src/Core/Content/ImportExport/Aggregate/ImportExportFile/ImportExportFileDefinition.php
+++ b/src/Core/Content/ImportExport/Aggregate/ImportExportFile/ImportExportFileDefinition.php
@@ -15,6 +15,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\StringField;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('fundamentals@after-sales')]
 class ImportExportFileDefinition extends EntityDefinition
 {

--- a/src/Core/Content/ImportExport/Aggregate/ImportExportFile/ImportExportFileEntity.php
+++ b/src/Core/Content/ImportExport/Aggregate/ImportExportFile/ImportExportFileEntity.php
@@ -8,6 +8,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityIdTrait;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Util\Random;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('fundamentals@after-sales')]
 class ImportExportFileEntity extends Entity
 {

--- a/src/Core/Content/ImportExport/Aggregate/ImportExportLog/ImportExportLogCollection.php
+++ b/src/Core/Content/ImportExport/Aggregate/ImportExportLog/ImportExportLogCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<ImportExportLogEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('fundamentals@after-sales')]
 class ImportExportLogCollection extends EntityCollection

--- a/src/Core/Content/ImportExport/Aggregate/ImportExportLog/ImportExportLogDefinition.php
+++ b/src/Core/Content/ImportExport/Aggregate/ImportExportLog/ImportExportLogDefinition.php
@@ -21,6 +21,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\User\UserDefinition;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('fundamentals@after-sales')]
 class ImportExportLogDefinition extends EntityDefinition
 {

--- a/src/Core/Content/ImportExport/Aggregate/ImportExportLog/ImportExportLogEntity.php
+++ b/src/Core/Content/ImportExport/Aggregate/ImportExportLog/ImportExportLogEntity.php
@@ -9,6 +9,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityIdTrait;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\User\UserEntity;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('fundamentals@after-sales')]
 class ImportExportLogEntity extends Entity
 {

--- a/src/Core/Content/ImportExport/Event/ImportExportAfterImportRecordEvent.php
+++ b/src/Core/Content/ImportExport/Event/ImportExportAfterImportRecordEvent.php
@@ -8,6 +8,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\Event\EntityWrittenContainerEve
 use Shopware\Core\Framework\Log\Package;
 use Symfony\Contracts\EventDispatcher\Event;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('fundamentals@after-sales')]
 class ImportExportAfterImportRecordEvent extends Event
 {

--- a/src/Core/Content/ImportExport/Event/ImportExportAfterProcessFinishedEvent.php
+++ b/src/Core/Content/ImportExport/Event/ImportExportAfterProcessFinishedEvent.php
@@ -8,6 +8,9 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Log\Package;
 use Symfony\Contracts\EventDispatcher\Event;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('fundamentals@after-sales')]
 class ImportExportAfterProcessFinishedEvent extends Event
 {

--- a/src/Core/Content/ImportExport/Event/ImportExportBeforeImportRecordEvent.php
+++ b/src/Core/Content/ImportExport/Event/ImportExportBeforeImportRecordEvent.php
@@ -7,6 +7,9 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Log\Package;
 use Symfony\Contracts\EventDispatcher\Event;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('fundamentals@after-sales')]
 class ImportExportBeforeImportRecordEvent extends Event
 {

--- a/src/Core/Content/ImportExport/Event/ImportExportBeforeImportRowEvent.php
+++ b/src/Core/Content/ImportExport/Event/ImportExportBeforeImportRowEvent.php
@@ -7,6 +7,9 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Log\Package;
 use Symfony\Contracts\EventDispatcher\Event;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('fundamentals@after-sales')]
 class ImportExportBeforeImportRowEvent extends Event
 {

--- a/src/Core/Content/ImportExport/Event/ImportExportExceptionExportRecordEvent.php
+++ b/src/Core/Content/ImportExport/Event/ImportExportExceptionExportRecordEvent.php
@@ -7,6 +7,9 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Log\Package;
 use Symfony\Contracts\EventDispatcher\Event;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('fundamentals@after-sales')]
 class ImportExportExceptionExportRecordEvent extends Event
 {

--- a/src/Core/Content/ImportExport/ImportExportProfileEntity.php
+++ b/src/Core/Content/ImportExport/ImportExportProfileEntity.php
@@ -9,6 +9,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityIdTrait;
 use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('fundamentals@after-sales')]
 class ImportExportProfileEntity extends Entity
 {

--- a/src/Core/Content/ImportExport/ImportExportProfileTranslationCollection.php
+++ b/src/Core/Content/ImportExport/ImportExportProfileTranslationCollection.php
@@ -10,6 +10,8 @@ use Shopware\Core\Framework\Log\Package;
  * @deprecated tag:v6.8.0 - reason:remove-entity - Will be removed
  *
  * @extends EntityCollection<ImportExportProfileTranslationEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('fundamentals@after-sales')]
 class ImportExportProfileTranslationCollection extends EntityCollection

--- a/src/Core/Content/ImportExport/ImportExportProfileTranslationDefinition.php
+++ b/src/Core/Content/ImportExport/ImportExportProfileTranslationDefinition.php
@@ -9,6 +9,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @deprecated tag:v6.8.0 - reason:remove-entity - Will be removed
+ *
+ * @codeCoverageIgnore
  */
 #[Package('fundamentals@after-sales')]
 class ImportExportProfileTranslationDefinition extends EntityTranslationDefinition

--- a/src/Core/Content/ImportExport/ImportExportProfileTranslationEntity.php
+++ b/src/Core/Content/ImportExport/ImportExportProfileTranslationEntity.php
@@ -8,6 +8,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @deprecated tag:v6.8.0 - reason:remove-entity - Will be removed
+ *
+ * @codeCoverageIgnore
  */
 #[Package('fundamentals@after-sales')]
 class ImportExportProfileTranslationEntity extends TranslationEntity

--- a/src/Core/Content/MailTemplate/Aggregate/MailHeaderFooter/MailHeaderFooterCollection.php
+++ b/src/Core/Content/MailTemplate/Aggregate/MailHeaderFooter/MailHeaderFooterCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<MailHeaderFooterEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('after-sales')]
 class MailHeaderFooterCollection extends EntityCollection

--- a/src/Core/Content/MailTemplate/Aggregate/MailHeaderFooter/MailHeaderFooterDefinition.php
+++ b/src/Core/Content/MailTemplate/Aggregate/MailHeaderFooter/MailHeaderFooterDefinition.php
@@ -16,6 +16,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelDefinition;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('after-sales')]
 class MailHeaderFooterDefinition extends EntityDefinition
 {

--- a/src/Core/Content/MailTemplate/Aggregate/MailHeaderFooter/MailHeaderFooterEntity.php
+++ b/src/Core/Content/MailTemplate/Aggregate/MailHeaderFooter/MailHeaderFooterEntity.php
@@ -8,6 +8,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityIdTrait;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelCollection;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('after-sales')]
 class MailHeaderFooterEntity extends Entity
 {

--- a/src/Core/Content/MailTemplate/Aggregate/MailHeaderFooterTranslation/MailHeaderFooterTranslationCollection.php
+++ b/src/Core/Content/MailTemplate/Aggregate/MailHeaderFooterTranslation/MailHeaderFooterTranslationCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<MailHeaderFooterTranslationEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('after-sales')]
 class MailHeaderFooterTranslationCollection extends EntityCollection

--- a/src/Core/Content/MailTemplate/Aggregate/MailHeaderFooterTranslation/MailHeaderFooterTranslationDefinition.php
+++ b/src/Core/Content/MailTemplate/Aggregate/MailHeaderFooterTranslation/MailHeaderFooterTranslationDefinition.php
@@ -12,6 +12,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\StringField;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('after-sales')]
 class MailHeaderFooterTranslationDefinition extends EntityTranslationDefinition
 {

--- a/src/Core/Content/MailTemplate/Aggregate/MailHeaderFooterTranslation/MailHeaderFooterTranslationEntity.php
+++ b/src/Core/Content/MailTemplate/Aggregate/MailHeaderFooterTranslation/MailHeaderFooterTranslationEntity.php
@@ -6,6 +6,9 @@ use Shopware\Core\Content\MailTemplate\Aggregate\MailHeaderFooter\MailHeaderFoot
 use Shopware\Core\Framework\DataAbstractionLayer\TranslationEntity;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('after-sales')]
 class MailHeaderFooterTranslationEntity extends TranslationEntity
 {

--- a/src/Core/Content/MailTemplate/Aggregate/MailTemplateMedia/MailTemplateMediaCollection.php
+++ b/src/Core/Content/MailTemplate/Aggregate/MailTemplateMedia/MailTemplateMediaCollection.php
@@ -8,6 +8,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<MailTemplateMediaEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('after-sales')]
 class MailTemplateMediaCollection extends EntityCollection

--- a/src/Core/Content/MailTemplate/Aggregate/MailTemplateMedia/MailTemplateMediaDefinition.php
+++ b/src/Core/Content/MailTemplate/Aggregate/MailTemplateMedia/MailTemplateMediaDefinition.php
@@ -16,6 +16,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\MappingEntityDefinition;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\Language\LanguageDefinition;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('after-sales')]
 class MailTemplateMediaDefinition extends MappingEntityDefinition
 {

--- a/src/Core/Content/MailTemplate/Aggregate/MailTemplateMedia/MailTemplateMediaEntity.php
+++ b/src/Core/Content/MailTemplate/Aggregate/MailTemplateMedia/MailTemplateMediaEntity.php
@@ -8,6 +8,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\Entity;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityIdTrait;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('after-sales')]
 class MailTemplateMediaEntity extends Entity
 {

--- a/src/Core/Content/MailTemplate/Aggregate/MailTemplateTranslation/MailTemplateTranslationCollection.php
+++ b/src/Core/Content/MailTemplate/Aggregate/MailTemplateTranslation/MailTemplateTranslationCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<MailTemplateTranslationEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('after-sales')]
 class MailTemplateTranslationCollection extends EntityCollection

--- a/src/Core/Content/MailTemplate/Aggregate/MailTemplateTranslation/MailTemplateTranslationDefinition.php
+++ b/src/Core/Content/MailTemplate/Aggregate/MailTemplateTranslation/MailTemplateTranslationDefinition.php
@@ -13,6 +13,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\StringField;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('after-sales')]
 class MailTemplateTranslationDefinition extends EntityTranslationDefinition
 {

--- a/src/Core/Content/MailTemplate/Aggregate/MailTemplateTranslation/MailTemplateTranslationEntity.php
+++ b/src/Core/Content/MailTemplate/Aggregate/MailTemplateTranslation/MailTemplateTranslationEntity.php
@@ -7,6 +7,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityCustomFieldsTrait;
 use Shopware\Core\Framework\DataAbstractionLayer\TranslationEntity;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('after-sales')]
 class MailTemplateTranslationEntity extends TranslationEntity
 {

--- a/src/Core/Content/MailTemplate/Aggregate/MailTemplateType/MailTemplateTypeCollection.php
+++ b/src/Core/Content/MailTemplate/Aggregate/MailTemplateType/MailTemplateTypeCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<MailTemplateTypeEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('after-sales')]
 class MailTemplateTypeCollection extends EntityCollection

--- a/src/Core/Content/MailTemplate/Aggregate/MailTemplateType/MailTemplateTypeEntity.php
+++ b/src/Core/Content/MailTemplate/Aggregate/MailTemplateType/MailTemplateTypeEntity.php
@@ -10,6 +10,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityIdTrait;
 use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('after-sales')]
 class MailTemplateTypeEntity extends Entity
 {

--- a/src/Core/Content/MailTemplate/Aggregate/MailTemplateTypeTranslation/MailTemplateTypeTranslationCollection.php
+++ b/src/Core/Content/MailTemplate/Aggregate/MailTemplateTypeTranslation/MailTemplateTypeTranslationCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<MailTemplateTypeTranslationEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('after-sales')]
 class MailTemplateTypeTranslationCollection extends EntityCollection

--- a/src/Core/Content/MailTemplate/Aggregate/MailTemplateTypeTranslation/MailTemplateTypeTranslationDefinition.php
+++ b/src/Core/Content/MailTemplate/Aggregate/MailTemplateTypeTranslation/MailTemplateTypeTranslationDefinition.php
@@ -11,6 +11,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\StringField;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('after-sales')]
 class MailTemplateTypeTranslationDefinition extends EntityTranslationDefinition
 {

--- a/src/Core/Content/MailTemplate/Aggregate/MailTemplateTypeTranslation/MailTemplateTypeTranslationEntity.php
+++ b/src/Core/Content/MailTemplate/Aggregate/MailTemplateTypeTranslation/MailTemplateTypeTranslationEntity.php
@@ -7,6 +7,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityCustomFieldsTrait;
 use Shopware\Core\Framework\DataAbstractionLayer\TranslationEntity;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('after-sales')]
 class MailTemplateTypeTranslationEntity extends TranslationEntity
 {

--- a/src/Core/Content/MailTemplate/MailTemplateCollection.php
+++ b/src/Core/Content/MailTemplate/MailTemplateCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<MailTemplateEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('after-sales')]
 class MailTemplateCollection extends EntityCollection

--- a/src/Core/Content/MailTemplate/MailTemplateDefinition.php
+++ b/src/Core/Content/MailTemplate/MailTemplateDefinition.php
@@ -22,6 +22,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\WasModifiedByUserField;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('after-sales')]
 class MailTemplateDefinition extends EntityDefinition
 {

--- a/src/Core/Content/MailTemplate/MailTemplateEntity.php
+++ b/src/Core/Content/MailTemplate/MailTemplateEntity.php
@@ -10,6 +10,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityCustomFieldsTrait;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityIdTrait;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('after-sales')]
 class MailTemplateEntity extends Entity
 {

--- a/src/Core/Content/MailTemplate/Service/Event/MailDataSimulatorFieldEvent.php
+++ b/src/Core/Content/MailTemplate/Service/Event/MailDataSimulatorFieldEvent.php
@@ -7,6 +7,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\Field;
 use Shopware\Core\Framework\Log\Package;
 use Symfony\Contracts\EventDispatcher\Event;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('after-sales')]
 class MailDataSimulatorFieldEvent extends Event
 {

--- a/src/Core/Content/MailTemplate/Service/Event/MailDataSimulatorFormDataEvent.php
+++ b/src/Core/Content/MailTemplate/Service/Event/MailDataSimulatorFormDataEvent.php
@@ -6,6 +6,9 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Log\Package;
 use Symfony\Contracts\EventDispatcher\Event;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('after-sales')]
 class MailDataSimulatorFormDataEvent extends Event
 {

--- a/src/Core/Content/Newsletter/Aggregate/NewsletterRecipient/NewsletterRecipientCollection.php
+++ b/src/Core/Content/Newsletter/Aggregate/NewsletterRecipient/NewsletterRecipientCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<NewsletterRecipientEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('after-sales')]
 class NewsletterRecipientCollection extends EntityCollection

--- a/src/Core/Content/Newsletter/Aggregate/NewsletterRecipient/NewsletterRecipientDefinition.php
+++ b/src/Core/Content/Newsletter/Aggregate/NewsletterRecipient/NewsletterRecipientDefinition.php
@@ -22,6 +22,9 @@ use Shopware\Core\System\SalesChannel\SalesChannelDefinition;
 use Shopware\Core\System\Salutation\SalutationDefinition;
 use Shopware\Core\System\Tag\TagDefinition;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('after-sales')]
 class NewsletterRecipientDefinition extends EntityDefinition
 {

--- a/src/Core/Content/Newsletter/Aggregate/NewsletterRecipient/NewsletterRecipientEntity.php
+++ b/src/Core/Content/Newsletter/Aggregate/NewsletterRecipient/NewsletterRecipientEntity.php
@@ -11,6 +11,9 @@ use Shopware\Core\System\SalesChannel\SalesChannelEntity;
 use Shopware\Core\System\Salutation\SalutationEntity;
 use Shopware\Core\System\Tag\TagCollection;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('after-sales')]
 class NewsletterRecipientEntity extends Entity
 {

--- a/src/Core/Content/Newsletter/Aggregate/NewsletterRecipientTag/NewsletterRecipientTagDefinition.php
+++ b/src/Core/Content/Newsletter/Aggregate/NewsletterRecipientTag/NewsletterRecipientTagDefinition.php
@@ -12,6 +12,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\MappingEntityDefinition;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\Tag\TagDefinition;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('after-sales')]
 class NewsletterRecipientTagDefinition extends MappingEntityDefinition
 {

--- a/src/Core/Content/Newsletter/Event/NewsletterRecipientIndexerEvent.php
+++ b/src/Core/Content/Newsletter/Event/NewsletterRecipientIndexerEvent.php
@@ -6,6 +6,9 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Event\NestedEvent;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('after-sales')]
 class NewsletterRecipientIndexerEvent extends NestedEvent
 {

--- a/src/Core/Content/Newsletter/Event/NewsletterSubscribeUrlEvent.php
+++ b/src/Core/Content/Newsletter/Event/NewsletterSubscribeUrlEvent.php
@@ -9,6 +9,9 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Contracts\EventDispatcher\Event;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('after-sales')]
 class NewsletterSubscribeUrlEvent extends Event implements ShopwareSalesChannelEvent
 {

--- a/src/Core/Content/Newsletter/Event/NewsletterSubscribeUrlEvent.php
+++ b/src/Core/Content/Newsletter/Event/NewsletterSubscribeUrlEvent.php
@@ -63,6 +63,9 @@ class NewsletterSubscribeUrlEvent extends Event implements ShopwareSalesChannelE
         return $this->hash;
     }
 
+    /**
+     * @return array<string, mixed>
+     */
     public function getData(): array
     {
         return $this->data;

--- a/src/Core/Content/Newsletter/SalesChannel/SalesChannelNewsletterRecipientDefinition.php
+++ b/src/Core/Content/Newsletter/SalesChannel/SalesChannelNewsletterRecipientDefinition.php
@@ -9,6 +9,9 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\Entity\SalesChannelDefinitionInterface;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('after-sales')]
 class SalesChannelNewsletterRecipientDefinition extends NewsletterRecipientDefinition implements SalesChannelDefinitionInterface
 {

--- a/src/Core/Content/Product/Aggregate/ProductReview/ProductReviewCollection.php
+++ b/src/Core/Content/Product/Aggregate/ProductReview/ProductReviewCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<ProductReviewEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('after-sales')]
 class ProductReviewCollection extends EntityCollection

--- a/src/Core/Content/Product/Aggregate/ProductReview/ProductReviewDefinition.php
+++ b/src/Core/Content/Product/Aggregate/ProductReview/ProductReviewDefinition.php
@@ -23,6 +23,9 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\Language\LanguageDefinition;
 use Shopware\Core\System\SalesChannel\SalesChannelDefinition;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('after-sales')]
 class ProductReviewDefinition extends EntityDefinition
 {

--- a/src/Core/Content/Product/Aggregate/ProductReview/ProductReviewEntity.php
+++ b/src/Core/Content/Product/Aggregate/ProductReview/ProductReviewEntity.php
@@ -11,6 +11,9 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\Language\LanguageEntity;
 use Shopware\Core\System\SalesChannel\SalesChannelEntity;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('after-sales')]
 class ProductReviewEntity extends Entity
 {

--- a/src/Core/Content/Product/DataAbstractionLayer/CheapestPrice/CheapestPriceField.php
+++ b/src/Core/Content/Product/DataAbstractionLayer/CheapestPrice/CheapestPriceField.php
@@ -7,6 +7,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\JsonField;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldSerializer\PHPUnserializeFieldSerializer;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('framework')]
 class CheapestPriceField extends JsonField
 {

--- a/src/Core/Content/Product/SalesChannel/Detail/Event/ResolveVariantIdEvent.php
+++ b/src/Core/Content/Product/SalesChannel/Detail/Event/ResolveVariantIdEvent.php
@@ -8,6 +8,9 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Contracts\EventDispatcher\Event;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('checkout')]
 class ResolveVariantIdEvent extends Event implements ShopwareSalesChannelEvent
 {

--- a/src/Core/Content/Product/SalesChannel/Review/Event/ProductReviewsLoadedEvent.php
+++ b/src/Core/Content/Product/SalesChannel/Review/Event/ProductReviewsLoadedEvent.php
@@ -10,6 +10,9 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\HttpFoundation\Request;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('after-sales')]
 final class ProductReviewsLoadedEvent extends NestedEvent implements ShopwareSalesChannelEvent
 {

--- a/src/Core/Content/RevocationRequest/Event/RevocationRequestEvent.php
+++ b/src/Core/Content/RevocationRequest/Event/RevocationRequestEvent.php
@@ -15,6 +15,9 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Validation\DataBag\DataBag;
 use Symfony\Contracts\EventDispatcher\Event;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('after-sales')]
 final class RevocationRequestEvent extends Event implements SalesChannelAware, MailAware, ScalarValuesAware, FlowEventAware
 {

--- a/src/Core/Content/Rule/Aggregate/RuleCondition/RuleConditionCollection.php
+++ b/src/Core/Content/Rule/Aggregate/RuleCondition/RuleConditionCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<RuleConditionEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('fundamentals@after-sales')]
 class RuleConditionCollection extends EntityCollection

--- a/src/Core/Content/Rule/Aggregate/RuleCondition/RuleConditionDefinition.php
+++ b/src/Core/Content/Rule/Aggregate/RuleCondition/RuleConditionDefinition.php
@@ -20,6 +20,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\StringField;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('fundamentals@after-sales')]
 class RuleConditionDefinition extends EntityDefinition
 {

--- a/src/Core/Content/Rule/Aggregate/RuleCondition/RuleConditionEntity.php
+++ b/src/Core/Content/Rule/Aggregate/RuleCondition/RuleConditionEntity.php
@@ -10,6 +10,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityCustomFieldsTrait;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityIdTrait;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('fundamentals@after-sales')]
 class RuleConditionEntity extends Entity implements IdAware
 {

--- a/src/Core/Content/Rule/Aggregate/RuleTag/RuleTagDefinition.php
+++ b/src/Core/Content/Rule/Aggregate/RuleTag/RuleTagDefinition.php
@@ -12,6 +12,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\MappingEntityDefinition;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\Tag\TagDefinition;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('fundamentals@after-sales')]
 class RuleTagDefinition extends MappingEntityDefinition
 {

--- a/src/Core/Content/Rule/Event/RuleIndexerEvent.php
+++ b/src/Core/Content/Rule/Event/RuleIndexerEvent.php
@@ -6,6 +6,9 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Event\NestedEvent;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('fundamentals@after-sales')]
 class RuleIndexerEvent extends NestedEvent
 {

--- a/src/Core/Content/Rule/RuleDefinition.php
+++ b/src/Core/Content/Rule/RuleDefinition.php
@@ -43,6 +43,9 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\Tag\TagDefinition;
 use Shopware\Core\System\TaxProvider\TaxProviderDefinition;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('fundamentals@after-sales')]
 class RuleDefinition extends EntityDefinition
 {

--- a/src/Core/Content/Rule/RuleEntity.php
+++ b/src/Core/Content/Rule/RuleEntity.php
@@ -19,6 +19,9 @@ use Shopware\Core\Framework\Rule\Rule;
 use Shopware\Core\System\Tag\TagCollection;
 use Shopware\Core\System\TaxProvider\TaxProviderCollection;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('fundamentals@after-sales')]
 class RuleEntity extends Entity
 {

--- a/src/Core/Content/Shared/MailFlow/Event/MailFlowDataCriteriaEvent.php
+++ b/src/Core/Content/Shared/MailFlow/Event/MailFlowDataCriteriaEvent.php
@@ -9,6 +9,9 @@ use Shopware\Core\Framework\Event\ShopwareEvent;
 use Shopware\Core\Framework\Log\Package;
 use Symfony\Contracts\EventDispatcher\Event;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('after-sales')]
 class MailFlowDataCriteriaEvent extends Event implements ShopwareEvent, GenericEvent
 {

--- a/tests/unit/Core/Content/Category/CategoryDefinitionTest.php
+++ b/tests/unit/Core/Content/Category/CategoryDefinitionTest.php
@@ -1,0 +1,60 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Content\Category;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Category\CategoryCollection;
+use Shopware\Core\Content\Category\CategoryDefinition;
+use Shopware\Core\Content\Category\CategoryEntity;
+use Shopware\Core\Framework\DataAbstractionLayer\Dbal\EntityWriteGateway;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\BoolField;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Test\Annotation\DisabledFeatures;
+use Shopware\Core\Test\Stub\DataAbstractionLayer\StaticDefinitionInstanceRegistry;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+/**
+ * @internal
+ */
+#[Package('discovery')]
+#[CoversClass(CategoryDefinition::class)]
+class CategoryDefinitionTest extends TestCase
+{
+    public function testEntityConfiguration(): void
+    {
+        $definition = $this->createDefinition();
+
+        static::assertSame(CategoryDefinition::ENTITY_NAME, $definition->getEntityName());
+        static::assertSame(CategoryEntity::class, $definition->getEntityClass());
+        static::assertSame(CategoryCollection::class, $definition->getCollectionClass());
+        static::assertSame('6.0.0.0', $definition->since());
+    }
+
+    public function testDeprecatedCmsPageIdSwitchedFieldIsGone(): void
+    {
+        static::assertNull($this->createDefinition()->getFields()->get('cmsPageIdSwitched'));
+    }
+
+    #[DisabledFeatures(['v6.8.0.0'])]
+    public function testDeprecatedCmsPageIdSwitchedFieldStillExistsInTheLegacyMajor(): void
+    {
+        $field = $this->createDefinition()->getFields()->get('cmsPageIdSwitched');
+
+        static::assertInstanceOf(BoolField::class, $field);
+    }
+
+    private function createDefinition(): CategoryDefinition
+    {
+        $registry = new StaticDefinitionInstanceRegistry(
+            [CategoryDefinition::class],
+            static::createStub(ValidatorInterface::class),
+            static::createStub(EntityWriteGateway::class),
+        );
+
+        $definition = $registry->getByEntityName(CategoryDefinition::ENTITY_NAME);
+        static::assertInstanceOf(CategoryDefinition::class, $definition);
+
+        return $definition;
+    }
+}

--- a/tests/unit/Core/Content/Category/CategoryEntityTest.php
+++ b/tests/unit/Core/Content/Category/CategoryEntityTest.php
@@ -49,6 +49,26 @@ class CategoryEntityTest extends TestCase
         static::assertSame(['root' => 'Root', 'middle' => 'Middle', 'leaf' => 'Leaf'], $category->getPlainBreadcrumb());
     }
 
+    public function testJsonSerializeContainsTheSortedBreadcrumb(): void
+    {
+        $category = new CategoryEntity();
+        $category->setId('leaf');
+        $category->setPath('|root|middle|');
+        $category->setTranslated(['breadcrumb' => [
+            'middle' => 'Middle',
+            'leaf' => 'Leaf',
+            'root' => 'Root',
+        ]]);
+
+        static::assertSame(['Root', 'Middle', 'Leaf'], $category->getBreadcrumb());
+
+        $data = $category->jsonSerialize();
+
+        static::assertSame(['Root', 'Middle', 'Leaf'], $data['breadcrumb']);
+        static::assertIsArray($data['translated']);
+        static::assertSame(['Root', 'Middle', 'Leaf'], $data['translated']['breadcrumb']);
+    }
+
     public function testShouldOpenInNewTabOnlyForLinkTypeCategoriesWithTheFlag(): void
     {
         $link = new CategoryEntity();

--- a/tests/unit/Core/Content/Category/CategoryEntityTest.php
+++ b/tests/unit/Core/Content/Category/CategoryEntityTest.php
@@ -1,0 +1,49 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Content\Category;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Category\CategoryEntity;
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * @internal
+ */
+#[Package('discovery')]
+#[CoversClass(CategoryEntity::class)]
+class CategoryEntityTest extends TestCase
+{
+    public function testPlainBreadcrumbIsEmptyWithoutATranslatedBreadcrumb(): void
+    {
+        $category = new CategoryEntity();
+        $category->setId('leaf');
+        $category->setTranslated([]);
+
+        static::assertSame([], $category->getPlainBreadcrumb());
+    }
+
+    public function testPlainBreadcrumbReturnsTheFullBreadcrumbWithoutAPath(): void
+    {
+        $category = new CategoryEntity();
+        $category->setId('leaf');
+        $category->setTranslated(['breadcrumb' => ['root' => 'Root', 'leaf' => 'Leaf']]);
+
+        static::assertSame(['root' => 'Root', 'leaf' => 'Leaf'], $category->getPlainBreadcrumb());
+    }
+
+    public function testPlainBreadcrumbFiltersToThePathAndItself(): void
+    {
+        $category = new CategoryEntity();
+        $category->setId('leaf');
+        $category->setPath('|root|middle|');
+        $category->setTranslated(['breadcrumb' => [
+            'root' => 'Root',
+            'middle' => 'Middle',
+            'unrelated' => 'Unrelated',
+            'leaf' => 'Leaf',
+        ]]);
+
+        static::assertSame(['root' => 'Root', 'middle' => 'Middle', 'leaf' => 'Leaf'], $category->getPlainBreadcrumb());
+    }
+}

--- a/tests/unit/Core/Content/Category/CategoryEntityTest.php
+++ b/tests/unit/Core/Content/Category/CategoryEntityTest.php
@@ -4,8 +4,10 @@ namespace Shopware\Tests\Unit\Core\Content\Category;
 
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Category\CategoryDefinition;
 use Shopware\Core\Content\Category\CategoryEntity;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Test\Annotation\DisabledFeatures;
 
 /**
  * @internal
@@ -45,5 +47,27 @@ class CategoryEntityTest extends TestCase
         ]]);
 
         static::assertSame(['root' => 'Root', 'middle' => 'Middle', 'leaf' => 'Leaf'], $category->getPlainBreadcrumb());
+    }
+
+    public function testShouldOpenInNewTabOnlyForLinkTypeCategoriesWithTheFlag(): void
+    {
+        $link = new CategoryEntity();
+        $link->setType(CategoryDefinition::TYPE_LINK);
+        $link->setTranslated(['linkNewTab' => true]);
+        static::assertTrue($link->shouldOpenInNewTab());
+
+        $page = new CategoryEntity();
+        $page->setType(CategoryDefinition::TYPE_PAGE);
+        $page->setTranslated(['linkNewTab' => true]);
+        static::assertFalse($page->shouldOpenInNewTab());
+    }
+
+    #[DisabledFeatures(['v6.8.0.0'])]
+    public function testDeprecatedCmsPageIdSwitchedRoundTrip(): void
+    {
+        $category = new CategoryEntity();
+        $category->setCmsPageIdSwitched(true);
+
+        static::assertTrue($category->getCmsPageIdSwitched());
     }
 }

--- a/tests/unit/Core/Content/Category/Event/SalesChannelCategoryIdsFetchedEventTest.php
+++ b/tests/unit/Core/Content/Category/Event/SalesChannelCategoryIdsFetchedEventTest.php
@@ -1,0 +1,27 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Content\Category\Event;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Category\Event\SalesChannelCategoryIdsFetchedEvent;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
+
+/**
+ * @internal
+ */
+#[Package('discovery')]
+#[CoversClass(SalesChannelCategoryIdsFetchedEvent::class)]
+class SalesChannelCategoryIdsFetchedEventTest extends TestCase
+{
+    public function testDeduplicatesTheFetchedIds(): void
+    {
+        $event = new SalesChannelCategoryIdsFetchedEvent(
+            ['id-a', 'id-b', 'id-a'],
+            static::createStub(SalesChannelContext::class),
+        );
+
+        static::assertSame(['id-a', 'id-b'], $event->getIds());
+    }
+}

--- a/tests/unit/Core/Content/Category/Event/SalesChannelCategoryIdsFetchedEventTest.php
+++ b/tests/unit/Core/Content/Category/Event/SalesChannelCategoryIdsFetchedEventTest.php
@@ -5,6 +5,7 @@ namespace Shopware\Tests\Unit\Core\Content\Category\Event;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Category\Event\SalesChannelCategoryIdsFetchedEvent;
+use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 
@@ -23,5 +24,32 @@ class SalesChannelCategoryIdsFetchedEventTest extends TestCase
         );
 
         static::assertSame(['id-a', 'id-b'], $event->getIds());
+    }
+
+    public function testFilterIdRemovesTheGivenId(): void
+    {
+        $event = new SalesChannelCategoryIdsFetchedEvent(
+            ['id-a', 'id-b'],
+            static::createStub(SalesChannelContext::class),
+        );
+
+        static::assertTrue($event->hasId('id-a'));
+
+        $event->filterId('id-a');
+
+        static::assertFalse($event->hasId('id-a'));
+        static::assertSame(['id-b'], $event->getIds());
+    }
+
+    public function testExposesTheSalesChannelContext(): void
+    {
+        $context = Context::createDefaultContext();
+        $salesChannelContext = static::createStub(SalesChannelContext::class);
+        $salesChannelContext->method('getContext')->willReturn($context);
+
+        $event = new SalesChannelCategoryIdsFetchedEvent(['id-a'], $salesChannelContext);
+
+        static::assertSame($salesChannelContext, $event->getSalesChannelContext());
+        static::assertSame($context, $event->getContext());
     }
 }

--- a/tests/unit/Core/Content/Cms/Aggregate/CmsSection/CmsSectionCollectionTest.php
+++ b/tests/unit/Core/Content/Cms/Aggregate/CmsSection/CmsSectionCollectionTest.php
@@ -1,0 +1,37 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Content\Cms\Aggregate\CmsSection;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Cms\Aggregate\CmsBlock\CmsBlockCollection;
+use Shopware\Core\Content\Cms\Aggregate\CmsBlock\CmsBlockEntity;
+use Shopware\Core\Content\Cms\Aggregate\CmsSection\CmsSectionCollection;
+use Shopware\Core\Content\Cms\Aggregate\CmsSection\CmsSectionEntity;
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * @internal
+ */
+#[Package('discovery')]
+#[CoversClass(CmsSectionCollection::class)]
+class CmsSectionCollectionTest extends TestCase
+{
+    public function testGetBlocksMergesAllSectionsAndSkipsSectionsWithoutBlocks(): void
+    {
+        $block = new CmsBlockEntity();
+        $block->setId('block-a');
+
+        $withBlocks = new CmsSectionEntity();
+        $withBlocks->setId('section-a');
+        $withBlocks->setBlocks(new CmsBlockCollection([$block]));
+
+        $withoutBlocks = new CmsSectionEntity();
+        $withoutBlocks->setId('section-b');
+
+        $blocks = (new CmsSectionCollection([$withBlocks, $withoutBlocks]))->getBlocks();
+
+        static::assertCount(1, $blocks);
+        static::assertSame($block, $blocks->first());
+    }
+}

--- a/tests/unit/Core/Content/Cms/Aggregate/CmsSlot/CmsSlotEntityTest.php
+++ b/tests/unit/Core/Content/Cms/Aggregate/CmsSlot/CmsSlotEntityTest.php
@@ -1,0 +1,46 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Content\Cms\Aggregate\CmsSlot;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Cms\Aggregate\CmsSlot\CmsSlotEntity;
+use Shopware\Core\Content\Cms\CmsException;
+use Shopware\Core\Content\Cms\DataResolver\FieldConfig;
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * @internal
+ */
+#[Package('discovery')]
+#[CoversClass(CmsSlotEntity::class)]
+class CmsSlotEntityTest extends TestCase
+{
+    public function testFieldConfigIsBuiltFromTheTranslatedConfigAndCached(): void
+    {
+        $slot = new CmsSlotEntity();
+        $slot->setTranslated(['config' => [
+            'content' => ['source' => FieldConfig::SOURCE_STATIC, 'value' => 'Hello'],
+        ]]);
+
+        $config = $slot->getFieldConfig();
+
+        static::assertCount(1, $config);
+        $field = $config->get('content');
+        static::assertInstanceOf(FieldConfig::class, $field);
+        static::assertSame('Hello', $field->getValue());
+        static::assertSame($config, $slot->getFieldConfig());
+    }
+
+    public function testFieldConfigRejectsANonStringSource(): void
+    {
+        $slot = new CmsSlotEntity();
+        $slot->setTranslated(['config' => [
+            'content' => ['source' => 42, 'value' => 'Hello'],
+        ]]);
+
+        $this->expectException(CmsException::class);
+
+        $slot->getFieldConfig();
+    }
+}

--- a/tests/unit/Core/Content/Cms/CmsPageEntityTest.php
+++ b/tests/unit/Core/Content/Cms/CmsPageEntityTest.php
@@ -1,0 +1,76 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Content\Cms;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Cms\Aggregate\CmsBlock\CmsBlockCollection;
+use Shopware\Core\Content\Cms\Aggregate\CmsBlock\CmsBlockEntity;
+use Shopware\Core\Content\Cms\Aggregate\CmsSection\CmsSectionCollection;
+use Shopware\Core\Content\Cms\Aggregate\CmsSection\CmsSectionEntity;
+use Shopware\Core\Content\Cms\Aggregate\CmsSlot\CmsSlotCollection;
+use Shopware\Core\Content\Cms\Aggregate\CmsSlot\CmsSlotEntity;
+use Shopware\Core\Content\Cms\CmsPageEntity;
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * @internal
+ */
+#[Package('discovery')]
+#[CoversClass(CmsPageEntity::class)]
+class CmsPageEntityTest extends TestCase
+{
+    public function testElementLookupsAreEmptyWithoutSections(): void
+    {
+        $page = new CmsPageEntity();
+
+        static::assertSame([], $page->getElementsOfType('image'));
+        static::assertSame([], $page->getAllElements());
+    }
+
+    public function testElementsOfTypeReturnsOnlyMatchingSlots(): void
+    {
+        $image = $this->createSlot('image-slot', 'image');
+        $text = $this->createSlot('text-slot', 'text');
+
+        $page = $this->createPageWithSlots($image, $text);
+
+        static::assertSame([$image], $page->getElementsOfType('image'));
+    }
+
+    public function testAllElementsReturnsEverySlot(): void
+    {
+        $image = $this->createSlot('image-slot', 'image');
+        $text = $this->createSlot('text-slot', 'text');
+
+        $page = $this->createPageWithSlots($image, $text);
+
+        static::assertSame([$image, $text], $page->getAllElements());
+    }
+
+    private function createSlot(string $id, string $type): CmsSlotEntity
+    {
+        $slot = new CmsSlotEntity();
+        $slot->setId($id);
+        $slot->setType($type);
+        $slot->setSlot($id);
+
+        return $slot;
+    }
+
+    private function createPageWithSlots(CmsSlotEntity ...$slots): CmsPageEntity
+    {
+        $block = new CmsBlockEntity();
+        $block->setId('block');
+        $block->setSlots(new CmsSlotCollection($slots));
+
+        $section = new CmsSectionEntity();
+        $section->setId('section');
+        $section->setBlocks(new CmsBlockCollection([$block]));
+
+        $page = new CmsPageEntity();
+        $page->setSections(new CmsSectionCollection([$section]));
+
+        return $page;
+    }
+}

--- a/tests/unit/Core/Content/Cms/Events/CmsPageLoadedEventTest.php
+++ b/tests/unit/Core/Content/Cms/Events/CmsPageLoadedEventTest.php
@@ -6,6 +6,9 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Cms\CmsPageCollection;
 use Shopware\Core\Content\Cms\Events\CmsPageLoadedEvent;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
+use Shopware\Core\Framework\Feature\FeatureException;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\HttpFoundation\Request;
@@ -24,5 +27,28 @@ class CmsPageLoadedEventTest extends TestCase
         $event = new CmsPageLoadedEvent(new Request(), $result, static::createStub(SalesChannelContext::class));
 
         static::assertSame($result, $event->getResult());
+    }
+
+    public function testRejectsAPlainEntityCollection(): void
+    {
+        $this->expectExceptionObject(FeatureException::error(
+            'Tried to access deprecated functionality: Passing a plain EntityCollection as $result is deprecated, pass a CmsPageCollection instead.'
+        ));
+        // @phpstan-ignore argument.type (the deprecated wide parameter type is exactly what this test exercises)
+        new CmsPageLoadedEvent(new Request(), new EntityCollection(), static::createStub(SalesChannelContext::class));
+    }
+
+    public function testExposesRequestAndSalesChannelContext(): void
+    {
+        $context = Context::createDefaultContext();
+        $salesChannelContext = static::createStub(SalesChannelContext::class);
+        $salesChannelContext->method('getContext')->willReturn($context);
+        $request = new Request();
+
+        $event = new CmsPageLoadedEvent($request, new CmsPageCollection(), $salesChannelContext);
+
+        static::assertSame($request, $event->getRequest());
+        static::assertSame($salesChannelContext, $event->getSalesChannelContext());
+        static::assertSame($context, $event->getContext());
     }
 }

--- a/tests/unit/Core/Content/Cms/Events/CmsPageLoadedEventTest.php
+++ b/tests/unit/Core/Content/Cms/Events/CmsPageLoadedEventTest.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Content\Cms\Events;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Cms\CmsPageCollection;
+use Shopware\Core\Content\Cms\Events\CmsPageLoadedEvent;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * @internal
+ */
+#[Package('discovery')]
+#[CoversClass(CmsPageLoadedEvent::class)]
+class CmsPageLoadedEventTest extends TestCase
+{
+    public function testAcceptsACmsPageCollection(): void
+    {
+        $result = new CmsPageCollection();
+
+        $event = new CmsPageLoadedEvent(new Request(), $result, static::createStub(SalesChannelContext::class));
+
+        static::assertSame($result, $event->getResult());
+    }
+}

--- a/tests/unit/Core/Content/ContactForm/Event/ContactFormEventTest.php
+++ b/tests/unit/Core/Content/ContactForm/Event/ContactFormEventTest.php
@@ -39,4 +39,19 @@ class ContactFormEventTest extends TestCase
         static::assertArrayHasKey('contactFormData', $flow->data());
         static::assertSame(['foo' => 'bar', 'bar' => 'baz'], $flow->data()['contactFormData']);
     }
+
+    public function testExposesItsPayload(): void
+    {
+        $context = Context::createDefaultContext();
+        $recipients = new MailRecipientStruct(['foo' => 'bar']);
+
+        $event = new ContactFormEvent($context, 'sales-channel-id', $recipients, new DataBag(['subject' => 'question']));
+
+        static::assertSame(ContactFormEvent::EVENT_NAME, $event->getName());
+        static::assertSame($context, $event->getContext());
+        static::assertSame($recipients, $event->getMailStruct());
+        static::assertSame('sales-channel-id', $event->getSalesChannelId());
+        static::assertSame(['subject' => 'question'], $event->getContactFormData());
+        static::assertSame(['contactFormData'], array_keys(ContactFormEvent::getAvailableData()->toArray()));
+    }
 }

--- a/tests/unit/Core/Content/Flow/Events/BeforeLoadStorableFlowDataEventTest.php
+++ b/tests/unit/Core/Content/Flow/Events/BeforeLoadStorableFlowDataEventTest.php
@@ -20,13 +20,17 @@ class BeforeLoadStorableFlowDataEventTest extends TestCase
     #[DisabledFeatures(['v6.8.0.0'])]
     public function testGetters(): void
     {
+        $criteria = new Criteria();
+        $context = Context::createDefaultContext();
         $event = new BeforeLoadStorableFlowDataEvent(
             'entity_name',
-            new Criteria(),
-            Context::createDefaultContext()
+            $criteria,
+            $context
         );
 
         static::assertSame('entity_name', $event->getEntityName());
         static::assertSame('flow.storer.entity_name.criteria.event', $event->getName());
+        static::assertSame($criteria, $event->getCriteria());
+        static::assertSame($context, $event->getContext());
     }
 }

--- a/tests/unit/Core/Content/ImportExport/Event/EnrichExportCriteriaEventTest.php
+++ b/tests/unit/Core/Content/ImportExport/Event/EnrichExportCriteriaEventTest.php
@@ -28,6 +28,24 @@ class EnrichExportCriteriaEventTest extends TestCase
         static::assertSame($context, $event->getContext());
     }
 
+    public function testCriteriaAndLogEntityCanBeReplaced(): void
+    {
+        $criteria = new Criteria();
+        $logEntity = new ImportExportLogEntity();
+        $event = new EnrichExportCriteriaEvent($criteria, $logEntity, Context::createDefaultContext());
+
+        static::assertSame($criteria, $event->getCriteria());
+        static::assertSame($logEntity, $event->getLogEntity());
+
+        $newCriteria = new Criteria();
+        $newLogEntity = new ImportExportLogEntity();
+        $event->setCriteria($newCriteria);
+        $event->setLogEntity($newLogEntity);
+
+        static::assertSame($newCriteria, $event->getCriteria());
+        static::assertSame($newLogEntity, $event->getLogEntity());
+    }
+
     #[DisabledFeatures(['v6.8.0.0'])]
     public function testGetNullableContextReturnsContextWhenFeatureInactiveAndContextProvided(): void
     {

--- a/tests/unit/Core/Content/ImportExport/Event/ImportExportBeforeExportRecordEventTest.php
+++ b/tests/unit/Core/Content/ImportExport/Event/ImportExportBeforeExportRecordEventTest.php
@@ -22,15 +22,20 @@ class ImportExportBeforeExportRecordEventTest extends TestCase
     public function testSetRecordDoesNotMutateOriginalRecord(): void
     {
         $originalRecord = ['key' => 'original'];
+        $config = new Config([], [], []);
         $event = new ImportExportBeforeExportRecordEvent(
-            new Config([], [], []),
+            $config,
             ['key' => 'value'],
             $originalRecord,
             Context::createDefaultContext()
         );
 
+        static::assertSame($config, $event->getConfig());
+        static::assertSame(['key' => 'value'], $event->getRecord());
+
         $event->setRecord(['key' => 'new']);
 
+        static::assertSame(['key' => 'new'], $event->getRecord());
         static::assertSame($originalRecord, $event->getOriginalRecord());
     }
 

--- a/tests/unit/Core/Content/ImportExport/Event/ImportExportExceptionImportExportHandlerEventTest.php
+++ b/tests/unit/Core/Content/ImportExport/Event/ImportExportExceptionImportExportHandlerEventTest.php
@@ -29,6 +29,8 @@ class ImportExportExceptionImportExportHandlerEventTest extends TestCase
             Context::createDefaultContext()
         );
 
+        static::assertSame($message, $event->getMessage());
+
         $event->clearException();
 
         static::assertFalse($event->hasException());

--- a/tests/unit/Core/Content/ImportExport/Event/ImportExportExceptionImportRecordEventTest.php
+++ b/tests/unit/Core/Content/ImportExport/Event/ImportExportExceptionImportRecordEventTest.php
@@ -1,0 +1,57 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Content\ImportExport\Event;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\ImportExport\Event\ImportExportExceptionImportRecordEvent;
+use Shopware\Core\Content\ImportExport\Struct\Config;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * @internal
+ */
+#[Package('fundamentals@after-sales')]
+#[CoversClass(ImportExportExceptionImportRecordEvent::class)]
+class ImportExportExceptionImportRecordEventTest extends TestCase
+{
+    public function testExposesItsPayload(): void
+    {
+        $config = new Config([], [], []);
+        $context = Context::createDefaultContext();
+
+        $event = new ImportExportExceptionImportRecordEvent(
+            new \RuntimeException('import failed'),
+            ['key' => 'record'],
+            ['key' => 'row'],
+            $config,
+            $context
+        );
+
+        static::assertSame(['key' => 'record'], $event->getRecord());
+        static::assertSame(['key' => 'row'], $event->getRow());
+        static::assertSame($config, $event->getConfig());
+        static::assertSame($context, $event->getContext());
+    }
+
+    public function testExceptionCanBeRemoved(): void
+    {
+        $exception = new \RuntimeException('import failed');
+        $event = new ImportExportExceptionImportRecordEvent(
+            $exception,
+            [],
+            [],
+            new Config([], [], []),
+            Context::createDefaultContext()
+        );
+
+        static::assertTrue($event->hasException());
+        static::assertSame($exception, $event->getException());
+
+        $event->removeException();
+
+        static::assertFalse($event->hasException());
+        static::assertNull($event->getException());
+    }
+}

--- a/tests/unit/Core/Content/ImportExport/ImportExportProfileDefinitionTest.php
+++ b/tests/unit/Core/Content/ImportExport/ImportExportProfileDefinitionTest.php
@@ -1,0 +1,57 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Content\ImportExport;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\ImportExport\ImportExportProfileDefinition;
+use Shopware\Core\Content\ImportExport\ImportExportProfileEntity;
+use Shopware\Core\Framework\DataAbstractionLayer\Dbal\EntityWriteGateway;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\TranslatedField;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Test\Annotation\DisabledFeatures;
+use Shopware\Core\Test\Stub\DataAbstractionLayer\StaticDefinitionInstanceRegistry;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+/**
+ * @internal
+ */
+#[Package('fundamentals@after-sales')]
+#[CoversClass(ImportExportProfileDefinition::class)]
+class ImportExportProfileDefinitionTest extends TestCase
+{
+    public function testEntityConfiguration(): void
+    {
+        $definition = $this->createDefinition();
+
+        static::assertSame(ImportExportProfileDefinition::ENTITY_NAME, $definition->getEntityName());
+        static::assertSame(ImportExportProfileEntity::class, $definition->getEntityClass());
+    }
+
+    public function testDeprecatedTranslatedLabelIsGone(): void
+    {
+        static::assertNull($this->createDefinition()->getFields()->get('label'));
+    }
+
+    #[DisabledFeatures(['v6.8.0.0'])]
+    public function testDeprecatedTranslatedLabelStillExistsInTheLegacyMajor(): void
+    {
+        $field = $this->createDefinition()->getFields()->get('label');
+
+        static::assertInstanceOf(TranslatedField::class, $field);
+    }
+
+    private function createDefinition(): ImportExportProfileDefinition
+    {
+        $registry = new StaticDefinitionInstanceRegistry(
+            [ImportExportProfileDefinition::class],
+            static::createStub(ValidatorInterface::class),
+            static::createStub(EntityWriteGateway::class),
+        );
+
+        $definition = $registry->getByEntityName(ImportExportProfileDefinition::ENTITY_NAME);
+        static::assertInstanceOf(ImportExportProfileDefinition::class, $definition);
+
+        return $definition;
+    }
+}

--- a/tests/unit/Core/Content/ImportExport/Processing/Mapping/UpdateByCollectionTest.php
+++ b/tests/unit/Core/Content/ImportExport/Processing/Mapping/UpdateByCollectionTest.php
@@ -1,0 +1,41 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Content\ImportExport\Processing\Mapping;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\ImportExport\Processing\Mapping\UpdateBy;
+use Shopware\Core\Content\ImportExport\Processing\Mapping\UpdateByCollection;
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * @internal
+ */
+#[Package('fundamentals@after-sales')]
+#[CoversClass(UpdateByCollection::class)]
+class UpdateByCollectionTest extends TestCase
+{
+    public function testFromIterableReturnsAnExistingCollectionUnchanged(): void
+    {
+        $collection = new UpdateByCollection();
+
+        static::assertSame($collection, UpdateByCollection::fromIterable($collection));
+    }
+
+    public function testFromIterableBuildsEntriesFromStringsAndArrays(): void
+    {
+        $collection = UpdateByCollection::fromIterable([
+            'product',
+            ['entityName' => 'category', 'mappedKey' => 'id'],
+        ]);
+
+        static::assertCount(2, $collection);
+        $first = $collection->first();
+        $last = $collection->last();
+        static::assertInstanceOf(UpdateBy::class, $first);
+        static::assertInstanceOf(UpdateBy::class, $last);
+        static::assertSame('product', $first->getEntityName());
+        static::assertSame('category', $last->getEntityName());
+        static::assertSame('id', $last->getMappedKey());
+    }
+}

--- a/tests/unit/Core/Content/LandingPage/Aggregate/LandingPageTranslation/LandingPageTranslationEntityTest.php
+++ b/tests/unit/Core/Content/LandingPage/Aggregate/LandingPageTranslation/LandingPageTranslationEntityTest.php
@@ -1,0 +1,33 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Content\LandingPage\Aggregate\LandingPageTranslation;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\LandingPage\Aggregate\LandingPageTranslation\LandingPageTranslationEntity;
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * @internal
+ */
+#[Package('discovery')]
+#[CoversClass(LandingPageTranslationEntity::class)]
+class LandingPageTranslationEntityTest extends TestCase
+{
+    public function testSlotConfigCanBeSet(): void
+    {
+        $landingPage = new LandingPageTranslationEntity();
+        $landingPage->setSlotConfig(['slot-id' => ['content' => ['source' => 'static']]]);
+
+        static::assertSame(['slot-id' => ['content' => ['source' => 'static']]], $landingPage->getSlotConfig());
+    }
+
+    public function testANullSlotConfigIsRejected(): void
+    {
+        $landingPage = new LandingPageTranslationEntity();
+
+        $this->expectException(\Throwable::class);
+
+        $landingPage->setSlotConfig(null);
+    }
+}

--- a/tests/unit/Core/Content/LandingPage/LandingPageEntityTest.php
+++ b/tests/unit/Core/Content/LandingPage/LandingPageEntityTest.php
@@ -1,0 +1,33 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Content\LandingPage;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\LandingPage\LandingPageEntity;
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * @internal
+ */
+#[Package('discovery')]
+#[CoversClass(LandingPageEntity::class)]
+class LandingPageEntityTest extends TestCase
+{
+    public function testSlotConfigCanBeSet(): void
+    {
+        $landingPage = new LandingPageEntity();
+        $landingPage->setSlotConfig(['slot-id' => ['content' => ['source' => 'static']]]);
+
+        static::assertSame(['slot-id' => ['content' => ['source' => 'static']]], $landingPage->getSlotConfig());
+    }
+
+    public function testANullSlotConfigIsRejected(): void
+    {
+        $landingPage = new LandingPageEntity();
+
+        $this->expectException(\Throwable::class);
+
+        $landingPage->setSlotConfig(null);
+    }
+}

--- a/tests/unit/Core/Content/MailTemplate/Aggregate/MailTemplateType/MailTemplateTypeDefinitionTest.php
+++ b/tests/unit/Core/Content/MailTemplate/Aggregate/MailTemplateType/MailTemplateTypeDefinitionTest.php
@@ -1,0 +1,59 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Content\MailTemplate\Aggregate\MailTemplateType;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\MailTemplate\Aggregate\MailTemplateType\MailTemplateTypeCollection;
+use Shopware\Core\Content\MailTemplate\Aggregate\MailTemplateType\MailTemplateTypeDefinition;
+use Shopware\Core\Content\MailTemplate\Aggregate\MailTemplateType\MailTemplateTypeEntity;
+use Shopware\Core\Framework\DataAbstractionLayer\Dbal\EntityWriteGateway;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\JsonField;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Test\Annotation\DisabledFeatures;
+use Shopware\Core\Test\Stub\DataAbstractionLayer\StaticDefinitionInstanceRegistry;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+/**
+ * @internal
+ */
+#[Package('after-sales')]
+#[CoversClass(MailTemplateTypeDefinition::class)]
+class MailTemplateTypeDefinitionTest extends TestCase
+{
+    public function testEntityConfiguration(): void
+    {
+        $definition = $this->createDefinition();
+
+        static::assertSame(MailTemplateTypeDefinition::ENTITY_NAME, $definition->getEntityName());
+        static::assertSame(MailTemplateTypeEntity::class, $definition->getEntityClass());
+        static::assertSame(MailTemplateTypeCollection::class, $definition->getCollectionClass());
+    }
+
+    public function testDeprecatedTemplateDataFieldIsGone(): void
+    {
+        static::assertNull($this->createDefinition()->getFields()->get('templateData'));
+    }
+
+    #[DisabledFeatures(['v6.8.0.0'])]
+    public function testDeprecatedTemplateDataFieldStillExistsInTheLegacyMajor(): void
+    {
+        $field = $this->createDefinition()->getFields()->get('templateData');
+
+        static::assertInstanceOf(JsonField::class, $field);
+    }
+
+    private function createDefinition(): MailTemplateTypeDefinition
+    {
+        $registry = new StaticDefinitionInstanceRegistry(
+            [MailTemplateTypeDefinition::class],
+            static::createStub(ValidatorInterface::class),
+            static::createStub(EntityWriteGateway::class),
+        );
+
+        $definition = $registry->getByEntityName(MailTemplateTypeDefinition::ENTITY_NAME);
+        static::assertInstanceOf(MailTemplateTypeDefinition::class, $definition);
+
+        return $definition;
+    }
+}

--- a/tests/unit/Core/Content/MailTemplate/Service/Event/MailBeforeSentEventTest.php
+++ b/tests/unit/Core/Content/MailTemplate/Service/Event/MailBeforeSentEventTest.php
@@ -74,5 +74,11 @@ class MailBeforeSentEventTest extends TestCase
             'eventName' => CheckoutOrderPlacedEvent::EVENT_NAME,
             'message' => $email,
         ], $event->getLogData());
+        static::assertSame($email, $event->getMessage());
+    }
+
+    public function testAvailableDataDescribesTheFlowPayload(): void
+    {
+        static::assertSame(['data', 'message'], array_keys(MailBeforeSentEvent::getAvailableData()->toArray()));
     }
 }

--- a/tests/unit/Core/Content/MailTemplate/Service/Event/MailBeforeValidateEventTest.php
+++ b/tests/unit/Core/Content/MailTemplate/Service/Event/MailBeforeValidateEventTest.php
@@ -85,4 +85,25 @@ class MailBeforeValidateEventTest extends TestCase
             ],
         ], $event->getLogData());
     }
+
+    public function testDataAndTemplateDataCanBeAmended(): void
+    {
+        $event = new MailBeforeValidateEvent(['foo' => 'bar'], Context::createDefaultContext());
+
+        $event->addData('baz', 'qux');
+        $event->setTemplateData(['template' => 'data']);
+        $event->addTemplateData('extra', 'value');
+
+        static::assertSame(['foo' => 'bar', 'baz' => 'qux'], $event->getData());
+        static::assertSame(['template' => 'data', 'extra' => 'value'], $event->getTemplateData());
+
+        $event->setData(['replaced' => true]);
+
+        static::assertSame(['replaced' => true], $event->getData());
+    }
+
+    public function testAvailableDataDescribesTheFlowPayload(): void
+    {
+        static::assertSame(['data', 'templateData'], array_keys(MailBeforeValidateEvent::getAvailableData()->toArray()));
+    }
 }

--- a/tests/unit/Core/Content/MailTemplate/Service/Event/MailErrorEventTest.php
+++ b/tests/unit/Core/Content/MailTemplate/Service/Event/MailErrorEventTest.php
@@ -69,5 +69,15 @@ class MailErrorEventTest extends TestCase
         static::assertSame('mail.sent.error', $event->getName());
         static::assertSame($context, $event->getContext());
         static::assertSame($exception, $event->getThrowable());
+        static::assertSame('{{ subject }}', $event->getTemplate());
+        static::assertSame([
+            'eventName' => 'checkout.order.placed',
+            'shopName' => 'Storefront',
+        ], $event->getTemplateData());
+    }
+
+    public function testAvailableDataDescribesTheFlowPayload(): void
+    {
+        static::assertSame(['name'], array_keys(MailErrorEvent::getAvailableData()->toArray()));
     }
 }

--- a/tests/unit/Core/Content/MailTemplate/Service/Event/MailSentEventTest.php
+++ b/tests/unit/Core/Content/MailTemplate/Service/Event/MailSentEventTest.php
@@ -88,4 +88,9 @@ class MailSentEventTest extends TestCase
             'text/html' => 'This is a html text',
         ], $event->getContents());
     }
+
+    public function testAvailableDataDescribesTheFlowPayload(): void
+    {
+        static::assertSame(['subject', 'contents', 'recipients'], array_keys(MailSentEvent::getAvailableData()->toArray()));
+    }
 }

--- a/tests/unit/Core/Content/Media/Aggregate/MediaFolder/MediaFolderEntityTest.php
+++ b/tests/unit/Core/Content/Media/Aggregate/MediaFolder/MediaFolderEntityTest.php
@@ -1,0 +1,36 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Content\Media\Aggregate\MediaFolder;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Media\Aggregate\MediaFolder\MediaFolderEntity;
+use Shopware\Core\Content\Media\MediaCollection;
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * @internal
+ */
+#[Package('discovery')]
+#[CoversClass(MediaFolderEntity::class)]
+class MediaFolderEntityTest extends TestCase
+{
+    public function testGetMediaFallsBackToAnEmptyCollection(): void
+    {
+        $folder = new MediaFolderEntity();
+
+        $media = $folder->getMedia();
+
+        static::assertCount(0, $media);
+        static::assertSame($media, $folder->getMedia());
+    }
+
+    public function testGetMediaReturnsTheAssignedCollection(): void
+    {
+        $folder = new MediaFolderEntity();
+        $media = new MediaCollection();
+        $folder->setMedia($media);
+
+        static::assertSame($media, $folder->getMedia());
+    }
+}

--- a/tests/unit/Core/Content/Media/Aggregate/MediaThumbnail/MediaThumbnailEntityTest.php
+++ b/tests/unit/Core/Content/Media/Aggregate/MediaThumbnail/MediaThumbnailEntityTest.php
@@ -1,0 +1,75 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Content\Media\Aggregate\MediaThumbnail;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Media\Aggregate\MediaThumbnail\MediaThumbnailEntity;
+use Shopware\Core\Content\Media\Aggregate\MediaThumbnailSize\MediaThumbnailSizeEntity;
+use Shopware\Core\Content\Media\MediaEntity;
+use Shopware\Core\Framework\Feature\FeatureException;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Test\Annotation\DisabledFeatures;
+
+/**
+ * @internal
+ */
+#[Package('discovery')]
+#[CoversClass(MediaThumbnailEntity::class)]
+class MediaThumbnailEntityTest extends TestCase
+{
+    public function testExposesItsData(): void
+    {
+        $media = new MediaEntity();
+        $size = new MediaThumbnailSizeEntity();
+
+        $entity = new MediaThumbnailEntity();
+        $entity->setWidth(120);
+        $entity->setHeight(80);
+        $entity->setUrl('https://shop.example/thumbnail.png');
+        $entity->setMediaId('media-id');
+        $entity->setMedia($media);
+        $entity->setMediaThumbnailSizeId('size-id');
+        $entity->setMediaThumbnailSize($size);
+        $entity->setPath('thumbnail/path.png');
+
+        static::assertSame(120, $entity->getWidth());
+        static::assertSame(80, $entity->getHeight());
+        static::assertSame('https://shop.example/thumbnail.png', $entity->getUrl());
+        static::assertSame('media-id', $entity->getMediaId());
+        static::assertSame($media, $entity->getMedia());
+        static::assertSame('size-id', $entity->getMediaThumbnailSizeId());
+        static::assertSame($size, $entity->getMediaThumbnailSize());
+        static::assertSame('120x80', $entity->getIdentifier());
+        static::assertSame('thumbnail/path.png', $entity->getPath());
+    }
+
+    public function testGetUrlFallsBackToAnEmptyString(): void
+    {
+        $entity = new MediaThumbnailEntity();
+        $entity->assign(['url' => null]);
+
+        static::assertSame('', $entity->getUrl());
+    }
+
+    public function testGetMediaIdThrowsWhenUnsetAndFeatureActive(): void
+    {
+        $this->expectExceptionObject(FeatureException::error('Tried to access deprecated functionality: $mediaId must not be null'));
+        (new MediaThumbnailEntity())->getMediaId();
+    }
+
+    public function testGetMediaThumbnailSizeIdThrowsWhenUnsetAndFeatureActive(): void
+    {
+        $this->expectExceptionObject(FeatureException::error('Tried to access deprecated functionality: $mediaThumbnailSizeId must not be null'));
+        (new MediaThumbnailEntity())->getMediaThumbnailSizeId();
+    }
+
+    #[DisabledFeatures(['v6.8.0.0'])]
+    public function testUnsetIdsFallBackToLegacyDefaults(): void
+    {
+        $entity = new MediaThumbnailEntity();
+
+        static::assertSame('', $entity->getMediaId());
+        static::assertNull($entity->getMediaThumbnailSizeId());
+    }
+}

--- a/tests/unit/Core/Content/Media/Event/MediaFileExtensionWhitelistEventTest.php
+++ b/tests/unit/Core/Content/Media/Event/MediaFileExtensionWhitelistEventTest.php
@@ -26,6 +26,17 @@ class MediaFileExtensionWhitelistEventTest extends TestCase
         static::assertSame($context, $event->getContext());
     }
 
+    public function testSetWhitelistReplacesTheWhitelist(): void
+    {
+        $event = new MediaFileExtensionWhitelistEvent(['jpg'], Context::createDefaultContext());
+
+        static::assertSame(['jpg'], $event->getWhitelist());
+
+        $event->setWhitelist(['jpg', 'png']);
+
+        static::assertSame(['jpg', 'png'], $event->getWhitelist());
+    }
+
     #[DisabledFeatures(['v6.8.0.0'])]
     public function testGetNullableContextReturnsContextWhenFeatureInactiveAndContextProvided(): void
     {

--- a/tests/unit/Core/Content/Media/MediaEntityTest.php
+++ b/tests/unit/Core/Content/Media/MediaEntityTest.php
@@ -40,4 +40,48 @@ class MediaEntityTest extends TestCase
         yield 'only-file' => ['file' => 'Tuscany-Landscape', 'ext' => null, 'expected' => null];
         yield 'file-and-ext' => ['file' => 'Tuscany-Landscape', 'ext' => 'jpg', 'expected' => 'Tuscany-Landscape.jpg'];
     }
+
+    public function testHasFileRequiresTheFileMetadataOrAPath(): void
+    {
+        $media = new MediaEntity();
+        static::assertFalse($media->hasFile());
+        static::assertFalse($media->hasPath());
+        static::assertSame('', $media->getPath());
+
+        $media->setPath('media/tuscany.jpg');
+        static::assertTrue($media->hasFile());
+        static::assertTrue($media->hasPath());
+        static::assertSame('media/tuscany.jpg', $media->getPath());
+
+        $withMetadata = new MediaEntity();
+        $withMetadata->setMimeType('image/jpeg');
+        $withMetadata->setFileExtension('jpg');
+        $withMetadata->setFileName('tuscany');
+        static::assertTrue($withMetadata->hasFile());
+    }
+
+    public function testGetResolvesHasFileAsAProperty(): void
+    {
+        $media = new MediaEntity();
+        $media->setPath('media/tuscany.jpg');
+        $media->setTitle('Tuscany');
+
+        static::assertTrue($media->get('hasFile'));
+        static::assertSame('Tuscany', $media->get('title'));
+    }
+
+    public function testJsonSerializeHidesTheRawDataAndAddsHasFile(): void
+    {
+        $media = new MediaEntity();
+        $media->setMediaTypeRaw('media-type-raw');
+        $media->setMetaDataRaw('meta-data-raw');
+
+        static::assertSame('media-type-raw', $media->getMediaTypeRaw());
+
+        $data = $media->jsonSerialize();
+
+        static::assertArrayNotHasKey('mediaTypeRaw', $data);
+        static::assertArrayNotHasKey('metaDataRaw', $data);
+        static::assertFalse($data['hasFile']);
+    }
 }

--- a/tests/unit/Core/Content/Newsletter/Event/NewsletterConfirmEventTest.php
+++ b/tests/unit/Core/Content/Newsletter/Event/NewsletterConfirmEventTest.php
@@ -27,8 +27,7 @@ class NewsletterConfirmEventTest extends TestCase
 
         static::assertSame(['jane@example.com' => 'Jane Doe'], $event->getMailStruct()->getRecipients());
 
-        // the struct is a snapshot taken on first access: later recipient
-        // changes must not leak into it
+        // the struct is a snapshot taken on first access: later recipient changes must not leak into it
         $recipient->setFirstName('Changed');
 
         static::assertSame(['jane@example.com' => 'Jane Doe'], $event->getMailStruct()->getRecipients());

--- a/tests/unit/Core/Content/Newsletter/Event/NewsletterConfirmEventTest.php
+++ b/tests/unit/Core/Content/Newsletter/Event/NewsletterConfirmEventTest.php
@@ -28,8 +28,11 @@ class NewsletterConfirmEventTest extends TestCase
         $mailStruct = $event->getMailStruct();
 
         static::assertSame(['jane@example.com' => 'Jane Doe'], $mailStruct->getRecipients());
-        // the struct is built lazily on first access; the second call must return the
-        // memoized instance instead of building a new, merely equal one
-        static::assertSame($mailStruct, $event->getMailStruct());
+
+        // the struct is a snapshot taken on first access: later recipient
+        // changes must not leak into it
+        $recipient->setFirstName('Changed');
+
+        static::assertSame(['jane@example.com' => 'Jane Doe'], $event->getMailStruct()->getRecipients());
     }
 }

--- a/tests/unit/Core/Content/Newsletter/Event/NewsletterConfirmEventTest.php
+++ b/tests/unit/Core/Content/Newsletter/Event/NewsletterConfirmEventTest.php
@@ -32,4 +32,20 @@ class NewsletterConfirmEventTest extends TestCase
 
         static::assertSame(['jane@example.com' => 'Jane Doe'], $event->getMailStruct()->getRecipients());
     }
+
+    public function testExposesItsPayload(): void
+    {
+        $recipient = new NewsletterRecipientEntity();
+        $recipient->setId('recipient-id');
+        $context = Context::createDefaultContext();
+
+        $event = new NewsletterConfirmEvent($context, $recipient, 'sales-channel-id');
+
+        static::assertSame(NewsletterConfirmEvent::EVENT_NAME, $event->getName());
+        static::assertSame($context, $event->getContext());
+        static::assertSame($recipient, $event->getNewsletterRecipient());
+        static::assertSame('recipient-id', $event->getNewsletterRecipientId());
+        static::assertSame('sales-channel-id', $event->getSalesChannelId());
+        static::assertSame(['newsletterRecipient'], array_keys(NewsletterConfirmEvent::getAvailableData()->toArray()));
+    }
 }

--- a/tests/unit/Core/Content/Newsletter/Event/NewsletterConfirmEventTest.php
+++ b/tests/unit/Core/Content/Newsletter/Event/NewsletterConfirmEventTest.php
@@ -28,6 +28,8 @@ class NewsletterConfirmEventTest extends TestCase
         $mailStruct = $event->getMailStruct();
 
         static::assertSame(['jane@example.com' => 'Jane Doe'], $mailStruct->getRecipients());
+        // the struct is built lazily on first access; the second call must return the
+        // memoized instance instead of building a new, merely equal one
         static::assertSame($mailStruct, $event->getMailStruct());
     }
 }

--- a/tests/unit/Core/Content/Newsletter/Event/NewsletterConfirmEventTest.php
+++ b/tests/unit/Core/Content/Newsletter/Event/NewsletterConfirmEventTest.php
@@ -1,0 +1,33 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Content\Newsletter\Event;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Newsletter\Aggregate\NewsletterRecipient\NewsletterRecipientEntity;
+use Shopware\Core\Content\Newsletter\Event\NewsletterConfirmEvent;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * @internal
+ */
+#[Package('after-sales')]
+#[CoversClass(NewsletterConfirmEvent::class)]
+class NewsletterConfirmEventTest extends TestCase
+{
+    public function testMailStructAddressesTheRecipientByFullName(): void
+    {
+        $recipient = new NewsletterRecipientEntity();
+        $recipient->setEmail('jane@example.com');
+        $recipient->setFirstName('Jane');
+        $recipient->setLastName('Doe');
+
+        $event = new NewsletterConfirmEvent(Context::createDefaultContext(), $recipient, 'sales-channel-id');
+
+        $mailStruct = $event->getMailStruct();
+
+        static::assertSame(['jane@example.com' => 'Jane Doe'], $mailStruct->getRecipients());
+        static::assertSame($mailStruct, $event->getMailStruct());
+    }
+}

--- a/tests/unit/Core/Content/Newsletter/Event/NewsletterConfirmEventTest.php
+++ b/tests/unit/Core/Content/Newsletter/Event/NewsletterConfirmEventTest.php
@@ -25,9 +25,7 @@ class NewsletterConfirmEventTest extends TestCase
 
         $event = new NewsletterConfirmEvent(Context::createDefaultContext(), $recipient, 'sales-channel-id');
 
-        $mailStruct = $event->getMailStruct();
-
-        static::assertSame(['jane@example.com' => 'Jane Doe'], $mailStruct->getRecipients());
+        static::assertSame(['jane@example.com' => 'Jane Doe'], $event->getMailStruct()->getRecipients());
 
         // the struct is a snapshot taken on first access: later recipient
         // changes must not leak into it

--- a/tests/unit/Core/Content/Newsletter/Event/NewsletterRegisterEventTest.php
+++ b/tests/unit/Core/Content/Newsletter/Event/NewsletterRegisterEventTest.php
@@ -28,9 +28,12 @@ class NewsletterRegisterEventTest extends TestCase
         $mailStruct = $event->getMailStruct();
 
         static::assertSame(['jane@example.com' => 'Jane Doe'], $mailStruct->getRecipients());
-        // the struct is built lazily on first access; the second call must return the
-        // memoized instance instead of building a new, merely equal one
-        static::assertSame($mailStruct, $event->getMailStruct());
+
+        // the struct is a snapshot taken on first access: later recipient
+        // changes must not leak into it
+        $recipient->setFirstName('Changed');
+
+        static::assertSame(['jane@example.com' => 'Jane Doe'], $event->getMailStruct()->getRecipients());
     }
 
     public function testAvailableDataDescribesTheEventPayload(): void

--- a/tests/unit/Core/Content/Newsletter/Event/NewsletterRegisterEventTest.php
+++ b/tests/unit/Core/Content/Newsletter/Event/NewsletterRegisterEventTest.php
@@ -25,9 +25,7 @@ class NewsletterRegisterEventTest extends TestCase
 
         $event = new NewsletterRegisterEvent(Context::createDefaultContext(), $recipient, 'https://shop.example/confirm', 'sales-channel-id');
 
-        $mailStruct = $event->getMailStruct();
-
-        static::assertSame(['jane@example.com' => 'Jane Doe'], $mailStruct->getRecipients());
+        static::assertSame(['jane@example.com' => 'Jane Doe'], $event->getMailStruct()->getRecipients());
 
         // the struct is a snapshot taken on first access: later recipient
         // changes must not leak into it

--- a/tests/unit/Core/Content/Newsletter/Event/NewsletterRegisterEventTest.php
+++ b/tests/unit/Core/Content/Newsletter/Event/NewsletterRegisterEventTest.php
@@ -27,8 +27,7 @@ class NewsletterRegisterEventTest extends TestCase
 
         static::assertSame(['jane@example.com' => 'Jane Doe'], $event->getMailStruct()->getRecipients());
 
-        // the struct is a snapshot taken on first access: later recipient
-        // changes must not leak into it
+        // the struct is a snapshot taken on first access: later recipient changes must not leak into it
         $recipient->setFirstName('Changed');
 
         static::assertSame(['jane@example.com' => 'Jane Doe'], $event->getMailStruct()->getRecipients());

--- a/tests/unit/Core/Content/Newsletter/Event/NewsletterRegisterEventTest.php
+++ b/tests/unit/Core/Content/Newsletter/Event/NewsletterRegisterEventTest.php
@@ -33,6 +33,23 @@ class NewsletterRegisterEventTest extends TestCase
         static::assertSame(['jane@example.com' => 'Jane Doe'], $event->getMailStruct()->getRecipients());
     }
 
+    public function testExposesItsPayload(): void
+    {
+        $recipient = new NewsletterRecipientEntity();
+        $recipient->setId('recipient-id');
+        $context = Context::createDefaultContext();
+
+        $event = new NewsletterRegisterEvent($context, $recipient, 'https://shop.example/confirm', 'sales-channel-id');
+
+        static::assertSame(NewsletterRegisterEvent::EVENT_NAME, $event->getName());
+        static::assertSame($context, $event->getContext());
+        static::assertSame($recipient, $event->getNewsletterRecipient());
+        static::assertSame('recipient-id', $event->getNewsletterRecipientId());
+        static::assertSame('https://shop.example/confirm', $event->getUrl());
+        static::assertSame('sales-channel-id', $event->getSalesChannelId());
+        static::assertSame(['url' => 'https://shop.example/confirm'], $event->getValues());
+    }
+
     public function testAvailableDataDescribesTheEventPayload(): void
     {
         $data = NewsletterRegisterEvent::getAvailableData()->toArray();

--- a/tests/unit/Core/Content/Newsletter/Event/NewsletterRegisterEventTest.php
+++ b/tests/unit/Core/Content/Newsletter/Event/NewsletterRegisterEventTest.php
@@ -4,8 +4,6 @@ namespace Shopware\Tests\Unit\Core\Content\Newsletter\Event;
 
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
-use Shopware\Core\Content\Flow\Dispatching\StorableFlow;
-use Shopware\Core\Content\Flow\Dispatching\Storer\ScalarValuesStorer;
 use Shopware\Core\Content\Newsletter\Aggregate\NewsletterRecipient\NewsletterRecipientEntity;
 use Shopware\Core\Content\Newsletter\Event\NewsletterRegisterEvent;
 use Shopware\Core\Framework\Context;
@@ -18,24 +16,28 @@ use Shopware\Core\Framework\Log\Package;
 #[CoversClass(NewsletterRegisterEvent::class)]
 class NewsletterRegisterEventTest extends TestCase
 {
-    public function testScalarValuesCorrectly(): void
+    public function testMailStructAddressesTheRecipientAndIsCached(): void
     {
-        $event = new NewsletterRegisterEvent(
-            Context::createDefaultContext(),
-            new NewsletterRecipientEntity(),
-            'my-url',
-            'my-sales-channel-id'
-        );
+        $recipient = new NewsletterRecipientEntity();
+        $recipient->setEmail('jane@example.com');
+        $recipient->setFirstName('Jane');
+        $recipient->setLastName('Doe');
 
-        $storer = new ScalarValuesStorer();
+        $event = new NewsletterRegisterEvent(Context::createDefaultContext(), $recipient, 'https://shop.example/confirm', 'sales-channel-id');
 
-        $stored = $storer->store($event, []);
+        $mailStruct = $event->getMailStruct();
 
-        $flow = new StorableFlow('foo', Context::createDefaultContext(), $stored);
+        static::assertSame(['jane@example.com' => 'Jane Doe'], $mailStruct->getRecipients());
+        // the struct is built lazily on first access; the second call must return the
+        // memoized instance instead of building a new, merely equal one
+        static::assertSame($mailStruct, $event->getMailStruct());
+    }
 
-        $storer->restore($flow);
+    public function testAvailableDataDescribesTheEventPayload(): void
+    {
+        $data = NewsletterRegisterEvent::getAvailableData()->toArray();
 
-        static::assertArrayHasKey('url', $flow->data());
-        static::assertSame('my-url', $flow->data()['url']);
+        static::assertArrayHasKey('newsletterRecipient', $data);
+        static::assertArrayHasKey('url', $data);
     }
 }

--- a/tests/unit/Core/Content/Newsletter/Event/NewsletterUnsubscribeEventTest.php
+++ b/tests/unit/Core/Content/Newsletter/Event/NewsletterUnsubscribeEventTest.php
@@ -32,4 +32,20 @@ class NewsletterUnsubscribeEventTest extends TestCase
 
         static::assertSame(['jane@example.com' => 'Jane Doe'], $event->getMailStruct()->getRecipients());
     }
+
+    public function testExposesItsPayload(): void
+    {
+        $recipient = new NewsletterRecipientEntity();
+        $recipient->setId('recipient-id');
+        $context = Context::createDefaultContext();
+
+        $event = new NewsletterUnsubscribeEvent($context, $recipient, 'sales-channel-id');
+
+        static::assertSame(NewsletterUnsubscribeEvent::EVENT_NAME, $event->getName());
+        static::assertSame($context, $event->getContext());
+        static::assertSame($recipient, $event->getNewsletterRecipient());
+        static::assertSame('recipient-id', $event->getNewsletterRecipientId());
+        static::assertSame('sales-channel-id', $event->getSalesChannelId());
+        static::assertSame(['newsletterRecipient'], array_keys(NewsletterUnsubscribeEvent::getAvailableData()->toArray()));
+    }
 }

--- a/tests/unit/Core/Content/Newsletter/Event/NewsletterUnsubscribeEventTest.php
+++ b/tests/unit/Core/Content/Newsletter/Event/NewsletterUnsubscribeEventTest.php
@@ -27,8 +27,7 @@ class NewsletterUnsubscribeEventTest extends TestCase
 
         static::assertSame(['jane@example.com' => 'Jane Doe'], $event->getMailStruct()->getRecipients());
 
-        // the struct is a snapshot taken on first access: later recipient
-        // changes must not leak into it
+        // the struct is a snapshot taken on first access: later recipient changes must not leak into it
         $recipient->setFirstName('Changed');
 
         static::assertSame(['jane@example.com' => 'Jane Doe'], $event->getMailStruct()->getRecipients());

--- a/tests/unit/Core/Content/Newsletter/Event/NewsletterUnsubscribeEventTest.php
+++ b/tests/unit/Core/Content/Newsletter/Event/NewsletterUnsubscribeEventTest.php
@@ -28,6 +28,8 @@ class NewsletterUnsubscribeEventTest extends TestCase
         $mailStruct = $event->getMailStruct();
 
         static::assertSame(['jane@example.com' => 'Jane Doe'], $mailStruct->getRecipients());
+        // the struct is built lazily on first access; the second call must return the
+        // memoized instance instead of building a new, merely equal one
         static::assertSame($mailStruct, $event->getMailStruct());
     }
 }

--- a/tests/unit/Core/Content/Newsletter/Event/NewsletterUnsubscribeEventTest.php
+++ b/tests/unit/Core/Content/Newsletter/Event/NewsletterUnsubscribeEventTest.php
@@ -25,9 +25,7 @@ class NewsletterUnsubscribeEventTest extends TestCase
 
         $event = new NewsletterUnsubscribeEvent(Context::createDefaultContext(), $recipient, 'sales-channel-id');
 
-        $mailStruct = $event->getMailStruct();
-
-        static::assertSame(['jane@example.com' => 'Jane Doe'], $mailStruct->getRecipients());
+        static::assertSame(['jane@example.com' => 'Jane Doe'], $event->getMailStruct()->getRecipients());
 
         // the struct is a snapshot taken on first access: later recipient
         // changes must not leak into it

--- a/tests/unit/Core/Content/Newsletter/Event/NewsletterUnsubscribeEventTest.php
+++ b/tests/unit/Core/Content/Newsletter/Event/NewsletterUnsubscribeEventTest.php
@@ -1,0 +1,33 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Content\Newsletter\Event;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Newsletter\Aggregate\NewsletterRecipient\NewsletterRecipientEntity;
+use Shopware\Core\Content\Newsletter\Event\NewsletterUnsubscribeEvent;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * @internal
+ */
+#[Package('after-sales')]
+#[CoversClass(NewsletterUnsubscribeEvent::class)]
+class NewsletterUnsubscribeEventTest extends TestCase
+{
+    public function testMailStructAddressesTheRecipientByFullName(): void
+    {
+        $recipient = new NewsletterRecipientEntity();
+        $recipient->setEmail('jane@example.com');
+        $recipient->setFirstName('Jane');
+        $recipient->setLastName('Doe');
+
+        $event = new NewsletterUnsubscribeEvent(Context::createDefaultContext(), $recipient, 'sales-channel-id');
+
+        $mailStruct = $event->getMailStruct();
+
+        static::assertSame(['jane@example.com' => 'Jane Doe'], $mailStruct->getRecipients());
+        static::assertSame($mailStruct, $event->getMailStruct());
+    }
+}

--- a/tests/unit/Core/Content/Newsletter/Event/NewsletterUnsubscribeEventTest.php
+++ b/tests/unit/Core/Content/Newsletter/Event/NewsletterUnsubscribeEventTest.php
@@ -28,8 +28,11 @@ class NewsletterUnsubscribeEventTest extends TestCase
         $mailStruct = $event->getMailStruct();
 
         static::assertSame(['jane@example.com' => 'Jane Doe'], $mailStruct->getRecipients());
-        // the struct is built lazily on first access; the second call must return the
-        // memoized instance instead of building a new, merely equal one
-        static::assertSame($mailStruct, $event->getMailStruct());
+
+        // the struct is a snapshot taken on first access: later recipient
+        // changes must not leak into it
+        $recipient->setFirstName('Changed');
+
+        static::assertSame(['jane@example.com' => 'Jane Doe'], $event->getMailStruct()->getRecipients());
     }
 }

--- a/tests/unit/Core/Content/Product/Aggregate/ProductConfiguratorSetting/ProductConfiguratorSettingCollectionTest.php
+++ b/tests/unit/Core/Content/Product/Aggregate/ProductConfiguratorSetting/ProductConfiguratorSettingCollectionTest.php
@@ -47,6 +47,31 @@ class ProductConfiguratorSettingCollectionTest extends TestCase
         static::assertNull($collection->getByOptionId('unknown'));
     }
 
+    public function testFiltersByProductAndOptionId(): void
+    {
+        $red = $this->createSetting('setting-red', 'color-group', 'option-red');
+        $red->setProductId('product-a');
+        $large = $this->createSetting('setting-l', 'size-group', 'option-l');
+        $large->setProductId('product-b');
+
+        $collection = new ProductConfiguratorSettingCollection([$red, $large]);
+
+        static::assertSame(['product-a', 'product-b'], array_values($collection->getProductIds()));
+        static::assertSame(['option-red', 'option-l'], array_values($collection->getOptionIds()));
+        static::assertSame(['setting-red'], $collection->filterByProductId('product-a')->getKeys());
+        static::assertSame(['setting-l'], $collection->filterByOptionId('option-l')->getKeys());
+    }
+
+    public function testGetOptionsCollectsTheAssignedOptions(): void
+    {
+        $collection = new ProductConfiguratorSettingCollection([
+            $this->createSetting('setting-red', 'color-group', 'option-red'),
+            $this->createSettingWithoutOption('setting-empty'),
+        ]);
+
+        static::assertSame(['option-red'], $collection->getOptions()->getKeys());
+    }
+
     private function createSetting(string $id, string $groupId, string $optionId): ProductConfiguratorSettingEntity
     {
         $group = new PropertyGroupEntity();

--- a/tests/unit/Core/Content/Product/Aggregate/ProductConfiguratorSetting/ProductConfiguratorSettingCollectionTest.php
+++ b/tests/unit/Core/Content/Product/Aggregate/ProductConfiguratorSetting/ProductConfiguratorSettingCollectionTest.php
@@ -1,0 +1,76 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Content\Product\Aggregate\ProductConfiguratorSetting;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Product\Aggregate\ProductConfiguratorSetting\ProductConfiguratorSettingCollection;
+use Shopware\Core\Content\Product\Aggregate\ProductConfiguratorSetting\ProductConfiguratorSettingEntity;
+use Shopware\Core\Content\Property\Aggregate\PropertyGroupOption\PropertyGroupOptionEntity;
+use Shopware\Core\Content\Property\PropertyGroupEntity;
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * @internal
+ */
+#[Package('inventory')]
+#[CoversClass(ProductConfiguratorSettingCollection::class)]
+class ProductConfiguratorSettingCollectionTest extends TestCase
+{
+    public function testGroupedOptionsGroupsByPropertyGroupAndSkipsSettingsWithoutOption(): void
+    {
+        $collection = new ProductConfiguratorSettingCollection([
+            $this->createSetting('setting-red', 'color-group', 'option-red'),
+            $this->createSetting('setting-blue', 'color-group', 'option-blue'),
+            $this->createSetting('setting-l', 'size-group', 'option-l'),
+            $this->createSettingWithoutOption('setting-empty'),
+        ]);
+
+        $groups = $collection->getGroupedOptions();
+
+        static::assertCount(2, $groups);
+        $colorGroup = $groups->get('color-group');
+        static::assertInstanceOf(PropertyGroupEntity::class, $colorGroup);
+        static::assertNotNull($colorGroup->getOptions());
+        static::assertCount(2, $colorGroup->getOptions());
+    }
+
+    public function testGetByOptionIdFindsTheMatchingSetting(): void
+    {
+        $match = $this->createSetting('setting-red', 'color-group', 'option-red');
+        $collection = new ProductConfiguratorSettingCollection([
+            $match,
+            $this->createSetting('setting-l', 'size-group', 'option-l'),
+        ]);
+
+        static::assertSame($match, $collection->getByOptionId('option-red'));
+        static::assertNull($collection->getByOptionId('unknown'));
+    }
+
+    private function createSetting(string $id, string $groupId, string $optionId): ProductConfiguratorSettingEntity
+    {
+        $group = new PropertyGroupEntity();
+        $group->setId($groupId);
+
+        $option = new PropertyGroupOptionEntity();
+        $option->setId($optionId);
+        $option->setGroupId($groupId);
+        $option->setGroup($group);
+
+        $setting = new ProductConfiguratorSettingEntity();
+        $setting->setId($id);
+        $setting->setOptionId($optionId);
+        $setting->setOption($option);
+
+        return $setting;
+    }
+
+    private function createSettingWithoutOption(string $id): ProductConfiguratorSettingEntity
+    {
+        $setting = new ProductConfiguratorSettingEntity();
+        $setting->setId($id);
+        $setting->setOptionId('missing');
+
+        return $setting;
+    }
+}

--- a/tests/unit/Core/Content/Product/Aggregate/ProductPrice/ProductPriceCollectionTest.php
+++ b/tests/unit/Core/Content/Product/Aggregate/ProductPrice/ProductPriceCollectionTest.php
@@ -1,0 +1,61 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Content\Product\Aggregate\ProductPrice;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Checkout\Cart\Price\Struct\CartPrice;
+use Shopware\Core\Content\Product\Aggregate\ProductPrice\ProductPriceCollection;
+use Shopware\Core\Content\Product\Aggregate\ProductPrice\ProductPriceEntity;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\Pricing\Price;
+use Shopware\Core\Framework\DataAbstractionLayer\Pricing\PriceCollection;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Uuid\Uuid;
+
+/**
+ * @internal
+ */
+#[Package('inventory')]
+#[CoversClass(ProductPriceCollection::class)]
+class ProductPriceCollectionTest extends TestCase
+{
+    public function testSortByPriceUsesGrossInGrossTaxState(): void
+    {
+        $context = Context::createDefaultContext();
+        $context->setTaxState(CartPrice::TAX_STATE_GROSS);
+
+        $collection = new ProductPriceCollection([
+            $this->createPrice('expensive-gross', gross: 200, net: 10),
+            $this->createPrice('cheap-gross', gross: 100, net: 20),
+        ]);
+
+        $collection->sortByPrice($context);
+
+        static::assertSame(['cheap-gross', 'expensive-gross'], $collection->getKeys());
+    }
+
+    public function testSortByPriceUsesNetInNetTaxState(): void
+    {
+        $context = Context::createDefaultContext();
+        $context->setTaxState(CartPrice::TAX_STATE_NET);
+
+        $collection = new ProductPriceCollection([
+            $this->createPrice('expensive-gross', gross: 200, net: 10),
+            $this->createPrice('cheap-gross', gross: 100, net: 20),
+        ]);
+
+        $collection->sortByPrice($context);
+
+        static::assertSame(['expensive-gross', 'cheap-gross'], $collection->getKeys());
+    }
+
+    private function createPrice(string $id, float $gross, float $net): ProductPriceEntity
+    {
+        $price = new ProductPriceEntity();
+        $price->setId($id);
+        $price->setPrice(new PriceCollection([new Price(Uuid::randomHex(), $net, $gross, false)]));
+
+        return $price;
+    }
+}

--- a/tests/unit/Core/Content/Product/Aggregate/ProductPrice/ProductPriceDefinitionTest.php
+++ b/tests/unit/Core/Content/Product/Aggregate/ProductPrice/ProductPriceDefinitionTest.php
@@ -1,0 +1,71 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Content\Product\Aggregate\ProductPrice;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Product\Aggregate\ProductPrice\ProductPriceCollection;
+use Shopware\Core\Content\Product\Aggregate\ProductPrice\ProductPriceDefinition;
+use Shopware\Core\Content\Product\Aggregate\ProductPrice\ProductPriceEntity;
+use Shopware\Core\Framework\DataAbstractionLayer\Dbal\EntityWriteGateway;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\Required;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\IntField;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Test\Annotation\DisabledFeatures;
+use Shopware\Core\Test\Stub\DataAbstractionLayer\StaticDefinitionInstanceRegistry;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+/**
+ * @internal
+ */
+#[Package('inventory')]
+#[CoversClass(ProductPriceDefinition::class)]
+class ProductPriceDefinitionTest extends TestCase
+{
+    public function testEntityConfiguration(): void
+    {
+        $definition = $this->createDefinition();
+
+        static::assertSame(ProductPriceDefinition::ENTITY_NAME, $definition->getEntityName());
+        static::assertSame(ProductPriceEntity::class, $definition->getEntityClass());
+        static::assertSame(ProductPriceCollection::class, $definition->getCollectionClass());
+    }
+
+    public function testQuantityRangeFieldsRequireAMinimumOfOne(): void
+    {
+        $fields = $this->createDefinition()->getFields();
+
+        $start = $fields->get('quantityStart');
+        static::assertInstanceOf(IntField::class, $start);
+        static::assertTrue($start->is(Required::class));
+        static::assertSame(1, $start->getMinValue());
+
+        $end = $fields->get('quantityEnd');
+        static::assertInstanceOf(IntField::class, $end);
+        static::assertSame(1, $end->getMinValue());
+    }
+
+    #[DisabledFeatures(['v6.8.0.0'])]
+    public function testQuantityRangeFieldsCarryNoMinimumInTheLegacyMajor(): void
+    {
+        $fields = $this->createDefinition()->getFields();
+
+        $start = $fields->get('quantityStart');
+        static::assertInstanceOf(IntField::class, $start);
+        static::assertNull($start->getMinValue());
+    }
+
+    private function createDefinition(): ProductPriceDefinition
+    {
+        $registry = new StaticDefinitionInstanceRegistry(
+            [ProductPriceDefinition::class],
+            static::createStub(ValidatorInterface::class),
+            static::createStub(EntityWriteGateway::class),
+        );
+
+        $definition = $registry->getByEntityName(ProductPriceDefinition::ENTITY_NAME);
+        static::assertInstanceOf(ProductPriceDefinition::class, $definition);
+
+        return $definition;
+    }
+}

--- a/tests/unit/Core/Content/Product/Events/ProductListingResolvePreviewEventTest.php
+++ b/tests/unit/Core/Content/Product/Events/ProductListingResolvePreviewEventTest.php
@@ -5,6 +5,7 @@ namespace Shopware\Tests\Unit\Core\Content\Product\Events;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Product\Events\ProductListingResolvePreviewEvent;
+use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
@@ -40,5 +41,20 @@ class ProductListingResolvePreviewEventTest extends TestCase
 
         static::expectException(\RuntimeException::class);
         $event->replace('p3', 'p2');
+    }
+
+    public function testExposesItsPayload(): void
+    {
+        $context = Context::createDefaultContext();
+        $salesChannelContext = static::createStub(SalesChannelContext::class);
+        $salesChannelContext->method('getContext')->willReturn($context);
+        $criteria = new Criteria();
+
+        $event = new ProductListingResolvePreviewEvent($salesChannelContext, $criteria, ['p1' => 'p1'], true);
+
+        static::assertSame($criteria, $event->getCriteria());
+        static::assertSame($salesChannelContext, $event->getSalesChannelContext());
+        static::assertSame($context, $event->getContext());
+        static::assertTrue($event->hasOptionFilter());
     }
 }

--- a/tests/unit/Core/Content/Product/Events/ProductStatesBeforeChangeEventTest.php
+++ b/tests/unit/Core/Content/Product/Events/ProductStatesBeforeChangeEventTest.php
@@ -7,8 +7,8 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Product\DataAbstractionLayer\UpdatedStates;
 use Shopware\Core\Content\Product\Events\ProductStatesBeforeChangeEvent;
 use Shopware\Core\Framework\Context;
-use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Test\Annotation\DisabledFeatures;
 
 /**
  * @internal
@@ -17,20 +17,20 @@ use Shopware\Core\Framework\Log\Package;
 #[CoversClass(ProductStatesBeforeChangeEvent::class)]
 class ProductStatesBeforeChangeEventTest extends TestCase
 {
-    public function testProductStatesBeforeChangeEvent(): void
+    #[DisabledFeatures(['v6.8.0.0'])]
+    public function testUpdatedStatesCanBeReadAndReplaced(): void
     {
-        Feature::skipTestIfActive('v6.8.0.0', $this);
-        $updatedStates = [new UpdatedStates('foobar', ['foo'], ['bar'])];
         $context = Context::createDefaultContext();
+        $initial = [new UpdatedStates('product-id', ['physical'], ['digital'])];
 
-        $event = new ProductStatesBeforeChangeEvent($updatedStates, $context);
+        $event = new ProductStatesBeforeChangeEvent($initial, $context);
 
-        static::assertSame($updatedStates, $event->getUpdatedStates());
+        static::assertSame($initial, $event->getUpdatedStates());
         static::assertSame($context, $event->getContext());
 
-        $updatedStates = [new UpdatedStates('foobar', ['foo'], ['baz'])];
-        $event->setUpdatedStates($updatedStates);
+        $replacement = [new UpdatedStates('other-id', ['digital'], ['physical'])];
+        $event->setUpdatedStates($replacement);
 
-        static::assertSame($updatedStates, $event->getUpdatedStates());
+        static::assertSame($replacement, $event->getUpdatedStates());
     }
 }

--- a/tests/unit/Core/Content/Product/Events/ProductStatesChangedEventTest.php
+++ b/tests/unit/Core/Content/Product/Events/ProductStatesChangedEventTest.php
@@ -7,8 +7,8 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Product\DataAbstractionLayer\UpdatedStates;
 use Shopware\Core\Content\Product\Events\ProductStatesChangedEvent;
 use Shopware\Core\Framework\Context;
-use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Test\Annotation\DisabledFeatures;
 
 /**
  * @internal
@@ -17,16 +17,15 @@ use Shopware\Core\Framework\Log\Package;
 #[CoversClass(ProductStatesChangedEvent::class)]
 class ProductStatesChangedEventTest extends TestCase
 {
-    public function testProductStatesChangedEvent(): void
+    #[DisabledFeatures(['v6.8.0.0'])]
+    public function testExposesTheUpdatedStatesAndContext(): void
     {
-        Feature::skipTestIfActive('v6.8.0.0', $this);
-
-        $updatedStates = [new UpdatedStates('foobar', ['foo'], ['bar'])];
         $context = Context::createDefaultContext();
+        $states = [new UpdatedStates('product-id', ['physical'], ['digital'])];
 
-        $event = new ProductStatesChangedEvent($updatedStates, $context);
+        $event = new ProductStatesChangedEvent($states, $context);
 
-        static::assertSame($updatedStates, $event->getUpdatedStates());
+        static::assertSame($states, $event->getUpdatedStates());
         static::assertSame($context, $event->getContext());
     }
 }

--- a/tests/unit/Core/Content/Product/ProductDefinitionTest.php
+++ b/tests/unit/Core/Content/Product/ProductDefinitionTest.php
@@ -4,10 +4,15 @@ namespace Shopware\Tests\Unit\Core\Content\Product;
 
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Product\ProductCollection;
 use Shopware\Core\Content\Product\ProductDefinition;
+use Shopware\Core\Content\Product\ProductEntity;
+use Shopware\Core\Content\Product\ProductHydrator;
 use Shopware\Core\Framework\DataAbstractionLayer\Dbal\EntityWriteGateway;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\Required;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\SearchRanking;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Test\Annotation\DisabledFeatures;
 use Shopware\Core\Test\Stub\DataAbstractionLayer\StaticDefinitionInstanceRegistry;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 
@@ -63,6 +68,39 @@ class ProductDefinitionTest extends TestCase
     public function testSince(): void
     {
         static::assertSame('6.0.0.0', $this->getDefinition()->since());
+    }
+
+    public function testDescribesItsEntity(): void
+    {
+        $definition = $this->getDefinition();
+
+        static::assertTrue($definition->isInheritanceAware());
+        static::assertSame(ProductCollection::class, $definition->getCollectionClass());
+        static::assertSame(ProductEntity::class, $definition->getEntityClass());
+        static::assertSame(ProductHydrator::class, $definition->getHydratorClass());
+    }
+
+    public function testTypeFieldIsRequiredWithoutALegacyStatesField(): void
+    {
+        $fields = $this->getDefinition()->getFields();
+
+        static::assertNull($fields->get('states'));
+
+        $type = $fields->get('type');
+        static::assertNotNull($type);
+        static::assertTrue($type->is(Required::class));
+    }
+
+    #[DisabledFeatures(['v6.8.0.0'])]
+    public function testLegacyFieldSetKeepsStatesAndAnOptionalType(): void
+    {
+        $fields = $this->getDefinition()->getFields();
+
+        static::assertNotNull($fields->get('states'));
+
+        $type = $fields->get('type');
+        static::assertNotNull($type);
+        static::assertFalse($type->is(Required::class));
     }
 
     private function getDefinition(): ProductDefinition

--- a/tests/unit/Core/Content/Product/ProductDefinitionTest.php
+++ b/tests/unit/Core/Content/Product/ProductDefinitionTest.php
@@ -44,4 +44,38 @@ class ProductDefinitionTest extends TestCase
 
         static::assertSame($expected, $keys);
     }
+
+    public function testDefaultsMakeANewProductAPhysicalSellableItem(): void
+    {
+        $defaults = $this->getDefinition()->getDefaults();
+
+        static::assertSame(ProductDefinition::TYPE_PHYSICAL, $defaults['type']);
+        static::assertFalse($defaults['isCloseout']);
+        static::assertTrue($defaults['active']);
+        static::assertSame(1, $defaults['minPurchase']);
+    }
+
+    public function testChildDefaultsOnlyPresetTheType(): void
+    {
+        static::assertSame(['type' => ProductDefinition::TYPE_PHYSICAL], $this->getDefinition()->getChildDefaults());
+    }
+
+    public function testSince(): void
+    {
+        static::assertSame('6.0.0.0', $this->getDefinition()->since());
+    }
+
+    private function getDefinition(): ProductDefinition
+    {
+        $registry = new StaticDefinitionInstanceRegistry(
+            [ProductDefinition::class],
+            static::createStub(ValidatorInterface::class),
+            static::createStub(EntityWriteGateway::class)
+        );
+
+        $definition = $registry->getByEntityName('product');
+        static::assertInstanceOf(ProductDefinition::class, $definition);
+
+        return $definition;
+    }
 }

--- a/tests/unit/Core/Content/Product/ProductEntityTest.php
+++ b/tests/unit/Core/Content/Product/ProductEntityTest.php
@@ -5,7 +5,9 @@ namespace Shopware\Tests\Unit\Core\Content\Product;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Product\ProductEntity;
+use Shopware\Core\Framework\Feature\FeatureException;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Test\Annotation\DisabledFeatures;
 
 /**
  * @internal
@@ -64,5 +66,26 @@ class ProductEntityTest extends TestCase
         $upcoming = new ProductEntity();
         $upcoming->setReleaseDate(new \DateTimeImmutable('+1 day'));
         static::assertFalse($upcoming->isReleased());
+    }
+
+    #[DisabledFeatures(['v6.8.0.0'])]
+    public function testStatesRoundTripOnTheLegacyPath(): void
+    {
+        $entity = new ProductEntity();
+        $entity->setStates(['is-physical']);
+
+        static::assertSame(['is-physical'], $entity->getStates());
+    }
+
+    public function testGetStatesThrowsWhenFeatureActive(): void
+    {
+        $this->expectException(FeatureException::class);
+        (new ProductEntity())->getStates();
+    }
+
+    public function testSetStatesThrowsWhenFeatureActive(): void
+    {
+        $this->expectException(FeatureException::class);
+        (new ProductEntity())->setStates(['is-physical']);
     }
 }

--- a/tests/unit/Core/Content/Product/ProductEntityTest.php
+++ b/tests/unit/Core/Content/Product/ProductEntityTest.php
@@ -31,4 +31,38 @@ class ProductEntityTest extends TestCase
 
         static::assertSame('translated foo', (string) $entity);
     }
+
+    public function testDeliveryDateSpansTomorrowToTheDayAfter(): void
+    {
+        $deliveryDate = (new ProductEntity())->getDeliveryDate();
+
+        static::assertTrue($deliveryDate->getEarliest() < $deliveryDate->getLatest());
+    }
+
+    public function testRestockDeliveryDateShiftsByTheRestockTime(): void
+    {
+        $product = new ProductEntity();
+        $product->setRestockTime(3);
+
+        $deliveryDate = $product->getDeliveryDate();
+        $restockDate = $product->getRestockDeliveryDate();
+
+        static::assertEquals($deliveryDate->getEarliest()->modify('+3 day'), $restockDate->getEarliest());
+    }
+
+    public function testIsReleasedWithoutAReleaseDate(): void
+    {
+        static::assertTrue((new ProductEntity())->isReleased());
+    }
+
+    public function testIsReleasedComparesTheReleaseDateWithNow(): void
+    {
+        $released = new ProductEntity();
+        $released->setReleaseDate(new \DateTimeImmutable('-1 day'));
+        static::assertTrue($released->isReleased());
+
+        $upcoming = new ProductEntity();
+        $upcoming->setReleaseDate(new \DateTimeImmutable('+1 day'));
+        static::assertFalse($upcoming->isReleased());
+    }
 }

--- a/tests/unit/Core/Content/Product/SalesChannel/Listing/FilterCollectionTest.php
+++ b/tests/unit/Core/Content/Product/SalesChannel/Listing/FilterCollectionTest.php
@@ -1,0 +1,44 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Content\Product\SalesChannel\Listing;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Product\SalesChannel\Listing\Filter;
+use Shopware\Core\Content\Product\SalesChannel\Listing\FilterCollection;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * @internal
+ */
+#[Package('inventory')]
+#[CoversClass(FilterCollection::class)]
+class FilterCollectionTest extends TestCase
+{
+    public function testSetIgnoresNull(): void
+    {
+        $collection = new FilterCollection();
+        $collection->set('empty', null);
+
+        static::assertCount(0, $collection);
+    }
+
+    public function testBlacklistReturnsANewCollectionWithoutTheExcludedKey(): void
+    {
+        $collection = new FilterCollection();
+        $collection->set('manufacturer', $this->createFilter('manufacturer'));
+        $collection->set('price', $this->createFilter('price'));
+
+        $filtered = $collection->blacklist('price');
+
+        static::assertNotSame($collection, $filtered);
+        static::assertSame(['manufacturer'], $filtered->getKeys());
+        static::assertSame(['manufacturer', 'price'], $collection->getKeys());
+    }
+
+    private function createFilter(string $name): Filter
+    {
+        return new Filter($name, true, [], new EqualsFilter('product.id', null), null);
+    }
+}

--- a/tests/unit/Core/Content/Product/SalesChannel/Listing/ProductListingCriteriaExtensionTest.php
+++ b/tests/unit/Core/Content/Product/SalesChannel/Listing/ProductListingCriteriaExtensionTest.php
@@ -18,7 +18,6 @@ use Symfony\Component\EventDispatcher\EventDispatcher;
  */
 #[Package('inventory')]
 #[CoversClass(ProductListingCriteriaExtension::class)]
-#[CoversClass(ProductListingCriteriaExtensionExample::class)]
 class ProductListingCriteriaExtensionTest extends TestCase
 {
     public function testProductListingCriteriaExample(): void

--- a/tests/unit/Core/Content/Product/SalesChannel/Review/Event/ReviewFormEventTest.php
+++ b/tests/unit/Core/Content/Product/SalesChannel/Review/Event/ReviewFormEventTest.php
@@ -10,6 +10,7 @@ use Shopware\Core\Content\Product\ProductEntity;
 use Shopware\Core\Content\Product\SalesChannel\Review\Event\ReviewFormEvent;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Event\EventData\MailRecipientStruct;
+use Shopware\Core\Framework\Feature\FeatureException;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Validation\DataBag\DataBag;
 
@@ -67,5 +68,34 @@ class ReviewFormEventTest extends TestCase
 
         static::assertArrayHasKey('reviewFormData', $flow->data());
         static::assertSame(['foo' => 'bar', 'bar' => 'baz'], $flow->data()['reviewFormData']);
+    }
+
+    public function testConstructorRequiresProductWhenFeatureActive(): void
+    {
+        $this->expectExceptionObject(FeatureException::error(
+            'Tried to access deprecated functionality: Not passing $product to ' . ReviewFormEvent::class . ' is deprecated and will be required in v6.8.0.'
+        ));
+        new ReviewFormEvent(
+            Context::createDefaultContext(),
+            'sales-channel-id',
+            new MailRecipientStruct(['foo' => 'bar']),
+            new DataBag(),
+            'product-id',
+            'customer-id'
+        );
+    }
+
+    public function testDescribesItsFlowContract(): void
+    {
+        static::assertSame(ReviewFormEvent::EVENT_NAME, (new ReviewFormEvent(
+            Context::createDefaultContext(),
+            'sales-channel-id',
+            new MailRecipientStruct(['foo' => 'bar']),
+            new DataBag(),
+            'product-id',
+            'customer-id',
+            new ProductEntity()
+        ))->getName());
+        static::assertSame(['reviewFormData', 'product'], array_keys(ReviewFormEvent::getAvailableData()->toArray()));
     }
 }

--- a/tests/unit/Core/Content/Product/SalesChannel/SalesChannelProductDefinitionTest.php
+++ b/tests/unit/Core/Content/Product/SalesChannel/SalesChannelProductDefinitionTest.php
@@ -4,10 +4,16 @@ namespace Shopware\Tests\Unit\Core\Content\Product\SalesChannel;
 
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Product\SalesChannel\ProductAvailableFilter;
+use Shopware\Core\Content\Product\SalesChannel\SalesChannelProductCollection;
 use Shopware\Core\Content\Product\SalesChannel\SalesChannelProductDefinition;
+use Shopware\Core\Content\Product\SalesChannel\SalesChannelProductEntity;
+use Shopware\Core\Framework\DataAbstractionLayer\Dbal\EntityWriteGateway;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Log\Package;
-use Shopware\Core\Test\Generator;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Shopware\Core\Test\Stub\DataAbstractionLayer\StaticDefinitionInstanceRegistry;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 /**
  * @internal
@@ -16,33 +22,82 @@ use Shopware\Core\Test\Generator;
 #[CoversClass(SalesChannelProductDefinition::class)]
 class SalesChannelProductDefinitionTest extends TestCase
 {
-    public function testProcessCriteriaRootLevel(): void
+    public function testEntityConfiguration(): void
     {
-        $definition = new SalesChannelProductDefinition();
-        $criteria = new Criteria();
-        $context = Generator::generateSalesChannelContext();
+        $definition = $this->createDefinition();
 
-        $definition->processCriteria($criteria, $context);
-
-        static::assertNotEmpty($criteria->getAssociations());
-        static::assertTrue($criteria->hasAssociation('prices'));
-        static::assertTrue($criteria->hasAssociation('unit'));
-        static::assertTrue($criteria->hasAssociation('deliveryTime'));
-        static::assertTrue($criteria->hasAssociation('cover'));
-
-        static::assertNotEmpty($criteria->getFilters());
+        static::assertSame(SalesChannelProductEntity::class, $definition->getEntityClass());
+        static::assertSame(SalesChannelProductCollection::class, $definition->getCollectionClass());
     }
 
-    public function testProcessCriteriaAssociationLevel(): void
+    public function testDefinesTheRuntimeCalculationFields(): void
     {
-        $definition = new SalesChannelProductDefinition();
-        $criteria = new Criteria(nestingLevel: 1);
-        $context = Generator::generateSalesChannelContext();
+        $fields = $this->createDefinition()->getFields();
 
-        $definition->processCriteria($criteria, $context);
+        foreach (['calculatedPrice', 'calculatedPrices', 'calculatedMaxPurchase', 'calculatedCheapestPrice', 'isNew', 'cheapestPrice', 'cheapestPriceContainer', 'sortedProperties', 'measurements'] as $field) {
+            static::assertNotNull($fields->get($field), $field . ' must be defined');
+        }
+    }
 
-        static::assertEmpty($criteria->getAssociations());
+    public function testProcessCriteriaAddsTheAvailableFilterAndDefaultAssociations(): void
+    {
+        $criteria = new Criteria();
 
-        static::assertNotEmpty($criteria->getFilters());
+        $this->createDefinition()->processCriteria($criteria, static::createStub(SalesChannelContext::class));
+
+        $availableFilters = array_filter($criteria->getFilters(), static fn ($f) => $f instanceof ProductAvailableFilter);
+        static::assertCount(1, $availableFilters);
+
+        foreach (['prices', 'unit', 'deliveryTime', 'cover', 'tax'] as $association) {
+            static::assertTrue($criteria->hasAssociation($association), $association . ' association expected');
+        }
+    }
+
+    public function testProcessCriteriaKeepsAnExistingAvailableFilter(): void
+    {
+        $criteria = new Criteria();
+        $criteria->addFilter(new ProductAvailableFilter('sales-channel-id'));
+
+        $this->createDefinition()->processCriteria($criteria, static::createStub(SalesChannelContext::class));
+
+        $availableFilters = array_filter($criteria->getFilters(), static fn ($f) => $f instanceof ProductAvailableFilter);
+        static::assertCount(1, $availableFilters);
+    }
+
+    public function testProcessCriteriaFiltersProductReviewsToActiveOnes(): void
+    {
+        $criteria = new Criteria();
+        $criteria->addAssociation('productReviews');
+
+        $this->createDefinition()->processCriteria($criteria, static::createStub(SalesChannelContext::class));
+
+        $filters = $criteria->getAssociation('productReviews')->getFilters();
+        static::assertCount(1, $filters);
+    }
+
+    public function testProcessCriteriaSkipsAssociationSetupBelowRootNestingLevel(): void
+    {
+        $criteria = new Criteria();
+        \Closure::bind(function () use ($criteria): void {
+            $criteria->nestingLevel = 1;
+        }, null, Criteria::class)();
+
+        $this->createDefinition()->processCriteria($criteria, static::createStub(SalesChannelContext::class));
+
+        static::assertFalse($criteria->hasAssociation('prices'));
+    }
+
+    private function createDefinition(): SalesChannelProductDefinition
+    {
+        $registry = new StaticDefinitionInstanceRegistry(
+            [SalesChannelProductDefinition::class],
+            static::createStub(ValidatorInterface::class),
+            static::createStub(EntityWriteGateway::class),
+        );
+
+        $definition = $registry->getByEntityName(SalesChannelProductDefinition::ENTITY_NAME);
+        static::assertInstanceOf(SalesChannelProductDefinition::class, $definition);
+
+        return $definition;
     }
 }

--- a/tests/unit/Core/Content/Product/SalesChannel/SalesChannelProductDefinitionTest.php
+++ b/tests/unit/Core/Content/Product/SalesChannel/SalesChannelProductDefinitionTest.php
@@ -77,10 +77,7 @@ class SalesChannelProductDefinitionTest extends TestCase
 
     public function testProcessCriteriaSkipsAssociationSetupBelowRootNestingLevel(): void
     {
-        $criteria = new Criteria();
-        \Closure::bind(function () use ($criteria): void {
-            $criteria->nestingLevel = 1;
-        }, null, Criteria::class)();
+        $criteria = new Criteria(nestingLevel: 1);
 
         $this->createDefinition()->processCriteria($criteria, static::createStub(SalesChannelContext::class));
 

--- a/tests/unit/Core/Content/Product/SearchKeyword/AnalyzedKeywordCollectionTest.php
+++ b/tests/unit/Core/Content/Product/SearchKeyword/AnalyzedKeywordCollectionTest.php
@@ -1,0 +1,43 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Content\Product\SearchKeyword;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Product\SearchKeyword\AnalyzedKeyword;
+use Shopware\Core\Content\Product\SearchKeyword\AnalyzedKeywordCollection;
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * @internal
+ */
+#[Package('inventory')]
+#[CoversClass(AnalyzedKeywordCollection::class)]
+class AnalyzedKeywordCollectionTest extends TestCase
+{
+    public function testAddKeepsTheHighestRankingPerKeyword(): void
+    {
+        $collection = new AnalyzedKeywordCollection();
+        $collection->add(new AnalyzedKeyword('shoe', 100));
+        $collection->add(new AnalyzedKeyword('shoe', 500));
+        $collection->add(new AnalyzedKeyword('shoe', 200));
+
+        static::assertCount(1, $collection);
+        static::assertSame(500.0, $collection->get('shoe')?->getRanking());
+    }
+
+    public function testSetKeysByKeywordAndOverwrites(): void
+    {
+        $collection = new AnalyzedKeywordCollection();
+        $collection->set('ignored', new AnalyzedKeyword('shoe', 300));
+        $collection->set('ignored', new AnalyzedKeyword('shoe', 100));
+
+        static::assertCount(1, $collection);
+        static::assertSame(100.0, $collection->get('shoe')?->getRanking());
+    }
+
+    public function testApiAlias(): void
+    {
+        static::assertSame('product_search_keyword_analyzed_collection', (new AnalyzedKeywordCollection())->getApiAlias());
+    }
+}

--- a/tests/unit/Core/Content/ProductExport/Event/ProductExportLoggingEventTest.php
+++ b/tests/unit/Core/Content/ProductExport/Event/ProductExportLoggingEventTest.php
@@ -2,10 +2,9 @@
 
 namespace Shopware\Tests\Unit\Core\Content\ProductExport\Event;
 
+use Monolog\Level;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
-use Shopware\Core\Content\Flow\Dispatching\StorableFlow;
-use Shopware\Core\Content\Flow\Dispatching\Storer\ScalarValuesStorer;
 use Shopware\Core\Content\ProductExport\Event\ProductExportLoggingEvent;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Log\Package;
@@ -17,22 +16,25 @@ use Shopware\Core\Framework\Log\Package;
 #[CoversClass(ProductExportLoggingEvent::class)]
 class ProductExportLoggingEventTest extends TestCase
 {
-    public function testScalarValuesCorrectly(): void
+    public function testFallsBackToTheDefaultNameAndDebugLevel(): void
     {
-        $event = new ProductExportLoggingEvent(
-            Context::createDefaultContext(),
-            'custom-name',
-            null
-        );
+        $event = new ProductExportLoggingEvent(Context::createDefaultContext(), null, null);
 
-        $storer = new ScalarValuesStorer();
-        $stored = $storer->store($event, []);
+        static::assertSame(ProductExportLoggingEvent::NAME, $event->getName());
+        static::assertSame(Level::Debug, $event->getLogLevel());
+        static::assertSame([], $event->getLogData());
+    }
 
-        $flow = new StorableFlow('foo', Context::createDefaultContext(), $stored);
+    public function testLogDataContainsTheThrowable(): void
+    {
+        $throwable = new \RuntimeException('export failed');
 
-        $storer->restore($flow);
+        $event = new ProductExportLoggingEvent(Context::createDefaultContext(), 'custom.name', Level::Error, $throwable);
 
-        static::assertArrayHasKey('name', $flow->data());
-        static::assertSame('custom-name', $flow->data()['name']);
+        static::assertSame('custom.name', $event->getName());
+        static::assertSame(Level::Error, $event->getLogLevel());
+        $exception = $event->getLogData()['exception'] ?? null;
+        static::assertIsString($exception);
+        static::assertStringContainsString('export failed', $exception);
     }
 }

--- a/tests/unit/Core/Content/ProductExport/Event/ProductExportLoggingEventTest.php
+++ b/tests/unit/Core/Content/ProductExport/Event/ProductExportLoggingEventTest.php
@@ -5,6 +5,7 @@ namespace Shopware\Tests\Unit\Core\Content\ProductExport\Event;
 use Monolog\Level;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\MailTemplate\Exception\MailEventConfigurationException;
 use Shopware\Core\Content\ProductExport\Event\ProductExportLoggingEvent;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Log\Package;
@@ -36,5 +37,24 @@ class ProductExportLoggingEventTest extends TestCase
         $exception = $event->getLogData()['exception'] ?? null;
         static::assertIsString($exception);
         static::assertStringContainsString('export failed', $exception);
+    }
+
+    public function testExposesItsFlowPayload(): void
+    {
+        $context = Context::createDefaultContext();
+        $event = new ProductExportLoggingEvent($context, 'custom.name', null);
+
+        static::assertSame($context, $event->getContext());
+        static::assertSame(['name' => 'custom.name'], $event->getValues());
+        static::assertNull($event->getSalesChannelId());
+        static::assertSame(['name'], array_keys(ProductExportLoggingEvent::getAvailableData()->toArray()));
+    }
+
+    public function testMailStructIsNotAvailable(): void
+    {
+        $event = new ProductExportLoggingEvent(Context::createDefaultContext(), null, null);
+
+        $this->expectException(MailEventConfigurationException::class);
+        $event->getMailStruct();
     }
 }

--- a/tests/unit/Core/Content/ProductExport/EventListener/ProductExportEventListenerTest.php
+++ b/tests/unit/Core/Content/ProductExport/EventListener/ProductExportEventListenerTest.php
@@ -109,6 +109,41 @@ class ProductExportEventListenerTest extends TestCase
         $listener->afterWrite($event);
     }
 
+    public function testAfterWriteStopsWhenTheExportNoLongerExists(): void
+    {
+        $id = Uuid::randomHex();
+        $context = Context::createDefaultContext();
+
+        $productExportRepository = $this->createMock(EntityRepository::class);
+        $productExportRepository->expects($this->once())->method('update');
+        $productExportRepository
+            ->method('search')
+            ->willReturn(new EntitySearchResult(
+                'product_export',
+                0,
+                new ProductExportCollection(),
+                null,
+                new Criteria([$id]),
+                $context
+            ));
+
+        $fileHandler = $this->createMock(ProductExportFileHandlerInterface::class);
+        $fileHandler->expects($this->never())->method('getFilePath');
+
+        $fs = $this->createMock(FilesystemOperator::class);
+        $fs->expects($this->never())->method('fileExists');
+
+        $listener = new ProductExportEventListener($productExportRepository, $fileHandler, $fs);
+
+        $writeResult = new EntityWriteResult(['id' => $id], ['interval' => 300], 'product_export', EntityWriteResult::OPERATION_UPDATE);
+        $listener->afterWrite(new EntityWrittenEvent('product_export', [$writeResult], $context));
+    }
+
+    public function testSubscribesToTheProductExportWrittenEvent(): void
+    {
+        static::assertSame(['product_export.written' => 'afterWrite'], ProductExportEventListener::getSubscribedEvents());
+    }
+
     public static function skipPayloadProvider(): \Generator
     {
         yield 'explicit generatedAt update' => [[

--- a/tests/unit/Core/Content/Property/Aggregate/PropertyGroupOption/PropertyGroupOptionCollectionTest.php
+++ b/tests/unit/Core/Content/Property/Aggregate/PropertyGroupOption/PropertyGroupOptionCollectionTest.php
@@ -56,4 +56,45 @@ class PropertyGroupOptionCollectionTest extends TestCase
         static::assertNotNull($firstOption);
         static::assertSame($propertyGroupOptionEntity->getId(), $firstOption->getId());
     }
+
+    public function testFiltersByGroupAndMediaId(): void
+    {
+        $red = $this->createOption('option-red', 'color-group', 'media-red');
+        $blue = $this->createOption('option-blue', 'color-group', null);
+        $large = $this->createOption('option-l', 'size-group', null);
+
+        $collection = new PropertyGroupOptionCollection([$red, $blue, $large]);
+
+        static::assertSame(['color-group', 'color-group', 'size-group'], array_values($collection->getPropertyGroupIds()));
+        static::assertSame(['media-red'], array_values($collection->getMediaIds()));
+        static::assertSame(['option-red', 'option-blue'], $collection->filterByGroupId('color-group')->getKeys());
+        static::assertSame(['option-red'], $collection->filterByMediaId('media-red')->getKeys());
+    }
+
+    public function testGetGroupsCollectsTheAssignedGroups(): void
+    {
+        $collection = new PropertyGroupOptionCollection([
+            $this->createOption('option-red', 'color-group', null),
+            $this->createOption('option-l', 'size-group', null),
+        ]);
+
+        static::assertSame(['color-group', 'size-group'], $collection->getGroups()->getKeys());
+    }
+
+    private function createOption(string $id, string $groupId, ?string $mediaId): PropertyGroupOptionEntity
+    {
+        $group = new PropertyGroupEntity();
+        $group->setId($groupId);
+
+        $option = new PropertyGroupOptionEntity();
+        $option->setId($id);
+        $option->setGroupId($groupId);
+        $option->setGroup($group);
+
+        if ($mediaId !== null) {
+            $option->setMediaId($mediaId);
+        }
+
+        return $option;
+    }
 }

--- a/tests/unit/Core/Content/Property/PropertyGroupCollectionTest.php
+++ b/tests/unit/Core/Content/Property/PropertyGroupCollectionTest.php
@@ -1,0 +1,72 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Content\Property;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Property\Aggregate\PropertyGroupOption\PropertyGroupOptionCollection;
+use Shopware\Core\Content\Property\Aggregate\PropertyGroupOption\PropertyGroupOptionEntity;
+use Shopware\Core\Content\Property\PropertyGroupCollection;
+use Shopware\Core\Content\Property\PropertyGroupEntity;
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * @internal
+ */
+#[Package('inventory')]
+#[CoversClass(PropertyGroupCollection::class)]
+class PropertyGroupCollectionTest extends TestCase
+{
+    public function testGetOptionIdMapMapsEveryOptionToItsGroup(): void
+    {
+        $collection = new PropertyGroupCollection([
+            $this->createGroup('color', ['red', 'blue']),
+            $this->createGroup('size', ['l']),
+            $this->createGroup('empty', []),
+        ]);
+
+        static::assertSame([
+            'red' => 'color',
+            'blue' => 'color',
+            'l' => 'size',
+        ], $collection->getOptionIdMap());
+    }
+
+    public function testSortByPositionsOrdersByPositionThenNaturalName(): void
+    {
+        $second = $this->createGroup('second', []);
+        $second->setTranslated(['position' => 2, 'name' => 'Alpha']);
+
+        $firstB = $this->createGroup('first-b', []);
+        $firstB->setTranslated(['position' => 1, 'name' => 'Group 10']);
+
+        $firstA = $this->createGroup('first-a', []);
+        $firstA->setTranslated(['position' => 1, 'name' => 'Group 2']);
+
+        $collection = new PropertyGroupCollection([$second, $firstB, $firstA]);
+        $collection->sortByPositions();
+
+        static::assertSame(['first-a', 'first-b', 'second'], array_keys($collection->getElements()));
+    }
+
+    /**
+     * @param list<string> $optionIds
+     */
+    private function createGroup(string $id, array $optionIds): PropertyGroupEntity
+    {
+        $group = new PropertyGroupEntity();
+        $group->setId($id);
+
+        if ($optionIds !== []) {
+            $options = new PropertyGroupOptionCollection();
+            foreach ($optionIds as $optionId) {
+                $option = new PropertyGroupOptionEntity();
+                $option->setId($optionId);
+                $options->add($option);
+            }
+            $group->setOptions($options);
+        }
+
+        return $group;
+    }
+}

--- a/tests/unit/Core/Content/Rule/RuleCollectionTest.php
+++ b/tests/unit/Core/Content/Rule/RuleCollectionTest.php
@@ -4,10 +4,14 @@ namespace Shopware\Tests\Unit\Core\Content\Rule;
 
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Checkout\Cart\Cart;
 use Shopware\Core\Content\Rule\RuleCollection;
 use Shopware\Core\Content\Rule\RuleEntity;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\RuleAreas;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Rule\Container\AndRule;
 use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
 
 /**
  * @internal
@@ -69,5 +73,74 @@ class RuleCollectionTest extends TestCase
 
         // the returned id lists must be sequentially indexed (real lists, no gaps)
         static::assertSame([0, 1], array_keys($result['a']));
+    }
+
+    public function testSortByPriorityOrdersDescending(): void
+    {
+        $low = $this->createRule('low', 10);
+        $high = $this->createRule('high', 100);
+
+        $collection = new RuleCollection([$low, $high]);
+        $collection->sortByPriority();
+
+        static::assertSame(['high', 'low'], array_keys($collection->getElements()));
+    }
+
+    public function testEqualsComparesCountAndIds(): void
+    {
+        $a = $this->createRule('a', 1);
+        $b = $this->createRule('b', 1);
+
+        $collection = new RuleCollection([$a, $b]);
+
+        static::assertTrue($collection->equals(new RuleCollection([$a, $b])));
+        static::assertFalse($collection->equals(new RuleCollection([$a])));
+        static::assertFalse($collection->equals(new RuleCollection([$a, $this->createRule('c', 1)])));
+    }
+
+    public function testFilterForContextExcludesFlowConditionRules(): void
+    {
+        $plain = $this->createRule('plain', 1);
+        $flowCondition = $this->createRule('flow-condition', 1);
+        $flowCondition->setAreas([RuleAreas::FLOW_CONDITION_AREA]);
+
+        $filtered = (new RuleCollection([$plain, $flowCondition]))->filterForContext();
+
+        static::assertSame(['plain'], array_keys($filtered->getElements()));
+    }
+
+    public function testFilterForFlowKeepsOnlyFlowAreaRules(): void
+    {
+        $plain = $this->createRule('plain', 1);
+        $flow = $this->createRule('flow', 1);
+        $flow->setAreas([RuleAreas::FLOW_AREA]);
+
+        $filtered = (new RuleCollection([$plain, $flow]))->filterForFlow();
+
+        static::assertSame(['flow'], array_keys($filtered->getElements()));
+    }
+
+    public function testFilterMatchingRulesEvaluatesThePayload(): void
+    {
+        $matching = $this->createRule('matching', 1);
+        $matching->setPayload(new AndRule([]));
+
+        $withoutPayload = $this->createRule('no-payload', 1);
+
+        $cart = new Cart('token');
+        $context = static::createStub(SalesChannelContext::class);
+
+        $filtered = (new RuleCollection([$matching, $withoutPayload]))->filterMatchingRules($cart, $context);
+
+        static::assertSame(['matching'], array_keys($filtered->getElements()));
+    }
+
+    private function createRule(string $id, int $priority): RuleEntity
+    {
+        $rule = new RuleEntity();
+        $rule->setId($id);
+        $rule->setPriority($priority);
+
+        return $rule;
     }
 }

--- a/tests/unit/Core/Content/Seo/Event/SeoUrlUpdateEventTest.php
+++ b/tests/unit/Core/Content/Seo/Event/SeoUrlUpdateEventTest.php
@@ -26,6 +26,14 @@ class SeoUrlUpdateEventTest extends TestCase
         static::assertSame($context, $event->getContext());
     }
 
+    public function testExposesTheSeoUrls(): void
+    {
+        $seoUrls = [['routeName' => 'frontend.detail.page', 'seoPathInfo' => 'awesome-product']];
+        $event = new SeoUrlUpdateEvent($seoUrls, Context::createDefaultContext());
+
+        static::assertSame($seoUrls, $event->getSeoUrls());
+    }
+
     #[DisabledFeatures(['v6.8.0.0'])]
     public function testGetNullableContextReturnsContextWhenFeatureInactiveAndContextProvided(): void
     {

--- a/tests/unit/Core/Content/Seo/MainCategory/MainCategoryEntityTest.php
+++ b/tests/unit/Core/Content/Seo/MainCategory/MainCategoryEntityTest.php
@@ -1,0 +1,32 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Content\Seo\MainCategory;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Category\CategoryEntity;
+use Shopware\Core\Content\Seo\MainCategory\MainCategoryEntity;
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * @internal
+ */
+#[Package('inventory')]
+#[CoversClass(MainCategoryEntity::class)]
+class MainCategoryEntityTest extends TestCase
+{
+    public function testGetCategoryFallsBackToAnEmptyCategory(): void
+    {
+        static::assertEquals(new CategoryEntity(), (new MainCategoryEntity())->getCategory());
+    }
+
+    public function testGetCategoryReturnsTheAssignedCategory(): void
+    {
+        $mainCategory = new MainCategoryEntity();
+        $category = new CategoryEntity();
+        $category->setId('category-id');
+        $mainCategory->setCategory($category);
+
+        static::assertSame($category, $mainCategory->getCategory());
+    }
+}

--- a/tests/unit/Core/Content/Sitemap/Event/SitemapFilterOpenTagEventTest.php
+++ b/tests/unit/Core/Content/Sitemap/Event/SitemapFilterOpenTagEventTest.php
@@ -1,0 +1,31 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Content\Sitemap\Event;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Sitemap\Event\SitemapFilterOpenTagEvent;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
+
+/**
+ * @internal
+ */
+#[Package('discovery')]
+#[CoversClass(SitemapFilterOpenTagEvent::class)]
+class SitemapFilterOpenTagEventTest extends TestCase
+{
+    public function testFullOpenTagRendersEveryRegisteredNamespace(): void
+    {
+        $event = new SitemapFilterOpenTagEvent(static::createStub(SalesChannelContext::class));
+        $event->setUrlsetNamespaces([
+            'xmlns' => 'http://www.sitemaps.org/schemas/sitemap/0.9',
+            'xmlns:image' => 'http://www.google.com/schemas/sitemap-image/1.1',
+        ]);
+
+        static::assertSame(
+            '<?xml version="1.0" encoding="UTF-8"?><urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">',
+            $event->getFullOpenTag(),
+        );
+    }
+}

--- a/tests/unit/Core/Content/Sitemap/Event/SitemapFilterOpenTagEventTest.php
+++ b/tests/unit/Core/Content/Sitemap/Event/SitemapFilterOpenTagEventTest.php
@@ -5,6 +5,7 @@ namespace Shopware\Tests\Unit\Core\Content\Sitemap\Event;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Sitemap\Event\SitemapFilterOpenTagEvent;
+use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 
@@ -27,5 +28,33 @@ class SitemapFilterOpenTagEventTest extends TestCase
             '<?xml version="1.0" encoding="UTF-8"?><urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">',
             $event->getFullOpenTag(),
         );
+    }
+
+    public function testSetOpenTagReplacesTheTemplate(): void
+    {
+        $event = new SitemapFilterOpenTagEvent(static::createStub(SalesChannelContext::class));
+
+        static::assertStringStartsWith('<?xml version="1.0"', $event->getOpenTag());
+
+        $event->setOpenTag('<urlset %urlsetNamespaces%>');
+        $event->addUrlsetNamespace('xmlns:custom', 'https://example.com/schema');
+
+        static::assertSame(
+            ['xmlns' => 'http://www.sitemaps.org/schemas/sitemap/0.9', 'xmlns:custom' => 'https://example.com/schema'],
+            $event->getUrlsetNamespaces(),
+        );
+        static::assertSame('<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:custom="https://example.com/schema">', $event->getFullOpenTag());
+    }
+
+    public function testExposesTheSalesChannelContext(): void
+    {
+        $context = Context::createDefaultContext();
+        $salesChannelContext = static::createStub(SalesChannelContext::class);
+        $salesChannelContext->method('getContext')->willReturn($context);
+
+        $event = new SitemapFilterOpenTagEvent($salesChannelContext);
+
+        static::assertSame($salesChannelContext, $event->getSalesChannelContext());
+        static::assertSame($context, $event->getContext());
     }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?

PHPUnit 12 validates every `#[CoversClass]` target against the coverage source, and the blanket suffix excludes for `src/Core/Content/` turn the covered DAL boilerplate classes into invalid targets. The excludes also hide untested logic that happens to live in classes whose name ends in a DAL suffix.

### 2. What does this change do, exactly?

Top of the stacked Content reversal series (Checkout precedent: #19268; layers below: #19461 inventory, #19462 discovery, #19463 after-sales): lifts the six `src/Core/Content/` suffix excludes from `phpunit.xml.dist` and covers the logic this surfaces.

- 22 logic-bearing classes flagged by `shopware.codeCoverageIgnoreOnLogic` get focused unit tests instead of an annotation: category breadcrumb filtering, CMS page/slot element traversal and field-config parsing, configurator option grouping, price sorting by tax state, search keyword ranking, listing filter blacklisting, import/export mapping conversion, newsletter mail structs, sitemap tag rendering, and the four definitions whose `defineFields()` is feature-flag dependent (asserted in both flag states via `#[DisabledFeatures]`).
- 56 classes already covered by unit or migration tests start counting real coverage.
- The two Content classes owned by framework and checkout carry their annotation here instead of a dedicated one-file layer.
- One pre-existing warning outside the suffix pattern is fixed on the way: `ProductListingCriteriaExtensionTest` covered a `Shopware\Tests\Examples` class, which is never part of the coverage source; the example remains exercised, only the covers target is dropped.
- The whole-directory excludes (`Cms/DataResolver/ResolverContext/`, `Cms/Extension/`, `Content/Test`) are deliberately untouched.

Each stack layer only shows its own diff and is reviewed by its owning team; merging the stack applies everything together, so the excludes never land without the annotations.

### 3. Describe each step to reproduce the issue or behaviour.

Run the Content unit suite under PHPUnit 12 with a coverage driver and `--display-phpunit-notices`: on trunk it reports "not a valid target for code coverage" warnings for covered Content DAL classes, with the full stack applied it reports none (verified locally with pcov). PHPStan is clean, including the coverage-annotation rule.

### 4. Please link to the relevant issues (if any).

- relates #18344

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
