### PR TITLE
test: align unit test package attributes with the covered after-sales classes

### DIFF
--- a/tests/unit/Core/Checkout/Cart/Rule/LineItemGoodsTotalRuleTest.php
+++ b/tests/unit/Core/Checkout/Cart/Rule/LineItemGoodsTotalRuleTest.php
@@ -28,7 +28,7 @@ use Symfony\Component\Validator\Constraints\Type;
 /**
  * @internal
  */
-#[Package('checkout')]
+#[Package('fundamentals@after-sales')]
 #[CoversClass(LineItemGoodsTotalRule::class)]
 #[Group('rules')]
 class LineItemGoodsTotalRuleTest extends TestCase

--- a/tests/unit/Core/Checkout/Cart/Rule/LineItemGroupRuleTest.php
+++ b/tests/unit/Core/Checkout/Cart/Rule/LineItemGroupRuleTest.php
@@ -18,7 +18,7 @@ use Symfony\Component\Validator\Constraints\Type;
 /**
  * @internal
  */
-#[Package('checkout')]
+#[Package('fundamentals@after-sales')]
 #[CoversClass(LineItemGroupRule::class)]
 class LineItemGroupRuleTest extends TestCase
 {

--- a/tests/unit/Core/Checkout/Cart/Rule/LineItemOfTypeRuleTest.php
+++ b/tests/unit/Core/Checkout/Cart/Rule/LineItemOfTypeRuleTest.php
@@ -23,7 +23,7 @@ use Shopware\Core\System\SalesChannel\SalesChannelContext;
 /**
  * @internal
  */
-#[Package('checkout')]
+#[Package('fundamentals@after-sales')]
 #[CoversClass(LineItemOfTypeRule::class)]
 class LineItemOfTypeRuleTest extends TestCase
 {

--- a/tests/unit/Core/Checkout/Cart/Rule/LineItemProductStatesRuleTest.php
+++ b/tests/unit/Core/Checkout/Cart/Rule/LineItemProductStatesRuleTest.php
@@ -24,7 +24,7 @@ use Shopware\Core\System\SalesChannel\SalesChannelContext;
 /**
  * @internal
  */
-#[Package('checkout')]
+#[Package('fundamentals@after-sales')]
 #[CoversClass(LineItemProductStatesRule::class)]
 class LineItemProductStatesRuleTest extends TestCase
 {

--- a/tests/unit/Core/Checkout/Cart/Rule/LineItemPropertyValueRuleTest.php
+++ b/tests/unit/Core/Checkout/Cart/Rule/LineItemPropertyValueRuleTest.php
@@ -23,7 +23,7 @@ use Shopware\Core\System\SalesChannel\SalesChannelContext;
 /**
  * @internal
  */
-#[Package('checkout')]
+#[Package('fundamentals@after-sales')]
 #[CoversClass(LineItemPropertyValueRule::class)]
 #[Group('rules')]
 class LineItemPropertyValueRuleTest extends TestCase

--- a/tests/unit/Core/Checkout/Cart/Rule/LineItemVariantValueRuleTest.php
+++ b/tests/unit/Core/Checkout/Cart/Rule/LineItemVariantValueRuleTest.php
@@ -23,7 +23,7 @@ use Shopware\Core\System\SalesChannel\SalesChannelContext;
 /**
  * @internal
  */
-#[Package('checkout')]
+#[Package('fundamentals@after-sales')]
 #[CoversClass(LineItemVariantValueRule::class)]
 #[Group('rules')]
 class LineItemVariantValueRuleTest extends TestCase

--- a/tests/unit/Core/Checkout/Cart/Validator/Container/NotRuleTest.php
+++ b/tests/unit/Core/Checkout/Cart/Validator/Container/NotRuleTest.php
@@ -14,7 +14,7 @@ use Shopware\Core\Test\Stub\Rule\TrueRule;
 /**
  * @internal
  */
-#[Package('checkout')]
+#[Package('fundamentals@after-sales')]
 #[CoversClass(NotRule::class)]
 class NotRuleTest extends TestCase
 {

--- a/tests/unit/Core/Checkout/Cart/Validator/Container/OrRuleTest.php
+++ b/tests/unit/Core/Checkout/Cart/Validator/Container/OrRuleTest.php
@@ -14,7 +14,7 @@ use Shopware\Core\Test\Stub\Rule\TrueRule;
 /**
  * @internal
  */
-#[Package('checkout')]
+#[Package('fundamentals@after-sales')]
 #[CoversClass(OrRule::class)]
 class OrRuleTest extends TestCase
 {

--- a/tests/unit/Core/Checkout/Cart/Validator/Container/XorRuleTest.php
+++ b/tests/unit/Core/Checkout/Cart/Validator/Container/XorRuleTest.php
@@ -14,7 +14,7 @@ use Shopware\Core\Test\Stub\Rule\TrueRule;
 /**
  * @internal
  */
-#[Package('checkout')]
+#[Package('fundamentals@after-sales')]
 #[CoversClass(XorRule::class)]
 class XorRuleTest extends TestCase
 {

--- a/tests/unit/Core/Checkout/Cart/Validator/RuleCollectionTest.php
+++ b/tests/unit/Core/Checkout/Cart/Validator/RuleCollectionTest.php
@@ -14,7 +14,7 @@ use Shopware\Core\Test\Stub\Rule\TrueRule;
 /**
  * @internal
  */
-#[Package('checkout')]
+#[Package('fundamentals@after-sales')]
 #[CoversClass(RuleCollection::class)]
 class RuleCollectionTest extends TestCase
 {

--- a/tests/unit/Core/Checkout/Promotion/Rule/PromotionLineItemRuleTest.php
+++ b/tests/unit/Core/Checkout/Promotion/Rule/PromotionLineItemRuleTest.php
@@ -22,7 +22,7 @@ use Symfony\Component\Validator\Constraints\NotBlank;
 /**
  * @internal
  */
-#[Package('checkout')]
+#[Package('fundamentals@after-sales')]
 #[CoversClass(PromotionLineItemRule::class)]
 class PromotionLineItemRuleTest extends TestCase
 {

--- a/tests/unit/Core/Content/Product/SalesChannel/Review/ProductReviewsWidgetLoadedHookTest.php
+++ b/tests/unit/Core/Content/Product/SalesChannel/Review/ProductReviewsWidgetLoadedHookTest.php
@@ -30,7 +30,7 @@ use Symfony\Component\HttpFoundation\Request;
 /**
  * @internal
  */
-#[Package('inventory')]
+#[Package('after-sales')]
 #[CoversClass(ProductReviewsWidgetLoadedHook::class)]
 class ProductReviewsWidgetLoadedHookTest extends TestCase
 {

--- a/tests/unit/Core/Framework/Store/Authentication/FrwRequestOptionsProviderTest.php
+++ b/tests/unit/Core/Framework/Store/Authentication/FrwRequestOptionsProviderTest.php
@@ -20,7 +20,7 @@ use Shopware\Core\System\User\Aggregate\UserConfig\UserConfigEntity;
 /**
  * @internal
  */
-#[Package('checkout')]
+#[Package('fundamentals@after-sales')]
 #[CoversClass(FrwRequestOptionsProvider::class)]
 class FrwRequestOptionsProviderTest extends TestCase
 {

--- a/tests/unit/Core/System/Currency/Rule/CurrencyRuleTest.php
+++ b/tests/unit/Core/System/Currency/Rule/CurrencyRuleTest.php
@@ -24,7 +24,7 @@ use Symfony\Component\Validator\Validation;
 /**
  * @internal
  */
-#[Package('fundamentals@discovery')]
+#[Package('fundamentals@after-sales')]
 #[CoversClass(CurrencyRule::class)]
 class CurrencyRuleTest extends TestCase
 {

--- a/tests/unit/Core/System/SalesChannel/Rule/SalesChannelRuleTest.php
+++ b/tests/unit/Core/System/SalesChannel/Rule/SalesChannelRuleTest.php
@@ -19,7 +19,7 @@ use Shopware\Core\Test\Generator;
 /**
  * @internal
  */
-#[Package('discovery')]
+#[Package('fundamentals@after-sales')]
 #[CoversClass(SalesChannelRule::class)]
 class SalesChannelRuleTest extends TestCase
 {


### PR DESCRIPTION
### 1. Why is this change necessary?

The `#[Package]` attribute of several unit tests differs from the ownership of the code they cover, so failing tests are routed to the wrong domain team.

### 2. What does this change do, exactly?

Sets the `#[Package]` value of the 15 unit tests whose covered classes carry a after-sales package to the value of their covered class. Attribute lines only.

Part of the stack that introduces the enforcement rule; the rule sits on top and lands once every alignment below it is merged.

### 3. Describe each step to reproduce the issue or behaviour.

Compare each test's `#[Package]` value with the `#[Package]` of its `CoversClass` target.

### 4. Please link to the relevant issues (if any).

- relates #18473
- relates #19493

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
