### PR TITLE
chore: move ConfiguredEntitySeoUrlRoute to the inventory package

### DIFF
--- a/src/Core/Content/Seo/ConfiguredEntitySeoUrlRoute.php
+++ b/src/Core/Content/Seo/ConfiguredEntitySeoUrlRoute.php
@@ -19,7 +19,7 @@ use function Symfony\Component\String\u;
 /**
  * @internal
  */
-#[Package('discovery')]
+#[Package('inventory')]
 class ConfiguredEntitySeoUrlRoute extends ConfiguredSeoUrlRoute
 {
     public function __construct(

--- a/tests/unit/Core/Content/Seo/ConfiguredEntitySeoUrlRouteTest.php
+++ b/tests/unit/Core/Content/Seo/ConfiguredEntitySeoUrlRouteTest.php
@@ -19,7 +19,7 @@ use Shopware\Core\System\SalesChannel\SalesChannelEntity;
 /**
  * @internal
  */
-#[Package('discovery')]
+#[Package('inventory')]
 #[CoversClass(ConfiguredEntitySeoUrlRoute::class)]
 class ConfiguredEntitySeoUrlRouteTest extends TestCase
 {


### PR DESCRIPTION
### 1. Why is this change necessary?

@marcelbrode discovered during review of test package alignment in #19488: `ConfiguredEntitySeoUrlRoute` belongs to the inventory team, not to discovery.

Yet the initial source code was pointing at discovery, the rest of files are pointing to inventory

### 2. What does this change do, exactly?

Sets the `#[Package]` value of `ConfiguredEntitySeoUrlRoute` and of its unit test to `inventory`. Attribute lines only.

### 3. Describe each step to reproduce the issue or behaviour.

Attribute-only change, no behaviour.

### 4. Please link to the relevant issues (if any).

- relates #19488

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
