### PR TITLE
fix(core): let ProductListingResult own its page and limit state

### DIFF
--- a/src/Core/Content/Product/SalesChannel/Listing/ProductListingResult.php
+++ b/src/Core/Content/Product/SalesChannel/Listing/ProductListingResult.php
@@ -32,7 +32,7 @@ class ProductListingResult extends EntitySearchResult
      * result owns this state independently of the search result it was created from.
      */
     // @phpstan-ignore property.parentPropertyFinalByPhpDoc (the listing result keeps its own page state)
-    protected int $page = 1;
+    protected int $page;
 
     // @phpstan-ignore property.parentPropertyFinalByPhpDoc (the listing result keeps its own limit state)
     protected ?int $limit = null;

--- a/src/Core/Content/Product/SalesChannel/Listing/ProductListingResult.php
+++ b/src/Core/Content/Product/SalesChannel/Listing/ProductListingResult.php
@@ -28,6 +28,16 @@ class ProductListingResult extends EntitySearchResult
     protected ?string $streamId = null;
 
     /**
+     * Declared here, not inherited: listing processors set the page and limit after construction, so the listing
+     * result owns this state independently of the search result it was created from.
+     */
+    // @phpstan-ignore property.parentPropertyFinalByPhpDoc (the listing result keeps its own page state)
+    protected int $page = 1;
+
+    // @phpstan-ignore property.parentPropertyFinalByPhpDoc (the listing result keeps its own limit state)
+    protected ?int $limit = null;
+
+    /**
      * Construction entry point with a stable signature across the v6.8.0 cut. Callers that adopt this method now will keep working after the structural change.
      *
      * @param EntitySearchResult<ProductCollection> $result
@@ -57,7 +67,6 @@ class ProductListingResult extends EntitySearchResult
      */
     public function setPage(int $page): void
     {
-        /** @phpstan-ignore shopware.futureIncompatibility.propertyBecomesReadonly (ProductListingResult no longer extends EntitySearchResult in v6.8.0, so this code path will be removed.) */
         $this->page = $page;
     }
 
@@ -66,7 +75,6 @@ class ProductListingResult extends EntitySearchResult
      */
     public function setLimit(int $limit): void
     {
-        /** @phpstan-ignore shopware.futureIncompatibility.propertyBecomesReadonly (ProductListingResult no longer extends EntitySearchResult in v6.8.0, so this code path will be removed.) */
         $this->limit = $limit;
     }
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
`ProductListingResult` writes `$page` and `$limit`, but those properties belong to `EntitySearchResult`, and in v6.8.0 the class stops extending `EntitySearchResult` and loses them completely. 

### 2. What does this change do, exactly?
Declaring `$page` and `$limit` on `ProductListingResult` itself keeps `setPage()` and `setLimit()` working as `UPGRADE-6.8.md` promises. 

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
