### PR TITLE
test: align unit and integration test package attributes with the checkout code they cover

### DIFF
--- a/tests/integration/Core/Checkout/Customer/Service/ProductReviewCountServiceTest.php
+++ b/tests/integration/Core/Checkout/Customer/Service/ProductReviewCountServiceTest.php
@@ -20,7 +20,7 @@ use Shopware\Core\Test\TestDefaults;
 /**
  * @internal
  */
-#[Package('fundamentals@after-sales')]
+#[Package('checkout')]
 class ProductReviewCountServiceTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Framework/App/Payment/AppAsyncPaymentHandlerTest.php
+++ b/tests/integration/Core/Framework/App/Payment/AppAsyncPaymentHandlerTest.php
@@ -22,7 +22,7 @@ use Symfony\Component\HttpFoundation\Request;
 /**
  * @internal
  */
-#[Package('framework')]
+#[Package('checkout')]
 class AppAsyncPaymentHandlerTest extends AbstractAppPaymentHandlerTestCase
 {
     final public const REDIRECT_URL = 'http://payment.app/do/something';

--- a/tests/integration/Core/Framework/App/Payment/AppPreparedPaymentHandlerTest.php
+++ b/tests/integration/Core/Framework/App/Payment/AppPreparedPaymentHandlerTest.php
@@ -16,7 +16,7 @@ use Shopware\Core\Test\Generator;
 /**
  * @internal
  */
-#[Package('framework')]
+#[Package('checkout')]
 class AppPreparedPaymentHandlerTest extends AbstractAppPaymentHandlerTestCase
 {
     public function testValidate(): void

--- a/tests/integration/Core/Framework/App/Payment/AppRefundHandlerTest.php
+++ b/tests/integration/Core/Framework/App/Payment/AppRefundHandlerTest.php
@@ -14,7 +14,7 @@ use Shopware\Core\Framework\Log\Package;
 /**
  * @internal
  */
-#[Package('framework')]
+#[Package('checkout')]
 class AppRefundHandlerTest extends AbstractAppPaymentHandlerTestCase
 {
     public function testRefund(): void

--- a/tests/integration/Storefront/Page/Checkout/CartPageTest.php
+++ b/tests/integration/Storefront/Page/Checkout/CartPageTest.php
@@ -23,7 +23,7 @@ use Symfony\Component\HttpFoundation\Request;
 /**
  * @internal
  */
-#[Package('discovery')]
+#[Package('checkout')]
 class CartPageTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Storefront/Page/Checkout/ConfirmPageTest.php
+++ b/tests/integration/Storefront/Page/Checkout/ConfirmPageTest.php
@@ -21,7 +21,7 @@ use Symfony\Component\HttpFoundation\Request;
 /**
  * @internal
  */
-#[Package('discovery')]
+#[Package('checkout')]
 class ConfirmPageTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Storefront/Page/Checkout/FinishPageTest.php
+++ b/tests/integration/Storefront/Page/Checkout/FinishPageTest.php
@@ -17,7 +17,7 @@ use Symfony\Component\HttpFoundation\Request;
 /**
  * @internal
  */
-#[Package('discovery')]
+#[Package('checkout')]
 class FinishPageTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/unit/Core/Checkout/Cart/CartCompressorTest.php
+++ b/tests/unit/Core/Checkout/Cart/CartCompressorTest.php
@@ -13,7 +13,7 @@ use Shopware\Core\Test\Assert\Serialization;
 /**
  * @internal
  */
-#[Package('framework')]
+#[Package('checkout')]
 #[CoversClass(CartCompressor::class)]
 class CartCompressorTest extends TestCase
 {

--- a/tests/unit/Core/Checkout/Cart/Delivery/Struct/DeliveryDateTest.php
+++ b/tests/unit/Core/Checkout/Cart/Delivery/Struct/DeliveryDateTest.php
@@ -15,7 +15,7 @@ use Shopware\Core\System\DeliveryTime\DeliveryTimeEntity;
 /**
  * @internal
  */
-#[Package('framework')]
+#[Package('checkout')]
 #[CoversClass(DeliveryDate::class)]
 class DeliveryDateTest extends TestCase
 {

--- a/tests/unit/Core/Checkout/Customer/Service/ProductReviewCountServiceTest.php
+++ b/tests/unit/Core/Checkout/Customer/Service/ProductReviewCountServiceTest.php
@@ -12,7 +12,7 @@ use Shopware\Core\Framework\Log\Package;
 /**
  * @internal
  */
-#[Package('after-sales')]
+#[Package('checkout')]
 #[CoversClass(ProductReviewCountService::class)]
 class ProductReviewCountServiceTest extends TestCase
 {

--- a/tests/unit/Storefront/Event/Subscriber/CartMergedSubscriberTest.php
+++ b/tests/unit/Storefront/Event/Subscriber/CartMergedSubscriberTest.php
@@ -22,7 +22,7 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 /**
  * @internal
  */
-#[Package('framework')]
+#[Package('checkout')]
 #[CoversClass(CartMergedSubscriber::class)]
 class CartMergedSubscriberTest extends TestCase
 {


### PR DESCRIPTION
### 1. Why is this change necessary?

The `#[Package]` attribute of several unit tests differs from the ownership of the code they cover, so failing tests are routed to the wrong domain team.

### 2. What does this change do, exactly?

Sets the `#[Package]` value of the 4 unit tests whose covered classes carry a checkout package to the value of their covered class, and aligns 7 integration tests with the packages of the `src/` directories their paths mirror. Attribute lines only.

Part of the stack that introduces the enforcement rule; the rule sits on top and lands once every alignment below it is merged.

### 3. Describe each step to reproduce the issue or behaviour.

Compare each unit test's `#[Package]` value with the `#[Package]` of its `CoversClass` target, and each integration test's value with the `#[Package]` values in the mirrored `src/` directory.

### 4. Please link to the relevant issues (if any).

- relates #18473
- relates #19493

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
