### PR TITLE
fix(checkout): keep cart persisted state during recalculation (backport: 6.6.x)

### DIFF
--- a/src/Core/Checkout/Cart/Cart.php
+++ b/src/Core/Checkout/Cart/Cart.php
@@ -82,6 +82,11 @@ class Cart extends Struct
 
     public function setToken(string $token): void
     {
+        if ($token !== $this->token) {
+            // the persisted state describes a storage entry for the previous token
+            $this->persisted = false;
+        }
+
         $this->token = $token;
     }
 

--- a/src/Core/Checkout/Cart/CartPersister.php
+++ b/src/Core/Checkout/Cart/CartPersister.php
@@ -82,6 +82,7 @@ class CartPersister extends AbstractCartPersister
 
         if (!$event->shouldBePersisted()) {
             $this->delete($cart->getToken(), $context);
+            $cart->setPersisted(false);
 
             return;
         }

--- a/src/Core/Checkout/Cart/Processor.php
+++ b/src/Core/Checkout/Cart/Processor.php
@@ -38,6 +38,7 @@ class Processor
             $cart->setCampaignCode($original->getCampaignCode());
             $cart->setSource($original->getSource());
             $cart->setErrorHash($original->getErrorHash());
+            $cart->setPersisted($original->isPersisted());
             $cart->setBehavior($behavior);
             $cart->addState(...$original->getStates());
 

--- a/src/Core/Checkout/Cart/RedisCartPersister.php
+++ b/src/Core/Checkout/Cart/RedisCartPersister.php
@@ -100,6 +100,7 @@ class RedisCartPersister extends AbstractCartPersister
         $this->eventDispatcher->dispatch($event);
         if (!$event->shouldBePersisted()) {
             $this->delete($cart->getToken(), $context);
+            $cart->setPersisted(false);
 
             return;
         }

--- a/tests/integration/Core/Checkout/Cart/CartPersisterTest.php
+++ b/tests/integration/Core/Checkout/Cart/CartPersisterTest.php
@@ -19,6 +19,8 @@ use Shopware\Core\Checkout\Cart\Exception\CartTokenNotFoundException;
 use Shopware\Core\Checkout\Cart\LineItem\LineItem;
 use Shopware\Core\Checkout\Cart\LineItem\LineItemCollection;
 use Shopware\Core\Checkout\Cart\Price\Struct\CalculatedPrice;
+use Shopware\Core\Checkout\Cart\Price\Struct\QuantityPriceDefinition;
+use Shopware\Core\Checkout\Cart\SalesChannel\CartService;
 use Shopware\Core\Checkout\Cart\Tax\Struct\CalculatedTaxCollection;
 use Shopware\Core\Checkout\Cart\Tax\Struct\TaxRuleCollection;
 use Shopware\Core\Defaults;
@@ -176,6 +178,68 @@ class CartPersisterTest extends TestCase
             ->fetchOne('SELECT token FROM cart WHERE token = :token', ['token' => $cart->getToken()]);
 
         static::assertFalse($token);
+    }
+
+    public function testRetokenizedCartIsInsertedUnderTheNewToken(): void
+    {
+        $cart = new Cart(Uuid::randomHex());
+        $cart->add(
+            (new LineItem('A', 'test'))
+                ->setPrice(new CalculatedPrice(0, 0, new CalculatedTaxCollection(), new TaxRuleCollection()))
+                ->setLabel('test')
+        );
+
+        $persister = static::getContainer()->get(CartPersister::class);
+        $persister->save($cart, $this->getSalesChannelContext($cart->getToken()));
+
+        $loaded = $persister->load($cart->getToken(), $this->getSalesChannelContext($cart->getToken()));
+
+        // extensions hand a persisted cart a new token and store it elsewhere, e.g. as a quote payload
+        $detachedToken = Uuid::randomHex();
+        $loaded->setToken($detachedToken);
+
+        $detached = unserialize(serialize($loaded));
+        static::assertInstanceOf(Cart::class, $detached);
+
+        $persister->save($detached, $this->getSalesChannelContext($detachedToken));
+
+        $connection = static::getContainer()->get(Connection::class);
+
+        static::assertSame($detachedToken, $connection->fetchOne(
+            'SELECT token FROM cart WHERE token = :token',
+            ['token' => $detachedToken]
+        ));
+        static::assertSame($cart->getToken(), $connection->fetchOne(
+            'SELECT token FROM cart WHERE token = :token',
+            ['token' => $cart->getToken()]
+        ));
+    }
+
+    public function testRecalculatingARetokenizedCartWritesItUnderTheNewToken(): void
+    {
+        $cart = new Cart(Uuid::randomHex());
+        $cart->add(
+            (new LineItem('A', LineItem::CUSTOM_LINE_ITEM_TYPE))
+                ->setPriceDefinition(new QuantityPriceDefinition(10.0, new TaxRuleCollection()))
+                ->setLabel('test')
+        );
+
+        $persister = static::getContainer()->get(CartPersister::class);
+        $persister->save($cart, $this->getSalesChannelContext($cart->getToken()));
+
+        $loaded = $persister->load($cart->getToken(), $this->getSalesChannelContext($cart->getToken()));
+
+        $newToken = Uuid::randomHex();
+        $loaded->setToken($newToken);
+
+        // Processor::process() carries the persisted state over, so a stale one loses the write here
+        static::getContainer()->get(CartService::class)
+            ->recalculate($loaded, $this->getSalesChannelContext($newToken));
+
+        static::assertSame($newToken, static::getContainer()->get(Connection::class)->fetchOne(
+            'SELECT token FROM cart WHERE token = :token',
+            ['token' => $newToken]
+        ));
     }
 
     /**

--- a/tests/integration/Core/Checkout/Cart/CartRuleLoaderTest.php
+++ b/tests/integration/Core/Checkout/Cart/CartRuleLoaderTest.php
@@ -1,0 +1,68 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Integration\Core\Checkout\Cart;
+
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Checkout\Cart\Cart;
+use Shopware\Core\Checkout\Cart\CartBehavior;
+use Shopware\Core\Checkout\Cart\CartPersister;
+use Shopware\Core\Checkout\Cart\CartRuleLoader;
+use Shopware\Core\Checkout\Cart\LineItem\LineItem;
+use Shopware\Core\Checkout\Cart\Price\Struct\QuantityPriceDefinition;
+use Shopware\Core\Checkout\Cart\Tax\Struct\TaxRuleCollection;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\System\SalesChannel\Context\SalesChannelContextFactory;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Shopware\Core\Test\TestDefaults;
+
+/**
+ * @internal
+ */
+#[Package('checkout')]
+class CartRuleLoaderTest extends TestCase
+{
+    use IntegrationTestBehaviour;
+
+    public function testExistingCartLoadDoesNotRecreateDeletedCart(): void
+    {
+        $cartRuleLoader = static::getContainer()->get(CartRuleLoader::class);
+        $cartPersister = static::getContainer()->get(CartPersister::class);
+
+        $cart = new Cart(Uuid::randomHex());
+        $cart->add(
+            (new LineItem('A', LineItem::CUSTOM_LINE_ITEM_TYPE))
+                ->setPriceDefinition(new QuantityPriceDefinition(10.0, new TaxRuleCollection()))
+                ->setLabel('test')
+        );
+
+        $context = $this->createSalesChannelContext($cart->getToken());
+
+        $cartPersister->save($cart, $context);
+
+        $loadedCart = $cartPersister->load($cart->getToken(), $context);
+        $loadedCart->setErrorHash('outdated');
+
+        $cartPersister->delete($loadedCart->getToken(), $context);
+
+        $result = $cartRuleLoader->loadByCart($context, $loadedCart, new CartBehavior());
+
+        static::assertTrue($result->getCart()->has('A'));
+
+        $count = static::getContainer()->get(Connection::class)->fetchOne(
+            'SELECT COUNT(*) FROM cart WHERE token = :token',
+            ['token' => $loadedCart->getToken()]
+        );
+
+        static::assertSame('0', (string) $count);
+    }
+
+    private function createSalesChannelContext(string $token): SalesChannelContext
+    {
+        return static::getContainer()
+            ->get(SalesChannelContextFactory::class)
+            ->create($token, TestDefaults::SALES_CHANNEL);
+    }
+}

--- a/tests/integration/Core/Checkout/Cart/ProcessorTest.php
+++ b/tests/integration/Core/Checkout/Cart/ProcessorTest.php
@@ -350,6 +350,19 @@ class ProcessorTest extends TestCase
         }
     }
 
+    public function testProcessKeepsPersistedStateOfOriginalCart(): void
+    {
+        $cart = new Cart('test');
+
+        $calculated = $this->processor->process($cart, $this->context, new CartBehavior());
+        static::assertFalse($calculated->isPersisted());
+
+        $cart->setPersisted(true);
+
+        $calculated = $this->processor->process($cart, $this->context, new CartBehavior());
+        static::assertTrue($calculated->isPersisted());
+    }
+
     public function testProcessorsAndCollectorsAreSkippedIfCartIsEmpty(): void
     {
         $cart = new Cart('test');

--- a/tests/unit/Core/Checkout/Cart/CartPersisterTest.php
+++ b/tests/unit/Core/Checkout/Cart/CartPersisterTest.php
@@ -83,6 +83,30 @@ class CartPersisterTest extends TestCase
         static::assertInstanceOf(CartSavedEvent::class, $eventDispatcher->getEvents()[1]);
     }
 
+    public function testSaveOfEmptiedPersistedCartResetsPersistedState(): void
+    {
+        $cart = new Cart('token');
+        $cart->setPersisted(true);
+
+        $statement = $this->createMock(Statement::class);
+        $statement->expects($this->once())
+            ->method('executeStatement')
+            ->willReturn(1);
+
+        $connection = $this->createMock(Connection::class);
+        $connection->expects($this->once())
+            ->method('prepare')
+            ->with(static::stringContains('DELETE FROM `cart`'))
+            ->willReturn($statement);
+
+        $cartSerializationCleaner = static::createStub(CartSerializationCleaner::class);
+        $persister = new CartPersister($connection, new CollectingEventDispatcher(), $cartSerializationCleaner, new CartCompressor(false, 'gzip'));
+
+        $persister->save($cart, Generator::generateSalesChannelContext());
+
+        static::assertFalse($cart->isPersisted());
+    }
+
     public function testSaveDoesNotDispatchSavedEventWhenPersistedCartUpdateAffectsZeroRows(): void
     {
         $cart = new Cart('token');

--- a/tests/unit/Core/Checkout/Cart/CartTest.php
+++ b/tests/unit/Core/Checkout/Cart/CartTest.php
@@ -21,6 +21,26 @@ class CartTest extends TestCase
         static::assertCount(0, $cart->getLineItems()->filterGoods());
     }
 
+    public function testChangingTheTokenDropsThePersistedState(): void
+    {
+        $cart = new Cart('test');
+        $cart->setPersisted(true);
+
+        $cart->setToken('other');
+
+        static::assertFalse($cart->isPersisted());
+    }
+
+    public function testKeepingTheTokenKeepsThePersistedState(): void
+    {
+        $cart = new Cart('test');
+        $cart->setPersisted(true);
+
+        $cart->setToken('test');
+
+        static::assertTrue($cart->isPersisted());
+    }
+
     public function testCartWithLineItemsHasGoods(): void
     {
         $cart = new Cart('test');

--- a/tests/unit/Core/Checkout/Cart/ProcessorTest.php
+++ b/tests/unit/Core/Checkout/Cart/ProcessorTest.php
@@ -1,0 +1,63 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Checkout\Cart;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Checkout\Cart\Cart;
+use Shopware\Core\Checkout\Cart\CartBehavior;
+use Shopware\Core\Checkout\Cart\Price\AmountCalculator;
+use Shopware\Core\Checkout\Cart\Price\Struct\CartPrice;
+use Shopware\Core\Checkout\Cart\Processor;
+use Shopware\Core\Checkout\Cart\Tax\Struct\CalculatedTaxCollection;
+use Shopware\Core\Checkout\Cart\Tax\Struct\TaxRuleCollection;
+use Shopware\Core\Checkout\Cart\Transaction\Struct\TransactionCollection;
+use Shopware\Core\Checkout\Cart\Transaction\TransactionProcessor;
+use Shopware\Core\Checkout\Cart\Validator;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Script\Execution\ScriptExecutor;
+use Shopware\Core\Test\Generator;
+
+/**
+ * @internal
+ */
+#[Package('checkout')]
+#[CoversClass(Processor::class)]
+class ProcessorTest extends TestCase
+{
+    public function testProcessKeepsPersistedStateOfOriginalCart(): void
+    {
+        $processor = $this->getProcessor();
+        $context = Generator::generateSalesChannelContext();
+
+        $cart = new Cart('test');
+
+        $calculated = $processor->process($cart, $context, new CartBehavior());
+        static::assertFalse($calculated->isPersisted());
+
+        $cart->setPersisted(true);
+
+        $calculated = $processor->process($cart, $context, new CartBehavior());
+        static::assertTrue($calculated->isPersisted());
+    }
+
+    private function getProcessor(): Processor
+    {
+        $amountCalculator = static::createStub(AmountCalculator::class);
+        $amountCalculator->method('calculate')->willReturn(
+            new CartPrice(0, 0, 0, new CalculatedTaxCollection(), new TaxRuleCollection(), CartPrice::TAX_STATE_GROSS)
+        );
+
+        $transactionProcessor = static::createStub(TransactionProcessor::class);
+        $transactionProcessor->method('process')->willReturn(new TransactionCollection());
+
+        return new Processor(
+            static::createStub(Validator::class),
+            $amountCalculator,
+            $transactionProcessor,
+            [],
+            [],
+            static::createStub(ScriptExecutor::class)
+        );
+    }
+}

--- a/tests/unit/Core/Checkout/Cart/RedisCartPersisterTest.php
+++ b/tests/unit/Core/Checkout/Cart/RedisCartPersisterTest.php
@@ -91,6 +91,32 @@ class RedisCartPersisterTest extends TestCase
         static::assertFalse($redis->exists(RedisCartPersister::PREFIX . $token));
     }
 
+    public function testEmptiedCartCanBePersistedAgain(): void
+    {
+        $token = Uuid::randomHex();
+        $cart = new Cart($token);
+        $cart->add((new LineItem('test', 'test'))->setRemovable(true));
+
+        $dispatcher = static::createStub(EventDispatcher::class);
+        $redis = new RedisStub();
+        $cartSerializationCleaner = static::createStub(CartSerializationCleaner::class);
+        $context = static::createStub(SalesChannelContext::class);
+
+        $persister = new RedisCartPersister($redis, $dispatcher, $cartSerializationCleaner, new CartCompressor(false, 'gzip'), 90);
+        $persister->save($cart, $context);
+
+        $cart->remove('test');
+        $persister->save($cart, $context);
+
+        static::assertFalse($redis->exists(RedisCartPersister::PREFIX . $token));
+        static::assertFalse($cart->isPersisted());
+
+        $cart->add(new LineItem('test', 'test'));
+        $persister->save($cart, $context);
+
+        static::assertTrue($redis->exists(RedisCartPersister::PREFIX . $token));
+    }
+
     public function testLoad(): void
     {
         $token = Uuid::randomHex();


### PR DESCRIPTION
### 1. Why is this change necessary?

`Processor::process()` drops the `persisted` flag during recalculation, so the save takes the insert/upsert path and a concurrent request resurrects the cart that order placement just deleted.

### 2. What does this change do, exactly?

- `Processor::process()` carries the persisted state over.
- `Cart::setToken()` drops it when the token actually changes, so a retokenized cart is still written.
- Both persisters reset it after deleting a cart that must no longer be persisted.

### 3. Describe each step to reproduce the issue or behaviour.

Send `POST /store-api/checkout/order` and `GET /store-api/checkout/cart` concurrently with the same context token: the deleted cart row reappears. Covered by `CartRuleLoaderTest::testExistingCartLoadDoesNotRecreateDeletedCart`.

### 4. Please link to the relevant issues (if any).

- closes #17840
- backport of #18526 and #18559
- relates #11928, #15501, #15581

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes — 6.6.x backports ship without one
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
