### PR TITLE
test: mark Content events codeCoverageIgnore

### DIFF
--- a/phpstan-baseline.php
+++ b/phpstan-baseline.php
@@ -140,12 +140,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/src/Core/Content/Media/TypeDetector/TypeDetector.php',
 ];
 $ignoreErrors[] = [
-    'rawMessage' => 'Method Shopware\\Core\\Content\\Newsletter\\Event\\NewsletterSubscribeUrlEvent::getData() return type has no value type specified in iterable type array.',
-    'identifier' => 'missingType.iterableValue',
-    'count' => 1,
-    'path' => __DIR__ . '/src/Core/Content/Newsletter/Event/NewsletterSubscribeUrlEvent.php',
-];
-$ignoreErrors[] = [
     'rawMessage' => 'Construct empty() is not allowed. Use more strict comparison.',
     'identifier' => 'empty.notAllowed',
     'count' => 1,

--- a/src/Core/Content/Category/Event/CategoryIndexerEvent.php
+++ b/src/Core/Content/Category/Event/CategoryIndexerEvent.php
@@ -6,6 +6,9 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Event\NestedEvent;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class CategoryIndexerEvent extends NestedEvent
 {

--- a/src/Core/Content/Category/Event/CategoryRouteCacheKeyEvent.php
+++ b/src/Core/Content/Category/Event/CategoryRouteCacheKeyEvent.php
@@ -12,6 +12,8 @@ use Symfony\Component\HttpFoundation\Request;
 #[Package('discovery')]
 /**
  * @deprecated tag:v6.8.0 - Will be removed in 6.8.0 as it was not used anymore
+ *
+ * @codeCoverageIgnore
  */
 class CategoryRouteCacheKeyEvent extends StoreApiRouteCacheKeyEvent
 {

--- a/src/Core/Content/Category/Event/CategoryRouteCacheTagsEvent.php
+++ b/src/Core/Content/Category/Event/CategoryRouteCacheTagsEvent.php
@@ -13,6 +13,8 @@ use Symfony\Component\HttpFoundation\Request;
 #[Package('discovery')]
 /**
  * @deprecated tag:v6.8.0 - Will be removed in 6.8.0 as it was not used anymore
+ *
+ * @codeCoverageIgnore
  */
 class CategoryRouteCacheTagsEvent extends StoreApiRouteCacheTagsEvent
 {

--- a/src/Core/Content/Category/Event/NavigationLoadedEvent.php
+++ b/src/Core/Content/Category/Event/NavigationLoadedEvent.php
@@ -9,6 +9,9 @@ use Shopware\Core\Framework\Event\ShopwareSalesChannelEvent;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class NavigationLoadedEvent extends NestedEvent implements ShopwareSalesChannelEvent
 {

--- a/src/Core/Content/Category/Event/NavigationRouteCacheKeyEvent.php
+++ b/src/Core/Content/Category/Event/NavigationRouteCacheKeyEvent.php
@@ -12,6 +12,8 @@ use Symfony\Component\HttpFoundation\Request;
 #[Package('discovery')]
 /**
  * @deprecated tag:v6.8.0 - Will be removed in 6.8.0 as it was not used anymore
+ *
+ * @codeCoverageIgnore
  */
 class NavigationRouteCacheKeyEvent extends StoreApiRouteCacheKeyEvent
 {

--- a/src/Core/Content/Category/Event/NavigationRouteCacheTagsEvent.php
+++ b/src/Core/Content/Category/Event/NavigationRouteCacheTagsEvent.php
@@ -13,6 +13,8 @@ use Symfony\Component\HttpFoundation\Request;
 #[Package('discovery')]
 /**
  * @deprecated tag:v6.8.0 - Will be removed in 6.8.0 as it was not used anymore
+ *
+ * @codeCoverageIgnore
  */
 class NavigationRouteCacheTagsEvent extends StoreApiRouteCacheTagsEvent
 {

--- a/src/Core/Content/Cms/Events/CmsPageLoaderCriteriaEvent.php
+++ b/src/Core/Content/Cms/Events/CmsPageLoaderCriteriaEvent.php
@@ -10,6 +10,9 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\HttpFoundation\Request;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class CmsPageLoaderCriteriaEvent extends NestedEvent implements ShopwareSalesChannelEvent
 {

--- a/src/Core/Content/Cookie/Event/CookieGroupCollectEvent.php
+++ b/src/Core/Content/Cookie/Event/CookieGroupCollectEvent.php
@@ -11,6 +11,9 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\HttpFoundation\Request;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class CookieGroupCollectEvent implements ShopwareSalesChannelEvent
 {

--- a/src/Core/Content/Flow/Events/FlowActionCollectorEvent.php
+++ b/src/Core/Content/Flow/Events/FlowActionCollectorEvent.php
@@ -7,6 +7,9 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Event\NestedEvent;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('after-sales')]
 class FlowActionCollectorEvent extends NestedEvent
 {

--- a/src/Core/Content/Flow/Events/FlowIndexerEvent.php
+++ b/src/Core/Content/Flow/Events/FlowIndexerEvent.php
@@ -6,6 +6,9 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Event\NestedEvent;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('after-sales')]
 class FlowIndexerEvent extends NestedEvent
 {

--- a/src/Core/Content/ImportExport/Event/ImportExportAfterImportRecordEvent.php
+++ b/src/Core/Content/ImportExport/Event/ImportExportAfterImportRecordEvent.php
@@ -8,6 +8,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\Event\EntityWrittenContainerEve
 use Shopware\Core\Framework\Log\Package;
 use Symfony\Contracts\EventDispatcher\Event;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('fundamentals@after-sales')]
 class ImportExportAfterImportRecordEvent extends Event
 {

--- a/src/Core/Content/ImportExport/Event/ImportExportAfterProcessFinishedEvent.php
+++ b/src/Core/Content/ImportExport/Event/ImportExportAfterProcessFinishedEvent.php
@@ -8,6 +8,9 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Log\Package;
 use Symfony\Contracts\EventDispatcher\Event;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('fundamentals@after-sales')]
 class ImportExportAfterProcessFinishedEvent extends Event
 {

--- a/src/Core/Content/ImportExport/Event/ImportExportBeforeImportRecordEvent.php
+++ b/src/Core/Content/ImportExport/Event/ImportExportBeforeImportRecordEvent.php
@@ -7,6 +7,9 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Log\Package;
 use Symfony\Contracts\EventDispatcher\Event;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('fundamentals@after-sales')]
 class ImportExportBeforeImportRecordEvent extends Event
 {

--- a/src/Core/Content/ImportExport/Event/ImportExportBeforeImportRowEvent.php
+++ b/src/Core/Content/ImportExport/Event/ImportExportBeforeImportRowEvent.php
@@ -7,6 +7,9 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Log\Package;
 use Symfony\Contracts\EventDispatcher\Event;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('fundamentals@after-sales')]
 class ImportExportBeforeImportRowEvent extends Event
 {

--- a/src/Core/Content/ImportExport/Event/ImportExportExceptionExportRecordEvent.php
+++ b/src/Core/Content/ImportExport/Event/ImportExportExceptionExportRecordEvent.php
@@ -7,6 +7,9 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Log\Package;
 use Symfony\Contracts\EventDispatcher\Event;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('fundamentals@after-sales')]
 class ImportExportExceptionExportRecordEvent extends Event
 {

--- a/src/Core/Content/LandingPage/Event/LandingPageIndexerEvent.php
+++ b/src/Core/Content/LandingPage/Event/LandingPageIndexerEvent.php
@@ -6,6 +6,9 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Event\NestedEvent;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class LandingPageIndexerEvent extends NestedEvent
 {

--- a/src/Core/Content/LandingPage/Event/LandingPageRouteCacheKeyEvent.php
+++ b/src/Core/Content/LandingPage/Event/LandingPageRouteCacheKeyEvent.php
@@ -12,6 +12,8 @@ use Symfony\Component\HttpFoundation\Request;
 #[Package('discovery')]
 /**
  * @deprecated tag:v6.8.0 - Will be removed in 6.8.0 as it was not used anymore
+ *
+ * @codeCoverageIgnore
  */
 class LandingPageRouteCacheKeyEvent extends StoreApiRouteCacheKeyEvent
 {

--- a/src/Core/Content/LandingPage/Event/LandingPageRouteCacheTagsEvent.php
+++ b/src/Core/Content/LandingPage/Event/LandingPageRouteCacheTagsEvent.php
@@ -14,6 +14,8 @@ use Symfony\Component\HttpFoundation\Request;
 #[Package('discovery')]
 /**
  * @deprecated tag:v6.8.0 - Will be removed in 6.8.0 as it was not used anymore
+ *
+ * @codeCoverageIgnore
  */
 class LandingPageRouteCacheTagsEvent extends StoreApiRouteCacheTagsEvent
 {

--- a/src/Core/Content/MailTemplate/Service/Event/MailDataSimulatorFieldEvent.php
+++ b/src/Core/Content/MailTemplate/Service/Event/MailDataSimulatorFieldEvent.php
@@ -7,6 +7,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\Field;
 use Shopware\Core\Framework\Log\Package;
 use Symfony\Contracts\EventDispatcher\Event;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('after-sales')]
 class MailDataSimulatorFieldEvent extends Event
 {

--- a/src/Core/Content/MailTemplate/Service/Event/MailDataSimulatorFormDataEvent.php
+++ b/src/Core/Content/MailTemplate/Service/Event/MailDataSimulatorFormDataEvent.php
@@ -6,6 +6,9 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Log\Package;
 use Symfony\Contracts\EventDispatcher\Event;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('after-sales')]
 class MailDataSimulatorFormDataEvent extends Event
 {

--- a/src/Core/Content/Media/Event/MediaFolderConfigurationIndexerEvent.php
+++ b/src/Core/Content/Media/Event/MediaFolderConfigurationIndexerEvent.php
@@ -6,6 +6,9 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Event\NestedEvent;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class MediaFolderConfigurationIndexerEvent extends NestedEvent
 {

--- a/src/Core/Content/Media/Event/MediaFolderIndexerEvent.php
+++ b/src/Core/Content/Media/Event/MediaFolderIndexerEvent.php
@@ -6,6 +6,9 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Event\NestedEvent;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class MediaFolderIndexerEvent extends NestedEvent
 {

--- a/src/Core/Content/Media/Event/MediaIndexerEvent.php
+++ b/src/Core/Content/Media/Event/MediaIndexerEvent.php
@@ -6,6 +6,9 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Event\NestedEvent;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class MediaIndexerEvent extends NestedEvent
 {

--- a/src/Core/Content/Media/Event/MediaPathChangedEvent.php
+++ b/src/Core/Content/Media/Event/MediaPathChangedEvent.php
@@ -9,6 +9,9 @@ use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Symfony\Contracts\EventDispatcher\Event;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class MediaPathChangedEvent extends Event
 {

--- a/src/Core/Content/Media/Event/MediaThumbnailDeletedEvent.php
+++ b/src/Core/Content/Media/Event/MediaThumbnailDeletedEvent.php
@@ -7,6 +7,9 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Log\Package;
 use Symfony\Contracts\EventDispatcher\Event;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class MediaThumbnailDeletedEvent extends Event
 {

--- a/src/Core/Content/Media/Event/ThumbnailGeneratedEvent.php
+++ b/src/Core/Content/Media/Event/ThumbnailGeneratedEvent.php
@@ -7,6 +7,9 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Log\Package;
 use Symfony\Contracts\EventDispatcher\Event;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class ThumbnailGeneratedEvent extends Event
 {

--- a/src/Core/Content/Media/Event/UnusedMediaSearchStartEvent.php
+++ b/src/Core/Content/Media/Event/UnusedMediaSearchStartEvent.php
@@ -6,6 +6,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @internal
+ *
+ * @codeCoverageIgnore
  */
 #[Package('discovery')]
 class UnusedMediaSearchStartEvent

--- a/src/Core/Content/Newsletter/Event/NewsletterRecipientIndexerEvent.php
+++ b/src/Core/Content/Newsletter/Event/NewsletterRecipientIndexerEvent.php
@@ -6,6 +6,9 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Event\NestedEvent;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('after-sales')]
 class NewsletterRecipientIndexerEvent extends NestedEvent
 {

--- a/src/Core/Content/Newsletter/Event/NewsletterSubscribeUrlEvent.php
+++ b/src/Core/Content/Newsletter/Event/NewsletterSubscribeUrlEvent.php
@@ -9,6 +9,9 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Contracts\EventDispatcher\Event;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('after-sales')]
 class NewsletterSubscribeUrlEvent extends Event implements ShopwareSalesChannelEvent
 {

--- a/src/Core/Content/Newsletter/Event/NewsletterSubscribeUrlEvent.php
+++ b/src/Core/Content/Newsletter/Event/NewsletterSubscribeUrlEvent.php
@@ -63,6 +63,9 @@ class NewsletterSubscribeUrlEvent extends Event implements ShopwareSalesChannelE
         return $this->hash;
     }
 
+    /**
+     * @return array<string, mixed>
+     */
     public function getData(): array
     {
         return $this->data;

--- a/src/Core/Content/Product/Events/CrossSellingRouteCacheKeyEvent.php
+++ b/src/Core/Content/Product/Events/CrossSellingRouteCacheKeyEvent.php
@@ -12,6 +12,8 @@ use Symfony\Component\HttpFoundation\Request;
 #[Package('inventory')]
 /**
  * @deprecated tag:v6.8.0 - Will be removed in 6.8.0 as it was not used anymore
+ *
+ * @codeCoverageIgnore
  */
 class CrossSellingRouteCacheKeyEvent extends StoreApiRouteCacheKeyEvent
 {

--- a/src/Core/Content/Product/Events/CrossSellingRouteCacheTagsEvent.php
+++ b/src/Core/Content/Product/Events/CrossSellingRouteCacheTagsEvent.php
@@ -13,6 +13,8 @@ use Symfony\Component\HttpFoundation\Request;
 #[Package('inventory')]
 /**
  * @deprecated tag:v6.8.0 - Will be removed in 6.8.0 as it was not used anymore
+ *
+ * @codeCoverageIgnore
  */
 class CrossSellingRouteCacheTagsEvent extends StoreApiRouteCacheTagsEvent
 {

--- a/src/Core/Content/Product/Events/ProductCrossSellingCriteriaEvent.php
+++ b/src/Core/Content/Product/Events/ProductCrossSellingCriteriaEvent.php
@@ -10,6 +10,9 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Contracts\EventDispatcher\Event;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 abstract class ProductCrossSellingCriteriaEvent extends Event implements ShopwareSalesChannelEvent
 {

--- a/src/Core/Content/Product/Events/ProductCrossSellingCriteriaLoadEvent.php
+++ b/src/Core/Content/Product/Events/ProductCrossSellingCriteriaLoadEvent.php
@@ -9,6 +9,9 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Contracts\EventDispatcher\Event;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductCrossSellingCriteriaLoadEvent extends Event implements ShopwareSalesChannelEvent
 {

--- a/src/Core/Content/Product/Events/ProductCrossSellingIdsCriteriaEvent.php
+++ b/src/Core/Content/Product/Events/ProductCrossSellingIdsCriteriaEvent.php
@@ -4,6 +4,9 @@ namespace Shopware\Core\Content\Product\Events;
 
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductCrossSellingIdsCriteriaEvent extends ProductCrossSellingCriteriaEvent
 {

--- a/src/Core/Content/Product/Events/ProductCrossSellingStreamCriteriaEvent.php
+++ b/src/Core/Content/Product/Events/ProductCrossSellingStreamCriteriaEvent.php
@@ -4,6 +4,9 @@ namespace Shopware\Core\Content\Product\Events;
 
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductCrossSellingStreamCriteriaEvent extends ProductCrossSellingCriteriaEvent
 {

--- a/src/Core/Content/Product/Events/ProductCrossSellingsLoadedEvent.php
+++ b/src/Core/Content/Product/Events/ProductCrossSellingsLoadedEvent.php
@@ -9,6 +9,9 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Contracts\EventDispatcher\Event;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductCrossSellingsLoadedEvent extends Event implements ShopwareSalesChannelEvent
 {

--- a/src/Core/Content/Product/Events/ProductDetailRouteCacheKeyEvent.php
+++ b/src/Core/Content/Product/Events/ProductDetailRouteCacheKeyEvent.php
@@ -8,6 +8,8 @@ use Shopware\Core\Framework\Log\Package;
 #[Package('inventory')]
 /**
  * @deprecated tag:v6.8.0 - Will be removed in 6.8.0 as it was not used anymore
+ *
+ * @codeCoverageIgnore
  */
 class ProductDetailRouteCacheKeyEvent extends StoreApiRouteCacheKeyEvent
 {

--- a/src/Core/Content/Product/Events/ProductDetailRouteCacheTagsEvent.php
+++ b/src/Core/Content/Product/Events/ProductDetailRouteCacheTagsEvent.php
@@ -8,6 +8,8 @@ use Shopware\Core\Framework\Log\Package;
 #[Package('inventory')]
 /**
  * @deprecated tag:v6.8.0 - Will be removed in 6.8.0 as it was not used anymore
+ *
+ * @codeCoverageIgnore
  */
 class ProductDetailRouteCacheTagsEvent extends StoreApiRouteCacheTagsEvent
 {

--- a/src/Core/Content/Product/Events/ProductGatewayCriteriaEvent.php
+++ b/src/Core/Content/Product/Events/ProductGatewayCriteriaEvent.php
@@ -9,6 +9,9 @@ use Shopware\Core\Framework\Event\ShopwareSalesChannelEvent;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductGatewayCriteriaEvent extends NestedEvent implements ShopwareSalesChannelEvent
 {

--- a/src/Core/Content/Product/Events/ProductIndexerEvent.php
+++ b/src/Core/Content/Product/Events/ProductIndexerEvent.php
@@ -6,6 +6,9 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Event\NestedEvent;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductIndexerEvent extends NestedEvent implements ProductChangedEventInterface
 {

--- a/src/Core/Content/Product/Events/ProductListingCollectFilterEvent.php
+++ b/src/Core/Content/Product/Events/ProductListingCollectFilterEvent.php
@@ -10,6 +10,9 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\HttpFoundation\Request;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductListingCollectFilterEvent extends NestedEvent implements ShopwareSalesChannelEvent
 {

--- a/src/Core/Content/Product/Events/ProductListingCriteriaEvent.php
+++ b/src/Core/Content/Product/Events/ProductListingCriteriaEvent.php
@@ -10,6 +10,9 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\HttpFoundation\Request;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductListingCriteriaEvent extends NestedEvent implements ShopwareSalesChannelEvent
 {

--- a/src/Core/Content/Product/Events/ProductListingPreviewCriteriaEvent.php
+++ b/src/Core/Content/Product/Events/ProductListingPreviewCriteriaEvent.php
@@ -9,6 +9,9 @@ use Shopware\Core\Framework\Event\ShopwareSalesChannelEvent;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductListingPreviewCriteriaEvent extends NestedEvent implements ShopwareSalesChannelEvent
 {

--- a/src/Core/Content/Product/Events/ProductListingResultEvent.php
+++ b/src/Core/Content/Product/Events/ProductListingResultEvent.php
@@ -10,6 +10,9 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\HttpFoundation\Request;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductListingResultEvent extends NestedEvent implements ShopwareSalesChannelEvent
 {

--- a/src/Core/Content/Product/Events/ProductListingRouteCacheKeyEvent.php
+++ b/src/Core/Content/Product/Events/ProductListingRouteCacheKeyEvent.php
@@ -12,6 +12,8 @@ use Symfony\Component\HttpFoundation\Request;
 #[Package('inventory')]
 /**
  * @deprecated tag:v6.8.0 - Will be removed in 6.8.0 as it was not used anymore
+ *
+ * @codeCoverageIgnore
  */
 class ProductListingRouteCacheKeyEvent extends StoreApiRouteCacheKeyEvent
 {

--- a/src/Core/Content/Product/Events/ProductListingRouteCacheTagsEvent.php
+++ b/src/Core/Content/Product/Events/ProductListingRouteCacheTagsEvent.php
@@ -14,6 +14,8 @@ use Symfony\Component\HttpFoundation\Request;
 #[Package('inventory')]
 /**
  * @deprecated tag:v6.8.0 - Will be removed in 6.8.0 as it was not used anymore
+ *
+ * @codeCoverageIgnore
  */
 class ProductListingRouteCacheTagsEvent extends StoreApiRouteCacheTagsEvent
 {

--- a/src/Core/Content/Product/Events/ProductNoLongerAvailableEvent.php
+++ b/src/Core/Content/Product/Events/ProductNoLongerAvailableEvent.php
@@ -7,6 +7,9 @@ use Shopware\Core\Framework\Event\ShopwareEvent;
 use Shopware\Core\Framework\Log\Package;
 use Symfony\Contracts\EventDispatcher\Event;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductNoLongerAvailableEvent extends Event implements ShopwareEvent, ProductChangedEventInterface
 {

--- a/src/Core/Content/Product/Events/ProductSearchCriteriaEvent.php
+++ b/src/Core/Content/Product/Events/ProductSearchCriteriaEvent.php
@@ -4,6 +4,9 @@ namespace Shopware\Core\Content\Product\Events;
 
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductSearchCriteriaEvent extends ProductListingCriteriaEvent
 {

--- a/src/Core/Content/Product/Events/ProductSearchResultEvent.php
+++ b/src/Core/Content/Product/Events/ProductSearchResultEvent.php
@@ -4,6 +4,9 @@ namespace Shopware\Core\Content\Product\Events;
 
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductSearchResultEvent extends ProductListingResultEvent
 {

--- a/src/Core/Content/Product/Events/ProductSearchRouteCacheKeyEvent.php
+++ b/src/Core/Content/Product/Events/ProductSearchRouteCacheKeyEvent.php
@@ -8,6 +8,8 @@ use Shopware\Core\Framework\Log\Package;
 #[Package('inventory')]
 /**
  * @deprecated tag:v6.8.0 - Will be removed in 6.8.0 as it was not used anymore
+ *
+ * @codeCoverageIgnore
  */
 class ProductSearchRouteCacheKeyEvent extends StoreApiRouteCacheKeyEvent
 {

--- a/src/Core/Content/Product/Events/ProductSearchRouteCacheTagsEvent.php
+++ b/src/Core/Content/Product/Events/ProductSearchRouteCacheTagsEvent.php
@@ -8,6 +8,8 @@ use Shopware\Core\Framework\Log\Package;
 #[Package('inventory')]
 /**
  * @deprecated tag:v6.8.0 - Will be removed in 6.8.0 as it was not used anymore
+ *
+ * @codeCoverageIgnore
  */
 class ProductSearchRouteCacheTagsEvent extends StoreApiRouteCacheTagsEvent
 {

--- a/src/Core/Content/Product/Events/ProductSliderStaticCriteriaEvent.php
+++ b/src/Core/Content/Product/Events/ProductSliderStaticCriteriaEvent.php
@@ -9,6 +9,9 @@ use Shopware\Core\Framework\Event\ShopwareSalesChannelEvent;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class ProductSliderStaticCriteriaEvent implements ShopwareSalesChannelEvent
 {

--- a/src/Core/Content/Product/Events/ProductSliderStreamCriteriaEvent.php
+++ b/src/Core/Content/Product/Events/ProductSliderStreamCriteriaEvent.php
@@ -9,6 +9,9 @@ use Shopware\Core\Framework\Event\ShopwareSalesChannelEvent;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class ProductSliderStreamCriteriaEvent implements ShopwareSalesChannelEvent
 {

--- a/src/Core/Content/Product/Events/ProductStockAlteredEvent.php
+++ b/src/Core/Content/Product/Events/ProductStockAlteredEvent.php
@@ -7,6 +7,9 @@ use Shopware\Core\Framework\Event\ShopwareEvent;
 use Shopware\Core\Framework\Log\Package;
 use Symfony\Contracts\EventDispatcher\Event;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductStockAlteredEvent extends Event implements ShopwareEvent, ProductChangedEventInterface
 {

--- a/src/Core/Content/Product/Events/ProductSuggestCriteriaEvent.php
+++ b/src/Core/Content/Product/Events/ProductSuggestCriteriaEvent.php
@@ -4,6 +4,9 @@ namespace Shopware\Core\Content\Product\Events;
 
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductSuggestCriteriaEvent extends ProductListingCriteriaEvent
 {

--- a/src/Core/Content/Product/Events/ProductSuggestResultEvent.php
+++ b/src/Core/Content/Product/Events/ProductSuggestResultEvent.php
@@ -4,6 +4,9 @@ namespace Shopware\Core\Content\Product\Events;
 
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductSuggestResultEvent extends ProductListingResultEvent
 {

--- a/src/Core/Content/Product/Events/ProductSuggestRouteCacheKeyEvent.php
+++ b/src/Core/Content/Product/Events/ProductSuggestRouteCacheKeyEvent.php
@@ -8,6 +8,8 @@ use Shopware\Core\Framework\Log\Package;
 #[Package('inventory')]
 /**
  * @deprecated tag:v6.8.0 - Will be removed in 6.8.0 as it was not used anymore
+ *
+ * @codeCoverageIgnore
  */
 class ProductSuggestRouteCacheKeyEvent extends StoreApiRouteCacheKeyEvent
 {

--- a/src/Core/Content/Product/Events/ProductSuggestRouteCacheTagsEvent.php
+++ b/src/Core/Content/Product/Events/ProductSuggestRouteCacheTagsEvent.php
@@ -8,6 +8,8 @@ use Shopware\Core\Framework\Log\Package;
 #[Package('inventory')]
 /**
  * @deprecated tag:v6.8.0 - Will be removed in 6.8.0 as it was not used anymore
+ *
+ * @codeCoverageIgnore
  */
 class ProductSuggestRouteCacheTagsEvent extends StoreApiRouteCacheTagsEvent
 {

--- a/src/Core/Content/Product/Events/ProductTypeBeforeChangeEvent.php
+++ b/src/Core/Content/Product/Events/ProductTypeBeforeChangeEvent.php
@@ -7,6 +7,9 @@ use Shopware\Core\Framework\Event\ShopwareEvent;
 use Shopware\Core\Framework\Log\Package;
 use Symfony\Contracts\EventDispatcher\Event;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductTypeBeforeChangeEvent extends Event implements ShopwareEvent
 {

--- a/src/Core/Content/Product/Events/ProductTypeChangedEvent.php
+++ b/src/Core/Content/Product/Events/ProductTypeChangedEvent.php
@@ -7,6 +7,9 @@ use Shopware\Core\Framework\Event\ShopwareEvent;
 use Shopware\Core\Framework\Log\Package;
 use Symfony\Contracts\EventDispatcher\Event;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductTypeChangedEvent extends Event implements ShopwareEvent
 {

--- a/src/Core/Content/Product/SalesChannel/Detail/Event/ResolveVariantIdEvent.php
+++ b/src/Core/Content/Product/SalesChannel/Detail/Event/ResolveVariantIdEvent.php
@@ -8,6 +8,9 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Contracts\EventDispatcher\Event;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('checkout')]
 class ResolveVariantIdEvent extends Event implements ShopwareSalesChannelEvent
 {

--- a/src/Core/Content/Product/SalesChannel/Review/Event/ProductReviewsLoadedEvent.php
+++ b/src/Core/Content/Product/SalesChannel/Review/Event/ProductReviewsLoadedEvent.php
@@ -10,6 +10,9 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\HttpFoundation\Request;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('after-sales')]
 final class ProductReviewsLoadedEvent extends NestedEvent implements ShopwareSalesChannelEvent
 {

--- a/src/Core/Content/ProductExport/Event/ProductExportChangeEncodingEvent.php
+++ b/src/Core/Content/ProductExport/Event/ProductExportChangeEncodingEvent.php
@@ -6,6 +6,9 @@ use Shopware\Core\Content\ProductExport\ProductExportEntity;
 use Shopware\Core\Framework\Log\Package;
 use Symfony\Contracts\EventDispatcher\Event;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductExportChangeEncodingEvent extends Event
 {

--- a/src/Core/Content/ProductExport/Event/ProductExportContentTypeEvent.php
+++ b/src/Core/Content/ProductExport/Event/ProductExportContentTypeEvent.php
@@ -5,6 +5,9 @@ namespace Shopware\Core\Content\ProductExport\Event;
 use Shopware\Core\Framework\Log\Package;
 use Symfony\Contracts\EventDispatcher\Event;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductExportContentTypeEvent extends Event
 {

--- a/src/Core/Content/ProductExport/Event/ProductExportProductCriteriaEvent.php
+++ b/src/Core/Content/ProductExport/Event/ProductExportProductCriteriaEvent.php
@@ -11,6 +11,9 @@ use Shopware\Core\Framework\Event\ShopwareSalesChannelEvent;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductExportProductCriteriaEvent extends NestedEvent implements ShopwareSalesChannelEvent
 {

--- a/src/Core/Content/ProductExport/Event/ProductExportRenderBodyContextEvent.php
+++ b/src/Core/Content/ProductExport/Event/ProductExportRenderBodyContextEvent.php
@@ -6,6 +6,9 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\Struct;
 use Symfony\Contracts\EventDispatcher\Event;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductExportRenderBodyContextEvent extends Event
 {

--- a/src/Core/Content/ProductExport/Event/ProductExportRenderFooterContextEvent.php
+++ b/src/Core/Content/ProductExport/Event/ProductExportRenderFooterContextEvent.php
@@ -6,6 +6,9 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\Struct;
 use Symfony\Contracts\EventDispatcher\Event;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductExportRenderFooterContextEvent extends Event
 {

--- a/src/Core/Content/ProductExport/Event/ProductExportRenderHeaderContextEvent.php
+++ b/src/Core/Content/ProductExport/Event/ProductExportRenderHeaderContextEvent.php
@@ -6,6 +6,9 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\Struct;
 use Symfony\Contracts\EventDispatcher\Event;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductExportRenderHeaderContextEvent extends Event
 {

--- a/src/Core/Content/ProductStream/Event/ProductStreamIndexerEvent.php
+++ b/src/Core/Content/ProductStream/Event/ProductStreamIndexerEvent.php
@@ -6,6 +6,9 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Event\NestedEvent;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductStreamIndexerEvent extends NestedEvent
 {

--- a/src/Core/Content/RevocationRequest/Event/RevocationRequestEvent.php
+++ b/src/Core/Content/RevocationRequest/Event/RevocationRequestEvent.php
@@ -15,6 +15,9 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Validation\DataBag\DataBag;
 use Symfony\Contracts\EventDispatcher\Event;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('after-sales')]
 final class RevocationRequestEvent extends Event implements SalesChannelAware, MailAware, ScalarValuesAware, FlowEventAware
 {

--- a/src/Core/Content/Rule/Event/RuleIndexerEvent.php
+++ b/src/Core/Content/Rule/Event/RuleIndexerEvent.php
@@ -6,6 +6,9 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Event\NestedEvent;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('fundamentals@after-sales')]
 class RuleIndexerEvent extends NestedEvent
 {

--- a/src/Core/Content/Shared/MailFlow/Event/MailFlowDataCriteriaEvent.php
+++ b/src/Core/Content/Shared/MailFlow/Event/MailFlowDataCriteriaEvent.php
@@ -9,6 +9,9 @@ use Shopware\Core\Framework\Event\ShopwareEvent;
 use Shopware\Core\Framework\Log\Package;
 use Symfony\Contracts\EventDispatcher\Event;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('after-sales')]
 class MailFlowDataCriteriaEvent extends Event implements ShopwareEvent, GenericEvent
 {

--- a/src/Core/Content/Sitemap/Event/SitemapGeneratedEvent.php
+++ b/src/Core/Content/Sitemap/Event/SitemapGeneratedEvent.php
@@ -8,6 +8,9 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Contracts\EventDispatcher\Event;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class SitemapGeneratedEvent extends Event implements ShopwareEvent
 {

--- a/src/Core/Content/Sitemap/Event/SitemapGenerationStartEvent.php
+++ b/src/Core/Content/Sitemap/Event/SitemapGenerationStartEvent.php
@@ -8,6 +8,9 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Contracts\EventDispatcher\Event;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class SitemapGenerationStartEvent extends Event implements ShopwareEvent
 {

--- a/src/Core/Content/Sitemap/Event/SitemapQueryEvent.php
+++ b/src/Core/Content/Sitemap/Event/SitemapQueryEvent.php
@@ -10,6 +10,9 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Contracts\EventDispatcher\Event;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 final class SitemapQueryEvent extends Event implements GenericEvent, ShopwareSalesChannelEvent
 {

--- a/src/Core/Content/Sitemap/Event/SitemapRouteCacheKeyEvent.php
+++ b/src/Core/Content/Sitemap/Event/SitemapRouteCacheKeyEvent.php
@@ -8,6 +8,8 @@ use Shopware\Core\Framework\Log\Package;
 #[Package('discovery')]
 /**
  * @deprecated tag:v6.8.0 - Will be removed in 6.8.0 as it was not used anymore
+ *
+ * @codeCoverageIgnore
  */
 class SitemapRouteCacheKeyEvent extends StoreApiRouteCacheKeyEvent
 {

--- a/src/Core/Content/Sitemap/Event/SitemapRouteCacheTagsEvent.php
+++ b/src/Core/Content/Sitemap/Event/SitemapRouteCacheTagsEvent.php
@@ -8,6 +8,8 @@ use Shopware\Core\Framework\Log\Package;
 #[Package('discovery')]
 /**
  * @deprecated tag:v6.8.0 - Will be removed in 6.8.0 as it was not used anymore
+ *
+ * @codeCoverageIgnore
  */
 class SitemapRouteCacheTagsEvent extends StoreApiRouteCacheTagsEvent
 {

--- a/src/Core/Content/Sitemap/Event/SitemapSalesChannelCriteriaEvent.php
+++ b/src/Core/Content/Sitemap/Event/SitemapSalesChannelCriteriaEvent.php
@@ -8,6 +8,9 @@ use Shopware\Core\Framework\Event\ShopwareEvent;
 use Shopware\Core\Framework\Log\Package;
 use Symfony\Contracts\EventDispatcher\Event;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class SitemapSalesChannelCriteriaEvent extends Event implements ShopwareEvent
 {


### PR DESCRIPTION
### 1. Why is this change necessary?

PHPUnit 12 validates every `#[CoversClass]` target against the coverage source, and the blanket suffix excludes for `src/Core/Content/` turn covered DAL boilerplate classes into invalid targets. The reversal replaces the blanket excludes with per-class annotations (Checkout precedent: #19268), split into per-suffix chunks for reviewability.

### 2. What does this change do, exactly?

Annotates 78 logic-free Content Event classes with a per-class `@codeCoverageIgnore`. The annotations have no effect while the suffix excludes in `phpunit.xml.dist` are still in place, so this chunk is behaviour-neutral and can merge in any order. The excludes are lifted in the final pull request of the series (#19449) once all chunks are merged.

Classes with logic or existing tests are deliberately not annotated here; they are handled in #19449.

### 3. Describe each step to reproduce the issue or behaviour.

Annotation-only change. Each touched class gains a `@codeCoverageIgnore` docblock line; no behaviour, no coverage change while the excludes remain.

### 4. Please link to the relevant issues (if any).

- relates #18344

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
