### PR TITLE
fix: merge document filename infixes per format

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-settings-document/page/sw-settings-document-detail/sw-settings-document-detail.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-document/page/sw-settings-document-detail/sw-settings-document-detail.spec.js
@@ -75,7 +75,7 @@ const documentBaseConfigRepositoryMock = {
                 documentTypeId: 'documentTypeId1',
                 config: {},
                 documentType: { id: 'documentTypeId1', technicalName: 'invoice' },
-                filenameInfixes: {},
+                filenameInfixes: null,
             });
         }
 

--- a/src/Core/Checkout/DocumentV2/Config/DocumentConfigLoader.php
+++ b/src/Core/Checkout/DocumentV2/Config/DocumentConfigLoader.php
@@ -200,7 +200,10 @@ final class DocumentConfigLoader implements EventSubscriberInterface, ResetInter
             itemsPerPage: $itemsPerPage,
             filenamePrefix: $salesChannelRow?->getFilenamePrefix() ?? $globalRow?->getFilenamePrefix(),
             filenameSuffix: $salesChannelRow?->getFilenameSuffix() ?? $globalRow?->getFilenameSuffix(),
-            filenameInfixes: $salesChannelRow?->getFilenameInfixes() ?? $globalRow?->getFilenameInfixes() ?? [],
+            filenameInfixes: array_merge(
+                $globalRow?->getFilenameInfixes() ?? [],
+                $salesChannelRow?->getFilenameInfixes() ?? [],
+            ),
             logo: $logo,
         );
     }

--- a/tests/unit/Core/Checkout/DocumentV2/Config/DocumentConfigLoaderTest.php
+++ b/tests/unit/Core/Checkout/DocumentV2/Config/DocumentConfigLoaderTest.php
@@ -87,7 +87,7 @@ class DocumentConfigLoaderTest extends TestCase
         static::assertSame('Matching Channel GmbH', $bundle->company->companyName);
     }
 
-    public function testLoadPicksMatchingSalesChannelFilenameInfixesOverGlobal(): void
+    public function testLoadSalesChannelFilenameInfixOverridesGlobalPerFormat(): void
     {
         $matchingSalesChannelId = Uuid::randomHex();
 
@@ -132,6 +132,144 @@ class DocumentConfigLoaderTest extends TestCase
         static::assertSame(['zugferd_embedded_pdf' => 'channel-infix'], $bundle->config->filenameInfixes);
     }
 
+    public function testLoadKeepsGlobalFilenameInfixesWhenSalesChannelMapIsEmpty(): void
+    {
+        $matchingSalesChannelId = Uuid::randomHex();
+
+        $globalRow = $this->createBaseConfig(
+            global: true,
+            pageSize: 'A4',
+            companyName: 'Global GmbH',
+            filenameInfixes: ['zugferd_embedded_pdf' => '_zugferd'],
+        );
+
+        $matchingRow = $this->createBaseConfig(
+            global: false,
+            pageSize: 'A4',
+            companyName: 'Matching Channel GmbH',
+            salesChannelId: $matchingSalesChannelId,
+            filenameInfixes: [],
+        );
+
+        $documentRepo = new StaticEntityRepository(
+            [new DocumentBaseConfigCollection([$globalRow, $matchingRow])],
+            new DocumentBaseConfigDefinition(),
+        );
+
+        $countryRepo = new StaticEntityRepository(
+            [new CountryCollection([$this->createCountry()])],
+            new CountryDefinition(),
+        );
+
+        $loader = new DocumentConfigLoader(
+            $documentRepo,
+            $countryRepo,
+            $this->createMediaRepository(),
+            $this->createSystemConfigService(),
+        );
+
+        $bundle = $loader->load(
+            DocumentType::INVOICE->value,
+            $matchingSalesChannelId,
+            Context::createDefaultContext(),
+        );
+
+        static::assertSame(['zugferd_embedded_pdf' => '_zugferd'], $bundle->config->filenameInfixes);
+    }
+
+    public function testLoadMergesFilenameInfixesPerFormat(): void
+    {
+        $matchingSalesChannelId = Uuid::randomHex();
+
+        $globalRow = $this->createBaseConfig(
+            global: true,
+            pageSize: 'A4',
+            companyName: 'Global GmbH',
+            filenameInfixes: ['zugferd_embedded_pdf' => '_zugferd'],
+        );
+
+        $matchingRow = $this->createBaseConfig(
+            global: false,
+            pageSize: 'A4',
+            companyName: 'Matching Channel GmbH',
+            salesChannelId: $matchingSalesChannelId,
+            filenameInfixes: ['pdf' => '_channel'],
+        );
+
+        $documentRepo = new StaticEntityRepository(
+            [new DocumentBaseConfigCollection([$globalRow, $matchingRow])],
+            new DocumentBaseConfigDefinition(),
+        );
+
+        $countryRepo = new StaticEntityRepository(
+            [new CountryCollection([$this->createCountry()])],
+            new CountryDefinition(),
+        );
+
+        $loader = new DocumentConfigLoader(
+            $documentRepo,
+            $countryRepo,
+            $this->createMediaRepository(),
+            $this->createSystemConfigService(),
+        );
+
+        $bundle = $loader->load(
+            DocumentType::INVOICE->value,
+            $matchingSalesChannelId,
+            Context::createDefaultContext(),
+        );
+
+        static::assertSame(
+            ['zugferd_embedded_pdf' => '_zugferd', 'pdf' => '_channel'],
+            $bundle->config->filenameInfixes,
+        );
+    }
+
+    public function testLoadKeepsSalesChannelFilenameInfixesWhenGlobalHasNone(): void
+    {
+        $matchingSalesChannelId = Uuid::randomHex();
+
+        $globalRow = $this->createBaseConfig(
+            global: true,
+            pageSize: 'A4',
+            companyName: 'Global GmbH',
+            filenameInfixes: null,
+        );
+
+        $matchingRow = $this->createBaseConfig(
+            global: false,
+            pageSize: 'A4',
+            companyName: 'Matching Channel GmbH',
+            salesChannelId: $matchingSalesChannelId,
+            filenameInfixes: ['pdf' => '_channel'],
+        );
+
+        $documentRepo = new StaticEntityRepository(
+            [new DocumentBaseConfigCollection([$globalRow, $matchingRow])],
+            new DocumentBaseConfigDefinition(),
+        );
+
+        $countryRepo = new StaticEntityRepository(
+            [new CountryCollection([$this->createCountry()])],
+            new CountryDefinition(),
+        );
+
+        $loader = new DocumentConfigLoader(
+            $documentRepo,
+            $countryRepo,
+            $this->createMediaRepository(),
+            $this->createSystemConfigService(),
+        );
+
+        $bundle = $loader->load(
+            DocumentType::INVOICE->value,
+            $matchingSalesChannelId,
+            Context::createDefaultContext(),
+        );
+
+        static::assertSame(['pdf' => '_channel'], $bundle->config->filenameInfixes);
+    }
+
     public function testLoadFallsBackToGlobalWhenNoSalesChannelRowMatches(): void
     {
         $globalRow = $this->createBaseConfig(
@@ -171,6 +309,7 @@ class DocumentConfigLoaderTest extends TestCase
 
         static::assertSame('A4', $bundle->config->pageSize);
         static::assertSame('Global GmbH', $bundle->company->companyName);
+        static::assertSame([], $bundle->config->filenameInfixes);
     }
 
     public function testLoadRejectsZeroItemsPerPage(): void


### PR DESCRIPTION
follow-up to #19185

When a merchant created a separate document configuration for a sales channel and left the infix fields empty, the admin stored an empty infix map. The loader treated that map as a real setting, so the seeded global ZUGFeRD infix never applied (e.g. `1007.pdf` instead of `1007_zugferd.pdf`). The loader now merges both maps per format, sales-channel values still win.