### PR TITLE
test: align unit and integration test package attributes with the framework code they cover

### DIFF
--- a/tests/integration/Core/Framework/App/Context/Gateway/AppContextGatewayTest.php
+++ b/tests/integration/Core/Framework/App/Context/Gateway/AppContextGatewayTest.php
@@ -26,7 +26,7 @@ use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 /**
  * @internal
  */
-#[Package('checkout')]
+#[Package('framework')]
 class AppContextGatewayTest extends TestCase
 {
     use AppSystemTestBehaviour;

--- a/tests/integration/Core/Migration/Traits/CreateMailTemplateTraitTest.php
+++ b/tests/integration/Core/Migration/Traits/CreateMailTemplateTraitTest.php
@@ -18,7 +18,7 @@ use Symfony\Component\Filesystem\Filesystem;
 /**
  * @internal
  */
-#[Package('after-sales')]
+#[Package('framework')]
 class CreateMailTemplateTraitTest extends TestCase
 {
     use CreateMailTemplateTrait;

--- a/tests/integration/Elasticsearch/Framework/Indexing/ElasticsearchIndexerTest.php
+++ b/tests/integration/Elasticsearch/Framework/Indexing/ElasticsearchIndexerTest.php
@@ -14,7 +14,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 /**
  * @internal
  */
-#[Package('inventory')]
+#[Package('framework')]
 class ElasticsearchIndexerTest extends TestCase
 {
     use BasicTestDataBehaviour;

--- a/tests/integration/Elasticsearch/Framework/Indexing/IndexManagerTest.php
+++ b/tests/integration/Elasticsearch/Framework/Indexing/IndexManagerTest.php
@@ -11,7 +11,7 @@ use Shopware\Elasticsearch\Framework\Indexing\IndexManager;
 /**
  * @internal
  */
-#[Package('inventory')]
+#[Package('framework')]
 class IndexManagerTest extends TestCase
 {
     use KernelTestBehaviour;

--- a/tests/integration/Storefront/Framework/App/AppLifecycleThemeTest.php
+++ b/tests/integration/Storefront/Framework/App/AppLifecycleThemeTest.php
@@ -30,7 +30,7 @@ use Symfony\Component\HttpKernel\Debug\TraceableEventDispatcher;
 /**
  * @internal
  */
-#[Package('discovery')]
+#[Package('framework')]
 class AppLifecycleThemeTest extends TestCase
 {
     use AppSystemTestBehaviour;

--- a/tests/unit/Administration/Controller/AdministrationControllerTest.php
+++ b/tests/unit/Administration/Controller/AdministrationControllerTest.php
@@ -54,7 +54,7 @@ use Twig\Environment;
 /**
  * @internal
  */
-#[Package('checkout')]
+#[Package('framework')]
 #[CoversClass(AdministrationController::class)]
 class AdministrationControllerTest extends TestCase
 {

--- a/tests/unit/Core/Checkout/Payment/Cart/Token/Constraint/PaymentTokenRegisteredValidatorTest.php
+++ b/tests/unit/Core/Checkout/Payment/Cart/Token/Constraint/PaymentTokenRegisteredValidatorTest.php
@@ -18,7 +18,7 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 /**
  * @internal
  */
-#[Package('checkout')]
+#[Package('framework')]
 #[CoversClass(PaymentTokenRegisteredValidator::class)]
 class PaymentTokenRegisteredValidatorTest extends TestCase
 {

--- a/tests/unit/Core/Framework/App/Checkout/Payload/AppCheckoutGatewayPayloadServiceTest.php
+++ b/tests/unit/Core/Framework/App/Checkout/Payload/AppCheckoutGatewayPayloadServiceTest.php
@@ -26,7 +26,7 @@ use Shopware\Core\Test\Generator;
 /**
  * @internal
  */
-#[Package('checkout')]
+#[Package('framework')]
 #[CoversClass(AppCheckoutGatewayPayloadService::class)]
 class AppCheckoutGatewayPayloadServiceTest extends TestCase
 {

--- a/tests/unit/Core/Framework/App/Payment/Payload/Struct/SourceTest.php
+++ b/tests/unit/Core/Framework/App/Payment/Payload/Struct/SourceTest.php
@@ -10,7 +10,7 @@ use Shopware\Core\Framework\Log\Package;
 /**
  * @internal
  */
-#[Package('checkout')]
+#[Package('framework')]
 #[CoversClass(Source::class)]
 class SourceTest extends TestCase
 {

--- a/tests/unit/Core/Framework/DataAbstractionLayer/FieldSerializer/CreatedByFieldSerializerTest.php
+++ b/tests/unit/Core/Framework/DataAbstractionLayer/FieldSerializer/CreatedByFieldSerializerTest.php
@@ -28,7 +28,7 @@ use Symfony\Component\Validator\Validator\ValidatorInterface;
 /**
  * @internal
  */
-#[Package('checkout')]
+#[Package('framework')]
 #[CoversClass(CreatedByFieldSerializer::class)]
 class CreatedByFieldSerializerTest extends TestCase
 {

--- a/tests/unit/Core/Framework/DataAbstractionLayer/FieldSerializer/UpdatedByFieldSerializerTest.php
+++ b/tests/unit/Core/Framework/DataAbstractionLayer/FieldSerializer/UpdatedByFieldSerializerTest.php
@@ -29,7 +29,7 @@ use Symfony\Component\Validator\Validator\ValidatorInterface;
 /**
  * @internal
  */
-#[Package('checkout')]
+#[Package('framework')]
 #[CoversClass(UpdatedByFieldSerializer::class)]
 class UpdatedByFieldSerializerTest extends TestCase
 {

--- a/tests/unit/Core/Framework/Gateway/Context/Command/Handler/ChangeShippingLocationCommandHandlerTest.php
+++ b/tests/unit/Core/Framework/Gateway/Context/Command/Handler/ChangeShippingLocationCommandHandlerTest.php
@@ -18,7 +18,7 @@ use Shopware\Core\Test\Generator;
 /**
  * @internal
  */
-#[Package('checkout')]
+#[Package('framework')]
 #[CoversClass(ChangeShippingLocationCommandHandler::class)]
 class ChangeShippingLocationCommandHandlerTest extends TestCase
 {

--- a/tests/unit/Core/Framework/Log/Monolog/AnnotatePackageProcessorTest.php
+++ b/tests/unit/Core/Framework/Log/Monolog/AnnotatePackageProcessorTest.php
@@ -23,7 +23,7 @@ use Symfony\Component\Messenger\Exception\HandlerFailedException;
 /**
  * @internal
  */
-#[Package('cause')]
+#[Package('framework')]
 #[CoversClass(AnnotatePackageProcessor::class)]
 class AnnotatePackageProcessorTest extends TestCase
 {
@@ -132,7 +132,7 @@ class AnnotatePackageProcessorTest extends TestCase
         $requestStack->push($request);
 
         $context = [
-            'exception' => new TestException('test'),
+            'exception' => TestCause::createException(),
         ];
 
         $record = new LogRecord(
@@ -171,7 +171,7 @@ class AnnotatePackageProcessorTest extends TestCase
         $requestStack->push($request);
 
         $context = [
-            'exception' => new TestExceptionNoPackage('test'),
+            'exception' => TestCause::createExceptionWithoutPackage(),
         ];
 
         $record = new LogRecord(
@@ -391,8 +391,24 @@ class TestNestedCommand extends Command
  * @internal
  */
 #[Package('cause')]
-class TestCause extends Command
+class TestCause
 {
+    /**
+     * The processor resolves the causing class from the exception's instantiation
+     * site, so exceptions that must be attributed to this fixture are created here.
+     * Deliberately not a Command: the entrypoint detection scans the trace for
+     * Command subclasses and must not match this fixture.
+     */
+    public static function createException(): TestException
+    {
+        return new TestException('test');
+    }
+
+    public static function createExceptionWithoutPackage(): TestExceptionNoPackage
+    {
+        return new TestExceptionNoPackage('test');
+    }
+
     public function throw(\Throwable $exception): never
     {
         throw $exception;

--- a/tests/unit/Core/Framework/Store/InAppPurchases/Event/InAppPurchaseChangedEventTest.php
+++ b/tests/unit/Core/Framework/Store/InAppPurchases/Event/InAppPurchaseChangedEventTest.php
@@ -13,7 +13,7 @@ use Shopware\Core\Framework\Webhook\AclPrivilegeCollection;
 /**
  * @internal
  */
-#[Package('checkout')]
+#[Package('framework')]
 #[CoversClass(InAppPurchaseChangedEvent::class)]
 class InAppPurchaseChangedEventTest extends TestCase
 {

--- a/tests/unit/Core/Framework/Store/StoreExceptionTest.php
+++ b/tests/unit/Core/Framework/Store/StoreExceptionTest.php
@@ -16,7 +16,7 @@ use Symfony\Component\HttpFoundation\Response;
 /**
  * @internal
  */
-#[Package('checkout')]
+#[Package('framework')]
 #[CoversClass(StoreException::class)]
 class StoreExceptionTest extends TestCase
 {

--- a/tests/unit/Core/System/Currency/CurrencyFormatterTest.php
+++ b/tests/unit/Core/System/Currency/CurrencyFormatterTest.php
@@ -19,7 +19,7 @@ use Shopware\Core\System\Locale\LanguageLocaleCodeProvider;
 /**
  * @internal
  */
-#[Package('fundamentals@discovery')]
+#[Package('fundamentals@framework')]
 #[CoversClass(CurrencyFormatter::class)]
 class CurrencyFormatterTest extends TestCase
 {

--- a/tests/unit/Core/System/SalesChannel/Api/StructEncoderTest.php
+++ b/tests/unit/Core/System/SalesChannel/Api/StructEncoderTest.php
@@ -41,7 +41,7 @@ use Symfony\Component\Validator\Validator\ValidatorInterface;
 /**
  * @internal
  */
-#[Package('discovery')]
+#[Package('framework')]
 #[CoversClass(StructEncoder::class)]
 class StructEncoderTest extends TestCase
 {

--- a/tests/unit/Core/System/SalesChannel/Context/BaseSalesChannelContextFactoryTest.php
+++ b/tests/unit/Core/System/SalesChannel/Context/BaseSalesChannelContextFactoryTest.php
@@ -57,7 +57,7 @@ use Shopware\Core\Test\TestDefaults;
  *
  * @phpstan-import-type ContextOptions from BaseSalesChannelContextFactory
  */
-#[Package('discovery')]
+#[Package('framework')]
 #[CoversClass(BaseSalesChannelContextFactory::class)]
 class BaseSalesChannelContextFactoryTest extends TestCase
 {

--- a/tests/unit/Core/System/SalesChannel/Context/CartRestorerTest.php
+++ b/tests/unit/Core/System/SalesChannel/Context/CartRestorerTest.php
@@ -22,7 +22,7 @@ use Symfony\Component\HttpFoundation\RequestStack;
 /**
  * @internal
  */
-#[Package('discovery')]
+#[Package('framework')]
 #[CoversClass(CartRestorer::class)]
 class CartRestorerTest extends TestCase
 {

--- a/tests/unit/Core/System/SalesChannel/Context/SalesChannelContextServiceTest.php
+++ b/tests/unit/Core/System/SalesChannel/Context/SalesChannelContextServiceTest.php
@@ -33,7 +33,7 @@ use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
 /**
  * @internal
  */
-#[Package('discovery')]
+#[Package('framework')]
 #[CoversClass(SalesChannelContextService::class)]
 class SalesChannelContextServiceTest extends TestCase
 {

--- a/tests/unit/Core/System/SalesChannel/ContextTokenResponseTest.php
+++ b/tests/unit/Core/System/SalesChannel/ContextTokenResponseTest.php
@@ -11,7 +11,7 @@ use Shopware\Core\System\SalesChannel\ContextTokenResponse;
 /**
  * @internal
  */
-#[Package('discovery')]
+#[Package('framework')]
 #[CoversClass(ContextTokenResponse::class)]
 class ContextTokenResponseTest extends TestCase
 {

--- a/tests/unit/Core/System/SalesChannel/Event/SalesChannelContextCreatedEventTest.php
+++ b/tests/unit/Core/System/SalesChannel/Event/SalesChannelContextCreatedEventTest.php
@@ -12,7 +12,7 @@ use Shopware\Core\System\SalesChannel\SalesChannelContext;
 /**
  * @internal
  */
-#[Package('discovery')]
+#[Package('framework')]
 #[CoversClass(SalesChannelContextCreatedEvent::class)]
 class SalesChannelContextCreatedEventTest extends TestCase
 {

--- a/tests/unit/Core/System/SalesChannel/SalesChannelContextTest.php
+++ b/tests/unit/Core/System/SalesChannel/SalesChannelContextTest.php
@@ -16,7 +16,7 @@ use Shopware\Core\Test\Generator;
 /**
  * @internal
  */
-#[Package('discovery')]
+#[Package('framework')]
 #[CoversClass(SalesChannelContext::class)]
 class SalesChannelContextTest extends TestCase
 {

--- a/tests/unit/Core/System/SalesChannel/StoreApiCustomFieldMapperTest.php
+++ b/tests/unit/Core/System/SalesChannel/StoreApiCustomFieldMapperTest.php
@@ -15,7 +15,7 @@ use Shopware\Core\System\SalesChannel\StoreApiCustomFieldMapper;
 /**
  * @internal
  */
-#[Package('discovery')]
+#[Package('framework')]
 #[CoversClass(StoreApiCustomFieldMapper::class)]
 class StoreApiCustomFieldMapperTest extends TestCase
 {

--- a/tests/unit/Elasticsearch/Product/ProductSearchQueryBuilderTest.php
+++ b/tests/unit/Elasticsearch/Product/ProductSearchQueryBuilderTest.php
@@ -49,7 +49,7 @@ use Symfony\Component\Validator\Validator\ValidatorInterface;
 /**
  * @internal
  */
-#[Package('inventory')]
+#[Package('framework')]
 #[CoversClass(AbstractProductSearchQueryBuilder::class)]
 #[CoversClass(ProductSearchQueryBuilder::class)]
 class ProductSearchQueryBuilderTest extends TestCase


### PR DESCRIPTION
### 1. Why is this change necessary?

The `#[Package]` attribute of several unit tests differs from the ownership of the code they cover, so failing tests are routed to the wrong domain team.

### 2. What does this change do, exactly?

Sets the `#[Package]` value of the 20 unit tests whose covered classes carry a framework package to the value of their covered class, and aligns 5 integration tests with the packages of the `src/` directories their paths mirror. Attribute lines only. One test could not simply be re-valued: `AnnotatePackageProcessorTest` used its own package attribute as test fixture data. It carried the fake package `cause` because the processor under test resolves the causing class from the exception's instantiation site and two tests instantiated exceptions in the test class body. Those exceptions are now created by factory methods on the existing `TestCause` fixture, so the test class carries its real package. `TestCause` also no longer extends `Command`: the processor's entrypoint detection scans the trace for `Command` subclasses and must not match the fixture.

Part of the stack that introduces the enforcement rule; the rule sits on top and lands once every alignment below it is merged.

### 3. Describe each step to reproduce the issue or behaviour.

Compare each unit test's `#[Package]` value with the `#[Package]` of its `CoversClass` target, and each integration test's value with the `#[Package]` values in the mirrored `src/` directory. The `AnnotatePackageProcessorTest` rework is covered by its own assertions, which are unchanged.

### 4. Please link to the relevant issues (if any).

- relates #18473
- relates #19493

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
