### PR TITLE
chore(translations): Remove crowdin-metadata.lock on setup

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -336,6 +336,7 @@
         "stylelint:storefront:fix": "Code Style checks for all Storefront SCSS files and fixes them if possible",
         "translation:lint-filenames": "Validates snippet filesnames",
         "translation:lint-filenames:fix": "Validates snippet filesnames and migrates them if necessary",
+        "translation:metadata:delete": "Deletes the local Crowdin translation metadata lock file",
         "translation:install": "Downloads and installs translations from the translations GitHub repository",
         "translation:lint": "Validates existence of snippets in all core-supported languages",
         "translation:update": "Updates all installed translations from the translations GitHub repository",
@@ -534,6 +535,7 @@
         "setup": [
             "@composer install -o",
             "mkdir -p custom/plugins || true",
+            "@translation:metadata:delete",
             "@init:db",
             "@init:js",
             "@build:js",
@@ -583,6 +585,7 @@
         "stylelint:storefront:fix": "@npm:storefront run lint:scss-fix",
         "translation:lint-filenames": "php bin/shopware translation:lint-filenames",
         "translation:lint-filenames:fix": "php bin/shopware translation:lint-filenames --fix",
+        "translation:metadata:delete": "rm -f files/translation/crowdin-metadata.lock",
         "translation:install": "php bin/shopware translation:install",
         "translation:lint": "@php bin/shopware translation:validate",
         "translation:update": "php bin/shopware translation:update",


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
After a clean setup, the old `crowdin-metadata.lock` still exists and suggests faulty translation update states. Only DE and EN are installed by default, but this could block installing a supported crowdin languages from being installed, despite not already exyisting at all

### 2. What does this change do, exactly?
Remove the lock file on `composer setup`

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
