### PR TITLE
feat(content-system): render assigned content layouts on product deta…

### DIFF
--- a/src/Core/Framework/Demodata/Command/DemodataCommand.php
+++ b/src/Core/Framework/Demodata/Command/DemodataCommand.php
@@ -13,6 +13,7 @@ use Shopware\Core\Content\MailTemplate\Aggregate\MailHeaderFooter\MailHeaderFoot
 use Shopware\Core\Content\MailTemplate\MailTemplateDefinition;
 use Shopware\Core\Content\Media\MediaDefinition;
 use Shopware\Core\Content\Newsletter\Aggregate\NewsletterRecipient\NewsletterRecipientDefinition;
+use Shopware\Core\Content\Product\Aggregate\ProductContentLayout\ProductContentLayoutDefinition;
 use Shopware\Core\Content\Product\Aggregate\ProductManufacturer\ProductManufacturerDefinition;
 use Shopware\Core\Content\Product\Aggregate\ProductReview\ProductReviewDefinition;
 use Shopware\Core\Content\Product\ProductDefinition;
@@ -113,6 +114,7 @@ class DemodataCommand extends Command
         $request->add(PromotionDefinition::class, $this->getCount($input, 'promotions'));
         $request->add(OrderDefinition::class, $this->getCount($input, 'orders'));
         $request->add(ProductReviewDefinition::class, $this->getCount($input, 'reviews'));
+        $request->add(ProductContentLayoutDefinition::class, $this->getCount($input, 'product-content-layouts'));
         $request->add(UserDefinition::class, $this->getCount($input, 'users'));
         $request->add(FlowDefinition::class, $this->getCount($input, 'flows'));
 

--- a/src/Core/Framework/Demodata/Generator/ProductContentLayoutGenerator.php
+++ b/src/Core/Framework/Demodata/Generator/ProductContentLayoutGenerator.php
@@ -1,0 +1,135 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\Demodata\Generator;
+
+use Doctrine\DBAL\Connection;
+use Faker\Generator;
+use Shopware\Core\Content\Product\Aggregate\ProductContentLayout\ProductContentLayoutCollection;
+use Shopware\Core\Content\Product\Aggregate\ProductContentLayout\ProductContentLayoutDefinition;
+use Shopware\Core\Defaults;
+use Shopware\Core\Framework\ContentSystem\Layout\Entity\ContentLayoutCollection;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\Demodata\DemodataContext;
+use Shopware\Core\Framework\Demodata\DemodataGeneratorInterface;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Uuid\Uuid;
+
+/**
+ * @internal
+ */
+#[Package('discovery')]
+class ProductContentLayoutGenerator implements DemodataGeneratorInterface
+{
+    /**
+     * @param EntityRepository<ContentLayoutCollection> $contentLayoutRepository
+     * @param EntityRepository<ProductContentLayoutCollection> $productContentLayoutRepository
+     */
+    public function __construct(
+        private readonly EntityRepository $contentLayoutRepository,
+        private readonly EntityRepository $productContentLayoutRepository,
+        private readonly Connection $connection,
+    ) {
+    }
+
+    public function getDefinition(): string
+    {
+        return ProductContentLayoutDefinition::class;
+    }
+
+    public function generate(int $numberOfItems, DemodataContext $context, array $options = []): void
+    {
+        $numberOfItems = max($numberOfItems, 1);
+
+        $productIds = $this->getProductIds($numberOfItems);
+
+        if ($productIds === []) {
+            return;
+        }
+
+        $faker = $context->getFaker();
+
+        $console = $context->getConsole();
+        $console->progressStart(\count($productIds));
+
+        $layouts = [];
+        $assignments = [];
+
+        foreach ($productIds as $productId) {
+            $layoutId = Uuid::randomHex();
+
+            $layouts[] = [
+                'id' => $layoutId,
+                'name' => $faker->words(3, true),
+                'version' => '1.0.0',
+                'rootSource' => 'product',
+                'layout' => $this->buildLayout($faker),
+            ];
+
+            $assignments[] = [
+                'id' => Uuid::randomHex(),
+                'productId' => $productId,
+                'salesChannelId' => null,
+                'contentLayoutId' => $layoutId,
+            ];
+
+            $console->progressAdvance();
+        }
+
+        $this->contentLayoutRepository->create($layouts, $context->getContext());
+        $this->productContentLayoutRepository->create($assignments, $context->getContext());
+
+        $console->progressFinish();
+    }
+
+    /**
+     * The most recently created main products, so a demo run assigns the layout to freshly
+     * generated demo products rather than to a shop's existing (possibly real) products.
+     *
+     * @return list<string>
+     */
+    private function getProductIds(int $limit): array
+    {
+        /** @var list<string> $ids */
+        $ids = $this->connection->fetchFirstColumn(
+            'SELECT LOWER(HEX(`id`))
+             FROM `product`
+             WHERE `parent_id` IS NULL AND `version_id` = UNHEX(:live)
+             ORDER BY `auto_increment` DESC
+             LIMIT ' . $limit,
+            ['live' => Defaults::LIVE_VERSION]
+        );
+
+        return $ids;
+    }
+
+    /**
+     * A minimal product detail page: a grid container with a single text element. Missing element
+     * properties are filled from the element-type defaults by the layout default seeder on write.
+     *
+     * @return list<array<string, mixed>>
+     */
+    private function buildLayout(Generator $faker): array
+    {
+        return [
+            [
+                'id' => Uuid::randomHex(),
+                'component' => 'Sw:Grid:Container',
+                'properties' => [
+                    'mode' => 'auto-fit',
+                    'itemMinWidth' => '400px',
+                ],
+                'slots' => [
+                    'content' => [
+                        [
+                            'id' => Uuid::randomHex(),
+                            'component' => 'Sw:Content:Text',
+                            'properties' => [
+                                'text' => '<p>' . $faker->sentences(20, true) . '</p>',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+    }
+}

--- a/src/Core/Framework/Demodata/Generator/ProductContentLayoutGenerator.php
+++ b/src/Core/Framework/Demodata/Generator/ProductContentLayoutGenerator.php
@@ -124,7 +124,7 @@ class ProductContentLayoutGenerator implements DemodataGeneratorInterface
                             'id' => Uuid::randomHex(),
                             'component' => 'Sw:Content:Text',
                             'properties' => [
-                                'text' => '<p>' . $faker->sentences(20, true) . '</p>',
+                                'text' => '<p>' . $faker->paragraph(20) . '</p>',
                             ],
                         ],
                     ],

--- a/src/Core/Framework/DependencyInjection/demodata.php
+++ b/src/Core/Framework/DependencyInjection/demodata.php
@@ -36,6 +36,7 @@ use Shopware\Core\Framework\Demodata\Generator\MailTemplateGenerator;
 use Shopware\Core\Framework\Demodata\Generator\MediaGenerator;
 use Shopware\Core\Framework\Demodata\Generator\NewsletterRecipientGenerator;
 use Shopware\Core\Framework\Demodata\Generator\OrderGenerator;
+use Shopware\Core\Framework\Demodata\Generator\ProductContentLayoutGenerator;
 use Shopware\Core\Framework\Demodata\Generator\ProductGenerator;
 use Shopware\Core\Framework\Demodata\Generator\ProductManufacturerGenerator;
 use Shopware\Core\Framework\Demodata\Generator\ProductReviewGenerator;
@@ -136,6 +137,14 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             service(ProductReviewCountService::class),
         ])
         ->tag('shopware.demodata_generator', ['option-name' => 'reviews', 'option-default' => 20, 'option_name' => 'reviews', 'option_default' => 20]);
+
+    $services->set(ProductContentLayoutGenerator::class)
+        ->args([
+            service('content_layout.repository'),
+            service('product_content_layout.repository'),
+            service(Connection::class),
+        ])
+        ->tag('shopware.demodata_generator', ['option-name' => 'product-content-layouts', 'option-default' => 1, 'option-description' => 'Product detail page content layouts (assigned to products)', 'option_name' => 'product-content-layouts', 'option_default' => 1, 'option_description' => 'Product detail page content layouts (assigned to products)']);
 
     $services->set(ProductGenerator::class)
         ->args([

--- a/src/Storefront/Controller/NavigationController.php
+++ b/src/Storefront/Controller/NavigationController.php
@@ -7,8 +7,6 @@ use Shopware\Core\Content\Category\CategoryException;
 use Shopware\Core\Content\Category\Service\AbstractCategoryUrlGenerator;
 use Shopware\Core\Content\Seo\SeoUrlPlaceholderHandlerInterface;
 use Shopware\Core\Framework\ContentSystem\Output\Struct\ContentPage;
-use Shopware\Core\Framework\ContentSystem\SalesChannel\AbstractContentRoute;
-use Shopware\Core\Framework\ContentSystem\SalesChannel\ContentRouteResponse;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\PlatformRequest;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
@@ -47,7 +45,6 @@ class NavigationController extends StorefrontController
         private readonly FooterPageletLoaderInterface $footerLoader,
         private readonly AbstractCategoryUrlGenerator $categoryUrlGenerator,
         private readonly SeoUrlPlaceholderHandlerInterface $seoUrlReplacer,
-        private readonly AbstractContentRoute $contentRoute,
     ) {
     }
 
@@ -234,22 +231,5 @@ class NavigationController extends StorefrontController
         $path = '/category/' . $categoryId;
 
         return $this->loadContentPage($path, $request, $context);
-    }
-
-    private function loadContentPage(string $path, Request $request, SalesChannelContext $context): ?ContentPage
-    {
-        try {
-            $contentPageResponse = $this->contentRoute->load($path, $request, $context);
-
-            if (!$contentPageResponse instanceof ContentRouteResponse) {
-                return null;
-            }
-
-            $contentPage = $contentPageResponse->getContentPage();
-        } catch (\Exception) {
-            $contentPage = null;
-        }
-
-        return $contentPage;
     }
 }

--- a/src/Storefront/Controller/ProductController.php
+++ b/src/Storefront/Controller/ProductController.php
@@ -12,6 +12,7 @@ use Shopware\Core\Content\Product\SalesChannel\Review\AbstractProductReviewSaveR
 use Shopware\Core\Content\Product\SalesChannel\Review\ProductReviewsWidgetLoadedHook;
 use Shopware\Core\Content\Seo\SeoUrlPlaceholderHandlerInterface;
 use Shopware\Core\Framework\Adapter\Request\RequestParamHelper;
+use Shopware\Core\Framework\ContentSystem\Output\Struct\ContentPage;
 use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Validation\DataBag\RequestDataBag;
@@ -22,6 +23,7 @@ use Shopware\Storefront\Controller\Exception\StorefrontException;
 use Shopware\Storefront\Framework\Routing\RequestTransformer;
 use Shopware\Storefront\Framework\Routing\StorefrontRouteScope;
 use Shopware\Storefront\Framework\Seo\SeoUrlRoute\ProductPageSeoUrlRoute;
+use Shopware\Storefront\Page\Product\ProductPage;
 use Shopware\Storefront\Page\Product\ProductPageLoadedHook;
 use Shopware\Storefront\Page\Product\ProductPageLoader;
 use Shopware\Storefront\Page\Product\QuickView\MinimalQuickViewPageLoader;
@@ -64,6 +66,20 @@ class ProductController extends StorefrontController
         $page = $this->productPageLoader->load($request, $context);
 
         $this->hook(new ProductPageLoadedHook($page, $context));
+
+        $contentPage = $this->loadProductContentPage($page, $request, $context);
+
+        if ($contentPage !== null) {
+            return $this->renderStorefront(
+                '@Storefront/storefront/page/content/page.html.twig',
+                [
+                    'page' => $page,
+                    'contentPage' => $contentPage,
+                    'isNewContentStructure' => true,
+                    'redirectTo' => ProductPageSeoUrlRoute::ROUTE_NAME,
+                ]
+            );
+        }
 
         return $this->renderStorefront(
             '@Storefront/storefront/page/content/product-detail.html.twig',
@@ -253,5 +269,13 @@ class ProductController extends StorefrontController
             'purchaseSteps' => $result->getPurchaseSteps(),
             'maxPurchase' => $result->getMaxPurchase(),
         ]);
+    }
+
+    private function loadProductContentPage(ProductPage $page, Request $request, SalesChannelContext $context): ?ContentPage
+    {
+        $productId = $page->getProduct()->getParentId() ?? $page->getProduct()->getId();
+        $path = '/product/' . $productId;
+
+        return $this->loadContentPage($path, $request, $context);
     }
 }

--- a/src/Storefront/Controller/StorefrontController.php
+++ b/src/Storefront/Controller/StorefrontController.php
@@ -9,6 +9,9 @@ use Shopware\Core\Content\Media\MediaUrlPlaceholderHandlerInterface;
 use Shopware\Core\Content\Seo\SeoUrlPlaceholderHandlerInterface;
 use Shopware\Core\Framework\Adapter\Request\RequestParamHelper;
 use Shopware\Core\Framework\Adapter\Twig\TemplateFinder;
+use Shopware\Core\Framework\ContentSystem\Output\Struct\ContentPage;
+use Shopware\Core\Framework\ContentSystem\SalesChannel\AbstractContentRoute;
+use Shopware\Core\Framework\ContentSystem\SalesChannel\ContentRouteResponse;
 use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Routing\RequestTransformerInterface;
@@ -16,6 +19,7 @@ use Shopware\Core\Framework\Script\Execution\Hook;
 use Shopware\Core\Framework\Script\Execution\ScriptExecutor;
 use Shopware\Core\PlatformRequest;
 use Shopware\Core\Profiling\Profiler;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
 use Shopware\Storefront\Controller\Exception\StorefrontException;
 use Shopware\Storefront\Event\StorefrontRedirectEvent;
@@ -57,8 +61,24 @@ abstract class StorefrontController extends AbstractController
         $services[ScriptExecutor::class] = ScriptExecutor::class;
         $services['translator'] = TranslatorInterface::class;
         $services[RequestTransformerInterface::class] = RequestTransformerInterface::class;
+        $services[AbstractContentRoute::class] = AbstractContentRoute::class;
 
         return $services;
+    }
+
+    protected function loadContentPage(string $path, Request $request, SalesChannelContext $context): ?ContentPage
+    {
+        try {
+            $contentPageResponse = $this->container->get(AbstractContentRoute::class)->load($path, $request, $context);
+        } catch (\Exception) {
+            return null;
+        }
+
+        if (!$contentPageResponse instanceof ContentRouteResponse) {
+            return null;
+        }
+
+        return $contentPageResponse->getContentPage();
     }
 
     /**

--- a/src/Storefront/DependencyInjection/controller.php
+++ b/src/Storefront/DependencyInjection/controller.php
@@ -59,7 +59,6 @@ use Shopware\Core\Framework\Adapter\Translation\ConstraintViolationTranslator;
 use Shopware\Core\Framework\App\Api\AppJWTGenerateRoute;
 use Shopware\Core\Framework\ContentSystem\Api\ContentPreviewPageBuilder;
 use Shopware\Core\Framework\ContentSystem\Api\ContentPreviewPayloadStore;
-use Shopware\Core\Framework\ContentSystem\SalesChannel\AbstractContentRoute;
 use Shopware\Core\Framework\Gateway\Context\SalesChannel\ContextGatewayRoute;
 use Shopware\Core\Framework\Script\Api\ScriptResponseEncoder;
 use Shopware\Core\Framework\Util\HtmlSanitizer;
@@ -321,7 +320,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             service(FooterPageletLoader::class),
             service(CategoryUrlGenerator::class),
             service(SeoUrlPlaceholderHandlerInterface::class),
-            service(AbstractContentRoute::class),
         ])
         ->call('setContainer', [service('service_container')]);
 

--- a/tests/unit/Core/Framework/Demodata/Command/DemodataCommandTest.php
+++ b/tests/unit/Core/Framework/Demodata/Command/DemodataCommandTest.php
@@ -13,6 +13,7 @@ use Shopware\Core\Content\MailTemplate\Aggregate\MailHeaderFooter\MailHeaderFoot
 use Shopware\Core\Content\MailTemplate\MailTemplateDefinition;
 use Shopware\Core\Content\Media\MediaDefinition;
 use Shopware\Core\Content\Newsletter\Aggregate\NewsletterRecipient\NewsletterRecipientDefinition;
+use Shopware\Core\Content\Product\Aggregate\ProductContentLayout\ProductContentLayoutDefinition;
 use Shopware\Core\Content\Product\Aggregate\ProductManufacturer\ProductManufacturerDefinition;
 use Shopware\Core\Content\Product\Aggregate\ProductReview\ProductReviewDefinition;
 use Shopware\Core\Content\Product\ProductDefinition;
@@ -52,6 +53,7 @@ class DemodataCommandTest extends TestCase
         PromotionDefinition::class,
         OrderDefinition::class,
         ProductReviewDefinition::class,
+        ProductContentLayoutDefinition::class,
         UserDefinition::class,
         FlowDefinition::class,
         CustomFieldSetDefinition::class,

--- a/tests/unit/Core/Framework/Demodata/Generator/ProductContentLayoutGeneratorTest.php
+++ b/tests/unit/Core/Framework/Demodata/Generator/ProductContentLayoutGeneratorTest.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\Demodata\Generator;
+
+use Doctrine\DBAL\Connection;
+use Faker\Factory;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Product\Aggregate\ProductContentLayout\ProductContentLayoutDefinition;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\Demodata\DemodataContext;
+use Shopware\Core\Framework\Demodata\Generator\ProductContentLayoutGenerator;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * @internal
+ */
+#[Package('discovery')]
+#[CoversClass(ProductContentLayoutGenerator::class)]
+class ProductContentLayoutGeneratorTest extends TestCase
+{
+    public function testGetDefinition(): void
+    {
+        $generator = new ProductContentLayoutGenerator(
+            static::createStub(EntityRepository::class),
+            static::createStub(EntityRepository::class),
+            static::createStub(Connection::class),
+        );
+
+        static::assertSame(ProductContentLayoutDefinition::class, $generator->getDefinition());
+    }
+
+    public function testGenerateCreatesLayoutAndAssignmentForProducts(): void
+    {
+        $productId = Uuid::randomHex();
+
+        $connection = $this->createMock(Connection::class);
+        $connection->expects($this->once())->method('fetchFirstColumn')->willReturn([$productId]);
+
+        $layoutPayload = null;
+        $contentLayoutRepository = $this->createMock(EntityRepository::class);
+        $contentLayoutRepository->expects($this->once())->method('create')->with(
+            static::callback(static function (array $payload) use (&$layoutPayload): bool {
+                $layoutPayload = $payload;
+
+                return true;
+            }),
+            static::anything(),
+        );
+
+        $assignmentPayload = null;
+        $productContentLayoutRepository = $this->createMock(EntityRepository::class);
+        $productContentLayoutRepository->expects($this->once())->method('create')->with(
+            static::callback(static function (array $payload) use (&$assignmentPayload): bool {
+                $assignmentPayload = $payload;
+
+                return true;
+            }),
+            static::anything(),
+        );
+
+        $console = $this->createMock(SymfonyStyle::class);
+        $console->expects($this->once())->method('progressStart')->with(1);
+        $console->expects($this->once())->method('progressAdvance');
+        $console->expects($this->once())->method('progressFinish');
+
+        $context = new DemodataContext(
+            Context::createDefaultContext(),
+            Factory::create(),
+            __DIR__,
+            $console,
+            static::createStub(DefinitionInstanceRegistry::class),
+        );
+
+        (new ProductContentLayoutGenerator(
+            $contentLayoutRepository,
+            $productContentLayoutRepository,
+            $connection,
+        ))->generate(1, $context);
+
+        static::assertIsArray($layoutPayload);
+        static::assertCount(1, $layoutPayload);
+        static::assertSame('product', $layoutPayload[0]['rootSource']);
+        static::assertSame('1.0.0', $layoutPayload[0]['version']);
+        static::assertIsArray($layoutPayload[0]['layout']);
+
+        $textElement = $layoutPayload[0]['layout'][0]['slots']['content'][0];
+        static::assertSame('Sw:Content:Text', $textElement['component']);
+        static::assertNotEmpty($textElement['properties']['text']);
+
+        $layoutId = $layoutPayload[0]['id'];
+
+        static::assertIsArray($assignmentPayload);
+        static::assertCount(1, $assignmentPayload);
+        static::assertSame($productId, $assignmentPayload[0]['productId']);
+        static::assertSame($layoutId, $assignmentPayload[0]['contentLayoutId']);
+        static::assertNull($assignmentPayload[0]['salesChannelId']);
+    }
+
+    public function testGenerateDoesNothingWithoutProducts(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection->expects($this->once())->method('fetchFirstColumn')->willReturn([]);
+
+        $contentLayoutRepository = $this->createMock(EntityRepository::class);
+        $contentLayoutRepository->expects($this->never())->method('create');
+
+        $productContentLayoutRepository = $this->createMock(EntityRepository::class);
+        $productContentLayoutRepository->expects($this->never())->method('create');
+
+        (new ProductContentLayoutGenerator(
+            $contentLayoutRepository,
+            $productContentLayoutRepository,
+            $connection,
+        ))->generate(1, static::createStub(DemodataContext::class));
+    }
+}

--- a/tests/unit/Storefront/Controller/NavigationControllerTest.php
+++ b/tests/unit/Storefront/Controller/NavigationControllerTest.php
@@ -17,7 +17,6 @@ use Shopware\Core\Content\Category\Service\CategoryUrlGenerator;
 use Shopware\Core\Content\Category\Tree\Tree;
 use Shopware\Core\Content\Seo\SeoUrlPlaceholderHandlerInterface;
 use Shopware\Core\Content\Seo\SeoUrlRoute\EntityRouteResolver;
-use Shopware\Core\Framework\ContentSystem\SalesChannel\AbstractContentRoute;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\Currency\CurrencyCollection;
@@ -58,8 +57,6 @@ class NavigationControllerTest extends TestCase
 
     private SeoUrlPlaceholderHandlerInterface&Stub $seoUrlReplacer;
 
-    private AbstractContentRoute&Stub $contentRoute;
-
     protected function setUp(): void
     {
         $this->pageLoader = static::createStub(NavigationPageLoaderInterface::class);
@@ -82,7 +79,6 @@ class NavigationControllerTest extends TestCase
                 };
             });
         $this->categoryUrlGenerator = new CategoryUrlGenerator($entityRouteResolver);
-        $this->contentRoute = static::createStub(AbstractContentRoute::class);
 
         $this->controller = new NavigationControllerTestClass(
             $this->pageLoader,
@@ -91,7 +87,6 @@ class NavigationControllerTest extends TestCase
             $this->footerLoader,
             $this->categoryUrlGenerator,
             $this->seoUrlReplacer,
-            $this->contentRoute,
         );
     }
 
@@ -296,7 +291,6 @@ class NavigationControllerTest extends TestCase
             $footerLoader ?? $this->footerLoader,
             $this->categoryUrlGenerator,
             $this->seoUrlReplacer,
-            $this->contentRoute,
         );
     }
 }

--- a/tests/unit/Storefront/Controller/ProductControllerTest.php
+++ b/tests/unit/Storefront/Controller/ProductControllerTest.php
@@ -24,6 +24,7 @@ use Shopware\Core\Content\Product\SalesChannel\Review\ProductReviewsWidgetLoaded
 use Shopware\Core\Content\Product\SalesChannel\Review\RatingMatrix;
 use Shopware\Core\Content\Product\SalesChannel\SalesChannelProductEntity;
 use Shopware\Core\Content\Seo\SeoUrlPlaceholderHandlerInterface;
+use Shopware\Core\Framework\ContentSystem\Output\Struct\ContentPage;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
@@ -105,6 +106,28 @@ class ProductControllerTest extends TestCase
         static::assertInstanceOf(ProductPage::class, $this->controller->renderStorefrontParameters['page']);
         static::assertSame('test', $this->controller->renderStorefrontParameters['page']->getProduct()->getId());
         static::assertSame('@Storefront/storefront/page/content/product-detail.html.twig', $this->controller->renderStorefrontView);
+    }
+
+    public function testIndexRendersContentPageWhenLayoutAssigned(): void
+    {
+        $productEntity = new SalesChannelProductEntity();
+        $productEntity->setId('test');
+        $productPage = new ProductPage();
+        $productPage->setProduct($productEntity);
+
+        $this->productPageLoaderMock->method('load')->willReturn($productPage);
+
+        $contentPage = new ContentPage('layout-id', [], 'PDP layout', null);
+        $this->controller->contentPage = $contentPage;
+
+        $response = $this->controller->index(static::createStub(SalesChannelContext::class), new Request());
+
+        static::assertSame(Response::HTTP_OK, $response->getStatusCode());
+        static::assertSame('/product/test', $this->controller->loadedContentPath);
+        static::assertSame('@Storefront/storefront/page/content/page.html.twig', $this->controller->renderStorefrontView);
+        static::assertSame($contentPage, $this->controller->renderStorefrontParameters['contentPage']);
+        static::assertTrue($this->controller->renderStorefrontParameters['isNewContentStructure']);
+        static::assertInstanceOf(ProductPage::class, $this->controller->renderStorefrontParameters['page']);
     }
 
     public function testSwitchNoVariantReturn(): void

--- a/tests/unit/Storefront/Controller/StorefrontControllerMockTrait.php
+++ b/tests/unit/Storefront/Controller/StorefrontControllerMockTrait.php
@@ -3,8 +3,11 @@
 namespace Shopware\Tests\Unit\Storefront\Controller;
 
 use Shopware\Core\Checkout\Cart\Cart;
+use Shopware\Core\Framework\ContentSystem\Output\Struct\ContentPage;
 use Shopware\Core\Framework\Script\Execution\Hook;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
@@ -21,6 +24,10 @@ trait StorefrontControllerMockTrait
     public array $renderStorefrontParameters;
 
     public Hook $calledHook;
+
+    public ?ContentPage $contentPage = null;
+
+    public ?string $loadedContentPath = null;
 
     public string $forwardToRoute;
 
@@ -90,6 +97,13 @@ trait StorefrontControllerMockTrait
     protected function hook(Hook $hook): void
     {
         $this->calledHook = $hook;
+    }
+
+    protected function loadContentPage(string $path, Request $request, SalesChannelContext $context): ?ContentPage
+    {
+        $this->loadedContentPath = $path;
+
+        return $this->contentPage;
     }
 
     /**


### PR DESCRIPTION
### 1. Why is this change necessary?

A content layout assigned to a product was never rendered — the PDP always used the legacy template.

### 2. What does this change do, exactly?

Renders a product's assigned content layout on the product detail page, falling back to the legacy template when none is assigned. The content-page loading is moved into a shared `loadContentPage()` helper on `StorefrontController`. Also adds demo data that ships an example PDP layout assigned to a product.

### 3. Describe each step to reproduce the issue or behaviour.

  1. Assign a content layout to a product in the Experience Studio.
  2. Open the product's detail page in the storefront.
  3. It renders the assigned layout instead of the default PDP.

### 4. Please link to the relevant issues (if any).

  closes #19503

### 5. Checklist

  - [x] I have written tests and verified that they fail without my change
  - [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
    - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
    - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
    - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
  - [ ] I have written or adjusted the documentation and agent skills according to my changes
  - [ ] This change has comments for package types, values, functions, and non-obvious lines of code
  - [x] I have read the contribution requirements and fulfilled them