### PR TITLE
test: mark checkout-owned Core System classes codeCoverageIgnore

### DIFF
--- a/src/Core/System/Country/Aggregate/CountryState/CountryStateDefinition.php
+++ b/src/Core/System/Country/Aggregate/CountryState/CountryStateDefinition.php
@@ -24,6 +24,9 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\Country\Aggregate\CountryStateTranslation\CountryStateTranslationDefinition;
 use Shopware\Core\System\Country\CountryDefinition;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('fundamentals@discovery')]
 class CountryStateDefinition extends EntityDefinition
 {

--- a/src/Core/System/Country/Aggregate/CountryState/CountryStateEntity.php
+++ b/src/Core/System/Country/Aggregate/CountryState/CountryStateEntity.php
@@ -11,6 +11,9 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\Country\Aggregate\CountryStateTranslation\CountryStateTranslationCollection;
 use Shopware\Core\System\Country\CountryEntity;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('fundamentals@discovery')]
 class CountryStateEntity extends Entity
 {

--- a/src/Core/System/Country/Aggregate/CountryState/SalesChannel/SalesChannelCountryStateDefinition.php
+++ b/src/Core/System/Country/Aggregate/CountryState/SalesChannel/SalesChannelCountryStateDefinition.php
@@ -9,9 +9,6 @@ use Shopware\Core\System\Country\Aggregate\CountryState\CountryStateDefinition;
 use Shopware\Core\System\SalesChannel\Entity\SalesChannelDefinitionInterface;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 
-/**
- * @codeCoverageIgnore
- */
 #[Package('fundamentals@discovery')]
 class SalesChannelCountryStateDefinition extends CountryStateDefinition implements SalesChannelDefinitionInterface
 {

--- a/src/Core/System/Country/Aggregate/CountryState/SalesChannel/SalesChannelCountryStateDefinition.php
+++ b/src/Core/System/Country/Aggregate/CountryState/SalesChannel/SalesChannelCountryStateDefinition.php
@@ -9,6 +9,9 @@ use Shopware\Core\System\Country\Aggregate\CountryState\CountryStateDefinition;
 use Shopware\Core\System\SalesChannel\Entity\SalesChannelDefinitionInterface;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('fundamentals@discovery')]
 class SalesChannelCountryStateDefinition extends CountryStateDefinition implements SalesChannelDefinitionInterface
 {

--- a/src/Core/System/Country/Aggregate/CountryStateTranslation/CountryStateTranslationCollection.php
+++ b/src/Core/System/Country/Aggregate/CountryStateTranslation/CountryStateTranslationCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<CountryStateTranslationEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('fundamentals@discovery')]
 class CountryStateTranslationCollection extends EntityCollection

--- a/src/Core/System/Country/Aggregate/CountryStateTranslation/CountryStateTranslationDefinition.php
+++ b/src/Core/System/Country/Aggregate/CountryStateTranslation/CountryStateTranslationDefinition.php
@@ -11,6 +11,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\Country\Aggregate\CountryState\CountryStateDefinition;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('fundamentals@discovery')]
 class CountryStateTranslationDefinition extends EntityTranslationDefinition
 {

--- a/src/Core/System/Country/Aggregate/CountryStateTranslation/CountryStateTranslationEntity.php
+++ b/src/Core/System/Country/Aggregate/CountryStateTranslation/CountryStateTranslationEntity.php
@@ -7,6 +7,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\TranslationEntity;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\Country\Aggregate\CountryState\CountryStateEntity;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('fundamentals@discovery')]
 class CountryStateTranslationEntity extends TranslationEntity
 {

--- a/src/Core/System/Country/Aggregate/CountryTranslation/CountryTranslationCollection.php
+++ b/src/Core/System/Country/Aggregate/CountryTranslation/CountryTranslationCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<CountryTranslationEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('fundamentals@discovery')]
 class CountryTranslationCollection extends EntityCollection

--- a/src/Core/System/Country/Aggregate/CountryTranslation/CountryTranslationDefinition.php
+++ b/src/Core/System/Country/Aggregate/CountryTranslation/CountryTranslationDefinition.php
@@ -12,6 +12,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\Country\CountryDefinition;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('fundamentals@discovery')]
 class CountryTranslationDefinition extends EntityTranslationDefinition
 {

--- a/src/Core/System/Country/Aggregate/CountryTranslation/CountryTranslationEntity.php
+++ b/src/Core/System/Country/Aggregate/CountryTranslation/CountryTranslationEntity.php
@@ -7,6 +7,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\TranslationEntity;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\Country\CountryEntity;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('fundamentals@discovery')]
 class CountryTranslationEntity extends TranslationEntity
 {

--- a/src/Core/System/Country/CountryDefinition.php
+++ b/src/Core/System/Country/CountryDefinition.php
@@ -30,6 +30,9 @@ use Shopware\Core\System\SalesChannel\Aggregate\SalesChannelCountry\SalesChannel
 use Shopware\Core\System\SalesChannel\SalesChannelDefinition;
 use Shopware\Core\System\Tax\Aggregate\TaxRule\TaxRuleDefinition;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('fundamentals@discovery')]
 class CountryDefinition extends EntityDefinition
 {

--- a/src/Core/System/Country/CountryEntity.php
+++ b/src/Core/System/Country/CountryEntity.php
@@ -15,6 +15,9 @@ use Shopware\Core\System\Currency\Aggregate\CurrencyCountryRounding\CurrencyCoun
 use Shopware\Core\System\SalesChannel\SalesChannelCollection;
 use Shopware\Core\System\Tax\Aggregate\TaxRule\TaxRuleCollection;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('fundamentals@discovery')]
 class CountryEntity extends Entity
 {

--- a/src/Core/System/Country/Event/CountryCriteriaEvent.php
+++ b/src/Core/System/Country/Event/CountryCriteriaEvent.php
@@ -10,6 +10,9 @@ use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Contracts\EventDispatcher\Event;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('fundamentals@discovery')]
 class CountryCriteriaEvent extends Event implements ShopwareSalesChannelEvent
 {

--- a/src/Core/System/Country/Event/CountryRouteCacheKeyEvent.php
+++ b/src/Core/System/Country/Event/CountryRouteCacheKeyEvent.php
@@ -5,6 +5,9 @@ namespace Shopware\Core\System\Country\Event;
 use Shopware\Core\Framework\Adapter\Cache\StoreApiRouteCacheKeyEvent;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('fundamentals@discovery')]
 /**
  * @deprecated tag:v6.8.0 - Will be removed in 6.8.0 as it was not used anymore

--- a/src/Core/System/Country/Event/CountryRouteCacheTagsEvent.php
+++ b/src/Core/System/Country/Event/CountryRouteCacheTagsEvent.php
@@ -5,6 +5,9 @@ namespace Shopware\Core\System\Country\Event;
 use Shopware\Core\Framework\Adapter\Cache\StoreApiRouteCacheTagsEvent;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('fundamentals@discovery')]
 /**
  * @deprecated tag:v6.8.0 - Will be removed in 6.8.0 as it was not used anymore

--- a/src/Core/System/Country/Event/CountryStateCriteriaEvent.php
+++ b/src/Core/System/Country/Event/CountryStateCriteriaEvent.php
@@ -10,6 +10,9 @@ use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Contracts\EventDispatcher\Event;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('fundamentals@discovery')]
 class CountryStateCriteriaEvent extends Event implements ShopwareSalesChannelEvent
 {

--- a/src/Core/System/Country/Event/CountryStateRouteCacheKeyEvent.php
+++ b/src/Core/System/Country/Event/CountryStateRouteCacheKeyEvent.php
@@ -5,6 +5,9 @@ namespace Shopware\Core\System\Country\Event;
 use Shopware\Core\Framework\Adapter\Cache\StoreApiRouteCacheKeyEvent;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('fundamentals@discovery')]
 /**
  * @deprecated tag:v6.8.0 - Will be removed in 6.8.0 as it was not used anymore

--- a/src/Core/System/Country/Event/CountryStateRouteCacheTagsEvent.php
+++ b/src/Core/System/Country/Event/CountryStateRouteCacheTagsEvent.php
@@ -5,6 +5,9 @@ namespace Shopware\Core\System\Country\Event;
 use Shopware\Core\Framework\Adapter\Cache\StoreApiRouteCacheTagsEvent;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('fundamentals@discovery')]
 /**
  * @deprecated tag:v6.8.0 - Will be removed in 6.8.0 as it was not used anymore

--- a/src/Core/System/Country/SalesChannel/SalesChannelCountryDefinition.php
+++ b/src/Core/System/Country/SalesChannel/SalesChannelCountryDefinition.php
@@ -9,6 +9,9 @@ use Shopware\Core\System\Country\CountryDefinition;
 use Shopware\Core\System\SalesChannel\Entity\SalesChannelDefinitionInterface;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('fundamentals@discovery')]
 class SalesChannelCountryDefinition extends CountryDefinition implements SalesChannelDefinitionInterface
 {

--- a/src/Core/System/Country/SalesChannel/SalesChannelCountryDefinition.php
+++ b/src/Core/System/Country/SalesChannel/SalesChannelCountryDefinition.php
@@ -9,9 +9,6 @@ use Shopware\Core\System\Country\CountryDefinition;
 use Shopware\Core\System\SalesChannel\Entity\SalesChannelDefinitionInterface;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 
-/**
- * @codeCoverageIgnore
- */
 #[Package('fundamentals@discovery')]
 class SalesChannelCountryDefinition extends CountryDefinition implements SalesChannelDefinitionInterface
 {

--- a/src/Core/System/Currency/Aggregate/CurrencyCountryRounding/CurrencyCountryRoundingCollection.php
+++ b/src/Core/System/Currency/Aggregate/CurrencyCountryRounding/CurrencyCountryRoundingCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<CurrencyCountryRoundingEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('fundamentals@framework')]
 class CurrencyCountryRoundingCollection extends EntityCollection

--- a/src/Core/System/Currency/Aggregate/CurrencyCountryRounding/CurrencyCountryRoundingDefinition.php
+++ b/src/Core/System/Currency/Aggregate/CurrencyCountryRounding/CurrencyCountryRoundingDefinition.php
@@ -15,6 +15,9 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\Country\CountryDefinition;
 use Shopware\Core\System\Currency\CurrencyDefinition;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('fundamentals@framework')]
 class CurrencyCountryRoundingDefinition extends EntityDefinition
 {

--- a/src/Core/System/Currency/Aggregate/CurrencyCountryRounding/CurrencyCountryRoundingEntity.php
+++ b/src/Core/System/Currency/Aggregate/CurrencyCountryRounding/CurrencyCountryRoundingEntity.php
@@ -9,6 +9,9 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\Country\CountryEntity;
 use Shopware\Core\System\Currency\CurrencyEntity;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('fundamentals@framework')]
 class CurrencyCountryRoundingEntity extends Entity
 {

--- a/src/Core/System/Currency/Aggregate/CurrencyTranslation/CurrencyTranslationCollection.php
+++ b/src/Core/System/Currency/Aggregate/CurrencyTranslation/CurrencyTranslationCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<CurrencyTranslationEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('fundamentals@framework')]
 class CurrencyTranslationCollection extends EntityCollection

--- a/src/Core/System/Currency/Aggregate/CurrencyTranslation/CurrencyTranslationDefinition.php
+++ b/src/Core/System/Currency/Aggregate/CurrencyTranslation/CurrencyTranslationDefinition.php
@@ -11,6 +11,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\Currency\CurrencyDefinition;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('fundamentals@framework')]
 class CurrencyTranslationDefinition extends EntityTranslationDefinition
 {

--- a/src/Core/System/Currency/Aggregate/CurrencyTranslation/CurrencyTranslationEntity.php
+++ b/src/Core/System/Currency/Aggregate/CurrencyTranslation/CurrencyTranslationEntity.php
@@ -7,6 +7,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\TranslationEntity;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\Currency\CurrencyEntity;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('fundamentals@framework')]
 class CurrencyTranslationEntity extends TranslationEntity
 {

--- a/src/Core/System/Currency/CurrencyCollection.php
+++ b/src/Core/System/Currency/CurrencyCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<CurrencyEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('fundamentals@framework')]
 class CurrencyCollection extends EntityCollection

--- a/src/Core/System/Currency/CurrencyDefinition.php
+++ b/src/Core/System/Currency/CurrencyDefinition.php
@@ -31,6 +31,9 @@ use Shopware\Core\System\SalesChannel\Aggregate\SalesChannelCurrency\SalesChanne
 use Shopware\Core\System\SalesChannel\Aggregate\SalesChannelDomain\SalesChannelDomainDefinition;
 use Shopware\Core\System\SalesChannel\SalesChannelDefinition;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('fundamentals@framework')]
 class CurrencyDefinition extends EntityDefinition
 {

--- a/src/Core/System/Currency/CurrencyEntity.php
+++ b/src/Core/System/Currency/CurrencyEntity.php
@@ -15,6 +15,9 @@ use Shopware\Core\System\Currency\Aggregate\CurrencyTranslation\CurrencyTranslat
 use Shopware\Core\System\SalesChannel\Aggregate\SalesChannelDomain\SalesChannelDomainCollection;
 use Shopware\Core\System\SalesChannel\SalesChannelCollection;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('fundamentals@framework')]
 class CurrencyEntity extends Entity
 {

--- a/src/Core/System/Currency/Event/CurrencyRouteCacheKeyEvent.php
+++ b/src/Core/System/Currency/Event/CurrencyRouteCacheKeyEvent.php
@@ -5,6 +5,9 @@ namespace Shopware\Core\System\Currency\Event;
 use Shopware\Core\Framework\Adapter\Cache\StoreApiRouteCacheKeyEvent;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('fundamentals@framework')]
 /**
  * @deprecated tag:v6.8.0 - Will be removed in 6.8.0 as it was not used anymore

--- a/src/Core/System/Currency/Event/CurrencyRouteCacheTagsEvent.php
+++ b/src/Core/System/Currency/Event/CurrencyRouteCacheTagsEvent.php
@@ -5,6 +5,9 @@ namespace Shopware\Core\System\Currency\Event;
 use Shopware\Core\Framework\Adapter\Cache\StoreApiRouteCacheTagsEvent;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('fundamentals@framework')]
 /**
  * @deprecated tag:v6.8.0 - Will be removed in 6.8.0 as it was not used anymore

--- a/src/Core/System/Currency/SalesChannel/SalesChannelCurrencyDefinition.php
+++ b/src/Core/System/Currency/SalesChannel/SalesChannelCurrencyDefinition.php
@@ -9,6 +9,9 @@ use Shopware\Core\System\Currency\CurrencyDefinition;
 use Shopware\Core\System\SalesChannel\Entity\SalesChannelDefinitionInterface;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('fundamentals@framework')]
 class SalesChannelCurrencyDefinition extends CurrencyDefinition implements SalesChannelDefinitionInterface
 {

--- a/src/Core/System/Currency/SalesChannel/SalesChannelCurrencyDefinition.php
+++ b/src/Core/System/Currency/SalesChannel/SalesChannelCurrencyDefinition.php
@@ -9,9 +9,6 @@ use Shopware\Core\System\Currency\CurrencyDefinition;
 use Shopware\Core\System\SalesChannel\Entity\SalesChannelDefinitionInterface;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 
-/**
- * @codeCoverageIgnore
- */
 #[Package('fundamentals@framework')]
 class SalesChannelCurrencyDefinition extends CurrencyDefinition implements SalesChannelDefinitionInterface
 {

--- a/src/Core/System/CustomEntity/CustomEntityCollection.php
+++ b/src/Core/System/CustomEntity/CustomEntityCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<CustomEntityEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('framework')]
 class CustomEntityCollection extends EntityCollection

--- a/src/Core/System/CustomEntity/CustomEntityDefinition.php
+++ b/src/Core/System/CustomEntity/CustomEntityDefinition.php
@@ -20,6 +20,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Plugin\PluginDefinition;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('framework')]
 class CustomEntityDefinition extends EntityDefinition
 {

--- a/src/Core/System/CustomEntity/Schema/DynamicTranslationEntityDefinition.php
+++ b/src/Core/System/CustomEntity/Schema/DynamicTranslationEntityDefinition.php
@@ -11,6 +11,8 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  * @internal Used for custom entities
  *
  * @phpstan-import-type CustomEntityField from CustomEntitySchemaUpdater
+ *
+ * @codeCoverageIgnore
  */
 #[Package('framework')]
 class DynamicTranslationEntityDefinition extends EntityTranslationDefinition

--- a/src/Core/System/CustomEntity/Xml/Field/AssociationField.php
+++ b/src/Core/System/CustomEntity/Xml/Field/AssociationField.php
@@ -6,6 +6,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @internal
+ *
+ * @codeCoverageIgnore
  */
 #[Package('framework')]
 abstract class AssociationField extends Field

--- a/src/Core/System/CustomEntity/Xml/Field/DateField.php
+++ b/src/Core/System/CustomEntity/Xml/Field/DateField.php
@@ -8,6 +8,8 @@ use Shopware\Core\System\CustomEntity\Xml\Field\Traits\TranslatableTrait;
 
 /**
  * @internal
+ *
+ * @codeCoverageIgnore
  */
 #[Package('framework')]
 class DateField extends Field

--- a/src/Core/System/CustomEntity/Xml/Field/EmailField.php
+++ b/src/Core/System/CustomEntity/Xml/Field/EmailField.php
@@ -8,6 +8,8 @@ use Shopware\Core\System\CustomEntity\Xml\Field\Traits\TranslatableTrait;
 
 /**
  * @internal
+ *
+ * @codeCoverageIgnore
  */
 #[Package('framework')]
 class EmailField extends Field

--- a/src/Core/System/CustomEntity/Xml/Field/Field.php
+++ b/src/Core/System/CustomEntity/Xml/Field/Field.php
@@ -8,6 +8,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @internal
+ *
+ * @codeCoverageIgnore
  */
 #[Package('framework')]
 abstract class Field extends XmlElement

--- a/src/Core/System/CustomEntity/Xml/Field/Field.php
+++ b/src/Core/System/CustomEntity/Xml/Field/Field.php
@@ -8,8 +8,6 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @internal
- *
- * @codeCoverageIgnore
  */
 #[Package('framework')]
 abstract class Field extends XmlElement

--- a/src/Core/System/CustomEntity/Xml/Field/JsonField.php
+++ b/src/Core/System/CustomEntity/Xml/Field/JsonField.php
@@ -8,6 +8,8 @@ use Shopware\Core\System\CustomEntity\Xml\Field\Traits\TranslatableTrait;
 
 /**
  * @internal
+ *
+ * @codeCoverageIgnore
  */
 #[Package('framework')]
 class JsonField extends Field

--- a/src/Core/System/CustomEntity/Xml/Field/LabelField.php
+++ b/src/Core/System/CustomEntity/Xml/Field/LabelField.php
@@ -6,6 +6,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @internal
+ *
+ * @codeCoverageIgnore
  */
 #[Package('framework')]
 class LabelField extends Field

--- a/src/Core/System/CustomEntity/Xml/Field/ManyToManyField.php
+++ b/src/Core/System/CustomEntity/Xml/Field/ManyToManyField.php
@@ -7,6 +7,8 @@ use Shopware\Core\System\CustomEntity\Xml\Field\Traits\RequiredTrait;
 
 /**
  * @internal
+ *
+ * @codeCoverageIgnore
  */
 #[Package('framework')]
 class ManyToManyField extends AssociationField

--- a/src/Core/System/CustomEntity/Xml/Field/ManyToOneField.php
+++ b/src/Core/System/CustomEntity/Xml/Field/ManyToOneField.php
@@ -7,6 +7,8 @@ use Shopware\Core\System\CustomEntity\Xml\Field\Traits\RequiredTrait;
 
 /**
  * @internal
+ *
+ * @codeCoverageIgnore
  */
 #[Package('framework')]
 class ManyToOneField extends AssociationField

--- a/src/Core/System/CustomEntity/Xml/Field/OneToManyField.php
+++ b/src/Core/System/CustomEntity/Xml/Field/OneToManyField.php
@@ -6,6 +6,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @internal
+ *
+ * @codeCoverageIgnore
  */
 #[Package('framework')]
 class OneToManyField extends AssociationField

--- a/src/Core/System/CustomEntity/Xml/Field/OneToOneField.php
+++ b/src/Core/System/CustomEntity/Xml/Field/OneToOneField.php
@@ -7,6 +7,8 @@ use Shopware\Core\System\CustomEntity\Xml\Field\Traits\RequiredTrait;
 
 /**
  * @internal
+ *
+ * @codeCoverageIgnore
  */
 #[Package('framework')]
 class OneToOneField extends AssociationField

--- a/src/Core/System/CustomEntity/Xml/Field/StringField.php
+++ b/src/Core/System/CustomEntity/Xml/Field/StringField.php
@@ -8,6 +8,8 @@ use Shopware\Core\System\CustomEntity\Xml\Field\Traits\TranslatableTrait;
 
 /**
  * @internal
+ *
+ * @codeCoverageIgnore
  */
 #[Package('framework')]
 class StringField extends Field

--- a/src/Core/System/CustomField/Aggregate/CustomFieldSet/CustomFieldSetCollection.php
+++ b/src/Core/System/CustomField/Aggregate/CustomFieldSet/CustomFieldSetCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<CustomFieldSetEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('framework')]
 class CustomFieldSetCollection extends EntityCollection

--- a/src/Core/System/CustomField/Aggregate/CustomFieldSet/CustomFieldSetDefinition.php
+++ b/src/Core/System/CustomField/Aggregate/CustomFieldSet/CustomFieldSetDefinition.php
@@ -25,6 +25,9 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\CustomField\Aggregate\CustomFieldSetRelation\CustomFieldSetRelationDefinition;
 use Shopware\Core\System\CustomField\CustomFieldDefinition;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('framework')]
 class CustomFieldSetDefinition extends EntityDefinition
 {

--- a/src/Core/System/CustomField/Aggregate/CustomFieldSet/CustomFieldSetEntity.php
+++ b/src/Core/System/CustomField/Aggregate/CustomFieldSet/CustomFieldSetEntity.php
@@ -10,6 +10,9 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\CustomField\Aggregate\CustomFieldSetRelation\CustomFieldSetRelationCollection;
 use Shopware\Core\System\CustomField\CustomFieldCollection;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('framework')]
 class CustomFieldSetEntity extends Entity
 {

--- a/src/Core/System/CustomField/Aggregate/CustomFieldSetRelation/CustomFieldSetRelationCollection.php
+++ b/src/Core/System/CustomField/Aggregate/CustomFieldSetRelation/CustomFieldSetRelationCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<CustomFieldSetRelationEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('framework')]
 class CustomFieldSetRelationCollection extends EntityCollection

--- a/src/Core/System/CustomField/Aggregate/CustomFieldSetRelation/CustomFieldSetRelationDefinition.php
+++ b/src/Core/System/CustomField/Aggregate/CustomFieldSetRelation/CustomFieldSetRelationDefinition.php
@@ -13,6 +13,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\CustomField\Aggregate\CustomFieldSet\CustomFieldSetDefinition;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('framework')]
 class CustomFieldSetRelationDefinition extends EntityDefinition
 {

--- a/src/Core/System/CustomField/Aggregate/CustomFieldSetRelation/CustomFieldSetRelationEntity.php
+++ b/src/Core/System/CustomField/Aggregate/CustomFieldSetRelation/CustomFieldSetRelationEntity.php
@@ -7,6 +7,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityIdTrait;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\CustomField\Aggregate\CustomFieldSet\CustomFieldSetEntity;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('framework')]
 class CustomFieldSetRelationEntity extends Entity
 {

--- a/src/Core/System/CustomField/CustomFieldCollection.php
+++ b/src/Core/System/CustomField/CustomFieldCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<CustomFieldEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('framework')]
 class CustomFieldCollection extends EntityCollection

--- a/src/Core/System/CustomField/CustomFieldDefinition.php
+++ b/src/Core/System/CustomField/CustomFieldDefinition.php
@@ -19,6 +19,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\CustomField\Aggregate\CustomFieldSet\CustomFieldSetDefinition;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('framework')]
 class CustomFieldDefinition extends EntityDefinition
 {

--- a/src/Core/System/CustomField/CustomFieldEntity.php
+++ b/src/Core/System/CustomField/CustomFieldEntity.php
@@ -8,6 +8,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityIdTrait;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\CustomField\Aggregate\CustomFieldSet\CustomFieldSetEntity;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('framework')]
 class CustomFieldEntity extends Entity
 {

--- a/src/Core/System/DeliveryTime/Aggregate/DeliveryTimeTranslation/DeliveryTimeTranslationCollection.php
+++ b/src/Core/System/DeliveryTime/Aggregate/DeliveryTimeTranslation/DeliveryTimeTranslationCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<DeliveryTimeTranslationEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('discovery')]
 class DeliveryTimeTranslationCollection extends EntityCollection

--- a/src/Core/System/DeliveryTime/Aggregate/DeliveryTimeTranslation/DeliveryTimeTranslationDefinition.php
+++ b/src/Core/System/DeliveryTime/Aggregate/DeliveryTimeTranslation/DeliveryTimeTranslationDefinition.php
@@ -11,6 +11,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\DeliveryTime\DeliveryTimeDefinition;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class DeliveryTimeTranslationDefinition extends EntityTranslationDefinition
 {

--- a/src/Core/System/DeliveryTime/Aggregate/DeliveryTimeTranslation/DeliveryTimeTranslationEntity.php
+++ b/src/Core/System/DeliveryTime/Aggregate/DeliveryTimeTranslation/DeliveryTimeTranslationEntity.php
@@ -7,6 +7,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\TranslationEntity;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\DeliveryTime\DeliveryTimeEntity;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class DeliveryTimeTranslationEntity extends TranslationEntity
 {

--- a/src/Core/System/DeliveryTime/DeliveryTimeCollection.php
+++ b/src/Core/System/DeliveryTime/DeliveryTimeCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<DeliveryTimeEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('discovery')]
 class DeliveryTimeCollection extends EntityCollection

--- a/src/Core/System/DeliveryTime/DeliveryTimeDefinition.php
+++ b/src/Core/System/DeliveryTime/DeliveryTimeDefinition.php
@@ -19,6 +19,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\DeliveryTime\Aggregate\DeliveryTimeTranslation\DeliveryTimeTranslationDefinition;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class DeliveryTimeDefinition extends EntityDefinition
 {

--- a/src/Core/System/DeliveryTime/DeliveryTimeEntity.php
+++ b/src/Core/System/DeliveryTime/DeliveryTimeEntity.php
@@ -11,6 +11,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityIdTrait;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\DeliveryTime\Aggregate\DeliveryTimeTranslation\DeliveryTimeTranslationCollection;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class DeliveryTimeEntity extends Entity
 {

--- a/src/Core/System/Integration/Aggregate/IntegrationRole/IntegrationRoleDefinition.php
+++ b/src/Core/System/Integration/Aggregate/IntegrationRole/IntegrationRoleDefinition.php
@@ -12,6 +12,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\MappingEntityDefinition;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\Integration\IntegrationDefinition;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('fundamentals@framework')]
 class IntegrationRoleDefinition extends MappingEntityDefinition
 {

--- a/src/Core/System/Integration/IntegrationCollection.php
+++ b/src/Core/System/Integration/IntegrationCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<IntegrationEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('fundamentals@framework')]
 class IntegrationCollection extends EntityCollection

--- a/src/Core/System/Integration/IntegrationDefinition.php
+++ b/src/Core/System/Integration/IntegrationDefinition.php
@@ -25,6 +25,9 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\Integration\Aggregate\IntegrationRole\IntegrationRoleDefinition;
 use Shopware\Core\System\StateMachine\Aggregation\StateMachineHistory\StateMachineHistoryDefinition;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('fundamentals@framework')]
 class IntegrationDefinition extends EntityDefinition
 {

--- a/src/Core/System/Integration/IntegrationEntity.php
+++ b/src/Core/System/Integration/IntegrationEntity.php
@@ -10,6 +10,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityIdTrait;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\StateMachine\Aggregation\StateMachineHistory\StateMachineHistoryCollection;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('fundamentals@framework')]
 class IntegrationEntity extends Entity
 {

--- a/src/Core/System/Language/Event/LanguageRouteCacheKeyEvent.php
+++ b/src/Core/System/Language/Event/LanguageRouteCacheKeyEvent.php
@@ -5,6 +5,9 @@ namespace Shopware\Core\System\Language\Event;
 use Shopware\Core\Framework\Adapter\Cache\StoreApiRouteCacheKeyEvent;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('fundamentals@discovery')]
 /**
  * @deprecated tag:v6.8.0 - Will be removed in 6.8.0 as it was not used anymore

--- a/src/Core/System/Language/Event/LanguageRouteCacheTagsEvent.php
+++ b/src/Core/System/Language/Event/LanguageRouteCacheTagsEvent.php
@@ -5,6 +5,9 @@ namespace Shopware\Core\System\Language\Event;
 use Shopware\Core\Framework\Adapter\Cache\StoreApiRouteCacheTagsEvent;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('fundamentals@discovery')]
 /**
  * @deprecated tag:v6.8.0 - Will be removed in 6.8.0 as it was not used anymore

--- a/src/Core/System/Language/LanguageCollection.php
+++ b/src/Core/System/Language/LanguageCollection.php
@@ -8,6 +8,8 @@ use Shopware\Core\System\Locale\LocaleCollection;
 
 /**
  * @extends EntityCollection<LanguageEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('fundamentals@discovery')]
 class LanguageCollection extends EntityCollection

--- a/src/Core/System/Language/LanguageEntity.php
+++ b/src/Core/System/Language/LanguageEntity.php
@@ -67,6 +67,9 @@ use Shopware\Core\System\Tax\Aggregate\TaxRuleTypeTranslation\TaxRuleTypeTransla
 use Shopware\Core\System\TaxProvider\Aggregate\TaxProviderTranslation\TaxProviderTranslationCollection;
 use Shopware\Core\System\Unit\Aggregate\UnitTranslation\UnitTranslationCollection;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('fundamentals@discovery')]
 class LanguageEntity extends Entity
 {

--- a/src/Core/System/Language/SalesChannel/SalesChannelLanguageDefinition.php
+++ b/src/Core/System/Language/SalesChannel/SalesChannelLanguageDefinition.php
@@ -9,9 +9,6 @@ use Shopware\Core\System\Language\LanguageDefinition;
 use Shopware\Core\System\SalesChannel\Entity\SalesChannelDefinitionInterface;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 
-/**
- * @codeCoverageIgnore
- */
 #[Package('fundamentals@discovery')]
 class SalesChannelLanguageDefinition extends LanguageDefinition implements SalesChannelDefinitionInterface
 {

--- a/src/Core/System/Language/SalesChannel/SalesChannelLanguageDefinition.php
+++ b/src/Core/System/Language/SalesChannel/SalesChannelLanguageDefinition.php
@@ -9,6 +9,9 @@ use Shopware\Core\System\Language\LanguageDefinition;
 use Shopware\Core\System\SalesChannel\Entity\SalesChannelDefinitionInterface;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('fundamentals@discovery')]
 class SalesChannelLanguageDefinition extends LanguageDefinition implements SalesChannelDefinitionInterface
 {

--- a/src/Core/System/Locale/Aggregate/LocaleTranslation/LocaleTranslationCollection.php
+++ b/src/Core/System/Locale/Aggregate/LocaleTranslation/LocaleTranslationCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<LocaleTranslationEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('discovery')]
 class LocaleTranslationCollection extends EntityCollection

--- a/src/Core/System/Locale/Aggregate/LocaleTranslation/LocaleTranslationDefinition.php
+++ b/src/Core/System/Locale/Aggregate/LocaleTranslation/LocaleTranslationDefinition.php
@@ -11,6 +11,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\Locale\LocaleDefinition;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class LocaleTranslationDefinition extends EntityTranslationDefinition
 {

--- a/src/Core/System/Locale/Aggregate/LocaleTranslation/LocaleTranslationEntity.php
+++ b/src/Core/System/Locale/Aggregate/LocaleTranslation/LocaleTranslationEntity.php
@@ -7,6 +7,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\TranslationEntity;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\Locale\LocaleEntity;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class LocaleTranslationEntity extends TranslationEntity
 {

--- a/src/Core/System/Locale/LocaleCollection.php
+++ b/src/Core/System/Locale/LocaleCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<LocaleEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('discovery')]
 class LocaleCollection extends EntityCollection

--- a/src/Core/System/Locale/LocaleDefinition.php
+++ b/src/Core/System/Locale/LocaleDefinition.php
@@ -20,6 +20,9 @@ use Shopware\Core\System\Language\LanguageDefinition;
 use Shopware\Core\System\Locale\Aggregate\LocaleTranslation\LocaleTranslationDefinition;
 use Shopware\Core\System\User\UserDefinition;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class LocaleDefinition extends EntityDefinition
 {

--- a/src/Core/System/Locale/LocaleEntity.php
+++ b/src/Core/System/Locale/LocaleEntity.php
@@ -10,6 +10,9 @@ use Shopware\Core\System\Language\LanguageCollection;
 use Shopware\Core\System\Locale\Aggregate\LocaleTranslation\LocaleTranslationCollection;
 use Shopware\Core\System\User\UserCollection;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class LocaleEntity extends Entity
 {

--- a/src/Core/System/NumberRange/Aggregate/NumberRangeSalesChannel/NumberRangeSalesChannelCollection.php
+++ b/src/Core/System/NumberRange/Aggregate/NumberRangeSalesChannel/NumberRangeSalesChannelCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<NumberRangeSalesChannelEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('framework')]
 class NumberRangeSalesChannelCollection extends EntityCollection

--- a/src/Core/System/NumberRange/Aggregate/NumberRangeSalesChannel/NumberRangeSalesChannelDefinition.php
+++ b/src/Core/System/NumberRange/Aggregate/NumberRangeSalesChannel/NumberRangeSalesChannelDefinition.php
@@ -14,6 +14,9 @@ use Shopware\Core\System\NumberRange\Aggregate\NumberRangeType\NumberRangeTypeDe
 use Shopware\Core\System\NumberRange\NumberRangeDefinition;
 use Shopware\Core\System\SalesChannel\SalesChannelDefinition;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('framework')]
 class NumberRangeSalesChannelDefinition extends EntityDefinition
 {

--- a/src/Core/System/NumberRange/Aggregate/NumberRangeSalesChannel/NumberRangeSalesChannelEntity.php
+++ b/src/Core/System/NumberRange/Aggregate/NumberRangeSalesChannel/NumberRangeSalesChannelEntity.php
@@ -9,6 +9,9 @@ use Shopware\Core\System\NumberRange\Aggregate\NumberRangeType\NumberRangeTypeEn
 use Shopware\Core\System\NumberRange\NumberRangeEntity;
 use Shopware\Core\System\SalesChannel\SalesChannelEntity;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('framework')]
 class NumberRangeSalesChannelEntity extends Entity
 {

--- a/src/Core/System/NumberRange/Aggregate/NumberRangeState/NumberRangeStateCollection.php
+++ b/src/Core/System/NumberRange/Aggregate/NumberRangeState/NumberRangeStateCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<NumberRangeStateEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('framework')]
 class NumberRangeStateCollection extends EntityCollection

--- a/src/Core/System/NumberRange/Aggregate/NumberRangeState/NumberRangeStateDefinition.php
+++ b/src/Core/System/NumberRange/Aggregate/NumberRangeState/NumberRangeStateDefinition.php
@@ -14,6 +14,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\NumberRange\NumberRangeDefinition;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('framework')]
 class NumberRangeStateDefinition extends EntityDefinition
 {

--- a/src/Core/System/NumberRange/Aggregate/NumberRangeState/NumberRangeStateEntity.php
+++ b/src/Core/System/NumberRange/Aggregate/NumberRangeState/NumberRangeStateEntity.php
@@ -7,6 +7,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityIdTrait;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\NumberRange\NumberRangeEntity;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('framework')]
 class NumberRangeStateEntity extends Entity
 {

--- a/src/Core/System/NumberRange/Aggregate/NumberRangeTranslation/NumberRangeTranslationCollection.php
+++ b/src/Core/System/NumberRange/Aggregate/NumberRangeTranslation/NumberRangeTranslationCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<NumberRangeTranslationEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('framework')]
 class NumberRangeTranslationCollection extends EntityCollection

--- a/src/Core/System/NumberRange/Aggregate/NumberRangeTranslation/NumberRangeTranslationDefinition.php
+++ b/src/Core/System/NumberRange/Aggregate/NumberRangeTranslation/NumberRangeTranslationDefinition.php
@@ -10,6 +10,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\NumberRange\NumberRangeDefinition;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('framework')]
 class NumberRangeTranslationDefinition extends EntityTranslationDefinition
 {

--- a/src/Core/System/NumberRange/Aggregate/NumberRangeTranslation/NumberRangeTranslationEntity.php
+++ b/src/Core/System/NumberRange/Aggregate/NumberRangeTranslation/NumberRangeTranslationEntity.php
@@ -7,6 +7,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\TranslationEntity;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\NumberRange\NumberRangeEntity;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('framework')]
 class NumberRangeTranslationEntity extends TranslationEntity
 {

--- a/src/Core/System/NumberRange/Aggregate/NumberRangeType/NumberRangeTypeCollection.php
+++ b/src/Core/System/NumberRange/Aggregate/NumberRangeType/NumberRangeTypeCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<NumberRangeTypeEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('framework')]
 class NumberRangeTypeCollection extends EntityCollection

--- a/src/Core/System/NumberRange/Aggregate/NumberRangeType/NumberRangeTypeDefinition.php
+++ b/src/Core/System/NumberRange/Aggregate/NumberRangeType/NumberRangeTypeDefinition.php
@@ -20,6 +20,9 @@ use Shopware\Core\System\NumberRange\Aggregate\NumberRangeSalesChannel\NumberRan
 use Shopware\Core\System\NumberRange\Aggregate\NumberRangeTypeTranslation\NumberRangeTypeTranslationDefinition;
 use Shopware\Core\System\NumberRange\NumberRangeDefinition;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('framework')]
 class NumberRangeTypeDefinition extends EntityDefinition
 {

--- a/src/Core/System/NumberRange/Aggregate/NumberRangeType/NumberRangeTypeEntity.php
+++ b/src/Core/System/NumberRange/Aggregate/NumberRangeType/NumberRangeTypeEntity.php
@@ -10,6 +10,9 @@ use Shopware\Core\System\NumberRange\Aggregate\NumberRangeSalesChannel\NumberRan
 use Shopware\Core\System\NumberRange\Aggregate\NumberRangeTypeTranslation\NumberRangeTypeTranslationCollection;
 use Shopware\Core\System\NumberRange\NumberRangeCollection;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('framework')]
 class NumberRangeTypeEntity extends Entity
 {

--- a/src/Core/System/NumberRange/Aggregate/NumberRangeTypeTranslation/NumberRangeTypeTranslationCollection.php
+++ b/src/Core/System/NumberRange/Aggregate/NumberRangeTypeTranslation/NumberRangeTypeTranslationCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<NumberRangeTypeTranslationEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('framework')]
 class NumberRangeTypeTranslationCollection extends EntityCollection

--- a/src/Core/System/NumberRange/Aggregate/NumberRangeTypeTranslation/NumberRangeTypeTranslationDefinition.php
+++ b/src/Core/System/NumberRange/Aggregate/NumberRangeTypeTranslation/NumberRangeTypeTranslationDefinition.php
@@ -10,6 +10,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\NumberRange\Aggregate\NumberRangeType\NumberRangeTypeDefinition;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('framework')]
 class NumberRangeTypeTranslationDefinition extends EntityTranslationDefinition
 {

--- a/src/Core/System/NumberRange/Aggregate/NumberRangeTypeTranslation/NumberRangeTypeTranslationEntity.php
+++ b/src/Core/System/NumberRange/Aggregate/NumberRangeTypeTranslation/NumberRangeTypeTranslationEntity.php
@@ -7,6 +7,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\TranslationEntity;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\NumberRange\Aggregate\NumberRangeType\NumberRangeTypeEntity;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('framework')]
 class NumberRangeTypeTranslationEntity extends TranslationEntity
 {

--- a/src/Core/System/NumberRange/DataAbstractionLayer/NumberRangeField.php
+++ b/src/Core/System/NumberRange/DataAbstractionLayer/NumberRangeField.php
@@ -5,9 +5,6 @@ namespace Shopware\Core\System\NumberRange\DataAbstractionLayer;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\StringField;
 use Shopware\Core\Framework\Log\Package;
 
-/**
- * @codeCoverageIgnore
- */
 #[Package('framework')]
 class NumberRangeField extends StringField
 {

--- a/src/Core/System/NumberRange/DataAbstractionLayer/NumberRangeField.php
+++ b/src/Core/System/NumberRange/DataAbstractionLayer/NumberRangeField.php
@@ -5,6 +5,9 @@ namespace Shopware\Core\System\NumberRange\DataAbstractionLayer;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\StringField;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('framework')]
 class NumberRangeField extends StringField
 {

--- a/src/Core/System/NumberRange/NumberRangeCollection.php
+++ b/src/Core/System/NumberRange/NumberRangeCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<NumberRangeEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('framework')]
 class NumberRangeCollection extends EntityCollection

--- a/src/Core/System/NumberRange/NumberRangeDefinition.php
+++ b/src/Core/System/NumberRange/NumberRangeDefinition.php
@@ -23,6 +23,9 @@ use Shopware\Core\System\NumberRange\Aggregate\NumberRangeState\NumberRangeState
 use Shopware\Core\System\NumberRange\Aggregate\NumberRangeTranslation\NumberRangeTranslationDefinition;
 use Shopware\Core\System\NumberRange\Aggregate\NumberRangeType\NumberRangeTypeDefinition;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('framework')]
 class NumberRangeDefinition extends EntityDefinition
 {

--- a/src/Core/System/NumberRange/NumberRangeEntity.php
+++ b/src/Core/System/NumberRange/NumberRangeEntity.php
@@ -11,6 +11,9 @@ use Shopware\Core\System\NumberRange\Aggregate\NumberRangeState\NumberRangeState
 use Shopware\Core\System\NumberRange\Aggregate\NumberRangeTranslation\NumberRangeTranslationCollection;
 use Shopware\Core\System\NumberRange\Aggregate\NumberRangeType\NumberRangeTypeEntity;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('framework')]
 class NumberRangeEntity extends Entity
 {

--- a/src/Core/System/NumberRange/ValueGenerator/NumberRangeGeneratedEvent.php
+++ b/src/Core/System/NumberRange/ValueGenerator/NumberRangeGeneratedEvent.php
@@ -6,6 +6,9 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Log\Package;
 use Symfony\Contracts\EventDispatcher\Event;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('framework')]
 class NumberRangeGeneratedEvent extends Event
 {

--- a/src/Core/System/SalesChannel/Aggregate/SalesChannelAnalytics/SalesChannelAnalyticsCollection.php
+++ b/src/Core/System/SalesChannel/Aggregate/SalesChannelAnalytics/SalesChannelAnalyticsCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<SalesChannelAnalyticsEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('discovery')]
 class SalesChannelAnalyticsCollection extends EntityCollection

--- a/src/Core/System/SalesChannel/Aggregate/SalesChannelAnalytics/SalesChannelAnalyticsDefinition.php
+++ b/src/Core/System/SalesChannel/Aggregate/SalesChannelAnalytics/SalesChannelAnalyticsDefinition.php
@@ -13,6 +13,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelDefinition;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class SalesChannelAnalyticsDefinition extends EntityDefinition
 {

--- a/src/Core/System/SalesChannel/Aggregate/SalesChannelCountry/SalesChannelCountryDefinition.php
+++ b/src/Core/System/SalesChannel/Aggregate/SalesChannelCountry/SalesChannelCountryDefinition.php
@@ -12,6 +12,9 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\Country\CountryDefinition;
 use Shopware\Core\System\SalesChannel\SalesChannelDefinition;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class SalesChannelCountryDefinition extends MappingEntityDefinition
 {

--- a/src/Core/System/SalesChannel/Aggregate/SalesChannelCurrency/SalesChannelCurrencyDefinition.php
+++ b/src/Core/System/SalesChannel/Aggregate/SalesChannelCurrency/SalesChannelCurrencyDefinition.php
@@ -12,6 +12,9 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\Currency\CurrencyDefinition;
 use Shopware\Core\System\SalesChannel\SalesChannelDefinition;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class SalesChannelCurrencyDefinition extends MappingEntityDefinition
 {

--- a/src/Core/System/SalesChannel/Aggregate/SalesChannelDomain/SalesChannelDomainDefinition.php
+++ b/src/Core/System/SalesChannel/Aggregate/SalesChannelDomain/SalesChannelDomainDefinition.php
@@ -25,6 +25,9 @@ use Shopware\Core\System\Language\LanguageDefinition;
 use Shopware\Core\System\SalesChannel\SalesChannelDefinition;
 use Shopware\Core\System\Snippet\Aggregate\SnippetSet\SnippetSetDefinition;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class SalesChannelDomainDefinition extends EntityDefinition
 {

--- a/src/Core/System/SalesChannel/Aggregate/SalesChannelDomain/SalesChannelDomainEntity.php
+++ b/src/Core/System/SalesChannel/Aggregate/SalesChannelDomain/SalesChannelDomainEntity.php
@@ -13,6 +13,9 @@ use Shopware\Core\System\Language\LanguageEntity;
 use Shopware\Core\System\SalesChannel\SalesChannelEntity;
 use Shopware\Core\System\Snippet\Aggregate\SnippetSet\SnippetSetEntity;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class SalesChannelDomainEntity extends Entity
 {

--- a/src/Core/System/SalesChannel/Aggregate/SalesChannelFile/SalesChannelFileCollection.php
+++ b/src/Core/System/SalesChannel/Aggregate/SalesChannelFile/SalesChannelFileCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<SalesChannelFileEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('framework')]
 class SalesChannelFileCollection extends EntityCollection

--- a/src/Core/System/SalesChannel/Aggregate/SalesChannelFile/SalesChannelFileDefinition.php
+++ b/src/Core/System/SalesChannel/Aggregate/SalesChannelFile/SalesChannelFileDefinition.php
@@ -17,6 +17,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelDefinition;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('framework')]
 class SalesChannelFileDefinition extends EntityDefinition
 {

--- a/src/Core/System/SalesChannel/Aggregate/SalesChannelFile/SalesChannelFileEntity.php
+++ b/src/Core/System/SalesChannel/Aggregate/SalesChannelFile/SalesChannelFileEntity.php
@@ -7,6 +7,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityIdTrait;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelEntity;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('framework')]
 class SalesChannelFileEntity extends Entity
 {

--- a/src/Core/System/SalesChannel/Aggregate/SalesChannelLanguage/SalesChannelLanguageDefinition.php
+++ b/src/Core/System/SalesChannel/Aggregate/SalesChannelLanguage/SalesChannelLanguageDefinition.php
@@ -12,6 +12,9 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\Language\LanguageDefinition;
 use Shopware\Core\System\SalesChannel\SalesChannelDefinition;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class SalesChannelLanguageDefinition extends MappingEntityDefinition
 {

--- a/src/Core/System/SalesChannel/Aggregate/SalesChannelPaymentMethod/SalesChannelPaymentMethodDefinition.php
+++ b/src/Core/System/SalesChannel/Aggregate/SalesChannelPaymentMethod/SalesChannelPaymentMethodDefinition.php
@@ -12,6 +12,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\MappingEntityDefinition;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelDefinition;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class SalesChannelPaymentMethodDefinition extends MappingEntityDefinition
 {

--- a/src/Core/System/SalesChannel/Aggregate/SalesChannelShippingMethod/SalesChannelShippingMethodDefinition.php
+++ b/src/Core/System/SalesChannel/Aggregate/SalesChannelShippingMethod/SalesChannelShippingMethodDefinition.php
@@ -12,6 +12,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\MappingEntityDefinition;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelDefinition;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class SalesChannelShippingMethodDefinition extends MappingEntityDefinition
 {

--- a/src/Core/System/SalesChannel/Aggregate/SalesChannelTranslation/SalesChannelTranslationCollection.php
+++ b/src/Core/System/SalesChannel/Aggregate/SalesChannelTranslation/SalesChannelTranslationCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<SalesChannelTranslationEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('discovery')]
 class SalesChannelTranslationCollection extends EntityCollection

--- a/src/Core/System/SalesChannel/Aggregate/SalesChannelTranslation/SalesChannelTranslationDefinition.php
+++ b/src/Core/System/SalesChannel/Aggregate/SalesChannelTranslation/SalesChannelTranslationDefinition.php
@@ -13,6 +13,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelDefinition;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class SalesChannelTranslationDefinition extends EntityTranslationDefinition
 {

--- a/src/Core/System/SalesChannel/Aggregate/SalesChannelTranslation/SalesChannelTranslationEntity.php
+++ b/src/Core/System/SalesChannel/Aggregate/SalesChannelTranslation/SalesChannelTranslationEntity.php
@@ -7,6 +7,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\TranslationEntity;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelEntity;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class SalesChannelTranslationEntity extends TranslationEntity
 {

--- a/src/Core/System/SalesChannel/Aggregate/SalesChannelType/SalesChannelTypeCollection.php
+++ b/src/Core/System/SalesChannel/Aggregate/SalesChannelType/SalesChannelTypeCollection.php
@@ -8,6 +8,8 @@ use Shopware\Core\System\SalesChannel\SalesChannelCollection;
 
 /**
  * @extends EntityCollection<SalesChannelTypeEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('discovery')]
 class SalesChannelTypeCollection extends EntityCollection

--- a/src/Core/System/SalesChannel/Aggregate/SalesChannelType/SalesChannelTypeDefinition.php
+++ b/src/Core/System/SalesChannel/Aggregate/SalesChannelType/SalesChannelTypeDefinition.php
@@ -16,6 +16,9 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\Aggregate\SalesChannelTypeTranslation\SalesChannelTypeTranslationDefinition;
 use Shopware\Core\System\SalesChannel\SalesChannelDefinition;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class SalesChannelTypeDefinition extends EntityDefinition
 {

--- a/src/Core/System/SalesChannel/Aggregate/SalesChannelTypeTranslation/SalesChannelTypeTranslationCollection.php
+++ b/src/Core/System/SalesChannel/Aggregate/SalesChannelTypeTranslation/SalesChannelTypeTranslationCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<SalesChannelTypeTranslationEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('discovery')]
 class SalesChannelTypeTranslationCollection extends EntityCollection

--- a/src/Core/System/SalesChannel/Aggregate/SalesChannelTypeTranslation/SalesChannelTypeTranslationDefinition.php
+++ b/src/Core/System/SalesChannel/Aggregate/SalesChannelTypeTranslation/SalesChannelTypeTranslationDefinition.php
@@ -13,6 +13,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\Aggregate\SalesChannelType\SalesChannelTypeDefinition;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class SalesChannelTypeTranslationDefinition extends EntityTranslationDefinition
 {

--- a/src/Core/System/SalesChannel/Aggregate/SalesChannelTypeTranslation/SalesChannelTypeTranslationEntity.php
+++ b/src/Core/System/SalesChannel/Aggregate/SalesChannelTypeTranslation/SalesChannelTypeTranslationEntity.php
@@ -7,6 +7,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\TranslationEntity;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\Aggregate\SalesChannelType\SalesChannelTypeEntity;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class SalesChannelTypeTranslationEntity extends TranslationEntity
 {

--- a/src/Core/System/SalesChannel/Entity/PartialSalesChannelEntityLoadedEvent.php
+++ b/src/Core/System/SalesChannel/Entity/PartialSalesChannelEntityLoadedEvent.php
@@ -9,6 +9,8 @@ use Shopware\Core\System\SalesChannel\SalesChannelContext;
 
 /**
  * @extends SalesChannelEntityLoadedEvent<PartialEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('discovery')]
 class PartialSalesChannelEntityLoadedEvent extends SalesChannelEntityLoadedEvent

--- a/src/Core/System/SalesChannel/Entity/SalesChannelEntityAggregationResultLoadedEvent.php
+++ b/src/Core/System/SalesChannel/Entity/SalesChannelEntityAggregationResultLoadedEvent.php
@@ -9,6 +9,9 @@ use Shopware\Core\Framework\Event\ShopwareSalesChannelEvent;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class SalesChannelEntityAggregationResultLoadedEvent extends EntityAggregationResultLoadedEvent implements ShopwareSalesChannelEvent
 {

--- a/src/Core/System/SalesChannel/Entity/SalesChannelEntityIdSearchResultLoadedEvent.php
+++ b/src/Core/System/SalesChannel/Entity/SalesChannelEntityIdSearchResultLoadedEvent.php
@@ -9,6 +9,9 @@ use Shopware\Core\Framework\Event\ShopwareSalesChannelEvent;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class SalesChannelEntityIdSearchResultLoadedEvent extends EntityIdSearchResultLoadedEvent implements ShopwareSalesChannelEvent
 {

--- a/src/Core/System/SalesChannel/Entity/SalesChannelEntityLoadedEvent.php
+++ b/src/Core/System/SalesChannel/Entity/SalesChannelEntityLoadedEvent.php
@@ -13,6 +13,8 @@ use Shopware\Core\System\SalesChannel\SalesChannelContext;
  * @template TEntity of Entity
  *
  * @extends EntityLoadedEvent<TEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('discovery')]
 class SalesChannelEntityLoadedEvent extends EntityLoadedEvent implements ShopwareSalesChannelEvent

--- a/src/Core/System/SalesChannel/Entity/SalesChannelEntitySearchResultLoadedEvent.php
+++ b/src/Core/System/SalesChannel/Entity/SalesChannelEntitySearchResultLoadedEvent.php
@@ -14,6 +14,8 @@ use Shopware\Core\System\SalesChannel\SalesChannelContext;
  * @template TEntityCollection of EntityCollection
  *
  * @extends EntitySearchResultLoadedEvent<TEntityCollection>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('discovery')]
 class SalesChannelEntitySearchResultLoadedEvent extends EntitySearchResultLoadedEvent implements ShopwareSalesChannelEvent

--- a/src/Core/System/SalesChannel/Event/ContextCreatedEvent.php
+++ b/src/Core/System/SalesChannel/Event/ContextCreatedEvent.php
@@ -10,6 +10,8 @@ use Shopware\Core\Framework\Log\Package;
 /**
  * This event can be used to react to the creation of a new context.
  * It must be used very carefully, as it practically effects every part of Shopware.
+ *
+ * @codeCoverageIgnore
  */
 #[Package('framework')]
 final class ContextCreatedEvent

--- a/src/Core/System/SalesChannel/Event/SalesChannelContextPermissionsChangedEvent.php
+++ b/src/Core/System/SalesChannel/Event/SalesChannelContextPermissionsChangedEvent.php
@@ -8,6 +8,9 @@ use Shopware\Core\Framework\Event\ShopwareSalesChannelEvent;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('framework')]
 class SalesChannelContextPermissionsChangedEvent extends NestedEvent implements ShopwareSalesChannelEvent
 {

--- a/src/Core/System/SalesChannel/Event/SalesChannelContextRestoredEvent.php
+++ b/src/Core/System/SalesChannel/Event/SalesChannelContextRestoredEvent.php
@@ -7,6 +7,9 @@ use Shopware\Core\Framework\Event\NestedEvent;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('framework')]
 class SalesChannelContextRestoredEvent extends NestedEvent
 {

--- a/src/Core/System/SalesChannel/Event/SalesChannelContextRestorerOrderCriteriaEvent.php
+++ b/src/Core/System/SalesChannel/Event/SalesChannelContextRestorerOrderCriteriaEvent.php
@@ -7,6 +7,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Event\NestedEvent;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('framework')]
 class SalesChannelContextRestorerOrderCriteriaEvent extends NestedEvent
 {

--- a/src/Core/System/SalesChannel/Event/SalesChannelContextSwitchEvent.php
+++ b/src/Core/System/SalesChannel/Event/SalesChannelContextSwitchEvent.php
@@ -9,6 +9,9 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Validation\DataBag\DataBag;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('framework')]
 class SalesChannelContextSwitchEvent extends NestedEvent implements ShopwareSalesChannelEvent
 {

--- a/src/Core/System/SalesChannel/Event/SalesChannelContextTokenChangeEvent.php
+++ b/src/Core/System/SalesChannel/Event/SalesChannelContextTokenChangeEvent.php
@@ -8,6 +8,9 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Contracts\EventDispatcher\Event;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('framework')]
 class SalesChannelContextTokenChangeEvent extends Event implements ShopwareSalesChannelEvent
 {

--- a/src/Core/System/SalesChannel/Event/SalesChannelIndexerEvent.php
+++ b/src/Core/System/SalesChannel/Event/SalesChannelIndexerEvent.php
@@ -6,6 +6,9 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Event\NestedEvent;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class SalesChannelIndexerEvent extends NestedEvent
 {

--- a/src/Core/System/SalesChannel/Event/SalesChannelProcessCriteriaEvent.php
+++ b/src/Core/System/SalesChannel/Event/SalesChannelProcessCriteriaEvent.php
@@ -8,6 +8,9 @@ use Shopware\Core\Framework\Event\ShopwareSalesChannelEvent;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class SalesChannelProcessCriteriaEvent implements ShopwareSalesChannelEvent
 {

--- a/src/Core/System/SalesChannel/Event/SwitchContextEvent.php
+++ b/src/Core/System/SalesChannel/Event/SwitchContextEvent.php
@@ -9,9 +9,6 @@ use Shopware\Core\Framework\Validation\DataBag\RequestDataBag;
 use Shopware\Core\Framework\Validation\DataValidationDefinition;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 
-/**
- * @codeCoverageIgnore
- */
 #[Package('framework')]
 class SwitchContextEvent implements ShopwareSalesChannelEvent
 {

--- a/src/Core/System/SalesChannel/Event/SwitchContextEvent.php
+++ b/src/Core/System/SalesChannel/Event/SwitchContextEvent.php
@@ -9,6 +9,9 @@ use Shopware\Core\Framework\Validation\DataBag\RequestDataBag;
 use Shopware\Core\Framework\Validation\DataValidationDefinition;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('framework')]
 class SwitchContextEvent implements ShopwareSalesChannelEvent
 {

--- a/src/Core/System/SalesChannel/File/Event/SalesChannelFileTemplateResolveEvent.php
+++ b/src/Core/System/SalesChannel/File/Event/SalesChannelFileTemplateResolveEvent.php
@@ -7,6 +7,8 @@ use Symfony\Contracts\EventDispatcher\Event;
 
 /**
  * @internal
+ *
+ * @codeCoverageIgnore
  */
 #[Package('framework')]
 final class SalesChannelFileTemplateResolveEvent extends Event

--- a/src/Core/System/SalesChannel/SalesChannelCollection.php
+++ b/src/Core/System/SalesChannel/SalesChannelCollection.php
@@ -10,6 +10,8 @@ use Shopware\Core\System\SalesChannel\Aggregate\SalesChannelType\SalesChannelTyp
 
 /**
  * @extends EntityCollection<SalesChannelEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('discovery')]
 class SalesChannelCollection extends EntityCollection

--- a/src/Core/System/SalesChannel/SalesChannelDefinition.php
+++ b/src/Core/System/SalesChannel/SalesChannelDefinition.php
@@ -66,6 +66,9 @@ use Shopware\Core\System\SalesChannel\Aggregate\SalesChannelTranslation\SalesCha
 use Shopware\Core\System\SalesChannel\Aggregate\SalesChannelType\SalesChannelTypeDefinition;
 use Shopware\Core\System\SystemConfig\SystemConfigDefinition;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class SalesChannelDefinition extends EntityDefinition
 {

--- a/src/Core/System/Salutation/Aggregate/SalutationTranslation/SalutationTranslationCollection.php
+++ b/src/Core/System/Salutation/Aggregate/SalutationTranslation/SalutationTranslationCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<SalutationTranslationEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('checkout')]
 class SalutationTranslationCollection extends EntityCollection

--- a/src/Core/System/Salutation/Aggregate/SalutationTranslation/SalutationTranslationDefinition.php
+++ b/src/Core/System/Salutation/Aggregate/SalutationTranslation/SalutationTranslationDefinition.php
@@ -11,6 +11,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\Salutation\SalutationDefinition;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('checkout')]
 class SalutationTranslationDefinition extends EntityTranslationDefinition
 {

--- a/src/Core/System/Salutation/Aggregate/SalutationTranslation/SalutationTranslationEntity.php
+++ b/src/Core/System/Salutation/Aggregate/SalutationTranslation/SalutationTranslationEntity.php
@@ -7,6 +7,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\TranslationEntity;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\Salutation\SalutationEntity;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('checkout')]
 class SalutationTranslationEntity extends TranslationEntity
 {

--- a/src/Core/System/Salutation/Event/SalutationRouteCacheKeyEvent.php
+++ b/src/Core/System/Salutation/Event/SalutationRouteCacheKeyEvent.php
@@ -5,6 +5,9 @@ namespace Shopware\Core\System\Salutation\Event;
 use Shopware\Core\Framework\Adapter\Cache\StoreApiRouteCacheKeyEvent;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('checkout')]
 /**
  * @deprecated tag:v6.8.0 - Will be removed in 6.8.0 as it was not used anymore

--- a/src/Core/System/Salutation/Event/SalutationRouteCacheTagsEvent.php
+++ b/src/Core/System/Salutation/Event/SalutationRouteCacheTagsEvent.php
@@ -5,6 +5,9 @@ namespace Shopware\Core\System\Salutation\Event;
 use Shopware\Core\Framework\Adapter\Cache\StoreApiRouteCacheTagsEvent;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('checkout')]
 /**
  * @deprecated tag:v6.8.0 - Will be removed in 6.8.0 as it was not used anymore

--- a/src/Core/System/Salutation/SalesChannel/SalesChannelSalutationDefinition.php
+++ b/src/Core/System/Salutation/SalesChannel/SalesChannelSalutationDefinition.php
@@ -8,6 +8,9 @@ use Shopware\Core\System\SalesChannel\Entity\SalesChannelDefinitionInterface;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\System\Salutation\SalutationDefinition;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('checkout')]
 class SalesChannelSalutationDefinition extends SalutationDefinition implements SalesChannelDefinitionInterface
 {

--- a/src/Core/System/Salutation/SalutationCollection.php
+++ b/src/Core/System/Salutation/SalutationCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<SalutationEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('checkout')]
 class SalutationCollection extends EntityCollection

--- a/src/Core/System/Salutation/SalutationDefinition.php
+++ b/src/Core/System/Salutation/SalutationDefinition.php
@@ -23,6 +23,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\Salutation\Aggregate\SalutationTranslation\SalutationTranslationDefinition;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('checkout')]
 class SalutationDefinition extends EntityDefinition
 {

--- a/src/Core/System/Salutation/SalutationEntity.php
+++ b/src/Core/System/Salutation/SalutationEntity.php
@@ -13,6 +13,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityIdTrait;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\Salutation\Aggregate\SalutationTranslation\SalutationTranslationCollection;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('checkout')]
 class SalutationEntity extends Entity
 {

--- a/src/Core/System/Snippet/Aggregate/SnippetSet/SnippetSetCollection.php
+++ b/src/Core/System/Snippet/Aggregate/SnippetSet/SnippetSetCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<SnippetSetEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('discovery')]
 class SnippetSetCollection extends EntityCollection

--- a/src/Core/System/Snippet/Aggregate/SnippetSet/SnippetSetDefinition.php
+++ b/src/Core/System/Snippet/Aggregate/SnippetSet/SnippetSetDefinition.php
@@ -17,6 +17,9 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\Aggregate\SalesChannelDomain\SalesChannelDomainDefinition;
 use Shopware\Core\System\Snippet\SnippetDefinition;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class SnippetSetDefinition extends EntityDefinition
 {

--- a/src/Core/System/Snippet/Aggregate/SnippetSet/SnippetSetEntity.php
+++ b/src/Core/System/Snippet/Aggregate/SnippetSet/SnippetSetEntity.php
@@ -9,6 +9,9 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\Aggregate\SalesChannelDomain\SalesChannelDomainCollection;
 use Shopware\Core\System\Snippet\SnippetCollection;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class SnippetSetEntity extends Entity
 {

--- a/src/Core/System/Snippet/DataTransfer/PluginMapping/PluginMappingCollection.php
+++ b/src/Core/System/Snippet/DataTransfer/PluginMapping/PluginMappingCollection.php
@@ -9,8 +9,6 @@ use Shopware\Core\Framework\Struct\Collection;
  * @internal
  *
  * @extends Collection<PluginMapping>
- *
- * @codeCoverageIgnore
  */
 #[Package('discovery')]
 class PluginMappingCollection extends Collection

--- a/src/Core/System/Snippet/DataTransfer/PluginMapping/PluginMappingCollection.php
+++ b/src/Core/System/Snippet/DataTransfer/PluginMapping/PluginMappingCollection.php
@@ -9,6 +9,8 @@ use Shopware\Core\Framework\Struct\Collection;
  * @internal
  *
  * @extends Collection<PluginMapping>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('discovery')]
 class PluginMappingCollection extends Collection

--- a/src/Core/System/Snippet/Event/SnippetsThemeResolveEvent.php
+++ b/src/Core/System/Snippet/Event/SnippetsThemeResolveEvent.php
@@ -7,6 +7,8 @@ use Symfony\Contracts\EventDispatcher\Event;
 
 /**
  * @internal
+ *
+ * @codeCoverageIgnore
  */
 #[Package('discovery')]
 class SnippetsThemeResolveEvent extends Event

--- a/src/Core/System/Snippet/Event/TranslationLoadedEvent.php
+++ b/src/Core/System/Snippet/Event/TranslationLoadedEvent.php
@@ -8,6 +8,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * Dispatched after the translations for a locale have been downloaded and installed.
+ *
+ * @codeCoverageIgnore
  */
 #[Package('discovery')]
 class TranslationLoadedEvent implements ShopwareEvent

--- a/src/Core/System/Snippet/Event/TranslationRemovedEvent.php
+++ b/src/Core/System/Snippet/Event/TranslationRemovedEvent.php
@@ -6,6 +6,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * Dispatched after the downloaded translation files and metadata entry for a locale have been removed.
+ *
+ * @codeCoverageIgnore
  */
 #[Package('discovery')]
 class TranslationRemovedEvent

--- a/src/Core/System/Snippet/SnippetCollection.php
+++ b/src/Core/System/Snippet/SnippetCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<SnippetEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('discovery')]
 class SnippetCollection extends EntityCollection

--- a/src/Core/System/Snippet/SnippetDefinition.php
+++ b/src/Core/System/Snippet/SnippetDefinition.php
@@ -19,6 +19,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\Snippet\Aggregate\SnippetSet\SnippetSetDefinition;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class SnippetDefinition extends EntityDefinition
 {

--- a/src/Core/System/Snippet/SnippetEntity.php
+++ b/src/Core/System/Snippet/SnippetEntity.php
@@ -8,6 +8,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityIdTrait;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\Snippet\Aggregate\SnippetSet\SnippetSetEntity;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class SnippetEntity extends Entity
 {

--- a/src/Core/System/Snippet/Struct/InvalidPluralizationCollection.php
+++ b/src/Core/System/Snippet/Struct/InvalidPluralizationCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Struct\Collection;
 
 /**
  * @extends Collection<InvalidPluralizationStruct>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('discovery')]
 class InvalidPluralizationCollection extends Collection

--- a/src/Core/System/Snippet/Struct/InvalidPluralizationStruct.php
+++ b/src/Core/System/Snippet/Struct/InvalidPluralizationStruct.php
@@ -5,6 +5,9 @@ namespace Shopware\Core\System\Snippet\Struct;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\Struct;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class InvalidPluralizationStruct extends Struct
 {

--- a/src/Core/System/Snippet/Struct/MissingSnippetCollection.php
+++ b/src/Core/System/Snippet/Struct/MissingSnippetCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Struct\Collection;
 
 /**
  * @extends Collection<MissingSnippetStruct>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('discovery')]
 class MissingSnippetCollection extends Collection

--- a/src/Core/System/Snippet/Struct/MissingSnippetStruct.php
+++ b/src/Core/System/Snippet/Struct/MissingSnippetStruct.php
@@ -5,6 +5,9 @@ namespace Shopware\Core\System\Snippet\Struct;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\Struct;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class MissingSnippetStruct extends Struct
 {

--- a/src/Core/System/Snippet/Struct/SnippetValidationStruct.php
+++ b/src/Core/System/Snippet/Struct/SnippetValidationStruct.php
@@ -5,6 +5,9 @@ namespace Shopware\Core\System\Snippet\Struct;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\Struct;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class SnippetValidationStruct extends Struct
 {

--- a/src/Core/System/Snippet/Struct/TranslationFileCollection.php
+++ b/src/Core/System/Snippet/Struct/TranslationFileCollection.php
@@ -9,6 +9,8 @@ use Shopware\Core\Framework\Struct\Collection;
  * @internal
  *
  * @extends Collection<TranslationFile>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('discovery')]
 class TranslationFileCollection extends Collection

--- a/src/Core/System/Snippet/Struct/TranslationFileCollection.php
+++ b/src/Core/System/Snippet/Struct/TranslationFileCollection.php
@@ -9,8 +9,6 @@ use Shopware\Core\Framework\Struct\Collection;
  * @internal
  *
  * @extends Collection<TranslationFile>
- *
- * @codeCoverageIgnore
  */
 #[Package('discovery')]
 class TranslationFileCollection extends Collection

--- a/src/Core/System/StateMachine/Aggregation/StateMachineHistory/StateMachineHistoryCollection.php
+++ b/src/Core/System/StateMachine/Aggregation/StateMachineHistory/StateMachineHistoryCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<StateMachineHistoryEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('checkout')]
 class StateMachineHistoryCollection extends EntityCollection

--- a/src/Core/System/StateMachine/Aggregation/StateMachineHistory/StateMachineHistoryDefinition.php
+++ b/src/Core/System/StateMachine/Aggregation/StateMachineHistory/StateMachineHistoryDefinition.php
@@ -18,6 +18,9 @@ use Shopware\Core\System\StateMachine\Aggregation\StateMachineState\StateMachine
 use Shopware\Core\System\StateMachine\StateMachineDefinition;
 use Shopware\Core\System\User\UserDefinition;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('checkout')]
 class StateMachineHistoryDefinition extends EntityDefinition
 {

--- a/src/Core/System/StateMachine/Aggregation/StateMachineHistory/StateMachineHistoryEntity.php
+++ b/src/Core/System/StateMachine/Aggregation/StateMachineHistory/StateMachineHistoryEntity.php
@@ -10,6 +10,9 @@ use Shopware\Core\System\StateMachine\Aggregation\StateMachineState\StateMachine
 use Shopware\Core\System\StateMachine\StateMachineEntity;
 use Shopware\Core\System\User\UserEntity;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('checkout')]
 class StateMachineHistoryEntity extends Entity
 {

--- a/src/Core/System/StateMachine/Aggregation/StateMachineState/StateMachineStateCollection.php
+++ b/src/Core/System/StateMachine/Aggregation/StateMachineState/StateMachineStateCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<StateMachineStateEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('checkout')]
 class StateMachineStateCollection extends EntityCollection

--- a/src/Core/System/StateMachine/Aggregation/StateMachineState/StateMachineStateDefinition.php
+++ b/src/Core/System/StateMachine/Aggregation/StateMachineState/StateMachineStateDefinition.php
@@ -26,6 +26,9 @@ use Shopware\Core\System\StateMachine\Aggregation\StateMachineHistory\StateMachi
 use Shopware\Core\System\StateMachine\Aggregation\StateMachineTransition\StateMachineTransitionDefinition;
 use Shopware\Core\System\StateMachine\StateMachineDefinition;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('checkout')]
 class StateMachineStateDefinition extends EntityDefinition
 {

--- a/src/Core/System/StateMachine/Aggregation/StateMachineState/StateMachineStateEntity.php
+++ b/src/Core/System/StateMachine/Aggregation/StateMachineState/StateMachineStateEntity.php
@@ -15,6 +15,9 @@ use Shopware\Core\System\StateMachine\Aggregation\StateMachineHistory\StateMachi
 use Shopware\Core\System\StateMachine\Aggregation\StateMachineTransition\StateMachineTransitionCollection;
 use Shopware\Core\System\StateMachine\StateMachineEntity;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('checkout')]
 class StateMachineStateEntity extends Entity
 {

--- a/src/Core/System/StateMachine/Aggregation/StateMachineState/StateMachineStateTranslationCollection.php
+++ b/src/Core/System/StateMachine/Aggregation/StateMachineState/StateMachineStateTranslationCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<StateMachineStateTranslationEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('checkout')]
 class StateMachineStateTranslationCollection extends EntityCollection

--- a/src/Core/System/StateMachine/Aggregation/StateMachineState/StateMachineStateTranslationDefinition.php
+++ b/src/Core/System/StateMachine/Aggregation/StateMachineState/StateMachineStateTranslationDefinition.php
@@ -9,6 +9,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\StringField;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('checkout')]
 class StateMachineStateTranslationDefinition extends EntityTranslationDefinition
 {

--- a/src/Core/System/StateMachine/Aggregation/StateMachineState/StateMachineStateTranslationEntity.php
+++ b/src/Core/System/StateMachine/Aggregation/StateMachineState/StateMachineStateTranslationEntity.php
@@ -6,6 +6,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityCustomFieldsTrait;
 use Shopware\Core\Framework\DataAbstractionLayer\TranslationEntity;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('checkout')]
 class StateMachineStateTranslationEntity extends TranslationEntity
 {

--- a/src/Core/System/StateMachine/Aggregation/StateMachineTransition/StateMachineTransitionCollection.php
+++ b/src/Core/System/StateMachine/Aggregation/StateMachineTransition/StateMachineTransitionCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<StateMachineTransitionEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('checkout')]
 class StateMachineTransitionCollection extends EntityCollection

--- a/src/Core/System/StateMachine/Aggregation/StateMachineTransition/StateMachineTransitionDefinition.php
+++ b/src/Core/System/StateMachine/Aggregation/StateMachineTransition/StateMachineTransitionDefinition.php
@@ -15,6 +15,9 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\StateMachine\Aggregation\StateMachineState\StateMachineStateDefinition;
 use Shopware\Core\System\StateMachine\StateMachineDefinition;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('checkout')]
 class StateMachineTransitionDefinition extends EntityDefinition
 {

--- a/src/Core/System/StateMachine/Aggregation/StateMachineTransition/StateMachineTransitionEntity.php
+++ b/src/Core/System/StateMachine/Aggregation/StateMachineTransition/StateMachineTransitionEntity.php
@@ -9,6 +9,9 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\StateMachine\Aggregation\StateMachineState\StateMachineStateEntity;
 use Shopware\Core\System\StateMachine\StateMachineEntity;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('checkout')]
 class StateMachineTransitionEntity extends Entity
 {

--- a/src/Core/System/StateMachine/Event/StateMachineTransitionEvent.php
+++ b/src/Core/System/StateMachine/Event/StateMachineTransitionEvent.php
@@ -7,6 +7,9 @@ use Shopware\Core\Framework\Event\NestedEvent;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\StateMachine\Aggregation\StateMachineState\StateMachineStateEntity;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('checkout')]
 class StateMachineTransitionEvent extends NestedEvent
 {

--- a/src/Core/System/StateMachine/StateMachineCollection.php
+++ b/src/Core/System/StateMachine/StateMachineCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<StateMachineEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('checkout')]
 class StateMachineCollection extends EntityCollection

--- a/src/Core/System/StateMachine/StateMachineDefinition.php
+++ b/src/Core/System/StateMachine/StateMachineDefinition.php
@@ -20,6 +20,9 @@ use Shopware\Core\System\StateMachine\Aggregation\StateMachineHistory\StateMachi
 use Shopware\Core\System\StateMachine\Aggregation\StateMachineState\StateMachineStateDefinition;
 use Shopware\Core\System\StateMachine\Aggregation\StateMachineTransition\StateMachineTransitionDefinition;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('checkout')]
 class StateMachineDefinition extends EntityDefinition
 {

--- a/src/Core/System/StateMachine/StateMachineTranslationCollection.php
+++ b/src/Core/System/StateMachine/StateMachineTranslationCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<StateMachineTranslationEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('checkout')]
 class StateMachineTranslationCollection extends EntityCollection

--- a/src/Core/System/StateMachine/StateMachineTranslationDefinition.php
+++ b/src/Core/System/StateMachine/StateMachineTranslationDefinition.php
@@ -10,6 +10,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\StringField;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('checkout')]
 class StateMachineTranslationDefinition extends EntityTranslationDefinition
 {

--- a/src/Core/System/StateMachine/StateMachineTranslationEntity.php
+++ b/src/Core/System/StateMachine/StateMachineTranslationEntity.php
@@ -6,6 +6,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityCustomFieldsTrait;
 use Shopware\Core\Framework\DataAbstractionLayer\TranslationEntity;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('checkout')]
 class StateMachineTranslationEntity extends TranslationEntity
 {

--- a/src/Core/System/SystemConfig/Event/BeforeSystemConfigChangedEvent.php
+++ b/src/Core/System/SystemConfig/Event/BeforeSystemConfigChangedEvent.php
@@ -5,6 +5,9 @@ namespace Shopware\Core\System\SystemConfig\Event;
 use Shopware\Core\Framework\Log\Package;
 use Symfony\Contracts\EventDispatcher\Event;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('framework')]
 class BeforeSystemConfigChangedEvent extends Event
 {

--- a/src/Core/System/SystemConfig/Event/BeforeSystemConfigMultipleChangedEvent.php
+++ b/src/Core/System/SystemConfig/Event/BeforeSystemConfigMultipleChangedEvent.php
@@ -5,6 +5,9 @@ namespace Shopware\Core\System\SystemConfig\Event;
 use Shopware\Core\Framework\Log\Package;
 use Symfony\Contracts\EventDispatcher\Event;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('framework')]
 class BeforeSystemConfigMultipleChangedEvent extends Event
 {

--- a/src/Core/System/SystemConfig/Event/SystemConfigChangedEvent.php
+++ b/src/Core/System/SystemConfig/Event/SystemConfigChangedEvent.php
@@ -5,6 +5,9 @@ namespace Shopware\Core\System\SystemConfig\Event;
 use Shopware\Core\Framework\Log\Package;
 use Symfony\Contracts\EventDispatcher\Event;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('framework')]
 class SystemConfigChangedEvent extends Event
 {

--- a/src/Core/System/SystemConfig/Event/SystemConfigDomainLoadedEvent.php
+++ b/src/Core/System/SystemConfig/Event/SystemConfigDomainLoadedEvent.php
@@ -5,6 +5,9 @@ namespace Shopware\Core\System\SystemConfig\Event;
 use Shopware\Core\Framework\Log\Package;
 use Symfony\Contracts\EventDispatcher\Event;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('framework')]
 class SystemConfigDomainLoadedEvent extends Event
 {

--- a/src/Core/System/SystemConfig/Event/SystemConfigMultipleChangedEvent.php
+++ b/src/Core/System/SystemConfig/Event/SystemConfigMultipleChangedEvent.php
@@ -5,6 +5,9 @@ namespace Shopware\Core\System\SystemConfig\Event;
 use Shopware\Core\Framework\Log\Package;
 use Symfony\Contracts\EventDispatcher\Event;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('framework')]
 class SystemConfigMultipleChangedEvent extends Event
 {

--- a/src/Core/System/SystemConfig/SystemConfigDefinition.php
+++ b/src/Core/System/SystemConfig/SystemConfigDefinition.php
@@ -15,6 +15,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelDefinition;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('framework')]
 class SystemConfigDefinition extends EntityDefinition
 {

--- a/src/Core/System/SystemConfig/SystemConfigEntity.php
+++ b/src/Core/System/SystemConfig/SystemConfigEntity.php
@@ -7,6 +7,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityIdTrait;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelEntity;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('framework')]
 class SystemConfigEntity extends Entity
 {

--- a/src/Core/System/Tag/Struct/FilteredTagIdsStruct.php
+++ b/src/Core/System/Tag/Struct/FilteredTagIdsStruct.php
@@ -5,6 +5,9 @@ namespace Shopware\Core\System\Tag\Struct;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\Struct;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('fundamentals@framework')]
 class FilteredTagIdsStruct extends Struct
 {

--- a/src/Core/System/Tag/TagCollection.php
+++ b/src/Core/System/Tag/TagCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<TagEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('fundamentals@framework')]
 class TagCollection extends EntityCollection

--- a/src/Core/System/Tag/TagDefinition.php
+++ b/src/Core/System/Tag/TagDefinition.php
@@ -32,6 +32,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\StringField;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('fundamentals@framework')]
 class TagDefinition extends EntityDefinition
 {

--- a/src/Core/System/Tag/TagEntity.php
+++ b/src/Core/System/Tag/TagEntity.php
@@ -15,6 +15,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\Entity;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityIdTrait;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('fundamentals@framework')]
 class TagEntity extends Entity
 {

--- a/src/Core/System/Tax/Aggregate/TaxRule/TaxRuleDefinition.php
+++ b/src/Core/System/Tax/Aggregate/TaxRule/TaxRuleDefinition.php
@@ -20,6 +20,9 @@ use Shopware\Core\System\Country\CountryDefinition;
 use Shopware\Core\System\Tax\Aggregate\TaxRuleType\TaxRuleTypeDefinition;
 use Shopware\Core\System\Tax\TaxDefinition;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('checkout')]
 class TaxRuleDefinition extends EntityDefinition
 {

--- a/src/Core/System/Tax/Aggregate/TaxRuleType/TaxRuleTypeDefinition.php
+++ b/src/Core/System/Tax/Aggregate/TaxRuleType/TaxRuleTypeDefinition.php
@@ -19,6 +19,9 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\Tax\Aggregate\TaxRule\TaxRuleDefinition;
 use Shopware\Core\System\Tax\Aggregate\TaxRuleTypeTranslation\TaxRuleTypeTranslationDefinition;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('checkout')]
 class TaxRuleTypeDefinition extends EntityDefinition
 {

--- a/src/Core/System/Tax/Aggregate/TaxRuleType/TaxRuleTypeEntity.php
+++ b/src/Core/System/Tax/Aggregate/TaxRuleType/TaxRuleTypeEntity.php
@@ -8,6 +8,9 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\Tax\Aggregate\TaxRule\TaxRuleCollection;
 use Shopware\Core\System\Tax\Aggregate\TaxRuleTypeTranslation\TaxRuleTypeTranslationCollection;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('checkout')]
 class TaxRuleTypeEntity extends Entity
 {

--- a/src/Core/System/Tax/Aggregate/TaxRuleTypeTranslation/TaxRuleTypeTranslationCollection.php
+++ b/src/Core/System/Tax/Aggregate/TaxRuleTypeTranslation/TaxRuleTypeTranslationCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<TaxRuleTypeTranslationEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('checkout')]
 class TaxRuleTypeTranslationCollection extends EntityCollection

--- a/src/Core/System/Tax/Aggregate/TaxRuleTypeTranslation/TaxRuleTypeTranslationDefinition.php
+++ b/src/Core/System/Tax/Aggregate/TaxRuleTypeTranslation/TaxRuleTypeTranslationDefinition.php
@@ -9,6 +9,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\Tax\Aggregate\TaxRuleType\TaxRuleTypeDefinition;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('checkout')]
 class TaxRuleTypeTranslationDefinition extends EntityTranslationDefinition
 {

--- a/src/Core/System/Tax/Aggregate/TaxRuleTypeTranslation/TaxRuleTypeTranslationEntity.php
+++ b/src/Core/System/Tax/Aggregate/TaxRuleTypeTranslation/TaxRuleTypeTranslationEntity.php
@@ -6,6 +6,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\TranslationEntity;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\Tax\Aggregate\TaxRuleType\TaxRuleTypeEntity;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('checkout')]
 class TaxRuleTypeTranslationEntity extends TranslationEntity
 {

--- a/src/Core/System/Tax/TaxCollection.php
+++ b/src/Core/System/Tax/TaxCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<TaxEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('checkout')]
 class TaxCollection extends EntityCollection

--- a/src/Core/System/Tax/TaxDefinition.php
+++ b/src/Core/System/Tax/TaxDefinition.php
@@ -22,6 +22,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\Tax\Aggregate\TaxRule\TaxRuleDefinition;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('checkout')]
 class TaxDefinition extends EntityDefinition
 {

--- a/src/Core/System/Tax/TaxEntity.php
+++ b/src/Core/System/Tax/TaxEntity.php
@@ -10,6 +10,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityIdTrait;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\Tax\Aggregate\TaxRule\TaxRuleCollection;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('checkout')]
 class TaxEntity extends Entity
 {

--- a/src/Core/System/TaxProvider/Aggregate/TaxProviderTranslation/TaxProviderTranslationCollection.php
+++ b/src/Core/System/TaxProvider/Aggregate/TaxProviderTranslation/TaxProviderTranslationCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<TaxProviderTranslationEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('checkout')]
 class TaxProviderTranslationCollection extends EntityCollection

--- a/src/Core/System/TaxProvider/Aggregate/TaxProviderTranslation/TaxProviderTranslationDefinition.php
+++ b/src/Core/System/TaxProvider/Aggregate/TaxProviderTranslation/TaxProviderTranslationDefinition.php
@@ -11,6 +11,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\TaxProvider\TaxProviderDefinition;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('checkout')]
 class TaxProviderTranslationDefinition extends EntityTranslationDefinition
 {

--- a/src/Core/System/TaxProvider/Aggregate/TaxProviderTranslation/TaxProviderTranslationEntity.php
+++ b/src/Core/System/TaxProvider/Aggregate/TaxProviderTranslation/TaxProviderTranslationEntity.php
@@ -7,6 +7,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\TranslationEntity;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\TaxProvider\TaxProviderEntity;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('checkout')]
 class TaxProviderTranslationEntity extends TranslationEntity
 {

--- a/src/Core/System/TaxProvider/TaxProviderCollection.php
+++ b/src/Core/System/TaxProvider/TaxProviderCollection.php
@@ -7,8 +7,6 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<TaxProviderEntity>
- *
- * @codeCoverageIgnore
  */
 #[Package('checkout')]
 class TaxProviderCollection extends EntityCollection

--- a/src/Core/System/TaxProvider/TaxProviderCollection.php
+++ b/src/Core/System/TaxProvider/TaxProviderCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<TaxProviderEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('checkout')]
 class TaxProviderCollection extends EntityCollection

--- a/src/Core/System/TaxProvider/TaxProviderDefinition.php
+++ b/src/Core/System/TaxProvider/TaxProviderDefinition.php
@@ -21,6 +21,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\TaxProvider\Aggregate\TaxProviderTranslation\TaxProviderTranslationDefinition;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('checkout')]
 class TaxProviderDefinition extends EntityDefinition
 {

--- a/src/Core/System/TaxProvider/TaxProviderEntity.php
+++ b/src/Core/System/TaxProvider/TaxProviderEntity.php
@@ -12,6 +12,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityIdTrait;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\TaxProvider\Aggregate\TaxProviderTranslation\TaxProviderTranslationCollection;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('checkout')]
 class TaxProviderEntity extends Entity implements IdAware, RuleIdAware
 {

--- a/src/Core/System/User/Aggregate/UserAccessKey/UserAccessKeyCollection.php
+++ b/src/Core/System/User/Aggregate/UserAccessKey/UserAccessKeyCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<UserAccessKeyEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('fundamentals@framework')]
 class UserAccessKeyCollection extends EntityCollection

--- a/src/Core/System/User/Aggregate/UserAccessKey/UserAccessKeyDefinition.php
+++ b/src/Core/System/User/Aggregate/UserAccessKey/UserAccessKeyDefinition.php
@@ -16,6 +16,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\User\UserDefinition;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('fundamentals@framework')]
 class UserAccessKeyDefinition extends EntityDefinition
 {

--- a/src/Core/System/User/Aggregate/UserAccessKey/UserAccessKeyEntity.php
+++ b/src/Core/System/User/Aggregate/UserAccessKey/UserAccessKeyEntity.php
@@ -8,6 +8,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityIdTrait;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\User\UserEntity;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('fundamentals@framework')]
 class UserAccessKeyEntity extends Entity
 {

--- a/src/Core/System/User/Aggregate/UserConfig/UserConfigCollection.php
+++ b/src/Core/System/User/Aggregate/UserConfig/UserConfigCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<UserConfigEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('fundamentals@framework')]
 class UserConfigCollection extends EntityCollection

--- a/src/Core/System/User/Aggregate/UserConfig/UserConfigDefinition.php
+++ b/src/Core/System/User/Aggregate/UserConfig/UserConfigDefinition.php
@@ -14,6 +14,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\User\UserDefinition;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('fundamentals@framework')]
 class UserConfigDefinition extends EntityDefinition
 {

--- a/src/Core/System/User/Aggregate/UserConfig/UserConfigEntity.php
+++ b/src/Core/System/User/Aggregate/UserConfig/UserConfigEntity.php
@@ -7,6 +7,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityIdTrait;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\User\UserEntity;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('fundamentals@framework')]
 class UserConfigEntity extends Entity
 {

--- a/src/Core/System/User/Aggregate/UserRecovery/UserRecoveryCollection.php
+++ b/src/Core/System/User/Aggregate/UserRecovery/UserRecoveryCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<UserRecoveryEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('fundamentals@framework')]
 class UserRecoveryCollection extends EntityCollection

--- a/src/Core/System/User/Aggregate/UserRecovery/UserRecoveryDefinition.php
+++ b/src/Core/System/User/Aggregate/UserRecovery/UserRecoveryDefinition.php
@@ -15,6 +15,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\User\UserDefinition;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('fundamentals@framework')]
 class UserRecoveryDefinition extends EntityDefinition
 {

--- a/src/Core/System/User/Aggregate/UserRecovery/UserRecoveryEntity.php
+++ b/src/Core/System/User/Aggregate/UserRecovery/UserRecoveryEntity.php
@@ -7,6 +7,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityIdTrait;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\User\UserEntity;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('fundamentals@framework')]
 class UserRecoveryEntity extends Entity
 {

--- a/src/Core/System/User/Aggregate/UserRecovery/UserRecoveryEntity.php
+++ b/src/Core/System/User/Aggregate/UserRecovery/UserRecoveryEntity.php
@@ -7,9 +7,6 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityIdTrait;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\User\UserEntity;
 
-/**
- * @codeCoverageIgnore
- */
 #[Package('fundamentals@framework')]
 class UserRecoveryEntity extends Entity
 {

--- a/src/Core/System/User/UserCollection.php
+++ b/src/Core/System/User/UserCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<UserEntity>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('fundamentals@framework')]
 class UserCollection extends EntityCollection

--- a/src/Core/System/User/UserDefinition.php
+++ b/src/Core/System/User/UserDefinition.php
@@ -41,6 +41,9 @@ use Shopware\Core\System\User\Aggregate\UserAccessKey\UserAccessKeyDefinition;
 use Shopware\Core\System\User\Aggregate\UserConfig\UserConfigDefinition;
 use Shopware\Core\System\User\Aggregate\UserRecovery\UserRecoveryDefinition;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('fundamentals@framework')]
 class UserDefinition extends EntityDefinition
 {

--- a/src/Core/System/User/UserEntity.php
+++ b/src/Core/System/User/UserEntity.php
@@ -18,9 +18,6 @@ use Shopware\Core\System\User\Aggregate\UserAccessKey\UserAccessKeyCollection;
 use Shopware\Core\System\User\Aggregate\UserConfig\UserConfigCollection;
 use Shopware\Core\System\User\Aggregate\UserRecovery\UserRecoveryEntity;
 
-/**
- * @codeCoverageIgnore
- */
 #[Package('fundamentals@framework')]
 class UserEntity extends Entity
 {

--- a/src/Core/System/User/UserEntity.php
+++ b/src/Core/System/User/UserEntity.php
@@ -18,6 +18,9 @@ use Shopware\Core\System\User\Aggregate\UserAccessKey\UserAccessKeyCollection;
 use Shopware\Core\System\User\Aggregate\UserConfig\UserConfigCollection;
 use Shopware\Core\System\User\Aggregate\UserRecovery\UserRecoveryEntity;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('fundamentals@framework')]
 class UserEntity extends Entity
 {


### PR DESCRIPTION
### 1. Why is this change necessary?

PHPUnit 12 reports classes that are excluded from the coverage source as invalid `#[CoversClass]` targets. The blanket suffix excludes for `src/Storefront` in `phpunit.xml.dist` are being replaced with per-class annotations so the excludes can be lifted.

### 2. What does this change do, exactly?

Adds a `@codeCoverageIgnore` docblock to the 42 checkout-owned Core System classes that are matched by the Core System suffix excludes and contain only logic-free boilerplate (constructors and plain accessors). The excludes themselves are lifted at the top of this stack, once every matched class carries an annotation or a test.

### 3. Describe each step to reproduce the issue or behaviour.

Not applicable, coverage configuration only.

### 4. Please link to the relevant issues (if any).

- relates #18344

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
