### PR TITLE
test: mark Content entities codeCoverageIgnore

### DIFF
--- a/src/Core/Content/Category/Aggregate/CategoryTranslation/CategoryTranslationEntity.php
+++ b/src/Core/Content/Category/Aggregate/CategoryTranslation/CategoryTranslationEntity.php
@@ -8,6 +8,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\TranslationEntity;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\Language\LanguageEntity;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class CategoryTranslationEntity extends TranslationEntity
 {

--- a/src/Core/Content/Category/SalesChannel/SalesChannelCategoryEntity.php
+++ b/src/Core/Content/Category/SalesChannel/SalesChannelCategoryEntity.php
@@ -5,6 +5,9 @@ namespace Shopware\Core\Content\Category\SalesChannel;
 use Shopware\Core\Content\Category\CategoryEntity;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class SalesChannelCategoryEntity extends CategoryEntity
 {

--- a/src/Core/Content/Cms/Aggregate/CmsBlock/CmsBlockEntity.php
+++ b/src/Core/Content/Cms/Aggregate/CmsBlock/CmsBlockEntity.php
@@ -10,6 +10,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityCustomFieldsTrait;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityIdTrait;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class CmsBlockEntity extends Entity
 {

--- a/src/Core/Content/Cms/Aggregate/CmsPageTranslation/CmsPageTranslationEntity.php
+++ b/src/Core/Content/Cms/Aggregate/CmsPageTranslation/CmsPageTranslationEntity.php
@@ -7,6 +7,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityCustomFieldsTrait;
 use Shopware\Core\Framework\DataAbstractionLayer\TranslationEntity;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class CmsPageTranslationEntity extends TranslationEntity
 {

--- a/src/Core/Content/Cms/Aggregate/CmsSection/CmsSectionEntity.php
+++ b/src/Core/Content/Cms/Aggregate/CmsSection/CmsSectionEntity.php
@@ -10,6 +10,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityCustomFieldsTrait;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityIdTrait;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class CmsSectionEntity extends Entity
 {

--- a/src/Core/Content/Cms/Aggregate/CmsSlotTranslation/CmsSlotTranslationEntity.php
+++ b/src/Core/Content/Cms/Aggregate/CmsSlotTranslation/CmsSlotTranslationEntity.php
@@ -7,6 +7,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityCustomFieldsTrait;
 use Shopware\Core\Framework\DataAbstractionLayer\TranslationEntity;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class CmsSlotTranslationEntity extends TranslationEntity
 {

--- a/src/Core/Content/Flow/Aggregate/FlowSequence/FlowSequenceEntity.php
+++ b/src/Core/Content/Flow/Aggregate/FlowSequence/FlowSequenceEntity.php
@@ -11,6 +11,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityCustomFieldsTrait;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityIdTrait;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('after-sales')]
 class FlowSequenceEntity extends Entity implements IdAware
 {

--- a/src/Core/Content/Flow/Aggregate/FlowTemplate/FlowTemplateEntity.php
+++ b/src/Core/Content/Flow/Aggregate/FlowTemplate/FlowTemplateEntity.php
@@ -6,6 +6,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\Entity;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityIdTrait;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('after-sales')]
 class FlowTemplateEntity extends Entity
 {

--- a/src/Core/Content/Flow/FlowEntity.php
+++ b/src/Core/Content/Flow/FlowEntity.php
@@ -10,6 +10,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityCustomFieldsTrait;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityIdTrait;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('after-sales')]
 class FlowEntity extends Entity
 {

--- a/src/Core/Content/ImportExport/Aggregate/ImportExportFile/ImportExportFileEntity.php
+++ b/src/Core/Content/ImportExport/Aggregate/ImportExportFile/ImportExportFileEntity.php
@@ -8,6 +8,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityIdTrait;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Util\Random;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('fundamentals@after-sales')]
 class ImportExportFileEntity extends Entity
 {

--- a/src/Core/Content/ImportExport/Aggregate/ImportExportLog/ImportExportLogEntity.php
+++ b/src/Core/Content/ImportExport/Aggregate/ImportExportLog/ImportExportLogEntity.php
@@ -9,6 +9,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityIdTrait;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\User\UserEntity;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('fundamentals@after-sales')]
 class ImportExportLogEntity extends Entity
 {

--- a/src/Core/Content/ImportExport/ImportExportProfileEntity.php
+++ b/src/Core/Content/ImportExport/ImportExportProfileEntity.php
@@ -9,6 +9,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityIdTrait;
 use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('fundamentals@after-sales')]
 class ImportExportProfileEntity extends Entity
 {

--- a/src/Core/Content/ImportExport/ImportExportProfileTranslationEntity.php
+++ b/src/Core/Content/ImportExport/ImportExportProfileTranslationEntity.php
@@ -8,6 +8,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @deprecated tag:v6.8.0 - reason:remove-entity - Will be removed
+ *
+ * @codeCoverageIgnore
  */
 #[Package('fundamentals@after-sales')]
 class ImportExportProfileTranslationEntity extends TranslationEntity

--- a/src/Core/Content/MailTemplate/Aggregate/MailHeaderFooter/MailHeaderFooterEntity.php
+++ b/src/Core/Content/MailTemplate/Aggregate/MailHeaderFooter/MailHeaderFooterEntity.php
@@ -8,6 +8,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityIdTrait;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelCollection;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('after-sales')]
 class MailHeaderFooterEntity extends Entity
 {

--- a/src/Core/Content/MailTemplate/Aggregate/MailHeaderFooterTranslation/MailHeaderFooterTranslationEntity.php
+++ b/src/Core/Content/MailTemplate/Aggregate/MailHeaderFooterTranslation/MailHeaderFooterTranslationEntity.php
@@ -6,6 +6,9 @@ use Shopware\Core\Content\MailTemplate\Aggregate\MailHeaderFooter\MailHeaderFoot
 use Shopware\Core\Framework\DataAbstractionLayer\TranslationEntity;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('after-sales')]
 class MailHeaderFooterTranslationEntity extends TranslationEntity
 {

--- a/src/Core/Content/MailTemplate/Aggregate/MailTemplateMedia/MailTemplateMediaEntity.php
+++ b/src/Core/Content/MailTemplate/Aggregate/MailTemplateMedia/MailTemplateMediaEntity.php
@@ -8,6 +8,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\Entity;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityIdTrait;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('after-sales')]
 class MailTemplateMediaEntity extends Entity
 {

--- a/src/Core/Content/MailTemplate/Aggregate/MailTemplateTranslation/MailTemplateTranslationEntity.php
+++ b/src/Core/Content/MailTemplate/Aggregate/MailTemplateTranslation/MailTemplateTranslationEntity.php
@@ -7,6 +7,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityCustomFieldsTrait;
 use Shopware\Core\Framework\DataAbstractionLayer\TranslationEntity;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('after-sales')]
 class MailTemplateTranslationEntity extends TranslationEntity
 {

--- a/src/Core/Content/MailTemplate/Aggregate/MailTemplateType/MailTemplateTypeEntity.php
+++ b/src/Core/Content/MailTemplate/Aggregate/MailTemplateType/MailTemplateTypeEntity.php
@@ -10,6 +10,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityIdTrait;
 use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('after-sales')]
 class MailTemplateTypeEntity extends Entity
 {

--- a/src/Core/Content/MailTemplate/Aggregate/MailTemplateTypeTranslation/MailTemplateTypeTranslationEntity.php
+++ b/src/Core/Content/MailTemplate/Aggregate/MailTemplateTypeTranslation/MailTemplateTypeTranslationEntity.php
@@ -7,6 +7,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityCustomFieldsTrait;
 use Shopware\Core\Framework\DataAbstractionLayer\TranslationEntity;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('after-sales')]
 class MailTemplateTypeTranslationEntity extends TranslationEntity
 {

--- a/src/Core/Content/MailTemplate/MailTemplateEntity.php
+++ b/src/Core/Content/MailTemplate/MailTemplateEntity.php
@@ -10,6 +10,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityCustomFieldsTrait;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityIdTrait;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('after-sales')]
 class MailTemplateEntity extends Entity
 {

--- a/src/Core/Content/MeasurementSystem/DataAbstractionLayer/MeasurementDisplayUnitEntity.php
+++ b/src/Core/Content/MeasurementSystem/DataAbstractionLayer/MeasurementDisplayUnitEntity.php
@@ -18,6 +18,8 @@ use Shopware\Core\Framework\Struct\ArrayEntity;
 
 /**
  * @internal
+ *
+ * @codeCoverageIgnore
  */
 #[Package('inventory')]
 #[Entity('measurement_display_unit', since: '6.7.1.0')]

--- a/src/Core/Content/MeasurementSystem/DataAbstractionLayer/MeasurementSystemEntity.php
+++ b/src/Core/Content/MeasurementSystem/DataAbstractionLayer/MeasurementSystemEntity.php
@@ -17,6 +17,8 @@ use Shopware\Core\Framework\Struct\ArrayEntity;
 
 /**
  * @internal
+ *
+ * @codeCoverageIgnore
  */
 #[Package('inventory')]
 #[Entity('measurement_system', since: '6.7.1.0')]

--- a/src/Core/Content/Media/Aggregate/MediaDefaultFolder/MediaDefaultFolderEntity.php
+++ b/src/Core/Content/Media/Aggregate/MediaDefaultFolder/MediaDefaultFolderEntity.php
@@ -8,6 +8,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityCustomFieldsTrait;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityIdTrait;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class MediaDefaultFolderEntity extends Entity
 {

--- a/src/Core/Content/Media/Aggregate/MediaFolderConfiguration/MediaFolderConfigurationEntity.php
+++ b/src/Core/Content/Media/Aggregate/MediaFolderConfiguration/MediaFolderConfigurationEntity.php
@@ -9,6 +9,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityCustomFieldsTrait;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityIdTrait;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class MediaFolderConfigurationEntity extends Entity
 {

--- a/src/Core/Content/Media/Aggregate/MediaThumbnailSize/MediaThumbnailSizeEntity.php
+++ b/src/Core/Content/Media/Aggregate/MediaThumbnailSize/MediaThumbnailSizeEntity.php
@@ -9,6 +9,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityCustomFieldsTrait;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityIdTrait;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class MediaThumbnailSizeEntity extends Entity
 {

--- a/src/Core/Content/Media/Aggregate/MediaTranslation/MediaTranslationEntity.php
+++ b/src/Core/Content/Media/Aggregate/MediaTranslation/MediaTranslationEntity.php
@@ -7,6 +7,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityCustomFieldsTrait;
 use Shopware\Core\Framework\DataAbstractionLayer\TranslationEntity;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class MediaTranslationEntity extends TranslationEntity
 {

--- a/src/Core/Content/Newsletter/Aggregate/NewsletterRecipient/NewsletterRecipientEntity.php
+++ b/src/Core/Content/Newsletter/Aggregate/NewsletterRecipient/NewsletterRecipientEntity.php
@@ -11,6 +11,9 @@ use Shopware\Core\System\SalesChannel\SalesChannelEntity;
 use Shopware\Core\System\Salutation\SalutationEntity;
 use Shopware\Core\System\Tag\TagCollection;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('after-sales')]
 class NewsletterRecipientEntity extends Entity
 {

--- a/src/Core/Content/Product/Aggregate/ProductConfiguratorSetting/ProductConfiguratorSettingEntity.php
+++ b/src/Core/Content/Product/Aggregate/ProductConfiguratorSetting/ProductConfiguratorSettingEntity.php
@@ -11,6 +11,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityIdTrait;
 use Shopware\Core\Framework\DataAbstractionLayer\Pricing\Price;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductConfiguratorSettingEntity extends Entity
 {

--- a/src/Core/Content/Product/Aggregate/ProductCrossSelling/ProductCrossSellingEntity.php
+++ b/src/Core/Content/Product/Aggregate/ProductCrossSelling/ProductCrossSellingEntity.php
@@ -11,6 +11,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityIdTrait;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Sorting\FieldSorting;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductCrossSellingEntity extends Entity
 {

--- a/src/Core/Content/Product/Aggregate/ProductCrossSellingAssignedProducts/ProductCrossSellingAssignedProductsEntity.php
+++ b/src/Core/Content/Product/Aggregate/ProductCrossSellingAssignedProducts/ProductCrossSellingAssignedProductsEntity.php
@@ -8,6 +8,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\Entity;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityIdTrait;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductCrossSellingAssignedProductsEntity extends Entity
 {

--- a/src/Core/Content/Product/Aggregate/ProductCrossSellingTranslation/ProductCrossSellingTranslationEntity.php
+++ b/src/Core/Content/Product/Aggregate/ProductCrossSellingTranslation/ProductCrossSellingTranslationEntity.php
@@ -6,6 +6,9 @@ use Shopware\Core\Content\Product\Aggregate\ProductCrossSelling\ProductCrossSell
 use Shopware\Core\Framework\DataAbstractionLayer\TranslationEntity;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductCrossSellingTranslationEntity extends TranslationEntity
 {

--- a/src/Core/Content/Product/Aggregate/ProductDownload/ProductDownloadEntity.php
+++ b/src/Core/Content/Product/Aggregate/ProductDownload/ProductDownloadEntity.php
@@ -9,6 +9,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityCustomFieldsTrait;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityIdTrait;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductDownloadEntity extends Entity
 {

--- a/src/Core/Content/Product/Aggregate/ProductFeatureSet/ProductFeatureSetEntity.php
+++ b/src/Core/Content/Product/Aggregate/ProductFeatureSet/ProductFeatureSetEntity.php
@@ -8,6 +8,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\Entity;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityIdTrait;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductFeatureSetEntity extends Entity
 {

--- a/src/Core/Content/Product/Aggregate/ProductFeatureSetTranslation/ProductFeatureSetTranslationEntity.php
+++ b/src/Core/Content/Product/Aggregate/ProductFeatureSetTranslation/ProductFeatureSetTranslationEntity.php
@@ -6,6 +6,9 @@ use Shopware\Core\Content\Product\Aggregate\ProductFeatureSet\ProductFeatureSetE
 use Shopware\Core\Framework\DataAbstractionLayer\TranslationEntity;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductFeatureSetTranslationEntity extends TranslationEntity
 {

--- a/src/Core/Content/Product/Aggregate/ProductKeywordDictionary/ProductKeywordDictionaryEntity.php
+++ b/src/Core/Content/Product/Aggregate/ProductKeywordDictionary/ProductKeywordDictionaryEntity.php
@@ -7,6 +7,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityIdTrait;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\Language\LanguageEntity;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductKeywordDictionaryEntity extends Entity
 {

--- a/src/Core/Content/Product/Aggregate/ProductManufacturer/ProductManufacturerEntity.php
+++ b/src/Core/Content/Product/Aggregate/ProductManufacturer/ProductManufacturerEntity.php
@@ -10,6 +10,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityCustomFieldsTrait;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityIdTrait;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductManufacturerEntity extends Entity
 {

--- a/src/Core/Content/Product/Aggregate/ProductManufacturerTranslation/ProductManufacturerTranslationEntity.php
+++ b/src/Core/Content/Product/Aggregate/ProductManufacturerTranslation/ProductManufacturerTranslationEntity.php
@@ -7,6 +7,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityCustomFieldsTrait;
 use Shopware\Core\Framework\DataAbstractionLayer\TranslationEntity;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductManufacturerTranslationEntity extends TranslationEntity
 {

--- a/src/Core/Content/Product/Aggregate/ProductMedia/ProductMediaEntity.php
+++ b/src/Core/Content/Product/Aggregate/ProductMedia/ProductMediaEntity.php
@@ -10,6 +10,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityCustomFieldsTrait;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityIdTrait;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductMediaEntity extends Entity
 {

--- a/src/Core/Content/Product/Aggregate/ProductPrice/ProductPriceEntity.php
+++ b/src/Core/Content/Product/Aggregate/ProductPrice/ProductPriceEntity.php
@@ -8,6 +8,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityCustomFieldsTrait;
 use Shopware\Core\Framework\DataAbstractionLayer\Pricing\PriceRuleEntity;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductPriceEntity extends PriceRuleEntity
 {

--- a/src/Core/Content/Product/Aggregate/ProductReview/ProductReviewEntity.php
+++ b/src/Core/Content/Product/Aggregate/ProductReview/ProductReviewEntity.php
@@ -11,6 +11,9 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\Language\LanguageEntity;
 use Shopware\Core\System\SalesChannel\SalesChannelEntity;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('after-sales')]
 class ProductReviewEntity extends Entity
 {

--- a/src/Core/Content/Product/Aggregate/ProductSearchConfig/ProductSearchConfigEntity.php
+++ b/src/Core/Content/Product/Aggregate/ProductSearchConfig/ProductSearchConfigEntity.php
@@ -8,6 +8,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityIdTrait;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\Language\LanguageEntity;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductSearchConfigEntity extends Entity
 {

--- a/src/Core/Content/Product/Aggregate/ProductSearchConfigField/ProductSearchConfigFieldEntity.php
+++ b/src/Core/Content/Product/Aggregate/ProductSearchConfigField/ProductSearchConfigFieldEntity.php
@@ -8,6 +8,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityIdTrait;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\CustomField\CustomFieldEntity;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductSearchConfigFieldEntity extends Entity
 {

--- a/src/Core/Content/Product/Aggregate/ProductSearchKeyword/ProductSearchKeywordEntity.php
+++ b/src/Core/Content/Product/Aggregate/ProductSearchKeyword/ProductSearchKeywordEntity.php
@@ -8,6 +8,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityIdTrait;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\Language\LanguageEntity;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductSearchKeywordEntity extends Entity
 {

--- a/src/Core/Content/Product/Aggregate/ProductTranslation/ProductTranslationEntity.php
+++ b/src/Core/Content/Product/Aggregate/ProductTranslation/ProductTranslationEntity.php
@@ -7,6 +7,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityCustomFieldsTrait;
 use Shopware\Core\Framework\DataAbstractionLayer\TranslationEntity;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductTranslationEntity extends TranslationEntity
 {

--- a/src/Core/Content/Product/Aggregate/ProductVisibility/ProductVisibilityEntity.php
+++ b/src/Core/Content/Product/Aggregate/ProductVisibility/ProductVisibilityEntity.php
@@ -8,6 +8,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityIdTrait;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelEntity;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductVisibilityEntity extends Entity
 {

--- a/src/Core/Content/Product/SalesChannel/SalesChannelProductEntity.php
+++ b/src/Core/Content/Product/SalesChannel/SalesChannelProductEntity.php
@@ -13,6 +13,9 @@ use Shopware\Core\Content\Product\ProductEntity;
 use Shopware\Core\Content\Property\PropertyGroupCollection;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class SalesChannelProductEntity extends ProductEntity
 {

--- a/src/Core/Content/Product/SalesChannel/Sorting/ProductSortingTranslationEntity.php
+++ b/src/Core/Content/Product/SalesChannel/Sorting/ProductSortingTranslationEntity.php
@@ -6,6 +6,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityIdTrait;
 use Shopware\Core\Framework\DataAbstractionLayer\TranslationEntity;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductSortingTranslationEntity extends TranslationEntity
 {

--- a/src/Core/Content/ProductExport/ProductExportEntity.php
+++ b/src/Core/Content/ProductExport/ProductExportEntity.php
@@ -11,6 +11,9 @@ use Shopware\Core\System\Currency\CurrencyEntity;
 use Shopware\Core\System\SalesChannel\Aggregate\SalesChannelDomain\SalesChannelDomainEntity;
 use Shopware\Core\System\SalesChannel\SalesChannelEntity;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductExportEntity extends Entity
 {

--- a/src/Core/Content/ProductStream/Aggregate/ProductStreamFilter/ProductStreamFilterEntity.php
+++ b/src/Core/Content/ProductStream/Aggregate/ProductStreamFilter/ProductStreamFilterEntity.php
@@ -8,6 +8,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityCustomFieldsTrait;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityIdTrait;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductStreamFilterEntity extends Entity
 {

--- a/src/Core/Content/ProductStream/Aggregate/ProductStreamTranslation/ProductStreamTranslationEntity.php
+++ b/src/Core/Content/ProductStream/Aggregate/ProductStreamTranslation/ProductStreamTranslationEntity.php
@@ -7,6 +7,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityCustomFieldsTrait;
 use Shopware\Core\Framework\DataAbstractionLayer\TranslationEntity;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductStreamTranslationEntity extends TranslationEntity
 {

--- a/src/Core/Content/ProductStream/ProductStreamEntity.php
+++ b/src/Core/Content/ProductStream/ProductStreamEntity.php
@@ -13,6 +13,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityCustomFieldsTrait;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityIdTrait;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductStreamEntity extends Entity
 {

--- a/src/Core/Content/Property/Aggregate/PropertyGroupOption/PropertyGroupOptionEntity.php
+++ b/src/Core/Content/Property/Aggregate/PropertyGroupOption/PropertyGroupOptionEntity.php
@@ -13,6 +13,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityCustomFieldsTrait;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityIdTrait;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class PropertyGroupOptionEntity extends Entity
 {

--- a/src/Core/Content/Property/Aggregate/PropertyGroupOptionTranslation/PropertyGroupOptionTranslationEntity.php
+++ b/src/Core/Content/Property/Aggregate/PropertyGroupOptionTranslation/PropertyGroupOptionTranslationEntity.php
@@ -7,6 +7,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityCustomFieldsTrait;
 use Shopware\Core\Framework\DataAbstractionLayer\TranslationEntity;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class PropertyGroupOptionTranslationEntity extends TranslationEntity
 {

--- a/src/Core/Content/Property/Aggregate/PropertyGroupTranslation/PropertyGroupTranslationEntity.php
+++ b/src/Core/Content/Property/Aggregate/PropertyGroupTranslation/PropertyGroupTranslationEntity.php
@@ -7,6 +7,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityCustomFieldsTrait;
 use Shopware\Core\Framework\DataAbstractionLayer\TranslationEntity;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class PropertyGroupTranslationEntity extends TranslationEntity
 {

--- a/src/Core/Content/Property/PropertyGroupEntity.php
+++ b/src/Core/Content/Property/PropertyGroupEntity.php
@@ -9,6 +9,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityCustomFieldsTrait;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityIdTrait;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class PropertyGroupEntity extends Entity
 {

--- a/src/Core/Content/Rule/Aggregate/RuleCondition/RuleConditionEntity.php
+++ b/src/Core/Content/Rule/Aggregate/RuleCondition/RuleConditionEntity.php
@@ -10,6 +10,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityCustomFieldsTrait;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityIdTrait;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('fundamentals@after-sales')]
 class RuleConditionEntity extends Entity implements IdAware
 {

--- a/src/Core/Content/Rule/RuleEntity.php
+++ b/src/Core/Content/Rule/RuleEntity.php
@@ -19,6 +19,9 @@ use Shopware\Core\Framework\Rule\Rule;
 use Shopware\Core\System\Tag\TagCollection;
 use Shopware\Core\System\TaxProvider\TaxProviderCollection;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('fundamentals@after-sales')]
 class RuleEntity extends Entity
 {

--- a/src/Core/Content/Seo/SeoUrl/SeoUrlEntity.php
+++ b/src/Core/Content/Seo/SeoUrl/SeoUrlEntity.php
@@ -9,6 +9,9 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\Language\LanguageEntity;
 use Shopware\Core\System\SalesChannel\SalesChannelEntity;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class SeoUrlEntity extends Entity
 {

--- a/src/Core/Content/Seo/SeoUrlTemplate/SeoUrlTemplateEntity.php
+++ b/src/Core/Content/Seo/SeoUrlTemplate/SeoUrlTemplateEntity.php
@@ -8,6 +8,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityIdTrait;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelEntity;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class SeoUrlTemplateEntity extends Entity
 {


### PR DESCRIPTION
### 1. Why is this change necessary?

PHPUnit 12 validates every `#[CoversClass]` target against the coverage source, and the blanket suffix excludes for `src/Core/Content/` turn covered DAL boilerplate classes into invalid targets. The reversal replaces the blanket excludes with per-class annotations (Checkout precedent: #19268), split into per-suffix chunks for reviewability.

### 2. What does this change do, exactly?

Annotates 59 logic-free Content Entity classes with a per-class `@codeCoverageIgnore`. The annotations have no effect while the suffix excludes in `phpunit.xml.dist` are still in place, so this chunk is behaviour-neutral and can merge in any order. The excludes are lifted in the final pull request of the series (#19449) once all chunks are merged.

Classes with logic or existing tests are deliberately not annotated here; they are handled in #19449.

### 3. Describe each step to reproduce the issue or behaviour.

Annotation-only change. Each touched class gains a `@codeCoverageIgnore` docblock line; no behaviour, no coverage change while the excludes remain.

### 4. Please link to the relevant issues (if any).

- relates #18344

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
