### PR TITLE
test: align unit and integration test package attributes with the inventory code they cover

### DIFF
--- a/tests/integration/Core/Content/ProductExport/Service/AgenticCommerceProductExportFlowTest.php
+++ b/tests/integration/Core/Content/ProductExport/Service/AgenticCommerceProductExportFlowTest.php
@@ -31,7 +31,7 @@ use Shopware\Core\System\SystemConfig\SystemConfigService;
 /**
  * @internal
  */
-#[Package('discovery')]
+#[Package('inventory')]
 class AgenticCommerceProductExportFlowTest extends TestCase
 {
     use DatabaseTransactionBehaviour;

--- a/tests/unit/Core/Checkout/Cart/ProductCartProcessorTest.php
+++ b/tests/unit/Core/Checkout/Cart/ProductCartProcessorTest.php
@@ -39,7 +39,7 @@ use Shopware\Core\Test\Stub\Checkout\EmptyPrice;
 /**
  * @internal
  */
-#[Package('checkout')]
+#[Package('inventory')]
 #[CoversClass(ProductCartProcessor::class)]
 class ProductCartProcessorTest extends TestCase
 {

--- a/tests/unit/Core/Content/Product/SalesChannel/Sorting/ProductSortingEntityTest.php
+++ b/tests/unit/Core/Content/Product/SalesChannel/Sorting/ProductSortingEntityTest.php
@@ -12,7 +12,7 @@ use Shopware\Core\Framework\Log\Package;
 /**
  * @internal
  */
-#[Package('framework')]
+#[Package('inventory')]
 #[CoversClass(ProductSortingEntity::class)]
 class ProductSortingEntityTest extends TestCase
 {

--- a/tests/unit/Core/Content/Seo/SeoUrlRoute/SeoUrlRouteConfigTest.php
+++ b/tests/unit/Core/Content/Seo/SeoUrlRoute/SeoUrlRouteConfigTest.php
@@ -12,7 +12,7 @@ use Shopware\Core\Framework\Log\Package;
 /**
  * @internal
  */
-#[Package('discovery')]
+#[Package('inventory')]
 #[CoversClass(SeoUrlRouteConfig::class)]
 class SeoUrlRouteConfigTest extends TestCase
 {

--- a/tests/unit/Storefront/Controller/SearchControllerTest.php
+++ b/tests/unit/Storefront/Controller/SearchControllerTest.php
@@ -45,7 +45,7 @@ use Twig\Environment;
 /**
  * @internal
  */
-#[Package('discovery')]
+#[Package('inventory')]
 #[CoversClass(SearchController::class)]
 class SearchControllerTest extends TestCase
 {


### PR DESCRIPTION
### 1. Why is this change necessary?

The `#[Package]` attribute of several unit tests differs from the ownership of the code they cover, so failing tests are routed to the wrong domain team.

### 2. What does this change do, exactly?

Sets the `#[Package]` value of the 4 unit tests whose covered classes carry a inventory package to the value of their covered class, and aligns 1 integration test with the packages of the `src/` directories their paths mirror. Attribute lines only.

Part of the stack that introduces the enforcement rule; the rule sits on top and lands once every alignment below it is merged.

### 3. Describe each step to reproduce the issue or behaviour.

Compare each unit test's `#[Package]` value with the `#[Package]` of its `CoversClass` target, and each integration test's value with the `#[Package]` values in the mirrored `src/` directory.

### 4. Please link to the relevant issues (if any).

- relates #18473
- relates #19493

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
