### PR TITLE
feat: sitemap generation for headless sales channels

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -17,6 +17,12 @@ Two new events give extensions a hook into the document lifecycle without pollin
 
 Both events are selectable as triggers in Flow Builder. `document.generation.completed` fires for both the legacy document pipeline (`Shopware\Core\Checkout\Document\Service\DocumentGenerator::generate()` and `::upload()`) and the Document V2 pipeline (`POST /_action/order/document-v2/create` and `POST /_action/order/document-v2/upload`); `document.generation.deleted` already covers both, since deletion goes through the shared `document` entity regardless of which pipeline created it.
 
+### Sitemap generation for headless sales channels
+
+Sitemaps are now generated for headless (API type) sales channels that have a domain flagged as external storefront (introduced in 6.7.14.0, see "SEO URLs for headless sales channels"). This applies to all refresh strategies: the scheduled task and `sitemap:generate` now include such sales channels, and the live strategy on `GET /store-api/sitemap` generates their files on request. The `<loc>` entries point at the external storefront domain and use the headless SEO URL paths; the file URLs returned by `GET /store-api/sitemap` point at the configured sitemap filesystem (the Shopware host or its CDN), since the external storefront does not serve the files — headless frontends can serve or proxy them from there, or download them via `GET /store-api/sitemap/{filePath}`.
+
+Headless sales channels without an external storefront domain for the requested language are skipped silently — matching the behavior of the SEO URL generation — instead of failing with `CONTENT__INVALID_DOMAIN` under the live strategy. Storefront sales channels are unaffected.
+
 ### Customer imports validate customer number patterns
 
 Customer import records whose `customerNumber` does not match the configured customer number range pattern for the resolved sales channel are now rejected and written to the invalid-records file. Adjust the imported customer numbers or the number range pattern before retrying the import.

--- a/src/Core/Content/DependencyInjection/sitemap.php
+++ b/src/Core/Content/DependencyInjection/sitemap.php
@@ -25,6 +25,7 @@ use Shopware\Core\Content\Sitemap\Service\SitemapExporter;
 use Shopware\Core\Content\Sitemap\Service\SitemapHandleFactory;
 use Shopware\Core\Content\Sitemap\Service\SitemapHandleFactoryInterface;
 use Shopware\Core\Content\Sitemap\Service\SitemapLister;
+use Shopware\Core\Content\Sitemap\Service\SitemapSalesChannelLoader;
 use Shopware\Core\Framework\Adapter\Cache\CacheTagCollector;
 use Shopware\Core\Framework\DataAbstractionLayer\Dbal\Common\IteratorFactory;
 use Shopware\Core\Framework\Extensions\ExtensionDispatcher;
@@ -130,12 +131,17 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         ])
         ->tag('shopware.sitemap.config_handler');
 
-    $services->set(SitemapGenerateCommand::class)
+    $services->set(SitemapSalesChannelLoader::class)
         ->args([
             service('sales_channel.repository'),
+            service('event_dispatcher'),
+        ]);
+
+    $services->set(SitemapGenerateCommand::class)
+        ->args([
+            service(SitemapSalesChannelLoader::class),
             service(SitemapExporter::class),
             service(SalesChannelContextFactory::class),
-            service('event_dispatcher'),
         ])
         ->tag('console.command');
 
@@ -146,10 +152,9 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         ->args([
             service('scheduled_task.repository'),
             service('logger'),
-            service('sales_channel.repository'),
+            service(SitemapSalesChannelLoader::class),
             service(SystemConfigService::class),
             service('messenger.default_bus'),
-            service('event_dispatcher'),
         ])
         ->tag('messenger.message_handler');
 

--- a/src/Core/Content/Sitemap/Commands/SitemapGenerateCommand.php
+++ b/src/Core/Content/Sitemap/Commands/SitemapGenerateCommand.php
@@ -2,27 +2,19 @@
 
 namespace Shopware\Core\Content\Sitemap\Commands;
 
-use Shopware\Core\Content\Sitemap\Event\SitemapSalesChannelCriteriaEvent;
 use Shopware\Core\Content\Sitemap\Exception\AlreadyLockedException;
 use Shopware\Core\Content\Sitemap\Service\SitemapExporterInterface;
-use Shopware\Core\Defaults;
+use Shopware\Core\Content\Sitemap\Service\SitemapSalesChannelLoader;
 use Shopware\Core\Framework\Context;
-use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
-use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
-use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
-use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\NotEqualsFilter;
 use Shopware\Core\Framework\Log\Package;
-use Shopware\Core\System\SalesChannel\Aggregate\SalesChannelDomain\SalesChannelDomainEntity;
 use Shopware\Core\System\SalesChannel\Context\AbstractSalesChannelContextFactory;
 use Shopware\Core\System\SalesChannel\Context\SalesChannelContextService;
-use Shopware\Core\System\SalesChannel\SalesChannelCollection;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 #[Package('discovery')]
 #[AsCommand(
@@ -33,14 +25,11 @@ class SitemapGenerateCommand extends Command
 {
     /**
      * @internal
-     *
-     * @param EntityRepository<SalesChannelCollection> $salesChannelRepository
      */
     public function __construct(
-        private readonly EntityRepository $salesChannelRepository,
+        private readonly SitemapSalesChannelLoader $salesChannelLoader,
         private readonly SitemapExporterInterface $sitemapExporter,
-        private readonly AbstractSalesChannelContextFactory $salesChannelContextFactory,
-        private readonly EventDispatcherInterface $eventDispatcher
+        private readonly AbstractSalesChannelContextFactory $salesChannelContextFactory
     ) {
         parent::__construct();
     }
@@ -68,20 +57,10 @@ class SitemapGenerateCommand extends Command
 
         $context = Context::createCLIContext();
 
-        $criteria = $this->createCriteria($salesChannelId);
-
-        $this->eventDispatcher->dispatch(
-            new SitemapSalesChannelCriteriaEvent($criteria, $context)
-        );
-
-        $salesChannels = $this->salesChannelRepository->search($criteria, $context)->getEntities();
+        $salesChannels = $this->salesChannelLoader->loadSalesChannels($context, $salesChannelId);
 
         foreach ($salesChannels as $salesChannel) {
-            $languageIds = $salesChannel->getDomains()?->map(static fn (SalesChannelDomainEntity $salesChannelDomain) => $salesChannelDomain->getLanguageId()) ?? [];
-
-            $languageIds = array_unique($languageIds);
-
-            foreach ($languageIds as $languageId) {
+            foreach ($this->salesChannelLoader->getLanguageIds($salesChannel) as $languageId) {
                 $salesChannelContext = $this->salesChannelContextFactory->create('', $salesChannel->getId(), [SalesChannelContextService::LANGUAGE_ID => $languageId]);
 
                 $output->writeln(\sprintf('Generating sitemaps for sales channel %s (%s) with and language %s...', $salesChannel->getId(), $salesChannel->getName() ?? '', $languageId));
@@ -105,17 +84,5 @@ class SitemapGenerateCommand extends Command
         if ($result->isFinish() === false) {
             $this->generateSitemap($salesChannelContext, $force, $result->getProvider(), $result->getOffset());
         }
-    }
-
-    private function createCriteria(?string $salesChannelId = null): Criteria
-    {
-        $criteria = $salesChannelId ? new Criteria([$salesChannelId]) : new Criteria();
-        $criteria->addAssociation('domains');
-        $criteria->addFilter(new NotEqualsFilter('domains.id', null));
-
-        $criteria->addAssociation('type');
-        $criteria->addFilter(new EqualsFilter('type.id', Defaults::SALES_CHANNEL_TYPE_STOREFRONT));
-
-        return $criteria;
     }
 }

--- a/src/Core/Content/Sitemap/ScheduledTask/SitemapGenerateTaskHandler.php
+++ b/src/Core/Content/Sitemap/ScheduledTask/SitemapGenerateTaskHandler.php
@@ -3,23 +3,16 @@
 namespace Shopware\Core\Content\Sitemap\ScheduledTask;
 
 use Psr\Log\LoggerInterface;
-use Shopware\Core\Content\Sitemap\Event\SitemapSalesChannelCriteriaEvent;
 use Shopware\Core\Content\Sitemap\Service\SitemapExporterInterface;
-use Shopware\Core\Defaults;
+use Shopware\Core\Content\Sitemap\Service\SitemapSalesChannelLoader;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
-use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
-use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
-use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\NotEqualsFilter;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTaskCollection;
 use Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTaskHandler;
-use Shopware\Core\System\SalesChannel\Aggregate\SalesChannelDomain\SalesChannelDomainEntity;
-use Shopware\Core\System\SalesChannel\SalesChannelCollection;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 use Symfony\Component\Messenger\MessageBusInterface;
-use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 /**
  * @internal
@@ -32,15 +25,13 @@ final class SitemapGenerateTaskHandler extends ScheduledTaskHandler
      * @internal
      *
      * @param EntityRepository<ScheduledTaskCollection> $scheduledTaskRepository
-     * @param EntityRepository<SalesChannelCollection> $salesChannelRepository
      */
     public function __construct(
         EntityRepository $scheduledTaskRepository,
         LoggerInterface $logger,
-        private readonly EntityRepository $salesChannelRepository,
+        private readonly SitemapSalesChannelLoader $salesChannelLoader,
         private readonly SystemConfigService $systemConfigService,
-        private readonly MessageBusInterface $messageBus,
-        private readonly EventDispatcherInterface $eventDispatcher
+        private readonly MessageBusInterface $messageBus
     ) {
         parent::__construct($scheduledTaskRepository, $logger);
     }
@@ -52,31 +43,10 @@ final class SitemapGenerateTaskHandler extends ScheduledTaskHandler
             return;
         }
 
-        $criteria = new Criteria();
-        $criteria->addAssociation('domains');
-        $criteria->addFilter(new NotEqualsFilter('domains.id', null));
-
-        $criteria->addAssociation('type');
-        $criteria->addFilter(new EqualsFilter('type.id', Defaults::SALES_CHANNEL_TYPE_STOREFRONT));
-
-        $context = Context::createCLIContext();
-
-        $this->eventDispatcher->dispatch(
-            new SitemapSalesChannelCriteriaEvent($criteria, $context)
-        );
-
-        $salesChannels = $this->salesChannelRepository->search($criteria, $context)->getEntities();
+        $salesChannels = $this->salesChannelLoader->loadSalesChannels(Context::createCLIContext());
 
         foreach ($salesChannels as $salesChannel) {
-            if ($salesChannel->getDomains() === null) {
-                continue;
-            }
-
-            $languageIds = $salesChannel->getDomains()->map(static fn (SalesChannelDomainEntity $salesChannelDomain) => $salesChannelDomain->getLanguageId());
-
-            $languageIds = array_unique($languageIds);
-
-            foreach ($languageIds as $languageId) {
+            foreach ($this->salesChannelLoader->getLanguageIds($salesChannel) as $languageId) {
                 $this->messageBus->dispatch(new SitemapMessage($salesChannel->getId(), $languageId, null, null, false));
             }
         }

--- a/src/Core/Content/Sitemap/Service/SitemapExporter.php
+++ b/src/Core/Content/Sitemap/Service/SitemapExporter.php
@@ -11,6 +11,7 @@ use Shopware\Core\Content\Sitemap\Provider\AbstractUrlProvider;
 use Shopware\Core\Content\Sitemap\SitemapException;
 use Shopware\Core\Content\Sitemap\Struct\SitemapGenerationResult;
 use Shopware\Core\Content\Sitemap\Struct\UrlResult;
+use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\Aggregate\SalesChannelDomain\SalesChannelDomainCollection;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
@@ -54,7 +55,17 @@ class SitemapExporter implements SitemapExporterInterface
         $this->lock($context, $force);
 
         try {
-            $this->initSitemapHandles($context);
+            if (!$this->initSitemapHandles($context)) {
+                // Headless sales channels without an external storefront domain for the current language have
+                // nothing to generate - mirrors the silent skip of the SEO URL generation.
+                return new SitemapGenerationResult(
+                    true,
+                    $lastProvider,
+                    null,
+                    $context->getSalesChannelId(),
+                    $context->getLanguageId()
+                );
+            }
 
             foreach ($this->urlProvider as $urlProvider) {
                 do {
@@ -120,15 +131,21 @@ class SitemapExporter implements SitemapExporterInterface
         return \sprintf('sitemap-exporter-running-%s-%s', $salesChannelContext->getSalesChannelId(), $salesChannelContext->getLanguageId());
     }
 
-    private function initSitemapHandles(SalesChannelContext $context): void
+    private function initSitemapHandles(SalesChannelContext $context): bool
     {
         $languageId = $context->getLanguageId();
         $domainsEntity = $context->getSalesChannel()->getDomains();
+        $isHeadless = $context->getSalesChannel()->getTypeId() === Defaults::SALES_CHANNEL_TYPE_API;
 
         $sitemapDomains = [];
         if ($domainsEntity instanceof SalesChannelDomainCollection) {
             foreach ($domainsEntity as $domain) {
                 if ($domain->getLanguageId() === $languageId) {
+                    // domains of headless sales channels only qualify when they point at the external storefront
+                    if ($isHeadless && !$domain->getIsExternalStorefront()) {
+                        continue;
+                    }
+
                     $urlParts = \parse_url($domain->getUrl());
 
                     if ($urlParts === false) {
@@ -156,10 +173,16 @@ class SitemapExporter implements SitemapExporterInterface
         }
 
         if ($sitemapHandles === []) {
+            if ($isHeadless) {
+                return false;
+            }
+
             throw SitemapException::invalidDomain();
         }
 
         $this->sitemapHandles = $sitemapHandles;
+
+        return true;
     }
 
     private function processSiteMapHandles(UrlResult $result): void

--- a/src/Core/Content/Sitemap/Service/SitemapLister.php
+++ b/src/Core/Content/Sitemap/Service/SitemapLister.php
@@ -5,6 +5,7 @@ namespace Shopware\Core\Content\Sitemap\Service;
 use League\Flysystem\FilesystemOperator;
 use Psr\Clock\ClockInterface;
 use Shopware\Core\Content\Sitemap\Struct\Sitemap;
+use Shopware\Core\Defaults;
 use Shopware\Core\System\SalesChannel\Aggregate\SalesChannelDomain\SalesChannelDomainCollection;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\Asset\Package;
@@ -34,6 +35,10 @@ class SitemapLister implements SitemapListerInterface
         /** @var SalesChannelDomainCollection $domains */
         $domains = $salesChannelContext->getSalesChannel()->getDomains();
 
+        // domains of headless sales channels point at the external storefront, which does not serve the
+        // sitemap files - they are always linked via the asset package (the host the files live on) instead
+        $isHeadless = $salesChannelContext->getSalesChannel()->getTypeId() === Defaults::SALES_CHANNEL_TYPE_API;
+
         foreach ($files as $file) {
             if ($file->isDir()) {
                 continue;
@@ -43,7 +48,7 @@ class SitemapLister implements SitemapListerInterface
 
             $exploded = explode('-', $filename);
 
-            if (isset($exploded[1]) && $domains->has($exploded[1])) {
+            if (!$isHeadless && isset($exploded[1]) && $domains->has($exploded[1])) {
                 $domain = $domains->get($exploded[1]);
 
                 $sitemaps[] = new Sitemap($domain->getUrl() . '/' . $file->path(), 0, new \DateTime('@' . ($file->lastModified() ?? $this->clock->now()->getTimestamp())));

--- a/src/Core/Content/Sitemap/Service/SitemapSalesChannelLoader.php
+++ b/src/Core/Content/Sitemap/Service/SitemapSalesChannelLoader.php
@@ -1,0 +1,79 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Content\Sitemap\Service;
+
+use Shopware\Core\Content\Sitemap\Event\SitemapSalesChannelCriteriaEvent;
+use Shopware\Core\Defaults;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\AndFilter;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\NotEqualsFilter;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\OrFilter;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\System\SalesChannel\Aggregate\SalesChannelDomain\SalesChannelDomainEntity;
+use Shopware\Core\System\SalesChannel\SalesChannelCollection;
+use Shopware\Core\System\SalesChannel\SalesChannelEntity;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+
+/**
+ * Determines which sales channels and languages sitemaps are generated for.
+ *
+ * @internal
+ */
+#[Package('discovery')]
+class SitemapSalesChannelLoader
+{
+    /**
+     * @param EntityRepository<SalesChannelCollection> $salesChannelRepository
+     */
+    public function __construct(
+        private readonly EntityRepository $salesChannelRepository,
+        private readonly EventDispatcherInterface $eventDispatcher,
+    ) {
+    }
+
+    /**
+     * Sitemaps are generated for storefront sales channels and for headless (API type) sales channels
+     * with a domain flagged as external storefront.
+     */
+    public function loadSalesChannels(Context $context, ?string $salesChannelId = null): SalesChannelCollection
+    {
+        $criteria = $salesChannelId ? new Criteria([$salesChannelId]) : new Criteria();
+        $criteria->addAssociation('domains');
+        $criteria->addFilter(new NotEqualsFilter('domains.id', null));
+
+        $criteria->addAssociation('type');
+        $criteria->addFilter(new OrFilter([
+            new EqualsFilter('type.id', Defaults::SALES_CHANNEL_TYPE_STOREFRONT),
+            new AndFilter([
+                new EqualsFilter('type.id', Defaults::SALES_CHANNEL_TYPE_API),
+                new EqualsFilter('domains.isExternalStorefront', true),
+            ]),
+        ]));
+
+        $this->eventDispatcher->dispatch(new SitemapSalesChannelCriteriaEvent($criteria, $context));
+
+        return $this->salesChannelRepository->search($criteria, $context)->getEntities();
+    }
+
+    /**
+     * For headless sales channels only languages with an external storefront domain generate sitemap entries.
+     *
+     * @return list<string>
+     */
+    public function getLanguageIds(SalesChannelEntity $salesChannel): array
+    {
+        $domains = $salesChannel->getDomains();
+        if ($domains === null) {
+            return [];
+        }
+
+        if ($salesChannel->getTypeId() === Defaults::SALES_CHANNEL_TYPE_API) {
+            $domains = $domains->filter(static fn (SalesChannelDomainEntity $domain) => $domain->getIsExternalStorefront());
+        }
+
+        return array_values(array_unique($domains->map(static fn (SalesChannelDomainEntity $domain) => $domain->getLanguageId())));
+    }
+}

--- a/tests/integration/Core/Content/Sitemap/Command/SitemapGenerateCommandTest.php
+++ b/tests/integration/Core/Content/Sitemap/Command/SitemapGenerateCommandTest.php
@@ -7,6 +7,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Sitemap\Commands\SitemapGenerateCommand;
 use Shopware\Core\Content\Sitemap\Service\SitemapExporter;
+use Shopware\Core\Content\Sitemap\Service\SitemapSalesChannelLoader;
 use Shopware\Core\Content\Sitemap\Struct\SitemapGenerationResult;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Log\Package;
@@ -35,10 +36,12 @@ class SitemapGenerateCommandTest extends TestCase
         $this->exporter = $this->createMock(SitemapExporter::class);
 
         $this->command = new SitemapGenerateCommand(
-            static::getContainer()->get('sales_channel.repository'),
+            new SitemapSalesChannelLoader(
+                static::getContainer()->get('sales_channel.repository'),
+                $this->createMock(EventDispatcher::class)
+            ),
             $this->exporter,
-            static::getContainer()->get(SalesChannelContextFactory::class),
-            $this->createMock(EventDispatcher::class)
+            static::getContainer()->get(SalesChannelContextFactory::class)
         );
     }
 
@@ -86,6 +89,50 @@ class SitemapGenerateCommandTest extends TestCase
             ->method('generate')
             ->with(static::callback(static function (SalesChannelContext $context) use ($storefrontId) {
                 static::assertSame($storefrontId, $context->getSalesChannelId());
+
+                return true;
+            }))
+            ->willReturn($result);
+
+        $input = new ArrayInput([]);
+        $this->command->run($input, new NullOutput());
+    }
+
+    public function testGeneratesHeadlessSalesChannelWithExternalStorefrontDomain(): void
+    {
+        $connection = static::getContainer()->get(Connection::class);
+        $connection->executeStatement('DELETE FROM sales_channel');
+
+        $headlessId = Uuid::randomHex();
+        $this->createSalesChannel([
+            'id' => $headlessId,
+            'name' => 'headless',
+            'typeId' => Defaults::SALES_CHANNEL_TYPE_API,
+            'domains' => [
+                [
+                    'languageId' => Defaults::LANGUAGE_SYSTEM,
+                    'currencyId' => Defaults::CURRENCY,
+                    'snippetSetId' => $this->getSnippetSetIdForLocale('en-GB'),
+                    'url' => 'http://frontend.test',
+                    'isExternalStorefront' => true,
+                ],
+                [
+                    'languageId' => Defaults::LANGUAGE_SYSTEM,
+                    'currencyId' => Defaults::CURRENCY,
+                    'snippetSetId' => $this->getSnippetSetIdForLocale('en-GB'),
+                    'url' => 'http://api.test',
+                ],
+            ],
+        ]);
+
+        $result = new SitemapGenerationResult(true, null, null, $headlessId, Defaults::LANGUAGE_SYSTEM);
+
+        // exactly one generation run: only the external storefront domain qualifies the language
+        $this->exporter->expects($this->once())
+            ->method('generate')
+            ->with(static::callback(static function (SalesChannelContext $context) use ($headlessId) {
+                static::assertSame($headlessId, $context->getSalesChannelId());
+                static::assertSame(Defaults::LANGUAGE_SYSTEM, $context->getLanguageId());
 
                 return true;
             }))

--- a/tests/integration/Core/Content/Sitemap/SalesChannel/SitemapRouteTest.php
+++ b/tests/integration/Core/Content/Sitemap/SalesChannel/SitemapRouteTest.php
@@ -4,10 +4,13 @@ namespace Shopware\Tests\Integration\Core\Content\Sitemap\SalesChannel;
 
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Sitemap\Service\SitemapExporterInterface;
+use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\SalesChannelApiTestBehaviour;
 use Shopware\Core\System\SalesChannel\Context\SalesChannelContextFactory;
+use Shopware\Core\System\SystemConfig\SystemConfigService;
 use Shopware\Core\Test\Stub\Framework\IdsCollection;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 
@@ -68,5 +71,66 @@ class SitemapRouteTest extends TestCase
         static::assertArrayHasKey('created', $response[0]);
         static::assertNotEmpty($response[0]['filename']);
         static::assertNotEmpty($response[0]['created']);
+    }
+
+    public function testLiveStrategyHeadlessWithoutExternalStorefrontDomainReturnsEmptyList(): void
+    {
+        $browser = $this->createCustomSalesChannelBrowser([
+            'id' => $this->ids->create('headless-sales-channel'),
+            'typeId' => Defaults::SALES_CHANNEL_TYPE_API,
+            'domains' => [[
+                'languageId' => Defaults::LANGUAGE_SYSTEM,
+                'currencyId' => Defaults::CURRENCY,
+                'snippetSetId' => $this->getSnippetSetIdForLocale('en-GB'),
+                'url' => 'http://default.headless.test',
+            ]],
+        ]);
+
+        static::getContainer()->get(SystemConfigService::class)
+            ->set('core.sitemap.sitemapRefreshStrategy', SitemapExporterInterface::STRATEGY_LIVE);
+
+        $browser->request('POST', '/store-api/sitemap');
+
+        $content = $browser->getResponse()->getContent();
+        static::assertIsString($content);
+
+        $response = json_decode($content, true, 512, \JSON_THROW_ON_ERROR);
+
+        // without an external storefront domain the generation is skipped silently instead of failing
+        static::assertSame(200, $browser->getResponse()->getStatusCode());
+        static::assertCount(0, $response);
+    }
+
+    public function testLiveStrategyHeadlessWithExternalStorefrontDomainGeneratesSitemap(): void
+    {
+        $browser = $this->createCustomSalesChannelBrowser([
+            'id' => $this->ids->create('headless-sales-channel'),
+            'typeId' => Defaults::SALES_CHANNEL_TYPE_API,
+            'domains' => [[
+                'languageId' => Defaults::LANGUAGE_SYSTEM,
+                'currencyId' => Defaults::CURRENCY,
+                'snippetSetId' => $this->getSnippetSetIdForLocale('en-GB'),
+                'url' => 'http://frontend.test',
+                'isExternalStorefront' => true,
+            ]],
+        ]);
+
+        static::getContainer()->get(SystemConfigService::class)
+            ->set('core.sitemap.sitemapRefreshStrategy', SitemapExporterInterface::STRATEGY_LIVE);
+
+        $browser->request('POST', '/store-api/sitemap');
+
+        $content = $browser->getResponse()->getContent();
+        static::assertIsString($content);
+
+        $response = json_decode($content, true, 512, \JSON_THROW_ON_ERROR);
+
+        static::assertSame(200, $browser->getResponse()->getStatusCode());
+        static::assertNotEmpty($response);
+
+        foreach ($response as $sitemap) {
+            // the external storefront does not serve the files, so the listing must not point at it
+            static::assertStringNotContainsString('frontend.test', $sitemap['filename']);
+        }
     }
 }

--- a/tests/integration/Core/Content/Sitemap/ScheduledTask/SitemapGenerateTaskHandlerTest.php
+++ b/tests/integration/Core/Content/Sitemap/ScheduledTask/SitemapGenerateTaskHandlerTest.php
@@ -8,6 +8,7 @@ use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Shopware\Core\Content\Sitemap\ScheduledTask\SitemapGenerateTaskHandler;
 use Shopware\Core\Content\Sitemap\ScheduledTask\SitemapMessage;
+use Shopware\Core\Content\Sitemap\Service\SitemapSalesChannelLoader;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Api\Util\AccessKeyHelper;
 use Shopware\Core\Framework\Context;
@@ -56,10 +57,9 @@ class SitemapGenerateTaskHandlerTest extends TestCase
         $this->sitemapHandler = new SitemapGenerateTaskHandler(
             static::getContainer()->get('scheduled_task.repository'),
             $this->createMock(LoggerInterface::class),
-            $this->salesChannelRepository,
+            new SitemapSalesChannelLoader($this->salesChannelRepository, static::getContainer()->get('event_dispatcher')),
             static::getContainer()->get(SystemConfigService::class),
-            $this->messageBusMock,
-            static::getContainer()->get('event_dispatcher')
+            $this->messageBusMock
         );
         $this->salesChannelDomainRepository = static::getContainer()->get('sales_channel_domain.repository');
     }
@@ -226,6 +226,50 @@ class SitemapGenerateTaskHandlerTest extends TestCase
             false
         );
 
+        $this->messageBusMock->expects($this->once())
+            ->method('dispatch')
+            ->with($message)
+            ->willReturn(new Envelope($message));
+
+        $this->sitemapHandler->run();
+    }
+
+    public function testDispatchesHeadlessSalesChannelWithExternalStorefrontDomain(): void
+    {
+        $connection = static::getContainer()->get(Connection::class);
+        $connection->executeStatement('DELETE FROM sales_channel');
+
+        $headlessId = Uuid::randomHex();
+        $this->createSalesChannel([
+            'id' => $headlessId,
+            'name' => 'headless',
+            'typeId' => Defaults::SALES_CHANNEL_TYPE_API,
+            'domains' => [
+                [
+                    'languageId' => Defaults::LANGUAGE_SYSTEM,
+                    'currencyId' => Defaults::CURRENCY,
+                    'snippetSetId' => $this->getSnippetSetIdForLocale('en-GB'),
+                    'url' => 'http://frontend.test',
+                    'isExternalStorefront' => true,
+                ],
+                [
+                    'languageId' => Defaults::LANGUAGE_SYSTEM,
+                    'currencyId' => Defaults::CURRENCY,
+                    'snippetSetId' => $this->getSnippetSetIdForLocale('en-GB'),
+                    'url' => 'http://api.test',
+                ],
+            ],
+        ]);
+
+        $message = new SitemapMessage(
+            $headlessId,
+            Defaults::LANGUAGE_SYSTEM,
+            null,
+            null,
+            false
+        );
+
+        // exactly one message: the external storefront domain qualifies the language once
         $this->messageBusMock->expects($this->once())
             ->method('dispatch')
             ->with($message)

--- a/tests/unit/Core/Content/Sitemap/Service/SitemapExporterTest.php
+++ b/tests/unit/Core/Content/Sitemap/Service/SitemapExporterTest.php
@@ -18,6 +18,7 @@ use Shopware\Core\Content\Sitemap\Service\SitemapHandleInterface;
 use Shopware\Core\Content\Sitemap\SitemapException;
 use Shopware\Core\Content\Sitemap\Struct\Url;
 use Shopware\Core\Content\Sitemap\Struct\UrlResult;
+use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Api\Context\SystemSource;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Log\Package;
@@ -121,6 +122,68 @@ class SitemapExporterTest extends TestCase
         $cartRuleLoader->expects($this->never())->method('loadByToken');
     }
 
+    public function testGenerateSkipsHeadlessSalesChannelWithoutExternalStorefrontDomain(): void
+    {
+        $urlProvider = $this->createMock(CustomUrlProvider::class);
+        $urlProvider->expects($this->never())->method('getUrls');
+
+        $sitemapHandlerFactory = $this->createMock(SitemapHandleFactoryInterface::class);
+        $sitemapHandlerFactory->expects($this->never())->method('create');
+
+        $cache = static::createStub(CacheItemPoolInterface::class);
+        $cache->method('getItem')->willReturn(new CacheItem());
+
+        $exporter = $this->createSitemapExporter($cache, [$urlProvider], $sitemapHandlerFactory);
+
+        $languageId = Uuid::randomHex();
+        $salesChannel = $this->createSalesChannel('headlessSalesChannel', $languageId, typeId: Defaults::SALES_CHANNEL_TYPE_API);
+        $salesChannel->setDomains(new SalesChannelDomainCollection([
+            $this->createSalesChannelDomain('plainDomain', 'default.headless0', $languageId),
+        ]));
+
+        $result = $exporter->generate($this->createSalesChannelContext($salesChannel, []));
+
+        static::assertTrue($result->isFinish());
+    }
+
+    public function testGenerateWritesOnlyExternalStorefrontDomainsForHeadlessSalesChannel(): void
+    {
+        $url = new Url();
+        $url->setLoc('awesome-product');
+
+        $urlProvider = $this->createMock(CustomUrlProvider::class);
+        $urlProvider->expects($this->once())->method('getUrls')->willReturn(new UrlResult([$url], null));
+
+        $sitemapHandle = $this->createMock(SitemapHandleInterface::class);
+        $sitemapHandle->expects($this->once())->method('write')->willReturnCallback(static function (array $urls): void {
+            static::assertCount(1, $urls);
+            static::assertInstanceOf(Url::class, $urls[0]);
+            static::assertSame('https://frontend.example/awesome-product', $urls[0]->getLoc());
+        });
+
+        $sitemapHandlerFactory = $this->createMock(SitemapHandleFactoryInterface::class);
+        $sitemapHandlerFactory->expects($this->once())
+            ->method('create')
+            ->with(static::anything(), static::anything(), 'https://frontend.example', 'externalDomain')
+            ->willReturn($sitemapHandle);
+
+        $cache = static::createStub(CacheItemPoolInterface::class);
+        $cache->method('getItem')->willReturn(new CacheItem());
+
+        $exporter = $this->createSitemapExporter($cache, [$urlProvider], $sitemapHandlerFactory);
+
+        $languageId = Uuid::randomHex();
+        $salesChannel = $this->createSalesChannel('headlessSalesChannel', $languageId, typeId: Defaults::SALES_CHANNEL_TYPE_API);
+        $salesChannel->setDomains(new SalesChannelDomainCollection([
+            $this->createSalesChannelDomain('externalDomain', 'https://frontend.example', $languageId, isExternalStorefront: true),
+            $this->createSalesChannelDomain('plainDomain', 'default.headless0', $languageId),
+        ]));
+
+        $result = $exporter->generate($this->createSalesChannelContext($salesChannel, []));
+
+        static::assertTrue($result->isFinish());
+    }
+
     public function testGenerateThrowsExceptionINoSitemapHandlesCreated(): void
     {
         $cache = static::createStub(CacheItemPoolInterface::class);
@@ -171,11 +234,13 @@ class SitemapExporterTest extends TestCase
 
     private function createSalesChannel(
         string $salesChannelId,
-        ?string $languageId = null
+        ?string $languageId = null,
+        string $typeId = Defaults::SALES_CHANNEL_TYPE_STOREFRONT
     ): SalesChannelEntity {
         $salesChannel = new SalesChannelEntity();
         $salesChannel->setId($salesChannelId);
         $salesChannel->setLanguageId($languageId ?? Uuid::randomHex());
+        $salesChannel->setTypeId($typeId);
 
         return $salesChannel;
     }
@@ -183,12 +248,14 @@ class SitemapExporterTest extends TestCase
     private function createSalesChannelDomain(
         string $domainId,
         string $domainUrl,
-        ?string $languageId = null
+        ?string $languageId = null,
+        bool $isExternalStorefront = false
     ): SalesChannelDomainEntity {
         $salesChannelDomain = new SalesChannelDomainEntity();
         $salesChannelDomain->setId($domainId);
         $salesChannelDomain->setUrl($domainUrl);
         $salesChannelDomain->setLanguageId($languageId ?? Uuid::randomHex());
+        $salesChannelDomain->setIsExternalStorefront($isExternalStorefront);
 
         return $salesChannelDomain;
     }

--- a/tests/unit/Core/Content/Sitemap/Service/SitemapListerTest.php
+++ b/tests/unit/Core/Content/Sitemap/Service/SitemapListerTest.php
@@ -8,9 +8,11 @@ use League\Flysystem\FilesystemOperator;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Sitemap\Service\SitemapLister;
+use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SalesChannel\Aggregate\SalesChannelDomain\SalesChannelDomainCollection;
 use Shopware\Core\System\SalesChannel\Aggregate\SalesChannelDomain\SalesChannelDomainEntity;
+use Shopware\Core\System\SalesChannel\SalesChannelEntity;
 use Shopware\Core\Test\Generator;
 use Symfony\Component\Asset\Package;
 use Symfony\Component\Clock\NativeClock;
@@ -88,5 +90,44 @@ class SitemapListerTest extends TestCase
         static::assertCount(2, $sitemaps);
         static::assertStringStartsWith($defaultDomainUrl, $sitemaps[0]->getFilename());
         static::assertStringStartsWith($domainUrl, $sitemaps[1]->getFilename());
+    }
+
+    public function testHeadlessSalesChannelListsFilesViaAssetPackage(): void
+    {
+        $salesChannel = new SalesChannelEntity();
+        $salesChannel->setId(Uuid::randomHex());
+        $salesChannel->setTypeId(Defaults::SALES_CHANNEL_TYPE_API);
+        $salesChannel->setLanguageId(Defaults::LANGUAGE_SYSTEM);
+
+        $context = Generator::generateSalesChannelContext(salesChannel: $salesChannel);
+
+        $domainId = Uuid::randomHex();
+        $domain = new SalesChannelDomainEntity();
+        $domain->setId($domainId);
+        $domain->setUrl('https://frontend.example');
+        $domain->setLanguageId($context->getLanguageId());
+        $domain->setIsExternalStorefront(true);
+
+        $context->getSalesChannel()->setDomains(new SalesChannelDomainCollection([$domain]));
+
+        $path = 'sitemap/salesChannel-' . $context->getSalesChannelId() . '-' . $context->getLanguageId() . '/' . $context->getSalesChannelId() . '-' . $domainId . '-sitemap-frontend-example-1.xml.gz';
+
+        $filesystem = static::createStub(FilesystemOperator::class);
+        $filesystem->method('listContents')->willReturn(new DirectoryListing([
+            new FileAttributes($path, 0, null, null, null),
+        ]));
+
+        $package = static::createStub(Package::class);
+        $package->method('getUrl')->willReturnCallback(static function (string $path) {
+            return 'https://shop.example/' . $path;
+        });
+
+        $sitemapLister = new SitemapLister($filesystem, $package, new NativeClock());
+
+        $sitemaps = $sitemapLister->getSitemaps($context);
+
+        static::assertCount(1, $sitemaps);
+        // the external storefront does not serve the files, so the asset host is used even though the domain matches
+        static::assertSame('https://shop.example/' . $path, $sitemaps[0]->getFilename());
     }
 }

--- a/tests/unit/Core/Content/Sitemap/Service/SitemapSalesChannelLoaderTest.php
+++ b/tests/unit/Core/Content/Sitemap/Service/SitemapSalesChannelLoaderTest.php
@@ -1,0 +1,134 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Content\Sitemap\Service;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Sitemap\Event\SitemapSalesChannelCriteriaEvent;
+use Shopware\Core\Content\Sitemap\Service\SitemapSalesChannelLoader;
+use Shopware\Core\Defaults;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\AndFilter;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\NotEqualsFilter;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\OrFilter;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\System\SalesChannel\Aggregate\SalesChannelDomain\SalesChannelDomainCollection;
+use Shopware\Core\System\SalesChannel\Aggregate\SalesChannelDomain\SalesChannelDomainEntity;
+use Shopware\Core\System\SalesChannel\SalesChannelCollection;
+use Shopware\Core\System\SalesChannel\SalesChannelEntity;
+use Shopware\Core\Test\Stub\DataAbstractionLayer\StaticEntityRepository;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+
+/**
+ * @internal
+ */
+#[Package('discovery')]
+#[CoversClass(SitemapSalesChannelLoader::class)]
+class SitemapSalesChannelLoaderTest extends TestCase
+{
+    public function testLoadSalesChannelsBuildsHeadlessAwareCriteriaAndDispatchesEvent(): void
+    {
+        $repository = new StaticEntityRepository([new SalesChannelCollection([])]);
+
+        $capturedCriteria = null;
+        $dispatcher = new EventDispatcher();
+        $dispatcher->addListener(SitemapSalesChannelCriteriaEvent::class, static function (SitemapSalesChannelCriteriaEvent $event) use (&$capturedCriteria): void {
+            $capturedCriteria = $event->getCriteria();
+        });
+
+        $loader = new SitemapSalesChannelLoader($repository, $dispatcher);
+        $loader->loadSalesChannels(Context::createDefaultContext());
+
+        static::assertInstanceOf(Criteria::class, $capturedCriteria);
+
+        $filters = $capturedCriteria->getFilters();
+        static::assertCount(2, $filters);
+        static::assertInstanceOf(NotEqualsFilter::class, $filters[0]);
+
+        $typeFilter = $filters[1];
+        static::assertInstanceOf(OrFilter::class, $typeFilter);
+
+        [$storefrontFilter, $headlessFilter] = $typeFilter->getQueries();
+        static::assertInstanceOf(EqualsFilter::class, $storefrontFilter);
+        static::assertSame(Defaults::SALES_CHANNEL_TYPE_STOREFRONT, $storefrontFilter->getValue());
+
+        static::assertInstanceOf(AndFilter::class, $headlessFilter);
+        [$apiTypeFilter, $externalDomainFilter] = $headlessFilter->getQueries();
+        static::assertInstanceOf(EqualsFilter::class, $apiTypeFilter);
+        static::assertSame(Defaults::SALES_CHANNEL_TYPE_API, $apiTypeFilter->getValue());
+        static::assertInstanceOf(EqualsFilter::class, $externalDomainFilter);
+        static::assertSame('domains.isExternalStorefront', $externalDomainFilter->getField());
+        static::assertTrue($externalDomainFilter->getValue());
+    }
+
+    /**
+     * @return \Generator<string, array{string, list<array{string, bool}>, list<string>}>
+     */
+    public static function languageIdCases(): \Generator
+    {
+        yield 'storefront channels use every domain language once' => [
+            Defaults::SALES_CHANNEL_TYPE_STOREFRONT,
+            [['language-a', false], ['language-a', false], ['language-b', false]],
+            ['language-a', 'language-b'],
+        ];
+
+        yield 'headless channels use only external storefront domain languages' => [
+            Defaults::SALES_CHANNEL_TYPE_API,
+            [['language-a', true], ['language-b', false]],
+            ['language-a'],
+        ];
+
+        yield 'headless channels without external storefront domain have no languages' => [
+            Defaults::SALES_CHANNEL_TYPE_API,
+            [['language-a', false]],
+            [],
+        ];
+    }
+
+    /**
+     * @param list<array{string, bool}> $domainSpecs
+     * @param list<string> $expectedLanguageIds
+     */
+    #[DataProvider('languageIdCases')]
+    public function testGetLanguageIds(string $typeId, array $domainSpecs, array $expectedLanguageIds): void
+    {
+        $domains = new SalesChannelDomainCollection();
+        foreach ($domainSpecs as [$languageId, $isExternalStorefront]) {
+            $domain = new SalesChannelDomainEntity();
+            $domain->setId(Uuid::randomHex());
+            $domain->setLanguageId($languageId);
+            $domain->setIsExternalStorefront($isExternalStorefront);
+            $domains->add($domain);
+        }
+
+        $salesChannel = new SalesChannelEntity();
+        $salesChannel->setId(Uuid::randomHex());
+        $salesChannel->setTypeId($typeId);
+        $salesChannel->setDomains($domains);
+
+        $loader = new SitemapSalesChannelLoader(
+            new StaticEntityRepository([new SalesChannelCollection([])]),
+            new EventDispatcher()
+        );
+
+        static::assertSame($expectedLanguageIds, $loader->getLanguageIds($salesChannel));
+    }
+
+    public function testGetLanguageIdsWithoutLoadedDomains(): void
+    {
+        $salesChannel = new SalesChannelEntity();
+        $salesChannel->setId(Uuid::randomHex());
+        $salesChannel->setTypeId(Defaults::SALES_CHANNEL_TYPE_STOREFRONT);
+
+        $loader = new SitemapSalesChannelLoader(
+            new StaticEntityRepository([new SalesChannelCollection([])]),
+            new EventDispatcher()
+        );
+
+        static::assertSame([], $loader->getLanguageIds($salesChannel));
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?

Headless (API type) sales channels never get a sitemap. The scheduled task and `sitemap:generate` hard-filter sales channels to the Storefront type, so under the default strategy `GET /store-api/sitemap` is guaranteed to return an empty list — while the `llms.txt` generated for headless channels advertises exactly that endpoint. Under the live strategy the route generates without any type check, but `SitemapExporter` ignores the `is_external_storefront` flag from #17991: with the migration-created pseudo-domain (`default.headlessN`) it emits scheme-less `<loc>` values like `default.headless0/store-api/product/{id}`, and a request in a language without a matching domain fails with HTTP 400 `CONTENT__INVALID_DOMAIN`. The sitemap URL providers are already headless-aware since #17991 (they resolve `store-api.*` routes and the headless SEO paths) — only the orchestration around them still excludes headless channels. This is the second remaining reason the Composable Frontends docs recommend the Storefront type as a workaround (https://developer.shopware.com/frontends/resources/troubleshooting.html#which-saleschannel-type-to-use-for-composable-frontends).

### 2. What does this change do, exactly?

- **New internal service `SitemapSalesChannelLoader`** — the single source of truth for "which sales channels and languages get sitemaps". `loadSalesChannels()` builds the criteria (`type = Storefront OR (type = API AND domains.isExternalStorefront = true)`) and dispatches `SitemapSalesChannelCriteriaEvent` as before, so plugins modifying the criteria keep working; `getLanguageIds()` returns the qualifying languages per channel (for API channels only languages with an external-storefront domain). The scheduled task handler and `sitemap:generate` both consume this service instead of duplicating the logic — their previously duplicated inline criteria/language code is removed. Effectively opt-in: an API channel only qualifies once the merchant flags a domain as external storefront — exactly the opt-in #17991 introduced for SEO URLs.
- **`SitemapExporter`:** for API-type channels only external-storefront domains create sitemap handles. An API channel with no such domain for the current language is skipped silently (finished result, no files) instead of throwing `invalidDomain` — mirroring the silent skip of `SeoUrlGenerator`. Storefront channels keep throwing (no behaviour change).
- **`SitemapLister`:** for API-type channels the file URLs always come from the asset package (`shopware.asset.sitemap`, i.e. the Shopware host or its CDN) instead of the matching domain URL — the external storefront does not serve the files. Frontends can serve/proxy them from there, or download them via the existing authenticated `GET /store-api/sitemap/{filePath}`. Alternatives considered: linking the external domain (points at a host that does not have the files) and absolute `store-api.sitemap.file` URLs (requires auth headers crawlers cannot send, and bypasses CDN setups).
- `<loc>` entries use the external-storefront domain as prefix with the headless SEO paths — no provider changes needed.

### 3. Describe each step to reproduce the issue or behaviour.

1. Create a headless (API type) sales channel and flag a domain as **External storefront**; reindex.
2. Run `bin/console sitemap:generate --salesChannelId <headless-id>` — before: silently filtered out; after: files are written to `sitemap/salesChannel-{id}-{languageId}/`.
3. Call `GET /store-api/sitemap` — before: `[]` (or HTTP 400 under the live strategy without a matching domain); after: the listing with downloadable file URLs; the XML `<loc>` entries point at the external storefront.

### 4. Please link to the relevant issues (if any).

- relates #19685
- relates #16619, builds on #17991
- relates #19687: both PRs are independently mergeable in any order; whichever merges second needs a trivial rebase — #19687's new command test constructs `SitemapGenerateCommand` manually and this PR changes the constructor to take the new `SitemapSalesChannelLoader`. Happy to rebase promptly once the other one lands.

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have updated developer-facing release notes if this change is **relevant** for external developers (`RELEASE_INFO-6.7.md`)
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
