### PR TITLE
test: coverage annotate content after sales

### DIFF
--- a/phpstan-baseline.php
+++ b/phpstan-baseline.php
@@ -140,12 +140,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/src/Core/Content/Media/TypeDetector/TypeDetector.php',
 ];
 $ignoreErrors[] = [
-    'rawMessage' => 'Method Shopware\\Core\\Content\\Newsletter\\Event\\NewsletterSubscribeUrlEvent::getData() return type has no value type specified in iterable type array.',
-    'identifier' => 'missingType.iterableValue',
-    'count' => 1,
-    'path' => __DIR__ . '/src/Core/Content/Newsletter/Event/NewsletterSubscribeUrlEvent.php',
-];
-$ignoreErrors[] = [
     'rawMessage' => 'Construct empty() is not allowed. Use more strict comparison.',
     'identifier' => 'empty.notAllowed',
     'count' => 1,

--- a/src/Core/Content/Flow/Aggregate/FlowSequence/FlowSequenceCollection.php
+++ b/src/Core/Content/Flow/Aggregate/FlowSequence/FlowSequenceCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<FlowSequenceEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('after-sales')]
 class FlowSequenceCollection extends EntityCollection

--- a/src/Core/Content/Flow/Aggregate/FlowSequence/FlowSequenceDefinition.php
+++ b/src/Core/Content/Flow/Aggregate/FlowSequence/FlowSequenceDefinition.php
@@ -23,6 +23,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\StringField;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('after-sales')]
 class FlowSequenceDefinition extends EntityDefinition
 {

--- a/src/Core/Content/Flow/Aggregate/FlowSequence/FlowSequenceEntity.php
+++ b/src/Core/Content/Flow/Aggregate/FlowSequence/FlowSequenceEntity.php
@@ -11,6 +11,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityCustomFieldsTrait;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityIdTrait;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('after-sales')]
 class FlowSequenceEntity extends Entity implements IdAware
 {

--- a/src/Core/Content/Flow/Aggregate/FlowTemplate/FlowTemplateCollection.php
+++ b/src/Core/Content/Flow/Aggregate/FlowTemplate/FlowTemplateCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<FlowTemplateEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('after-sales')]
 class FlowTemplateCollection extends EntityCollection

--- a/src/Core/Content/Flow/Aggregate/FlowTemplate/FlowTemplateDefinition.php
+++ b/src/Core/Content/Flow/Aggregate/FlowTemplate/FlowTemplateDefinition.php
@@ -11,6 +11,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\StringField;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('after-sales')]
 class FlowTemplateDefinition extends EntityDefinition
 {

--- a/src/Core/Content/Flow/Aggregate/FlowTemplate/FlowTemplateEntity.php
+++ b/src/Core/Content/Flow/Aggregate/FlowTemplate/FlowTemplateEntity.php
@@ -6,6 +6,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\Entity;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityIdTrait;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('after-sales')]
 class FlowTemplateEntity extends Entity
 {

--- a/src/Core/Content/Flow/Api/FlowActionDefinition.php
+++ b/src/Core/Content/Flow/Api/FlowActionDefinition.php
@@ -5,6 +5,9 @@ namespace Shopware\Core\Content\Flow\Api;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\Struct;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('after-sales')]
 class FlowActionDefinition extends Struct
 {

--- a/src/Core/Content/Flow/Events/FlowActionCollectorEvent.php
+++ b/src/Core/Content/Flow/Events/FlowActionCollectorEvent.php
@@ -7,6 +7,9 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Event\NestedEvent;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('after-sales')]
 class FlowActionCollectorEvent extends NestedEvent
 {

--- a/src/Core/Content/Flow/Events/FlowIndexerEvent.php
+++ b/src/Core/Content/Flow/Events/FlowIndexerEvent.php
@@ -6,6 +6,9 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Event\NestedEvent;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('after-sales')]
 class FlowIndexerEvent extends NestedEvent
 {

--- a/src/Core/Content/Flow/FlowCollection.php
+++ b/src/Core/Content/Flow/FlowCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<FlowEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('after-sales')]
 class FlowCollection extends EntityCollection

--- a/src/Core/Content/Flow/FlowDefinition.php
+++ b/src/Core/Content/Flow/FlowDefinition.php
@@ -23,6 +23,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\StringField;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('after-sales')]
 class FlowDefinition extends EntityDefinition
 {

--- a/src/Core/Content/Flow/FlowEntity.php
+++ b/src/Core/Content/Flow/FlowEntity.php
@@ -10,6 +10,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityCustomFieldsTrait;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityIdTrait;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('after-sales')]
 class FlowEntity extends Entity
 {

--- a/src/Core/Content/ImportExport/Aggregate/ImportExportFile/ImportExportFileDefinition.php
+++ b/src/Core/Content/ImportExport/Aggregate/ImportExportFile/ImportExportFileDefinition.php
@@ -15,6 +15,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\StringField;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('fundamentals@after-sales')]
 class ImportExportFileDefinition extends EntityDefinition
 {

--- a/src/Core/Content/ImportExport/Aggregate/ImportExportFile/ImportExportFileEntity.php
+++ b/src/Core/Content/ImportExport/Aggregate/ImportExportFile/ImportExportFileEntity.php
@@ -8,6 +8,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityIdTrait;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Util\Random;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('fundamentals@after-sales')]
 class ImportExportFileEntity extends Entity
 {

--- a/src/Core/Content/ImportExport/Aggregate/ImportExportLog/ImportExportLogCollection.php
+++ b/src/Core/Content/ImportExport/Aggregate/ImportExportLog/ImportExportLogCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<ImportExportLogEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('fundamentals@after-sales')]
 class ImportExportLogCollection extends EntityCollection

--- a/src/Core/Content/ImportExport/Aggregate/ImportExportLog/ImportExportLogDefinition.php
+++ b/src/Core/Content/ImportExport/Aggregate/ImportExportLog/ImportExportLogDefinition.php
@@ -21,6 +21,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\User\UserDefinition;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('fundamentals@after-sales')]
 class ImportExportLogDefinition extends EntityDefinition
 {

--- a/src/Core/Content/ImportExport/Aggregate/ImportExportLog/ImportExportLogEntity.php
+++ b/src/Core/Content/ImportExport/Aggregate/ImportExportLog/ImportExportLogEntity.php
@@ -9,6 +9,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityIdTrait;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\User\UserEntity;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('fundamentals@after-sales')]
 class ImportExportLogEntity extends Entity
 {

--- a/src/Core/Content/ImportExport/Event/ImportExportAfterImportRecordEvent.php
+++ b/src/Core/Content/ImportExport/Event/ImportExportAfterImportRecordEvent.php
@@ -8,6 +8,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\Event\EntityWrittenContainerEve
 use Shopware\Core\Framework\Log\Package;
 use Symfony\Contracts\EventDispatcher\Event;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('fundamentals@after-sales')]
 class ImportExportAfterImportRecordEvent extends Event
 {

--- a/src/Core/Content/ImportExport/Event/ImportExportAfterProcessFinishedEvent.php
+++ b/src/Core/Content/ImportExport/Event/ImportExportAfterProcessFinishedEvent.php
@@ -8,6 +8,9 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Log\Package;
 use Symfony\Contracts\EventDispatcher\Event;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('fundamentals@after-sales')]
 class ImportExportAfterProcessFinishedEvent extends Event
 {

--- a/src/Core/Content/ImportExport/Event/ImportExportBeforeImportRecordEvent.php
+++ b/src/Core/Content/ImportExport/Event/ImportExportBeforeImportRecordEvent.php
@@ -7,6 +7,9 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Log\Package;
 use Symfony\Contracts\EventDispatcher\Event;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('fundamentals@after-sales')]
 class ImportExportBeforeImportRecordEvent extends Event
 {

--- a/src/Core/Content/ImportExport/Event/ImportExportBeforeImportRowEvent.php
+++ b/src/Core/Content/ImportExport/Event/ImportExportBeforeImportRowEvent.php
@@ -7,6 +7,9 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Log\Package;
 use Symfony\Contracts\EventDispatcher\Event;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('fundamentals@after-sales')]
 class ImportExportBeforeImportRowEvent extends Event
 {

--- a/src/Core/Content/ImportExport/Event/ImportExportExceptionExportRecordEvent.php
+++ b/src/Core/Content/ImportExport/Event/ImportExportExceptionExportRecordEvent.php
@@ -7,6 +7,9 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Log\Package;
 use Symfony\Contracts\EventDispatcher\Event;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('fundamentals@after-sales')]
 class ImportExportExceptionExportRecordEvent extends Event
 {

--- a/src/Core/Content/ImportExport/ImportExportProfileEntity.php
+++ b/src/Core/Content/ImportExport/ImportExportProfileEntity.php
@@ -9,6 +9,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityIdTrait;
 use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('fundamentals@after-sales')]
 class ImportExportProfileEntity extends Entity
 {

--- a/src/Core/Content/ImportExport/ImportExportProfileTranslationCollection.php
+++ b/src/Core/Content/ImportExport/ImportExportProfileTranslationCollection.php
@@ -10,6 +10,8 @@ use Shopware\Core\Framework\Log\Package;
  * @deprecated tag:v6.8.0 - reason:remove-entity - Will be removed
  *
  * @extends EntityCollection<ImportExportProfileTranslationEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('fundamentals@after-sales')]
 class ImportExportProfileTranslationCollection extends EntityCollection

--- a/src/Core/Content/ImportExport/ImportExportProfileTranslationDefinition.php
+++ b/src/Core/Content/ImportExport/ImportExportProfileTranslationDefinition.php
@@ -9,6 +9,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @deprecated tag:v6.8.0 - reason:remove-entity - Will be removed
+ *
+ * @codeCoverageIgnore
  */
 #[Package('fundamentals@after-sales')]
 class ImportExportProfileTranslationDefinition extends EntityTranslationDefinition

--- a/src/Core/Content/ImportExport/ImportExportProfileTranslationEntity.php
+++ b/src/Core/Content/ImportExport/ImportExportProfileTranslationEntity.php
@@ -8,6 +8,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @deprecated tag:v6.8.0 - reason:remove-entity - Will be removed
+ *
+ * @codeCoverageIgnore
  */
 #[Package('fundamentals@after-sales')]
 class ImportExportProfileTranslationEntity extends TranslationEntity

--- a/src/Core/Content/MailTemplate/Aggregate/MailHeaderFooter/MailHeaderFooterCollection.php
+++ b/src/Core/Content/MailTemplate/Aggregate/MailHeaderFooter/MailHeaderFooterCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<MailHeaderFooterEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('after-sales')]
 class MailHeaderFooterCollection extends EntityCollection

--- a/src/Core/Content/MailTemplate/Aggregate/MailHeaderFooter/MailHeaderFooterDefinition.php
+++ b/src/Core/Content/MailTemplate/Aggregate/MailHeaderFooter/MailHeaderFooterDefinition.php
@@ -16,6 +16,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelDefinition;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('after-sales')]
 class MailHeaderFooterDefinition extends EntityDefinition
 {

--- a/src/Core/Content/MailTemplate/Aggregate/MailHeaderFooter/MailHeaderFooterEntity.php
+++ b/src/Core/Content/MailTemplate/Aggregate/MailHeaderFooter/MailHeaderFooterEntity.php
@@ -8,6 +8,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityIdTrait;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelCollection;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('after-sales')]
 class MailHeaderFooterEntity extends Entity
 {

--- a/src/Core/Content/MailTemplate/Aggregate/MailHeaderFooterTranslation/MailHeaderFooterTranslationCollection.php
+++ b/src/Core/Content/MailTemplate/Aggregate/MailHeaderFooterTranslation/MailHeaderFooterTranslationCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<MailHeaderFooterTranslationEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('after-sales')]
 class MailHeaderFooterTranslationCollection extends EntityCollection

--- a/src/Core/Content/MailTemplate/Aggregate/MailHeaderFooterTranslation/MailHeaderFooterTranslationDefinition.php
+++ b/src/Core/Content/MailTemplate/Aggregate/MailHeaderFooterTranslation/MailHeaderFooterTranslationDefinition.php
@@ -12,6 +12,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\StringField;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('after-sales')]
 class MailHeaderFooterTranslationDefinition extends EntityTranslationDefinition
 {

--- a/src/Core/Content/MailTemplate/Aggregate/MailHeaderFooterTranslation/MailHeaderFooterTranslationEntity.php
+++ b/src/Core/Content/MailTemplate/Aggregate/MailHeaderFooterTranslation/MailHeaderFooterTranslationEntity.php
@@ -6,6 +6,9 @@ use Shopware\Core\Content\MailTemplate\Aggregate\MailHeaderFooter\MailHeaderFoot
 use Shopware\Core\Framework\DataAbstractionLayer\TranslationEntity;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('after-sales')]
 class MailHeaderFooterTranslationEntity extends TranslationEntity
 {

--- a/src/Core/Content/MailTemplate/Aggregate/MailTemplateMedia/MailTemplateMediaCollection.php
+++ b/src/Core/Content/MailTemplate/Aggregate/MailTemplateMedia/MailTemplateMediaCollection.php
@@ -8,6 +8,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<MailTemplateMediaEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('after-sales')]
 class MailTemplateMediaCollection extends EntityCollection

--- a/src/Core/Content/MailTemplate/Aggregate/MailTemplateMedia/MailTemplateMediaDefinition.php
+++ b/src/Core/Content/MailTemplate/Aggregate/MailTemplateMedia/MailTemplateMediaDefinition.php
@@ -16,6 +16,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\MappingEntityDefinition;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\Language\LanguageDefinition;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('after-sales')]
 class MailTemplateMediaDefinition extends MappingEntityDefinition
 {

--- a/src/Core/Content/MailTemplate/Aggregate/MailTemplateMedia/MailTemplateMediaEntity.php
+++ b/src/Core/Content/MailTemplate/Aggregate/MailTemplateMedia/MailTemplateMediaEntity.php
@@ -8,6 +8,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\Entity;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityIdTrait;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('after-sales')]
 class MailTemplateMediaEntity extends Entity
 {

--- a/src/Core/Content/MailTemplate/Aggregate/MailTemplateTranslation/MailTemplateTranslationCollection.php
+++ b/src/Core/Content/MailTemplate/Aggregate/MailTemplateTranslation/MailTemplateTranslationCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<MailTemplateTranslationEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('after-sales')]
 class MailTemplateTranslationCollection extends EntityCollection

--- a/src/Core/Content/MailTemplate/Aggregate/MailTemplateTranslation/MailTemplateTranslationDefinition.php
+++ b/src/Core/Content/MailTemplate/Aggregate/MailTemplateTranslation/MailTemplateTranslationDefinition.php
@@ -13,6 +13,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\StringField;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('after-sales')]
 class MailTemplateTranslationDefinition extends EntityTranslationDefinition
 {

--- a/src/Core/Content/MailTemplate/Aggregate/MailTemplateTranslation/MailTemplateTranslationEntity.php
+++ b/src/Core/Content/MailTemplate/Aggregate/MailTemplateTranslation/MailTemplateTranslationEntity.php
@@ -7,6 +7,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityCustomFieldsTrait;
 use Shopware\Core\Framework\DataAbstractionLayer\TranslationEntity;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('after-sales')]
 class MailTemplateTranslationEntity extends TranslationEntity
 {

--- a/src/Core/Content/MailTemplate/Aggregate/MailTemplateType/MailTemplateTypeCollection.php
+++ b/src/Core/Content/MailTemplate/Aggregate/MailTemplateType/MailTemplateTypeCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<MailTemplateTypeEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('after-sales')]
 class MailTemplateTypeCollection extends EntityCollection

--- a/src/Core/Content/MailTemplate/Aggregate/MailTemplateType/MailTemplateTypeEntity.php
+++ b/src/Core/Content/MailTemplate/Aggregate/MailTemplateType/MailTemplateTypeEntity.php
@@ -10,6 +10,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityIdTrait;
 use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('after-sales')]
 class MailTemplateTypeEntity extends Entity
 {

--- a/src/Core/Content/MailTemplate/Aggregate/MailTemplateTypeTranslation/MailTemplateTypeTranslationCollection.php
+++ b/src/Core/Content/MailTemplate/Aggregate/MailTemplateTypeTranslation/MailTemplateTypeTranslationCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<MailTemplateTypeTranslationEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('after-sales')]
 class MailTemplateTypeTranslationCollection extends EntityCollection

--- a/src/Core/Content/MailTemplate/Aggregate/MailTemplateTypeTranslation/MailTemplateTypeTranslationDefinition.php
+++ b/src/Core/Content/MailTemplate/Aggregate/MailTemplateTypeTranslation/MailTemplateTypeTranslationDefinition.php
@@ -11,6 +11,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\StringField;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('after-sales')]
 class MailTemplateTypeTranslationDefinition extends EntityTranslationDefinition
 {

--- a/src/Core/Content/MailTemplate/Aggregate/MailTemplateTypeTranslation/MailTemplateTypeTranslationEntity.php
+++ b/src/Core/Content/MailTemplate/Aggregate/MailTemplateTypeTranslation/MailTemplateTypeTranslationEntity.php
@@ -7,6 +7,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityCustomFieldsTrait;
 use Shopware\Core\Framework\DataAbstractionLayer\TranslationEntity;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('after-sales')]
 class MailTemplateTypeTranslationEntity extends TranslationEntity
 {

--- a/src/Core/Content/MailTemplate/MailTemplateCollection.php
+++ b/src/Core/Content/MailTemplate/MailTemplateCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<MailTemplateEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('after-sales')]
 class MailTemplateCollection extends EntityCollection

--- a/src/Core/Content/MailTemplate/MailTemplateDefinition.php
+++ b/src/Core/Content/MailTemplate/MailTemplateDefinition.php
@@ -22,6 +22,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\WasModifiedByUserField;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('after-sales')]
 class MailTemplateDefinition extends EntityDefinition
 {

--- a/src/Core/Content/MailTemplate/MailTemplateEntity.php
+++ b/src/Core/Content/MailTemplate/MailTemplateEntity.php
@@ -10,6 +10,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityCustomFieldsTrait;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityIdTrait;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('after-sales')]
 class MailTemplateEntity extends Entity
 {

--- a/src/Core/Content/MailTemplate/Service/Event/MailDataSimulatorFieldEvent.php
+++ b/src/Core/Content/MailTemplate/Service/Event/MailDataSimulatorFieldEvent.php
@@ -7,6 +7,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\Field;
 use Shopware\Core\Framework\Log\Package;
 use Symfony\Contracts\EventDispatcher\Event;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('after-sales')]
 class MailDataSimulatorFieldEvent extends Event
 {

--- a/src/Core/Content/MailTemplate/Service/Event/MailDataSimulatorFormDataEvent.php
+++ b/src/Core/Content/MailTemplate/Service/Event/MailDataSimulatorFormDataEvent.php
@@ -6,6 +6,9 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Log\Package;
 use Symfony\Contracts\EventDispatcher\Event;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('after-sales')]
 class MailDataSimulatorFormDataEvent extends Event
 {

--- a/src/Core/Content/Newsletter/Aggregate/NewsletterRecipient/NewsletterRecipientCollection.php
+++ b/src/Core/Content/Newsletter/Aggregate/NewsletterRecipient/NewsletterRecipientCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<NewsletterRecipientEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('after-sales')]
 class NewsletterRecipientCollection extends EntityCollection

--- a/src/Core/Content/Newsletter/Aggregate/NewsletterRecipient/NewsletterRecipientDefinition.php
+++ b/src/Core/Content/Newsletter/Aggregate/NewsletterRecipient/NewsletterRecipientDefinition.php
@@ -22,6 +22,9 @@ use Shopware\Core\System\SalesChannel\SalesChannelDefinition;
 use Shopware\Core\System\Salutation\SalutationDefinition;
 use Shopware\Core\System\Tag\TagDefinition;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('after-sales')]
 class NewsletterRecipientDefinition extends EntityDefinition
 {

--- a/src/Core/Content/Newsletter/Aggregate/NewsletterRecipient/NewsletterRecipientEntity.php
+++ b/src/Core/Content/Newsletter/Aggregate/NewsletterRecipient/NewsletterRecipientEntity.php
@@ -11,6 +11,9 @@ use Shopware\Core\System\SalesChannel\SalesChannelEntity;
 use Shopware\Core\System\Salutation\SalutationEntity;
 use Shopware\Core\System\Tag\TagCollection;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('after-sales')]
 class NewsletterRecipientEntity extends Entity
 {

--- a/src/Core/Content/Newsletter/Aggregate/NewsletterRecipientTag/NewsletterRecipientTagDefinition.php
+++ b/src/Core/Content/Newsletter/Aggregate/NewsletterRecipientTag/NewsletterRecipientTagDefinition.php
@@ -12,6 +12,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\MappingEntityDefinition;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\Tag\TagDefinition;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('after-sales')]
 class NewsletterRecipientTagDefinition extends MappingEntityDefinition
 {

--- a/src/Core/Content/Newsletter/Event/NewsletterRecipientIndexerEvent.php
+++ b/src/Core/Content/Newsletter/Event/NewsletterRecipientIndexerEvent.php
@@ -6,6 +6,9 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Event\NestedEvent;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('after-sales')]
 class NewsletterRecipientIndexerEvent extends NestedEvent
 {

--- a/src/Core/Content/Newsletter/Event/NewsletterSubscribeUrlEvent.php
+++ b/src/Core/Content/Newsletter/Event/NewsletterSubscribeUrlEvent.php
@@ -9,6 +9,9 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Contracts\EventDispatcher\Event;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('after-sales')]
 class NewsletterSubscribeUrlEvent extends Event implements ShopwareSalesChannelEvent
 {

--- a/src/Core/Content/Newsletter/Event/NewsletterSubscribeUrlEvent.php
+++ b/src/Core/Content/Newsletter/Event/NewsletterSubscribeUrlEvent.php
@@ -63,6 +63,9 @@ class NewsletterSubscribeUrlEvent extends Event implements ShopwareSalesChannelE
         return $this->hash;
     }
 
+    /**
+     * @return array<string, mixed>
+     */
     public function getData(): array
     {
         return $this->data;

--- a/src/Core/Content/Newsletter/SalesChannel/SalesChannelNewsletterRecipientDefinition.php
+++ b/src/Core/Content/Newsletter/SalesChannel/SalesChannelNewsletterRecipientDefinition.php
@@ -9,6 +9,9 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\Entity\SalesChannelDefinitionInterface;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('after-sales')]
 class SalesChannelNewsletterRecipientDefinition extends NewsletterRecipientDefinition implements SalesChannelDefinitionInterface
 {

--- a/src/Core/Content/Product/Aggregate/ProductReview/ProductReviewCollection.php
+++ b/src/Core/Content/Product/Aggregate/ProductReview/ProductReviewCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<ProductReviewEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('after-sales')]
 class ProductReviewCollection extends EntityCollection

--- a/src/Core/Content/Product/Aggregate/ProductReview/ProductReviewDefinition.php
+++ b/src/Core/Content/Product/Aggregate/ProductReview/ProductReviewDefinition.php
@@ -23,6 +23,9 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\Language\LanguageDefinition;
 use Shopware\Core\System\SalesChannel\SalesChannelDefinition;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('after-sales')]
 class ProductReviewDefinition extends EntityDefinition
 {

--- a/src/Core/Content/Product/Aggregate/ProductReview/ProductReviewEntity.php
+++ b/src/Core/Content/Product/Aggregate/ProductReview/ProductReviewEntity.php
@@ -11,6 +11,9 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\Language\LanguageEntity;
 use Shopware\Core\System\SalesChannel\SalesChannelEntity;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('after-sales')]
 class ProductReviewEntity extends Entity
 {

--- a/src/Core/Content/Product/SalesChannel/Review/Event/ProductReviewsLoadedEvent.php
+++ b/src/Core/Content/Product/SalesChannel/Review/Event/ProductReviewsLoadedEvent.php
@@ -10,6 +10,9 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\HttpFoundation\Request;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('after-sales')]
 final class ProductReviewsLoadedEvent extends NestedEvent implements ShopwareSalesChannelEvent
 {

--- a/src/Core/Content/RevocationRequest/Event/RevocationRequestEvent.php
+++ b/src/Core/Content/RevocationRequest/Event/RevocationRequestEvent.php
@@ -15,6 +15,9 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Validation\DataBag\DataBag;
 use Symfony\Contracts\EventDispatcher\Event;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('after-sales')]
 final class RevocationRequestEvent extends Event implements SalesChannelAware, MailAware, ScalarValuesAware, FlowEventAware
 {

--- a/src/Core/Content/Rule/Aggregate/RuleCondition/RuleConditionCollection.php
+++ b/src/Core/Content/Rule/Aggregate/RuleCondition/RuleConditionCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<RuleConditionEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('fundamentals@after-sales')]
 class RuleConditionCollection extends EntityCollection

--- a/src/Core/Content/Rule/Aggregate/RuleCondition/RuleConditionDefinition.php
+++ b/src/Core/Content/Rule/Aggregate/RuleCondition/RuleConditionDefinition.php
@@ -20,6 +20,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\StringField;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('fundamentals@after-sales')]
 class RuleConditionDefinition extends EntityDefinition
 {

--- a/src/Core/Content/Rule/Aggregate/RuleCondition/RuleConditionEntity.php
+++ b/src/Core/Content/Rule/Aggregate/RuleCondition/RuleConditionEntity.php
@@ -10,6 +10,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityCustomFieldsTrait;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityIdTrait;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('fundamentals@after-sales')]
 class RuleConditionEntity extends Entity implements IdAware
 {

--- a/src/Core/Content/Rule/Aggregate/RuleTag/RuleTagDefinition.php
+++ b/src/Core/Content/Rule/Aggregate/RuleTag/RuleTagDefinition.php
@@ -12,6 +12,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\MappingEntityDefinition;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\Tag\TagDefinition;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('fundamentals@after-sales')]
 class RuleTagDefinition extends MappingEntityDefinition
 {

--- a/src/Core/Content/Rule/Event/RuleIndexerEvent.php
+++ b/src/Core/Content/Rule/Event/RuleIndexerEvent.php
@@ -6,6 +6,9 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Event\NestedEvent;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('fundamentals@after-sales')]
 class RuleIndexerEvent extends NestedEvent
 {

--- a/src/Core/Content/Rule/RuleDefinition.php
+++ b/src/Core/Content/Rule/RuleDefinition.php
@@ -43,6 +43,9 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\Tag\TagDefinition;
 use Shopware\Core\System\TaxProvider\TaxProviderDefinition;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('fundamentals@after-sales')]
 class RuleDefinition extends EntityDefinition
 {

--- a/src/Core/Content/Rule/RuleEntity.php
+++ b/src/Core/Content/Rule/RuleEntity.php
@@ -19,6 +19,9 @@ use Shopware\Core\Framework\Rule\Rule;
 use Shopware\Core\System\Tag\TagCollection;
 use Shopware\Core\System\TaxProvider\TaxProviderCollection;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('fundamentals@after-sales')]
 class RuleEntity extends Entity
 {

--- a/src/Core/Content/Shared/MailFlow/Event/MailFlowDataCriteriaEvent.php
+++ b/src/Core/Content/Shared/MailFlow/Event/MailFlowDataCriteriaEvent.php
@@ -9,6 +9,9 @@ use Shopware\Core\Framework\Event\ShopwareEvent;
 use Shopware\Core\Framework\Log\Package;
 use Symfony\Contracts\EventDispatcher\Event;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('after-sales')]
 class MailFlowDataCriteriaEvent extends Event implements ShopwareEvent, GenericEvent
 {


### PR DESCRIPTION
### 1. Why is this change necessary?

PHPUnit 12 validates every `#[CoversClass]` target against the coverage source, and the blanket suffix excludes for `src/Core/Content/` turn covered DAL boilerplate classes into invalid targets. The reversal replaces the blanket excludes with per-class annotations (Checkout precedent: #19268), stacked per owning domain so every team reviews only its own classes.

### 2. What does this change do, exactly?

Annotates the 68 logic-free after-sales-owned Content DAL classes (Struct/Collection/Event/Definition/Entity/Field) with a per-class `@codeCoverageIgnore`. The annotations have no effect while the suffix excludes in `phpunit.xml.dist` are still in place, so this layer is behaviour-neutral. The excludes are lifted by the top of the stack (#19449), which also covers the logic-bearing classes with unit tests.

Stack layer 3 of 4 (base: the discovery layer #19462). Also fixes the PHPStan-baselined missing return type in NewsletterSubscribeUrlEvent touched by this layer, as requested by the Danger boyscout rule.

### 3. Describe each step to reproduce the issue or behaviour.

Annotation-only change. Each touched class gains a `@codeCoverageIgnore` docblock line; no behaviour, no coverage change while the excludes remain.

### 4. Please link to the relevant issues (if any).

- relates #18344

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
