### PR TITLE
fix: EU guarantee labels translated manufacturers

### DIFF
--- a/src/Core/Content/Product/Garan/GaranLabelResolver.php
+++ b/src/Core/Content/Product/Garan/GaranLabelResolver.php
@@ -26,7 +26,7 @@ class GaranLabelResolver
             return null;
         }
 
-        $brand = trim((string) $product->getManufacturer()?->getName());
+        $brand = trim((string) $product->getManufacturer()?->getTranslation('name'));
         $modelIdentifier = trim((string) $product->getManufacturerNumber());
         $duration = $this->durationFormatter->formatMonths($product->getGuaranteeMonths());
 

--- a/tests/integration/Core/Content/Product/SalesChannel/Garan/GaranLabelRouteTest.php
+++ b/tests/integration/Core/Content/Product/SalesChannel/Garan/GaranLabelRouteTest.php
@@ -5,7 +5,10 @@ namespace Shopware\Tests\Integration\Core\Content\Product\SalesChannel\Garan;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Test\Product\ProductBuilder;
+use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\SalesChannelApiTestBehaviour;
@@ -124,5 +127,63 @@ class GaranLabelRouteTest extends TestCase
         $this->browser->request('GET', '/store-api/product/' . $this->ids->create('unknown-product') . '/garan-label');
 
         static::assertSame(404, $this->browser->getResponse()->getStatusCode());
+    }
+
+    public function testGaranLabelIsRenderedForLanguageWithoutOwnManufacturerTranslation(): void
+    {
+        $context = Context::createDefaultContext();
+
+        $localeCriteria = new Criteria();
+        $localeCriteria->addFilter(new EqualsFilter('code', 'vi-VN'));
+        $localeId = static::getContainer()->get('locale.repository')->searchIds($localeCriteria, $context)->firstId();
+        static::assertIsString($localeId);
+
+        static::getContainer()->get('language.repository')->create([[
+            'id' => $this->ids->get('language'),
+            'name' => 'TestLanguage',
+            'parentId' => Defaults::LANGUAGE_SYSTEM,
+            'active' => true,
+            'localeId' => $localeId,
+            'translationCodeId' => $localeId,
+        ]], $context);
+
+        $browser = $this->createCustomSalesChannelBrowser([
+            'id' => $this->ids->get('translated-sales-channel'),
+            'languageId' => $this->ids->get('language'),
+            'languages' => [
+                ['id' => Defaults::LANGUAGE_SYSTEM],
+                ['id' => $this->ids->get('language')],
+            ],
+            'domains' => [[
+                'languageId' => $this->ids->get('language'),
+                'currencyId' => Defaults::CURRENCY,
+                'snippetSetId' => $this->getSnippetSetIdForLocale('en-GB'),
+                'url' => 'http://localhost/garan-language-test',
+            ]],
+        ]);
+
+        // the manufacturer is only written for the system language, so the sales channel language
+        // above has to fall back to its parent language to resolve the brand name
+        $product = (new ProductBuilder($this->ids, 'garan-product-translated'))
+            ->price(10)
+            ->visibility($this->ids->get('translated-sales-channel'))
+            ->manufacturer('acme')
+            ->build();
+        $product['manufacturerNumber'] = 'ACME-123';
+        $product['guaranteeMonths'] = 36;
+        $product['guaranteeConfirmed'] = true;
+
+        static::getContainer()->get('product.repository')->create([$product], $context);
+
+        $browser->request('GET', '/store-api/product/' . $this->ids->get('garan-product-translated') . '/garan-label');
+
+        $response = json_decode((string) $browser->getResponse()->getContent(), true, 512, \JSON_THROW_ON_ERROR);
+
+        static::assertIsString($response['svg']);
+        static::assertStringContainsString('acme', $response['svg']);
+        static::assertStringContainsString('ACME-123', $response['svg']);
+
+        static::assertIsString($response['nestedSvg']);
+        static::assertStringContainsString('3', $response['nestedSvg']);
     }
 }

--- a/tests/unit/Core/Content/Product/Garan/GaranLabelResolverTest.php
+++ b/tests/unit/Core/Content/Product/Garan/GaranLabelResolverTest.php
@@ -40,6 +40,48 @@ class GaranLabelResolverTest extends TestCase
         static::assertNull($this->createResolver()->resolve($product));
     }
 
+    public function testResolvesToNullWhenManufacturerNameMissing(): void
+    {
+        $product = $this->createProduct(
+            guaranteeConfirmed: true,
+            manufacturerNumber: 'ACME-123',
+            guaranteeMonths: 36,
+            manufacturer: $this->createManufacturer(name: null, translatedName: null)
+        );
+
+        static::assertNull($this->createResolver()->resolve($product));
+    }
+
+    public function testResolvesLabelWhenManufacturerNameIsOnlyAvailableThroughTranslationFallback(): void
+    {
+        $product = $this->createProduct(
+            guaranteeConfirmed: true,
+            manufacturerNumber: 'ACME-123',
+            guaranteeMonths: 36,
+            manufacturer: $this->createManufacturer(name: null, translatedName: 'ACME')
+        );
+
+        $svg = $this->createResolver()->resolve($product);
+
+        static::assertIsString($svg);
+        static::assertStringContainsString('ACME', $svg);
+    }
+
+    public function testResolvesNestedLabelWhenManufacturerNameIsOnlyAvailableThroughTranslationFallback(): void
+    {
+        $product = $this->createProduct(
+            guaranteeConfirmed: true,
+            manufacturerNumber: 'ACME-123',
+            guaranteeMonths: 36,
+            manufacturer: $this->createManufacturer(name: null, translatedName: 'ACME')
+        );
+
+        $svg = $this->createResolver()->resolve($product, GaranLabelResolver::LABEL_TYPE_NESTED);
+
+        static::assertIsString($svg);
+        static::assertStringContainsString('nested', $svg);
+    }
+
     public function testResolvesToSvgForCompleteConfirmedProduct(): void
     {
         $product = $this->createProduct(guaranteeConfirmed: true, manufacturerNumber: 'ACME-123', guaranteeMonths: 36);
@@ -106,15 +148,25 @@ class GaranLabelResolverTest extends TestCase
         return new GaranLabelResolver(new GaranLabelDurationFormatter(), new GaranLabelRenderer($twig));
     }
 
-    private function createProduct(bool $guaranteeConfirmed, ?string $manufacturerNumber, ?int $guaranteeMonths): ProductEntity
+    /**
+     * The DAL only fills `name` with the translation of the current language, while the resolved
+     * translation chain (including the parent language fallback) ends up in `translated`.
+     */
+    private function createManufacturer(?string $name, ?string $translatedName): ProductManufacturerEntity
     {
         $manufacturer = new ProductManufacturerEntity();
         $manufacturer->setId('manufacturer-id');
-        $manufacturer->setName('ACME');
+        $manufacturer->setName($name);
+        $manufacturer->setTranslated(['name' => $translatedName]);
 
+        return $manufacturer;
+    }
+
+    private function createProduct(bool $guaranteeConfirmed, ?string $manufacturerNumber, ?int $guaranteeMonths, ?ProductManufacturerEntity $manufacturer = null): ProductEntity
+    {
         $product = new ProductEntity();
         $product->setId('product-id');
-        $product->setManufacturer($manufacturer);
+        $product->setManufacturer($manufacturer ?? $this->createManufacturer(name: 'ACME', translatedName: 'ACME'));
         $product->setManufacturerNumber($manufacturerNumber);
         $product->setGuaranteeMonths($guaranteeMonths);
         $product->setGuaranteeConfirmed($guaranteeConfirmed);

--- a/tests/unit/Core/Content/Product/Garan/GaranLabelTwigFilterTest.php
+++ b/tests/unit/Core/Content/Product/Garan/GaranLabelTwigFilterTest.php
@@ -200,6 +200,7 @@ class GaranLabelTwigFilterTest extends TestCase
         $manufacturer = new ProductManufacturerEntity();
         $manufacturer->setId('manufacturer-id');
         $manufacturer->setName('ACME');
+        $manufacturer->setTranslated(['name' => 'ACME']);
 
         $product = new ProductEntity();
         $product->setId('product-id');


### PR DESCRIPTION
fixes https://github.com/shopware/shopware/issues/19444

Use translated manufacturer name instead of the `getName` property.

When a new language is added *after* creating a merchant, a name is not available for this merchant in that language. This would lead to the EU Garan Label not showing, due to manufcaturer information missing.

Using the translation property uses a fallback and will always generate an EU Garan Label.