### PR TITLE
feat(framework): enforce test package attributes matching covered classes

### DIFF
--- a/.agents/skills/shopware-phpunit-tests/SKILL.md
+++ b/.agents/skills/shopware-phpunit-tests/SKILL.md
@@ -58,7 +58,7 @@ Tests should read like executable examples.
 ## Meta-information of test classes
 
 - Give every test class a `#[Package('…')]` attribute (import `Shopware\Core\Framework\Log\Package`) so failing CI jobs — especially the nightlies — can be routed to the owning domain team. A Danger rule fails PRs that add test classes without it.
-- In unit and migration tests, copy the value from the `#[CoversClass]` target's `#[Package]`.
+- In unit and migration tests, copy the value from the `#[CoversClass]` target's `#[Package]`. A PHPStan rule (`CoversPackageMatchRule`) fails on mismatches; `fundamentals@<area>` counts as equal to `<area>`.
 - Integration tests carry no `#[CoversClass]`; use the dominant `#[Package]` value of the `src/` directory the test path mirrors (e.g. `tests/integration/Core/Checkout/Cart/…` → `src/Core/Checkout/Cart`).
 - When a change moves the covered class to another package, update the test's attribute in the same change so the two stay in sync.
 - Every test class needs to be marked as internal with `@internal` PHPDoc class annotation.

--- a/src/Core/DevOps/StaticAnalyze/PHPStan/Rules/Tests/CoversPackageMatchRule.php
+++ b/src/Core/DevOps/StaticAnalyze/PHPStan/Rules/Tests/CoversPackageMatchRule.php
@@ -1,0 +1,177 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\DevOps\StaticAnalyze\PHPStan\Rules\Tests;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\ClassConstFetch;
+use PhpParser\Node\Scalar\String_;
+use PHPStan\Analyser\Scope;
+use PHPStan\Node\InClassNode;
+use PHPStan\Reflection\ReflectionProvider;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleError;
+use PHPStan\Rules\RuleErrorBuilder;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversTrait;
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * A test's #[Package] value must match the #[Package] of at least one class or trait
+ * named in its CoversClass/CoversTrait attributes, so the routing of a test cannot
+ * drift from the ownership of the code it covers. `fundamentals@<area>` routes to the
+ * <area> team and counts as equal to the plain <area> value in both directions.
+ *
+ * The migration suite is excluded until it is aligned: several migrations carry
+ * `framework` although they migrate feature-domain tables, and there the source
+ * value is the one that has to change.
+ *
+ * @internal
+ *
+ * @implements Rule<InClassNode>
+ */
+#[Package('framework')]
+class CoversPackageMatchRule implements Rule
+{
+    private const EXCLUDED_NAMESPACE = 'Shopware\Tests\Migration\\';
+
+    public function __construct(
+        private readonly ReflectionProvider $reflectionProvider,
+    ) {
+    }
+
+    public function getNodeType(): string
+    {
+        return InClassNode::class;
+    }
+
+    /**
+     * @param InClassNode $node
+     *
+     * @return array<array-key, RuleError|string>
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        $classReflection = $node->getClassReflection();
+
+        if (\str_starts_with($classReflection->getName(), self::EXCLUDED_NAMESPACE)) {
+            return [];
+        }
+
+        if (!TestRuleHelper::isTestClass($classReflection)) {
+            return [];
+        }
+
+        $testPackage = $this->getOwnPackage($node);
+        if ($testPackage === null) {
+            return [];
+        }
+
+        $coveredPackages = $this->getCoveredPackages($node);
+        if ($coveredPackages === []) {
+            return [];
+        }
+
+        $normalizedTestPackage = $this->normalize($testPackage);
+        foreach ($coveredPackages as $coveredPackage) {
+            if ($this->normalize($coveredPackage) === $normalizedTestPackage) {
+                return [];
+            }
+        }
+
+        $covered = [];
+        foreach ($coveredPackages as $target => $coveredPackage) {
+            $covered[] = \sprintf('%s (%s)', $target, $coveredPackage);
+        }
+
+        return [
+            RuleErrorBuilder::message(\sprintf(
+                'The #[Package(\'%s\')] attribute of this test does not match the covered %s',
+                $testPackage,
+                \implode(', ', $covered),
+            ))
+                ->identifier('shopware.coversPackageMismatch')
+                ->build(),
+        ];
+    }
+
+    private function getOwnPackage(InClassNode $class): ?string
+    {
+        foreach ($class->getOriginalNode()->attrGroups as $group) {
+            foreach ($group->attrs as $attribute) {
+                if ($attribute->name->toString() !== Package::class) {
+                    continue;
+                }
+
+                $argument = $attribute->args[0]->value ?? null;
+
+                return $argument instanceof String_ ? $argument->value : null;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @return array<string, string> covered class name => its #[Package] value; targets
+     *                               without a resolvable package are left out, so a test
+     *                               covering only unpackaged code is not checked
+     */
+    private function getCoveredPackages(InClassNode $class): array
+    {
+        $packages = [];
+
+        foreach ($class->getOriginalNode()->attrGroups as $group) {
+            foreach ($group->attrs as $attribute) {
+                if (!\in_array($attribute->name->toString(), [CoversClass::class, CoversTrait::class], true)) {
+                    continue;
+                }
+
+                $target = $this->resolveTargetName($attribute->args[0]->value ?? null);
+                if ($target === null || !$this->reflectionProvider->hasClass($target)) {
+                    continue;
+                }
+
+                $package = $this->getReflectedPackage($target);
+                if ($package !== null) {
+                    $packages[$target] = $package;
+                }
+            }
+        }
+
+        return $packages;
+    }
+
+    private function resolveTargetName(?Node $argument): ?string
+    {
+        if ($argument instanceof ClassConstFetch && $argument->class instanceof Node\Name) {
+            return $argument->class->toString();
+        }
+
+        if ($argument instanceof String_) {
+            return $argument->value;
+        }
+
+        return null;
+    }
+
+    private function getReflectedPackage(string $className): ?string
+    {
+        $attributes = $this->reflectionProvider
+            ->getClass($className)
+            ->getNativeReflection()
+            ->getAttributes(Package::class);
+
+        if ($attributes === []) {
+            return null;
+        }
+
+        $package = $attributes[0]->getArguments()[0] ?? null;
+
+        return \is_string($package) ? $package : null;
+    }
+
+    private function normalize(string $package): string
+    {
+        return \str_starts_with($package, 'fundamentals@') ? \substr($package, \strlen('fundamentals@')) : $package;
+    }
+}

--- a/src/Core/DevOps/StaticAnalyze/PHPStan/core-rules.neon
+++ b/src/Core/DevOps/StaticAnalyze/PHPStan/core-rules.neon
@@ -34,6 +34,8 @@ rules:
     - Shopware\Core\DevOps\StaticAnalyze\PHPStan\Rules\NoRuntimeExceptionInDomainExceptionsRule
     # core-only until the commercial repositories have swept their own reflection backlogs
     - Shopware\Core\DevOps\StaticAnalyze\PHPStan\Rules\Tests\NoReflectionOnNonPublicMethodsRule
+    # core-only: the commercial repositories carry their own package values and routing
+    - Shopware\Core\DevOps\StaticAnalyze\PHPStan\Rules\Tests\CoversPackageMatchRule
 
 services:
     -

--- a/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/CoversPackageMatchRuleTest.php
+++ b/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/CoversPackageMatchRuleTest.php
@@ -1,0 +1,92 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\DevOps\Core\DevOps\StaticAnalyse\PHPStan\Rules;
+
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\TestDox;
+use Shopware\Core\DevOps\StaticAnalyze\PHPStan\Rules\Tests\CoversPackageMatchRule;
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * @internal
+ *
+ * @extends RuleTestCase<CoversPackageMatchRule>
+ */
+#[Package('framework')]
+class CoversPackageMatchRuleTest extends RuleTestCase
+{
+    private const FIXTURE_DIR = __DIR__ . '/data/CoversPackageMatchRule/Tests';
+
+    #[TestDox('accepts a test whose package matches the covered class')]
+    public function testMatchingPackage(): void
+    {
+        $this->analyse([self::FIXTURE_DIR . '/MatchingPackageFixture.php'], []);
+    }
+
+    #[TestDox('rejects a test whose package differs from the covered class')]
+    public function testMismatchedPackage(): void
+    {
+        $this->analyse([self::FIXTURE_DIR . '/MismatchedPackageFixture.php'], [
+            [
+                'The #[Package(\'framework\')] attribute of this test does not match the covered Shopware\Tests\DevOps\Core\DevOps\StaticAnalyse\PHPStan\Rules\data\CoversPackageMatchRule\Covered\CheckoutService (checkout)',
+                10,
+            ],
+        ]);
+    }
+
+    #[TestDox('treats fundamentals@<area> on the covered class as equal to <area>')]
+    public function testFundamentalsOnCoveredClass(): void
+    {
+        $this->analyse([self::FIXTURE_DIR . '/FundamentalsEquivalenceFixture.php'], []);
+    }
+
+    #[TestDox('treats fundamentals@<area> on the test as equal to <area>')]
+    public function testFundamentalsOnTest(): void
+    {
+        $this->analyse([self::FIXTURE_DIR . '/FundamentalsOnTestFixture.php'], []);
+    }
+
+    #[TestDox('accepts a test matching at least one of several covered classes')]
+    public function testOneOfManyMatches(): void
+    {
+        $this->analyse([self::FIXTURE_DIR . '/OneOfManyMatchesFixture.php'], []);
+    }
+
+    #[TestDox('skips tests without a package attribute')]
+    public function testMissingTestPackage(): void
+    {
+        $this->analyse([self::FIXTURE_DIR . '/MissingTestPackageFixture.php'], []);
+    }
+
+    #[TestDox('skips tests covering only unpackaged code')]
+    public function testUnpackagedCoveredClass(): void
+    {
+        $this->analyse([self::FIXTURE_DIR . '/UnpackagedCoveredFixture.php'], []);
+    }
+
+    #[TestDox('skips tests in the migration suite')]
+    public function testMigrationSuiteExcluded(): void
+    {
+        $this->analyse([self::FIXTURE_DIR . '/MigrationSuiteFixture.php'], []);
+    }
+
+    #[TestDox('rejects a test whose package differs from the covered trait')]
+    public function testMismatchedTrait(): void
+    {
+        $this->analyse([self::FIXTURE_DIR . '/MismatchedTraitFixture.php'], [
+            [
+                'The #[Package(\'framework\')] attribute of this test does not match the covered Shopware\Tests\DevOps\Core\DevOps\StaticAnalyse\PHPStan\Rules\data\CoversPackageMatchRule\Covered\CheckoutHelperTrait (checkout)',
+                10,
+            ],
+        ]);
+    }
+
+    /**
+     * @return CoversPackageMatchRule
+     */
+    protected function getRule(): Rule
+    {
+        return new CoversPackageMatchRule($this->createReflectionProvider());
+    }
+}

--- a/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/data/CoversPackageMatchRule/Covered/CheckoutHelperTrait.php
+++ b/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/data/CoversPackageMatchRule/Covered/CheckoutHelperTrait.php
@@ -1,0 +1,10 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\DevOps\Core\DevOps\StaticAnalyse\PHPStan\Rules\data\CoversPackageMatchRule\Covered;
+
+use Shopware\Core\Framework\Log\Package;
+
+#[Package('checkout')]
+trait CheckoutHelperTrait
+{
+}

--- a/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/data/CoversPackageMatchRule/Covered/CheckoutService.php
+++ b/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/data/CoversPackageMatchRule/Covered/CheckoutService.php
@@ -1,0 +1,10 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\DevOps\Core\DevOps\StaticAnalyse\PHPStan\Rules\data\CoversPackageMatchRule\Covered;
+
+use Shopware\Core\Framework\Log\Package;
+
+#[Package('checkout')]
+class CheckoutService
+{
+}

--- a/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/data/CoversPackageMatchRule/Covered/FundamentalsFrameworkService.php
+++ b/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/data/CoversPackageMatchRule/Covered/FundamentalsFrameworkService.php
@@ -1,0 +1,10 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\DevOps\Core\DevOps\StaticAnalyse\PHPStan\Rules\data\CoversPackageMatchRule\Covered;
+
+use Shopware\Core\Framework\Log\Package;
+
+#[Package('fundamentals@framework')]
+class FundamentalsFrameworkService
+{
+}

--- a/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/data/CoversPackageMatchRule/Covered/UnpackagedService.php
+++ b/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/data/CoversPackageMatchRule/Covered/UnpackagedService.php
@@ -1,0 +1,7 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\DevOps\Core\DevOps\StaticAnalyse\PHPStan\Rules\data\CoversPackageMatchRule\Covered;
+
+class UnpackagedService
+{
+}

--- a/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/data/CoversPackageMatchRule/Tests/FundamentalsEquivalenceFixture.php
+++ b/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/data/CoversPackageMatchRule/Tests/FundamentalsEquivalenceFixture.php
@@ -1,0 +1,14 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\DevOps\Core\DevOps\StaticAnalyse\PHPStan\Rules\data\CoversPackageMatchRule\Tests;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Tests\DevOps\Core\DevOps\StaticAnalyse\PHPStan\Rules\data\CoversPackageMatchRule\Covered\FundamentalsFrameworkService;
+
+#[Package('framework')]
+#[CoversClass(FundamentalsFrameworkService::class)]
+class FundamentalsEquivalenceFixture extends TestCase
+{
+}

--- a/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/data/CoversPackageMatchRule/Tests/FundamentalsOnTestFixture.php
+++ b/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/data/CoversPackageMatchRule/Tests/FundamentalsOnTestFixture.php
@@ -1,0 +1,14 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\DevOps\Core\DevOps\StaticAnalyse\PHPStan\Rules\data\CoversPackageMatchRule\Tests;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Tests\DevOps\Core\DevOps\StaticAnalyse\PHPStan\Rules\data\CoversPackageMatchRule\Covered\CheckoutService;
+
+#[Package('fundamentals@checkout')]
+#[CoversClass(CheckoutService::class)]
+class FundamentalsOnTestFixture extends TestCase
+{
+}

--- a/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/data/CoversPackageMatchRule/Tests/MatchingPackageFixture.php
+++ b/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/data/CoversPackageMatchRule/Tests/MatchingPackageFixture.php
@@ -1,0 +1,14 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\DevOps\Core\DevOps\StaticAnalyse\PHPStan\Rules\data\CoversPackageMatchRule\Tests;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Tests\DevOps\Core\DevOps\StaticAnalyse\PHPStan\Rules\data\CoversPackageMatchRule\Covered\CheckoutService;
+
+#[Package('checkout')]
+#[CoversClass(CheckoutService::class)]
+class MatchingPackageFixture extends TestCase
+{
+}

--- a/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/data/CoversPackageMatchRule/Tests/MigrationSuiteFixture.php
+++ b/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/data/CoversPackageMatchRule/Tests/MigrationSuiteFixture.php
@@ -1,0 +1,14 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Migration\Core\DevOps\StaticAnalyse\PHPStan\Rules\data\CoversPackageMatchRule;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Tests\DevOps\Core\DevOps\StaticAnalyse\PHPStan\Rules\data\CoversPackageMatchRule\Covered\CheckoutService;
+
+#[Package('framework')]
+#[CoversClass(CheckoutService::class)]
+class MigrationSuiteFixture extends TestCase
+{
+}

--- a/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/data/CoversPackageMatchRule/Tests/MismatchedPackageFixture.php
+++ b/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/data/CoversPackageMatchRule/Tests/MismatchedPackageFixture.php
@@ -1,0 +1,14 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\DevOps\Core\DevOps\StaticAnalyse\PHPStan\Rules\data\CoversPackageMatchRule\Tests;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Tests\DevOps\Core\DevOps\StaticAnalyse\PHPStan\Rules\data\CoversPackageMatchRule\Covered\CheckoutService;
+
+#[Package('framework')]
+#[CoversClass(CheckoutService::class)]
+class MismatchedPackageFixture extends TestCase
+{
+}

--- a/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/data/CoversPackageMatchRule/Tests/MismatchedTraitFixture.php
+++ b/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/data/CoversPackageMatchRule/Tests/MismatchedTraitFixture.php
@@ -1,0 +1,14 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\DevOps\Core\DevOps\StaticAnalyse\PHPStan\Rules\data\CoversPackageMatchRule\Tests;
+
+use PHPUnit\Framework\Attributes\CoversTrait;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Tests\DevOps\Core\DevOps\StaticAnalyse\PHPStan\Rules\data\CoversPackageMatchRule\Covered\CheckoutHelperTrait;
+
+#[Package('framework')]
+#[CoversTrait(CheckoutHelperTrait::class)]
+class MismatchedTraitFixture extends TestCase
+{
+}

--- a/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/data/CoversPackageMatchRule/Tests/MissingTestPackageFixture.php
+++ b/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/data/CoversPackageMatchRule/Tests/MissingTestPackageFixture.php
@@ -1,0 +1,12 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\DevOps\Core\DevOps\StaticAnalyse\PHPStan\Rules\data\CoversPackageMatchRule\Tests;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Tests\DevOps\Core\DevOps\StaticAnalyse\PHPStan\Rules\data\CoversPackageMatchRule\Covered\CheckoutService;
+
+#[CoversClass(CheckoutService::class)]
+class MissingTestPackageFixture extends TestCase
+{
+}

--- a/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/data/CoversPackageMatchRule/Tests/OneOfManyMatchesFixture.php
+++ b/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/data/CoversPackageMatchRule/Tests/OneOfManyMatchesFixture.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\DevOps\Core\DevOps\StaticAnalyse\PHPStan\Rules\data\CoversPackageMatchRule\Tests;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Tests\DevOps\Core\DevOps\StaticAnalyse\PHPStan\Rules\data\CoversPackageMatchRule\Covered\CheckoutService;
+use Shopware\Tests\DevOps\Core\DevOps\StaticAnalyse\PHPStan\Rules\data\CoversPackageMatchRule\Covered\FundamentalsFrameworkService;
+
+#[Package('checkout')]
+#[CoversClass(CheckoutService::class)]
+#[CoversClass(FundamentalsFrameworkService::class)]
+class OneOfManyMatchesFixture extends TestCase
+{
+}

--- a/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/data/CoversPackageMatchRule/Tests/UnpackagedCoveredFixture.php
+++ b/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/data/CoversPackageMatchRule/Tests/UnpackagedCoveredFixture.php
@@ -1,0 +1,14 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\DevOps\Core\DevOps\StaticAnalyse\PHPStan\Rules\data\CoversPackageMatchRule\Tests;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Tests\DevOps\Core\DevOps\StaticAnalyse\PHPStan\Rules\data\CoversPackageMatchRule\Covered\UnpackagedService;
+
+#[Package('framework')]
+#[CoversClass(UnpackagedService::class)]
+class UnpackagedCoveredFixture extends TestCase
+{
+}

--- a/tests/unit/Administration/Controller/AdministrationControllerTest.php
+++ b/tests/unit/Administration/Controller/AdministrationControllerTest.php
@@ -54,7 +54,7 @@ use Twig\Environment;
 /**
  * @internal
  */
-#[Package('checkout')]
+#[Package('framework')]
 #[CoversClass(AdministrationController::class)]
 class AdministrationControllerTest extends TestCase
 {

--- a/tests/unit/Administration/Snippet/CachedSnippetFinderTest.php
+++ b/tests/unit/Administration/Snippet/CachedSnippetFinderTest.php
@@ -14,7 +14,7 @@ use Symfony\Component\Cache\CacheItem;
 /**
  * @internal
  */
-#[Package('framework')]
+#[Package('discovery')]
 #[CoversClass(CachedSnippetFinder::class)]
 class CachedSnippetFinderTest extends TestCase
 {

--- a/tests/unit/Core/Checkout/Cart/CartCompressorTest.php
+++ b/tests/unit/Core/Checkout/Cart/CartCompressorTest.php
@@ -13,7 +13,7 @@ use Shopware\Core\Test\Assert\Serialization;
 /**
  * @internal
  */
-#[Package('framework')]
+#[Package('checkout')]
 #[CoversClass(CartCompressor::class)]
 class CartCompressorTest extends TestCase
 {

--- a/tests/unit/Core/Checkout/Cart/Delivery/Struct/DeliveryDateTest.php
+++ b/tests/unit/Core/Checkout/Cart/Delivery/Struct/DeliveryDateTest.php
@@ -15,7 +15,7 @@ use Shopware\Core\System\DeliveryTime\DeliveryTimeEntity;
 /**
  * @internal
  */
-#[Package('framework')]
+#[Package('checkout')]
 #[CoversClass(DeliveryDate::class)]
 class DeliveryDateTest extends TestCase
 {

--- a/tests/unit/Core/Checkout/Cart/ProductCartProcessorTest.php
+++ b/tests/unit/Core/Checkout/Cart/ProductCartProcessorTest.php
@@ -39,7 +39,7 @@ use Shopware\Core\Test\Stub\Checkout\EmptyPrice;
 /**
  * @internal
  */
-#[Package('checkout')]
+#[Package('inventory')]
 #[CoversClass(ProductCartProcessor::class)]
 class ProductCartProcessorTest extends TestCase
 {

--- a/tests/unit/Core/Checkout/Cart/Rule/LineItemGoodsTotalRuleTest.php
+++ b/tests/unit/Core/Checkout/Cart/Rule/LineItemGoodsTotalRuleTest.php
@@ -28,7 +28,7 @@ use Symfony\Component\Validator\Constraints\Type;
 /**
  * @internal
  */
-#[Package('checkout')]
+#[Package('fundamentals@after-sales')]
 #[CoversClass(LineItemGoodsTotalRule::class)]
 #[Group('rules')]
 class LineItemGoodsTotalRuleTest extends TestCase

--- a/tests/unit/Core/Checkout/Cart/Rule/LineItemGroupRuleTest.php
+++ b/tests/unit/Core/Checkout/Cart/Rule/LineItemGroupRuleTest.php
@@ -18,7 +18,7 @@ use Symfony\Component\Validator\Constraints\Type;
 /**
  * @internal
  */
-#[Package('checkout')]
+#[Package('fundamentals@after-sales')]
 #[CoversClass(LineItemGroupRule::class)]
 class LineItemGroupRuleTest extends TestCase
 {

--- a/tests/unit/Core/Checkout/Cart/Rule/LineItemOfTypeRuleTest.php
+++ b/tests/unit/Core/Checkout/Cart/Rule/LineItemOfTypeRuleTest.php
@@ -23,7 +23,7 @@ use Shopware\Core\System\SalesChannel\SalesChannelContext;
 /**
  * @internal
  */
-#[Package('checkout')]
+#[Package('fundamentals@after-sales')]
 #[CoversClass(LineItemOfTypeRule::class)]
 class LineItemOfTypeRuleTest extends TestCase
 {

--- a/tests/unit/Core/Checkout/Cart/Rule/LineItemProductStatesRuleTest.php
+++ b/tests/unit/Core/Checkout/Cart/Rule/LineItemProductStatesRuleTest.php
@@ -24,7 +24,7 @@ use Shopware\Core\System\SalesChannel\SalesChannelContext;
 /**
  * @internal
  */
-#[Package('checkout')]
+#[Package('fundamentals@after-sales')]
 #[CoversClass(LineItemProductStatesRule::class)]
 class LineItemProductStatesRuleTest extends TestCase
 {

--- a/tests/unit/Core/Checkout/Cart/Rule/LineItemPropertyValueRuleTest.php
+++ b/tests/unit/Core/Checkout/Cart/Rule/LineItemPropertyValueRuleTest.php
@@ -23,7 +23,7 @@ use Shopware\Core\System\SalesChannel\SalesChannelContext;
 /**
  * @internal
  */
-#[Package('checkout')]
+#[Package('fundamentals@after-sales')]
 #[CoversClass(LineItemPropertyValueRule::class)]
 #[Group('rules')]
 class LineItemPropertyValueRuleTest extends TestCase

--- a/tests/unit/Core/Checkout/Cart/Rule/LineItemVariantValueRuleTest.php
+++ b/tests/unit/Core/Checkout/Cart/Rule/LineItemVariantValueRuleTest.php
@@ -23,7 +23,7 @@ use Shopware\Core\System\SalesChannel\SalesChannelContext;
 /**
  * @internal
  */
-#[Package('checkout')]
+#[Package('fundamentals@after-sales')]
 #[CoversClass(LineItemVariantValueRule::class)]
 #[Group('rules')]
 class LineItemVariantValueRuleTest extends TestCase

--- a/tests/unit/Core/Checkout/Cart/Validator/Container/NotRuleTest.php
+++ b/tests/unit/Core/Checkout/Cart/Validator/Container/NotRuleTest.php
@@ -14,7 +14,7 @@ use Shopware\Core\Test\Stub\Rule\TrueRule;
 /**
  * @internal
  */
-#[Package('checkout')]
+#[Package('fundamentals@after-sales')]
 #[CoversClass(NotRule::class)]
 class NotRuleTest extends TestCase
 {

--- a/tests/unit/Core/Checkout/Cart/Validator/Container/OrRuleTest.php
+++ b/tests/unit/Core/Checkout/Cart/Validator/Container/OrRuleTest.php
@@ -14,7 +14,7 @@ use Shopware\Core\Test\Stub\Rule\TrueRule;
 /**
  * @internal
  */
-#[Package('checkout')]
+#[Package('fundamentals@after-sales')]
 #[CoversClass(OrRule::class)]
 class OrRuleTest extends TestCase
 {

--- a/tests/unit/Core/Checkout/Cart/Validator/Container/XorRuleTest.php
+++ b/tests/unit/Core/Checkout/Cart/Validator/Container/XorRuleTest.php
@@ -14,7 +14,7 @@ use Shopware\Core\Test\Stub\Rule\TrueRule;
 /**
  * @internal
  */
-#[Package('checkout')]
+#[Package('fundamentals@after-sales')]
 #[CoversClass(XorRule::class)]
 class XorRuleTest extends TestCase
 {

--- a/tests/unit/Core/Checkout/Cart/Validator/RuleCollectionTest.php
+++ b/tests/unit/Core/Checkout/Cart/Validator/RuleCollectionTest.php
@@ -14,7 +14,7 @@ use Shopware\Core\Test\Stub\Rule\TrueRule;
 /**
  * @internal
  */
-#[Package('checkout')]
+#[Package('fundamentals@after-sales')]
 #[CoversClass(RuleCollection::class)]
 class RuleCollectionTest extends TestCase
 {

--- a/tests/unit/Core/Checkout/Customer/Service/ProductReviewCountServiceTest.php
+++ b/tests/unit/Core/Checkout/Customer/Service/ProductReviewCountServiceTest.php
@@ -12,7 +12,7 @@ use Shopware\Core\Framework\Log\Package;
 /**
  * @internal
  */
-#[Package('after-sales')]
+#[Package('checkout')]
 #[CoversClass(ProductReviewCountService::class)]
 class ProductReviewCountServiceTest extends TestCase
 {

--- a/tests/unit/Core/Checkout/Payment/Cart/Token/Constraint/PaymentTokenRegisteredValidatorTest.php
+++ b/tests/unit/Core/Checkout/Payment/Cart/Token/Constraint/PaymentTokenRegisteredValidatorTest.php
@@ -18,7 +18,7 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 /**
  * @internal
  */
-#[Package('checkout')]
+#[Package('framework')]
 #[CoversClass(PaymentTokenRegisteredValidator::class)]
 class PaymentTokenRegisteredValidatorTest extends TestCase
 {

--- a/tests/unit/Core/Checkout/Promotion/Rule/PromotionLineItemRuleTest.php
+++ b/tests/unit/Core/Checkout/Promotion/Rule/PromotionLineItemRuleTest.php
@@ -22,7 +22,7 @@ use Symfony\Component\Validator\Constraints\NotBlank;
 /**
  * @internal
  */
-#[Package('checkout')]
+#[Package('fundamentals@after-sales')]
 #[CoversClass(PromotionLineItemRule::class)]
 class PromotionLineItemRuleTest extends TestCase
 {

--- a/tests/unit/Core/Content/Category/Tree/CategoryTreePathResolverTest.php
+++ b/tests/unit/Core/Content/Category/Tree/CategoryTreePathResolverTest.php
@@ -11,7 +11,7 @@ use Shopware\Core\Framework\Log\Package;
 /**
  * @internal
  */
-#[Package('framework')]
+#[Package('discovery')]
 #[CoversClass(CategoryTreePathResolver::class)]
 class CategoryTreePathResolverTest extends TestCase
 {

--- a/tests/unit/Core/Content/Media/Infrastructure/Path/BanMediaUrlTest.php
+++ b/tests/unit/Core/Content/Media/Infrastructure/Path/BanMediaUrlTest.php
@@ -17,7 +17,7 @@ use Shopware\Core\Test\Stub\Framework\IdsCollection;
 /**
  * @internal
  */
-#[Package('framework')]
+#[Package('discovery')]
 #[CoversClass(BanMediaUrl::class)]
 class BanMediaUrlTest extends TestCase
 {

--- a/tests/unit/Core/Content/Media/SalesChannel/MediaRouteTest.php
+++ b/tests/unit/Core/Content/Media/SalesChannel/MediaRouteTest.php
@@ -21,7 +21,7 @@ use Symfony\Component\HttpFoundation\Request;
 /**
  * @internal
  */
-#[Package('framework')]
+#[Package('discovery')]
 #[CoversClass(MediaRoute::class)]
 class MediaRouteTest extends TestCase
 {

--- a/tests/unit/Core/Content/Product/SalesChannel/Review/ProductReviewsWidgetLoadedHookTest.php
+++ b/tests/unit/Core/Content/Product/SalesChannel/Review/ProductReviewsWidgetLoadedHookTest.php
@@ -30,7 +30,7 @@ use Symfony\Component\HttpFoundation\Request;
 /**
  * @internal
  */
-#[Package('inventory')]
+#[Package('after-sales')]
 #[CoversClass(ProductReviewsWidgetLoadedHook::class)]
 class ProductReviewsWidgetLoadedHookTest extends TestCase
 {

--- a/tests/unit/Core/Content/Product/SalesChannel/Sorting/ProductSortingEntityTest.php
+++ b/tests/unit/Core/Content/Product/SalesChannel/Sorting/ProductSortingEntityTest.php
@@ -12,7 +12,7 @@ use Shopware\Core\Framework\Log\Package;
 /**
  * @internal
  */
-#[Package('framework')]
+#[Package('inventory')]
 #[CoversClass(ProductSortingEntity::class)]
 class ProductSortingEntityTest extends TestCase
 {

--- a/tests/unit/Core/Content/Seo/ConfiguredEntitySeoUrlRouteTest.php
+++ b/tests/unit/Core/Content/Seo/ConfiguredEntitySeoUrlRouteTest.php
@@ -19,7 +19,7 @@ use Shopware\Core\System\SalesChannel\SalesChannelEntity;
 /**
  * @internal
  */
-#[Package('inventory')]
+#[Package('discovery')]
 #[CoversClass(ConfiguredEntitySeoUrlRoute::class)]
 class ConfiguredEntitySeoUrlRouteTest extends TestCase
 {

--- a/tests/unit/Core/Content/Seo/SeoUrlRoute/SeoUrlRouteConfigTest.php
+++ b/tests/unit/Core/Content/Seo/SeoUrlRoute/SeoUrlRouteConfigTest.php
@@ -12,7 +12,7 @@ use Shopware\Core\Framework\Log\Package;
 /**
  * @internal
  */
-#[Package('discovery')]
+#[Package('inventory')]
 #[CoversClass(SeoUrlRouteConfig::class)]
 class SeoUrlRouteConfigTest extends TestCase
 {

--- a/tests/unit/Core/Framework/App/Checkout/Payload/AppCheckoutGatewayPayloadServiceTest.php
+++ b/tests/unit/Core/Framework/App/Checkout/Payload/AppCheckoutGatewayPayloadServiceTest.php
@@ -26,7 +26,7 @@ use Shopware\Core\Test\Generator;
 /**
  * @internal
  */
-#[Package('checkout')]
+#[Package('framework')]
 #[CoversClass(AppCheckoutGatewayPayloadService::class)]
 class AppCheckoutGatewayPayloadServiceTest extends TestCase
 {

--- a/tests/unit/Core/Framework/App/Payment/Payload/Struct/SourceTest.php
+++ b/tests/unit/Core/Framework/App/Payment/Payload/Struct/SourceTest.php
@@ -10,7 +10,7 @@ use Shopware\Core\Framework\Log\Package;
 /**
  * @internal
  */
-#[Package('checkout')]
+#[Package('framework')]
 #[CoversClass(Source::class)]
 class SourceTest extends TestCase
 {

--- a/tests/unit/Core/Framework/DataAbstractionLayer/FieldSerializer/CreatedByFieldSerializerTest.php
+++ b/tests/unit/Core/Framework/DataAbstractionLayer/FieldSerializer/CreatedByFieldSerializerTest.php
@@ -28,7 +28,7 @@ use Symfony\Component\Validator\Validator\ValidatorInterface;
 /**
  * @internal
  */
-#[Package('checkout')]
+#[Package('framework')]
 #[CoversClass(CreatedByFieldSerializer::class)]
 class CreatedByFieldSerializerTest extends TestCase
 {

--- a/tests/unit/Core/Framework/DataAbstractionLayer/FieldSerializer/UpdatedByFieldSerializerTest.php
+++ b/tests/unit/Core/Framework/DataAbstractionLayer/FieldSerializer/UpdatedByFieldSerializerTest.php
@@ -29,7 +29,7 @@ use Symfony\Component\Validator\Validator\ValidatorInterface;
 /**
  * @internal
  */
-#[Package('checkout')]
+#[Package('framework')]
 #[CoversClass(UpdatedByFieldSerializer::class)]
 class UpdatedByFieldSerializerTest extends TestCase
 {

--- a/tests/unit/Core/Framework/Gateway/Context/Command/Handler/ChangeShippingLocationCommandHandlerTest.php
+++ b/tests/unit/Core/Framework/Gateway/Context/Command/Handler/ChangeShippingLocationCommandHandlerTest.php
@@ -18,7 +18,7 @@ use Shopware\Core\Test\Generator;
 /**
  * @internal
  */
-#[Package('checkout')]
+#[Package('framework')]
 #[CoversClass(ChangeShippingLocationCommandHandler::class)]
 class ChangeShippingLocationCommandHandlerTest extends TestCase
 {

--- a/tests/unit/Core/Framework/Log/Monolog/AnnotatePackageProcessorTest.php
+++ b/tests/unit/Core/Framework/Log/Monolog/AnnotatePackageProcessorTest.php
@@ -23,7 +23,7 @@ use Symfony\Component\Messenger\Exception\HandlerFailedException;
 /**
  * @internal
  */
-#[Package('cause')]
+#[Package('framework')]
 #[CoversClass(AnnotatePackageProcessor::class)]
 class AnnotatePackageProcessorTest extends TestCase
 {
@@ -132,7 +132,7 @@ class AnnotatePackageProcessorTest extends TestCase
         $requestStack->push($request);
 
         $context = [
-            'exception' => new TestException('test'),
+            'exception' => TestCause::createException(),
         ];
 
         $record = new LogRecord(
@@ -171,7 +171,7 @@ class AnnotatePackageProcessorTest extends TestCase
         $requestStack->push($request);
 
         $context = [
-            'exception' => new TestExceptionNoPackage('test'),
+            'exception' => TestCause::createExceptionWithoutPackage(),
         ];
 
         $record = new LogRecord(
@@ -391,8 +391,24 @@ class TestNestedCommand extends Command
  * @internal
  */
 #[Package('cause')]
-class TestCause extends Command
+class TestCause
 {
+    /**
+     * The processor resolves the causing class from the exception's instantiation
+     * site, so exceptions that must be attributed to this fixture are created here.
+     * Deliberately not a Command: the entrypoint detection scans the trace for
+     * Command subclasses and must not match this fixture.
+     */
+    public static function createException(): TestException
+    {
+        return new TestException('test');
+    }
+
+    public static function createExceptionWithoutPackage(): TestExceptionNoPackage
+    {
+        return new TestExceptionNoPackage('test');
+    }
+
     public function throw(\Throwable $exception): never
     {
         throw $exception;

--- a/tests/unit/Core/Framework/Store/Authentication/FrwRequestOptionsProviderTest.php
+++ b/tests/unit/Core/Framework/Store/Authentication/FrwRequestOptionsProviderTest.php
@@ -20,7 +20,7 @@ use Shopware\Core\System\User\Aggregate\UserConfig\UserConfigEntity;
 /**
  * @internal
  */
-#[Package('checkout')]
+#[Package('fundamentals@after-sales')]
 #[CoversClass(FrwRequestOptionsProvider::class)]
 class FrwRequestOptionsProviderTest extends TestCase
 {

--- a/tests/unit/Core/Framework/Store/InAppPurchases/Event/InAppPurchaseChangedEventTest.php
+++ b/tests/unit/Core/Framework/Store/InAppPurchases/Event/InAppPurchaseChangedEventTest.php
@@ -13,7 +13,7 @@ use Shopware\Core\Framework\Webhook\AclPrivilegeCollection;
 /**
  * @internal
  */
-#[Package('checkout')]
+#[Package('framework')]
 #[CoversClass(InAppPurchaseChangedEvent::class)]
 class InAppPurchaseChangedEventTest extends TestCase
 {

--- a/tests/unit/Core/Framework/Store/StoreExceptionTest.php
+++ b/tests/unit/Core/Framework/Store/StoreExceptionTest.php
@@ -16,7 +16,7 @@ use Symfony\Component\HttpFoundation\Response;
 /**
  * @internal
  */
-#[Package('checkout')]
+#[Package('framework')]
 #[CoversClass(StoreException::class)]
 class StoreExceptionTest extends TestCase
 {

--- a/tests/unit/Core/Maintenance/SalesChannel/Command/SalesChannelListCommandTest.php
+++ b/tests/unit/Core/Maintenance/SalesChannel/Command/SalesChannelListCommandTest.php
@@ -17,7 +17,7 @@ use Symfony\Component\Console\Tester\CommandTester;
 /**
  * @internal
  */
-#[Package('framework')]
+#[Package('discovery')]
 #[CoversClass(SalesChannelListCommand::class)]
 class SalesChannelListCommandTest extends TestCase
 {

--- a/tests/unit/Core/System/Currency/CurrencyFormatterTest.php
+++ b/tests/unit/Core/System/Currency/CurrencyFormatterTest.php
@@ -19,7 +19,7 @@ use Shopware\Core\System\Locale\LanguageLocaleCodeProvider;
 /**
  * @internal
  */
-#[Package('fundamentals@discovery')]
+#[Package('fundamentals@framework')]
 #[CoversClass(CurrencyFormatter::class)]
 class CurrencyFormatterTest extends TestCase
 {

--- a/tests/unit/Core/System/Currency/Rule/CurrencyRuleTest.php
+++ b/tests/unit/Core/System/Currency/Rule/CurrencyRuleTest.php
@@ -24,7 +24,7 @@ use Symfony\Component\Validator\Validation;
 /**
  * @internal
  */
-#[Package('fundamentals@discovery')]
+#[Package('fundamentals@after-sales')]
 #[CoversClass(CurrencyRule::class)]
 class CurrencyRuleTest extends TestCase
 {

--- a/tests/unit/Core/System/SalesChannel/Api/StructEncoderTest.php
+++ b/tests/unit/Core/System/SalesChannel/Api/StructEncoderTest.php
@@ -41,7 +41,7 @@ use Symfony\Component\Validator\Validator\ValidatorInterface;
 /**
  * @internal
  */
-#[Package('discovery')]
+#[Package('framework')]
 #[CoversClass(StructEncoder::class)]
 class StructEncoderTest extends TestCase
 {

--- a/tests/unit/Core/System/SalesChannel/Context/BaseSalesChannelContextFactoryTest.php
+++ b/tests/unit/Core/System/SalesChannel/Context/BaseSalesChannelContextFactoryTest.php
@@ -57,7 +57,7 @@ use Shopware\Core\Test\TestDefaults;
  *
  * @phpstan-import-type ContextOptions from BaseSalesChannelContextFactory
  */
-#[Package('discovery')]
+#[Package('framework')]
 #[CoversClass(BaseSalesChannelContextFactory::class)]
 class BaseSalesChannelContextFactoryTest extends TestCase
 {

--- a/tests/unit/Core/System/SalesChannel/Context/CartRestorerTest.php
+++ b/tests/unit/Core/System/SalesChannel/Context/CartRestorerTest.php
@@ -22,7 +22,7 @@ use Symfony\Component\HttpFoundation\RequestStack;
 /**
  * @internal
  */
-#[Package('discovery')]
+#[Package('framework')]
 #[CoversClass(CartRestorer::class)]
 class CartRestorerTest extends TestCase
 {

--- a/tests/unit/Core/System/SalesChannel/Context/SalesChannelContextServiceTest.php
+++ b/tests/unit/Core/System/SalesChannel/Context/SalesChannelContextServiceTest.php
@@ -33,7 +33,7 @@ use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
 /**
  * @internal
  */
-#[Package('discovery')]
+#[Package('framework')]
 #[CoversClass(SalesChannelContextService::class)]
 class SalesChannelContextServiceTest extends TestCase
 {

--- a/tests/unit/Core/System/SalesChannel/ContextTokenResponseTest.php
+++ b/tests/unit/Core/System/SalesChannel/ContextTokenResponseTest.php
@@ -11,7 +11,7 @@ use Shopware\Core\System\SalesChannel\ContextTokenResponse;
 /**
  * @internal
  */
-#[Package('discovery')]
+#[Package('framework')]
 #[CoversClass(ContextTokenResponse::class)]
 class ContextTokenResponseTest extends TestCase
 {

--- a/tests/unit/Core/System/SalesChannel/Event/SalesChannelContextCreatedEventTest.php
+++ b/tests/unit/Core/System/SalesChannel/Event/SalesChannelContextCreatedEventTest.php
@@ -12,7 +12,7 @@ use Shopware\Core\System\SalesChannel\SalesChannelContext;
 /**
  * @internal
  */
-#[Package('discovery')]
+#[Package('framework')]
 #[CoversClass(SalesChannelContextCreatedEvent::class)]
 class SalesChannelContextCreatedEventTest extends TestCase
 {

--- a/tests/unit/Core/System/SalesChannel/Rule/SalesChannelRuleTest.php
+++ b/tests/unit/Core/System/SalesChannel/Rule/SalesChannelRuleTest.php
@@ -19,7 +19,7 @@ use Shopware\Core\Test\Generator;
 /**
  * @internal
  */
-#[Package('discovery')]
+#[Package('fundamentals@after-sales')]
 #[CoversClass(SalesChannelRule::class)]
 class SalesChannelRuleTest extends TestCase
 {

--- a/tests/unit/Core/System/SalesChannel/SalesChannelContextTest.php
+++ b/tests/unit/Core/System/SalesChannel/SalesChannelContextTest.php
@@ -16,7 +16,7 @@ use Shopware\Core\Test\Generator;
 /**
  * @internal
  */
-#[Package('discovery')]
+#[Package('framework')]
 #[CoversClass(SalesChannelContext::class)]
 class SalesChannelContextTest extends TestCase
 {

--- a/tests/unit/Core/System/SalesChannel/StoreApiCustomFieldMapperTest.php
+++ b/tests/unit/Core/System/SalesChannel/StoreApiCustomFieldMapperTest.php
@@ -15,7 +15,7 @@ use Shopware\Core\System\SalesChannel\StoreApiCustomFieldMapper;
 /**
  * @internal
  */
-#[Package('discovery')]
+#[Package('framework')]
 #[CoversClass(StoreApiCustomFieldMapper::class)]
 class StoreApiCustomFieldMapperTest extends TestCase
 {

--- a/tests/unit/Elasticsearch/Product/ProductSearchQueryBuilderTest.php
+++ b/tests/unit/Elasticsearch/Product/ProductSearchQueryBuilderTest.php
@@ -49,7 +49,7 @@ use Symfony\Component\Validator\Validator\ValidatorInterface;
 /**
  * @internal
  */
-#[Package('inventory')]
+#[Package('framework')]
 #[CoversClass(AbstractProductSearchQueryBuilder::class)]
 #[CoversClass(ProductSearchQueryBuilder::class)]
 class ProductSearchQueryBuilderTest extends TestCase

--- a/tests/unit/Storefront/Controller/Api/CaptchaControllerTest.php
+++ b/tests/unit/Storefront/Controller/Api/CaptchaControllerTest.php
@@ -11,7 +11,7 @@ use Shopware\Storefront\Framework\Captcha\AbstractCaptcha;
 /**
  * @internal
  */
-#[Package('checkout')]
+#[Package('discovery')]
 #[CoversClass(CaptchaController::class)]
 class CaptchaControllerTest extends TestCase
 {

--- a/tests/unit/Storefront/Controller/SearchControllerTest.php
+++ b/tests/unit/Storefront/Controller/SearchControllerTest.php
@@ -45,7 +45,7 @@ use Twig\Environment;
 /**
  * @internal
  */
-#[Package('discovery')]
+#[Package('inventory')]
 #[CoversClass(SearchController::class)]
 class SearchControllerTest extends TestCase
 {

--- a/tests/unit/Storefront/Controller/StorefrontControllerTest.php
+++ b/tests/unit/Storefront/Controller/StorefrontControllerTest.php
@@ -46,7 +46,7 @@ use Twig\Error\SyntaxError;
 /**
  * @internal
  */
-#[Package('framework')]
+#[Package('discovery')]
 #[CoversClass(StorefrontController::class)]
 class StorefrontControllerTest extends TestCase
 {

--- a/tests/unit/Storefront/DependencyInjection/StorefrontMigrationReplacementCompilerPassTest.php
+++ b/tests/unit/Storefront/DependencyInjection/StorefrontMigrationReplacementCompilerPassTest.php
@@ -12,7 +12,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 /**
  * @internal
  */
-#[Package('framework')]
+#[Package('discovery')]
 #[CoversClass(StorefrontMigrationReplacementCompilerPass::class)]
 class StorefrontMigrationReplacementCompilerPassTest extends TestCase
 {

--- a/tests/unit/Storefront/Event/StorefrontRedirectEventTest.php
+++ b/tests/unit/Storefront/Event/StorefrontRedirectEventTest.php
@@ -11,7 +11,7 @@ use Symfony\Component\HttpFoundation\Response;
 /**
  * @internal
  */
-#[Package('framework')]
+#[Package('discovery')]
 #[CoversClass(StorefrontRedirectEvent::class)]
 class StorefrontRedirectEventTest extends TestCase
 {

--- a/tests/unit/Storefront/Event/Subscriber/CartMergedSubscriberTest.php
+++ b/tests/unit/Storefront/Event/Subscriber/CartMergedSubscriberTest.php
@@ -22,7 +22,7 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 /**
  * @internal
  */
-#[Package('framework')]
+#[Package('checkout')]
 #[CoversClass(CartMergedSubscriber::class)]
 class CartMergedSubscriberTest extends TestCase
 {

--- a/tests/unit/Storefront/Framework/Routing/CachedDomainLoaderTest.php
+++ b/tests/unit/Storefront/Framework/Routing/CachedDomainLoaderTest.php
@@ -14,7 +14,7 @@ use Symfony\Component\Cache\Adapter\ArrayAdapter;
 /**
  * @internal
  */
-#[Package('framework')]
+#[Package('discovery')]
 #[CoversClass(CachedDomainLoader::class)]
 class CachedDomainLoaderTest extends TestCase
 {

--- a/tests/unit/Storefront/Framework/Script/Api/StorefrontScriptResponseFactoryFacadeTest.php
+++ b/tests/unit/Storefront/Framework/Script/Api/StorefrontScriptResponseFactoryFacadeTest.php
@@ -15,7 +15,7 @@ use Symfony\Component\Routing\RouterInterface;
 /**
  * @internal
  */
-#[Package('framework')]
+#[Package('discovery')]
 #[CoversClass(StorefrontScriptResponseFactoryFacade::class)]
 class StorefrontScriptResponseFactoryFacadeTest extends TestCase
 {

--- a/tests/unit/Storefront/Framework/Store/Subscriber/ExtensionThemeDetectionSubscriberTest.php
+++ b/tests/unit/Storefront/Framework/Store/Subscriber/ExtensionThemeDetectionSubscriberTest.php
@@ -23,7 +23,7 @@ use Shopware\Tests\Unit\Storefront\Theme\fixtures\MockStorefront\MockStorefront;
 /**
  * @internal
  */
-#[Package('framework')]
+#[Package('discovery')]
 #[CoversClass(ExtensionThemeDetectionSubscriber::class)]
 class ExtensionThemeDetectionSubscriberTest extends TestCase
 {

--- a/tests/unit/Storefront/Framework/Twig/Extension/UrlEncodingTwigFilterTest.php
+++ b/tests/unit/Storefront/Framework/Twig/Extension/UrlEncodingTwigFilterTest.php
@@ -17,7 +17,7 @@ use Twig\TwigFilter;
 /**
  * @internal
  */
-#[Package('framework')]
+#[Package('discovery')]
 #[CoversClass(UrlEncodingTwigFilter::class)]
 class UrlEncodingTwigFilterTest extends TestCase
 {

--- a/tests/unit/Storefront/Mcp/Tool/ThemeConfigToolTest.php
+++ b/tests/unit/Storefront/Mcp/Tool/ThemeConfigToolTest.php
@@ -18,7 +18,7 @@ use Shopware\Storefront\Theme\ThemeService;
 /**
  * @internal
  */
-#[Package('framework')]
+#[Package('discovery')]
 #[CoversClass(ThemeConfigTool::class)]
 class ThemeConfigToolTest extends TestCase
 {

--- a/tests/unit/Storefront/StorefrontTest.php
+++ b/tests/unit/Storefront/StorefrontTest.php
@@ -23,7 +23,7 @@ use Symfony\Component\DependencyInjection\Extension\Extension;
 /**
  * @internal
  */
-#[Package('framework')]
+#[Package('discovery')]
 #[CoversClass(Storefront::class)]
 class StorefrontTest extends TestCase
 {

--- a/tests/unit/Storefront/Theme/Command/ThemeCompileCommandTest.php
+++ b/tests/unit/Storefront/Theme/Command/ThemeCompileCommandTest.php
@@ -18,7 +18,7 @@ use Symfony\Component\Console\Tester\CommandTester;
 /**
  * @internal
  */
-#[Package('framework')]
+#[Package('discovery')]
 #[CoversClass(ThemeCompileCommand::class)]
 class ThemeCompileCommandTest extends TestCase
 {

--- a/tests/unit/Storefront/Theme/Command/ThemeDumpCommandTest.php
+++ b/tests/unit/Storefront/Theme/Command/ThemeDumpCommandTest.php
@@ -30,7 +30,7 @@ use Symfony\Component\Console\Tester\CommandTester;
 /**
  * @internal
  */
-#[Package('framework')]
+#[Package('discovery')]
 #[CoversClass(ThemeDumpCommand::class)]
 class ThemeDumpCommandTest extends TestCase
 {

--- a/tests/unit/Storefront/Theme/ConfigLoader/DatabaseConfigLoaderTest.php
+++ b/tests/unit/Storefront/Theme/ConfigLoader/DatabaseConfigLoaderTest.php
@@ -22,7 +22,7 @@ use Shopware\Storefront\Theme\ThemeEntity;
 /**
  * @internal
  */
-#[Package('framework')]
+#[Package('discovery')]
 #[CoversClass(DatabaseConfigLoader::class)]
 class DatabaseConfigLoaderTest extends TestCase
 {

--- a/tests/unit/Storefront/Theme/ConfigLoader/StaticFileConfigLoaderTest.php
+++ b/tests/unit/Storefront/Theme/ConfigLoader/StaticFileConfigLoaderTest.php
@@ -16,7 +16,7 @@ use Shopware\Storefront\Theme\ConfigLoader\StaticFileConfigLoader;
 /**
  * @internal
  */
-#[Package('framework')]
+#[Package('discovery')]
 #[CoversClass(StaticFileConfigLoader::class)]
 class StaticFileConfigLoaderTest extends TestCase
 {

--- a/tests/unit/Storefront/Theme/Exception/ThemeAssignmentExceptionTest.php
+++ b/tests/unit/Storefront/Theme/Exception/ThemeAssignmentExceptionTest.php
@@ -15,7 +15,7 @@ use Symfony\Component\HttpFoundation\Response;
  *
  * @deprecated tag:v6.8.0 - reason: the tested class is superseded by ThemeException::themeAssignmentException - to be removed
  */
-#[Package('framework')]
+#[Package('discovery')]
 #[CoversClass(ThemeAssignmentException::class)]
 #[DisabledFeatures(['v6.8.0.0'])]
 class ThemeAssignmentExceptionTest extends TestCase

--- a/tests/unit/Storefront/Theme/Exception/ThemeConfigExceptionTest.php
+++ b/tests/unit/Storefront/Theme/Exception/ThemeConfigExceptionTest.php
@@ -13,7 +13,7 @@ use Symfony\Component\HttpFoundation\Response;
 /**
  * @internal
  */
-#[Package('framework')]
+#[Package('discovery')]
 #[CoversClass(ThemeConfigException::class)]
 class ThemeConfigExceptionTest extends TestCase
 {

--- a/tests/unit/Storefront/Theme/Exception/ThemeExceptionTest.php
+++ b/tests/unit/Storefront/Theme/Exception/ThemeExceptionTest.php
@@ -12,7 +12,7 @@ use Symfony\Component\HttpFoundation\Response;
 /**
  * @internal
  */
-#[Package('framework')]
+#[Package('discovery')]
 #[CoversClass(ThemeException::class)]
 class ThemeExceptionTest extends TestCase
 {

--- a/tests/unit/Storefront/Theme/ThemeRuntimeConfigServiceTest.php
+++ b/tests/unit/Storefront/Theme/ThemeRuntimeConfigServiceTest.php
@@ -24,7 +24,7 @@ use Symfony\Component\Clock\NativeClock;
 /**
  * @internal
  */
-#[Package('framework')]
+#[Package('discovery')]
 #[CoversClass(ThemeRuntimeConfigService::class)]
 class ThemeRuntimeConfigServiceTest extends TestCase
 {

--- a/tests/unit/Storefront/Theme/ThemeRuntimeConfigTest.php
+++ b/tests/unit/Storefront/Theme/ThemeRuntimeConfigTest.php
@@ -10,7 +10,7 @@ use Shopware\Storefront\Theme\ThemeRuntimeConfig;
 /**
  * @internal
  */
-#[Package('framework')]
+#[Package('discovery')]
 #[CoversClass(ThemeRuntimeConfig::class)]
 class ThemeRuntimeConfigTest extends TestCase
 {

--- a/tests/unit/Storefront/Theme/Validator/SCSSValidatorTest.php
+++ b/tests/unit/Storefront/Theme/Validator/SCSSValidatorTest.php
@@ -13,7 +13,7 @@ use Shopware\Storefront\Theme\Validator\SCSSValidator;
 /**
  * @internal
  */
-#[Package('framework')]
+#[Package('discovery')]
 #[CoversClass(SCSSValidator::class)]
 class SCSSValidatorTest extends TestCase
 {


### PR DESCRIPTION
### 1. Why is this change necessary?

Nothing keeps a test's `#[Package]` attribute in sync with the ownership of the code it covers, so test routing (nightly failure issues, domain attribution) drifts whenever either side changes.

### 2. What does this change do, exactly?

Adds `CoversPackageMatchRule` to the core-only PHPStan rule set (`core-rules.neon`): a test class whose `#[Package]` value differs from the `#[Package]` of every class or trait named in its `CoversClass`/`CoversTrait` attributes fails the analysis.

- The rule only fires when both sides carry a `#[Package]` attribute; presence stays a separate concern. Since the covers attributes are only allowed on unit and migration tests, no other suite can be affected.
- A test covering several classes passes when it matches at least one of them.
- `fundamentals@<area>` routes to the `<area>` team and counts as equal to the plain `<area>` value in both directions.
- The migration suite is excluded for now: several migrations carry `framework` although they migrate feature-domain tables, and there the source value is the one that has to change.
- The rule is registered in `core-rules.neon` and not in the shared `rules.neon` on purpose: the commercial repositories carry their own package values and routing.

The existing mismatches in the unit suite are aligned in per-domain pull requests based on this branch, one per receiving domain team. The analysis of this pull request turns green once they are merged into it.

The `shopware-phpunit-tests` skill line about copying the covered class's package value now mentions the enforcement.

### 3. Describe each step to reproduce the issue or behaviour.

Change a `#[Package]` value on a unit test or on its covered class so the two differ and run `composer phpstan`: the analysis fails with `shopware.coversPackageMismatch`, naming the covered class and both values. The rule's behaviour is covered by `CoversPackageMatchRuleTest` (match, mismatch, both `fundamentals@` directions, several covered classes, missing attributes, trait targets, migration suite exclusion).

### 4. Please link to the relevant issues (if any).

- relates #18473

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
