### PR TITLE
feat(a11y): Allow `strong` and `em` for html sanitizers (backport: 6.6.x)

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/utils/sw-notification-center-item/sw-notification-center-item.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/utils/sw-notification-center-item/sw-notification-center-item.html.twig
@@ -30,7 +30,7 @@
         {% block sw_notification_center_item_content_message %}
         <p
             class="sw-notification-center-item__message"
-            v-html="$sanitize(notification.message, { ALLOWED_TAGS: ['a', 'b', 'i', 'u', 'br'], ALLOWED_ATTR: ['href', 'target'] })"
+            v-html="$sanitize(notification.message, { ALLOWED_TAGS: ['a', 'b', 'i', 'u', 'strong', 'em', 'br'], ALLOWED_ATTR: ['href', 'target'] })"
         ></p>
         {% endblock %}
         {% block sw_notification_center_item_loader %}

--- a/src/Administration/Resources/app/administration/src/app/component/utils/sw-notifications/sw-notifications.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/utils/sw-notifications/sw-notifications.html.twig
@@ -25,7 +25,7 @@
             >
 
                 {% block sw_notifications_item_content %}
-                <div v-html="$sanitize(notification.message, { ALLOWED_TAGS: ['a', 'b', 'i', 'u', 'br'], ALLOWED_ATTR: ['href', 'target'] })"></div>
+                <div v-html="$sanitize(notification.message, { ALLOWED_TAGS: ['a', 'b', 'i', 'u', 'strong', 'em', 'br'], ALLOWED_ATTR: ['href', 'target'] })"></div>
                 {% endblock %}
 
                 {% block sw_notifications_item_actions_slot %}


### PR DESCRIPTION
**Backport:** https://github.com/shopware/shopware/pull/11050
relates #19539

---

### 1. Why is this change necessary?
Manual backport of #11050 to 6.6.x (a11y). The automated cherry-pick conflicts; see below.

In terms of accessibility, `strong` and `em` are the semantically better choices than `b` and `i`, but the admin sanitizers stripped them from notification messages.

### 2. What does this change do, exactly?
Adds `strong` and `em` to the `ALLOWED_TAGS` allowlists of the `$sanitize()` calls that render notification messages, so those tags survive sanitization instead of being stripped.

**Conflict resolution vs. trunk commit 885ed718d6b:**
- `src/app/component/structure/sw-modals-renderer/index.ts` — hunk **dropped entirely**, file kept unchanged at its 6.6.x state. The trunk hunk extends a `sanitizeTextContent()` method that only exists on trunk (introduced by trunk-only #9597); it does not exist on 6.6.x. Taking the hunk would reference an undefined `DOMPurify` and break the build.
- `src/app/component/utils/sw-notifications/sw-notifications.html.twig` — kept the 6.6.x single-line `<div v-html="$sanitize(...)"></div>` markup and only extended `ALLOWED_TAGS`. The trunk version additionally adds `class="sw-notifications__message"`, which was not taken because 6.6.x has no SCSS rule for that class.
- `sw-notification-center-item.html.twig` applied cleanly (same `ALLOWED_TAGS` extension).

The resulting backport diff is therefore exactly two Twig files, `ALLOWED_TAGS` only.

### 3. Describe each step to reproduce the issue or behaviour.
See original PR.

### 4. Please link to the relevant issues (if any).
- relates #19539

### 5. Checklist
- [x] Cherry-picked from trunk with `-x`, conflicts resolved as described above
- [ ] Tests run locally: nothing to run — no Jest spec on 6.6.x asserts these `ALLOWED_TAGS` allowlists, and the change is Twig-only (no admin Twig lint on 6.6.x). Markup was verified by eye.
