### PR TITLE
ci: remove the CodeQL analysis

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -161,38 +161,6 @@ jobs:
 
       - name: Run on platform
         run: ./local-php-security-checker
-  code-ql:
-    name: Analyze
-    needs:
-      - markdown-only-changes
-    if: ${{ github.repository == 'shopware/shopware' && needs.markdown-only-changes.outputs.docs_only != 'true' }}
-    runs-on: ubuntu-24.04
-
-    strategy:
-      fail-fast: false
-      matrix:
-        language: ["javascript"]
-    permissions:
-      contents: read
-      security-events: write
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          fetch-depth: 2
-
-      - name: Initialize CodeQL
-        uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
-
-        with:
-          languages: ${{ matrix.language }}
-
-      - name: Autobuild
-        uses: github/codeql-action/autobuild@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
-
-      - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
-
   blue-green-67-68:
     name: "PHP blue green 6.7 -> 6.8 -> 6.7"
     needs:
@@ -444,7 +412,6 @@ jobs:
       - markdown-only-changes
       - phpunit
       - win-checkout
-      - code-ql
       - php-security
       - blue-green-66-67
       - blue-green-67-68
@@ -456,5 +423,5 @@ jobs:
         with:
           # allowed-failures: docs, linters
           # allow markdown-only PRs to skip the expensive jobs, and allow jobs which do not run on a PR or outside the public repository to skip
-          allowed-skips: ${{ needs.markdown-only-changes.outputs.docs_only == 'true' && 'phpunit, win-checkout, code-ql, php-security, blue-green-66-67, blue-green-67-68' || github.repository != 'shopware/shopware' && github.event_name == 'pull_request' && 'win-checkout, code-ql' || github.repository != 'shopware/shopware' && 'code-ql' || github.event_name == 'pull_request' && 'win-checkout' || '' }}
+          allowed-skips: ${{ needs.markdown-only-changes.outputs.docs_only == 'true' && 'phpunit, win-checkout, php-security, blue-green-66-67, blue-green-67-68' || github.event_name == 'pull_request' && 'win-checkout' || '' }}
           jobs: ${{ toJSON(needs) }}


### PR DESCRIPTION
### 1. Why is this change necessary?

The CodeQL job runs on every pull request without gating anything: a configuration mismatch between the pull request runs and the nightly call means code scanning cannot compute the alerts a pull request introduces, every pull request shows the neutral "1 configuration not found" warning, and the green check suggests a scan that effectively does not evaluate the change.

### 2. What does this change do, exactly?

Removes the `code-ql` job from `integration.yml`, its entry in the `check` job, and its mentions in the `allowed-skips` expression. The nightly analysis stops with it, since the nightly calls this workflow.

Open and dismissed alerts stay listed on the code scanning page until the configurations are deleted via the tool status page.

This is one of the routes of the linked issue; only one of the linked pull requests gets merged.

### 3. Describe each step to reproduce the issue or behaviour.

Open the checks of any current pull request: a CodeQL check reports "1 configuration not found". With this change no CodeQL job is spawned.

### 4. Please link to the relevant issues (if any).

- closes #19511

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
