### PR TITLE
fix: remove faulty _isTranslatable() check at max zoom in _setActionButtonState

### DIFF
--- a/src/Storefront/Resources/app/storefront/src/plugin/image-zoom/image-zoom.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/image-zoom/image-zoom.plugin.js
@@ -100,7 +100,7 @@ export default class ImageZoomPlugin extends Plugin {
         this._updateTranslateRange();
         this._initHammer();
         this._registerEvents();
-        
+
         // Set button state after a brief delay to ensure image is laid out
         setTimeout(() => {
             this._setActionButtonState();
@@ -114,15 +114,15 @@ export default class ImageZoomPlugin extends Plugin {
         // Reset transform state when switching images
         this._storedTransform = new Vector3(0, 0, 1);
         this._transform = new Vector3(0, 0, 1);
-        
+
         // Recalculate sizes for the new image
         this._imageMaxSize = new Vector2(this._image.naturalWidth, this._image.naturalHeight).multiply(2);
         this._imageSize = new Vector2(this._image.offsetWidth, this._image.offsetHeight);
         this._containerSize = new Vector2(this.el.offsetWidth, this.el.offsetHeight);
-        
+
         this._updateTranslateRange();
         this._updateTransform(true);
-        
+
         // Set button state after a brief delay to ensure image is laid out
         setTimeout(() => {
             this._setActionButtonState();
@@ -139,7 +139,7 @@ export default class ImageZoomPlugin extends Plugin {
             touchAction: 'none',
         });
         this._hammer.get('pinch').set({ enable: true });
-        this._hammer.get('pan').set({ 
+        this._hammer.get('pan').set({
             direction: Hammer.DIRECTION_ALL,
             threshold: 0,
         });
@@ -410,10 +410,6 @@ export default class ImageZoomPlugin extends Plugin {
         const maxZoom = this._getMaxZoomValue();
 
         if (currentZoom === 1 && maxZoom === 1) {
-            this._setButtonDisabledState(this._zoomResetActionElement);
-            this._setButtonDisabledState(this._zoomOutActionElement);
-            this._setButtonDisabledState(this._zoomInActionElement);
-        } else if (maxZoom === currentZoom && !this._isTranslatable()) {
             this._setButtonDisabledState(this._zoomResetActionElement);
             this._setButtonDisabledState(this._zoomOutActionElement);
             this._setButtonDisabledState(this._zoomInActionElement);


### PR DESCRIPTION
### 1. Why is this change necessary?
The condition disabled reset/zoom-out buttons when at max zoom and the image still fit the container (!this._isTranslatable()), leaving users stuck with no way to reset. At max zoom, only zoom-in should disable; reset/zoom-out must remain enabled whenever z !== 1 regardless of panning availability.

### 2. What does this change do, exactly?
Removes the faulty else if branch in _setActionButtonState() that checked !this._isTranslatable() at max zoom. This branch incorrectly disabled the reset and zoom-out buttons when the image was at maximum zoom but still fit within the container (no panning room). After this change, at max zoom only the zoom-in button is disabled; reset and zoom-out remain enabled whenever the image is zoomed in (z !== 1), regardless of whether panning is available.

### 3. Describe each step to reproduce the issue or behaviour.
Open a product detail page with a zoomable image
Click the image to open the zoom modal
Zoom in to the maximum zoom level using the zoom-in button or mouse wheel
If the scaled image still fits the container (no panning room), observe that the reset and zoom-out buttons are disabled
User is now stuck at max zoom with no way to reset or zoom out via the action buttons

### 4. Please link to the relevant issues (if any).
- closes the issue https://github.com/shopware/shopware/issues/19590 when the PR is merged
