### PR TITLE
test: mark discovery-owned Content classes codeCoverageIgnore

### DIFF
--- a/src/Core/Content/Category/Aggregate/CategoryTag/CategoryTagDefinition.php
+++ b/src/Core/Content/Category/Aggregate/CategoryTag/CategoryTagDefinition.php
@@ -13,6 +13,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\MappingEntityDefinition;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\Tag\TagDefinition;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class CategoryTagDefinition extends MappingEntityDefinition
 {

--- a/src/Core/Content/Category/Aggregate/CategoryTranslation/CategoryTranslationCollection.php
+++ b/src/Core/Content/Category/Aggregate/CategoryTranslation/CategoryTranslationCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<CategoryTranslationEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('discovery')]
 class CategoryTranslationCollection extends EntityCollection

--- a/src/Core/Content/Category/Aggregate/CategoryTranslation/CategoryTranslationDefinition.php
+++ b/src/Core/Content/Category/Aggregate/CategoryTranslation/CategoryTranslationDefinition.php
@@ -19,6 +19,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\StringField;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class CategoryTranslationDefinition extends EntityTranslationDefinition
 {

--- a/src/Core/Content/Category/Aggregate/CategoryTranslation/CategoryTranslationEntity.php
+++ b/src/Core/Content/Category/Aggregate/CategoryTranslation/CategoryTranslationEntity.php
@@ -8,6 +8,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\TranslationEntity;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\Language\LanguageEntity;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class CategoryTranslationEntity extends TranslationEntity
 {

--- a/src/Core/Content/Category/CategoryCollection.php
+++ b/src/Core/Content/Category/CategoryCollection.php
@@ -8,6 +8,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<CategoryEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('discovery')]
 class CategoryCollection extends EntityCollection

--- a/src/Core/Content/Category/Event/CategoryIndexerEvent.php
+++ b/src/Core/Content/Category/Event/CategoryIndexerEvent.php
@@ -6,6 +6,9 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Event\NestedEvent;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class CategoryIndexerEvent extends NestedEvent
 {

--- a/src/Core/Content/Category/Event/CategoryRouteCacheKeyEvent.php
+++ b/src/Core/Content/Category/Event/CategoryRouteCacheKeyEvent.php
@@ -9,12 +9,12 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\HttpFoundation\Request;
 
-#[Package('discovery')]
 /**
  * @deprecated tag:v6.8.0 - Will be removed in 6.8.0 as it was not used anymore
  *
  * @codeCoverageIgnore
  */
+#[Package('discovery')]
 class CategoryRouteCacheKeyEvent extends StoreApiRouteCacheKeyEvent
 {
     /**

--- a/src/Core/Content/Category/Event/CategoryRouteCacheKeyEvent.php
+++ b/src/Core/Content/Category/Event/CategoryRouteCacheKeyEvent.php
@@ -12,6 +12,8 @@ use Symfony\Component\HttpFoundation\Request;
 #[Package('discovery')]
 /**
  * @deprecated tag:v6.8.0 - Will be removed in 6.8.0 as it was not used anymore
+ *
+ * @codeCoverageIgnore
  */
 class CategoryRouteCacheKeyEvent extends StoreApiRouteCacheKeyEvent
 {

--- a/src/Core/Content/Category/Event/CategoryRouteCacheKeyEvent.php
+++ b/src/Core/Content/Category/Event/CategoryRouteCacheKeyEvent.php
@@ -27,6 +27,11 @@ class CategoryRouteCacheKeyEvent extends StoreApiRouteCacheKeyEvent
         SalesChannelContext $context,
         ?Criteria $criteria
     ) {
+        Feature::triggerDeprecationOrThrow(
+            'v6.8.0.0',
+            Feature::deprecatedClassMessage(self::class, 'v6.8.0.0'),
+        );
+
         parent::__construct($parts, $request, $context, $criteria);
     }
 

--- a/src/Core/Content/Category/Event/CategoryRouteCacheTagsEvent.php
+++ b/src/Core/Content/Category/Event/CategoryRouteCacheTagsEvent.php
@@ -13,6 +13,8 @@ use Symfony\Component\HttpFoundation\Request;
 #[Package('discovery')]
 /**
  * @deprecated tag:v6.8.0 - Will be removed in 6.8.0 as it was not used anymore
+ *
+ * @codeCoverageIgnore
  */
 class CategoryRouteCacheTagsEvent extends StoreApiRouteCacheTagsEvent
 {

--- a/src/Core/Content/Category/Event/CategoryRouteCacheTagsEvent.php
+++ b/src/Core/Content/Category/Event/CategoryRouteCacheTagsEvent.php
@@ -10,12 +10,12 @@ use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\System\SalesChannel\StoreApiResponse;
 use Symfony\Component\HttpFoundation\Request;
 
-#[Package('discovery')]
 /**
  * @deprecated tag:v6.8.0 - Will be removed in 6.8.0 as it was not used anymore
  *
  * @codeCoverageIgnore
  */
+#[Package('discovery')]
 class CategoryRouteCacheTagsEvent extends StoreApiRouteCacheTagsEvent
 {
     /**

--- a/src/Core/Content/Category/Event/NavigationLoadedEvent.php
+++ b/src/Core/Content/Category/Event/NavigationLoadedEvent.php
@@ -9,6 +9,9 @@ use Shopware\Core\Framework\Event\ShopwareSalesChannelEvent;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class NavigationLoadedEvent extends NestedEvent implements ShopwareSalesChannelEvent
 {

--- a/src/Core/Content/Category/Event/NavigationRouteCacheKeyEvent.php
+++ b/src/Core/Content/Category/Event/NavigationRouteCacheKeyEvent.php
@@ -12,6 +12,8 @@ use Symfony\Component\HttpFoundation\Request;
 #[Package('discovery')]
 /**
  * @deprecated tag:v6.8.0 - Will be removed in 6.8.0 as it was not used anymore
+ *
+ * @codeCoverageIgnore
  */
 class NavigationRouteCacheKeyEvent extends StoreApiRouteCacheKeyEvent
 {

--- a/src/Core/Content/Category/Event/NavigationRouteCacheKeyEvent.php
+++ b/src/Core/Content/Category/Event/NavigationRouteCacheKeyEvent.php
@@ -59,6 +59,11 @@ class NavigationRouteCacheKeyEvent extends StoreApiRouteCacheKeyEvent
 
     public function getDepth(): int
     {
+        Feature::triggerDeprecationOrThrow(
+            'v6.8.0.0',
+            Feature::deprecatedClassMessage(self::class, 'v6.8.0.0'),
+        );
+
         return $this->depth;
     }
 }

--- a/src/Core/Content/Category/Event/NavigationRouteCacheKeyEvent.php
+++ b/src/Core/Content/Category/Event/NavigationRouteCacheKeyEvent.php
@@ -9,12 +9,12 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\HttpFoundation\Request;
 
-#[Package('discovery')]
 /**
  * @deprecated tag:v6.8.0 - Will be removed in 6.8.0 as it was not used anymore
  *
  * @codeCoverageIgnore
  */
+#[Package('discovery')]
 class NavigationRouteCacheKeyEvent extends StoreApiRouteCacheKeyEvent
 {
     /**

--- a/src/Core/Content/Category/Event/NavigationRouteCacheTagsEvent.php
+++ b/src/Core/Content/Category/Event/NavigationRouteCacheTagsEvent.php
@@ -10,12 +10,12 @@ use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\System\SalesChannel\StoreApiResponse;
 use Symfony\Component\HttpFoundation\Request;
 
-#[Package('discovery')]
 /**
  * @deprecated tag:v6.8.0 - Will be removed in 6.8.0 as it was not used anymore
  *
  * @codeCoverageIgnore
  */
+#[Package('discovery')]
 class NavigationRouteCacheTagsEvent extends StoreApiRouteCacheTagsEvent
 {
     /**

--- a/src/Core/Content/Category/Event/NavigationRouteCacheTagsEvent.php
+++ b/src/Core/Content/Category/Event/NavigationRouteCacheTagsEvent.php
@@ -13,6 +13,8 @@ use Symfony\Component\HttpFoundation\Request;
 #[Package('discovery')]
 /**
  * @deprecated tag:v6.8.0 - Will be removed in 6.8.0 as it was not used anymore
+ *
+ * @codeCoverageIgnore
  */
 class NavigationRouteCacheTagsEvent extends StoreApiRouteCacheTagsEvent
 {

--- a/src/Core/Content/Category/SalesChannel/SalesChannelCategoryDefinition.php
+++ b/src/Core/Content/Category/SalesChannel/SalesChannelCategoryDefinition.php
@@ -12,6 +12,9 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\Entity\SalesChannelDefinitionInterface;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class SalesChannelCategoryDefinition extends CategoryDefinition implements SalesChannelDefinitionInterface
 {

--- a/src/Core/Content/Category/SalesChannel/SalesChannelCategoryEntity.php
+++ b/src/Core/Content/Category/SalesChannel/SalesChannelCategoryEntity.php
@@ -5,6 +5,9 @@ namespace Shopware\Core\Content\Category\SalesChannel;
 use Shopware\Core\Content\Category\CategoryEntity;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class SalesChannelCategoryEntity extends CategoryEntity
 {

--- a/src/Core/Content/Cms/Aggregate/CmsBlock/CmsBlockDefinition.php
+++ b/src/Core/Content/Cms/Aggregate/CmsBlock/CmsBlockDefinition.php
@@ -25,6 +25,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\VersionField;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class CmsBlockDefinition extends EntityDefinition
 {

--- a/src/Core/Content/Cms/Aggregate/CmsBlock/CmsBlockEntity.php
+++ b/src/Core/Content/Cms/Aggregate/CmsBlock/CmsBlockEntity.php
@@ -10,6 +10,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityCustomFieldsTrait;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityIdTrait;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class CmsBlockEntity extends Entity
 {

--- a/src/Core/Content/Cms/Aggregate/CmsPageTranslation/CmsPageTranslationDefinition.php
+++ b/src/Core/Content/Cms/Aggregate/CmsPageTranslation/CmsPageTranslationDefinition.php
@@ -10,6 +10,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\StringField;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class CmsPageTranslationDefinition extends EntityTranslationDefinition
 {

--- a/src/Core/Content/Cms/Aggregate/CmsPageTranslation/CmsPageTranslationEntity.php
+++ b/src/Core/Content/Cms/Aggregate/CmsPageTranslation/CmsPageTranslationEntity.php
@@ -7,6 +7,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityCustomFieldsTrait;
 use Shopware\Core\Framework\DataAbstractionLayer\TranslationEntity;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class CmsPageTranslationEntity extends TranslationEntity
 {

--- a/src/Core/Content/Cms/Aggregate/CmsSection/CmsSectionDefinition.php
+++ b/src/Core/Content/Cms/Aggregate/CmsSection/CmsSectionDefinition.php
@@ -26,6 +26,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\VersionField;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class CmsSectionDefinition extends EntityDefinition
 {

--- a/src/Core/Content/Cms/Aggregate/CmsSection/CmsSectionEntity.php
+++ b/src/Core/Content/Cms/Aggregate/CmsSection/CmsSectionEntity.php
@@ -10,6 +10,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityCustomFieldsTrait;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityIdTrait;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class CmsSectionEntity extends Entity
 {

--- a/src/Core/Content/Cms/Aggregate/CmsSlot/CmsSlotDefinition.php
+++ b/src/Core/Content/Cms/Aggregate/CmsSlot/CmsSlotDefinition.php
@@ -23,6 +23,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\VersionField;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class CmsSlotDefinition extends EntityDefinition
 {

--- a/src/Core/Content/Cms/Aggregate/CmsSlotTranslation/CmsSlotTranslationDefinition.php
+++ b/src/Core/Content/Cms/Aggregate/CmsSlotTranslation/CmsSlotTranslationDefinition.php
@@ -10,6 +10,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\ApiAware;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class CmsSlotTranslationDefinition extends EntityTranslationDefinition
 {

--- a/src/Core/Content/Cms/Aggregate/CmsSlotTranslation/CmsSlotTranslationEntity.php
+++ b/src/Core/Content/Cms/Aggregate/CmsSlotTranslation/CmsSlotTranslationEntity.php
@@ -7,6 +7,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityCustomFieldsTrait;
 use Shopware\Core\Framework\DataAbstractionLayer\TranslationEntity;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class CmsSlotTranslationEntity extends TranslationEntity
 {

--- a/src/Core/Content/Cms/CmsPageCollection.php
+++ b/src/Core/Content/Cms/CmsPageCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<CmsPageEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('discovery')]
 class CmsPageCollection extends EntityCollection

--- a/src/Core/Content/Cms/CmsPageDefinition.php
+++ b/src/Core/Content/Cms/CmsPageDefinition.php
@@ -28,6 +28,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelDefinition;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class CmsPageDefinition extends EntityDefinition
 {

--- a/src/Core/Content/Cms/DataAbstractionLayer/Field/SlotConfigField.php
+++ b/src/Core/Content/Cms/DataAbstractionLayer/Field/SlotConfigField.php
@@ -6,6 +6,9 @@ use Shopware\Core\Content\Cms\DataAbstractionLayer\FieldSerializer\SlotConfigFie
 use Shopware\Core\Framework\DataAbstractionLayer\Field\JsonField;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class SlotConfigField extends JsonField
 {

--- a/src/Core/Content/Cms/DataResolver/FieldConfigCollection.php
+++ b/src/Core/Content/Cms/DataResolver/FieldConfigCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Struct\Collection;
 
 /**
  * @extends Collection<FieldConfig>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('discovery')]
 class FieldConfigCollection extends Collection

--- a/src/Core/Content/Cms/Events/CmsPageLoaderCriteriaEvent.php
+++ b/src/Core/Content/Cms/Events/CmsPageLoaderCriteriaEvent.php
@@ -10,6 +10,9 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\HttpFoundation\Request;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class CmsPageLoaderCriteriaEvent extends NestedEvent implements ShopwareSalesChannelEvent
 {

--- a/src/Core/Content/Cms/SalesChannel/Struct/BuyBoxStruct.php
+++ b/src/Core/Content/Cms/SalesChannel/Struct/BuyBoxStruct.php
@@ -7,6 +7,9 @@ use Shopware\Core\Content\Property\PropertyGroupCollection;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\Struct;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class BuyBoxStruct extends Struct
 {

--- a/src/Core/Content/Cms/SalesChannel/Struct/CrossSellingStruct.php
+++ b/src/Core/Content/Cms/SalesChannel/Struct/CrossSellingStruct.php
@@ -6,6 +6,9 @@ use Shopware\Core\Content\Product\SalesChannel\CrossSelling\CrossSellingElementC
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\Struct;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class CrossSellingStruct extends Struct
 {

--- a/src/Core/Content/Cms/SalesChannel/Struct/HtmlStruct.php
+++ b/src/Core/Content/Cms/SalesChannel/Struct/HtmlStruct.php
@@ -5,6 +5,9 @@ namespace Shopware\Core\Content\Cms\SalesChannel\Struct;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\Struct;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class HtmlStruct extends Struct
 {

--- a/src/Core/Content/Cms/SalesChannel/Struct/ImageSliderItemStruct.php
+++ b/src/Core/Content/Cms/SalesChannel/Struct/ImageSliderItemStruct.php
@@ -6,6 +6,9 @@ use Shopware\Core\Content\Media\MediaEntity;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\Struct;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class ImageSliderItemStruct extends Struct
 {

--- a/src/Core/Content/Cms/SalesChannel/Struct/ImageSliderStruct.php
+++ b/src/Core/Content/Cms/SalesChannel/Struct/ImageSliderStruct.php
@@ -5,6 +5,9 @@ namespace Shopware\Core\Content\Cms\SalesChannel\Struct;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\Struct;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class ImageSliderStruct extends Struct
 {

--- a/src/Core/Content/Cms/SalesChannel/Struct/ManufacturerLogoStruct.php
+++ b/src/Core/Content/Cms/SalesChannel/Struct/ManufacturerLogoStruct.php
@@ -5,6 +5,9 @@ namespace Shopware\Core\Content\Cms\SalesChannel\Struct;
 use Shopware\Core\Content\Product\Aggregate\ProductManufacturer\ProductManufacturerEntity;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class ManufacturerLogoStruct extends ImageStruct
 {

--- a/src/Core/Content/Cms/SalesChannel/Struct/ProductBoxStruct.php
+++ b/src/Core/Content/Cms/SalesChannel/Struct/ProductBoxStruct.php
@@ -6,6 +6,9 @@ use Shopware\Core\Content\Product\SalesChannel\SalesChannelProductEntity;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\Struct;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class ProductBoxStruct extends Struct
 {

--- a/src/Core/Content/Cms/SalesChannel/Struct/ProductDescriptionReviewsStruct.php
+++ b/src/Core/Content/Cms/SalesChannel/Struct/ProductDescriptionReviewsStruct.php
@@ -7,6 +7,9 @@ use Shopware\Core\Content\Product\SalesChannel\SalesChannelProductEntity;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\Struct;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class ProductDescriptionReviewsStruct extends Struct
 {

--- a/src/Core/Content/Cms/SalesChannel/Struct/ProductListingStruct.php
+++ b/src/Core/Content/Cms/SalesChannel/Struct/ProductListingStruct.php
@@ -7,6 +7,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\Struct;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class ProductListingStruct extends Struct
 {

--- a/src/Core/Content/Cms/SalesChannel/Struct/ProductSliderStruct.php
+++ b/src/Core/Content/Cms/SalesChannel/Struct/ProductSliderStruct.php
@@ -6,6 +6,9 @@ use Shopware\Core\Content\Product\ProductCollection;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\Struct;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class ProductSliderStruct extends Struct
 {

--- a/src/Core/Content/Cms/SalesChannel/Struct/TextStruct.php
+++ b/src/Core/Content/Cms/SalesChannel/Struct/TextStruct.php
@@ -5,6 +5,9 @@ namespace Shopware\Core\Content\Cms\SalesChannel\Struct;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\Struct;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class TextStruct extends Struct
 {

--- a/src/Core/Content/ContactForm/SalesChannel/ContactFormRouteResponseStruct.php
+++ b/src/Core/Content/ContactForm/SalesChannel/ContactFormRouteResponseStruct.php
@@ -5,6 +5,9 @@ namespace Shopware\Core\Content\ContactForm\SalesChannel;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\Struct;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class ContactFormRouteResponseStruct extends Struct
 {

--- a/src/Core/Content/Cookie/Event/CookieGroupCollectEvent.php
+++ b/src/Core/Content/Cookie/Event/CookieGroupCollectEvent.php
@@ -11,6 +11,9 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\HttpFoundation\Request;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class CookieGroupCollectEvent implements ShopwareSalesChannelEvent
 {

--- a/src/Core/Content/LandingPage/Aggregate/LandingPageSalesChannel/LandingPageSalesChannelDefinition.php
+++ b/src/Core/Content/LandingPage/Aggregate/LandingPageSalesChannel/LandingPageSalesChannelDefinition.php
@@ -13,6 +13,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\MappingEntityDefinition;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelDefinition;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class LandingPageSalesChannelDefinition extends MappingEntityDefinition
 {

--- a/src/Core/Content/LandingPage/Aggregate/LandingPageTag/LandingPageTagDefinition.php
+++ b/src/Core/Content/LandingPage/Aggregate/LandingPageTag/LandingPageTagDefinition.php
@@ -13,6 +13,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\MappingEntityDefinition;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\Tag\TagDefinition;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class LandingPageTagDefinition extends MappingEntityDefinition
 {

--- a/src/Core/Content/LandingPage/Aggregate/LandingPageTranslation/LandingPageTranslationCollection.php
+++ b/src/Core/Content/LandingPage/Aggregate/LandingPageTranslation/LandingPageTranslationCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<LandingPageTranslationEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('discovery')]
 class LandingPageTranslationCollection extends EntityCollection

--- a/src/Core/Content/LandingPage/Aggregate/LandingPageTranslation/LandingPageTranslationDefinition.php
+++ b/src/Core/Content/LandingPage/Aggregate/LandingPageTranslation/LandingPageTranslationDefinition.php
@@ -13,6 +13,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\StringField;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class LandingPageTranslationDefinition extends EntityTranslationDefinition
 {

--- a/src/Core/Content/LandingPage/Event/LandingPageIndexerEvent.php
+++ b/src/Core/Content/LandingPage/Event/LandingPageIndexerEvent.php
@@ -6,6 +6,9 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Event\NestedEvent;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class LandingPageIndexerEvent extends NestedEvent
 {

--- a/src/Core/Content/LandingPage/Event/LandingPageRouteCacheKeyEvent.php
+++ b/src/Core/Content/LandingPage/Event/LandingPageRouteCacheKeyEvent.php
@@ -9,12 +9,12 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\HttpFoundation\Request;
 
-#[Package('discovery')]
 /**
  * @deprecated tag:v6.8.0 - Will be removed in 6.8.0 as it was not used anymore
  *
  * @codeCoverageIgnore
  */
+#[Package('discovery')]
 class LandingPageRouteCacheKeyEvent extends StoreApiRouteCacheKeyEvent
 {
     public function __construct(

--- a/src/Core/Content/LandingPage/Event/LandingPageRouteCacheKeyEvent.php
+++ b/src/Core/Content/LandingPage/Event/LandingPageRouteCacheKeyEvent.php
@@ -12,6 +12,8 @@ use Symfony\Component\HttpFoundation\Request;
 #[Package('discovery')]
 /**
  * @deprecated tag:v6.8.0 - Will be removed in 6.8.0 as it was not used anymore
+ *
+ * @codeCoverageIgnore
  */
 class LandingPageRouteCacheKeyEvent extends StoreApiRouteCacheKeyEvent
 {

--- a/src/Core/Content/LandingPage/Event/LandingPageRouteCacheTagsEvent.php
+++ b/src/Core/Content/LandingPage/Event/LandingPageRouteCacheTagsEvent.php
@@ -11,12 +11,12 @@ use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\System\SalesChannel\StoreApiResponse;
 use Symfony\Component\HttpFoundation\Request;
 
-#[Package('discovery')]
 /**
  * @deprecated tag:v6.8.0 - Will be removed in 6.8.0 as it was not used anymore
  *
  * @codeCoverageIgnore
  */
+#[Package('discovery')]
 class LandingPageRouteCacheTagsEvent extends StoreApiRouteCacheTagsEvent
 {
     /**

--- a/src/Core/Content/LandingPage/Event/LandingPageRouteCacheTagsEvent.php
+++ b/src/Core/Content/LandingPage/Event/LandingPageRouteCacheTagsEvent.php
@@ -14,6 +14,8 @@ use Symfony\Component\HttpFoundation\Request;
 #[Package('discovery')]
 /**
  * @deprecated tag:v6.8.0 - Will be removed in 6.8.0 as it was not used anymore
+ *
+ * @codeCoverageIgnore
  */
 class LandingPageRouteCacheTagsEvent extends StoreApiRouteCacheTagsEvent
 {

--- a/src/Core/Content/LandingPage/LandingPageCollection.php
+++ b/src/Core/Content/LandingPage/LandingPageCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<LandingPageEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('discovery')]
 class LandingPageCollection extends EntityCollection

--- a/src/Core/Content/LandingPage/LandingPageDefinition.php
+++ b/src/Core/Content/LandingPage/LandingPageDefinition.php
@@ -28,6 +28,9 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelDefinition;
 use Shopware\Core\System\Tag\TagDefinition;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class LandingPageDefinition extends EntityDefinition
 {

--- a/src/Core/Content/LandingPage/SalesChannel/SalesChannelLandingPageDefinition.php
+++ b/src/Core/Content/LandingPage/SalesChannel/SalesChannelLandingPageDefinition.php
@@ -8,6 +8,9 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\Entity\SalesChannelDefinitionInterface;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class SalesChannelLandingPageDefinition extends LandingPageDefinition implements SalesChannelDefinitionInterface
 {

--- a/src/Core/Content/Media/Aggregate/MediaDefaultFolder/MediaDefaultFolderCollection.php
+++ b/src/Core/Content/Media/Aggregate/MediaDefaultFolder/MediaDefaultFolderCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<MediaDefaultFolderEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('discovery')]
 class MediaDefaultFolderCollection extends EntityCollection

--- a/src/Core/Content/Media/Aggregate/MediaDefaultFolder/MediaDefaultFolderDefinition.php
+++ b/src/Core/Content/Media/Aggregate/MediaDefaultFolder/MediaDefaultFolderDefinition.php
@@ -13,6 +13,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\StringField;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class MediaDefaultFolderDefinition extends EntityDefinition
 {

--- a/src/Core/Content/Media/Aggregate/MediaDefaultFolder/MediaDefaultFolderEntity.php
+++ b/src/Core/Content/Media/Aggregate/MediaDefaultFolder/MediaDefaultFolderEntity.php
@@ -8,6 +8,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityCustomFieldsTrait;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityIdTrait;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class MediaDefaultFolderEntity extends Entity
 {

--- a/src/Core/Content/Media/Aggregate/MediaFolder/MediaFolderCollection.php
+++ b/src/Core/Content/Media/Aggregate/MediaFolder/MediaFolderCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<MediaFolderEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('discovery')]
 class MediaFolderCollection extends EntityCollection

--- a/src/Core/Content/Media/Aggregate/MediaFolder/MediaFolderDefinition.php
+++ b/src/Core/Content/Media/Aggregate/MediaFolder/MediaFolderDefinition.php
@@ -26,6 +26,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\TreePathField;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class MediaFolderDefinition extends EntityDefinition
 {

--- a/src/Core/Content/Media/Aggregate/MediaFolderConfiguration/MediaFolderConfigurationCollection.php
+++ b/src/Core/Content/Media/Aggregate/MediaFolderConfiguration/MediaFolderConfigurationCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<MediaFolderConfigurationEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('discovery')]
 class MediaFolderConfigurationCollection extends EntityCollection

--- a/src/Core/Content/Media/Aggregate/MediaFolderConfiguration/MediaFolderConfigurationDefinition.php
+++ b/src/Core/Content/Media/Aggregate/MediaFolderConfiguration/MediaFolderConfigurationDefinition.php
@@ -20,6 +20,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\OneToManyAssociationField
 use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class MediaFolderConfigurationDefinition extends EntityDefinition
 {

--- a/src/Core/Content/Media/Aggregate/MediaFolderConfiguration/MediaFolderConfigurationEntity.php
+++ b/src/Core/Content/Media/Aggregate/MediaFolderConfiguration/MediaFolderConfigurationEntity.php
@@ -9,6 +9,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityCustomFieldsTrait;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityIdTrait;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class MediaFolderConfigurationEntity extends Entity
 {

--- a/src/Core/Content/Media/Aggregate/MediaFolderConfigurationMediaThumbnailSize/MediaFolderConfigurationMediaThumbnailSizeDefinition.php
+++ b/src/Core/Content/Media/Aggregate/MediaFolderConfigurationMediaThumbnailSize/MediaFolderConfigurationMediaThumbnailSizeDefinition.php
@@ -12,6 +12,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\MappingEntityDefinition;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class MediaFolderConfigurationMediaThumbnailSizeDefinition extends MappingEntityDefinition
 {

--- a/src/Core/Content/Media/Aggregate/MediaTag/MediaTagDefinition.php
+++ b/src/Core/Content/Media/Aggregate/MediaTag/MediaTagDefinition.php
@@ -13,6 +13,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\MappingEntityDefinition;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\Tag\TagDefinition;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class MediaTagDefinition extends MappingEntityDefinition
 {

--- a/src/Core/Content/Media/Aggregate/MediaThumbnail/MediaThumbnailCollection.php
+++ b/src/Core/Content/Media/Aggregate/MediaThumbnail/MediaThumbnailCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<MediaThumbnailEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('discovery')]
 class MediaThumbnailCollection extends EntityCollection

--- a/src/Core/Content/Media/Aggregate/MediaThumbnail/MediaThumbnailDefinition.php
+++ b/src/Core/Content/Media/Aggregate/MediaThumbnail/MediaThumbnailDefinition.php
@@ -20,6 +20,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\StringField;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class MediaThumbnailDefinition extends EntityDefinition
 {

--- a/src/Core/Content/Media/Aggregate/MediaThumbnailSize/MediaThumbnailSizeCollection.php
+++ b/src/Core/Content/Media/Aggregate/MediaThumbnailSize/MediaThumbnailSizeCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<MediaThumbnailSizeEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('discovery')]
 class MediaThumbnailSizeCollection extends EntityCollection

--- a/src/Core/Content/Media/Aggregate/MediaThumbnailSize/MediaThumbnailSizeDefinition.php
+++ b/src/Core/Content/Media/Aggregate/MediaThumbnailSize/MediaThumbnailSizeDefinition.php
@@ -17,6 +17,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\OneToManyAssociationField
 use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class MediaThumbnailSizeDefinition extends EntityDefinition
 {

--- a/src/Core/Content/Media/Aggregate/MediaThumbnailSize/MediaThumbnailSizeEntity.php
+++ b/src/Core/Content/Media/Aggregate/MediaThumbnailSize/MediaThumbnailSizeEntity.php
@@ -9,6 +9,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityCustomFieldsTrait;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityIdTrait;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class MediaThumbnailSizeEntity extends Entity
 {

--- a/src/Core/Content/Media/Aggregate/MediaTranslation/MediaTranslationCollection.php
+++ b/src/Core/Content/Media/Aggregate/MediaTranslation/MediaTranslationCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<MediaTranslationEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('discovery')]
 class MediaTranslationCollection extends EntityCollection

--- a/src/Core/Content/Media/Aggregate/MediaTranslation/MediaTranslationDefinition.php
+++ b/src/Core/Content/Media/Aggregate/MediaTranslation/MediaTranslationDefinition.php
@@ -11,6 +11,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\StringField;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class MediaTranslationDefinition extends EntityTranslationDefinition
 {

--- a/src/Core/Content/Media/Aggregate/MediaTranslation/MediaTranslationEntity.php
+++ b/src/Core/Content/Media/Aggregate/MediaTranslation/MediaTranslationEntity.php
@@ -7,6 +7,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityCustomFieldsTrait;
 use Shopware\Core\Framework\DataAbstractionLayer\TranslationEntity;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class MediaTranslationEntity extends TranslationEntity
 {

--- a/src/Core/Content/Media/Core/Params/MediaLocationStruct.php
+++ b/src/Core/Content/Media/Core/Params/MediaLocationStruct.php
@@ -12,6 +12,8 @@ use Shopware\Core\Framework\Struct\Struct;
  * and build over the database or by the request when the media was uploaded or renamed
  *
  * @final
+ *
+ * @codeCoverageIgnore
  */
 #[Package('discovery')]
 class MediaLocationStruct extends Struct

--- a/src/Core/Content/Media/Core/Params/ThumbnailLocationStruct.php
+++ b/src/Core/Content/Media/Core/Params/ThumbnailLocationStruct.php
@@ -12,6 +12,8 @@ use Shopware\Core\Framework\Struct\Struct;
  * and build over the database or by the request when the media was uploaded or renamed
  *
  * @final
+ *
+ * @codeCoverageIgnore
  */
 #[Package('discovery')]
 class ThumbnailLocationStruct extends Struct

--- a/src/Core/Content/Media/Event/MediaFolderConfigurationIndexerEvent.php
+++ b/src/Core/Content/Media/Event/MediaFolderConfigurationIndexerEvent.php
@@ -6,6 +6,9 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Event\NestedEvent;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class MediaFolderConfigurationIndexerEvent extends NestedEvent
 {

--- a/src/Core/Content/Media/Event/MediaFolderIndexerEvent.php
+++ b/src/Core/Content/Media/Event/MediaFolderIndexerEvent.php
@@ -6,6 +6,9 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Event\NestedEvent;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class MediaFolderIndexerEvent extends NestedEvent
 {

--- a/src/Core/Content/Media/Event/MediaIndexerEvent.php
+++ b/src/Core/Content/Media/Event/MediaIndexerEvent.php
@@ -6,6 +6,9 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Event\NestedEvent;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class MediaIndexerEvent extends NestedEvent
 {

--- a/src/Core/Content/Media/Event/MediaPathChangedEvent.php
+++ b/src/Core/Content/Media/Event/MediaPathChangedEvent.php
@@ -9,6 +9,9 @@ use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Symfony\Contracts\EventDispatcher\Event;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class MediaPathChangedEvent extends Event
 {

--- a/src/Core/Content/Media/Event/MediaThumbnailDeletedEvent.php
+++ b/src/Core/Content/Media/Event/MediaThumbnailDeletedEvent.php
@@ -7,6 +7,9 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Log\Package;
 use Symfony\Contracts\EventDispatcher\Event;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class MediaThumbnailDeletedEvent extends Event
 {

--- a/src/Core/Content/Media/Event/ThumbnailGeneratedEvent.php
+++ b/src/Core/Content/Media/Event/ThumbnailGeneratedEvent.php
@@ -7,6 +7,9 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Log\Package;
 use Symfony\Contracts\EventDispatcher\Event;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class ThumbnailGeneratedEvent extends Event
 {

--- a/src/Core/Content/Media/Event/UnusedMediaSearchStartEvent.php
+++ b/src/Core/Content/Media/Event/UnusedMediaSearchStartEvent.php
@@ -6,6 +6,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @internal
+ *
+ * @codeCoverageIgnore
  */
 #[Package('discovery')]
 class UnusedMediaSearchStartEvent

--- a/src/Core/Content/Media/MediaCollection.php
+++ b/src/Core/Content/Media/MediaCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<MediaEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('discovery')]
 class MediaCollection extends EntityCollection

--- a/src/Core/Content/Media/MediaDefinition.php
+++ b/src/Core/Content/Media/MediaDefinition.php
@@ -59,6 +59,9 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\Tag\TagDefinition;
 use Shopware\Core\System\User\UserDefinition;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class MediaDefinition extends EntityDefinition
 {

--- a/src/Core/Content/Media/Thumbnail/ExternalThumbnailCollection.php
+++ b/src/Core/Content/Media/Thumbnail/ExternalThumbnailCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Struct\Collection;
 
 /**
  * @extends Collection<ExternalThumbnailData>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('discovery')]
 class ExternalThumbnailCollection extends Collection

--- a/src/Core/Content/Product/Events/ProductSliderStaticCriteriaEvent.php
+++ b/src/Core/Content/Product/Events/ProductSliderStaticCriteriaEvent.php
@@ -9,6 +9,9 @@ use Shopware\Core\Framework\Event\ShopwareSalesChannelEvent;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class ProductSliderStaticCriteriaEvent implements ShopwareSalesChannelEvent
 {

--- a/src/Core/Content/Product/Events/ProductSliderStreamCriteriaEvent.php
+++ b/src/Core/Content/Product/Events/ProductSliderStreamCriteriaEvent.php
@@ -9,6 +9,9 @@ use Shopware\Core\Framework\Event\ShopwareSalesChannelEvent;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class ProductSliderStreamCriteriaEvent implements ShopwareSalesChannelEvent
 {

--- a/src/Core/Content/Sitemap/Event/SitemapGeneratedEvent.php
+++ b/src/Core/Content/Sitemap/Event/SitemapGeneratedEvent.php
@@ -8,6 +8,9 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Contracts\EventDispatcher\Event;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class SitemapGeneratedEvent extends Event implements ShopwareEvent
 {

--- a/src/Core/Content/Sitemap/Event/SitemapGenerationStartEvent.php
+++ b/src/Core/Content/Sitemap/Event/SitemapGenerationStartEvent.php
@@ -8,6 +8,9 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Contracts\EventDispatcher\Event;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class SitemapGenerationStartEvent extends Event implements ShopwareEvent
 {

--- a/src/Core/Content/Sitemap/Event/SitemapQueryEvent.php
+++ b/src/Core/Content/Sitemap/Event/SitemapQueryEvent.php
@@ -10,6 +10,9 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Contracts\EventDispatcher\Event;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 final class SitemapQueryEvent extends Event implements GenericEvent, ShopwareSalesChannelEvent
 {

--- a/src/Core/Content/Sitemap/Event/SitemapRouteCacheKeyEvent.php
+++ b/src/Core/Content/Sitemap/Event/SitemapRouteCacheKeyEvent.php
@@ -8,6 +8,8 @@ use Shopware\Core\Framework\Log\Package;
 #[Package('discovery')]
 /**
  * @deprecated tag:v6.8.0 - Will be removed in 6.8.0 as it was not used anymore
+ *
+ * @codeCoverageIgnore
  */
 class SitemapRouteCacheKeyEvent extends StoreApiRouteCacheKeyEvent
 {

--- a/src/Core/Content/Sitemap/Event/SitemapRouteCacheTagsEvent.php
+++ b/src/Core/Content/Sitemap/Event/SitemapRouteCacheTagsEvent.php
@@ -8,6 +8,8 @@ use Shopware\Core\Framework\Log\Package;
 #[Package('discovery')]
 /**
  * @deprecated tag:v6.8.0 - Will be removed in 6.8.0 as it was not used anymore
+ *
+ * @codeCoverageIgnore
  */
 class SitemapRouteCacheTagsEvent extends StoreApiRouteCacheTagsEvent
 {

--- a/src/Core/Content/Sitemap/Event/SitemapSalesChannelCriteriaEvent.php
+++ b/src/Core/Content/Sitemap/Event/SitemapSalesChannelCriteriaEvent.php
@@ -8,6 +8,9 @@ use Shopware\Core\Framework\Event\ShopwareEvent;
 use Shopware\Core\Framework\Log\Package;
 use Symfony\Contracts\EventDispatcher\Event;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class SitemapSalesChannelCriteriaEvent extends Event implements ShopwareEvent
 {

--- a/src/Core/Content/Sitemap/Struct/SitemapCollection.php
+++ b/src/Core/Content/Sitemap/Struct/SitemapCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Struct\Collection;
 
 /**
  * @extends Collection<Sitemap>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('discovery')]
 class SitemapCollection extends Collection


### PR DESCRIPTION
### 1. Why is this change necessary?

PHPUnit 12 validates every `#[CoversClass]` target against the coverage source, and the blanket suffix excludes for `src/Core/Content/` turn covered DAL boilerplate classes into invalid targets. The reversal replaces the blanket excludes with per-class annotations (Checkout precedent: #19268), stacked per owning domain so every team reviews only its own classes.

### 2. What does this change do, exactly?

Annotates the 89 logic-free discovery-owned Content DAL classes (Struct/Collection/Event/Definition/Entity/Field) with a per-class `@codeCoverageIgnore`. The annotations have no effect while the suffix excludes in `phpunit.xml.dist` are still in place, so this layer is behaviour-neutral. The excludes are lifted by the top of the stack (#19449), which also covers the logic-bearing classes with unit tests.

Stack layer 2 of 4 (base: the inventory layer #19461; this diff contains only the discovery files).

### 3. Describe each step to reproduce the issue or behaviour.

Annotation-only change. Each touched class gains a `@codeCoverageIgnore` docblock line; no behaviour, no coverage change while the excludes remain.

### 4. Please link to the relevant issues (if any).

- relates #18344

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
