### PR TITLE
test: mark Content structs, collections and fields codeCoverageIgnore

### DIFF
--- a/src/Core/Content/Category/Aggregate/CategoryTranslation/CategoryTranslationCollection.php
+++ b/src/Core/Content/Category/Aggregate/CategoryTranslation/CategoryTranslationCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<CategoryTranslationEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('discovery')]
 class CategoryTranslationCollection extends EntityCollection

--- a/src/Core/Content/Category/CategoryCollection.php
+++ b/src/Core/Content/Category/CategoryCollection.php
@@ -8,6 +8,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<CategoryEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('discovery')]
 class CategoryCollection extends EntityCollection

--- a/src/Core/Content/Cms/CmsPageCollection.php
+++ b/src/Core/Content/Cms/CmsPageCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<CmsPageEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('discovery')]
 class CmsPageCollection extends EntityCollection

--- a/src/Core/Content/Cms/DataAbstractionLayer/Field/SlotConfigField.php
+++ b/src/Core/Content/Cms/DataAbstractionLayer/Field/SlotConfigField.php
@@ -6,6 +6,9 @@ use Shopware\Core\Content\Cms\DataAbstractionLayer\FieldSerializer\SlotConfigFie
 use Shopware\Core\Framework\DataAbstractionLayer\Field\JsonField;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class SlotConfigField extends JsonField
 {

--- a/src/Core/Content/Cms/DataResolver/FieldConfigCollection.php
+++ b/src/Core/Content/Cms/DataResolver/FieldConfigCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Struct\Collection;
 
 /**
  * @extends Collection<FieldConfig>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('discovery')]
 class FieldConfigCollection extends Collection

--- a/src/Core/Content/Cms/SalesChannel/Struct/BuyBoxStruct.php
+++ b/src/Core/Content/Cms/SalesChannel/Struct/BuyBoxStruct.php
@@ -7,6 +7,9 @@ use Shopware\Core\Content\Property\PropertyGroupCollection;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\Struct;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class BuyBoxStruct extends Struct
 {

--- a/src/Core/Content/Cms/SalesChannel/Struct/CrossSellingStruct.php
+++ b/src/Core/Content/Cms/SalesChannel/Struct/CrossSellingStruct.php
@@ -6,6 +6,9 @@ use Shopware\Core\Content\Product\SalesChannel\CrossSelling\CrossSellingElementC
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\Struct;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class CrossSellingStruct extends Struct
 {

--- a/src/Core/Content/Cms/SalesChannel/Struct/HtmlStruct.php
+++ b/src/Core/Content/Cms/SalesChannel/Struct/HtmlStruct.php
@@ -5,6 +5,9 @@ namespace Shopware\Core\Content\Cms\SalesChannel\Struct;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\Struct;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class HtmlStruct extends Struct
 {

--- a/src/Core/Content/Cms/SalesChannel/Struct/ImageSliderItemStruct.php
+++ b/src/Core/Content/Cms/SalesChannel/Struct/ImageSliderItemStruct.php
@@ -6,6 +6,9 @@ use Shopware\Core\Content\Media\MediaEntity;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\Struct;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class ImageSliderItemStruct extends Struct
 {

--- a/src/Core/Content/Cms/SalesChannel/Struct/ImageSliderStruct.php
+++ b/src/Core/Content/Cms/SalesChannel/Struct/ImageSliderStruct.php
@@ -5,6 +5,9 @@ namespace Shopware\Core\Content\Cms\SalesChannel\Struct;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\Struct;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class ImageSliderStruct extends Struct
 {

--- a/src/Core/Content/Cms/SalesChannel/Struct/ManufacturerLogoStruct.php
+++ b/src/Core/Content/Cms/SalesChannel/Struct/ManufacturerLogoStruct.php
@@ -5,6 +5,9 @@ namespace Shopware\Core\Content\Cms\SalesChannel\Struct;
 use Shopware\Core\Content\Product\Aggregate\ProductManufacturer\ProductManufacturerEntity;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class ManufacturerLogoStruct extends ImageStruct
 {

--- a/src/Core/Content/Cms/SalesChannel/Struct/ProductBoxStruct.php
+++ b/src/Core/Content/Cms/SalesChannel/Struct/ProductBoxStruct.php
@@ -6,6 +6,9 @@ use Shopware\Core\Content\Product\SalesChannel\SalesChannelProductEntity;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\Struct;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class ProductBoxStruct extends Struct
 {

--- a/src/Core/Content/Cms/SalesChannel/Struct/ProductDescriptionReviewsStruct.php
+++ b/src/Core/Content/Cms/SalesChannel/Struct/ProductDescriptionReviewsStruct.php
@@ -7,6 +7,9 @@ use Shopware\Core\Content\Product\SalesChannel\SalesChannelProductEntity;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\Struct;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class ProductDescriptionReviewsStruct extends Struct
 {

--- a/src/Core/Content/Cms/SalesChannel/Struct/ProductListingStruct.php
+++ b/src/Core/Content/Cms/SalesChannel/Struct/ProductListingStruct.php
@@ -7,6 +7,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\Struct;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class ProductListingStruct extends Struct
 {

--- a/src/Core/Content/Cms/SalesChannel/Struct/ProductSliderStruct.php
+++ b/src/Core/Content/Cms/SalesChannel/Struct/ProductSliderStruct.php
@@ -6,6 +6,9 @@ use Shopware\Core\Content\Product\ProductCollection;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\Struct;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class ProductSliderStruct extends Struct
 {

--- a/src/Core/Content/Cms/SalesChannel/Struct/TextStruct.php
+++ b/src/Core/Content/Cms/SalesChannel/Struct/TextStruct.php
@@ -5,6 +5,9 @@ namespace Shopware\Core\Content\Cms\SalesChannel\Struct;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\Struct;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class TextStruct extends Struct
 {

--- a/src/Core/Content/ContactForm/SalesChannel/ContactFormRouteResponseStruct.php
+++ b/src/Core/Content/ContactForm/SalesChannel/ContactFormRouteResponseStruct.php
@@ -5,6 +5,9 @@ namespace Shopware\Core\Content\ContactForm\SalesChannel;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\Struct;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class ContactFormRouteResponseStruct extends Struct
 {

--- a/src/Core/Content/Flow/Aggregate/FlowSequence/FlowSequenceCollection.php
+++ b/src/Core/Content/Flow/Aggregate/FlowSequence/FlowSequenceCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<FlowSequenceEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('after-sales')]
 class FlowSequenceCollection extends EntityCollection

--- a/src/Core/Content/Flow/Aggregate/FlowTemplate/FlowTemplateCollection.php
+++ b/src/Core/Content/Flow/Aggregate/FlowTemplate/FlowTemplateCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<FlowTemplateEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('after-sales')]
 class FlowTemplateCollection extends EntityCollection

--- a/src/Core/Content/Flow/FlowCollection.php
+++ b/src/Core/Content/Flow/FlowCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<FlowEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('after-sales')]
 class FlowCollection extends EntityCollection

--- a/src/Core/Content/ImportExport/Aggregate/ImportExportLog/ImportExportLogCollection.php
+++ b/src/Core/Content/ImportExport/Aggregate/ImportExportLog/ImportExportLogCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<ImportExportLogEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('fundamentals@after-sales')]
 class ImportExportLogCollection extends EntityCollection

--- a/src/Core/Content/ImportExport/ImportExportProfileTranslationCollection.php
+++ b/src/Core/Content/ImportExport/ImportExportProfileTranslationCollection.php
@@ -10,6 +10,8 @@ use Shopware\Core\Framework\Log\Package;
  * @deprecated tag:v6.8.0 - reason:remove-entity - Will be removed
  *
  * @extends EntityCollection<ImportExportProfileTranslationEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('fundamentals@after-sales')]
 class ImportExportProfileTranslationCollection extends EntityCollection

--- a/src/Core/Content/LandingPage/Aggregate/LandingPageTranslation/LandingPageTranslationCollection.php
+++ b/src/Core/Content/LandingPage/Aggregate/LandingPageTranslation/LandingPageTranslationCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<LandingPageTranslationEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('discovery')]
 class LandingPageTranslationCollection extends EntityCollection

--- a/src/Core/Content/LandingPage/LandingPageCollection.php
+++ b/src/Core/Content/LandingPage/LandingPageCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<LandingPageEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('discovery')]
 class LandingPageCollection extends EntityCollection

--- a/src/Core/Content/MailTemplate/Aggregate/MailHeaderFooter/MailHeaderFooterCollection.php
+++ b/src/Core/Content/MailTemplate/Aggregate/MailHeaderFooter/MailHeaderFooterCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<MailHeaderFooterEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('after-sales')]
 class MailHeaderFooterCollection extends EntityCollection

--- a/src/Core/Content/MailTemplate/Aggregate/MailHeaderFooterTranslation/MailHeaderFooterTranslationCollection.php
+++ b/src/Core/Content/MailTemplate/Aggregate/MailHeaderFooterTranslation/MailHeaderFooterTranslationCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<MailHeaderFooterTranslationEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('after-sales')]
 class MailHeaderFooterTranslationCollection extends EntityCollection

--- a/src/Core/Content/MailTemplate/Aggregate/MailTemplateMedia/MailTemplateMediaCollection.php
+++ b/src/Core/Content/MailTemplate/Aggregate/MailTemplateMedia/MailTemplateMediaCollection.php
@@ -8,6 +8,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<MailTemplateMediaEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('after-sales')]
 class MailTemplateMediaCollection extends EntityCollection

--- a/src/Core/Content/MailTemplate/Aggregate/MailTemplateTranslation/MailTemplateTranslationCollection.php
+++ b/src/Core/Content/MailTemplate/Aggregate/MailTemplateTranslation/MailTemplateTranslationCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<MailTemplateTranslationEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('after-sales')]
 class MailTemplateTranslationCollection extends EntityCollection

--- a/src/Core/Content/MailTemplate/Aggregate/MailTemplateType/MailTemplateTypeCollection.php
+++ b/src/Core/Content/MailTemplate/Aggregate/MailTemplateType/MailTemplateTypeCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<MailTemplateTypeEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('after-sales')]
 class MailTemplateTypeCollection extends EntityCollection

--- a/src/Core/Content/MailTemplate/Aggregate/MailTemplateTypeTranslation/MailTemplateTypeTranslationCollection.php
+++ b/src/Core/Content/MailTemplate/Aggregate/MailTemplateTypeTranslation/MailTemplateTypeTranslationCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<MailTemplateTypeTranslationEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('after-sales')]
 class MailTemplateTypeTranslationCollection extends EntityCollection

--- a/src/Core/Content/MailTemplate/MailTemplateCollection.php
+++ b/src/Core/Content/MailTemplate/MailTemplateCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<MailTemplateEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('after-sales')]
 class MailTemplateCollection extends EntityCollection

--- a/src/Core/Content/MeasurementSystem/Field/MeasurementUnitsField.php
+++ b/src/Core/Content/MeasurementSystem/Field/MeasurementUnitsField.php
@@ -5,6 +5,9 @@ namespace Shopware\Core\Content\MeasurementSystem\Field;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\ObjectField;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class MeasurementUnitsField extends ObjectField
 {

--- a/src/Core/Content/Media/Aggregate/MediaDefaultFolder/MediaDefaultFolderCollection.php
+++ b/src/Core/Content/Media/Aggregate/MediaDefaultFolder/MediaDefaultFolderCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<MediaDefaultFolderEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('discovery')]
 class MediaDefaultFolderCollection extends EntityCollection

--- a/src/Core/Content/Media/Aggregate/MediaFolder/MediaFolderCollection.php
+++ b/src/Core/Content/Media/Aggregate/MediaFolder/MediaFolderCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<MediaFolderEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('discovery')]
 class MediaFolderCollection extends EntityCollection

--- a/src/Core/Content/Media/Aggregate/MediaFolderConfiguration/MediaFolderConfigurationCollection.php
+++ b/src/Core/Content/Media/Aggregate/MediaFolderConfiguration/MediaFolderConfigurationCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<MediaFolderConfigurationEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('discovery')]
 class MediaFolderConfigurationCollection extends EntityCollection

--- a/src/Core/Content/Media/Aggregate/MediaThumbnail/MediaThumbnailCollection.php
+++ b/src/Core/Content/Media/Aggregate/MediaThumbnail/MediaThumbnailCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<MediaThumbnailEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('discovery')]
 class MediaThumbnailCollection extends EntityCollection

--- a/src/Core/Content/Media/Aggregate/MediaThumbnailSize/MediaThumbnailSizeCollection.php
+++ b/src/Core/Content/Media/Aggregate/MediaThumbnailSize/MediaThumbnailSizeCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<MediaThumbnailSizeEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('discovery')]
 class MediaThumbnailSizeCollection extends EntityCollection

--- a/src/Core/Content/Media/Aggregate/MediaTranslation/MediaTranslationCollection.php
+++ b/src/Core/Content/Media/Aggregate/MediaTranslation/MediaTranslationCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<MediaTranslationEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('discovery')]
 class MediaTranslationCollection extends EntityCollection

--- a/src/Core/Content/Media/Core/Params/MediaLocationStruct.php
+++ b/src/Core/Content/Media/Core/Params/MediaLocationStruct.php
@@ -12,6 +12,8 @@ use Shopware\Core\Framework\Struct\Struct;
  * and build over the database or by the request when the media was uploaded or renamed
  *
  * @final
+ *
+ * @codeCoverageIgnore
  */
 #[Package('discovery')]
 class MediaLocationStruct extends Struct

--- a/src/Core/Content/Media/Core/Params/ThumbnailLocationStruct.php
+++ b/src/Core/Content/Media/Core/Params/ThumbnailLocationStruct.php
@@ -12,6 +12,8 @@ use Shopware\Core\Framework\Struct\Struct;
  * and build over the database or by the request when the media was uploaded or renamed
  *
  * @final
+ *
+ * @codeCoverageIgnore
  */
 #[Package('discovery')]
 class ThumbnailLocationStruct extends Struct

--- a/src/Core/Content/Media/MediaCollection.php
+++ b/src/Core/Content/Media/MediaCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<MediaEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('discovery')]
 class MediaCollection extends EntityCollection

--- a/src/Core/Content/Media/Thumbnail/ExternalThumbnailCollection.php
+++ b/src/Core/Content/Media/Thumbnail/ExternalThumbnailCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Struct\Collection;
 
 /**
  * @extends Collection<ExternalThumbnailData>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('discovery')]
 class ExternalThumbnailCollection extends Collection

--- a/src/Core/Content/Newsletter/Aggregate/NewsletterRecipient/NewsletterRecipientCollection.php
+++ b/src/Core/Content/Newsletter/Aggregate/NewsletterRecipient/NewsletterRecipientCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<NewsletterRecipientEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('after-sales')]
 class NewsletterRecipientCollection extends EntityCollection

--- a/src/Core/Content/Product/Aggregate/ProductCrossSelling/ProductCrossSellingCollection.php
+++ b/src/Core/Content/Product/Aggregate/ProductCrossSelling/ProductCrossSellingCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<ProductCrossSellingEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('inventory')]
 class ProductCrossSellingCollection extends EntityCollection

--- a/src/Core/Content/Product/Aggregate/ProductCrossSellingAssignedProducts/ProductCrossSellingAssignedProductsCollection.php
+++ b/src/Core/Content/Product/Aggregate/ProductCrossSellingAssignedProducts/ProductCrossSellingAssignedProductsCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<ProductCrossSellingAssignedProductsEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('inventory')]
 class ProductCrossSellingAssignedProductsCollection extends EntityCollection

--- a/src/Core/Content/Product/Aggregate/ProductCrossSellingTranslation/ProductCrossSellingTranslationCollection.php
+++ b/src/Core/Content/Product/Aggregate/ProductCrossSellingTranslation/ProductCrossSellingTranslationCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<ProductCrossSellingTranslationEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('inventory')]
 class ProductCrossSellingTranslationCollection extends EntityCollection

--- a/src/Core/Content/Product/Aggregate/ProductDownload/ProductDownloadCollection.php
+++ b/src/Core/Content/Product/Aggregate/ProductDownload/ProductDownloadCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<ProductDownloadEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('inventory')]
 class ProductDownloadCollection extends EntityCollection

--- a/src/Core/Content/Product/Aggregate/ProductFeatureSet/ProductFeatureSetCollection.php
+++ b/src/Core/Content/Product/Aggregate/ProductFeatureSet/ProductFeatureSetCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<ProductFeatureSetEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('inventory')]
 class ProductFeatureSetCollection extends EntityCollection

--- a/src/Core/Content/Product/Aggregate/ProductFeatureSetTranslation/ProductFeatureSetTranslationCollection.php
+++ b/src/Core/Content/Product/Aggregate/ProductFeatureSetTranslation/ProductFeatureSetTranslationCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<ProductFeatureSetTranslationEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('inventory')]
 class ProductFeatureSetTranslationCollection extends EntityCollection

--- a/src/Core/Content/Product/Aggregate/ProductKeywordDictionary/ProductKeywordDictionaryCollection.php
+++ b/src/Core/Content/Product/Aggregate/ProductKeywordDictionary/ProductKeywordDictionaryCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<ProductKeywordDictionaryEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('inventory')]
 class ProductKeywordDictionaryCollection extends EntityCollection

--- a/src/Core/Content/Product/Aggregate/ProductManufacturer/ProductManufacturerCollection.php
+++ b/src/Core/Content/Product/Aggregate/ProductManufacturer/ProductManufacturerCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<ProductManufacturerEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('inventory')]
 class ProductManufacturerCollection extends EntityCollection

--- a/src/Core/Content/Product/Aggregate/ProductManufacturerTranslation/ProductManufacturerTranslationCollection.php
+++ b/src/Core/Content/Product/Aggregate/ProductManufacturerTranslation/ProductManufacturerTranslationCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<ProductManufacturerTranslationEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('inventory')]
 class ProductManufacturerTranslationCollection extends EntityCollection

--- a/src/Core/Content/Product/Aggregate/ProductMedia/ProductMediaCollection.php
+++ b/src/Core/Content/Product/Aggregate/ProductMedia/ProductMediaCollection.php
@@ -9,6 +9,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<ProductMediaEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('inventory')]
 class ProductMediaCollection extends EntityCollection

--- a/src/Core/Content/Product/Aggregate/ProductReview/ProductReviewCollection.php
+++ b/src/Core/Content/Product/Aggregate/ProductReview/ProductReviewCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<ProductReviewEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('after-sales')]
 class ProductReviewCollection extends EntityCollection

--- a/src/Core/Content/Product/Aggregate/ProductSearchConfig/ProductSearchConfigCollection.php
+++ b/src/Core/Content/Product/Aggregate/ProductSearchConfig/ProductSearchConfigCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<ProductSearchConfigEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('inventory')]
 class ProductSearchConfigCollection extends EntityCollection

--- a/src/Core/Content/Product/Aggregate/ProductSearchConfigField/ProductSearchConfigFieldCollection.php
+++ b/src/Core/Content/Product/Aggregate/ProductSearchConfigField/ProductSearchConfigFieldCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<ProductSearchConfigFieldEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('inventory')]
 class ProductSearchConfigFieldCollection extends EntityCollection

--- a/src/Core/Content/Product/Aggregate/ProductSearchKeyword/ProductSearchKeywordCollection.php
+++ b/src/Core/Content/Product/Aggregate/ProductSearchKeyword/ProductSearchKeywordCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<ProductSearchKeywordEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('inventory')]
 class ProductSearchKeywordCollection extends EntityCollection

--- a/src/Core/Content/Product/Aggregate/ProductTranslation/ProductTranslationCollection.php
+++ b/src/Core/Content/Product/Aggregate/ProductTranslation/ProductTranslationCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<ProductTranslationEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('inventory')]
 class ProductTranslationCollection extends EntityCollection

--- a/src/Core/Content/Product/Aggregate/ProductVisibility/ProductVisibilityCollection.php
+++ b/src/Core/Content/Product/Aggregate/ProductVisibility/ProductVisibilityCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<ProductVisibilityEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('inventory')]
 class ProductVisibilityCollection extends EntityCollection

--- a/src/Core/Content/Product/DataAbstractionLayer/CheapestPrice/CheapestPriceField.php
+++ b/src/Core/Content/Product/DataAbstractionLayer/CheapestPrice/CheapestPriceField.php
@@ -7,6 +7,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\JsonField;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldSerializer\PHPUnserializeFieldSerializer;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('framework')]
 class CheapestPriceField extends JsonField
 {

--- a/src/Core/Content/Product/ProductCollection.php
+++ b/src/Core/Content/Product/ProductCollection.php
@@ -9,6 +9,8 @@ use Shopware\Core\Framework\Log\Package;
  * @template TElement of ProductEntity = ProductEntity
  *
  * @extends EntityCollection<TElement>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('inventory')]
 class ProductCollection extends EntityCollection

--- a/src/Core/Content/Product/SalesChannel/CrossSelling/CrossSellingElementCollection.php
+++ b/src/Core/Content/Product/SalesChannel/CrossSelling/CrossSellingElementCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Struct\Collection;
 
 /**
  * @extends Collection<CrossSellingElement>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('inventory')]
 class CrossSellingElementCollection extends Collection

--- a/src/Core/Content/Product/SalesChannel/SalesChannelProductCollection.php
+++ b/src/Core/Content/Product/SalesChannel/SalesChannelProductCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends ProductCollection<SalesChannelProductEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('inventory')]
 class SalesChannelProductCollection extends ProductCollection

--- a/src/Core/Content/Product/SalesChannel/Sorting/ProductSortingTranslationCollection.php
+++ b/src/Core/Content/Product/SalesChannel/Sorting/ProductSortingTranslationCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<ProductSortingTranslationEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('inventory')]
 class ProductSortingTranslationCollection extends EntityCollection

--- a/src/Core/Content/ProductExport/Error/ErrorCollection.php
+++ b/src/Core/Content/ProductExport/Error/ErrorCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Struct\Collection;
 
 /**
  * @extends Collection<Error>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('inventory')]
 class ErrorCollection extends Collection

--- a/src/Core/Content/ProductExport/ProductExportCollection.php
+++ b/src/Core/Content/ProductExport/ProductExportCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<ProductExportEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('inventory')]
 class ProductExportCollection extends EntityCollection

--- a/src/Core/Content/ProductStream/Aggregate/ProductStreamFilter/ProductStreamFilterCollection.php
+++ b/src/Core/Content/ProductStream/Aggregate/ProductStreamFilter/ProductStreamFilterCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<ProductStreamFilterEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('inventory')]
 class ProductStreamFilterCollection extends EntityCollection

--- a/src/Core/Content/ProductStream/Aggregate/ProductStreamTranslation/ProductStreamTranslationCollection.php
+++ b/src/Core/Content/ProductStream/Aggregate/ProductStreamTranslation/ProductStreamTranslationCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<ProductStreamTranslationEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('inventory')]
 class ProductStreamTranslationCollection extends EntityCollection

--- a/src/Core/Content/ProductStream/ProductStreamCollection.php
+++ b/src/Core/Content/ProductStream/ProductStreamCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<ProductStreamEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('inventory')]
 class ProductStreamCollection extends EntityCollection

--- a/src/Core/Content/Property/Aggregate/PropertyGroupOptionTranslation/PropertyGroupOptionTranslationCollection.php
+++ b/src/Core/Content/Property/Aggregate/PropertyGroupOptionTranslation/PropertyGroupOptionTranslationCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<PropertyGroupOptionTranslationEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('inventory')]
 class PropertyGroupOptionTranslationCollection extends EntityCollection

--- a/src/Core/Content/Property/Aggregate/PropertyGroupTranslation/PropertyGroupTranslationCollection.php
+++ b/src/Core/Content/Property/Aggregate/PropertyGroupTranslation/PropertyGroupTranslationCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<PropertyGroupTranslationEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('inventory')]
 class PropertyGroupTranslationCollection extends EntityCollection

--- a/src/Core/Content/Rule/Aggregate/RuleCondition/RuleConditionCollection.php
+++ b/src/Core/Content/Rule/Aggregate/RuleCondition/RuleConditionCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<RuleConditionEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('fundamentals@after-sales')]
 class RuleConditionCollection extends EntityCollection

--- a/src/Core/Content/Seo/Hreflang/HreflangCollection.php
+++ b/src/Core/Content/Seo/Hreflang/HreflangCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Struct\StructCollection;
 
 /**
  * @extends StructCollection<HreflangStruct>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('inventory')]
 class HreflangCollection extends StructCollection

--- a/src/Core/Content/Seo/Hreflang/HreflangStruct.php
+++ b/src/Core/Content/Seo/Hreflang/HreflangStruct.php
@@ -5,6 +5,9 @@ namespace Shopware\Core\Content\Seo\Hreflang;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\Struct;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class HreflangStruct extends Struct
 {

--- a/src/Core/Content/Seo/MainCategory/MainCategoryCollection.php
+++ b/src/Core/Content/Seo/MainCategory/MainCategoryCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<MainCategoryEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('inventory')]
 class MainCategoryCollection extends EntityCollection

--- a/src/Core/Content/Seo/SeoUrl/SeoUrlCollection.php
+++ b/src/Core/Content/Seo/SeoUrl/SeoUrlCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<SeoUrlEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('inventory')]
 class SeoUrlCollection extends EntityCollection

--- a/src/Core/Content/Seo/SeoUrlTemplate/SeoUrlTemplateCollection.php
+++ b/src/Core/Content/Seo/SeoUrlTemplate/SeoUrlTemplateCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<SeoUrlTemplateEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('inventory')]
 class SeoUrlTemplateCollection extends EntityCollection

--- a/src/Core/Content/Sitemap/Struct/SitemapCollection.php
+++ b/src/Core/Content/Sitemap/Struct/SitemapCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Struct\Collection;
 
 /**
  * @extends Collection<Sitemap>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('discovery')]
 class SitemapCollection extends Collection


### PR DESCRIPTION
### 1. Why is this change necessary?

PHPUnit 12 validates every `#[CoversClass]` target against the coverage source, and the blanket suffix excludes for `src/Core/Content/` turn covered DAL boilerplate classes into invalid targets. The reversal replaces the blanket excludes with per-class annotations (Checkout precedent: #19268), split into per-suffix chunks for reviewability.

### 2. What does this change do, exactly?

Annotates 78 logic-free Content Struct, Collection and Field classes with a per-class `@codeCoverageIgnore`. The annotations have no effect while the suffix excludes in `phpunit.xml.dist` are still in place, so this chunk is behaviour-neutral and can merge in any order. The excludes are lifted in the final pull request of the series (#19449) once all chunks are merged.

Classes with logic or existing tests are deliberately not annotated here; they are handled in #19449.

### 3. Describe each step to reproduce the issue or behaviour.

Annotation-only change. Each touched class gains a `@codeCoverageIgnore` docblock line; no behaviour, no coverage change while the excludes remain.

### 4. Please link to the relevant issues (if any).

- relates #18344

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
