### PR TITLE
test: align unit and integration test package attributes with the discovery code they cover

### DIFF
--- a/tests/integration/Core/Content/ContactForm/ContactFormServiceTest.php
+++ b/tests/integration/Core/Content/ContactForm/ContactFormServiceTest.php
@@ -19,7 +19,7 @@ use Shopware\Core\Test\TestDefaults;
 /**
  * @internal
  */
-#[Package('framework')]
+#[Package('discovery')]
 class ContactFormServiceTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Content/Media/Subscriber/CustomFieldsUnusedMediaSubscriberTest.php
+++ b/tests/integration/Core/Content/Media/Subscriber/CustomFieldsUnusedMediaSubscriberTest.php
@@ -22,7 +22,7 @@ use Shopware\Core\Test\Stub\Framework\IdsCollection;
 /**
  * @internal
  */
-#[Package('framework')]
+#[Package('discovery')]
 class CustomFieldsUnusedMediaSubscriberTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Maintenance/SalesChannel/Command/SalesChannelMaintenanceDisableCommandTest.php
+++ b/tests/integration/Core/Maintenance/SalesChannel/Command/SalesChannelMaintenanceDisableCommandTest.php
@@ -15,7 +15,7 @@ use Symfony\Component\Console\Tester\CommandTester;
 /**
  * @internal
  */
-#[Package('framework')]
+#[Package('discovery')]
 class SalesChannelMaintenanceDisableCommandTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Maintenance/SalesChannel/Command/SalesChannelMaintenanceEnableCommandTest.php
+++ b/tests/integration/Core/Maintenance/SalesChannel/Command/SalesChannelMaintenanceEnableCommandTest.php
@@ -15,7 +15,7 @@ use Symfony\Component\Console\Tester\CommandTester;
 /**
  * @internal
  */
-#[Package('framework')]
+#[Package('discovery')]
 class SalesChannelMaintenanceEnableCommandTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Maintenance/SalesChannel/Command/SalesChannelUpdateDomainCommandTest.php
+++ b/tests/integration/Core/Maintenance/SalesChannel/Command/SalesChannelUpdateDomainCommandTest.php
@@ -20,7 +20,7 @@ use Symfony\Component\Console\Tester\CommandTester;
 /**
  * @internal
  */
-#[Package('framework')]
+#[Package('discovery')]
 class SalesChannelUpdateDomainCommandTest extends TestCase
 {
     use DatabaseTransactionBehaviour;

--- a/tests/integration/Core/Maintenance/SalesChannel/Service/SalesChannelCreatorTest.php
+++ b/tests/integration/Core/Maintenance/SalesChannel/Service/SalesChannelCreatorTest.php
@@ -16,7 +16,7 @@ use Shopware\Core\System\SalesChannel\SalesChannelCollection;
 /**
  * @internal
  */
-#[Package('framework')]
+#[Package('discovery')]
 class SalesChannelCreatorTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/System/Language/LanguageRuleTest.php
+++ b/tests/integration/Core/System/Language/LanguageRuleTest.php
@@ -20,7 +20,7 @@ use Symfony\Component\Validator\Constraints\NotBlank;
 /**
  * @internal
  */
-#[Package('fundamentals@after-sales')]
+#[Package('fundamentals@discovery')]
 class LanguageRuleTest extends TestCase
 {
     use DatabaseTransactionBehaviour;

--- a/tests/integration/Storefront/Theme/ConfigLoader/DatabaseAvailableThemeProviderTest.php
+++ b/tests/integration/Storefront/Theme/ConfigLoader/DatabaseAvailableThemeProviderTest.php
@@ -14,7 +14,7 @@ use Shopware\Storefront\Theme\ConfigLoader\DatabaseAvailableThemeProvider;
 /**
  * @internal
  */
-#[Package('framework')]
+#[Package('discovery')]
 class DatabaseAvailableThemeProviderTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/unit/Administration/Snippet/CachedSnippetFinderTest.php
+++ b/tests/unit/Administration/Snippet/CachedSnippetFinderTest.php
@@ -14,7 +14,7 @@ use Symfony\Component\Cache\CacheItem;
 /**
  * @internal
  */
-#[Package('framework')]
+#[Package('discovery')]
 #[CoversClass(CachedSnippetFinder::class)]
 class CachedSnippetFinderTest extends TestCase
 {

--- a/tests/unit/Core/Content/Category/Tree/CategoryTreePathResolverTest.php
+++ b/tests/unit/Core/Content/Category/Tree/CategoryTreePathResolverTest.php
@@ -11,7 +11,7 @@ use Shopware\Core\Framework\Log\Package;
 /**
  * @internal
  */
-#[Package('framework')]
+#[Package('discovery')]
 #[CoversClass(CategoryTreePathResolver::class)]
 class CategoryTreePathResolverTest extends TestCase
 {

--- a/tests/unit/Core/Content/Media/Infrastructure/Path/BanMediaUrlTest.php
+++ b/tests/unit/Core/Content/Media/Infrastructure/Path/BanMediaUrlTest.php
@@ -17,7 +17,7 @@ use Shopware\Core\Test\Stub\Framework\IdsCollection;
 /**
  * @internal
  */
-#[Package('framework')]
+#[Package('discovery')]
 #[CoversClass(BanMediaUrl::class)]
 class BanMediaUrlTest extends TestCase
 {

--- a/tests/unit/Core/Content/Media/SalesChannel/MediaRouteTest.php
+++ b/tests/unit/Core/Content/Media/SalesChannel/MediaRouteTest.php
@@ -21,7 +21,7 @@ use Symfony\Component\HttpFoundation\Request;
 /**
  * @internal
  */
-#[Package('framework')]
+#[Package('discovery')]
 #[CoversClass(MediaRoute::class)]
 class MediaRouteTest extends TestCase
 {

--- a/tests/unit/Core/Content/Seo/ConfiguredEntitySeoUrlRouteTest.php
+++ b/tests/unit/Core/Content/Seo/ConfiguredEntitySeoUrlRouteTest.php
@@ -19,7 +19,7 @@ use Shopware\Core\System\SalesChannel\SalesChannelEntity;
 /**
  * @internal
  */
-#[Package('inventory')]
+#[Package('discovery')]
 #[CoversClass(ConfiguredEntitySeoUrlRoute::class)]
 class ConfiguredEntitySeoUrlRouteTest extends TestCase
 {

--- a/tests/unit/Core/Maintenance/SalesChannel/Command/SalesChannelListCommandTest.php
+++ b/tests/unit/Core/Maintenance/SalesChannel/Command/SalesChannelListCommandTest.php
@@ -17,7 +17,7 @@ use Symfony\Component\Console\Tester\CommandTester;
 /**
  * @internal
  */
-#[Package('framework')]
+#[Package('discovery')]
 #[CoversClass(SalesChannelListCommand::class)]
 class SalesChannelListCommandTest extends TestCase
 {

--- a/tests/unit/Storefront/Controller/Api/CaptchaControllerTest.php
+++ b/tests/unit/Storefront/Controller/Api/CaptchaControllerTest.php
@@ -11,7 +11,7 @@ use Shopware\Storefront\Framework\Captcha\AbstractCaptcha;
 /**
  * @internal
  */
-#[Package('checkout')]
+#[Package('discovery')]
 #[CoversClass(CaptchaController::class)]
 class CaptchaControllerTest extends TestCase
 {

--- a/tests/unit/Storefront/Controller/StorefrontControllerTest.php
+++ b/tests/unit/Storefront/Controller/StorefrontControllerTest.php
@@ -46,7 +46,7 @@ use Twig\Error\SyntaxError;
 /**
  * @internal
  */
-#[Package('framework')]
+#[Package('discovery')]
 #[CoversClass(StorefrontController::class)]
 class StorefrontControllerTest extends TestCase
 {

--- a/tests/unit/Storefront/DependencyInjection/StorefrontMigrationReplacementCompilerPassTest.php
+++ b/tests/unit/Storefront/DependencyInjection/StorefrontMigrationReplacementCompilerPassTest.php
@@ -12,7 +12,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 /**
  * @internal
  */
-#[Package('framework')]
+#[Package('discovery')]
 #[CoversClass(StorefrontMigrationReplacementCompilerPass::class)]
 class StorefrontMigrationReplacementCompilerPassTest extends TestCase
 {

--- a/tests/unit/Storefront/Event/StorefrontRedirectEventTest.php
+++ b/tests/unit/Storefront/Event/StorefrontRedirectEventTest.php
@@ -11,7 +11,7 @@ use Symfony\Component\HttpFoundation\Response;
 /**
  * @internal
  */
-#[Package('framework')]
+#[Package('discovery')]
 #[CoversClass(StorefrontRedirectEvent::class)]
 class StorefrontRedirectEventTest extends TestCase
 {

--- a/tests/unit/Storefront/Framework/Routing/CachedDomainLoaderTest.php
+++ b/tests/unit/Storefront/Framework/Routing/CachedDomainLoaderTest.php
@@ -14,7 +14,7 @@ use Symfony\Component\Cache\Adapter\ArrayAdapter;
 /**
  * @internal
  */
-#[Package('framework')]
+#[Package('discovery')]
 #[CoversClass(CachedDomainLoader::class)]
 class CachedDomainLoaderTest extends TestCase
 {

--- a/tests/unit/Storefront/Framework/Script/Api/StorefrontScriptResponseFactoryFacadeTest.php
+++ b/tests/unit/Storefront/Framework/Script/Api/StorefrontScriptResponseFactoryFacadeTest.php
@@ -15,7 +15,7 @@ use Symfony\Component\Routing\RouterInterface;
 /**
  * @internal
  */
-#[Package('framework')]
+#[Package('discovery')]
 #[CoversClass(StorefrontScriptResponseFactoryFacade::class)]
 class StorefrontScriptResponseFactoryFacadeTest extends TestCase
 {

--- a/tests/unit/Storefront/Framework/Store/Subscriber/ExtensionThemeDetectionSubscriberTest.php
+++ b/tests/unit/Storefront/Framework/Store/Subscriber/ExtensionThemeDetectionSubscriberTest.php
@@ -23,7 +23,7 @@ use Shopware\Tests\Unit\Storefront\Theme\fixtures\MockStorefront\MockStorefront;
 /**
  * @internal
  */
-#[Package('framework')]
+#[Package('discovery')]
 #[CoversClass(ExtensionThemeDetectionSubscriber::class)]
 class ExtensionThemeDetectionSubscriberTest extends TestCase
 {

--- a/tests/unit/Storefront/Framework/Twig/Extension/UrlEncodingTwigFilterTest.php
+++ b/tests/unit/Storefront/Framework/Twig/Extension/UrlEncodingTwigFilterTest.php
@@ -17,7 +17,7 @@ use Twig\TwigFilter;
 /**
  * @internal
  */
-#[Package('framework')]
+#[Package('discovery')]
 #[CoversClass(UrlEncodingTwigFilter::class)]
 class UrlEncodingTwigFilterTest extends TestCase
 {

--- a/tests/unit/Storefront/Mcp/Tool/ThemeConfigToolTest.php
+++ b/tests/unit/Storefront/Mcp/Tool/ThemeConfigToolTest.php
@@ -18,7 +18,7 @@ use Shopware\Storefront\Theme\ThemeService;
 /**
  * @internal
  */
-#[Package('framework')]
+#[Package('discovery')]
 #[CoversClass(ThemeConfigTool::class)]
 class ThemeConfigToolTest extends TestCase
 {

--- a/tests/unit/Storefront/StorefrontTest.php
+++ b/tests/unit/Storefront/StorefrontTest.php
@@ -23,7 +23,7 @@ use Symfony\Component\DependencyInjection\Extension\Extension;
 /**
  * @internal
  */
-#[Package('framework')]
+#[Package('discovery')]
 #[CoversClass(Storefront::class)]
 class StorefrontTest extends TestCase
 {

--- a/tests/unit/Storefront/Theme/Command/ThemeCompileCommandTest.php
+++ b/tests/unit/Storefront/Theme/Command/ThemeCompileCommandTest.php
@@ -18,7 +18,7 @@ use Symfony\Component\Console\Tester\CommandTester;
 /**
  * @internal
  */
-#[Package('framework')]
+#[Package('discovery')]
 #[CoversClass(ThemeCompileCommand::class)]
 class ThemeCompileCommandTest extends TestCase
 {

--- a/tests/unit/Storefront/Theme/Command/ThemeDumpCommandTest.php
+++ b/tests/unit/Storefront/Theme/Command/ThemeDumpCommandTest.php
@@ -30,7 +30,7 @@ use Symfony\Component\Console\Tester\CommandTester;
 /**
  * @internal
  */
-#[Package('framework')]
+#[Package('discovery')]
 #[CoversClass(ThemeDumpCommand::class)]
 class ThemeDumpCommandTest extends TestCase
 {

--- a/tests/unit/Storefront/Theme/ConfigLoader/DatabaseConfigLoaderTest.php
+++ b/tests/unit/Storefront/Theme/ConfigLoader/DatabaseConfigLoaderTest.php
@@ -22,7 +22,7 @@ use Shopware\Storefront\Theme\ThemeEntity;
 /**
  * @internal
  */
-#[Package('framework')]
+#[Package('discovery')]
 #[CoversClass(DatabaseConfigLoader::class)]
 class DatabaseConfigLoaderTest extends TestCase
 {

--- a/tests/unit/Storefront/Theme/ConfigLoader/StaticFileConfigLoaderTest.php
+++ b/tests/unit/Storefront/Theme/ConfigLoader/StaticFileConfigLoaderTest.php
@@ -16,7 +16,7 @@ use Shopware\Storefront\Theme\ConfigLoader\StaticFileConfigLoader;
 /**
  * @internal
  */
-#[Package('framework')]
+#[Package('discovery')]
 #[CoversClass(StaticFileConfigLoader::class)]
 class StaticFileConfigLoaderTest extends TestCase
 {

--- a/tests/unit/Storefront/Theme/Exception/ThemeAssignmentExceptionTest.php
+++ b/tests/unit/Storefront/Theme/Exception/ThemeAssignmentExceptionTest.php
@@ -15,7 +15,7 @@ use Symfony\Component\HttpFoundation\Response;
  *
  * @deprecated tag:v6.8.0 - reason: the tested class is superseded by ThemeException::themeAssignmentException - to be removed
  */
-#[Package('framework')]
+#[Package('discovery')]
 #[CoversClass(ThemeAssignmentException::class)]
 #[DisabledFeatures(['v6.8.0.0'])]
 class ThemeAssignmentExceptionTest extends TestCase

--- a/tests/unit/Storefront/Theme/Exception/ThemeConfigExceptionTest.php
+++ b/tests/unit/Storefront/Theme/Exception/ThemeConfigExceptionTest.php
@@ -13,7 +13,7 @@ use Symfony\Component\HttpFoundation\Response;
 /**
  * @internal
  */
-#[Package('framework')]
+#[Package('discovery')]
 #[CoversClass(ThemeConfigException::class)]
 class ThemeConfigExceptionTest extends TestCase
 {

--- a/tests/unit/Storefront/Theme/Exception/ThemeExceptionTest.php
+++ b/tests/unit/Storefront/Theme/Exception/ThemeExceptionTest.php
@@ -12,7 +12,7 @@ use Symfony\Component\HttpFoundation\Response;
 /**
  * @internal
  */
-#[Package('framework')]
+#[Package('discovery')]
 #[CoversClass(ThemeException::class)]
 class ThemeExceptionTest extends TestCase
 {

--- a/tests/unit/Storefront/Theme/ThemeRuntimeConfigServiceTest.php
+++ b/tests/unit/Storefront/Theme/ThemeRuntimeConfigServiceTest.php
@@ -24,7 +24,7 @@ use Symfony\Component\Clock\NativeClock;
 /**
  * @internal
  */
-#[Package('framework')]
+#[Package('discovery')]
 #[CoversClass(ThemeRuntimeConfigService::class)]
 class ThemeRuntimeConfigServiceTest extends TestCase
 {

--- a/tests/unit/Storefront/Theme/ThemeRuntimeConfigTest.php
+++ b/tests/unit/Storefront/Theme/ThemeRuntimeConfigTest.php
@@ -10,7 +10,7 @@ use Shopware\Storefront\Theme\ThemeRuntimeConfig;
 /**
  * @internal
  */
-#[Package('framework')]
+#[Package('discovery')]
 #[CoversClass(ThemeRuntimeConfig::class)]
 class ThemeRuntimeConfigTest extends TestCase
 {

--- a/tests/unit/Storefront/Theme/Validator/SCSSValidatorTest.php
+++ b/tests/unit/Storefront/Theme/Validator/SCSSValidatorTest.php
@@ -13,7 +13,7 @@ use Shopware\Storefront\Theme\Validator\SCSSValidator;
 /**
  * @internal
  */
-#[Package('framework')]
+#[Package('discovery')]
 #[CoversClass(SCSSValidator::class)]
 class SCSSValidatorTest extends TestCase
 {


### PR DESCRIPTION
### 1. Why is this change necessary?

The `#[Package]` attribute of several unit tests differs from the ownership of the code they cover, so failing tests are routed to the wrong domain team.

### 2. What does this change do, exactly?

Sets the `#[Package]` value of the 26 unit tests whose covered classes carry a discovery package to the value of their covered class, and aligns 8 integration tests with the packages of the `src/` directories their paths mirror. Attribute lines only.

Part of the stack that introduces the enforcement rule; the rule sits on top and lands once every alignment below it is merged.

### 3. Describe each step to reproduce the issue or behaviour.

Compare each unit test's `#[Package]` value with the `#[Package]` of its `CoversClass` target, and each integration test's value with the `#[Package]` values in the mirrored `src/` directory.

### 4. Please link to the relevant issues (if any).

- relates #18473
- relates #19493

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
