### PR TITLE
fix(dal): preserve association criteria ids

### DIFF
--- a/phpstan-baseline.php
+++ b/phpstan-baseline.php
@@ -326,12 +326,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/src/Core/Framework/DataAbstractionLayer/CompiledFieldCollection.php',
 ];
 $ignoreErrors[] = [
-    'rawMessage' => 'Construct empty() is not allowed. Use more strict comparison.',
-    'identifier' => 'empty.notAllowed',
-    'count' => 1,
-    'path' => __DIR__ . '/src/Core/Framework/DataAbstractionLayer/Dbal/EntityReader.php',
-];
-$ignoreErrors[] = [
     'rawMessage' => 'Throwing new exceptions within classes are not allowed. Please use domain exception pattern. See https://github.com/shopware/platform/blob/v6.4.20.0/adr/2022-02-24-domain-exceptions.md',
     'identifier' => 'shopware.domainException',
     'count' => 1,

--- a/src/Core/Framework/DataAbstractionLayer/Dbal/EntityReader.php
+++ b/src/Core/Framework/DataAbstractionLayer/Dbal/EntityReader.php
@@ -840,10 +840,12 @@ class EntityReader implements EntityReaderInterface
         /** @var EntityCollection<Entity> $collectionClass */
         $collectionClass = $referenceClass->getCollectionClass();
 
+        if ($criteria->getIds() !== []) {
+            $ids = array_values(array_intersect($ids, $criteria->getIds()));
+        }
+
         if ($ids !== []) {
-            if ($criteria->getIds() === []) {
-                $criteria->setIds($ids);
-            }
+            $criteria->setIds($ids);
 
             $data = $this->_read(
                 $criteria,
@@ -1043,12 +1045,14 @@ class EntityReader implements EntityReaderInterface
         /** @var EntityCollection<Entity> $collectionClass */
         $collectionClass = $referenceClass->getCollectionClass();
 
+        if ($fieldCriteria->getIds() !== []) {
+            $ids = array_values(array_intersect($ids, $fieldCriteria->getIds()));
+        }
+
         if ($ids !== []) {
             // only read data when we have found mapped IDs
             // otherwise we would load the whole reference table
-            if ($fieldCriteria->getIds() === []) {
-                $fieldCriteria->setIds($ids);
-            }
+            $fieldCriteria->setIds($ids);
 
             $data = $this->_read(
                 $fieldCriteria,

--- a/src/Core/Framework/DataAbstractionLayer/Dbal/EntityReader.php
+++ b/src/Core/Framework/DataAbstractionLayer/Dbal/EntityReader.php
@@ -1230,7 +1230,7 @@ class EntityReader implements EntityReaderInterface
                 $grouped[$id] = [];
             }
 
-            if (empty($row['child_id'])) {
+            if ($row['child_id'] === null) {
                 continue;
             }
 

--- a/src/Core/Framework/DataAbstractionLayer/Dbal/EntityReader.php
+++ b/src/Core/Framework/DataAbstractionLayer/Dbal/EntityReader.php
@@ -841,7 +841,9 @@ class EntityReader implements EntityReaderInterface
         $collectionClass = $referenceClass->getCollectionClass();
 
         if ($ids !== []) {
-            $criteria->setIds($ids);
+            if ($criteria->getIds() === []) {
+                $criteria->setIds($ids);
+            }
 
             $data = $this->_read(
                 $criteria,
@@ -1044,7 +1046,9 @@ class EntityReader implements EntityReaderInterface
         if ($ids !== []) {
             // only read data when we have found mapped IDs
             // otherwise we would load the whole reference table
-            $fieldCriteria->setIds($ids);
+            if ($fieldCriteria->getIds() === []) {
+                $fieldCriteria->setIds($ids);
+            }
 
             $data = $this->_read(
                 $fieldCriteria,

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Reader/EntityReaderTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Reader/EntityReaderTest.php
@@ -1734,6 +1734,40 @@ class EntityReaderTest extends TestCase
 
         static::assertContains($id2, $category2->getProducts()->getIds());
         static::assertContains($id3, $category2->getProducts()->getIds());
+
+        $criteria = new Criteria([$id1, $id2]);
+        $criteria->getAssociation('products')->setIds([$id1]);
+
+        $categories = $this->categoryRepository
+            ->search($criteria, $context)
+            ->getEntities();
+
+        $category1 = $categories->get($id1);
+        $category2 = $categories->get($id2);
+
+        static::assertInstanceOf(CategoryEntity::class, $category1);
+        static::assertSame([$id1], array_values($category1->getProducts()?->getIds() ?? []));
+
+        static::assertInstanceOf(CategoryEntity::class, $category2);
+        static::assertEmpty($category2->getProducts()?->getIds() ?? []);
+
+        $criteria = new Criteria([$id1, $id2]);
+        $criteria->getAssociation('products')
+            ->setIds([$id1])
+            ->addSorting(new FieldSorting('product.name'));
+
+        $categories = $this->categoryRepository
+            ->search($criteria, $context)
+            ->getEntities();
+
+        $category1 = $categories->get($id1);
+        $category2 = $categories->get($id2);
+
+        static::assertInstanceOf(CategoryEntity::class, $category1);
+        static::assertSame([$id1], array_values($category1->getProducts()?->getIds() ?? []));
+
+        static::assertInstanceOf(CategoryEntity::class, $category2);
+        static::assertEmpty($category2->getProducts()?->getIds() ?? []);
     }
 
     public function testLoadManyToManySupportsFilter(): void

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Reader/EntityReaderTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Reader/EntityReaderTest.php
@@ -1767,7 +1767,7 @@ class EntityReaderTest extends TestCase
         static::assertSame([$id1], array_values($category1->getProducts()?->getIds() ?? []));
 
         static::assertInstanceOf(CategoryEntity::class, $category2);
-        static::assertEmpty($category2->getProducts()?->getIds() ?? []);
+        static::assertSame([], $category2->getProducts()?->getIds() ?? []);
     }
 
     public function testLoadManyToManySupportsFilter(): void

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Reader/EntityReaderTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Reader/EntityReaderTest.php
@@ -1749,7 +1749,7 @@ class EntityReaderTest extends TestCase
         static::assertSame([$id1], array_values($category1->getProducts()?->getIds() ?? []));
 
         static::assertInstanceOf(CategoryEntity::class, $category2);
-        static::assertEmpty($category2->getProducts()?->getIds() ?? []);
+        static::assertSame([], $category2->getProducts()?->getIds() ?? []);
 
         $criteria = new Criteria([$id1, $id2]);
         $criteria->getAssociation('products')


### PR DESCRIPTION
### 1. Why is this change necessary?

Explicit IDs on a many-to-many association criteria are currently replaced by all IDs discovered in the association mapping. This makes `setIds()` ineffective for nested many-to-many associations.

### 2. What does this change do, exactly?

Intersects the mapped association IDs with explicit association criteria IDs before loading the referenced entities, in both many-to-many reader paths.

### 3. Describe each step to reproduce the issue or behaviour.

1. Load two categories with their `products` association.
2. Set the nested association criteria IDs to one product.
3. Before this change, every mapped product is returned; afterwards, only the requested mapped product is returned.

The integration test covers both the regular and restricted association-loading paths.

### 4. Please link to the relevant issues (if any).

Relates to shopware/SwagCommercial#3646.

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have updated developer-facing release notes if this change is **relevant** for external developers
  - Not applicable: this restores existing DAL criteria behavior without changing the public API.
- [x] I have written or adjusted the documentation and agent skills according to my changes
  - Not applicable: no documentation or skill changes are needed.
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them