### PR TITLE
ci: pin the CodeQL analysis category across calling workflows

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -192,6 +192,11 @@ jobs:
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
+        with:
+          # without an explicit category the upload is categorized by the calling
+          # workflow, so the nightly call registers a second configuration that no
+          # pull request can produce and every PR warns "1 configuration not found"
+          category: "/language:${{ matrix.language }}"
 
   blue-green-67-68:
     name: "PHP blue green 6.7 -> 6.8 -> 6.7"


### PR DESCRIPTION
### 1. Why is this change necessary?

Every pull request shows a neutral CodeQL check "1 configuration not found: `.github/workflows/nightly.yml:code-ql/language:javascript`". Without an explicit category, CodeQL categorizes an upload by the top-level calling workflow. The `code-ql` job lives in `integration.yml`, which also runs as a reusable workflow inside `nightly.yml`, so the nightly run on trunk registers a second configuration that no pull request can ever produce, and code scanning warns about it on every PR.

### 2. What does this change do, exactly?

Passes an explicit `category` to `github/codeql-action/analyze`, so pull request runs and nightly runs upload into the same configuration regardless of the calling workflow.

After the merge, the stale configuration `.github/workflows/nightly.yml:code-ql/language:javascript` stays registered on trunk and keeps the warning on open pull requests until it is removed:

1. Wait for one nightly run to upload under the new `/language:javascript` category, so the active configuration holds every alert.
2. Delete the stale configuration via the three-dots menu on the code scanning tool status page (or via the analyses API).

**Do not delete it before step 1.** It is currently the only configuration holding the javascript alerts; deleting it first also deletes them, including 100+ dismissals (won't fix, false positive) that would return as open alerts on the next upload. Alternatively the warning resolves on its own once the stale configuration's latest analysis is older than roughly 90 days.

### 3. Describe each step to reproduce the issue or behaviour.

Open the checks of any current pull request: the CodeQL check reports "1 configuration not found". The CodeQL run of this pull request shows the analyze step uploading with the pinned category.

### 4. Please link to the relevant issues (if any).

- closes #19511

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
