### PR TITLE
test: align migration package attributes with the framework domain

### DIFF
--- a/tests/migration/Core/V6_6/Migration1733323215AddHashToAppTemplateTest.php
+++ b/tests/migration/Core/V6_6/Migration1733323215AddHashToAppTemplateTest.php
@@ -13,7 +13,7 @@ use Shopware\Core\Migration\V6_6\Migration1733323215AddHashToAppTemplate;
 /**
  * @internal
  */
-#[Package('checkout')]
+#[Package('framework')]
 #[CoversClass(Migration1733323215AddHashToAppTemplate::class)]
 class Migration1733323215AddHashToAppTemplateTest extends TestCase
 {


### PR DESCRIPTION
### 1. Why is this change necessary?

The `#[Package]` attribute of several migrations and migration tests differs from the domain the migration belongs to, so failing tests are routed to the wrong domain team. Several migrations carry `framework` although they migrate feature-domain tables; there the source value is the one that changes.

### 2. What does this change do, exactly?

Sets the `#[Package]` value of one migration test to the framework value of its covered migration. Attribute lines only.


> [!WARNING]
> Unlike the recent unit and integration alignments, where the `src/` side was the trusted source, these values are taken from the migration _tests_: migration files saw a gradual, wild ownership drift, so the source values could not be trusted. There is no guarantee the resulting value is accurate; only your team can confirm that these migrations actually belong to framework.

Part of the stack that extends the enforcement rule to the migration suite; the extension sits on top and lands once every alignment below it is merged.

### 3. Describe each step to reproduce the issue or behaviour.

Compare each migration test's `#[Package]` value with the `#[Package]` of its `CoversClass` target, and each migration's value with the domain of the tables it migrates.

### 4. Please link to the relevant issues (if any).

- relates #18473
- relates #19581

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
