### PR TITLE
test(acceptance): capture cancel order modal diagnostics

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -158,7 +158,7 @@ jobs:
           project: "Platform"
           install: true
           extra-options: >-
-            --repeat-each="10" -- ${{ format(' {0}', steps.changed-files.outputs.all_changed_files) }}
+            --repeat-each="50" -- ${{ format(' {0}', steps.changed-files.outputs.all_changed_files) }}
           artifact-prefix: "ats-changed"
 
   tested-update-versions:

--- a/tests/acceptance/tests/Account/CancelOrder.spec.ts
+++ b/tests/acceptance/tests/Account/CancelOrder.spec.ts
@@ -1,4 +1,92 @@
 import { test } from '@fixtures/AcceptanceTest';
+import type { ConsoleMessage, Locator, Page } from '@playwright/test';
+
+interface CancelOrderModalState {
+    modalEvents: string[];
+    modalSelector: string | null;
+    triggerEvents: string[];
+}
+
+/**
+ * Captures the modal data API state only when the known flaky dialog activation fails.
+ */
+async function openCancelOrderModal(
+    page: Page,
+    trigger: Locator,
+    dialog: Locator,
+    triggerModal: () => Promise<void>,
+    assertDialogFocused: () => Promise<void>,
+): Promise<void> {
+    const pageErrors: string[] = [];
+    const consoleErrors: string[] = [];
+    const pageErrorListener = (error: Error) => pageErrors.push(error.message);
+    const consoleListener = (message: ConsoleMessage) => {
+        if (message.type() === 'error') {
+            consoleErrors.push(message.text());
+        }
+    };
+
+    page.on('pageerror', pageErrorListener);
+    page.on('console', consoleListener);
+
+    await trigger.evaluate((button) => {
+        const modalSelector = button.getAttribute('data-bs-target');
+        const modal = modalSelector ? document.querySelector(modalSelector) : null;
+        const state: CancelOrderModalState = {
+            modalEvents: [],
+            modalSelector,
+            triggerEvents: [],
+        };
+
+        for (const eventName of ['keydown', 'keyup', 'click']) {
+            button.addEventListener(eventName, () => state.triggerEvents.push(eventName), { once: true });
+        }
+
+        if (modal) {
+            for (const eventName of ['show.bs.modal', 'shown.bs.modal']) {
+                modal.addEventListener(eventName, () => state.modalEvents.push(eventName), { once: true });
+            }
+        }
+
+        (window as unknown as { cancelOrderModalState?: CancelOrderModalState }).cancelOrderModalState = state;
+    });
+
+    try {
+        await triggerModal();
+        await assertDialogFocused();
+    } catch (error) {
+        const state = await page.evaluate(({ consoleErrors, pageErrors }) => {
+            const windowWithState = window as unknown as { cancelOrderModalState?: CancelOrderModalState };
+            const modal = windowWithState.cancelOrderModalState?.modalSelector
+                ? document.querySelector(windowWithState.cancelOrderModalState.modalSelector)
+                : null;
+
+            return {
+                activeElement: document.activeElement?.outerHTML,
+                bootstrapLoaded: 'bootstrap' in window,
+                consoleErrors,
+                modal: modal instanceof HTMLElement ? {
+                    ariaHidden: modal.getAttribute('aria-hidden'),
+                    className: modal.className,
+                    connected: modal.isConnected,
+                } : null,
+                pageErrors,
+                readyState: document.readyState,
+                state: windowWithState.cancelOrderModalState ?? null,
+            };
+        }, { consoleErrors, pageErrors });
+
+        const message = error instanceof Error ? error.message : String(error);
+
+        throw new Error(`${message}\nCancel order modal diagnostics:\n${JSON.stringify(state, null, 2)}`);
+    } finally {
+        page.off('pageerror', pageErrorListener);
+        page.off('console', consoleListener);
+        await page.evaluate(() => {
+            delete (window as unknown as { cancelOrderModalState?: CancelOrderModalState }).cancelOrderModalState;
+        });
+    }
+}
 
 test(
     'Customers are able to cancel orders in storefront account.',
@@ -9,7 +97,7 @@ test(
             '@Storefront',
         ],
     },
-    async ({ ShopCustomer, StorefrontAccountOrder, TestDataService, Login }) => {
+    async ({ ShopCustomer, StorefrontAccountOrder, TestDataService, Login, page }) => {
         const product = await TestDataService.createBasicProduct();
         const customer = await TestDataService.createCustomer();
         const order = await TestDataService.createOrder([{ product: product, quantity: 5 }], customer);
@@ -27,8 +115,13 @@ test(
         const orderItemLocators = await StorefrontAccountOrder.getOrderByOrderNumber(order.orderNumber);
         await ShopCustomer.expects(orderItemLocators.orderStatus).toContainText('Open');
         await ShopCustomer.presses(orderItemLocators.orderActionsButton);
-        await ShopCustomer.presses(orderItemLocators.orderCancelButton);
-        await ShopCustomer.expects(StorefrontAccountOrder.dialogOrderCancel).toBeFocused();
+        await openCancelOrderModal(
+            page,
+            orderItemLocators.orderCancelButton,
+            StorefrontAccountOrder.dialogOrderCancel,
+            () => ShopCustomer.presses(orderItemLocators.orderCancelButton),
+            () => ShopCustomer.expects(StorefrontAccountOrder.dialogOrderCancel).toBeFocused(),
+        );
         await ShopCustomer.presses(StorefrontAccountOrder.dialogOrderCancelButton);
         await ShopCustomer.goesTo(StorefrontAccountOrder.url());
         await ShopCustomer.expects(orderItemLocators.orderShippingStatus).toContainText('Open');
@@ -51,7 +144,7 @@ test(
             '@Storefront',
         ],
     },
-    async ({ ShopCustomer, StorefrontAccountOrder, TestDataService, Login, StorefrontCheckoutOrderEdit }) => {
+    async ({ ShopCustomer, StorefrontAccountOrder, TestDataService, Login, StorefrontCheckoutOrderEdit, page }) => {
         const product = await TestDataService.createBasicProduct();
         const customer = await TestDataService.createCustomer();
         const order = await TestDataService.createOrder([{ product: product, quantity: 5 }], customer);
@@ -64,8 +157,13 @@ test(
         await ShopCustomer.expects(orderItemLocators.orderStatus).toContainText('Open');
         await ShopCustomer.presses(orderItemLocators.orderActionsButton);
         await ShopCustomer.presses(orderItemLocators.orderChangePaymentMethodButton);
-        await ShopCustomer.presses(StorefrontCheckoutOrderEdit.orderCancelButton);
-        await ShopCustomer.expects(StorefrontCheckoutOrderEdit.dialogOrderCancel).toBeFocused();
+        await openCancelOrderModal(
+            page,
+            StorefrontCheckoutOrderEdit.orderCancelButton,
+            StorefrontCheckoutOrderEdit.dialogOrderCancel,
+            () => ShopCustomer.presses(StorefrontCheckoutOrderEdit.orderCancelButton),
+            () => ShopCustomer.expects(StorefrontCheckoutOrderEdit.dialogOrderCancel).toBeFocused(),
+        );
         await ShopCustomer.presses(StorefrontCheckoutOrderEdit.dialogOrderCancelButton);
         await ShopCustomer.goesTo(StorefrontAccountOrder.url());
         await ShopCustomer.expects(orderItemLocators.orderShippingStatus).toContainText('Open');


### PR DESCRIPTION
### 1. Why is this change necessary?

The recurring CancelOrder retries show a rendered trigger and modal, but do not reveal whether the keyboard activation, Bootstrap modal lifecycle, or storefront JavaScript failed.

### 2. What does this change do, exactly?

On failure only, capture the trigger keyboard/click events, Bootstrap modal lifecycle events, modal state, document readiness, and browser console/page errors for the two affected cancellation flows. It adds neither retries nor production behaviour changes.

### 3. Describe each step to reproduce the issue or behaviour.

1. Run the Platform acceptance suite under CI load.
2. Open the cancellation dialog from account orders or the checkout order-edit page.
3. If the dialog does not receive focus, inspect the diagnostic payload appended to the assertion error.

### 4. Please link to the relevant issues (if any).

Relates to #19302.

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them