### PR TITLE
test: move `filename_infixes` rollback out of setup

### DIFF
--- a/tests/migration/Core/V6_7/Migration1786378835AddDocumentBaseConfigFilenameInfixesTest.php
+++ b/tests/migration/Core/V6_7/Migration1786378835AddDocumentBaseConfigFilenameInfixesTest.php
@@ -30,7 +30,6 @@ class Migration1786378835AddDocumentBaseConfigFilenameInfixesTest extends TestCa
     protected function setUp(): void
     {
         $this->connection = KernelLifecycleManager::getConnection();
-        $this->rollback();
     }
 
     protected function tearDown(): void
@@ -48,6 +47,8 @@ class Migration1786378835AddDocumentBaseConfigFilenameInfixesTest extends TestCa
 
     public function testMigrationAddsNullableColumn(): void
     {
+        $this->rollback();
+
         static::assertFalse($this->columnExists());
 
         $migration = new Migration1786378835AddDocumentBaseConfigFilenameInfixes();
@@ -66,6 +67,8 @@ class Migration1786378835AddDocumentBaseConfigFilenameInfixesTest extends TestCa
 
     public function testMigrationSeedsZugferdEmbeddedPdfInfixOnlyForTypesThatSupportIt(): void
     {
+        $this->rollback();
+
         $invoiceTypeId = $this->fetchDocumentTypeId('invoice');
         $deliveryNoteTypeId = $this->fetchDocumentTypeId('delivery_note');
 


### PR DESCRIPTION
follow-up to #19185

The migration test dropped `document_base_config.filename_infixes` in `setUp()`, but only the two tests that run `update()` restored it, so a random execution order ending on `testGetCreationTimestamp` left the column dropped in the test database. The drop now runs inside the two tests that re-add the column.