### PR TITLE
test: mark checkout-owned Storefront classes codeCoverageIgnore

### DIFF
--- a/src/Storefront/Event/RouteRequest/AccountNewsletterRecipientRouteRequestEvent.php
+++ b/src/Storefront/Event/RouteRequest/AccountNewsletterRecipientRouteRequestEvent.php
@@ -4,6 +4,9 @@ namespace Shopware\Storefront\Event\RouteRequest;
 
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('checkout')]
 class AccountNewsletterRecipientRouteRequestEvent extends RouteRequestEvent
 {

--- a/src/Storefront/Event/RouteRequest/CancelOrderRouteRequestEvent.php
+++ b/src/Storefront/Event/RouteRequest/CancelOrderRouteRequestEvent.php
@@ -4,6 +4,9 @@ namespace Shopware\Storefront\Event\RouteRequest;
 
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('checkout')]
 class CancelOrderRouteRequestEvent extends RouteRequestEvent
 {

--- a/src/Storefront/Event/RouteRequest/HandlePaymentMethodRouteRequestEvent.php
+++ b/src/Storefront/Event/RouteRequest/HandlePaymentMethodRouteRequestEvent.php
@@ -4,6 +4,9 @@ namespace Shopware\Storefront\Event\RouteRequest;
 
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('checkout')]
 class HandlePaymentMethodRouteRequestEvent extends RouteRequestEvent
 {

--- a/src/Storefront/Event/RouteRequest/OrderRouteRequestEvent.php
+++ b/src/Storefront/Event/RouteRequest/OrderRouteRequestEvent.php
@@ -4,6 +4,9 @@ namespace Shopware\Storefront\Event\RouteRequest;
 
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('checkout')]
 class OrderRouteRequestEvent extends RouteRequestEvent
 {

--- a/src/Storefront/Event/RouteRequest/PaymentMethodRouteRequestEvent.php
+++ b/src/Storefront/Event/RouteRequest/PaymentMethodRouteRequestEvent.php
@@ -4,6 +4,9 @@ namespace Shopware\Storefront\Event\RouteRequest;
 
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('checkout')]
 class PaymentMethodRouteRequestEvent extends RouteRequestEvent
 {

--- a/src/Storefront/Event/RouteRequest/SetPaymentOrderRouteRequestEvent.php
+++ b/src/Storefront/Event/RouteRequest/SetPaymentOrderRouteRequestEvent.php
@@ -4,6 +4,9 @@ namespace Shopware\Storefront\Event\RouteRequest;
 
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('checkout')]
 class SetPaymentOrderRouteRequestEvent extends RouteRequestEvent
 {

--- a/src/Storefront/Event/RouteRequest/ShippingMethodRouteRequestEvent.php
+++ b/src/Storefront/Event/RouteRequest/ShippingMethodRouteRequestEvent.php
@@ -4,6 +4,9 @@ namespace Shopware\Storefront\Event\RouteRequest;
 
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('checkout')]
 class ShippingMethodRouteRequestEvent extends RouteRequestEvent
 {

--- a/src/Storefront/Page/Account/CustomerGroupRegistration/CustomerGroupRegistrationPageLoadedEvent.php
+++ b/src/Storefront/Page/Account/CustomerGroupRegistration/CustomerGroupRegistrationPageLoadedEvent.php
@@ -7,6 +7,9 @@ use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Storefront\Page\PageLoadedEvent;
 use Symfony\Component\HttpFoundation\Request;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('checkout')]
 class CustomerGroupRegistrationPageLoadedEvent extends PageLoadedEvent
 {

--- a/src/Storefront/Page/Account/Login/AccountLoginPageLoadedEvent.php
+++ b/src/Storefront/Page/Account/Login/AccountLoginPageLoadedEvent.php
@@ -7,6 +7,9 @@ use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Storefront\Page\PageLoadedEvent;
 use Symfony\Component\HttpFoundation\Request;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('checkout')]
 class AccountLoginPageLoadedEvent extends PageLoadedEvent
 {

--- a/src/Storefront/Page/Account/Order/AccountEditOrderPageLoadedEvent.php
+++ b/src/Storefront/Page/Account/Order/AccountEditOrderPageLoadedEvent.php
@@ -7,6 +7,9 @@ use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Storefront\Page\PageLoadedEvent;
 use Symfony\Component\HttpFoundation\Request;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('checkout')]
 class AccountEditOrderPageLoadedEvent extends PageLoadedEvent
 {

--- a/src/Storefront/Page/Account/Order/AccountOrderPageLoadedEvent.php
+++ b/src/Storefront/Page/Account/Order/AccountOrderPageLoadedEvent.php
@@ -7,6 +7,9 @@ use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Storefront\Page\PageLoadedEvent;
 use Symfony\Component\HttpFoundation\Request;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('checkout')]
 class AccountOrderPageLoadedEvent extends PageLoadedEvent
 {

--- a/src/Storefront/Page/Account/Overview/AccountOverviewPageLoadedEvent.php
+++ b/src/Storefront/Page/Account/Overview/AccountOverviewPageLoadedEvent.php
@@ -7,6 +7,9 @@ use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Storefront\Page\PageLoadedEvent;
 use Symfony\Component\HttpFoundation\Request;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('checkout')]
 class AccountOverviewPageLoadedEvent extends PageLoadedEvent
 {

--- a/src/Storefront/Page/Account/Profile/AccountProfilePageLoadedEvent.php
+++ b/src/Storefront/Page/Account/Profile/AccountProfilePageLoadedEvent.php
@@ -7,6 +7,9 @@ use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Storefront\Page\PageLoadedEvent;
 use Symfony\Component\HttpFoundation\Request;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('checkout')]
 class AccountProfilePageLoadedEvent extends PageLoadedEvent
 {

--- a/src/Storefront/Page/Account/RecoverPassword/AccountRecoverPasswordPageLoadedEvent.php
+++ b/src/Storefront/Page/Account/RecoverPassword/AccountRecoverPasswordPageLoadedEvent.php
@@ -7,6 +7,9 @@ use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Storefront\Page\PageLoadedEvent;
 use Symfony\Component\HttpFoundation\Request;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('checkout')]
 class AccountRecoverPasswordPageLoadedEvent extends PageLoadedEvent
 {

--- a/src/Storefront/Page/Address/AddressEditorModalStruct.php
+++ b/src/Storefront/Page/Address/AddressEditorModalStruct.php
@@ -7,6 +7,9 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\Struct;
 use Shopware\Storefront\Page\Page;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('checkout')]
 class AddressEditorModalStruct extends Struct
 {

--- a/src/Storefront/Page/Address/Detail/AddressDetailPageLoadedEvent.php
+++ b/src/Storefront/Page/Address/Detail/AddressDetailPageLoadedEvent.php
@@ -7,6 +7,9 @@ use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Storefront\Page\PageLoadedEvent;
 use Symfony\Component\HttpFoundation\Request;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('checkout')]
 class AddressDetailPageLoadedEvent extends PageLoadedEvent
 {

--- a/src/Storefront/Page/Address/Listing/AddressListingPageLoadedEvent.php
+++ b/src/Storefront/Page/Address/Listing/AddressListingPageLoadedEvent.php
@@ -7,6 +7,9 @@ use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Storefront\Page\PageLoadedEvent;
 use Symfony\Component\HttpFoundation\Request;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('checkout')]
 class AddressListingPageLoadedEvent extends PageLoadedEvent
 {

--- a/src/Storefront/Page/Checkout/Cart/CheckoutCartPageLoadedEvent.php
+++ b/src/Storefront/Page/Checkout/Cart/CheckoutCartPageLoadedEvent.php
@@ -7,6 +7,9 @@ use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Storefront\Page\PageLoadedEvent;
 use Symfony\Component\HttpFoundation\Request;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('checkout')]
 class CheckoutCartPageLoadedEvent extends PageLoadedEvent
 {

--- a/src/Storefront/Page/Checkout/Confirm/CheckoutConfirmPageLoadedEvent.php
+++ b/src/Storefront/Page/Checkout/Confirm/CheckoutConfirmPageLoadedEvent.php
@@ -7,6 +7,9 @@ use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Storefront\Page\PageLoadedEvent;
 use Symfony\Component\HttpFoundation\Request;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('checkout')]
 class CheckoutConfirmPageLoadedEvent extends PageLoadedEvent
 {

--- a/src/Storefront/Page/Checkout/Finish/CheckoutFinishPageLoadedEvent.php
+++ b/src/Storefront/Page/Checkout/Finish/CheckoutFinishPageLoadedEvent.php
@@ -7,6 +7,9 @@ use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Storefront\Page\PageLoadedEvent;
 use Symfony\Component\HttpFoundation\Request;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('checkout')]
 class CheckoutFinishPageLoadedEvent extends PageLoadedEvent
 {

--- a/src/Storefront/Page/Checkout/Finish/CheckoutFinishPageOrderCriteriaEvent.php
+++ b/src/Storefront/Page/Checkout/Finish/CheckoutFinishPageOrderCriteriaEvent.php
@@ -8,6 +8,9 @@ use Shopware\Core\Framework\Event\ShopwareSalesChannelEvent;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('checkout')]
 class CheckoutFinishPageOrderCriteriaEvent implements ShopwareSalesChannelEvent
 {

--- a/src/Storefront/Page/Checkout/Offcanvas/OffcanvasCartPageLoadedEvent.php
+++ b/src/Storefront/Page/Checkout/Offcanvas/OffcanvasCartPageLoadedEvent.php
@@ -7,6 +7,9 @@ use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Storefront\Page\PageLoadedEvent;
 use Symfony\Component\HttpFoundation\Request;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('checkout')]
 class OffcanvasCartPageLoadedEvent extends PageLoadedEvent
 {

--- a/src/Storefront/Page/Checkout/Register/CheckoutRegisterPageLoadedEvent.php
+++ b/src/Storefront/Page/Checkout/Register/CheckoutRegisterPageLoadedEvent.php
@@ -7,6 +7,9 @@ use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Storefront\Page\PageLoadedEvent;
 use Symfony\Component\HttpFoundation\Request;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('checkout')]
 class CheckoutRegisterPageLoadedEvent extends PageLoadedEvent
 {

--- a/src/Storefront/Page/Newsletter/Subscribe/NewsletterSubscribePageLoadedEvent.php
+++ b/src/Storefront/Page/Newsletter/Subscribe/NewsletterSubscribePageLoadedEvent.php
@@ -7,6 +7,9 @@ use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Storefront\Page\PageLoadedEvent;
 use Symfony\Component\HttpFoundation\Request;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('checkout')]
 class NewsletterSubscribePageLoadedEvent extends PageLoadedEvent
 {

--- a/src/Storefront/Pagelet/Newsletter/Account/NewsletterAccountPageletLoadedEvent.php
+++ b/src/Storefront/Pagelet/Newsletter/Account/NewsletterAccountPageletLoadedEvent.php
@@ -7,6 +7,9 @@ use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Storefront\Pagelet\PageletLoadedEvent;
 use Symfony\Component\HttpFoundation\Request;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('checkout')]
 class NewsletterAccountPageletLoadedEvent extends PageletLoadedEvent
 {


### PR DESCRIPTION
### 1. Why is this change necessary?

PHPUnit 12 reports classes that are excluded from the coverage source as invalid `#[CoversClass]` targets. The blanket suffix excludes for `src/Storefront` in `phpunit.xml.dist` are being replaced with per-class annotations so the excludes can be lifted.

### 2. What does this change do, exactly?

Adds a `@codeCoverageIgnore` docblock to the 25 checkout-owned Storefront classes that are matched by the Storefront suffix excludes and contain only logic-free boilerplate (constructors and plain accessors). The excludes themselves are lifted at the top of this stack, once every matched class carries an annotation or a test.

### 3. Describe each step to reproduce the issue or behaviour.

Not applicable, coverage configuration only.

### 4. Please link to the relevant issues (if any).

- relates #18344

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
