### PR TITLE
test: coverage annotate content inventory

### DIFF
--- a/src/Core/Content/MeasurementSystem/DataAbstractionLayer/MeasurementDisplayUnitEntity.php
+++ b/src/Core/Content/MeasurementSystem/DataAbstractionLayer/MeasurementDisplayUnitEntity.php
@@ -18,6 +18,8 @@ use Shopware\Core\Framework\Struct\ArrayEntity;
 
 /**
  * @internal
+ *
+ * @codeCoverageIgnore
  */
 #[Package('inventory')]
 #[Entity('measurement_display_unit', since: '6.7.1.0')]

--- a/src/Core/Content/MeasurementSystem/DataAbstractionLayer/MeasurementSystemEntity.php
+++ b/src/Core/Content/MeasurementSystem/DataAbstractionLayer/MeasurementSystemEntity.php
@@ -17,6 +17,8 @@ use Shopware\Core\Framework\Struct\ArrayEntity;
 
 /**
  * @internal
+ *
+ * @codeCoverageIgnore
  */
 #[Package('inventory')]
 #[Entity('measurement_system', since: '6.7.1.0')]

--- a/src/Core/Content/MeasurementSystem/Field/MeasurementUnitsField.php
+++ b/src/Core/Content/MeasurementSystem/Field/MeasurementUnitsField.php
@@ -5,6 +5,9 @@ namespace Shopware\Core\Content\MeasurementSystem\Field;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\ObjectField;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class MeasurementUnitsField extends ObjectField
 {

--- a/src/Core/Content/Product/Aggregate/ProductCategory/ProductCategoryDefinition.php
+++ b/src/Core/Content/Product/Aggregate/ProductCategory/ProductCategoryDefinition.php
@@ -13,6 +13,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\MappingEntityDefinition;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductCategoryDefinition extends MappingEntityDefinition
 {

--- a/src/Core/Content/Product/Aggregate/ProductCategoryTree/ProductCategoryTreeDefinition.php
+++ b/src/Core/Content/Product/Aggregate/ProductCategoryTree/ProductCategoryTreeDefinition.php
@@ -13,6 +13,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\MappingEntityDefinition;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductCategoryTreeDefinition extends MappingEntityDefinition
 {

--- a/src/Core/Content/Product/Aggregate/ProductConfiguratorSetting/ProductConfiguratorSettingDefinition.php
+++ b/src/Core/Content/Product/Aggregate/ProductConfiguratorSetting/ProductConfiguratorSettingDefinition.php
@@ -20,6 +20,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\VersionField;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductConfiguratorSettingDefinition extends EntityDefinition
 {

--- a/src/Core/Content/Product/Aggregate/ProductConfiguratorSetting/ProductConfiguratorSettingEntity.php
+++ b/src/Core/Content/Product/Aggregate/ProductConfiguratorSetting/ProductConfiguratorSettingEntity.php
@@ -11,6 +11,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityIdTrait;
 use Shopware\Core\Framework\DataAbstractionLayer\Pricing\Price;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductConfiguratorSettingEntity extends Entity
 {

--- a/src/Core/Content/Product/Aggregate/ProductCrossSelling/ProductCrossSellingCollection.php
+++ b/src/Core/Content/Product/Aggregate/ProductCrossSelling/ProductCrossSellingCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<ProductCrossSellingEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('inventory')]
 class ProductCrossSellingCollection extends EntityCollection

--- a/src/Core/Content/Product/Aggregate/ProductCrossSelling/ProductCrossSellingDefinition.php
+++ b/src/Core/Content/Product/Aggregate/ProductCrossSelling/ProductCrossSellingDefinition.php
@@ -26,6 +26,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Sorting\FieldSorting;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductCrossSellingDefinition extends EntityDefinition
 {

--- a/src/Core/Content/Product/Aggregate/ProductCrossSelling/ProductCrossSellingEntity.php
+++ b/src/Core/Content/Product/Aggregate/ProductCrossSelling/ProductCrossSellingEntity.php
@@ -11,6 +11,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityIdTrait;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Sorting\FieldSorting;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductCrossSellingEntity extends Entity
 {

--- a/src/Core/Content/Product/Aggregate/ProductCrossSellingAssignedProducts/ProductCrossSellingAssignedProductsCollection.php
+++ b/src/Core/Content/Product/Aggregate/ProductCrossSellingAssignedProducts/ProductCrossSellingAssignedProductsCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<ProductCrossSellingAssignedProductsEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('inventory')]
 class ProductCrossSellingAssignedProductsCollection extends EntityCollection

--- a/src/Core/Content/Product/Aggregate/ProductCrossSellingAssignedProducts/ProductCrossSellingAssignedProductsDefinition.php
+++ b/src/Core/Content/Product/Aggregate/ProductCrossSellingAssignedProducts/ProductCrossSellingAssignedProductsDefinition.php
@@ -15,6 +15,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\ReferenceVersionField;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductCrossSellingAssignedProductsDefinition extends EntityDefinition
 {

--- a/src/Core/Content/Product/Aggregate/ProductCrossSellingAssignedProducts/ProductCrossSellingAssignedProductsEntity.php
+++ b/src/Core/Content/Product/Aggregate/ProductCrossSellingAssignedProducts/ProductCrossSellingAssignedProductsEntity.php
@@ -8,6 +8,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\Entity;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityIdTrait;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductCrossSellingAssignedProductsEntity extends Entity
 {

--- a/src/Core/Content/Product/Aggregate/ProductCrossSellingTranslation/ProductCrossSellingTranslationCollection.php
+++ b/src/Core/Content/Product/Aggregate/ProductCrossSellingTranslation/ProductCrossSellingTranslationCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<ProductCrossSellingTranslationEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('inventory')]
 class ProductCrossSellingTranslationCollection extends EntityCollection

--- a/src/Core/Content/Product/Aggregate/ProductCrossSellingTranslation/ProductCrossSellingTranslationDefinition.php
+++ b/src/Core/Content/Product/Aggregate/ProductCrossSellingTranslation/ProductCrossSellingTranslationDefinition.php
@@ -10,6 +10,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\StringField;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductCrossSellingTranslationDefinition extends EntityTranslationDefinition
 {

--- a/src/Core/Content/Product/Aggregate/ProductCrossSellingTranslation/ProductCrossSellingTranslationEntity.php
+++ b/src/Core/Content/Product/Aggregate/ProductCrossSellingTranslation/ProductCrossSellingTranslationEntity.php
@@ -6,6 +6,9 @@ use Shopware\Core\Content\Product\Aggregate\ProductCrossSelling\ProductCrossSell
 use Shopware\Core\Framework\DataAbstractionLayer\TranslationEntity;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductCrossSellingTranslationEntity extends TranslationEntity
 {

--- a/src/Core/Content/Product/Aggregate/ProductCustomFieldSet/ProductCustomFieldSetDefinition.php
+++ b/src/Core/Content/Product/Aggregate/ProductCustomFieldSet/ProductCustomFieldSetDefinition.php
@@ -13,6 +13,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\MappingEntityDefinition;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\CustomField\Aggregate\CustomFieldSet\CustomFieldSetDefinition;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductCustomFieldSetDefinition extends MappingEntityDefinition
 {

--- a/src/Core/Content/Product/Aggregate/ProductDownload/ProductDownloadCollection.php
+++ b/src/Core/Content/Product/Aggregate/ProductDownload/ProductDownloadCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<ProductDownloadEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('inventory')]
 class ProductDownloadCollection extends EntityCollection

--- a/src/Core/Content/Product/Aggregate/ProductDownload/ProductDownloadDefinition.php
+++ b/src/Core/Content/Product/Aggregate/ProductDownload/ProductDownloadDefinition.php
@@ -18,6 +18,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\VersionField;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductDownloadDefinition extends EntityDefinition
 {

--- a/src/Core/Content/Product/Aggregate/ProductDownload/ProductDownloadEntity.php
+++ b/src/Core/Content/Product/Aggregate/ProductDownload/ProductDownloadEntity.php
@@ -9,6 +9,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityCustomFieldsTrait;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityIdTrait;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductDownloadEntity extends Entity
 {

--- a/src/Core/Content/Product/Aggregate/ProductFeatureSet/ProductFeatureSetCollection.php
+++ b/src/Core/Content/Product/Aggregate/ProductFeatureSet/ProductFeatureSetCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<ProductFeatureSetEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('inventory')]
 class ProductFeatureSetCollection extends EntityCollection

--- a/src/Core/Content/Product/Aggregate/ProductFeatureSet/ProductFeatureSetDefinition.php
+++ b/src/Core/Content/Product/Aggregate/ProductFeatureSet/ProductFeatureSetDefinition.php
@@ -17,6 +17,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\TranslationsAssociationFi
 use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductFeatureSetDefinition extends EntityDefinition
 {

--- a/src/Core/Content/Product/Aggregate/ProductFeatureSet/ProductFeatureSetEntity.php
+++ b/src/Core/Content/Product/Aggregate/ProductFeatureSet/ProductFeatureSetEntity.php
@@ -8,6 +8,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\Entity;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityIdTrait;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductFeatureSetEntity extends Entity
 {

--- a/src/Core/Content/Product/Aggregate/ProductFeatureSetTranslation/ProductFeatureSetTranslationCollection.php
+++ b/src/Core/Content/Product/Aggregate/ProductFeatureSetTranslation/ProductFeatureSetTranslationCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<ProductFeatureSetTranslationEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('inventory')]
 class ProductFeatureSetTranslationCollection extends EntityCollection

--- a/src/Core/Content/Product/Aggregate/ProductFeatureSetTranslation/ProductFeatureSetTranslationDefinition.php
+++ b/src/Core/Content/Product/Aggregate/ProductFeatureSetTranslation/ProductFeatureSetTranslationDefinition.php
@@ -10,6 +10,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\StringField;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductFeatureSetTranslationDefinition extends EntityTranslationDefinition
 {

--- a/src/Core/Content/Product/Aggregate/ProductFeatureSetTranslation/ProductFeatureSetTranslationEntity.php
+++ b/src/Core/Content/Product/Aggregate/ProductFeatureSetTranslation/ProductFeatureSetTranslationEntity.php
@@ -6,6 +6,9 @@ use Shopware\Core\Content\Product\Aggregate\ProductFeatureSet\ProductFeatureSetE
 use Shopware\Core\Framework\DataAbstractionLayer\TranslationEntity;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductFeatureSetTranslationEntity extends TranslationEntity
 {

--- a/src/Core/Content/Product/Aggregate/ProductKeywordDictionary/ProductKeywordDictionaryCollection.php
+++ b/src/Core/Content/Product/Aggregate/ProductKeywordDictionary/ProductKeywordDictionaryCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<ProductKeywordDictionaryEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('inventory')]
 class ProductKeywordDictionaryCollection extends EntityCollection

--- a/src/Core/Content/Product/Aggregate/ProductKeywordDictionary/ProductKeywordDictionaryDefinition.php
+++ b/src/Core/Content/Product/Aggregate/ProductKeywordDictionary/ProductKeywordDictionaryDefinition.php
@@ -15,6 +15,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\Language\LanguageDefinition;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductKeywordDictionaryDefinition extends EntityDefinition
 {

--- a/src/Core/Content/Product/Aggregate/ProductKeywordDictionary/ProductKeywordDictionaryEntity.php
+++ b/src/Core/Content/Product/Aggregate/ProductKeywordDictionary/ProductKeywordDictionaryEntity.php
@@ -7,6 +7,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityIdTrait;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\Language\LanguageEntity;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductKeywordDictionaryEntity extends Entity
 {

--- a/src/Core/Content/Product/Aggregate/ProductManufacturer/ProductManufacturerCollection.php
+++ b/src/Core/Content/Product/Aggregate/ProductManufacturer/ProductManufacturerCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<ProductManufacturerEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('inventory')]
 class ProductManufacturerCollection extends EntityCollection

--- a/src/Core/Content/Product/Aggregate/ProductManufacturer/ProductManufacturerDefinition.php
+++ b/src/Core/Content/Product/Aggregate/ProductManufacturer/ProductManufacturerDefinition.php
@@ -22,6 +22,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\VersionField;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductManufacturerDefinition extends EntityDefinition
 {

--- a/src/Core/Content/Product/Aggregate/ProductManufacturer/ProductManufacturerEntity.php
+++ b/src/Core/Content/Product/Aggregate/ProductManufacturer/ProductManufacturerEntity.php
@@ -10,6 +10,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityCustomFieldsTrait;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityIdTrait;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductManufacturerEntity extends Entity
 {

--- a/src/Core/Content/Product/Aggregate/ProductManufacturerTranslation/ProductManufacturerTranslationCollection.php
+++ b/src/Core/Content/Product/Aggregate/ProductManufacturerTranslation/ProductManufacturerTranslationCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<ProductManufacturerTranslationEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('inventory')]
 class ProductManufacturerTranslationCollection extends EntityCollection

--- a/src/Core/Content/Product/Aggregate/ProductManufacturerTranslation/ProductManufacturerTranslationDefinition.php
+++ b/src/Core/Content/Product/Aggregate/ProductManufacturerTranslation/ProductManufacturerTranslationDefinition.php
@@ -13,6 +13,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\StringField;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductManufacturerTranslationDefinition extends EntityTranslationDefinition
 {

--- a/src/Core/Content/Product/Aggregate/ProductManufacturerTranslation/ProductManufacturerTranslationEntity.php
+++ b/src/Core/Content/Product/Aggregate/ProductManufacturerTranslation/ProductManufacturerTranslationEntity.php
@@ -7,6 +7,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityCustomFieldsTrait;
 use Shopware\Core\Framework\DataAbstractionLayer\TranslationEntity;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductManufacturerTranslationEntity extends TranslationEntity
 {

--- a/src/Core/Content/Product/Aggregate/ProductMedia/ProductMediaCollection.php
+++ b/src/Core/Content/Product/Aggregate/ProductMedia/ProductMediaCollection.php
@@ -9,6 +9,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<ProductMediaEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('inventory')]
 class ProductMediaCollection extends EntityCollection

--- a/src/Core/Content/Product/Aggregate/ProductMedia/ProductMediaDefinition.php
+++ b/src/Core/Content/Product/Aggregate/ProductMedia/ProductMediaDefinition.php
@@ -21,6 +21,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\VersionField;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductMediaDefinition extends EntityDefinition
 {

--- a/src/Core/Content/Product/Aggregate/ProductMedia/ProductMediaEntity.php
+++ b/src/Core/Content/Product/Aggregate/ProductMedia/ProductMediaEntity.php
@@ -10,6 +10,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityCustomFieldsTrait;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityIdTrait;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductMediaEntity extends Entity
 {

--- a/src/Core/Content/Product/Aggregate/ProductOption/ProductOptionDefinition.php
+++ b/src/Core/Content/Product/Aggregate/ProductOption/ProductOptionDefinition.php
@@ -13,6 +13,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\MappingEntityDefinition;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductOptionDefinition extends MappingEntityDefinition
 {

--- a/src/Core/Content/Product/Aggregate/ProductPrice/ProductPriceEntity.php
+++ b/src/Core/Content/Product/Aggregate/ProductPrice/ProductPriceEntity.php
@@ -8,6 +8,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityCustomFieldsTrait;
 use Shopware\Core\Framework\DataAbstractionLayer\Pricing\PriceRuleEntity;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductPriceEntity extends PriceRuleEntity
 {

--- a/src/Core/Content/Product/Aggregate/ProductProperty/ProductPropertyDefinition.php
+++ b/src/Core/Content/Product/Aggregate/ProductProperty/ProductPropertyDefinition.php
@@ -13,6 +13,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\MappingEntityDefinition;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductPropertyDefinition extends MappingEntityDefinition
 {

--- a/src/Core/Content/Product/Aggregate/ProductSearchConfig/ProductSearchConfigCollection.php
+++ b/src/Core/Content/Product/Aggregate/ProductSearchConfig/ProductSearchConfigCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<ProductSearchConfigEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('inventory')]
 class ProductSearchConfigCollection extends EntityCollection

--- a/src/Core/Content/Product/Aggregate/ProductSearchConfig/ProductSearchConfigDefinition.php
+++ b/src/Core/Content/Product/Aggregate/ProductSearchConfig/ProductSearchConfigDefinition.php
@@ -19,6 +19,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\Language\LanguageDefinition;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductSearchConfigDefinition extends EntityDefinition
 {

--- a/src/Core/Content/Product/Aggregate/ProductSearchConfig/ProductSearchConfigEntity.php
+++ b/src/Core/Content/Product/Aggregate/ProductSearchConfig/ProductSearchConfigEntity.php
@@ -8,6 +8,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityIdTrait;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\Language\LanguageEntity;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductSearchConfigEntity extends Entity
 {

--- a/src/Core/Content/Product/Aggregate/ProductSearchConfigField/ProductSearchConfigFieldCollection.php
+++ b/src/Core/Content/Product/Aggregate/ProductSearchConfigField/ProductSearchConfigFieldCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<ProductSearchConfigFieldEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('inventory')]
 class ProductSearchConfigFieldCollection extends EntityCollection

--- a/src/Core/Content/Product/Aggregate/ProductSearchConfigField/ProductSearchConfigFieldDefinition.php
+++ b/src/Core/Content/Product/Aggregate/ProductSearchConfigField/ProductSearchConfigFieldDefinition.php
@@ -16,6 +16,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\CustomField\CustomFieldDefinition;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductSearchConfigFieldDefinition extends EntityDefinition
 {

--- a/src/Core/Content/Product/Aggregate/ProductSearchConfigField/ProductSearchConfigFieldEntity.php
+++ b/src/Core/Content/Product/Aggregate/ProductSearchConfigField/ProductSearchConfigFieldEntity.php
@@ -8,6 +8,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityIdTrait;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\CustomField\CustomFieldEntity;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductSearchConfigFieldEntity extends Entity
 {

--- a/src/Core/Content/Product/Aggregate/ProductSearchKeyword/ProductSearchKeywordCollection.php
+++ b/src/Core/Content/Product/Aggregate/ProductSearchKeyword/ProductSearchKeywordCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<ProductSearchKeywordEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('inventory')]
 class ProductSearchKeywordCollection extends EntityCollection

--- a/src/Core/Content/Product/Aggregate/ProductSearchKeyword/ProductSearchKeywordDefinition.php
+++ b/src/Core/Content/Product/Aggregate/ProductSearchKeyword/ProductSearchKeywordDefinition.php
@@ -17,6 +17,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\Language\LanguageDefinition;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductSearchKeywordDefinition extends EntityDefinition
 {

--- a/src/Core/Content/Product/Aggregate/ProductSearchKeyword/ProductSearchKeywordEntity.php
+++ b/src/Core/Content/Product/Aggregate/ProductSearchKeyword/ProductSearchKeywordEntity.php
@@ -8,6 +8,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityIdTrait;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\Language\LanguageEntity;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductSearchKeywordEntity extends Entity
 {

--- a/src/Core/Content/Product/Aggregate/ProductStreamMapping/ProductStreamMappingDefinition.php
+++ b/src/Core/Content/Product/Aggregate/ProductStreamMapping/ProductStreamMappingDefinition.php
@@ -13,6 +13,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\MappingEntityDefinition;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductStreamMappingDefinition extends MappingEntityDefinition
 {

--- a/src/Core/Content/Product/Aggregate/ProductTag/ProductTagDefinition.php
+++ b/src/Core/Content/Product/Aggregate/ProductTag/ProductTagDefinition.php
@@ -13,6 +13,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\MappingEntityDefinition;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\Tag\TagDefinition;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductTagDefinition extends MappingEntityDefinition
 {

--- a/src/Core/Content/Product/Aggregate/ProductTranslation/ProductTranslationCollection.php
+++ b/src/Core/Content/Product/Aggregate/ProductTranslation/ProductTranslationCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<ProductTranslationEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('inventory')]
 class ProductTranslationCollection extends EntityCollection

--- a/src/Core/Content/Product/Aggregate/ProductTranslation/ProductTranslationDefinition.php
+++ b/src/Core/Content/Product/Aggregate/ProductTranslation/ProductTranslationDefinition.php
@@ -17,6 +17,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\StringField;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductTranslationDefinition extends EntityTranslationDefinition
 {

--- a/src/Core/Content/Product/Aggregate/ProductTranslation/ProductTranslationEntity.php
+++ b/src/Core/Content/Product/Aggregate/ProductTranslation/ProductTranslationEntity.php
@@ -7,6 +7,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityCustomFieldsTrait;
 use Shopware\Core\Framework\DataAbstractionLayer\TranslationEntity;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductTranslationEntity extends TranslationEntity
 {

--- a/src/Core/Content/Product/Aggregate/ProductVisibility/ProductVisibilityCollection.php
+++ b/src/Core/Content/Product/Aggregate/ProductVisibility/ProductVisibilityCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<ProductVisibilityEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('inventory')]
 class ProductVisibilityCollection extends EntityCollection

--- a/src/Core/Content/Product/Aggregate/ProductVisibility/ProductVisibilityDefinition.php
+++ b/src/Core/Content/Product/Aggregate/ProductVisibility/ProductVisibilityDefinition.php
@@ -16,6 +16,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelDefinition;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductVisibilityDefinition extends EntityDefinition
 {

--- a/src/Core/Content/Product/Aggregate/ProductVisibility/ProductVisibilityEntity.php
+++ b/src/Core/Content/Product/Aggregate/ProductVisibility/ProductVisibilityEntity.php
@@ -8,6 +8,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityIdTrait;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelEntity;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductVisibilityEntity extends Entity
 {

--- a/src/Core/Content/Product/Events/CrossSellingRouteCacheKeyEvent.php
+++ b/src/Core/Content/Product/Events/CrossSellingRouteCacheKeyEvent.php
@@ -9,12 +9,12 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\HttpFoundation\Request;
 
-#[Package('inventory')]
 /**
  * @deprecated tag:v6.8.0 - Will be removed in 6.8.0 as it was not used anymore
  *
  * @codeCoverageIgnore
  */
+#[Package('inventory')]
 class CrossSellingRouteCacheKeyEvent extends StoreApiRouteCacheKeyEvent
 {
     public function __construct(

--- a/src/Core/Content/Product/Events/CrossSellingRouteCacheKeyEvent.php
+++ b/src/Core/Content/Product/Events/CrossSellingRouteCacheKeyEvent.php
@@ -12,6 +12,8 @@ use Symfony\Component\HttpFoundation\Request;
 #[Package('inventory')]
 /**
  * @deprecated tag:v6.8.0 - Will be removed in 6.8.0 as it was not used anymore
+ *
+ * @codeCoverageIgnore
  */
 class CrossSellingRouteCacheKeyEvent extends StoreApiRouteCacheKeyEvent
 {

--- a/src/Core/Content/Product/Events/CrossSellingRouteCacheTagsEvent.php
+++ b/src/Core/Content/Product/Events/CrossSellingRouteCacheTagsEvent.php
@@ -10,12 +10,12 @@ use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\System\SalesChannel\StoreApiResponse;
 use Symfony\Component\HttpFoundation\Request;
 
-#[Package('inventory')]
 /**
  * @deprecated tag:v6.8.0 - Will be removed in 6.8.0 as it was not used anymore
  *
  * @codeCoverageIgnore
  */
+#[Package('inventory')]
 class CrossSellingRouteCacheTagsEvent extends StoreApiRouteCacheTagsEvent
 {
     public function __construct(

--- a/src/Core/Content/Product/Events/CrossSellingRouteCacheTagsEvent.php
+++ b/src/Core/Content/Product/Events/CrossSellingRouteCacheTagsEvent.php
@@ -13,6 +13,8 @@ use Symfony\Component\HttpFoundation\Request;
 #[Package('inventory')]
 /**
  * @deprecated tag:v6.8.0 - Will be removed in 6.8.0 as it was not used anymore
+ *
+ * @codeCoverageIgnore
  */
 class CrossSellingRouteCacheTagsEvent extends StoreApiRouteCacheTagsEvent
 {

--- a/src/Core/Content/Product/Events/ProductCrossSellingCriteriaEvent.php
+++ b/src/Core/Content/Product/Events/ProductCrossSellingCriteriaEvent.php
@@ -10,6 +10,9 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Contracts\EventDispatcher\Event;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 abstract class ProductCrossSellingCriteriaEvent extends Event implements ShopwareSalesChannelEvent
 {

--- a/src/Core/Content/Product/Events/ProductCrossSellingCriteriaLoadEvent.php
+++ b/src/Core/Content/Product/Events/ProductCrossSellingCriteriaLoadEvent.php
@@ -9,6 +9,9 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Contracts\EventDispatcher\Event;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductCrossSellingCriteriaLoadEvent extends Event implements ShopwareSalesChannelEvent
 {

--- a/src/Core/Content/Product/Events/ProductCrossSellingIdsCriteriaEvent.php
+++ b/src/Core/Content/Product/Events/ProductCrossSellingIdsCriteriaEvent.php
@@ -4,6 +4,9 @@ namespace Shopware\Core\Content\Product\Events;
 
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductCrossSellingIdsCriteriaEvent extends ProductCrossSellingCriteriaEvent
 {

--- a/src/Core/Content/Product/Events/ProductCrossSellingStreamCriteriaEvent.php
+++ b/src/Core/Content/Product/Events/ProductCrossSellingStreamCriteriaEvent.php
@@ -4,6 +4,9 @@ namespace Shopware\Core\Content\Product\Events;
 
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductCrossSellingStreamCriteriaEvent extends ProductCrossSellingCriteriaEvent
 {

--- a/src/Core/Content/Product/Events/ProductCrossSellingsLoadedEvent.php
+++ b/src/Core/Content/Product/Events/ProductCrossSellingsLoadedEvent.php
@@ -9,6 +9,9 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Contracts\EventDispatcher\Event;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductCrossSellingsLoadedEvent extends Event implements ShopwareSalesChannelEvent
 {

--- a/src/Core/Content/Product/Events/ProductDetailRouteCacheKeyEvent.php
+++ b/src/Core/Content/Product/Events/ProductDetailRouteCacheKeyEvent.php
@@ -8,6 +8,8 @@ use Shopware\Core\Framework\Log\Package;
 #[Package('inventory')]
 /**
  * @deprecated tag:v6.8.0 - Will be removed in 6.8.0 as it was not used anymore
+ *
+ * @codeCoverageIgnore
  */
 class ProductDetailRouteCacheKeyEvent extends StoreApiRouteCacheKeyEvent
 {

--- a/src/Core/Content/Product/Events/ProductDetailRouteCacheTagsEvent.php
+++ b/src/Core/Content/Product/Events/ProductDetailRouteCacheTagsEvent.php
@@ -8,6 +8,8 @@ use Shopware\Core\Framework\Log\Package;
 #[Package('inventory')]
 /**
  * @deprecated tag:v6.8.0 - Will be removed in 6.8.0 as it was not used anymore
+ *
+ * @codeCoverageIgnore
  */
 class ProductDetailRouteCacheTagsEvent extends StoreApiRouteCacheTagsEvent
 {

--- a/src/Core/Content/Product/Events/ProductGatewayCriteriaEvent.php
+++ b/src/Core/Content/Product/Events/ProductGatewayCriteriaEvent.php
@@ -9,6 +9,9 @@ use Shopware\Core\Framework\Event\ShopwareSalesChannelEvent;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductGatewayCriteriaEvent extends NestedEvent implements ShopwareSalesChannelEvent
 {

--- a/src/Core/Content/Product/Events/ProductIndexerEvent.php
+++ b/src/Core/Content/Product/Events/ProductIndexerEvent.php
@@ -6,6 +6,9 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Event\NestedEvent;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductIndexerEvent extends NestedEvent implements ProductChangedEventInterface
 {

--- a/src/Core/Content/Product/Events/ProductListingCollectFilterEvent.php
+++ b/src/Core/Content/Product/Events/ProductListingCollectFilterEvent.php
@@ -10,6 +10,9 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\HttpFoundation\Request;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductListingCollectFilterEvent extends NestedEvent implements ShopwareSalesChannelEvent
 {

--- a/src/Core/Content/Product/Events/ProductListingCriteriaEvent.php
+++ b/src/Core/Content/Product/Events/ProductListingCriteriaEvent.php
@@ -10,6 +10,9 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\HttpFoundation\Request;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductListingCriteriaEvent extends NestedEvent implements ShopwareSalesChannelEvent
 {

--- a/src/Core/Content/Product/Events/ProductListingPreviewCriteriaEvent.php
+++ b/src/Core/Content/Product/Events/ProductListingPreviewCriteriaEvent.php
@@ -9,6 +9,9 @@ use Shopware\Core\Framework\Event\ShopwareSalesChannelEvent;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductListingPreviewCriteriaEvent extends NestedEvent implements ShopwareSalesChannelEvent
 {

--- a/src/Core/Content/Product/Events/ProductListingResultEvent.php
+++ b/src/Core/Content/Product/Events/ProductListingResultEvent.php
@@ -10,6 +10,9 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\HttpFoundation\Request;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductListingResultEvent extends NestedEvent implements ShopwareSalesChannelEvent
 {

--- a/src/Core/Content/Product/Events/ProductListingRouteCacheKeyEvent.php
+++ b/src/Core/Content/Product/Events/ProductListingRouteCacheKeyEvent.php
@@ -9,12 +9,12 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\HttpFoundation\Request;
 
-#[Package('inventory')]
 /**
  * @deprecated tag:v6.8.0 - Will be removed in 6.8.0 as it was not used anymore
  *
  * @codeCoverageIgnore
  */
+#[Package('inventory')]
 class ProductListingRouteCacheKeyEvent extends StoreApiRouteCacheKeyEvent
 {
     public function __construct(

--- a/src/Core/Content/Product/Events/ProductListingRouteCacheKeyEvent.php
+++ b/src/Core/Content/Product/Events/ProductListingRouteCacheKeyEvent.php
@@ -12,6 +12,8 @@ use Symfony\Component\HttpFoundation\Request;
 #[Package('inventory')]
 /**
  * @deprecated tag:v6.8.0 - Will be removed in 6.8.0 as it was not used anymore
+ *
+ * @codeCoverageIgnore
  */
 class ProductListingRouteCacheKeyEvent extends StoreApiRouteCacheKeyEvent
 {

--- a/src/Core/Content/Product/Events/ProductListingRouteCacheTagsEvent.php
+++ b/src/Core/Content/Product/Events/ProductListingRouteCacheTagsEvent.php
@@ -11,12 +11,12 @@ use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\System\SalesChannel\StoreApiResponse;
 use Symfony\Component\HttpFoundation\Request;
 
-#[Package('inventory')]
 /**
  * @deprecated tag:v6.8.0 - Will be removed in 6.8.0 as it was not used anymore
  *
  * @codeCoverageIgnore
  */
+#[Package('inventory')]
 class ProductListingRouteCacheTagsEvent extends StoreApiRouteCacheTagsEvent
 {
     /**

--- a/src/Core/Content/Product/Events/ProductListingRouteCacheTagsEvent.php
+++ b/src/Core/Content/Product/Events/ProductListingRouteCacheTagsEvent.php
@@ -14,6 +14,8 @@ use Symfony\Component\HttpFoundation\Request;
 #[Package('inventory')]
 /**
  * @deprecated tag:v6.8.0 - Will be removed in 6.8.0 as it was not used anymore
+ *
+ * @codeCoverageIgnore
  */
 class ProductListingRouteCacheTagsEvent extends StoreApiRouteCacheTagsEvent
 {

--- a/src/Core/Content/Product/Events/ProductNoLongerAvailableEvent.php
+++ b/src/Core/Content/Product/Events/ProductNoLongerAvailableEvent.php
@@ -7,6 +7,9 @@ use Shopware\Core\Framework\Event\ShopwareEvent;
 use Shopware\Core\Framework\Log\Package;
 use Symfony\Contracts\EventDispatcher\Event;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductNoLongerAvailableEvent extends Event implements ShopwareEvent, ProductChangedEventInterface
 {

--- a/src/Core/Content/Product/Events/ProductSearchCriteriaEvent.php
+++ b/src/Core/Content/Product/Events/ProductSearchCriteriaEvent.php
@@ -4,6 +4,9 @@ namespace Shopware\Core\Content\Product\Events;
 
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductSearchCriteriaEvent extends ProductListingCriteriaEvent
 {

--- a/src/Core/Content/Product/Events/ProductSearchResultEvent.php
+++ b/src/Core/Content/Product/Events/ProductSearchResultEvent.php
@@ -4,6 +4,9 @@ namespace Shopware\Core\Content\Product\Events;
 
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductSearchResultEvent extends ProductListingResultEvent
 {

--- a/src/Core/Content/Product/Events/ProductSearchRouteCacheKeyEvent.php
+++ b/src/Core/Content/Product/Events/ProductSearchRouteCacheKeyEvent.php
@@ -8,6 +8,8 @@ use Shopware\Core\Framework\Log\Package;
 #[Package('inventory')]
 /**
  * @deprecated tag:v6.8.0 - Will be removed in 6.8.0 as it was not used anymore
+ *
+ * @codeCoverageIgnore
  */
 class ProductSearchRouteCacheKeyEvent extends StoreApiRouteCacheKeyEvent
 {

--- a/src/Core/Content/Product/Events/ProductSearchRouteCacheTagsEvent.php
+++ b/src/Core/Content/Product/Events/ProductSearchRouteCacheTagsEvent.php
@@ -8,6 +8,8 @@ use Shopware\Core\Framework\Log\Package;
 #[Package('inventory')]
 /**
  * @deprecated tag:v6.8.0 - Will be removed in 6.8.0 as it was not used anymore
+ *
+ * @codeCoverageIgnore
  */
 class ProductSearchRouteCacheTagsEvent extends StoreApiRouteCacheTagsEvent
 {

--- a/src/Core/Content/Product/Events/ProductStockAlteredEvent.php
+++ b/src/Core/Content/Product/Events/ProductStockAlteredEvent.php
@@ -7,6 +7,9 @@ use Shopware\Core\Framework\Event\ShopwareEvent;
 use Shopware\Core\Framework\Log\Package;
 use Symfony\Contracts\EventDispatcher\Event;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductStockAlteredEvent extends Event implements ShopwareEvent, ProductChangedEventInterface
 {

--- a/src/Core/Content/Product/Events/ProductSuggestCriteriaEvent.php
+++ b/src/Core/Content/Product/Events/ProductSuggestCriteriaEvent.php
@@ -4,6 +4,9 @@ namespace Shopware\Core\Content\Product\Events;
 
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductSuggestCriteriaEvent extends ProductListingCriteriaEvent
 {

--- a/src/Core/Content/Product/Events/ProductSuggestResultEvent.php
+++ b/src/Core/Content/Product/Events/ProductSuggestResultEvent.php
@@ -4,6 +4,9 @@ namespace Shopware\Core\Content\Product\Events;
 
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductSuggestResultEvent extends ProductListingResultEvent
 {

--- a/src/Core/Content/Product/Events/ProductSuggestRouteCacheKeyEvent.php
+++ b/src/Core/Content/Product/Events/ProductSuggestRouteCacheKeyEvent.php
@@ -8,6 +8,8 @@ use Shopware\Core\Framework\Log\Package;
 #[Package('inventory')]
 /**
  * @deprecated tag:v6.8.0 - Will be removed in 6.8.0 as it was not used anymore
+ *
+ * @codeCoverageIgnore
  */
 class ProductSuggestRouteCacheKeyEvent extends StoreApiRouteCacheKeyEvent
 {

--- a/src/Core/Content/Product/Events/ProductSuggestRouteCacheTagsEvent.php
+++ b/src/Core/Content/Product/Events/ProductSuggestRouteCacheTagsEvent.php
@@ -8,6 +8,8 @@ use Shopware\Core\Framework\Log\Package;
 #[Package('inventory')]
 /**
  * @deprecated tag:v6.8.0 - Will be removed in 6.8.0 as it was not used anymore
+ *
+ * @codeCoverageIgnore
  */
 class ProductSuggestRouteCacheTagsEvent extends StoreApiRouteCacheTagsEvent
 {

--- a/src/Core/Content/Product/Events/ProductTypeBeforeChangeEvent.php
+++ b/src/Core/Content/Product/Events/ProductTypeBeforeChangeEvent.php
@@ -7,6 +7,9 @@ use Shopware\Core\Framework\Event\ShopwareEvent;
 use Shopware\Core\Framework\Log\Package;
 use Symfony\Contracts\EventDispatcher\Event;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductTypeBeforeChangeEvent extends Event implements ShopwareEvent
 {

--- a/src/Core/Content/Product/Events/ProductTypeChangedEvent.php
+++ b/src/Core/Content/Product/Events/ProductTypeChangedEvent.php
@@ -7,6 +7,9 @@ use Shopware\Core\Framework\Event\ShopwareEvent;
 use Shopware\Core\Framework\Log\Package;
 use Symfony\Contracts\EventDispatcher\Event;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductTypeChangedEvent extends Event implements ShopwareEvent
 {

--- a/src/Core/Content/Product/ProductCollection.php
+++ b/src/Core/Content/Product/ProductCollection.php
@@ -9,6 +9,8 @@ use Shopware\Core\Framework\Log\Package;
  * @template TElement of ProductEntity = ProductEntity
  *
  * @extends EntityCollection<TElement>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('inventory')]
 class ProductCollection extends EntityCollection

--- a/src/Core/Content/Product/SalesChannel/CrossSelling/CrossSellingElementCollection.php
+++ b/src/Core/Content/Product/SalesChannel/CrossSelling/CrossSellingElementCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Struct\Collection;
 
 /**
  * @extends Collection<CrossSellingElement>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('inventory')]
 class CrossSellingElementCollection extends Collection

--- a/src/Core/Content/Product/SalesChannel/SalesChannelProductCollection.php
+++ b/src/Core/Content/Product/SalesChannel/SalesChannelProductCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends ProductCollection<SalesChannelProductEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('inventory')]
 class SalesChannelProductCollection extends ProductCollection

--- a/src/Core/Content/Product/SalesChannel/SalesChannelProductEntity.php
+++ b/src/Core/Content/Product/SalesChannel/SalesChannelProductEntity.php
@@ -13,6 +13,9 @@ use Shopware\Core\Content\Product\ProductEntity;
 use Shopware\Core\Content\Property\PropertyGroupCollection;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class SalesChannelProductEntity extends ProductEntity
 {

--- a/src/Core/Content/Product/SalesChannel/Sorting/ProductSortingDefinition.php
+++ b/src/Core/Content/Product/SalesChannel/Sorting/ProductSortingDefinition.php
@@ -18,6 +18,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\TranslationsAssociationFi
 use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductSortingDefinition extends EntityDefinition
 {

--- a/src/Core/Content/Product/SalesChannel/Sorting/ProductSortingTranslationCollection.php
+++ b/src/Core/Content/Product/SalesChannel/Sorting/ProductSortingTranslationCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<ProductSortingTranslationEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('inventory')]
 class ProductSortingTranslationCollection extends EntityCollection

--- a/src/Core/Content/Product/SalesChannel/Sorting/ProductSortingTranslationDefinition.php
+++ b/src/Core/Content/Product/SalesChannel/Sorting/ProductSortingTranslationDefinition.php
@@ -9,6 +9,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\StringField;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductSortingTranslationDefinition extends EntityTranslationDefinition
 {

--- a/src/Core/Content/Product/SalesChannel/Sorting/ProductSortingTranslationEntity.php
+++ b/src/Core/Content/Product/SalesChannel/Sorting/ProductSortingTranslationEntity.php
@@ -6,6 +6,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityIdTrait;
 use Shopware\Core\Framework\DataAbstractionLayer\TranslationEntity;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductSortingTranslationEntity extends TranslationEntity
 {

--- a/src/Core/Content/ProductExport/Error/ErrorCollection.php
+++ b/src/Core/Content/ProductExport/Error/ErrorCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Struct\Collection;
 
 /**
  * @extends Collection<Error>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('inventory')]
 class ErrorCollection extends Collection

--- a/src/Core/Content/ProductExport/Event/ProductExportChangeEncodingEvent.php
+++ b/src/Core/Content/ProductExport/Event/ProductExportChangeEncodingEvent.php
@@ -6,6 +6,9 @@ use Shopware\Core\Content\ProductExport\ProductExportEntity;
 use Shopware\Core\Framework\Log\Package;
 use Symfony\Contracts\EventDispatcher\Event;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductExportChangeEncodingEvent extends Event
 {

--- a/src/Core/Content/ProductExport/Event/ProductExportContentTypeEvent.php
+++ b/src/Core/Content/ProductExport/Event/ProductExportContentTypeEvent.php
@@ -5,6 +5,9 @@ namespace Shopware\Core\Content\ProductExport\Event;
 use Shopware\Core\Framework\Log\Package;
 use Symfony\Contracts\EventDispatcher\Event;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductExportContentTypeEvent extends Event
 {

--- a/src/Core/Content/ProductExport/Event/ProductExportProductCriteriaEvent.php
+++ b/src/Core/Content/ProductExport/Event/ProductExportProductCriteriaEvent.php
@@ -11,6 +11,9 @@ use Shopware\Core\Framework\Event\ShopwareSalesChannelEvent;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductExportProductCriteriaEvent extends NestedEvent implements ShopwareSalesChannelEvent
 {

--- a/src/Core/Content/ProductExport/Event/ProductExportRenderBodyContextEvent.php
+++ b/src/Core/Content/ProductExport/Event/ProductExportRenderBodyContextEvent.php
@@ -6,6 +6,9 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\Struct;
 use Symfony\Contracts\EventDispatcher\Event;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductExportRenderBodyContextEvent extends Event
 {

--- a/src/Core/Content/ProductExport/Event/ProductExportRenderFooterContextEvent.php
+++ b/src/Core/Content/ProductExport/Event/ProductExportRenderFooterContextEvent.php
@@ -6,6 +6,9 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\Struct;
 use Symfony\Contracts\EventDispatcher\Event;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductExportRenderFooterContextEvent extends Event
 {

--- a/src/Core/Content/ProductExport/Event/ProductExportRenderHeaderContextEvent.php
+++ b/src/Core/Content/ProductExport/Event/ProductExportRenderHeaderContextEvent.php
@@ -6,6 +6,9 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\Struct;
 use Symfony\Contracts\EventDispatcher\Event;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductExportRenderHeaderContextEvent extends Event
 {

--- a/src/Core/Content/ProductExport/ProductExportCollection.php
+++ b/src/Core/Content/ProductExport/ProductExportCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<ProductExportEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('inventory')]
 class ProductExportCollection extends EntityCollection

--- a/src/Core/Content/ProductExport/ProductExportDefinition.php
+++ b/src/Core/Content/ProductExport/ProductExportDefinition.php
@@ -22,6 +22,9 @@ use Shopware\Core\System\Currency\CurrencyDefinition;
 use Shopware\Core\System\SalesChannel\Aggregate\SalesChannelDomain\SalesChannelDomainDefinition;
 use Shopware\Core\System\SalesChannel\SalesChannelDefinition;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductExportDefinition extends EntityDefinition
 {

--- a/src/Core/Content/ProductExport/ProductExportEntity.php
+++ b/src/Core/Content/ProductExport/ProductExportEntity.php
@@ -11,6 +11,9 @@ use Shopware\Core\System\Currency\CurrencyEntity;
 use Shopware\Core\System\SalesChannel\Aggregate\SalesChannelDomain\SalesChannelDomainEntity;
 use Shopware\Core\System\SalesChannel\SalesChannelEntity;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductExportEntity extends Entity
 {

--- a/src/Core/Content/ProductStream/Aggregate/ProductStreamFilter/ProductStreamFilterCollection.php
+++ b/src/Core/Content/ProductStream/Aggregate/ProductStreamFilter/ProductStreamFilterCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<ProductStreamFilterEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('inventory')]
 class ProductStreamFilterCollection extends EntityCollection

--- a/src/Core/Content/ProductStream/Aggregate/ProductStreamFilter/ProductStreamFilterDefinition.php
+++ b/src/Core/Content/ProductStream/Aggregate/ProductStreamFilter/ProductStreamFilterDefinition.php
@@ -20,6 +20,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\StringField;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductStreamFilterDefinition extends EntityDefinition
 {

--- a/src/Core/Content/ProductStream/Aggregate/ProductStreamFilter/ProductStreamFilterEntity.php
+++ b/src/Core/Content/ProductStream/Aggregate/ProductStreamFilter/ProductStreamFilterEntity.php
@@ -8,6 +8,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityCustomFieldsTrait;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityIdTrait;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductStreamFilterEntity extends Entity
 {

--- a/src/Core/Content/ProductStream/Aggregate/ProductStreamTranslation/ProductStreamTranslationCollection.php
+++ b/src/Core/Content/ProductStream/Aggregate/ProductStreamTranslation/ProductStreamTranslationCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<ProductStreamTranslationEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('inventory')]
 class ProductStreamTranslationCollection extends EntityCollection

--- a/src/Core/Content/ProductStream/Aggregate/ProductStreamTranslation/ProductStreamTranslationDefinition.php
+++ b/src/Core/Content/ProductStream/Aggregate/ProductStreamTranslation/ProductStreamTranslationDefinition.php
@@ -12,6 +12,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\StringField;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductStreamTranslationDefinition extends EntityTranslationDefinition
 {

--- a/src/Core/Content/ProductStream/Aggregate/ProductStreamTranslation/ProductStreamTranslationEntity.php
+++ b/src/Core/Content/ProductStream/Aggregate/ProductStreamTranslation/ProductStreamTranslationEntity.php
@@ -7,6 +7,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityCustomFieldsTrait;
 use Shopware\Core\Framework\DataAbstractionLayer\TranslationEntity;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductStreamTranslationEntity extends TranslationEntity
 {

--- a/src/Core/Content/ProductStream/Event/ProductStreamIndexerEvent.php
+++ b/src/Core/Content/ProductStream/Event/ProductStreamIndexerEvent.php
@@ -6,6 +6,9 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Event\NestedEvent;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductStreamIndexerEvent extends NestedEvent
 {

--- a/src/Core/Content/ProductStream/ProductStreamCollection.php
+++ b/src/Core/Content/ProductStream/ProductStreamCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<ProductStreamEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('inventory')]
 class ProductStreamCollection extends EntityCollection

--- a/src/Core/Content/ProductStream/ProductStreamDefinition.php
+++ b/src/Core/Content/ProductStream/ProductStreamDefinition.php
@@ -27,6 +27,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\TranslationsAssociationFi
 use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductStreamDefinition extends EntityDefinition
 {

--- a/src/Core/Content/ProductStream/ProductStreamEntity.php
+++ b/src/Core/Content/ProductStream/ProductStreamEntity.php
@@ -13,6 +13,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityCustomFieldsTrait;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityIdTrait;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductStreamEntity extends Entity
 {

--- a/src/Core/Content/Property/Aggregate/PropertyGroupOption/PropertyGroupOptionDefinition.php
+++ b/src/Core/Content/Property/Aggregate/PropertyGroupOption/PropertyGroupOptionDefinition.php
@@ -30,6 +30,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\TranslationsAssociationFi
 use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class PropertyGroupOptionDefinition extends EntityDefinition
 {

--- a/src/Core/Content/Property/Aggregate/PropertyGroupOption/PropertyGroupOptionEntity.php
+++ b/src/Core/Content/Property/Aggregate/PropertyGroupOption/PropertyGroupOptionEntity.php
@@ -13,6 +13,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityCustomFieldsTrait;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityIdTrait;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class PropertyGroupOptionEntity extends Entity
 {

--- a/src/Core/Content/Property/Aggregate/PropertyGroupOptionTranslation/PropertyGroupOptionTranslationCollection.php
+++ b/src/Core/Content/Property/Aggregate/PropertyGroupOptionTranslation/PropertyGroupOptionTranslationCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<PropertyGroupOptionTranslationEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('inventory')]
 class PropertyGroupOptionTranslationCollection extends EntityCollection

--- a/src/Core/Content/Property/Aggregate/PropertyGroupOptionTranslation/PropertyGroupOptionTranslationDefinition.php
+++ b/src/Core/Content/Property/Aggregate/PropertyGroupOptionTranslation/PropertyGroupOptionTranslationDefinition.php
@@ -12,6 +12,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\StringField;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class PropertyGroupOptionTranslationDefinition extends EntityTranslationDefinition
 {

--- a/src/Core/Content/Property/Aggregate/PropertyGroupOptionTranslation/PropertyGroupOptionTranslationEntity.php
+++ b/src/Core/Content/Property/Aggregate/PropertyGroupOptionTranslation/PropertyGroupOptionTranslationEntity.php
@@ -7,6 +7,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityCustomFieldsTrait;
 use Shopware\Core\Framework\DataAbstractionLayer\TranslationEntity;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class PropertyGroupOptionTranslationEntity extends TranslationEntity
 {

--- a/src/Core/Content/Property/Aggregate/PropertyGroupTranslation/PropertyGroupTranslationCollection.php
+++ b/src/Core/Content/Property/Aggregate/PropertyGroupTranslation/PropertyGroupTranslationCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<PropertyGroupTranslationEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('inventory')]
 class PropertyGroupTranslationCollection extends EntityCollection

--- a/src/Core/Content/Property/Aggregate/PropertyGroupTranslation/PropertyGroupTranslationDefinition.php
+++ b/src/Core/Content/Property/Aggregate/PropertyGroupTranslation/PropertyGroupTranslationDefinition.php
@@ -13,6 +13,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\StringField;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class PropertyGroupTranslationDefinition extends EntityTranslationDefinition
 {

--- a/src/Core/Content/Property/Aggregate/PropertyGroupTranslation/PropertyGroupTranslationEntity.php
+++ b/src/Core/Content/Property/Aggregate/PropertyGroupTranslation/PropertyGroupTranslationEntity.php
@@ -7,6 +7,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityCustomFieldsTrait;
 use Shopware\Core\Framework\DataAbstractionLayer\TranslationEntity;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class PropertyGroupTranslationEntity extends TranslationEntity
 {

--- a/src/Core/Content/Property/PropertyGroupDefinition.php
+++ b/src/Core/Content/Property/PropertyGroupDefinition.php
@@ -19,6 +19,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\TranslationsAssociationFi
 use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class PropertyGroupDefinition extends EntityDefinition
 {

--- a/src/Core/Content/Property/PropertyGroupEntity.php
+++ b/src/Core/Content/Property/PropertyGroupEntity.php
@@ -9,6 +9,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityCustomFieldsTrait;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityIdTrait;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class PropertyGroupEntity extends Entity
 {

--- a/src/Core/Content/Seo/Hreflang/HreflangCollection.php
+++ b/src/Core/Content/Seo/Hreflang/HreflangCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Struct\StructCollection;
 
 /**
  * @extends StructCollection<HreflangStruct>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('inventory')]
 class HreflangCollection extends StructCollection

--- a/src/Core/Content/Seo/Hreflang/HreflangStruct.php
+++ b/src/Core/Content/Seo/Hreflang/HreflangStruct.php
@@ -5,6 +5,9 @@ namespace Shopware\Core\Content\Seo\Hreflang;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\Struct;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class HreflangStruct extends Struct
 {

--- a/src/Core/Content/Seo/MainCategory/MainCategoryCollection.php
+++ b/src/Core/Content/Seo/MainCategory/MainCategoryCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<MainCategoryEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('inventory')]
 class MainCategoryCollection extends EntityCollection

--- a/src/Core/Content/Seo/MainCategory/MainCategoryDefinition.php
+++ b/src/Core/Content/Seo/MainCategory/MainCategoryDefinition.php
@@ -16,6 +16,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelDefinition;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class MainCategoryDefinition extends EntityDefinition
 {

--- a/src/Core/Content/Seo/MainCategory/SalesChannel/SalesChannelMainCategoryDefinition.php
+++ b/src/Core/Content/Seo/MainCategory/SalesChannel/SalesChannelMainCategoryDefinition.php
@@ -9,6 +9,9 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\Entity\SalesChannelDefinitionInterface;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class SalesChannelMainCategoryDefinition extends MainCategoryDefinition implements SalesChannelDefinitionInterface
 {

--- a/src/Core/Content/Seo/SeoUrl/SeoUrlCollection.php
+++ b/src/Core/Content/Seo/SeoUrl/SeoUrlCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<SeoUrlEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('inventory')]
 class SeoUrlCollection extends EntityCollection

--- a/src/Core/Content/Seo/SeoUrl/SeoUrlDefinition.php
+++ b/src/Core/Content/Seo/SeoUrl/SeoUrlDefinition.php
@@ -18,6 +18,9 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\Language\LanguageDefinition;
 use Shopware\Core\System\SalesChannel\SalesChannelDefinition;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class SeoUrlDefinition extends EntityDefinition
 {

--- a/src/Core/Content/Seo/SeoUrl/SeoUrlEntity.php
+++ b/src/Core/Content/Seo/SeoUrl/SeoUrlEntity.php
@@ -9,6 +9,9 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\Language\LanguageEntity;
 use Shopware\Core\System\SalesChannel\SalesChannelEntity;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class SeoUrlEntity extends Entity
 {

--- a/src/Core/Content/Seo/SeoUrlTemplate/SeoUrlTemplateCollection.php
+++ b/src/Core/Content/Seo/SeoUrlTemplate/SeoUrlTemplateCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<SeoUrlTemplateEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('inventory')]
 class SeoUrlTemplateCollection extends EntityCollection

--- a/src/Core/Content/Seo/SeoUrlTemplate/SeoUrlTemplateDefinition.php
+++ b/src/Core/Content/Seo/SeoUrlTemplate/SeoUrlTemplateDefinition.php
@@ -17,6 +17,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelDefinition;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class SeoUrlTemplateDefinition extends EntityDefinition
 {

--- a/src/Core/Content/Seo/SeoUrlTemplate/SeoUrlTemplateEntity.php
+++ b/src/Core/Content/Seo/SeoUrlTemplate/SeoUrlTemplateEntity.php
@@ -8,6 +8,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityIdTrait;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelEntity;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class SeoUrlTemplateEntity extends Entity
 {


### PR DESCRIPTION
### 1. Why is this change necessary?

PHPUnit 12 validates every `#[CoversClass]` target against the coverage source, and the blanket suffix excludes for `src/Core/Content/` turn covered DAL boilerplate classes into invalid targets. The reversal replaces the blanket excludes with per-class annotations (Checkout precedent: #19268), stacked per owning domain so every team reviews only its own classes.

### 2. What does this change do, exactly?

Annotates the 136 logic-free inventory-owned Content DAL classes (Struct/Collection/Event/Definition/Entity/Field) with a per-class `@codeCoverageIgnore`. The annotations have no effect while the suffix excludes in `phpunit.xml.dist` are still in place, so this layer is behaviour-neutral. The excludes are lifted by the top of the stack (#19449), which also covers the logic-bearing classes with unit tests.

Stack layer 1 of 4 (base: trunk).

### 3. Describe each step to reproduce the issue or behaviour.

Annotation-only change. Each touched class gains a `@codeCoverageIgnore` docblock line; no behaviour, no coverage change while the excludes remain.

### 4. Please link to the relevant issues (if any).

- relates #18344

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
