### PR TITLE
test: mark Content definitions codeCoverageIgnore

### DIFF
--- a/src/Core/Content/Category/Aggregate/CategoryTag/CategoryTagDefinition.php
+++ b/src/Core/Content/Category/Aggregate/CategoryTag/CategoryTagDefinition.php
@@ -13,6 +13,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\MappingEntityDefinition;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\Tag\TagDefinition;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class CategoryTagDefinition extends MappingEntityDefinition
 {

--- a/src/Core/Content/Category/Aggregate/CategoryTranslation/CategoryTranslationDefinition.php
+++ b/src/Core/Content/Category/Aggregate/CategoryTranslation/CategoryTranslationDefinition.php
@@ -19,6 +19,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\StringField;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class CategoryTranslationDefinition extends EntityTranslationDefinition
 {

--- a/src/Core/Content/Category/SalesChannel/SalesChannelCategoryDefinition.php
+++ b/src/Core/Content/Category/SalesChannel/SalesChannelCategoryDefinition.php
@@ -12,6 +12,9 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\Entity\SalesChannelDefinitionInterface;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class SalesChannelCategoryDefinition extends CategoryDefinition implements SalesChannelDefinitionInterface
 {

--- a/src/Core/Content/Cms/Aggregate/CmsBlock/CmsBlockDefinition.php
+++ b/src/Core/Content/Cms/Aggregate/CmsBlock/CmsBlockDefinition.php
@@ -25,6 +25,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\VersionField;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class CmsBlockDefinition extends EntityDefinition
 {

--- a/src/Core/Content/Cms/Aggregate/CmsPageTranslation/CmsPageTranslationDefinition.php
+++ b/src/Core/Content/Cms/Aggregate/CmsPageTranslation/CmsPageTranslationDefinition.php
@@ -10,6 +10,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\StringField;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class CmsPageTranslationDefinition extends EntityTranslationDefinition
 {

--- a/src/Core/Content/Cms/Aggregate/CmsSection/CmsSectionDefinition.php
+++ b/src/Core/Content/Cms/Aggregate/CmsSection/CmsSectionDefinition.php
@@ -26,6 +26,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\VersionField;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class CmsSectionDefinition extends EntityDefinition
 {

--- a/src/Core/Content/Cms/Aggregate/CmsSlot/CmsSlotDefinition.php
+++ b/src/Core/Content/Cms/Aggregate/CmsSlot/CmsSlotDefinition.php
@@ -23,6 +23,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\VersionField;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class CmsSlotDefinition extends EntityDefinition
 {

--- a/src/Core/Content/Cms/Aggregate/CmsSlotTranslation/CmsSlotTranslationDefinition.php
+++ b/src/Core/Content/Cms/Aggregate/CmsSlotTranslation/CmsSlotTranslationDefinition.php
@@ -10,6 +10,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\ApiAware;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class CmsSlotTranslationDefinition extends EntityTranslationDefinition
 {

--- a/src/Core/Content/Cms/CmsPageDefinition.php
+++ b/src/Core/Content/Cms/CmsPageDefinition.php
@@ -28,6 +28,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelDefinition;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class CmsPageDefinition extends EntityDefinition
 {

--- a/src/Core/Content/Flow/Aggregate/FlowSequence/FlowSequenceDefinition.php
+++ b/src/Core/Content/Flow/Aggregate/FlowSequence/FlowSequenceDefinition.php
@@ -23,6 +23,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\StringField;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('after-sales')]
 class FlowSequenceDefinition extends EntityDefinition
 {

--- a/src/Core/Content/Flow/Aggregate/FlowTemplate/FlowTemplateDefinition.php
+++ b/src/Core/Content/Flow/Aggregate/FlowTemplate/FlowTemplateDefinition.php
@@ -11,6 +11,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\StringField;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('after-sales')]
 class FlowTemplateDefinition extends EntityDefinition
 {

--- a/src/Core/Content/Flow/Api/FlowActionDefinition.php
+++ b/src/Core/Content/Flow/Api/FlowActionDefinition.php
@@ -5,6 +5,9 @@ namespace Shopware\Core\Content\Flow\Api;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\Struct;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('after-sales')]
 class FlowActionDefinition extends Struct
 {

--- a/src/Core/Content/Flow/FlowDefinition.php
+++ b/src/Core/Content/Flow/FlowDefinition.php
@@ -23,6 +23,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\StringField;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('after-sales')]
 class FlowDefinition extends EntityDefinition
 {

--- a/src/Core/Content/ImportExport/Aggregate/ImportExportFile/ImportExportFileDefinition.php
+++ b/src/Core/Content/ImportExport/Aggregate/ImportExportFile/ImportExportFileDefinition.php
@@ -15,6 +15,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\StringField;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('fundamentals@after-sales')]
 class ImportExportFileDefinition extends EntityDefinition
 {

--- a/src/Core/Content/ImportExport/Aggregate/ImportExportLog/ImportExportLogDefinition.php
+++ b/src/Core/Content/ImportExport/Aggregate/ImportExportLog/ImportExportLogDefinition.php
@@ -21,6 +21,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\User\UserDefinition;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('fundamentals@after-sales')]
 class ImportExportLogDefinition extends EntityDefinition
 {

--- a/src/Core/Content/ImportExport/ImportExportProfileTranslationDefinition.php
+++ b/src/Core/Content/ImportExport/ImportExportProfileTranslationDefinition.php
@@ -9,6 +9,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @deprecated tag:v6.8.0 - reason:remove-entity - Will be removed
+ *
+ * @codeCoverageIgnore
  */
 #[Package('fundamentals@after-sales')]
 class ImportExportProfileTranslationDefinition extends EntityTranslationDefinition

--- a/src/Core/Content/LandingPage/Aggregate/LandingPageSalesChannel/LandingPageSalesChannelDefinition.php
+++ b/src/Core/Content/LandingPage/Aggregate/LandingPageSalesChannel/LandingPageSalesChannelDefinition.php
@@ -13,6 +13,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\MappingEntityDefinition;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelDefinition;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class LandingPageSalesChannelDefinition extends MappingEntityDefinition
 {

--- a/src/Core/Content/LandingPage/Aggregate/LandingPageTag/LandingPageTagDefinition.php
+++ b/src/Core/Content/LandingPage/Aggregate/LandingPageTag/LandingPageTagDefinition.php
@@ -13,6 +13,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\MappingEntityDefinition;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\Tag\TagDefinition;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class LandingPageTagDefinition extends MappingEntityDefinition
 {

--- a/src/Core/Content/LandingPage/Aggregate/LandingPageTranslation/LandingPageTranslationDefinition.php
+++ b/src/Core/Content/LandingPage/Aggregate/LandingPageTranslation/LandingPageTranslationDefinition.php
@@ -13,6 +13,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\StringField;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class LandingPageTranslationDefinition extends EntityTranslationDefinition
 {

--- a/src/Core/Content/LandingPage/LandingPageDefinition.php
+++ b/src/Core/Content/LandingPage/LandingPageDefinition.php
@@ -28,6 +28,9 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelDefinition;
 use Shopware\Core\System\Tag\TagDefinition;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class LandingPageDefinition extends EntityDefinition
 {

--- a/src/Core/Content/LandingPage/SalesChannel/SalesChannelLandingPageDefinition.php
+++ b/src/Core/Content/LandingPage/SalesChannel/SalesChannelLandingPageDefinition.php
@@ -8,6 +8,9 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\Entity\SalesChannelDefinitionInterface;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class SalesChannelLandingPageDefinition extends LandingPageDefinition implements SalesChannelDefinitionInterface
 {

--- a/src/Core/Content/MailTemplate/Aggregate/MailHeaderFooter/MailHeaderFooterDefinition.php
+++ b/src/Core/Content/MailTemplate/Aggregate/MailHeaderFooter/MailHeaderFooterDefinition.php
@@ -16,6 +16,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelDefinition;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('after-sales')]
 class MailHeaderFooterDefinition extends EntityDefinition
 {

--- a/src/Core/Content/MailTemplate/Aggregate/MailHeaderFooterTranslation/MailHeaderFooterTranslationDefinition.php
+++ b/src/Core/Content/MailTemplate/Aggregate/MailHeaderFooterTranslation/MailHeaderFooterTranslationDefinition.php
@@ -12,6 +12,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\StringField;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('after-sales')]
 class MailHeaderFooterTranslationDefinition extends EntityTranslationDefinition
 {

--- a/src/Core/Content/MailTemplate/Aggregate/MailTemplateMedia/MailTemplateMediaDefinition.php
+++ b/src/Core/Content/MailTemplate/Aggregate/MailTemplateMedia/MailTemplateMediaDefinition.php
@@ -16,6 +16,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\MappingEntityDefinition;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\Language\LanguageDefinition;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('after-sales')]
 class MailTemplateMediaDefinition extends MappingEntityDefinition
 {

--- a/src/Core/Content/MailTemplate/Aggregate/MailTemplateTranslation/MailTemplateTranslationDefinition.php
+++ b/src/Core/Content/MailTemplate/Aggregate/MailTemplateTranslation/MailTemplateTranslationDefinition.php
@@ -13,6 +13,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\StringField;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('after-sales')]
 class MailTemplateTranslationDefinition extends EntityTranslationDefinition
 {

--- a/src/Core/Content/MailTemplate/Aggregate/MailTemplateTypeTranslation/MailTemplateTypeTranslationDefinition.php
+++ b/src/Core/Content/MailTemplate/Aggregate/MailTemplateTypeTranslation/MailTemplateTypeTranslationDefinition.php
@@ -11,6 +11,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\StringField;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('after-sales')]
 class MailTemplateTypeTranslationDefinition extends EntityTranslationDefinition
 {

--- a/src/Core/Content/MailTemplate/MailTemplateDefinition.php
+++ b/src/Core/Content/MailTemplate/MailTemplateDefinition.php
@@ -22,6 +22,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\WasModifiedByUserField;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('after-sales')]
 class MailTemplateDefinition extends EntityDefinition
 {

--- a/src/Core/Content/Media/Aggregate/MediaDefaultFolder/MediaDefaultFolderDefinition.php
+++ b/src/Core/Content/Media/Aggregate/MediaDefaultFolder/MediaDefaultFolderDefinition.php
@@ -13,6 +13,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\StringField;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class MediaDefaultFolderDefinition extends EntityDefinition
 {

--- a/src/Core/Content/Media/Aggregate/MediaFolder/MediaFolderDefinition.php
+++ b/src/Core/Content/Media/Aggregate/MediaFolder/MediaFolderDefinition.php
@@ -26,6 +26,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\TreePathField;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class MediaFolderDefinition extends EntityDefinition
 {

--- a/src/Core/Content/Media/Aggregate/MediaFolderConfiguration/MediaFolderConfigurationDefinition.php
+++ b/src/Core/Content/Media/Aggregate/MediaFolderConfiguration/MediaFolderConfigurationDefinition.php
@@ -20,6 +20,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\OneToManyAssociationField
 use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class MediaFolderConfigurationDefinition extends EntityDefinition
 {

--- a/src/Core/Content/Media/Aggregate/MediaFolderConfigurationMediaThumbnailSize/MediaFolderConfigurationMediaThumbnailSizeDefinition.php
+++ b/src/Core/Content/Media/Aggregate/MediaFolderConfigurationMediaThumbnailSize/MediaFolderConfigurationMediaThumbnailSizeDefinition.php
@@ -12,6 +12,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\MappingEntityDefinition;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class MediaFolderConfigurationMediaThumbnailSizeDefinition extends MappingEntityDefinition
 {

--- a/src/Core/Content/Media/Aggregate/MediaTag/MediaTagDefinition.php
+++ b/src/Core/Content/Media/Aggregate/MediaTag/MediaTagDefinition.php
@@ -13,6 +13,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\MappingEntityDefinition;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\Tag\TagDefinition;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class MediaTagDefinition extends MappingEntityDefinition
 {

--- a/src/Core/Content/Media/Aggregate/MediaThumbnail/MediaThumbnailDefinition.php
+++ b/src/Core/Content/Media/Aggregate/MediaThumbnail/MediaThumbnailDefinition.php
@@ -20,6 +20,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\StringField;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class MediaThumbnailDefinition extends EntityDefinition
 {

--- a/src/Core/Content/Media/Aggregate/MediaThumbnailSize/MediaThumbnailSizeDefinition.php
+++ b/src/Core/Content/Media/Aggregate/MediaThumbnailSize/MediaThumbnailSizeDefinition.php
@@ -17,6 +17,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\OneToManyAssociationField
 use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class MediaThumbnailSizeDefinition extends EntityDefinition
 {

--- a/src/Core/Content/Media/Aggregate/MediaTranslation/MediaTranslationDefinition.php
+++ b/src/Core/Content/Media/Aggregate/MediaTranslation/MediaTranslationDefinition.php
@@ -11,6 +11,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\StringField;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class MediaTranslationDefinition extends EntityTranslationDefinition
 {

--- a/src/Core/Content/Media/MediaDefinition.php
+++ b/src/Core/Content/Media/MediaDefinition.php
@@ -59,6 +59,9 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\Tag\TagDefinition;
 use Shopware\Core\System\User\UserDefinition;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class MediaDefinition extends EntityDefinition
 {

--- a/src/Core/Content/Newsletter/Aggregate/NewsletterRecipient/NewsletterRecipientDefinition.php
+++ b/src/Core/Content/Newsletter/Aggregate/NewsletterRecipient/NewsletterRecipientDefinition.php
@@ -22,6 +22,9 @@ use Shopware\Core\System\SalesChannel\SalesChannelDefinition;
 use Shopware\Core\System\Salutation\SalutationDefinition;
 use Shopware\Core\System\Tag\TagDefinition;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('after-sales')]
 class NewsletterRecipientDefinition extends EntityDefinition
 {

--- a/src/Core/Content/Newsletter/Aggregate/NewsletterRecipientTag/NewsletterRecipientTagDefinition.php
+++ b/src/Core/Content/Newsletter/Aggregate/NewsletterRecipientTag/NewsletterRecipientTagDefinition.php
@@ -12,6 +12,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\MappingEntityDefinition;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\Tag\TagDefinition;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('after-sales')]
 class NewsletterRecipientTagDefinition extends MappingEntityDefinition
 {

--- a/src/Core/Content/Newsletter/SalesChannel/SalesChannelNewsletterRecipientDefinition.php
+++ b/src/Core/Content/Newsletter/SalesChannel/SalesChannelNewsletterRecipientDefinition.php
@@ -9,6 +9,9 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\Entity\SalesChannelDefinitionInterface;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('after-sales')]
 class SalesChannelNewsletterRecipientDefinition extends NewsletterRecipientDefinition implements SalesChannelDefinitionInterface
 {

--- a/src/Core/Content/Product/Aggregate/ProductCategory/ProductCategoryDefinition.php
+++ b/src/Core/Content/Product/Aggregate/ProductCategory/ProductCategoryDefinition.php
@@ -13,6 +13,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\MappingEntityDefinition;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductCategoryDefinition extends MappingEntityDefinition
 {

--- a/src/Core/Content/Product/Aggregate/ProductCategoryTree/ProductCategoryTreeDefinition.php
+++ b/src/Core/Content/Product/Aggregate/ProductCategoryTree/ProductCategoryTreeDefinition.php
@@ -13,6 +13,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\MappingEntityDefinition;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductCategoryTreeDefinition extends MappingEntityDefinition
 {

--- a/src/Core/Content/Product/Aggregate/ProductConfiguratorSetting/ProductConfiguratorSettingDefinition.php
+++ b/src/Core/Content/Product/Aggregate/ProductConfiguratorSetting/ProductConfiguratorSettingDefinition.php
@@ -20,6 +20,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\VersionField;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductConfiguratorSettingDefinition extends EntityDefinition
 {

--- a/src/Core/Content/Product/Aggregate/ProductCrossSelling/ProductCrossSellingDefinition.php
+++ b/src/Core/Content/Product/Aggregate/ProductCrossSelling/ProductCrossSellingDefinition.php
@@ -26,6 +26,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Sorting\FieldSorting;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductCrossSellingDefinition extends EntityDefinition
 {

--- a/src/Core/Content/Product/Aggregate/ProductCrossSellingAssignedProducts/ProductCrossSellingAssignedProductsDefinition.php
+++ b/src/Core/Content/Product/Aggregate/ProductCrossSellingAssignedProducts/ProductCrossSellingAssignedProductsDefinition.php
@@ -15,6 +15,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\ReferenceVersionField;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductCrossSellingAssignedProductsDefinition extends EntityDefinition
 {

--- a/src/Core/Content/Product/Aggregate/ProductCrossSellingTranslation/ProductCrossSellingTranslationDefinition.php
+++ b/src/Core/Content/Product/Aggregate/ProductCrossSellingTranslation/ProductCrossSellingTranslationDefinition.php
@@ -10,6 +10,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\StringField;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductCrossSellingTranslationDefinition extends EntityTranslationDefinition
 {

--- a/src/Core/Content/Product/Aggregate/ProductCustomFieldSet/ProductCustomFieldSetDefinition.php
+++ b/src/Core/Content/Product/Aggregate/ProductCustomFieldSet/ProductCustomFieldSetDefinition.php
@@ -13,6 +13,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\MappingEntityDefinition;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\CustomField\Aggregate\CustomFieldSet\CustomFieldSetDefinition;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductCustomFieldSetDefinition extends MappingEntityDefinition
 {

--- a/src/Core/Content/Product/Aggregate/ProductDownload/ProductDownloadDefinition.php
+++ b/src/Core/Content/Product/Aggregate/ProductDownload/ProductDownloadDefinition.php
@@ -18,6 +18,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\VersionField;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductDownloadDefinition extends EntityDefinition
 {

--- a/src/Core/Content/Product/Aggregate/ProductFeatureSet/ProductFeatureSetDefinition.php
+++ b/src/Core/Content/Product/Aggregate/ProductFeatureSet/ProductFeatureSetDefinition.php
@@ -17,6 +17,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\TranslationsAssociationFi
 use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductFeatureSetDefinition extends EntityDefinition
 {

--- a/src/Core/Content/Product/Aggregate/ProductFeatureSetTranslation/ProductFeatureSetTranslationDefinition.php
+++ b/src/Core/Content/Product/Aggregate/ProductFeatureSetTranslation/ProductFeatureSetTranslationDefinition.php
@@ -10,6 +10,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\StringField;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductFeatureSetTranslationDefinition extends EntityTranslationDefinition
 {

--- a/src/Core/Content/Product/Aggregate/ProductKeywordDictionary/ProductKeywordDictionaryDefinition.php
+++ b/src/Core/Content/Product/Aggregate/ProductKeywordDictionary/ProductKeywordDictionaryDefinition.php
@@ -15,6 +15,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\Language\LanguageDefinition;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductKeywordDictionaryDefinition extends EntityDefinition
 {

--- a/src/Core/Content/Product/Aggregate/ProductManufacturer/ProductManufacturerDefinition.php
+++ b/src/Core/Content/Product/Aggregate/ProductManufacturer/ProductManufacturerDefinition.php
@@ -22,6 +22,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\VersionField;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductManufacturerDefinition extends EntityDefinition
 {

--- a/src/Core/Content/Product/Aggregate/ProductManufacturerTranslation/ProductManufacturerTranslationDefinition.php
+++ b/src/Core/Content/Product/Aggregate/ProductManufacturerTranslation/ProductManufacturerTranslationDefinition.php
@@ -13,6 +13,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\StringField;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductManufacturerTranslationDefinition extends EntityTranslationDefinition
 {

--- a/src/Core/Content/Product/Aggregate/ProductMedia/ProductMediaDefinition.php
+++ b/src/Core/Content/Product/Aggregate/ProductMedia/ProductMediaDefinition.php
@@ -21,6 +21,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\VersionField;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductMediaDefinition extends EntityDefinition
 {

--- a/src/Core/Content/Product/Aggregate/ProductOption/ProductOptionDefinition.php
+++ b/src/Core/Content/Product/Aggregate/ProductOption/ProductOptionDefinition.php
@@ -13,6 +13,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\MappingEntityDefinition;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductOptionDefinition extends MappingEntityDefinition
 {

--- a/src/Core/Content/Product/Aggregate/ProductProperty/ProductPropertyDefinition.php
+++ b/src/Core/Content/Product/Aggregate/ProductProperty/ProductPropertyDefinition.php
@@ -13,6 +13,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\MappingEntityDefinition;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductPropertyDefinition extends MappingEntityDefinition
 {

--- a/src/Core/Content/Product/Aggregate/ProductReview/ProductReviewDefinition.php
+++ b/src/Core/Content/Product/Aggregate/ProductReview/ProductReviewDefinition.php
@@ -23,6 +23,9 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\Language\LanguageDefinition;
 use Shopware\Core\System\SalesChannel\SalesChannelDefinition;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('after-sales')]
 class ProductReviewDefinition extends EntityDefinition
 {

--- a/src/Core/Content/Product/Aggregate/ProductSearchConfig/ProductSearchConfigDefinition.php
+++ b/src/Core/Content/Product/Aggregate/ProductSearchConfig/ProductSearchConfigDefinition.php
@@ -19,6 +19,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\Language\LanguageDefinition;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductSearchConfigDefinition extends EntityDefinition
 {

--- a/src/Core/Content/Product/Aggregate/ProductSearchConfigField/ProductSearchConfigFieldDefinition.php
+++ b/src/Core/Content/Product/Aggregate/ProductSearchConfigField/ProductSearchConfigFieldDefinition.php
@@ -16,6 +16,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\CustomField\CustomFieldDefinition;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductSearchConfigFieldDefinition extends EntityDefinition
 {

--- a/src/Core/Content/Product/Aggregate/ProductSearchKeyword/ProductSearchKeywordDefinition.php
+++ b/src/Core/Content/Product/Aggregate/ProductSearchKeyword/ProductSearchKeywordDefinition.php
@@ -17,6 +17,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\Language\LanguageDefinition;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductSearchKeywordDefinition extends EntityDefinition
 {

--- a/src/Core/Content/Product/Aggregate/ProductStreamMapping/ProductStreamMappingDefinition.php
+++ b/src/Core/Content/Product/Aggregate/ProductStreamMapping/ProductStreamMappingDefinition.php
@@ -13,6 +13,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\MappingEntityDefinition;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductStreamMappingDefinition extends MappingEntityDefinition
 {

--- a/src/Core/Content/Product/Aggregate/ProductTag/ProductTagDefinition.php
+++ b/src/Core/Content/Product/Aggregate/ProductTag/ProductTagDefinition.php
@@ -13,6 +13,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\MappingEntityDefinition;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\Tag\TagDefinition;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductTagDefinition extends MappingEntityDefinition
 {

--- a/src/Core/Content/Product/Aggregate/ProductTranslation/ProductTranslationDefinition.php
+++ b/src/Core/Content/Product/Aggregate/ProductTranslation/ProductTranslationDefinition.php
@@ -17,6 +17,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\StringField;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductTranslationDefinition extends EntityTranslationDefinition
 {

--- a/src/Core/Content/Product/Aggregate/ProductVisibility/ProductVisibilityDefinition.php
+++ b/src/Core/Content/Product/Aggregate/ProductVisibility/ProductVisibilityDefinition.php
@@ -16,6 +16,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelDefinition;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductVisibilityDefinition extends EntityDefinition
 {

--- a/src/Core/Content/Product/SalesChannel/Sorting/ProductSortingDefinition.php
+++ b/src/Core/Content/Product/SalesChannel/Sorting/ProductSortingDefinition.php
@@ -18,6 +18,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\TranslationsAssociationFi
 use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductSortingDefinition extends EntityDefinition
 {

--- a/src/Core/Content/Product/SalesChannel/Sorting/ProductSortingTranslationDefinition.php
+++ b/src/Core/Content/Product/SalesChannel/Sorting/ProductSortingTranslationDefinition.php
@@ -9,6 +9,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\StringField;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductSortingTranslationDefinition extends EntityTranslationDefinition
 {

--- a/src/Core/Content/ProductExport/ProductExportDefinition.php
+++ b/src/Core/Content/ProductExport/ProductExportDefinition.php
@@ -22,6 +22,9 @@ use Shopware\Core\System\Currency\CurrencyDefinition;
 use Shopware\Core\System\SalesChannel\Aggregate\SalesChannelDomain\SalesChannelDomainDefinition;
 use Shopware\Core\System\SalesChannel\SalesChannelDefinition;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductExportDefinition extends EntityDefinition
 {

--- a/src/Core/Content/ProductStream/Aggregate/ProductStreamFilter/ProductStreamFilterDefinition.php
+++ b/src/Core/Content/ProductStream/Aggregate/ProductStreamFilter/ProductStreamFilterDefinition.php
@@ -20,6 +20,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\StringField;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductStreamFilterDefinition extends EntityDefinition
 {

--- a/src/Core/Content/ProductStream/Aggregate/ProductStreamTranslation/ProductStreamTranslationDefinition.php
+++ b/src/Core/Content/ProductStream/Aggregate/ProductStreamTranslation/ProductStreamTranslationDefinition.php
@@ -12,6 +12,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\StringField;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductStreamTranslationDefinition extends EntityTranslationDefinition
 {

--- a/src/Core/Content/ProductStream/ProductStreamDefinition.php
+++ b/src/Core/Content/ProductStream/ProductStreamDefinition.php
@@ -27,6 +27,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\TranslationsAssociationFi
 use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductStreamDefinition extends EntityDefinition
 {

--- a/src/Core/Content/Property/Aggregate/PropertyGroupOption/PropertyGroupOptionDefinition.php
+++ b/src/Core/Content/Property/Aggregate/PropertyGroupOption/PropertyGroupOptionDefinition.php
@@ -30,6 +30,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\TranslationsAssociationFi
 use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class PropertyGroupOptionDefinition extends EntityDefinition
 {

--- a/src/Core/Content/Property/Aggregate/PropertyGroupOptionTranslation/PropertyGroupOptionTranslationDefinition.php
+++ b/src/Core/Content/Property/Aggregate/PropertyGroupOptionTranslation/PropertyGroupOptionTranslationDefinition.php
@@ -12,6 +12,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\StringField;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class PropertyGroupOptionTranslationDefinition extends EntityTranslationDefinition
 {

--- a/src/Core/Content/Property/Aggregate/PropertyGroupTranslation/PropertyGroupTranslationDefinition.php
+++ b/src/Core/Content/Property/Aggregate/PropertyGroupTranslation/PropertyGroupTranslationDefinition.php
@@ -13,6 +13,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\StringField;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class PropertyGroupTranslationDefinition extends EntityTranslationDefinition
 {

--- a/src/Core/Content/Property/PropertyGroupDefinition.php
+++ b/src/Core/Content/Property/PropertyGroupDefinition.php
@@ -19,6 +19,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\TranslationsAssociationFi
 use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class PropertyGroupDefinition extends EntityDefinition
 {

--- a/src/Core/Content/Rule/Aggregate/RuleCondition/RuleConditionDefinition.php
+++ b/src/Core/Content/Rule/Aggregate/RuleCondition/RuleConditionDefinition.php
@@ -20,6 +20,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\StringField;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('fundamentals@after-sales')]
 class RuleConditionDefinition extends EntityDefinition
 {

--- a/src/Core/Content/Rule/Aggregate/RuleTag/RuleTagDefinition.php
+++ b/src/Core/Content/Rule/Aggregate/RuleTag/RuleTagDefinition.php
@@ -12,6 +12,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\MappingEntityDefinition;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\Tag\TagDefinition;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('fundamentals@after-sales')]
 class RuleTagDefinition extends MappingEntityDefinition
 {

--- a/src/Core/Content/Rule/RuleDefinition.php
+++ b/src/Core/Content/Rule/RuleDefinition.php
@@ -43,6 +43,9 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\Tag\TagDefinition;
 use Shopware\Core\System\TaxProvider\TaxProviderDefinition;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('fundamentals@after-sales')]
 class RuleDefinition extends EntityDefinition
 {

--- a/src/Core/Content/Seo/MainCategory/MainCategoryDefinition.php
+++ b/src/Core/Content/Seo/MainCategory/MainCategoryDefinition.php
@@ -16,6 +16,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelDefinition;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class MainCategoryDefinition extends EntityDefinition
 {

--- a/src/Core/Content/Seo/MainCategory/SalesChannel/SalesChannelMainCategoryDefinition.php
+++ b/src/Core/Content/Seo/MainCategory/SalesChannel/SalesChannelMainCategoryDefinition.php
@@ -9,6 +9,9 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\Entity\SalesChannelDefinitionInterface;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class SalesChannelMainCategoryDefinition extends MainCategoryDefinition implements SalesChannelDefinitionInterface
 {

--- a/src/Core/Content/Seo/SeoUrl/SeoUrlDefinition.php
+++ b/src/Core/Content/Seo/SeoUrl/SeoUrlDefinition.php
@@ -18,6 +18,9 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\Language\LanguageDefinition;
 use Shopware\Core\System\SalesChannel\SalesChannelDefinition;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class SeoUrlDefinition extends EntityDefinition
 {

--- a/src/Core/Content/Seo/SeoUrlTemplate/SeoUrlTemplateDefinition.php
+++ b/src/Core/Content/Seo/SeoUrlTemplate/SeoUrlTemplateDefinition.php
@@ -17,6 +17,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelDefinition;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class SeoUrlTemplateDefinition extends EntityDefinition
 {


### PR DESCRIPTION
### 1. Why is this change necessary?

PHPUnit 12 validates every `#[CoversClass]` target against the coverage source, and the blanket suffix excludes for `src/Core/Content/` turn covered DAL boilerplate classes into invalid targets. The reversal replaces the blanket excludes with per-class annotations (Checkout precedent: #19268), split into per-suffix chunks for reviewability.

### 2. What does this change do, exactly?

Annotates 80 logic-free Content Definition classes with a per-class `@codeCoverageIgnore`. The annotations have no effect while the suffix excludes in `phpunit.xml.dist` are still in place, so this chunk is behaviour-neutral and can merge in any order. The excludes are lifted in the final pull request of the series (#19449) once all chunks are merged.

Classes with logic or existing tests are deliberately not annotated here; they are handled in #19449.

### 3. Describe each step to reproduce the issue or behaviour.

Annotation-only change. Each touched class gains a `@codeCoverageIgnore` docblock line; no behaviour, no coverage change while the excludes remain.

### 4. Please link to the relevant issues (if any).

- relates #18344

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
