### PR TITLE
test(core): match entity names to collections in search result fixtures

### DIFF
--- a/src/Core/Test/Stub/DataAbstractionLayer/StaticEntityRepository.php
+++ b/src/Core/Test/Stub/DataAbstractionLayer/StaticEntityRepository.php
@@ -3,6 +3,7 @@
 namespace Shopware\Core\Test\Stub\DataAbstractionLayer;
 
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\Entity;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
@@ -126,7 +127,7 @@ class StaticEntityRepository extends EntityRepository
 
         if ($result instanceof EntityCollection) {
             /** @var TEntityCollection $result */
-            return new EntitySearchResult($this->getDummyEntityName(), $result->count(), $result, null, $criteria, $context);
+            return new EntitySearchResult($this->getDummyEntityName($result), $result->count(), $result, null, $criteria, $context);
         }
 
         if ($result instanceof AggregationResultCollection) {
@@ -313,10 +314,13 @@ class StaticEntityRepository extends EntityRepository
         return $primaryKeys;
     }
 
-    private function getDummyEntityName(): string
+    /**
+     * @param EntityCollection<Entity>|null $entities
+     */
+    private function getDummyEntityName(?EntityCollection $entities = null): string
     {
         if (!$this->definition) {
-            return 'mock';
+            return $entities?->first()?->getApiAlias() ?? 'mock';
         }
 
         return $this->definition->getEntityName();

--- a/src/Core/Test/Stub/DataAbstractionLayer/StaticSalesChannelRepository.php
+++ b/src/Core/Test/Stub/DataAbstractionLayer/StaticSalesChannelRepository.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Core\Test\Stub\DataAbstractionLayer;
 
+use Shopware\Core\Framework\DataAbstractionLayer\Entity;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\AggregationResult\AggregationResultCollection;
@@ -66,7 +67,7 @@ class StaticSalesChannelRepository extends SalesChannelRepository
         if ($result instanceof EntityCollection) {
             /** @var TEntityCollection $result */
             return new EntitySearchResult(
-                $this->getDummyEntityName(),
+                $this->getDummyEntityName($result),
                 $result->count(),
                 $result,
                 null,
@@ -122,8 +123,11 @@ class StaticSalesChannelRepository extends SalesChannelRepository
         throw new \Exception('Aggregate is not implemented in static repository');
     }
 
-    private function getDummyEntityName(): string
+    /**
+     * @param EntityCollection<Entity>|null $entities
+     */
+    private function getDummyEntityName(?EntityCollection $entities = null): string
     {
-        return $this->definition?->getEntityName() ?? 'mock';
+        return $this->definition?->getEntityName() ?? $entities?->first()?->getApiAlias() ?? 'mock';
     }
 }

--- a/tests/unit/Core/Checkout/Cart/Order/OrderConverterTest.php
+++ b/tests/unit/Core/Checkout/Cart/Order/OrderConverterTest.php
@@ -878,7 +878,7 @@ class OrderConverterTest extends TestCase
         if ($orderAddressRepositoryResultArray !== null) {
             $orderAddressRepository->method('search')->willReturn(
                 new EntitySearchResult(
-                    'orderAddress',
+                    'order_address',
                     1,
                     new EntityCollection($orderAddressRepositoryResultArray),
                     null,
@@ -906,7 +906,7 @@ class OrderConverterTest extends TestCase
             }
 
             return new EntitySearchResult(
-                'productDownload',
+                'product_download',
                 1,
                 new EntityCollection([$productDownload]),
                 null,

--- a/tests/unit/Core/Checkout/Customer/Subscriber/CustomerBeforeDeleteSubscriberTest.php
+++ b/tests/unit/Core/Checkout/Customer/Subscriber/CustomerBeforeDeleteSubscriberTest.php
@@ -60,7 +60,7 @@ class CustomerBeforeDeleteSubscriberTest extends TestCase
 
         $customerRepository = new StaticEntityRepository([
             new EntitySearchResult(
-                CustomerEntity::class,
+                'customer',
                 1,
                 new CustomerCollection([$customer]),
                 null,
@@ -206,7 +206,7 @@ class CustomerBeforeDeleteSubscriberTest extends TestCase
 
         $customerRepository = new StaticEntityRepository([
             new EntitySearchResult(
-                CustomerEntity::class,
+                'customer',
                 1,
                 new CustomerCollection([$customer]),
                 null,
@@ -293,7 +293,7 @@ class CustomerBeforeDeleteSubscriberTest extends TestCase
 
         $customerRepository = new StaticEntityRepository([
             new EntitySearchResult(
-                CustomerEntity::class,
+                'customer',
                 1,
                 new CustomerCollection([$customer]),
                 null,

--- a/tests/unit/Core/Checkout/Customer/Subscriber/CustomerLanguageSalesChannelSubscriberTest.php
+++ b/tests/unit/Core/Checkout/Customer/Subscriber/CustomerLanguageSalesChannelSubscriberTest.php
@@ -12,6 +12,7 @@ use Shopware\Core\Framework\Api\Context\SalesChannelApiSource;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\DataAbstractionLayer\FieldVisibility;
 use Shopware\Core\Framework\DataAbstractionLayer\PartialEntity;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
@@ -161,6 +162,7 @@ class CustomerLanguageSalesChannelSubscriberTest extends TestCase
             'id' => $salesChannelId,
             'languages' => new EntityCollection([$language]),
         ]);
+        $salesChannel->internalSetEntityData('sales_channel', new FieldVisibility([]));
         $salesChannels = new EntityCollection([$salesChannel]);
         $salesChannelRepository = $this->createMock(EntityRepository::class);
         $salesChannelRepository->expects($this->once())
@@ -201,6 +203,7 @@ class CustomerLanguageSalesChannelSubscriberTest extends TestCase
             'id' => $salesChannelId,
             'languages' => new EntityCollection([]),
         ]);
+        $salesChannel->internalSetEntityData('sales_channel', new FieldVisibility([]));
         $salesChannels = new EntityCollection([$salesChannel]);
         $salesChannelRepository = $this->createMock(EntityRepository::class);
         $salesChannelRepository->expects($this->once())
@@ -291,6 +294,7 @@ class CustomerLanguageSalesChannelSubscriberTest extends TestCase
             'languages' => new EntityCollection([$language]),
             'customers' => new EntityCollection([$customerRef]),
         ]);
+        $salesChannel->internalSetEntityData('sales_channel', new FieldVisibility([]));
         $salesChannels = new EntityCollection([$salesChannel]);
         $salesChannelRepository = $this->createMock(EntityRepository::class);
         $salesChannelRepository->expects($this->once())
@@ -331,6 +335,7 @@ class CustomerLanguageSalesChannelSubscriberTest extends TestCase
             'languages' => new EntityCollection([]),
             'customers' => new EntityCollection([$customerRef]),
         ]);
+        $salesChannel->internalSetEntityData('sales_channel', new FieldVisibility([]));
         $salesChannels = new EntityCollection([$salesChannel]);
         $salesChannelRepository = $this->createMock(EntityRepository::class);
         $salesChannelRepository->expects($this->once())
@@ -384,6 +389,7 @@ class CustomerLanguageSalesChannelSubscriberTest extends TestCase
             'id' => $salesChannelId,
             'languages' => new EntityCollection([$language]),
         ]);
+        $salesChannel->internalSetEntityData('sales_channel', new FieldVisibility([]));
         $salesChannelRepository = $this->createMock(EntityRepository::class);
         $salesChannelRepository->expects($this->once())
             ->method('search')
@@ -427,6 +433,7 @@ class CustomerLanguageSalesChannelSubscriberTest extends TestCase
             'id' => $salesChannelId,
             'languages' => new EntityCollection([$language]),
         ]);
+        $salesChannel->internalSetEntityData('sales_channel', new FieldVisibility([]));
         $salesChannelRepository = $this->createMock(EntityRepository::class);
         $salesChannelRepository->expects($this->once())
             ->method('search')
@@ -464,6 +471,7 @@ class CustomerLanguageSalesChannelSubscriberTest extends TestCase
             'languages' => new EntityCollection([new PartialEntity(['id' => $languageId])]),
             'customers' => new EntityCollection([new PartialEntity(['id' => $otherCustomerId])]),
         ]);
+        $salesChannel->internalSetEntityData('sales_channel', new FieldVisibility([]));
         $salesChannelRepository = $this->createMock(EntityRepository::class);
         $salesChannelRepository->expects($this->once())
             ->method('search')

--- a/tests/unit/Core/Checkout/Document/Subscriber/DocumentDeleteSubscriberTest.php
+++ b/tests/unit/Core/Checkout/Document/Subscriber/DocumentDeleteSubscriberTest.php
@@ -53,7 +53,7 @@ class DocumentDeleteSubscriberTest extends TestCase
         $documentRepository = new StaticEntityRepository([
             new DocumentCollection([]), // dependency check with empty result
             new EntitySearchResult(
-                DocumentEntity::class,
+                DocumentDefinition::ENTITY_NAME,
                 1,
                 new DocumentCollection([$document]),
                 null,
@@ -123,7 +123,7 @@ class DocumentDeleteSubscriberTest extends TestCase
         $documentRepository = new StaticEntityRepository([
             new DocumentCollection([]), // dependency check with empty result
             new EntitySearchResult(
-                DocumentEntity::class,
+                DocumentDefinition::ENTITY_NAME,
                 1,
                 new DocumentCollection([$document]),
                 null,
@@ -186,7 +186,7 @@ class DocumentDeleteSubscriberTest extends TestCase
 
         $documentRepository = new StaticEntityRepository([
             new EntitySearchResult(
-                DocumentEntity::class,
+                DocumentDefinition::ENTITY_NAME,
                 1,
                 new DocumentCollection([$dependingDocument]),
                 null,

--- a/tests/unit/Core/Checkout/Shipping/SalesChannel/ShippingMethodRouteResponseTest.php
+++ b/tests/unit/Core/Checkout/Shipping/SalesChannel/ShippingMethodRouteResponseTest.php
@@ -25,7 +25,7 @@ class ShippingMethodRouteResponseTest extends TestCase
         $shippingMethod->setUniqueIdentifier('foo');
 
         $result = new EntitySearchResult(
-            'shipping-method',
+            'shipping_method',
             1,
             $collection = new ShippingMethodCollection([$shippingMethod]),
             null,

--- a/tests/unit/Core/Content/Category/SalesChannel/CategoryRouteTest.php
+++ b/tests/unit/Core/Content/Category/SalesChannel/CategoryRouteTest.php
@@ -139,7 +139,7 @@ class CategoryRouteTest extends TestCase
                 ],
                 new EntityResolverContext($salesChannelContext, $request, new CategoryDefinition(), $category),
             )->willReturn(new EntitySearchResult(
-                'cms-page',
+                'cms_page',
                 1,
                 new CmsPageCollection([$cmsPage]),
                 null,
@@ -230,7 +230,7 @@ class CategoryRouteTest extends TestCase
 
         $cmsPageLoader = static::createStub(SalesChannelCmsPageLoaderInterface::class);
         $cmsPageLoader->method('load')->willReturn(new EntitySearchResult(
-            'cms-page',
+            'cms_page',
             1,
             new CmsPageCollection([$cmsPage]),
             null,

--- a/tests/unit/Core/Content/Category/Service/CategoryBreadcrumbBuilderTest.php
+++ b/tests/unit/Core/Content/Category/Service/CategoryBreadcrumbBuilderTest.php
@@ -20,6 +20,7 @@ use Shopware\Core\Content\Seo\MainCategory\MainCategoryCollection;
 use Shopware\Core\Content\Seo\SeoUrlRoute\EntityRouteResolver;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\DataAbstractionLayer\FieldVisibility;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\AndFilter;
@@ -488,6 +489,7 @@ class CategoryBreadcrumbBuilderTest extends TestCase
         $product->setId(Uuid::randomHex());
         $product->setStreamIds($streamIds);
         $product->setCategoryIds($categoryIds);
+        $product->internalSetEntityData('product', new FieldVisibility([]));
 
         return $product;
     }

--- a/tests/unit/Core/Content/Cms/DataResolver/CmsSlotsDataResolverTest.php
+++ b/tests/unit/Core/Content/Cms/DataResolver/CmsSlotsDataResolverTest.php
@@ -22,6 +22,7 @@ use Shopware\Core\Content\Product\ProductDefinition;
 use Shopware\Core\Content\Product\SalesChannel\SalesChannelProductCollection;
 use Shopware\Core\Content\Product\SalesChannel\SalesChannelProductEntity;
 use Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry;
+use Shopware\Core\Framework\DataAbstractionLayer\FieldVisibility;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
@@ -210,6 +211,8 @@ class CmsSlotsDataResolverTest extends TestCase
 
         $wanted = (new SalesChannelProductEntity())->assign(['id' => 'id-1']);
         $other = (new SalesChannelProductEntity())->assign(['id' => 'id-2']);
+        $wanted->internalSetEntityData('product', new FieldVisibility([]));
+        $other->internalSetEntityData('product', new FieldVisibility([]));
 
         // the merged direct read fetches the ids of all slots at once, each slot only gets its own ids back
         $this->productRepository->method('search')->willReturn(new EntitySearchResult(

--- a/tests/unit/Core/Content/ImportExport/ImportExportTest.php
+++ b/tests/unit/Core/Content/ImportExport/ImportExportTest.php
@@ -294,7 +294,7 @@ class ImportExportTest extends TestCase
         /** @var StaticEntityRepository<OrderCollection> */
         $repository = new StaticEntityRepository(
             [new EntitySearchResult(
-                OrderEntity::class,
+                OrderDefinition::ENTITY_NAME,
                 1,
                 new EntityCollection([(new OrderEntity())->assign(['id' => $orderId])]),
                 null,
@@ -421,7 +421,7 @@ class ImportExportTest extends TestCase
                     );
 
                     return new EntitySearchResult(
-                        ProductKeywordDictionaryEntity::class,
+                        ProductKeywordDictionaryDefinition::ENTITY_NAME,
                         1,
                         new EntityCollection([(new ProductKeywordDictionaryEntity())->assign(['id' => $dictId])]),
                         null,
@@ -557,7 +557,7 @@ class ImportExportTest extends TestCase
         /** @var StaticEntityRepository<OrderCollection> */
         $repository = new StaticEntityRepository(
             [new EntitySearchResult(
-                OrderEntity::class,
+                OrderDefinition::ENTITY_NAME,
                 1,
                 new EntityCollection([
                     (new OrderEntity())->assign(['id' => Uuid::randomHex(), 'language' => new LanguageEntity()]),

--- a/tests/unit/Core/Content/Media/Commands/GenerateThumbnailsCommandTest.php
+++ b/tests/unit/Core/Content/Media/Commands/GenerateThumbnailsCommandTest.php
@@ -12,6 +12,7 @@ use Shopware\Core\Content\Media\MediaEntity;
 use Shopware\Core\Content\Media\MediaException;
 use Shopware\Core\Content\Media\Message\UpdateThumbnailsMessage;
 use Shopware\Core\Content\Media\Thumbnail\ThumbnailService;
+use Shopware\Core\Framework\DataAbstractionLayer\FieldVisibility;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\Test\Stub\DataAbstractionLayer\StaticEntityRepository;
@@ -202,6 +203,7 @@ class GenerateThumbnailsCommandTest extends TestCase
     private function createMediaEntity(): MediaEntity
     {
         $media = new MediaEntity();
+        $media->internalSetEntityData(TestEntityDefinition::ENTITY_NAME, new FieldVisibility([]));
         $media->setId(Uuid::randomHex());
         $media->setFileName('test');
         $media->setMimeType('image/png');

--- a/tests/unit/Core/Content/Media/Service/VideoCoverServiceTest.php
+++ b/tests/unit/Core/Content/Media/Service/VideoCoverServiceTest.php
@@ -283,7 +283,7 @@ class VideoCoverServiceTest extends TestCase
         }
 
         return new EntitySearchResult(
-            MediaDefinition::class,
+            MediaDefinition::ENTITY_NAME,
             1,
             $collection,
             null,

--- a/tests/unit/Core/Content/Media/Subscriber/VideoCoverLoadedSubscriberTest.php
+++ b/tests/unit/Core/Content/Media/Subscriber/VideoCoverLoadedSubscriberTest.php
@@ -219,7 +219,7 @@ class VideoCoverLoadedSubscriberTest extends TestCase
         $collection = new MediaCollection($entities);
 
         return new EntitySearchResult(
-            MediaDefinition::class,
+            MediaDefinition::ENTITY_NAME,
             \count($entities),
             $collection,
             null,

--- a/tests/unit/Core/Content/Product/Cms/ProductBoxCmsElementResolverTest.php
+++ b/tests/unit/Core/Content/Product/Cms/ProductBoxCmsElementResolverTest.php
@@ -18,6 +18,7 @@ use Shopware\Core\Content\Product\ProductCollection;
 use Shopware\Core\Content\Product\ProductDefinition;
 use Shopware\Core\Content\Product\SalesChannel\SalesChannelProductDefinition;
 use Shopware\Core\Content\Product\SalesChannel\SalesChannelProductEntity;
+use Shopware\Core\Framework\DataAbstractionLayer\FieldVisibility;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
 use Shopware\Core\Framework\Log\Package;
@@ -194,6 +195,7 @@ class ProductBoxCmsElementResolverTest extends TestCase
         $product->setStock($availableStock);
         $product->setIsCloseout($closeout);
         $product->setAvailableStock($availableStock);
+        $product->internalSetEntityData('product', new FieldVisibility([]));
 
         $salesChannel = new SalesChannelEntity();
         $salesChannel->setId($salesChannelId);

--- a/tests/unit/Core/Content/Product/Cms/Type/ProductBoxTypeDataResolverTest.php
+++ b/tests/unit/Core/Content/Product/Cms/Type/ProductBoxTypeDataResolverTest.php
@@ -24,6 +24,7 @@ use Shopware\Core\Content\Product\ProductCollection;
 use Shopware\Core\Content\Product\ProductDefinition;
 use Shopware\Core\Content\Product\SalesChannel\SalesChannelProductEntity;
 use Shopware\Core\Framework\DataAbstractionLayer\Exception\PropertyNotFoundException;
+use Shopware\Core\Framework\DataAbstractionLayer\FieldVisibility;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
 use Shopware\Core\Framework\Log\Package;
@@ -137,6 +138,7 @@ class ProductBoxTypeDataResolverTest extends TestCase
         $product->setStock($availableStock);
         $product->setIsCloseout($closeout);
         $product->setAvailableStock($availableStock);
+        $product->internalSetEntityData('product', new FieldVisibility([]));
 
         $salesChannel = new SalesChannelEntity();
         $salesChannel->setId($salesChannelId);

--- a/tests/unit/Core/Content/Product/SalesChannel/Detail/ProductDetailRouteTest.php
+++ b/tests/unit/Core/Content/Product/SalesChannel/Detail/ProductDetailRouteTest.php
@@ -32,6 +32,7 @@ use Shopware\Core\Content\Product\SalesChannel\SalesChannelProductDefinition;
 use Shopware\Core\Content\Product\SalesChannel\SalesChannelProductEntity;
 use Shopware\Core\Framework\Adapter\Cache\CacheTagCollector;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\DataAbstractionLayer\FieldVisibility;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
@@ -109,6 +110,7 @@ class ProductDetailRouteTest extends TestCase
         $productEntity->setId(Uuid::randomHex());
         $productEntity->setCmsPageId('4');
         $productEntity->setUniqueIdentifier('mainVariant');
+        $productEntity->internalSetEntityData('product', new FieldVisibility([]));
         $productRepository = $this->createMock(SalesChannelRepository::class);
         $productRepository->expects($this->exactly(1))
             ->method('search')
@@ -137,6 +139,7 @@ class ProductDetailRouteTest extends TestCase
         $productEntity->setId($this->idsCollection->create('product1'));
         $productEntity->setAvailable(true);
         $productEntity->setUniqueIdentifier('BestVariant');
+        $productEntity->internalSetEntityData('product', new FieldVisibility([]));
 
         $product1Id = $this->idsCollection->create('product1');
         $idsSearchResult = new IdSearchResult(
@@ -188,6 +191,7 @@ class ProductDetailRouteTest extends TestCase
         $productTerm->setId($this->idsCollection->create('term'));
         $productTerm->setUniqueIdentifier('term');
         $productTerm->setName('term');
+        $productTerm->internalSetEntityData('product', new FieldVisibility([]));
 
         $product1Id = $this->idsCollection->create('product1');
         $idsSearchResult = new IdSearchResult(
@@ -244,6 +248,7 @@ class ProductDetailRouteTest extends TestCase
         $productEntity->setId($mainVariantId);
         $productEntity->setCmsPageId('4');
         $productEntity->setUniqueIdentifier('mainVariant');
+        $productEntity->internalSetEntityData('product', new FieldVisibility([]));
 
         $this->eventDispatcher->addListener(ResolveVariantIdEvent::class, static function (ResolveVariantIdEvent $event) use ($mainVariantId): void {
             static::assertSame($mainVariantId, $event->getResolvedVariantId());
@@ -290,6 +295,7 @@ class ProductDetailRouteTest extends TestCase
         $productEntity->setCmsPageId('4');
         $productEntity->setUniqueIdentifier('2');
         $productEntity->setAvailable(true);
+        $productEntity->internalSetEntityData('product', new FieldVisibility([]));
         $productRepository = $this->createMock(SalesChannelRepository::class);
         $productRepository->expects($this->once())
             ->method('search')
@@ -334,6 +340,7 @@ class ProductDetailRouteTest extends TestCase
         $productEntity->setCmsPageId('4');
         $productEntity->setUniqueIdentifier('best-variant');
         $productEntity->setAvailable(true);
+        $productEntity->internalSetEntityData('product', new FieldVisibility([]));
         $productRepository = $this->createMock(SalesChannelRepository::class);
         $productRepository->expects($this->once())
             ->method('searchIds')
@@ -397,6 +404,7 @@ class ProductDetailRouteTest extends TestCase
         $productEntity->setId($variantId);
         $productEntity->setCmsPageId('4');
         $productEntity->setAvailable(true);
+        $productEntity->internalSetEntityData('product', new FieldVisibility([]));
         $productRepository = $this->createMock(SalesChannelRepository::class);
         $productRepository->expects($this->once())
             ->method('search')
@@ -445,6 +453,7 @@ class ProductDetailRouteTest extends TestCase
         $productEntity->setCmsPageId('4');
         $productEntity->setUniqueIdentifier('2');
         $productEntity->setAvailable(true);
+        $productEntity->internalSetEntityData('product', new FieldVisibility([]));
         $productRepository = $this->createMock(SalesChannelRepository::class);
         $productRepository->expects($this->once())
             ->method('search')
@@ -488,6 +497,7 @@ class ProductDetailRouteTest extends TestCase
         $productEntity->setCmsPageId('4');
         $productEntity->setUniqueIdentifier('2');
         $productEntity->setAvailable(true);
+        $productEntity->internalSetEntityData('product', new FieldVisibility([]));
         $productRepository = $this->createMock(SalesChannelRepository::class);
         $productRepository->expects($this->once())
             ->method('search')
@@ -520,6 +530,7 @@ class ProductDetailRouteTest extends TestCase
         $productEntity->setId(Uuid::randomHex());
         $productEntity->setCmsPageId('4');
         $productEntity->setUniqueIdentifier('BestVariant');
+        $productEntity->internalSetEntityData('product', new FieldVisibility([]));
 
         $criteria2 = new Criteria([$this->idsCollection->get('product2')]);
         $criteria2->setTitle('product-detail-route');
@@ -553,6 +564,7 @@ class ProductDetailRouteTest extends TestCase
         $productEntity->setId(Uuid::randomHex());
         $productEntity->setCmsPageId('4');
         $productEntity->setUniqueIdentifier('mainVariant');
+        $productEntity->internalSetEntityData('product', new FieldVisibility([]));
         $productRepository = $this->createMock(SalesChannelRepository::class);
         $productRepository->expects($this->exactly(2))
             ->method('search')
@@ -591,6 +603,7 @@ class ProductDetailRouteTest extends TestCase
         $productEntity->setId(Uuid::randomHex());
         $productEntity->setCmsPageId('4');
         $productEntity->setUniqueIdentifier('mainVariant');
+        $productEntity->internalSetEntityData('product', new FieldVisibility([]));
 
         $productRepository = $this->createMock(SalesChannelRepository::class);
         $productRepository->expects($this->exactly(2))
@@ -719,9 +732,11 @@ class ProductDetailRouteTest extends TestCase
         $product = new SalesChannelProductEntity();
         $product->setId(Uuid::randomHex());
         $product->setCategoryIds([$defaultBreadcrumbCategory->getId(), $secondCategory->getId()]);
+        $product->internalSetEntityData('product', new FieldVisibility([]));
 
         $productWithoutCategories = new SalesChannelProductEntity();
         $productWithoutCategories->setId(Uuid::randomHex());
+        $productWithoutCategories->internalSetEntityData('product', new FieldVisibility([]));
 
         yield 'Load default breadcrumb category with disabled referrer feature' => [
             $product,

--- a/tests/unit/Core/Content/Product/SalesChannel/PurchaseLimit/ProductPurchaseLimitRouteTest.php
+++ b/tests/unit/Core/Content/Product/SalesChannel/PurchaseLimit/ProductPurchaseLimitRouteTest.php
@@ -11,6 +11,7 @@ use Shopware\Core\Content\Product\ProductException;
 use Shopware\Core\Content\Product\SalesChannel\PurchaseLimit\ProductPurchaseLimitRoute;
 use Shopware\Core\Content\Product\SalesChannel\SalesChannelProductCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
+use Shopware\Core\Framework\DataAbstractionLayer\FieldVisibility;
 use Shopware\Core\Framework\DataAbstractionLayer\PartialEntity;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
@@ -65,6 +66,9 @@ class ProductPurchaseLimitRouteTest extends TestCase
             'stock' => 3,
         ]);
 
+        $productA->internalSetEntityData('product', new FieldVisibility([]));
+        $productB->internalSetEntityData('product', new FieldVisibility([]));
+
         $this->productRepository->method('search')->willReturn(
             new EntitySearchResult('product', 2, new EntityCollection([$productA, $productB]), null, new Criteria(), $context->getContext())
         );
@@ -102,6 +106,8 @@ class ProductPurchaseLimitRouteTest extends TestCase
         $product = (new PartialEntity())->assign([
             'id' => $productId,
         ]);
+
+        $product->internalSetEntityData('product', new FieldVisibility([]));
 
         $this->productRepository->method('search')->willReturn(
             new EntitySearchResult('product', 1, new EntityCollection([$product]), null, new Criteria(), $context->getContext())

--- a/tests/unit/Core/Content/Product/SalesChannel/Review/ProductReviewsWidgetLoadedHookTest.php
+++ b/tests/unit/Core/Content/Product/SalesChannel/Review/ProductReviewsWidgetLoadedHookTest.php
@@ -70,7 +70,7 @@ class ProductReviewsWidgetLoadedHookTest extends TestCase
         $productReview->setUniqueIdentifier($ids->get('productReview'));
         $reviewResult = ProductReviewResult::fromSearchResult(
             new EntitySearchResult(
-                'review',
+                'product_review',
                 1,
                 new ProductReviewCollection([$productReview]),
                 null,

--- a/tests/unit/Core/Content/ProductExport/Service/ProductExportGeneratorTest.php
+++ b/tests/unit/Core/Content/ProductExport/Service/ProductExportGeneratorTest.php
@@ -31,6 +31,7 @@ use Shopware\Core\Framework\Adapter\Translation\AbstractTranslator;
 use Shopware\Core\Framework\Adapter\Twig\TwigVariableParser;
 use Shopware\Core\Framework\Adapter\Twig\TwigVariableParserFactory;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\FieldVisibility;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
@@ -996,6 +997,7 @@ class ProductExportGeneratorTest extends TestCase
         $product->setParentId($parentId);
         $product->setChildCount($childCount);
         $product->setAutoIncrement($autoIncrement);
+        $product->internalSetEntityData('product', new FieldVisibility([]));
 
         return $product;
     }

--- a/tests/unit/Core/Content/Seo/SalesChannel/StoreApiSeoResolverTest.php
+++ b/tests/unit/Core/Content/Seo/SalesChannel/StoreApiSeoResolverTest.php
@@ -22,6 +22,7 @@ use Shopware\Core\Content\Seo\SeoUrlRoute\SeoUrlRouteRegistry;
 use Shopware\Core\Content\Test\TestProductSeoUrlRoute;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry;
+use Shopware\Core\Framework\DataAbstractionLayer\FieldVisibility;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\EntityWriteGatewayInterface;
@@ -315,6 +316,7 @@ class StoreApiSeoResolverTest extends TestCase
     private function createProductEntity(string $identifier = 'random'): SalesChannelProductEntity
     {
         $productEntity = new SalesChannelProductEntity();
+        $productEntity->internalSetEntityData('product', new FieldVisibility([]));
         $productEntity->setUniqueIdentifier($identifier);
 
         return $productEntity;
@@ -338,7 +340,7 @@ class StoreApiSeoResolverTest extends TestCase
         }
 
         $entitySearchResult = new EntitySearchResult(
-            'seoUrl',
+            'seo_url',
             1,
             $seoUrlCollection,
             null,

--- a/tests/unit/Core/Content/Seo/SeoUrlGeneratorTest.php
+++ b/tests/unit/Core/Content/Seo/SeoUrlGeneratorTest.php
@@ -23,6 +23,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\Runtime;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\IdField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\StringField;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
+use Shopware\Core\Framework\DataAbstractionLayer\FieldVisibility;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\ArrayEntity;
 use Shopware\Core\System\SalesChannel\Aggregate\SalesChannelDomain\SalesChannelDomainCollection;
@@ -60,7 +61,7 @@ class SeoUrlGeneratorTest extends TestCase
 
     public function testGenerateProducesSeoUrlWithCorrectFields(): void
     {
-        $entity = new ArrayEntity(['id' => 'entity-1']);
+        $entity = $this->createTestEntity();
 
         $entityRepository = new StaticEntityRepository([
             new EntityCollection([$entity]),
@@ -109,7 +110,7 @@ class SeoUrlGeneratorTest extends TestCase
 
     public function testGenerateForHeadlessStoresRelativeSeoPathInfo(): void
     {
-        $entity = new ArrayEntity(['id' => 'entity-1']);
+        $entity = $this->createTestEntity();
 
         $entityRepository = new StaticEntityRepository([
             new EntityCollection([$entity]),
@@ -174,7 +175,7 @@ class SeoUrlGeneratorTest extends TestCase
 
     public function testGenerateSkipsEmptySeoPathInfo(): void
     {
-        $entity = new ArrayEntity(['id' => 'entity-1']);
+        $entity = $this->createTestEntity();
         $entityRepository = new StaticEntityRepository([
             new EntityCollection([$entity]),
             new EntityCollection(),
@@ -209,7 +210,7 @@ class SeoUrlGeneratorTest extends TestCase
 
     public function testGenerateYieldsAnErrorWhenTheTemplateRendersAnEmptyPath(): void
     {
-        $entity = new ArrayEntity(['id' => 'entity-1']);
+        $entity = $this->createTestEntity();
         $entityRepository = new StaticEntityRepository([
             new EntityCollection([$entity]),
             new EntityCollection(),
@@ -247,7 +248,7 @@ class SeoUrlGeneratorTest extends TestCase
 
     public function testGenerateKeepsTheMappingErrorWhenTheTemplateRendersAnEmptyPath(): void
     {
-        $entity = new ArrayEntity(['id' => 'entity-1']);
+        $entity = $this->createTestEntity();
         $entityRepository = new StaticEntityRepository([
             new EntityCollection([$entity]),
             new EntityCollection(),
@@ -328,7 +329,7 @@ class SeoUrlGeneratorTest extends TestCase
 
     public function testGenerateFlagsRenderingErrorsIfConfiguredToSkipInvalid(): void
     {
-        $entity = new ArrayEntity(['id' => 'entity-1']);
+        $entity = $this->createTestEntity();
         $entityRepository = new StaticEntityRepository([
             new EntityCollection([$entity]),
             new EntityCollection(),
@@ -369,7 +370,7 @@ class SeoUrlGeneratorTest extends TestCase
 
     public function testGenerateThrowsOnRenderingErrorIfNotConfiguredToSkip(): void
     {
-        $entity = new ArrayEntity(['id' => 'entity-1']);
+        $entity = $this->createTestEntity();
         $entityRepository = new StaticEntityRepository([
             new EntityCollection([$entity]),
             new EntityCollection(),
@@ -402,7 +403,7 @@ class SeoUrlGeneratorTest extends TestCase
 
     public function testGenerateThrowsExceptionWhileParsingTemplate(): void
     {
-        $entity = new ArrayEntity(['id' => 'entity-1']);
+        $entity = $this->createTestEntity();
         $entityRepository = new StaticEntityRepository([
             new EntityCollection([$entity]),
         ], $this->createTestDefinition());
@@ -418,7 +419,7 @@ class SeoUrlGeneratorTest extends TestCase
 
     public function testGenerateWithLastFieldHasRuntimeFlag(): void
     {
-        $entity = new ArrayEntity(['id' => 'entity-1']);
+        $entity = $this->createTestEntity();
         $entityRepository = new StaticEntityRepository([
             new EntityCollection([$entity]),
             new EntityCollection(),
@@ -498,6 +499,14 @@ class SeoUrlGeneratorTest extends TestCase
         }
 
         return $twig;
+    }
+
+    private function createTestEntity(): ArrayEntity
+    {
+        $entity = new ArrayEntity(['id' => 'entity-1']);
+        $entity->internalSetEntityData(self::TEST_ENTITY_NAME, new FieldVisibility([]));
+
+        return $entity;
     }
 
     private function createTestDefinition(): EntityDefinition

--- a/tests/unit/Core/Framework/Adapter/Twig/Extension/BuildBreadcrumbExtensionTest.php
+++ b/tests/unit/Core/Framework/Adapter/Twig/Extension/BuildBreadcrumbExtensionTest.php
@@ -14,6 +14,7 @@ use Shopware\Core\Content\Category\Service\CategoryBreadcrumbBuilder;
 use Shopware\Core\Framework\Adapter\Twig\Extension\BuildBreadcrumbExtension;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
+use Shopware\Core\Framework\DataAbstractionLayer\FieldVisibility;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
 use Shopware\Core\Framework\Log\Package;
@@ -143,6 +144,7 @@ class BuildBreadcrumbExtensionTest extends TestCase
         if ($categoryId !== null) {
             $category = new SalesChannelCategoryEntity();
             $category->setUniqueIdentifier($categoryId);
+            $category->internalSetEntityData(CategoryDefinition::ENTITY_NAME, new FieldVisibility([]));
             $categories->add($category);
         }
 

--- a/tests/unit/Core/Framework/App/Lifecycle/Persister/McpPromptPersisterTest.php
+++ b/tests/unit/Core/Framework/App/Lifecycle/Persister/McpPromptPersisterTest.php
@@ -6,6 +6,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\App\Aggregate\AppMcpPrompt\AppMcpPromptCollection;
+use Shopware\Core\Framework\App\Aggregate\AppMcpPrompt\AppMcpPromptDefinition;
 use Shopware\Core\Framework\App\Aggregate\AppMcpPrompt\AppMcpPromptEntity;
 use Shopware\Core\Framework\App\Lifecycle\Persister\AbstractMcpCapabilityPersister;
 use Shopware\Core\Framework\App\Lifecycle\Persister\McpPromptPersister;
@@ -52,7 +53,7 @@ class McpPromptPersisterTest extends TestCase
 
         $collection = new AppMcpPromptCollection([$existingEntity]);
         $searchResult = new EntitySearchResult(
-            AppMcpPromptEntity::class,
+            AppMcpPromptDefinition::ENTITY_NAME,
             1,
             $collection,
             null,
@@ -83,7 +84,7 @@ class McpPromptPersisterTest extends TestCase
 
         $collection = new AppMcpPromptCollection([$existingEntity]);
         $searchResult = new EntitySearchResult(
-            AppMcpPromptEntity::class,
+            AppMcpPromptDefinition::ENTITY_NAME,
             1,
             $collection,
             null,
@@ -126,7 +127,7 @@ class McpPromptPersisterTest extends TestCase
     public function testUpdatePromptsWithNewPromptCallsUpsertWithoutId(): void
     {
         $searchResult = new EntitySearchResult(
-            AppMcpPromptEntity::class,
+            AppMcpPromptDefinition::ENTITY_NAME,
             0,
             new AppMcpPromptCollection([]),
             null,

--- a/tests/unit/Core/Framework/App/Lifecycle/Persister/McpResourcePersisterTest.php
+++ b/tests/unit/Core/Framework/App/Lifecycle/Persister/McpResourcePersisterTest.php
@@ -6,6 +6,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\App\Aggregate\AppMcpResource\AppMcpResourceCollection;
+use Shopware\Core\Framework\App\Aggregate\AppMcpResource\AppMcpResourceDefinition;
 use Shopware\Core\Framework\App\Aggregate\AppMcpResource\AppMcpResourceEntity;
 use Shopware\Core\Framework\App\Lifecycle\Persister\AbstractMcpCapabilityPersister;
 use Shopware\Core\Framework\App\Lifecycle\Persister\McpResourcePersister;
@@ -53,7 +54,7 @@ class McpResourcePersisterTest extends TestCase
 
         $collection = new AppMcpResourceCollection([$existingEntity]);
         $searchResult = new EntitySearchResult(
-            AppMcpResourceEntity::class,
+            AppMcpResourceDefinition::ENTITY_NAME,
             1,
             $collection,
             null,
@@ -85,7 +86,7 @@ class McpResourcePersisterTest extends TestCase
 
         $collection = new AppMcpResourceCollection([$existingEntity]);
         $searchResult = new EntitySearchResult(
-            AppMcpResourceEntity::class,
+            AppMcpResourceDefinition::ENTITY_NAME,
             1,
             $collection,
             null,
@@ -130,7 +131,7 @@ class McpResourcePersisterTest extends TestCase
     public function testUpdateResourcesWithNewResourceCallsUpsertWithoutId(): void
     {
         $searchResult = new EntitySearchResult(
-            AppMcpResourceEntity::class,
+            AppMcpResourceDefinition::ENTITY_NAME,
             0,
             new AppMcpResourceCollection([]),
             null,

--- a/tests/unit/Core/Framework/App/Lifecycle/Persister/McpToolPersisterTest.php
+++ b/tests/unit/Core/Framework/App/Lifecycle/Persister/McpToolPersisterTest.php
@@ -7,6 +7,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\App\Aggregate\AppMcpTool\AppMcpToolCollection;
+use Shopware\Core\Framework\App\Aggregate\AppMcpTool\AppMcpToolDefinition;
 use Shopware\Core\Framework\App\Aggregate\AppMcpTool\AppMcpToolEntity;
 use Shopware\Core\Framework\App\AppException;
 use Shopware\Core\Framework\App\Lifecycle\Persister\AbstractMcpCapabilityPersister;
@@ -57,7 +58,7 @@ class McpToolPersisterTest extends TestCase
 
         $collection = new AppMcpToolCollection([$existingEntity]);
         $searchResult = new EntitySearchResult(
-            AppMcpToolEntity::class,
+            AppMcpToolDefinition::ENTITY_NAME,
             1,
             $collection,
             null,
@@ -90,7 +91,7 @@ class McpToolPersisterTest extends TestCase
 
         $collection = new AppMcpToolCollection([$existingEntity]);
         $searchResult = new EntitySearchResult(
-            AppMcpToolEntity::class,
+            AppMcpToolDefinition::ENTITY_NAME,
             1,
             $collection,
             null,
@@ -135,7 +136,7 @@ class McpToolPersisterTest extends TestCase
     public function testUpdateToolsWithNewToolCallsUpsertWithoutId(): void
     {
         $searchResult = new EntitySearchResult(
-            AppMcpToolEntity::class,
+            AppMcpToolDefinition::ENTITY_NAME,
             0,
             new AppMcpToolCollection([]),
             null,

--- a/tests/unit/Core/Framework/DataAbstractionLayer/Dbal/Common/SalesChannelRepositoryIteratorTest.php
+++ b/tests/unit/Core/Framework/DataAbstractionLayer/Dbal/Common/SalesChannelRepositoryIteratorTest.php
@@ -10,6 +10,7 @@ use Shopware\Core\Content\Product\ProductDefinition;
 use Shopware\Core\Content\Product\SalesChannel\SalesChannelProductCollection;
 use Shopware\Core\Content\Product\SalesChannel\SalesChannelProductEntity;
 use Shopware\Core\Framework\DataAbstractionLayer\Dbal\Common\SalesChannelRepositoryIterator;
+use Shopware\Core\Framework\DataAbstractionLayer\FieldVisibility;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\RangeFilter;
@@ -157,6 +158,7 @@ class SalesChannelRepositoryIteratorTest extends TestCase
     private function product(int $autoIncrement): SalesChannelProductEntity
     {
         $product = new SalesChannelProductEntity();
+        $product->internalSetEntityData('product', new FieldVisibility([]));
         $product->setId(Uuid::randomHex());
         $product->setAutoIncrement($autoIncrement);
 

--- a/tests/unit/Core/Framework/DataAbstractionLayer/EntityRepositoryTest.php
+++ b/tests/unit/Core/Framework/DataAbstractionLayer/EntityRepositoryTest.php
@@ -23,6 +23,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Event\EntitySearchedEvent;
 use Shopware\Core\Framework\DataAbstractionLayer\Event\EntityWrittenContainerEvent;
 use Shopware\Core\Framework\DataAbstractionLayer\Event\EntityWrittenEvent;
 use Shopware\Core\Framework\DataAbstractionLayer\Event\PartialEntityLoadedEvent;
+use Shopware\Core\Framework\DataAbstractionLayer\FieldVisibility;
 use Shopware\Core\Framework\DataAbstractionLayer\PartialEntity;
 use Shopware\Core\Framework\DataAbstractionLayer\Read\EntityReaderInterface;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Aggregation\Bucket\TermsAggregation;
@@ -236,6 +237,7 @@ class EntityRepositoryTest extends TestCase
     {
         $product = new PartialEntity();
         $product->setUniqueIdentifier('test');
+        $product->internalSetEntityData('product', new FieldVisibility([]));
 
         $reader = static::createStub(EntityReaderInterface::class);
         $reader
@@ -248,8 +250,11 @@ class EntityRepositoryTest extends TestCase
             $event = $inner;
         });
 
+        $definition = static::createStub(EntityDefinition::class);
+        $definition->method('getEntityName')->willReturn('product');
+
         $repo = new EntityRepository(
-            static::createStub(EntityDefinition::class),
+            $definition,
             $reader,
             static::createStub(VersionManager::class),
             static::createStub(EntitySearcherInterface::class),

--- a/tests/unit/Core/Framework/Demodata/Generator/ProductGeneratorTest.php
+++ b/tests/unit/Core/Framework/Demodata/Generator/ProductGeneratorTest.php
@@ -105,7 +105,7 @@ class ProductGeneratorTest extends TestCase
 
         $taxRepository = new StaticEntityRepository([
             new EntitySearchResult(
-                TaxEntity::class,
+                'tax',
                 1,
                 new TaxCollection([$taxEntity]),
                 null,

--- a/tests/unit/Core/Framework/Mcp/Tool/EntityReadToolTest.php
+++ b/tests/unit/Core/Framework/Mcp/Tool/EntityReadToolTest.php
@@ -13,6 +13,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\DataAbstractionLayer\FieldVisibility;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\RequestCriteriaBuilder;
@@ -34,6 +35,7 @@ class EntityReadToolTest extends TestCase
     {
         $context = Context::createDefaultContext();
         $entity = new ArrayEntity(['id' => 'prod-123', 'name' => 'Test Product']);
+        $entity->internalSetEntityData('product', new FieldVisibility([]));
         $collection = new EntitySearchResult(
             'product',
             1,

--- a/tests/unit/Core/Framework/Store/Api/FirstRunWizardControllerTest.php
+++ b/tests/unit/Core/Framework/Store/Api/FirstRunWizardControllerTest.php
@@ -600,7 +600,7 @@ class FirstRunWizardControllerTest extends TestCase
     private function createPluginSearchResult(Context $context, array $pluginData): EntitySearchResult
     {
         return new EntitySearchResult(
-            PluginEntity::class,
+            'plugin',
             \count($pluginData),
             $this->createPluginCollection($pluginData),
             null,

--- a/tests/unit/Core/SsoUser/SsoUserInvitationMailServiceTest.php
+++ b/tests/unit/Core/SsoUser/SsoUserInvitationMailServiceTest.php
@@ -6,6 +6,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Mail\Service\AbstractMailService;
 use Shopware\Core\Content\MailTemplate\Aggregate\MailTemplateType\MailTemplateTypeCollection;
+use Shopware\Core\Content\MailTemplate\Aggregate\MailTemplateType\MailTemplateTypeDefinition;
 use Shopware\Core\Content\MailTemplate\Aggregate\MailTemplateType\MailTemplateTypeEntity;
 use Shopware\Core\Content\MailTemplate\MailTemplateCollection;
 use Shopware\Core\Content\MailTemplate\MailTemplateDefinition;
@@ -60,7 +61,7 @@ class SsoUserInvitationMailServiceTest extends TestCase
         $mailTemplateTypeEntity->setId(Uuid::randomHex());
         $mailTemplateTypeRepository = new StaticEntityRepository([
             new MailTemplateTypeCollection([$mailTemplateTypeEntity]),
-        ], new MailTemplateDefinition());
+        ], new MailTemplateTypeDefinition());
 
         $userEntity = new UserEntity();
         $userEntity->setUniqueIdentifier(Uuid::randomHex());

--- a/tests/unit/Core/System/StateMachine/StateMachineRegistryTest.php
+++ b/tests/unit/Core/System/StateMachine/StateMachineRegistryTest.php
@@ -22,6 +22,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\StateMachineStateField;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
+use Shopware\Core\Framework\DataAbstractionLayer\FieldVisibility;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
 use Shopware\Core\Framework\Log\Package;
@@ -435,11 +436,12 @@ class StateMachineRegistryTest extends TestCase
             });
 
         $entityRepository->method('search')
-            ->willReturnCallback(fn (Criteria $criteria, Context $context): EntitySearchResult => $this->createSearchResult(
-                'order_transaction',
-                new EntityCollection([new ArrayEntity(['id' => $criteria->getIds()[0], 'stateId' => $fromPlace->getId()])]),
-                $context
-            ));
+            ->willReturnCallback(function (Criteria $criteria, Context $context) use ($fromPlace): EntitySearchResult {
+                $entity = new ArrayEntity(['id' => $criteria->getIds()[0], 'stateId' => $fromPlace->getId()]);
+                $entity->internalSetEntityData('order_transaction', new FieldVisibility([]));
+
+                return $this->createSearchResult('order_transaction', new EntityCollection([$entity]), $context);
+            });
 
         $definitionRegistry->method('getByEntityName')
             ->willReturnMap([['order_transaction', $definition]]);

--- a/tests/unit/Elasticsearch/Framework/ElasticsearchOutdatedIndexDetectorTest.php
+++ b/tests/unit/Elasticsearch/Framework/ElasticsearchOutdatedIndexDetectorTest.php
@@ -63,7 +63,7 @@ class ElasticsearchOutdatedIndexDetectorTest extends TestCase
 
         $makeLanguage = static fn () => (new LanguageEntity())->assign(['id' => Uuid::randomHex()]);
 
-        $collection = new EntitySearchResult('test', 1, new LanguageCollection([$makeLanguage(), $makeLanguage(), $makeLanguage()]), null, new Criteria(), Context::createDefaultContext());
+        $collection = new EntitySearchResult('language', 1, new LanguageCollection([$makeLanguage(), $makeLanguage(), $makeLanguage()]), null, new Criteria(), Context::createDefaultContext());
 
         $repository = static::createStub(EntityRepository::class);
         $repository

--- a/tests/unit/Storefront/Controller/ProductControllerTest.php
+++ b/tests/unit/Storefront/Controller/ProductControllerTest.php
@@ -279,7 +279,7 @@ class ProductControllerTest extends TestCase
         $productReview->setUniqueIdentifier($ids->get('productReview'));
         $reviewResult = ProductReviewResult::fromSearchResult(
             new EntitySearchResult(
-                'review',
+                'product_review',
                 1,
                 new ProductReviewCollection([$productReview]),
                 null,

--- a/tests/unit/Storefront/Storybook/StorybookServiceTest.php
+++ b/tests/unit/Storefront/Storybook/StorybookServiceTest.php
@@ -13,6 +13,7 @@ use Shopware\Core\Content\Product\SalesChannel\SalesChannelProductCollection;
 use Shopware\Core\Content\Product\SalesChannel\SalesChannelProductEntity;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\DataAbstractionLayer\FieldVisibility;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\IdSearchResult;
@@ -163,6 +164,7 @@ class StorybookServiceTest extends TestCase
         $salesChannelContext = Generator::generateSalesChannelContext();
 
         $product = new SalesChannelProductEntity();
+        $product->internalSetEntityData(ProductDefinition::ENTITY_NAME, new FieldVisibility([]));
         $product->setId('product-id-123');
         $product->setUniqueIdentifier('product-id-123');
 


### PR DESCRIPTION
### 1. Why is this change necessary?

#18916 added an assert to the `EntitySearchResult` constructor that the entity name matches the collection's first entity api alias. CI runs with `zend.assertions` disabled, so it never fires there, but running the unit suite locally with assertions enabled hits ~500 fixtures that violate it.

### 2. What does this change do, exactly?

Most violations came from one place: `StaticEntityRepository` and `StaticSalesChannelRepository` label search results `'mock'` when built without a definition. They now fall back to the first queued entity's api alias.

The remaining fixtures constructed results with mismatching names and are fixed individually, the way production would look: entities get stamped with their real entity name via `internalSetEntityData()` where the result name is the production one (e.g. `SalesChannelProductEntity` under `'product'`), and plainly wrong name strings (FQCNs, camelCase, dashes) are corrected to the actual entity name.

### 3. Describe each step to reproduce the issue or behaviour.

Run `php -d zend.assertions=1 vendor/bin/phpunit --testsuite unit` — before this change ~500 tests fail with "The entity name must match the entity collection", after it none do.

### 4. Please link to the relevant issues (if any).

- relates #18916

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
