### PR TITLE
fix: announce active category to screen readers via aria-current (backport: 6.6.x)

### DIFF
--- a/src/Storefront/Resources/views/storefront/layout/navigation/offcanvas/item-link.html.twig
+++ b/src/Storefront/Resources/views/storefront/layout/navigation/offcanvas/item-link.html.twig
@@ -7,6 +7,7 @@
     <li class="navigation-offcanvas-list-item">
         {% block layout_navigation_offcanvas_navigation_categories_list_category_item_link %}
             <a class="navigation-offcanvas-link nav-item nav-link{% if isActive %} active{% endif %}{% if hasChildren %} js-navigation-offcanvas-link{% endif %}"
+               {% if isActive %}aria-current="page"{% endif %}
                href="{{ url }}"
                 {% if hasChildren %}
                     data-href="{{ path('frontend.menu.offcanvas', {navigationId: item.category.id}) }}"

--- a/src/Storefront/Resources/views/storefront/layout/sidebar/category-navigation.html.twig
+++ b/src/Storefront/Resources/views/storefront/layout/sidebar/category-navigation.html.twig
@@ -33,6 +33,7 @@
                                 {% block layout_navigation_categories_link_children %}
                                     <a class="category-navigation-link{% if categoryId is same as(activeId) %} is-active{% endif %}{% if categoryId in activePath %} in-path{% endif %}"
                                         href="{{ categoryUrl }}"
+                                        {% if categoryId is same as(activeId) %}aria-current="page"{% endif %}
                                         {% if categoryLinkNewTab %}target="_blank"{% endif %}>
                                         {% block layout_navigation_categories_link_children_name %}
                                             {{ categoryName }}
@@ -60,6 +61,7 @@
                                 {% block layout_navigation_categories_link %}
                                     <a class="category-navigation-link{% if categoryId is same as(activeId) %} is-active{% endif %}"
                                         href="{{ categoryUrl }}"
+                                        {% if categoryId is same as(activeId) %}aria-current="page"{% endif %}
                                         {% if categoryLinkNewTab %}target="_blank"{% endif %}>
                                         {% block layout_navigation_categories_link_name %}
                                             {{ categoryName }}


### PR DESCRIPTION
**Backport:** https://github.com/shopware/shopware/pull/17105
Resolves: https://github.com/shopware/shopware/issues/16028
relates #19539

---

### 1. Why is this change necessary?

Manual backport of #17105 to 6.6.x (a11y). The automated cherry-pick conflicts; see below.

The breadcrumb and the desktop top navigation already mark the active category with `aria-current="page"` (the latter via `navbar.plugin.js`). The server-rendered sidebar category navigation and the offcanvas mobile navigation did not expose the current location, so screen readers did not announce it after a page reload.

### 2. What does this change do, exactly?

Adds `aria-current="page"` to the active link in two server-rendered category navigation templates: `layout/navigation/offcanvas/item-link.html.twig` (when `isActive`, alongside the existing `active` class) and `layout/sidebar/category-navigation.html.twig` (when `categoryId is same as(activeId)`, in both the in-path and out-of-path branches, alongside the existing `is-active` class). Purely additive — one conditional attribute per link; only the leaf gets `aria-current`, ancestors keep just their styling class.

**Conflict resolution vs. trunk commit 7acb499cc72:**
- `src/Storefront/Resources/views/storefront/layout/navigation/offcanvas/item-link.html.twig`: pure context conflict. On trunk the `<a>` tag was reformatted by the 6.8 microdata deprecation (multi-line attributes, `{# @deprecated tag:v6.8.0 … #}` comment, `{% if not feature('JSON_LD_DATA') %}itemprop="url"{% endif %}`), none of which exists on 6.6.x. Kept the 6.6.x tag exactly as it is and only added `{% if isActive %}aria-current="page"{% endif %}` in the same position as trunk (directly after the `class` attribute). No trunk refactoring pulled in.
- `src/Storefront/Resources/views/storefront/layout/sidebar/category-navigation.html.twig`: applied cleanly (offset only).

### 3. Describe each step to reproduce the issue or behaviour.

See original PR.

### 4. Please link to the relevant issues (if any).

- relates #16028
- relates #19539

### 5. Checklist

- [x] Cherry-picked from trunk with `-x`, conflicts resolved as described above
- [ ] Tests run locally: the PR is Twig-only and contains no tests; 6.6.x has no storefront Twig linter. Verified by inspection that all referenced variables (`isActive`, `categoryId`, `activeId`) exist in the 6.6.x versions of both templates, and that the Jest tests referencing `.navigation-offcanvas-link` use their own inline HTML fixtures and are therefore unaffected.
