### PR TITLE
feat(storefront): add collapse mode to Sw:Navigation:Tree

### DIFF
--- a/src/Core/Framework/ContentSystem/Layout/Type/Definitions/navigation/tree.yaml
+++ b/src/Core/Framework/ContentSystem/Layout/Type/Definitions/navigation/tree.yaml
@@ -8,7 +8,7 @@ meta:
     hints:
       - "Add a navigationTree data requirement with source 'navigation' to load the tree."
       - "The highlighted category follows the page, no configuration needed."
-      - "Pick the service or footer binding to render one of the other navigation roots."
+      - "Set displayType to 'collapsible' to let shoppers open and close the levels below a category."
 
 properties:
   navigationTree:
@@ -28,13 +28,25 @@ properties:
     adminUI:
       helpText: "Filled automatically from the page you are on — leave this as it is."
 
+  displayType:
+    type: string
+    title: "Display type"
+    description: "Whether sub-levels are fixed as rendered or can be opened and closed by the shopper."
+    default: "static"
+    enum:
+      - "static"
+      - "collapsible"
+    adminUI:
+      component: "select"
+      helpText: "'Static' renders the tree as it is. 'Collapsible' adds a plus button to every category that has children, so shoppers can open the levels below it down to the navigation depth configured on the sales channel."
+
   expandAll:
     type: boolean
     title: "Expand all"
     description: "Render all children instead of only the branch containing the active category."
     default: false
     adminUI:
-      helpText: "When off, only the branch leading to the current category is expanded. When on, the tree expands to the navigation depth configured on the sales channel."
+      helpText: "When off, only the branch leading to the current category is expanded. When on, the tree expands to the navigation depth configured on the sales channel. In collapsible mode this sets which branches start open."
 
   ariaLabel:
     type: string

--- a/src/Core/Framework/ContentSystem/Layout/Type/Definitions/navigation/tree.yaml
+++ b/src/Core/Framework/ContentSystem/Layout/Type/Definitions/navigation/tree.yaml
@@ -1,6 +1,6 @@
 meta:
   label: "Navigation Tree"
-  description: "Renders a category navigation tree with links, folders and active item highlighting."
+  description: "Renders a category navigation tree with links, folders, active item highlighting and optionally expandable sub-levels."
   icon: "regular-sitemap"
   category: "content"
   copilot:
@@ -8,7 +8,7 @@ meta:
     hints:
       - "Add a navigationTree data requirement with source 'navigation' to load the tree."
       - "The highlighted category follows the page, no configuration needed."
-      - "Set displayType to 'collapsible' to let shoppers open and close the levels below a category."
+      - "Set displayType to 'collapsible' to let shoppers open and close the levels below a category; expandAll then only decides which branches start open, not whether children are rendered."
 
 properties:
   navigationTree:

--- a/src/Core/Framework/ContentSystem/Layout/Type/Definitions/navigation/tree.yaml
+++ b/src/Core/Framework/ContentSystem/Layout/Type/Definitions/navigation/tree.yaml
@@ -38,7 +38,7 @@ properties:
       - "collapsible"
     adminUI:
       component: "select"
-      helpText: "'Static' renders the tree as it is. 'Collapsible' adds a plus button to every category that has children, so shoppers can open the levels below it down to the navigation depth configured on the sales channel."
+      helpText: "'Static' renders the tree as it is. 'Collapsible' adds a plus button to every category whose sub-levels are rendered, so shoppers can open them. This mode renders the whole tree down to the navigation depth of the sales channel, which makes every page carrying the element heavier on a deep catalogue."
 
   expandAll:
     type: boolean

--- a/src/Core/Framework/ContentSystem/Layout/Type/Definitions/navigation/tree.yaml
+++ b/src/Core/Framework/ContentSystem/Layout/Type/Definitions/navigation/tree.yaml
@@ -8,7 +8,8 @@ meta:
     hints:
       - "Add a navigationTree data requirement with source 'navigation' to load the tree."
       - "The highlighted category follows the page, no configuration needed."
-      - "Set displayType to 'collapsible' to let shoppers open and close the levels below a category; expandAll then only decides which branches start open, not whether children are rendered."
+      - "Set displayType to 'static' for a fixed tree, or to 'collapse' to let shoppers open and close the levels below a category."
+      - "In collapse mode expandAll only decides which branches start open, not whether children are rendered."
 
 properties:
   navigationTree:
@@ -35,10 +36,10 @@ properties:
     default: "static"
     enum:
       - "static"
-      - "collapsible"
+      - "collapse"
     adminUI:
       component: "select"
-      helpText: "'Static' renders the tree as it is. 'Collapsible' adds a plus button to every category whose sub-levels are rendered, so shoppers can open them. This mode renders the whole tree down to the navigation depth of the sales channel, which makes every page carrying the element heavier on a deep catalogue."
+      helpText: "'Static' renders the tree as it is. 'Collapse' adds a plus button to every category whose sub-levels are rendered, so shoppers can open them. That mode renders the whole tree down to the navigation depth of the sales channel, which makes every page carrying the element heavier on a deep catalogue."
 
   expandAll:
     type: boolean
@@ -46,7 +47,7 @@ properties:
     description: "Render all children instead of only the branch containing the active category."
     default: false
     adminUI:
-      helpText: "When off, only the branch leading to the current category is expanded. When on, the tree expands to the navigation depth configured on the sales channel. In collapsible mode this sets which branches start open."
+      helpText: "When off, only the branch leading to the current category is expanded. When on, the tree expands to the navigation depth configured on the sales channel. In collapse mode this sets which branches start open."
 
   ariaLabel:
     type: string

--- a/src/Storefront/Resources/snippet/storefront.de.json
+++ b/src/Storefront/Resources/snippet/storefront.de.json
@@ -41,6 +41,7 @@
     "collapse": "Einklappen",
     "categories": "Kategorien",
     "showCategory": "%category% anzeigen",
+    "toggleSubcategories": "Unterkategorien von %category% ein- oder ausblenden",
     "required": "*",
     "privacyTitle": "Datenschutz",
     "privacyNoticeText": "Ich habe die <a data-ajax-modal=\"true\" data-url=\"%privacyUrl%\" href=\"%privacyUrl%\" title=\"Datenschutzbestimmungen\">Datenschutzbestimmungen</a> zur Kenntnis genommen und die <a data-ajax-modal=\"true\" data-url=\"%tosUrl%\" href=\"%tosUrl%\" title=\"AGB\">AGB</a> gelesen und bin mit ihnen einverstanden.",

--- a/src/Storefront/Resources/snippet/storefront.en.json
+++ b/src/Storefront/Resources/snippet/storefront.en.json
@@ -41,6 +41,7 @@
     "collapse": "Collapse",
     "categories": "Categories",
     "showCategory": "Show %category%",
+    "toggleSubcategories": "Show or hide the subcategories of %category%",
     "required": "*",
     "privacyTitle": "Privacy",
     "privacyNoticeText": "I have acknowledged the <a data-ajax-modal=\"true\" data-url=\"%privacyUrl%\" href=\"%privacyUrl%\" title=\"Privacy policy\">privacy policy</a> and have read and agree to the <a data-ajax-modal=\"true\" data-url=\"%tosUrl%\" href=\"%tosUrl%\" title=\"general terms and conditions\">general terms and conditions</a>.",

--- a/src/Storefront/Resources/views/components/Sw/Navigation/Tree.html.twig
+++ b/src/Storefront/Resources/views/components/Sw/Navigation/Tree.html.twig
@@ -5,6 +5,7 @@
 {% props
     navigationTree = [],
     navigationMaxDepth = context.salesChannel.navigationCategoryDepth,
+    displayType = 'static',
     expandAll = false,
     activeId = shopware.navigation.id,
     activePath = shopware.navigation.pathIdList,
@@ -29,6 +30,7 @@
         <twig:Sw:Navigation:TreeItems
             :navigationTree="treeItems"
             :navigationMaxDepth="navigationMaxDepth"
+            :displayType="displayType"
             :expandAll="expandAll"
             :activeId="activeId"
             :activePath="activePath"

--- a/src/Storefront/Resources/views/components/Sw/Navigation/Tree.stories.json
+++ b/src/Storefront/Resources/views/components/Sw/Navigation/Tree.stories.json
@@ -25,9 +25,19 @@
                 }
             }
         },
+        "displayType": {
+            "control": "select",
+            "options": ["static", "collapsible"],
+            "description": "Whether sub-levels are fixed as rendered, or get a toggle the shopper can open and close.",
+            "table": {
+                "defaultValue": {
+                    "summary": "static"
+                }
+            }
+        },
         "expandAll": {
             "control": "boolean",
-            "description": "Render all children instead of only the branch containing the active category.",
+            "description": "Render all children instead of only the branch containing the active category. In collapsible mode it sets which branches start open.",
             "table": {
                 "defaultValue": {
                     "summary": false
@@ -67,6 +77,15 @@
             "name": "Tree",
             "args": {
                 "navigationTree": [],
+                "displayType": "static",
+                "expandAll": false
+            }
+        },
+        {
+            "name": "Collapsible",
+            "args": {
+                "navigationTree": [],
+                "displayType": "collapsible",
                 "expandAll": false
             }
         }

--- a/src/Storefront/Resources/views/components/Sw/Navigation/Tree.stories.json
+++ b/src/Storefront/Resources/views/components/Sw/Navigation/Tree.stories.json
@@ -27,7 +27,7 @@
         },
         "displayType": {
             "control": "select",
-            "options": ["static", "collapsible"],
+            "options": ["static", "collapse"],
             "description": "Whether sub-levels are fixed as rendered, or get a toggle the shopper can open and close.",
             "table": {
                 "defaultValue": {
@@ -37,7 +37,7 @@
         },
         "expandAll": {
             "control": "boolean",
-            "description": "Render all children instead of only the branch containing the active category. In collapsible mode it sets which branches start open.",
+            "description": "Render all children instead of only the branch containing the active category. In collapse mode it sets which branches start open.",
             "table": {
                 "defaultValue": {
                     "summary": false
@@ -82,10 +82,10 @@
             }
         },
         {
-            "name": "Collapsible",
+            "name": "Collapse",
             "args": {
                 "navigationTree": [],
-                "displayType": "collapsible",
+                "displayType": "collapse",
                 "expandAll": false
             }
         }

--- a/src/Storefront/Resources/views/components/Sw/Navigation/TreeItems.html.twig
+++ b/src/Storefront/Resources/views/components/Sw/Navigation/TreeItems.html.twig
@@ -14,7 +14,7 @@
     expanded = true,
 %}
 
-{% set isCollapsible = displayType == 'collapsible' %}
+{% set isCollapse = displayType == 'collapse' %}
 {% set isPanel = panelId is not null %}
 
 {% set treeItemsCVA = cva({
@@ -26,7 +26,7 @@
         },
         displayType: {
             static: null,
-            collapsible: ['is--collapsible'],
+            collapse: ['is--collapse'],
         },
         panel: {
             true: ['collapse'],
@@ -63,15 +63,10 @@
         {# NavigationRoute loads the active path beyond the requested depth on purpose, so the limit
            must not reach it — clipping it would drop the item carrying aria-current. #}
         {% set showChildren = treeItem.children|length > 0
-            and (onActivePath or ((expandAll or isCollapsible) and navigationLevel < navigationMaxDepth)) %}
+            and (onActivePath or ((expandAll or isCollapse) and navigationLevel < navigationMaxDepth)) %}
 
-        {# A branch has to be in the DOM to be expandable at all, so in collapsible mode expandAll
-           picks the initial state instead of gating the markup. #}
-        {% set startExpanded = not isCollapsible or expandAll or onActivePath %}
-
-        {# Keyed off the rendered children, not off children|length: the depth limit can drop the
-           children of a node that has some, and a toggle controlling nothing is worse than none. #}
-        {% set childPanelId = (isCollapsible and showChildren) ? ('sw-navigation-tree-panel-' ~ random()) : null %}
+        {% set startExpanded = not isCollapse or expandAll or onActivePath %}
+        {% set childPanelId = (isCollapse and showChildren) ? ('sw-navigation-tree-panel-' ~ random()) : null %}
 
         <li class="sw-navigation-tree-items__item">
             {% if category.seoUrl %}
@@ -89,9 +84,6 @@
                 </span>
             {% endif %}
 
-            {# The toggle sits beside the label instead of replacing it, following the footer
-               column accordion: the label keeps navigating, and a span never has to carry
-               aria-expanded, which assistive technology would ignore on it. #}
             {% if childPanelId %}
                 <twig:Sw:Button
                     variant="inline"

--- a/src/Storefront/Resources/views/components/Sw/Navigation/TreeItems.html.twig
+++ b/src/Storefront/Resources/views/components/Sw/Navigation/TreeItems.html.twig
@@ -6,10 +6,16 @@
     navigationTree = [],
     navigationLevel = 1,
     navigationMaxDepth = context.salesChannel.navigationCategoryDepth,
+    displayType = 'static',
     expandAll = false,
     activeId = shopware.navigation.id,
     activePath = shopware.navigation.pathIdList,
+    panelId = null,
+    expanded = true,
 %}
+
+{% set isCollapsible = displayType == 'collapsible' %}
+{% set isPanel = panelId is not null %}
 
 {% set treeItemsCVA = cva({
     base: 'sw-navigation-tree-items nav flex-column',
@@ -18,13 +24,34 @@
             true: ['is--root'],
             false: null,
         },
+        displayType: {
+            static: null,
+            collapsible: ['is--collapsible'],
+        },
+        panel: {
+            true: ['collapse'],
+            false: null,
+        },
+        expanded: {
+            true: ['show'],
+            false: null,
+        },
     },
 }) %}
 
 {% set attributeDefaults = {
-    class: treeItemsCVA.apply({ root: navigationLevel == 1 }),
+    class: treeItemsCVA.apply({
+        root: navigationLevel == 1,
+        displayType,
+        panel: isPanel,
+        expanded: isPanel and expanded,
+    }),
     style: '--sw-navigation-tree-items-level: ' ~ navigationLevel ~ ';',
 } %}
+
+{% if isPanel %}
+    {% set attributeDefaults = attributeDefaults|merge({ id: panelId }) %}
+{% endif %}
 
 <ul {{ attributes.defaults(attributeDefaults) }}>
     {% for treeItem in navigationTree %}
@@ -36,7 +63,15 @@
         {# NavigationRoute loads the active path beyond the requested depth on purpose, so the limit
            must not reach it — clipping it would drop the item carrying aria-current. #}
         {% set showChildren = treeItem.children|length > 0
-            and (onActivePath or (expandAll and navigationLevel < navigationMaxDepth)) %}
+            and (onActivePath or ((expandAll or isCollapsible) and navigationLevel < navigationMaxDepth)) %}
+
+        {# A branch has to be in the DOM to be expandable at all, so in collapsible mode expandAll
+           picks the initial state instead of gating the markup. #}
+        {% set startExpanded = not isCollapsible or expandAll or onActivePath %}
+
+        {# Keyed off the rendered children, not off children|length: the depth limit can drop the
+           children of a node that has some, and a toggle controlling nothing is worse than none. #}
+        {% set childPanelId = (isCollapsible and showChildren) ? ('sw-navigation-tree-panel-' ~ random()) : null %}
 
         <li class="sw-navigation-tree-items__item">
             {% if category.seoUrl %}
@@ -54,14 +89,36 @@
                 </span>
             {% endif %}
 
+            {# The toggle sits beside the label instead of replacing it, following the footer
+               column accordion: the label keeps navigating, and a span never has to carry
+               aria-expanded, which assistive technology would ignore on it. #}
+            {% if childPanelId %}
+                <twig:Sw:Button
+                    variant="inline"
+                    :iconOnly="true"
+                    class="sw-navigation-tree-items__toggle"
+                    data-bs-toggle="collapse"
+                    data-bs-target="#{{ childPanelId }}"
+                    aria-controls="{{ childPanelId }}"
+                    aria-expanded="{{ startExpanded ? 'true' : 'false' }}"
+                    aria-label="{{ 'general.toggleSubcategories'|trans({'%category%': category.translated.name})|striptags }}"
+                >
+                    <twig:Sw:Icon name="plus" size="xs" />
+                    <twig:Sw:Icon name="minus" size="xs" />
+                </twig:Sw:Button>
+            {% endif %}
+
             {% if showChildren %}
                 <twig:Sw:Navigation:TreeItems
                     :navigationTree="treeItem.children"
                     :navigationLevel="navigationLevel + 1"
                     :navigationMaxDepth="navigationMaxDepth"
+                    :displayType="displayType"
                     :expandAll="expandAll"
                     :activeId="activeId"
                     :activePath="activePath"
+                    :panelId="childPanelId"
+                    :expanded="startExpanded"
                 />
             {% endif %}
         </li>

--- a/src/Storefront/Resources/views/components/Sw/Navigation/TreeItems.scss
+++ b/src/Storefront/Resources/views/components/Sw/Navigation/TreeItems.scss
@@ -40,3 +40,54 @@
 .sw-navigation-tree-items__folder:hover {
     color: var(--bs-secondary-color);
 }
+
+// Bootstrap animates the panel open from height 0, and `.nav` sets flex-wrap: wrap, which
+// the flex-column utility does not reset. A wrapping column box with no height puts every
+// child in its own column, so the sub-levels flash side by side while it opens.
+.sw-navigation-tree-items.is--collapsible {
+    flex-wrap: nowrap;
+}
+
+// Collapsible mode puts the toggle beside the label and drops the panel onto its own row.
+// The stripe moves to the row itself here: `.btn:hover` rewrites border-color, which would
+// blank out the segment above the toggle whenever the pointer touches it.
+.sw-navigation-tree-items.is--collapsible > .sw-navigation-tree-items__item {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: stretch;
+    border-top: var(--sw-navigation-tree-items-stripe-width) solid var(--sw-navigation-tree-items-stripe-color);
+}
+
+.sw-navigation-tree-items.is--collapsible.is--root > .sw-navigation-tree-items__item:first-child {
+    border-top: 0;
+}
+
+.sw-navigation-tree-items.is--collapsible > .sw-navigation-tree-items__item > .sw-navigation-tree-items__link,
+.sw-navigation-tree-items.is--collapsible > .sw-navigation-tree-items__item > .sw-navigation-tree-items__folder {
+    border-top: 0;
+    flex: 1 1 auto;
+}
+
+.sw-navigation-tree-items.is--collapsible > .sw-navigation-tree-items__item > .sw-navigation-tree-items {
+    flex-basis: 100%;
+}
+
+.sw-navigation-tree-items__toggle {
+    flex: 0 0 auto;
+    color: var(--bs-secondary-color);
+    text-decoration: none;
+}
+
+// Two icons swapped by state rather than one rotated: nothing can look wrong mid-transition,
+// and it matches the footer column accordion shoppers already know.
+.sw-navigation-tree-items__toggle .sw-icon--default-minus {
+    display: none;
+}
+
+.sw-navigation-tree-items__toggle[aria-expanded="true"] .sw-icon--default-plus {
+    display: none;
+}
+
+.sw-navigation-tree-items__toggle[aria-expanded="true"] .sw-icon--default-minus {
+    display: inline-flex;
+}

--- a/src/Storefront/Resources/views/components/Sw/Navigation/TreeItems.scss
+++ b/src/Storefront/Resources/views/components/Sw/Navigation/TreeItems.scss
@@ -54,7 +54,7 @@
 .sw-navigation-tree-items.is--collapsible > .sw-navigation-tree-items__item {
     display: flex;
     flex-wrap: wrap;
-    align-items: stretch;
+    align-items: flex-start;
     border-top: var(--sw-navigation-tree-items-stripe-width) solid var(--sw-navigation-tree-items-stripe-color);
 }
 
@@ -72,9 +72,14 @@
     flex-basis: 100%;
 }
 
-.sw-navigation-tree-items__toggle {
+// Scoped, and colour set through the button's own custom properties: `.btn-link-inline`
+// declares text-decoration twice, once under `:hover`, both above the weight of a bare
+// class selector, and it owns `--bs-btn-color`.
+.sw-navigation-tree-items.is--collapsible .sw-navigation-tree-items__toggle,
+.sw-navigation-tree-items.is--collapsible .sw-navigation-tree-items__toggle:hover {
+    --bs-btn-color: var(--bs-secondary-color);
+    --bs-btn-hover-color: var(--bs-nav-link-hover-color);
     flex: 0 0 auto;
-    color: var(--bs-secondary-color);
     text-decoration: none;
 }
 

--- a/src/Storefront/Resources/views/components/Sw/Navigation/TreeItems.scss
+++ b/src/Storefront/Resources/views/components/Sw/Navigation/TreeItems.scss
@@ -41,50 +41,39 @@
     color: var(--bs-secondary-color);
 }
 
-// Bootstrap animates the panel open from height 0, and `.nav` sets flex-wrap: wrap, which
-// the flex-column utility does not reset. A wrapping column box with no height puts every
-// child in its own column, so the sub-levels flash side by side while it opens.
-.sw-navigation-tree-items.is--collapsible {
+.sw-navigation-tree-items.is--collapse {
     flex-wrap: nowrap;
 }
 
-// Collapsible mode puts the toggle beside the label and drops the panel onto its own row.
-// The stripe moves to the row itself here: `.btn:hover` rewrites border-color, which would
-// blank out the segment above the toggle whenever the pointer touches it.
-.sw-navigation-tree-items.is--collapsible > .sw-navigation-tree-items__item {
+.sw-navigation-tree-items.is--collapse > .sw-navigation-tree-items__item {
     display: flex;
     flex-wrap: wrap;
     align-items: flex-start;
     border-top: var(--sw-navigation-tree-items-stripe-width) solid var(--sw-navigation-tree-items-stripe-color);
 }
 
-.sw-navigation-tree-items.is--collapsible.is--root > .sw-navigation-tree-items__item:first-child {
+.sw-navigation-tree-items.is--collapse.is--root > .sw-navigation-tree-items__item:first-child {
     border-top: 0;
 }
 
-.sw-navigation-tree-items.is--collapsible > .sw-navigation-tree-items__item > .sw-navigation-tree-items__link,
-.sw-navigation-tree-items.is--collapsible > .sw-navigation-tree-items__item > .sw-navigation-tree-items__folder {
+.sw-navigation-tree-items.is--collapse > .sw-navigation-tree-items__item > .sw-navigation-tree-items__link,
+.sw-navigation-tree-items.is--collapse > .sw-navigation-tree-items__item > .sw-navigation-tree-items__folder {
     border-top: 0;
     flex: 1 1 auto;
 }
 
-.sw-navigation-tree-items.is--collapsible > .sw-navigation-tree-items__item > .sw-navigation-tree-items {
+.sw-navigation-tree-items.is--collapse > .sw-navigation-tree-items__item > .sw-navigation-tree-items {
     flex-basis: 100%;
 }
 
-// Scoped, and colour set through the button's own custom properties: `.btn-link-inline`
-// declares text-decoration twice, once under `:hover`, both above the weight of a bare
-// class selector, and it owns `--bs-btn-color`.
-.sw-navigation-tree-items.is--collapsible .sw-navigation-tree-items__toggle,
-.sw-navigation-tree-items.is--collapsible .sw-navigation-tree-items__toggle:hover {
+.sw-navigation-tree-items.is--collapse .sw-navigation-tree-items__toggle,
+.sw-navigation-tree-items.is--collapse .sw-navigation-tree-items__toggle:hover {
     --bs-btn-color: var(--bs-secondary-color);
     --bs-btn-hover-color: var(--bs-nav-link-hover-color);
     flex: 0 0 auto;
     text-decoration: none;
 }
 
-// Two icons swapped by state rather than one rotated: nothing can look wrong mid-transition,
-// and it matches the footer column accordion shoppers already know.
 .sw-navigation-tree-items__toggle .sw-icon--default-minus {
     display: none;
 }

--- a/tests/integration/Storefront/Framework/Twig/NavigationTreeComponentTest.php
+++ b/tests/integration/Storefront/Framework/Twig/NavigationTreeComponentTest.php
@@ -109,6 +109,23 @@ class NavigationTreeComponentTest extends TestCase
     }
 
     /**
+     * The Studio derives the control from this schema and ships no code of its own for it, so a
+     * toSchema() regression that dropped the enum would render a select with no options while
+     * every render test here kept passing.
+     */
+    public function testDisplayTypeReachesTheSchemaWithItsOptions(): void
+    {
+        $types = static::getContainer()->get(ContentSystemElementTypeRegistry::class);
+        static::assertInstanceOf(AbstractContentSystemElementTypeRegistry::class, $types);
+
+        $displayType = $types->get('Sw:Navigation:Tree')->properties()['displayType']->toSchema();
+
+        static::assertSame('static', $displayType['default']);
+        static::assertSame(['static', 'collapsible'], $displayType['enum']);
+        static::assertSame('select', $displayType['adminUI']['component'] ?? null);
+    }
+
+    /**
      * A landmark with an empty name is worse than an unnamed one: screen readers announce it without
      * any hint of what it contains. A stored empty value must therefore not beat the snippet default.
      */
@@ -492,7 +509,9 @@ class NavigationTreeComponentTest extends TestCase
 
     /**
      * Every prop is passed explicitly so the component's global-reading defaults
-     * (`shopware.navigation`, `context.salesChannel`, the translator) are never evaluated.
+     * (`shopware.navigation`, `context.salesChannel`) are never evaluated. The translator is the
+     * exception since collapsible mode names its toggle from `general.toggleSubcategories`: a
+     * missing snippet makes those tests fail on the name rather than on what they assert.
      *
      * @param array<string, mixed> $props
      */

--- a/tests/integration/Storefront/Framework/Twig/NavigationTreeComponentTest.php
+++ b/tests/integration/Storefront/Framework/Twig/NavigationTreeComponentTest.php
@@ -249,6 +249,196 @@ class NavigationTreeComponentTest extends TestCase
         static::assertStringContainsString('HiddenChild', $expanded);
     }
 
+    public function testStaticModeRendersNoInteractiveMarkup(): void
+    {
+        $child = $this->treeItem('Shirts', '/shirts');
+        $parent = $this->treeItem('Clothing', '/clothing', children: [$child]);
+
+        $html = $this->render([
+            'navigationTree' => [$parent],
+            'expandAll' => true,
+        ]);
+
+        static::assertStringNotContainsString('<button', $html);
+        static::assertStringNotContainsString('aria-expanded', $html);
+        static::assertStringNotContainsString('data-bs-toggle', $html);
+        static::assertStringNotContainsString('is--collapsible', $html);
+    }
+
+    /**
+     * A toggle pointing at an id that is not on the page silently does nothing, so the wiring is
+     * asserted end to end rather than attribute by attribute.
+     */
+    public function testCollapsibleModeWiresTheToggleToThePanelItControls(): void
+    {
+        $child = $this->treeItem('Shirts', '/shirts');
+        $parent = $this->treeItem('Clothing', '/clothing', children: [$child]);
+
+        $html = $this->render([
+            'navigationTree' => [$parent],
+            'displayType' => 'collapsible',
+        ]);
+
+        static::assertStringContainsString('data-bs-toggle="collapse"', $html);
+        static::assertSame(1, preg_match('/aria-controls="([^"]+)"/', $html, $matches));
+        static::assertStringContainsString('data-bs-target="#' . $matches[1] . '"', $html);
+        static::assertStringContainsString('id="' . $matches[1] . '"', $html);
+
+        // The label still navigates; only the button beside it discloses.
+        static::assertStringContainsString('href="/clothing"', $html);
+    }
+
+    /**
+     * Two icons swapped by state, matching the footer column accordion. A missing icon file makes
+     * Sw:Icon render nothing at all, which would leave the button visually empty.
+     */
+    public function testCollapsibleModeRendersThePlusAndMinusIcons(): void
+    {
+        $child = $this->treeItem('Shirts', '/shirts');
+        $parent = $this->treeItem('Clothing', '/clothing', children: [$child]);
+
+        $html = $this->render([
+            'navigationTree' => [$parent],
+            'displayType' => 'collapsible',
+        ]);
+
+        static::assertStringContainsString('sw-icon--default-plus', $html);
+        static::assertStringContainsString('sw-icon--default-minus', $html);
+        static::assertStringNotContainsString('arrow-head', $html);
+        static::assertSame(2, substr_count($html, '<svg'));
+    }
+
+    public function testCollapsibleModeGivesTheToggleANameOfItsOwn(): void
+    {
+        $child = $this->treeItem('Shirts', '/shirts');
+        $parent = $this->treeItem('Clothing', '/clothing', children: [$child]);
+
+        $html = $this->render([
+            'navigationTree' => [$parent],
+            'displayType' => 'collapsible',
+        ]);
+
+        // Naming it after the category alone would give the row two controls with one name.
+        static::assertMatchesRegularExpression('/aria-label="[^"]*Clothing[^"]*"/', $html);
+        static::assertStringNotContainsString('aria-label="Clothing"', $html);
+    }
+
+    public function testCollapsibleModeStartsTheActiveBranchOpenAndLeavesSiblingsClosed(): void
+    {
+        $activeChild = $this->treeItem('ActiveChild', '/active-child');
+        $activeBranch = $this->treeItem('ActiveBranch', '/active-branch', children: [$activeChild]);
+
+        $siblingChild = $this->treeItem('SiblingChild', '/sibling-child');
+        $siblingBranch = $this->treeItem('SiblingBranch', '/sibling-branch', children: [$siblingChild]);
+
+        $html = $this->render([
+            'navigationTree' => [$activeBranch, $siblingBranch],
+            'displayType' => 'collapsible',
+            'activePath' => [$activeBranch->getCategory()->getId()],
+        ]);
+
+        // Both branches are in the DOM — that is what makes the closed one expandable at all.
+        static::assertStringContainsString('ActiveChild', $html);
+        static::assertStringContainsString('SiblingChild', $html);
+
+        static::assertSame(1, substr_count($html, 'aria-expanded="true"'));
+        static::assertSame(1, substr_count($html, 'aria-expanded="false"'));
+        static::assertSame(1, substr_count($html, 'collapse show'));
+    }
+
+    public function testCollapsibleModeUsesExpandAllAsTheInitialState(): void
+    {
+        $child = $this->treeItem('HiddenChild', '/hidden-child');
+        $branch = $this->treeItem('Branch', '/branch', children: [$child]);
+
+        $closed = $this->render(['navigationTree' => [$branch], 'displayType' => 'collapsible']);
+        $open = $this->render(['navigationTree' => [$branch], 'displayType' => 'collapsible', 'expandAll' => true]);
+
+        // expandAll stops gating the markup here: a branch has to exist to be expandable.
+        static::assertStringContainsString('HiddenChild', $closed);
+        static::assertStringContainsString('HiddenChild', $open);
+
+        static::assertStringContainsString('aria-expanded="false"', $closed);
+        static::assertStringContainsString('aria-expanded="true"', $open);
+    }
+
+    /**
+     * A toggle whose panel was clipped by the depth limit would control nothing, so the button keys
+     * off the rendered children rather than off the children the tree carries.
+     */
+    public function testCollapsibleModeRendersNoToggleWhenTheDepthLimitDropsTheChildren(): void
+    {
+        $level3 = $this->treeItem('Level3', '/level-3');
+        $level2 = $this->treeItem('Level2', '/level-2', children: [$level3]);
+        $level1 = $this->treeItem('Level1', '/level-1', children: [$level2]);
+
+        $html = $this->render([
+            'navigationTree' => [$level1],
+            'navigationMaxDepth' => 2,
+            'displayType' => 'collapsible',
+        ]);
+
+        static::assertStringContainsString('Level2', $html);
+        static::assertStringNotContainsString('Level3', $html);
+        static::assertSame(1, substr_count($html, 'data-bs-toggle="collapse"'));
+    }
+
+    public function testCollapsibleModeKeepsTheActivePathBeyondTheRenderDepth(): void
+    {
+        $active = $this->treeItem('Sneakers', '/sneakers');
+        $middle = $this->treeItem('Shoes', '/shoes', children: [$active]);
+        $top = $this->treeItem('Clothing', '/clothing', children: [$middle]);
+
+        $html = $this->render([
+            'navigationTree' => [$top],
+            'navigationMaxDepth' => 2,
+            'displayType' => 'collapsible',
+            'activeId' => $active->getCategory()->getId(),
+            'activePath' => [$top->getCategory()->getId(), $middle->getCategory()->getId()],
+        ]);
+
+        static::assertStringContainsString('Sneakers', $html);
+        static::assertSame(1, substr_count($html, 'aria-current="page"'));
+
+        // Every panel on the active path starts open, so nothing hides the current page.
+        static::assertSame(2, substr_count($html, 'aria-expanded="true"'));
+        static::assertSame(0, substr_count($html, 'aria-expanded="false"'));
+    }
+
+    /**
+     * The toggle sits beside the label instead of replacing it, so a folder stays a span. Putting
+     * aria-expanded on a span would make the state invisible to assistive technology.
+     */
+    public function testCollapsibleModeKeepsAFolderASpanAndPutsTheToggleBesideIt(): void
+    {
+        $child = $this->treeItem('Shirts', '/shirts');
+        $folder = $this->treeItem('Structure', null, CategoryDefinition::TYPE_FOLDER, children: [$child]);
+
+        $html = $this->render([
+            'navigationTree' => [$folder],
+            'displayType' => 'collapsible',
+        ]);
+
+        static::assertStringContainsString('sw-navigation-tree-items__folder nav-link', $html);
+        static::assertStringContainsString('sw-navigation-tree-items__toggle', $html);
+        static::assertStringContainsString('aria-expanded="false"', $html);
+        static::assertStringNotContainsString('<span class="sw-navigation-tree-items__folder nav-link" aria-expanded', $html);
+    }
+
+    public function testCollapsibleModeKeepsAChildlessFolderNonInteractive(): void
+    {
+        $folder = $this->treeItem('Structure', null, CategoryDefinition::TYPE_FOLDER);
+
+        $html = $this->render([
+            'navigationTree' => [$folder],
+            'displayType' => 'collapsible',
+        ]);
+
+        static::assertStringContainsString('sw-navigation-tree-items__folder nav-link', $html);
+        static::assertStringNotContainsString('<button', $html);
+        static::assertStringNotContainsString('aria-expanded', $html);
+    }
+
     public function testAcceptsTreeStructAsWellAsItemList(): void
     {
         $item = $this->treeItem('Clothing', '/clothing');
@@ -313,6 +503,7 @@ class NavigationTreeComponentTest extends TestCase
 
         $props = \array_merge([
             'navigationMaxDepth' => 3,
+            'displayType' => 'static',
             'expandAll' => false,
             'activeId' => Uuid::randomHex(),
             'activePath' => [],

--- a/tests/integration/Storefront/Framework/Twig/NavigationTreeComponentTest.php
+++ b/tests/integration/Storefront/Framework/Twig/NavigationTreeComponentTest.php
@@ -109,9 +109,8 @@ class NavigationTreeComponentTest extends TestCase
     }
 
     /**
-     * The Studio derives the control from this schema and ships no code of its own for it, so a
-     * toSchema() regression that dropped the enum would render a select with no options while
-     * every render test here kept passing.
+     * The Studio ships no code for this control, so a dropped enum would render an empty select
+     * while every render test here kept passing.
      */
     public function testDisplayTypeReachesTheSchemaWithItsOptions(): void
     {
@@ -121,7 +120,7 @@ class NavigationTreeComponentTest extends TestCase
         $displayType = $types->get('Sw:Navigation:Tree')->properties()['displayType']->toSchema();
 
         static::assertSame('static', $displayType['default']);
-        static::assertSame(['static', 'collapsible'], $displayType['enum']);
+        static::assertSame(['static', 'collapse'], $displayType['enum']);
         static::assertSame('select', $displayType['adminUI']['component'] ?? null);
     }
 
@@ -279,44 +278,38 @@ class NavigationTreeComponentTest extends TestCase
         static::assertStringNotContainsString('<button', $html);
         static::assertStringNotContainsString('aria-expanded', $html);
         static::assertStringNotContainsString('data-bs-toggle', $html);
-        static::assertStringNotContainsString('is--collapsible', $html);
+        static::assertStringNotContainsString('is--collapse', $html);
     }
 
-    /**
-     * A toggle pointing at an id that is not on the page silently does nothing, so the wiring is
-     * asserted end to end rather than attribute by attribute.
-     */
-    public function testCollapsibleModeWiresTheToggleToThePanelItControls(): void
+    public function testCollapseModeWiresTheToggleToThePanelItControls(): void
     {
         $child = $this->treeItem('Shirts', '/shirts');
         $parent = $this->treeItem('Clothing', '/clothing', children: [$child]);
 
         $html = $this->render([
             'navigationTree' => [$parent],
-            'displayType' => 'collapsible',
+            'displayType' => 'collapse',
         ]);
 
         static::assertStringContainsString('data-bs-toggle="collapse"', $html);
         static::assertSame(1, preg_match('/aria-controls="([^"]+)"/', $html, $matches));
         static::assertStringContainsString('data-bs-target="#' . $matches[1] . '"', $html);
         static::assertStringContainsString('id="' . $matches[1] . '"', $html);
-
-        // The label still navigates; only the button beside it discloses.
         static::assertStringContainsString('href="/clothing"', $html);
     }
 
     /**
-     * Two icons swapped by state, matching the footer column accordion. A missing icon file makes
-     * Sw:Icon render nothing at all, which would leave the button visually empty.
+     * Sw:Icon renders nothing at all when the icon file is missing, so the button would ship empty
+     * with every other assertion here still passing.
      */
-    public function testCollapsibleModeRendersThePlusAndMinusIcons(): void
+    public function testCollapseModeRendersThePlusAndMinusIcons(): void
     {
         $child = $this->treeItem('Shirts', '/shirts');
         $parent = $this->treeItem('Clothing', '/clothing', children: [$child]);
 
         $html = $this->render([
             'navigationTree' => [$parent],
-            'displayType' => 'collapsible',
+            'displayType' => 'collapse',
         ]);
 
         static::assertStringContainsString('sw-icon--default-plus', $html);
@@ -325,14 +318,14 @@ class NavigationTreeComponentTest extends TestCase
         static::assertSame(2, substr_count($html, '<svg'));
     }
 
-    public function testCollapsibleModeGivesTheToggleANameOfItsOwn(): void
+    public function testCollapseModeGivesTheToggleANameOfItsOwn(): void
     {
         $child = $this->treeItem('Shirts', '/shirts');
         $parent = $this->treeItem('Clothing', '/clothing', children: [$child]);
 
         $html = $this->render([
             'navigationTree' => [$parent],
-            'displayType' => 'collapsible',
+            'displayType' => 'collapse',
         ]);
 
         // Naming it after the category alone would give the row two controls with one name.
@@ -340,7 +333,7 @@ class NavigationTreeComponentTest extends TestCase
         static::assertStringNotContainsString('aria-label="Clothing"', $html);
     }
 
-    public function testCollapsibleModeStartsTheActiveBranchOpenAndLeavesSiblingsClosed(): void
+    public function testCollapseModeStartsTheActiveBranchOpenAndLeavesSiblingsClosed(): void
     {
         $activeChild = $this->treeItem('ActiveChild', '/active-child');
         $activeBranch = $this->treeItem('ActiveBranch', '/active-branch', children: [$activeChild]);
@@ -350,7 +343,7 @@ class NavigationTreeComponentTest extends TestCase
 
         $html = $this->render([
             'navigationTree' => [$activeBranch, $siblingBranch],
-            'displayType' => 'collapsible',
+            'displayType' => 'collapse',
             'activePath' => [$activeBranch->getCategory()->getId()],
         ]);
 
@@ -363,15 +356,14 @@ class NavigationTreeComponentTest extends TestCase
         static::assertSame(1, substr_count($html, 'collapse show'));
     }
 
-    public function testCollapsibleModeUsesExpandAllAsTheInitialState(): void
+    public function testCollapseModeUsesExpandAllAsTheInitialState(): void
     {
         $child = $this->treeItem('HiddenChild', '/hidden-child');
         $branch = $this->treeItem('Branch', '/branch', children: [$child]);
 
-        $closed = $this->render(['navigationTree' => [$branch], 'displayType' => 'collapsible']);
-        $open = $this->render(['navigationTree' => [$branch], 'displayType' => 'collapsible', 'expandAll' => true]);
+        $closed = $this->render(['navigationTree' => [$branch], 'displayType' => 'collapse']);
+        $open = $this->render(['navigationTree' => [$branch], 'displayType' => 'collapse', 'expandAll' => true]);
 
-        // expandAll stops gating the markup here: a branch has to exist to be expandable.
         static::assertStringContainsString('HiddenChild', $closed);
         static::assertStringContainsString('HiddenChild', $open);
 
@@ -379,11 +371,7 @@ class NavigationTreeComponentTest extends TestCase
         static::assertStringContainsString('aria-expanded="true"', $open);
     }
 
-    /**
-     * A toggle whose panel was clipped by the depth limit would control nothing, so the button keys
-     * off the rendered children rather than off the children the tree carries.
-     */
-    public function testCollapsibleModeRendersNoToggleWhenTheDepthLimitDropsTheChildren(): void
+    public function testCollapseModeRendersNoToggleWhenTheDepthLimitDropsTheChildren(): void
     {
         $level3 = $this->treeItem('Level3', '/level-3');
         $level2 = $this->treeItem('Level2', '/level-2', children: [$level3]);
@@ -392,7 +380,7 @@ class NavigationTreeComponentTest extends TestCase
         $html = $this->render([
             'navigationTree' => [$level1],
             'navigationMaxDepth' => 2,
-            'displayType' => 'collapsible',
+            'displayType' => 'collapse',
         ]);
 
         static::assertStringContainsString('Level2', $html);
@@ -400,7 +388,7 @@ class NavigationTreeComponentTest extends TestCase
         static::assertSame(1, substr_count($html, 'data-bs-toggle="collapse"'));
     }
 
-    public function testCollapsibleModeKeepsTheActivePathBeyondTheRenderDepth(): void
+    public function testCollapseModeKeepsTheActivePathBeyondTheRenderDepth(): void
     {
         $active = $this->treeItem('Sneakers', '/sneakers');
         $middle = $this->treeItem('Shoes', '/shoes', children: [$active]);
@@ -409,31 +397,29 @@ class NavigationTreeComponentTest extends TestCase
         $html = $this->render([
             'navigationTree' => [$top],
             'navigationMaxDepth' => 2,
-            'displayType' => 'collapsible',
+            'displayType' => 'collapse',
             'activeId' => $active->getCategory()->getId(),
             'activePath' => [$top->getCategory()->getId(), $middle->getCategory()->getId()],
         ]);
 
         static::assertStringContainsString('Sneakers', $html);
         static::assertSame(1, substr_count($html, 'aria-current="page"'));
-
-        // Every panel on the active path starts open, so nothing hides the current page.
         static::assertSame(2, substr_count($html, 'aria-expanded="true"'));
         static::assertSame(0, substr_count($html, 'aria-expanded="false"'));
     }
 
     /**
-     * The toggle sits beside the label instead of replacing it, so a folder stays a span. Putting
-     * aria-expanded on a span would make the state invisible to assistive technology.
+     * Assistive technology ignores aria-expanded on a span, so the toggle has to be its own
+     * control rather than the folder itself.
      */
-    public function testCollapsibleModeKeepsAFolderASpanAndPutsTheToggleBesideIt(): void
+    public function testCollapseModeKeepsAFolderASpanAndPutsTheToggleBesideIt(): void
     {
         $child = $this->treeItem('Shirts', '/shirts');
         $folder = $this->treeItem('Structure', null, CategoryDefinition::TYPE_FOLDER, children: [$child]);
 
         $html = $this->render([
             'navigationTree' => [$folder],
-            'displayType' => 'collapsible',
+            'displayType' => 'collapse',
         ]);
 
         static::assertStringContainsString('sw-navigation-tree-items__folder nav-link', $html);
@@ -442,13 +428,13 @@ class NavigationTreeComponentTest extends TestCase
         static::assertStringNotContainsString('<span class="sw-navigation-tree-items__folder nav-link" aria-expanded', $html);
     }
 
-    public function testCollapsibleModeKeepsAChildlessFolderNonInteractive(): void
+    public function testCollapseModeKeepsAChildlessFolderNonInteractive(): void
     {
         $folder = $this->treeItem('Structure', null, CategoryDefinition::TYPE_FOLDER);
 
         $html = $this->render([
             'navigationTree' => [$folder],
-            'displayType' => 'collapsible',
+            'displayType' => 'collapse',
         ]);
 
         static::assertStringContainsString('sw-navigation-tree-items__folder nav-link', $html);
@@ -510,8 +496,8 @@ class NavigationTreeComponentTest extends TestCase
     /**
      * Every prop is passed explicitly so the component's global-reading defaults
      * (`shopware.navigation`, `context.salesChannel`) are never evaluated. The translator is the
-     * exception since collapsible mode names its toggle from `general.toggleSubcategories`: a
-     * missing snippet makes those tests fail on the name rather than on what they assert.
+     * exception. Collapse mode names its toggle from `general.toggleSubcategories`, so a missing
+     * snippet makes those tests fail on the name rather than on what they assert.
      *
      * @param array<string, mixed> $props
      */


### PR DESCRIPTION
### 1. Why is this change necessary?

`Sw:Navigation:Tree` renders only the branch leading to the current category, or — with
`expandAll` — every level at once. A shopper cannot open a branch they are not standing in, so
reaching a sibling subtree always costs a page load.

### 2. What does this change do, exactly?

1. 2 display types (static & collapse):
<img width="476" height="564" alt="Bildschirmfoto 2026-08-21 um 09 39 01" src="https://github.com/user-attachments/assets/71f312d2-b0ae-487e-bfa6-11a6329a4ee3" />

2. Collapse mode:
<img width="771" height="742" alt="Bildschirmfoto 2026-08-21 um 09 38 55" src="https://github.com/user-attachments/assets/8852e708-da6e-4672-a921-06809210c2d3" />

Adds a `displayType` prop with two values, matching the prop `Sw:Filter:Item` already ships:

* `static` (default) — unchanged. The rendered output is byte-identical to before, verified by
  rendering the storefront home page against the base branch: zero difference inside the
  navigation region. All new CSS is scoped under `is--collapse`, a class static mode never emits.
* `collapse` — every category whose children are actually rendered gets a toggle beside its
  label. Children are rendered into a Bootstrap `collapse` panel and the active branch starts open.

Design decisions worth reviewing:

* **The toggle is a real `<button>` carrying `aria-expanded` and `aria-controls`**, not a styled
  span. This is the WAI-ARIA APG *Disclosure Navigation* pattern, which has the most uniform
  assistive-technology support. `<details>`/`<summary>` was considered and rejected: it would
  need a link inside `<summary>`, which is the documented weak spot of that element.
* **The toggle sits beside the label instead of replacing it**, following the footer column
  accordion (`layout/footer/footer.html.twig:142-160`). A folder therefore stays a `<span>` and
  never has to carry `aria-expanded`, which assistive technology ignores on a span.
* **Icons are `plus`/`minus` swapped by state**, not one rotating chevron — same as the footer
  accordion, so the affordance is one customers already know. The predecessor
  (`layout/sidebar/category-navigation.html.twig`) has no expansion at all, so there was nothing
  to copy for the tree itself.
* **The toggle uses `Sw:Button variant="inline" :iconOnly="true"`**, giving `btn-link-inline
  btn-icon`: no padding, no border, and a 2.5rem square target that matches the height of a
  `nav-link` row and clears the WCAG minimum target size.
* **`expandAll` becomes the initial state in this mode**, not a render gate. A branch has to be
  in the DOM to be expandable, so with `displayType: collapse` every branch within the depth
  limit is rendered and `expandAll` decides which ones start open. Its meaning in `static` mode
  is unchanged. Consequence worth weighing: this mode always pays the full-depth payload, with
  no cap short of switching back to `static`. The help text says so.
* **The toggle keys off rendered children, not `children|length`.** The depth limit can drop the
  children of a category that has some, and a button controlling nothing is worse than no button.

Two Bootstrap behaviours the stylesheet works around. Both are one-liners that look removable and
are not, so they are recorded here rather than in the file:

* `.sw-navigation-tree-items.is--collapse > … __item { border-top: … }` — the stripe between rows
  moves from the link to the row in this mode. `.btn:hover` rewrites `border-color`
  (`bootstrap/scss/_buttons.scss:47`) at specificity 0,2,0, which blanked the segment above the
  toggle whenever the pointer touched it. On the row it is immune to every button state.
* `.sw-navigation-tree-items.is--collapse { flex-wrap: nowrap }` — Bootstrap animates a collapse
  open from `height: 0` (`collapse.js:140`, `_transitions.scss:16`) while `.nav` sets
  `flex-wrap: wrap` and the `flex-column` utility never resets it. A wrapping column box with no
  height puts each child in its own column, so the sub-levels flashed side by side while opening.
* The toggle's own rules are scoped and set colour through `--bs-btn-color`, because
  `.btn-link-inline` declares `text-decoration` twice, once under `:hover`
  (`Sw/Button/index.scss:60-69`), above the weight of a bare class selector.

The existing invariant that the depth limit must not clip the active path is preserved in both
modes and covered by its own test — clipping it would drop the element carrying `aria-current`.

`displayType` is exposed on the element type in `navigation/tree.yaml` as an enum with
`adminUI.component: select`, so the Studio derives the control from the schema without any
Administration change.

### 3. Describe each step to reproduce the issue or behaviour.

1. Check out `feat/experience-studio` and place a `Sw:Navigation:Tree` element in a layout bound
   to a category that has children.
2. Leave **Display type** on `static` — the tree shows only the branch of the current category,
   exactly as before.
4. Set **Display type** to `collapse` and switch **Expand all** off.
5. In the storefront, every category with sub-levels now has a `+` beside it. The branch of the
   current page starts open with `−`. Tab reaches each toggle, Enter or Space opens the branch and
   flips `aria-expanded`.

Note for reviewers touching the SCSS: component stylesheets are compiled by a separate Vite build
and their hashed filename is baked into the compiled theme, so a change needs
`npm run build:components`, `bin/console assets:install` **and** `bin/console theme:compile` before
it shows up. Without the theme compile the page keeps linking the previous hash and answers 404.

### 4. Please link to the relevant issues (if any).

- closes #19502
- relates #19057

Flyout and mobile-category-menu integration stay out of scope, as stated in #19057 and repeated in
#19502.

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
  - 11 new tests, 28 in `NavigationTreeComponentTest` in total, all passing. Verified by stashing
    only `Tree.html.twig` and `TreeItems.html.twig` and re-running: 8 of the 9 `CollapseMode`
    tests fail. The ninth (`KeepsAChildlessFolderNonInteractive`) passes either way by design — it
    is a guard that a childless folder gains no control, not a new-behaviour test.
  - **Test layers, so a reviewer does not have to look**: there are no unit tests and none are
    possible here. The component-system unit layer is Vitest over component JS
    (`test/component-system/embed-video.test.js` is the only spec in the repo, for the two video
    components that ship a `.js`), and this change adds no JavaScript. Integration is the layer
    that fits and carries all 28 tests: markup, toggle-to-panel wiring, the ARIA attributes, the
    icon pair, depth handling, the active-path exemption, and the element-type schema.
  - **Not covered, for either this component or any other in the new system**: the CSS and the
    actual click. `lint:scss` only covers `app/storefront/src/scss`, so component stylesheets are
    not linted at all — the Vite component build is what catches a broken one. And no acceptance
    test references any `views/components` component, so no Playwright test exercises a component
    interaction today. Adding the first one is a larger decision than this PR.
- [ ] I have updated developer-facing release notes if this change is **relevant** for external
      developers
  - Not applicable. The content system and its components are `@internal` and unreleased on this
    branch, and the predecessor #19156 added no entry either.
- [x] I have written or adjusted the documentation and agent skills according to my changes
  - `Tree.stories.json` gains a `displayType` argType and a story per mode. The element type's
    `copilot` hints state both values and that `expandAll` changes role in `collapse`.
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
  - The template and the stylesheet carry no added comments. The two non-obvious workarounds are
    documented in section 2 above instead.
- [x] I have read the contribution requirements and fulfilled them

---

**CI note:** `lint`, `Commercial`, `Rufus` and `downstream-check` are red on the base branch, not
from this PR. The lint errors are Vue and TS violations in `sw-experience-studio` Administration
files, and this branch touches zero files under `src/Administration`. The suites that cover this
change pass: `8.2 Storefront mysql:8.0`, `8.2 Core/Content mysql:8.0`, `Jest Storefront` and
`BC check`.
