### PR TITLE
feat(framework): enforce test package attributes in the migration suite

### DIFF
--- a/src/Core/DevOps/StaticAnalyze/PHPStan/Rules/Tests/TestPackageMatchRule.php
+++ b/src/Core/DevOps/StaticAnalyze/PHPStan/Rules/Tests/TestPackageMatchRule.php
@@ -22,17 +22,14 @@ use Symfony\Component\Finder\Finder;
  * routes to the <area> team and counts as equal to the plain <area> value in both
  * directions.
  *
- * Unit tests are compared against the #[Package] of the classes and traits named in
- * their CoversClass/CoversTrait attributes. Integration tests carry no covers
- * attributes; they are compared against the #[Package] values found in the nearest
- * existing `src/` directory their namespace mirrors, and pass when they match at
- * least one of them.
+ * Unit and migration tests are compared against the #[Package] of the classes and
+ * traits named in their CoversClass/CoversTrait attributes. Integration tests carry
+ * no covers attributes; they are compared against the #[Package] values found in the
+ * nearest existing `src/` directory their namespace mirrors, and pass when they match
+ * at least one of them.
  *
- * Enforced for the core unit and integration suites only. The migration suite joins
- * once it is aligned: several migrations carry `framework` although they migrate
- * feature-domain tables, and there the source value is the one that has to change.
- * Downstream repositories load this rule set as well and carry their own package
- * taxonomy, so their test namespaces stay out.
+ * Enforced for the core test suites only. Downstream repositories load this rule set
+ * as well and carry their own package taxonomy, so their test namespaces stay out.
  *
  * @internal
  *
@@ -42,6 +39,8 @@ use Symfony\Component\Finder\Finder;
 class TestPackageMatchRule implements Rule
 {
     private const UNIT_NAMESPACE = 'Shopware\Tests\Unit\\';
+
+    private const MIGRATION_NAMESPACE = 'Shopware\Tests\Migration\\';
 
     private const INTEGRATION_NAMESPACE = 'Shopware\Tests\Integration\\';
 
@@ -71,8 +70,9 @@ class TestPackageMatchRule implements Rule
         $classReflection = $node->getClassReflection();
         $className = $classReflection->getName();
 
-        $unit = \str_starts_with($className, self::UNIT_NAMESPACE);
-        if (!$unit && !\str_starts_with($className, self::INTEGRATION_NAMESPACE)) {
+        $covers = \str_starts_with($className, self::UNIT_NAMESPACE)
+            || \str_starts_with($className, self::MIGRATION_NAMESPACE);
+        if (!$covers && !\str_starts_with($className, self::INTEGRATION_NAMESPACE)) {
             return [];
         }
 
@@ -85,7 +85,7 @@ class TestPackageMatchRule implements Rule
             return [];
         }
 
-        return $unit
+        return $covers
             ? $this->matchCoveredClasses($node, $testPackage)
             : $this->matchMirroredDirectory($className, $testPackage);
     }

--- a/src/Core/DevOps/StaticAnalyze/PHPStan/core-rules.neon
+++ b/src/Core/DevOps/StaticAnalyze/PHPStan/core-rules.neon
@@ -36,7 +36,7 @@ rules:
     - Shopware\Core\DevOps\StaticAnalyze\PHPStan\Rules\Tests\NoReflectionOnNonPublicMethodsRule
 
 services:
-    # gated to the core unit and integration test namespaces inside the rule; downstream repositories carry their own package taxonomy
+    # gated to the core test namespaces inside the rule; downstream repositories carry their own package taxonomy
     -
         class: Shopware\Core\DevOps\StaticAnalyze\PHPStan\Rules\Tests\TestPackageMatchRule
         arguments:

--- a/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/TestPackageMatchRuleTest.php
+++ b/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/TestPackageMatchRuleTest.php
@@ -65,10 +65,15 @@ class TestPackageMatchRuleTest extends RuleTestCase
         $this->analyse([self::FIXTURE_DIR . '/UnpackagedCoveredFixture.php'], []);
     }
 
-    #[TestDox('skips tests outside the core unit and integration suites, like the migration suite')]
-    public function testMigrationSuiteNotEnforced(): void
+    #[TestDox('compares migration tests against their covered class')]
+    public function testMigrationSuiteEnforced(): void
     {
-        $this->analyse([self::FIXTURE_DIR . '/MigrationSuiteFixture.php'], []);
+        $this->analyse([self::FIXTURE_DIR . '/MigrationSuiteFixture.php'], [
+            [
+                'The #[Package(\'framework\')] attribute of this test does not match the covered Shopware\Tests\DevOps\Core\DevOps\StaticAnalyse\PHPStan\Rules\data\TestPackageMatchRule\Covered\CheckoutService (checkout)',
+                10,
+            ],
+        ]);
     }
 
     #[TestDox('skips tests of downstream repositories, which carry their own package taxonomy')]


### PR DESCRIPTION
### 1. Why is this change necessary?

`TestPackageMatchRule` has excluded the migration suite so far: several migrations carried `framework` although they migrate feature-domain tables, and the suite could not be enforced before those values were corrected.

### 2. What does this change do, exactly?

Adds `Shopware\Tests\Migration` to the namespaces the rule enforces; migration tests are compared against their `CoversClass` target, like unit tests.

The remaining mismatches are aligned in per-domain pull requests below this one in the stack, one per receiving domain team. This pull request sits on top and lands last, when no mismatch is left.

### 3. Describe each step to reproduce the issue or behaviour.

Change a `#[Package]` value on a migration test or on the migration it covers so the two differ and run `composer phpstan`: the analysis fails with `shopware.coversPackageMismatch`. The behaviour is covered by `TestPackageMatchRuleTest`.

### 4. Please link to the relevant issues (if any).

- relates #18473

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
