### PR TITLE
perf(media): add configurable remote request timeouts

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -272,6 +272,7 @@ Resolving the sales channel context now calculates the cart through `CartCalcula
 ### Headless sales channels return their SEO URLs via `sw-include-seo-urls`
 
 Store API responses requested with the `sw-include-seo-urls` header now also include the SEO URLs generated for headless (API type) sales channels. Previously only the storefront SEO URL routes were considered when loading the `seoUrls` of products, categories and landing pages, so the association stayed empty on headless sales channels even though SEO URLs had been generated for them (see "SEO URLs for headless sales channels" in 6.7.14.0). Storefront sales channels are unaffected.
+
 ### Remote media request timeouts are configurable
 
 Installations can configure `shopware.media.url_upload_timeout` and

--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -673,6 +673,12 @@ Replace a matrix in a single request, so the method is never priceless in betwee
   { "key": "write-prices", "entity": "shipping_method_price", "action": "upsert", "payload": [{ "id": "…", "shippingMethodId": "…", "calculation": 1, "quantityStart": 0, "currencyPrice": [{ "currencyId": "…", "net": 0, "gross": 0, "linked": false }] }] }
 ]
 ```
+### Remote media request timeouts are configurable
+
+Installations can configure `shopware.media.url_upload_timeout` and
+`shopware.media.external_link_timeout` in seconds to bound remote media URL
+uploads and external-media link checks. Both values default to `0.0`, which
+preserves the previous unlimited behavior.
 
 ### E-invoice line positions state the correct price base quantity
 

--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -272,6 +272,12 @@ Resolving the sales channel context now calculates the cart through `CartCalcula
 ### Headless sales channels return their SEO URLs via `sw-include-seo-urls`
 
 Store API responses requested with the `sw-include-seo-urls` header now also include the SEO URLs generated for headless (API type) sales channels. Previously only the storefront SEO URL routes were considered when loading the `seoUrls` of products, categories and landing pages, so the association stayed empty on headless sales channels even though SEO URLs had been generated for them (see "SEO URLs for headless sales channels" in 6.7.14.0). Storefront sales channels are unaffected.
+### Remote media request timeouts are configurable
+
+Installations can configure `shopware.media.url_upload_timeout` and
+`shopware.media.external_link_timeout` in seconds to bound remote media URL
+uploads and external-media link checks. Both values default to `0.0`, which
+preserves the previous unlimited behavior.
 
 ## Administration
 
@@ -673,12 +679,6 @@ Replace a matrix in a single request, so the method is never priceless in betwee
   { "key": "write-prices", "entity": "shipping_method_price", "action": "upsert", "payload": [{ "id": "…", "shippingMethodId": "…", "calculation": 1, "quantityStart": 0, "currencyPrice": [{ "currencyId": "…", "net": 0, "gross": 0, "linked": false }] }] }
 ]
 ```
-### Remote media request timeouts are configurable
-
-Installations can configure `shopware.media.url_upload_timeout` and
-`shopware.media.external_link_timeout` in seconds to bound remote media URL
-uploads and external-media link checks. Both values default to `0.0`, which
-preserves the previous unlimited behavior.
 
 ### E-invoice line positions state the correct price base quantity
 

--- a/config-schema.json
+++ b/config-schema.json
@@ -1485,6 +1485,16 @@
                 "url_upload_max_size": {
                     "type": "string"
                 },
+                "url_upload_timeout": {
+                    "type": "number",
+                    "minimum": 0,
+                    "title": "Maximum duration in seconds for fetching a media file from a URL. Set to 0 to disable the timeout."
+                },
+                "external_link_timeout": {
+                    "type": "number",
+                    "minimum": 0,
+                    "title": "Maximum duration in seconds for checking an external media link. Set to 0 to disable the timeout."
+                },
                 "remote_thumbnails": {
                     "type": "object",
                     "additionalProperties": false,

--- a/src/Core/Content/DependencyInjection/media.php
+++ b/src/Core/Content/DependencyInjection/media.php
@@ -188,6 +188,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             param('shopware.media.enable_url_upload_feature'),
             param('shopware.media.enable_url_validation'),
             param('shopware.media.url_upload_max_size'),
+            param('shopware.media.url_upload_timeout'),
         ]);
 
     $services->set(FileUrlValidatorInterface::class, FileUrlValidator::class)
@@ -437,6 +438,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             service(FileUrlValidatorInterface::class),
             service(TrustedUrlResolver::class),
             param('shopware.media.enable_url_validation'),
+            param('shopware.media.external_link_timeout'),
         ]);
 
     $services->set(VideoCoverService::class)

--- a/src/Core/Content/Media/File/FileFetcher.php
+++ b/src/Core/Content/Media/File/FileFetcher.php
@@ -167,16 +167,16 @@ class FileFetcher
             'resolve' => [$resolved->host => $resolved->ip],
         ];
 
+        if ($this->urlUploadTimeout > 0) {
+            $options['max_duration'] = $this->urlUploadTimeout;
+        }
+
         if ($this->enableUrlValidation) {
             $client = new NoPrivateNetworkHttpClient($client, TrustedUrlResolver::BLOCKED_SUBNETS);
         }
 
         $destStream = $this->openDestinationStream($fileName);
         $writtenBytes = 0;
-
-        if ($this->urlUploadTimeout > 0) {
-            stream_context_set_option($streamContext, 'http', 'timeout', $this->urlUploadTimeout);
-        }
 
         try {
             $response = $client->request('GET', $url, $options);

--- a/src/Core/Content/Media/File/FileFetcher.php
+++ b/src/Core/Content/Media/File/FileFetcher.php
@@ -23,7 +23,8 @@ class FileFetcher
         private readonly HttpClientInterface $httpClient,
         private readonly bool $enableUrlUploadFeature = true,
         private readonly bool $enableUrlValidation = true,
-        private readonly int $maxFileSize = 0
+        private readonly int $maxFileSize = 0,
+        private readonly float $urlUploadTimeout = 0.0,
     ) {
     }
 
@@ -172,6 +173,10 @@ class FileFetcher
 
         $destStream = $this->openDestinationStream($fileName);
         $writtenBytes = 0;
+
+        if ($this->urlUploadTimeout > 0) {
+            stream_context_set_option($streamContext, 'http', 'timeout', $this->urlUploadTimeout);
+        }
 
         try {
             $response = $client->request('GET', $url, $options);

--- a/src/Core/Content/Media/Upload/MediaUploadService.php
+++ b/src/Core/Content/Media/Upload/MediaUploadService.php
@@ -322,7 +322,6 @@ readonly class MediaUploadService
     {
         $this->assertValidExternalUrl($url);
 
-<<<<<<< HEAD
         $resolved = $this->trustedUrlResolver->resolve($url);
 
         $client = $this->httpClient;
@@ -340,14 +339,6 @@ readonly class MediaUploadService
         }
 
         $headers = $client->request('HEAD', $url, $options)->getHeaders();
-=======
-        $options = ['max_redirects' => 0];
-        if ($this->externalLinkTimeout > 0) {
-            $options['max_duration'] = $this->externalLinkTimeout;
-        }
-
-        $headers = $this->httpClient->request('HEAD', $url, $options)->getHeaders();
->>>>>>> fba1347b034 (perf(media): add configurable remote request timeouts)
         if (!\array_key_exists('content-length', $headers)) {
             throw MediaException::fileNotFound($url);
         }

--- a/src/Core/Content/Media/Upload/MediaUploadService.php
+++ b/src/Core/Content/Media/Upload/MediaUploadService.php
@@ -54,6 +54,7 @@ readonly class MediaUploadService
         private FileUrlValidatorInterface $fileUrlValidator,
         private TrustedUrlResolver $trustedUrlResolver,
         private bool $enableUrlValidation = true,
+        private float $externalLinkTimeout = 0.0,
     ) {
     }
 
@@ -321,6 +322,7 @@ readonly class MediaUploadService
     {
         $this->assertValidExternalUrl($url);
 
+<<<<<<< HEAD
         $resolved = $this->trustedUrlResolver->resolve($url);
 
         $client = $this->httpClient;
@@ -329,11 +331,23 @@ readonly class MediaUploadService
             'resolve' => [$resolved->host => $resolved->ip],
         ];
 
+        if ($this->externalLinkTimeout > 0) {
+            $options['max_duration'] = $this->externalLinkTimeout;
+        }
+
         if ($this->enableUrlValidation) {
             $client = new NoPrivateNetworkHttpClient($client, TrustedUrlResolver::BLOCKED_SUBNETS);
         }
 
         $headers = $client->request('HEAD', $url, $options)->getHeaders();
+=======
+        $options = ['max_redirects' => 0];
+        if ($this->externalLinkTimeout > 0) {
+            $options['max_duration'] = $this->externalLinkTimeout;
+        }
+
+        $headers = $this->httpClient->request('HEAD', $url, $options)->getHeaders();
+>>>>>>> fba1347b034 (perf(media): add configurable remote request timeouts)
         if (!\array_key_exists('content-length', $headers)) {
             throw MediaException::fileNotFound($url);
         }

--- a/src/Core/Framework/DependencyInjection/Configuration.php
+++ b/src/Core/Framework/DependencyInjection/Configuration.php
@@ -371,6 +371,8 @@ class Configuration implements ConfigurationInterface
                 ->scalarNode('url_upload_max_size')->defaultValue(0)
                     ->validate()->always()->then(static fn ($value) => abs(MemorySizeCalculator::convertToBytes((string) $value)))->end()
                 ->end()
+                ->floatNode('url_upload_timeout')->defaultValue(0.0)->min(0)->end()
+                ->floatNode('external_link_timeout')->defaultValue(0.0)->min(0)->end()
                 ->arrayNode('presigned_upload')
                     ->addDefaultsIfNotSet()
                     ->children()

--- a/src/Core/Framework/Resources/config/packages/shopware.yaml
+++ b/src/Core/Framework/Resources/config/packages/shopware.yaml
@@ -429,6 +429,8 @@ shopware:
         enable_url_upload_feature: true
         enable_url_validation: true
         url_upload_max_size: 0
+        url_upload_timeout: 0.0
+        external_link_timeout: 0.0
         remote_thumbnails:
             enable: false
             pattern: '{mediaUrl}/{mediaPath}?width={width}&ts={mediaUpdatedAt}'

--- a/tests/unit/Core/Content/Media/File/FileFetcherTest.php
+++ b/tests/unit/Core/Content/Media/File/FileFetcherTest.php
@@ -148,6 +148,54 @@ class FileFetcherTest extends TestCase
         static::assertSame($expectedExtension, $media->getFileExtension());
     }
 
+    public function testFetchFileFromURLAppliesConfiguredTimeout(): void
+    {
+        stream_wrapper_register('shopware-test-timeout', TimeoutCapturingStreamWrapper::class);
+
+        try {
+            $fileValidator = static::createStub(FileUrlValidatorInterface::class);
+            $fileValidator->method('isValid')->willReturn(true);
+
+            $fileService = static::createStub(FileService::class);
+            $fileService->method('isUrl')->willReturn(true);
+
+            $fileFetcher = new FileFetcher(
+                $fileValidator,
+                $fileService,
+                true,
+                true,
+                0,
+                1.5,
+            );
+
+            $fileFetcher->fetchFromURL('shopware-test-timeout://image.jpg', self::TEMP_FILE, self::IMAGE_EXTENSION);
+
+            static::assertSame(1.5, TimeoutCapturingStreamWrapper::$options['http']['timeout']);
+        } finally {
+            stream_wrapper_unregister('shopware-test-timeout');
+        }
+    }
+
+    public function testFetchFileFromURLDoesNotApplyTimeoutByDefault(): void
+    {
+        stream_wrapper_register('shopware-test-timeout', TimeoutCapturingStreamWrapper::class);
+
+        try {
+            $fileValidator = static::createStub(FileUrlValidatorInterface::class);
+            $fileValidator->method('isValid')->willReturn(true);
+
+            $fileService = static::createStub(FileService::class);
+            $fileService->method('isUrl')->willReturn(true);
+
+            $fileFetcher = new FileFetcher($fileValidator, $fileService);
+            $fileFetcher->fetchFromURL('shopware-test-timeout://image.jpg', self::TEMP_FILE, self::IMAGE_EXTENSION);
+
+            static::assertArrayNotHasKey('timeout', TimeoutCapturingStreamWrapper::$options['http']);
+        } finally {
+            stream_wrapper_unregister('shopware-test-timeout');
+        }
+    }
+
     public static function fetchFileFromUrlDataProvider(): \Generator
     {
         yield 'image resource without an extension' => [
@@ -461,5 +509,39 @@ class FileFetcherTest extends TestCase
         if (\is_dir(self::TEMP_DIR)) {
             static::assertTrue(rmdir(self::TEMP_DIR));
         }
+    }
+}
+
+final class TimeoutCapturingStreamWrapper
+{
+    public static array $options = [];
+
+    /**
+     * @var resource|null
+     */
+    public $context;
+
+    private int $position = 0;
+
+    public function stream_open(string $path, string $mode, int $options, ?string &$openedPath): bool
+    {
+        static::$options = stream_context_get_options($this->context);
+
+        return true;
+    }
+
+    public function stream_read(int $count): string
+    {
+        $content = file_get_contents(__DIR__ . '/_fixtures/image1x1.png');
+        $content = $content === false ? '' : $content;
+        $result = substr($content, $this->position, $count);
+        $this->position += \strlen($result);
+
+        return $result;
+    }
+
+    public function stream_eof(): bool
+    {
+        return $this->position >= filesize(__DIR__ . '/_fixtures/image1x1.png');
     }
 }

--- a/tests/unit/Core/Content/Media/File/FileFetcherTest.php
+++ b/tests/unit/Core/Content/Media/File/FileFetcherTest.php
@@ -150,50 +150,34 @@ class FileFetcherTest extends TestCase
 
     public function testFetchFileFromURLAppliesConfiguredTimeout(): void
     {
-        stream_wrapper_register('shopware-test-timeout', TimeoutCapturingStreamWrapper::class);
+        $capturedOptions = [];
+        $httpClient = new MockHttpClient(function (string $method, string $url, array $options) use (&$capturedOptions): MockResponse {
+            $capturedOptions = $options;
 
-        try {
-            $fileValidator = static::createStub(FileUrlValidatorInterface::class);
-            $fileValidator->method('isValid')->willReturn(true);
+            return new MockResponse((string) file_get_contents(self::IMAGE_URL_WITH_EXTENSION));
+        });
 
-            $fileService = static::createStub(FileService::class);
-            $fileService->method('isUrl')->willReturn(true);
+        $fileFetcher = $this->createFileFetcher(httpClient: $httpClient, urlUploadTimeout: 1.5);
 
-            $fileFetcher = new FileFetcher(
-                $fileValidator,
-                $fileService,
-                true,
-                true,
-                0,
-                1.5,
-            );
+        $fileFetcher->fetchFromURL('https://example.com/image.jpg', self::TEMP_FILE, self::IMAGE_EXTENSION);
 
-            $fileFetcher->fetchFromURL('shopware-test-timeout://image.jpg', self::TEMP_FILE, self::IMAGE_EXTENSION);
-
-            static::assertSame(1.5, TimeoutCapturingStreamWrapper::$options['http']['timeout']);
-        } finally {
-            stream_wrapper_unregister('shopware-test-timeout');
-        }
+        static::assertSame(1.5, $capturedOptions['max_duration']);
     }
 
     public function testFetchFileFromURLDoesNotApplyTimeoutByDefault(): void
     {
-        stream_wrapper_register('shopware-test-timeout', TimeoutCapturingStreamWrapper::class);
+        $capturedOptions = [];
+        $httpClient = new MockHttpClient(function (string $method, string $url, array $options) use (&$capturedOptions): MockResponse {
+            $capturedOptions = $options;
 
-        try {
-            $fileValidator = static::createStub(FileUrlValidatorInterface::class);
-            $fileValidator->method('isValid')->willReturn(true);
+            return new MockResponse((string) file_get_contents(self::IMAGE_URL_WITH_EXTENSION));
+        });
 
-            $fileService = static::createStub(FileService::class);
-            $fileService->method('isUrl')->willReturn(true);
+        $fileFetcher = $this->createFileFetcher(httpClient: $httpClient);
 
-            $fileFetcher = new FileFetcher($fileValidator, $fileService);
-            $fileFetcher->fetchFromURL('shopware-test-timeout://image.jpg', self::TEMP_FILE, self::IMAGE_EXTENSION);
+        $fileFetcher->fetchFromURL('https://example.com/image.jpg', self::TEMP_FILE, self::IMAGE_EXTENSION);
 
-            static::assertArrayNotHasKey('timeout', TimeoutCapturingStreamWrapper::$options['http']);
-        } finally {
-            stream_wrapper_unregister('shopware-test-timeout');
-        }
+        static::assertTrue(!isset($capturedOptions['max_duration']) || $capturedOptions['max_duration'] <= 0);
     }
 
     public static function fetchFileFromUrlDataProvider(): \Generator
@@ -465,6 +449,7 @@ class FileFetcherTest extends TestCase
         bool $enableUploadFeature = true,
         bool $enableValidation = true,
         int $maxFileSize = 0,
+        float $urlUploadTimeout = 0.0,
     ): FileFetcher {
         if ($validator === null) {
             $validator = static::createStub(FileUrlValidatorInterface::class);
@@ -484,6 +469,7 @@ class FileFetcherTest extends TestCase
             $enableUploadFeature,
             $enableValidation,
             $maxFileSize,
+            $urlUploadTimeout,
         );
     }
 
@@ -509,49 +495,5 @@ class FileFetcherTest extends TestCase
         if (\is_dir(self::TEMP_DIR)) {
             static::assertTrue(rmdir(self::TEMP_DIR));
         }
-    }
-}
-
-/**
- * @internal
- */
-final class TimeoutCapturingStreamWrapper
-{
-    /**
-     * @var array<string, mixed>
-     */
-    public static array $options = [];
-
-    /**
-     * @var resource|null
-     */
-    public $context;
-
-    private int $position = 0;
-
-    public function stream_open(string $path, string $mode, int $options, ?string &$openedPath): bool
-    {
-        if (!\is_resource($this->context)) {
-            return false;
-        }
-
-        static::$options = stream_context_get_options($this->context);
-
-        return true;
-    }
-
-    public function stream_read(int $count): string
-    {
-        $content = file_get_contents(__DIR__ . '/_fixtures/image1x1.png');
-        $content = $content === false ? '' : $content;
-        $result = substr($content, $this->position, $count);
-        $this->position += \strlen($result);
-
-        return $result;
-    }
-
-    public function stream_eof(): bool
-    {
-        return $this->position >= filesize(__DIR__ . '/_fixtures/image1x1.png');
     }
 }

--- a/tests/unit/Core/Content/Media/File/FileFetcherTest.php
+++ b/tests/unit/Core/Content/Media/File/FileFetcherTest.php
@@ -512,8 +512,14 @@ class FileFetcherTest extends TestCase
     }
 }
 
+/**
+ * @internal
+ */
 final class TimeoutCapturingStreamWrapper
 {
+    /**
+     * @var array<string, mixed>
+     */
     public static array $options = [];
 
     /**
@@ -525,6 +531,10 @@ final class TimeoutCapturingStreamWrapper
 
     public function stream_open(string $path, string $mode, int $options, ?string &$openedPath): bool
     {
+        if (!\is_resource($this->context)) {
+            return false;
+        }
+
         static::$options = stream_context_get_options($this->context);
 
         return true;

--- a/tests/unit/Core/Content/Media/Upload/MediaUploadServiceTest.php
+++ b/tests/unit/Core/Content/Media/Upload/MediaUploadServiceTest.php
@@ -264,22 +264,19 @@ class MediaUploadServiceTest extends TestCase
         $url = 'https://example.com/image.jpg';
         $params = new MediaUploadParameters(fileName: 'test.jpg', mimeType: 'image/jpeg');
 
-        $response = static::createStub(ResponseInterface::class);
-        $response->method('getHeaders')->willReturn(['content-length' => ['1024']]);
+        $capturedOptions = [];
+        $httpClient = new MockHttpClient(function (string $method, string $requestUrl, array $options) use (&$capturedOptions): MockResponse {
+            $capturedOptions = $options;
 
-        $httpClient = $this->createMock(HttpClientInterface::class);
-        $httpClient
-            ->expects($this->once())
-            ->method('request')
-            ->with('HEAD', $url, [
-                'max_redirects' => 0,
-                'resolve' => ['example.com' => '93.184.216.34'],
-                'max_duration' => 2.5,
-            ])
-            ->willReturn($response);
+            return new MockResponse('', ['response_headers' => ['content-length' => '1024']]);
+        });
 
         $this->buildService(httpClient: $httpClient, externalLinkTimeout: 2.5)
             ->linkURL($url, $this->context, $params);
+
+        static::assertSame(0, $capturedOptions['max_redirects']);
+        static::assertSame(['example.com' => '93.184.216.34'], $capturedOptions['resolve']);
+        static::assertSame(2.5, $capturedOptions['max_duration']);
     }
 
     public function testLinkURLWithoutMimeType(): void

--- a/tests/unit/Core/Content/Media/Upload/MediaUploadServiceTest.php
+++ b/tests/unit/Core/Content/Media/Upload/MediaUploadServiceTest.php
@@ -259,6 +259,29 @@ class MediaUploadServiceTest extends TestCase
         static::assertSame('image/jpeg', $createdMedia['mimeType']);
     }
 
+    public function testLinkURLAppliesConfiguredMaximumDuration(): void
+    {
+        $url = 'https://example.com/image.jpg';
+        $params = new MediaUploadParameters(fileName: 'test.jpg', mimeType: 'image/jpeg');
+
+        $response = static::createStub(ResponseInterface::class);
+        $response->method('getHeaders')->willReturn(['content-length' => ['1024']]);
+
+        $httpClient = $this->createMock(HttpClientInterface::class);
+        $httpClient
+            ->expects($this->once())
+            ->method('request')
+            ->with('HEAD', $url, [
+                'max_redirects' => 0,
+                'resolve' => ['example.com' => '93.184.216.34'],
+                'max_duration' => 2.5,
+            ])
+            ->willReturn($response);
+
+        $this->buildService(httpClient: $httpClient, externalLinkTimeout: 2.5)
+            ->linkURL($url, $this->context, $params);
+    }
+
     public function testLinkURLWithoutMimeType(): void
     {
         $url = 'https://example.com/image.jpg';
@@ -722,6 +745,7 @@ class MediaUploadServiceTest extends TestCase
         ?HttpClientInterface $httpClient = null,
         ?FileUrlValidatorInterface $fileUrlValidator = null,
         ?TrustedUrlResolver $trustedUrlResolver = null,
+        float $externalLinkTimeout = 0.0,
     ): MediaUploadService {
         $service = new MediaUploadService(
             $this->mediaRepository,
@@ -733,6 +757,7 @@ class MediaUploadServiceTest extends TestCase
             $this->mediaThumbnailSizeRepository,
             $fileUrlValidator ?? $this->fileUrlValidator,
             $trustedUrlResolver ?? $this->trustedUrlResolver,
+            externalLinkTimeout: $externalLinkTimeout,
         );
 
         $this->mediaUploadService = $service;


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

The SaaS performance investigation in issue 790 identified that synchronous remote media operations in Shopware core have no Shopware-configurable wall-clock timeout. A slow or unavailable remote host can keep a request open until the PHP stream or HTTP client default limit is reached.

### 2. What does this change do, exactly?

Adds two opt-in media settings:

- `shopware.media.url_upload_timeout` limits remote media URL uploads performed by `FileFetcher`.
- `shopware.media.external_link_timeout` limits the external-link HEAD request performed by `MediaUploadService`.

Both values are measured in seconds and default to `0.0`, preserving the existing unlimited behavior. The configuration schema, default configuration, release information, and focused unit tests are updated.

### 3. Describe each step to reproduce the issue or behaviour.

1. Use the media upload-from-URL endpoint or external-link endpoint with a remote host that responds slowly or does not respond.
2. Observe that the request has no Shopware-configurable wall-clock limit.
3. Configure the corresponding timeout under `shopware.media` and repeat the request.
4. The remote operation is bounded by the configured duration; leaving the value at `0.0` retains the previous behavior.

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

- relates https://github.com/shopware/saas/issues/790

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<minor>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
