### PR TITLE
test: mark discovery-owned Storefront classes codeCoverageIgnore

### DIFF
--- a/phpstan-baseline.php
+++ b/phpstan-baseline.php
@@ -1046,30 +1046,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/src/Storefront/Theme/ConfigLoader/StaticFileConfigLoader.php',
 ];
 $ignoreErrors[] = [
-    'rawMessage' => 'Method Shopware\\Storefront\\Theme\\Event\\ThemeIndexerEvent::__construct() has parameter $ids with no value type specified in iterable type array.',
-    'identifier' => 'missingType.iterableValue',
-    'count' => 1,
-    'path' => __DIR__ . '/src/Storefront/Theme/Event/ThemeIndexerEvent.php',
-];
-$ignoreErrors[] = [
-    'rawMessage' => 'Method Shopware\\Storefront\\Theme\\Event\\ThemeIndexerEvent::__construct() has parameter $skip with no value type specified in iterable type array.',
-    'identifier' => 'missingType.iterableValue',
-    'count' => 1,
-    'path' => __DIR__ . '/src/Storefront/Theme/Event/ThemeIndexerEvent.php',
-];
-$ignoreErrors[] = [
-    'rawMessage' => 'Method Shopware\\Storefront\\Theme\\Event\\ThemeIndexerEvent::getIds() return type has no value type specified in iterable type array.',
-    'identifier' => 'missingType.iterableValue',
-    'count' => 1,
-    'path' => __DIR__ . '/src/Storefront/Theme/Event/ThemeIndexerEvent.php',
-];
-$ignoreErrors[] = [
-    'rawMessage' => 'Method Shopware\\Storefront\\Theme\\Event\\ThemeIndexerEvent::getSkip() return type has no value type specified in iterable type array.',
-    'identifier' => 'missingType.iterableValue',
-    'count' => 1,
-    'path' => __DIR__ . '/src/Storefront/Theme/Event/ThemeIndexerEvent.php',
-];
-$ignoreErrors[] = [
     'rawMessage' => 'Throwing new exceptions within classes are not allowed. Please use domain exception pattern. See https://github.com/shopware/platform/blob/v6.4.20.0/adr/2022-02-24-domain-exceptions.md',
     'identifier' => 'shopware.domainException',
     'count' => 1,

--- a/src/Storefront/Event/MaintenanceRedirectEvent.php
+++ b/src/Storefront/Event/MaintenanceRedirectEvent.php
@@ -4,6 +4,9 @@ namespace Shopware\Storefront\Event;
 
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class MaintenanceRedirectEvent extends StorefrontRedirectEvent
 {

--- a/src/Storefront/Event/RouteRequest/LanguageRouteRequestEvent.php
+++ b/src/Storefront/Event/RouteRequest/LanguageRouteRequestEvent.php
@@ -4,6 +4,9 @@ namespace Shopware\Storefront\Event\RouteRequest;
 
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class LanguageRouteRequestEvent extends RouteRequestEvent
 {

--- a/src/Storefront/Event/RouteRequest/SalutationRouteRequestEvent.php
+++ b/src/Storefront/Event/RouteRequest/SalutationRouteRequestEvent.php
@@ -4,6 +4,9 @@ namespace Shopware\Storefront\Event\RouteRequest;
 
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class SalutationRouteRequestEvent extends RouteRequestEvent
 {

--- a/src/Storefront/Event/SwitchBuyBoxVariantEvent.php
+++ b/src/Storefront/Event/SwitchBuyBoxVariantEvent.php
@@ -11,6 +11,9 @@ use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Contracts\EventDispatcher\Event;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class SwitchBuyBoxVariantEvent extends Event implements ShopwareSalesChannelEvent
 {

--- a/src/Storefront/Event/ThemeCompilerConcatenatedStylesEvent.php
+++ b/src/Storefront/Event/ThemeCompilerConcatenatedStylesEvent.php
@@ -5,6 +5,9 @@ namespace Shopware\Storefront\Event;
 use Shopware\Core\Framework\Log\Package;
 use Symfony\Contracts\EventDispatcher\Event;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class ThemeCompilerConcatenatedStylesEvent extends Event
 {

--- a/src/Storefront/Framework/Twig/ErrorTemplateStruct.php
+++ b/src/Storefront/Framework/Twig/ErrorTemplateStruct.php
@@ -5,6 +5,9 @@ namespace Shopware\Storefront\Framework\Twig;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\Struct;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class ErrorTemplateStruct extends Struct
 {

--- a/src/Storefront/Page/GenericPageLoadedEvent.php
+++ b/src/Storefront/Page/GenericPageLoadedEvent.php
@@ -6,6 +6,9 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\HttpFoundation\Request;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class GenericPageLoadedEvent extends PageLoadedEvent
 {

--- a/src/Storefront/Page/LandingPage/LandingPageLoadedEvent.php
+++ b/src/Storefront/Page/LandingPage/LandingPageLoadedEvent.php
@@ -7,6 +7,9 @@ use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Storefront\Page\PageLoadedEvent;
 use Symfony\Component\HttpFoundation\Request;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class LandingPageLoadedEvent extends PageLoadedEvent
 {

--- a/src/Storefront/Page/Maintenance/MaintenancePageLoadedEvent.php
+++ b/src/Storefront/Page/Maintenance/MaintenancePageLoadedEvent.php
@@ -7,6 +7,9 @@ use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Storefront\Page\PageLoadedEvent;
 use Symfony\Component\HttpFoundation\Request;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class MaintenancePageLoadedEvent extends PageLoadedEvent
 {

--- a/src/Storefront/Page/Navigation/Error/ErrorPageLoadedEvent.php
+++ b/src/Storefront/Page/Navigation/Error/ErrorPageLoadedEvent.php
@@ -7,6 +7,9 @@ use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Storefront\Page\PageLoadedEvent;
 use Symfony\Component\HttpFoundation\Request;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class ErrorPageLoadedEvent extends PageLoadedEvent
 {

--- a/src/Storefront/Page/Navigation/NavigationPageLoadedEvent.php
+++ b/src/Storefront/Page/Navigation/NavigationPageLoadedEvent.php
@@ -7,6 +7,9 @@ use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Storefront\Page\PageLoadedEvent;
 use Symfony\Component\HttpFoundation\Request;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class NavigationPageLoadedEvent extends PageLoadedEvent
 {

--- a/src/Storefront/Page/PageLoadedEvent.php
+++ b/src/Storefront/Page/PageLoadedEvent.php
@@ -10,6 +10,9 @@ use Shopware\Core\Framework\Struct\Struct;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\HttpFoundation\Request;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 abstract class PageLoadedEvent extends NestedEvent implements ShopwareSalesChannelEvent
 {

--- a/src/Storefront/Page/Product/QuickView/MinimalQuickViewPageCriteriaEvent.php
+++ b/src/Storefront/Page/Product/QuickView/MinimalQuickViewPageCriteriaEvent.php
@@ -9,6 +9,9 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Contracts\EventDispatcher\Event;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class MinimalQuickViewPageCriteriaEvent extends Event implements ShopwareSalesChannelEvent
 {

--- a/src/Storefront/Page/Product/QuickView/MinimalQuickViewPageLoadedEvent.php
+++ b/src/Storefront/Page/Product/QuickView/MinimalQuickViewPageLoadedEvent.php
@@ -7,6 +7,9 @@ use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Storefront\Page\PageLoadedEvent;
 use Symfony\Component\HttpFoundation\Request;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class MinimalQuickViewPageLoadedEvent extends PageLoadedEvent
 {

--- a/src/Storefront/Page/Robots/Event/RobotsUnknownDirectiveEvent.php
+++ b/src/Storefront/Page/Robots/Event/RobotsUnknownDirectiveEvent.php
@@ -17,6 +17,8 @@ use Symfony\Contracts\EventDispatcher\Event;
  * - Set custom issues for specific directive types
  *
  *  Simple DTO with no business logic
+ *
+ * @codeCoverageIgnore
  */
 #[Package('discovery')]
 class RobotsUnknownDirectiveEvent extends Event implements ShopwareEvent

--- a/src/Storefront/Page/Robots/RobotsPageLoadedEvent.php
+++ b/src/Storefront/Page/Robots/RobotsPageLoadedEvent.php
@@ -8,6 +8,9 @@ use Shopware\Core\Framework\Event\ShopwareEvent;
 use Shopware\Core\Framework\Log\Package;
 use Symfony\Component\HttpFoundation\Request;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class RobotsPageLoadedEvent extends NestedEvent implements ShopwareEvent
 {

--- a/src/Storefront/Page/Robots/Struct/DomainRuleCollection.php
+++ b/src/Storefront/Page/Robots/Struct/DomainRuleCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Struct\Collection;
 
 /**
  * @extends Collection<DomainRuleStruct>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('discovery')]
 class DomainRuleCollection extends Collection

--- a/src/Storefront/Page/Sitemap/SitemapPageLoadedEvent.php
+++ b/src/Storefront/Page/Sitemap/SitemapPageLoadedEvent.php
@@ -7,6 +7,9 @@ use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Storefront\Page\PageLoadedEvent;
 use Symfony\Component\HttpFoundation\Request;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class SitemapPageLoadedEvent extends PageLoadedEvent
 {

--- a/src/Storefront/Page/Suggest/SuggestPageLoadedEvent.php
+++ b/src/Storefront/Page/Suggest/SuggestPageLoadedEvent.php
@@ -7,6 +7,9 @@ use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Storefront\Page\PageLoadedEvent;
 use Symfony\Component\HttpFoundation\Request;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class SuggestPageLoadedEvent extends PageLoadedEvent
 {

--- a/src/Storefront/Page/Wishlist/GuestWishlistPageLoadedEvent.php
+++ b/src/Storefront/Page/Wishlist/GuestWishlistPageLoadedEvent.php
@@ -7,6 +7,9 @@ use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Storefront\Page\PageLoadedEvent;
 use Symfony\Component\HttpFoundation\Request;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class GuestWishlistPageLoadedEvent extends PageLoadedEvent
 {

--- a/src/Storefront/Page/Wishlist/WishListPageProductCriteriaEvent.php
+++ b/src/Storefront/Page/Wishlist/WishListPageProductCriteriaEvent.php
@@ -10,6 +10,9 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\HttpFoundation\Request;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class WishListPageProductCriteriaEvent extends NestedEvent implements ShopwareSalesChannelEvent
 {

--- a/src/Storefront/Page/Wishlist/WishlistPageLoadedEvent.php
+++ b/src/Storefront/Page/Wishlist/WishlistPageLoadedEvent.php
@@ -7,6 +7,9 @@ use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Storefront\Page\PageLoadedEvent;
 use Symfony\Component\HttpFoundation\Request;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class WishlistPageLoadedEvent extends PageLoadedEvent
 {

--- a/src/Storefront/Pagelet/Captcha/BasicCaptchaPageletLoadedEvent.php
+++ b/src/Storefront/Pagelet/Captcha/BasicCaptchaPageletLoadedEvent.php
@@ -7,6 +7,9 @@ use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Storefront\Pagelet\PageletLoadedEvent;
 use Symfony\Component\HttpFoundation\Request;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class BasicCaptchaPageletLoadedEvent extends PageletLoadedEvent
 {

--- a/src/Storefront/Pagelet/Country/CountryStateDataPageletCriteriaEvent.php
+++ b/src/Storefront/Pagelet/Country/CountryStateDataPageletCriteriaEvent.php
@@ -10,6 +10,9 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\HttpFoundation\Request;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class CountryStateDataPageletCriteriaEvent extends NestedEvent implements ShopwareSalesChannelEvent
 {

--- a/src/Storefront/Pagelet/Country/CountryStateDataPageletLoadedEvent.php
+++ b/src/Storefront/Pagelet/Country/CountryStateDataPageletLoadedEvent.php
@@ -7,6 +7,9 @@ use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Storefront\Pagelet\PageletLoadedEvent;
 use Symfony\Component\HttpFoundation\Request;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class CountryStateDataPageletLoadedEvent extends PageletLoadedEvent
 {

--- a/src/Storefront/Pagelet/Footer/FooterPageletLoadedEvent.php
+++ b/src/Storefront/Pagelet/Footer/FooterPageletLoadedEvent.php
@@ -7,6 +7,9 @@ use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Storefront\Pagelet\PageletLoadedEvent;
 use Symfony\Component\HttpFoundation\Request;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class FooterPageletLoadedEvent extends PageletLoadedEvent
 {

--- a/src/Storefront/Pagelet/Header/HeaderPageletLoadedEvent.php
+++ b/src/Storefront/Pagelet/Header/HeaderPageletLoadedEvent.php
@@ -7,6 +7,9 @@ use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Storefront\Pagelet\PageletLoadedEvent;
 use Symfony\Component\HttpFoundation\Request;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class HeaderPageletLoadedEvent extends PageletLoadedEvent
 {

--- a/src/Storefront/Pagelet/Menu/Offcanvas/MenuOffcanvasPageletLoadedEvent.php
+++ b/src/Storefront/Pagelet/Menu/Offcanvas/MenuOffcanvasPageletLoadedEvent.php
@@ -7,6 +7,9 @@ use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Storefront\Pagelet\PageletLoadedEvent;
 use Symfony\Component\HttpFoundation\Request;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class MenuOffcanvasPageletLoadedEvent extends PageletLoadedEvent
 {

--- a/src/Storefront/Pagelet/PageletLoadedEvent.php
+++ b/src/Storefront/Pagelet/PageletLoadedEvent.php
@@ -9,6 +9,9 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\HttpFoundation\Request;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 abstract class PageletLoadedEvent extends NestedEvent implements ShopwareSalesChannelEvent
 {

--- a/src/Storefront/Pagelet/Wishlist/GuestWishListPageletProductCriteriaEvent.php
+++ b/src/Storefront/Pagelet/Wishlist/GuestWishListPageletProductCriteriaEvent.php
@@ -10,6 +10,9 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\HttpFoundation\Request;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class GuestWishListPageletProductCriteriaEvent extends NestedEvent implements ShopwareSalesChannelEvent
 {

--- a/src/Storefront/Pagelet/Wishlist/GuestWishlistPageletLoadedEvent.php
+++ b/src/Storefront/Pagelet/Wishlist/GuestWishlistPageletLoadedEvent.php
@@ -7,6 +7,9 @@ use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Storefront\Pagelet\PageletLoadedEvent;
 use Symfony\Component\HttpFoundation\Request;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class GuestWishlistPageletLoadedEvent extends PageletLoadedEvent
 {

--- a/src/Storefront/Theme/Aggregate/ThemeChildDefinition.php
+++ b/src/Storefront/Theme/Aggregate/ThemeChildDefinition.php
@@ -11,6 +11,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\MappingEntityDefinition;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Storefront\Theme\ThemeDefinition;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class ThemeChildDefinition extends MappingEntityDefinition
 {

--- a/src/Storefront/Theme/Aggregate/ThemeMediaDefinition.php
+++ b/src/Storefront/Theme/Aggregate/ThemeMediaDefinition.php
@@ -12,6 +12,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\MappingEntityDefinition;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Storefront\Theme\ThemeDefinition;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class ThemeMediaDefinition extends MappingEntityDefinition
 {

--- a/src/Storefront/Theme/Aggregate/ThemeSalesChannelDefinition.php
+++ b/src/Storefront/Theme/Aggregate/ThemeSalesChannelDefinition.php
@@ -12,6 +12,9 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelDefinition;
 use Shopware\Storefront\Theme\ThemeDefinition;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class ThemeSalesChannelDefinition extends MappingEntityDefinition
 {

--- a/src/Storefront/Theme/Aggregate/ThemeTranslationDefinition.php
+++ b/src/Storefront/Theme/Aggregate/ThemeTranslationDefinition.php
@@ -11,6 +11,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Storefront\Theme\ThemeDefinition;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class ThemeTranslationDefinition extends EntityTranslationDefinition
 {

--- a/src/Storefront/Theme/Event/ThemeIndexerEvent.php
+++ b/src/Storefront/Theme/Event/ThemeIndexerEvent.php
@@ -6,6 +6,9 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Event\NestedEvent;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class ThemeIndexerEvent extends NestedEvent
 {

--- a/src/Storefront/Theme/Event/ThemeIndexerEvent.php
+++ b/src/Storefront/Theme/Event/ThemeIndexerEvent.php
@@ -12,6 +12,10 @@ use Shopware\Core\Framework\Log\Package;
 #[Package('discovery')]
 class ThemeIndexerEvent extends NestedEvent
 {
+    /**
+     * @param array<string> $ids
+     * @param array<string> $skip
+     */
     public function __construct(
         private readonly array $ids,
         private readonly Context $context,
@@ -24,11 +28,17 @@ class ThemeIndexerEvent extends NestedEvent
         return $this->context;
     }
 
+    /**
+     * @return array<string>
+     */
     public function getIds(): array
     {
         return $this->ids;
     }
 
+    /**
+     * @return array<string>
+     */
     public function getSkip(): array
     {
         return $this->skip;

--- a/src/Storefront/Theme/ThemeDefinition.php
+++ b/src/Storefront/Theme/ThemeDefinition.php
@@ -25,6 +25,9 @@ use Shopware\Storefront\Theme\Aggregate\ThemeMediaDefinition;
 use Shopware\Storefront\Theme\Aggregate\ThemeSalesChannelDefinition;
 use Shopware\Storefront\Theme\Aggregate\ThemeTranslationDefinition;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class ThemeDefinition extends EntityDefinition
 {

--- a/src/Storefront/Theme/ThemeSalesChannelCollection.php
+++ b/src/Storefront/Theme/ThemeSalesChannelCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Struct\Collection;
 
 /**
  * @extends Collection<ThemeSalesChannel>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('discovery')]
 class ThemeSalesChannelCollection extends Collection


### PR DESCRIPTION
### 1. Why is this change necessary?

PHPUnit 12 reports classes that are excluded from the coverage source as invalid `#[CoversClass]` targets. The blanket suffix excludes for `src/Storefront` in `phpunit.xml.dist` are being replaced with per-class annotations so the excludes can be lifted.

### 2. What does this change do, exactly?

Adds a `@codeCoverageIgnore` docblock to the 38 discovery-owned Storefront classes that are matched by the Storefront suffix excludes and contain only logic-free boilerplate (constructors and plain accessors). The excludes themselves are lifted at the top of this stack, once every matched class carries an annotation or a test.

### 3. Describe each step to reproduce the issue or behaviour.

Not applicable, coverage configuration only.

### 4. Please link to the relevant issues (if any).

- relates #18344

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
