### PR TITLE
ci: run the CodeQL analysis on pull requests only with the codeql label

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -165,7 +165,10 @@ jobs:
     name: Analyze
     needs:
       - markdown-only-changes
-    if: ${{ github.repository == 'shopware/shopware' && needs.markdown-only-changes.outputs.docs_only != 'true' }}
+    # On pull requests only with the `codeql` label; this workflow does not run on `labeled`
+    # events, so add the label before pushing, or re-run the workflow after labeling.
+    # Nightly (workflow_call) and manual runs are unaffected.
+    if: ${{ github.repository == 'shopware/shopware' && needs.markdown-only-changes.outputs.docs_only != 'true' && (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'codeql')) }}
     runs-on: ubuntu-24.04
 
     strategy:
@@ -192,6 +195,11 @@ jobs:
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
+        with:
+          # without an explicit category the upload is categorized by the calling
+          # workflow, and analyses of labeled pull requests could not be compared
+          # against the baseline the nightly call uploads on trunk
+          category: "/language:${{ matrix.language }}"
 
   blue-green-67-68:
     name: "PHP blue green 6.7 -> 6.8 -> 6.7"
@@ -456,5 +464,5 @@ jobs:
         with:
           # allowed-failures: docs, linters
           # allow markdown-only PRs to skip the expensive jobs, and allow jobs which do not run on a PR or outside the public repository to skip
-          allowed-skips: ${{ needs.markdown-only-changes.outputs.docs_only == 'true' && 'phpunit, win-checkout, code-ql, php-security, blue-green-66-67, blue-green-67-68' || github.repository != 'shopware/shopware' && github.event_name == 'pull_request' && 'win-checkout, code-ql' || github.repository != 'shopware/shopware' && 'code-ql' || github.event_name == 'pull_request' && 'win-checkout' || '' }}
+          allowed-skips: ${{ needs.markdown-only-changes.outputs.docs_only == 'true' && 'phpunit, win-checkout, code-ql, php-security, blue-green-66-67, blue-green-67-68' || github.repository != 'shopware/shopware' && github.event_name == 'pull_request' && 'win-checkout, code-ql' || github.repository != 'shopware/shopware' && 'code-ql' || github.event_name == 'pull_request' && 'win-checkout, code-ql' || '' }}
           jobs: ${{ toJSON(needs) }}


### PR DESCRIPTION
### 1. Why is this change necessary?

The CodeQL job runs on every pull request without gating anything: a configuration mismatch between the pull request runs and the nightly call means code scanning cannot compute the alerts a pull request introduces, every pull request shows the neutral "1 configuration not found" warning, and the green check suggests a scan that effectively does not evaluate the change.

### 2. What does this change do, exactly?

Runs the `code-ql` job on pull requests only when the new `codeql` label is present, following the `major-php` opt-in pattern. Nightly and manual runs are unaffected, so the trunk baseline keeps updating. Also pins an explicit analysis `category` so labeled pull request runs are compared against the baseline the nightly uploads.

Two limitations, stated on the job:

- `integration.yml` does not run on `labeled` events (that would re-trigger the whole integration suite on any labeling), so the label must be added before pushing, or the workflow re-run after labeling.
- Pull requests without the label keep showing the neutral "1 configuration not found" warning as long as a CodeQL configuration exists on trunk.

This is one of the routes of the linked issue; only one of the linked pull requests gets merged.

### 3. Describe each step to reproduce the issue or behaviour.

Open the checks of any current pull request: the CodeQL check reports "1 configuration not found" although the job ran. This pull request carries the `codeql` label, so its own checks show the job running with the pinned category; a pull request without the label skips it.

### 4. Please link to the relevant issues (if any).

- closes #19511

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
