### PR TITLE
feat: native extension to twig bridge

### DIFF
--- a/src/Administration/Resources/app/administration/build/vue-setup-transform/index.spec/override-transform.spec.ts
+++ b/src/Administration/Resources/app/administration/build/vue-setup-transform/index.spec/override-transform.spec.ts
@@ -34,15 +34,23 @@ describe('build/vue-setup-transform override transforms', () => {
             </script>
         `;
 
-        // The one end-to-end assertion for override lowering, covering the three generated constructs that
-        // only co-occur on the <sw-block extends> path: the module-root Symbol() namespace, the
-        // `__swOverride` payload keyed by it, and the `#default` slot scope that forwards the
-        // override-local `suffix` into the block content. Imports are lifted out of the callback; the
-        // author body is preserved inside it.
+        // The one end-to-end assertion for override lowering, covering the generated constructs that
+        // only co-occur on the <sw-block extends> path: the module-scope target announcement, the
+        // module-root Symbol() namespace, the `__swOverride` payload keyed by it, and the `#default`
+        // slot scope that forwards the override-local `suffix` into the block content. Imports are
+        // lifted out of the callback; the author body is preserved inside it.
         //
         // Whitespace-insensitive on both sides - the transform does not beautify its output, so its
         // blank-line residue is not behaviour. The Vue round-trip below guards the token sequence.
         const expected = stripWhitespace`
+            <script lang="ts">
+            Shopware.Component.registerNativeExtensionTargets({
+                component: 'sw-example',
+                blocks: [
+                    'sw_example_headline',
+                ],
+            });
+            </script>
             <template>
                 <sw-block extends="sw_example_headline" #default="{ __swOverride: { [__swSetupNamespace]: { suffix } }, headline }">
                     <h1>{{ headline }} - {{ suffix }}</h1>

--- a/src/Administration/Resources/app/administration/build/vue-setup-transform/lower/override.ts
+++ b/src/Administration/Resources/app/administration/build/vue-setup-transform/lower/override.ts
@@ -78,6 +78,40 @@ function toSlotScopeEdit(scope: OverrideSlotScope): SourceEdit {
 }
 
 /**
+ * Emits the module-scope announcement of what this override extends.
+ *
+ * A plain `<script>` block, not `<script setup>`: its body has to run when the file is *imported*, which
+ * is while plugin entries load - before the Twig templates are merged and before any component is built.
+ * The `<script setup>` body only runs when the hidden registration component mounts, which is long after
+ * both. The compatibility bridge for non-migrated components reads this registry at exactly that boot
+ * point to decide which legacy `{% block %}` needs a native extension point and which Options API base
+ * has to become extendable.
+ *
+ * `lang` mirrors the setup block because Vue rejects an SFC whose two script blocks disagree on it.
+ */
+function buildNativeExtensionTargetsScript(block: ShopwareSetupBlock, templateAnalysis: TemplateAnalysis): string {
+    const langAttribute = block.lang ? ` lang="${block.lang}"` : '';
+    const blockNames = Array.from(new Set(templateAnalysis.extendedBlockNames));
+    const blocksProperty =
+        blockNames.length > 0
+            ? [
+                  '    blocks: [',
+                  ...blockNames.map((blockName) => `        '${escapeSingleQuoted(blockName)}',`),
+                  '    ],',
+              ]
+            : [];
+
+    return [
+        `<script${langAttribute}>`,
+        'Shopware.Component.registerNativeExtensionTargets({',
+        `    component: '${escapeSingleQuoted(block.componentName)}',`,
+        ...blocksProperty,
+        '});',
+        '</script>\n',
+    ].join('\n');
+}
+
+/**
  * Lowers override mode into a hidden override component consumed by
  * registerOverrideComponent.
  *
@@ -155,18 +189,19 @@ function buildOverrideScript(
         generated('\n});\n'),
     );
 
-    const registrationTemplate: SourceEdit[] = block.template
-        ? []
-        : [
-              {
-                  start: 0,
-                  end: 0,
-                  replacement: '<template><!-- Shopware override registration component --></template>\n',
-              },
-          ];
+    // Both prelude parts are one edit: `applySourceEdits` sorts by start offset, and two separate
+    // zero-width edits at 0 would only keep their order by accident of sort stability.
+    const registrationTemplate = block.template
+        ? ''
+        : '<template><!-- Shopware override registration component --></template>\n';
+    const prelude = `${buildNativeExtensionTargetsScript(block, templateAnalysis)}${registrationTemplate}`;
 
     return [
-        ...registrationTemplate,
+        {
+            start: 0,
+            end: 0,
+            replacement: prelude,
+        },
         ...templateAnalysis.slotScopes.map(toSlotScopeEdit),
         {
             start: block.contentStart,

--- a/src/Administration/Resources/app/administration/src/app/adapter/_mocks_/sw-jest-bridge-fixture.override.vue
+++ b/src/Administration/Resources/app/administration/src/app/adapter/_mocks_/sw-jest-bridge-fixture.override.vue
@@ -1,0 +1,17 @@
+<template>
+    <sw-block extends="sw_jest_bridge_fixture_content">
+        <sw-block-parent />
+        <div class="native-extension">{{ headline }}</div>
+    </sw-block>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+
+const previousState = useSwPreviousState();
+const headline = computed(() => `${previousState.headline.value}!`);
+
+swDefineOverride({
+    headline,
+});
+</script>

--- a/src/Administration/Resources/app/administration/src/app/adapter/native-extensions-twig-bridge.integrative.spec.ts
+++ b/src/Administration/Resources/app/administration/src/app/adapter/native-extensions-twig-bridge.integrative.spec.ts
@@ -1,0 +1,127 @@
+/**
+ * @sw-package framework
+ * @group disabledCompat
+ */
+
+/**
+ * End-to-end coverage of the Native → Twig Extension Bridge: a real `.override.vue` file, compiled by
+ * the Jest Vue transformer, extending a component that still uses a `.html.twig` template and the
+ * Options API.
+ *
+ * Both channels are exercised at once, which is the point of the bridge - the template channel gives the
+ * extension its rendering position, the setup channel gives it the base's state.
+ */
+
+import { mount } from '@vue/test-utils';
+import { _overridesMap } from 'src/app/adapter/composition-extension-system';
+import TemplateFactory from 'src/core/factory/template.factory';
+import { resetNativeBlockHosts } from 'src/core/factory/native-extensions-twig-bridge';
+import swBlock from 'src/app/component/structure/sw-block-override/sw-block/index';
+import swBlockParent from 'src/app/component/structure/sw-block-override/sw-block-parent/index';
+import swNativeBlockHost from 'src/app/component/structure/sw-block-override/sw-native-block-host/index';
+import createDataScopeFixture from 'src/app/component/structure/sw-block-override/sw-block-override.spec/test-utils/create-data-scope-fixture';
+import BridgeFixtureOverride from './_mocks_/sw-jest-bridge-fixture.override.vue';
+
+const COMPONENT_NAME = 'sw-jest-bridge-fixture';
+const TEMPLATE = `{% block sw_jest_bridge_fixture_content %}<div class="legacy-content">{{ headline }}</div>{% endblock %}`;
+const UNTARGETED_COMPONENT_NAME = 'sw-jest-bridge-untargeted';
+const UNTARGETED_TEMPLATE = `{% block sw_jest_bridge_untargeted_content %}<div class="legacy-content">{{ headline }}</div>{% endblock %}`;
+
+const globalMountOptions = {
+    components: {
+        'sw-block': swBlock,
+        'sw-block-parent': swBlockParent,
+        'sw-native-block-host': swNativeBlockHost,
+    },
+};
+
+/**
+ * Registers the not-yet-migrated component the override targets: a Twig template plus Options API state.
+ */
+function registerLegacyComponent(): void {
+    /** @private test fixture component */
+    Shopware.Component.register(COMPONENT_NAME, () =>
+        Promise.resolve({
+            template: TEMPLATE,
+            data() {
+                return { headline: 'Legacy' };
+            },
+        }),
+    );
+}
+
+/**
+ * Registers a second legacy component that no override targets, as the control case.
+ */
+function registerUntargetedLegacyComponent(): void {
+    /** @private test fixture component */
+    Shopware.Component.register(UNTARGETED_COMPONENT_NAME, () =>
+        Promise.resolve({
+            template: UNTARGETED_TEMPLATE,
+            data() {
+                return { headline: 'Legacy' };
+            },
+        }),
+    );
+}
+
+function cleanUpRegistries(): void {
+    [
+        COMPONENT_NAME,
+        UNTARGETED_COMPONENT_NAME,
+    ].forEach((componentName) => {
+        Shopware.Component.getComponentRegistry().delete(componentName);
+        Shopware.Component.getOverrideRegistry().delete(componentName);
+        TemplateFactory.getTemplateRegistry().delete(componentName);
+        TemplateFactory.getNormalizedTemplateRegistry().delete(componentName);
+    });
+
+    TemplateFactory.clearTwigCache();
+    resetNativeBlockHosts();
+}
+
+describe('Native → Twig Extension Bridge (integrative)', () => {
+    beforeEach(() => {
+        cleanUpRegistries();
+    });
+
+    afterEach(() => {
+        cleanUpRegistries();
+        delete _overridesMap[COMPONENT_NAME];
+    });
+
+    it('renders a native extension inside a component that still uses a Twig template', async () => {
+        registerLegacyComponent();
+
+        const config = await Shopware.Component.build(COMPONENT_NAME);
+
+        // The override component registers its <sw-block extends> slot and its setup override on mount.
+        mount(BridgeFixtureOverride, { global: globalMountOptions });
+
+        const wrapper = mount(config, { global: { ...globalMountOptions, plugins: [createDataScopeFixture()] } });
+
+        await flushPromises();
+
+        // Setup channel: the override reads the converted Options API state and replaces it.
+        expect(wrapper.get('.legacy-content').text()).toBe('Legacy!');
+        // Template channel: the extension renders after the block's original content.
+        expect(wrapper.get('.native-extension').text()).toBe('Legacy!');
+        expect(wrapper.find('.legacy-content + .native-extension').exists()).toBe(true);
+    });
+
+    it('leaves a legacy component no override targets untouched', async () => {
+        registerUntargetedLegacyComponent();
+
+        const config = await Shopware.Component.build(UNTARGETED_COMPONENT_NAME);
+
+        mount(BridgeFixtureOverride, { global: globalMountOptions });
+
+        const wrapper = mount(config, { global: { ...globalMountOptions, plugins: [createDataScopeFixture()] } });
+
+        await flushPromises();
+
+        expect(wrapper.get('.legacy-content').text()).toBe('Legacy');
+        expect(wrapper.find('.native-extension').exists()).toBe(false);
+        expect(wrapper.html()).not.toContain('sw-native-block-host');
+    });
+});

--- a/src/Administration/Resources/app/administration/src/app/adapter/options-composition-base-shim.spec.ts
+++ b/src/Administration/Resources/app/administration/src/app/adapter/options-composition-base-shim.spec.ts
@@ -1,0 +1,350 @@
+/**
+ * @sw-package framework
+ */
+
+/**
+ * Options API bodies read their own state off `this`, which the compatibility proxy types as `any` by
+ * design - the same relaxation the sibling override spec applies.
+ */
+/* eslint-disable @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any */
+
+/**
+ * Covers the setup channel of the Native → Twig Extension Bridge: turning an Options API base component
+ * into one whose state runs through `createExtendableSetup()`, so native `.override.vue` setup
+ * extensions apply to a component that was never migrated.
+ */
+
+import { mount } from '@vue/test-utils';
+import { computed } from 'vue';
+import { _overridesMap, getScriptSetupDataScope } from 'src/app/adapter/composition-extension-system';
+import {
+    convertOptionsApiBaseToExtendableSetup,
+    getOptionsApiBaseConversionBlocker,
+} from 'src/app/adapter/options-composition-shim';
+import type { ComponentConfig } from 'src/core/factory/async-component.factory';
+
+function convert(componentName: string, config: ComponentConfig): ComponentConfig {
+    return convertOptionsApiBaseToExtendableSetup(componentName, config);
+}
+
+describe('src/app/adapter/options-composition-shim — base conversion', () => {
+    beforeEach(() => {
+        Object.keys(_overridesMap).forEach((key) => {
+            delete _overridesMap[key];
+        });
+    });
+
+    describe('getOptionsApiBaseConversionBlocker():', () => {
+        it('reports no blocker for a plain Options API component', () => {
+            expect(getOptionsApiBaseConversionBlocker({ data: () => ({}) })).toBeNull();
+        });
+
+        it('blocks a component with a custom render function', () => {
+            expect(getOptionsApiBaseConversionBlocker({ render: () => null })).toContain('render()');
+        });
+
+        it('blocks a component with a resolved extends chain', () => {
+            expect(getOptionsApiBaseConversionBlocker({ extends: { name: 'sw-base' } })).toContain('extends');
+        });
+    });
+
+    describe('converted state:', () => {
+        it('exposes data, computed and methods to the template', async () => {
+            const wrapper = mount(
+                convert('sw-legacy', {
+                    template: '<button class="value" @click="increase">{{ doubled }}</button>',
+                    data() {
+                        return { count: 2 };
+                    },
+                    computed: {
+                        doubled() {
+                            return this.count * 2;
+                        },
+                    },
+                    methods: {
+                        increase() {
+                            this.count += 1;
+                        },
+                    },
+                }),
+            );
+
+            expect(wrapper.get('.value').text()).toBe('4');
+
+            await wrapper.get('.value').trigger('click');
+
+            expect(wrapper.get('.value').text()).toBe('6');
+        });
+
+        it('calls data() with a receiver that resolves props', () => {
+            const wrapper = mount(
+                convert('sw-legacy', {
+                    template: '<div class="value">{{ label }}</div>',
+                    props: {
+                        initialLabel: {
+                            type: String,
+                            default: 'fallback',
+                        },
+                    },
+                    data() {
+                        return { label: this.initialLabel };
+                    },
+                }),
+                {
+                    props: { initialLabel: 'from-prop' },
+                },
+            );
+
+            expect(wrapper.get('.value').text()).toBe('from-prop');
+        });
+
+        it('runs the created hook and keeps writes visible in the template', () => {
+            const wrapper = mount(
+                convert('sw-legacy', {
+                    template: '<div class="value">{{ label }}</div>',
+                    data() {
+                        return { label: 'before' };
+                    },
+                    created() {
+                        this.label = 'after';
+                    },
+                }),
+            );
+
+            expect(wrapper.get('.value').text()).toBe('after');
+        });
+
+        it('registers mounted and unmounted hooks', () => {
+            const mounted = jest.fn();
+            const unmounted = jest.fn();
+
+            const wrapper = mount(
+                convert('sw-legacy', {
+                    template: '<div></div>',
+                    mounted,
+                    unmounted,
+                }),
+            );
+
+            expect(mounted).toHaveBeenCalledTimes(1);
+
+            wrapper.unmount();
+
+            expect(unmounted).toHaveBeenCalledTimes(1);
+        });
+
+        it('registers watchers, including dot-notation paths', async () => {
+            const flatWatcher = jest.fn();
+            const pathWatcher = jest.fn();
+
+            const wrapper = mount(
+                convert('sw-legacy', {
+                    template: '<button class="trigger" @click="update"></button>',
+                    data() {
+                        return {
+                            count: 0,
+                            user: { name: 'initial' },
+                        };
+                    },
+                    watch: {
+                        count: flatWatcher,
+                        'user.name': pathWatcher,
+                    },
+                    methods: {
+                        update() {
+                            this.count += 1;
+                            this.user = { name: 'changed' };
+                        },
+                    },
+                }),
+            );
+
+            await wrapper.get('.trigger').trigger('click');
+
+            expect(flatWatcher).toHaveBeenCalledWith(1, 0);
+            expect(pathWatcher).toHaveBeenCalledWith('changed', 'initial');
+        });
+
+        it('resolves inject for the template and for converted methods', () => {
+            const wrapper = mount({
+                template: '<sw-legacy />',
+                provide: { greeting: 'hello' },
+                components: {
+                    'sw-legacy': convert('sw-legacy', {
+                        template: '<div class="value">{{ greeting }} / {{ shouted }}</div>',
+                        inject: ['greeting'],
+                        computed: {
+                            shouted() {
+                                return (this.greeting as string).toUpperCase();
+                            },
+                        },
+                    }),
+                },
+            });
+
+            expect(wrapper.get('.value').text()).toBe('hello / HELLO');
+        });
+
+        it('keeps provide, components and inheritAttrs on the converted config', () => {
+            const config = convert('sw-legacy', {
+                template: '<div></div>',
+                inheritAttrs: false,
+                provide() {
+                    return { fromBase: true };
+                },
+                components: { 'sw-child': { template: '<span></span>' } },
+                data: () => ({ count: 1 }),
+            });
+
+            expect(config.inheritAttrs).toBe(false);
+            expect(config.provide).toBeDefined();
+            expect(config.components).toBeDefined();
+            expect(config.data).toBeUndefined();
+            expect(typeof config.setup).toBe('function');
+        });
+    });
+
+    describe('mixins:', () => {
+        it('folds mixin data, computed and methods into the setup state', () => {
+            const wrapper = mount(
+                convert('sw-legacy', {
+                    template: '<div class="value">{{ mixinComputed }}</div>',
+                    mixins: [
+                        {
+                            data() {
+                                return { fromMixin: 'mixin' };
+                            },
+                            computed: {
+                                mixinComputed(this: { fromMixin: string; fromComponent: string }): string {
+                                    return `${this.fromMixin}-${this.fromComponent}`;
+                                },
+                            },
+                        },
+                    ],
+                    data() {
+                        return { fromComponent: 'component' };
+                    },
+                }),
+            );
+
+            expect(wrapper.get('.value').text()).toBe('mixin-component');
+        });
+
+        it('runs a mixin lifecycle hook exactly once', () => {
+            const created = jest.fn();
+
+            mount(
+                convert('sw-legacy', {
+                    template: '<div></div>',
+                    mixins: [{ created }],
+                }),
+            );
+
+            expect(created).toHaveBeenCalledTimes(1);
+        });
+
+        it('resolves mixins referenced by name', () => {
+            // The registry is keyed by the generated MixinContainer union, which a spec-only mixin is not
+            // part of; the runtime lookup only ever sees the string.
+            Shopware.Mixin.register('sw-native-bridge-spec-mixin' as keyof MixinContainer, {
+                data() {
+                    return { fromNamedMixin: 'named' };
+                },
+            });
+
+            const wrapper = mount(
+                convert('sw-legacy', {
+                    template: '<div class="value">{{ fromNamedMixin }}</div>',
+                    mixins: ['sw-native-bridge-spec-mixin'],
+                }),
+            );
+
+            expect(wrapper.get('.value').text()).toBe('named');
+        });
+
+        it('keeps mixin props on the converted component', () => {
+            const wrapper = mount(
+                convert('sw-legacy', {
+                    template: '<div class="value">{{ title }}</div>',
+                    mixins: [
+                        {
+                            props: {
+                                title: {
+                                    type: String,
+                                    default: 'default-title',
+                                },
+                            },
+                        },
+                    ],
+                }),
+                {
+                    props: { title: 'from-mixin-prop' },
+                },
+            );
+
+            expect(wrapper.get('.value').text()).toBe('from-mixin-prop');
+        });
+    });
+
+    describe('extension surface:', () => {
+        it('applies a native setup override to the converted base', () => {
+            Shopware.Component.overrideComponentSetup()('sw-legacy', (previousState: any) => ({
+                label: computed(() => `${previousState.label.value}!`),
+            }));
+
+            const wrapper = mount(
+                convert('sw-legacy', {
+                    template: '<div class="value">{{ label }}</div>',
+                    data() {
+                        return { label: 'base' };
+                    },
+                }),
+            );
+
+            expect(wrapper.get('.value').text()).toBe('base!');
+        });
+
+        it('lets a native setup override replace a converted method', async () => {
+            const wrapper = mount(
+                convert('sw-legacy', {
+                    template: '<button class="value" @click="increase">{{ count }}</button>',
+                    data() {
+                        return { count: 0 };
+                    },
+                    methods: {
+                        increase() {
+                            this.count += 1;
+                        },
+                    },
+                }),
+            );
+
+            Shopware.Component.overrideComponentSetup()('sw-legacy', (previousState: any) => ({
+                increase: () => {
+                    previousState.count.value += 10;
+                },
+            }));
+
+            await flushPromises();
+            await wrapper.get('.value').trigger('click');
+
+            expect(wrapper.get('.value').text()).toBe('10');
+        });
+
+        it('registers a block data scope so sw-native-block-host can read the converted state', () => {
+            const wrapper = mount(
+                convert('sw-legacy', {
+                    template: '<div class="value">{{ label }}</div>',
+                    data() {
+                        return { label: 'scoped' };
+                    },
+                }),
+            );
+
+            const dataScope = getScriptSetupDataScope(wrapper.vm.$) as Record<string, unknown> | null;
+
+            expect(dataScope).not.toBeNull();
+            expect(dataScope?.label).toBe('scoped');
+        });
+    });
+});

--- a/src/Administration/Resources/app/administration/src/app/adapter/options-composition-shim.spec.ts
+++ b/src/Administration/Resources/app/administration/src/app/adapter/options-composition-shim.spec.ts
@@ -1884,24 +1884,21 @@ describe('src/app/adapter/options-composition-shim', () => {
     });
 
     describe('setupWatchers() — dot-notation paths:', () => {
-        it('should warn and skip dot-notation watch keys', async () => {
-            // Use a single spy that covers all console.warn calls to avoid nested-spy issues.
-            const consoleWarn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+        it('should watch a dot-notation path on previous state', async () => {
             const watchCallback = jest.fn();
 
             const originalComponent = defineComponent({
                 template: '<div></div>',
                 setup: (props, context) =>
                     createExtendableSetup({ props, context, name: 'originalComponent' }, () => {
-                        return { public: {} };
+                        const user = ref({ name: 'initial' });
+                        return { public: { user } };
                     }),
             });
 
-            mount(originalComponent);
+            const wrapper = mount(originalComponent);
 
-            // Call convertOptionsApiOverrideToCompositionApi directly so the deprecation
-            // warning is also captured by our single spy (filtered out below).
-            const overrideFn = convertOptionsApiOverrideToCompositionApi('originalComponent', {
+            const overrideFn = convertWithSilencedWarning('originalComponent', {
                 watch: {
                     'user.name'(newVal: any) {
                         watchCallback(newVal);
@@ -1913,35 +1910,79 @@ describe('src/app/adapter/options-composition-shim', () => {
 
             await flushPromises();
 
-            const dotNotationWarnings = consoleWarn.mock.calls.filter(
-                (call) => typeof call[0] === 'string' && call[0].includes('Dot-notation watch path'),
-            );
+            _overridesMap.originalComponent.push((previousState: any) => {
+                previousState.user.value = { name: 'changed' };
+                return {};
+            });
 
-            expect(dotNotationWarnings).toHaveLength(1);
-            expect(dotNotationWarnings[0][0]).toContain('"user.name"');
-            expect(watchCallback).not.toHaveBeenCalled();
+            await flushPromises();
+            await nextTick();
 
-            consoleWarn.mockRestore();
+            expect(watchCallback).toHaveBeenCalledWith('changed');
+
+            wrapper.unmount();
         });
 
-        it('should still process non-dot-notation watch keys alongside dot-notation ones', async () => {
-            const consoleWarn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+        it('should yield undefined instead of throwing when a path segment is missing', async () => {
+            const watchCallback = jest.fn();
+
+            const originalComponent = defineComponent({
+                template: '<div></div>',
+                setup: (props, context) =>
+                    createExtendableSetup({ props, context, name: 'originalComponent' }, () => {
+                        const user = ref<{ name?: string } | null>(null);
+                        return { public: { user } };
+                    }),
+            });
+
+            const wrapper = mount(originalComponent);
+
+            const overrideFn = convertWithSilencedWarning('originalComponent', {
+                watch: {
+                    'user.name'(newVal: any) {
+                        watchCallback(newVal);
+                    },
+                },
+            });
+
+            _overridesMap.originalComponent.push(overrideFn);
+
+            await flushPromises();
+
+            _overridesMap.originalComponent.push((previousState: any) => {
+                previousState.user.value = { name: 'now-there' };
+                return {};
+            });
+
+            await flushPromises();
+            await nextTick();
+
+            expect(watchCallback).toHaveBeenCalledWith('now-there');
+
+            wrapper.unmount();
+        });
+
+        it('should process flat and dot-notation watch keys side by side', async () => {
             const flatCallback = jest.fn();
+            const pathCallback = jest.fn();
 
             const originalComponent = defineComponent({
                 template: '<div class="count">{{ count }}</div>',
                 setup: (props, context) =>
                     createExtendableSetup({ props, context, name: 'originalComponent' }, () => {
                         const count = ref(0);
-                        return { public: { count } };
+                        const user = ref({ name: 'initial' });
+                        return { public: { count, user } };
                     }),
             });
 
             const wrapper = mount(originalComponent);
 
-            const overrideFn = convertOptionsApiOverrideToCompositionApi('originalComponent', {
+            const overrideFn = convertWithSilencedWarning('originalComponent', {
                 watch: {
-                    'nested.prop'(newVal: any) {},
+                    'user.name'(newVal: any) {
+                        pathCallback(newVal);
+                    },
                     count(newVal: number) {
                         flatCallback(newVal);
                     },
@@ -1952,9 +1993,9 @@ describe('src/app/adapter/options-composition-shim', () => {
 
             await flushPromises();
 
-            // Trigger a count change to fire the valid watcher
             _overridesMap.originalComponent.push((previousState: any) => {
                 previousState.count.value = 99;
+                previousState.user.value = { name: 'changed' };
                 return {};
             });
 
@@ -1962,13 +2003,8 @@ describe('src/app/adapter/options-composition-shim', () => {
             await nextTick();
 
             expect(flatCallback).toHaveBeenCalledWith(99);
+            expect(pathCallback).toHaveBeenCalledWith('changed');
 
-            const dotNotationWarnings = consoleWarn.mock.calls.filter(
-                (call) => typeof call[0] === 'string' && call[0].includes('Dot-notation watch path'),
-            );
-            expect(dotNotationWarnings).toHaveLength(1);
-
-            consoleWarn.mockRestore();
             wrapper.unmount();
         });
     });

--- a/src/Administration/Resources/app/administration/src/app/adapter/options-composition-shim.ts
+++ b/src/Administration/Resources/app/administration/src/app/adapter/options-composition-shim.ts
@@ -28,6 +28,7 @@ import {
     onErrorCaptured,
 } from 'vue';
 import type { Ref, ComputedRef, WatchOptions } from 'vue';
+import MixinFactory from 'src/core/factory/mixin.factory';
 import type { ComponentConfig } from 'src/core/factory/async-component.factory';
 
 // ─── Local types ────────────────────────────────────────────────────────────
@@ -117,7 +118,7 @@ const OPTION_KEYS = [
 ] as const;
 
 interface MergedConfig extends Omit<ComponentConfig, 'data' | 'computed' | 'methods' | 'watch' | 'inject'> {
-    data?: () => Record<string, unknown>;
+    data?: (thisArg?: object) => Record<string, unknown>;
     computed?: Record<string, ComputedDefinition>;
     methods?: Record<string, AnyFn>;
     watch?: Record<string, WatchDefinition>;
@@ -301,7 +302,7 @@ function mergeMixins(config: ComponentConfig): MergedConfig {
     // Collect data factories in merge order so each is called exactly once.
     // Mixin factories are pushed first (deepest ancestor first via flattenMixins),
     // then the component's own factory last — so component keys win on conflict.
-    const allDataFns: Array<() => Record<string, unknown>> = [];
+    const allDataFns: Array<(thisArg?: object) => Record<string, unknown>> = [];
 
     // Vue's ComponentOptions types methods/computed/watch as `any` internally,
     // so we cast once here at the boundary and let MergedConfig carry the correct types.
@@ -333,7 +334,8 @@ function mergeMixins(config: ComponentConfig): MergedConfig {
                 const mixinData = mixin.data;
                 allDataFns.push(
                     typeof mixinData === 'function'
-                        ? () => (mixinData as unknown as () => Record<string, unknown>)()
+                        ? (thisArg?: object) =>
+                              (mixinData as unknown as (this: object | undefined) => Record<string, unknown>).call(thisArg)
                         : () => mixinData as unknown as Record<string, unknown>,
                 );
             }
@@ -361,14 +363,16 @@ function mergeMixins(config: ComponentConfig): MergedConfig {
         const configData = config.data;
         allDataFns.push(
             typeof configData === 'function'
-                ? () => (configData as unknown as () => Record<string, unknown>)()
+                ? (thisArg?: object) =>
+                      (configData as unknown as (this: object | undefined) => Record<string, unknown>).call(thisArg)
                 : () => configData as unknown as Record<string, unknown>,
         );
     }
 
     // Produce a single merged factory that calls each original factory exactly once
     if (allDataFns.length > 0) {
-        merged.data = () => allDataFns.reduce<Record<string, unknown>>((acc, fn) => ({ ...acc, ...fn() }), {});
+        merged.data = (thisArg?: object) =>
+            allDataFns.reduce<Record<string, unknown>>((acc, fn) => ({ ...acc, ...fn(thisArg) }), {});
     }
 
     // Component's own hooks go last (after mixin hooks), matching Vue's merge strategy
@@ -564,9 +568,15 @@ function convertComputed(computedDefs: Record<string, ComputedDefinition>, thisP
 
 /**
  * Converts Options API data() function to refs
+ *
+ * `thisArg` is only passed on the base-conversion path, where `data()` bodies legitimately read props and
+ * injections off `this`. Override configs keep calling the factory without a receiver, as before.
  */
-function convertData(dataFn: (() => Record<string, unknown>) | Record<string, unknown>): Record<string, Ref> {
-    const data = typeof dataFn === 'function' ? dataFn() : dataFn;
+function convertData(
+    dataFn: ((thisArg?: object) => Record<string, unknown>) | Record<string, unknown>,
+    thisArg?: object,
+): Record<string, Ref> {
+    const data = typeof dataFn === 'function' ? dataFn(thisArg) : dataFn;
     const converted: Record<string, Ref> = {};
 
     if (!data || typeof data !== 'object') {
@@ -623,6 +633,30 @@ function registerSingleWatcher(source: () => unknown, handler: SingleWatchDefini
 }
 
 /**
+ * Builds the reactive getter one Options API watch key describes.
+ *
+ * Dot paths (`watch: { 'product.name'() {} }`) are common in the Administration, so the getter walks the
+ * path and yields `undefined` as soon as a segment is nullish - the same tolerance Vue's own path
+ * watchers have.
+ */
+function createWatchSource(thisProxy: object, key: string): () => unknown {
+    if (!key.includes('.')) {
+        return (): unknown => (thisProxy as ComponentState)[key];
+    }
+
+    const path = key.split('.');
+
+    return () =>
+        path.reduce<unknown>((value, segment) => {
+            if (value === null || value === undefined) {
+                return undefined;
+            }
+
+            return (value as ComponentState)[segment];
+        }, thisProxy);
+}
+
+/**
  * Sets up watchers for Options API watch configuration
  */
 function setupWatchers(watchConfig: Record<string, WatchDefinition>, thisProxy: object): void {
@@ -631,15 +665,7 @@ function setupWatchers(watchConfig: Record<string, WatchDefinition>, thisProxy: 
             key,
             handler,
         ]) => {
-            if (key.includes('.')) {
-                console.warn(
-                    `[Options API Shim] Dot-notation watch path "${key}" is not supported by the compatibility shim. ` +
-                        `Please migrate your watcher to Composition API.`,
-                );
-                return;
-            }
-
-            const source = (): unknown => (thisProxy as ComponentState)[key];
+            const source = createWatchSource(thisProxy, key);
 
             if (Array.isArray(handler)) {
                 handler.forEach((h) => registerSingleWatcher(source, h, thisProxy));
@@ -756,4 +782,173 @@ function logDeprecationWarning(componentName: string): void {
             `Please migrate your override to use Shopware.Component.overrideComponentSetup(). ` +
             `See: https://developer.shopware.com/docs/resources/references/core-reference/administration-reference/composition-api`,
     );
+}
+
+// ─── Options API base conversion ─────────────────────────────────────────────
+
+/**
+ * Options that the base conversion re-implements in `setup()` and therefore has to remove from the
+ * config; leaving them in would make Vue apply them a second time, and mixin lifecycle hooks would fire
+ * twice.
+ *
+ * Everything else - `props`, `emits`, `components`, `directives`, `provide`, `inheritAttrs`, `template` -
+ * stays on the config and keeps working: Vue resolves template identifiers against the setup state
+ * first, and Options API `provide()` runs with the instance proxy as its receiver, which resolves setup
+ * state too.
+ *
+ * `inject` deliberately stays as well. It is resolved a second time inside the conversion, purely so the
+ * `this` proxy can reach the values; leaving the option in place is what keeps injected keys readable
+ * from the template, where Vue exposes them on the instance context. Resolving twice is side-effect free
+ * - `inject()` only walks the provides chain.
+ */
+const CONVERTED_OPTION_KEYS = [
+    'data',
+    'computed',
+    'methods',
+    'watch',
+    ...LIFECYCLE_HOOKS,
+] as const;
+
+/**
+ * Resolves `mixins: ['name']` entries against the mixin registry, recursively.
+ *
+ * The view adapter resolves mixin names too, but only *after* `build()` has returned - and the conversion
+ * runs inside `build()`, so it has to do its own pass or it would fold a string into the setup state.
+ * `getByName` throws for an unregistered name, which the caller's fail-safe turns into an unconverted
+ * component rather than a broken one.
+ *
+ * @example
+ * const mixins = resolveMixinReferences(config.mixins);
+ */
+function resolveMixinReferences(mixins: ComponentConfig['mixins']): ComponentConfig[] {
+    return (mixins ?? []).map((mixin) => {
+        const resolved = (
+            typeof mixin === 'string' ? MixinFactory.getByName(mixin as keyof MixinContainer) : mixin
+        ) as ComponentConfig;
+
+        if (!resolved.mixins) {
+            return resolved;
+        }
+
+        return {
+            ...resolved,
+            mixins: resolveMixinReferences(resolved.mixins),
+        };
+    });
+}
+
+/**
+ * Copies a config without the options the conversion takes over.
+ *
+ * @example
+ * const remaining = withoutConvertedOptions(config);
+ */
+function withoutConvertedOptions<TConfig extends ComponentConfig>(config: TConfig): TConfig {
+    const remaining = { ...config } as ExtendedComponentConfig;
+
+    CONVERTED_OPTION_KEYS.forEach((key) => {
+        delete remaining[key];
+    });
+
+    delete remaining.mixins;
+
+    return remaining as TConfig;
+}
+
+/**
+ * @private
+ *
+ * Reports why an Options API base cannot be converted into an extendable setup component, or `null` when
+ * it can.
+ *
+ * Both blockers are about state the conversion cannot see: a custom `render()` bypasses the template
+ * entirely, and an `extends` chain keeps its own `data`/`computed`/`methods` on a config level this
+ * conversion never touches - so a converted method would resolve `this.x` against setup state that never
+ * received the inherited half.
+ *
+ * @example
+ * const blocker = getOptionsApiBaseConversionBlocker(config);
+ */
+export function getOptionsApiBaseConversionBlocker(config: ComponentConfig): string | null {
+    if (typeof config.render === 'function') {
+        return 'it defines a custom render() function';
+    }
+
+    if (config.extends) {
+        return 'it extends another component or carries a legacy Options API override, which keeps part of its state outside the converted config';
+    }
+
+    return null;
+}
+
+/**
+ * @private
+ *
+ * Converts an Options API base component into a component whose state runs through
+ * `createExtendableSetup()`, which is what makes native `.override.vue` setup extensions apply to it.
+ *
+ * All converted state is returned as `public`: legacy Twig overrides were allowed to reach every
+ * property of the component, so introducing a public/private split here would break expectations that
+ * predate the extension system.
+ *
+ * `Shopware.Component.createExtendableSetup` is read off the global rather than imported: the extension
+ * system imports this module, and taking the reverse import would close a module cycle.
+ *
+ * @example
+ * const converted = convertOptionsApiBaseToExtendableSetup('sw-product-detail', config);
+ */
+export function convertOptionsApiBaseToExtendableSetup(componentName: string, config: ComponentConfig): ComponentConfig {
+    const resolvedMixins = resolveMixinReferences(config.mixins);
+    const mergedConfig = mergeMixins({ ...config, mixins: resolvedMixins });
+    // Mixins keep contributing what the conversion does not take over (props, components, directives,
+    // provide). Flattened first so Vue does not re-apply the nested ones the merge already folded in.
+    const sanitizedMixins = resolvedMixins
+        .flatMap((mixin) => flattenMixins(mixin))
+        .map((mixin) => withoutConvertedOptions(mixin));
+
+    return {
+        ...withoutConvertedOptions(config),
+        ...(sanitizedMixins.length > 0 ? { mixins: sanitizedMixins } : {}),
+        setup(props: ComponentState, context: unknown) {
+            return Shopware.Component.createExtendableSetup(
+                {
+                    name: componentName,
+                    props,
+                    context,
+                },
+                () => {
+                    const result: ComponentState = {};
+
+                    // Resolved before anything else because `data()` bodies may read injections, and
+                    // `vueInject` only works while the setup call is on the stack.
+                    const injectedValues = resolveInject(mergedConfig.inject);
+                    // Created before the state it exposes: the proxy reads `result` lazily, so every
+                    // later Object.assign is visible through `this` without rebuilding the proxy.
+                    const thisProxy = createThisProxy({}, props, result, injectedValues);
+
+                    if (mergedConfig.data) {
+                        Object.assign(result, convertData(mergedConfig.data, thisProxy));
+                    }
+
+                    if (mergedConfig.computed) {
+                        Object.assign(result, convertComputed(mergedConfig.computed, thisProxy));
+                    }
+
+                    if (mergedConfig.methods) {
+                        Object.assign(result, convertMethods(mergedConfig.methods, thisProxy));
+                    }
+
+                    if (mergedConfig.watch) {
+                        setupWatchers(mergedConfig.watch, thisProxy);
+                    }
+
+                    if (mergedConfig._lifecycleHooks) {
+                        setupLifecycleHooks(mergedConfig._lifecycleHooks, thisProxy);
+                    }
+
+                    return { public: result };
+                },
+            );
+        },
+    };
 }

--- a/src/Administration/Resources/app/administration/src/app/component/index.ts
+++ b/src/Administration/Resources/app/administration/src/app/component/index.ts
@@ -111,6 +111,10 @@ export default () => {
         () => import('src/app/component/structure/sw-block-override/sw-block-parent/index'),
     );
     Shopware.Component.register('sw-block', () => import('src/app/component/structure/sw-block-override/sw-block/index'));
+    Shopware.Component.register(
+        'sw-native-block-host',
+        () => import('src/app/component/structure/sw-block-override/sw-native-block-host/index'),
+    );
     Shopware.Component.register('sw-admin-menu-item', () => import('src/app/component/structure/sw-admin-menu-item/index'));
     Shopware.Component.register('sw-admin-menu', () => import('src/app/component/structure/sw-admin-menu/index'));
     Shopware.Component.register('sw-admin', () => import('src/app/component/structure/sw-admin/index'));

--- a/src/Administration/Resources/app/administration/src/app/component/structure/sw-block-override/shared/use-block-node-stack.spec.ts
+++ b/src/Administration/Resources/app/administration/src/app/component/structure/sw-block-override/shared/use-block-node-stack.spec.ts
@@ -1,0 +1,128 @@
+/**
+ * @sw-package framework
+ * @group disabledCompat
+ */
+
+import { defineComponent, h, ref, type Slot } from 'vue';
+import { mount } from '@vue/test-utils';
+import useBlockNodeStack from './use-block-node-stack';
+import swBlockParent from '../sw-block-parent/index';
+
+type DataScope = { label: string };
+
+/**
+ * Builds a minimal host around the composable, standing in for `sw-block` / `sw-native-block-host`.
+ */
+function createHost(resolveSlots: () => Slot[], data: DataScope = { label: 'scope' }) {
+    return defineComponent({
+        setup() {
+            const template = useBlockNodeStack(resolveSlots, () => data);
+
+            return { template };
+        },
+        render() {
+            return this.template;
+        },
+    });
+}
+
+function marker(className: string): Slot {
+    return () => [h('div', { class: className })];
+}
+
+describe('src/app/component/structure/sw-block-override/shared/use-block-node-stack', () => {
+    it('renders only the last slot of the stack', () => {
+        const wrapper = mount(
+            createHost(() => [
+                marker('first'),
+                marker('second'),
+                marker('third'),
+            ]),
+        );
+
+        expect(wrapper.find('.third').exists()).toBe(true);
+        expect(wrapper.find('.first').exists()).toBe(false);
+        expect(wrapper.find('.second').exists()).toBe(false);
+    });
+
+    it('renders nothing for an empty stack', () => {
+        const wrapper = mount(createHost(() => []));
+
+        expect(wrapper.html()).toBe('');
+    });
+
+    it('passes the data scope to every slot', () => {
+        const received: unknown[] = [];
+        const recordingSlot: Slot = (data) => {
+            received.push(data);
+
+            return [h('div')];
+        };
+
+        mount(
+            createHost(() => [
+                recordingSlot,
+                recordingSlot,
+            ]),
+        );
+
+        expect(received).toEqual([
+            { label: 'scope' },
+            { label: 'scope' },
+        ]);
+    });
+
+    it('lets sw-block-parent claim the slot below it', () => {
+        const wrapper = mount(
+            createHost(() => [
+                marker('parent-content'),
+                () => [
+                    h(swBlockParent),
+                    h('div', { class: 'extension' }),
+                ],
+            ]),
+        );
+
+        const children = wrapper.findAll('div');
+
+        expect(children.map((child) => child.classes()[0])).toEqual([
+            'parent-content',
+            'extension',
+        ]);
+    });
+
+    it('chains one sw-block-parent per stack entry', () => {
+        const wrapper = mount(
+            createHost(() => [
+                marker('base'),
+                () => [
+                    h(swBlockParent),
+                    h('div', { class: 'first-extension' }),
+                ],
+                () => [
+                    h(swBlockParent),
+                    h('div', { class: 'second-extension' }),
+                ],
+            ]),
+        );
+
+        expect(wrapper.findAll('div').map((child) => child.classes()[0])).toEqual([
+            'base',
+            'first-extension',
+            'second-extension',
+        ]);
+    });
+
+    it('re-renders when the resolved stack changes', async () => {
+        const withExtension = ref(false);
+        const wrapper = mount(createHost(() => (withExtension.value ? [marker('extension')] : [marker('base')])));
+
+        expect(wrapper.find('.base').exists()).toBe(true);
+
+        withExtension.value = true;
+        await wrapper.vm.$nextTick();
+
+        expect(wrapper.find('.extension').exists()).toBe(true);
+        expect(wrapper.find('.base').exists()).toBe(false);
+    });
+});

--- a/src/Administration/Resources/app/administration/src/app/component/structure/sw-block-override/shared/use-block-node-stack.ts
+++ b/src/Administration/Resources/app/administration/src/app/component/structure/sw-block-override/shared/use-block-node-stack.ts
@@ -1,0 +1,45 @@
+/**
+ * @sw-package framework
+ * @private
+ *
+ * Shared render stack for block extension points.
+ *
+ * `sw-block` (native base templates) and `sw-native-block-host` (legacy Twig base templates) differ only
+ * in *which* slots they stack; how the stack renders — last slot wins, everything below it becomes the
+ * parent chain `<sw-block-parent />` pops from — is identical and lives here.
+ */
+
+import { computed, provide, ref, type ComputedRef, type Slot } from 'vue';
+import parentsInjectionKey from '../sw-block/parents-injection-key';
+
+/**
+ * @private
+ *
+ * Renders the last slot of a block stack and provides the remaining ones as its parent chain.
+ *
+ * `resolveSlots` is called on every render so late-registered extensions (native override components
+ * mount after the app root) are picked up reactively.
+ *
+ * @example
+ * const template = useBlockNodeStack(() => [defaultSlot, ...getBlocks(name)], () => props.data);
+ */
+export default function useBlockNodeStack(
+    resolveSlots: () => Slot[],
+    resolveData: () => unknown,
+): ComputedRef<ReturnType<Slot> | undefined> {
+    const providedParents = ref<ReturnType<Slot>[]>([]);
+    provide(parentsInjectionKey, providedParents);
+
+    return computed(() => {
+        const blockNodes = resolveSlots().map((slot) => slot?.(resolveData()));
+
+        const lastNode = blockNodes.pop();
+        // Each <sw-block-parent /> calls .pop() exactly once in its own setup()
+        // to claim its parent slot. The array must be reset to the current render's
+        // ordered list so that each parent instance pops the correct slot — not a
+        // stale or accumulated list from a previous render cycle.
+        providedParents.value = blockNodes;
+
+        return lastNode;
+    });
+}

--- a/src/Administration/Resources/app/administration/src/app/component/structure/sw-block-override/sw-block/index.ts
+++ b/src/Administration/Resources/app/administration/src/app/component/structure/sw-block-override/sw-block/index.ts
@@ -2,19 +2,10 @@
  * @sw-package framework
  *
  */
-import {
-    computed,
-    getCurrentInstance,
-    onBeforeUnmount,
-    provide,
-    ref,
-    watch,
-    type ComponentInternalInstance,
-    type Slot,
-} from 'vue';
+import { getCurrentInstance, onBeforeUnmount, watch, type ComponentInternalInstance, type Slot } from 'vue';
 import { hasBlockEntries, getBlockEntries } from 'src/core/factory/twig-block-index';
-import parentsInjectionKey from './parents-injection-key';
 import useBlockContext from '../../../../composables/use-block-context';
+import useBlockNodeStack from '../shared/use-block-node-stack';
 import { createShimSlot } from '../shim/create-shim-slot';
 import useLegacyConditionContext from '../shim/legacy-condition-context';
 
@@ -141,34 +132,24 @@ export default Shopware.Component.wrapComponentConfig({
             );
         }
 
-        const providedParents = ref<ReturnType<Slot>[]>([]);
-        provide(parentsInjectionKey, providedParents);
+        const template = useBlockNodeStack(
+            () => {
+                if (!props.name) {
+                    throw new Error('[sw-block] The "name" prop is required when "extends" is not set.');
+                }
 
-        const template = computed(() => {
-            if (!props.name) {
-                throw new Error('[sw-block] The "name" prop is required when "extends" is not set.');
-            }
-
-            // shimSlots come before nativeBlocks so that Twig plugin overrides (registered
-            // at boot time) are positioned below native <sw-block extends> overrides
-            // (registered at mount time), matching the expected stacking order:
-            //   default → shim (legacy plugin) → native (newer plugin or core extension)
-            const nativeBlocks = getBlocks(props.name);
-            const blocksAndParent = [
-                slots.default ?? (() => []),
-                ...shimSlots,
-                ...nativeBlocks,
-            ];
-            const blocksNodes = blocksAndParent.map((block) => block?.(props.data));
-
-            const lastNode = blocksNodes.pop();
-            // Each <sw-block-parent /> calls .pop() exactly once in its own setup()
-            // to claim its parent slot. The array must be reset to the current render's
-            // ordered list so that each parent instance pops the correct slot — not a
-            // stale or accumulated list from a previous render cycle.
-            providedParents.value = blocksNodes;
-            return lastNode;
-        });
+                // shimSlots come before nativeBlocks so that Twig plugin overrides (registered
+                // at boot time) are positioned below native <sw-block extends> overrides
+                // (registered at mount time), matching the expected stacking order:
+                //   default → shim (legacy plugin) → native (newer plugin or core extension)
+                return [
+                    slots.default ?? (() => []),
+                    ...shimSlots,
+                    ...getBlocks(props.name),
+                ];
+            },
+            () => props.data,
+        );
 
         return {
             template,

--- a/src/Administration/Resources/app/administration/src/app/component/structure/sw-block-override/sw-native-block-host/index.ts
+++ b/src/Administration/Resources/app/administration/src/app/component/structure/sw-block-override/sw-native-block-host/index.ts
@@ -1,0 +1,67 @@
+/**
+ * @sw-package framework
+ */
+import { inject, provide, type ComponentInternalInstance, type Slot } from 'vue';
+import useBlockContext from '../../../../composables/use-block-context';
+import useBlockNodeStack from '../shared/use-block-node-stack';
+import nativeBlockHostsInjectionKey from './native-block-hosts-injection-key';
+
+const emptySlot: Slot = () => [];
+
+/**
+ * @private
+ *
+ * @component sw-native-block-host
+ * @description
+ * Extension point injected by the Native → Twig Extension Bridge into components whose template still uses
+ * the TwigJS block system. It is never authored by hand: `native-extensions-twig-bridge.ts` registers a
+ * synthetic Twig override that replaces a `{% block %}` body with this component, moving the original
+ * body — including every legacy Twig override merged into it — into the `#parent` slot.
+ *
+ * Unlike `sw-block` it does not create Twig shim slots: legacy overrides are already part of the merged
+ * `#parent` content, so shimming them again would render them twice.
+ *
+ * @example injected markup
+ * <sw-native-block-host name="sw_product_detail_base" :data="$dataScope">
+ *     <template #parent>...original block body...</template>
+ * </sw-native-block-host>
+ */
+export default Shopware.Component.wrapComponentConfig({
+    props: {
+        name: {
+            type: String,
+            required: true,
+        },
+        data: {
+            type: Object as PropType<ComponentInternalInstance['proxy']>,
+            default: null,
+        },
+    },
+    setup(props, { slots }) {
+        const { getBlocks } = useBlockContext();
+        const mountedHosts = inject(nativeBlockHostsInjectionKey, []);
+        const isNestedHostForSameBlock = mountedHosts.includes(props.name);
+
+        provide(nativeBlockHostsInjectionKey, [
+            ...mountedHosts,
+            props.name,
+        ]);
+
+        const template = useBlockNodeStack(
+            () => [
+                slots.parent ?? emptySlot,
+                // The outermost host for a block name owns its native extensions; an inner host renders
+                // the legacy content only, so the extension keeps its single, outermost position.
+                ...(isNestedHostForSameBlock ? [] : getBlocks(props.name)),
+            ],
+            () => props.data,
+        );
+
+        return {
+            template,
+        };
+    },
+    render() {
+        return this.template;
+    },
+});

--- a/src/Administration/Resources/app/administration/src/app/component/structure/sw-block-override/sw-native-block-host/native-block-hosts-injection-key.ts
+++ b/src/Administration/Resources/app/administration/src/app/component/structure/sw-block-override/sw-native-block-host/native-block-hosts-injection-key.ts
@@ -1,0 +1,15 @@
+/**
+ * @sw-package framework
+ */
+import type { InjectionKey } from 'vue';
+
+/**
+ * @private
+ *
+ * Carries the block names of the `sw-native-block-host` instances already mounted above the current one.
+ *
+ * A component that redeclares a block of the component it extends gets a wrapper on both templates, and
+ * `{% parent %}` nests one inside the other. The inner host reads this list to stay inert instead of
+ * rendering the same native extension twice.
+ */
+export default Symbol('nativeBlockHosts') as InjectionKey<string[]>;

--- a/src/Administration/Resources/app/administration/src/app/component/structure/sw-block-override/sw-native-block-host/sw-native-block-host.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/structure/sw-block-override/sw-native-block-host/sw-native-block-host.spec.js
@@ -1,0 +1,189 @@
+/**
+ * @sw-package framework
+ * @group disabledCompat
+ */
+import { mount } from '@vue/test-utils';
+import blockOverrideStore from '../../../../store/block-override.store';
+import createDataScopeFixture from '../sw-block-override.spec/test-utils/create-data-scope-fixture';
+
+/**
+ * Mirrors what the bridge injects into a legacy Twig template: the original block body moves into the
+ * `#parent` slot of a `sw-native-block-host`, and native `<sw-block extends>` overrides render on top.
+ */
+async function createWrapper({
+    parentContent = '<div class="parent-content"></div>',
+    extensions = '',
+    hostMarkup = null,
+    renderExtensions = true,
+    extraData = {},
+} = {}) {
+    const host =
+        hostMarkup ??
+        `<sw-native-block-host name="test-extension-point" :data="$dataScope">
+            <template #parent>${parentContent}</template>
+        </sw-native-block-host>`;
+
+    const wrapper = mount(
+        {
+            template: `
+            <div class="component-root">
+                ${host}
+            </div>
+            <template v-if="renderExtensions">
+                ${extensions}
+            </template>
+        `,
+            components: {
+                'sw-native-block-host': await wrapTestComponent('sw-native-block-host', { sync: true }),
+                'sw-block': await wrapTestComponent('sw-block', { sync: true }),
+                'sw-block-parent': await wrapTestComponent('sw-block-parent', { sync: true }),
+            },
+            data() {
+                return {
+                    renderExtensions,
+                    ...extraData,
+                };
+            },
+        },
+        {
+            global: {
+                plugins: [createDataScopeFixture()],
+            },
+        },
+    );
+
+    async function toggleExtensions() {
+        await wrapper.setData({
+            renderExtensions: !wrapper.vm.renderExtensions,
+        });
+    }
+
+    return {
+        wrapper,
+        toggleExtensions,
+    };
+}
+
+describe('sw-native-block-host', () => {
+    beforeAll(() => {
+        Shopware.Store.register('blockOverride', blockOverrideStore);
+    });
+
+    it('renders the merged Twig content from the parent slot', async () => {
+        const { wrapper } = await createWrapper();
+
+        expect(wrapper.find('.component-root > .parent-content').exists()).toBe(true);
+    });
+
+    it('renders nothing when the block body is empty and no extension is registered', async () => {
+        const { wrapper } = await createWrapper({ parentContent: '' });
+
+        expect(wrapper.findAll('.component-root > *')).toHaveLength(0);
+    });
+
+    it('replaces the merged Twig content with a native extension that has no parent', async () => {
+        const { wrapper } = await createWrapper({
+            extensions: `
+                <sw-block extends="test-extension-point">
+                    <div class="native-content"></div>
+                </sw-block>
+            `,
+        });
+
+        expect(wrapper.find('.component-root > .native-content').exists()).toBe(true);
+        expect(wrapper.find('.parent-content').exists()).toBe(false);
+    });
+
+    it('renders the merged Twig content below a native extension using sw-block-parent', async () => {
+        const { wrapper } = await createWrapper({
+            extensions: `
+                <sw-block extends="test-extension-point">
+                    <sw-block-parent />
+                    <div class="native-content"></div>
+                </sw-block>
+            `,
+        });
+
+        const children = wrapper.findAll('.component-root > *');
+
+        expect(children).toHaveLength(2);
+        expect(children[0].classes()).toContain('parent-content');
+        expect(children[1].classes()).toContain('native-content');
+    });
+
+    it('chains multiple native extensions on the same block', async () => {
+        const { wrapper } = await createWrapper({
+            extensions: `
+                <sw-block extends="test-extension-point">
+                    <sw-block-parent />
+                    <div class="first-native"></div>
+                </sw-block>
+                <sw-block extends="test-extension-point">
+                    <sw-block-parent />
+                    <div class="second-native"></div>
+                </sw-block>
+            `,
+        });
+
+        const children = wrapper.findAll('.component-root > *');
+
+        expect(children.map((child) => child.classes()[0])).toEqual([
+            'parent-content',
+            'first-native',
+            'second-native',
+        ]);
+    });
+
+    it('renders the merged Twig content again once the extension unmounts', async () => {
+        const { wrapper, toggleExtensions } = await createWrapper({
+            extensions: `
+                <sw-block extends="test-extension-point">
+                    <div class="native-content"></div>
+                </sw-block>
+            `,
+        });
+
+        expect(wrapper.find('.native-content').exists()).toBe(true);
+
+        await toggleExtensions();
+
+        expect(wrapper.find('.native-content').exists()).toBe(false);
+        expect(wrapper.find('.component-root > .parent-content').exists()).toBe(true);
+    });
+
+    it('exposes the host component data scope to the extension content', async () => {
+        const { wrapper } = await createWrapper({
+            extraData: { headline: 'From the host' },
+            extensions: `
+                <sw-block extends="test-extension-point" #default="{ headline }">
+                    <div class="native-content">{{ headline }}</div>
+                </sw-block>
+            `,
+        });
+
+        expect(wrapper.find('.native-content').text()).toBe('From the host');
+    });
+
+    it('renders a native extension once when two hosts for the same block are nested', async () => {
+        const { wrapper } = await createWrapper({
+            hostMarkup: `
+                <sw-native-block-host name="test-extension-point" :data="$dataScope">
+                    <template #parent>
+                        <sw-native-block-host name="test-extension-point" :data="$dataScope">
+                            <template #parent><div class="parent-content"></div></template>
+                        </sw-native-block-host>
+                    </template>
+                </sw-native-block-host>
+            `,
+            extensions: `
+                <sw-block extends="test-extension-point">
+                    <sw-block-parent />
+                    <div class="native-content"></div>
+                </sw-block>
+            `,
+        });
+
+        expect(wrapper.findAll('.native-content')).toHaveLength(1);
+        expect(wrapper.findAll('.parent-content')).toHaveLength(1);
+    });
+});

--- a/src/Administration/Resources/app/administration/src/core/factory/async-component.factory.ts
+++ b/src/Administration/Resources/app/administration/src/core/factory/async-component.factory.ts
@@ -7,6 +7,11 @@ import { warn } from 'src/core/service/utils/debug.utils';
 import { cloneDeep } from 'src/core/service/utils/object.utils';
 import TemplateFactory from 'src/core/factory/template.factory';
 import { indexTwigBlocksFromTemplate } from 'src/core/factory/twig-block-index';
+import {
+    bridgeNativeSetupExtensions,
+    injectNativeBlockHosts,
+    injectNativeBlockHostsForComponent,
+} from 'src/core/factory/native-extensions-twig-bridge';
 import type {
     AllowedComponentProps,
     ComponentCustomProps,
@@ -687,6 +692,10 @@ function override(
 async function getComponentTemplate(componentName: string): Promise<string | null> {
     await initComponent(componentName);
 
+    // The component's own template and every registered Twig override are in the registry now, and the
+    // merge below has not run yet - the only window in which the bridge can still contribute a wrapper.
+    injectNativeBlockHostsForComponent(componentName);
+
     return TemplateFactory.getRenderedTemplate(componentName);
 }
 
@@ -782,6 +791,12 @@ async function build(componentName: string, skipTemplate = false): Promise<Compo
             ...addSuperBehaviour(inheritedFrom, superRegistry),
         };
     }
+
+    /**
+     * Runs on the fully merged config - extends chain, legacy overrides and $super wiring are all in
+     * place - so the bridge sees exactly the component Vue would otherwise receive.
+     */
+    config = bridgeNativeSetupExtensions(componentName, config);
 
     /**
      * if config has a render function it will ignore template
@@ -1266,6 +1281,8 @@ function isNotEmptyObject(obj: $TSFixMe): boolean {
  * @private
  */
 function resolveComponentTemplates(): boolean {
+    // Must run first: the bridge contributes Twig overrides, which only the merge below can apply.
+    injectNativeBlockHosts();
     TemplateFactory.resolveTemplates();
     return true;
 }

--- a/src/Administration/Resources/app/administration/src/core/factory/native-extension-targets.spec.ts
+++ b/src/Administration/Resources/app/administration/src/core/factory/native-extension-targets.spec.ts
@@ -1,0 +1,68 @@
+/**
+ * @sw-package framework
+ */
+
+import {
+    getNativeBlockExtensionTargets,
+    hasNativeSetupExtensionTarget,
+    registerNativeExtensionTargets,
+    resetNativeExtensionTargets,
+} from 'src/core/factory/native-extension-targets';
+
+describe('core/factory/native-extension-targets.ts', () => {
+    afterEach(() => {
+        resetNativeExtensionTargets();
+    });
+
+    it('registers the target component of an override without blocks', () => {
+        registerNativeExtensionTargets({ component: 'sw-product-detail' });
+
+        expect(hasNativeSetupExtensionTarget('sw-product-detail')).toBe(true);
+        expect(getNativeBlockExtensionTargets().size).toBe(0);
+    });
+
+    it('registers every extended block name', () => {
+        registerNativeExtensionTargets({
+            component: 'sw-product-detail',
+            blocks: [
+                'sw_product_detail_base',
+                'sw_product_detail_content',
+            ],
+        });
+
+        expect(Array.from(getNativeBlockExtensionTargets()).sort()).toEqual([
+            'sw_product_detail_base',
+            'sw_product_detail_content',
+        ]);
+    });
+
+    it('merges the targets of multiple override files', () => {
+        registerNativeExtensionTargets({
+            component: 'sw-product-detail',
+            blocks: ['sw_product_detail_base'],
+        });
+        registerNativeExtensionTargets({
+            component: 'sw-order-detail',
+            blocks: ['sw_product_detail_base'],
+        });
+
+        expect(getNativeBlockExtensionTargets().size).toBe(1);
+        expect(hasNativeSetupExtensionTarget('sw-order-detail')).toBe(true);
+    });
+
+    it('reports unknown components as untargeted', () => {
+        expect(hasNativeSetupExtensionTarget('sw-unknown')).toBe(false);
+    });
+
+    it('clears all registered targets on reset', () => {
+        registerNativeExtensionTargets({
+            component: 'sw-product-detail',
+            blocks: ['sw_product_detail_base'],
+        });
+
+        resetNativeExtensionTargets();
+
+        expect(hasNativeSetupExtensionTarget('sw-product-detail')).toBe(false);
+        expect(getNativeBlockExtensionTargets().size).toBe(0);
+    });
+});

--- a/src/Administration/Resources/app/administration/src/core/factory/native-extension-targets.ts
+++ b/src/Administration/Resources/app/administration/src/core/factory/native-extension-targets.ts
@@ -1,0 +1,88 @@
+/**
+ * @sw-package framework
+ * @private
+ *
+ * Boot-time registry of the components and blocks that native `.override.vue` extensions target.
+ *
+ * The override lowering emits one `registerNativeExtensionTargets(...)` call per override SFC into a
+ * module-scope `<script>` block, so every target is known once the plugin entries are imported — which
+ * happens before `resolveComponentTemplates()` and before the first component is built. That ordering is
+ * what lets the Twig bridge decide, at boot, which legacy components need a compatibility wrapper.
+ */
+
+/**
+ * Describes the extension surface one `.override.vue` file claims.
+ *
+ * `component` is the override's target component (derived from the filename), `blocks` are the static
+ * `<sw-block extends="...">` names in its template.
+ *
+ * @example
+ * registerNativeExtensionTargets({ component: 'sw-product-detail', blocks: ['sw_product_detail_base'] });
+ */
+type NativeExtensionTargets = {
+    component: string;
+    blocks?: string[];
+};
+
+const nativeBlockExtensionTargets = new Set<string>();
+const nativeSetupExtensionTargets = new Set<string>();
+
+/**
+ * @private
+ *
+ * Records the component and block names one native override file extends.
+ *
+ * Generated code calls this at module scope; author code never does.
+ *
+ * @example
+ * Shopware.Component.registerNativeExtensionTargets({ component: 'sw-product-detail' });
+ */
+export function registerNativeExtensionTargets(targets: NativeExtensionTargets): void {
+    if (targets.component) {
+        nativeSetupExtensionTargets.add(targets.component);
+    }
+
+    targets.blocks?.forEach((blockName) => nativeBlockExtensionTargets.add(blockName));
+}
+
+/**
+ * @private
+ *
+ * Lists every block name a native override extends.
+ *
+ * Use it when deciding which legacy Twig blocks need a `sw-native-block-host` wrapper.
+ *
+ * @example
+ * getNativeBlockExtensionTargets().has('sw_product_detail_base');
+ */
+export function getNativeBlockExtensionTargets(): ReadonlySet<string> {
+    return nativeBlockExtensionTargets;
+}
+
+/**
+ * @private
+ *
+ * Reports whether a native override registers setup state for `componentName`.
+ *
+ * Use it in the component factory to decide whether an Options API base has to be converted into an
+ * extendable setup component.
+ *
+ * @example
+ * hasNativeSetupExtensionTarget('sw-product-detail');
+ */
+export function hasNativeSetupExtensionTarget(componentName: string): boolean {
+    return nativeSetupExtensionTargets.has(componentName);
+}
+
+/**
+ * @private
+ *
+ * Clears the registry. Test teardown only — never call this in production code.
+ *
+ * @example
+ * resetNativeExtensionTargets();
+ */
+export function resetNativeExtensionTargets(): void {
+    nativeBlockExtensionTargets.clear();
+    nativeSetupExtensionTargets.clear();
+}

--- a/src/Administration/Resources/app/administration/src/core/factory/native-extensions-twig-bridge.spec.ts
+++ b/src/Administration/Resources/app/administration/src/core/factory/native-extensions-twig-bridge.spec.ts
@@ -1,0 +1,266 @@
+/**
+ * @sw-package framework
+ */
+
+import TemplateFactory from 'src/core/factory/template.factory';
+import {
+    bridgeNativeSetupExtensions,
+    injectNativeBlockHosts,
+    injectNativeBlockHostsForComponent,
+    resetNativeBlockHosts,
+} from 'src/core/factory/native-extensions-twig-bridge';
+import { registerNativeExtensionTargets, resetNativeExtensionTargets } from 'src/core/factory/native-extension-targets';
+
+/**
+ * Reads the merged markup the Twig pipeline produced for one component.
+ */
+function renderedHtml(componentName: string): string {
+    const normalizedTemplates = TemplateFactory.getNormalizedTemplateRegistry() as Map<string, { html?: string }>;
+
+    return normalizedTemplates.get(componentName)?.html ?? '';
+}
+
+/**
+ * Renders one component through the real Twig merge, exactly as `resolveComponentTemplates()` does.
+ */
+function renderTemplate(componentName: string): string {
+    injectNativeBlockHosts();
+    TemplateFactory.resolveTemplates();
+
+    return renderedHtml(componentName);
+}
+
+describe('core/factory/native-extensions-twig-bridge.ts', () => {
+    beforeEach(() => {
+        TemplateFactory.getTemplateRegistry().clear();
+        TemplateFactory.getNormalizedTemplateRegistry().clear();
+        TemplateFactory.clearTwigCache();
+        resetNativeBlockHosts();
+        resetNativeExtensionTargets();
+    });
+
+    afterEach(() => {
+        TemplateFactory.getTemplateRegistry().clear();
+        TemplateFactory.getNormalizedTemplateRegistry().clear();
+        TemplateFactory.clearTwigCache();
+        resetNativeBlockHosts();
+        resetNativeExtensionTargets();
+    });
+
+    it('wraps a targeted legacy block in a sw-native-block-host', () => {
+        TemplateFactory.registerComponentTemplate(
+            'sw-legacy',
+            '{% block sw_legacy_content %}<div class="content"></div>{% endblock %}',
+        );
+        registerNativeExtensionTargets({
+            component: 'sw-legacy',
+            blocks: ['sw_legacy_content'],
+        });
+
+        const html = renderTemplate('sw-legacy');
+
+        expect(html).toContain('<sw-native-block-host name="sw_legacy_content" :data="$dataScope">');
+        expect(html).toContain('<template #parent><div class="content"></div></template>');
+    });
+
+    it('leaves untargeted blocks untouched', () => {
+        TemplateFactory.registerComponentTemplate(
+            'sw-legacy',
+            '{% block sw_legacy_content %}<div class="content"></div>{% endblock %}',
+        );
+
+        const html = renderTemplate('sw-legacy');
+
+        expect(html).not.toContain('sw-native-block-host');
+        expect(html).toContain('<div class="content"></div>');
+    });
+
+    it('merges the wrapper after every registered Twig override', () => {
+        TemplateFactory.registerComponentTemplate(
+            'sw-legacy',
+            '{% block sw_legacy_content %}<div class="base"></div>{% endblock %}',
+        );
+        TemplateFactory.registerTemplateOverride(
+            'sw-legacy',
+            '{% block sw_legacy_content %}{% parent %}<div class="plugin"></div>{% endblock %}',
+            0,
+        );
+        registerNativeExtensionTargets({
+            component: 'sw-legacy',
+            blocks: ['sw_legacy_content'],
+        });
+
+        const html = renderTemplate('sw-legacy');
+
+        // Both the default content and the legacy plugin override end up inside the wrapper's parent
+        // slot, which is what keeps the stacking order default -> Twig override -> native extension.
+        expect(html).toContain('<template #parent><div class="base"></div><div class="plugin"></div></template>');
+    });
+
+    it('wraps a nested block independently of its parent block', () => {
+        TemplateFactory.registerComponentTemplate(
+            'sw-legacy',
+            '{% block sw_legacy_outer %}<div>{% block sw_legacy_inner %}<span></span>{% endblock %}</div>{% endblock %}',
+        );
+        registerNativeExtensionTargets({
+            component: 'sw-legacy',
+            blocks: ['sw_legacy_inner'],
+        });
+
+        const html = renderTemplate('sw-legacy');
+
+        expect(html).toContain('<sw-native-block-host name="sw_legacy_inner" :data="$dataScope">');
+        expect(html).not.toContain('name="sw_legacy_outer"');
+    });
+
+    it('skips a block whose conditional chain crosses the block boundary and reports it', () => {
+        jest.spyOn(console, 'error').mockImplementation(() => {});
+        TemplateFactory.registerComponentTemplate(
+            'sw-legacy',
+            '{% block sw_legacy_first %}<div v-if="a"></div>{% endblock %}{% block sw_legacy_second %}<div v-else></div>{% endblock %}',
+        );
+        registerNativeExtensionTargets({
+            component: 'sw-legacy',
+            blocks: ['sw_legacy_first'],
+        });
+
+        const html = renderTemplate('sw-legacy');
+
+        expect(html).not.toContain('sw-native-block-host');
+        expect(console.error).toHaveBeenCalledWith(
+            expect.stringContaining('takes part in a v-if/v-else chain that crosses its block boundary'),
+        );
+    });
+
+    it('registers a wrapper for every component declaring the targeted block', () => {
+        TemplateFactory.registerComponentTemplate('sw-base', '{% block shared %}<div class="base"></div>{% endblock %}');
+        TemplateFactory.extendComponentTemplate(
+            'sw-child',
+            'sw-base',
+            '{% block shared %}{% parent %}<div class="child"></div>{% endblock %}',
+        );
+        registerNativeExtensionTargets({
+            component: 'sw-base',
+            blocks: ['shared'],
+        });
+
+        injectNativeBlockHosts();
+        TemplateFactory.resolveTemplates();
+
+        expect(renderedHtml('sw-base')).toContain('<sw-native-block-host name="shared"');
+        // The child redeclares the block, so it gets its own wrapper; the inherited inner one stays in
+        // the parent slot and is neutralised at runtime by the host's nesting guard.
+        expect(renderedHtml('sw-child')).toContain('<sw-native-block-host name="shared"');
+    });
+
+    it('registers a wrapper on the extended component when only the child is built', () => {
+        TemplateFactory.registerComponentTemplate('sw-base', '{% block shared %}<div class="base"></div>{% endblock %}');
+        TemplateFactory.extendComponentTemplate('sw-child', 'sw-base', '');
+        registerNativeExtensionTargets({
+            component: 'sw-base',
+            blocks: ['shared'],
+        });
+
+        injectNativeBlockHostsForComponent('sw-child');
+        TemplateFactory.resolveTemplates();
+
+        expect(renderedHtml('sw-child')).toContain('<sw-native-block-host name="shared"');
+    });
+
+    it('does not parse a template that mentions no targeted block', () => {
+        jest.spyOn(console, 'warn').mockImplementation(() => {});
+        // Unparsable on purpose: reaching the parser at all would surface as a warning.
+        TemplateFactory.registerComponentTemplate('sw-legacy', '{% block sw_other_content %}');
+        registerNativeExtensionTargets({
+            component: 'sw-legacy',
+            blocks: ['sw_legacy_content'],
+        });
+
+        injectNativeBlockHosts();
+
+        expect(console.warn).not.toHaveBeenCalled();
+        expect(TemplateFactory.getTemplateOverrides('sw-legacy')).toHaveLength(0);
+    });
+
+    it('registers the wrapper only once across repeated resolve runs', () => {
+        TemplateFactory.registerComponentTemplate(
+            'sw-legacy',
+            '{% block sw_legacy_content %}<div class="content"></div>{% endblock %}',
+        );
+        registerNativeExtensionTargets({
+            component: 'sw-legacy',
+            blocks: ['sw_legacy_content'],
+        });
+
+        injectNativeBlockHosts();
+        injectNativeBlockHosts();
+
+        expect(TemplateFactory.getTemplateOverrides('sw-legacy')).toHaveLength(1);
+    });
+
+    describe('bridgeNativeSetupExtensions', () => {
+        it('converts an Options API base that a native override targets', () => {
+            registerNativeExtensionTargets({ component: 'sw-legacy' });
+
+            const config = bridgeNativeSetupExtensions('sw-legacy', {
+                template: '<div></div>',
+                data: () => ({ count: 1 }),
+            });
+
+            expect(typeof config.setup).toBe('function');
+            expect(config.data).toBeUndefined();
+        });
+
+        it('leaves an untargeted component untouched', () => {
+            const original = {
+                template: '<div></div>',
+                data: () => ({ count: 1 }),
+            };
+
+            expect(bridgeNativeSetupExtensions('sw-legacy', original)).toBe(original);
+        });
+
+        it('leaves a component that already has a setup function untouched', () => {
+            registerNativeExtensionTargets({ component: 'sw-legacy' });
+
+            const original = {
+                template: '<div></div>',
+                setup: () => ({}),
+            };
+
+            expect(bridgeNativeSetupExtensions('sw-legacy', original)).toBe(original);
+        });
+
+        it('reports why a component with an extends chain is skipped', () => {
+            jest.spyOn(console, 'error').mockImplementation(() => {});
+            registerNativeExtensionTargets({ component: 'sw-legacy' });
+
+            const original = {
+                template: '<div></div>',
+                extends: { name: 'sw-base' },
+                data: () => ({ count: 1 }),
+            };
+
+            expect(bridgeNativeSetupExtensions('sw-legacy', original)).toBe(original);
+            expect(console.error).toHaveBeenCalledWith(expect.stringContaining('cannot be made extendable'));
+        });
+
+        it('falls back to the unconverted config when the conversion throws', () => {
+            jest.spyOn(console, 'error').mockImplementation(() => {});
+            registerNativeExtensionTargets({ component: 'sw-legacy' });
+
+            const original = {
+                template: '<div></div>',
+                get mixins(): never {
+                    throw new Error('broken mixin accessor');
+                },
+            } as unknown as Parameters<typeof bridgeNativeSetupExtensions>[1];
+
+            expect(bridgeNativeSetupExtensions('sw-legacy', original)).toBe(original);
+            expect(console.error).toHaveBeenCalledWith(
+                expect.stringContaining('into an extendable setup'),
+                expect.any(Error),
+            );
+        });
+    });
+});

--- a/src/Administration/Resources/app/administration/src/core/factory/native-extensions-twig-bridge.ts
+++ b/src/Administration/Resources/app/administration/src/core/factory/native-extensions-twig-bridge.ts
@@ -1,0 +1,272 @@
+/**
+ * @sw-package framework
+ * @private
+ *
+ * Native → Twig Extension Bridge.
+ *
+ * The mirror image of the Twig → Native Block Runtime Adapter: that adapter keeps legacy `{% block %}`
+ * overrides working on migrated components, this bridge keeps native `.override.vue` extensions working
+ * on components that are *not* migrated yet. It has one entry point per extension channel.
+ *
+ * **Template channel.** One synthetic Twig override per targeted block, at the highest possible override
+ * index so it merges last. `{% parent %}` inlines the block body — including every legacy plugin override
+ * already merged into it — into the wrapper's `#parent` slot, which keeps the stacking order intact:
+ * default → Twig overrides → native extensions.
+ *
+ * **Setup channel.** The Options API base is converted into a component whose state runs through
+ * `createExtendableSetup()`, which is what makes `swDefineOverride()` apply to it.
+ */
+
+import TemplateFactory from 'src/core/factory/template.factory';
+import {
+    convertOptionsApiBaseToExtendableSetup,
+    getOptionsApiBaseConversionBlocker,
+} from 'src/app/adapter/options-composition-shim';
+import type { ComponentConfig } from 'src/core/factory/async-component.factory';
+import { getNativeBlockExtensionTargets, hasNativeSetupExtensionTarget } from './native-extension-targets';
+import { analyzeTwigTemplateBlocks } from './twig-template-blocks';
+
+/**
+ * Merges the wrapper last so it sits above every plugin override of the same block.
+ *
+ * `registerTemplateOverride` sorts by index, and no plugin can register a higher one.
+ */
+const NATIVE_BLOCK_HOST_OVERRIDE_INDEX = Number.MAX_SAFE_INTEGER;
+
+const injectedBlockHosts = new Set<string>();
+
+/**
+ * Builds the synthetic Twig override that turns one legacy block into a native extension point.
+ *
+ * `$dataScope` is the same global accessor migrated templates pass to `<sw-block name>`: on an Options
+ * API component it resolves to the instance proxy, and once the base is converted to an extendable setup
+ * (the bridge's setup channel) it resolves to the real data scope including override-local state.
+ *
+ * @example
+ * createNativeBlockHostOverride('sw_product_detail_base');
+ */
+function createNativeBlockHostOverride(blockName: string): string {
+    return (
+        `{% block ${blockName} %}` +
+        `<sw-native-block-host name="${blockName}" :data="$dataScope">` +
+        `<template #parent>{% parent %}</template>` +
+        `</sw-native-block-host>` +
+        `{% endblock %}`
+    );
+}
+
+/**
+ * Represents one entry of `TemplateFactory`'s raw template registry.
+ *
+ * @example
+ * const entry = TemplateFactory.getTemplateRegistry().get('sw-product-detail');
+ */
+type TwigTemplateRegistryEntry = {
+    name: string;
+    raw?: string | null;
+    extend?: string | null;
+    overrides?: { raw?: string | null }[];
+};
+
+/**
+ * Cheap pre-filter deciding whether a raw template is worth parsing.
+ *
+ * The bridge runs for every built component, but only a handful of them own a targeted block. A plain
+ * substring scan over the raw template rules the rest out before the TwigJS and DOM parses, which is what
+ * keeps the bridge off the boot path of a shop whose extensions target a few blocks.
+ *
+ * A false positive (the name appears in an attribute or a comment) only means the template is parsed;
+ * `collectBlockNames` still decides what actually gets a wrapper.
+ *
+ * @example
+ * mentionsTargetedBlock(entry.raw, targetBlockNames);
+ */
+function mentionsTargetedBlock(rawTemplate: string, targetBlockNames: ReadonlySet<string>): boolean {
+    return Array.from(targetBlockNames).some((blockName) => rawTemplate.includes(blockName));
+}
+
+/**
+ * Registers the wrappers one raw template needs.
+ *
+ * Both the template and its registered Twig overrides are analyzed for conditional chains: an override
+ * may well be the half that pulls a block's content into a chain the base template alone does not show.
+ *
+ * @example
+ * injectNativeBlockHostsForTemplate(entry, targetBlockNames);
+ */
+function injectNativeBlockHostsForTemplate(entry: TwigTemplateRegistryEntry, targetBlockNames: ReadonlySet<string>): void {
+    if (typeof entry.raw !== 'string' || !mentionsTargetedBlock(entry.raw, targetBlockNames)) {
+        return;
+    }
+
+    const analysis = analyzeTwigTemplateBlocks(entry.name, entry.raw);
+
+    (entry.overrides ?? []).forEach((override) => {
+        if (typeof override.raw !== 'string' || override.raw.length === 0) {
+            return;
+        }
+
+        analyzeTwigTemplateBlocks(entry.name, override.raw).unsafeBlockNames.forEach((blockName) => {
+            analysis.unsafeBlockNames.add(blockName);
+        });
+    });
+
+    analysis.blockNames.forEach((blockName) => {
+        if (!targetBlockNames.has(blockName)) {
+            return;
+        }
+
+        const injectionKey = `${entry.name}:${blockName}`;
+
+        // A template is rendered more than once per session (the factory can mark templates as
+        // unresolved and rebuild, and every extending component re-resolves its ancestors), so without
+        // this guard the same wrapper would stack and nest.
+        if (injectedBlockHosts.has(injectionKey)) {
+            return;
+        }
+
+        if (analysis.unsafeBlockNames.has(blockName)) {
+            injectedBlockHosts.add(injectionKey);
+            console.error(
+                `[sw-native-block-host] Block "${blockName}" in component "${entry.name}" takes part in a ` +
+                    `v-if/v-else chain that crosses its block boundary. Native extensions for this block are ` +
+                    `not applied. Migrate the component to <sw-block name="${blockName}"> or move the whole ` +
+                    `conditional chain into a single block.`,
+            );
+
+            return;
+        }
+
+        injectedBlockHosts.add(injectionKey);
+        TemplateFactory.registerTemplateOverride(
+            entry.name,
+            createNativeBlockHostOverride(blockName),
+            NATIVE_BLOCK_HOST_OVERRIDE_INDEX,
+        );
+    });
+}
+
+/**
+ * @private
+ *
+ * Registers a `sw-native-block-host` wrapper for every targeted block of one component and its template
+ * extension chain.
+ *
+ * Called once a component's own template and overrides are registered but before the Twig merge renders
+ * it - the only window in which a synthetic override can still take part. The extension chain is walked
+ * too: a component inherits the blocks of the template it extends, and the merge reads the extended
+ * component's *resolved* tokens, so the ancestor needs its wrapper before the child renders.
+ *
+ * @example
+ * injectNativeBlockHostsForComponent('sw-product-detail');
+ */
+export function injectNativeBlockHostsForComponent(componentName: string): void {
+    const targetBlockNames = getNativeBlockExtensionTargets();
+
+    if (targetBlockNames.size === 0) {
+        return;
+    }
+
+    const templateRegistry = TemplateFactory.getTemplateRegistry() as Map<string, TwigTemplateRegistryEntry>;
+    const visited = new Set<string>();
+    let entry = templateRegistry.get(componentName);
+
+    while (entry && !visited.has(entry.name)) {
+        visited.add(entry.name);
+        injectNativeBlockHostsForTemplate(entry, targetBlockNames);
+        entry = entry.extend ? templateRegistry.get(entry.extend) : undefined;
+    }
+}
+
+/**
+ * @private
+ *
+ * Registers the wrappers for every template known to the registry.
+ *
+ * Components are built lazily, so this pass only sees the templates registered up front; the per
+ * component pass above covers the rest. Running both is safe - the injection key guards against
+ * registering a wrapper twice.
+ *
+ * @example
+ * injectNativeBlockHosts();
+ */
+export function injectNativeBlockHosts(): void {
+    const targetBlockNames = getNativeBlockExtensionTargets();
+
+    if (targetBlockNames.size === 0) {
+        return;
+    }
+
+    const templateRegistry = TemplateFactory.getTemplateRegistry() as Map<string, TwigTemplateRegistryEntry>;
+
+    Array.from(templateRegistry.values()).forEach((entry) => {
+        injectNativeBlockHostsForTemplate(entry, targetBlockNames);
+    });
+}
+
+/**
+ * @private
+ *
+ * Clears the record of already-injected wrappers. Test teardown only.
+ *
+ * @example
+ * resetNativeBlockHosts();
+ */
+export function resetNativeBlockHosts(): void {
+    injectedBlockHosts.clear();
+}
+
+/**
+ * @private
+ *
+ * Makes an Options API base component extendable when a native `.override.vue` registers setup state for
+ * it.
+ *
+ * This is the bridge's second channel: the template channel (above) gives a native extension its
+ * rendering position, this one gives it the base's setup state - the point at which `swDefineOverride()`,
+ * `useSwPreviousState()` and override-local `__swOverride` bindings start working on a component that was
+ * never migrated. Once the base runs through `createExtendableSetup()`, `$dataScope` also resolves to the
+ * real data scope, so the injected `sw-native-block-host` picks it up without any extra wiring.
+ *
+ * Returns the config unchanged whenever the conversion does not apply or fails: a plugin override must
+ * never take a core screen down with it.
+ *
+ * @example
+ * config = bridgeNativeSetupExtensions('sw-product-detail', config);
+ */
+export function bridgeNativeSetupExtensions(componentName: string, config: ComponentConfig): ComponentConfig {
+    if (!hasNativeSetupExtensionTarget(componentName)) {
+        return config;
+    }
+
+    // Already a Composition API component: either a native setup SFC, which is extendable by
+    // construction, or a hand-written setup() the conversion has nothing to say about.
+    if (typeof config.setup === 'function') {
+        return config;
+    }
+
+    const blocker = getOptionsApiBaseConversionBlocker(config);
+
+    if (blocker) {
+        console.error(
+            `[sw-native-setup-bridge] Component "${componentName}" cannot be made extendable because ${blocker}. ` +
+                `Native setup extensions for this component are not applied. Template extensions ` +
+                `(<sw-block extends="...">) are unaffected.`,
+        );
+
+        return config;
+    }
+
+    try {
+        return convertOptionsApiBaseToExtendableSetup(componentName, config);
+    } catch (error) {
+        console.error(
+            `[sw-native-setup-bridge] Converting component "${componentName}" into an extendable setup ` +
+                `component failed. The unconverted component is used instead, so native setup extensions ` +
+                `for it are not applied.`,
+            error,
+        );
+
+        return config;
+    }
+}

--- a/src/Administration/Resources/app/administration/src/core/factory/transform-legacy-block-conditionals.ts
+++ b/src/Administration/Resources/app/administration/src/core/factory/transform-legacy-block-conditionals.ts
@@ -324,8 +324,10 @@ function escapeDoubleQuotedAttributeValue(value: string): string {
  *
  * @example
  * normalizeSelfClosingTags('<sw-field />');
+ *
+ * @private
  */
-function normalizeSelfClosingTags(template: string): string {
+export function normalizeSelfClosingTags(template: string): string {
     return template.replace(SELF_CLOSING_TAG_REG_EXP, (match, tagName: string, attributes: string = '') => {
         const trimmedAttributes = attributes.trim();
         const normalizedAttributes = trimmedAttributes.length > 0 ? ` ${trimmedAttributes}` : '';

--- a/src/Administration/Resources/app/administration/src/core/factory/twig-template-blocks.spec.ts
+++ b/src/Administration/Resources/app/administration/src/core/factory/twig-template-blocks.spec.ts
@@ -1,0 +1,111 @@
+/**
+ * @sw-package framework
+ */
+
+import { analyzeTwigTemplateBlocks } from 'src/core/factory/twig-template-blocks';
+
+describe('core/factory/twig-template-blocks.ts', () => {
+    describe('analyzeTwigTemplateBlocks', () => {
+        it('collects top-level and nested block names', () => {
+            const analysis = analyzeTwigTemplateBlocks(
+                'sw-product-detail',
+                `{% block outer %}<div>{% block inner %}<span></span>{% endblock %}</div>{% endblock %}`,
+            );
+
+            expect(analysis.blockNames).toEqual([
+                'outer',
+                'inner',
+            ]);
+        });
+
+        it('reports no unsafe blocks for a conditional chain that stays inside one block', () => {
+            const analysis = analyzeTwigTemplateBlocks(
+                'sw-product-detail',
+                `{% block only %}<div v-if="a"></div><div v-else></div>{% endblock %}`,
+            );
+
+            expect(Array.from(analysis.unsafeBlockNames)).toEqual([]);
+        });
+
+        it('reports both blocks when a conditional chain crosses a block boundary', () => {
+            const analysis = analyzeTwigTemplateBlocks(
+                'sw-product-detail',
+                `{% block first %}<div v-if="a"></div>{% endblock %}{% block second %}<div v-else></div>{% endblock %}`,
+            );
+
+            expect(Array.from(analysis.unsafeBlockNames).sort()).toEqual([
+                'first',
+                'second',
+            ]);
+        });
+
+        it('reports a block whose chain continues in content outside every block', () => {
+            const analysis = analyzeTwigTemplateBlocks(
+                'sw-product-detail',
+                `<div><div v-if="a"></div>{% block tail %}<div v-else></div>{% endblock %}</div>`,
+            );
+
+            expect(Array.from(analysis.unsafeBlockNames)).toEqual(['tail']);
+        });
+
+        it('reports a nested block that continues its parent block chain', () => {
+            const analysis = analyzeTwigTemplateBlocks(
+                'sw-product-detail',
+                `{% block outer %}<div v-if="a"></div>{% block inner %}<div v-else></div>{% endblock %}{% endblock %}`,
+            );
+
+            expect(Array.from(analysis.unsafeBlockNames).sort()).toEqual([
+                'inner',
+                'outer',
+            ]);
+        });
+
+        it('keeps a deeply nested chain that stays inside one block safe', () => {
+            const analysis = analyzeTwigTemplateBlocks(
+                'sw-product-detail',
+                `{% block only %}<div><span v-if="a"></span><span v-else-if="b"></span><span v-else></span></div>{% endblock %}`,
+            );
+
+            expect(Array.from(analysis.unsafeBlockNames)).toEqual([]);
+        });
+
+        it('reports an empty block that sits between two cases of a chain', () => {
+            const analysis = analyzeTwigTemplateBlocks(
+                'sw-product-detail',
+                `<div><div v-if="a"></div>{% block gap %}{% endblock %}<div v-else></div></div>`,
+            );
+
+            expect(Array.from(analysis.unsafeBlockNames)).toEqual(['gap']);
+        });
+
+        it('keeps an empty block trailing a finished chain safe', () => {
+            const analysis = analyzeTwigTemplateBlocks(
+                'sw-product-detail',
+                `<div><div v-if="a"></div><div v-else></div>{% block tail %}{% endblock %}</div>`,
+            );
+
+            expect(Array.from(analysis.unsafeBlockNames)).toEqual([]);
+        });
+
+        it('keeps an empty block in front of a chain safe', () => {
+            const analysis = analyzeTwigTemplateBlocks(
+                'sw-product-detail',
+                `<div>{% block head %}{% endblock %}<div v-if="a"></div><div v-else></div></div>`,
+            );
+
+            expect(Array.from(analysis.unsafeBlockNames)).toEqual([]);
+        });
+
+        it('returns an empty analysis and warns for an unparsable template', () => {
+            jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+            const analysis = analyzeTwigTemplateBlocks('sw-product-detail', '{% block broken %}');
+
+            expect(analysis.blockNames).toEqual([]);
+            expect(console.warn).toHaveBeenCalledWith(
+                expect.stringContaining('Failed to parse the Twig template of "sw-product-detail"'),
+                expect.anything(),
+            );
+        });
+    });
+});

--- a/src/Administration/Resources/app/administration/src/core/factory/twig-template-blocks.ts
+++ b/src/Administration/Resources/app/administration/src/core/factory/twig-template-blocks.ts
@@ -1,0 +1,271 @@
+/**
+ * @sw-package framework
+ * @private
+ *
+ * Block analysis of legacy base templates for the Native → Twig Extension Bridge.
+ *
+ * The counterpart of `twig-block-index.ts`: that module indexes the blocks legacy *overrides* declare,
+ * this one reports the blocks a legacy *base* template owns - and which of them a `sw-native-block-host`
+ * wrapper has to stay away from.
+ *
+ * TwigJS is used as a parser only. The global TwigJS singleton is configured by `template.factory.js`
+ * (output tokens filtered, `{% parent %}` registered) before this module is first used.
+ */
+
+import Twig from 'twig';
+import reconstructInnerTemplate, { type TwigToken } from './reconstruct-twig-template';
+import { normalizeSelfClosingTags } from './transform-legacy-block-conditionals';
+
+const CONDITIONAL_ATTRIBUTES = [
+    'v-if',
+    'v-else-if',
+    'v-else',
+] as const;
+
+/**
+ * Pairs a rendered element with the block that owns it.
+ *
+ * `blockName` is `null` for content that sits outside every `{% block %}` of the analyzed template.
+ * `isBlockPlaceholder` marks an empty block, which contributes no element of its own but still occupies a
+ * position - wrapping it would insert a component tag there.
+ *
+ * @example
+ * const owned: OwnedElement = { element, blockName: 'sw_product_detail_base' };
+ */
+type OwnedElement = {
+    element: Element;
+    blockName: string | null;
+    isBlockPlaceholder?: boolean;
+};
+
+/**
+ * Parses a raw Twig template into its token tree.
+ *
+ * Returns `null` for templates TwigJS cannot parse; the normal template pipeline surfaces the error
+ * again later, so the bridge only has to opt out.
+ *
+ * @example
+ * const tokens = parseTwigTokens('sw-product-detail', rawTemplate);
+ */
+function parseTwigTokens(componentName: string, rawTemplate: string): TwigToken[] | null {
+    try {
+        return Twig.twig({ data: rawTemplate, rethrow: true }).tokens as TwigToken[];
+    } catch (error) {
+        console.warn(`[sw-native-block-host] Failed to parse the Twig template of "${componentName}":`, error);
+
+        return null;
+    }
+}
+
+/**
+ * Collects every `{% block %}` name declared anywhere in a token tree.
+ *
+ * Nested blocks count as owned too: the bridge can wrap them independently of their parent block.
+ *
+ * @example
+ * const names = collectBlockNames(tokens);
+ */
+function collectBlockNames(tokens: TwigToken[]): string[] {
+    return tokens.flatMap((token) => {
+        if (token.type !== 'logic' || token.token?.blockName === undefined) {
+            return [];
+        }
+
+        return [
+            token.token.blockName,
+            ...collectBlockNames(token.token.output ?? []),
+        ];
+    });
+}
+
+/**
+ * Checks whether an element carries any Vue conditional directive.
+ *
+ * @example
+ * isConditional(element);
+ */
+function isConditional(element: Element): boolean {
+    return CONDITIONAL_ATTRIBUTES.some((attribute) => element.hasAttribute(attribute));
+}
+
+/**
+ * Flattens one element list so `{% block %}` boundaries become transparent.
+ *
+ * `reconstructInnerTemplate` renders every block as `<sw-block name="...">`, so splicing those children
+ * into their parent's list reproduces the element sequence Vue will actually compile — which is what
+ * decides whether a `v-if` chain crosses a block boundary.
+ *
+ * @example
+ * const owned = flattenBlockBoundaries(root.children, null);
+ */
+function flattenBlockBoundaries(elements: HTMLCollection | Element[], blockName: string | null): OwnedElement[] {
+    return Array.from(elements).flatMap((element) => {
+        const ownBlockName = element.tagName.toLowerCase() === 'sw-block' ? element.getAttribute('name') : null;
+
+        if (ownBlockName !== null) {
+            const nested = flattenBlockBoundaries(element.children, ownBlockName);
+
+            // An empty block still holds a position between its siblings, so it stays in the list as a
+            // placeholder; dropping it would hide a chain that a wrapper for it would break.
+            return nested.length > 0
+                ? nested
+                : [
+                      {
+                          element,
+                          blockName: ownBlockName,
+                          isBlockPlaceholder: true,
+                      },
+                  ];
+        }
+
+        return [
+            {
+                element,
+                blockName,
+            },
+        ];
+    });
+}
+
+/**
+ * Records every block whose content shares a conditional chain with content it does not own.
+ *
+ * Wrapping such a block would put a component tag between a `v-if` and its `v-else`, which Vue rejects at
+ * template-compile time — so the bridge has to leave those blocks alone.
+ *
+ * @example
+ * collectCrossingChains(owned, unsafeBlockNames);
+ */
+function collectCrossingChains(owned: OwnedElement[], unsafeBlockNames: Set<string>): void {
+    let chainOwners = new Set<string | null>();
+    // Empty blocks seen since the last chain member. They only matter once another case joins the chain
+    // behind them - an empty block trailing a finished chain is harmless to wrap.
+    let pendingPlaceholders: (string | null)[] = [];
+
+    const closeChain = (): void => {
+        if (chainOwners.size > 1) {
+            chainOwners.forEach((blockName) => {
+                if (blockName !== null) {
+                    unsafeBlockNames.add(blockName);
+                }
+            });
+        }
+
+        chainOwners = new Set<string | null>();
+        pendingPlaceholders = [];
+    };
+
+    owned.forEach((entry) => {
+        if (entry.isBlockPlaceholder) {
+            if (chainOwners.size > 0) {
+                pendingPlaceholders.push(entry.blockName);
+            }
+
+            return;
+        }
+
+        if (!isConditional(entry.element)) {
+            closeChain();
+
+            return;
+        }
+
+        if (entry.element.hasAttribute('v-if')) {
+            closeChain();
+        }
+
+        pendingPlaceholders.forEach((blockName) => chainOwners.add(blockName));
+        pendingPlaceholders = [];
+        chainOwners.add(entry.blockName);
+    });
+
+    closeChain();
+}
+
+/**
+ * Walks the parsed template and reports every block that cannot be wrapped safely.
+ *
+ * `blockName` is the block owning `parent`'s direct children, which the flattening step then refines per
+ * element as nested `{% block %}` markers are resolved.
+ *
+ * @example
+ * collectUnsafeBlockNamesFromElements(root, null, unsafeBlockNames);
+ */
+function collectUnsafeBlockNamesFromElements(
+    parent: Element | DocumentFragment,
+    blockName: string | null,
+    unsafeBlockNames: Set<string>,
+): void {
+    const owned = flattenBlockBoundaries(parent.children, blockName);
+
+    collectCrossingChains(owned, unsafeBlockNames);
+
+    owned.forEach((entry) => {
+        collectUnsafeBlockNamesFromElements(entry.element, entry.blockName, unsafeBlockNames);
+    });
+}
+
+/**
+ * @private
+ *
+ * Reports the blocks of one raw Twig template whose content takes part in a conditional chain that
+ * crosses the block boundary.
+ *
+ * Runs on the DOM parser, so it is a no-op outside a browser environment — the bridge then treats every
+ * block as unsafe rather than emitting a wrapper it cannot validate.
+ *
+ * @example
+ * const unsafe = collectUnsafeBlockNames(tokens);
+ */
+export function collectUnsafeBlockNames(tokens: TwigToken[]): Set<string> {
+    const unsafeBlockNames = new Set<string>();
+    const template = reconstructInnerTemplate(tokens);
+
+    if (typeof document === 'undefined') {
+        collectBlockNames(tokens).forEach((blockName) => unsafeBlockNames.add(blockName));
+
+        return unsafeBlockNames;
+    }
+
+    const parsedTemplate = document.createElement('template');
+    parsedTemplate.innerHTML = normalizeSelfClosingTags(template);
+
+    collectUnsafeBlockNamesFromElements(parsedTemplate.content, null, unsafeBlockNames);
+
+    return unsafeBlockNames;
+}
+
+/**
+ * Describes the blocks one raw Twig template owns, plus the ones no wrapper may touch.
+ *
+ * @example
+ * const analysis: TwigTemplateBlockAnalysis = { blockNames: ['sw_card'], unsafeBlockNames: new Set() };
+ */
+type TwigTemplateBlockAnalysis = {
+    blockNames: string[];
+    unsafeBlockNames: Set<string>;
+};
+
+/**
+ * @private
+ *
+ * Parses one raw Twig template into its owned block names plus the subset that cannot be wrapped.
+ *
+ * @example
+ * const analysis = analyzeTwigTemplateBlocks('sw-product-detail', rawTemplate);
+ */
+export function analyzeTwigTemplateBlocks(componentName: string, rawTemplate: string): TwigTemplateBlockAnalysis {
+    const tokens = parseTwigTokens(componentName, rawTemplate);
+
+    if (!tokens) {
+        return {
+            blockNames: [],
+            unsafeBlockNames: new Set<string>(),
+        };
+    }
+
+    return {
+        blockNames: collectBlockNames(tokens),
+        unsafeBlockNames: collectUnsafeBlockNames(tokens),
+    };
+}

--- a/src/Administration/Resources/app/administration/src/core/shopware.ts
+++ b/src/Administration/Resources/app/administration/src/core/shopware.ts
@@ -48,6 +48,7 @@ import {
     createExtendableSetup,
     overrideComponentSetup,
 } from 'src/app/adapter/composition-extension-system';
+import { registerNativeExtensionTargets } from 'src/core/factory/native-extension-targets';
 import * as Vue from 'vue';
 import type { DefineComponent, Ref } from 'vue';
 import CMS from '../module/sw-cms/constant/sw-cms.constant';
@@ -146,6 +147,16 @@ class ShopwareClass implements CustomShopwareProperties {
         createExtendableSetup: createExtendableSetup,
         attachOverrides: attachOverrides,
         overrideComponentSetup: overrideComponentSetup,
+
+        /**
+         * @private
+         *
+         * Boot-time announcement of what a generated override SFC extends, emitted into a module-scope
+         * `<script>` block by the native setup transform. Runs while plugin entries are imported, which
+         * is before the Twig templates are merged - the point where the bridge has to know its targets.
+         * Not for author use.
+         */
+        registerNativeExtensionTargets: registerNativeExtensionTargets,
 
         /**
          * @private


### PR DESCRIPTION
### 1. Why is this change necessary?

Currently it is not possible to use the Vue 3 single file components with the composition api inside extensions to extend twig blocks inside admin core components which are not migrated to SFCs yet.

### 2. What does this change do, exactly?

It introduces a bridge from native vue extensions to twig options api components.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).

