### PR TITLE
feat(core): accept EU VAT IDs from any member state for the intra-community delivery note

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -338,6 +338,14 @@ This affects every write path, not just Settings > Shop > SEO:
 - Writes that do not change the stored `template` value do not queue anything: update commands request a DAL change set, so an idempotent Sync API push of an identical template stays inert. Inserts with an empty or `null` template are skipped as well.
 - Extensions and deployment scripts that write `seo_url_template` rows on every install or update will therefore queue a full regeneration pass for the affected route each time. Guard such writes with a value comparison if that is not intended.
 
+### Intra-community delivery note accepts VAT IDs from any EU member state
+
+The intra-community delivery note on invoices, cancellation invoices and credit notes previously only appeared while the commercial customer's VAT ID matched the delivery country's VAT ID pattern. A customer with a Dutch VAT ID and a Belgian delivery address was treated as tax free but received a document without the note.
+
+Both document stacks now fall back to the VAT ID patterns of all EU member states (Settings > Countries) when the VAT ID does not match the delivery country's pattern, so the note follows the same rule as the tax exemption. A VAT ID that matches no member state still suppresses the note.
+
+The change is contained in `AbstractDocumentRenderer::isValidVat()` (inherited by the invoice, cancellation invoice and credit note renderers) and in the DocumentV2 `InvoiceDataProvider`. No method signatures changed, so renderers and providers that extend or decorate these classes keep working unchanged.
+
 ## Administration
 
 ### Admin Worker loads correctly when the Administration is hosted under a base path

--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -338,14 +338,6 @@ This affects every write path, not just Settings > Shop > SEO:
 - Writes that do not change the stored `template` value do not queue anything: update commands request a DAL change set, so an idempotent Sync API push of an identical template stays inert. Inserts with an empty or `null` template are skipped as well.
 - Extensions and deployment scripts that write `seo_url_template` rows on every install or update will therefore queue a full regeneration pass for the affected route each time. Guard such writes with a value comparison if that is not intended.
 
-### Intra-community delivery note accepts VAT IDs from any EU member state
-
-The intra-community delivery note on invoices, cancellation invoices and credit notes previously only appeared while the commercial customer's VAT ID matched the delivery country's VAT ID pattern. A customer with a Dutch VAT ID and a Belgian delivery address was treated as tax free but received a document without the note.
-
-Both document stacks now fall back to the VAT ID patterns of all EU member states (Settings > Countries) when the VAT ID does not match the delivery country's pattern, so the note follows the same rule as the tax exemption. A VAT ID that matches no member state still suppresses the note.
-
-The change is contained in `AbstractDocumentRenderer::isValidVat()` (inherited by the invoice, cancellation invoice and credit note renderers) and in the DocumentV2 `InvoiceDataProvider`. No method signatures changed, so renderers and providers that extend or decorate these classes keep working unchanged.
-
 ## Administration
 
 ### Admin Worker loads correctly when the Administration is hosted under a base path

--- a/src/Core/Checkout/Document/Renderer/AbstractDocumentRenderer.php
+++ b/src/Core/Checkout/Document/Renderer/AbstractDocumentRenderer.php
@@ -108,6 +108,7 @@ abstract class AbstractDocumentRenderer
             return true;
         }
 
+        $vatIdPattern = $country->getVatIdPattern();
         $vatIds = $order->getOrderCustomer()?->getVatIds();
         if (!\is_array($vatIds)) {
             return false;
@@ -115,7 +116,11 @@ abstract class AbstractDocumentRenderer
 
         $violations = $validator->validate($vatIds, [
             new NotBlank(),
-            new CustomerVatIdentification(countryId: $country->getId()),
+            // The exemption follows the member state that issued the VAT ID, not the delivery country
+            new CustomerVatIdentification(
+                countryId: $country->getId(),
+                matchesAnyEuVat: $vatIdPattern !== null && $vatIdPattern !== '',
+            ),
         ]);
 
         return $violations->count() === 0;

--- a/src/Core/Checkout/DocumentV2/Provider/InvoiceDataProvider.php
+++ b/src/Core/Checkout/DocumentV2/Provider/InvoiceDataProvider.php
@@ -210,6 +210,8 @@ final readonly class InvoiceDataProvider extends AbstractDocumentDataProvider
             return true;
         }
 
+        $vatIdPattern = $country->getVatIdPattern();
+
         $vatIds = $order->getOrderCustomer()?->getVatIds();
 
         if (!\is_array($vatIds)) {
@@ -220,8 +222,10 @@ final readonly class InvoiceDataProvider extends AbstractDocumentDataProvider
             $vatIds,
             [
                 new NotBlank(),
+                // The exemption follows the member state that issued the VAT ID, not the delivery country
                 new CustomerVatIdentification(
                     countryId: $country->getId(),
+                    matchesAnyEuVat: $vatIdPattern !== null && $vatIdPattern !== '',
                 ),
             ],
         )->count() === 0;

--- a/tests/integration/Core/Checkout/Document/Renderer/InvoiceRendererTest.php
+++ b/tests/integration/Core/Checkout/Document/Renderer/InvoiceRendererTest.php
@@ -960,5 +960,25 @@ class InvoiceRendererTest extends TestCase
             'vatNumber' => 'invalid',
             'shouldDisplay' => false,
         ];
+
+        yield 'should be displayed because the VAT ID belongs to another EU member state' => [
+            'customerType' => CustomerEntity::ACCOUNT_TYPE_BUSINESS,
+            'enableIntraCommunityDeliveryLabel' => true,
+            'enableTaxFreeB2bOption' => true,
+            'isEuMember' => true,
+            'validateVat' => true,
+            'vatNumber' => 'NL123456789B01',
+            'shouldDisplay' => true,
+        ];
+
+        yield 'should not be displayed because the VAT ID belongs to no EU member state' => [
+            'customerType' => CustomerEntity::ACCOUNT_TYPE_BUSINESS,
+            'enableIntraCommunityDeliveryLabel' => true,
+            'enableTaxFreeB2bOption' => true,
+            'isEuMember' => true,
+            'validateVat' => true,
+            'vatNumber' => 'CHE116281838',
+            'shouldDisplay' => false,
+        ];
     }
 }

--- a/tests/unit/Core/Checkout/Document/Renderer/InvoiceRendererTest.php
+++ b/tests/unit/Core/Checkout/Document/Renderer/InvoiceRendererTest.php
@@ -7,6 +7,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\Customer\CustomerEntity;
+use Shopware\Core\Checkout\Customer\Validation\Constraint\CustomerVatIdentification;
 use Shopware\Core\Checkout\Document\Aggregate\DocumentBaseConfig\DocumentBaseConfigCollection;
 use Shopware\Core\Checkout\Document\Aggregate\DocumentBaseConfig\DocumentBaseConfigDefinition;
 use Shopware\Core\Checkout\Document\Aggregate\DocumentBaseConfig\DocumentBaseConfigEntity;
@@ -57,6 +58,16 @@ use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 class InvoiceRendererTest extends TestCase
 {
     private const COUNTRY_ID = 'country-id';
+
+    public function testIntraCommunityDeliveryRequestsEuWideMatchingWhenTheDeliveryCountryHasAPattern(): void
+    {
+        static::assertTrue($this->captureVatIdConstraint('DE\d{9}')->getMatchesAnyEuVat());
+    }
+
+    public function testIntraCommunityDeliveryKeepsEuWideMatchingOffWithoutADeliveryCountryPattern(): void
+    {
+        static::assertFalse($this->captureVatIdConstraint(null)->getMatchesAnyEuVat());
+    }
 
     /**
      * @param OrderSettings $orderSettings
@@ -424,6 +435,93 @@ class InvoiceRendererTest extends TestCase
             ],
             'expectedResult' => true,
         ];
+    }
+
+    /**
+     * Renders an EU business order and returns the VAT ID constraint the renderer handed to the validator.
+     */
+    private function captureVatIdConstraint(?string $vatIdPattern): CustomerVatIdentification
+    {
+        $context = Context::createDefaultContext();
+
+        $order = $this->createOrder([
+            'accountType' => CustomerEntity::ACCOUNT_TYPE_BUSINESS,
+            'isCountryCompanyTaxFree' => true,
+            'setOrderDelivery' => true,
+            'setShippingCountry' => true,
+            'setEuCountry' => true,
+            'shouldCheckVatIdPattern' => true,
+        ]);
+
+        $delivery = $order->getPrimaryOrderDelivery() ?? $order->getDeliveries()?->first();
+        static::assertNotNull($delivery);
+
+        $country = $delivery->getShippingOrderAddress()?->getCountry();
+        static::assertNotNull($country);
+
+        if ($vatIdPattern !== null) {
+            $country->setVatIdPattern($vatIdPattern);
+        }
+
+        $order->getOrderCustomer()?->setVatIds(['NL123456789B01']);
+
+        $constraints = [];
+
+        $validator = static::createStub(ValidatorInterface::class);
+        $validator->method('validate')->willReturnCallback(
+            function (mixed $value, mixed $given) use (&$constraints): ConstraintViolationList {
+                $constraints = \is_array($given) ? $given : [$given];
+
+                return new ConstraintViolationList();
+            }
+        );
+
+        $orderRepository = static::createStub(EntityRepository::class);
+        $orderRepository->method('search')->willReturn(new EntitySearchResult(
+            OrderDefinition::ENTITY_NAME,
+            1,
+            new OrderCollection([$order]),
+            null,
+            new Criteria(),
+            $context
+        ));
+
+        $documentConfigRepository = static::createStub(EntityRepository::class);
+        $documentConfigRepository->method('search')->willReturn($this->createDocumentConfigSearchResult(
+            ['displayAdditionalNoteDelivery' => true, 'fileTypes' => ['pdf']],
+            $context
+        ));
+
+        $connection = static::createStub(Connection::class);
+        $connection->method('fetchAllAssociative')->willReturn([
+            ['language_id' => Defaults::LANGUAGE_SYSTEM, 'ids' => $order->getId()],
+        ]);
+
+        $renderer = new InvoiceRenderer(
+            $orderRepository,
+            new DocumentConfigLoader($documentConfigRepository, static::createStub(EntityRepository::class)),
+            static::createStub(EventDispatcherInterface::class),
+            static::createStub(NumberRangeValueGeneratorInterface::class),
+            $connection,
+            static::createStub(DocumentFileRendererRegistry::class),
+            $validator,
+            new NativeClock()
+        );
+
+        $renderer->render(
+            [$order->getId() => new DocumentGenerateOperation($order->getId())],
+            $context,
+            new DocumentRendererConfig()
+        );
+
+        $vatConstraints = array_values(array_filter(
+            $constraints,
+            static fn (mixed $constraint): bool => $constraint instanceof CustomerVatIdentification
+        ));
+
+        static::assertCount(1, $vatConstraints);
+
+        return $vatConstraints[0];
     }
 
     /**

--- a/tests/unit/Core/Checkout/DocumentV2/Provider/InvoiceDataProviderTest.php
+++ b/tests/unit/Core/Checkout/DocumentV2/Provider/InvoiceDataProviderTest.php
@@ -10,6 +10,7 @@ use Shopware\Core\Checkout\Cart\Price\Struct\CartPrice;
 use Shopware\Core\Checkout\Cart\Tax\Struct\CalculatedTaxCollection;
 use Shopware\Core\Checkout\Cart\Tax\Struct\TaxRuleCollection;
 use Shopware\Core\Checkout\Customer\CustomerEntity;
+use Shopware\Core\Checkout\Customer\Validation\Constraint\CustomerVatIdentification;
 use Shopware\Core\Checkout\Document\Aggregate\DocumentBaseConfig\DocumentBaseConfigCollection;
 use Shopware\Core\Checkout\Document\Aggregate\DocumentBaseConfig\DocumentBaseConfigDefinition;
 use Shopware\Core\Checkout\Document\Aggregate\DocumentBaseConfig\DocumentBaseConfigEntity;
@@ -361,6 +362,66 @@ class InvoiceDataProviderTest extends TestCase
             'expectedIntraCommunityDelivery' => true,
             'vatViolationCount' => 0,
         ];
+    }
+
+    public function testIntraCommunityDeliveryRequestsEuWideMatchingWhenTheDeliveryCountryHasAPattern(): void
+    {
+        static::assertTrue($this->captureVatIdConstraint('DE\d{9}')->getMatchesAnyEuVat());
+    }
+
+    public function testIntraCommunityDeliveryKeepsEuWideMatchingOffWithoutADeliveryCountryPattern(): void
+    {
+        static::assertFalse($this->captureVatIdConstraint(null)->getMatchesAnyEuVat());
+    }
+
+    /**
+     * Renders an EU business order and returns the VAT ID constraint the provider handed to the validator.
+     */
+    private function captureVatIdConstraint(?string $vatIdPattern): CustomerVatIdentification
+    {
+        $constraints = [];
+
+        $validator = static::createStub(ValidatorInterface::class);
+        $validator->method('validate')->willReturnCallback(
+            function (mixed $value, mixed $given) use (&$constraints): ConstraintViolationList {
+                $constraints = \is_array($given) ? $given : [$given];
+
+                return new ConstraintViolationList();
+            }
+        );
+
+        $country = self::createCountry(companyTaxEnabled: true, isEu: true);
+
+        if ($vatIdPattern !== null) {
+            $country->setVatIdPattern($vatIdPattern);
+        }
+
+        $order = self::createOrder(
+            accountType: CustomerEntity::ACCOUNT_TYPE_BUSINESS,
+            country: $country,
+            vatIds: ['NL123456789B01'],
+        );
+
+        $this->createProvider(['displayAdditionalNoteDelivery' => true], $validator)
+            ->provideRenderingData(
+                new ProviderInput($order, new DocumentGenerationRequest(
+                    $order->getId(),
+                    DocumentType::INVOICE,
+                    [DocumentFormat::PDF],
+                    '12345',
+                    documentDate: '2026-05-05T12:00:00+00:00',
+                )),
+                Context::createDefaultContext()
+            );
+
+        $vatConstraints = array_values(array_filter(
+            $constraints,
+            static fn (mixed $constraint): bool => $constraint instanceof CustomerVatIdentification
+        ));
+
+        static::assertCount(1, $vatConstraints);
+
+        return $vatConstraints[0];
     }
 
     /**


### PR DESCRIPTION



<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
Both document stacks decided the note from the delivery country's VAT ID pattern alone, so an order that TaxDetector treats as tax free still rendered an invoice without the note when the customer holds the VAT ID of another member state



### 2. What does this change do, exactly?
The delivery-country pattern stays the fast path; the EU-wide fallback is requested only when that pattern exists, which keeps the verdict identical to TaxDetector for every other configuration


### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->
- closes #19175
### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
