### PR TITLE
ci: don't flag our bots as external-contributor

### DIFF
--- a/.github/workflows/external-contributor-label.yml
+++ b/.github/workflows/external-contributor-label.yml
@@ -18,6 +18,11 @@ jobs:
           script: |
             const pullRequestNumber = context.payload.pull_request.number;
             const contribLabel = process.env.CONTRIBUTOR_LABEL;
+            const allowedBotUsers = [
+                "BOT_kgDOCV3tAw", // octo-sts
+                "BOT_kgDODjoiJw", // shopware-octo-sts-app
+                "BOT_kgDODoqSag"  // shopware-octo-sts-app-2
+            ];
 
             let hasWriteAccess = false;
 
@@ -29,7 +34,7 @@ jobs:
             if (permissionLevel.status !== 200) {
               core.info(`Failed to get permission level for "${context.actor}", assuming no write access.`);
             } else {
-              hasWriteAccess = ['admin', 'write'].includes(permissionLevel?.data?.permission) || permissionLevel?.data?.user.node_id == "BOT_kgDOCV3tAw";
+              hasWriteAccess = ['admin', 'write'].includes(permissionLevel?.data?.permission) || allowedBotUsers.includes(permissionLevel?.data?.user.node_id);
             }
 
             if (hasWriteAccess) {


### PR DESCRIPTION
### 1. Why is this change necessary?
Currently only the offical `octo-sts` bot is a whitelisted bot. Our self-hosted octo-sts bots are tagged as `external-contributors`.

### 2. What does this change do, exactly?
I've defined a list of allowed bot users and check against this list.

### 3. Describe each step to reproduce the issue or behaviour.
Let a octo-sts bot create an PR