### PR TITLE
chore: prepare removal of document_type

### DIFF
--- a/src/Core/Checkout/Document/Aggregate/DocumentBaseConfig/DocumentBaseConfigDefinition.php
+++ b/src/Core/Checkout/Document/Aggregate/DocumentBaseConfig/DocumentBaseConfigDefinition.php
@@ -70,7 +70,6 @@ class DocumentBaseConfigDefinition extends EntityDefinition
         return new FieldCollection([
             (new IdField('id', 'id'))->addFlags(new ApiAware(), new PrimaryKey(), new Required())->setDescription('Unique identity of the document base config.'),
 
-            (new FkField('document_type_id', 'documentTypeId', DocumentTypeDefinition::class))->addFlags(new ApiAware(), new Required())->setDescription('Unique identity of the document type.'),
             (new StringField('type_name', 'typeName'))->addFlags(new ApiAware())->setDescription('Technical name of the document type.'),
             (new FkField('logo_id', 'logoId', MediaDefinition::class))->addFlags(new ApiAware())->setDescription('Unique identity of the company logo.'),
 
@@ -92,11 +91,12 @@ class DocumentBaseConfigDefinition extends EntityDefinition
             (new CustomFields())->addFlags(new ApiAware())->setDescription('Additional fields that offer a possibility to add own fields for the different program-areas.'),
             (new CreatedAtField())->addFlags(new ApiAware()),
 
-            new ManyToOneAssociationField('documentType', 'document_type_id', DocumentTypeDefinition::class, 'id'),
             (new ManyToOneAssociationField('logo', 'logo_id', MediaDefinition::class, 'id'))->addFlags(new ApiAware())->setDescription('Logo in the document at the top-right corner.'),
             (new OneToManyAssociationField('salesChannels', DocumentBaseConfigSalesChannelDefinition::class, 'document_base_config_id', 'id'))->addFlags(new CascadeDelete()),
 
             (new JsonField('config', 'config'))->addFlags(new ApiAware(), new Deprecated('v6.7.11.0', 'v6.9.0.0', 'type'))->setDescription('Specifies detailed information about the component.'),
+            (new FkField('document_type_id', 'documentTypeId', DocumentTypeDefinition::class))->addFlags(new ApiAware(), new Required(), new Deprecated('v6.7.14.0', 'v6.9.0.0', 'typeName'))->setDescription('Unique identity of the document type.'),
+            (new ManyToOneAssociationField('documentType', 'document_type_id', DocumentTypeDefinition::class, 'id'))->addFlags(new Deprecated('v6.7.14.0', 'v6.9.0.0', 'typeName')),
         ]);
     }
 }

--- a/src/Core/Checkout/Document/Aggregate/DocumentBaseConfig/DocumentBaseConfigEntity.php
+++ b/src/Core/Checkout/Document/Aggregate/DocumentBaseConfig/DocumentBaseConfigEntity.php
@@ -116,11 +116,17 @@ class DocumentBaseConfigEntity extends Entity
         $this->salesChannels = $salesChannels;
     }
 
+    /**
+     * @deprecated tag:v6.9.0 reason:experimental-replacement - Will be removed. Use getTypeName() instead.
+     */
     public function getDocumentTypeId(): ?string
     {
         return $this->documentTypeId;
     }
 
+    /**
+     * @deprecated tag:v6.9.0 reason:experimental-replacement - Will be removed. Use setTypeName() instead.
+     */
     public function setDocumentTypeId(?string $documentTypeId): void
     {
         $this->documentTypeId = $documentTypeId;
@@ -156,11 +162,17 @@ class DocumentBaseConfigEntity extends Entity
         $this->global = $global;
     }
 
+    /**
+     * @deprecated tag:v6.9.0 reason:experimental-replacement - Will be removed. Use getTypeName() instead.
+     */
     public function getDocumentType(): ?DocumentTypeEntity
     {
         return $this->documentType;
     }
 
+    /**
+     * @deprecated tag:v6.9.0 reason:experimental-replacement - Will be removed. Use setTypeName() instead.
+     */
     public function setDocumentType(DocumentTypeEntity $documentType): void
     {
         $this->documentType = $documentType;

--- a/src/Core/Checkout/Document/Aggregate/DocumentBaseConfigSalesChannel/DocumentBaseConfigSalesChannelDefinition.php
+++ b/src/Core/Checkout/Document/Aggregate/DocumentBaseConfigSalesChannel/DocumentBaseConfigSalesChannelDefinition.php
@@ -7,6 +7,7 @@ use Shopware\Core\Checkout\Document\Aggregate\DocumentType\DocumentTypeDefinitio
 use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\FkField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\ApiAware;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\Deprecated;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\PrimaryKey;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\Required;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\IdField;
@@ -55,11 +56,12 @@ class DocumentBaseConfigSalesChannelDefinition extends EntityDefinition
             (new IdField('id', 'id'))->addFlags(new ApiAware(), new PrimaryKey(), new Required())->setDescription('Unique identity of document\'s base config sales channel.'),
             (new FkField('document_base_config_id', 'documentBaseConfigId', DocumentBaseConfigDefinition::class))->addFlags(new ApiAware(), new Required())->setDescription('Unique identity of document\'s base config.'),
             (new FkField('sales_channel_id', 'salesChannelId', SalesChannelDefinition::class))->addFlags(new ApiAware())->setDescription('Unique identity of sales channel.'),
-            (new FkField('document_type_id', 'documentTypeId', DocumentTypeDefinition::class))->addFlags(new ApiAware())->setDescription('Unique identity of document type.'),
             (new StringField('type_name', 'typeName'))->addFlags(new ApiAware())->setDescription('Technical name of the document type.'),
-            new ManyToOneAssociationField('documentType', 'document_type_id', DocumentTypeDefinition::class, 'id'),
             new ManyToOneAssociationField('documentBaseConfig', 'document_base_config_id', DocumentBaseConfigDefinition::class, 'id'),
             new ManyToOneAssociationField('salesChannel', 'sales_channel_id', SalesChannelDefinition::class, 'id'),
+
+            (new FkField('document_type_id', 'documentTypeId', DocumentTypeDefinition::class))->addFlags(new ApiAware(), new Deprecated('v6.7.14.0', 'v6.9.0.0', 'typeName'))->setDescription('Unique identity of document type.'),
+            (new ManyToOneAssociationField('documentType', 'document_type_id', DocumentTypeDefinition::class, 'id'))->addFlags(new Deprecated('v6.7.14.0', 'v6.9.0.0', 'typeName')),
         ]);
     }
 }

--- a/src/Core/Checkout/Document/Aggregate/DocumentBaseConfigSalesChannel/DocumentBaseConfigSalesChannelEntity.php
+++ b/src/Core/Checkout/Document/Aggregate/DocumentBaseConfigSalesChannel/DocumentBaseConfigSalesChannelEntity.php
@@ -51,11 +51,17 @@ class DocumentBaseConfigSalesChannelEntity extends Entity
         $this->salesChannelId = $salesChannelId;
     }
 
+    /**
+     * @deprecated tag:v6.9.0 reason:experimental-replacement - Will be removed. Use getTypeName() instead.
+     */
     public function getDocumentTypeId(): string
     {
         return $this->documentTypeId;
     }
 
+    /**
+     * @deprecated tag:v6.9.0 reason:experimental-replacement - Will be removed. Use setTypeName() instead.
+     */
     public function setDocumentTypeId(string $documentTypeId): void
     {
         $this->documentTypeId = $documentTypeId;
@@ -71,11 +77,17 @@ class DocumentBaseConfigSalesChannelEntity extends Entity
         $this->typeName = $typeName;
     }
 
+    /**
+     * @deprecated tag:v6.9.0 reason:experimental-replacement - Will be removed. Use getTypeName() instead.
+     */
     public function getDocumentType(): ?DocumentTypeEntity
     {
         return $this->documentType;
     }
 
+    /**
+     * @deprecated tag:v6.9.0 reason:experimental-replacement - Will be removed. Use setTypeName() instead.
+     */
     public function setDocumentType(DocumentTypeEntity $documentType): void
     {
         $this->documentType = $documentType;

--- a/src/Core/Checkout/Document/Aggregate/DocumentType/DocumentTypeCollection.php
+++ b/src/Core/Checkout/Document/Aggregate/DocumentType/DocumentTypeCollection.php
@@ -9,6 +9,8 @@ use Shopware\Core\Framework\Log\Package;
  * @extends EntityCollection<DocumentTypeEntity>
  *
  * @codeCoverageIgnore
+ *
+ * @deprecated tag:v6.9.0 reason:remove-entity - Will be removed. Use `document.type_name` instead.
  */
 #[Package('after-sales')]
 class DocumentTypeCollection extends EntityCollection

--- a/src/Core/Checkout/Document/Aggregate/DocumentType/DocumentTypeDefinition.php
+++ b/src/Core/Checkout/Document/Aggregate/DocumentType/DocumentTypeDefinition.php
@@ -22,6 +22,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @codeCoverageIgnore
+ *
+ * @deprecated tag:v6.9.0 reason:remove-entity - Will be removed. Use `document.type_name` instead.
  */
 #[Package('after-sales')]
 class DocumentTypeDefinition extends EntityDefinition

--- a/src/Core/Checkout/Document/Aggregate/DocumentType/DocumentTypeEntity.php
+++ b/src/Core/Checkout/Document/Aggregate/DocumentType/DocumentTypeEntity.php
@@ -13,6 +13,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @codeCoverageIgnore
+ *
+ * @deprecated tag:v6.9.0 reason:remove-entity - Will be removed. Use `document.type_name` instead.
  */
 #[Package('after-sales')]
 class DocumentTypeEntity extends Entity

--- a/src/Core/Checkout/Document/Aggregate/DocumentTypeTranslation/DocumentTypeTranslationCollection.php
+++ b/src/Core/Checkout/Document/Aggregate/DocumentTypeTranslation/DocumentTypeTranslationCollection.php
@@ -9,6 +9,8 @@ use Shopware\Core\Framework\Log\Package;
  * @extends EntityCollection<DocumentTypeTranslationEntity>
  *
  * @codeCoverageIgnore
+ *
+ * @deprecated tag:v6.9.0 reason:remove-entity - Will be removed
  */
 #[Package('after-sales')]
 class DocumentTypeTranslationCollection extends EntityCollection

--- a/src/Core/Checkout/Document/Aggregate/DocumentTypeTranslation/DocumentTypeTranslationDefinition.php
+++ b/src/Core/Checkout/Document/Aggregate/DocumentTypeTranslation/DocumentTypeTranslationDefinition.php
@@ -13,6 +13,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @codeCoverageIgnore
+ *
+ * @deprecated tag:v6.9.0 reason:remove-entity - Will be removed
  */
 #[Package('after-sales')]
 class DocumentTypeTranslationDefinition extends EntityTranslationDefinition

--- a/src/Core/Checkout/Document/Aggregate/DocumentTypeTranslation/DocumentTypeTranslationEntity.php
+++ b/src/Core/Checkout/Document/Aggregate/DocumentTypeTranslation/DocumentTypeTranslationEntity.php
@@ -9,6 +9,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @codeCoverageIgnore
+ *
+ * @deprecated tag:v6.9.0 reason:remove-entity - Will be removed
  */
 #[Package('after-sales')]
 class DocumentTypeTranslationEntity extends TranslationEntity

--- a/src/Core/Checkout/Document/DocumentDefinition.php
+++ b/src/Core/Checkout/Document/DocumentDefinition.php
@@ -11,6 +11,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\BoolField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\CustomFields;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\FkField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\ApiAware;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\Deprecated;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\PrimaryKey;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\Required;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\SearchRanking;
@@ -62,7 +63,6 @@ class DocumentDefinition extends EntityDefinition
         return new FieldCollection([
             (new IdField('id', 'id'))->addFlags(new ApiAware(), new PrimaryKey(), new Required()),
 
-            (new FkField('document_type_id', 'documentTypeId', DocumentTypeDefinition::class))->addFlags(new ApiAware(), new Required()),
             (new StringField('type_name', 'typeName'))->addFlags(new ApiAware())->setDescription('Technical name of the document type.'),
             (new FkField('referenced_document_id', 'referencedDocumentId', self::class))->addFlags(new ApiAware()),
 
@@ -78,13 +78,15 @@ class DocumentDefinition extends EntityDefinition
             (new NumberRangeField('document_number', 'documentNumber'))->addFlags(new ApiAware(), new SearchRanking(SearchRanking::HIGH_SEARCH_RANKING)),
             (new CustomFields())->addFlags(new ApiAware()),
 
-            (new ManyToOneAssociationField('documentType', 'document_type_id', DocumentTypeDefinition::class, 'id'))->addFlags(new ApiAware(), new SearchRanking(SearchRanking::ASSOCIATION_SEARCH_RANKING)),
             (new ManyToOneAssociationField('order', 'order_id', OrderDefinition::class, 'id', false))->addFlags(new ApiAware()),
             (new ManyToOneAssociationField('referencedDocument', 'referenced_document_id', self::class, 'id', false))->addFlags(new ApiAware()),
             (new OneToManyAssociationField('dependentDocuments', self::class, 'referenced_document_id'))->addFlags(new ApiAware()),
             (new ManyToOneAssociationField('documentMediaFile', 'document_media_file_id', MediaDefinition::class, 'id', false))->addFlags(new ApiAware()),
             (new ManyToOneAssociationField('documentA11yMediaFile', 'document_a11y_media_file_id', MediaDefinition::class, 'id', false))->addFlags(new ApiAware()),
             new OneToManyAssociationField('documentFiles', DocumentFileDefinition::class, 'document_id'),
+
+            (new FkField('document_type_id', 'documentTypeId', DocumentTypeDefinition::class))->addFlags(new ApiAware(), new Required(), new Deprecated('v6.7.14.0', 'v6.9.0.0', 'typeName')),
+            (new ManyToOneAssociationField('documentType', 'document_type_id', DocumentTypeDefinition::class, 'id'))->addFlags(new ApiAware(), new SearchRanking(SearchRanking::ASSOCIATION_SEARCH_RANKING), new Deprecated('v6.7.14.0', 'v6.9.0.0', 'typeName')),
         ]);
     }
 }

--- a/src/Core/Checkout/Document/DocumentEntity.php
+++ b/src/Core/Checkout/Document/DocumentEntity.php
@@ -130,21 +130,33 @@ class DocumentEntity extends Entity
         $this->deepLinkCode = $deepLinkCode;
     }
 
+    /**
+     * @deprecated tag:v6.9.0 reason:experimental-replacement - Will be removed. Use getTypeName() instead.
+     */
     public function getDocumentType(): ?DocumentTypeEntity
     {
         return $this->documentType;
     }
 
+    /**
+     * @deprecated tag:v6.9.0 reason:experimental-replacement - Will be removed. Use setTypeName() instead.
+     */
     public function setDocumentType(DocumentTypeEntity $documentType): void
     {
         $this->documentType = $documentType;
     }
 
+    /**
+     * @deprecated tag:v6.9.0 reason:experimental-replacement - Will be removed. Use getTypeName() instead.
+     */
     public function getDocumentTypeId(): string
     {
         return $this->documentTypeId;
     }
 
+    /**
+     * @deprecated tag:v6.9.0 reason:experimental-replacement - Will be removed. Use setTypeName() instead.
+     */
     public function setDocumentTypeId(string $documentTypeId): void
     {
         $this->documentTypeId = $documentTypeId;

--- a/src/Core/Checkout/DocumentV2/Config/DocumentConfigLoader.php
+++ b/src/Core/Checkout/DocumentV2/Config/DocumentConfigLoader.php
@@ -115,7 +115,7 @@ final class DocumentConfigLoader implements EventSubscriberInterface, ResetInter
         }
 
         $criteria = (new Criteria())
-            ->addFilter(new EqualsFilter('documentType.technicalName', $documentType))
+            ->addFilter(new EqualsFilter('typeName', $documentType))
             ->addAssociation('logo');
 
         $criteria->getAssociation('salesChannels')

--- a/src/Core/Checkout/DocumentV2/Controller/DocumentV2Controller.php
+++ b/src/Core/Checkout/DocumentV2/Controller/DocumentV2Controller.php
@@ -150,6 +150,7 @@ final class DocumentV2Controller extends AbstractController
         $documentId = Uuid::randomHex();
         $deepLinkCode = Random::getAlphanumericString(32);
         $mediaId = $payload->getString('mediaId');
+        $documentNumber = $payload->getString('documentNumber');
 
         if ($mediaId === '') {
             $mediaId = $context->scope(
@@ -174,20 +175,23 @@ final class DocumentV2Controller extends AbstractController
             );
         }
 
-        $this->documentRepository->create([
-            [
-                'id' => $documentId,
-                'orderId' => $this->requirePayloadString($payload, 'orderId'),
-                'orderVersionId' => $this->requirePayloadString($payload, 'orderVersionId'),
-                'documentTypeId' => $this->getDocumentTypeId($documentType, $context),
-                'documentMediaFileId' => $mediaId,
-                'static' => true,
-                'deepLinkCode' => $deepLinkCode,
-                'config' => [
-                    'documentNumber' => $payload->getString('documentNumber'),
-                ],
-            ],
-        ], $context);
+        $document = [
+            'id' => $documentId,
+            'orderId' => $this->requirePayloadString($payload, 'orderId'),
+            'orderVersionId' => $this->requirePayloadString($payload, 'orderVersionId'),
+            'documentTypeId' => $this->getDocumentTypeId($documentType, $context),
+            'documentMediaFileId' => $mediaId,
+            'static' => true,
+            'deepLinkCode' => $deepLinkCode,
+            'config' => ['documentNumber' => $documentNumber],
+        ];
+
+        if ($documentNumber === '') {
+            // Omit an empty document number so the generated document_number column stays NULL
+            $document['config'] = [];
+        }
+
+        $this->documentRepository->create([$document], $context);
 
         $this->documentFileRepository->create([
             [

--- a/src/Core/Checkout/DocumentV2/Generation/DocumentPersister.php
+++ b/src/Core/Checkout/DocumentV2/Generation/DocumentPersister.php
@@ -165,7 +165,7 @@ final readonly class DocumentPersister
     ): void {
         $criteria = (new Criteria())
             ->addFilter(new EqualsFilter('documentNumber', $documentNumber))
-            ->addFilter(new EqualsFilter('documentType.technicalName', $generationRequest->documentType))
+            ->addFilter(new EqualsFilter('typeName', $generationRequest->documentType))
             ->setLimit(1);
 
         $exists = $this->documentRepository->searchIds($criteria, $context)->firstId() !== null;

--- a/src/Core/DevOps/StaticAnalyze/PHPStan/Rules/Deprecation/DeprecatedMethodsThrowDeprecationRule.php
+++ b/src/Core/DevOps/StaticAnalyze/PHPStan/Rules/Deprecation/DeprecatedMethodsThrowDeprecationRule.php
@@ -43,6 +43,8 @@ class DeprecatedMethodsThrowDeprecationRule implements Rule
         'reason:remove-exception',
         // Getter setter that could be serialized when dispatched via bus needs to be deprecated and removed silently
         'reason:remove-getter-setter',
+        // The replacement is still experimental, so the deprecation is announced but stays silent for now.
+        'reason:experimental-replacement',
         // The method is used purely for blue-green deployment, therefor it will be removed from the next major without replacement
         'reason:blue-green-deployment',
         // The class is a decorating class and will be removed. Third party code should never rely on explicit decorators

--- a/src/Core/Migration/V6_7/Migration1787216476AddDocumentNumberTypeNameUniqueIndex.php
+++ b/src/Core/Migration/V6_7/Migration1787216476AddDocumentNumberTypeNameUniqueIndex.php
@@ -40,6 +40,8 @@ class Migration1787216476AddDocumentNumberTypeNameUniqueIndex extends MigrationS
              LIMIT 1'
         );
 
+        // No unique index existed before this migration, so a shop can carry pre-existing duplicate
+        // (document_number, type_name) rows. Adding the index would abort the whole update, so we skip it instead.
         if ($hasDuplicates !== false) {
             return;
         }

--- a/src/Core/Migration/V6_7/Migration1787216476AddDocumentNumberTypeNameUniqueIndex.php
+++ b/src/Core/Migration/V6_7/Migration1787216476AddDocumentNumberTypeNameUniqueIndex.php
@@ -1,0 +1,51 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Migration\V6_7;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Migration\MigrationStep;
+
+/**
+ * @internal
+ */
+#[Package('after-sales')]
+class Migration1787216476AddDocumentNumberTypeNameUniqueIndex extends MigrationStep
+{
+    final public const INDEX_NAME = 'uniq.document.document_number__type_name';
+
+    public function getCreationTimestamp(): int
+    {
+        return 1787216476;
+    }
+
+    public function update(Connection $connection): void
+    {
+        if ($this->indexExists($connection, 'document', self::INDEX_NAME)) {
+            return;
+        }
+
+        $connection->executeStatement(
+            'UPDATE `document` AS `d`
+             INNER JOIN `document_type` AS `dt` ON `dt`.`id` = `d`.`document_type_id`
+             SET `d`.`type_name` = `dt`.`technical_name`
+             WHERE `d`.`type_name` IS NULL'
+        );
+
+        $hasDuplicates = $connection->fetchOne(
+            'SELECT 1 FROM `document`
+             WHERE `document_number` IS NOT NULL AND `type_name` IS NOT NULL
+             GROUP BY `document_number`, `type_name`
+             HAVING COUNT(*) > 1
+             LIMIT 1'
+        );
+
+        if ($hasDuplicates !== false) {
+            return;
+        }
+
+        $connection->executeStatement(
+            'ALTER TABLE `document` ADD UNIQUE INDEX `uniq.document.document_number__type_name` (`document_number`, `type_name`)'
+        );
+    }
+}

--- a/tests/integration/Core/Checkout/DocumentV2/Generation/DocumentPersisterCompatTest.php
+++ b/tests/integration/Core/Checkout/DocumentV2/Generation/DocumentPersisterCompatTest.php
@@ -34,8 +34,6 @@ class DocumentPersisterCompatTest extends TestCase
 
     protected function setUp(): void
     {
-        Feature::skipTestIfInActive('DOCUMENT_GENERATION_REWORK', $this);
-
         $this->context = Context::createDefaultContext();
 
         $shippingAddressId = Uuid::randomHex();

--- a/tests/integration/Core/Checkout/DocumentV2/Generation/DocumentPersisterCompatTest.php
+++ b/tests/integration/Core/Checkout/DocumentV2/Generation/DocumentPersisterCompatTest.php
@@ -13,7 +13,6 @@ use Shopware\Core\Framework\Adapter\Translation\Translator;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
-use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Util\Random;
 use Shopware\Core\Framework\Uuid\Uuid;

--- a/tests/integration/Core/Checkout/DocumentV2/Subscriber/DocumentTypeNameSyncSubscriberTest.php
+++ b/tests/integration/Core/Checkout/DocumentV2/Subscriber/DocumentTypeNameSyncSubscriberTest.php
@@ -8,7 +8,6 @@ use Shopware\Core\Checkout\Document\Aggregate\DocumentBaseConfigSalesChannel\Doc
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
-use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -24,8 +23,6 @@ class DocumentTypeNameSyncSubscriberTest extends TestCase
 
     public function testTypeNameIsWrittenFromDocumentTypeIdOnBaseConfigWrite(): void
     {
-        Feature::skipTestIfInActive('DOCUMENT_GENERATION_REWORK', $this);
-
         $context = Context::createDefaultContext();
         $documentTypeId = $this->getDocumentTypeId('invoice', $context);
 
@@ -46,8 +43,6 @@ class DocumentTypeNameSyncSubscriberTest extends TestCase
 
     public function testTypeNameIsWrittenForSalesChannelConfigWrite(): void
     {
-        Feature::skipTestIfInActive('DOCUMENT_GENERATION_REWORK', $this);
-
         $context = Context::createDefaultContext();
         $documentTypeId = $this->getDocumentTypeId('invoice', $context);
 

--- a/tests/migration/Core/V6_7/Migration1787130171AddDocumentTypeNameColumnsTest.php
+++ b/tests/migration/Core/V6_7/Migration1787130171AddDocumentTypeNameColumnsTest.php
@@ -9,6 +9,7 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
 use Shopware\Core\Framework\Util\Database\TableHelper;
 use Shopware\Core\Migration\V6_7\Migration1787130171AddDocumentTypeNameColumns;
+use Shopware\Core\Migration\V6_7\Migration1787216476AddDocumentNumberTypeNameUniqueIndex;
 
 /**
  * @internal
@@ -45,6 +46,12 @@ class Migration1787130171AddDocumentTypeNameColumnsTest extends TestCase
 
     private function dropTypeNameColumns(): void
     {
+        $indexName = Migration1787216476AddDocumentNumberTypeNameUniqueIndex::INDEX_NAME;
+
+        if ($this->connection->fetchOne('SHOW INDEX FROM `document` WHERE `Key_name` = :name', ['name' => $indexName]) !== false) {
+            $this->connection->executeStatement(\sprintf('ALTER TABLE `document` DROP INDEX `%s`', $indexName));
+        }
+
         foreach (Migration1787130171AddDocumentTypeNameColumns::DOCUMENT_TYPE_TABLES as $table) {
             if (TableHelper::columnExists($this->connection, $table, 'type_name')) {
                 $this->connection->executeStatement(\sprintf('ALTER TABLE `%s` DROP COLUMN `type_name`', $table));

--- a/tests/migration/Core/V6_7/Migration1787216476AddDocumentNumberTypeNameUniqueIndexTest.php
+++ b/tests/migration/Core/V6_7/Migration1787216476AddDocumentNumberTypeNameUniqueIndexTest.php
@@ -1,0 +1,64 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Migration\Core\V6_7;
+
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
+use Shopware\Core\Migration\V6_7\Migration1787216476AddDocumentNumberTypeNameUniqueIndex;
+
+/**
+ * @internal
+ */
+#[Package('after-sales')]
+#[CoversClass(Migration1787216476AddDocumentNumberTypeNameUniqueIndex::class)]
+class Migration1787216476AddDocumentNumberTypeNameUniqueIndexTest extends TestCase
+{
+    private Connection $connection;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->connection = KernelLifecycleManager::getConnection();
+        $this->dropIndex();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->dropIndex();
+
+        parent::tearDown();
+    }
+
+    public function testUpdateAddsUniqueIndex(): void
+    {
+        static::assertFalse($this->indexExists());
+
+        $migration = new Migration1787216476AddDocumentNumberTypeNameUniqueIndex();
+        $migration->update($this->connection);
+        $migration->update($this->connection);
+
+        static::assertTrue($this->indexExists());
+    }
+
+    private function indexExists(): bool
+    {
+        return $this->connection->fetchOne(
+            'SHOW INDEX FROM `document` WHERE `Key_name` = :name',
+            ['name' => Migration1787216476AddDocumentNumberTypeNameUniqueIndex::INDEX_NAME],
+        ) !== false;
+    }
+
+    private function dropIndex(): void
+    {
+        if ($this->indexExists()) {
+            $this->connection->executeStatement(\sprintf(
+                'ALTER TABLE `document` DROP INDEX `%s`',
+                Migration1787216476AddDocumentNumberTypeNameUniqueIndex::INDEX_NAME
+            ));
+        }
+    }
+}

--- a/tests/migration/Core/V6_7/Migration1787216476AddDocumentNumberTypeNameUniqueIndexTest.php
+++ b/tests/migration/Core/V6_7/Migration1787216476AddDocumentNumberTypeNameUniqueIndexTest.php
@@ -7,6 +7,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
+use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\Migration\V6_7\Migration1787216476AddDocumentNumberTypeNameUniqueIndex;
 
 /**
@@ -16,6 +17,11 @@ use Shopware\Core\Migration\V6_7\Migration1787216476AddDocumentNumberTypeNameUni
 #[CoversClass(Migration1787216476AddDocumentNumberTypeNameUniqueIndex::class)]
 class Migration1787216476AddDocumentNumberTypeNameUniqueIndexTest extends TestCase
 {
+    /**
+     * @var list<string>
+     */
+    private array $seededIds = [];
+
     private Connection $connection;
 
     protected function setUp(): void
@@ -28,6 +34,7 @@ class Migration1787216476AddDocumentNumberTypeNameUniqueIndexTest extends TestCa
 
     protected function tearDown(): void
     {
+        $this->removeSeededDocuments();
         $this->dropIndex();
 
         parent::tearDown();
@@ -42,6 +49,51 @@ class Migration1787216476AddDocumentNumberTypeNameUniqueIndexTest extends TestCa
         $migration->update($this->connection);
 
         static::assertTrue($this->indexExists());
+    }
+
+    public function testUpdateSkipsIndexWhenDuplicatesExist(): void
+    {
+        static::assertFalse($this->indexExists());
+
+        $this->seedDocument();
+        $this->seedDocument();
+
+        (new Migration1787216476AddDocumentNumberTypeNameUniqueIndex())->update($this->connection);
+
+        static::assertFalse($this->indexExists());
+    }
+
+    private function seedDocument(): void
+    {
+        $id = Uuid::randomBytes();
+
+        $this->connection->executeStatement('SET FOREIGN_KEY_CHECKS = 0');
+
+        try {
+            $this->connection->insert('document', [
+                'id' => $id,
+                'document_type_id' => Uuid::randomBytes(),
+                'order_id' => Uuid::randomBytes(),
+                'order_version_id' => Uuid::randomBytes(),
+                'type_name' => 'invoice',
+                'config' => \json_encode(['documentNumber' => 'INV-1'], \JSON_THROW_ON_ERROR),
+                'deep_link_code' => Uuid::randomHex(),
+                'created_at' => (new \DateTimeImmutable())->format('Y-m-d H:i:s.v'),
+            ]);
+        } finally {
+            $this->connection->executeStatement('SET FOREIGN_KEY_CHECKS = 1');
+        }
+
+        $this->seededIds[] = $id;
+    }
+
+    private function removeSeededDocuments(): void
+    {
+        foreach ($this->seededIds as $id) {
+            $this->connection->delete('document', ['id' => $id]);
+        }
+
+        $this->seededIds = [];
     }
 
     private function indexExists(): bool


### PR DESCRIPTION
part of https://github.com/shopware/shopware/issues/16151, downstream https://github.com/shopware/SwagCommercial/pull/3758

### Changes

- Set up 6.9 migration infrastructure (`core.V6_9` MigrationSource + `MAJOR_VERSIONS`)
- Un-gate the `type_name` fill so it's always populated
- switch v2 reads to `type_name`
- Deprecate the three `document_type_id` FK fields + `documentType` associations
- Stage the destructive drop of `document_type_id` across `document`, `document_base_config`, `document_base_config_sales_channel`
