### PR TITLE
feat: announce wishlist changes (backport: 6.6.x)

### DIFF
--- a/src/Storefront/Resources/app/storefront/src/plugin/header/wishlist-widget.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/header/wishlist-widget.plugin.js
@@ -5,6 +5,8 @@ export default class WishlistWidgetPlugin extends Plugin {
 
     static options = {
         showCounter: true,
+        liveAreaSelector: '#wishlist-basket-live-area',
+        liveAreaTextAttribute: 'data-wishlist-live-area-text',
     };
 
     init() {
@@ -37,6 +39,30 @@ export default class WishlistWidgetPlugin extends Plugin {
         }
 
         this.el.innerHTML = this._wishlistStorage.getCurrentCounter() || '';
+
+        this._updateLiveArea();
+    }
+
+    /**
+     * @private
+     */
+    _updateLiveArea() {
+        const liveArea = this._getLiveArea();
+
+        if (!liveArea) {
+            return;
+        }
+
+        const counter = this._wishlistStorage.getCurrentCounter() || 0;
+        const textTemplate = liveArea.getAttribute(this.options.liveAreaTextAttribute) || '%counter%';
+        liveArea.innerHTML = `<p>${ textTemplate.replace('%counter%', counter) }</p>`;
+    }
+
+    /**
+     * @private
+     */
+    _getLiveArea() {
+        return document.querySelector(this.options.liveAreaSelector);
     }
 
     /**

--- a/src/Storefront/Resources/app/storefront/test/plugin/header/wishlist-widget.plugin.test.js
+++ b/src/Storefront/Resources/app/storefront/test/plugin/header/wishlist-widget.plugin.test.js
@@ -69,6 +69,22 @@ describe('WishlistWidgetPlugin tests', () => {
         expect(document.body.querySelector('.wishlist-widget').innerHTML).toBe('');
     });
 
+    test('Wishlist widget will update live-area content on change', () => {
+        let expectedCounter = null;
+        wishlistWidgetPlugin._wishlistStorage.getCurrentCounter = jest.fn(() => expectedCounter);
+
+        const liveArea = document.createElement('div');
+        liveArea.id = 'wishlist-basket-live-area';
+        document.body.appendChild(liveArea);
+
+        expectedCounter = 5;
+        wishlistWidgetPlugin._wishlistStorage.$emitter.publish('Wishlist/onProductsLoaded');
+        expect(liveArea.innerHTML).toBe('<p>5</p>');
+
+        expectedCounter = 10;
+        wishlistWidgetPlugin._wishlistStorage.$emitter.publish('Wishlist/onProductsLoaded');
+        expect(liveArea.innerHTML).toBe('<p>10</p>');
+    });
 });
 
 

--- a/src/Storefront/Resources/snippet/de_DE/storefront.de-DE.json
+++ b/src/Storefront/Resources/snippet/de_DE/storefront.de-DE.json
@@ -83,6 +83,7 @@
     "indexLinkService": "Service/Hilfe",
     "searchNoResult": "Keine Suchergebnisse gefunden.",
     "wishlist": "Merkzettel",
+    "wishlistAriaLiveTemplate": "Du hast %counter% Produkte auf dem Merkzettel",
     "navigationAriaLabel": "Hauptnavigation",
     "topBarAriaLabel": "Shop-Einstellungen",
     "languageTrigger": "Sprache ändern (%lang% ist die aktuelle Sprache)",

--- a/src/Storefront/Resources/snippet/en_GB/storefront.en-GB.json
+++ b/src/Storefront/Resources/snippet/en_GB/storefront.en-GB.json
@@ -83,6 +83,7 @@
     "indexLinkService": "Service/help",
     "searchNoResult": "No results found.",
     "wishlist": "Wishlist",
+    "wishlistAriaLiveTemplate": "You have %counter% wishlist items",
     "navigationAriaLabel": "Main navigation",
     "topBarAriaLabel": "Shop settings",
     "languageTrigger": "Change language (%lang% is the current language)",

--- a/src/Storefront/Resources/views/storefront/layout/header/actions/wishlist-widget.html.twig
+++ b/src/Storefront/Resources/views/storefront/layout/header/actions/wishlist-widget.html.twig
@@ -21,5 +21,12 @@
           data-wishlist-storage-options="{{ wishlistStorageOptions|json_encode }}"
           data-wishlist-widget="true"
           data-wishlist-widget-options="{{ wishlistWidgetOptions|json_encode }}"
+          aria-labelledby="wishlist-basket-live-area"
+    ></span>
+
+    <span class="visually-hidden"
+          id="wishlist-basket-live-area"
+          data-wishlist-live-area-text="{{ 'header.wishlistAriaLiveTemplate'|trans }}"
+          aria-live="polite"
     ></span>
 {% endblock %}

--- a/src/Storefront/Resources/views/storefront/layout/header/actions/wishlist-widget.html.twig
+++ b/src/Storefront/Resources/views/storefront/layout/header/actions/wishlist-widget.html.twig
@@ -21,7 +21,6 @@
           data-wishlist-storage-options="{{ wishlistStorageOptions|json_encode }}"
           data-wishlist-widget="true"
           data-wishlist-widget-options="{{ wishlistWidgetOptions|json_encode }}"
-          aria-labelledby="wishlist-basket-live-area"
     ></span>
 
     <span class="visually-hidden"

--- a/src/Storefront/Resources/views/storefront/layout/header/header.html.twig
+++ b/src/Storefront/Resources/views/storefront/layout/header/header.html.twig
@@ -84,7 +84,8 @@
                                         <a class="btn header-wishlist-btn header-actions-btn"
                                            href="{{ path('frontend.wishlist.page') }}"
                                            title="{{ 'header.wishlist'|trans|striptags }}"
-                                           aria-label="{{ 'header.wishlist'|trans|striptags }}">
+                                           aria-labelledby="wishlist-basket-live-area"
+                                        >
                                             {% sw_include '@Storefront/storefront/layout/header/actions/wishlist-widget.html.twig' %}
                                         </a>
                                     </div>


### PR DESCRIPTION
**Backport:** https://github.com/shopware/shopware/pull/9100, https://github.com/shopware/shopware/pull/14281
Resolves: https://github.com/shopware/shopware/issues/7084, https://github.com/shopware/shopware/issues/13975

---

### 1. Why is this change necessary?

After adding / removing a product from the watch list, the change is not communicated to screen reader users. What is particularly critical here is that the display of the number of products visible to everyone does not adjust despite successful deletion, so that screen reader users must assume that the deletion process has failed and blind users are not informed that the deletion process was successful.

### 2. What does this change do, exactly?

Adds a live region to the wishlist element and updates its content in the JS plugin responsible for updating the count badge on the wishlist icon. The updates are now announced properly when adding/removing items.

### 3. Describe each step to reproduce the issue or behaviour.

1. Use a screen reader and enable Wishlist (Admin > Settings > Cart Settings).
2. Add/remove products to the wishlist. The screen reader should announce that the button was pressed and the changed wishlist count.

### 4. Please link to the relevant issues (if any).

- closes #7084