### PR TITLE
chore: drop the stale (upcoming) marker from 6.7.14.0

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -196,7 +196,7 @@ With v6.8.0.0 the footer (`layout/footer/footer.html.twig`) will use semantic el
 
 Applying a second (individual) code that belongs to a promotion already present in the cart no longer fails silently or shows a generic error. The redundant code is dropped and the customer is informed with a dedicated notice, because a promotion can only be applied once per order. The message uses the new snippet key `checkout.promotion-not-eligible-already-added`, which theme and translation developers can override.
 
-# 6.7.14.0 (upcoming)
+# 6.7.14.0
 
 ## Features
 


### PR DESCRIPTION
### 1. Why is this change necessary?

6.7.14.0 has branched off, so its section is not upcoming anymore and takes no new trunk entries. The stale marker makes contributors remove it by hand while adding their own entry (e.g. #19277), and the `release-info/section` check counts that removal as an added line in the older section.

### 2. What does this change do, exactly?

Drops `(upcoming)` from the `# 6.7.14.0` heading in `RELEASE_INFO-6.7.md`. From the next branch-off on, the split-off job does this itself: shopware/saas#820.

### 3. Describe each step to reproduce the issue or behaviour.

n/a

### 4. Please link to the relevant issues (if any).

relates #19277

### 5. Checklist

- [x] I have read the contribution requirements and fulfilled them
