### PR TITLE
fix(core): skip unused remote thumbnail dispatches

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -463,6 +463,9 @@ Calling `defineExpose()` yourself is rejected in base and override components: i
 The empty states of Extensions > My extensions and the Shopware Store activation page render `mt-empty-state`. The Twig blocks and snippet keys are unchanged, but overrides that build on the previous markup need to adapt: the listing empty state is no longer a `sw-meteor-card`, and on the activation page the "Now available" badge (`.sw-extension-store-landing-page__wrapper-label`) and the `sw-label` of the success and error states no longer exist.
 
 The `assetFilter` computed of both components is deprecated for removal in v6.9.0; use `Shopware.Filter.getByName('asset')` instead.
+### Reduced remote thumbnail URL generation overhead
+
+Remote thumbnail URL generation now avoids unnecessary extension dispatching when no listeners are registered. Existing extensions that listen to remote thumbnail URL events continue to work unchanged.
 
 ## Storefront
 

--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -89,6 +89,10 @@ Timeline: 6.7 opt-in, 6.8 default (opt-out), 6.9 legacy implementation and flag 
 
 ## Core
 
+### Reduced remote thumbnail URL generation overhead
+
+Remote thumbnail URL generation now avoids unnecessary extension dispatching when no listeners are registered. Existing extensions that listen to remote thumbnail URL events continue to work unchanged.
+
 ### GARAN label in the order confirmation mail is sized and sits next to the line item
 
 The GARAN label that 6.7.14.0 added to the `order_confirmation_mail` template (see "GARAN commercial guarantee label and EU legal guarantee notice") rendered without dimensions on a full width row of its own, so mail clients scaled the SVG data URI up to the width of the mail and cut it off. The label now carries explicit `width`/`height` attributes and renders inside the line item's description cell, with a translated `alt` text instead of an empty one.
@@ -463,9 +467,6 @@ Calling `defineExpose()` yourself is rejected in base and override components: i
 The empty states of Extensions > My extensions and the Shopware Store activation page render `mt-empty-state`. The Twig blocks and snippet keys are unchanged, but overrides that build on the previous markup need to adapt: the listing empty state is no longer a `sw-meteor-card`, and on the activation page the "Now available" badge (`.sw-extension-store-landing-page__wrapper-label`) and the `sw-label` of the success and error states no longer exist.
 
 The `assetFilter` computed of both components is deprecated for removal in v6.9.0; use `Shopware.Filter.getByName('asset')` instead.
-### Reduced remote thumbnail URL generation overhead
-
-Remote thumbnail URL generation now avoids unnecessary extension dispatching when no listeners are registered. Existing extensions that listen to remote thumbnail URL events continue to work unchanged.
 
 ## Storefront
 

--- a/src/Core/Content/Media/Core/Application/RemoteThumbnailLoader.php
+++ b/src/Core/Content/Media/Core/Application/RemoteThumbnailLoader.php
@@ -214,49 +214,56 @@ class RemoteThumbnailLoader implements ResetInterface
 
     private function getUrl(MediaEntity|PartialEntity $mediaEntity, string $mediaUrl, string $width, string $height): ?string
     {
-        return $this->extensions->publish(
-            name: ResolveRemoteThumbnailUrlExtension::NAME,
-            extension: new ResolveRemoteThumbnailUrlExtension(
-                $mediaUrl,
-                $mediaEntity->get('path'),
+        $extension = new ResolveRemoteThumbnailUrlExtension(
+            $mediaUrl,
+            $mediaEntity->get('path'),
+            $width,
+            $height,
+            $this->pattern,
+            $mediaEntity->get('updatedAt') ?? $mediaEntity->get('createdAt'),
+            $mediaEntity,
+        );
+        $function = static function (
+            string $mediaUrl,
+            string $mediaPath,
+            string $width,
+            string $height,
+            string $pattern,
+            ?\DateTimeInterface $mediaUpdatedAt,
+            Entity $mediaEntity,
+        ): string {
+            if (Feature::isActive('v6.8.0.0')) {
+                $mediaPath = $mediaEntity->get('path');
+                \assert(\is_string($mediaPath));
+                $mediaUpdatedAt = $mediaEntity->get('updatedAt') ?? $mediaEntity->get('createdAt');
+                \assert($mediaUpdatedAt instanceof \DateTimeInterface || $mediaUpdatedAt === null);
+            }
+
+            $replacements = [
+                str_starts_with($mediaPath, 'http') ? '' : $mediaUrl,
+                $mediaPath,
                 $width,
                 $height,
-                $this->pattern,
-                $mediaEntity->get('updatedAt') ?? $mediaEntity->get('createdAt'),
-                $mediaEntity,
-            ),
-            function: static function (
-                string $mediaUrl,
-                string $mediaPath,
-                string $width,
-                string $height,
-                string $pattern,
-                ?\DateTimeInterface $mediaUpdatedAt,
-                Entity $mediaEntity,
-            ): string {
-                if (Feature::isActive('v6.8.0.0')) {
-                    $mediaPath = $mediaEntity->get('path');
-                    \assert(\is_string($mediaPath));
-                    $mediaUpdatedAt = $mediaEntity->get('updatedAt') ?? $mediaEntity->get('createdAt');
-                    \assert($mediaUpdatedAt instanceof \DateTimeInterface || $mediaUpdatedAt === null);
-                }
+                (string) $mediaUpdatedAt?->getTimestamp() ?: '',
+            ];
 
-                $replacements = [
-                    str_starts_with($mediaPath, 'http') ? '' : $mediaUrl,
-                    $mediaPath,
-                    $width,
-                    $height,
-                    (string) $mediaUpdatedAt?->getTimestamp() ?: '',
-                ];
+            $url = str_replace(
+                ['{mediaUrl}', '{mediaPath}', '{width}', '{height}', '{mediaUpdatedAt}'],
+                $replacements,
+                $pattern
+            );
 
-                $url = str_replace(
-                    ['{mediaUrl}', '{mediaPath}', '{width}', '{height}', '{mediaUpdatedAt}'],
-                    $replacements,
-                    $pattern
-                );
+            return str_starts_with($mediaPath, 'http') ? ltrim($url, '/') : $url;
+        };
 
-                return str_starts_with($mediaPath, 'http') ? ltrim($url, '/') : $url;
-            }
+        if (!$this->extensions->hasListeners(ResolveRemoteThumbnailUrlExtension::NAME)) {
+            return $function(...$extension->getParams());
+        }
+
+        return $this->extensions->publish(
+            name: ResolveRemoteThumbnailUrlExtension::NAME,
+            extension: $extension,
+            function: $function,
         );
     }
 }

--- a/src/Core/Framework/Extensions/ExtensionDispatcher.php
+++ b/src/Core/Framework/Extensions/ExtensionDispatcher.php
@@ -43,6 +43,13 @@ final readonly class ExtensionDispatcher
         return $name . '.error';
     }
 
+    public function hasListeners(string $name): bool
+    {
+        return $this->dispatcher->hasListeners(self::pre($name))
+            || $this->dispatcher->hasListeners(self::post($name))
+            || $this->dispatcher->hasListeners(self::error($name));
+    }
+
     /**
      * @template TExtensionType of mixed
      *

--- a/tests/unit/Core/Content/Media/Core/Application/RemoteThumbnailLoaderTest.php
+++ b/tests/unit/Core/Content/Media/Core/Application/RemoteThumbnailLoaderTest.php
@@ -19,6 +19,7 @@ use Shopware\Core\Framework\Extensions\ExtensionDispatcher;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Test\Stub\Framework\IdsCollection;
 use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 /**
  * @internal
@@ -449,5 +450,52 @@ class RemoteThumbnailLoaderTest extends TestCase
         $thumbnail = $thumbnails->first();
         static::assertInstanceOf(MediaThumbnailEntity::class, $thumbnail);
         static::assertSame('http://localhost:8000/foo/bar.png?width=200&ts=', $thumbnail->getUrl());
+    }
+
+    public function testDoesNotDispatchExtensionWhenNoListenerIsRegistered(): void
+    {
+        $ids = new IdsCollection();
+        $filesystem = new Filesystem(new InMemoryFilesystemAdapter(), ['public_url' => 'http://localhost:8000']);
+
+        $connection = static::createStub(Connection::class);
+        $connection->method('fetchAllAssociative')->willReturnOnConsecutiveCalls([], [[
+            'folder_id' => $ids->get('mediaFolderId'),
+            'configuration_id' => $ids->get('mediaFolderConfigurationId'),
+            'create_thumbnails' => '1',
+        ]]);
+
+        $dispatcher = $this->createMock(EventDispatcherInterface::class);
+        $dispatcher->expects($this->exactly(9))
+            ->method('hasListeners')
+            ->willReturn(false);
+        $dispatcher->expects($this->never())->method('dispatch');
+
+        $entity = (new PartialEntity())->assign([
+            'id' => $ids->get('media'),
+            'path' => 'foo/bar.png',
+            'mediaFolderId' => $ids->get('mediaFolderId'),
+            'private' => false,
+        ]);
+
+        $prefixFilesystem = static::createStub(PrefixFilesystem::class);
+        $prefixFilesystem->method('publicUrl')->willReturn('http://localhost:8000');
+
+        $loader = new RemoteThumbnailLoader(
+            new MediaUrlGenerator($filesystem),
+            $connection,
+            $prefixFilesystem,
+            new ExtensionDispatcher($dispatcher),
+            '{mediaUrl}/{mediaPath}?width={width}&ts={mediaUpdatedAt}',
+            [
+                ['width' => 200, 'height' => 200],
+                ['width' => 400, 'height' => 400],
+                ['width' => 600, 'height' => 600],
+            ]
+        );
+
+        $loader->load([$entity]);
+
+        static::assertSame('http://localhost:8000/foo/bar.png', $entity->get('url'));
+        static::assertCount(3, $entity->get('thumbnails'));
     }
 }

--- a/tests/unit/Core/Framework/Extensions/ExtensionDispatcherTest.php
+++ b/tests/unit/Core/Framework/Extensions/ExtensionDispatcherTest.php
@@ -42,6 +42,29 @@ class ExtensionDispatcherTest extends TestCase
         ], $dispatcher->getEvents());
     }
 
+    public function testDetectsListenersForEveryLifecycleEvent(): void
+    {
+        $dispatcher = $this->createMock(EventDispatcherInterface::class);
+        $eventNames = [];
+        $dispatcher->expects($this->exactly(3))
+            ->method('hasListeners')
+            ->with(static::callback(static function (string $eventName) use (&$eventNames): bool {
+                $eventNames[] = $eventName;
+
+                return true;
+            }))
+            ->willReturnOnConsecutiveCalls(false, false, true);
+
+        $extensionDispatcher = new ExtensionDispatcher($dispatcher);
+
+        static::assertTrue($extensionDispatcher->hasListeners('test.extension'));
+        static::assertSame([
+            'test.extension.pre',
+            'test.extension.post',
+            'test.extension.error',
+        ], $eventNames);
+    }
+
     public function testHandlesExceptionGracefully(): void
     {
         $dispatcher = $this->createMock(EventDispatcherInterface::class);


### PR DESCRIPTION
### 1. Why is this change necessary?

Remote thumbnail URL generation dispatches extension lifecycle events for every thumbnail size, even when no listeners are registered. This creates avoidable work on storefront requests.

### 2. What does this change do, exactly?

`ExtensionDispatcher` can now detect listeners across the `.pre`, `.post`, and `.error` lifecycle events. `RemoteThumbnailLoader` invokes the existing URL generation callback directly when none are registered, while preserving the extension dispatch path for existing listeners.

A focused release information entry was added to `RELEASE_INFO-6.7.md`.

### 3. Describe each step to reproduce the issue or behaviour.

1. Enable remote thumbnail URL generation.
2. Load media with multiple configured thumbnail sizes.
3. Observe that `remote_thumbnail_url.resolve.pre` and `.post` are dispatched for each thumbnail size, even when no listeners handle the events.
4. With this change, no lifecycle events are dispatched when no listeners exist; registered listeners continue to receive the events.

### 4. Please link to the relevant issues (if any).

- relates https://github.com/shopware/saas/issues/791

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [x] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them