### PR TITLE
fix(storefront): preserve video playback state across slider rebuilds

### DIFF
--- a/src/Storefront/Resources/app/storefront/src/plugin/slider/base-slider.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/slider/base-slider.plugin.js
@@ -56,6 +56,8 @@ export default class BaseSliderPlugin extends Plugin {
     rebuild(viewport = ViewportDetection.getCurrentViewport(), resetIndex = false) {
         this._getSettings(viewport.toLowerCase());
 
+        const activeVideoState = this._captureActiveVideoState();
+
         // get the current index and use it as the start index
         try {
             if (this._slider && !resetIndex) {
@@ -68,7 +70,59 @@ export default class BaseSliderPlugin extends Plugin {
             // something went wrong
         }
 
+        this._restoreActiveVideoState(activeVideoState);
+
         this.$emitter.publish('rebuild');
+    }
+
+    /**
+     * Captures the playback position of a video on the currently active slide, since destroying and
+     * re-initialising the slider moves the slide markup and stops any video that was playing.
+     *
+     * @returns {{currentTime: number, wasPlaying: boolean}|null}
+     * @private
+     */
+    _captureActiveVideoState() {
+        if (!this._slider) {
+            return null;
+        }
+
+        const activeSlide = this.getActiveSlideElement();
+        const video = activeSlide ? activeSlide.querySelector('video') : null;
+
+        if (!video) {
+            return null;
+        }
+
+        return {
+            currentTime: video.currentTime,
+            wasPlaying: !video.paused,
+        };
+    }
+
+    /**
+     * Resumes video playback on the new active slide after a rebuild, using the previously captured state.
+     *
+     * @param {{currentTime: number, wasPlaying: boolean}|null} state
+     * @private
+     */
+    _restoreActiveVideoState(state) {
+        if (!state || !this._slider) {
+            return;
+        }
+
+        const activeSlide = this.getActiveSlideElement();
+        const video = activeSlide ? activeSlide.querySelector('video') : null;
+
+        if (!video) {
+            return;
+        }
+
+        video.currentTime = state.currentTime;
+
+        if (state.wasPlaying) {
+            video.play().catch(() => {});
+        }
     }
 
     /**

--- a/src/Storefront/Resources/app/storefront/src/plugin/slider/base-slider.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/slider/base-slider.plugin.js
@@ -168,6 +168,10 @@ export default class BaseSliderPlugin extends Plugin {
     getActiveSlideElement() {
         const info = this._slider.getInfo();
 
+        if (!info.slideItems) {
+            return undefined;
+        }
+
         return info.slideItems[info.displayIndex];
     }
 

--- a/src/Storefront/Resources/app/storefront/src/plugin/slider/gallery-slider.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/slider/gallery-slider.plugin.js
@@ -96,6 +96,8 @@ export default class GallerySliderPlugin extends BaseSliderPlugin {
     rebuild(viewport = ViewportDetection.getCurrentViewport()) {
         this._getSettings(viewport.toLowerCase());
 
+        const activeVideoState = this._captureActiveVideoState();
+
         // get the current index and use it as the start index
         try {
             if (this._slider) {
@@ -109,6 +111,8 @@ export default class GallerySliderPlugin extends BaseSliderPlugin {
         } catch (e) {
             // something went wrong
         }
+
+        this._restoreActiveVideoState(activeVideoState);
 
         this.$emitter.publish('rebuild');
     }

--- a/src/Storefront/Resources/app/storefront/test/plugin/base-slider/base-slider.plugin.test.js
+++ b/src/Storefront/Resources/app/storefront/test/plugin/base-slider/base-slider.plugin.test.js
@@ -5,6 +5,38 @@ describe('BaseSliderPlugin tests', () => {
     let baseSliderPlugin = undefined;
     let spyInit = jest.fn();
 
+    const mockCurrentTime = (video, initial = 0) => {
+        let currentTime = initial;
+        Object.defineProperty(video, 'currentTime', {
+            get: () => currentTime,
+            set: (value) => { currentTime = value; },
+            configurable: true,
+        });
+    };
+
+    const definePaused = (video, paused) => {
+        Object.defineProperty(video, 'paused', {
+            get: () => paused,
+            configurable: true,
+        });
+    };
+
+    const createSliderWithSlides = () => {
+        document.body.innerHTML = `
+            <div class="base-slider image-slider js-slider-initialized">
+                <div class="image-slider-item" id="slide-0"><img src="test.jpg"></div>
+                <div class="image-slider-item" id="slide-1"><video></video></div>
+            </div>
+        `;
+
+        const element = document.querySelector('.base-slider');
+
+        return {
+            sliderInstance: new BaseSliderPlugin(element),
+            slideItems: document.querySelectorAll('.image-slider-item'),
+        };
+    };
+
     beforeEach(() => {
         document.body.innerHTML = `
             <div class="base-slider image-slider js-slider-initialized">
@@ -108,6 +140,113 @@ describe('BaseSliderPlugin tests', () => {
         sliderInstance.rebuild('xl');
 
         expect(startIndexAtReInit).toBe(0);
+    });
+
+    test('getActiveSlideElement returns undefined when the slider info has no slideItems', () => {
+        const { sliderInstance } = createSliderWithSlides();
+
+        sliderInstance._slider = {
+            getInfo: () => ({ displayIndex: 1 }),
+        };
+
+        expect(sliderInstance.getActiveSlideElement()).toBeUndefined();
+    });
+
+    test('_captureActiveVideoState returns null when the slider is not initialised', () => {
+        const { sliderInstance } = createSliderWithSlides();
+        sliderInstance._slider = false;
+
+        expect(sliderInstance._captureActiveVideoState()).toBeNull();
+    });
+
+    test('_captureActiveVideoState returns null when the active slide has no video', () => {
+        const { sliderInstance, slideItems } = createSliderWithSlides();
+
+        sliderInstance._slider = {
+            getInfo: () => ({ slideItems, displayIndex: 0 }),
+        };
+
+        expect(sliderInstance._captureActiveVideoState()).toBeNull();
+    });
+
+    test('_captureActiveVideoState captures the playback position of the active slide video', () => {
+        const { sliderInstance, slideItems } = createSliderWithSlides();
+        const video = slideItems[1].querySelector('video');
+        mockCurrentTime(video, 12.5);
+        definePaused(video, false);
+
+        sliderInstance._slider = {
+            getInfo: () => ({ slideItems, displayIndex: 1 }),
+        };
+
+        expect(sliderInstance._captureActiveVideoState()).toEqual({
+            currentTime: 12.5,
+            wasPlaying: true,
+        });
+    });
+
+    test('_restoreActiveVideoState does nothing when there is no captured state', () => {
+        const { sliderInstance, slideItems } = createSliderWithSlides();
+        const video = slideItems[1].querySelector('video');
+        video.play = jest.fn();
+
+        sliderInstance._slider = {
+            getInfo: () => ({ slideItems, displayIndex: 1 }),
+        };
+
+        expect(() => sliderInstance._restoreActiveVideoState(null)).not.toThrow();
+        expect(video.play).not.toHaveBeenCalled();
+    });
+
+    test('_restoreActiveVideoState resumes playback on the new active slide video', () => {
+        const { sliderInstance, slideItems } = createSliderWithSlides();
+        const video = slideItems[1].querySelector('video');
+        mockCurrentTime(video);
+        video.play = jest.fn(() => Promise.resolve());
+
+        sliderInstance._slider = {
+            getInfo: () => ({ slideItems, displayIndex: 1 }),
+        };
+
+        sliderInstance._restoreActiveVideoState({ currentTime: 8, wasPlaying: true });
+
+        expect(video.currentTime).toBe(8);
+        expect(video.play).toHaveBeenCalled();
+    });
+
+    test('_restoreActiveVideoState restores the position without resuming playback when it was paused', () => {
+        const { sliderInstance, slideItems } = createSliderWithSlides();
+        const video = slideItems[1].querySelector('video');
+        mockCurrentTime(video);
+        video.play = jest.fn(() => Promise.resolve());
+
+        sliderInstance._slider = {
+            getInfo: () => ({ slideItems, displayIndex: 1 }),
+        };
+
+        sliderInstance._restoreActiveVideoState({ currentTime: 3, wasPlaying: false });
+
+        expect(video.currentTime).toBe(3);
+        expect(video.play).not.toHaveBeenCalled();
+    });
+
+    test('rebuild preserves the video playback state across the destroy/init cycle', () => {
+        const { sliderInstance, slideItems } = createSliderWithSlides();
+        const video = slideItems[1].querySelector('video');
+        mockCurrentTime(video, 4.2);
+        definePaused(video, false);
+        video.play = jest.fn(() => Promise.resolve());
+
+        jest.spyOn(sliderInstance, '_initSlider').mockImplementation(() => {});
+
+        sliderInstance._slider = {
+            getInfo: () => ({ index: 1, displayIndex: 1, slideCount: 2, slideItems }),
+        };
+
+        sliderInstance.rebuild('xl');
+
+        expect(video.currentTime).toBe(4.2);
+        expect(video.play).toHaveBeenCalled();
     });
 
     test('should apply accessibility tweaks', () => {


### PR DESCRIPTION
### 1. Why is this change necessary?
BaseSliderPlugin.rebuild() and GallerySliderPlugin.rebuild() are triggered on every Viewport/hasChanged event (i.e. whenever a responsive breakpoint boundary is crossed, not just on device rotation). Both destroy the current tiny-slider instance and immediately re-initialize it. This moves/replaces the slide markup in the DOM, which causes any currently playing native <video> element on the active slide to stop and reset, since browsers halt playback when a video element is reparented or recreated. This affects any storefront using video in a PDP or CMS image gallery — playback breaks simply by resizing the browser window or rotating a mobile device.

### 2. What does this change do, exactly?
Adds two private helpers to BaseSliderPlugin:
- _captureActiveVideoState() — reads the currentTime and playing state of the <video> element on the currently active slide, before the slider is destroyed.
- _restoreActiveVideoState(state) — after the slider is reinitialized, applies the captured currentTime back to the (new) active slide's video and resumes playback if it was playing before.
  
BaseSliderPlugin.rebuild() now calls these around its existing destroy()/_initSlider() calls. GallerySliderPlugin.rebuild() overrides rebuild() independently and now calls the same inherited helpers around its own destroy()/_initSlider() calls, so the fix applies to the PDP gallery slider as well as any other slider extending BaseSliderPlugin.


### 3. Describe each step to reproduce the issue or behaviour.
1. Add a product with a video (native, uploaded video file) in its PDP media gallery.
2. Open the product detail page and start playing the video.
3. Resize the browser window across a responsive breakpoint (e.g. from lg to md), or rotate a mobile device.
4. Before the fix: the video stops playing and resets to the beginning, because GallerySliderPlugin.rebuild() destroys and recreates the slider.
5. After the fix: the video resumes playback from where it left off.


### 4. Please link to the relevant issues (if any).
No existing GitHub issue was found for this behaviour