### PR TITLE
fix(administration): restore currency price input width

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-maintain-currencies-modal/sw-maintain-currencies-modal.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-maintain-currencies-modal/sw-maintain-currencies-modal.scss
@@ -20,7 +20,7 @@
             margin-right: 5px;
         }
 
-        .sw-field {
+        .mt-field {
             width: 130px;
         }
     }


### PR DESCRIPTION
### 1. Why is this change necessary?

The currency-dependent pricing modal renders price inputs with a very small width, making values difficult to read and edit.

### 2. What does this change do, exactly?

Updates the modal stylesheet to target the `.mt-field` class used by the current Meteor number fields, restoring the intended input width.

### 3. Describe each step to reproduce the issue or behaviour.

1. Open a product in the Administration.
2. Open the currency-dependent pricing modal from the price field.
3. Observe that the gross and net price inputs are too narrow to display their values.

### 4. Please link to the relevant issues (if any).

No issue reference available.

<img width="1150" height="1100" alt="image" src="https://github.com/user-attachments/assets/a91cd5a9-fa55-452f-8734-1a10695a7315" />

