### PR TITLE
ci: Make sure PR title does not end with ellipsis

### DIFF
--- a/.github/workflows/check-pr-title.yml
+++ b/.github/workflows/check-pr-title.yml
@@ -20,7 +20,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          subjectPattern: …$
+          subjectPattern: ^.*(?<!…)$
           subjectPatternError: |
             PR title ends with "…", probably because it was shortened by GitHub.
             Make sure the title is descriptive enough, as it will be used as the commit message.

--- a/.github/workflows/check-pr-title.yml
+++ b/.github/workflows/check-pr-title.yml
@@ -22,5 +22,5 @@ jobs:
         with:
           subjectPattern: …$
           subjectPatternError: |
-              PR title ends with "…", probably because it was shortened by GitHub.
-              Make sure the title is descriptive enough, as it will be used as the commit message.
+            PR title ends with "…", probably because it was shortened by GitHub.
+            Make sure the title is descriptive enough, as it will be used as the commit message.

--- a/.github/workflows/check-pr-title.yml
+++ b/.github/workflows/check-pr-title.yml
@@ -19,3 +19,8 @@ jobs:
       - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # 6.1.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          subjectPattern: …$
+          subjectPatternError: |
+              PR title ends with "…", probably because it was shortened by GitHub.
+              Make sure the title is descriptive enough, as it will be used as the commit message.

--- a/.github/workflows/check-pr-title.yml
+++ b/.github/workflows/check-pr-title.yml
@@ -20,7 +20,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          subjectPattern: ^.*(?<!…)$
+          subjectPattern: ^.*(?<!…)$ # PR title needs to match regex, so ensure it does not end with ellipsis
           subjectPatternError: |
             PR title ends with "…", probably because it was shortened by GitHub.
             Make sure the title is descriptive enough, as it will be used as the commit message.


### PR DESCRIPTION
### 1. Why is this change necessary?

The PR title will be used as commit message for the squashed commits during merge. If the initial commit message is to long, GitHub cuts it and add the `…` at the end. People tend to not re-check the PR title being valid for a good looking commit message. So something like this could happen: https://github.com/shopware/shopware/commit/4f6a339334b8eccacdae52096beca9f8f64fdc3e

### 2. What does this change do, exactly?

Add a custom regex to the PR title checker with an additional error message

Test run: https://github.com/shopware/shopware/actions/runs/32368570358/job/96423599208

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
