### PR TITLE
fix(storefront): correct the theme manager card padding and borders

### DIFF
--- a/src/Storefront/Resources/app/administration/src/modules/sw-theme-manager/component/sw-theme-list-item/sw-theme-list-item.scss
+++ b/src/Storefront/Resources/app/administration/src/modules/sw-theme-manager/component/sw-theme-list-item/sw-theme-list-item.scss
@@ -5,13 +5,13 @@
     grid-auto-rows: 120px 40px;
     padding: 10px 10px 0 10px;
     background: var(--color-elevation-surface-raised);
-    border: 1px solid var(--color-border-primary-default);
+    border: 1px solid var(--color-border-secondary-default);
     border-radius: 4px;
     position: relative;
 
     &.is--disabled {
         &:hover {
-            border: 1px solid var(--color-border-primary-default);
+            border: 1px solid var(--color-border-secondary-default);
             box-shadow: none;
             cursor: not-allowed;
         }
@@ -30,7 +30,7 @@
     .sw-theme-list-item__image {
         background: center center no-repeat var(--color-elevation-surface-raised);
         background-size: 90% 90%;
-        border: 1px solid var(--color-border-primary-default);
+        border: 1px solid var(--color-border-secondary-default);
         border-radius: 4px;
         height: 120px;
 

--- a/src/Storefront/Resources/app/administration/src/modules/sw-theme-manager/page/sw-theme-manager-detail/sw-theme-manager-detail.scss
+++ b/src/Storefront/Resources/app/administration/src/modules/sw-theme-manager/page/sw-theme-manager-detail/sw-theme-manager-detail.scss
@@ -53,6 +53,10 @@
             .sw-card__content {
                 padding: 0;
             }
+
+            .sw-card-section {
+                padding: 0;
+            }
         }
     }
 
@@ -98,6 +102,7 @@
 
     .sw-theme-manager-detail__sales-channels-select {
         margin-top: 20px;
+        margin-bottom: 0;
     }
 
     .sw-theme-manager-detail__content-section-field {

--- a/src/Storefront/Resources/app/administration/src/modules/sw-theme-manager/page/sw-theme-manager-detail/sw-theme-manager-detail.scss
+++ b/src/Storefront/Resources/app/administration/src/modules/sw-theme-manager/page/sw-theme-manager-detail/sw-theme-manager-detail.scss
@@ -50,10 +50,6 @@
         margin-top: 25px;
 
         .sw-theme-manager-detail__area {
-            .sw-card__content {
-                padding: 0;
-            }
-
             .sw-card-section {
                 padding: 0;
             }


### PR DESCRIPTION
### 1. Why is this change necessary?

The generated theme configuration cards applied padding twice: once from the card and once from the nested `sw-card-section`, which made the theme detail view look noticeably more indented than every other detail page.

The reset that used to prevent this targets `.sw-card__content`, but the view renders `mt-card` only, so the selector had stopped matching anything and the inner padding came back unnoticed.

### 2. What does this change do, exactly?

- Repoints the dead `.sw-card__content` reset inside `.sw-theme-manager-detail__area` at `.sw-card-section`, so the inner padding is removed again while the card padding stays untouched everywhere else.
- Drops the trailing margin of the sales channel select in the theme info card, which was left over once the surrounding card content lost its padding.
- Aligns the `sw-theme-list-item` card and preview borders with `--color-border-secondary-default`, matching the reworked card borders. The context button keeps `--color-border-primary-default` because it is an interactive control.

### 3. Describe each step to reproduce the issue or behaviour.

1. Open Content > Themes and select a theme.
2. The configuration cards use the same inner padding as any other detail page card.

### Screenshots

| Before (trunk) | After (this PR) |
| --- | --- |
|  |  |

### 4. Please link to the relevant issues (if any).

- relates #19346

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
