### PR TITLE
test(acceptance): skip MultiDomainCORS-RealDomains on SaaS too

### DIFF
--- a/tests/acceptance/tests/SalesChannels/MultiDomainCORS-RealDomains.spec.ts
+++ b/tests/acceptance/tests/SalesChannels/MultiDomainCORS-RealDomains.spec.ts
@@ -12,10 +12,13 @@ test(
         ],
     },
     async ({ ShopCustomer, ShopAdmin, TestDataService, InstanceMeta }) => {
-        // On PaaS, APP_URL is a real remote host, not localhost - the nip.io trick below only
-        // works when the shop itself is reachable at 127.0.0.1 (local dev, or CI's single
+        // On PaaS/SaaS, APP_URL is a real remote host, not localhost - the nip.io trick below
+        // only works when the shop itself is reachable at 127.0.0.1 (local dev, or CI's single
         // webserver setup), so it fails there with ERR_CONNECTION_REFUSED.
-        test.skip(InstanceMeta.isPaaS, 'The second-domain nip.io trick only works when the shop is reachable at 127.0.0.1.');
+        test.skip(
+            InstanceMeta.isPaaS || InstanceMeta.isSaaS,
+            'The second-domain nip.io trick only works when the shop is reachable at 127.0.0.1.',
+        );
 
         // CI only exposes a single webserver (APP_URL), so we cannot rely on a second port or
         // hostname being reachable. `nip.io` is a wildcard DNS service that resolves any


### PR DESCRIPTION
### 1. Why is this change necessary?

Follow-up to #19442. `tests/SalesChannels/MultiDomainCORS-RealDomains.spec.ts` was skipped on PaaS because `APP_URL` there is a real remote host, not `localhost`. SaaS instances have the exact same property, so this test would fail there for the identical reason.

### 2. What does this change do, exactly?

Extends the existing `test.skip(...)` condition to also cover `InstanceMeta.isSaaS`, alongside the already-skipped `InstanceMeta.isPaaS`.

### 3. Describe each step to reproduce the issue or behaviour.

The test registers a second sales channel domain on `*.127.0.0.1.nip.io` to get a genuinely cross-origin URL that still points at the same shop, which only works when the shop itself is reachable at `127.0.0.1` (true for local dev and for CI's single-webserver setup). On SaaS, `APP_URL` is a real remote host, so the second domain resolves to `127.0.0.1` but nothing is listening there, failing with `net::ERR_CONNECTION_REFUSED`.

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them