### PR TITLE
fix(framework): enforce ACL on number range admin action endpoints

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -12,6 +12,15 @@ Apps can now modify or remove cookie consent groups and entries with an app scri
 
 ## API
 
+### Number range admin action endpoints now require ACL privileges
+
+Three admin action endpoints that previously only required authentication now enforce ACL privileges. Requests with tokens lacking the privilege receive a `403` with `FRAMEWORK__MISSING_PRIVILEGE_ERROR`:
+
+* `GET /api/_action/number-range/reserve/{type}/{salesChannelId}` requires `number_range:read`. Without `preview=1` this endpoint permanently advances the number range state, so it was possible for any authenticated backend account to consume invoice, order, delivery-note and credit-note numbers and create gaps in the sequence.
+* `GET /api/_action/number-range/{numberRangeId}/preview-pattern` and the deprecated `GET /api/_action/number-range/preview-pattern/{type}` require `number_range:read`.
+
+Administration users are not affected: `number_range:read` is already part of the "Products viewer" and "Number ranges viewer" permissions, it is now also part of the "Orders editor" and "Customers creator" permissions — these are the roles whose users reserve document, order and customer numbers — and a migration grants it to existing roles that already hold one of those permissions. Integrations and API clients with manually assigned privilege lists must add `number_range:read` to their ACL role.
+
 ### Added new shop setting endpoint
 
 Added new Store API route `GET /store-api/shop-settings`, which exposes the UI- and validation-relevant, non-sensitive subset of the system configuration (grouped into `general`, `loginRegistration`, `cart`, `listing` and `newsletter`) resolved for the current sales channel, so headless frontends (e.g. Composable Frontends) can render the shop consistently with the administration settings.

--- a/src/Administration/Resources/app/administration/src/module/sw-customer/acl/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-customer/acl/index.js
@@ -53,6 +53,7 @@ Shopware.Service('privileges').addPrivilegeMappingEntry({
         creator: {
             privileges: [
                 'customer:create',
+                'number_range:read',
             ],
             dependencies: [
                 'customer.viewer',

--- a/src/Administration/Resources/app/administration/src/module/sw-order/acl/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/acl/index.js
@@ -86,6 +86,7 @@ Shopware.Service('privileges')
                     'order_line_item:delete',
                     'salutation:read',
                     'order_address:create',
+                    'number_range:read',
                 ],
                 dependencies: [
                     'order.viewer',

--- a/src/Core/Migration/V6_7/Migration1787205808AddNumberRangeReadAclPrivilege.php
+++ b/src/Core/Migration/V6_7/Migration1787205808AddNumberRangeReadAclPrivilege.php
@@ -1,0 +1,33 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Migration\V6_7;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Migration\MigrationStep;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+class Migration1787205808AddNumberRangeReadAclPrivilege extends MigrationStep
+{
+    final public const NEW_PRIVILEGES = [
+        'order.editor' => [
+            'number_range:read',
+        ],
+        'customer.creator' => [
+            'number_range:read',
+        ],
+    ];
+
+    public function getCreationTimestamp(): int
+    {
+        return 1787205808;
+    }
+
+    public function update(Connection $connection): void
+    {
+        $this->addAdditionalPrivileges($connection, self::NEW_PRIVILEGES);
+    }
+}

--- a/src/Core/System/NumberRange/Api/NumberRangeController.php
+++ b/src/Core/System/NumberRange/Api/NumberRangeController.php
@@ -28,7 +28,12 @@ class NumberRangeController extends AbstractController
     }
 
     #[Cache(mustRevalidate: true)]
-    #[Route(path: '/api/_action/number-range/reserve/{type}/{saleschannel?}', name: 'api.action.number-range.reserve', methods: ['GET'])]
+    #[Route(
+        path: '/api/_action/number-range/reserve/{type}/{saleschannel?}',
+        name: 'api.action.number-range.reserve',
+        defaults: [PlatformRequest::ATTRIBUTE_ACL => ['number_range:read']],
+        methods: ['GET']
+    )]
     public function reserve(string $type, ?string $saleschannel, Context $context, Request $request): JsonResponse
     {
         $generatedNumber = $this->valueGenerator->getValue($type, $context, $saleschannel, $request->query->getBoolean('preview'));
@@ -42,7 +47,12 @@ class NumberRangeController extends AbstractController
      * @deprecated tag:v6.8.0 - use previewPatternByNumberRange() with a concrete number range id instead
      */
     #[Cache(mustRevalidate: true)]
-    #[Route(path: '/api/_action/number-range/preview-pattern/{type}', defaults: ['type' => 'default'], name: 'api.action.number-range.preview-pattern', methods: ['GET'])]
+    #[Route(
+        path: '/api/_action/number-range/preview-pattern/{type}',
+        name: 'api.action.number-range.preview-pattern',
+        defaults: ['type' => 'default', PlatformRequest::ATTRIBUTE_ACL => ['number_range:read']],
+        methods: ['GET']
+    )]
     public function previewPattern(string $type, Request $request): JsonResponse
     {
         Feature::triggerDeprecationOrThrow(
@@ -65,7 +75,13 @@ class NumberRangeController extends AbstractController
     }
 
     #[Cache(mustRevalidate: true)]
-    #[Route(path: '/api/_action/number-range/{numberRangeId}/preview-pattern', name: 'api.action.number-range.preview-pattern-by-id', requirements: ['numberRangeId' => Uuid::VALID_PATTERN], methods: ['GET'])]
+    #[Route(
+        path: '/api/_action/number-range/{numberRangeId}/preview-pattern',
+        name: 'api.action.number-range.preview-pattern-by-id',
+        defaults: [PlatformRequest::ATTRIBUTE_ACL => ['number_range:read']],
+        requirements: ['numberRangeId' => Uuid::VALID_PATTERN],
+        methods: ['GET']
+    )]
     public function previewPatternByNumberRange(string $numberRangeId, Request $request): JsonResponse
     {
         $generatedNumber = $this->valueGenerator->previewPatternByNumberRangeId(

--- a/tests/migration/Core/V6_7/Migration1787205808AddNumberRangeReadAclPrivilegeTest.php
+++ b/tests/migration/Core/V6_7/Migration1787205808AddNumberRangeReadAclPrivilegeTest.php
@@ -1,0 +1,119 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Migration\Core\V6_7;
+
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Defaults;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\Migration\V6_7\Migration1787205808AddNumberRangeReadAclPrivilege;
+use Shopware\Tests\Migration\MigrationTestTrait;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+#[CoversClass(Migration1787205808AddNumberRangeReadAclPrivilege::class)]
+class Migration1787205808AddNumberRangeReadAclPrivilegeTest extends TestCase
+{
+    use MigrationTestTrait;
+
+    private Connection $connection;
+
+    private Migration1787205808AddNumberRangeReadAclPrivilege $migration;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->connection = KernelLifecycleManager::getConnection();
+        $this->migration = new Migration1787205808AddNumberRangeReadAclPrivilege();
+    }
+
+    public function testGetCreationTimestamp(): void
+    {
+        static::assertSame(1787205808, $this->migration->getCreationTimestamp());
+    }
+
+    #[DataProvider('reservingRoleProvider')]
+    public function testAddsNumberRangeReadToReservingRoles(string $reservingRole): void
+    {
+        $roleId = $this->createRole([$reservingRole]);
+
+        // run twice to prove idempotency
+        $this->migration->update($this->connection);
+        $this->migration->update($this->connection);
+
+        $privileges = $this->fetchPrivileges($roleId);
+
+        static::assertContains($reservingRole, $privileges);
+        static::assertContains('number_range:read', $privileges);
+        static::assertCount(1, \array_keys($privileges, 'number_range:read', true));
+    }
+
+    /**
+     * @return \Generator<string, array{0: string}>
+     */
+    public static function reservingRoleProvider(): \Generator
+    {
+        yield 'order editors reserve document numbers' => ['order.editor'];
+        yield 'customer creators reserve customer numbers' => ['customer.creator'];
+    }
+
+    public function testUnrelatedRolesAreNotUpdated(): void
+    {
+        $roleId = $this->createRole(['customer.viewer']);
+        $before = $this->connection->fetchAssociative('SELECT * FROM `acl_role` WHERE id = :id', ['id' => $roleId]);
+
+        $this->migration->update($this->connection);
+
+        $after = $this->connection->fetchAssociative('SELECT * FROM `acl_role` WHERE id = :id', ['id' => $roleId]);
+
+        static::assertSame($before, $after);
+    }
+
+    /**
+     * @param list<string> $privileges
+     */
+    private function createRole(array $privileges): string
+    {
+        $roleId = Uuid::randomBytes();
+
+        $this->connection->insert('acl_role', [
+            'id' => $roleId,
+            'name' => 'test number range acl migration',
+            'privileges' => \json_encode($privileges, \JSON_THROW_ON_ERROR),
+            'created_at' => (new \DateTimeImmutable())->format(Defaults::STORAGE_DATE_TIME_FORMAT),
+        ]);
+
+        return $roleId;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function fetchPrivileges(string $roleId): array
+    {
+        $privileges = $this->connection->fetchOne(
+            'SELECT `privileges` FROM `acl_role` WHERE id = :id',
+            ['id' => $roleId]
+        );
+
+        static::assertIsString($privileges);
+
+        $decodedPrivileges = \json_decode($privileges, true, 512, \JSON_THROW_ON_ERROR);
+
+        static::assertIsArray($decodedPrivileges);
+        static::assertTrue(\array_is_list($decodedPrivileges));
+        foreach ($decodedPrivileges as $decodedPrivilege) {
+            static::assertIsString($decodedPrivilege);
+        }
+
+        /** @var list<string> $decodedPrivileges */
+        return $decodedPrivileges;
+    }
+}

--- a/tests/unit/Core/System/NumberRange/Api/NumberRangeControllerTest.php
+++ b/tests/unit/Core/System/NumberRange/Api/NumberRangeControllerTest.php
@@ -3,14 +3,17 @@
 namespace Shopware\Tests\Unit\Core\System\NumberRange\Api;
 
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Feature\FeatureException;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\PlatformRequest;
 use Shopware\Core\System\NumberRange\Api\NumberRangeController;
 use Shopware\Core\System\NumberRange\ValueGenerator\AbstractNumberRangeValueGenerator;
 use Shopware\Core\Test\Annotation\DisabledFeatures;
+use Symfony\Bundle\FrameworkBundle\Routing\AttributeRouteControllerLoader;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -88,5 +91,27 @@ class NumberRangeControllerTest extends TestCase
         $this->expectException(FeatureException::class);
 
         (new NumberRangeController($valueGenerator))->previewPattern('customer', new Request());
+    }
+
+    #[DataProvider('aclProtectedRouteProvider')]
+    public function testRouteRequiresNumberRangeReadPrivilege(string $routeName): void
+    {
+        $route = (new AttributeRouteControllerLoader())->load(NumberRangeController::class)->get($routeName);
+
+        static::assertNotNull(
+            $route,
+            \sprintf('Route "%s" is not defined on %s', $routeName, NumberRangeController::class)
+        );
+        static::assertSame(['number_range:read'], $route->getDefault(PlatformRequest::ATTRIBUTE_ACL));
+    }
+
+    /**
+     * @return \Generator<string, array{0: string}>
+     */
+    public static function aclProtectedRouteProvider(): \Generator
+    {
+        yield 'reserving a number consumes the range state' => ['api.action.number-range.reserve'];
+        yield 'previewing a pattern exposes the range configuration' => ['api.action.number-range.preview-pattern'];
+        yield 'previewing a pattern by id exposes the range configuration' => ['api.action.number-range.preview-pattern-by-id'];
     }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
`GET /api/_action/number-range/reserve/{type}/{salesChannelId}` declared no `PlatformRequest::ATTRIBUTE_ACL`, and its sink `IncrementSqlStorage::reserve()` is a raw DBAL `INSERT ... ON DUPLICATE KEY UPDATE`. So         
  `AclAnnotationValidator::validate()` returns early and `AclWriteValidator::preValidate()` never sees a `WriteCommand`. Any authenticated backend account — even one holding only `product:read` — could consume            
  `document_invoice`, `order`, `document_delivery_note` and `document_credit_note` numbers in a loop. Consumption is irreversible through the API, and gapless invoice numbering is a legal requirement in `DE`/`FR`. The    
  routes `GET /api/_action/number-range/{numberRangeId}/preview-pattern` and `GET /api/_action/number-range/preview-pattern/{type}` had the same gap and leak the range `pattern`/`start`.

### 2. What does this change do, exactly?
- Adds `defaults: [PlatformRequest::ATTRIBUTE_ACL => ['number_range:read']]` to all three routes on `NumberRangeController`: `api.action.number-range.reserve`, `api.action.number-range.preview-pattern-by-id`, and the   
  deprecated `api.action.number-range.preview-pattern`.                                                                                                                                                                      
  - Adds `number_range:read` to `order.editor` and `customer.creator` in the Administration privilege mappings — the roles whose users reserve document and customer numbers. `product.viewer` and `number_ranges.viewer`    
  already carry it.                                                                                                                                                                                                          
  - `Migration1787205808AddNumberRangeReadAclPrivilege` grants `number_range:read` to existing roles holding those permissions via `addAdditionalPrivileges()`.                                                              
  - Tests: route-attribute assertions in `NumberRangeControllerTest`, plus an idempotency migration test.                                                                                                                    
  - `RELEASE_INFO-6.7.md` entry for integrations with manually assigned privilege lists.

### 3. Describe each step to reproduce the issue or behaviour.
 1. Create an `acl_role` with privileges exactly `["product:read"]` and assign it to a non-admin user.                                                                                                                    
  2. Get an Admin API token for that user via `POST /api/oauth/token` (`grant_type: password`).                                                                                                                              
  3. Control: `POST /api/search/number-range` → `403` `FRAMEWORK__MISSING_PRIVILEGE_ERROR`, `missingPrivileges: ["number_range:read"]`.                                                                                      
  4. `GET /api/_action/number-range/reserve/document_invoice/{salesChannelId}` three times.                                                                                                                                  
     - Before: `200` with `{"number":"1000"}`, `"1001"`, `"1002"` — `number_range_state.last_value` advanced.                                                                                                                
     - After: `403` `FRAMEWORK__MISSING_PRIVILEGE_ERROR` on every call.                                                                                                                                                      
  5. Add `number_range:read` to the role and repeat step 4 → `200` again. 

### 4. Please link to the relevant issues (if any).
relates https://github.com/shopware/shopware/security/advisories/GHSA-3wj5-3j9c-3gmp

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
