### PR TITLE
feat(checkout): record the origin of an order state transition

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -10,6 +10,12 @@ Rule Builder and Flow Builder are now reachable from a dedicated top-level "Auto
 
 Apps can now modify or remove cookie consent groups and entries with an app script under `Resources/scripts/cookie-group-collect/`. The hook exposes the collected `cookieGroups` collection and the current sales channel context, and provides the `services.repository`, `services.store` and `services.config` script services. Scripts run after cookies from plugins and app manifests were collected, so an app can, for example, declare its cookies in the manifest and remove them when the related payment method is not active in the current sales channel — with full backwards compatibility, since older Shopware versions simply ignore scripts for unknown hooks.
 
+### Order state history records where a state change came from
+
+`state_machine_history` entries now carry a `sourceType` field holding the type of the API context source that triggered the transition (`admin-api`, `sales-channel` or `system`). The order detail page and the status history modal use it to show state changes that a customer made in the storefront as "Customer" instead of "System", so a cancellation by the customer can be told apart from one made by a plugin or an integration.
+
+State changes that an administrator performs in a sales channel context, for example while creating an order in the Administration, are now attributed to that administrator instead of to the system.
+
 ## API
 
 ### Added experimental Store API snippet endpoint

--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -12,7 +12,7 @@ Apps can now modify or remove cookie consent groups and entries with an app scri
 
 ### Order state history records where a state change came from
 
-`state_machine_history` entries now carry a `sourceType` field holding the type of the API context source that triggered the transition (`admin-api`, `sales-channel` or `system`). The order detail page and the status history modal use it to show state changes that a customer made in the storefront as "Customer" instead of "System", so a cancellation by the customer can be told apart from one made by a plugin or an integration.
+`state_machine_history` entries now carry a `sourceType` field holding the type of the API context source that triggered the transition (`admin-api`, `sales-channel` or `system`). A custom `ContextSource` contributes whatever its public `$type` property holds. The order detail page and the status history modal use it to show state changes that a customer made in the storefront as "Customer" instead of "System", so a cancellation by the customer can be told apart from one made by a plugin or an integration.
 
 State changes that an administrator performs in a sales channel context, for example while creating an order in the Administration, are now attributed to that administrator instead of to the system.
 

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-details-state-card/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-details-state-card/index.js
@@ -152,6 +152,9 @@ export default {
                 const integrationLabel = this.lastStateChange.integration.label;
                 return `${integrationLabel} (${this.$t('sw-order.stateCard.labelIntegration')})`;
             }
+            if (this.lastStateChange?.sourceType === 'sales-channel') {
+                return this.$t('sw-order.stateCard.labelCustomer');
+            }
 
             return this.$t('sw-order.stateCard.labelSystemUser');
         },

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-details-state-card/sw-order-details-state-card.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-details-state-card/sw-order-details-state-card.spec.js
@@ -53,7 +53,15 @@ orderMock.deliveries.first = () => ({
     },
 });
 
-async function createWrapper() {
+const lastStateChangeByAdminUser = {
+    user: {
+        firstName: 'John',
+        lastName: 'Doe',
+    },
+    createdAt: new Date(),
+};
+
+async function createWrapper(lastStateChange = lastStateChangeByAdminUser) {
     return mount(await wrapTestComponent('sw-order-details-state-card', { sync: true }), {
         props: {
             order: orderMock,
@@ -88,15 +96,7 @@ async function createWrapper() {
                             search: () => {
                                 if (entity === 'state_machine_history') {
                                     return Promise.resolve({
-                                        first: () => {
-                                            return {
-                                                user: {
-                                                    firstName: 'John',
-                                                    lastName: 'Doe',
-                                                },
-                                                createdAt: new Date(),
-                                            };
-                                        },
+                                        first: () => lastStateChange,
                                     });
                                 }
 
@@ -136,11 +136,11 @@ describe('src/module/sw-order/component/sw-order-details-state-card', () => {
         Shopware.Store.unregister('swOrderDetail');
         Shopware.Store.register({
             id: 'swOrderDetail',
-            state: {
+            state: () => ({
                 isLoading: false,
                 isSavedSuccessful: false,
                 versionContext: {},
-            },
+            }),
         });
     });
 
@@ -154,5 +154,33 @@ describe('src/module/sw-order/component/sw-order-details-state-card', () => {
 
         expect(summary.text()).toBe('John Doe');
         expect(summary.findComponent('.sw-time-ago').props('date')).toEqual(new Date(170363865609544));
+    });
+
+    it('should show the customer as author when the state was changed from the storefront', async () => {
+        global.repositoryFactoryMock.showError = false;
+
+        const wrapper = await createWrapper({
+            sourceType: 'sales-channel',
+            createdAt: new Date(),
+        });
+        await flushPromises();
+
+        expect(wrapper.get('.sw-order-detail-state-card__state-history-text').text()).toBe(
+            'sw-order.stateCard.labelCustomer',
+        );
+    });
+
+    it('should fall back to the system author for internal state changes', async () => {
+        global.repositoryFactoryMock.showError = false;
+
+        const wrapper = await createWrapper({
+            sourceType: 'system',
+            createdAt: new Date(),
+        });
+        await flushPromises();
+
+        expect(wrapper.get('.sw-order-detail-state-card__state-history-text').text()).toBe(
+            'sw-order.stateCard.labelSystemUser',
+        );
     });
 });

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-state-history-modal/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-state-history-modal/index.ts
@@ -25,6 +25,7 @@ interface StateMachineHistoryData {
     entity: string;
     referencedId?: string;
     internalComment?: string;
+    sourceType?: string;
 }
 
 interface CombinedStates {
@@ -290,6 +291,7 @@ export default Component.wrapComponentConfig({
                 entity: 'entityName' in entry ? entry.entityName : entry.getEntityName(),
                 referencedId: 'referencedId' in entry ? entry.referencedId : entry.id,
                 internalComment: 'internalComment' in entry ? entry.internalComment : undefined,
+                sourceType: !hideUser && 'sourceType' in entry ? entry.sourceType : undefined,
             };
         },
 
@@ -325,6 +327,9 @@ export default Component.wrapComponentConfig({
             if (item.integration) {
                 const integrationLabel = item.integration.label;
                 return `${integrationLabel} (${this.$t('sw-order.stateHistoryModal.labelIntegration')})`;
+            }
+            if (item.sourceType === 'sales-channel') {
+                return this.$t('sw-order.stateHistoryModal.labelCustomer');
             }
 
             return this.$t('sw-order.stateHistoryModal.labelSystemUser');

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-state-history-modal/sw-order-state-history-modal.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-state-history-modal/sw-order-state-history-modal.spec.js
@@ -424,4 +424,35 @@ describe('src/module/sw-order/component/sw-order-state-history-modal', () => {
         const thirdRow = stateHistoryRows.at(2);
         expect(thirdRow.find('.sw-data-grid__cell--user').text()).toBe('user@example.com');
     });
+
+    it('should display the customer label for state changes coming from the storefront', async () => {
+        const stateHistoryFromStorefront = [
+            {
+                entityName: 'order',
+                fromStateMachineState: {
+                    technicalName: 'open',
+                    translated: { name: 'Open' },
+                },
+                toStateMachineState: {
+                    technicalName: 'cancelled',
+                    translated: { name: 'Cancelled' },
+                },
+                sourceType: 'sales-channel',
+                createdAt: '2022-10-12T10:01:28.535+00:00',
+            },
+        ];
+
+        const wrapper = await createWrapper({}, orderProp, stateHistoryFromStorefront);
+        await flushPromises();
+
+        const stateHistoryRows = wrapper.findAll('.sw-data-grid__body .sw-data-grid__row');
+
+        // The prepended initial state has no source
+        expect(stateHistoryRows.at(0).find('.sw-data-grid__cell--user').text()).toBe(
+            'sw-order.stateHistoryModal.labelSystemUser',
+        );
+        expect(stateHistoryRows.at(1).find('.sw-data-grid__cell--user').text()).toBe(
+            'sw-order.stateHistoryModal.labelCustomer',
+        );
+    });
 });

--- a/src/Administration/Resources/app/administration/src/module/sw-order/snippet/de.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/snippet/de.json
@@ -331,6 +331,7 @@
       "labelShowHistoryModal": "Statusverlauf anzeigen",
       "labelLastEditedBy": "Zuletzt geändert von",
       "labelSystemUser": "System",
+      "labelCustomer": "Kunde",
       "labelSelectStatePlaceholder": "Bitte wählen ...",
       "labelInternalComment": "Interner Kommentar",
       "labelSelectStateButton": "Status aktualisieren",
@@ -471,6 +472,7 @@
       "modalTitle": "Statusverlauf",
       "labelSystemUser": "System",
       "labelIntegration": "Integration",
+      "labelCustomer": "Kunde",
       "column": {
         "createdAt": "Datum",
         "entity": "Geändert",

--- a/src/Administration/Resources/app/administration/src/module/sw-order/snippet/en.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/snippet/en.json
@@ -331,6 +331,7 @@
       "labelShowHistoryModal": "Show status history",
       "labelLastEditedBy": "Last edited by",
       "labelSystemUser": "System",
+      "labelCustomer": "Customer",
       "labelSelectStatePlaceholder": "Select a status...",
       "labelInternalComment": "Internal comment",
       "labelSelectStateButton": "Update status",
@@ -471,6 +472,7 @@
       "modalTitle": "Status history",
       "labelSystemUser": "System",
       "labelIntegration": "Integration",
+      "labelCustomer": "Customer",
       "column": {
         "createdAt": "Date",
         "entity": "Changed",

--- a/src/Core/Migration/V6_7/Migration1787311123AddSourceTypeToStateMachineHistory.php
+++ b/src/Core/Migration/V6_7/Migration1787311123AddSourceTypeToStateMachineHistory.php
@@ -1,0 +1,25 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Migration\V6_7;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Migration\MigrationStep;
+use Shopware\Core\System\StateMachine\Aggregation\StateMachineHistory\StateMachineHistoryDefinition;
+
+/**
+ * @internal
+ */
+#[Package('checkout')]
+class Migration1787311123AddSourceTypeToStateMachineHistory extends MigrationStep
+{
+    public function getCreationTimestamp(): int
+    {
+        return 1787311123;
+    }
+
+    public function update(Connection $connection): void
+    {
+        $this->addColumn($connection, StateMachineHistoryDefinition::ENTITY_NAME, 'source_type', 'VARCHAR(32)');
+    }
+}

--- a/src/Core/System/StateMachine/Aggregation/StateMachineHistory/StateMachineHistoryDefinition.php
+++ b/src/Core/System/StateMachine/Aggregation/StateMachineHistory/StateMachineHistoryDefinition.php
@@ -64,6 +64,7 @@ class StateMachineHistoryDefinition extends EntityDefinition
             (new FkField('user_id', 'userId', UserDefinition::class))->setDescription('Unique identity of user.'),
             new FkField('integration_id', 'integrationId', IntegrationDefinition::class),
             new LongTextField('internal_comment', 'internalComment'),
+            (new StringField('source_type', 'sourceType', 32))->setDescription('Type of the API context source which triggered the transition.'),
 
             new ManyToOneAssociationField('user', 'user_id', UserDefinition::class, 'id', false),
             new ManyToOneAssociationField('integration', 'integration_id', IntegrationDefinition::class, 'id', false),

--- a/src/Core/System/StateMachine/Aggregation/StateMachineHistory/StateMachineHistoryEntity.php
+++ b/src/Core/System/StateMachine/Aggregation/StateMachineHistory/StateMachineHistoryEntity.php
@@ -45,6 +45,8 @@ class StateMachineHistoryEntity extends Entity
 
     protected ?string $internalComment = null;
 
+    protected ?string $sourceType = null;
+
     public function getTransitionActionName(): string
     {
         return $this->transitionActionName;
@@ -193,5 +195,15 @@ class StateMachineHistoryEntity extends Entity
     public function setInternalComment(?string $internalComment): void
     {
         $this->internalComment = $internalComment;
+    }
+
+    public function getSourceType(): ?string
+    {
+        return $this->sourceType;
+    }
+
+    public function setSourceType(?string $sourceType): void
+    {
+        $this->sourceType = $sourceType;
     }
 }

--- a/src/Core/System/StateMachine/StateMachineRegistry.php
+++ b/src/Core/System/StateMachine/StateMachineRegistry.php
@@ -7,8 +7,6 @@ use Shopware\Core\Content\Flow\Dispatching\Action\SetOrderStateAction;
 use Shopware\Core\Framework\Api\Context\AdminApiSource;
 use Shopware\Core\Framework\Api\Context\AdminSalesChannelApiSource;
 use Shopware\Core\Framework\Api\Context\ContextSource;
-use Shopware\Core\Framework\Api\Context\SalesChannelApiSource;
-use Shopware\Core\Framework\Api\Context\SystemSource;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry;
 use Shopware\Core\Framework\DataAbstractionLayer\Doctrine\RetryableTransaction;
@@ -238,11 +236,9 @@ class StateMachineRegistry implements ResetInterface
 
     private function resolveSourceType(ContextSource $source): ?string
     {
-        if ($source instanceof AdminApiSource || $source instanceof SalesChannelApiSource || $source instanceof SystemSource) {
-            return $source->type;
-        }
+        $type = get_object_vars($source)['type'] ?? null;
 
-        return null;
+        return \is_string($type) ? $type : null;
     }
 
     private function dispatchTransitionEvents(Transition $transition, Context $context, StateMachineTransitionResult $result): void

--- a/src/Core/System/StateMachine/StateMachineRegistry.php
+++ b/src/Core/System/StateMachine/StateMachineRegistry.php
@@ -236,6 +236,7 @@ class StateMachineRegistry implements ResetInterface
 
     private function resolveSourceType(ContextSource $source): ?string
     {
+        // read from the source itself, so a custom ContextSource can contribute its own type
         $type = get_object_vars($source)['type'] ?? null;
 
         return \is_string($type) ? $type : null;

--- a/src/Core/System/StateMachine/StateMachineRegistry.php
+++ b/src/Core/System/StateMachine/StateMachineRegistry.php
@@ -5,6 +5,10 @@ namespace Shopware\Core\System\StateMachine;
 use Doctrine\DBAL\Connection;
 use Shopware\Core\Content\Flow\Dispatching\Action\SetOrderStateAction;
 use Shopware\Core\Framework\Api\Context\AdminApiSource;
+use Shopware\Core\Framework\Api\Context\AdminSalesChannelApiSource;
+use Shopware\Core\Framework\Api\Context\ContextSource;
+use Shopware\Core\Framework\Api\Context\SalesChannelApiSource;
+use Shopware\Core\Framework\Api\Context\SystemSource;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry;
 use Shopware\Core\Framework\DataAbstractionLayer\Doctrine\RetryableTransaction;
@@ -181,14 +185,17 @@ class StateMachineRegistry implements ResetInterface
             );
         }
 
+        $source = $this->resolveOriginalSource($context->getSource());
+
         $stateMachineHistoryEntity = [
             'stateMachineId' => $toPlace->getStateMachineId(),
             'entityName' => $transition->getEntityName(),
             'fromStateId' => $fromPlace->getId(),
             'toStateId' => $toPlace->getId(),
             'transitionActionName' => $transition->getTransitionName(),
-            'userId' => $context->getSource() instanceof AdminApiSource ? $context->getSource()->getUserId() : null,
-            'integrationId' => $context->getSource() instanceof AdminApiSource ? $context->getSource()->getIntegrationId() : null,
+            'userId' => $source instanceof AdminApiSource ? $source->getUserId() : null,
+            'integrationId' => $source instanceof AdminApiSource ? $source->getIntegrationId() : null,
+            'sourceType' => $this->resolveSourceType($source),
             'referencedId' => $transition->getEntityId(),
             'referencedVersionId' => $context->getVersionId(),
             'internalComment' => $transition->getInternalComment(),
@@ -218,6 +225,24 @@ class StateMachineRegistry implements ResetInterface
             $fromPlace,
             $toPlace,
         );
+    }
+
+    private function resolveOriginalSource(ContextSource $source): ContextSource
+    {
+        if ($source instanceof AdminSalesChannelApiSource) {
+            return $source->getOriginalContext()->getSource();
+        }
+
+        return $source;
+    }
+
+    private function resolveSourceType(ContextSource $source): ?string
+    {
+        if ($source instanceof AdminApiSource || $source instanceof SalesChannelApiSource || $source instanceof SystemSource) {
+            return $source->type;
+        }
+
+        return null;
     }
 
     private function dispatchTransitionEvents(Transition $transition, Context $context, StateMachineTransitionResult $result): void

--- a/tests/integration/Core/Checkout/Order/SalesChannel/CancelOrderRouteTest.php
+++ b/tests/integration/Core/Checkout/Order/SalesChannel/CancelOrderRouteTest.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Tests\Integration\Core\Checkout\Order\SalesChannel;
 
+use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\Cart\LineItem\LineItem;
 use Shopware\Core\Checkout\Cart\Price\Struct\CalculatedPrice;
@@ -102,6 +103,35 @@ class CancelOrderRouteTest extends TestCase
 
         static::assertNotNull($order->getStateMachineState());
         static::assertSame('cancelled', $order->getStateMachineState()->getTechnicalName());
+    }
+
+    public function testCancellingMyOwnOrderIsRecordedAsSalesChannelStateChange(): void
+    {
+        $this->browser
+            ->request(
+                'POST',
+                '/store-api/order/state/cancel',
+                [
+                    'orderId' => $this->ids->get('order-1'),
+                ]
+            );
+
+        static::assertSame(Response::HTTP_OK, $this->browser->getResponse()->getStatusCode());
+
+        $connection = static::getContainer()->get(Connection::class);
+        static::assertInstanceOf(Connection::class, $connection);
+
+        $history = $connection->fetchAssociative(
+            'SELECT source_type, user_id, integration_id FROM `state_machine_history` WHERE referenced_id = :id ORDER BY created_at DESC LIMIT 1',
+            ['id' => Uuid::fromHexToBytes($this->ids->get('order-1'))]
+        );
+
+        static::assertNotFalse($history);
+        static::assertSame([
+            'source_type' => 'sales-channel',
+            'user_id' => null,
+            'integration_id' => null,
+        ], $history);
     }
 
     public function testCancelRandomOrder(): void

--- a/tests/integration/Core/System/StateMachine/StateMachineRegistryTest.php
+++ b/tests/integration/Core/System/StateMachine/StateMachineRegistryTest.php
@@ -209,7 +209,7 @@ EOF;
         static::assertNotNull($orderAfter->getUpdatedAt());
     }
 
-    public function testStateMachineTransitionStoresUserAndIntegrationIdAndInternalComment(): void
+    public function testStateMachineTransitionStoresTheActorTheSourceAndTheInternalComment(): void
     {
         $ids = new IdsCollection();
 
@@ -251,7 +251,7 @@ EOF;
         $connection = self::getContainer()->get(Connection::class);
         static::assertInstanceOf(Connection::class, $connection);
 
-        $historyData = $connection->fetchAssociative('SELECT LOWER(HEX(integration_id)) as integration_id, LOWER(HEX(user_id)) as user_id, internal_comment FROM `state_machine_history` WHERE referenced_id = :id AND referenced_version_id = :version ORDER BY created_at DESC LIMIT 1', [
+        $historyData = $connection->fetchAssociative('SELECT LOWER(HEX(integration_id)) as integration_id, LOWER(HEX(user_id)) as user_id, source_type, internal_comment FROM `state_machine_history` WHERE referenced_id = :id AND referenced_version_id = :version ORDER BY created_at DESC LIMIT 1', [
             'id' => Uuid::fromHexToBytes($ids->get('o-1')),
             'version' => Uuid::fromHexToBytes(Defaults::LIVE_VERSION),
         ]);
@@ -260,6 +260,7 @@ EOF;
         static::assertSame([
             'integration_id' => $ids->get('integration-1'),
             'user_id' => $userId,
+            'source_type' => 'admin-api',
             'internal_comment' => 'internal comment',
         ], $historyData);
     }

--- a/tests/migration/Core/V6_7/Migration1787311123AddSourceTypeToStateMachineHistoryTest.php
+++ b/tests/migration/Core/V6_7/Migration1787311123AddSourceTypeToStateMachineHistoryTest.php
@@ -1,0 +1,49 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Migration\Core\V6_7;
+
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
+use Shopware\Core\Framework\Util\Database\TableHelper;
+use Shopware\Core\Migration\V6_7\Migration1787311123AddSourceTypeToStateMachineHistory;
+
+/**
+ * @internal
+ */
+#[Package('checkout')]
+#[CoversClass(Migration1787311123AddSourceTypeToStateMachineHistory::class)]
+class Migration1787311123AddSourceTypeToStateMachineHistoryTest extends TestCase
+{
+    private Connection $connection;
+
+    protected function setUp(): void
+    {
+        $this->connection = KernelLifecycleManager::getConnection();
+    }
+
+    public function testCreationTimestamp(): void
+    {
+        static::assertSame(1787311123, (new Migration1787311123AddSourceTypeToStateMachineHistory())->getCreationTimestamp());
+    }
+
+    public function testMigrationAddsTheColumnAndCanRunTwice(): void
+    {
+        $this->rollback();
+
+        $migration = new Migration1787311123AddSourceTypeToStateMachineHistory();
+        $migration->update($this->connection);
+        $migration->update($this->connection);
+
+        static::assertTrue(TableHelper::columnExists($this->connection, 'state_machine_history', 'source_type'));
+    }
+
+    private function rollback(): void
+    {
+        if (TableHelper::columnExists($this->connection, 'state_machine_history', 'source_type')) {
+            $this->connection->executeStatement('ALTER TABLE `state_machine_history` DROP COLUMN `source_type`;');
+        }
+    }
+}

--- a/tests/unit/Core/System/StateMachine/StateMachineRegistryTest.php
+++ b/tests/unit/Core/System/StateMachine/StateMachineRegistryTest.php
@@ -163,8 +163,15 @@ class StateMachineRegistryTest extends TestCase
             'admin-api',
         ];
 
-        yield 'custom context source without a known type is recorded without source' => [
+        yield 'custom context source contributes its own type' => [
             new Context(new StateMachineRegistryTestContextSource()),
+            null,
+            null,
+            'custom-source',
+        ];
+
+        yield 'context source without a public type is recorded without source' => [
+            new Context(new StateMachineRegistryTestTypelessContextSource()),
             null,
             null,
             null,
@@ -575,6 +582,15 @@ class StateMachineRegistryFixture
  */
 class StateMachineRegistryTestContextSource implements ContextSource
 {
+    public string $type = 'custom-source';
+}
+
+/**
+ * @internal
+ */
+class StateMachineRegistryTestTypelessContextSource implements ContextSource
+{
+    protected string $type = 'not-readable-from-outside';
 }
 
 /**

--- a/tests/unit/Core/System/StateMachine/StateMachineRegistryTest.php
+++ b/tests/unit/Core/System/StateMachine/StateMachineRegistryTest.php
@@ -4,11 +4,16 @@ namespace Shopware\Tests\Unit\Core\System\StateMachine;
 
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Flow\Dispatching\Action\SetOrderStateAction;
 use Shopware\Core\Framework\Api\Context\AdminApiSource;
+use Shopware\Core\Framework\Api\Context\AdminSalesChannelApiSource;
+use Shopware\Core\Framework\Api\Context\ContextSource;
+use Shopware\Core\Framework\Api\Context\SalesChannelApiSource;
+use Shopware\Core\Framework\Api\Context\SystemSource;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry;
 use Shopware\Core\Framework\DataAbstractionLayer\Entity;
@@ -73,6 +78,7 @@ class StateMachineRegistryTest extends TestCase
                     'transitionActionName' => 'paid',
                     'userId' => 'user-id',
                     'integrationId' => 'integration-id',
+                    'sourceType' => 'admin-api',
                     'referencedId' => $transition->getEntityId(),
                     'referencedVersionId' => $context->getVersionId(),
                     'internalComment' => 'internal comment',
@@ -89,6 +95,80 @@ class StateMachineRegistryTest extends TestCase
         static::assertSame($fromPlace, $stateMachineStates->get('fromPlace'));
         static::assertSame($toPlace, $stateMachineStates->get('toPlace'));
         static::assertCount(3, $dispatcher->events);
+    }
+
+    #[DataProvider('transitionSourceProvider')]
+    public function testTransitionRecordsWhereTheStateChangeCameFrom(
+        Context $context,
+        ?string $expectedUserId,
+        ?string $expectedIntegrationId,
+        ?string $expectedSourceType
+    ): void {
+        $transition = new Transition('order_transaction', Uuid::randomHex(), 'paid', 'stateId');
+        $fromPlace = $this->createState('open');
+        $toPlace = $this->createState('paid');
+        $stateMachine = $this->createStateMachine([
+            $this->createStateTransition('paid', $fromPlace, $toPlace),
+        ]);
+        $fixture = $this->createRegistryFixture(
+            $stateMachine,
+            $fromPlace,
+            new CollectingEventDispatcher(),
+            $this->createMock(EntityRepository::class),
+            $this->createMock(EntityRepository::class)
+        );
+
+        $fixture->historyRepository->expects($this->once())
+            ->method('create')
+            ->with(
+                [[
+                    'stateMachineId' => $toPlace->getStateMachineId(),
+                    'entityName' => 'order_transaction',
+                    'fromStateId' => $fromPlace->getId(),
+                    'toStateId' => $toPlace->getId(),
+                    'transitionActionName' => 'paid',
+                    'userId' => $expectedUserId,
+                    'integrationId' => $expectedIntegrationId,
+                    'sourceType' => $expectedSourceType,
+                    'referencedId' => $transition->getEntityId(),
+                    'referencedVersionId' => $context->getVersionId(),
+                    'internalComment' => null,
+                ]],
+                $context
+            );
+
+        $fixture->registry->transition($transition, $context);
+    }
+
+    public static function transitionSourceProvider(): \Generator
+    {
+        yield 'store-api request has no admin actor and is recorded as sales channel source' => [
+            new Context(new SalesChannelApiSource('sales-channel-id')),
+            null,
+            null,
+            'sales-channel',
+        ];
+
+        yield 'internal transition without a request is recorded as system source' => [
+            new Context(new SystemSource()),
+            null,
+            null,
+            'system',
+        ];
+
+        yield 'admin user acting in a sales channel context stays the admin actor' => [
+            new Context(new AdminSalesChannelApiSource('sales-channel-id', new Context(new AdminApiSource('user-id')))),
+            'user-id',
+            null,
+            'admin-api',
+        ];
+
+        yield 'custom context source without a known type is recorded without source' => [
+            new Context(new StateMachineRegistryTestContextSource()),
+            null,
+            null,
+            null,
+        ];
     }
 
     public function testTransitionDoesNotUpdateStateWhenHistoryWriteFails(): void
@@ -488,6 +568,13 @@ class StateMachineRegistryFixture
         public readonly EntityRepository&MockObject $historyRepository,
     ) {
     }
+}
+
+/**
+ * @internal
+ */
+class StateMachineRegistryTestContextSource implements ContextSource
+{
 }
 
 /**


### PR DESCRIPTION
### 1. Why is this change necessary?

A merchant looking at a cancelled order cannot tell whether the customer cancelled it in the storefront, a payment plugin did it, or a colleague did it in the Administration. The order state card and the status history already answer "who changed this", but they resolve the author from the admin API source only, so anything arriving through the store API renders as "System" — the same thing an internal transition from a flow or the queue looks like.

A separate "cancelled by customer" state would solve that for one transition while duplicating a state that flows, rules, documents and mail templates match on. The missing information is not a state, it is the origin of the transition.

### 2. What does this change do, exactly?

The state history now records the type of the API context source that caused a transition, read off the source itself so a custom `ContextSource` is covered as well. The Administration labels a sales channel origin "Customer", so a storefront cancellation reads "Status set 12/03 by Customer". A label rather than the customer name, so nothing in that column can be mistaken for a member of staff.

The same resolution closes a related blind spot: an administrator acting in a sales channel context, for example while creating an order, was recorded with no actor at all and is now attributed to that administrator.

Entry points:

- `Shopware\Core\System\StateMachine\StateMachineRegistry`
- `sw-order-details-state-card`
- `sw-order-state-history-modal`

Existing history rows keep reading "System".

### 3. Describe each step to reproduce the issue or behaviour.

Cancel an order from the storefront account, then open that order in the Administration: the state card and the "Changed By" column now say "Customer".

### 4. Please link to the relevant issues (if any).

closes #17504

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
