### PR TITLE
test: mark checkout-owned Core Framework classes codeCoverageIgnore

### DIFF
--- a/phpstan-baseline.php
+++ b/phpstan-baseline.php
@@ -680,12 +680,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/src/Core/Framework/Store/Authentication/LocaleProvider.php',
 ];
 $ignoreErrors[] = [
-    'rawMessage' => 'Method Shopware\\Core\\Framework\\Store\\Search\\EqualsFilterStruct::fromArray() has parameter $data with no value type specified in iterable type array.',
-    'identifier' => 'missingType.iterableValue',
-    'count' => 1,
-    'path' => __DIR__ . '/src/Core/Framework/Store/Search/EqualsFilterStruct.php',
-];
-$ignoreErrors[] = [
     'rawMessage' => 'Method Shopware\\Core\\Framework\\Store\\Search\\ExtensionCriteria::addFilter() has parameter $filter with no value type specified in iterable type array.',
     'identifier' => 'missingType.iterableValue',
     'count' => 1,

--- a/src/Core/Framework/App/InAppPurchases/Event/InAppPurchasesGatewayEvent.php
+++ b/src/Core/Framework/App/InAppPurchases/Event/InAppPurchasesGatewayEvent.php
@@ -14,6 +14,8 @@ use Symfony\Contracts\EventDispatcher\Event;
  * @internal
  *
  * @see InAppPurchasesGateway::process() for an example implementation
+ *
+ * @codeCoverageIgnore
  */
 #[Package('checkout')]
 class InAppPurchasesGatewayEvent extends Event

--- a/src/Core/Framework/JWT/Struct/JWKStruct.php
+++ b/src/Core/Framework/JWT/Struct/JWKStruct.php
@@ -9,6 +9,8 @@ use Symfony\Component\Validator\Constraints\Type;
 
 /**
  * @phpstan-type JSONWebKey array{kty: string, kid: string, use: string, alg: string, n: string, e: string}
+ *
+ * @codeCoverageIgnore
  */
 #[Package('checkout')]
 class JWKStruct

--- a/src/Core/Framework/Store/Event/ExtensionLoadedEvent.php
+++ b/src/Core/Framework/Store/Event/ExtensionLoadedEvent.php
@@ -15,6 +15,8 @@ use Symfony\Contracts\EventDispatcher\Event;
  * checks the source and flags themes via $extension->setIsTheme(true) - without Core depending on Storefront.
  *
  * @internal
+ *
+ * @codeCoverageIgnore
  */
 #[Package('checkout')]
 final class ExtensionLoadedEvent extends Event

--- a/src/Core/Framework/Store/Event/InstalledExtensionsListingLoadedEvent.php
+++ b/src/Core/Framework/Store/Event/InstalledExtensionsListingLoadedEvent.php
@@ -9,6 +9,8 @@ use Symfony\Contracts\EventDispatcher\Event;
 
 /**
  * @internal
+ *
+ * @codeCoverageIgnore
  */
 #[Package('checkout')]
 class InstalledExtensionsListingLoadedEvent extends Event

--- a/src/Core/Framework/Store/Search/EqualsFilterStruct.php
+++ b/src/Core/Framework/Store/Search/EqualsFilterStruct.php
@@ -6,6 +6,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @internal
+ *
+ * @codeCoverageIgnore
  */
 #[Package('checkout')]
 class EqualsFilterStruct extends FilterStruct
@@ -14,6 +16,9 @@ class EqualsFilterStruct extends FilterStruct
 
     protected string $value;
 
+    /**
+     * @param array<string, string> $data
+     */
     public static function fromArray(array $data): FilterStruct
     {
         $filter = new EqualsFilterStruct();

--- a/src/Core/Framework/Store/Struct/AccessTokenStruct.php
+++ b/src/Core/Framework/Store/Struct/AccessTokenStruct.php
@@ -5,6 +5,9 @@ namespace Shopware\Core\Framework\Store\Struct;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\Struct;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('checkout')]
 class AccessTokenStruct extends Struct
 {

--- a/src/Core/Framework/Store/Struct/BinaryCollection.php
+++ b/src/Core/Framework/Store/Struct/BinaryCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @template-extends StoreCollection<BinaryStruct>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('checkout')]
 class BinaryCollection extends StoreCollection

--- a/src/Core/Framework/Store/Struct/BinaryStruct.php
+++ b/src/Core/Framework/Store/Struct/BinaryStruct.php
@@ -4,6 +4,9 @@ namespace Shopware\Core\Framework\Store\Struct;
 
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('checkout')]
 class BinaryStruct extends StoreStruct
 {

--- a/src/Core/Framework/Store/Struct/CartPositionStruct.php
+++ b/src/Core/Framework/Store/Struct/CartPositionStruct.php
@@ -5,6 +5,9 @@ namespace Shopware\Core\Framework\Store\Struct;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\Struct;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('checkout')]
 class CartPositionStruct extends Struct
 {

--- a/src/Core/Framework/Store/Struct/CartPositionStruct.php
+++ b/src/Core/Framework/Store/Struct/CartPositionStruct.php
@@ -5,9 +5,6 @@ namespace Shopware\Core\Framework\Store\Struct;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\Struct;
 
-/**
- * @codeCoverageIgnore
- */
 #[Package('checkout')]
 class CartPositionStruct extends Struct
 {

--- a/src/Core/Framework/Store/Struct/CartStruct.php
+++ b/src/Core/Framework/Store/Struct/CartStruct.php
@@ -5,6 +5,9 @@ namespace Shopware\Core\Framework\Store\Struct;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\Struct;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('checkout')]
 class CartStruct extends Struct
 {

--- a/src/Core/Framework/Store/Struct/CartStruct.php
+++ b/src/Core/Framework/Store/Struct/CartStruct.php
@@ -5,9 +5,6 @@ namespace Shopware\Core\Framework\Store\Struct;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\Struct;
 
-/**
- * @codeCoverageIgnore
- */
 #[Package('checkout')]
 class CartStruct extends Struct
 {

--- a/src/Core/Framework/Store/Struct/DomainVerificationRequestStruct.php
+++ b/src/Core/Framework/Store/Struct/DomainVerificationRequestStruct.php
@@ -6,6 +6,9 @@ use Shopware\Core\Framework\Deprecation\BCChange\ParameterNameChange;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\Struct;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('checkout')]
 class DomainVerificationRequestStruct extends Struct
 {

--- a/src/Core/Framework/Store/Struct/FaqCollection.php
+++ b/src/Core/Framework/Store/Struct/FaqCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @template-extends StoreCollection<FaqStruct>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('checkout')]
 class FaqCollection extends StoreCollection

--- a/src/Core/Framework/Store/Struct/FaqStruct.php
+++ b/src/Core/Framework/Store/Struct/FaqStruct.php
@@ -4,6 +4,9 @@ namespace Shopware\Core\Framework\Store\Struct;
 
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('checkout')]
 class FaqStruct extends StoreStruct
 {

--- a/src/Core/Framework/Store/Struct/ImageCollection.php
+++ b/src/Core/Framework/Store/Struct/ImageCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @template-extends StoreCollection<ImageStruct>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('checkout')]
 class ImageCollection extends StoreCollection

--- a/src/Core/Framework/Store/Struct/LicenseCollection.php
+++ b/src/Core/Framework/Store/Struct/LicenseCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Struct\Collection;
 
 /**
  * @extends Collection<LicenseStruct>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('checkout')]
 class LicenseCollection extends Collection

--- a/src/Core/Framework/Store/Struct/LicenseDomainCollection.php
+++ b/src/Core/Framework/Store/Struct/LicenseDomainCollection.php
@@ -7,8 +7,6 @@ use Shopware\Core\Framework\Struct\Collection;
 
 /**
  * @extends Collection<LicenseDomainStruct>
- *
- * @codeCoverageIgnore
  */
 #[Package('checkout')]
 class LicenseDomainCollection extends Collection

--- a/src/Core/Framework/Store/Struct/LicenseDomainCollection.php
+++ b/src/Core/Framework/Store/Struct/LicenseDomainCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Struct\Collection;
 
 /**
  * @extends Collection<LicenseDomainStruct>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('checkout')]
 class LicenseDomainCollection extends Collection

--- a/src/Core/Framework/Store/Struct/LicenseDomainStruct.php
+++ b/src/Core/Framework/Store/Struct/LicenseDomainStruct.php
@@ -5,6 +5,9 @@ namespace Shopware\Core\Framework\Store\Struct;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\Struct;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('checkout')]
 class LicenseDomainStruct extends Struct
 {

--- a/src/Core/Framework/Store/Struct/PermissionStruct.php
+++ b/src/Core/Framework/Store/Struct/PermissionStruct.php
@@ -4,6 +4,9 @@ namespace Shopware\Core\Framework\Store\Struct;
 
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('checkout')]
 class PermissionStruct extends StoreStruct
 {

--- a/src/Core/Framework/Store/Struct/PluginCategoryCollection.php
+++ b/src/Core/Framework/Store/Struct/PluginCategoryCollection.php
@@ -9,6 +9,8 @@ use Shopware\Core\Framework\Struct\Collection;
  * Pseudo immutable collection
  *
  * @extends Collection<PluginCategoryStruct>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('checkout')]
 final class PluginCategoryCollection extends Collection

--- a/src/Core/Framework/Store/Struct/PluginCategoryStruct.php
+++ b/src/Core/Framework/Store/Struct/PluginCategoryStruct.php
@@ -5,6 +5,9 @@ namespace Shopware\Core\Framework\Store\Struct;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\Struct;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('checkout')]
 class PluginCategoryStruct extends Struct
 {

--- a/src/Core/Framework/Store/Struct/PluginDownloadDataStruct.php
+++ b/src/Core/Framework/Store/Struct/PluginDownloadDataStruct.php
@@ -5,6 +5,9 @@ namespace Shopware\Core\Framework\Store\Struct;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\Struct;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('checkout')]
 class PluginDownloadDataStruct extends Struct
 {

--- a/src/Core/Framework/Store/Struct/PluginRegionCollection.php
+++ b/src/Core/Framework/Store/Struct/PluginRegionCollection.php
@@ -9,6 +9,8 @@ use Shopware\Core\Framework\Struct\Collection;
  * Pseudo immutable collection
  *
  * @extends Collection<PluginRegionStruct>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('checkout')]
 final class PluginRegionCollection extends Collection

--- a/src/Core/Framework/Store/Struct/PluginRegionStruct.php
+++ b/src/Core/Framework/Store/Struct/PluginRegionStruct.php
@@ -5,6 +5,9 @@ namespace Shopware\Core\Framework\Store\Struct;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\Struct;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('checkout')]
 class PluginRegionStruct extends Struct
 {

--- a/src/Core/Framework/Store/Struct/ReviewCollection.php
+++ b/src/Core/Framework/Store/Struct/ReviewCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @template-extends StoreCollection<ReviewStruct>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('checkout')]
 class ReviewCollection extends StoreCollection

--- a/src/Core/Framework/Store/Struct/ReviewSummaryStruct.php
+++ b/src/Core/Framework/Store/Struct/ReviewSummaryStruct.php
@@ -4,6 +4,9 @@ namespace Shopware\Core\Framework\Store\Struct;
 
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('checkout')]
 class ReviewSummaryStruct extends StoreStruct
 {

--- a/src/Core/Framework/Store/Struct/ShopUserTokenStruct.php
+++ b/src/Core/Framework/Store/Struct/ShopUserTokenStruct.php
@@ -5,6 +5,9 @@ namespace Shopware\Core\Framework\Store\Struct;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\Struct;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('checkout')]
 class ShopUserTokenStruct extends Struct
 {

--- a/src/Core/Framework/Store/Struct/StoreActionStruct.php
+++ b/src/Core/Framework/Store/Struct/StoreActionStruct.php
@@ -5,6 +5,9 @@ namespace Shopware\Core\Framework\Store\Struct;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\Struct;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('checkout')]
 class StoreActionStruct extends Struct
 {

--- a/src/Core/Framework/Store/Struct/StoreCategoryCollection.php
+++ b/src/Core/Framework/Store/Struct/StoreCategoryCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @template-extends StoreCollection<StoreCategoryStruct>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('checkout')]
 class StoreCategoryCollection extends StoreCollection

--- a/src/Core/Framework/Store/Struct/StoreCategoryStruct.php
+++ b/src/Core/Framework/Store/Struct/StoreCategoryStruct.php
@@ -4,6 +4,9 @@ namespace Shopware\Core\Framework\Store\Struct;
 
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('checkout')]
 class StoreCategoryStruct extends StoreStruct
 {

--- a/src/Core/Framework/Store/Struct/StoreLicenseStruct.php
+++ b/src/Core/Framework/Store/Struct/StoreLicenseStruct.php
@@ -5,6 +5,9 @@ namespace Shopware\Core\Framework\Store\Struct;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\Struct;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('checkout')]
 class StoreLicenseStruct extends Struct
 {

--- a/src/Core/Framework/Store/Struct/StoreLicenseSubscriptionStruct.php
+++ b/src/Core/Framework/Store/Struct/StoreLicenseSubscriptionStruct.php
@@ -5,6 +5,9 @@ namespace Shopware\Core\Framework\Store\Struct;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\Struct;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('checkout')]
 class StoreLicenseSubscriptionStruct extends Struct
 {

--- a/src/Core/Framework/Store/Struct/StoreLicenseTypeStruct.php
+++ b/src/Core/Framework/Store/Struct/StoreLicenseTypeStruct.php
@@ -5,6 +5,9 @@ namespace Shopware\Core\Framework\Store\Struct;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\Struct;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('checkout')]
 class StoreLicenseTypeStruct extends Struct
 {

--- a/src/Core/Framework/Store/Struct/StoreLicenseViolationStruct.php
+++ b/src/Core/Framework/Store/Struct/StoreLicenseViolationStruct.php
@@ -5,6 +5,9 @@ namespace Shopware\Core\Framework\Store\Struct;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\Struct;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('checkout')]
 class StoreLicenseViolationStruct extends Struct
 {

--- a/src/Core/Framework/Store/Struct/StoreLicenseViolationTypeStruct.php
+++ b/src/Core/Framework/Store/Struct/StoreLicenseViolationTypeStruct.php
@@ -5,6 +5,9 @@ namespace Shopware\Core\Framework\Store\Struct;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\Struct;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('checkout')]
 class StoreLicenseViolationTypeStruct extends Struct
 {

--- a/src/Core/Framework/Store/Struct/StorePluginStruct.php
+++ b/src/Core/Framework/Store/Struct/StorePluginStruct.php
@@ -5,6 +5,9 @@ namespace Shopware\Core\Framework\Store\Struct;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\Struct;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('checkout')]
 class StorePluginStruct extends Struct
 {

--- a/src/Core/Framework/Store/Struct/StoreStruct.php
+++ b/src/Core/Framework/Store/Struct/StoreStruct.php
@@ -5,6 +5,9 @@ namespace Shopware\Core\Framework\Store\Struct;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\Struct;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('checkout')]
 abstract class StoreStruct extends Struct
 {

--- a/src/Core/Framework/Store/Struct/StoreUpdateStruct.php
+++ b/src/Core/Framework/Store/Struct/StoreUpdateStruct.php
@@ -5,6 +5,9 @@ namespace Shopware\Core\Framework\Store\Struct;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\Struct;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('checkout')]
 class StoreUpdateStruct extends Struct
 {

--- a/src/Core/Framework/Store/Struct/VariantCollection.php
+++ b/src/Core/Framework/Store/Struct/VariantCollection.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @template-extends StoreCollection<VariantStruct>
+ *
+ * @codeCoverageIgnore
  */
 #[Package('checkout')]
 class VariantCollection extends StoreCollection

--- a/tests/unit/Core/Framework/Store/Struct/CartPositionStructTest.php
+++ b/tests/unit/Core/Framework/Store/Struct/CartPositionStructTest.php
@@ -1,0 +1,27 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\Store\Struct;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Store\Struct\CartPositionStruct;
+
+/**
+ * @internal
+ */
+#[Package('checkout')]
+#[CoversClass(CartPositionStruct::class)]
+class CartPositionStructTest extends TestCase
+{
+    public function testJsonSerializeOmitsTheExtensions(): void
+    {
+        $position = CartPositionStruct::fromArray(['netPrice' => 10.0, 'grossPrice' => 11.9]);
+
+        $data = $position->jsonSerialize();
+
+        static::assertArrayNotHasKey('extensions', $data);
+        static::assertSame(10.0, $data['netPrice']);
+        static::assertSame(11.9, $data['grossPrice']);
+    }
+}

--- a/tests/unit/Core/Framework/Store/Struct/CartStructTest.php
+++ b/tests/unit/Core/Framework/Store/Struct/CartStructTest.php
@@ -1,0 +1,43 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\Store\Struct;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Store\Struct\CartPositionStruct;
+use Shopware\Core\Framework\Store\Struct\CartStruct;
+
+/**
+ * @internal
+ */
+#[Package('checkout')]
+#[CoversClass(CartStruct::class)]
+class CartStructTest extends TestCase
+{
+    public function testFromArrayWrapsThePositionsInACollection(): void
+    {
+        $cart = CartStruct::fromArray([
+            'netPrice' => 10.0,
+            'positions' => [
+                ['netPrice' => 10.0, 'grossPrice' => 11.9],
+            ],
+        ]);
+
+        static::assertSame(10.0, $cart->getNetPrice());
+        static::assertCount(1, $cart->getPositions());
+        $position = $cart->getPositions()->first();
+        static::assertInstanceOf(CartPositionStruct::class, $position);
+        static::assertSame(11.9, $position->getGrossPrice());
+    }
+
+    public function testJsonSerializeOmitsTheExtensions(): void
+    {
+        $cart = CartStruct::fromArray(['netPrice' => 10.0, 'positions' => []]);
+
+        $data = $cart->jsonSerialize();
+
+        static::assertArrayNotHasKey('extensions', $data);
+        static::assertSame(10.0, $data['netPrice']);
+    }
+}

--- a/tests/unit/Core/Framework/Store/Struct/LicenseDomainCollectionTest.php
+++ b/tests/unit/Core/Framework/Store/Struct/LicenseDomainCollectionTest.php
@@ -1,0 +1,43 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\Store\Struct;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Store\Struct\LicenseDomainCollection;
+use Shopware\Core\Framework\Store\Struct\LicenseDomainStruct;
+
+/**
+ * @internal
+ */
+#[Package('checkout')]
+#[CoversClass(LicenseDomainCollection::class)]
+class LicenseDomainCollectionTest extends TestCase
+{
+    public function testAddKeysTheElementByItsDomain(): void
+    {
+        $collection = new LicenseDomainCollection();
+        $domain = (new LicenseDomainStruct())->assign(['domain' => 'example.com']);
+
+        $collection->add($domain);
+
+        static::assertSame($domain, $collection->get('example.com'));
+    }
+
+    public function testSetIgnoresTheGivenKeyInFavorOfTheDomain(): void
+    {
+        $collection = new LicenseDomainCollection();
+        $domain = (new LicenseDomainStruct())->assign(['domain' => 'example.com']);
+
+        $collection->set('custom-key', $domain);
+
+        static::assertNull($collection->get('custom-key'));
+        static::assertSame($domain, $collection->get('example.com'));
+    }
+
+    public function testApiAlias(): void
+    {
+        static::assertSame('store_license_domain_collection', (new LicenseDomainCollection())->getApiAlias());
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?

PHPUnit 12 reports classes that are excluded from the coverage source as invalid `#[CoversClass]` targets. The blanket suffix excludes for `src/Storefront` in `phpunit.xml.dist` are being replaced with per-class annotations so the excludes can be lifted.

### 2. What does this change do, exactly?

Adds a `@codeCoverageIgnore` docblock to the 38 checkout-owned classes under src/Core/Framework that are matched by the remaining Core suffix excludes and contain only logic-free boilerplate (constructors and plain accessors). The excludes themselves are lifted at the top of this stack, once every matched class carries an annotation or a test.

### 3. Describe each step to reproduce the issue or behaviour.

Not applicable, coverage configuration only.

### 4. Please link to the relevant issues (if any).

- relates #18344

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
