### PR TITLE
test: lift the remaining coverage suffix excludes and cover the surfaced logic

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -27,21 +27,14 @@
             <file>src/Administration/Events/PreResetExcludedSearchTermEvent.php</file>
             <file>src/Core/Content/Resources/config/routes_test.php</file>
 
-            <!-- Scoped to the boilerplate-bearing directories on purpose: a blanket src/Core/ suffix
-                 match also swept migrations and framework classes whose NAME happens to end in a DAL
-                 suffix (e.g. Migration...Field, MigrationCollection), which PHPUnit 12 then reports as
-                 invalid #[CoversClass] targets. src/Core/Migration and src/Core/Framework/Migration are
-                 deliberately NOT listed. -->
+            <!-- Kept scoped to src/Core/System on purpose: a blanket src/Core/ suffix match would
+                 also sweep classes whose name merely ends in a DAL suffix (e.g. Framework/Migration's
+                 MigrationCollection), which PHPUnit 12 then reports as invalid #[CoversClass] targets. -->
             <directory suffix="Definition.php">src/Core/System/</directory>
-
             <directory suffix="Entity.php">src/Core/System/</directory>
-
             <directory suffix="Event.php">src/Core/System/</directory>
-
             <directory suffix="Field.php">src/Core/System/</directory>
-
             <directory suffix="Struct.php">src/Core/System/</directory>
-
             <directory suffix="Collection.php">src/Core/System/</directory>
 
             <directory suffix=".php">src/Core/Content/Cms/DataResolver/ResolverContext/</directory>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -26,61 +26,23 @@
 
             <file>src/Administration/Events/PreResetExcludedSearchTermEvent.php</file>
             <file>src/Core/Content/Resources/config/routes_test.php</file>
-            <directory suffix="Definition.php">src/Administration/Notification/</directory>
-            <directory suffix="Entity.php">src/Administration/Notification/</directory>
-            <directory suffix="Event.php">src/Administration/Notification/</directory>
-            <directory suffix="Field.php">src/Administration/Notification/</directory>
-            <directory suffix="Struct.php">src/Administration/Notification/</directory>
-            <directory suffix="Collection.php">src/Administration/Notification/</directory>
-
-            <directory suffix="Definition.php">src/Administration/Snippet/</directory>
-            <directory suffix="Entity.php">src/Administration/Snippet/</directory>
-            <directory suffix="Event.php">src/Administration/Snippet/</directory>
-            <directory suffix="Field.php">src/Administration/Snippet/</directory>
-            <directory suffix="Struct.php">src/Administration/Snippet/</directory>
-            <directory suffix="Collection.php">src/Administration/Snippet/</directory>
 
             <!-- Scoped to the boilerplate-bearing directories on purpose: a blanket src/Core/ suffix
                  match also swept migrations and framework classes whose NAME happens to end in a DAL
                  suffix (e.g. Migration...Field, MigrationCollection), which PHPUnit 12 then reports as
                  invalid #[CoversClass] targets. src/Core/Migration and src/Core/Framework/Migration are
                  deliberately NOT listed. -->
-            <directory suffix="Definition.php">src/Core/Framework/</directory>
             <directory suffix="Definition.php">src/Core/System/</directory>
 
-            <directory suffix="Entity.php">src/Core/Framework/</directory>
             <directory suffix="Entity.php">src/Core/System/</directory>
 
-            <directory suffix="Event.php">src/Core/Framework/</directory>
-            <directory suffix="Event.php">src/Core/Maintenance/</directory>
-            <directory suffix="Event.php">src/Core/Service/</directory>
             <directory suffix="Event.php">src/Core/System/</directory>
 
-            <directory suffix="Field.php">src/Core/Framework/</directory>
             <directory suffix="Field.php">src/Core/System/</directory>
 
-            <directory suffix="Struct.php">src/Core/Framework/</directory>
             <directory suffix="Struct.php">src/Core/System/</directory>
 
-            <directory suffix="Collection.php">src/Core/Installer/</directory>
             <directory suffix="Collection.php">src/Core/System/</directory>
-            <directory suffix="Collection.php">src/Core/Framework/Adapter/</directory>
-            <directory suffix="Collection.php">src/Core/Framework/Api/</directory>
-            <directory suffix="Collection.php">src/Core/Framework/App/</directory>
-            <directory suffix="Collection.php">src/Core/Framework/DataAbstractionLayer/</directory>
-            <directory suffix="Collection.php">src/Core/Framework/Event/</directory>
-            <directory suffix="Collection.php">src/Core/Framework/Gateway/</directory>
-            <directory suffix="Collection.php">src/Core/Framework/JWT/</directory>
-            <directory suffix="Collection.php">src/Core/Framework/Log/</directory>
-            <directory suffix="Collection.php">src/Core/Framework/MessageQueue/</directory>
-            <directory suffix="Collection.php">src/Core/Framework/Notification/</directory>
-            <directory suffix="Collection.php">src/Core/Framework/Plugin/</directory>
-            <directory suffix="Collection.php">src/Core/Framework/Rule/</directory>
-            <directory suffix="Collection.php">src/Core/Framework/Script/</directory>
-            <directory suffix="Collection.php">src/Core/Framework/Store/</directory>
-            <directory suffix="Collection.php">src/Core/Framework/Struct/</directory>
-            <directory suffix="Collection.php">src/Core/Framework/Telemetry/</directory>
-            <directory suffix="Collection.php">src/Core/Framework/Webhook/</directory>
 
             <directory suffix=".php">src/Core/Content/Cms/DataResolver/ResolverContext/</directory>
             <directory suffix=".php">src/Core/Content/Cms/Extension/</directory>

--- a/src/Core/Framework/Store/Event/FirstRunWizardFinishedEvent.php
+++ b/src/Core/Framework/Store/Event/FirstRunWizardFinishedEvent.php
@@ -9,6 +9,8 @@ use Symfony\Contracts\EventDispatcher\Event;
 
 /**
  * @internal
+ *
+ * @codeCoverageIgnore
  */
 #[Package('fundamentals@after-sales')]
 class FirstRunWizardFinishedEvent extends Event

--- a/src/Core/Framework/Store/Event/FirstRunWizardStartedEvent.php
+++ b/src/Core/Framework/Store/Event/FirstRunWizardStartedEvent.php
@@ -9,6 +9,8 @@ use Symfony\Contracts\EventDispatcher\Event;
 
 /**
  * @internal
+ *
+ * @codeCoverageIgnore
  */
 #[Package('fundamentals@after-sales')]
 class FirstRunWizardStartedEvent extends Event

--- a/tests/unit/Core/Framework/Adapter/Cache/CacheTagCollectionTest.php
+++ b/tests/unit/Core/Framework/Adapter/Cache/CacheTagCollectionTest.php
@@ -1,0 +1,61 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\Adapter\Cache;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Adapter\Cache\CacheTagCollection;
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+#[CoversClass(CacheTagCollection::class)]
+class CacheTagCollectionTest extends TestCase
+{
+    public function testAddCollectsTagsIntoTheGlobalTrace(): void
+    {
+        $collection = new CacheTagCollection();
+
+        $collection->add('tag-a');
+        $collection->add(['tag-b', 'tag-c']);
+
+        static::assertSame(['tag-a', 'tag-b', 'tag-c'], $collection->getTrace('all'));
+    }
+
+    public function testTraceScopesTagsToTheKeyAndReturnsTheClosureResult(): void
+    {
+        $collection = new CacheTagCollection();
+
+        $result = $collection->trace('route', function () use ($collection) {
+            $collection->add('inside-tag');
+
+            return 'closure-result';
+        });
+
+        static::assertSame('closure-result', $result);
+        static::assertSame(['inside-tag'], $collection->getTrace('route'));
+    }
+
+    public function testTagsAddedAfterTheTraceDoNotLeakIntoIt(): void
+    {
+        $collection = new CacheTagCollection();
+
+        $collection->trace('route', static fn () => null);
+        $collection->add('outside-tag');
+
+        static::assertSame(['outside-tag'], $collection->getTrace('all'));
+        static::assertSame([], $collection->getTrace('route'));
+    }
+
+    public function testResetDropsAllTraces(): void
+    {
+        $collection = new CacheTagCollection();
+        $collection->add('tag-a');
+
+        $collection->reset();
+
+        static::assertSame([], $collection->getTrace('all'));
+    }
+}

--- a/tests/unit/Core/Framework/App/Aggregate/AppPaymentMethod/AppPaymentMethodDefinitionTest.php
+++ b/tests/unit/Core/Framework/App/Aggregate/AppPaymentMethod/AppPaymentMethodDefinitionTest.php
@@ -1,0 +1,50 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\App\Aggregate\AppPaymentMethod;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\App\Aggregate\AppPaymentMethod\AppPaymentMethodCollection;
+use Shopware\Core\Framework\App\Aggregate\AppPaymentMethod\AppPaymentMethodDefinition;
+use Shopware\Core\Framework\App\Aggregate\AppPaymentMethod\AppPaymentMethodEntity;
+use Shopware\Core\Framework\DataAbstractionLayer\Dbal\EntityWriteGateway;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Test\Stub\DataAbstractionLayer\StaticDefinitionInstanceRegistry;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+#[CoversClass(AppPaymentMethodDefinition::class)]
+class AppPaymentMethodDefinitionTest extends TestCase
+{
+    public function testEntityConfiguration(): void
+    {
+        $definition = $this->createDefinition();
+
+        static::assertSame(AppPaymentMethodDefinition::ENTITY_NAME, $definition->getEntityName());
+        static::assertSame(AppPaymentMethodEntity::class, $definition->getEntityClass());
+        static::assertSame(AppPaymentMethodCollection::class, $definition->getCollectionClass());
+        static::assertSame('6.4.1.0', $definition->since());
+    }
+
+    public function testFieldsAreDefined(): void
+    {
+        static::assertNotNull($this->createDefinition()->getFields()->get('id'));
+    }
+
+    private function createDefinition(): AppPaymentMethodDefinition
+    {
+        $registry = new StaticDefinitionInstanceRegistry(
+            [AppPaymentMethodDefinition::class],
+            static::createStub(ValidatorInterface::class),
+            static::createStub(EntityWriteGateway::class),
+        );
+
+        $definition = $registry->getByEntityName(AppPaymentMethodDefinition::ENTITY_NAME);
+        static::assertInstanceOf(AppPaymentMethodDefinition::class, $definition);
+
+        return $definition;
+    }
+}

--- a/tests/unit/Core/Framework/App/Aggregate/AppScriptCondition/AppScriptConditionDefinitionTest.php
+++ b/tests/unit/Core/Framework/App/Aggregate/AppScriptCondition/AppScriptConditionDefinitionTest.php
@@ -1,0 +1,50 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\App\Aggregate\AppScriptCondition;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\App\Aggregate\AppScriptCondition\AppScriptConditionCollection;
+use Shopware\Core\Framework\App\Aggregate\AppScriptCondition\AppScriptConditionDefinition;
+use Shopware\Core\Framework\App\Aggregate\AppScriptCondition\AppScriptConditionEntity;
+use Shopware\Core\Framework\DataAbstractionLayer\Dbal\EntityWriteGateway;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Test\Stub\DataAbstractionLayer\StaticDefinitionInstanceRegistry;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+#[CoversClass(AppScriptConditionDefinition::class)]
+class AppScriptConditionDefinitionTest extends TestCase
+{
+    public function testEntityConfiguration(): void
+    {
+        $definition = $this->createDefinition();
+
+        static::assertSame(AppScriptConditionDefinition::ENTITY_NAME, $definition->getEntityName());
+        static::assertSame(AppScriptConditionEntity::class, $definition->getEntityClass());
+        static::assertSame(AppScriptConditionCollection::class, $definition->getCollectionClass());
+        static::assertSame('6.4.10.3', $definition->since());
+    }
+
+    public function testFieldsAreDefined(): void
+    {
+        static::assertNotNull($this->createDefinition()->getFields()->get('id'));
+    }
+
+    private function createDefinition(): AppScriptConditionDefinition
+    {
+        $registry = new StaticDefinitionInstanceRegistry(
+            [AppScriptConditionDefinition::class],
+            static::createStub(ValidatorInterface::class),
+            static::createStub(EntityWriteGateway::class),
+        );
+
+        $definition = $registry->getByEntityName(AppScriptConditionDefinition::ENTITY_NAME);
+        static::assertInstanceOf(AppScriptConditionDefinition::class, $definition);
+
+        return $definition;
+    }
+}

--- a/tests/unit/Core/Framework/App/Aggregate/AppScriptCondition/AppScriptConditionEntityTest.php
+++ b/tests/unit/Core/Framework/App/Aggregate/AppScriptCondition/AppScriptConditionEntityTest.php
@@ -4,7 +4,10 @@ namespace Shopware\Tests\Unit\Core\Framework\App\Aggregate\AppScriptCondition;
 
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Rule\Aggregate\RuleCondition\RuleConditionCollection;
 use Shopware\Core\Framework\App\Aggregate\AppScriptCondition\AppScriptConditionEntity;
+use Shopware\Core\Framework\App\Aggregate\AppScriptConditionTranslation\AppScriptConditionTranslationCollection;
+use Shopware\Core\Framework\App\AppEntity;
 use Shopware\Core\Framework\Log\Package;
 
 /**
@@ -20,5 +23,40 @@ class AppScriptConditionEntityTest extends TestCase
         $entity->setConstraints(['operator' => []]);
 
         static::assertSame(['operator' => []], $entity->getConstraints());
+    }
+
+    public function testAccessorsRoundTrip(): void
+    {
+        $entity = new AppScriptConditionEntity();
+
+        $app = new AppEntity();
+        $ruleConditions = new RuleConditionCollection();
+        $translations = new AppScriptConditionTranslationCollection();
+
+        $entity->setAppId('app-id');
+        $entity->setApp($app);
+        $entity->setIdentifier('app_condition');
+        $entity->setName('Condition');
+        $entity->setActive(true);
+        $entity->setGroup('general');
+        $entity->setScript('return true;');
+        $config = [
+            'name' => 'operator',
+            'config' => ['label' => ['en-GB' => 'Operator'], 'helpText' => ['en-GB' => 'Pick an operator'], 'customFieldPosition' => 1],
+        ];
+        $entity->setConfig($config);
+        $entity->setRuleConditions($ruleConditions);
+        $entity->setTranslations($translations);
+
+        static::assertSame('app-id', $entity->getAppId());
+        static::assertSame($app, $entity->getApp());
+        static::assertSame('app_condition', $entity->getIdentifier());
+        static::assertSame('Condition', $entity->getName());
+        static::assertTrue($entity->isActive());
+        static::assertSame('general', $entity->getGroup());
+        static::assertSame('return true;', $entity->getScript());
+        static::assertSame($config, $entity->getConfig());
+        static::assertSame($ruleConditions, $entity->getRuleConditions());
+        static::assertSame($translations, $entity->getTranslations());
     }
 }

--- a/tests/unit/Core/Framework/App/Aggregate/FlowAction/AppFlowActionDefinitionTest.php
+++ b/tests/unit/Core/Framework/App/Aggregate/FlowAction/AppFlowActionDefinitionTest.php
@@ -1,0 +1,50 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\App\Aggregate\FlowAction;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\App\Aggregate\FlowAction\AppFlowActionCollection;
+use Shopware\Core\Framework\App\Aggregate\FlowAction\AppFlowActionDefinition;
+use Shopware\Core\Framework\App\Aggregate\FlowAction\AppFlowActionEntity;
+use Shopware\Core\Framework\DataAbstractionLayer\Dbal\EntityWriteGateway;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Test\Stub\DataAbstractionLayer\StaticDefinitionInstanceRegistry;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+#[CoversClass(AppFlowActionDefinition::class)]
+class AppFlowActionDefinitionTest extends TestCase
+{
+    public function testEntityConfiguration(): void
+    {
+        $definition = $this->createDefinition();
+
+        static::assertSame(AppFlowActionDefinition::ENTITY_NAME, $definition->getEntityName());
+        static::assertSame(AppFlowActionEntity::class, $definition->getEntityClass());
+        static::assertSame(AppFlowActionCollection::class, $definition->getCollectionClass());
+        static::assertSame('6.4.10.0', $definition->since());
+    }
+
+    public function testFieldsAreDefined(): void
+    {
+        static::assertNotNull($this->createDefinition()->getFields()->get('id'));
+    }
+
+    private function createDefinition(): AppFlowActionDefinition
+    {
+        $registry = new StaticDefinitionInstanceRegistry(
+            [AppFlowActionDefinition::class],
+            static::createStub(ValidatorInterface::class),
+            static::createStub(EntityWriteGateway::class),
+        );
+
+        $definition = $registry->getByEntityName(AppFlowActionDefinition::ENTITY_NAME);
+        static::assertInstanceOf(AppFlowActionDefinition::class, $definition);
+
+        return $definition;
+    }
+}

--- a/tests/unit/Core/Framework/App/Aggregate/FlowAction/AppFlowActionEntityTest.php
+++ b/tests/unit/Core/Framework/App/Aggregate/FlowAction/AppFlowActionEntityTest.php
@@ -5,6 +5,8 @@ namespace Shopware\Tests\Unit\Core\Framework\App\Aggregate\FlowAction;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\App\Aggregate\FlowAction\AppFlowActionEntity;
+use Shopware\Core\Framework\App\Aggregate\FlowActionTranslation\AppFlowActionTranslationCollection;
+use Shopware\Core\Framework\App\AppEntity;
 use Shopware\Core\Framework\Log\Package;
 
 /**
@@ -25,5 +27,49 @@ class AppFlowActionEntityTest extends TestCase
 
         static::assertArrayNotHasKey('iconRaw', $data);
         static::assertSame('action', $data['name']);
+    }
+
+    public function testAccessorsRoundTrip(): void
+    {
+        $entity = new AppFlowActionEntity();
+
+        $app = new AppEntity();
+        $translations = new AppFlowActionTranslationCollection();
+
+        $entity->setAppId('app-id');
+        $entity->setApp($app);
+        $entity->setName('action');
+        $entity->setBadge('badge');
+        $entity->setLabel('label');
+        $entity->setParameters(['to' => 'admin']);
+        $entity->setConfig(['subject' => 'Hello']);
+        $entity->setHeaders(['content-type' => 'application/json']);
+        $entity->setRequirements(['orderAware']);
+        $entity->setDescription('description');
+        $entity->setHeadline('headline');
+        $entity->setIconRaw('icon-raw');
+        $entity->setIcon('icon');
+        $entity->setSwIcon('sw-icon');
+        $entity->setUrl('https://example.com/action');
+        $entity->setDelayable(true);
+        $entity->setTranslations($translations);
+
+        static::assertSame('app-id', $entity->getAppId());
+        static::assertSame($app, $entity->getApp());
+        static::assertSame('action', $entity->getName());
+        static::assertSame('badge', $entity->getBadge());
+        static::assertSame('label', $entity->getLabel());
+        static::assertSame(['to' => 'admin'], $entity->getParameters());
+        static::assertSame(['subject' => 'Hello'], $entity->getConfig());
+        static::assertSame(['content-type' => 'application/json'], $entity->getHeaders());
+        static::assertSame(['orderAware'], $entity->getRequirements());
+        static::assertSame('description', $entity->getDescription());
+        static::assertSame('headline', $entity->getHeadline());
+        static::assertSame('icon-raw', $entity->getIconRaw());
+        static::assertSame('icon', $entity->getIcon());
+        static::assertSame('sw-icon', $entity->getSwIcon());
+        static::assertSame('https://example.com/action', $entity->getUrl());
+        static::assertTrue($entity->getDelayable());
+        static::assertSame($translations, $entity->getTranslations());
     }
 }

--- a/tests/unit/Core/Framework/App/Aggregate/FlowEvent/AppFlowEventDefinitionTest.php
+++ b/tests/unit/Core/Framework/App/Aggregate/FlowEvent/AppFlowEventDefinitionTest.php
@@ -1,0 +1,50 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\App\Aggregate\FlowEvent;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\App\Aggregate\FlowEvent\AppFlowEventCollection;
+use Shopware\Core\Framework\App\Aggregate\FlowEvent\AppFlowEventDefinition;
+use Shopware\Core\Framework\App\Aggregate\FlowEvent\AppFlowEventEntity;
+use Shopware\Core\Framework\DataAbstractionLayer\Dbal\EntityWriteGateway;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Test\Stub\DataAbstractionLayer\StaticDefinitionInstanceRegistry;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+#[CoversClass(AppFlowEventDefinition::class)]
+class AppFlowEventDefinitionTest extends TestCase
+{
+    public function testEntityConfiguration(): void
+    {
+        $definition = $this->createDefinition();
+
+        static::assertSame(AppFlowEventDefinition::ENTITY_NAME, $definition->getEntityName());
+        static::assertSame(AppFlowEventEntity::class, $definition->getEntityClass());
+        static::assertSame(AppFlowEventCollection::class, $definition->getCollectionClass());
+        static::assertSame('6.5.2.0', $definition->since());
+    }
+
+    public function testFieldsAreDefined(): void
+    {
+        static::assertNotNull($this->createDefinition()->getFields()->get('id'));
+    }
+
+    private function createDefinition(): AppFlowEventDefinition
+    {
+        $registry = new StaticDefinitionInstanceRegistry(
+            [AppFlowEventDefinition::class],
+            static::createStub(ValidatorInterface::class),
+            static::createStub(EntityWriteGateway::class),
+        );
+
+        $definition = $registry->getByEntityName(AppFlowEventDefinition::ENTITY_NAME);
+        static::assertInstanceOf(AppFlowEventDefinition::class, $definition);
+
+        return $definition;
+    }
+}

--- a/tests/unit/Core/Framework/App/AppDefinitionTest.php
+++ b/tests/unit/Core/Framework/App/AppDefinitionTest.php
@@ -1,0 +1,51 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\App;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\App\AppCollection;
+use Shopware\Core\Framework\App\AppDefinition;
+use Shopware\Core\Framework\App\AppEntity;
+use Shopware\Core\Framework\DataAbstractionLayer\Dbal\EntityWriteGateway;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Test\Stub\DataAbstractionLayer\StaticDefinitionInstanceRegistry;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+#[CoversClass(AppDefinition::class)]
+class AppDefinitionTest extends TestCase
+{
+    public function testEntityConfiguration(): void
+    {
+        $definition = $this->createDefinition();
+
+        static::assertSame(AppDefinition::ENTITY_NAME, $definition->getEntityName());
+        static::assertSame(AppEntity::class, $definition->getEntityClass());
+        static::assertSame(AppCollection::class, $definition->getCollectionClass());
+        static::assertSame('6.3.1.0', $definition->since());
+        static::assertNotSame([], $definition->getDefaults());
+    }
+
+    public function testFieldsAreDefined(): void
+    {
+        static::assertNotNull($this->createDefinition()->getFields()->get('id'));
+    }
+
+    private function createDefinition(): AppDefinition
+    {
+        $registry = new StaticDefinitionInstanceRegistry(
+            [AppDefinition::class],
+            static::createStub(ValidatorInterface::class),
+            static::createStub(EntityWriteGateway::class),
+        );
+
+        $definition = $registry->getByEntityName(AppDefinition::ENTITY_NAME);
+        static::assertInstanceOf(AppDefinition::class, $definition);
+
+        return $definition;
+    }
+}

--- a/tests/unit/Core/Framework/App/AppEntityTest.php
+++ b/tests/unit/Core/Framework/App/AppEntityTest.php
@@ -1,0 +1,163 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\App;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Api\Acl\Role\AclRoleEntity;
+use Shopware\Core\Framework\App\Aggregate\ActionButton\ActionButtonCollection;
+use Shopware\Core\Framework\App\Aggregate\AppMcpPrompt\AppMcpPromptCollection;
+use Shopware\Core\Framework\App\Aggregate\AppMcpResource\AppMcpResourceCollection;
+use Shopware\Core\Framework\App\Aggregate\AppMcpTool\AppMcpToolCollection;
+use Shopware\Core\Framework\App\Aggregate\AppPaymentMethod\AppPaymentMethodCollection;
+use Shopware\Core\Framework\App\Aggregate\AppScriptCondition\AppScriptConditionCollection;
+use Shopware\Core\Framework\App\Aggregate\AppTranslation\AppTranslationCollection;
+use Shopware\Core\Framework\App\Aggregate\CmsBlock\AppCmsBlockCollection;
+use Shopware\Core\Framework\App\Aggregate\FlowAction\AppFlowActionCollection;
+use Shopware\Core\Framework\App\Aggregate\FlowEvent\AppFlowEventCollection;
+use Shopware\Core\Framework\App\AppEntity;
+use Shopware\Core\Framework\App\Template\TemplateCollection;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Script\ScriptCollection;
+use Shopware\Core\Framework\Webhook\WebhookCollection;
+use Shopware\Core\System\CustomField\Aggregate\CustomFieldSet\CustomFieldSetCollection;
+use Shopware\Core\System\Integration\IntegrationEntity;
+use Shopware\Core\System\TaxProvider\TaxProviderCollection;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+#[CoversClass(AppEntity::class)]
+class AppEntityTest extends TestCase
+{
+    public function testScalarAccessorsRoundTrip(): void
+    {
+        $app = new AppEntity();
+
+        $app->setName('name');
+        $app->setPath('path');
+        $app->setAuthor('author');
+        $app->setCopyright('copyright');
+        $app->setLicense('license');
+        $app->setPrivacy('privacy');
+        $app->setVersion('version');
+        $app->setBaseAppUrl('base-app-url');
+        $app->setCheckoutGatewayUrl('checkout-gateway-url');
+        $app->setContextGatewayUrl('context-gateway-url');
+        $app->setInAppPurchasesGatewayUrl('in-app-purchases-gateway-url');
+        $app->setModules([['name' => 'module', 'label' => ['en-GB' => 'Module'], 'parent' => 'app', 'position' => 1]]);
+        $app->setMainModule(['name' => 'main', 'label' => ['en-GB' => 'Main'], 'parent' => 'app', 'position' => 1]);
+        $app->setCookies([['snippet_name' => 'cookie.name']]);
+        $app->setAllowedHosts(['example.com']);
+        $app->setIconRaw('icon-raw');
+        $app->setIcon('icon');
+        $app->setLabel('label');
+        $app->setDescription('description');
+        $app->setIntegrationId('integration-id');
+        $app->setAclRoleId('acl-role-id');
+        $app->setActive(true);
+        $app->setConfigurable(true);
+        $app->setPrivacyPolicyExtensions('privacy-policy-extensions');
+        $app->setAllowDisable(true);
+        $app->setTemplateLoadPriority(7);
+        $app->setSourceType('source-type');
+        $app->setSourceConfig(['config' => 'config']);
+        $app->setSelfManaged(true);
+        $app->setRequestedPrivileges(['product:read']);
+
+        static::assertSame('name', $app->getName());
+        static::assertSame('path', $app->getPath());
+        static::assertSame('author', $app->getAuthor());
+        static::assertSame('copyright', $app->getCopyright());
+        static::assertSame('license', $app->getLicense());
+        static::assertSame('privacy', $app->getPrivacy());
+        static::assertSame('version', $app->getVersion());
+        static::assertSame('base-app-url', $app->getBaseAppUrl());
+        static::assertSame('checkout-gateway-url', $app->getCheckoutGatewayUrl());
+        static::assertSame('context-gateway-url', $app->getContextGatewayUrl());
+        static::assertSame('in-app-purchases-gateway-url', $app->getInAppPurchasesGatewayUrl());
+        static::assertSame([['name' => 'module', 'label' => ['en-GB' => 'Module'], 'parent' => 'app', 'position' => 1]], $app->getModules());
+        static::assertSame(['name' => 'main', 'label' => ['en-GB' => 'Main'], 'parent' => 'app', 'position' => 1], $app->getMainModule());
+        static::assertSame([['snippet_name' => 'cookie.name']], $app->getCookies());
+        static::assertSame(['example.com'], $app->getAllowedHosts());
+        static::assertSame('icon-raw', $app->getIconRaw());
+        static::assertSame('icon', $app->getIcon());
+        static::assertSame('label', $app->getLabel());
+        static::assertSame('description', $app->getDescription());
+        static::assertSame('integration-id', $app->getIntegrationId());
+        static::assertSame('acl-role-id', $app->getAclRoleId());
+        static::assertTrue($app->isActive());
+        static::assertTrue($app->isConfigurable());
+        static::assertSame('privacy-policy-extensions', $app->getPrivacyPolicyExtensions());
+        static::assertTrue($app->getAllowDisable());
+        static::assertSame(7, $app->getTemplateLoadPriority());
+        static::assertSame('source-type', $app->getSourceType());
+        static::assertSame(['config' => 'config'], $app->getSourceConfig());
+        static::assertTrue($app->isSelfManaged());
+        static::assertSame(['product:read'], $app->getRequestedPrivileges());
+    }
+
+    public function testAssociationAccessorsRoundTrip(): void
+    {
+        $app = new AppEntity();
+
+        $translations = new AppTranslationCollection();
+        $integration = new IntegrationEntity();
+        $aclRole = new AclRoleEntity();
+        $customFieldSets = new CustomFieldSetCollection();
+        $actionButtons = new ActionButtonCollection();
+        $webhooks = new WebhookCollection();
+        $templates = new TemplateCollection();
+        $scripts = new ScriptCollection();
+        $paymentMethods = new AppPaymentMethodCollection();
+        $taxProviders = new TaxProviderCollection();
+        $scriptConditions = new AppScriptConditionCollection();
+        $cmsBlocks = new AppCmsBlockCollection();
+        $flowActions = new AppFlowActionCollection();
+        $flowEvents = new AppFlowEventCollection();
+        $appShippingMethods = new EntityCollection();
+        $mcpTools = new AppMcpToolCollection();
+        $mcpPrompts = new AppMcpPromptCollection();
+        $mcpResources = new AppMcpResourceCollection();
+
+        $app->setTranslations($translations);
+        $app->setIntegration($integration);
+        $app->setAclRole($aclRole);
+        $app->setCustomFieldSets($customFieldSets);
+        $app->setActionButtons($actionButtons);
+        $app->setWebhooks($webhooks);
+        $app->setTemplates($templates);
+        $app->setScripts($scripts);
+        $app->setPaymentMethods($paymentMethods);
+        $app->setTaxProviders($taxProviders);
+        $app->setScriptConditions($scriptConditions);
+        $app->setCmsBlocks($cmsBlocks);
+        $app->setFlowActions($flowActions);
+        $app->setFlowEvents($flowEvents);
+        $app->setAppShippingMethods($appShippingMethods);
+        $app->setMcpTools($mcpTools);
+        $app->setMcpPrompts($mcpPrompts);
+        $app->setMcpResources($mcpResources);
+
+        static::assertSame($translations, $app->getTranslations());
+        static::assertSame($integration, $app->getIntegration());
+        static::assertSame($aclRole, $app->getAclRole());
+        static::assertSame($customFieldSets, $app->getCustomFieldSets());
+        static::assertSame($actionButtons, $app->getActionButtons());
+        static::assertSame($webhooks, $app->getWebhooks());
+        static::assertSame($templates, $app->getTemplates());
+        static::assertSame($scripts, $app->getScripts());
+        static::assertSame($paymentMethods, $app->getPaymentMethods());
+        static::assertSame($taxProviders, $app->getTaxProviders());
+        static::assertSame($scriptConditions, $app->getScriptConditions());
+        static::assertSame($cmsBlocks, $app->getCmsBlocks());
+        static::assertSame($flowActions, $app->getFlowActions());
+        static::assertSame($flowEvents, $app->getFlowEvents());
+        static::assertSame($appShippingMethods, $app->getAppShippingMethods());
+        static::assertSame($mcpTools, $app->getMcpTools());
+        static::assertSame($mcpPrompts, $app->getMcpPrompts());
+        static::assertSame($mcpResources, $app->getMcpResources());
+    }
+}

--- a/tests/unit/Core/Framework/App/Payload/AppPayloadStructTest.php
+++ b/tests/unit/Core/Framework/App/Payload/AppPayloadStructTest.php
@@ -1,0 +1,54 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\App\Payload;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\App\Payload\AppPayloadStruct;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * @internal
+ */
+#[Package('checkout')]
+#[CoversClass(AppPayloadStruct::class)]
+class AppPayloadStructTest extends TestCase
+{
+    public function testConstructorAssignsTheRequestOptions(): void
+    {
+        $context = Context::createDefaultContext();
+
+        $struct = new AppPayloadStruct([
+            'app_request_context' => $context,
+            'request_type' => ['app_secret' => 'secret', 'validated_response' => true],
+            'headers' => ['Content-Type' => 'application/json'],
+            'body' => '{"payload": true}',
+        ]);
+
+        static::assertSame($context, $struct->appRequestContext);
+        static::assertSame(['app_secret' => 'secret', 'validated_response' => true], $struct->requestType);
+        static::assertSame(['Content-Type' => 'application/json'], $struct->headers);
+        static::assertSame('{"payload": true}', $struct->body);
+        static::assertNull($struct->timeout);
+    }
+
+    public function testJsonSerializeUsesSnakeCaseKeys(): void
+    {
+        $struct = new AppPayloadStruct([
+            'app_request_context' => Context::createDefaultContext(),
+            'request_type' => ['app_secret' => 'secret', 'validated_response' => true],
+            'headers' => ['Content-Type' => 'application/json'],
+            'body' => '{}',
+            'timeout' => 5,
+        ]);
+
+        $data = $struct->jsonSerialize();
+
+        static::assertSame(
+            ['app_request_context', 'request_type', 'headers', 'body', 'timeout'],
+            array_keys($data)
+        );
+        static::assertSame(5, $data['timeout']);
+    }
+}

--- a/tests/unit/Core/Framework/App/Template/TemplateDefinitionTest.php
+++ b/tests/unit/Core/Framework/App/Template/TemplateDefinitionTest.php
@@ -1,0 +1,50 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\App\Template;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\App\Template\TemplateCollection;
+use Shopware\Core\Framework\App\Template\TemplateDefinition;
+use Shopware\Core\Framework\App\Template\TemplateEntity;
+use Shopware\Core\Framework\DataAbstractionLayer\Dbal\EntityWriteGateway;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Test\Stub\DataAbstractionLayer\StaticDefinitionInstanceRegistry;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+#[CoversClass(TemplateDefinition::class)]
+class TemplateDefinitionTest extends TestCase
+{
+    public function testEntityConfiguration(): void
+    {
+        $definition = $this->createDefinition();
+
+        static::assertSame(TemplateDefinition::ENTITY_NAME, $definition->getEntityName());
+        static::assertSame(TemplateEntity::class, $definition->getEntityClass());
+        static::assertSame(TemplateCollection::class, $definition->getCollectionClass());
+        static::assertSame('6.3.1.0', $definition->since());
+    }
+
+    public function testFieldsAreDefined(): void
+    {
+        static::assertNotNull($this->createDefinition()->getFields()->get('id'));
+    }
+
+    private function createDefinition(): TemplateDefinition
+    {
+        $registry = new StaticDefinitionInstanceRegistry(
+            [TemplateDefinition::class],
+            static::createStub(ValidatorInterface::class),
+            static::createStub(EntityWriteGateway::class),
+        );
+
+        $definition = $registry->getByEntityName(TemplateDefinition::ENTITY_NAME);
+        static::assertInstanceOf(TemplateDefinition::class, $definition);
+
+        return $definition;
+    }
+}

--- a/tests/unit/Core/Framework/DataAbstractionLayer/AttributeMappingDefinitionTest.php
+++ b/tests/unit/Core/Framework/DataAbstractionLayer/AttributeMappingDefinitionTest.php
@@ -1,0 +1,123 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\DataAbstractionLayer;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\DataAbstractionLayer\AttributeMappingDefinition;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\FkField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\ApiAware;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\PrimaryKey;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\Required;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\IdField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\ReferenceVersionField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\VersionField;
+use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
+use Shopware\Core\Framework\DataAbstractionLayer\Write\EntityWriteGatewayInterface;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Test\Stub\DataAbstractionLayer\StaticDefinitionInstanceRegistry;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+#[CoversClass(AttributeMappingDefinition::class)]
+class AttributeMappingDefinitionTest extends TestCase
+{
+    public function testFieldsAreBuiltFromTheMeta(): void
+    {
+        $definition = new AttributeMappingDefinition([
+            'entity_name' => 'foo_bar_mapping',
+            'source' => 'attribute_mapping_test_source',
+            'reference' => 'attribute_mapping_test_reference',
+            'fields' => [
+                [
+                    'class' => FkField::class,
+                    'args' => ['source_id', 'sourceId', 'attribute_mapping_test_source'],
+                    'flags' => [
+                        PrimaryKey::class => ['class' => PrimaryKey::class],
+                        Required::class => ['class' => Required::class],
+                    ],
+                ],
+                [
+                    'class' => FkField::class,
+                    'args' => ['reference_id', 'referenceId', 'attribute_mapping_test_reference'],
+                ],
+                [
+                    // entries without a field class are skipped
+                    'args' => ['ignored'],
+                ],
+            ],
+        ]);
+
+        new StaticDefinitionInstanceRegistry(
+            [
+                $definition,
+                AttributeMappingTestSourceDefinition::class,
+                AttributeMappingTestReferenceDefinition::class,
+            ],
+            static::createStub(ValidatorInterface::class),
+            static::createStub(EntityWriteGatewayInterface::class)
+        );
+
+        static::assertSame('foo_bar_mapping', $definition->getEntityName());
+
+        $fields = $definition->getFields();
+
+        $sourceId = $fields->get('sourceId');
+        static::assertInstanceOf(FkField::class, $sourceId);
+        static::assertTrue($sourceId->is(PrimaryKey::class));
+        static::assertTrue($sourceId->is(Required::class));
+
+        $referenceId = $fields->get('referenceId');
+        static::assertInstanceOf(FkField::class, $referenceId);
+        static::assertFalse($referenceId->is(PrimaryKey::class));
+
+        // the version-aware source gets a reference version field, the plain reference does not
+        $sourceVersion = $fields->get('attributeMappingTestSourceVersionId');
+        static::assertInstanceOf(ReferenceVersionField::class, $sourceVersion);
+        static::assertTrue($sourceVersion->is(PrimaryKey::class));
+        static::assertNull($fields->get('attributeMappingTestReferenceVersionId'));
+
+        static::assertCount(3, $fields);
+    }
+}
+
+/**
+ * @internal
+ */
+class AttributeMappingTestSourceDefinition extends EntityDefinition
+{
+    public function getEntityName(): string
+    {
+        return 'attribute_mapping_test_source';
+    }
+
+    protected function defineFields(): FieldCollection
+    {
+        return new FieldCollection([
+            (new IdField('id', 'id'))->addFlags(new ApiAware(), new PrimaryKey()),
+            new VersionField(),
+        ]);
+    }
+}
+
+/**
+ * @internal
+ */
+class AttributeMappingTestReferenceDefinition extends EntityDefinition
+{
+    public function getEntityName(): string
+    {
+        return 'attribute_mapping_test_reference';
+    }
+
+    protected function defineFields(): FieldCollection
+    {
+        return new FieldCollection([
+            (new IdField('id', 'id'))->addFlags(new ApiAware(), new PrimaryKey()),
+        ]);
+    }
+}

--- a/tests/unit/Core/Framework/DataAbstractionLayer/CompiledFieldCollectionTest.php
+++ b/tests/unit/Core/Framework/DataAbstractionLayer/CompiledFieldCollectionTest.php
@@ -1,0 +1,94 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\DataAbstractionLayer;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\DataAbstractionLayer\CompiledFieldCollection;
+use Shopware\Core\Framework\DataAbstractionLayer\Dbal\EntityWriteGateway;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\BoolField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\ApiAware;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\Required;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\StringField;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Test\Stub\DataAbstractionLayer\StaticDefinitionInstanceRegistry;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+#[CoversClass(CompiledFieldCollection::class)]
+class CompiledFieldCollectionTest extends TestCase
+{
+    public function testAddNewFieldCompilesAndMapsTheField(): void
+    {
+        $collection = $this->createCollection();
+
+        $field = (new StringField('short_name', 'shortName'))->addFlags(new ApiAware());
+        $collection->addNewField($field);
+
+        static::assertSame($field, $collection->get('shortName'));
+        static::assertSame($field, $collection->getByStorageName('short_name'));
+        static::assertNull($collection->get('unknown'));
+        static::assertNull($collection->getByStorageName('unknown'));
+    }
+
+    public function testAddRejectsUncompiledFields(): void
+    {
+        $collection = $this->createCollection();
+
+        $this->expectException(\BadMethodCallException::class);
+
+        $collection->add(new StringField('short_name', 'shortName'));
+    }
+
+    public function testRemoveDropsTheStorageMapping(): void
+    {
+        $collection = $this->createCollection();
+        $collection->addNewField(new StringField('short_name', 'shortName'));
+
+        $collection->remove('short_name');
+
+        static::assertNull($collection->getByStorageName('short_name'));
+    }
+
+    public function testFilterByFlagKeepsOnlyFlaggedFields(): void
+    {
+        $collection = $this->createCollection();
+        $collection->addNewField((new StringField('short_name', 'shortName'))->addFlags(new Required()));
+        $collection->addNewField(new BoolField('active', 'active'));
+
+        $filtered = $collection->filterByFlag(Required::class);
+
+        static::assertCount(1, $filtered);
+        static::assertNotNull($filtered->get('shortName'));
+    }
+
+    public function testBasicFieldsAndTranslatedAndExtensionFieldsDefaults(): void
+    {
+        $collection = $this->createCollection();
+        $collection->addNewField(new StringField('short_name', 'shortName'));
+
+        static::assertCount(1, $collection->getBasicFields());
+        static::assertSame([], $collection->getTranslatedFields());
+        static::assertSame([], $collection->getExtensionFields());
+        static::assertNull($collection->getChildrenAssociationField());
+    }
+
+    public function testGetApiAlias(): void
+    {
+        static::assertSame('dal_compiled_field_collection', $this->createCollection()->getApiAlias());
+    }
+
+    private function createCollection(): CompiledFieldCollection
+    {
+        $registry = new StaticDefinitionInstanceRegistry(
+            [],
+            static::createStub(ValidatorInterface::class),
+            static::createStub(EntityWriteGateway::class),
+        );
+
+        return new CompiledFieldCollection($registry);
+    }
+}

--- a/tests/unit/Core/Framework/DataAbstractionLayer/Event/EntityLoadedEventTest.php
+++ b/tests/unit/Core/Framework/DataAbstractionLayer/Event/EntityLoadedEventTest.php
@@ -1,0 +1,56 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\DataAbstractionLayer\Event;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\Dbal\EntityWriteGateway;
+use Shopware\Core\Framework\DataAbstractionLayer\Event\EntityLoadedEvent;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Plugin\PluginDefinition;
+use Shopware\Core\Framework\Struct\ArrayEntity;
+use Shopware\Core\Test\Stub\DataAbstractionLayer\StaticDefinitionInstanceRegistry;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+#[CoversClass(EntityLoadedEvent::class)]
+class EntityLoadedEventTest extends TestCase
+{
+    public function testTheEventNameIsDerivedFromTheEntityName(): void
+    {
+        static::assertSame('plugin.loaded', $this->createEvent()->getName());
+    }
+
+    public function testGettersReturnTheConstructorArguments(): void
+    {
+        $event = $this->createEvent();
+
+        static::assertSame(PluginDefinition::ENTITY_NAME, $event->getDefinition()->getEntityName());
+        static::assertCount(2, $event->getEntities());
+        static::assertNull($event->getEvents());
+        static::assertSame(['entity-a', 'entity-b'], $event->getIds());
+        static::assertCount(2, iterator_to_array($event->getIterator()));
+    }
+
+    /**
+     * @return EntityLoadedEvent<ArrayEntity>
+     */
+    private function createEvent(): EntityLoadedEvent
+    {
+        $registry = new StaticDefinitionInstanceRegistry(
+            [PluginDefinition::class],
+            static::createStub(ValidatorInterface::class),
+            static::createStub(EntityWriteGateway::class),
+        );
+
+        return new EntityLoadedEvent(
+            $registry->getByEntityName(PluginDefinition::ENTITY_NAME),
+            [new ArrayEntity(['id' => 'entity-a']), new ArrayEntity(['id' => 'entity-b'])],
+            Context::createDefaultContext(),
+        );
+    }
+}

--- a/tests/unit/Core/Framework/DataAbstractionLayer/Field/ManyToManyAssociationFieldTest.php
+++ b/tests/unit/Core/Framework/DataAbstractionLayer/Field/ManyToManyAssociationFieldTest.php
@@ -1,0 +1,36 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\DataAbstractionLayer\Field;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Category\CategoryDefinition;
+use Shopware\Core\Content\Product\Aggregate\ProductCategory\ProductCategoryDefinition;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\ManyToManyAssociationField;
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+#[CoversClass(ManyToManyAssociationField::class)]
+class ManyToManyAssociationFieldTest extends TestCase
+{
+    public function testConstructorConfiguresTheMappingColumns(): void
+    {
+        $field = new ManyToManyAssociationField(
+            'categories',
+            CategoryDefinition::class,
+            ProductCategoryDefinition::class,
+            'product_id',
+            'category_id'
+        );
+
+        static::assertSame('categories', $field->getPropertyName());
+        static::assertSame(ProductCategoryDefinition::class, $field->getReferenceClass());
+        static::assertSame('id', $field->getReferenceField());
+        static::assertSame('product_id', $field->getMappingLocalColumn());
+        static::assertSame('category_id', $field->getMappingReferenceColumn());
+        static::assertSame('id', $field->getLocalField());
+    }
+}

--- a/tests/unit/Core/Framework/DataAbstractionLayer/Field/ReferenceVersionFieldTest.php
+++ b/tests/unit/Core/Framework/DataAbstractionLayer/Field/ReferenceVersionFieldTest.php
@@ -1,0 +1,34 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\DataAbstractionLayer\Field;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Product\ProductDefinition;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\ReferenceVersionField;
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+#[CoversClass(ReferenceVersionField::class)]
+class ReferenceVersionFieldTest extends TestCase
+{
+    public function testConstructorDerivesStorageAndPropertyNameFromTheDefinition(): void
+    {
+        $field = new ReferenceVersionField(ProductDefinition::class);
+
+        static::assertSame('product_version_id', $field->getStorageName());
+        static::assertSame('productVersionId', $field->getPropertyName());
+        static::assertSame(ProductDefinition::class, $field->getVersionReferenceClass());
+    }
+
+    public function testConstructorUsesAnExplicitStorageName(): void
+    {
+        $field = new ReferenceVersionField(ProductDefinition::class, 'origin_version_id');
+
+        static::assertSame('origin_version_id', $field->getStorageName());
+        static::assertSame('originVersionId', $field->getPropertyName());
+    }
+}

--- a/tests/unit/Core/Framework/Event/NestedEventCollectionTest.php
+++ b/tests/unit/Core/Framework/Event/NestedEventCollectionTest.php
@@ -1,0 +1,59 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\Event;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\Dbal\EntityWriteGateway;
+use Shopware\Core\Framework\DataAbstractionLayer\Event\EntityLoadedEvent;
+use Shopware\Core\Framework\Event\NestedEventCollection;
+use Shopware\Core\Framework\Feature\FeatureException;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Plugin\PluginDefinition;
+use Shopware\Core\Framework\Struct\ArrayEntity;
+use Shopware\Core\Test\Annotation\DisabledFeatures;
+use Shopware\Core\Test\Stub\DataAbstractionLayer\StaticDefinitionInstanceRegistry;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+#[CoversClass(NestedEventCollection::class)]
+class NestedEventCollectionTest extends TestCase
+{
+    public function testGetApiAlias(): void
+    {
+        static::assertSame('dal_nested_event_collection', (new NestedEventCollection())->getApiAlias());
+    }
+
+    public function testGetFlatEventListThrowsWhenTheFeatureIsActive(): void
+    {
+        $this->expectExceptionObject(FeatureException::error(
+            'Tried to access deprecated functionality: Method "Shopware\Core\Framework\Event\NestedEventCollection::getFlatEventList()" is deprecated and will be removed in v6.8.0.0.'
+        ));
+
+        (new NestedEventCollection())->getFlatEventList();
+    }
+
+    #[DisabledFeatures(['v6.8.0.0'])]
+    public function testGetFlatEventListFlattensTheContainedEvents(): void
+    {
+        $registry = new StaticDefinitionInstanceRegistry(
+            [PluginDefinition::class],
+            static::createStub(ValidatorInterface::class),
+            static::createStub(EntityWriteGateway::class),
+        );
+
+        $event = new EntityLoadedEvent(
+            $registry->getByEntityName(PluginDefinition::ENTITY_NAME),
+            [new ArrayEntity(['id' => 'entity-id'])],
+            Context::createDefaultContext(),
+        );
+
+        $flat = (new NestedEventCollection([$event]))->getFlatEventList();
+
+        static::assertSame([$event], array_values($flat->getElements()));
+    }
+}

--- a/tests/unit/Core/Framework/MessageQueue/ScheduledTask/ScheduledTaskEntityTest.php
+++ b/tests/unit/Core/Framework/MessageQueue/ScheduledTask/ScheduledTaskEntityTest.php
@@ -1,0 +1,48 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\MessageQueue\ScheduledTask;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Adapter\Cache\InvalidateCacheTask;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTaskEntity;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+#[CoversClass(ScheduledTaskEntity::class)]
+class ScheduledTaskEntityTest extends TestCase
+{
+    public function testScalarAccessorsRoundTrip(): void
+    {
+        $task = new ScheduledTaskEntity();
+
+        $task->setName('name');
+        $task->setScheduledTaskClass(InvalidateCacheTask::class);
+        $task->setRunInterval(7);
+        $task->setDefaultRunInterval(7);
+        $task->setStatus('status');
+
+        static::assertSame('name', $task->getName());
+        static::assertSame(InvalidateCacheTask::class, $task->getScheduledTaskClass());
+        static::assertSame(7, $task->getRunInterval());
+        static::assertSame(7, $task->getDefaultRunInterval());
+        static::assertSame('status', $task->getStatus());
+    }
+
+    public function testAssociationAccessorsRoundTrip(): void
+    {
+        $task = new ScheduledTaskEntity();
+
+        $lastExecutionTime = new \DateTimeImmutable('2026-01-01 00:00:00');
+        $nextExecutionTime = new \DateTimeImmutable('2026-01-01 00:00:00');
+
+        $task->setLastExecutionTime($lastExecutionTime);
+        $task->setNextExecutionTime($nextExecutionTime);
+
+        static::assertSame($lastExecutionTime, $task->getLastExecutionTime());
+        static::assertSame($nextExecutionTime, $task->getNextExecutionTime());
+    }
+}

--- a/tests/unit/Core/Framework/Notification/NotificationDefinitionTest.php
+++ b/tests/unit/Core/Framework/Notification/NotificationDefinitionTest.php
@@ -1,0 +1,51 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\Notification;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\DataAbstractionLayer\Dbal\EntityWriteGateway;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Notification\NotificationCollection;
+use Shopware\Core\Framework\Notification\NotificationDefinition;
+use Shopware\Core\Framework\Notification\NotificationEntity;
+use Shopware\Core\Test\Stub\DataAbstractionLayer\StaticDefinitionInstanceRegistry;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+#[CoversClass(NotificationDefinition::class)]
+class NotificationDefinitionTest extends TestCase
+{
+    public function testEntityConfiguration(): void
+    {
+        $definition = $this->createDefinition();
+
+        static::assertSame(NotificationDefinition::ENTITY_NAME, $definition->getEntityName());
+        static::assertSame(NotificationEntity::class, $definition->getEntityClass());
+        static::assertSame(NotificationCollection::class, $definition->getCollectionClass());
+        static::assertSame('6.4.7.0', $definition->since());
+        static::assertNotSame([], $definition->getDefaults());
+    }
+
+    public function testFieldsAreDefined(): void
+    {
+        static::assertNotNull($this->createDefinition()->getFields()->get('id'));
+    }
+
+    private function createDefinition(): NotificationDefinition
+    {
+        $registry = new StaticDefinitionInstanceRegistry(
+            [NotificationDefinition::class],
+            static::createStub(ValidatorInterface::class),
+            static::createStub(EntityWriteGateway::class),
+        );
+
+        $definition = $registry->getByEntityName(NotificationDefinition::ENTITY_NAME);
+        static::assertInstanceOf(NotificationDefinition::class, $definition);
+
+        return $definition;
+    }
+}

--- a/tests/unit/Core/Framework/Plugin/KernelPluginCollectionTest.php
+++ b/tests/unit/Core/Framework/Plugin/KernelPluginCollectionTest.php
@@ -1,0 +1,72 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\Plugin;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Plugin\KernelPluginCollection;
+use Shopware\Tests\Unit\Core\Framework\Plugin\_fixtures\ExampleBundle\ExampleBundle;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+#[CoversClass(KernelPluginCollection::class)]
+class KernelPluginCollectionTest extends TestCase
+{
+    public function testAddKeysThePluginByClassAndIgnoresDuplicates(): void
+    {
+        $plugin = new ExampleBundle(true, __DIR__);
+        $duplicate = new ExampleBundle(true, __DIR__);
+
+        $collection = new KernelPluginCollection();
+        $collection->add($plugin);
+        $collection->add($duplicate);
+
+        static::assertTrue($collection->has(ExampleBundle::class));
+        static::assertSame($plugin, $collection->get(ExampleBundle::class));
+        static::assertSame([ExampleBundle::class => $plugin], $collection->all());
+    }
+
+    public function testAddListAddsAllPlugins(): void
+    {
+        $plugin = new ExampleBundle(true, __DIR__);
+
+        $collection = new KernelPluginCollection();
+        $collection->addList([$plugin]);
+
+        static::assertSame([ExampleBundle::class => $plugin], $collection->all());
+    }
+
+    public function testGetReturnsNullForUnknownPlugins(): void
+    {
+        static::assertNull((new KernelPluginCollection())->get('Unknown\Plugin'));
+    }
+
+    public function testGetActivesFiltersInactivePlugins(): void
+    {
+        static::assertSame([], (new KernelPluginCollection())->getActives());
+
+        $active = new ExampleBundle(true, __DIR__);
+        $collection = new KernelPluginCollection([ExampleBundle::class => $active]);
+
+        static::assertSame([ExampleBundle::class => $active], $collection->getActives());
+
+        $inactive = new ExampleBundle(false, __DIR__);
+        $inactiveCollection = new KernelPluginCollection([ExampleBundle::class => $inactive]);
+
+        static::assertSame([], $inactiveCollection->getActives());
+    }
+
+    public function testFilter(): void
+    {
+        $plugin = new ExampleBundle(true, __DIR__);
+        $collection = new KernelPluginCollection([ExampleBundle::class => $plugin]);
+
+        static::assertSame(
+            [ExampleBundle::class => $plugin],
+            $collection->filter(static fn (ExampleBundle $candidate) => $candidate->isActive())->all()
+        );
+    }
+}

--- a/tests/unit/Core/Framework/Plugin/PluginDefinitionTest.php
+++ b/tests/unit/Core/Framework/Plugin/PluginDefinitionTest.php
@@ -1,0 +1,50 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\Plugin;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\DataAbstractionLayer\Dbal\EntityWriteGateway;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Plugin\PluginCollection;
+use Shopware\Core\Framework\Plugin\PluginDefinition;
+use Shopware\Core\Framework\Plugin\PluginEntity;
+use Shopware\Core\Test\Stub\DataAbstractionLayer\StaticDefinitionInstanceRegistry;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+#[CoversClass(PluginDefinition::class)]
+class PluginDefinitionTest extends TestCase
+{
+    public function testEntityConfiguration(): void
+    {
+        $definition = $this->createDefinition();
+
+        static::assertSame(PluginDefinition::ENTITY_NAME, $definition->getEntityName());
+        static::assertSame(PluginEntity::class, $definition->getEntityClass());
+        static::assertSame(PluginCollection::class, $definition->getCollectionClass());
+        static::assertSame('6.0.0.0', $definition->since());
+    }
+
+    public function testFieldsAreDefined(): void
+    {
+        static::assertNotNull($this->createDefinition()->getFields()->get('id'));
+    }
+
+    private function createDefinition(): PluginDefinition
+    {
+        $registry = new StaticDefinitionInstanceRegistry(
+            [PluginDefinition::class],
+            static::createStub(ValidatorInterface::class),
+            static::createStub(EntityWriteGateway::class),
+        );
+
+        $definition = $registry->getByEntityName(PluginDefinition::ENTITY_NAME);
+        static::assertInstanceOf(PluginDefinition::class, $definition);
+
+        return $definition;
+    }
+}

--- a/tests/unit/Core/Framework/Plugin/PluginEntityTest.php
+++ b/tests/unit/Core/Framework/Plugin/PluginEntityTest.php
@@ -1,0 +1,82 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\Plugin;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Checkout\Payment\PaymentMethodCollection;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Plugin\Aggregate\PluginTranslation\PluginTranslationCollection;
+use Shopware\Core\Framework\Plugin\PluginEntity;
+use Shopware\Tests\Unit\Core\Framework\Plugin\_fixtures\ExampleBundle\ExampleBundle;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+#[CoversClass(PluginEntity::class)]
+class PluginEntityTest extends TestCase
+{
+    public function testScalarAccessorsRoundTrip(): void
+    {
+        $plugin = new PluginEntity();
+
+        $plugin->setBaseClass(ExampleBundle::class);
+        $plugin->setName('name');
+        $plugin->setComposerName('composer-name');
+        $plugin->setActive(true);
+        $plugin->setManagedByComposer(true);
+        $plugin->setPath('path');
+        $plugin->setAuthor('author');
+        $plugin->setCopyright('copyright');
+        $plugin->setLicense('license');
+        $plugin->setVersion('version');
+        $plugin->setUpgradeVersion('upgrade-version');
+        $plugin->setIconRaw('icon-raw');
+        $plugin->setIcon('icon');
+        $plugin->setLabel('label');
+        $plugin->setDescription('description');
+        $plugin->setManufacturerLink('manufacturer-link');
+        $plugin->setSupportLink('support-link');
+        $plugin->setAutoload(['psr-4' => ['Swag\\' => 'src/']]);
+
+        static::assertSame(ExampleBundle::class, $plugin->getBaseClass());
+        static::assertSame('name', $plugin->getName());
+        static::assertSame('composer-name', $plugin->getComposerName());
+        static::assertTrue($plugin->getActive());
+        static::assertTrue($plugin->getManagedByComposer());
+        static::assertSame('path', $plugin->getPath());
+        static::assertSame('author', $plugin->getAuthor());
+        static::assertSame('copyright', $plugin->getCopyright());
+        static::assertSame('license', $plugin->getLicense());
+        static::assertSame('version', $plugin->getVersion());
+        static::assertSame('upgrade-version', $plugin->getUpgradeVersion());
+        static::assertSame('icon-raw', $plugin->getIconRaw());
+        static::assertSame('icon', $plugin->getIcon());
+        static::assertSame('label', $plugin->getLabel());
+        static::assertSame('description', $plugin->getDescription());
+        static::assertSame('manufacturer-link', $plugin->getManufacturerLink());
+        static::assertSame('support-link', $plugin->getSupportLink());
+        static::assertSame(['psr-4' => ['Swag\\' => 'src/']], $plugin->getAutoload());
+    }
+
+    public function testAssociationAccessorsRoundTrip(): void
+    {
+        $plugin = new PluginEntity();
+
+        $installedAt = new \DateTimeImmutable('2026-01-01 00:00:00');
+        $upgradedAt = new \DateTimeImmutable('2026-01-01 00:00:00');
+        $translations = new PluginTranslationCollection();
+        $paymentMethods = new PaymentMethodCollection();
+
+        $plugin->setInstalledAt($installedAt);
+        $plugin->setUpgradedAt($upgradedAt);
+        $plugin->setTranslations($translations);
+        $plugin->setPaymentMethods($paymentMethods);
+
+        static::assertSame($installedAt, $plugin->getInstalledAt());
+        static::assertSame($upgradedAt, $plugin->getUpgradedAt());
+        static::assertSame($translations, $plugin->getTranslations());
+        static::assertSame($paymentMethods, $plugin->getPaymentMethods());
+    }
+}

--- a/tests/unit/Core/Framework/Store/Struct/CartPositionStructTest.php
+++ b/tests/unit/Core/Framework/Store/Struct/CartPositionStructTest.php
@@ -24,4 +24,31 @@ class CartPositionStructTest extends TestCase
         static::assertSame(10.0, $data['netPrice']);
         static::assertSame(11.9, $data['grossPrice']);
     }
+
+    public function testAccessorsRoundTrip(): void
+    {
+        $position = new CartPositionStruct();
+
+        $position->setNetPrice(10.0);
+        $position->setTaxValue(1.9);
+        $position->setGrossPrice(11.9);
+        $position->setPseudoPrice(14.9);
+        $position->setFirstMonthFree(true);
+        $position->setDiscountAppliesForMonths(3);
+        $position->setExtensionInformation(['id' => 7, 'name' => 'SwagExtension']);
+        $position->setVariant(['id' => 11, 'name' => 'rent']);
+
+        static::assertSame(10.0, $position->getNetPrice());
+        static::assertSame(1.9, $position->getTaxValue());
+        static::assertSame(11.9, $position->getGrossPrice());
+        static::assertSame(14.9, $position->getPseudoPrice());
+        static::assertTrue($position->isFirstMonthFree());
+        static::assertSame(3, $position->getDiscountAppliesForMonths());
+        static::assertSame(['id' => 7, 'name' => 'SwagExtension'], $position->getExtensionInformation());
+        static::assertSame(7, $position->getExtensionId());
+        static::assertSame('SwagExtension', $position->getExtensionName());
+        static::assertSame(['id' => 11, 'name' => 'rent'], $position->getVariant());
+        static::assertSame(11, $position->getVariantId());
+        static::assertSame('rent', $position->getVariantType());
+    }
 }

--- a/tests/unit/Core/Framework/Store/Struct/CartStructTest.php
+++ b/tests/unit/Core/Framework/Store/Struct/CartStructTest.php
@@ -5,6 +5,7 @@ namespace Shopware\Tests\Unit\Core\Framework\Store\Struct;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Store\Struct\CartPositionCollection;
 use Shopware\Core\Framework\Store\Struct\CartPositionStruct;
 use Shopware\Core\Framework\Store\Struct\CartStruct;
 
@@ -39,5 +40,28 @@ class CartStructTest extends TestCase
 
         static::assertArrayNotHasKey('extensions', $data);
         static::assertSame(10.0, $data['netPrice']);
+    }
+
+    public function testAccessorsRoundTrip(): void
+    {
+        $cart = new CartStruct();
+
+        $positions = new CartPositionCollection();
+
+        $cart->setNetPrice(10.0);
+        $cart->setTaxValue(1.9);
+        $cart->setTaxRate(19.0);
+        $cart->setGrossPrice(11.9);
+        $cart->setPositions($positions);
+        $cart->setShop(['id' => 7, 'domain' => 'example.com']);
+
+        static::assertSame(10.0, $cart->getNetPrice());
+        static::assertSame(1.9, $cart->getTaxValue());
+        static::assertSame(19.0, $cart->getTaxRate());
+        static::assertSame(11.9, $cart->getGrossPrice());
+        static::assertSame($positions, $cart->getPositions());
+        static::assertSame(['id' => 7, 'domain' => 'example.com'], $cart->getShop());
+        static::assertSame(7, $cart->getShopId());
+        static::assertSame('example.com', $cart->getShopDomain());
     }
 }

--- a/tests/unit/Core/Framework/Store/Struct/DiscountCampaignStructTest.php
+++ b/tests/unit/Core/Framework/Store/Struct/DiscountCampaignStructTest.php
@@ -1,0 +1,56 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\Store\Struct;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Store\Struct\DiscountCampaignStruct;
+
+/**
+ * @internal
+ */
+#[Package('checkout')]
+#[CoversClass(DiscountCampaignStruct::class)]
+class DiscountCampaignStructTest extends TestCase
+{
+    public function testFromArrayConvertsTheDateStrings(): void
+    {
+        $campaign = DiscountCampaignStruct::fromArray([
+            'name' => 'Summer Sale',
+            'discount' => 25.0,
+            'startDate' => '2026-06-01 00:00:00',
+            'endDate' => '2026-06-30 00:00:00',
+        ]);
+
+        static::assertInstanceOf(DiscountCampaignStruct::class, $campaign);
+        static::assertSame('Summer Sale', $campaign->getName());
+        static::assertSame(25.0, $campaign->getDiscount());
+        static::assertSame('2026-06-01', $campaign->getStartDate()->format('Y-m-d'));
+        static::assertSame('2026-06-30', $campaign->getEndDate()->format('Y-m-d'));
+    }
+
+    public function testAccessorsRoundTrip(): void
+    {
+        $campaign = new DiscountCampaignStruct();
+
+        $start = new \DateTimeImmutable('2026-06-01');
+        $end = new \DateTimeImmutable('2026-06-30');
+
+        $campaign->setName('Summer Sale');
+        $campaign->setStartDate($start);
+        $campaign->setEndDate($end);
+        $campaign->setDiscount(25.0);
+        $campaign->setDiscountedPrice(14.25);
+        $campaign->setDiscountedPricePerMonth(1.19);
+        $campaign->setDiscountAppliesForMonths(3);
+
+        static::assertSame('Summer Sale', $campaign->getName());
+        static::assertSame($start, $campaign->getStartDate());
+        static::assertSame($end, $campaign->getEndDate());
+        static::assertSame(25.0, $campaign->getDiscount());
+        static::assertSame(14.25, $campaign->getDiscountedPrice());
+        static::assertSame(1.19, $campaign->getDiscountedPricePerMonth());
+        static::assertSame(3, $campaign->getDiscountAppliesForMonths());
+    }
+}

--- a/tests/unit/Core/Framework/Store/Struct/ExtensionStructTest.php
+++ b/tests/unit/Core/Framework/Store/Struct/ExtensionStructTest.php
@@ -7,8 +7,14 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\FrameworkException;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Store\Struct\BinaryCollection;
 use Shopware\Core\Framework\Store\Struct\ExtensionStruct;
+use Shopware\Core\Framework\Store\Struct\FaqCollection;
+use Shopware\Core\Framework\Store\Struct\ImageCollection;
+use Shopware\Core\Framework\Store\Struct\LicenseStruct;
 use Shopware\Core\Framework\Store\Struct\PermissionCollection;
+use Shopware\Core\Framework\Store\Struct\StoreCategoryCollection;
+use Shopware\Core\Framework\Store\Struct\VariantCollection;
 
 /**
  * @internal
@@ -65,6 +71,113 @@ class ExtensionStructTest extends TestCase
         yield [['type' => 'foo']];
         yield [['name' => 'foo', 'label' => 'bar']];
         yield [['label' => 'bar', 'type' => 'foobar']];
+    }
+
+    public function testScalarAccessorsRoundTrip(): void
+    {
+        $extension = new ExtensionStruct();
+
+        $extension->setId(7);
+        $extension->setLocalId('local-id');
+        $extension->setName('name');
+        $extension->setLabel('label');
+        $extension->setDescription('description');
+        $extension->setShortDescription('short-description');
+        $extension->setProducerName('producer-name');
+        $extension->setLicense('license');
+        $extension->setVersion('version');
+        $extension->setLatestVersion('latest-version');
+        $extension->setPrivacyPolicyLink('privacy-policy-link');
+        $extension->setLanguages(['languages' => 'languages']);
+        $extension->setRating(7.5);
+        $extension->setNumberOfRatings(7);
+        $extension->setIcon('icon');
+        $extension->setIconRaw('icon-raw');
+        $extension->setActive(true);
+        $extension->setType('type');
+        $extension->setConfigurable(true);
+        $extension->setPrivacyPolicyExtension('privacy-policy-extension');
+        $extension->setNotices(['notices' => 'notices']);
+        $extension->setSource('source');
+        $extension->setUpdateSource('update-source');
+        $extension->setAllowDisable(true);
+        $extension->setAllowUpdate(true);
+        $extension->setDomains(['domains' => 'domains']);
+        $extension->setLastUpdateDate('last-update-date');
+        $extension->setProducerWebsite('producer-website');
+        $extension->setStoreUrl('store-url');
+        $extension->setInAppFeaturesAvailable(true);
+        $extension->setInAppPurchases(['iap-1']);
+
+        static::assertSame(7, $extension->getId());
+        static::assertSame('local-id', $extension->getLocalId());
+        static::assertSame('name', $extension->getName());
+        static::assertSame('label', $extension->getLabel());
+        static::assertSame('description', $extension->getDescription());
+        static::assertSame('short-description', $extension->getShortDescription());
+        static::assertSame('producer-name', $extension->getProducerName());
+        static::assertSame('license', $extension->getLicense());
+        static::assertSame('version', $extension->getVersion());
+        static::assertSame('latest-version', $extension->getLatestVersion());
+        static::assertSame('privacy-policy-link', $extension->getPrivacyPolicyLink());
+        static::assertSame(['languages' => 'languages'], $extension->getLanguages());
+        static::assertSame(7.5, $extension->getRating());
+        static::assertSame(7, $extension->getNumberOfRatings());
+        static::assertSame('icon', $extension->getIcon());
+        static::assertSame('icon-raw', $extension->getIconRaw());
+        static::assertTrue($extension->getActive());
+        static::assertSame('type', $extension->getType());
+        static::assertTrue($extension->isConfigurable());
+        static::assertSame('privacy-policy-extension', $extension->getPrivacyPolicyExtension());
+        static::assertSame(['notices' => 'notices'], $extension->getNotices());
+        static::assertSame('source', $extension->getSource());
+        static::assertSame('update-source', $extension->getUpdateSource());
+        static::assertTrue($extension->isAllowDisable());
+        static::assertTrue($extension->isAllowUpdate());
+        static::assertSame(['domains' => 'domains'], $extension->getDomains());
+        static::assertSame('last-update-date', $extension->getLastUpdateDate());
+        static::assertSame('producer-website', $extension->getProducerWebsite());
+        static::assertSame('store-url', $extension->getStoreUrl());
+        static::assertTrue($extension->isInAppFeaturesAvailable());
+        static::assertSame(['iap-1'], $extension->getInAppPurchases());
+    }
+
+    public function testAssociationAccessorsRoundTrip(): void
+    {
+        $extension = new ExtensionStruct();
+
+        $variants = new VariantCollection();
+        $faq = new FaqCollection();
+        $binaries = new BinaryCollection();
+        $images = new ImageCollection();
+        $categories = new StoreCategoryCollection();
+        $permissions = new PermissionCollection();
+        $storeLicense = new LicenseStruct();
+        $installedAt = new \DateTimeImmutable('2026-01-01 00:00:00');
+        $storeExtension = new ExtensionStruct();
+        $updatedAt = new \DateTimeImmutable('2026-01-01 00:00:00');
+
+        $extension->setVariants($variants);
+        $extension->setFaq($faq);
+        $extension->setBinaries($binaries);
+        $extension->setImages($images);
+        $extension->setCategories($categories);
+        $extension->setPermissions($permissions);
+        $extension->setStoreLicense($storeLicense);
+        $extension->setInstalledAt($installedAt);
+        $extension->setStoreExtension($storeExtension);
+        $extension->setUpdatedAt($updatedAt);
+
+        static::assertSame($variants, $extension->getVariants());
+        static::assertSame($faq, $extension->getFaq());
+        static::assertSame($binaries, $extension->getBinaries());
+        static::assertSame($images, $extension->getImages());
+        static::assertSame($categories, $extension->getCategories());
+        static::assertSame($permissions, $extension->getPermissions());
+        static::assertSame($storeLicense, $extension->getStoreLicense());
+        static::assertSame($installedAt, $extension->getInstalledAt());
+        static::assertSame($storeExtension, $extension->getStoreExtension());
+        static::assertSame($updatedAt, $extension->getUpdatedAt());
     }
 
     /**

--- a/tests/unit/Core/Framework/Store/Struct/LicenseStructTest.php
+++ b/tests/unit/Core/Framework/Store/Struct/LicenseStructTest.php
@@ -1,0 +1,57 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\Store\Struct;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Store\Struct\ExtensionStruct;
+use Shopware\Core\Framework\Store\Struct\LicenseStruct;
+use Shopware\Core\Framework\Store\Struct\StoreLicenseSubscriptionStruct;
+
+/**
+ * @internal
+ */
+#[Package('checkout')]
+#[CoversClass(LicenseStruct::class)]
+class LicenseStructTest extends TestCase
+{
+    public function testFromArrayConvertsTheDateStrings(): void
+    {
+        $license = LicenseStruct::fromArray([
+            'id' => 7,
+            'variant' => 'rent',
+            'netPrice' => 19.0,
+            'creationDate' => '2026-01-01 00:00:00',
+            'nextBookingDate' => '2026-02-01 00:00:00',
+            'expirationDate' => '2026-03-01 00:00:00',
+        ]);
+
+        static::assertSame(7, $license->getId());
+        static::assertSame('rent', $license->getVariant());
+        static::assertSame(19.0, $license->getNetPrice());
+        static::assertSame('2026-01-01', $license->getCreationDate()->format('Y-m-d'));
+        static::assertSame('2026-02-01', $license->getNextBookingDate()?->format('Y-m-d'));
+        static::assertSame('2026-03-01', $license->getExpirationDate()?->format('Y-m-d'));
+    }
+
+    public function testAccessorsRoundTrip(): void
+    {
+        $license = new LicenseStruct();
+
+        $extension = new ExtensionStruct();
+        $subscription = new StoreLicenseSubscriptionStruct();
+
+        $license->setLicensedExtension($extension);
+        $license->setSubscription($subscription);
+        $license->setTrialPhaseIncluded(true);
+        $license->setDiscountInformation(['discountedPrice' => 9.5, 'firstDateOfFullCharging' => '2026-04-01']);
+
+        static::assertSame($extension, $license->getLicensedExtension());
+        static::assertSame(['discountedPrice' => 9.5, 'firstDateOfFullCharging' => '2026-04-01'], $license->getDiscountInformation());
+        static::assertSame($subscription, $license->getSubscription());
+        static::assertTrue($license->isTrialPhaseIncluded());
+        static::assertNull($license->getNextBookingDate());
+        static::assertNull($license->getExpirationDate());
+    }
+}

--- a/tests/unit/Core/Framework/Store/Struct/VariantStructTest.php
+++ b/tests/unit/Core/Framework/Store/Struct/VariantStructTest.php
@@ -1,0 +1,51 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\Store\Struct;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Store\Struct\DiscountCampaignStruct;
+use Shopware\Core\Framework\Store\Struct\VariantStruct;
+
+/**
+ * @internal
+ */
+#[Package('checkout')]
+#[CoversClass(VariantStruct::class)]
+class VariantStructTest extends TestCase
+{
+    public function testFromArrayBuildsTheNestedDiscountCampaign(): void
+    {
+        $variant = VariantStruct::fromArray([
+            'id' => 7,
+            'type' => VariantStruct::TYPE_RENT,
+            'netPrice' => 12.0,
+            'netPricePerMonth' => 1.0,
+            'duration' => VariantStruct::RENT_DURATION_YEARLY,
+            'discountCampaign' => ['name' => 'Summer Sale', 'discount' => 25.0],
+        ]);
+
+        static::assertInstanceOf(VariantStruct::class, $variant);
+        static::assertSame(7, $variant->getId());
+        static::assertSame(VariantStruct::TYPE_RENT, $variant->getType());
+        static::assertSame(12.0, $variant->getNetPrice());
+        static::assertSame(1.0, $variant->getNetPricePerMonth());
+        static::assertSame(VariantStruct::RENT_DURATION_YEARLY, $variant->getDuration());
+        static::assertSame('Summer Sale', $variant->getDiscountCampaign()?->getName());
+        static::assertFalse($variant->isTrialPhaseIncluded());
+    }
+
+    public function testAccessorsRoundTrip(): void
+    {
+        $variant = new VariantStruct();
+
+        $campaign = new DiscountCampaignStruct();
+
+        $variant->setTrialPhaseIncluded(true);
+        $variant->setDiscountCampaign($campaign);
+
+        static::assertTrue($variant->isTrialPhaseIncluded());
+        static::assertSame($campaign, $variant->getDiscountCampaign());
+    }
+}

--- a/tests/unit/Core/Framework/Struct/ArrayEntityTest.php
+++ b/tests/unit/Core/Framework/Struct/ArrayEntityTest.php
@@ -1,0 +1,110 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\Struct;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Struct\ArrayEntity;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+#[CoversClass(ArrayEntity::class)]
+class ArrayEntityTest extends TestCase
+{
+    public function testMagicAccessReadsAndWritesTheData(): void
+    {
+        $entity = new ArrayEntity(['name' => 'shopware']);
+
+        static::assertSame('shopware', $entity->__get('name'));
+        static::assertTrue($entity->__isset('name'));
+        static::assertFalse($entity->__isset('version'));
+
+        $entity->__set('version', '6.7');
+        static::assertSame('6.7', $entity->__get('version'));
+    }
+
+    public function testSettingTheIdUpdatesTheUniqueIdentifier(): void
+    {
+        $entity = new ArrayEntity();
+        $entity->__set('id', 'entity-id');
+
+        static::assertSame('entity-id', $entity->getId());
+        static::assertSame('entity-id', $entity->getUniqueIdentifier());
+    }
+
+    public function testGetUniqueIdentifierFallsBackToTheIdInTheData(): void
+    {
+        static::assertSame('data-id', (new ArrayEntity(['id' => 'data-id']))->getUniqueIdentifier());
+    }
+
+    public function testArrayAccess(): void
+    {
+        $entity = new ArrayEntity(['name' => 'shopware']);
+
+        static::assertTrue($entity->offsetExists('name'));
+        static::assertSame('shopware', $entity->offsetGet('name'));
+        static::assertNull($entity->offsetGet('unknown'));
+
+        $entity->offsetSet('version', '6.7');
+        static::assertSame('6.7', $entity->offsetGet('version'));
+
+        $entity->offsetUnset('version');
+        static::assertFalse($entity->offsetExists('version'));
+    }
+
+    public function testGetSetHasAndAll(): void
+    {
+        $entity = new ArrayEntity(['name' => 'shopware']);
+
+        static::assertTrue($entity->has('name'));
+        static::assertFalse($entity->has('version'));
+        static::assertSame('shopware', $entity->get('name'));
+
+        $entity->set('version', '6.7');
+
+        static::assertSame(['name' => 'shopware', 'version' => '6.7'], $entity->all());
+    }
+
+    public function testAssignMergesTheDataAndUpdatesTheUniqueIdentifier(): void
+    {
+        $entity = new ArrayEntity(['name' => 'shopware', 'config' => ['a' => 1]]);
+
+        $entity->assign(['id' => 'assigned-id', 'config' => ['b' => 2]]);
+
+        static::assertSame('assigned-id', $entity->getUniqueIdentifier());
+        static::assertSame(['a' => 1, 'b' => 2], $entity->get('config'));
+    }
+
+    public function testTranslationsLiveInTheTranslatedDataKey(): void
+    {
+        $entity = new ArrayEntity();
+
+        static::assertSame([], $entity->getTranslated());
+        static::assertNull($entity->getTranslation('name'));
+
+        $entity->addTranslated('name', 'shopware');
+
+        static::assertSame('shopware', $entity->getTranslation('name'));
+        static::assertSame(['name' => 'shopware'], $entity->getTranslated());
+    }
+
+    public function testGetVarsMergesTheDataOneLevelUp(): void
+    {
+        $vars = (new ArrayEntity(['name' => 'shopware']))->getVars();
+
+        static::assertArrayNotHasKey('data', $vars);
+        static::assertSame('shopware', $vars['name']);
+    }
+
+    public function testJsonSerializeFlattensTheData(): void
+    {
+        $json = (new ArrayEntity(['name' => 'shopware']))->jsonSerialize();
+
+        static::assertArrayNotHasKey('data', $json);
+        static::assertArrayNotHasKey('createdAt', $json);
+        static::assertSame('shopware', $json['name']);
+    }
+}

--- a/tests/unit/Core/Framework/Webhook/EventLog/WebhookEventLogDefinitionTest.php
+++ b/tests/unit/Core/Framework/Webhook/EventLog/WebhookEventLogDefinitionTest.php
@@ -1,0 +1,51 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\Webhook\EventLog;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\DataAbstractionLayer\Dbal\EntityWriteGateway;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Webhook\EventLog\WebhookEventLogCollection;
+use Shopware\Core\Framework\Webhook\EventLog\WebhookEventLogDefinition;
+use Shopware\Core\Framework\Webhook\EventLog\WebhookEventLogEntity;
+use Shopware\Core\Test\Stub\DataAbstractionLayer\StaticDefinitionInstanceRegistry;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+#[CoversClass(WebhookEventLogDefinition::class)]
+class WebhookEventLogDefinitionTest extends TestCase
+{
+    public function testEntityConfiguration(): void
+    {
+        $definition = $this->createDefinition();
+
+        static::assertSame(WebhookEventLogDefinition::ENTITY_NAME, $definition->getEntityName());
+        static::assertSame(WebhookEventLogEntity::class, $definition->getEntityClass());
+        static::assertSame(WebhookEventLogCollection::class, $definition->getCollectionClass());
+        static::assertSame('6.4.1.0', $definition->since());
+        static::assertNotSame([], $definition->getDefaults());
+    }
+
+    public function testFieldsAreDefined(): void
+    {
+        static::assertNotNull($this->createDefinition()->getFields()->get('id'));
+    }
+
+    private function createDefinition(): WebhookEventLogDefinition
+    {
+        $registry = new StaticDefinitionInstanceRegistry(
+            [WebhookEventLogDefinition::class],
+            static::createStub(ValidatorInterface::class),
+            static::createStub(EntityWriteGateway::class),
+        );
+
+        $definition = $registry->getByEntityName(WebhookEventLogDefinition::ENTITY_NAME);
+        static::assertInstanceOf(WebhookEventLogDefinition::class, $definition);
+
+        return $definition;
+    }
+}

--- a/tests/unit/Core/Framework/Webhook/EventLog/WebhookEventLogEntityTest.php
+++ b/tests/unit/Core/Framework/Webhook/EventLog/WebhookEventLogEntityTest.php
@@ -21,4 +21,39 @@ class WebhookEventLogEntityTest extends TestCase
 
         static::assertSame('serialized-message', $entity->getSerializedWebhookMessage());
     }
+
+    public function testAccessorsRoundTrip(): void
+    {
+        $entity = new WebhookEventLogEntity();
+
+        $entity->setAppName('app');
+        $entity->setWebhookName('hook');
+        $entity->setEventName('checkout.order.placed');
+        $entity->setDeliveryStatus('queued');
+        $entity->setTimestamp(1725105600);
+        $entity->setProcessingTime(42);
+        $entity->setAppVersion('1.2.3');
+        $entity->setRequestContent(['payload' => 'request']);
+        $entity->setResponseContent(['payload' => 'response']);
+        $entity->setResponseStatusCode(200);
+        $entity->setResponseReasonPhrase('OK');
+        $entity->setUrl('https://example.com/hook');
+        $entity->setOnlyLiveVersion(true);
+        $entity->setSequence(7);
+
+        static::assertSame('app', $entity->getAppName());
+        static::assertSame('hook', $entity->getWebhookName());
+        static::assertSame('checkout.order.placed', $entity->getEventName());
+        static::assertSame('queued', $entity->getDeliveryStatus());
+        static::assertSame(1725105600, $entity->getTimestamp());
+        static::assertSame(42, $entity->getProcessingTime());
+        static::assertSame('1.2.3', $entity->getAppVersion());
+        static::assertSame(['payload' => 'request'], $entity->getRequestContent());
+        static::assertSame(['payload' => 'response'], $entity->getResponseContent());
+        static::assertSame(200, $entity->getResponseStatusCode());
+        static::assertSame('OK', $entity->getResponseReasonPhrase());
+        static::assertSame('https://example.com/hook', $entity->getUrl());
+        static::assertTrue($entity->getOnlyLiveVersion());
+        static::assertSame(7, $entity->getSequence());
+    }
 }

--- a/tests/unit/Core/Framework/Webhook/WebhookCollectionTest.php
+++ b/tests/unit/Core/Framework/Webhook/WebhookCollectionTest.php
@@ -1,0 +1,80 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\Webhook;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\App\AppEntity;
+use Shopware\Core\Framework\App\Event\AppUpdatedEvent;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\Framework\Webhook\WebhookCollection;
+use Shopware\Core\Framework\Webhook\WebhookEntity;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+#[CoversClass(WebhookCollection::class)]
+class WebhookCollectionTest extends TestCase
+{
+    public function testFilterForEvent(): void
+    {
+        $match = self::webhook('order', 'checkout.order.placed');
+
+        $collection = new WebhookCollection([$match, self::webhook('customer', 'customer.registered')]);
+        $filtered = $collection->filterForEvent('checkout.order.placed');
+
+        static::assertSame([$match], array_values($filtered->getElements()));
+    }
+
+    public function testGetAclRoleIdsAsBinaryCollectsOnlyAppWebhooks(): void
+    {
+        $aclRoleId = Uuid::randomHex();
+
+        $appWebhook = self::webhook('app-hook', 'checkout.order.placed');
+        $app = new AppEntity();
+        $app->setAclRoleId($aclRoleId);
+        $appWebhook->setApp($app);
+
+        $collection = new WebhookCollection([$appWebhook, self::webhook('plain', 'customer.registered')]);
+
+        static::assertSame([Uuid::fromHexToBytes($aclRoleId)], $collection->getAclRoleIdsAsBinary());
+    }
+
+    public function testAllowedForDispatching(): void
+    {
+        $plain = self::webhook('plain', 'customer.registered');
+
+        $activeApp = new AppEntity();
+        $activeApp->setActive(true);
+        $activeAppWebhook = self::webhook('active-app', 'checkout.order.placed');
+        $activeAppWebhook->setApp($activeApp);
+
+        $inactiveApp = new AppEntity();
+        $inactiveApp->setActive(false);
+        $inactiveAppWebhook = self::webhook('inactive-app', 'checkout.order.placed');
+        $inactiveAppWebhook->setApp($inactiveApp);
+
+        $lifecycleWebhook = self::webhook('lifecycle', AppUpdatedEvent::NAME);
+        $inactiveAppForLifecycle = new AppEntity();
+        $inactiveAppForLifecycle->setActive(false);
+        $lifecycleWebhook->setApp($inactiveAppForLifecycle);
+
+        $collection = new WebhookCollection([$plain, $activeAppWebhook, $inactiveAppWebhook, $lifecycleWebhook]);
+
+        static::assertSame(
+            ['plain', 'active-app', 'lifecycle'],
+            array_keys($collection->allowedForDispatching()->getElements())
+        );
+    }
+
+    private static function webhook(string $id, string $eventName): WebhookEntity
+    {
+        $webhook = new WebhookEntity();
+        $webhook->setUniqueIdentifier($id);
+        $webhook->setEventName($eventName);
+
+        return $webhook;
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?

PHPUnit 12 reports classes that are excluded from the coverage source as invalid `#[CoversClass]` targets. With every remaining matched class annotated or tested in the layers below, the last blanket suffix excludes can go.

### 2. What does this change do, exactly?

- Removes the remaining suffix excludes from `phpunit.xml.dist`: `src/Core/Framework`, `src/Core/Installer`, `src/Core/Maintenance`, `src/Core/Service`, and the `src/Administration` Notification and Snippet directories. The deliberate whole-directory excludes (migrations, DevOps tooling, test fixtures, BC-change markers) stay.
- Annotates the 2 remaining after-sales-owned boilerplate classes with `@codeCoverageIgnore`.
- Adds unit tests for the logic the lifted excludes surface: accessor round trips for the app, plugin, scheduled-task, and extension entities and structs, entity configuration tests for nine DAL definitions, and behavioral tests for the array entity, the compiled field collection, the cache tag collection, the kernel plugin and webhook collections, the nested event collection, the entity loaded event, and the store license, discount campaign, and variant structs.

### 3. Describe each step to reproduce the issue or behaviour.

Run the unit suite with a coverage driver under PHPUnit 12: the remaining suffix excludes previously reported every `#[CoversClass]` pointing at a matched class as an invalid coverage target.

### 4. Please link to the relevant issues (if any).

- relates #18344

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
