### PR TITLE
fix: a11y active main nav entry (backport: 6.6.x)

### DIFF
--- a/changelog/_unreleased/2025-03-04-set-aria-current-page-for-activatenavigationid-in-navbar.md
+++ b/changelog/_unreleased/2025-03-04-set-aria-current-page-for-activatenavigationid-in-navbar.md
@@ -1,0 +1,11 @@
+---
+title: Set aria-current page for activateNavigationId in navbar
+issue: NEXT-40842
+author: Björn Meyer
+author_email: b.meyer@shopware.com
+author_github: @BrocksiNet
+---
+# Storefront
+* Changed `navbar.plugin.js` to set `aria-current="page"` for the active navigation item depending on `window.activeNavigationId`.
+
+This change improves accessibility by indicating the current page in the main navigation menu.

--- a/src/Storefront/Resources/app/storefront/src/plugin/main-menu/flyout-menu.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/main-menu/flyout-menu.plugin.js
@@ -65,6 +65,7 @@ export default class FlyoutMenuPlugin extends Plugin {
         this._flyoutEls = this.el.querySelectorAll(`[${this.options.flyoutIdDataAttribute}]`);
         this._hasOpenedFlyouts = false;
         this._registerEvents();
+        this._setAriaCurrentPage();
     }
 
     /**
@@ -123,9 +124,6 @@ export default class FlyoutMenuPlugin extends Plugin {
             });
         }
 
-        window.addEventListener('load', () => {
-            this._setAriaCurrentPage();
-        });
     }
 
     /**
@@ -287,4 +285,3 @@ export default class FlyoutMenuPlugin extends Plugin {
         }
     }
 }
-

--- a/src/Storefront/Resources/app/storefront/src/plugin/main-menu/flyout-menu.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/main-menu/flyout-menu.plugin.js
@@ -51,6 +51,11 @@ export default class FlyoutMenuPlugin extends Plugin {
          * Should be the same as 'flyoutIdDataAttribute'
          */
         triggerDataAttribute: 'data-flyout-menu-trigger',
+
+        /**
+         * Class to select the current page to add aria label current page to it.
+         */
+        ariaCurrentPageSelector: '.nav-item-{id}-link',
     };
 
     init() {
@@ -117,6 +122,10 @@ export default class FlyoutMenuPlugin extends Plugin {
                 el.addEventListener('mouseleave', () => this._debounce(this._closeAllFlyouts));
             });
         }
+
+        window.addEventListener('load', () => {
+            this._setAriaCurrentPage();
+        });
     }
 
     /**
@@ -262,6 +271,19 @@ export default class FlyoutMenuPlugin extends Plugin {
         if (event && event.cancelable) {
             event.preventDefault();
             event.stopImmediatePropagation();
+        }
+    }
+
+    /**
+     * Sets the aria-current attribute on the configured selector.
+     * @private
+     */
+    _setAriaCurrentPage() {
+        if (!window.activeNavigationId) { return; }
+        const selector = this.options.ariaCurrentPageSelector.replace('{id}', window.activeNavigationId);
+        const activeNavItem = this.el.querySelector(selector);
+        if (activeNavItem) {
+            activeNavItem.setAttribute('aria-current', 'page');
         }
     }
 }

--- a/src/Storefront/Resources/app/storefront/src/plugin/navbar/navbar.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/navbar/navbar.plugin.js
@@ -22,6 +22,7 @@ export default class NavbarPlugin extends Plugin {
         this._topLevelLinks = this.el.querySelectorAll(`${this.options.topLevelLinksSelector}`);
         this._registerEvents();
         this._isMouseOver = false;
+        this._setAriaCurrentPage();
     }
 
     _registerEvents() {
@@ -33,9 +34,6 @@ export default class NavbarPlugin extends Plugin {
             el.addEventListener(openEvent, this._toggleNavbar.bind(this, el));
             el.addEventListener(closeEvent, this._toggleNavbar.bind(this, el));
             el.addEventListener(clickEvent, this._navigateToLinkOnClick.bind(this, el));
-        });
-        window.addEventListener('load', () => {
-            this._setAriaCurrentPage();
         });
     }
 

--- a/src/Storefront/Resources/app/storefront/src/plugin/navbar/navbar.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/navbar/navbar.plugin.js
@@ -12,6 +12,10 @@ export default class NavbarPlugin extends Plugin {
          * Class to select the top level links.
          */
         topLevelLinksSelector: '.main-navigation-link',
+        /**
+         * Class to select the current page to add aria label current page to it.
+         */
+        ariaCurrentPageSelector: '.nav-item-{id}-link',
     };
 
     init() {
@@ -30,7 +34,9 @@ export default class NavbarPlugin extends Plugin {
             el.addEventListener(closeEvent, this._toggleNavbar.bind(this, el));
             el.addEventListener(clickEvent, this._navigateToLinkOnClick.bind(this, el));
         });
-
+        window.addEventListener('load', () => {
+            this._setAriaCurrentPage();
+        });
     }
 
     _toggleNavbar(topLevelLink, event) {
@@ -98,5 +104,18 @@ export default class NavbarPlugin extends Plugin {
      */
     _clearDebounce() {
         clearTimeout(this._debouncer);
+    }
+
+    /**
+     * Sets the aria-current attribute on the configured selector.
+     * @private
+     */
+    _setAriaCurrentPage() {
+        if (!window.activeNavigationId) { return; }
+        const selector = this.options.ariaCurrentPageSelector.replace('{id}', window.activeNavigationId);
+        const activeNavItem = this.el.querySelector(selector);
+        if (activeNavItem) {
+            activeNavItem.setAttribute('aria-current', 'page');
+        }
     }
 }

--- a/src/Storefront/Resources/app/storefront/test/plugin/main-menu/flyout-menu.plugin.test.js
+++ b/src/Storefront/Resources/app/storefront/test/plugin/main-menu/flyout-menu.plugin.test.js
@@ -219,11 +219,10 @@ describe('FlyoutMenu tests', () => {
         expect(plugin._flyoutEls[0].style.top).toBe('');
     });
 
-    test('_setAriaCurrentPage should be called on load event', () => {
+    test('_setAriaCurrentPage should be called during initialization', () => {
         jest.spyOn(plugin, '_setAriaCurrentPage');
 
         plugin.init();
-        window.dispatchEvent(new Event('load'));
 
         expect(plugin._setAriaCurrentPage).toHaveBeenCalled();
     });

--- a/src/Storefront/Resources/app/storefront/test/plugin/main-menu/flyout-menu.plugin.test.js
+++ b/src/Storefront/Resources/app/storefront/test/plugin/main-menu/flyout-menu.plugin.test.js
@@ -4,7 +4,7 @@ import Feature from 'src/helper/feature.helper';
 const html = `<div class="main-navigation" id="mainNavigation" data-flyout-menu="true">
             <div class="container">
             <nav class="nav main-navigation-menu" itemscope="itemscope" itemtype="https://schema.org/SiteNavigationElement">
-                <a class="nav-link main-navigation-link home-link" href="/" itemprop="url" title="Home">
+                <a class="nav-link main-navigation-link home-link nav-item-1-link" href="/" itemprop="url" title="Home">
                     <div class="main-navigation-link-text">
                         <span itemprop="name">Home</span>
                     </div>
@@ -217,5 +217,25 @@ describe('FlyoutMenu tests', () => {
         jest.runAllTimers();
         expect(plugin._hasOpenedFlyouts).toBe(false);
         expect(plugin._flyoutEls[0].style.top).toBe('');
+    });
+
+    test('_setAriaCurrentPage should be called on load event', () => {
+        jest.spyOn(plugin, '_setAriaCurrentPage');
+
+        plugin.init();
+        window.dispatchEvent(new Event('load'));
+
+        expect(plugin._setAriaCurrentPage).toHaveBeenCalled();
+    });
+
+    test('if aria-current is set for one nav-item', () => {
+        window.activeNavigationId = 1; // Set the activeNavigationId
+
+        plugin._setAriaCurrentPage();
+
+        const activeElement = document.querySelector(`.nav-item-${window.activeNavigationId}-link`);
+
+        expect(activeElement).not.toBeNull();
+        expect(activeElement.getAttribute('aria-current')).toBe('page');
     });
 });

--- a/src/Storefront/Resources/app/storefront/test/plugin/navbar/navbar.plugin.test.js
+++ b/src/Storefront/Resources/app/storefront/test/plugin/navbar/navbar.plugin.test.js
@@ -147,14 +147,10 @@ describe('NavbarPlugin', () => {
         expect(mockDropdown.hide).toHaveBeenCalled();
     });
 
-    test('_setAriaCurrentPage should be called on load event', () => {
-        const mockEvent = new Event('load');
-        jest.spyOn(navbarPlugin, '_setAriaCurrentPage'); // Spy on the method
+    test('_setAriaCurrentPage should be called during initialization', () => {
+        jest.spyOn(navbarPlugin, '_setAriaCurrentPage');
 
-        window.addEventListener('load', () => {
-            navbarPlugin._setAriaCurrentPage();
-        });
-        window.dispatchEvent(mockEvent);
+        navbarPlugin.init();
 
         expect(navbarPlugin._setAriaCurrentPage).toHaveBeenCalled();
     });

--- a/src/Storefront/Resources/app/storefront/test/plugin/navbar/navbar.plugin.test.js
+++ b/src/Storefront/Resources/app/storefront/test/plugin/navbar/navbar.plugin.test.js
@@ -146,4 +146,29 @@ describe('NavbarPlugin', () => {
         navbarPlugin._closeAllDropdowns();
         expect(mockDropdown.hide).toHaveBeenCalled();
     });
+
+    test('_setAriaCurrentPage should be called on load event', () => {
+        const mockEvent = new Event('load');
+        jest.spyOn(navbarPlugin, '_setAriaCurrentPage'); // Spy on the method
+
+        window.addEventListener('load', () => {
+            navbarPlugin._setAriaCurrentPage();
+        });
+        window.dispatchEvent(mockEvent);
+
+        expect(navbarPlugin._setAriaCurrentPage).toHaveBeenCalled();
+    });
+
+    test('if aria-current is set for one nav-item', () => {
+        const mockLink = document.createElement('a');
+        mockLink.classList.add('nav-item-1-link');
+        mockLink.setAttribute('href', 'https://example.com');
+        mockElement.appendChild(mockLink);
+
+        window.activeNavigationId = 1; // Set the activeNavigationId
+
+        navbarPlugin._setAriaCurrentPage();
+
+        expect(mockLink.getAttribute('aria-current')).toBe('page');
+    });
 });

--- a/src/Storefront/Resources/views/storefront/layout/navigation/categories.html.twig
+++ b/src/Storefront/Resources/views/storefront/layout/navigation/categories.html.twig
@@ -24,7 +24,7 @@
                                 <span itemprop="name">{{ name }}</span>
                             </div>
                         {% else %}
-                            <a class="nav-item nav-link navigation-flyout-link is-level-{{ level }}{% if id == activeId or id in activePath %} active{% endif %}"
+                            <a class="nav-item nav-link navigation-flyout-link is-level-{{ level }}{% if id == activeId or id in activePath %} active{% endif %} nav-item-{{ id }}-link"
                                href="{{ link }}"
                                itemprop="url"
                                {% if category_linknewtab(treeItem.category) %}target="_blank"

--- a/src/Storefront/Resources/views/storefront/layout/navigation/navigation.html.twig
+++ b/src/Storefront/Resources/views/storefront/layout/navigation/navigation.html.twig
@@ -19,7 +19,7 @@
 
                         {% block layout_main_navigation_menu_home %}
                             {% if context.salesChannel.translated.homeEnabled %}
-                                <a class="nav-link main-navigation-link nav-item-{{ context.salesChannel.navigationCategoryId }} {% if controllerAction is same as('home') %} active{% endif %} home-link"
+                                <a class="nav-link main-navigation-link nav-item-{{ context.salesChannel.navigationCategoryId }} {% if controllerAction is same as('home') %} active{% endif %} home-link nav-item-{{ context.salesChannel.navigationCategoryId }}-link"
                                     href="{{ path('frontend.home.page') }}"
                                     itemprop="url"
                                     title="{{ homeLabel|striptags }}">
@@ -71,7 +71,7 @@
                                             {% set active = 'active' %}
                                         {% endif %}
 
-                                        <a class="nav-link main-navigation-link nav-item-{{ category.id}} {{ active }}"
+                                        <a class="nav-link main-navigation-link nav-item-{{ category.id}} {{ active }} nav-item-{{ category.id }}-link"
                                            href="{{ category_url(category) }}"
                                            itemprop="url"
                                            {% if treeItem.children|length > 0 %}data-flyout-menu-trigger="{{ category.id }}"{% endif %}


### PR DESCRIPTION
**Backport:** https://github.com/shopware/shopware/pull/7253  
Resolves: https://github.com/shopware/shopware/issues/7088

### Backport notes

The implementation was adapted to work with the old flyout navigation used in 6.6.x.

---

### 1. Why is this change necessary?
To identify the current Page also in the main navigation.

### 2. What does this change do, exactly?
Adds the aria-current attribute with value page to the active navigation item.

### 3. Describe each step to reproduce the issue or behaviour.
Navigate with the main navigation and check the DOM if the aria-current is set correctly.

### 4. Please link to the relevant issues (if any).
- closes #7088
- Jira issue: https://shopware.atlassian.net/browse/NEXT-40842

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have created a changelog file with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.