### PR TITLE
fix: honor REST indexing behavior header

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -244,6 +244,10 @@ The tag association routes and a nested `tags` payload on the order or category 
 
 ## API
 
+### REST API indexing behavior header is honored
+
+The `indexing-behavior` header now supports `use-queue-indexing` and `disable-indexing` on REST API writes, matching the existing Sync API behavior. Requests without this header retain the current synchronous indexing behavior.
+
 ### Store API currency headers validate sales channel availability
 
 Store API requests that supply `sw-currency-id` now reject currencies that are not available on the requested sales channel.
@@ -531,13 +535,6 @@ The new `shopware.app_system.enable_url_validation` option turns off app system 
 While it is `false`, `shopware.app_system.allow_unencrypted_traffic` and `shopware.app_system.allowed_private_ip_addresses` have no effect. Keep the validation enabled in production.
 
 # 6.7.14.0
-## API
-
-### REST API indexing behavior header is honored
-
-The `indexing-behavior` header now supports `use-queue-indexing` and `disable-indexing` on REST API writes, matching the existing Sync API behavior. Requests without this header retain the current synchronous indexing behavior.
-
-# 6.7.14.0 (upcoming)
 
 ## Features
 

--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -531,6 +531,13 @@ The new `shopware.app_system.enable_url_validation` option turns off app system 
 While it is `false`, `shopware.app_system.allow_unencrypted_traffic` and `shopware.app_system.allowed_private_ip_addresses` have no effect. Keep the validation enabled in production.
 
 # 6.7.14.0
+## API
+
+### REST API indexing behavior header is honored
+
+The `indexing-behavior` header now supports `use-queue-indexing` and `disable-indexing` on REST API writes, matching the existing Sync API behavior. Requests without this header retain the current synchronous indexing behavior.
+
+# 6.7.14.0 (upcoming)
 
 ## Features
 

--- a/src/Core/Framework/Routing/ApiRequestContextResolver.php
+++ b/src/Core/Framework/Routing/ApiRequestContextResolver.php
@@ -12,6 +12,7 @@ use Shopware\Core\Framework\Api\Context\SystemSource;
 use Shopware\Core\Framework\Api\Exception\MissingPrivilegeException;
 use Shopware\Core\Framework\Api\Util\AccessKeyHelper;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\Indexing\EntityIndexerRegistry;
 use Shopware\Core\Framework\DataAbstractionLayer\Pricing\CashRoundingConfig;
 use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
@@ -71,6 +72,11 @@ class ApiRequestContextResolver implements RequestContextResolverInterface
             if ($skipTriggerFlow) {
                 $context->addState(Context::SKIP_TRIGGER_FLOW);
             }
+        }
+
+        $indexingBehavior = $request->headers->get(PlatformRequest::HEADER_INDEXING_BEHAVIOR);
+        if (\in_array($indexingBehavior, [EntityIndexerRegistry::DISABLE_INDEXING, EntityIndexerRegistry::USE_INDEXING_QUEUE], true)) {
+            $context->addState($indexingBehavior);
         }
 
         $request->attributes->set(PlatformRequest::ATTRIBUTE_CONTEXT_OBJECT, $context);

--- a/tests/integration/Core/Framework/Routing/ApiRequestContextResolverTest.php
+++ b/tests/integration/Core/Framework/Routing/ApiRequestContextResolverTest.php
@@ -9,6 +9,7 @@ use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Api\Context\AdminApiSource;
 use Shopware\Core\Framework\Api\Util\AccessKeyHelper;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\Indexing\EntityIndexerRegistry;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\Log\Package;
@@ -241,6 +242,38 @@ class ApiRequestContextResolverTest extends TestCase
         static::assertInstanceOf(Context::class, $context);
 
         static::assertTrue($context->hasState(Context::SKIP_TRIGGER_FLOW));
+    }
+
+    public function testContextUsesQueueIndexingWhenRequested(): void
+    {
+        $context = $this->resolveContextWithIndexingBehavior(EntityIndexerRegistry::USE_INDEXING_QUEUE);
+
+        static::assertTrue($context->hasState(EntityIndexerRegistry::USE_INDEXING_QUEUE));
+        static::assertFalse($context->hasState(EntityIndexerRegistry::DISABLE_INDEXING));
+    }
+
+    public function testContextDisablesIndexingWhenRequested(): void
+    {
+        $context = $this->resolveContextWithIndexingBehavior(EntityIndexerRegistry::DISABLE_INDEXING);
+
+        static::assertTrue($context->hasState(EntityIndexerRegistry::DISABLE_INDEXING));
+        static::assertFalse($context->hasState(EntityIndexerRegistry::USE_INDEXING_QUEUE));
+    }
+
+    public function testContextKeepsSynchronousIndexingWhenBehaviorIsNotProvided(): void
+    {
+        $context = $this->resolveContextWithIndexingBehavior();
+
+        static::assertFalse($context->hasState(EntityIndexerRegistry::DISABLE_INDEXING));
+        static::assertFalse($context->hasState(EntityIndexerRegistry::USE_INDEXING_QUEUE));
+    }
+
+    public function testContextIgnoresUnsupportedIndexingBehavior(): void
+    {
+        $context = $this->resolveContextWithIndexingBehavior('unsupported');
+
+        static::assertFalse($context->hasState(EntityIndexerRegistry::DISABLE_INDEXING));
+        static::assertFalse($context->hasState(EntityIndexerRegistry::USE_INDEXING_QUEUE));
     }
 
     public function testResolveAdminSourceAddsDefaultUserPrivileges(): void
@@ -1100,5 +1133,25 @@ class ApiRequestContextResolverTest extends TestCase
         );
 
         return $accessKey;
+    }
+
+    private function resolveContextWithIndexingBehavior(?string $behavior = null): Context
+    {
+        $user = $this->createUser([], true);
+
+        $request = new Request();
+        $request->attributes->set(PlatformRequest::ATTRIBUTE_OAUTH_ACCESS_TOKEN_ID, 'test');
+        $request->attributes->set(PlatformRequest::ATTRIBUTE_OAUTH_CLIENT_ID, $this->createAccessKey($user->getUserId()));
+        $request->attributes->set(PlatformRequest::ATTRIBUTE_ROUTE_SCOPE, [ApiRouteScope::ID]);
+        if ($behavior !== null) {
+            $request->headers->set(PlatformRequest::HEADER_INDEXING_BEHAVIOR, $behavior);
+        }
+
+        $this->resolver->resolve($request);
+
+        $context = $request->attributes->get(PlatformRequest::ATTRIBUTE_CONTEXT_OBJECT);
+        static::assertInstanceOf(Context::class, $context);
+
+        return $context;
     }
 }

--- a/tests/integration/Core/Framework/Routing/ApiRequestContextResolverTest.php
+++ b/tests/integration/Core/Framework/Routing/ApiRequestContextResolverTest.php
@@ -244,36 +244,13 @@ class ApiRequestContextResolverTest extends TestCase
         static::assertTrue($context->hasState(Context::SKIP_TRIGGER_FLOW));
     }
 
-    public function testContextUsesQueueIndexingWhenRequested(): void
+    #[DataProvider('indexingBehaviorProvider')]
+    public function testContextHonorsIndexingBehaviorHeader(?string $behavior, bool $usesQueueIndexing, bool $disablesIndexing): void
     {
-        $context = $this->resolveContextWithIndexingBehavior(EntityIndexerRegistry::USE_INDEXING_QUEUE);
+        $context = $this->resolveContextWithIndexingBehavior($behavior);
 
-        static::assertTrue($context->hasState(EntityIndexerRegistry::USE_INDEXING_QUEUE));
-        static::assertFalse($context->hasState(EntityIndexerRegistry::DISABLE_INDEXING));
-    }
-
-    public function testContextDisablesIndexingWhenRequested(): void
-    {
-        $context = $this->resolveContextWithIndexingBehavior(EntityIndexerRegistry::DISABLE_INDEXING);
-
-        static::assertTrue($context->hasState(EntityIndexerRegistry::DISABLE_INDEXING));
-        static::assertFalse($context->hasState(EntityIndexerRegistry::USE_INDEXING_QUEUE));
-    }
-
-    public function testContextKeepsSynchronousIndexingWhenBehaviorIsNotProvided(): void
-    {
-        $context = $this->resolveContextWithIndexingBehavior();
-
-        static::assertFalse($context->hasState(EntityIndexerRegistry::DISABLE_INDEXING));
-        static::assertFalse($context->hasState(EntityIndexerRegistry::USE_INDEXING_QUEUE));
-    }
-
-    public function testContextIgnoresUnsupportedIndexingBehavior(): void
-    {
-        $context = $this->resolveContextWithIndexingBehavior('unsupported');
-
-        static::assertFalse($context->hasState(EntityIndexerRegistry::DISABLE_INDEXING));
-        static::assertFalse($context->hasState(EntityIndexerRegistry::USE_INDEXING_QUEUE));
+        static::assertSame($usesQueueIndexing, $context->hasState(EntityIndexerRegistry::USE_INDEXING_QUEUE));
+        static::assertSame($disablesIndexing, $context->hasState(EntityIndexerRegistry::DISABLE_INDEXING));
     }
 
     public function testResolveAdminSourceAddsDefaultUserPrivileges(): void
@@ -338,6 +315,33 @@ class ApiRequestContextResolverTest extends TestCase
                 'product:delete' => false,
             ],
             [],
+            false,
+        ];
+    }
+
+    /**
+     * @return iterable<string, array{0: ?string, 1: bool, 2: bool}>
+     */
+    public static function indexingBehaviorProvider(): iterable
+    {
+        yield 'queue indexing is enabled' => [
+            EntityIndexerRegistry::USE_INDEXING_QUEUE,
+            true,
+            false,
+        ];
+        yield 'indexing is disabled' => [
+            EntityIndexerRegistry::DISABLE_INDEXING,
+            false,
+            true,
+        ];
+        yield 'no header keeps synchronous indexing' => [
+            null,
+            false,
+            false,
+        ];
+        yield 'unsupported header is ignored' => [
+            'unsupported',
+            false,
             false,
         ];
     }


### PR DESCRIPTION
### 1. Why is this change necessary?

The public `indexing-behavior` header is advertised for API requests, but REST API writes do not translate it into indexing context state. Integrations sending `use-queue-indexing` therefore still execute indexers synchronously, increasing write latency.

### 2. What does this change do, exactly?

`ApiRequestContextResolver` now honors the existing `use-queue-indexing` and `disable-indexing` values and adds the corresponding context state. Missing or unsupported values retain the current synchronous indexing behavior. Focused integration tests cover both values, the default, and unsupported input. Developer-facing release information was added under the API section.

### 3. Describe each step to reproduce the issue or behaviour.

1. Authenticate against the Admin API.
2. Send a REST write request such as `PATCH /api/product/{id}` with the header `indexing-behavior: use-queue-indexing`.
3. Observe that, before this change, the request context does not contain the queue-indexing state and indexers run synchronously.
4. With this change, the header activates queue indexing; `disable-indexing` similarly activates the existing disable-indexing behavior.

### 4. Please link to the relevant issues (if any).

- relates https://github.com/shopware/saas/issues/789

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Added an entry to `RELEASE_INFO-6.7.md`; no breaking upgrade instructions are required.
- [x] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them