### PR TITLE
fix: initialize navbar aria-current state

### DIFF
--- a/src/Storefront/Resources/app/storefront/src/plugin/navbar/navbar.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/navbar/navbar.plugin.js
@@ -36,6 +36,7 @@ export default class NavbarPlugin extends Plugin {
         this._topLevelLinks = this.el.querySelectorAll(`${this.options.topLevelLinksSelector}`);
         this._registerEvents();
         this._isMouseOver = false;
+        this._setCurrentPage();
     }
 
     _registerEvents() {
@@ -52,10 +53,6 @@ export default class NavbarPlugin extends Plugin {
             if (el.getAttribute('href') !== null) {
                 el.addEventListener(clickEvent, this._navigateToLinkOnClick.bind(this, el));
             }
-        });
-
-        window.addEventListener('load', () => {
-            this._setCurrentPage();
         });
     }
 

--- a/src/Storefront/Resources/app/storefront/test/plugin/navbar/navbar.plugin.test.js
+++ b/src/Storefront/Resources/app/storefront/test/plugin/navbar/navbar.plugin.test.js
@@ -218,14 +218,10 @@ describe('NavbarPlugin', () => {
         expect(navbarPlugin._debounce).toHaveBeenCalled();
     });
 
-    test('current page is applied on load event', () => {
-        const mockEvent = new Event('load');
+    test('current page is applied during initialization', () => {
         jest.spyOn(navbarPlugin, '_setCurrentPage'); // Spy on the method
 
-        window.addEventListener('load', () => {
-            navbarPlugin._setCurrentPage();
-        });
-        window.dispatchEvent(mockEvent);
+        navbarPlugin.init();
 
         expect(navbarPlugin._setCurrentPage).toHaveBeenCalled();
     });


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

Forward-port the accessibility fix (#19598) for setting `aria-current="page"` on the active main navigation item.

### 2. What does this change do, exactly?

The attribute is now applied directly during `NavbarPlugin` initialization instead of waiting for the window `load` event. This ensures the state is applied reliably, including when the plugins are loaded asynchronously after the load event.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
