### PR TITLE
test: lift the Storefront coverage suffix excludes and cover the surfaced logic

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -92,42 +92,6 @@
             <file>src/Core/DevOps/StaticAnalyze/print-ignored-errors-by-area.php</file>
             <directory suffix=".php">src/Core/Framework/Telemetry/Metrics/Metric</directory>
 
-            <directory suffix="Definition.php">src/Storefront/Checkout</directory>
-            <directory suffix="Entity.php">src/Storefront/Checkout</directory>
-            <directory suffix="Event.php">src/Storefront/Checkout</directory>
-            <directory suffix="Field.php">src/Storefront/Checkout</directory>
-            <directory suffix="Struct.php">src/Storefront/Checkout</directory>
-            <directory suffix="Collection.php">src/Storefront/Checkout</directory>
-            <directory suffix="Event.php">src/Storefront/Event</directory>
-
-            <directory suffix="Definition.php">src/Storefront/Framework</directory>
-            <directory suffix="Entity.php">src/Storefront/Framework</directory>
-            <directory suffix="Event.php">src/Storefront/Framework</directory>
-            <directory suffix="Field.php">src/Storefront/Framework</directory>
-            <directory suffix="Struct.php">src/Storefront/Framework</directory>
-            <directory suffix="Collection.php">src/Storefront/Framework</directory>
-
-            <directory suffix="Definition.php">src/Storefront/Page</directory>
-            <directory suffix="Entity.php">src/Storefront/Page</directory>
-            <directory suffix="Event.php">src/Storefront/Page</directory>
-            <directory suffix="Field.php">src/Storefront/Page</directory>
-            <directory suffix="Struct.php">src/Storefront/Page</directory>
-            <directory suffix="Collection.php">src/Storefront/Page</directory>
-
-            <directory suffix="Definition.php">src/Storefront/Pagelet</directory>
-            <directory suffix="Entity.php">src/Storefront/Pagelet</directory>
-            <directory suffix="Event.php">src/Storefront/Pagelet</directory>
-            <directory suffix="Field.php">src/Storefront/Pagelet</directory>
-            <directory suffix="Struct.php">src/Storefront/Pagelet</directory>
-            <directory suffix="Collection.php">src/Storefront/Pagelet</directory>
-
-            <directory suffix="Definition.php">src/Storefront/Theme</directory>
-            <directory suffix="Entity.php">src/Storefront/Theme</directory>
-            <directory suffix="Event.php">src/Storefront/Theme</directory>
-            <directory suffix="Field.php">src/Storefront/Theme</directory>
-            <directory suffix="Struct.php">src/Storefront/Theme</directory>
-            <directory suffix="Collection.php">src/Storefront/Theme</directory>
-
             <!-- All fixtures, stubs, traits used for tests -->
             <directory suffix=".php">src/Core/Content/Test</directory>
             <!-- Only the test fixtures under DevOps/Test; the tooling classes stay covered by their unit tests. -->

--- a/src/Storefront/Event/RouteRequest/CurrencyRouteRequestEvent.php
+++ b/src/Storefront/Event/RouteRequest/CurrencyRouteRequestEvent.php
@@ -4,6 +4,9 @@ namespace Shopware\Storefront\Event\RouteRequest;
 
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('framework')]
 class CurrencyRouteRequestEvent extends RouteRequestEvent
 {

--- a/src/Storefront/Page/Product/ProductPageCriteriaEvent.php
+++ b/src/Storefront/Page/Product/ProductPageCriteriaEvent.php
@@ -9,6 +9,9 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Contracts\EventDispatcher\Event;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductPageCriteriaEvent extends Event implements ShopwareSalesChannelEvent
 {

--- a/src/Storefront/Page/Product/ProductPageLoadedEvent.php
+++ b/src/Storefront/Page/Product/ProductPageLoadedEvent.php
@@ -7,6 +7,9 @@ use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Storefront\Page\PageLoadedEvent;
 use Symfony\Component\HttpFoundation\Request;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class ProductPageLoadedEvent extends PageLoadedEvent
 {

--- a/src/Storefront/Page/Search/SearchPageLoadedEvent.php
+++ b/src/Storefront/Page/Search/SearchPageLoadedEvent.php
@@ -7,6 +7,9 @@ use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Storefront\Page\PageLoadedEvent;
 use Symfony\Component\HttpFoundation\Request;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('inventory')]
 class SearchPageLoadedEvent extends PageLoadedEvent
 {

--- a/tests/unit/Storefront/Event/RouteRequest/RouteRequestEventTest.php
+++ b/tests/unit/Storefront/Event/RouteRequest/RouteRequestEventTest.php
@@ -1,0 +1,43 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Storefront\Event\RouteRequest;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Test\Generator;
+use Shopware\Storefront\Event\RouteRequest\LanguageRouteRequestEvent;
+use Shopware\Storefront\Event\RouteRequest\RouteRequestEvent;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * @internal
+ */
+#[Package('discovery')]
+#[CoversClass(RouteRequestEvent::class)]
+class RouteRequestEventTest extends TestCase
+{
+    public function testGettersReturnTheConstructorArguments(): void
+    {
+        $storefrontRequest = new Request();
+        $storeApiRequest = new Request();
+        $salesChannelContext = Generator::generateSalesChannelContext();
+        $criteria = new Criteria();
+
+        $event = new LanguageRouteRequestEvent($storefrontRequest, $storeApiRequest, $salesChannelContext, $criteria);
+
+        static::assertSame($storefrontRequest, $event->getStorefrontRequest());
+        static::assertSame($storeApiRequest, $event->getStoreApiRequest());
+        static::assertSame($salesChannelContext, $event->getSalesChannelContext());
+        static::assertSame($salesChannelContext->getContext(), $event->getContext());
+        static::assertSame($criteria, $event->getCriteria());
+    }
+
+    public function testCriteriaDefaultsToAnEmptyCriteria(): void
+    {
+        $event = new LanguageRouteRequestEvent(new Request(), new Request(), Generator::generateSalesChannelContext());
+
+        static::assertEquals(new Criteria(), $event->getCriteria());
+    }
+}

--- a/tests/unit/Storefront/Event/StorefrontRenderEventTest.php
+++ b/tests/unit/Storefront/Event/StorefrontRenderEventTest.php
@@ -1,0 +1,91 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Storefront\Event;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Test\Generator;
+use Shopware\Storefront\Event\StorefrontRenderEvent;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * @internal
+ */
+#[Package('discovery')]
+#[CoversClass(StorefrontRenderEvent::class)]
+class StorefrontRenderEventTest extends TestCase
+{
+    public function testParametersAreMergedWithTheDefaults(): void
+    {
+        $salesChannelContext = Generator::generateSalesChannelContext();
+
+        $event = new StorefrontRenderEvent(
+            '@Storefront/storefront/page/content/index.html.twig',
+            ['page' => 'content'],
+            new Request(),
+            $salesChannelContext,
+        );
+
+        static::assertSame(
+            [
+                'context' => $salesChannelContext,
+                'headerParameters' => [],
+                'footerParameters' => [],
+                'page' => 'content',
+            ],
+            $event->getParameters()
+        );
+    }
+
+    public function testPassedParametersOverrideTheDefaults(): void
+    {
+        $event = new StorefrontRenderEvent(
+            'index.html.twig',
+            ['headerParameters' => ['navigationId' => 'foo']],
+            new Request(),
+            Generator::generateSalesChannelContext(),
+        );
+
+        static::assertSame(['navigationId' => 'foo'], $event->getParameter('headerParameters'));
+    }
+
+    public function testGetParameterReturnsNullForUnknownKeys(): void
+    {
+        $event = new StorefrontRenderEvent('index.html.twig', [], new Request(), Generator::generateSalesChannelContext());
+
+        static::assertNull($event->getParameter('unknown'));
+    }
+
+    public function testSetParameterAddsToTheParameters(): void
+    {
+        $event = new StorefrontRenderEvent('index.html.twig', [], new Request(), Generator::generateSalesChannelContext());
+
+        $event->setParameter('page', 'content');
+
+        static::assertSame('content', $event->getParameter('page'));
+    }
+
+    public function testGettersReturnTheConstructorArguments(): void
+    {
+        $request = new Request();
+        $salesChannelContext = Generator::generateSalesChannelContext();
+
+        $event = new StorefrontRenderEvent('index.html.twig', [], $request, $salesChannelContext);
+
+        static::assertSame('index.html.twig', $event->getView());
+        static::assertSame($request, $event->getRequest());
+        static::assertSame($salesChannelContext, $event->getSalesChannelContext());
+        static::assertSame($salesChannelContext->getContext(), $event->getContext());
+    }
+
+    public function testSetSalesChannelContextReplacesTheContext(): void
+    {
+        $event = new StorefrontRenderEvent('index.html.twig', [], new Request(), Generator::generateSalesChannelContext());
+
+        $replacement = Generator::generateSalesChannelContext();
+        $event->setSalesChannelContext($replacement);
+
+        static::assertSame($replacement, $event->getSalesChannelContext());
+    }
+}

--- a/tests/unit/Storefront/Framework/Routing/Struct/DomainCollectionTest.php
+++ b/tests/unit/Storefront/Framework/Routing/Struct/DomainCollectionTest.php
@@ -1,0 +1,62 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Storefront\Framework\Routing\Struct;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Storefront\Framework\Routing\Struct\DomainCollection;
+use Shopware\Storefront\Framework\Routing\Struct\DomainStruct;
+
+/**
+ * @internal
+ */
+#[Package('discovery')]
+#[CoversClass(DomainCollection::class)]
+class DomainCollectionTest extends TestCase
+{
+    public function testAddKeysTheDomainByItsUrlWithATrailingSlash(): void
+    {
+        $domain = DomainStruct::fromArray(self::row('https://example.com/de/'));
+
+        $collection = new DomainCollection();
+        $collection->add($domain);
+
+        static::assertSame($domain, $collection->get('https://example.com/de/'));
+    }
+
+    public function testFromArrayBuildsOneDomainPerRow(): void
+    {
+        $collection = DomainCollection::fromArray([
+            'https://example.com/' => self::row('https://example.com'),
+            'https://example.com/en/' => self::row('https://example.com/en'),
+        ]);
+
+        static::assertCount(2, $collection);
+        static::assertInstanceOf(DomainStruct::class, $collection->get('https://example.com/'));
+        static::assertInstanceOf(DomainStruct::class, $collection->get('https://example.com/en/'));
+    }
+
+    public function testGetApiAlias(): void
+    {
+        static::assertSame('storefront_domain_collection', (new DomainCollection())->getApiAlias());
+    }
+
+    /**
+     * @return array<string, string|null>
+     */
+    private static function row(string $url): array
+    {
+        return [
+            'url' => $url,
+            'id' => 'domain-id',
+            'salesChannelId' => 'sales-channel-id',
+            'typeId' => 'type-id',
+            'snippetSetId' => 'snippet-set-id',
+            'currencyId' => 'currency-id',
+            'languageId' => 'language-id',
+            'maintenance' => '0',
+            'locale' => 'en-GB',
+        ];
+    }
+}

--- a/tests/unit/Storefront/Framework/Routing/Struct/DomainStructTest.php
+++ b/tests/unit/Storefront/Framework/Routing/Struct/DomainStructTest.php
@@ -1,0 +1,76 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Storefront\Framework\Routing\Struct;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Storefront\Framework\Routing\Struct\DomainStruct;
+
+/**
+ * @internal
+ */
+#[Package('discovery')]
+#[CoversClass(DomainStruct::class)]
+class DomainStructTest extends TestCase
+{
+    public function testFromArrayTrimsTrailingSlashesFromTheUrl(): void
+    {
+        $domain = DomainStruct::fromArray(self::row(['url' => 'https://example.com/de/']));
+
+        static::assertSame('https://example.com/de', $domain->url);
+    }
+
+    public function testFromArrayMapsAllFields(): void
+    {
+        $domain = DomainStruct::fromArray(self::row([
+            'themeId' => 'theme-id',
+            'maintenanceIpAllowlist' => '["127.0.0.1"]',
+            'themeName' => 'Storefront',
+            'parentThemeName' => 'Base',
+        ]));
+
+        static::assertSame('domain-id', $domain->id);
+        static::assertSame('sales-channel-id', $domain->salesChannelId);
+        static::assertSame('type-id', $domain->typeId);
+        static::assertSame('snippet-set-id', $domain->snippetSetId);
+        static::assertSame('currency-id', $domain->currencyId);
+        static::assertSame('language-id', $domain->languageId);
+        static::assertSame('theme-id', $domain->themeId);
+        static::assertSame('1', $domain->maintenance);
+        static::assertSame('["127.0.0.1"]', $domain->maintenanceIpAllowlist);
+        static::assertSame('en-GB', $domain->locale);
+        static::assertSame('Storefront', $domain->themeName);
+        static::assertSame('Base', $domain->parentThemeName);
+    }
+
+    public function testFromArrayKeepsUnsetOptionalFieldsNull(): void
+    {
+        $domain = DomainStruct::fromArray(self::row());
+
+        static::assertNull($domain->themeId);
+        static::assertNull($domain->maintenanceIpAllowlist);
+        static::assertNull($domain->themeName);
+        static::assertNull($domain->parentThemeName);
+    }
+
+    /**
+     * @param array<string, string|null> $overrides
+     *
+     * @return array<string, string|null>
+     */
+    private static function row(array $overrides = []): array
+    {
+        return array_merge([
+            'url' => 'https://example.com',
+            'id' => 'domain-id',
+            'salesChannelId' => 'sales-channel-id',
+            'typeId' => 'type-id',
+            'snippetSetId' => 'snippet-set-id',
+            'currencyId' => 'currency-id',
+            'languageId' => 'language-id',
+            'maintenance' => '1',
+            'locale' => 'en-GB',
+        ], $overrides);
+    }
+}

--- a/tests/unit/Storefront/Page/Account/Order/AccountOrderDetailPageLoadedEventTest.php
+++ b/tests/unit/Storefront/Page/Account/Order/AccountOrderDetailPageLoadedEventTest.php
@@ -1,0 +1,45 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Storefront\Page\Account\Order;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Feature\FeatureException;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Test\Annotation\DisabledFeatures;
+use Shopware\Core\Test\Generator;
+use Shopware\Storefront\Page\Account\Order\AccountOrderDetailPage;
+use Shopware\Storefront\Page\Account\Order\AccountOrderDetailPageLoadedEvent;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * @internal
+ */
+#[Package('checkout')]
+#[CoversClass(AccountOrderDetailPageLoadedEvent::class)]
+class AccountOrderDetailPageLoadedEventTest extends TestCase
+{
+    public function testConstructorThrowsWhenTheFeatureIsActive(): void
+    {
+        $this->expectExceptionObject(FeatureException::error(
+            'Tried to access deprecated functionality: Class "Shopware\Storefront\Page\Account\Order\AccountOrderDetailPageLoadedEvent" is deprecated and will be removed in v6.8.0.0.'
+        ));
+
+        new AccountOrderDetailPageLoadedEvent(new AccountOrderDetailPage(), Generator::generateSalesChannelContext(), new Request());
+    }
+
+    #[DisabledFeatures(['v6.8.0.0'])]
+    public function testGettersReturnTheConstructorArgumentsWhenTheFeatureIsInactive(): void
+    {
+        $page = new AccountOrderDetailPage();
+        $salesChannelContext = Generator::generateSalesChannelContext();
+        $request = new Request();
+
+        $event = new AccountOrderDetailPageLoadedEvent($page, $salesChannelContext, $request);
+
+        static::assertSame($page, $event->getPage());
+        static::assertSame($salesChannelContext, $event->getSalesChannelContext());
+        static::assertSame($salesChannelContext->getContext(), $event->getContext());
+        static::assertSame($request, $event->getRequest());
+    }
+}

--- a/tests/unit/Storefront/Page/Robots/Struct/DomainRuleStructTest.php
+++ b/tests/unit/Storefront/Page/Robots/Struct/DomainRuleStructTest.php
@@ -5,6 +5,7 @@ namespace Shopware\Tests\Unit\Storefront\Page\Robots\Struct;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Feature\FeatureException;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Test\Annotation\DisabledFeatures;
 use Shopware\Storefront\Page\Robots\Parser\ParsedRobots;
@@ -161,5 +162,54 @@ class DomainRuleStructTest extends TestCase
         $domainRuleStruct = new DomainRuleStruct($parsed, '');
 
         static::assertSame([], $domainRuleStruct->getDirectives());
+    }
+
+    public function testOrphanedPathDirectivesGetTheBasePathApplied(): void
+    {
+        $parsed = new ParsedRobots([], [
+            new RobotsDirective(RobotsDirectiveType::DISALLOW, '/account/'),
+        ]);
+
+        $directives = (new DomainRuleStruct($parsed, '/en'))->getDirectives();
+
+        static::assertCount(1, $directives);
+        static::assertSame('/en/account/', $directives[0]->value);
+    }
+
+    public function testConstructorRejectsRuleStringsWhenTheFeatureIsActive(): void
+    {
+        $this->expectExceptionObject(FeatureException::error(
+            'Tried to access deprecated functionality: Passing a string to DomainRuleStruct constructor is deprecated. Use RobotsDirectiveParser::parse() and pass the ParsedRobots object instead.'
+        ));
+
+        new DomainRuleStruct('Disallow: /private/', '');
+    }
+
+    public function testGetRulesThrowsWhenTheFeatureIsActive(): void
+    {
+        $domainRuleStruct = new DomainRuleStruct(new ParsedRobots([], []), '');
+
+        $this->expectExceptionObject(FeatureException::error(
+            'Tried to access deprecated functionality: Method "Shopware\Storefront\Page\Robots\Struct\DomainRuleStruct::getRules()" is deprecated and will be removed in v6.8.0.0. Use "getDirectives" instead.'
+        ));
+
+        $domainRuleStruct->getRules();
+    }
+
+    /**
+     * @deprecated tag:v6.8.0 - Tests the deprecated legacy rule arrays, will be removed
+     */
+    #[DisabledFeatures(['v6.8.0.0'])]
+    public function testGetRulesReturnsTheLegacyRuleArraysWhenTheFeatureIsInactive(): void
+    {
+        $parsed = new ParsedRobots([], [
+            new RobotsDirective(RobotsDirectiveType::DISALLOW, '/account/'),
+        ]);
+
+        $fromParsed = new DomainRuleStruct($parsed, '/en');
+        static::assertSame([['type' => 'Disallow', 'path' => '/en/account/']], $fromParsed->getRules());
+
+        $fromString = new DomainRuleStruct('Disallow: /private/', '/en');
+        static::assertSame([['type' => 'Disallow', 'path' => '/en/private/']], $fromString->getRules());
     }
 }

--- a/tests/unit/Storefront/Theme/Aggregate/ThemeTranslationCollectionTest.php
+++ b/tests/unit/Storefront/Theme/Aggregate/ThemeTranslationCollectionTest.php
@@ -1,0 +1,73 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Storefront\Theme\Aggregate;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Storefront\Theme\Aggregate\ThemeTranslationCollection;
+use Shopware\Storefront\Theme\Aggregate\ThemeTranslationEntity;
+
+/**
+ * @internal
+ */
+#[Package('discovery')]
+#[CoversClass(ThemeTranslationCollection::class)]
+class ThemeTranslationCollectionTest extends TestCase
+{
+    public function testGetThemeIds(): void
+    {
+        $collection = new ThemeTranslationCollection([
+            self::translation('theme-a', 'language-a'),
+            self::translation('theme-b', 'language-b'),
+        ]);
+
+        static::assertSame(
+            ['theme-a-language-a' => 'theme-a', 'theme-b-language-b' => 'theme-b'],
+            $collection->getThemeIds()
+        );
+    }
+
+    public function testFilterByThemeId(): void
+    {
+        $match = self::translation('theme-a', 'language-a');
+
+        $collection = new ThemeTranslationCollection([$match, self::translation('theme-b', 'language-b')]);
+        $filtered = $collection->filterByThemeId('theme-a');
+
+        static::assertSame([$match], array_values($filtered->getElements()));
+    }
+
+    public function testGetLanguageIds(): void
+    {
+        $collection = new ThemeTranslationCollection([
+            self::translation('theme-a', 'language-a'),
+            self::translation('theme-b', 'language-b'),
+        ]);
+
+        static::assertSame(
+            ['theme-a-language-a' => 'language-a', 'theme-b-language-b' => 'language-b'],
+            $collection->getLanguageIds()
+        );
+    }
+
+    public function testFilterByLanguageId(): void
+    {
+        $match = self::translation('theme-a', 'language-a');
+
+        $collection = new ThemeTranslationCollection([$match, self::translation('theme-b', 'language-b')]);
+        $filtered = $collection->filterByLanguageId('language-a');
+
+        static::assertSame([$match], array_values($filtered->getElements()));
+    }
+
+    private static function translation(string $themeId, string $languageId): ThemeTranslationEntity
+    {
+        $translation = new ThemeTranslationEntity();
+        $translation->setUniqueIdentifier($themeId . '-' . $languageId);
+        $translation->setThemeId($themeId);
+        $translation->setLanguageId($languageId);
+
+        return $translation;
+    }
+}

--- a/tests/unit/Storefront/Theme/Aggregate/ThemeTranslationEntityTest.php
+++ b/tests/unit/Storefront/Theme/Aggregate/ThemeTranslationEntityTest.php
@@ -1,0 +1,81 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Storefront\Theme\Aggregate;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Feature\FeatureException;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Test\Annotation\DisabledFeatures;
+use Shopware\Storefront\Theme\Aggregate\ThemeTranslationEntity;
+use Shopware\Storefront\Theme\ThemeEntity;
+
+/**
+ * @internal
+ */
+#[Package('discovery')]
+#[CoversClass(ThemeTranslationEntity::class)]
+class ThemeTranslationEntityTest extends TestCase
+{
+    public function testAccessorsRoundTrip(): void
+    {
+        $translation = new ThemeTranslationEntity();
+        $theme = new ThemeEntity();
+
+        $translation->setDescription('A theme');
+        $translation->setThemeId('theme-id');
+        $translation->setTheme($theme);
+
+        static::assertSame('A theme', $translation->getDescription());
+        static::assertSame('theme-id', $translation->getThemeId());
+        static::assertSame($theme, $translation->getTheme());
+    }
+
+    public function testGetLabelsThrowsWhenTheFeatureIsActive(): void
+    {
+        $this->expectExceptionObject(FeatureException::error(
+            'Tried to access deprecated functionality: Method "Shopware\Storefront\Theme\Aggregate\ThemeTranslationEntity::getLabels()" is deprecated and will be removed in v6.8.0.0. Use "ThemeConfigField::getLabelSnippetKey" instead.'
+        ));
+
+        (new ThemeTranslationEntity())->getLabels();
+    }
+
+    public function testGetHelpTextsThrowsWhenTheFeatureIsActive(): void
+    {
+        $this->expectExceptionObject(FeatureException::error(
+            'Tried to access deprecated functionality: Method "Shopware\Storefront\Theme\Aggregate\ThemeTranslationEntity::getHelpTexts()" is deprecated and will be removed in v6.8.0.0. Use "ThemeConfigField::getHelpTextSnippetKey" instead.'
+        ));
+
+        (new ThemeTranslationEntity())->getHelpTexts();
+    }
+
+    public function testSetLabelsThrowsWhenTheFeatureIsActive(): void
+    {
+        $this->expectExceptionObject(FeatureException::error(
+            'Tried to access deprecated functionality: Method "Shopware\Storefront\Theme\Aggregate\ThemeTranslationEntity::setLabels()" is deprecated and will be removed in v6.8.0.0.'
+        ));
+
+        (new ThemeTranslationEntity())->setLabels(['fields.sw-color-brand-primary' => 'Primary colour']);
+    }
+
+    public function testSetHelpTextsThrowsWhenTheFeatureIsActive(): void
+    {
+        $this->expectExceptionObject(FeatureException::error(
+            'Tried to access deprecated functionality: Method "Shopware\Storefront\Theme\Aggregate\ThemeTranslationEntity::setHelpTexts()" is deprecated and will be removed in v6.8.0.0.'
+        ));
+
+        (new ThemeTranslationEntity())->setHelpTexts(['fields.sw-color-brand-primary' => 'The main colour']);
+    }
+
+    #[DisabledFeatures(['v6.8.0.0'])]
+    public function testLabelsAndHelpTextsRoundTripWhenTheFeatureIsInactive(): void
+    {
+        $translation = new ThemeTranslationEntity();
+
+        $translation->setLabels(['fields.sw-color-brand-primary' => 'Primary colour']);
+        $translation->setHelpTexts(['fields.sw-color-brand-primary' => 'The main colour']);
+
+        static::assertSame(['fields.sw-color-brand-primary' => 'Primary colour'], $translation->getLabels());
+        static::assertSame(['fields.sw-color-brand-primary' => 'The main colour'], $translation->getHelpTexts());
+    }
+}

--- a/tests/unit/Storefront/Theme/Event/ThemeCompilerEnrichScssVariablesEventTest.php
+++ b/tests/unit/Storefront/Theme/Event/ThemeCompilerEnrichScssVariablesEventTest.php
@@ -1,0 +1,46 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Storefront\Theme\Event;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\TestDox;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Storefront\Theme\Event\ThemeCompilerEnrichScssVariablesEvent;
+
+/**
+ * @internal
+ */
+#[Package('discovery')]
+#[CoversClass(ThemeCompilerEnrichScssVariablesEvent::class)]
+class ThemeCompilerEnrichScssVariablesEventTest extends TestCase
+{
+    #[DataProvider('addVariableProvider')]
+    #[TestDox('addVariable stores $_dataName')]
+    public function testAddVariable(bool $sanitize, string $value, string $expected): void
+    {
+        $event = new ThemeCompilerEnrichScssVariablesEvent([], 'sales-channel-id', Context::createDefaultContext());
+
+        $event->addVariable('sw-color-brand-primary', $value, $sanitize);
+
+        static::assertSame(['sw-color-brand-primary' => $expected], $event->getVariables());
+    }
+
+    public static function addVariableProvider(): \Generator
+    {
+        yield 'the raw value' => ['sanitize' => false, 'value' => '#0042a0', 'expected' => '#0042a0'];
+        yield 'a quoted value with escaped quotes' => ['sanitize' => true, 'value' => 'URW Din\', sans-serif', 'expected' => '\'URW Din\\\', sans-serif\''];
+    }
+
+    public function testGettersReturnTheConstructorArguments(): void
+    {
+        $context = Context::createDefaultContext();
+        $event = new ThemeCompilerEnrichScssVariablesEvent(['sw-font' => 'serif'], 'sales-channel-id', $context);
+
+        static::assertSame(['sw-font' => 'serif'], $event->getVariables());
+        static::assertSame('sales-channel-id', $event->getSalesChannelId());
+        static::assertSame($context, $event->getContext());
+    }
+}

--- a/tests/unit/Storefront/Theme/StorefrontPluginConfiguration/StorefrontPluginConfigurationCollectionTest.php
+++ b/tests/unit/Storefront/Theme/StorefrontPluginConfiguration/StorefrontPluginConfigurationCollectionTest.php
@@ -1,0 +1,64 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Storefront\Theme\StorefrontPluginConfiguration;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Storefront\Theme\StorefrontPluginConfiguration\StorefrontPluginConfiguration;
+use Shopware\Storefront\Theme\StorefrontPluginConfiguration\StorefrontPluginConfigurationCollection;
+
+/**
+ * @internal
+ */
+#[Package('discovery')]
+#[CoversClass(StorefrontPluginConfigurationCollection::class)]
+class StorefrontPluginConfigurationCollectionTest extends TestCase
+{
+    public function testElementsAreKeyedByTechnicalName(): void
+    {
+        $theme = self::configuration('SwagTheme', isTheme: true);
+
+        $collection = new StorefrontPluginConfigurationCollection([$theme]);
+
+        static::assertSame($theme, $collection->get('SwagTheme'));
+    }
+
+    public function testAddKeysTheElementByTechnicalName(): void
+    {
+        $plugin = self::configuration('SwagPlugin', isTheme: false);
+
+        $collection = new StorefrontPluginConfigurationCollection();
+        $collection->add($plugin);
+
+        static::assertSame($plugin, $collection->get('SwagPlugin'));
+    }
+
+    public function testGetByTechnicalName(): void
+    {
+        $theme = self::configuration('SwagTheme', isTheme: true);
+        $collection = new StorefrontPluginConfigurationCollection([$theme]);
+
+        static::assertSame($theme, $collection->getByTechnicalName('SwagTheme'));
+        static::assertNull($collection->getByTechnicalName('Unknown'));
+    }
+
+    public function testGetThemesReturnsOnlyThemes(): void
+    {
+        $theme = self::configuration('SwagTheme', isTheme: true);
+        $plugin = self::configuration('SwagPlugin', isTheme: false);
+
+        $collection = new StorefrontPluginConfigurationCollection([$theme, $plugin]);
+
+        static::assertSame([$theme], array_values($collection->getThemes()->getElements()));
+        static::assertSame([$plugin], array_values($collection->getNoneThemes()->getElements()));
+    }
+
+    private static function configuration(string $technicalName, bool $isTheme): StorefrontPluginConfiguration
+    {
+        $configuration = new StorefrontPluginConfiguration($technicalName);
+        $configuration->setIsTheme($isTheme);
+
+        return $configuration;
+    }
+}

--- a/tests/unit/Storefront/Theme/ThemeCollectionTest.php
+++ b/tests/unit/Storefront/Theme/ThemeCollectionTest.php
@@ -1,0 +1,36 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Storefront\Theme;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Storefront\Theme\ThemeCollection;
+use Shopware\Storefront\Theme\ThemeEntity;
+
+/**
+ * @internal
+ */
+#[Package('discovery')]
+#[CoversClass(ThemeCollection::class)]
+class ThemeCollectionTest extends TestCase
+{
+    public function testGetByTechnicalName(): void
+    {
+        $storefront = self::theme('Storefront');
+
+        $collection = new ThemeCollection([$storefront, self::theme('SwagTheme')]);
+
+        static::assertSame($storefront, $collection->getByTechnicalName('Storefront'));
+        static::assertNull($collection->getByTechnicalName('Unknown'));
+    }
+
+    private static function theme(string $technicalName): ThemeEntity
+    {
+        $theme = new ThemeEntity();
+        $theme->setUniqueIdentifier($technicalName);
+        $theme->setTechnicalName($technicalName);
+
+        return $theme;
+    }
+}

--- a/tests/unit/Storefront/Theme/ThemeConfigFieldTest.php
+++ b/tests/unit/Storefront/Theme/ThemeConfigFieldTest.php
@@ -56,4 +56,89 @@ class ThemeConfigFieldTest extends TestCase
 
         static::assertSame($value, $field->getValue());
     }
+
+    public function testAccessorsRoundTrip(): void
+    {
+        $field = new ThemeConfigField();
+
+        $field->setName('sw-color-brand-primary');
+        $field->setLabelSnippetKey('sw-theme.fields.sw-color-brand-primary.label');
+        $field->setHelpTextSnippetKey('sw-theme.fields.sw-color-brand-primary.helpText');
+        $field->setType('color');
+        $field->setEditable(true);
+        $field->setBlock('themeColors');
+        $field->setSection('mainColors');
+        $field->setTab('colors');
+        $field->setOrder(1);
+        $field->setTabOrder(2);
+        $field->setSectionOrder(3);
+        $field->setBlockOrder(4);
+        $field->setCustom(['componentName' => 'sw-colorpicker']);
+        $field->setScss(false);
+        $field->setFullWidth(true);
+
+        static::assertSame('sw-color-brand-primary', $field->getName());
+        static::assertSame('sw-theme.fields.sw-color-brand-primary.label', $field->getLabelSnippetKey());
+        static::assertSame('sw-theme.fields.sw-color-brand-primary.helpText', $field->getHelpTextSnippetKey());
+        static::assertSame('color', $field->getType());
+        static::assertTrue($field->getEditable());
+        static::assertSame('themeColors', $field->getBlock());
+        static::assertSame('mainColors', $field->getSection());
+        static::assertSame('colors', $field->getTab());
+        static::assertSame(1, $field->getOrder());
+        static::assertSame(2, $field->getTabOrder());
+        static::assertSame(3, $field->getSectionOrder());
+        static::assertSame(4, $field->getBlockOrder());
+        static::assertSame(['componentName' => 'sw-colorpicker'], $field->getCustom());
+        static::assertFalse($field->getScss());
+        static::assertTrue($field->getFullWidth());
+    }
+
+    public function testGetLabelThrowsWhenTheFeatureIsActive(): void
+    {
+        $this->expectExceptionObject(FeatureException::error(
+            'Tried to access deprecated functionality: Method "Shopware\Storefront\Theme\ThemeConfigField::getLabel()" is deprecated and will be removed in v6.8.0.0. Use "getLabelSnippetKey" instead.'
+        ));
+
+        (new ThemeConfigField())->getLabel();
+    }
+
+    public function testSetLabelThrowsWhenTheFeatureIsActive(): void
+    {
+        $this->expectExceptionObject(FeatureException::error(
+            'Tried to access deprecated functionality: Method "Shopware\Storefront\Theme\ThemeConfigField::setLabel()" is deprecated and will be removed in v6.8.0.0.'
+        ));
+
+        (new ThemeConfigField())->setLabel(['fields' => ['sw-color-brand-primary' => 'Primary colour']]);
+    }
+
+    public function testGetHelpTextThrowsWhenTheFeatureIsActive(): void
+    {
+        $this->expectExceptionObject(FeatureException::error(
+            'Tried to access deprecated functionality: Method "Shopware\Storefront\Theme\ThemeConfigField::getHelpText()" is deprecated and will be removed in v6.8.0.0. Use "getHelpTextSnippetKey" instead.'
+        ));
+
+        (new ThemeConfigField())->getHelpText();
+    }
+
+    public function testSetHelpTextThrowsWhenTheFeatureIsActive(): void
+    {
+        $this->expectExceptionObject(FeatureException::error(
+            'Tried to access deprecated functionality: Method "Shopware\Storefront\Theme\ThemeConfigField::setHelpText()" is deprecated and will be removed in v6.8.0.0.'
+        ));
+
+        (new ThemeConfigField())->setHelpText(['en-GB' => ['label' => 'The main colour']]);
+    }
+
+    #[DisabledFeatures(['v6.8.0.0'])]
+    public function testLabelAndHelpTextRoundTripWhenTheFeatureIsInactive(): void
+    {
+        $field = new ThemeConfigField();
+
+        $field->setLabel(['fields' => ['sw-color-brand-primary' => 'Primary colour']]);
+        $field->setHelpText(['en-GB' => ['label' => 'The main colour']]);
+
+        static::assertSame(['fields' => ['sw-color-brand-primary' => 'Primary colour']], $field->getLabel());
+        static::assertSame(['en-GB' => ['label' => 'The main colour']], $field->getHelpText());
+    }
 }

--- a/tests/unit/Storefront/Theme/ThemeEntityTest.php
+++ b/tests/unit/Storefront/Theme/ThemeEntityTest.php
@@ -1,0 +1,127 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Storefront\Theme;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Media\MediaCollection;
+use Shopware\Core\Content\Media\MediaEntity;
+use Shopware\Core\Framework\Feature\FeatureException;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\System\SalesChannel\SalesChannelCollection;
+use Shopware\Core\Test\Annotation\DisabledFeatures;
+use Shopware\Storefront\Theme\Aggregate\ThemeTranslationCollection;
+use Shopware\Storefront\Theme\ThemeCollection;
+use Shopware\Storefront\Theme\ThemeEntity;
+
+/**
+ * @internal
+ */
+#[Package('discovery')]
+#[CoversClass(ThemeEntity::class)]
+class ThemeEntityTest extends TestCase
+{
+    public function testScalarAccessorsRoundTrip(): void
+    {
+        $theme = new ThemeEntity();
+
+        $theme->setTechnicalName('SwagTheme');
+        $theme->setName('Swag Theme');
+        $theme->setAuthor('shopware AG');
+        $theme->setDescription('A theme');
+        $theme->setPreviewMediaId('preview-media-id');
+        $theme->setParentThemeId('parent-theme-id');
+        $theme->setThemeJson(['name' => 'Swag Theme']);
+        $theme->setBaseConfig(['fields' => []]);
+        $theme->setConfigValues(['sw-color-brand-primary' => ['value' => '#0042a0']]);
+        $theme->setActive(true);
+
+        static::assertSame('SwagTheme', $theme->getTechnicalName());
+        static::assertSame('Swag Theme', $theme->getName());
+        static::assertSame('shopware AG', $theme->getAuthor());
+        static::assertSame('A theme', $theme->getDescription());
+        static::assertSame('preview-media-id', $theme->getPreviewMediaId());
+        static::assertSame('parent-theme-id', $theme->getParentThemeId());
+        static::assertSame(['name' => 'Swag Theme'], $theme->getThemeJson());
+        static::assertSame(['fields' => []], $theme->getBaseConfig());
+        static::assertSame(['sw-color-brand-primary' => ['value' => '#0042a0']], $theme->getConfigValues());
+        static::assertTrue($theme->isActive());
+    }
+
+    public function testAssociationAccessorsRoundTrip(): void
+    {
+        $theme = new ThemeEntity();
+
+        static::assertNull($theme->getSalesChannels());
+        static::assertNull($theme->getMedia());
+        static::assertNull($theme->getPreviewMedia());
+        static::assertNull($theme->getTranslations());
+        static::assertNull($theme->getDependentThemes());
+
+        $salesChannels = new SalesChannelCollection();
+        $media = new MediaCollection();
+        $previewMedia = new MediaEntity();
+        $translations = new ThemeTranslationCollection();
+        $dependentThemes = new ThemeCollection();
+
+        $theme->setSalesChannels($salesChannels);
+        $theme->setMedia($media);
+        $theme->setPreviewMedia($previewMedia);
+        $theme->setTranslations($translations);
+        $theme->setDependentThemes($dependentThemes);
+
+        static::assertSame($salesChannels, $theme->getSalesChannels());
+        static::assertSame($media, $theme->getMedia());
+        static::assertSame($previewMedia, $theme->getPreviewMedia());
+        static::assertSame($translations, $theme->getTranslations());
+        static::assertSame($dependentThemes, $theme->getDependentThemes());
+    }
+
+    public function testGetLabelsThrowsWhenTheFeatureIsActive(): void
+    {
+        $this->expectExceptionObject(FeatureException::error(
+            'Tried to access deprecated functionality: Method "Shopware\Storefront\Theme\ThemeEntity::getLabels()" is deprecated and will be removed in v6.8.0.0. Use "ThemeConfigField::getLabelSnippetKey" instead.'
+        ));
+
+        (new ThemeEntity())->getLabels();
+    }
+
+    public function testGetHelpTextsThrowsWhenTheFeatureIsActive(): void
+    {
+        $this->expectExceptionObject(FeatureException::error(
+            'Tried to access deprecated functionality: Method "Shopware\Storefront\Theme\ThemeEntity::getHelpTexts()" is deprecated and will be removed in v6.8.0.0. Use "ThemeConfigField::getHelpTextSnippetKey" instead.'
+        ));
+
+        (new ThemeEntity())->getHelpTexts();
+    }
+
+    public function testSetLabelsThrowsWhenTheFeatureIsActive(): void
+    {
+        $this->expectExceptionObject(FeatureException::error(
+            'Tried to access deprecated functionality: Method "Shopware\Storefront\Theme\ThemeEntity::setLabels()" is deprecated and will be removed in v6.8.0.0.'
+        ));
+
+        (new ThemeEntity())->setLabels(['fields.sw-color-brand-primary' => 'Primary colour']);
+    }
+
+    public function testSetHelpTextsThrowsWhenTheFeatureIsActive(): void
+    {
+        $this->expectExceptionObject(FeatureException::error(
+            'Tried to access deprecated functionality: Method "Shopware\Storefront\Theme\ThemeEntity::setHelpTexts()" is deprecated and will be removed in v6.8.0.0.'
+        ));
+
+        (new ThemeEntity())->setHelpTexts(['fields.sw-color-brand-primary' => 'The main colour']);
+    }
+
+    #[DisabledFeatures(['v6.8.0.0'])]
+    public function testLabelsAndHelpTextsRoundTripWhenTheFeatureIsInactive(): void
+    {
+        $theme = new ThemeEntity();
+
+        $theme->setLabels(['fields.sw-color-brand-primary' => 'Primary colour']);
+        $theme->setHelpTexts(['fields.sw-color-brand-primary' => 'The main colour']);
+
+        static::assertSame(['fields.sw-color-brand-primary' => 'Primary colour'], $theme->getLabels());
+        static::assertSame(['fields.sw-color-brand-primary' => 'The main colour'], $theme->getHelpTexts());
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?

PHPUnit 12 reports classes that are excluded from the coverage source as invalid `#[CoversClass]` targets. With every matched Storefront class annotated or tested in the layers below, the blanket suffix excludes can go.

### 2. What does this change do, exactly?

- Removes all `src/Storefront` suffix excludes from `phpunit.xml.dist`.
- Annotates the remaining 4 inventory- and framework-owned boilerplate classes with `@codeCoverageIgnore`.
- Adds unit tests for the logic the lifted excludes surface: the route request event base, the storefront render event, the routing domain structs, the theme collections and entities including their deprecation branches, and the checkout account order detail page event.
- Extends the existing tests for `ThemeConfigField` and `DomainRuleStruct` to cover their accessors and deprecated code paths.

### 3. Describe each step to reproduce the issue or behaviour.

Run the unit suite with a coverage driver under PHPUnit 12: the Storefront suffix excludes previously reported every `#[CoversClass]` pointing at a matched class as an invalid coverage target.

### 4. Please link to the relevant issues (if any).

- relates #18344

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
