### PR TITLE
fix(content): apply hideCloseoutProductsWhenOutOfStock to stream sliders (backport: 6.6.x)

### DIFF
--- a/changelog/_unreleased/2026-08-19-apply-hide-closeout-products-when-out-of-stock-to-stream-sliders.md
+++ b/changelog/_unreleased/2026-08-19-apply-hide-closeout-products-when-out-of-stock-to-stream-sliders.md
@@ -1,0 +1,9 @@
+---
+title: Apply hide closeout products when out of stock to stream sliders
+issue: 15902
+---
+# Core
+* Changed `ProductSliderCmsElementResolver::collectByProductStream()` to add a `ProductCloseoutFilter` to the product stream criteria before the slider limit is applied when `core.listing.hideCloseoutProductsWhenOutOfStock` is enabled for the sales channel. CMS product sliders sourced from a product stream now hide out-of-stock closeout products, like sliders with manually assigned products already did, and hidden products no longer consume slider slots.
+* Changed `ProductSliderCmsElementResolver::enrich()` to also run the resolved stream products through the closeout filtering, because a stream hit can be remapped to its display parent or main variant, which may itself be a hidden closeout product.
+* Changed `ProductSliderCmsElementResolver::filterOutOutOfStockHiddenCloseoutProducts()` to keep products that still have children, so a variant parent is not hidden because of its own stock.
+* Added `Shopware\Core\Content\Product\SalesChannel\AbstractProductCloseoutFilterFactory` as a new constructor argument of the `@internal` `ProductSliderCmsElementResolver`.

--- a/src/Core/Content/DependencyInjection/product.xml
+++ b/src/Core/Content/DependencyInjection/product.xml
@@ -243,6 +243,7 @@
             <argument type="service" id="Shopware\Core\Content\ProductStream\Service\ProductStreamBuilder"/>
             <argument type="service" id="Shopware\Core\System\SystemConfig\SystemConfigService"/>
             <argument type="service" id="sales_channel.product.repository"/>
+            <argument type="service" id="Shopware\Core\Content\Product\SalesChannel\ProductCloseoutFilterFactory"/>
             <tag name="shopware.cms.data_resolver"/>
         </service>
 

--- a/src/Core/Content/Product/Cms/ProductSliderCmsElementResolver.php
+++ b/src/Core/Content/Product/Cms/ProductSliderCmsElementResolver.php
@@ -14,6 +14,7 @@ use Shopware\Core\Content\Cms\SalesChannel\Struct\ProductSliderStruct;
 use Shopware\Core\Content\Product\ProductCollection;
 use Shopware\Core\Content\Product\ProductDefinition;
 use Shopware\Core\Content\Product\ProductEntity;
+use Shopware\Core\Content\Product\SalesChannel\AbstractProductCloseoutFilterFactory;
 use Shopware\Core\Content\Product\SalesChannel\SalesChannelProductCollection;
 use Shopware\Core\Content\ProductStream\Service\ProductStreamBuilderInterface;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
@@ -50,6 +51,7 @@ class ProductSliderCmsElementResolver extends AbstractCmsElementResolver
         private readonly ProductStreamBuilderInterface $productStreamBuilder,
         private readonly SystemConfigService $systemConfigService,
         private readonly SalesChannelRepository $productRepository,
+        private readonly AbstractProductCloseoutFilterFactory $productCloseoutFilterFactory,
     ) {
     }
 
@@ -128,7 +130,18 @@ class ProductSliderCmsElementResolver extends AbstractCmsElementResolver
                 return;
             }
 
-            $slider->setProducts($this->handleProductStream($streamResult, $resolverContext->getSalesChannelContext(), $entitySearchResult->getCriteria()));
+            $salesChannelContext = $resolverContext->getSalesChannelContext();
+
+            $products = $this->handleProductStream($streamResult, $salesChannelContext, $entitySearchResult->getCriteria());
+
+            // Safety net: handleProductStream() can remap stream hits to their display
+            // parent or main variant, which may itself be a hidden closeout product even
+            // though the stream criteria already filtered unavailable closeout products.
+            if ($this->hideUnavailableProducts($salesChannelContext)) {
+                $products = $this->filterOutOutOfStockHiddenCloseoutProducts($products);
+            }
+
+            $slider->setProducts($products);
             $slider->setStreamId($productConfig->getStringValue());
         }
     }
@@ -140,16 +153,30 @@ class ProductSliderCmsElementResolver extends AbstractCmsElementResolver
             return;
         }
 
-        if ($this->systemConfigService->get('core.listing.hideCloseoutProductsWhenOutOfStock', $saleschannelContext->getSalesChannelId())) {
+        if ($this->hideUnavailableProducts($saleschannelContext)) {
             $products = $this->filterOutOutOfStockHiddenCloseoutProducts($products);
         }
 
         $slider->setProducts($products);
     }
 
+    private function hideUnavailableProducts(SalesChannelContext $context): bool
+    {
+        return $this->systemConfigService->getBool(
+            'core.listing.hideCloseoutProductsWhenOutOfStock',
+            $context->getSalesChannelId()
+        );
+    }
+
     private function filterOutOutOfStockHiddenCloseoutProducts(ProductCollection $products): ProductCollection
     {
         return $products->filter(function (ProductEntity $product) {
+            // Variant parents are represented by their children; the parent's own stock
+            // is not meaningful, so never hide a product that still has children.
+            if ($product->getChildCount() > 0) {
+                return true;
+            }
+
             if ($product->getIsCloseout() && $product->getStock() <= 0) {
                 return false;
             }
@@ -183,6 +210,14 @@ class ProductSliderCmsElementResolver extends AbstractCmsElementResolver
 
         $criteria = new Criteria();
         $criteria->addFilter(...$filters);
+
+        // Exclude unavailable closeout products before the limit is applied, so they
+        // do not consume slider slots (same handling as listing and cross-selling).
+        $salesChannelContext = $resolverContext->getSalesChannelContext();
+        if ($this->hideUnavailableProducts($salesChannelContext)) {
+            $criteria->addFilter($this->productCloseoutFilterFactory->create($salesChannelContext));
+        }
+
         $criteria->setLimit($elementConfig->get('productStreamLimit')?->getIntValue() ?? self::FALLBACK_LIMIT);
 
         if (!Feature::isActive('v6.7.0.0')) {

--- a/tests/integration/Core/Content/Product/Cms/ProductSliderCmsElementResolverTest.php
+++ b/tests/integration/Core/Content/Product/Cms/ProductSliderCmsElementResolverTest.php
@@ -1,0 +1,170 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Integration\Core\Content\Product\Cms;
+
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Cms\Aggregate\CmsSlot\CmsSlotCollection;
+use Shopware\Core\Content\Cms\Aggregate\CmsSlot\CmsSlotEntity;
+use Shopware\Core\Content\Cms\DataResolver\CmsSlotsDataResolver;
+use Shopware\Core\Content\Cms\DataResolver\FieldConfig;
+use Shopware\Core\Content\Cms\DataResolver\FieldConfigCollection;
+use Shopware\Core\Content\Cms\DataResolver\ResolverContext\ResolverContext;
+use Shopware\Core\Content\Cms\SalesChannel\Struct\ProductSliderStruct;
+use Shopware\Core\Content\Product\ProductCollection;
+use Shopware\Core\Content\Test\Product\ProductBuilder;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
+use Shopware\Core\Framework\Test\TestCaseBase\TaxAddToSalesChannelTestBehaviour;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\System\SalesChannel\Context\SalesChannelContextFactory;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Shopware\Core\System\SystemConfig\SystemConfigService;
+use Shopware\Core\Test\Stub\Framework\IdsCollection;
+use Shopware\Core\Test\TestDefaults;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * @internal
+ */
+#[Package('discovery')]
+class ProductSliderCmsElementResolverTest extends TestCase
+{
+    use IntegrationTestBehaviour;
+    use TaxAddToSalesChannelTestBehaviour;
+
+    private IdsCollection $ids;
+
+    private SalesChannelContext $context;
+
+    protected function setUp(): void
+    {
+        $this->ids = new IdsCollection();
+        $this->context = static::getContainer()->get(SalesChannelContextFactory::class)
+            ->create(Uuid::randomHex(), TestDefaults::SALES_CHANNEL);
+
+        $this->createStreamAndProducts();
+    }
+
+    public function testStreamSliderHidesOutOfStockCloseoutProductsWhenSettingEnabled(): void
+    {
+        static::getContainer()->get(SystemConfigService::class)
+            ->set('core.listing.hideCloseoutProductsWhenOutOfStock', true);
+
+        $products = $this->resolveStreamSlider();
+
+        static::assertInstanceOf(ProductCollection::class, $products);
+        static::assertTrue($products->has($this->ids->get('available-product')));
+        static::assertFalse(
+            $products->has($this->ids->get('closeout-oos-product')),
+            'OOS closeout product must not appear in stream slider when hideCloseoutProductsWhenOutOfStock is enabled'
+        );
+    }
+
+    public function testStreamSliderKeepsOutOfStockCloseoutProductsWhenSettingDisabled(): void
+    {
+        static::getContainer()->get(SystemConfigService::class)
+            ->set('core.listing.hideCloseoutProductsWhenOutOfStock', false);
+
+        $products = $this->resolveStreamSlider();
+
+        static::assertInstanceOf(ProductCollection::class, $products);
+        static::assertTrue($products->has($this->ids->get('available-product')));
+        static::assertTrue($products->has($this->ids->get('closeout-oos-product')));
+    }
+
+    public function testHiddenCloseoutProductsDoNotConsumeSliderLimit(): void
+    {
+        static::getContainer()->get(SystemConfigService::class)
+            ->set('core.listing.hideCloseoutProductsWhenOutOfStock', true);
+
+        // stock ASC puts the OOS closeout product first; with a limit of 1 it would
+        // consume the only slot if filtering happened after the stream search.
+        $products = $this->resolveStreamSlider(1, 'stock:ASC');
+
+        static::assertInstanceOf(ProductCollection::class, $products);
+        static::assertCount(1, $products);
+        static::assertTrue(
+            $products->has($this->ids->get('available-product')),
+            'Hidden closeout products must not consume slider limit slots'
+        );
+    }
+
+    private function resolveStreamSlider(?int $limit = null, ?string $sorting = null): ?ProductCollection
+    {
+        $resolverContext = new ResolverContext($this->context, new Request());
+
+        $configs = new FieldConfigCollection();
+        $configs->add(new FieldConfig('products', FieldConfig::SOURCE_PRODUCT_STREAM, $this->ids->get('stream')));
+
+        if ($limit !== null) {
+            $configs->add(new FieldConfig('productStreamLimit', FieldConfig::SOURCE_STATIC, $limit));
+        }
+
+        if ($sorting !== null) {
+            $configs->add(new FieldConfig('productStreamSorting', FieldConfig::SOURCE_STATIC, $sorting));
+        }
+
+        $slot = new CmsSlotEntity();
+        $slot->setId(Uuid::randomHex());
+        $slot->setType('product-slider');
+        $slot->setSlot('productSlider');
+        $slot->setFieldConfig($configs);
+        $slot->setBlockId(Uuid::randomHex());
+
+        $slots = new CmsSlotCollection();
+        $slots->add($slot);
+
+        $result = static::getContainer()->get(CmsSlotsDataResolver::class)->resolve($slots, $resolverContext);
+
+        $data = $result->first()?->getData();
+        static::assertInstanceOf(ProductSliderStruct::class, $data);
+
+        return $data->getProducts();
+    }
+
+    private function createStreamAndProducts(): void
+    {
+        $context = Context::createDefaultContext();
+
+        static::getContainer()->get('product_stream.repository')->create([
+            [
+                'id' => $this->ids->get('stream'),
+                'filters' => [
+                    [
+                        'type' => 'equals',
+                        'field' => 'active',
+                        'value' => '1',
+                    ],
+                ],
+                'name' => 'testStream',
+            ],
+        ], $context);
+
+        $products = [
+            (new ProductBuilder($this->ids, 'available-product'))
+                ->price(100)
+                ->visibility()
+                ->stock(10)
+                ->closeout(false)
+                ->build(),
+            (new ProductBuilder($this->ids, 'closeout-oos-product'))
+                ->price(100)
+                ->visibility()
+                ->stock(0)
+                ->closeout(true)
+                ->build(),
+        ];
+
+        static::getContainer()->get('product.repository')->create($products, $context);
+
+        // Products created via ProductBuilder get their own tax; the SalesChannelContext
+        // needs to know those taxes so price calculation during slider resolution does
+        // not fail with "Could not find tax with id ...".
+        foreach ($products as $product) {
+            if (isset($product['tax'])) {
+                $this->addTaxDataToSalesChannel($this->context, $product['tax']);
+            }
+        }
+    }
+}

--- a/tests/unit/Core/Content/Product/Cms/ProductSliderCmsElementResolverTest.php
+++ b/tests/unit/Core/Content/Product/Cms/ProductSliderCmsElementResolverTest.php
@@ -33,6 +33,8 @@ use Shopware\Core\Content\Product\DataAbstractionLayer\VariantListingConfig;
 use Shopware\Core\Content\Product\ProductCollection;
 use Shopware\Core\Content\Product\ProductDefinition;
 use Shopware\Core\Content\Product\ProductEntity;
+use Shopware\Core\Content\Product\SalesChannel\ProductCloseoutFilter;
+use Shopware\Core\Content\Product\SalesChannel\ProductCloseoutFilterFactory;
 use Shopware\Core\Content\Product\SalesChannel\SalesChannelProductEntity;
 use Shopware\Core\Content\ProductStream\ProductStreamDefinition;
 use Shopware\Core\Content\ProductStream\Service\ProductStreamBuilder;
@@ -54,11 +56,11 @@ use Shopware\Core\System\SalesChannel\Context\SalesChannelContextFactory;
 use Shopware\Core\System\SalesChannel\Entity\SalesChannelRepository;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\System\SalesChannel\SalesChannelEntity;
-use Shopware\Core\System\SystemConfig\SystemConfigService;
 use Shopware\Core\System\Tag\TagDefinition;
 use Shopware\Core\System\Tax\TaxDefinition;
 use Shopware\Core\System\Unit\UnitDefinition;
 use Shopware\Core\Test\Generator;
+use Shopware\Core\Test\Stub\SystemConfigService\StaticSystemConfigService;
 use Shopware\Core\Test\TestDefaults;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\HttpFoundation\Request;
@@ -73,16 +75,16 @@ class ProductSliderCmsElementResolverTest extends TestCase
 
     private string $productStreamId;
 
-    private MockObject&SystemConfigService $systemConfig;
+    private StaticSystemConfigService $systemConfig;
 
     private MockObject&SalesChannelRepository $productRepository;
 
     protected function setUp(): void
     {
-        $this->systemConfig = $this->createMock(SystemConfigService::class);
+        $this->systemConfig = new StaticSystemConfigService();
         $this->productRepository = $this->createMock(SalesChannelRepository::class);
 
-        $this->sliderResolver = new ProductSliderCmsElementResolver($this->createMock(ProductStreamBuilder::class), $this->systemConfig, $this->productRepository);
+        $this->sliderResolver = $this->createResolver();
 
         $this->productStreamId = Uuid::randomHex();
     }
@@ -267,6 +269,38 @@ class ProductSliderCmsElementResolverTest extends TestCase
         }
     }
 
+    public function testCollectAddsCloseoutFilterToStreamCriteriaWhenHideCloseoutEnabled(): void
+    {
+        $salesChannelContext = Generator::generateSalesChannelContext();
+        $this->enableHideCloseout($salesChannelContext->getSalesChannelId());
+
+        $criteria = $this->collectStreamCriteria($salesChannelContext);
+
+        $closeoutFilters = array_filter(
+            $criteria->getFilters(),
+            static fn ($filter) => $filter instanceof ProductCloseoutFilter
+        );
+
+        static::assertCount(
+            1,
+            $closeoutFilters,
+            'Closeout filter must be part of the stream criteria so hidden products do not consume the slider limit'
+        );
+    }
+
+    public function testCollectDoesNotAddCloseoutFilterToStreamCriteriaWhenHideCloseoutDisabled(): void
+    {
+        // $this->systemConfig is left at its empty default: hide closeout off.
+        $criteria = $this->collectStreamCriteria(Generator::generateSalesChannelContext());
+
+        $closeoutFilters = array_filter(
+            $criteria->getFilters(),
+            static fn ($filter) => $filter instanceof ProductCloseoutFilter
+        );
+
+        static::assertCount(0, $closeoutFilters);
+    }
+
     public function testCollectWithMappedConfigButEmptyManyToManyRelation(): void
     {
         $category = new CategoryEntity();
@@ -363,11 +397,11 @@ class ProductSliderCmsElementResolverTest extends TestCase
     #[DataProvider('enrichDataProvider')]
     public function testEnrich(bool $closeout, bool $hidden, int $availableStock): void
     {
-        if ($hidden) {
-            $this->systemConfig->method('get')->willReturn(true);
-        }
-
         $salesChannelId = 'f3489c46df62422abdea4aa1bb03511c';
+
+        if ($hidden) {
+            $this->enableHideCloseout($salesChannelId);
+        }
 
         $product = new SalesChannelProductEntity();
         $product->setId('product123');
@@ -382,7 +416,7 @@ class ProductSliderCmsElementResolverTest extends TestCase
         $salesChannelContext->method('getSalesChannelId')->willReturn($salesChannelId);
         $salesChannelContext->method('getSalesChannel')->willReturn($salesChannel);
 
-        $productSliderResolver = new ProductSliderCmsElementResolver($this->createMock(ProductStreamBuilder::class), $this->systemConfig, $this->productRepository);
+        $productSliderResolver = $this->createResolver();
         $resolverContext = new ResolverContext($salesChannelContext, new Request());
         $result = new ElementDataCollection();
         $result->add('product-slider_product_id', new EntitySearchResult(
@@ -554,6 +588,68 @@ class ProductSliderCmsElementResolverTest extends TestCase
         ];
     }
 
+    public function testEnrichFiltersOutOfStockCloseoutMainVariantFromStream(): void
+    {
+        $variantId = Uuid::randomHex();
+        $mainVariantId = Uuid::randomHex();
+
+        $variant = self::createProduct($variantId, Uuid::randomHex(), new VariantListingConfig(false, $mainVariantId, []));
+
+        // The main variant is not part of the stream result, so the closeout filter on
+        // the stream criteria never saw it; only the post-search filter can hide it.
+        $mainVariant = self::createProduct($mainVariantId, null);
+        $mainVariant->setIsCloseout(true);
+        $mainVariant->setStock(0);
+
+        $salesChannelContext = Generator::generateSalesChannelContext();
+        $this->enableHideCloseout($salesChannelContext->getSalesChannelId());
+
+        $products = $this->enrichStreamSlider($salesChannelContext, [$variant], [$variant, $mainVariant]);
+
+        static::assertCount(0, $products);
+    }
+
+    public function testEnrichKeepsDisplayParentWithChildrenFromStream(): void
+    {
+        $parentId = Uuid::randomHex();
+        $variantId = Uuid::randomHex();
+
+        $variant = self::createProduct($variantId, $parentId, new VariantListingConfig(true, null, []));
+
+        // A display parent carries its own stock, which says nothing about the
+        // availability of its children, so it must not be filtered out.
+        $parent = self::createProduct($parentId, null);
+        $parent->setIsCloseout(true);
+        $parent->setStock(0);
+        $parent->setChildCount(1);
+
+        $salesChannelContext = Generator::generateSalesChannelContext();
+        $this->enableHideCloseout($salesChannelContext->getSalesChannelId());
+
+        $products = $this->enrichStreamSlider($salesChannelContext, [$variant], [$variant, $parent]);
+
+        static::assertCount(1, $products);
+        static::assertTrue($products->has($parentId));
+    }
+
+    public function testEnrichKeepsOutOfStockCloseoutProductsFromStreamWhenHideCloseoutDisabled(): void
+    {
+        $variantId = Uuid::randomHex();
+        $mainVariantId = Uuid::randomHex();
+
+        $variant = self::createProduct($variantId, Uuid::randomHex(), new VariantListingConfig(false, $mainVariantId, []));
+
+        $mainVariant = self::createProduct($mainVariantId, null);
+        $mainVariant->setIsCloseout(true);
+        $mainVariant->setStock(0);
+
+        // $this->systemConfig is left at its empty default: hide closeout off.
+        $products = $this->enrichStreamSlider(Generator::generateSalesChannelContext(), [$variant], [$variant, $mainVariant]);
+
+        static::assertCount(1, $products);
+        static::assertTrue($products->has($mainVariantId));
+    }
+
     private static function createManufacturer(string $id, string $name): ProductManufacturerEntity
     {
         $manufacturer = new ProductManufacturerEntity();
@@ -573,6 +669,83 @@ class ProductSliderCmsElementResolverTest extends TestCase
         $product->setManufacturerId($manufacturerId);
 
         return $product;
+    }
+
+    private function collectStreamCriteria(SalesChannelContext $salesChannelContext): Criteria
+    {
+        $fieldConfig = new FieldConfigCollection();
+        $fieldConfig->add(new FieldConfig('products', FieldConfig::SOURCE_PRODUCT_STREAM, $this->productStreamId));
+
+        $slot = new CmsSlotEntity();
+        $slot->setUniqueIdentifier('id');
+        $slot->setType('product-slider');
+        $slot->setFieldConfig($fieldConfig);
+
+        $collection = $this->createResolver()->collect($slot, new ResolverContext($salesChannelContext, new Request()));
+        static::assertInstanceOf(CriteriaCollection::class, $collection);
+
+        $criteria = $collection->all()[ProductDefinition::class]['product-slider-entity-fallback_id'] ?? null;
+        static::assertInstanceOf(Criteria::class, $criteria);
+
+        return $criteria;
+    }
+
+    /**
+     * @param SalesChannelProductEntity[] $streamProducts products the stream itself matched
+     * @param SalesChannelProductEntity[] $repositoryProducts products the follow-up read can resolve
+     */
+    private function enrichStreamSlider(
+        SalesChannelContext $salesChannelContext,
+        array $streamProducts,
+        array $repositoryProducts
+    ): ProductCollection {
+        $this->configureProductRepositoryMock($repositoryProducts);
+
+        $entitySearchResult = $this->createMock(EntitySearchResult::class);
+        $entitySearchResult->method('getEntities')->willReturn(new ProductCollection($streamProducts));
+        $entitySearchResult->method('getCriteria')->willReturn(new Criteria());
+
+        $fieldConfig = new FieldConfigCollection();
+        $fieldConfig->add(new FieldConfig('products', FieldConfig::SOURCE_PRODUCT_STREAM, $this->productStreamId));
+
+        $slot = new CmsSlotEntity();
+        $slot->setUniqueIdentifier('product_id');
+        $slot->setType('product-slider');
+        $slot->setFieldConfig($fieldConfig);
+
+        $elementDataCollection = new ElementDataCollection();
+        $elementDataCollection->add('product-slider-entity-fallback_product_id', $entitySearchResult);
+
+        $this->createResolver()->enrich($slot, new ResolverContext($salesChannelContext, new Request()), $elementDataCollection);
+
+        $slider = $slot->getData();
+        static::assertInstanceOf(ProductSliderStruct::class, $slider);
+
+        $products = $slider->getProducts();
+        static::assertInstanceOf(ProductCollection::class, $products);
+
+        return $products;
+    }
+
+    /**
+     * Scoped to the sales channel so a resolver that looked the setting up globally,
+     * or under a different key, would still read `false` here.
+     */
+    private function enableHideCloseout(string $salesChannelId): void
+    {
+        $this->systemConfig = new StaticSystemConfigService([
+            $salesChannelId => ['core.listing.hideCloseoutProductsWhenOutOfStock' => true],
+        ]);
+    }
+
+    private function createResolver(): ProductSliderCmsElementResolver
+    {
+        return new ProductSliderCmsElementResolver(
+            $this->createMock(ProductStreamBuilder::class),
+            $this->systemConfig,
+            $this->productRepository,
+            new ProductCloseoutFilterFactory()
+        );
     }
 
     /**


### PR DESCRIPTION
### 1. Why is this change necessary?

Backport of #16335 to `6.6.x`, requested in #15902.

`core.listing.hideCloseoutProductsWhenOutOfStock` was only applied to CMS product sliders with manually assigned products. For sliders sourced from a product stream, out-of-stock closeout products were still loaded and shown in the storefront, so the two slider sources behaved differently under the same setting.

### 2. What does this change do, exactly?

`6.6.x` does not have the `ProductSlider/*Processor` split that trunk introduced, so the fix lives in `ProductSliderCmsElementResolver` instead of `ProductStreamProcessor`. The behaviour is the same as on trunk, in two layers:

- **Criteria level** (`collectByProductStream()`): when the setting is enabled for the sales channel, a `ProductCloseoutFilter` (via `AbstractProductCloseoutFilterFactory`) is added to the stream criteria **before the slider limit is applied** — the same handling as product listing and cross-selling. Hidden closeout products therefore do not consume `productStreamLimit` slots.
- **Post-search safety net** (`enrich()`): the resolved collection is additionally run through the existing `filterOutOutOfStockHiddenCloseoutProducts()` helper, because `handleProductStream()` can remap stream hits to their display parent or main variant via `cloneForRead()` (which drops filters). The remapped product was never seen by the stream criteria and can itself be a hidden closeout product.

Implementation notes:

- `ProductSliderCmsElementResolver`'s `@internal` constructor takes one additional argument, `AbstractProductCloseoutFilterFactory` (wired in `src/Core/Content/DependencyInjection/product.xml`). `SystemConfigService` was already injected, so unlike trunk no second argument is needed.
- `filterOutOutOfStockHiddenCloseoutProducts()` now keeps products with `childCount > 0`. Without this guard the new safety net would hide a display parent because of the parent's own stock, which says nothing about the availability of its variants. Trunk already has this guard (added by #13653, which was never backported), so this also aligns `6.6.x` with trunk for the static slider path.
- The config lookup was extracted into a private `hideUnavailableProducts()` helper used by both the static and the stream path.

### 3. Describe each step to reproduce the issue or behaviour.

1. Set up a product stream matching some products. Create a CMS product slider sourced from that stream (Shopping Experiences → Product slider → assignment type "Dynamic product group").
2. Enable "Hide products after clearance".
3. Set one of the products to clearance and empty its stock.
4. Before the fix: the product still appears in the slider.
5. After the fix: the product is excluded, matching the behaviour of manually assigned sliders — and it does not occupy a slider slot, so the slider still shows up to the configured limit of available products.

### 4. Please link to the relevant issues (if any).

- closes #15902
- backport of #16335

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
