### PR TITLE
fix(administration): admin menu active state plugin detail routes

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/structure/sw-admin-menu-item/menu-item-active.helper.spec.ts
+++ b/src/Administration/Resources/app/administration/src/app/component/structure/sw-admin-menu-item/menu-item-active.helper.spec.ts
@@ -72,6 +72,128 @@ describe('src/app/component/structure/sw-admin-menu-item/menu-item-active.helper
             expect(names.has('sw.settings.index')).toBe(true);
         });
 
+        it('bridges a module route to its own menu entry when no parentPath is declared', () => {
+            // A plugin detail route sits next to the nav target instead of below it, so `matched` cannot reach it
+            const route = {
+                name: 'sw.foo.detail',
+                matched: [{ name: 'sw.foo.detail' }],
+                meta: { $module: { navigation: [{ path: 'sw.foo.index' }] } },
+            };
+
+            expect(getActiveRouteNames(route)).toEqual(
+                new Set([
+                    'sw.foo.detail',
+                    'sw.foo.index',
+                ]),
+            );
+        });
+
+        it('continues the parentPath walk from the module navigation entry', () => {
+            const route = {
+                name: 'sw.foo.detail',
+                matched: [{ name: 'sw.foo.detail' }],
+                meta: { $module: { navigation: [{ path: 'sw.foo.index' }] } },
+            };
+            const router = { getRoutes: () => [{ name: 'sw.foo.index', meta: { parentPath: 'sw.settings.index' } }] };
+
+            const names = getActiveRouteNames(route, router);
+
+            // The detail page has to reach the same ancestors as the module's own list page
+            expect(names.has('sw.foo.index')).toBe(true);
+            expect(names.has('sw.settings.index')).toBe(true);
+        });
+
+        it('prefers a declared parentPath over the module navigation entry', () => {
+            const route = {
+                name: 'sw.foo.detail',
+                matched: [{ name: 'sw.foo.detail' }],
+                meta: {
+                    parentPath: 'sw.foo.overview',
+                    $module: { navigation: [{ path: 'sw.foo.index' }] },
+                },
+            };
+
+            expect(getActiveRouteNames(route)).toEqual(
+                new Set([
+                    'sw.foo.detail',
+                    'sw.foo.overview',
+                ]),
+            );
+        });
+
+        it('does not guess for a core module contributing several menu entries', () => {
+            // sw-extension contributes both "Store" and "My extensions"; core declares parentPath instead
+            const route = {
+                name: 'sw.extension.module',
+                matched: [{ name: 'sw.extension.module' }],
+                meta: {
+                    $module: {
+                        type: 'core' as const,
+                        navigation: [
+                            { path: 'sw.extension.store' },
+                            { path: 'sw.extension.my-extensions' },
+                        ],
+                    },
+                },
+            };
+
+            expect(getActiveRouteNames(route)).toEqual(new Set(['sw.extension.module']));
+        });
+
+        it('bridges an extension module contributing several menu entries', () => {
+            // An extension cannot be asked to add parentPath after the fact, so its entries are used as-is
+            const route = {
+                name: 'sw.foo.detail',
+                matched: [{ name: 'sw.foo.detail' }],
+                meta: {
+                    $module: {
+                        navigation: [
+                            { path: 'sw.foo.index' },
+                            { path: 'sw.foo.reports' },
+                        ],
+                    },
+                },
+            };
+
+            expect(getActiveRouteNames(route)).toEqual(
+                new Set([
+                    'sw.foo.detail',
+                    'sw.foo.index',
+                    'sw.foo.reports',
+                ]),
+            );
+        });
+
+        it('does not add sibling menu entries to a route the matched chain already anchors', () => {
+            // sw-product-reviews contributes five entries and every route is one of them
+            const route = {
+                name: 'sw.product.reviews.pending',
+                matched: [{ name: 'sw.product.reviews.pending' }],
+                meta: {
+                    $module: {
+                        navigation: [
+                            { path: 'sw.product.reviews.index' },
+                            { path: 'sw.product.reviews.pending' },
+                        ],
+                    },
+                },
+            };
+
+            expect(getActiveRouteNames(route)).toEqual(new Set(['sw.product.reviews.pending']));
+        });
+
+        it('tolerates a module without a usable navigation entry', () => {
+            const withoutPath = {
+                name: 'sw.foo.detail',
+                matched: [{ name: 'sw.foo.detail' }],
+                meta: { $module: { navigation: [{ path: undefined }] } },
+            };
+
+            expect(getActiveRouteNames({ name: 'a', meta: { $module: {} } })).toEqual(new Set(['a']));
+            expect(getActiveRouteNames({ name: 'a', meta: { $module: { navigation: [] } } })).toEqual(new Set(['a']));
+            expect(getActiveRouteNames(withoutPath)).toEqual(new Set(['sw.foo.detail']));
+        });
+
         it('does not loop on a cyclic parentPath chain', () => {
             const route = { name: 'a', matched: [{ name: 'a' }], meta: { parentPath: 'b' } };
             const router = {
@@ -158,6 +280,23 @@ describe('src/app/component/structure/sw-admin-menu-item/menu-item-active.helper
 
             expect(isEntryOnActiveRoute(entryA, route)).toBe(true);
             expect(isEntryOnActiveRoute(entryB, route)).toBe(false);
+        });
+
+        it('lights a plugin leaf and its path-less group through the module navigation entry', () => {
+            const route = {
+                name: 'sw.foo.detail',
+                matched: [{ name: 'sw.foo.detail' }],
+                meta: { $module: { navigation: [{ path: 'sw.foo.index' }] } },
+                params: {},
+            };
+            const catalogue = {
+                id: 'sw-catalogue',
+                children: [{ id: 'sw-foo', path: 'sw.foo.index', children: [] }],
+            };
+            const activeNames = getActiveRouteNames(route);
+
+            expect(isEntryOnActiveRoute(catalogue.children[0], route, activeNames)).toBe(true);
+            expect(isEntryOnActiveRoute(catalogue, route, activeNames)).toBe(true);
         });
 
         it('lights a leaf reachable only through the parentPath bridge', () => {

--- a/src/Administration/Resources/app/administration/src/app/component/structure/sw-admin-menu-item/menu-item-active.helper.ts
+++ b/src/Administration/Resources/app/administration/src/app/component/structure/sw-admin-menu-item/menu-item-active.helper.ts
@@ -4,12 +4,18 @@
  * Which admin menu entry is active, derived from Vue Router's resolved `$route.matched` chain.
  */
 
+import type { ModuleManifest, ModuleTypes } from 'src/core/factory/module.factory';
+
+type ModuleNavigationPath = Pick<Exclude<ModuleManifest['navigation'], undefined>[number], 'path'>;
+
 type RouteLike = {
     name?: string;
     matched?: Array<{ name?: string }>;
     params?: Record<string, unknown>;
     meta?: {
         parentPath?: string;
+        // Written for every module route by `addModuleInfoToTarget`, see core/factory/router.factory
+        $module?: { type?: ModuleTypes; navigation?: ModuleNavigationPath[] };
     };
 };
 
@@ -23,6 +29,27 @@ type MenuEntryLike = {
     params?: Record<string, unknown>;
     children?: MenuEntryLike[];
 };
+
+/**
+ * Stand-in for a missing `parentPath`: the menu entries the route's own module contributes.
+ *
+ * Extensions cannot be asked to declare `parentPath` retroactively, so an ambiguous set is used as-is
+ * and highlights the module's entries. Core modules declare it, so there the ambiguity is declined.
+ */
+function ownModuleMenuPaths(route: RouteLike | undefined, activeNames: Set<string>): string[] {
+    const module = route?.meta?.$module;
+    const menuPaths = (module?.navigation ?? []).map((entry) => entry.path).filter((path): path is string => !!path);
+
+    if (menuPaths.some((path) => activeNames.has(path))) {
+        return [];
+    }
+
+    if (menuPaths.length > 1 && module?.type === 'core') {
+        return [];
+    }
+
+    return menuPaths;
+}
 
 /**
  * Route names counting as "current": the `matched` chain plus everything reachable via `parentPath`.
@@ -44,12 +71,24 @@ export function getActiveRouteNames(route?: RouteLike, router?: RouterLike): Set
 
     const findRoute = (name: string) => router?.getRoutes?.().find((candidate) => candidate.name === name) ?? null;
     const visited = new Set<string>();
-    let parentPath = route?.meta?.parentPath;
+    // An explicit `parentPath` wins; the module's own entries fill in for routes that declare none.
+    const pending = route?.meta?.parentPath ? [route.meta.parentPath] : ownModuleMenuPaths(route, names);
 
-    while (parentPath && !visited.has(parentPath)) {
+    while (pending.length) {
+        const parentPath = pending.shift() as string;
+
+        if (visited.has(parentPath)) {
+            continue;
+        }
+
         visited.add(parentPath);
         names.add(parentPath);
-        parentPath = findRoute(parentPath)?.meta?.parentPath ?? undefined;
+
+        const grandParentPath = findRoute(parentPath)?.meta?.parentPath;
+
+        if (grandParentPath) {
+            pending.push(grandParentPath);
+        }
     }
 
     return names;

--- a/src/Administration/Resources/app/administration/src/app/component/structure/sw-admin-menu-item/sw-admin-menu-item.spec/active-state.spec.ts
+++ b/src/Administration/Resources/app/administration/src/app/component/structure/sw-admin-menu-item/sw-admin-menu-item.spec/active-state.spec.ts
@@ -3,6 +3,7 @@
  */
 
 import createWrapper from './create-wrapper';
+import catalogues from './catalogues';
 
 type MenuItemVm = { rowActive: boolean; childRouteActive: boolean; collapsibleOpen: boolean };
 
@@ -76,6 +77,17 @@ const appModuleEntry = (withOwnRoute = false) => ({
         },
     ],
 });
+
+// A plugin route that is not itself a menu target and declares no parentPath: the menu entry
+// is only reachable through the module manifest the router guard put on the route.
+const pluginEntry = (id: string) => catalogues.children.find((child) => child.id === id);
+
+const pluginDetailRoute = {
+    name: 'sw.foo.detail',
+    matched: [{ name: 'sw.foo.detail' }],
+    params: { id: 'abc' },
+    meta: { $module: { navigation: [{ path: 'sw.foo.index' }] } },
+};
 
 describe('src/app/component/structure/sw-admin-menu-item: active state', () => {
     beforeEach(() => {
@@ -198,6 +210,67 @@ describe('src/app/component/structure/sw-admin-menu-item: active state', () => {
         await flushPromises();
 
         expect((wrapper.vm as unknown as MenuItemVm).rowActive).toBe(true);
+    });
+
+    it('should keep a plugin entry active on its detail page without a declared parentPath', async () => {
+        const wrapper = await createWrapper({
+            route: pluginDetailRoute,
+            props: {
+                entry: pluginEntry('sw-foo'),
+                menuDepth: 2,
+            },
+        });
+
+        await flushPromises();
+
+        expect((wrapper.vm as unknown as MenuItemVm).rowActive).toBe(true);
+    });
+
+    it('should mark the catalogue branch child-active on a plugin detail page', async () => {
+        const wrapper = await createWrapper({
+            route: pluginDetailRoute,
+            props: {
+                entry: catalogues,
+                sidebarExpanded: true,
+                isExpanded: true,
+            },
+        });
+
+        await flushPromises();
+
+        const vm = wrapper.vm as unknown as MenuItemVm;
+
+        expect(vm.collapsibleOpen).toBe(true);
+        expect(vm.rowActive).toBe(false);
+        expect(vm.childRouteActive).toBe(true);
+    });
+
+    it('should mark the catalogue branch active on a plugin detail page when the sidebar is collapsed', async () => {
+        const wrapper = await createWrapper({
+            route: pluginDetailRoute,
+            props: {
+                entry: catalogues,
+                sidebarExpanded: false,
+            },
+        });
+
+        await flushPromises();
+
+        expect((wrapper.vm as unknown as MenuItemVm).rowActive).toBe(true);
+    });
+
+    it('should not light a plugin entry from another module detail page', async () => {
+        const wrapper = await createWrapper({
+            route: pluginDetailRoute,
+            props: {
+                entry: pluginEntry('sw-bar'),
+                menuDepth: 2,
+            },
+        });
+
+        await flushPromises();
+
+        expect((wrapper.vm as unknown as MenuItemVm).rowActive).toBe(false);
     });
 
     it('should hand the highlight to the active app child inside the collapsed flyout', async () => {

--- a/src/Administration/Resources/app/administration/src/app/component/structure/sw-admin-menu-item/sw-admin-menu-item.spec/create-wrapper.ts
+++ b/src/Administration/Resources/app/administration/src/app/component/structure/sw-admin-menu-item/sw-admin-menu-item.spec/create-wrapper.ts
@@ -25,7 +25,7 @@ type CreateWrapperOptions = {
         matched?: { name?: string }[];
         meta?: Record<string, unknown>;
     };
-    routerRoutes?: { name?: string; meta?: { privilege?: string } }[] | null;
+    routerRoutes?: { name?: string; meta?: { privilege?: string; parentPath?: string } }[] | null;
 };
 
 async function createWrapper({ props = {}, privileges = [], route = {}, routerRoutes = null }: CreateWrapperOptions = {}) {

--- a/src/Administration/Resources/app/administration/src/app/component/structure/sw-admin-menu/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/structure/sw-admin-menu/index.js
@@ -821,9 +821,16 @@ The admin menu only supports up to three levels of nesting.`,
             }
 
             const activeNames = getActiveRouteNames(this.$route, this.$router);
-            const owner = this.mainMenuEntries.find(
-                (entry) => (entry.children?.length ?? 0) > 0 && isEntryOnActiveRoute(entry, this.$route, activeNames),
+            const activeEntries = this.mainMenuEntries.filter((entry) =>
+                isEntryOnActiveRoute(entry, this.$route, activeNames),
             );
+
+            // Pages the menu does not list at all own no branch — leave the tree as the user left it
+            if (!activeEntries.length) {
+                return;
+            }
+
+            const owner = activeEntries.find((entry) => (entry.children?.length ?? 0) > 0);
             const ownerKey = owner ? (owner.id ?? owner.path) : null;
 
             // The cached owner may have been collapsed manually
@@ -831,7 +838,7 @@ The admin menu only supports up to three levels of nesting.`,
                 return;
             }
 
-            // Branches only stay open while they own the active item.
+            // Branches only stay open while they own the active item, or while nothing in the menu does.
             this.collapseInactiveBranches(owner);
             this.activeBranchKey = ownerKey;
 

--- a/src/Administration/Resources/app/administration/src/app/component/structure/sw-admin-menu/sw-admin-menu.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/structure/sw-admin-menu/sw-admin-menu.spec.js
@@ -2,108 +2,11 @@
  * @sw-package framework
  */
 
-import { mount, config, DOMWrapper } from '@vue/test-utils';
-import { createRouter, createWebHashHistory } from 'vue-router';
-import createMenuService from 'src/app/service/menu.service';
+import { config, DOMWrapper } from '@vue/test-utils';
+import createWrapper, { registerAdminModules } from './sw-admin-menu.spec/create-wrapper';
 
 /** fixtures */
-import adminModules from '../../../service/_mocks/adminModules.json';
 import testApps from '../../../service/_mocks/testApps.json';
-
-const menuService = createMenuService(Shopware.Module);
-Shopware.Service().register('menuService', () => menuService);
-
-async function createWrapper(options = {}) {
-    const router = createRouter({
-        routes: [
-            ...Shopware.Module.getModuleRoutes(),
-            {
-                path: '/sw/custom/entity/index',
-                name: 'sw.custom.entity.index',
-                type: 'core',
-                components: { default: 'sw-index' },
-                isChildren: false,
-                routeKey: 'index',
-            },
-        ],
-        route: {
-            meta: {
-                $module: {
-                    name: '',
-                },
-            },
-        },
-        history: createWebHashHistory(),
-    });
-
-    router.resolve = jest.fn(() => {
-        return {};
-    });
-
-    return mount(await wrapTestComponent('sw-admin-menu', { sync: true }), {
-        global: {
-            stubs: {
-                'sw-version': true,
-                'sw-admin-menu-item': await wrapTestComponent('sw-admin-menu-item'),
-                'mt-loader': true,
-                'sw-avatar': true,
-                'sw-shortcut-overview': true,
-                'router-link': {
-                    template: '<a class="router-link" href="#"><slot /></a>',
-                },
-                'mt-link': true,
-                'mt-icon': true,
-                'mt-floating-ui': {
-                    template: '<div class="mt-floating-ui"><slot v-if="isOpened" /></div>',
-                    props: ['isOpened'],
-                },
-            },
-            provide: {
-                menuService,
-                loginService: {
-                    notifyOnLoginListener: () => {},
-                },
-                userService: {
-                    getUser: () => Promise.resolve({ data: { password: '' } }),
-                },
-                appModulesService: {
-                    fetchAppModules: () => Promise.resolve([]),
-                },
-                systemConfigApiService: {
-                    getValues: () => Promise.resolve({}),
-                },
-                acl: {
-                    can: (privilege) => {
-                        return privilege !== 'shouldReturnFalse';
-                    },
-                },
-                customEntityDefinitionService: {
-                    getMenuEntries: () => {
-                        const entityName = 'customEntityName';
-                        return [
-                            {
-                                id: `custom-entity/${entityName}`,
-                                label: `${entityName}.moduleTitle`,
-                                moduleType: 'plugin',
-                                path: 'sw.custom.entity.index',
-                                params: {
-                                    entityName: entityName,
-                                },
-                                position: 100,
-                                parent: 'sw.second.top.level',
-                            },
-                        ];
-                    },
-                },
-            },
-            mocks: {
-                $route: { meta: { $module: { name: '' } } },
-                $router: router,
-            },
-        },
-        ...options,
-    });
-}
 
 describe('src/app/component/structure/sw-admin-menu', () => {
     let wrapper;
@@ -112,10 +15,7 @@ describe('src/app/component/structure/sw-admin-menu', () => {
         Shopware.Store.get('session').currentLocale = 'en-GB';
         Shopware.Context.app.fallbackLocale = 'en-GB';
 
-        Shopware.Module.getModuleRegistry().clear();
-        adminModules.forEach((adminModule) => {
-            Shopware.Module.register(adminModule.name, adminModule);
-        });
+        registerAdminModules();
     });
 
     beforeEach(async () => {

--- a/src/Administration/Resources/app/administration/src/app/component/structure/sw-admin-menu/sw-admin-menu.spec/branch-expansion.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/structure/sw-admin-menu/sw-admin-menu.spec/branch-expansion.spec.js
@@ -1,0 +1,106 @@
+/**
+ * @sw-package framework
+ */
+
+import { config } from '@vue/test-utils';
+import createWrapper, { registerAdminModules } from './create-wrapper';
+
+describe('src/app/component/structure/sw-admin-menu: branch expansion', () => {
+    let wrapper;
+
+    beforeAll(() => {
+        Shopware.Store.get('session').currentLocale = 'en-GB';
+        Shopware.Context.app.fallbackLocale = 'en-GB';
+
+        registerAdminModules();
+
+        // The shared fixture has no childless top level entry, and Dashboard/Settings are exactly that
+        Shopware.Module.register('childless-module', {
+            type: 'core',
+            icon: 'default-icon',
+            routes: { index: { path: 'index', component: 'sw-index' } },
+            navigation: [
+                {
+                    id: 'sw.childless.top.level',
+                    path: 'childless.module.index',
+                    label: 'childless top level entry',
+                    icon: 'default-icon',
+                    position: 90,
+                },
+            ],
+        });
+    });
+
+    beforeEach(async () => {
+        config.global.stubs = {
+            ...config.global.stubs,
+            transition: false,
+        };
+
+        jest.spyOn(Shopware.Utils.debug, 'error').mockImplementation(() => true);
+
+        Shopware.Store.get('session').setCurrentUser(null);
+        Shopware.Store.get('settingsItems').settingsGroups.shop = [];
+        Shopware.Store.get('settingsItems').settingsGroups.system = [];
+        Shopware.Store.get('shopwareApps').apps = [];
+
+        wrapper = await createWrapper();
+        await flushPromises();
+    });
+
+    function openBranchOnItsOwnRoute() {
+        const branch = wrapper.vm.mainMenuEntries.find((entry) => (entry.children?.length ?? 0) > 0);
+
+        Shopware.Store.get('adminMenu').clearExpandedMenuEntries();
+        wrapper.vm.activeBranchKey = null;
+
+        wrapper.vm.$route.name = branch.children[0].path;
+        wrapper.vm.$route.matched = [{ name: branch.children[0].path }];
+        wrapper.vm.expandAncestorBranchesForCurrentRoute();
+
+        expect(wrapper.vm.isNavigationEntryExpanded(branch)).toBe(true);
+
+        return branch;
+    }
+
+    it('should keep the branch open when a module route reaches its entry through the module manifest', async () => {
+        const branch = openBranchOnItsOwnRoute();
+        const menuPath = branch.children[0].path;
+
+        // A detail route next to the menu target, declaring no parentPath
+        wrapper.vm.$route.name = `${menuPath}.detail`;
+        wrapper.vm.$route.matched = [{ name: `${menuPath}.detail` }];
+        wrapper.vm.$route.meta = { $module: { navigation: [{ path: menuPath }] } };
+        wrapper.vm.expandAncestorBranchesForCurrentRoute();
+
+        expect(wrapper.vm.isNavigationEntryExpanded(branch)).toBe(true);
+        expect(wrapper.vm.activeBranchKey).toBe(branch.id ?? branch.path);
+    });
+
+    it('should leave the tree untouched on a route the menu does not list', async () => {
+        const branch = openBranchOnItsOwnRoute();
+        const branchKey = wrapper.vm.activeBranchKey;
+
+        // Sales channels, the profile page and the privilege error page all land here
+        wrapper.vm.$route.name = 'sw.profile.index';
+        wrapper.vm.$route.matched = [{ name: 'sw.profile.index' }];
+        wrapper.vm.expandAncestorBranchesForCurrentRoute();
+
+        expect(wrapper.vm.isNavigationEntryExpanded(branch)).toBe(true);
+        expect(wrapper.vm.activeBranchKey).toBe(branchKey);
+    });
+
+    it('should still close the tree for a childless top level entry', async () => {
+        const branch = openBranchOnItsOwnRoute();
+        const childless = wrapper.vm.mainMenuEntries.find((entry) => entry.id === 'sw.childless.top.level');
+
+        expect(childless.children).toHaveLength(0);
+
+        wrapper.vm.$route.name = childless.path;
+        wrapper.vm.$route.matched = [{ name: childless.path }];
+        wrapper.vm.expandAncestorBranchesForCurrentRoute();
+
+        expect(wrapper.vm.isNavigationEntryExpanded(branch)).toBe(false);
+        expect(wrapper.vm.activeBranchKey).toBeNull();
+    });
+});

--- a/src/Administration/Resources/app/administration/src/app/component/structure/sw-admin-menu/sw-admin-menu.spec/create-wrapper.js
+++ b/src/Administration/Resources/app/administration/src/app/component/structure/sw-admin-menu/sw-admin-menu.spec/create-wrapper.js
@@ -1,0 +1,118 @@
+/**
+ * @sw-package framework
+ */
+
+import { mount } from '@vue/test-utils';
+import { createRouter, createWebHashHistory } from 'vue-router';
+import createMenuService from 'src/app/service/menu.service';
+
+/** fixtures */
+import adminModules from '../../../../service/_mocks/adminModules.json';
+
+const menuService = createMenuService(Shopware.Module);
+Shopware.Service().register('menuService', () => menuService);
+
+/**
+ * @private
+ */
+export function registerAdminModules() {
+    Shopware.Module.getModuleRegistry().clear();
+    adminModules.forEach((adminModule) => {
+        Shopware.Module.register(adminModule.name, adminModule);
+    });
+}
+
+/**
+ * @private
+ */
+export default async function createWrapper(options = {}) {
+    const router = createRouter({
+        routes: [
+            ...Shopware.Module.getModuleRoutes(),
+            {
+                path: '/sw/custom/entity/index',
+                name: 'sw.custom.entity.index',
+                type: 'core',
+                components: { default: 'sw-index' },
+                isChildren: false,
+                routeKey: 'index',
+            },
+        ],
+        route: {
+            meta: {
+                $module: {
+                    name: '',
+                },
+            },
+        },
+        history: createWebHashHistory(),
+    });
+
+    router.resolve = jest.fn(() => {
+        return {};
+    });
+
+    return mount(await wrapTestComponent('sw-admin-menu', { sync: true }), {
+        global: {
+            stubs: {
+                'sw-version': true,
+                'sw-admin-menu-item': await wrapTestComponent('sw-admin-menu-item'),
+                'mt-loader': true,
+                'sw-avatar': true,
+                'sw-shortcut-overview': true,
+                'router-link': {
+                    template: '<a class="router-link" href="#"><slot /></a>',
+                },
+                'mt-link': true,
+                'mt-icon': true,
+                'mt-floating-ui': {
+                    template: '<div class="mt-floating-ui"><slot v-if="isOpened" /></div>',
+                    props: ['isOpened'],
+                },
+            },
+            provide: {
+                menuService,
+                loginService: {
+                    notifyOnLoginListener: () => {},
+                },
+                userService: {
+                    getUser: () => Promise.resolve({ data: { password: '' } }),
+                },
+                appModulesService: {
+                    fetchAppModules: () => Promise.resolve([]),
+                },
+                systemConfigApiService: {
+                    getValues: () => Promise.resolve({}),
+                },
+                acl: {
+                    can: (privilege) => {
+                        return privilege !== 'shouldReturnFalse';
+                    },
+                },
+                customEntityDefinitionService: {
+                    getMenuEntries: () => {
+                        const entityName = 'customEntityName';
+                        return [
+                            {
+                                id: `custom-entity/${entityName}`,
+                                label: `${entityName}.moduleTitle`,
+                                moduleType: 'plugin',
+                                path: 'sw.custom.entity.index',
+                                params: {
+                                    entityName: entityName,
+                                },
+                                position: 100,
+                                parent: 'sw.second.top.level',
+                            },
+                        ];
+                    },
+                },
+            },
+            mocks: {
+                $route: { meta: { $module: { name: '' } } },
+                $router: router,
+            },
+        },
+        ...options,
+    });
+}


### PR DESCRIPTION
### 1. Why is this change necessary?
The shell rework (#15271) caused two admin menu regressions. First, a module route that declares no meta.parentPath no longer matches any menu entry, so nothing in the sidebar is highlighted and every row reports aria-current="false". Core modules all declare parentPath, so this only surfaces with installed extensions. 

Second, whenever no menu entry owns the current route, collapseInactiveBranches(undefined) collapsed every expanded branch — this also affects a stock install, e.g. sales channel detail routes (whose parentPath points at sw.sales.channel.list, which no menu entry owns), the profile page, and the privilege error page.

### 2. What does this change do, exactly?
menu-item-active.helper.ts — getActiveRouteNames falls back to the navigation entries of the route's own module, already on meta.$module. Seeding the entry's path covers ancestors too, via isEntryOnActiveRoute's children.some(). An explicit parentPath still wins.

### 3. Describe each step to reproduce the issue or behaviour.
Register a plugin module with a detail route declaring no parentPath and navigation: [{ path: 'sw.foo.index', parent: 'sw-catalogue' }].

Open the plugin's list page under Catalogues — branch opens, row highlighted.
Click a row to open the detail page.
Before: highlight gone sidebar-wide, every open branch folds shut. After: row stays highlighted, Catalogues stays open.

Sales channels need no extension: expand a branch, click a sales channel. Before it folds shut, after it stays open.

### 4. Please link to the relevant issues (if any).
relates #15271

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
