### PR TITLE
refactor(administration): use mt-empty-state on the product detail tabs

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -205,11 +205,11 @@ The listing reloads once after the batch finishes rather than after every indivi
 
 The empty states of the product detail tabs "Advanced pricing" and "Cross Selling" now render `mt-empty-state` instead of custom markup with an illustration. The headline, description, icon and the link to the parent product are `mt-empty-state` props.
 
-The Twig blocks of `sw-product-detail-context-prices.html.twig` and `sw-product-detail-cross-selling.html.twig` that wrapped the image, icon and description texts still exist with their previous render conditions, but are empty and deprecated for removal in v6.9.0.
+The Twig blocks of `sw-product-detail-context-prices.html.twig` and `sw-product-detail-cross-selling.html.twig` that wrapped the image, icon and description texts still exist with their previous render conditions, but are empty and deprecated for removal in v6.8.0.
 
 `sw_product_detail_cross_selling_empty_state_icon` and `sw_product_detail_cross_selling_empty_state_actions` no longer wrap a `<template #icon>` / `<template #actions>`; overrides that reproduced these slot wrappers must drop them. The add button lives in `sw_product_detail_cross_selling_empty_state_actions_add` inside the `button` slot of `mt-empty-state`.
 
-The `assetFilter` computed of both components is deprecated for removal in v6.9.0; use `Shopware.Filter.getByName('asset')` instead.
+The `assetFilter` computed of both components is deprecated for removal in v6.8.0; use `Shopware.Filter.getByName('asset')` instead.
 
 The classes `.sw-product-detail-context-prices__parent-prices-link` and `.sw-product-detail-cross-selling__parent-cross-sellings-link` no longer exist; the parent link is rendered as `.mt-empty-state__link`.
 

--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -201,6 +201,30 @@ The bar offers the same actions already available per card:
 - All actions respect the existing `system.plugin_maintain` permission and the runtime extension-management setting, exactly like the single-card actions.
 
 The listing reloads once after the batch finishes rather than after every individual extension. With nothing selected, the listing behaves exactly as before, so the feature is fully opt-in.
+### Product detail empty states use `mt-empty-state`
+
+The empty states of the product detail tabs "Advanced pricing" and "Cross Selling" now render `mt-empty-state` instead of custom markup with an illustration. The headline, description, icon and the link to the parent product are `mt-empty-state` props.
+
+The following blocks still exist but are empty and deprecated for removal in v6.9.0, because the content they wrapped became component props:
+
+- `src/module/sw-product/view/sw-product-detail-context-prices/sw-product-detail-context-prices.html.twig`
+  - `sw_product_detail_prices_empty_state_image`
+  - `sw_product_detail_prices_price_empty_state_text`
+  - `sw_product_detail_prices_price_empty_state_text_child`
+  - `sw_product_detail_prices_price_empty_state_text_inherited`
+  - `sw_product_detail_prices_price_empty_state_text_link`
+  - `sw_product_detail_prices_price_empty_state_text_not_inherited`
+  - `sw_product_detail_prices_price_empty_state_text_empty`
+- `src/module/sw-product/view/sw-product-detail-cross-selling/sw-product-detail-cross-selling.html.twig`
+  - `sw_product_detail_cross_selling_empty_state_icon`
+  - `sw_product_detail_cross_selling_empty_state_actions`
+  - `sw_product_detail_cross_selling_empty_state_content` and its child blocks
+
+`sw_product_detail_cross_selling_empty_state_actions` no longer wraps a `<template #actions>`; the add button lives in `sw_product_detail_cross_selling_empty_state_actions_add` inside the `button` slot of `mt-empty-state`. Overrides that reproduced the slot wrapper must drop it.
+
+The `assetFilter` computed of both components is deprecated for removal in v6.9.0. It is still available for template overrides that render their own image.
+
+The classes `.sw-product-detail-context-prices__parent-prices-link` and `.sw-product-detail-cross-selling__parent-cross-sellings-link` no longer exist; the parent link is rendered as `.mt-empty-state__link`.
 
 ## Storefront
 

--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -205,24 +205,11 @@ The listing reloads once after the batch finishes rather than after every indivi
 
 The empty states of the product detail tabs "Advanced pricing" and "Cross Selling" now render `mt-empty-state` instead of custom markup with an illustration. The headline, description, icon and the link to the parent product are `mt-empty-state` props.
 
-The following blocks still exist but are empty and deprecated for removal in v6.9.0, because the content they wrapped became component props:
+The Twig blocks of `sw-product-detail-context-prices.html.twig` and `sw-product-detail-cross-selling.html.twig` that wrapped the image, icon and description texts still exist with their previous render conditions, but are empty and deprecated for removal in v6.9.0.
 
-- `src/module/sw-product/view/sw-product-detail-context-prices/sw-product-detail-context-prices.html.twig`
-  - `sw_product_detail_prices_empty_state_image`
-  - `sw_product_detail_prices_price_empty_state_text`
-  - `sw_product_detail_prices_price_empty_state_text_child`
-  - `sw_product_detail_prices_price_empty_state_text_inherited`
-  - `sw_product_detail_prices_price_empty_state_text_link`
-  - `sw_product_detail_prices_price_empty_state_text_not_inherited`
-  - `sw_product_detail_prices_price_empty_state_text_empty`
-- `src/module/sw-product/view/sw-product-detail-cross-selling/sw-product-detail-cross-selling.html.twig`
-  - `sw_product_detail_cross_selling_empty_state_icon`
-  - `sw_product_detail_cross_selling_empty_state_actions`
-  - `sw_product_detail_cross_selling_empty_state_content` and its child blocks
+`sw_product_detail_cross_selling_empty_state_icon` and `sw_product_detail_cross_selling_empty_state_actions` no longer wrap a `<template #icon>` / `<template #actions>`; overrides that reproduced these slot wrappers must drop them. The add button lives in `sw_product_detail_cross_selling_empty_state_actions_add` inside the `button` slot of `mt-empty-state`.
 
-`sw_product_detail_cross_selling_empty_state_actions` no longer wraps a `<template #actions>`; the add button lives in `sw_product_detail_cross_selling_empty_state_actions_add` inside the `button` slot of `mt-empty-state`. Overrides that reproduced the slot wrapper must drop it.
-
-The `assetFilter` computed of both components is deprecated for removal in v6.9.0. It is still available for template overrides that render their own image.
+The `assetFilter` computed of both components is deprecated for removal in v6.9.0; use `Shopware.Filter.getByName('asset')` instead.
 
 The classes `.sw-product-detail-context-prices__parent-prices-link` and `.sw-product-detail-cross-selling__parent-cross-sellings-link` no longer exist; the parent link is rendered as `.mt-empty-state__link`.
 

--- a/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-context-prices/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-context-prices/index.js
@@ -45,7 +45,7 @@ export default {
     },
 
     computed: {
-        /** @deprecated tag:v6.9.0 - Kept for overrides, the empty states no longer render an image. */
+        /** @deprecated tag:v6.9.0 - Will be removed, use Shopware.Filter.getByName('asset') instead. */
         assetFilter() {
             return Shopware.Filter.getByName('asset');
         },
@@ -222,11 +222,11 @@ export default {
             return this.$t('sw-product.advancedPrices.advancedPricesNotInherited');
         },
 
-        showParentPricesLink() {
-            return this.isChild && this.isInherited;
-        },
-
         parentPricesHref() {
+            if (!this.isChild || !this.isInherited) {
+                return undefined;
+            }
+
             return this.$router.resolve({
                 name: 'sw.product.detail.prices',
                 params: { id: this.product.parentId },

--- a/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-context-prices/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-context-prices/index.js
@@ -45,10 +45,11 @@ export default {
     },
 
     computed: {
-        /** @deprecated tag:v6.9.0 - Will be removed, use Shopware.Filter.getByName('asset') instead. */
+        /** @deprecated tag:v6.8.0 - Will be removed, use Shopware.Filter.getByName('asset') instead. */
         assetFilter() {
             return Shopware.Filter.getByName('asset');
         },
+
         product() {
             return Shopware.Store.get('swProductDetail').product;
         },

--- a/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-context-prices/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-context-prices/index.js
@@ -45,6 +45,10 @@ export default {
     },
 
     computed: {
+        /** @deprecated tag:v6.9.0 - Kept for overrides, the empty states no longer render an image. */
+        assetFilter() {
+            return Shopware.Filter.getByName('asset');
+        },
         product() {
             return Shopware.Store.get('swProductDetail').product;
         },
@@ -206,8 +210,27 @@ export default {
             ];
         },
 
-        assetFilter() {
-            return Shopware.Filter.getByName('asset');
+        emptyStateDescription() {
+            if (!this.isChild) {
+                return this.$t('sw-product.advancedPrices.advancedPricesNotExisting');
+            }
+
+            if (this.isInherited) {
+                return this.$t('sw-product.advancedPrices.advancedPricesInherited');
+            }
+
+            return this.$t('sw-product.advancedPrices.advancedPricesNotInherited');
+        },
+
+        showParentPricesLink() {
+            return this.isChild && this.isInherited;
+        },
+
+        parentPricesHref() {
+            return this.$router.resolve({
+                name: 'sw.product.detail.prices',
+                params: { id: this.product.parentId },
+            }).href;
         },
     },
 

--- a/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-context-prices/sw-product-detail-context-prices.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-context-prices/sw-product-detail-context-prices.html.twig
@@ -306,40 +306,38 @@
         {% block sw_product_detail_prices_price_empty_state %}
         <mt-empty-state
             class="sw-product-detail-context-prices__empty-state"
-            role="status"
             :centered="true"
             icon="regular-money-bill"
             :headline="$t('sw-product.detail.tabAdvancedPrices')"
             :description="emptyStateDescription"
-            :link-text="showParentPricesLink ? $t('sw-product.advancedPrices.linkAdvancedPricesOfParent') : undefined"
-            :link-href="showParentPricesLink ? parentPricesHref : undefined"
+            :link-text="$t('sw-product.advancedPrices.linkAdvancedPricesOfParent')"
+            :link-href="parentPricesHref"
         >
             <template #button>
                 {% block sw_product_detail_prices_price_empty_state__inherit_switch %}
-                <template v-if="isChild">
-                    <div
-                        class="sw-product-detail-context-prices__inherit-toggle-wrapper"
-                        :class="{ 'is--inherited': isInherited }"
-                    >
+                <div
+                    v-if="isChild"
+                    class="sw-product-detail-context-prices__inherit-toggle-wrapper"
+                    :class="{ 'is--inherited': isInherited }"
+                >
 
-                        <mt-switch
-                            v-model="isInherited"
-                            class="sw-product-detail-context-prices__inherit-switch"
-                            :disabled="!acl.can('product.editor')"
-                        />
-                        <sw-inheritance-switch
-                            class="sw-product-detail-context-prices__inheritance-icon"
-                            :is-inherited="isInherited"
-                            :disabled="!acl.can('product.editor')"
-                            @inheritance-restore="restoreInheritance"
-                            @inheritance-remove="removeInheritance"
-                        />
-                        <!-- eslint-disable-next-line vuejs-accessibility/label-has-for -->
-                        <label class="sw-product-detail-context-prices__inheritance-label">
-                            {{ $t('sw-product.advancedPrices.inheritSwitchLabel') }}
-                        </label>
-                    </div>
-                </template>
+                    <mt-switch
+                        v-model="isInherited"
+                        class="sw-product-detail-context-prices__inherit-switch"
+                        :disabled="!acl.can('product.editor')"
+                    />
+                    <sw-inheritance-switch
+                        class="sw-product-detail-context-prices__inheritance-icon"
+                        :is-inherited="isInherited"
+                        :disabled="!acl.can('product.editor')"
+                        @inheritance-restore="restoreInheritance"
+                        @inheritance-remove="removeInheritance"
+                    />
+                    <!-- eslint-disable-next-line vuejs-accessibility/label-has-for -->
+                    <label class="sw-product-detail-context-prices__inheritance-label">
+                        {{ $t('sw-product.advancedPrices.inheritSwitchLabel') }}
+                    </label>
+                </div>
                 {% endblock %}
 
                 {% block sw_product_detail_prices_price_empty_state_select_rule %}
@@ -361,13 +359,21 @@
         {# @deprecated tag:v6.9.0 - Kept as extension anchors, the image and the texts became mt-empty-state props. #}
         {% block sw_product_detail_prices_empty_state_image %}{% endblock %}
         {% block sw_product_detail_prices_price_empty_state_text %}
+        <template v-if="isChild">
             {% block sw_product_detail_prices_price_empty_state_text_child %}
+            <template v-if="isInherited">
                 {% block sw_product_detail_prices_price_empty_state_text_inherited %}
                     {% block sw_product_detail_prices_price_empty_state_text_link %}{% endblock %}
                 {% endblock %}
+            </template>
+            <template v-else>
                 {% block sw_product_detail_prices_price_empty_state_text_not_inherited %}{% endblock %}
+            </template>
             {% endblock %}
+        </template>
+        <template v-else>
             {% block sw_product_detail_prices_price_empty_state_text_empty %}{% endblock %}
+        </template>
         {% endblock %}
         {% endblock %}
     </mt-card>

--- a/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-context-prices/sw-product-detail-context-prices.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-context-prices/sw-product-detail-context-prices.html.twig
@@ -356,7 +356,7 @@
             </template>
         </mt-empty-state>
 
-        {# @deprecated tag:v6.9.0 - Kept as extension anchors, the image and the texts became mt-empty-state props. #}
+        {# @deprecated tag:v6.8.0 - Kept as extension anchors, the image and the texts became mt-empty-state props. #}
         {% block sw_product_detail_prices_empty_state_image %}{% endblock %}
         {% block sw_product_detail_prices_price_empty_state_text %}
         <template v-if="isChild">

--- a/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-context-prices/sw-product-detail-context-prices.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-context-prices/sw-product-detail-context-prices.html.twig
@@ -258,7 +258,7 @@
             {% block sw_product_detail_prices_price_card_price_group_empty_state %}
                 <div
                     v-else
-                    class="sw-product-detail-context-prices__empty-state"
+                    class="sw-product-detail-context-prices__empty-state sw-product-detail-context-prices__price-group-hint"
                 >
 
                 {% block sw_product_detail_prices_price_card_price_group_empty_state_warning %}
@@ -304,93 +304,71 @@
         position-identifier="sw-product-detail-context-prices-empty-state-card"
     >
         {% block sw_product_detail_prices_price_empty_state %}
-        <div class="sw-product-detail-context-prices__empty-state">
-
-            {% block sw_product_detail_prices_empty_state_image %}
-            <img
-                :src="assetFilter('/administration/administration/static/img/empty-states/products-empty-state.svg')"
-                alt=""
-            >
-            {% endblock %}
-
-            {% block sw_product_detail_prices_price_empty_state_text %}
-            <template v-if="isChild">
-                {% block sw_product_detail_prices_price_empty_state_text_child %}
-                <template v-if="isInherited">
-                    {% block sw_product_detail_prices_price_empty_state_text_inherited %}
-                    <p>{{ $t('sw-product.advancedPrices.advancedPricesInherited') }}</p>
-                    {% block sw_product_detail_prices_price_empty_state_text_link %}
-                    <router-link
-                        v-if="isInherited"
-                        :to="{ name: 'sw.product.detail.prices', params: { id: product.parentId } }"
-                        class="sw-product-detail-context-prices__parent-prices-link"
+        <mt-empty-state
+            class="sw-product-detail-context-prices__empty-state"
+            role="status"
+            :centered="true"
+            icon="regular-money-bill"
+            :headline="$t('sw-product.detail.tabAdvancedPrices')"
+            :description="emptyStateDescription"
+            :link-text="showParentPricesLink ? $t('sw-product.advancedPrices.linkAdvancedPricesOfParent') : undefined"
+            :link-href="showParentPricesLink ? parentPricesHref : undefined"
+        >
+            <template #button>
+                {% block sw_product_detail_prices_price_empty_state__inherit_switch %}
+                <template v-if="isChild">
+                    <div
+                        class="sw-product-detail-context-prices__inherit-toggle-wrapper"
+                        :class="{ 'is--inherited': isInherited }"
                     >
-                        {{ $t('sw-product.advancedPrices.linkAdvancedPricesOfParent') }}
-                        <mt-icon
-                            name="regular-long-arrow-right"
-                            size="var(--scale-size-16)"
+
+                        <mt-switch
+                            v-model="isInherited"
+                            class="sw-product-detail-context-prices__inherit-switch"
+                            :disabled="!acl.can('product.editor')"
                         />
-                    </router-link>
-                    {% endblock %}
-                    {% endblock %}
-                </template>
-
-                <template v-else>
-                    {% block sw_product_detail_prices_price_empty_state_text_not_inherited %}
-                    <p>{{ $t('sw-product.advancedPrices.advancedPricesNotInherited') }}</p>
-                    {% endblock %}
+                        <sw-inheritance-switch
+                            class="sw-product-detail-context-prices__inheritance-icon"
+                            :is-inherited="isInherited"
+                            :disabled="!acl.can('product.editor')"
+                            @inheritance-restore="restoreInheritance"
+                            @inheritance-remove="removeInheritance"
+                        />
+                        <!-- eslint-disable-next-line vuejs-accessibility/label-has-for -->
+                        <label class="sw-product-detail-context-prices__inheritance-label">
+                            {{ $t('sw-product.advancedPrices.inheritSwitchLabel') }}
+                        </label>
+                    </div>
                 </template>
                 {% endblock %}
-            </template>
 
-            <template v-else>
-                {% block sw_product_detail_prices_price_empty_state_text_empty %}
-                <p>{{ $t('sw-product.advancedPrices.advancedPricesNotExisting') }}</p>
+                {% block sw_product_detail_prices_price_empty_state_select_rule %}
+                <sw-select-rule-create
+                    v-if="rules.entity"
+                    id="rule"
+                    class="sw-product-detail-context-prices__empty-state-select-rule"
+                    :placeholder="$t('sw-product.advancedPrices.selectRule')"
+                    :disabled="isInherited || !acl.can('product.editor')"
+                    rule-aware-group-key="productPrices"
+                    :restricted-rule-ids="Object.keys(priceRuleGroups)"
+                    :restricted-rule-ids-tooltip-label="$t('sw-product.advancedPrices.ruleAlreadyUsed')"
+                    @save-rule="onAddNewPriceGroup($event)"
+                />
                 {% endblock %}
             </template>
-            {% endblock %}
+        </mt-empty-state>
 
-            {% block sw_product_detail_prices_price_empty_state__inherit_switch %}
-            <template v-if="isChild">
-                <div
-                    class="sw-product-detail-context-prices__inherit-toggle-wrapper"
-                    :class="{ 'is--inherited': isInherited }"
-                >
-
-                    <mt-switch
-                        v-model="isInherited"
-                        class="sw-product-detail-context-prices__inherit-switch"
-                        :disabled="!acl.can('product.editor')"
-                    />
-                    <sw-inheritance-switch
-                        class="sw-product-detail-context-prices__inheritance-icon"
-                        :is-inherited="isInherited"
-                        :disabled="!acl.can('product.editor')"
-                        @inheritance-restore="restoreInheritance"
-                        @inheritance-remove="removeInheritance"
-                    />
-                    <!-- eslint-disable-next-line vuejs-accessibility/label-has-for -->
-                    <label class="sw-product-detail-context-prices__inheritance-label">
-                        {{ $t('sw-product.advancedPrices.inheritSwitchLabel') }}
-                    </label>
-                </div>
-            </template>
+        {# @deprecated tag:v6.9.0 - Kept as extension anchors, the image and the texts became mt-empty-state props. #}
+        {% block sw_product_detail_prices_empty_state_image %}{% endblock %}
+        {% block sw_product_detail_prices_price_empty_state_text %}
+            {% block sw_product_detail_prices_price_empty_state_text_child %}
+                {% block sw_product_detail_prices_price_empty_state_text_inherited %}
+                    {% block sw_product_detail_prices_price_empty_state_text_link %}{% endblock %}
+                {% endblock %}
+                {% block sw_product_detail_prices_price_empty_state_text_not_inherited %}{% endblock %}
             {% endblock %}
-
-            {% block sw_product_detail_prices_price_empty_state_select_rule %}
-            <sw-select-rule-create
-                v-if="rules.entity"
-                id="rule"
-                class="sw-product-detail-context-prices__empty-state-select-rule"
-                :placeholder="$t('sw-product.advancedPrices.selectRule')"
-                :disabled="isInherited || !acl.can('product.editor')"
-                rule-aware-group-key="productPrices"
-                :restricted-rule-ids="Object.keys(priceRuleGroups)"
-                :restricted-rule-ids-tooltip-label="$t('sw-product.advancedPrices.ruleAlreadyUsed')"
-                @save-rule="onAddNewPriceGroup($event)"
-            />
-            {% endblock %}
-        </div>
+            {% block sw_product_detail_prices_price_empty_state_text_empty %}{% endblock %}
+        {% endblock %}
         {% endblock %}
     </mt-card>
 

--- a/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-context-prices/sw-product-detail-context-prices.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-context-prices/sw-product-detail-context-prices.scss
@@ -82,16 +82,11 @@
 
     .sw-product-detail-context-prices__empty-state {
         margin: 0 auto;
-        padding: calc(var(--scale-size-40) + var(--scale-size-20)) var(--scale-size-20);
+        padding: var(--scale-size-64);
 
         &-card {
             width: 100%;
             max-width: none;
-        }
-
-        // sw-select-rule-create sets inheritAttrs: false, so this class lands on the inner select, not the wrapper
-        &-select-rule {
-            width: 100%;
         }
 
         .mt-empty-state__button {
@@ -105,8 +100,7 @@
             width: 100%;
             max-width: 400px;
 
-            .sw-field,
-            .mt-field {
+            .sw-field {
                 margin-bottom: 0;
             }
         }

--- a/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-context-prices/sw-product-detail-context-prices.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-context-prices/sw-product-detail-context-prices.scss
@@ -81,31 +81,46 @@
     }
 
     .sw-product-detail-context-prices__empty-state {
-        max-width: calc(var(--scale-size-224) + var(--scale-size-56) + var(--scale-size-40) + var(--scale-size-30));
         margin: 0 auto;
         padding: calc(var(--scale-size-40) + var(--scale-size-20)) var(--scale-size-20);
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        flex-direction: column;
 
         &-card {
             width: 100%;
             max-width: none;
         }
 
-        p {
-            text-align: center;
-            margin-block: var(--scale-size-10);
-        }
-
         &-select-rule {
             width: 100%;
         }
 
-        .sw-product-detail-context-prices__parent-prices-link {
-            color: var(--color-text-brand-default);
-            margin-bottom: var(--scale-size-20);
+        .mt-empty-state__button {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            width: 100%;
+        }
+
+        .sw-select-rule-create {
+            width: 100%;
+            max-width: 400px;
+
+            .sw-field,
+            .mt-field {
+                margin-bottom: 0;
+            }
+        }
+    }
+
+    .sw-product-detail-context-prices__price-group-hint {
+        max-width: calc(var(--scale-size-224) + var(--scale-size-56) + var(--scale-size-40) + var(--scale-size-30));
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        flex-direction: column;
+
+        p {
+            text-align: center;
+            margin-block: var(--scale-size-10);
         }
     }
 

--- a/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-context-prices/sw-product-detail-context-prices.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-context-prices/sw-product-detail-context-prices.scss
@@ -89,6 +89,7 @@
             max-width: none;
         }
 
+        // sw-select-rule-create sets inheritAttrs: false, so this class lands on the inner select, not the wrapper
         &-select-rule {
             width: 100%;
         }

--- a/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-context-prices/sw-product-detail-context-prices.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-context-prices/sw-product-detail-context-prices.spec.js
@@ -14,10 +14,6 @@ const createWrapper = async () => {
         {
             global: {
                 mocks: {
-                    $route: {
-                        params: {},
-                        meta: { $module: { icon: 'regular-products' } },
-                    },
                     $router: {
                         resolve: jest.fn((route) => ({
                             href: `#/sw/product/detail/${route.params.id}/prices`,
@@ -165,7 +161,6 @@ describe('src/module/sw-product/view/sw-product-detail-context-prices', () => {
 
         const emptyState = wrapper.find('.sw-product-detail-context-prices__empty-state');
         expect(emptyState.classes()).toContain('mt-empty-state');
-        expect(emptyState.attributes('role')).toBe('status');
         expect(emptyState.text()).toContain('sw-product.advancedPrices.advancedPricesNotExisting');
         expect(emptyState.find('.mt-empty-state__link').exists()).toBe(false);
     });

--- a/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-context-prices/sw-product-detail-context-prices.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-context-prices/sw-product-detail-context-prices.spec.js
@@ -410,4 +410,10 @@ describe('src/module/sw-product/view/sw-product-detail-context-prices', () => {
         expect(wrapper.vm.product.prices).toHaveLength(2);
         expect(wrapper.vm.product.prices[0].quantityEnd).toBe(newValue);
     });
+
+    it('should keep the deprecated assetFilter for template overrides', async () => {
+        wrapper = await createWrapper();
+
+        expect(wrapper.vm.assetFilter).toBe(Shopware.Filter.getByName('asset'));
+    });
 });

--- a/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-context-prices/sw-product-detail-context-prices.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-context-prices/sw-product-detail-context-prices.spec.js
@@ -13,6 +13,17 @@ const createWrapper = async () => {
         }),
         {
             global: {
+                mocks: {
+                    $route: {
+                        params: {},
+                        meta: { $module: { icon: 'regular-products' } },
+                    },
+                    $router: {
+                        resolve: jest.fn((route) => ({
+                            href: `#/sw/product/detail/${route.params.id}/prices`,
+                        })),
+                    },
+                },
                 stubs: {
                     'sw-container': await wrapTestComponent('sw-container'),
                     'sw-loader': true,
@@ -140,6 +151,62 @@ describe('src/module/sw-product/view/sw-product-detail-context-prices', () => {
 
         expect(wrapper.vm.isChild).toBe(false);
         expect(wrapper.vm.isInherited).toBe(false);
+    });
+
+    it('should render the empty state without a parent link for a main product', async () => {
+        Shopware.Store.get('swProductDetail').product = {
+            id: 'productId',
+            parentId: null,
+            prices: [],
+        };
+
+        wrapper = await createWrapper();
+        await wrapper.vm.$nextTick();
+
+        const emptyState = wrapper.find('.sw-product-detail-context-prices__empty-state');
+        expect(emptyState.classes()).toContain('mt-empty-state');
+        expect(emptyState.attributes('role')).toBe('status');
+        expect(emptyState.text()).toContain('sw-product.advancedPrices.advancedPricesNotExisting');
+        expect(emptyState.find('.mt-empty-state__link').exists()).toBe(false);
+    });
+
+    it('should link to the parent prices while the variant inherits', async () => {
+        Shopware.Store.get('swProductDetail').product = {
+            id: 'productId',
+            parentId: 'parentProductId',
+            prices: [],
+        };
+        Shopware.Store.get('swProductDetail').parentProduct = {
+            id: 'parentProductId',
+        };
+
+        wrapper = await createWrapper();
+        await wrapper.vm.$nextTick();
+
+        const emptyState = wrapper.find('.sw-product-detail-context-prices__empty-state');
+        expect(emptyState.text()).toContain('sw-product.advancedPrices.advancedPricesInherited');
+        expect(emptyState.find('.mt-empty-state__link').exists()).toBe(true);
+    });
+
+    it('should describe the removed inheritance without a parent link', async () => {
+        Shopware.Store.get('swProductDetail').product = {
+            id: 'productId',
+            parentId: 'parentProductId',
+            prices: [],
+        };
+        Shopware.Store.get('swProductDetail').parentProduct = {
+            id: 'parentProductId',
+        };
+
+        wrapper = await createWrapper();
+        await wrapper.vm.$nextTick();
+
+        wrapper.vm.isInherited = false;
+        await wrapper.vm.$nextTick();
+
+        const emptyState = wrapper.find('.sw-product-detail-context-prices__empty-state');
+        expect(emptyState.text()).toContain('sw-product.advancedPrices.advancedPricesNotInherited');
+        expect(emptyState.find('.mt-empty-state__link').exists()).toBe(false);
     });
 
     it('first start quantity input should be disabled', async () => {

--- a/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-cross-selling/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-cross-selling/index.js
@@ -33,6 +33,10 @@ export default {
     },
 
     computed: {
+        /** @deprecated tag:v6.9.0 - Kept for overrides, the empty states no longer render an image. */
+        assetFilter() {
+            return Shopware.Filter.getByName('asset');
+        },
         product() {
             return Shopware.Store.get('swProductDetail').product;
         },
@@ -61,8 +65,27 @@ export default {
             return this.$t('sw-product.crossselling.buttonAddCrossSellingLanguageWarning');
         },
 
-        assetFilter() {
-            return Shopware.Filter.getByName('asset');
+        emptyStateDescription() {
+            if (!this.isChild) {
+                return this.$t('sw-product.crossselling.emptyStateDescription');
+            }
+
+            if (this.isInherited) {
+                return this.$t('sw-product.crossselling.inheritedEmptyStateDescription');
+            }
+
+            return this.$t('sw-product.crossselling.notInheritedEmptyStateDescription');
+        },
+
+        showParentCrossSellingLink() {
+            return this.isChild && this.isInherited;
+        },
+
+        parentCrossSellingHref() {
+            return this.$router.resolve({
+                name: 'sw.product.detail.crossSelling',
+                params: { id: this.product.parentId },
+            }).href;
         },
 
         crossSellingRepository() {

--- a/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-cross-selling/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-cross-selling/index.js
@@ -33,10 +33,11 @@ export default {
     },
 
     computed: {
-        /** @deprecated tag:v6.9.0 - Will be removed, use Shopware.Filter.getByName('asset') instead. */
+        /** @deprecated tag:v6.8.0 - Will be removed, use Shopware.Filter.getByName('asset') instead. */
         assetFilter() {
             return Shopware.Filter.getByName('asset');
         },
+
         product() {
             return Shopware.Store.get('swProductDetail').product;
         },

--- a/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-cross-selling/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-cross-selling/index.js
@@ -33,7 +33,7 @@ export default {
     },
 
     computed: {
-        /** @deprecated tag:v6.9.0 - Kept for overrides, the empty states no longer render an image. */
+        /** @deprecated tag:v6.9.0 - Will be removed, use Shopware.Filter.getByName('asset') instead. */
         assetFilter() {
             return Shopware.Filter.getByName('asset');
         },
@@ -77,11 +77,11 @@ export default {
             return this.$t('sw-product.crossselling.notInheritedEmptyStateDescription');
         },
 
-        showParentCrossSellingLink() {
-            return this.isChild && this.isInherited;
-        },
-
         parentCrossSellingHref() {
+            if (!this.isChild || !this.isInherited) {
+                return undefined;
+            }
+
             return this.$router.resolve({
                 name: 'sw.product.detail.crossSelling',
                 params: { id: this.product.parentId },

--- a/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-cross-selling/sw-product-detail-cross-selling.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-cross-selling/sw-product-detail-cross-selling.html.twig
@@ -64,41 +64,39 @@
         {% block sw_product_detail_cross_selling_empty_state %}
         <mt-empty-state
             class="sw-product-detail-cross-selling__empty-state"
-            role="status"
             :centered="true"
-            :icon="$route.meta.$module.icon"
+            icon="regular-products"
             :headline="$t('sw-product.crossselling.cardTitleCrossSelling')"
             :description="emptyStateDescription"
-            :link-text="showParentCrossSellingLink ? $t('sw-product.crossselling.linkCrossSellingsOfParent') : undefined"
-            :link-href="showParentCrossSellingLink ? parentCrossSellingHref : undefined"
+            :link-text="$t('sw-product.crossselling.linkCrossSellingsOfParent')"
+            :link-href="parentCrossSellingHref"
         >
             <template #button>
                 {% block sw_product_detail_cross_selling_empty_state_inherit_switch %}
-                <template v-if="isChild">
-                    <div
-                        class="sw-product-detail-cross-selling__inherit-toggle-wrapper"
-                        :class="{ 'is--inherited': isInherited }"
-                    >
-                        <mt-switch
-                            v-model="isInherited"
-                            class="sw-product-detail-cross-selling__inherit-switch"
-                            :disabled="!acl.can('product.editor') || !isSystemDefaultLanguage"
-                        />
+                <div
+                    v-if="isChild"
+                    class="sw-product-detail-cross-selling__inherit-toggle-wrapper"
+                    :class="{ 'is--inherited': isInherited }"
+                >
+                    <mt-switch
+                        v-model="isInherited"
+                        class="sw-product-detail-cross-selling__inherit-switch"
+                        :disabled="!acl.can('product.editor') || !isSystemDefaultLanguage"
+                    />
 
-                        <sw-inheritance-switch
-                            class="sw-product-detail-cross-selling__inheritance-icon"
-                            :is-inherited="isInherited"
-                            :disabled="!acl.can('product.editor') || !isSystemDefaultLanguage"
-                            @inheritance-restore="restoreInheritance"
-                            @inheritance-remove="removeInheritance"
-                        />
+                    <sw-inheritance-switch
+                        class="sw-product-detail-cross-selling__inheritance-icon"
+                        :is-inherited="isInherited"
+                        :disabled="!acl.can('product.editor') || !isSystemDefaultLanguage"
+                        @inheritance-restore="restoreInheritance"
+                        @inheritance-remove="removeInheritance"
+                    />
 
-                        <!-- eslint-disable-next-line vuejs-accessibility/label-has-for -->
-                        <label class="sw-product-detail-cross-selling__inheritance-label">
-                            {{ $t('sw-product.crossselling.inheritSwitchLabel') }}
-                        </label>
-                    </div>
-                </template>
+                    <!-- eslint-disable-next-line vuejs-accessibility/label-has-for -->
+                    <label class="sw-product-detail-cross-selling__inheritance-label">
+                        {{ $t('sw-product.crossselling.inheritSwitchLabel') }}
+                    </label>
+                </div>
                 {% endblock %}
 
                 {% block sw_product_detail_cross_selling_empty_state_actions_add %}
@@ -123,12 +121,20 @@
         {% block sw_product_detail_cross_selling_empty_state_actions %}{% endblock %}
         {% block sw_product_detail_cross_selling_empty_state_icon %}{% endblock %}
         {% block sw_product_detail_cross_selling_empty_state_content %}
+        <template v-if="isChild">
             {% block sw_product_detail_cross_selling_empty_state_content_child %}
+            <template v-if="isInherited">
                 {% block sw_product_detail_cross_selling_empty_state_content_child_inherited %}{% endblock %}
                 {% block sw_product_detail_cross_selling_empty_state_content_child_inherited_link %}{% endblock %}
+            </template>
+            <template v-else>
                 {% block sw_product_detail_cross_selling_empty_state_content_child_not_inherited %}{% endblock %}
+            </template>
             {% endblock %}
+        </template>
+        <template v-else>
             {% block sw_product_detail_cross_selling_empty_state_content_empty %}{% endblock %}
+        </template>
         {% endblock %}
         {% endblock %}
     </mt-card>

--- a/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-cross-selling/sw-product-detail-cross-selling.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-cross-selling/sw-product-detail-cross-selling.html.twig
@@ -117,7 +117,7 @@
             </template>
         </mt-empty-state>
 
-        {# @deprecated tag:v6.9.0 - Kept as extension anchors, the icon and the descriptions became mt-empty-state props. #}
+        {# @deprecated tag:v6.8.0 - Kept as extension anchors, the icon and the descriptions became mt-empty-state props. #}
         {% block sw_product_detail_cross_selling_empty_state_actions %}{% endblock %}
         {% block sw_product_detail_cross_selling_empty_state_icon %}{% endblock %}
         {% block sw_product_detail_cross_selling_empty_state_content %}

--- a/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-cross-selling/sw-product-detail-cross-selling.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-cross-selling/sw-product-detail-cross-selling.html.twig
@@ -62,59 +62,17 @@
         position-identifier="sw-product-detail-cross-selling-empty-state"
     >
         {% block sw_product_detail_cross_selling_empty_state %}
-        <sw-empty-state
-            :title="$t('sw-product.crossselling.cardTitleCrossSelling')"
-            :absolute="false"
-            empty-module
+        <mt-empty-state
+            class="sw-product-detail-cross-selling__empty-state"
+            role="status"
+            :centered="true"
+            :icon="$route.meta.$module.icon"
+            :headline="$t('sw-product.crossselling.cardTitleCrossSelling')"
+            :description="emptyStateDescription"
+            :link-text="showParentCrossSellingLink ? $t('sw-product.crossselling.linkCrossSellingsOfParent') : undefined"
+            :link-href="showParentCrossSellingLink ? parentCrossSellingHref : undefined"
         >
-            {% block sw_product_detail_cross_selling_empty_state_icon %}
-            <template #icon>
-                <img
-                    :src="assetFilter('/administration/administration/static/img/empty-states/products-empty-state.svg')"
-                    :alt="$t('sw-product.crossselling.cardTitleCrossSelling')"
-                >
-            </template>
-            {% endblock %}
-
-            <template #default>
-                {% block sw_product_detail_cross_selling_empty_state_content %}
-                <template v-if="isChild">
-                    {% block sw_product_detail_cross_selling_empty_state_content_child %}
-                    <template v-if="isInherited">
-                        {% block sw_product_detail_cross_selling_empty_state_content_child_inherited %}
-                        <p>{{ $t('sw-product.crossselling.inheritedEmptyStateDescription') }}</p>
-                        {% endblock %}
-
-                        {% block sw_product_detail_cross_selling_empty_state_content_child_inherited_link %}
-                        <router-link
-                            v-if="isChild && isInherited"
-                            :to="{ name: 'sw.product.detail.crossSelling', params: { id: product.parentId } }"
-                            class="sw-product-detail-cross-selling__parent-cross-sellings-link"
-                        >
-                            {{ $t('sw-product.crossselling.linkCrossSellingsOfParent') }}
-                            <mt-icon
-                                name="regular-long-arrow-right"
-                                size="var(--scale-size-16)"
-                            />
-                        </router-link>
-                        {% endblock %}
-                    </template>
-
-                    <template v-else>
-                        {% block sw_product_detail_cross_selling_empty_state_content_child_not_inherited %}
-                        <p>{{ $t('sw-product.crossselling.notInheritedEmptyStateDescription') }}</p>
-                        {% endblock %}
-                    </template>
-                    {% endblock %}
-                </template>
-
-                <template v-else>
-                    {% block sw_product_detail_cross_selling_empty_state_content_empty %}
-                    <p>{{ $t('sw-product.crossselling.emptyStateDescription') }}</p>
-                    {% endblock %}
-                </template>
-                {% endblock %}
-
+            <template #button>
                 {% block sw_product_detail_cross_selling_empty_state_inherit_switch %}
                 <template v-if="isChild">
                     <div
@@ -142,10 +100,7 @@
                     </div>
                 </template>
                 {% endblock %}
-            </template>
 
-            {% block sw_product_detail_cross_selling_empty_state_actions %}
-            <template #actions>
                 {% block sw_product_detail_cross_selling_empty_state_actions_add %}
                 <mt-button
                     v-tooltip="{
@@ -155,14 +110,26 @@
                     }"
                     :disabled="isInherited || !acl.can('product.editor') || !isSystemDefaultLanguage"
                     variant="secondary"
+                    size="small"
                     @click="onAddCrossSelling"
                 >
                     {{ $t('sw-product.crossselling.buttonAddCrossSelling') }}
                 </mt-button>
                 {% endblock %}
             </template>
+        </mt-empty-state>
+
+        {# @deprecated tag:v6.9.0 - Kept as extension anchors, the icon and the descriptions became mt-empty-state props. #}
+        {% block sw_product_detail_cross_selling_empty_state_actions %}{% endblock %}
+        {% block sw_product_detail_cross_selling_empty_state_icon %}{% endblock %}
+        {% block sw_product_detail_cross_selling_empty_state_content %}
+            {% block sw_product_detail_cross_selling_empty_state_content_child %}
+                {% block sw_product_detail_cross_selling_empty_state_content_child_inherited %}{% endblock %}
+                {% block sw_product_detail_cross_selling_empty_state_content_child_inherited_link %}{% endblock %}
+                {% block sw_product_detail_cross_selling_empty_state_content_child_not_inherited %}{% endblock %}
             {% endblock %}
-        </sw-empty-state>
+            {% block sw_product_detail_cross_selling_empty_state_content_empty %}{% endblock %}
+        {% endblock %}
         {% endblock %}
     </mt-card>
     {% endblock %}

--- a/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-cross-selling/sw-product-detail-cross-selling.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-cross-selling/sw-product-detail-cross-selling.scss
@@ -47,7 +47,13 @@
         width: fit-content;
     }
 
-    .sw-empty-state__icon {
-        display: inline-block;
+    &__empty-state {
+        margin: 0 auto;
+
+        .mt-empty-state__button {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+        }
     }
 }

--- a/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-cross-selling/sw-product-detail-cross-selling.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-cross-selling/sw-product-detail-cross-selling.scss
@@ -49,6 +49,7 @@
 
     &__empty-state {
         margin: 0 auto;
+        padding: var(--scale-size-64);
 
         .mt-empty-state__button {
             display: flex;

--- a/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-cross-selling/sw-product-detail-cross-selling.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-cross-selling/sw-product-detail-cross-selling.spec.js
@@ -15,10 +15,6 @@ async function createWrapper() {
             },
             global: {
                 mocks: {
-                    $route: {
-                        params: {},
-                        meta: { $module: { icon: 'regular-products' } },
-                    },
                     $router: {
                         resolve: jest.fn((route) => ({
                             href: `#/sw/product/detail/${route.params.id}/cross-selling`,

--- a/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-cross-selling/sw-product-detail-cross-selling.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-cross-selling/sw-product-detail-cross-selling.spec.js
@@ -14,9 +14,19 @@ async function createWrapper() {
                 crossSelling: null,
             },
             global: {
+                mocks: {
+                    $route: {
+                        params: {},
+                        meta: { $module: { icon: 'regular-products' } },
+                    },
+                    $router: {
+                        resolve: jest.fn((route) => ({
+                            href: `#/sw/product/detail/${route.params.id}/cross-selling`,
+                        })),
+                    },
+                },
                 stubs: {
                     'sw-product-cross-selling-form': true,
-                    'sw-empty-state': true,
                     'sw-skeleton': true,
                     'sw-inheritance-switch': true,
 
@@ -116,5 +126,60 @@ describe('src/module/sw-product/view/sw-product-detail-cross-selling', () => {
 
         expect(wrapper.vm.isChild).toBe(false);
         expect(wrapper.vm.isInherited).toBe(false);
+    });
+
+    it('should render the empty state without a parent link for a main product', async () => {
+        Shopware.Store.get('swProductDetail').product = {
+            id: 'productId',
+            parentId: null,
+            crossSellings: [],
+        };
+
+        wrapper = await createWrapper();
+        await wrapper.vm.$nextTick();
+
+        const emptyState = wrapper.find('.sw-product-detail-cross-selling__empty-state');
+        expect(emptyState.exists()).toBe(true);
+        expect(emptyState.text()).toContain('sw-product.crossselling.emptyStateDescription');
+        expect(emptyState.find('.mt-empty-state__link').exists()).toBe(false);
+    });
+
+    it('should link to the parent cross sellings while the variant inherits', async () => {
+        Shopware.Store.get('swProductDetail').product = {
+            id: 'productId',
+            parentId: 'parentProductId',
+            crossSellings: [],
+        };
+        Shopware.Store.get('swProductDetail').parentProduct = {
+            id: 'parentProductId',
+        };
+
+        wrapper = await createWrapper();
+        await wrapper.vm.$nextTick();
+
+        const emptyState = wrapper.find('.sw-product-detail-cross-selling__empty-state');
+        expect(emptyState.text()).toContain('sw-product.crossselling.inheritedEmptyStateDescription');
+        expect(emptyState.find('.mt-empty-state__link').exists()).toBe(true);
+    });
+
+    it('should describe the removed inheritance without a parent link', async () => {
+        Shopware.Store.get('swProductDetail').product = {
+            id: 'productId',
+            parentId: 'parentProductId',
+            crossSellings: [],
+        };
+        Shopware.Store.get('swProductDetail').parentProduct = {
+            id: 'parentProductId',
+        };
+
+        wrapper = await createWrapper();
+        await wrapper.vm.$nextTick();
+
+        wrapper.vm.isInherited = false;
+        await wrapper.vm.$nextTick();
+
+        const emptyState = wrapper.find('.sw-product-detail-cross-selling__empty-state');
+        expect(emptyState.text()).toContain('sw-product.crossselling.notInheritedEmptyStateDescription');
+        expect(emptyState.find('.mt-empty-state__link').exists()).toBe(false);
     });
 });

--- a/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-cross-selling/sw-product-detail-cross-selling.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-cross-selling/sw-product-detail-cross-selling.spec.js
@@ -182,4 +182,10 @@ describe('src/module/sw-product/view/sw-product-detail-cross-selling', () => {
         expect(emptyState.text()).toContain('sw-product.crossselling.notInheritedEmptyStateDescription');
         expect(emptyState.find('.mt-empty-state__link').exists()).toBe(false);
     });
+
+    it('should keep the deprecated assetFilter for template overrides', async () => {
+        wrapper = await createWrapper();
+
+        expect(wrapper.vm.assetFilter).toBe(Shopware.Filter.getByName('asset'));
+    });
 });


### PR DESCRIPTION
### 1. Why is this change necessary?

The advanced pricing and cross selling tabs rendered hand-built empty states with an illustration, their own headings and their own link markup instead of the shared `mt-empty-state` pattern.

### 2. What does this change do, exactly?

- Replaces both empty states with `mt-empty-state`; headline, description, icon and the link to the parent product are component props, backed by the new computeds `emptyStateDescription` and `parentPricesHref` / `parentCrossSellingHref` (the href is only set while a variant inherits).
- Stretches `sw-select-rule-create` in the advanced pricing empty state to the full slot width with a `max-width` of 400px.
- Keeps all replaced markup blocks — with their previous render conditions — and the `assetFilter` computeds as `@deprecated tag:v6.9.0` extension anchors. The cross selling icon and actions blocks no longer wrap `v-slot` templates, so full-replacement overrides must drop those wrappers (documented in the release info).

### 3. Describe each step to reproduce the issue or behaviour.

1. Open a product without advanced prices, tab "Advanced pricing": the empty state shows the money icon, a headline and the rule select underneath.
2. Open a product without cross selling, tab "Cross Selling": the empty state shows the product icon and the "Add cross selling" button.
3. Open a variant: the empty state additionally offers the inheritance toggle and a link to the parent product.

### Screenshots
<img width="3260" height="1078" alt="product-advanced-pricing" src="https://github.com/user-attachments/assets/301ff048-a05a-4d61-8ad4-1faf04387699" />
<img width="3260" height="1078" alt="product-cross-selling" src="https://github.com/user-attachments/assets/2514b043-2b8b-4ee7-8974-139225256bd3" />

### 4. Please link to the relevant issues (if any).

- relates #19346

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
