### PR TITLE
fix: include seo urls in store-api responses for headless sales channels

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -1,11 +1,5 @@
 # 6.7.15.0 (upcoming)
 
-## API
-
-### Headless sales channels return their SEO URLs via `sw-include-seo-urls`
-
-Store API responses requested with the `sw-include-seo-urls` header now also include the SEO URLs generated for headless (API type) sales channels. Previously only the storefront SEO URL routes were considered when loading the `seoUrls` of products, categories and landing pages, so the association stayed empty on headless sales channels even though SEO URLs had been generated for them (see "SEO URLs for headless sales channels" in 6.7.14.0). Storefront sales channels are unaffected.
-
 ## Core
 
 ### `system:install` dispatches `SystemInstallCompletedEvent`
@@ -117,6 +111,11 @@ Store API responses no longer echo the request `sw-context-token` header on cach
 ### Dedicated error code for invalid child line item quantity
 
 `CartException::invalidChildQuantity()` now returns the error code `CHECKOUT__CART_INVALID_CHILD_LINE_ITEM_QUANTITY` (constant `CartException::CART_INVALID_CHILD_LINE_ITEM_QUANTITY_CODE`) instead of reusing `CHECKOUT__CART_INVALID_LINE_ITEM_QUANTITY`. Previously both `invalidChildQuantity()` and `invalidQuantity()` shared the same error code, so the shared storefront message `The quantity (%quantity%) is incorrect.` was rendered with an empty `%quantity%` placeholder for the child quantity case (`invalidChildQuantity()` never provided that parameter). If you match on the previous error code to detect invalid child quantities, switch to the new code.
+
+### Headless sales channels return their SEO URLs via `sw-include-seo-urls`
+
+Store API responses requested with the `sw-include-seo-urls` header now also include the SEO URLs generated for headless (API type) sales channels. Previously only the storefront SEO URL routes were considered when loading the `seoUrls` of products, categories and landing pages, so the association stayed empty on headless sales channels even though SEO URLs had been generated for them (see "SEO URLs for headless sales channels" in 6.7.14.0). Storefront sales channels are unaffected.
+
 ## Administration
 
 ### Shipping prices can be linked to the tax rate

--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -1,5 +1,11 @@
 # 6.7.15.0 (upcoming)
 
+## API
+
+### Headless sales channels return their SEO URLs via `sw-include-seo-urls`
+
+Store API responses requested with the `sw-include-seo-urls` header now also include the SEO URLs generated for headless (API type) sales channels. Previously only the storefront SEO URL routes were considered when loading the `seoUrls` of products, categories and landing pages, so the association stayed empty on headless sales channels even though SEO URLs had been generated for them (see "SEO URLs for headless sales channels" in 6.7.14.0). Storefront sales channels are unaffected.
+
 ## Core
 
 ### `system:install` dispatches `SystemInstallCompletedEvent`

--- a/src/Core/Content/Seo/SalesChannel/StoreApiSeoResolver.php
+++ b/src/Core/Content/Seo/SalesChannel/StoreApiSeoResolver.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Core\Content\Seo\SalesChannel;
 
+use Shopware\Core\Content\Seo\Exception\SeoUrlRouteConfigException;
 use Shopware\Core\Content\Seo\SeoUrl\SeoUrlCollection;
 use Shopware\Core\Content\Seo\SeoUrlRoute\EntityRouteResolver;
 use Shopware\Core\Content\Seo\SeoUrlRoute\SeoUrlRouteInterface as SeoUrlRouteConfigRoute;
@@ -198,9 +199,13 @@ class StoreApiSeoResolver implements EventSubscriberInterface
 
         // Headless sales channels persist their SEO URLs against the store-api route family. The storefront
         // route names stay in the filter as a fallback for entities without a store-api counterpart.
-        return array_values(array_unique([
-            ...$this->entityRouteResolver->getEntitySeoUrlRouteNames($entityName),
-            ...$routeNames,
-        ]));
+        try {
+            return array_values(array_unique([
+                $this->entityRouteResolver->getRouteNameForEntityName($entityName, $context->getSalesChannel()->getTypeId()),
+                ...$routeNames,
+            ]));
+        } catch (SeoUrlRouteConfigException) {
+            return $routeNames;
+        }
     }
 }

--- a/src/Core/Content/Seo/SalesChannel/StoreApiSeoResolver.php
+++ b/src/Core/Content/Seo/SalesChannel/StoreApiSeoResolver.php
@@ -3,8 +3,10 @@
 namespace Shopware\Core\Content\Seo\SalesChannel;
 
 use Shopware\Core\Content\Seo\SeoUrl\SeoUrlCollection;
+use Shopware\Core\Content\Seo\SeoUrlRoute\EntityRouteResolver;
 use Shopware\Core\Content\Seo\SeoUrlRoute\SeoUrlRouteInterface as SeoUrlRouteConfigRoute;
 use Shopware\Core\Content\Seo\SeoUrlRoute\SeoUrlRouteRegistry;
+use Shopware\Core\Defaults;
 use Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry;
 use Shopware\Core\Framework\DataAbstractionLayer\Entity;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\AggregationResult\AggregationResultCollection;
@@ -41,7 +43,8 @@ class StoreApiSeoResolver implements EventSubscriberInterface
         private readonly SalesChannelRepository $salesChannelRepository,
         private readonly DefinitionInstanceRegistry $definitionInstanceRegistry,
         private readonly SalesChannelDefinitionInstanceRegistry $salesChannelDefinitionInstanceRegistry,
-        private readonly SeoUrlRouteRegistry $seoUrlRouteRegistry
+        private readonly SeoUrlRouteRegistry $seoUrlRouteRegistry,
+        private readonly EntityRouteResolver $entityRouteResolver
     ) {
     }
 
@@ -144,16 +147,14 @@ class StoreApiSeoResolver implements EventSubscriberInterface
             $definition = (string) $definition;
 
             $ids = $data->getIds($definition);
-            $routes = $this->seoUrlRouteRegistry->findByDefinition($definition);
-            if ($routes === []) {
+            $routeNames = $this->getRouteNames($definition, $context);
+            if ($routeNames === []) {
                 continue;
             }
 
-            $routes = array_map(static fn (SeoUrlRouteConfigRoute $seoUrlRoute) => $seoUrlRoute->getConfig()->getRouteName(), $routes);
-
             $criteria = new Criteria();
             $criteria->addFilter(new EqualsFilter('isCanonical', true));
-            $criteria->addFilter(new EqualsAnyFilter('routeName', $routes));
+            $criteria->addFilter(new EqualsAnyFilter('routeName', $routeNames));
             $criteria->addFilter(new EqualsAnyFilter('foreignKey', $ids));
             $criteria->addFilter(new EqualsFilter('languageId', $context->getLanguageId()));
             $criteria->addSorting(new FieldSorting('salesChannelId'));
@@ -179,5 +180,27 @@ class StoreApiSeoResolver implements EventSubscriberInterface
                 }
             }
         }
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function getRouteNames(string $entityName, SalesChannelContext $context): array
+    {
+        $routeNames = array_values(array_map(
+            static fn (SeoUrlRouteConfigRoute $seoUrlRoute) => $seoUrlRoute->getConfig()->getRouteName(),
+            $this->seoUrlRouteRegistry->findByDefinition($entityName)
+        ));
+
+        if ($context->getSalesChannel()->getTypeId() !== Defaults::SALES_CHANNEL_TYPE_API) {
+            return $routeNames;
+        }
+
+        // Headless sales channels persist their SEO URLs against the store-api route family. The storefront
+        // route names stay in the filter as a fallback for entities without a store-api counterpart.
+        return array_values(array_unique([
+            ...$this->entityRouteResolver->getEntitySeoUrlRouteNames($entityName),
+            ...$routeNames,
+        ]));
     }
 }

--- a/src/Core/Content/Seo/SeoUrlRoute/EntityRouteResolver.php
+++ b/src/Core/Content/Seo/SeoUrlRoute/EntityRouteResolver.php
@@ -52,6 +52,26 @@ class EntityRouteResolver
         return $this->router->generate($config->getRouteName(), $config->getPrimaryKeyParameter($primaryKey));
     }
 
+    /**
+     * Returns the route names of all store-api SEO URL routes registered for the given entity.
+     *
+     * @return list<string>
+     */
+    public function getEntitySeoUrlRouteNames(string $entityName): array
+    {
+        $routeNames = [];
+
+        foreach ($this->storeApiSeoUrlRoutes as $storeApiSeoUrlRoute) {
+            $config = $storeApiSeoUrlRoute->getConfig();
+
+            if ($config->getDefinition()->getEntityName() === $entityName) {
+                $routeNames[] = $config->getRouteName();
+            }
+        }
+
+        return $routeNames;
+    }
+
     public function findEntitySeoUrlRoute(string $routeName): ?EntitySeoUrlRouteInterface
     {
         foreach ($this->storeApiSeoUrlRoutes as $entitySeoUrlRoute) {

--- a/src/Core/Content/Seo/SeoUrlRoute/EntityRouteResolver.php
+++ b/src/Core/Content/Seo/SeoUrlRoute/EntityRouteResolver.php
@@ -52,26 +52,6 @@ class EntityRouteResolver
         return $this->router->generate($config->getRouteName(), $config->getPrimaryKeyParameter($primaryKey));
     }
 
-    /**
-     * Returns the route names of all store-api SEO URL routes registered for the given entity.
-     *
-     * @return list<string>
-     */
-    public function getEntitySeoUrlRouteNames(string $entityName): array
-    {
-        $routeNames = [];
-
-        foreach ($this->storeApiSeoUrlRoutes as $storeApiSeoUrlRoute) {
-            $config = $storeApiSeoUrlRoute->getConfig();
-
-            if ($config->getDefinition()->getEntityName() === $entityName) {
-                $routeNames[] = $config->getRouteName();
-            }
-        }
-
-        return $routeNames;
-    }
-
     public function findEntitySeoUrlRoute(string $routeName): ?EntitySeoUrlRouteInterface
     {
         foreach ($this->storeApiSeoUrlRoutes as $entitySeoUrlRoute) {

--- a/src/Core/Framework/DependencyInjection/seo.php
+++ b/src/Core/Framework/DependencyInjection/seo.php
@@ -240,6 +240,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             service(DefinitionInstanceRegistry::class),
             service(SalesChannelDefinitionInstanceRegistry::class),
             service(SeoUrlRouteRegistry::class),
+            service(EntityRouteResolver::class),
         ])
         ->tag('kernel.event_subscriber');
 

--- a/tests/integration/Core/Content/Seo/SalesChannel/StoreApiSeoResolverTest.php
+++ b/tests/integration/Core/Content/Seo/SalesChannel/StoreApiSeoResolverTest.php
@@ -4,6 +4,7 @@ namespace Shopware\Tests\Integration\Core\Content\Seo\SalesChannel;
 
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Product\Aggregate\ProductVisibility\ProductVisibilityDefinition;
+use Shopware\Core\Content\Seo\SeoUrlRoute\CategoryStoreApiUrlRoute;
 use Shopware\Core\Content\Test\TestNavigationSeoUrlRoute;
 use Shopware\Core\Content\Test\TestProductSeoUrlRoute;
 use Shopware\Core\Defaults;
@@ -109,6 +110,37 @@ class StoreApiSeoResolverTest extends TestCase
         static::assertIsArray($response['cmsPage']['sections'][0]['blocks'][0]['slots'][0]['data']['listing']['elements'][0]['seoUrls']);
     }
 
+    public function testEnabledHeadlessSalesChannel(): void
+    {
+        $browser = $this->createCustomSalesChannelBrowser([
+            'id' => $this->ids->create('headless-sales-channel'),
+            'typeId' => Defaults::SALES_CHANNEL_TYPE_API,
+            'navigationCategoryId' => $this->ids->get('category'),
+        ]);
+
+        $browser->setServerParameter('HTTP_sw-include-seo-urls', '1');
+
+        $browser->request('POST', '/store-api/category/home');
+
+        $content = $browser->getResponse()->getContent();
+        static::assertIsString($content);
+
+        $response = json_decode($content, true, 512, \JSON_THROW_ON_ERROR);
+
+        static::assertArrayHasKey('seoUrls', $response);
+        static::assertIsArray($response['seoUrls']);
+
+        $routeNames = array_column($response['seoUrls'], 'routeName');
+
+        static::assertContains(CategoryStoreApiUrlRoute::ROUTE_NAME, $routeNames);
+        // storefront route names stay in the filter as a fallback, so their rows are returned as well
+        static::assertContains(TestNavigationSeoUrlRoute::ROUTE_NAME, $routeNames);
+
+        foreach ($response['seoUrls'] as $seoUrl) {
+            static::assertSame($this->ids->get('category'), $seoUrl['foreignKey']);
+        }
+    }
+
     public function testEnabledNoAuthentication(): void
     {
         $this->browser->setServerParameter('HTTP_sw-include-seo-urls', '1');
@@ -188,6 +220,13 @@ class StoreApiSeoResolverTest extends TestCase
                     'routeName' => TestNavigationSeoUrlRoute::ROUTE_NAME,
                     'pathInfo' => 'foo',
                     'seoPathInfo' => 'foo',
+                    'isCanonical' => true,
+                ],
+                [
+                    'languageId' => Defaults::LANGUAGE_SYSTEM,
+                    'routeName' => CategoryStoreApiUrlRoute::ROUTE_NAME,
+                    'pathInfo' => 'headless-foo',
+                    'seoPathInfo' => 'headless-foo',
                     'isCanonical' => true,
                 ],
             ],

--- a/tests/unit/Core/Content/Seo/SalesChannel/StoreApiSeoResolverTest.php
+++ b/tests/unit/Core/Content/Seo/SalesChannel/StoreApiSeoResolverTest.php
@@ -324,7 +324,7 @@ class StoreApiSeoResolverTest extends TestCase
     }
 
     /**
-     * @return \Generator<string, array{bool, bool, list<string>}>
+     * @return \Generator<string, array{bool, bool, list<string>, 3?: bool}>
      */
     public static function routeNameFilterCases(): \Generator
     {
@@ -345,13 +345,20 @@ class StoreApiSeoResolverTest extends TestCase
             false,
             [ProductStoreApiUrlRoute::ROUTE_NAME],
         ];
+
+        yield 'headless sales channels fall back to the storefront names for entities without a store-api route' => [
+            true,
+            true,
+            [TestProductSeoUrlRoute::ROUTE_NAME],
+            false,
+        ];
     }
 
     /**
      * @param list<string> $expectedRouteNames
      */
     #[DataProvider('routeNameFilterCases')]
-    public function testRouteNameFilterMatchesSalesChannelType(bool $headless, bool $withStorefrontRoutes, array $expectedRouteNames): void
+    public function testRouteNameFilterMatchesSalesChannelType(bool $headless, bool $withStorefrontRoutes, array $expectedRouteNames, bool $withStoreApiRoutes = true): void
     {
         $context = $headless ? $this->createHeadlessSalesChannelContext() : Generator::generateSalesChannelContext();
 
@@ -361,6 +368,7 @@ class StoreApiSeoResolverTest extends TestCase
         $capturedCriteria = null;
         $storeApiSeoResolver = $this->createStoreApiSeoResolver(
             seoUrlRouteRegistry: $withStorefrontRoutes ? null : new SeoUrlRouteRegistry([]),
+            withStoreApiRoutes: $withStoreApiRoutes,
             onSearch: static function (Criteria $criteria) use (&$capturedCriteria): void {
                 $capturedCriteria = $criteria;
             },
@@ -435,6 +443,7 @@ class StoreApiSeoResolverTest extends TestCase
         array $foreignKeys = ['random'],
         ?SeoUrlRouteRegistry $seoUrlRouteRegistry = null,
         ?\Closure $onSearch = null,
+        bool $withStoreApiRoutes = true,
     ): StoreApiSeoResolver {
         $definitionInstanceRegistry = $this->getDefinitionRegistry();
 
@@ -482,7 +491,7 @@ class StoreApiSeoResolverTest extends TestCase
                 new SeoUrlRouteRegistry([]),
                 static::createStub(SeoUrlPlaceholderHandlerInterface::class),
                 static::createStub(RouterInterface::class),
-                [new ProductStoreApiUrlRoute($productDefinition)],
+                $withStoreApiRoutes ? [new ProductStoreApiUrlRoute($productDefinition)] : [],
             ),
         );
     }

--- a/tests/unit/Core/Content/Seo/SalesChannel/StoreApiSeoResolverTest.php
+++ b/tests/unit/Core/Content/Seo/SalesChannel/StoreApiSeoResolverTest.php
@@ -3,6 +3,7 @@
 namespace Shopware\Tests\Unit\Core\Content\Seo\SalesChannel;
 
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Product\Aggregate\ProductCrossSelling\ProductCrossSellingCollection;
@@ -18,25 +19,34 @@ use Shopware\Core\Content\Seo\SalesChannel\StoreApiSeoResolver;
 use Shopware\Core\Content\Seo\SeoUrl\SeoUrlCollection;
 use Shopware\Core\Content\Seo\SeoUrl\SeoUrlDefinition;
 use Shopware\Core\Content\Seo\SeoUrl\SeoUrlEntity;
+use Shopware\Core\Content\Seo\SeoUrlPlaceholderHandlerInterface;
+use Shopware\Core\Content\Seo\SeoUrlRoute\EntityRouteResolver;
+use Shopware\Core\Content\Seo\SeoUrlRoute\ProductStoreApiUrlRoute;
 use Shopware\Core\Content\Seo\SeoUrlRoute\SeoUrlRouteRegistry;
 use Shopware\Core\Content\Test\TestProductSeoUrlRoute;
+use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldVisibility;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsAnyFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\EntityWriteGatewayInterface;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\PlatformRequest;
 use Shopware\Core\System\SalesChannel\Entity\SalesChannelDefinitionInstanceRegistry;
 use Shopware\Core\System\SalesChannel\Entity\SalesChannelRepository;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Shopware\Core\System\SalesChannel\SalesChannelEntity;
+use Shopware\Core\Test\Generator;
 use Shopware\Core\Test\Stub\DataAbstractionLayer\StaticDefinitionInstanceRegistry;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 /**
@@ -313,6 +323,78 @@ class StoreApiSeoResolverTest extends TestCase
         static::assertNull($productEntity->getSeoUrls());
     }
 
+    /**
+     * @return \Generator<string, array{bool, bool, list<string>}>
+     */
+    public static function routeNameFilterCases(): \Generator
+    {
+        yield 'storefront sales channels query only the storefront route names' => [
+            false,
+            true,
+            [TestProductSeoUrlRoute::ROUTE_NAME],
+        ];
+
+        yield 'headless sales channels query the store-api route names, storefront names stay as fallback' => [
+            true,
+            true,
+            [ProductStoreApiUrlRoute::ROUTE_NAME, TestProductSeoUrlRoute::ROUTE_NAME],
+        ];
+
+        yield 'headless sales channels work without any storefront routes registered' => [
+            true,
+            false,
+            [ProductStoreApiUrlRoute::ROUTE_NAME],
+        ];
+    }
+
+    /**
+     * @param list<string> $expectedRouteNames
+     */
+    #[DataProvider('routeNameFilterCases')]
+    public function testRouteNameFilterMatchesSalesChannelType(bool $headless, bool $withStorefrontRoutes, array $expectedRouteNames): void
+    {
+        $context = $headless ? $this->createHeadlessSalesChannelContext() : Generator::generateSalesChannelContext();
+
+        $productEntity = $this->createProductEntity();
+        $event = $this->createProductListResponseEvent($productEntity, $context);
+
+        $capturedCriteria = null;
+        $storeApiSeoResolver = $this->createStoreApiSeoResolver(
+            seoUrlRouteRegistry: $withStorefrontRoutes ? null : new SeoUrlRouteRegistry([]),
+            onSearch: static function (Criteria $criteria) use (&$capturedCriteria): void {
+                $capturedCriteria = $criteria;
+            },
+        );
+        $storeApiSeoResolver->addSeoInformation($event);
+
+        static::assertInstanceOf(Criteria::class, $capturedCriteria);
+        static::assertSame($expectedRouteNames, $this->getRouteNameFilterValues($capturedCriteria));
+        static::assertNotEmpty($productEntity->getSeoUrls());
+    }
+
+    private function createProductListResponseEvent(SalesChannelProductEntity $productEntity, SalesChannelContext $context): ResponseEvent
+    {
+        $request = new Request();
+        $request->headers->set(PlatformRequest::HEADER_INCLUDE_SEO_URLS, 'true');
+        $request->attributes->set(PlatformRequest::ATTRIBUTE_SALES_CHANNEL_CONTEXT_OBJECT, $context);
+
+        $response = new ProductListResponse(new EntitySearchResult(
+            'product',
+            1,
+            new ProductCollection([$productEntity]),
+            null,
+            new Criteria(),
+            Context::createDefaultContext(),
+        ));
+
+        return new ResponseEvent(
+            static::createStub(HttpKernelInterface::class),
+            $request,
+            HttpKernelInterface::MAIN_REQUEST,
+            $response
+        );
+    }
+
     private function createProductEntity(string $identifier = 'random'): SalesChannelProductEntity
     {
         $productEntity = new SalesChannelProductEntity();
@@ -322,11 +404,38 @@ class StoreApiSeoResolverTest extends TestCase
         return $productEntity;
     }
 
+    private function createHeadlessSalesChannelContext(): SalesChannelContext
+    {
+        $salesChannel = new SalesChannelEntity();
+        $salesChannel->setId(Uuid::randomHex());
+        $salesChannel->setTypeId(Defaults::SALES_CHANNEL_TYPE_API);
+        $salesChannel->setLanguageId(Defaults::LANGUAGE_SYSTEM);
+
+        return Generator::generateSalesChannelContext(salesChannel: $salesChannel);
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function getRouteNameFilterValues(Criteria $criteria): array
+    {
+        foreach ($criteria->getFilters() as $filter) {
+            if ($filter instanceof EqualsAnyFilter && $filter->getField() === 'routeName') {
+                return array_values(array_map('strval', $filter->getValue()));
+            }
+        }
+
+        return [];
+    }
+
     /**
      * @param array<string> $foreignKeys
      */
-    private function createStoreApiSeoResolver(array $foreignKeys = ['random']): StoreApiSeoResolver
-    {
+    private function createStoreApiSeoResolver(
+        array $foreignKeys = ['random'],
+        ?SeoUrlRouteRegistry $seoUrlRouteRegistry = null,
+        ?\Closure $onSearch = null,
+    ): StoreApiSeoResolver {
         $definitionInstanceRegistry = $this->getDefinitionRegistry();
 
         $seoUrlCollection = new SeoUrlCollection();
@@ -356,13 +465,25 @@ class StoreApiSeoResolverTest extends TestCase
         $salesChannelRepository = static::createStub(SalesChannelRepository::class);
         $salesChannelRepository
             ->method('search')
-            ->willReturn($entitySearchResult);
+            ->willReturnCallback(static function (Criteria $criteria) use ($entitySearchResult, $onSearch): EntitySearchResult {
+                if ($onSearch !== null) {
+                    $onSearch($criteria);
+                }
+
+                return $entitySearchResult;
+            });
 
         return new StoreApiSeoResolver(
             $salesChannelRepository,
             $definitionInstanceRegistry,
             static::createStub(SalesChannelDefinitionInstanceRegistry::class),
-            new SeoUrlRouteRegistry([new TestProductSeoUrlRoute($productDefinition)]),
+            $seoUrlRouteRegistry ?? new SeoUrlRouteRegistry([new TestProductSeoUrlRoute($productDefinition)]),
+            new EntityRouteResolver(
+                new SeoUrlRouteRegistry([]),
+                static::createStub(SeoUrlPlaceholderHandlerInterface::class),
+                static::createStub(RouterInterface::class),
+                [new ProductStoreApiUrlRoute($productDefinition)],
+            ),
         );
     }
 


### PR DESCRIPTION
### 1. Why is this change necessary?

Since #17991 headless (API type) sales channels generate SEO URLs against dedicated store-api routes (`store-api.product.detail`, `store-api.category.detail`, `store-api.landing-page.detail`). The `sw-include-seo-urls` header — the mechanism Composable Frontends use to receive the `seoUrls` of products, categories and landing pages — never returns them: `StoreApiSeoResolver::enrich()` resolves the candidate route names from `SeoUrlRouteRegistry`, which only knows the storefront (`frontend.*`) routes. For a headless channel all persisted rows carry `store-api.*` route names, so the enrichment finds nothing and the generated SEO URLs never reach the frontend. This is one of the two remaining reasons the Composable Frontends docs still recommend the Storefront channel type as a workaround (https://developer.shopware.com/frontends/resources/troubleshooting.html#which-saleschannel-type-to-use-for-composable-frontends).

### 2. What does this change do, exactly?

- `EntityRouteResolver` gets a new method `getEntitySeoUrlRouteNames()` returning the route names of all tagged `shopware.entity.seo_url.route` routes for a given entity (the class is `@internal`, the addition is additive).
- `StoreApiSeoResolver` receives the `EntityRouteResolver` and, for API-type sales channels, filters `seo_url` rows by the **union** of the store-api route names and the registry (storefront) route names. The union mirrors the fallback in `EntityRouteResolver::getRouteConfig()`: entities without a store-api counterpart (e.g. plugin-registered SEO routes) keep working, and the extra names in the `EqualsAnyFilter` are harmless since only persisted rows match. For every other channel type the behaviour is byte-for-byte unchanged.
- Because the store-api routes are registered in Core, the enrichment now also works on installations without the Storefront bundle (where the registry is empty).

### 3. Describe each step to reproduce the issue or behaviour.

1. Create a headless (API type) sales channel; add a domain flagged as *external storefront*; reindex so SEO URLs are generated.
2. Call `POST /store-api/category/home` (or a product/landing-page route) with the `sw-include-seo-urls` header.
3. Before: `seoUrls` is empty. After: `seoUrls` contains the rows with `routeName: store-api.category.detail` etc.

### 4. Please link to the relevant issues (if any).

- relates #19685
- relates #16619, builds on #17991

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have updated developer-facing release notes if this change is **relevant** for external developers (`RELEASE_INFO-6.7.md`)
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
