### PR TITLE
test: align Checkout unit test package attributes with the covered classes

### DIFF
--- a/tests/unit/Core/Checkout/Cart/CartCompressorTest.php
+++ b/tests/unit/Core/Checkout/Cart/CartCompressorTest.php
@@ -13,7 +13,7 @@ use Shopware\Core\Test\Assert\Serialization;
 /**
  * @internal
  */
-#[Package('framework')]
+#[Package('checkout')]
 #[CoversClass(CartCompressor::class)]
 class CartCompressorTest extends TestCase
 {

--- a/tests/unit/Core/Checkout/Cart/Delivery/Struct/DeliveryDateTest.php
+++ b/tests/unit/Core/Checkout/Cart/Delivery/Struct/DeliveryDateTest.php
@@ -15,7 +15,7 @@ use Shopware\Core\System\DeliveryTime\DeliveryTimeEntity;
 /**
  * @internal
  */
-#[Package('framework')]
+#[Package('checkout')]
 #[CoversClass(DeliveryDate::class)]
 class DeliveryDateTest extends TestCase
 {

--- a/tests/unit/Core/Checkout/Cart/ProductCartProcessorTest.php
+++ b/tests/unit/Core/Checkout/Cart/ProductCartProcessorTest.php
@@ -39,7 +39,7 @@ use Shopware\Core\Test\Stub\Checkout\EmptyPrice;
 /**
  * @internal
  */
-#[Package('checkout')]
+#[Package('inventory')]
 #[CoversClass(ProductCartProcessor::class)]
 class ProductCartProcessorTest extends TestCase
 {

--- a/tests/unit/Core/Checkout/Cart/Rule/LineItemGoodsTotalRuleTest.php
+++ b/tests/unit/Core/Checkout/Cart/Rule/LineItemGoodsTotalRuleTest.php
@@ -28,7 +28,7 @@ use Symfony\Component\Validator\Constraints\Type;
 /**
  * @internal
  */
-#[Package('checkout')]
+#[Package('fundamentals@after-sales')]
 #[CoversClass(LineItemGoodsTotalRule::class)]
 #[Group('rules')]
 class LineItemGoodsTotalRuleTest extends TestCase

--- a/tests/unit/Core/Checkout/Cart/Rule/LineItemGroupRuleTest.php
+++ b/tests/unit/Core/Checkout/Cart/Rule/LineItemGroupRuleTest.php
@@ -18,7 +18,7 @@ use Symfony\Component\Validator\Constraints\Type;
 /**
  * @internal
  */
-#[Package('checkout')]
+#[Package('fundamentals@after-sales')]
 #[CoversClass(LineItemGroupRule::class)]
 class LineItemGroupRuleTest extends TestCase
 {

--- a/tests/unit/Core/Checkout/Cart/Rule/LineItemOfTypeRuleTest.php
+++ b/tests/unit/Core/Checkout/Cart/Rule/LineItemOfTypeRuleTest.php
@@ -23,7 +23,7 @@ use Shopware\Core\System\SalesChannel\SalesChannelContext;
 /**
  * @internal
  */
-#[Package('checkout')]
+#[Package('fundamentals@after-sales')]
 #[CoversClass(LineItemOfTypeRule::class)]
 class LineItemOfTypeRuleTest extends TestCase
 {

--- a/tests/unit/Core/Checkout/Cart/Rule/LineItemProductStatesRuleTest.php
+++ b/tests/unit/Core/Checkout/Cart/Rule/LineItemProductStatesRuleTest.php
@@ -24,7 +24,7 @@ use Shopware\Core\System\SalesChannel\SalesChannelContext;
 /**
  * @internal
  */
-#[Package('checkout')]
+#[Package('fundamentals@after-sales')]
 #[CoversClass(LineItemProductStatesRule::class)]
 class LineItemProductStatesRuleTest extends TestCase
 {

--- a/tests/unit/Core/Checkout/Cart/Rule/LineItemPropertyValueRuleTest.php
+++ b/tests/unit/Core/Checkout/Cart/Rule/LineItemPropertyValueRuleTest.php
@@ -23,7 +23,7 @@ use Shopware\Core\System\SalesChannel\SalesChannelContext;
 /**
  * @internal
  */
-#[Package('checkout')]
+#[Package('fundamentals@after-sales')]
 #[CoversClass(LineItemPropertyValueRule::class)]
 #[Group('rules')]
 class LineItemPropertyValueRuleTest extends TestCase

--- a/tests/unit/Core/Checkout/Cart/Rule/LineItemVariantValueRuleTest.php
+++ b/tests/unit/Core/Checkout/Cart/Rule/LineItemVariantValueRuleTest.php
@@ -23,7 +23,7 @@ use Shopware\Core\System\SalesChannel\SalesChannelContext;
 /**
  * @internal
  */
-#[Package('checkout')]
+#[Package('fundamentals@after-sales')]
 #[CoversClass(LineItemVariantValueRule::class)]
 #[Group('rules')]
 class LineItemVariantValueRuleTest extends TestCase

--- a/tests/unit/Core/Checkout/Cart/Validator/Container/NotRuleTest.php
+++ b/tests/unit/Core/Checkout/Cart/Validator/Container/NotRuleTest.php
@@ -14,7 +14,7 @@ use Shopware\Core\Test\Stub\Rule\TrueRule;
 /**
  * @internal
  */
-#[Package('checkout')]
+#[Package('fundamentals@after-sales')]
 #[CoversClass(NotRule::class)]
 class NotRuleTest extends TestCase
 {

--- a/tests/unit/Core/Checkout/Cart/Validator/Container/OrRuleTest.php
+++ b/tests/unit/Core/Checkout/Cart/Validator/Container/OrRuleTest.php
@@ -14,7 +14,7 @@ use Shopware\Core\Test\Stub\Rule\TrueRule;
 /**
  * @internal
  */
-#[Package('checkout')]
+#[Package('fundamentals@after-sales')]
 #[CoversClass(OrRule::class)]
 class OrRuleTest extends TestCase
 {

--- a/tests/unit/Core/Checkout/Cart/Validator/Container/XorRuleTest.php
+++ b/tests/unit/Core/Checkout/Cart/Validator/Container/XorRuleTest.php
@@ -14,7 +14,7 @@ use Shopware\Core\Test\Stub\Rule\TrueRule;
 /**
  * @internal
  */
-#[Package('checkout')]
+#[Package('fundamentals@after-sales')]
 #[CoversClass(XorRule::class)]
 class XorRuleTest extends TestCase
 {

--- a/tests/unit/Core/Checkout/Cart/Validator/RuleCollectionTest.php
+++ b/tests/unit/Core/Checkout/Cart/Validator/RuleCollectionTest.php
@@ -14,7 +14,7 @@ use Shopware\Core\Test\Stub\Rule\TrueRule;
 /**
  * @internal
  */
-#[Package('checkout')]
+#[Package('fundamentals@after-sales')]
 #[CoversClass(RuleCollection::class)]
 class RuleCollectionTest extends TestCase
 {

--- a/tests/unit/Core/Checkout/Customer/Service/ProductReviewCountServiceTest.php
+++ b/tests/unit/Core/Checkout/Customer/Service/ProductReviewCountServiceTest.php
@@ -12,7 +12,7 @@ use Shopware\Core\Framework\Log\Package;
 /**
  * @internal
  */
-#[Package('after-sales')]
+#[Package('checkout')]
 #[CoversClass(ProductReviewCountService::class)]
 class ProductReviewCountServiceTest extends TestCase
 {

--- a/tests/unit/Core/Checkout/Payment/Cart/Token/Constraint/PaymentTokenRegisteredValidatorTest.php
+++ b/tests/unit/Core/Checkout/Payment/Cart/Token/Constraint/PaymentTokenRegisteredValidatorTest.php
@@ -18,7 +18,7 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 /**
  * @internal
  */
-#[Package('checkout')]
+#[Package('framework')]
 #[CoversClass(PaymentTokenRegisteredValidator::class)]
 class PaymentTokenRegisteredValidatorTest extends TestCase
 {

--- a/tests/unit/Core/Checkout/Promotion/Rule/PromotionLineItemRuleTest.php
+++ b/tests/unit/Core/Checkout/Promotion/Rule/PromotionLineItemRuleTest.php
@@ -22,7 +22,7 @@ use Symfony\Component\Validator\Constraints\NotBlank;
 /**
  * @internal
  */
-#[Package('checkout')]
+#[Package('fundamentals@after-sales')]
 #[CoversClass(PromotionLineItemRule::class)]
 class PromotionLineItemRuleTest extends TestCase
 {


### PR DESCRIPTION
### 1. Why is this change necessary?

The `#[Package]` attribute of several tests differs from the ownership of the code they cover, so failing tests are routed to the wrong domain team.

### 2. What does this change do, exactly?

Sets the `#[Package]` value of 16 Checkout unit tests to the value of their covered class. Attribute lines only.

Once this suite is aligned, its namespace is added to the `coversPackageMatchNamespaces` rollout list of the enforcement rule (#19394), which keeps the values in sync from then on.

### 3. Describe each step to reproduce the issue or behaviour.

Attribute-only changes, no behaviour. Compare each test's `#[Package]` value with the `#[Package]` of its `CoversClass` target.

### 4. Please link to the relevant issues (if any).

- relates #18473

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
