### PR TITLE
fix(administration): keep services page usable without registry

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-settings-services/component/sw-settings-services-hero/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-services/component/sw-settings-services-hero/index.ts
@@ -21,11 +21,11 @@ export default Shopware.Component.wrapComponentConfig({
     props: {
         feedbackLink: {
             type: String,
-            required: true,
+            default: '',
         },
         documentationLink: {
             type: String,
-            required: true,
+            default: '',
         },
     },
 

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-services/component/sw-settings-services-hero/sw-settings-services-hero.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-services/component/sw-settings-services-hero/sw-settings-services-hero.html.twig
@@ -73,6 +73,7 @@
 
             <div class="sw-settings-services-hero__actions">
                 <mt-button
+                    v-if="feedbackLink"
                     variant="secondary"
                     :link="feedbackLink"
                 >
@@ -87,6 +88,7 @@
                 </mt-button>
 
                 <mt-link
+                    v-if="documentationLink"
                     as="a"
                     target="_blank"
                     rel="noopener noreferrer"

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-services/page/sw-settings-services-index/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-services/page/sw-settings-services-index/index.ts
@@ -21,6 +21,7 @@ type SwSettingsPageData = {
     services: ServiceDescription[];
     suspended: boolean;
     loadingError: string;
+    registryError: boolean;
 };
 
 /**
@@ -52,6 +53,7 @@ export default Shopware.Component.wrapComponentConfig({
             services: [],
             suspended: true,
             loadingError: '',
+            registryError: false,
         };
     },
 
@@ -61,6 +63,12 @@ export default Shopware.Component.wrapComponentConfig({
             'currentRevision',
             'consentGiven',
         ]),
+        documentationLink(): string {
+            return this.currentRevision?.links['docs-url'] ?? '';
+        },
+        feedbackLink(): string {
+            return this.currentRevision?.links['feedback-url'] ?? '';
+        },
         servicesWithAccountRequirement(): ServiceWithShopwareAccountRequirement[] {
             return getServicesWithShopwareAccountRequirement(this.services);
         },
@@ -77,11 +85,6 @@ export default Shopware.Component.wrapComponentConfig({
             shopwareServicesService.getServicesContext().then((servicesConsent) => {
                 shopwareServicesStore.config = servicesConsent;
             }),
-            serviceRegistryClient
-                .getCurrentRevision(sessionStore.currentLocale.value ?? 'en-GB')
-                .then((serviceRevisions) => {
-                    shopwareServicesStore.revisions = serviceRevisions;
-                }),
         ])
             .then(() => {
                 this.suspended = false;
@@ -95,9 +98,24 @@ export default Shopware.Component.wrapComponentConfig({
                     message: errorMessage,
                 });
             });
+
+        void this.loadServiceRegistry(serviceRegistryClient, sessionStore.currentLocale.value ?? 'en-GB');
     },
 
     methods: {
+        async loadServiceRegistry(
+            serviceRegistryClient = Shopware.Service('serviceRegistryClient'),
+            locale = useSession().currentLocale.value ?? 'en-GB',
+        ) {
+            try {
+                this.registryError = false;
+                useShopwareServicesStore().revisions = await serviceRegistryClient.getCurrentRevision(locale);
+            } catch {
+                // Registry metadata is only required for links and permission consent. Keep local service management usable.
+                this.registryError = true;
+            }
+        },
+
         async activateServices() {
             try {
                 const shopwareServicesService = Shopware.Service('shopwareServicesService');

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-services/page/sw-settings-services-index/sw-settings-services-index.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-services/page/sw-settings-services-index/sw-settings-services-index.html.twig
@@ -56,6 +56,7 @@
 
                     <mt-button
                         size="small"
+                        secondary
                         @click="loadServiceRegistry"
                     >
                         {{ $t('sw-settings-services.exception.retry') }}

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-services/page/sw-settings-services-index/sw-settings-services-index.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-services/page/sw-settings-services-index/sw-settings-services-index.html.twig
@@ -19,8 +19,8 @@
         />
 
         <sw-settings-services-hero
-            :documentation-link="currentRevision.links['docs-url']"
-            :feedback-link="currentRevision.links['feedback-url']"
+            :documentation-link="documentationLink"
+            :feedback-link="feedbackLink"
         />
 
         <sw-extension-component-section
@@ -29,7 +29,7 @@
 
         <div class="sw-settings-services-index__content">
             <sw-settings-services-grant-permissions-card
-                v-if="!consentGiven && !config.disabled && services.length > 0"
+                v-if="currentRevision && !consentGiven && !config.disabled && services.length > 0"
                 :docs-link="currentRevision.links['docs-url']"
             />
 
@@ -45,6 +45,21 @@
                     <p><b>{{ $t('sw-settings-services.exception.service-list') }}</b></p>
 
                     <p>{{ loadingError }}</p>
+                </mt-banner>
+
+                <mt-banner
+                    v-if="registryError"
+                    class="sw-settings-services-index__registry-error"
+                    variant="attention"
+                >
+                    <p>{{ $t('sw-settings-services.exception.service-registry') }}</p>
+
+                    <mt-button
+                        size="small"
+                        @click="loadServiceRegistry"
+                    >
+                        {{ $t('sw-settings-services.exception.retry') }}
+                    </mt-button>
                 </mt-banner>
 
                 <mt-banner
@@ -93,21 +108,23 @@
             </div>
 
             <div class="sw-settings-services__footer">
-                <a
-                    class="mt-link--external"
-                    :href="currentRevision.links['docs-url']"
-                    target="_blank"
-                >
-                    {{ $t('sw-settings-services.index.label-documentation-link') }}
-                </a>
+                <template v-if="currentRevision">
+                    <a
+                        class="mt-link--external"
+                        :href="currentRevision.links['docs-url']"
+                        target="_blank"
+                    >
+                        {{ $t('sw-settings-services.index.label-documentation-link') }}
+                    </a>
 
-                <a
-                    class="mt-link--external"
-                    :href="currentRevision.links['tos-url']"
-                    target="_blank"
-                >
-                    {{ $t('sw-settings-services.index.label-tos-link') }}
-                </a>
+                    <a
+                        class="mt-link--external"
+                        :href="currentRevision.links['tos-url']"
+                        target="_blank"
+                    >
+                        {{ $t('sw-settings-services.index.label-tos-link') }}
+                    </a>
+                </template>
 
                 <sw-settings-services-revoke-permissions-modal
                     v-if="!config.disabled && config.permissionsConsent"
@@ -117,7 +134,7 @@
                 <sw-settings-services-deactivate-modal
                     v-if="!config.disabled"
                     :services-with-account-requirement="servicesWithAccountRequirement"
-                    :feedback-link="currentRevision.links['feedback-url']"
+                    :feedback-link="feedbackLink"
                 />
             </div>
         </div>

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-services/page/sw-settings-services-index/sw-settings-services-index.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-services/page/sw-settings-services-index/sw-settings-services-index.spec.js
@@ -300,7 +300,7 @@ describe('/src/module/sw-setting-services/page/sw-settings-services-index', () =
         const page = await mountPage();
         await flushPromises();
 
-        expect(page.getComponent(SwSettingsServicesHero).text()).toContain('Future proof your store with Shopware Services');
+        expect(page.findComponent(SwSettingsServicesHero).exists()).toBe(true);
         expect(page.find('.sw-settings-services-index__registry-error').exists()).toBe(true);
         expect(page.findComponent(SwSettingsServicesGrantPermissionsCard).exists()).toBe(false);
         expect(page.findAll('sw-settings-services-service-card-stub')).toHaveLength(2);

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-services/page/sw-settings-services-index/sw-settings-services-index.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-services/page/sw-settings-services-index/sw-settings-services-index.spec.js
@@ -291,4 +291,18 @@ describe('/src/module/sw-setting-services/page/sw-settings-services-index', () =
         expect(errorBanner.props('variant')).toBe('critical');
         expect(errorBanner.text()).toContain('failed loading services');
     });
+
+    it('keeps local service management available when registry metadata cannot be loaded', async () => {
+        Shopware.Service('serviceRegistryClient').getCurrentRevision.mockRejectedValueOnce(
+            new Error('failed loading registry metadata'),
+        );
+
+        const page = await mountPage();
+        await flushPromises();
+
+        expect(page.getComponent(SwSettingsServicesHero).text()).toContain('Future proof your store with Shopware Services');
+        expect(page.find('.sw-settings-services-index__registry-error').exists()).toBe(true);
+        expect(page.findComponent(SwSettingsServicesGrantPermissionsCard).exists()).toBe(false);
+        expect(page.findAll('sw-settings-services-service-card-stub')).toHaveLength(2);
+    });
 });

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-services/snippet/de.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-services/snippet/de.json
@@ -7,7 +7,9 @@
       "deactivate": "Deaktivieren"
     },
     "exception": {
-      "service-list": "Fehler beim Laden der Services"
+      "service-list": "Fehler beim Laden der Services",
+      "service-registry": "Einige Informationen zu Shopware Services konnten nicht geladen werden. Du kannst Deine installierten Services weiterhin verwalten.",
+      "retry": "Erneut versuchen"
     },
     "sw-settings-services-hero": {
       "title": "Mach Deinen Shop zukunftssicher mit Shopware Services",

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-services/snippet/en.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-services/snippet/en.json
@@ -7,7 +7,9 @@
       "deactivate": "Deactivate"
     },
     "exception": {
-      "service-list": "Error loading services"
+      "service-list": "Error loading services",
+      "service-registry": "Some Shopware Services information could not be loaded. You can continue managing your installed services.",
+      "retry": "Retry"
     },
     "sw-settings-services-hero": {
       "title": "Future proof your store with Shopware Services",

--- a/tests/acceptance/tests/Settings/ShopwareServices.spec.ts
+++ b/tests/acceptance/tests/Settings/ShopwareServices.spec.ts
@@ -1,6 +1,26 @@
 import { test } from '@fixtures/AcceptanceTest';
 import { satisfies } from 'compare-versions';
-import { expect } from '@playwright/test';
+import { expect, Page } from '@playwright/test';
+
+const servicesDashboardBannerConfig = {
+    'core.hide-services-dashboard-banner': [false],
+};
+
+async function showServicesDashboardBanner(page: Page): Promise<void> {
+    await page.evaluate(async (config) => {
+        const response = await fetch('/api/_info/config-me', {
+            method: 'PATCH',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify(config),
+        });
+
+        if (!response.ok) {
+            throw new Error(`Failed to reset the Shopware Services dashboard banner: ${response.status}`);
+        }
+    }, servicesDashboardBannerConfig);
+}
 
 test.describe('Shopware Services', () => {
     test.describe.configure({ mode: 'serial' });
@@ -14,6 +34,7 @@ test.describe('Shopware Services', () => {
         initialServicesState = await AdminShopwareServices.deactivateServicesButton
             .isVisible({ timeout: 5000 })
             .catch(() => false);
+        await showServicesDashboardBanner(AdminShopwareServices.page);
     });
 
     test.afterAll(async ({ ShopAdmin, AdminShopwareServices, InstanceMeta }) => {
@@ -37,6 +58,8 @@ test.describe('Shopware Services', () => {
                         timeout: 15000,
                     });
                 }
+
+                await showServicesDashboardBanner(AdminShopwareServices.page);
             } catch (error) {
                 console.error('Failed to restore Shopware Services state:', error);
             }

--- a/tests/acceptance/tests/Settings/ShopwareServices.spec.ts
+++ b/tests/acceptance/tests/Settings/ShopwareServices.spec.ts
@@ -8,17 +8,7 @@ const servicesDashboardBannerConfig = {
 
 async function showServicesDashboardBanner(page: Page): Promise<void> {
     await page.evaluate(async (config) => {
-        const response = await fetch('/api/_info/config-me', {
-            method: 'PATCH',
-            headers: {
-                'Content-Type': 'application/json',
-            },
-            body: JSON.stringify(config),
-        });
-
-        if (!response.ok) {
-            throw new Error(`Failed to reset the Shopware Services dashboard banner: ${response.status}`);
-        }
+        await Shopware.Service('userConfigService').upsert(config);
     }, servicesDashboardBannerConfig);
 }
 


### PR DESCRIPTION
### 1. Why is this change necessary?

A Shopware Services page visit waits for the external permission-revision registry together with local service data. When that external request is unavailable or slow, the page remains empty although local service management is available.

The acceptance test also persists its dashboard-banner dismissal for the shared primary admin, allowing later executions to start with the banner hidden.

### 2. What does this change do, exactly?

It makes local service/configuration data the page readiness boundary and loads registry metadata independently. The page stays usable when registry metadata is unavailable, shows a retry banner, and withholds only revision-dependent links and permission actions.

The Services acceptance spec explicitly resets the primary admin’s banner preference before and after its serial scenarios.

Focused Administration and ATS lint checks pass. The focused Jest regression test is included but could not execute locally because the clean worktree lacks the generated Administration entity-schema fixture.

### 3. Describe each step to reproduce the issue or behaviour.

1. Block or delay the request to `registry.services.shopware.io/api/service/permission-revisions`.
2. Open the Shopware Services page in Administration.
3. Before this change, its content stays empty because `suspended` is never cleared.
4. With this change, installed services remain visible and registry-dependent actions display a retry state.

### 4. Please link to the relevant issues (if any).

- None

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them