### PR TITLE
fix(administration): use elevation surface tokens for module toolbars

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-category/view/sw-category-detail-custom-entity/sw-category-detail-custom-entity.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-category/view/sw-category-detail-custom-entity/sw-category-detail-custom-entity.scss
@@ -1,9 +1,9 @@
 .sw-category-detail-custom-entity {
     .sw-many-to-many-assignment-card__select-container {
-        background-color: var(--color-background-secondary-default);
+        background-color: var(--color-elevation-surface-sunken);
     }
 
     .sw-card .sw-card__content {
-        background-color: var(--color-background-secondary-default);
+        background-color: var(--color-elevation-surface-default);
     }
 }

--- a/src/Administration/Resources/app/administration/src/module/sw-category/view/sw-category-detail-products/sw-category-detail-products.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-category/view/sw-category-detail-products/sw-category-detail-products.scss
@@ -19,7 +19,7 @@
     }
 
     .sw-many-to-many-assignment-card__select-container {
-        background-color: var(--color-background-secondary-default);
+        background-color: var(--color-elevation-surface-sunken);
     }
 
     .sw-product-stream-grid-preview__grid {

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-line-items-grid/sw-order-line-items-grid.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-line-items-grid/sw-order-line-items-grid.scss
@@ -2,7 +2,7 @@
     .sw-order-line-items-grid__actions-container {
         padding: 24px;
         border-bottom: 1px solid var(--color-border-secondary-default);
-        background: var(--color-background-tertiary-default);
+        background: var(--color-elevation-surface-sunken);
 
         .sw-order-line-items-grid__delete-button {
             &.mt-button--square:not([disabled]) .mt-icon,

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-cache/page/sw-settings-cache-index/sw-settings-cache-index.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-cache/page/sw-settings-cache-index/sw-settings-cache-index.scss
@@ -7,9 +7,9 @@
     &__card {
         &-toolbar {
             display: flex;
-            justify-content: space-around;
-            align-items: center;
-            gap: var(--scale-size-8);
+            column-gap: var(--scale-size-32);
+            row-gap: var(--scale-size-16);
+            flex-wrap: wrap;
             padding: var(--scale-size-6) 0;
             width: 100%;
             font-size: var(--font-size-xs);

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-language/page/sw-settings-language-detail/sw-settings-language-detail.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-language/page/sw-settings-language-detail/sw-settings-language-detail.scss
@@ -88,7 +88,7 @@
         justify-content: center;
         width: var(--scale-size-32);
         height: var(--scale-size-32);
-        border: 1px solid var(--color-border-primary-default);
+        border: 1px solid var(--color-border-secondary-default);
         border-radius: var(--border-radius-xs);
         background-color: var(--color-elevation-surface-sunken);
         flex-shrink: 0;

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-search/component/sw-settings-search-excluded-search-terms/sw-settings-search-excluded-search-terms.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-search/component/sw-settings-search-excluded-search-terms/sw-settings-search-excluded-search-terms.scss
@@ -4,7 +4,7 @@
         align-items: center;
         padding: var(--scale-size-20) var(--scale-size-24);
         border-bottom: var(--scale-size-1) solid var(--color-border-secondary-default);
-        background-color: var(--color-background-secondary-default);
+        background-color: var(--color-elevation-surface-sunken);
         gap: var(--scale-size-12);
 
         .sw-card-filter {

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-shipping/component/sw-settings-shipping-price-matrix/sw-settings-shipping-price-matrix.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-shipping/component/sw-settings-shipping-price-matrix/sw-settings-shipping-price-matrix.scss
@@ -6,7 +6,7 @@
 
     .sw-settings-shipping-price-matrix__top-container {
         padding: 32px 24px;
-        background-color: var(--color-background-tertiary-default);
+        background-color: var(--color-elevation-surface-sunken);
         border-bottom: 1px solid var(--color-border-secondary-default);
 
         .sw-select__single-selection {


### PR DESCRIPTION
### 1. Why is this change necessary?

Several module toolbars still used the deprecated `--color-background-secondary-default` and `--color-background-tertiary-default` tokens. They no longer match the reworked card surfaces, so toolbars appeared in a slightly different shade than the sunken surfaces around them. The cache settings toolbar additionally squeezed its items together instead of wrapping.

### 2. What does this change do, exactly?

- Replaces the deprecated background tokens with the matching elevation surface tokens (`--color-elevation-surface-sunken` for toolbars and select containers, `--color-elevation-surface-default` for the category custom entity card content) in the category, order line item and settings views.
- Uses `--color-border-secondary-default` for the decorative border in the language detail view.
- Lets `.sw-settings-cache-index__card-toolbar` wrap with an explicit column and row gap instead of `justify-content: space-around`.

No token is removed, this is a purely visual alignment.

### 3. Describe each step to reproduce the issue or behaviour.

1. Open Settings > Caches & indexes: the toolbar items wrap onto a second row on narrow viewports instead of overlapping.
2. Open a category detail page, an order detail page or the shipping price matrix: the toolbars use the same sunken surface as the surrounding cards.

### 4. Please link to the relevant issues (if any).

- relates #19346

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
