### PR TITLE
test(core): derive expected currency name from Intl in ShopConfiguratorTest

### DIFF
--- a/tests/integration/Core/Maintenance/System/Service/ShopConfiguratorTest.php
+++ b/tests/integration/Core/Maintenance/System/Service/ShopConfiguratorTest.php
@@ -16,6 +16,7 @@ use Shopware\Core\Maintenance\System\Service\ShopConfigurator;
 use Shopware\Core\System\Currency\CurrencyCollection;
 use Shopware\Core\System\Language\LanguageCollection;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
+use Symfony\Component\Intl\Currencies;
 
 /**
  * @internal
@@ -103,7 +104,9 @@ class ShopConfiguratorTest extends TestCase
 
         static::assertNotNull($currency);
         static::assertSame('RUB', $currency->getSymbol());
-        static::assertSame('Russian Ruble', $currency->getName());
+        // Derived from the same source as ShopConfigurator::createNewCurrency() so the
+        // expectation tracks CLDR data updates instead of pinning one spelling.
+        static::assertSame(Currencies::getName('RUB', 'en_GB'), $currency->getName());
         static::assertSame('RUB', $currency->getShortName());
         static::assertSame('RUB', $currency->getIsoCode());
         static::assertSame(1.0, $currency->getFactor());


### PR DESCRIPTION
### 1. Why is this change necessary?

`ShopConfiguratorTest::testSwitchDefaultCurrencyWithNewCurrency` pins the literal string `'Russian Ruble'`. `composer.lock` is not tracked in this repository, so CI resolves `symfony/intl: ~7.4.0` fresh on every run. `symfony/intl` v7.4.17 updated the en_GB CLDR data for `RUB` to the British spelling `'Russian Rouble'`, so the assertion now fails.

(see https://github.com/shopware/shopware/actions/runs/32614284926/job/97169283679?pr=17733)

### 2. What does this change do, exactly?

Derives the expected currency name from `Symfony\Component\Intl\Currencies::getName()` — the same call `ShopConfigurator::createNewCurrency()` uses to write the value — instead of hard-coding one spelling. The expectation now follows CLDR data updates automatically.

The locale argument mirrors the production fallback in `ShopConfigurator::createNewCurrency()`, which uses the current system locale and falls back to `en_GB`.

### 3. Describe each step to reproduce the issue or behaviour.

1. Ensure `symfony/intl` resolves to v7.4.17 or later (`composer update symfony/intl`).
2. Run `vendor/bin/phpunit tests/integration/Core/Maintenance/System/Service/ShopConfiguratorTest.php`.
3. Before this change, `testSwitchDefaultCurrencyWithNewCurrency` fails with `-'Russian Ruble'` / `+'Russian Rouble'`. After it, the suite passes.

### 4. Please link to the relevant issues (if any).

None.

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
