### PR TITLE
docs(administration): drop the incorrect sw-page color prop note

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -111,7 +111,6 @@ Both page components declare `container-type: inline-size`. This creates a new c
 
 #### Color props without effect
 
-- `sw-page`: `headerBorderColor` (and the derived `pageColor`) no longer affect the header — the smart bar no longer renders a module-colored border.
 - `sw-search-bar`: `entitySearchColor` and the `entityIconColor` prop of `sw-search-bar-item` are only applied while the user set the "Module colors" preference to "Colored" (see below). By default search results use the standard icon colors.
 
 #### Optional module icon colors


### PR DESCRIPTION
### 1. Why is this change necessary?

`RELEASE_INFO-6.7.md` lists `sw-page`'s `headerBorderColor` (and the derived `pageColor`) under "Color props without effect" as part of the admin ui shell rework. That is wrong: `headerStyles` was already unbound from the smart bar in `8d4f444eef7`, shipped with v6.7.10.0, so the props did not render a colored border before the rework either.

### 2. What does this change do, exactly?

Removes the single incorrect bullet. The remaining `sw-search-bar` entry is unaffected.

### 3. Describe each step to reproduce the issue or behaviour.

Not applicable, documentation only.

### 4. Please link to the relevant issues (if any).

- relates #19346

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [x] I have written or adjusted the documentation and agent skills according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
