### PR TITLE
fix: invalidate category route cache on slot config changes

### DIFF
--- a/src/Core/Content/Category/SalesChannel/CategoryRoute.php
+++ b/src/Core/Content/Category/SalesChannel/CategoryRoute.php
@@ -60,8 +60,6 @@ class CategoryRoute extends AbstractCategoryRoute
     )]
     public function load(string $navigationId, Request $request, SalesChannelContext $context): CategoryRouteResponse
     {
-        $this->cacheTagCollector->addTag(self::buildName($navigationId));
-
         if ($navigationId === self::HOME) {
             $navigationId = $context->getSalesChannel()->getNavigationCategoryId();
             $request->attributes->set('navigationId', $navigationId);
@@ -70,6 +68,8 @@ class CategoryRoute extends AbstractCategoryRoute
             $routeParams['navigationId'] = $navigationId;
             $request->attributes->set('_route_params', $routeParams);
         }
+
+        $this->cacheTagCollector->addTag(self::buildName($navigationId));
 
         $category = $this->loadCategory($navigationId, $context);
 

--- a/src/Core/Framework/Adapter/Cache/CacheInvalidationSubscriber.php
+++ b/src/Core/Framework/Adapter/Cache/CacheInvalidationSubscriber.php
@@ -159,6 +159,32 @@ class CacheInvalidationSubscriber
         $this->cacheInvalidator->invalidate($ids);
     }
 
+    public function invalidateCategoryRouteByCategoryTranslationChanges(EntityWrittenContainerEvent $event): void
+    {
+        $changedCategoryTranslations = $event->getPrimaryKeysWithPropertyChange(
+            CategoryTranslationDefinition::ENTITY_NAME,
+            ['slotConfig']
+        );
+
+        if ($changedCategoryTranslations === []) {
+            return;
+        }
+
+        /** @var array<string, true> $categoryIds */
+        $categoryIds = [];
+        foreach ($changedCategoryTranslations as $primaryKey) {
+            if (isset($primaryKey['categoryId']) && \is_string($primaryKey['categoryId'])) {
+                $categoryIds[$primaryKey['categoryId']] = true;
+            }
+        }
+
+        if ($categoryIds === []) {
+            return;
+        }
+
+        $this->cacheInvalidator->invalidate(array_map(CategoryRoute::buildName(...), array_keys($categoryIds)));
+    }
+
     public function invalidateProduct(InvalidateProductCache $event): void
     {
         $listing = array_map(ProductListingRoute::buildName(...), $this->getProductCategoryIds($event->getIds()));

--- a/src/Core/Framework/DependencyInjection/cache.php
+++ b/src/Core/Framework/DependencyInjection/cache.php
@@ -203,6 +203,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         ->tag('kernel.event_listener', ['event' => InvalidateProductCache::class, 'method' => 'invalidateProduct', 'priority' => 2001])
         ->tag('kernel.event_listener', ['event' => EntityDeleteEvent::class, 'method' => 'invalidateProductCrossSellingBeforeDeletion', 'priority' => 2001])
         ->tag('kernel.event_listener', ['event' => EntityWrittenContainerEvent::class, 'method' => 'invalidateCmsPageIds', 'priority' => 2001])
+        ->tag('kernel.event_listener', ['event' => EntityWrittenContainerEvent::class, 'method' => 'invalidateCategoryRouteByCategoryTranslationChanges', 'priority' => 2001])
         ->tag('kernel.event_listener', ['event' => EntityWrittenContainerEvent::class, 'method' => 'invalidateProductCrossSelling', 'priority' => 2001])
         ->tag('kernel.event_listener', ['event' => EntityWrittenContainerEvent::class, 'method' => 'invalidateCurrencyRoute', 'priority' => 2002])
         ->tag('kernel.event_listener', ['event' => EntityWrittenContainerEvent::class, 'method' => 'invalidateLanguageRoute', 'priority' => 2003])

--- a/tests/unit/Core/Content/Category/SalesChannel/CategoryRouteTest.php
+++ b/tests/unit/Core/Content/Category/SalesChannel/CategoryRouteTest.php
@@ -38,6 +38,7 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SalesChannel\Entity\SalesChannelRepository;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Shopware\Core\System\SalesChannel\SalesChannelEntity;
 use Shopware\Core\Test\Generator;
 use Shopware\Core\Test\Stub\Framework\IdsCollection;
 use Symfony\Component\HttpFoundation\Request;
@@ -196,6 +197,62 @@ class CategoryRouteTest extends TestCase
             $salesChannelContext,
             $request
         );
+    }
+
+    public function testHomeRouteIsTaggedWithNavigationCategoryId(): void
+    {
+        $request = new Request();
+        $category = $this->buildPageCategory(['en']);
+        $cmsPage = $this->buildCmsPage();
+        $salesChannel = new SalesChannelEntity();
+        $salesChannel->setId(Uuid::randomHex());
+        $salesChannel->setNavigationCategoryId($category->getId());
+        $salesChannel->setNavigationCategoryDepth(2);
+        $salesChannel->setTaxCalculationType(Generator::TAX_CALCULATION_TYPE);
+        $salesChannel->setTypeId(Defaults::SALES_CHANNEL_TYPE_STOREFRONT);
+        $salesChannelContext = Generator::generateSalesChannelContext(
+            new Context(new SalesChannelApiSource(Uuid::randomHex()), [], Defaults::CURRENCY, [Defaults::LANGUAGE_SYSTEM]),
+            salesChannel: $salesChannel,
+        );
+
+        $categoryRepository = $this->createMock(SalesChannelRepository::class);
+        $categoryRepository
+            ->expects($this->once())
+            ->method('search')
+            ->willReturn(new EntitySearchResult(
+                'category',
+                1,
+                new CategoryCollection([$category]),
+                null,
+                new Criteria(),
+                $salesChannelContext->getContext(),
+            ));
+
+        $cmsPageLoader = static::createStub(SalesChannelCmsPageLoaderInterface::class);
+        $cmsPageLoader->method('load')->willReturn(new EntitySearchResult(
+            'cms-page',
+            1,
+            new CmsPageCollection([$cmsPage]),
+            null,
+            new Criteria(),
+            $salesChannelContext->getContext(),
+        ));
+
+        $cacheTagCollector = $this->createMock(CacheTagCollector::class);
+        $cacheTagCollector
+            ->expects($this->once())
+            ->method('addTag')
+            ->with(CategoryRoute::buildName($category->getId()));
+
+        $categoryRoute = new CategoryRoute(
+            $categoryRepository,
+            $cmsPageLoader,
+            new EntityCmsSlotConfigInheritanceBuilder($this->createConnectionWithParentLanguageIds(['en'])),
+            new CategoryDefinition(),
+            $cacheTagCollector,
+        );
+
+        $categoryRoute->load(CategoryRoute::HOME, $request, $salesChannelContext);
     }
 
     private function buildCmsPage(): CmsPageEntity

--- a/tests/unit/Core/Framework/Adapter/Cache/CacheInvalidationSubscriberTest.php
+++ b/tests/unit/Core/Framework/Adapter/Cache/CacheInvalidationSubscriberTest.php
@@ -9,6 +9,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Category\Aggregate\CategoryTranslation\CategoryTranslationDefinition;
 use Shopware\Core\Content\Category\CategoryDefinition;
+use Shopware\Core\Content\Category\SalesChannel\CategoryRoute;
 use Shopware\Core\Content\Category\SalesChannel\NavigationRoute;
 use Shopware\Core\Content\Media\Event\MediaIndexerEvent;
 use Shopware\Core\Content\Media\SalesChannel\MediaRoute;
@@ -301,6 +302,98 @@ class CacheInvalidationSubscriberTest extends TestCase
             ->with([NavigationRoute::ALL_TAG]);
 
         $subscriber->invalidateNavigationRoute($event);
+    }
+
+    public function testInvalidateCategoryRouteForCategoryTranslationSlotConfigChanges(): void
+    {
+        $categoryId = Uuid::randomHex();
+        $categoryTranslationId = ['categoryId' => $categoryId, 'languageId' => Uuid::randomHex()];
+        $context = Context::createDefaultContext();
+        $this->connection->expects($this->never())->method('fetchAllAssociative');
+
+        $event = new EntityWrittenContainerEvent(
+            $context,
+            new NestedEventCollection([
+                new EntityWrittenEvent(
+                    CategoryTranslationDefinition::ENTITY_NAME,
+                    [
+                        new EntityWriteResult(
+                            $categoryTranslationId,
+                            [
+                                'slotConfig' => ['slot-id' => ['content' => ['value' => 'new content']]],
+                            ],
+                            CategoryTranslationDefinition::ENTITY_NAME,
+                            EntityWriteResult::OPERATION_UPDATE,
+                        ),
+                    ],
+                    $context,
+                ),
+            ]),
+            [],
+        );
+
+        $this->cacheInvalidator
+            ->expects($this->once())
+            ->method('invalidate')
+            ->with([CategoryRoute::buildName($categoryId)]);
+
+        $this->createSubscriber()->invalidateCategoryRouteByCategoryTranslationChanges($event);
+    }
+
+    public function testDoesNotInvalidateCategoryRouteForOtherCategoryTranslationChanges(): void
+    {
+        $context = Context::createDefaultContext();
+        $this->connection->expects($this->never())->method('fetchAllAssociative');
+        $event = new EntityWrittenContainerEvent(
+            $context,
+            new NestedEventCollection([
+                new EntityWrittenEvent(
+                    CategoryTranslationDefinition::ENTITY_NAME,
+                    [
+                        new EntityWriteResult(
+                            ['categoryId' => Uuid::randomHex(), 'languageId' => Uuid::randomHex()],
+                            ['metaDescription' => 'new description'],
+                            CategoryTranslationDefinition::ENTITY_NAME,
+                            EntityWriteResult::OPERATION_UPDATE,
+                        ),
+                    ],
+                    $context,
+                ),
+            ]),
+            [],
+        );
+
+        $this->cacheInvalidator->expects($this->never())->method('invalidate');
+
+        $this->createSubscriber()->invalidateCategoryRouteByCategoryTranslationChanges($event);
+    }
+
+    public function testDoesNotInvalidateCategoryRouteWhenChangedTranslationHasNoCategoryId(): void
+    {
+        $context = Context::createDefaultContext();
+        $this->connection->expects($this->never())->method('fetchAllAssociative');
+        $event = new EntityWrittenContainerEvent(
+            $context,
+            new NestedEventCollection([
+                new EntityWrittenEvent(
+                    CategoryTranslationDefinition::ENTITY_NAME,
+                    [
+                        new EntityWriteResult(
+                            ['languageId' => Uuid::randomHex()],
+                            ['slotConfig' => ['slot-id' => ['content' => ['value' => 'new content']]]],
+                            CategoryTranslationDefinition::ENTITY_NAME,
+                            EntityWriteResult::OPERATION_UPDATE,
+                        ),
+                    ],
+                    $context,
+                ),
+            ]),
+            [],
+        );
+
+        $this->cacheInvalidator->expects($this->never())->method('invalidate');
+
+        $this->createSubscriber()->invalidateCategoryRouteByCategoryTranslationChanges($event);
     }
 
     public function testInvalidateNavigationRouteWithMultipleTriggers(): void


### PR DESCRIPTION
### 1. Why is this change necessary?

Category CMS slot-config changes did not invalidate the affected category route cache.

While investigating, a second cache-tag issue was found: the `home` alias used a different tag from its resolved navigation category. This only affects cached Store API responses with `CACHE_REWORK` enabled.

### 2. What does this change do, exactly?

Invalidates the category route cache when `category_translation.slotConfig` changes.

Additionally, the `home` route now uses the resolved navigation-category cache tag, keeping it aligned with the invalidation tag.

### 3. Describe each step to reproduce the issue or behaviour.

1. Enable HTTP caching and cache a category page with a CMS slot configuration.
2. Change the category’s slot configuration.
3. Reload the category page; it still returns the previous content.

For the additional issue:

1. Enable `CACHE_REWORK` and prime the cached `GET /store-api/category/home` response.
2. Change the navigation category’s slot configuration.
3. Request `/store-api/category/home` again; the stale response is returned because it was tagged as `category-route-home`, while invalidation targets the resolved category ID.

If scheduled tasks and the messenger are not running, delayed invalidations are not processed automatically. Clear them manually with:

```bash
bin/console cache:clear:delayed
```

### 4. Please link to the relevant issues (if any).

- closes #19389

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [[Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md)](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them