### PR TITLE
fix(administration): preserve SSO select options in major tests

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-users-permissions/components/sw-user-sso-invitation-modal/sw-user-sso-invitation-modal.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-users-permissions/components/sw-user-sso-invitation-modal/sw-user-sso-invitation-modal.spec.js
@@ -59,6 +59,9 @@ async function createWrapper() {
                     'sw-select-result-list': await wrapTestComponent('sw-select-result-list'),
                     'sw-popover': await wrapTestComponent('sw-popover'),
                     'sw-popover-deprecated': await wrapTestComponent('sw-popover-deprecated', { sync: true }),
+                    'mt-floating-ui': {
+                        template: '<div><slot /></div>',
+                    },
                     'sw-select-result': await wrapTestComponent('sw-select-result'),
                     'sw-highlight-text': await wrapTestComponent('sw-highlight-text'),
                     'sw-inheritance-switch': true,


### PR DESCRIPTION
### 1. Why is this change necessary?

The Administration major nightly still fails the SSO invitation modal tests because the language options disappear from the test DOM when the Meteor floating UI component is mounted.

### 2. What does this change do, exactly?

Adds a slot-forwarding `mt-floating-ui` stub to the SSO invitation modal Jest setup so the select options remain available to the test, matching the major component structure.

### 3. Describe each step to reproduce the issue or behaviour.

1. Run the Administration Jest suite with the `v6.8.0.0` feature flag enabled.
2. Open the SSO invitation modal test.
3. Select a language in either invitation event test.
4. Observe that `.sw-select-option--0` or `.sw-select-option--1` is missing from the DOM.

### 4. Please link to the relevant issues (if any).

Fixes #18574

relates #18567

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
