### PR TITLE
fix(administration): restore intrinsic width of meteor number fields

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/assets/scss/global.scss
+++ b/src/Administration/Resources/app/administration/src/app/assets/scss/global.scss
@@ -98,6 +98,11 @@ a[target="_blank"]:not(.sw-external-link, .sw-internal-link, .mt-button, .mt-lin
     }
 }
 
+// TODO: remove when the issue is fixed https://github.com/shopware/meteor/issues/1341
+.mt-number-field.mt-number-field {
+    container-type: normal;
+}
+
 // TODO: remove when the bottom margin issue is fixed in checkbox field
 .mt-field--checkbox__container .mt-field--checkbox.mt-field--checkbox {
     margin-bottom: 0;


### PR DESCRIPTION
### 1. Why is this change necessary?

Since meteor-component-library 5.3.2 (on trunk since 6.7.14), `.mt-number-field` is an inline-size query container, which zeroes its intrinsic width — fields inside shrink-wrapped wrappers collapse or squeeze to their `min-width` floor. #19224 patched only the shipping price matrix; @fabianhueske [reported](https://github.com/shopware/shopware/pull/19224#issuecomment-5409408350) the same across the Admin (Advanced pricing, variant surcharges, etc.). The root cause is filed upstream as shopware/meteor#1341.

### 2. What does this change do, exactly?

Adds one global override, `container-type: normal`, restoring pre-5.3.2 sizing admin-wide until the meteor fix lands (the selector is doubled to beat the component's own rule regardless of style injection order). Verified live on all affected screens: Advanced pricing, variant surcharges (overview + modal), and the maintain-currencies modal go from 45px gross/net inputs back to filling their columns, while all other usages are unchanged. Only trade-off: the stepper auto-hide below 180px reverts to always-visible, as before 5.3.2 (data grids already hide steppers explicitly).

### 3. Describe each step to reproduce the issue or behaviour.

Open a product → Advanced pricing → select a rule: gross/net inputs are ~45px wide in a ~270px column. The same squeeze appears in the variant overview/modal price inline edit and the maintain-currencies modal. With this change they fill their cells again.

### 4. Please link to the relevant issues (if any).

- relates #19224
- upstream: shopware/meteor#1341

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
