### PR TITLE
fix(administration): align shared admin component styles

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -120,6 +120,16 @@ The main menu and the search bar no longer color their icons by the `color` of t
 
 The `color` property of `Module.register()` is unchanged and keeps feeding these icons, so extensions do not need to adapt.
 
+### Shared administration component styling
+
+Three shared components changed their appearance or behaviour. Extensions using them do not need to adapt, but the visual result differs:
+
+- `sw-overlay` uses the `--color-elevation-backdrop-default` token instead of a hard coded `rgba(255, 255, 255, 40%)`. The scrim is now dark and follows the light and dark theme.
+- `sw-meteor-card` renders a `1px` border in `--color-border-secondary-default` instead of a drop shadow, matching `mt-card`.
+- `sw-sorting-select` renders in the `small` size and no longer offers a clear button, because a sorting can not be empty. This also affects the CMS layout modal, the theme manager list and any extension embedding the component.
+
+`sw-language-switch` truncates long language names with an ellipsis instead of wrapping onto a second line.
+
 ## Storefront
 
 ### Semantic footer markup

--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -120,16 +120,6 @@ The main menu and the search bar no longer color their icons by the `color` of t
 
 The `color` property of `Module.register()` is unchanged and keeps feeding these icons, so extensions do not need to adapt.
 
-### Shared administration component styling
-
-Three shared components changed their appearance or behaviour. Extensions using them do not need to adapt, but the visual result differs:
-
-- `sw-overlay` uses the `--color-elevation-backdrop-default` token instead of a hard coded `rgba(255, 255, 255, 40%)`. The scrim is now dark and follows the light and dark theme.
-- `sw-meteor-card` renders a `1px` border in `--color-border-secondary-default` instead of a drop shadow, matching `mt-card`.
-- `sw-sorting-select` renders in the `small` size and no longer offers a clear button, because a sorting can not be empty. This also affects the CMS layout modal, the theme manager list and any extension embedding the component.
-
-`sw-language-switch` truncates long language names with an ellipsis instead of wrapping onto a second line.
-
 ## Storefront
 
 ### Semantic footer markup

--- a/src/Administration/Resources/app/administration/src/app/assets/scss/global.scss
+++ b/src/Administration/Resources/app/administration/src/app/assets/scss/global.scss
@@ -111,7 +111,7 @@ a[target="_blank"]:not(.sw-external-link, .sw-internal-link, .mt-button, .mt-lin
     flex-basis: 100%;
     padding: 30px;
     background-color: var(--color-elevation-surface-sunken);
-    border-bottom: 1px solid var(--color-border-primary-default);
+    border-bottom: 1px solid var(--color-border-secondary-default);
 }
 
 .mt-button {

--- a/src/Administration/Resources/app/administration/src/app/component/base/sw-product-image/sw-product-image.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/base/sw-product-image/sw-product-image.scss
@@ -6,7 +6,7 @@
     border: 2px solid var(--color-border-secondary-default);
 
     &.is--placeholder {
-        border: 2px dashed var(--color-border-primary-default);
+        border: 2px dashed var(--color-border-secondary-default);
         display: flex;
         align-items: center;
         justify-content: center;

--- a/src/Administration/Resources/app/administration/src/app/component/base/sw-sorting-select/sw-sorting-select.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/base/sw-sorting-select/sw-sorting-select.html.twig
@@ -5,6 +5,8 @@
         :label="$t('sw-cms.sorting.labelSort')"
         :model-value="sortingConditionConcatenation"
         :options="sortingConditionOptions"
+        hide-clearable-button
+        small
         @update:model-value="onSortingChanged"
     />
 </div>

--- a/src/Administration/Resources/app/administration/src/app/component/meteor/sw-meteor-card/sw-meteor-card.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/meteor/sw-meteor-card/sw-meteor-card.scss
@@ -6,10 +6,9 @@
     margin: 0 auto 40px;
     position: relative;
     color: var(--color-text-primary-default);
-    border-radius: $border-radius-lg;
+    border-radius: var(--border-radius-card);
     background: var(--color-elevation-surface-raised);
-
-    @include drop-shadow-default;
+    border: 1px solid var(--color-border-secondary-default);
 
     .sw-meteor-card__header {
         .sw-meteor-card__header-grid {

--- a/src/Administration/Resources/app/administration/src/app/component/meteor/sw-meteor-card/sw-meteor-card.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/meteor/sw-meteor-card/sw-meteor-card.scss
@@ -1,4 +1,3 @@
-@import "~scss/mixins";
 @import "~scss/variables";
 
 .sw-meteor-card {
@@ -42,7 +41,7 @@
 
     &.sw-meteor-card--hero {
         background: none;
-        box-shadow: none;
+        border: none;
 
         .sw-meteor-card__content {
             background: none;

--- a/src/Administration/Resources/app/administration/src/app/component/structure/sw-language-switch/sw-language-switch.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/structure/sw-language-switch/sw-language-switch.scss
@@ -13,5 +13,12 @@
         .sw-block-field__block {
             height: 40px;
         }
+
+        .sw-entity-single-select__selection-text {
+            max-width: 100%;
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+        }
     }
 }

--- a/src/Administration/Resources/app/administration/src/app/component/utils/sw-overlay/sw-overlay.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/utils/sw-overlay/sw-overlay.scss
@@ -1,6 +1,6 @@
 @import "~scss/variables";
 
-$sw-overlay-color-overlay: rgba(255, 255, 255, 40%);
+$sw-overlay-color-overlay: var(--color-elevation-backdrop-default);
 $sw-overlay-z-index: $z-index-overlay;
 
 .sw-overlay {


### PR DESCRIPTION
### 1. Why is this change necessary?

A few shared administration components were left behind by the ui shell rework: `sw-meteor-card` still used a drop shadow while every other card uses a border, `sw-overlay` hard coded a white scrim that is unreadable in dark mode, the sorting select offered a clear button for a value that can never be empty, and long language names wrapped the language switch onto two lines.

### 2. What does this change do, exactly?

- `sw-meteor-card`: replaces `drop-shadow-default` with a `1px` border in `--color-border-secondary-default` and switches the radius from `$border-radius-lg` to `--border-radius-card` (same computed value).
- `sw-overlay`: uses `--color-elevation-backdrop-default` instead of `rgba(255, 255, 255, 40%)`, so the scrim follows the theme.
- `sw-sorting-select`: renders `small` and with `hide-clearable-button`. Note that this is a shared base component, so it also affects the CMS layout modal, the theme manager list and the scene listing.
- `sw-language-switch`: truncates `.sw-entity-single-select__selection-text` with an ellipsis instead of wrapping.
- Card toolbar in `global.scss` and `sw-product-image`: use `--color-border-secondary-default` for the decorative borders.

### 3. Describe each step to reproduce the issue or behaviour.

1. Open Extensions > My extensions: the cards are outlined instead of shadowed.
2. Open any detail page and switch to a language with a long name: the name is truncated with an ellipsis.
3. Trigger any `sw-overlay`, for example while a listing reloads: the scrim follows the light/dark theme.

### 4. Please link to the relevant issues (if any).

- relates #19346

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
