### PR TITLE
fix: footer columns accessibility (backport: 6.6.x)

### DIFF
--- a/src/Storefront/Resources/views/storefront/layout/footer/footer.html.twig
+++ b/src/Storefront/Resources/views/storefront/layout/footer/footer.html.twig
@@ -13,7 +13,7 @@
                 role="list"
             >
                 {% block layout_footer_navigation_hotline %}
-                    <div class="col-md-4 footer-column js-footer-column pb-4 pb-md-0" role="listitem">
+                    <div class="col-md-4 footer-column js-footer-column pb-4 pb-md-0"{% if feature('ACCESSIBILITY_TWEAKS') %} role="listitem"{% endif %}>
                         {% block layout_footer_navigation_hotline_headline %}
                             {% if feature('ACCESSIBILITY_TWEAKS') %}
 
@@ -45,7 +45,8 @@
                                      data-bs-target="#collapseFooterHotline"
                                      data-bs-toggle="collapse"
                                      aria-expanded="true"
-                                     aria-controls="collapseFooterHotline">
+                                     aria-controls="collapseFooterHotline"
+                                     role="listitem">
                                     {{ 'footer.serviceHotlineHeadline'|trans|sw_sanitize }}
 
                                     {% block layout_footer_navigation_hotline_icons %}
@@ -71,7 +72,8 @@
 
                             <div id="collapseFooterHotline"
                                  class="footer-column-content collapse js-footer-column-content footer-contact{% if feature('ACCESSIBILITY_TWEAKS') %} mb-4 mb-md-0{% endif %}"
-                                 aria-labelledby="collapseFooterHotlineTitle">
+                                 aria-labelledby="collapseFooterHotlineTitle"{% if not feature('ACCESSIBILITY_TWEAKS') %}
+                                 role="listitem"{% endif %}>
 
                                 <div class="footer-column-content-inner">
                                     <p class="footer-contact-hotline">
@@ -135,7 +137,7 @@
                 {% block layout_footer_navigation_columns %}
                     {% for root in footer.navigation.tree %}
                         {% block layout_footer_navigation_column %}
-                            <div class="col-md-4 footer-column js-footer-column" role="listitem">
+                            <div class="col-md-4 footer-column js-footer-column"{% if feature('ACCESSIBILITY_TWEAKS') %} role="listitem"{% endif %}>
                                 {% block layout_footer_navigation_information_headline %}
 
                                     {% if feature('ACCESSIBILITY_TWEAKS') %}
@@ -211,7 +213,8 @@
                                 {% block layout_footer_navigation_information_content %}
                                     <div id="collapseFooter{{ loop.index }}"
                                          class="footer-column-content collapse js-footer-column-content"
-                                         aria-labelledby="collapseFooterTitle{{ loop.index }}">
+                                         aria-labelledby="collapseFooterTitle{{ loop.index }}"{% if not feature('ACCESSIBILITY_TWEAKS') %}
+                                         role="listitem"{% endif %}>
 
                                         <div class="footer-column-content-inner">
                                             {% block layout_footer_navigation_information_links %}

--- a/src/Storefront/Resources/views/storefront/layout/footer/footer.html.twig
+++ b/src/Storefront/Resources/views/storefront/layout/footer/footer.html.twig
@@ -13,13 +13,12 @@
                 role="list"
             >
                 {% block layout_footer_navigation_hotline %}
-                    <div class="col-md-4 footer-column js-footer-column pb-4 pb-md-0">
+                    <div class="col-md-4 footer-column js-footer-column pb-4 pb-md-0" role="listitem">
                         {% block layout_footer_navigation_hotline_headline %}
                             {% if feature('ACCESSIBILITY_TWEAKS') %}
 
                                 <div class="footer-column-headline footer-headline js-footer-column-headline"
-                                     id="collapseFooterHotlineTitle"
-                                     role="listitem">
+                                     id="collapseFooterHotlineTitle">
                                     {{ 'footer.serviceHotlineHeadline'|trans|sw_sanitize }}
 
                                     <button class="footer-column-toggle btn btn-link btn-link-inline js-collapse-footer-column-trigger"
@@ -46,8 +45,7 @@
                                      data-bs-target="#collapseFooterHotline"
                                      data-bs-toggle="collapse"
                                      aria-expanded="true"
-                                     aria-controls="collapseFooterHotline"
-                                     role="listitem">
+                                     aria-controls="collapseFooterHotline">
                                     {{ 'footer.serviceHotlineHeadline'|trans|sw_sanitize }}
 
                                     {% block layout_footer_navigation_hotline_icons %}
@@ -73,8 +71,7 @@
 
                             <div id="collapseFooterHotline"
                                  class="footer-column-content collapse js-footer-column-content footer-contact{% if feature('ACCESSIBILITY_TWEAKS') %} mb-4 mb-md-0{% endif %}"
-                                 aria-labelledby="collapseFooterHotlineTitle"
-                                 role="listitem">
+                                 aria-labelledby="collapseFooterHotlineTitle">
 
                                 <div class="footer-column-content-inner">
                                     <p class="footer-contact-hotline">
@@ -138,13 +135,12 @@
                 {% block layout_footer_navigation_columns %}
                     {% for root in footer.navigation.tree %}
                         {% block layout_footer_navigation_column %}
-                            <div class="col-md-4 footer-column js-footer-column">
+                            <div class="col-md-4 footer-column js-footer-column" role="listitem">
                                 {% block layout_footer_navigation_information_headline %}
 
                                     {% if feature('ACCESSIBILITY_TWEAKS') %}
                                         <div class="footer-column-headline footer-headline js-footer-column-headline"
-                                             id="collapseFooterTitle{{ loop.index }}"
-                                             role="listitem">
+                                             id="collapseFooterTitle{{ loop.index }}">
 
                                             {% if root.category.type == 'folder' %}
                                                 {{ root.category.translated.name }}
@@ -215,8 +211,7 @@
                                 {% block layout_footer_navigation_information_content %}
                                     <div id="collapseFooter{{ loop.index }}"
                                          class="footer-column-content collapse js-footer-column-content"
-                                         aria-labelledby="collapseFooterTitle{{ loop.index }}"
-                                         role="listitem">
+                                         aria-labelledby="collapseFooterTitle{{ loop.index }}">
 
                                         <div class="footer-column-content-inner">
                                             {% block layout_footer_navigation_information_links %}


### PR DESCRIPTION
**Backport:** https://github.com/shopware/shopware/pull/17276
Resolves: https://github.com/shopware/shopware/issues/13988
relates #19539

---

### 1. Why is this change necessary?
Manual backport of #17276 to 6.6.x (a11y). The automated cherry-pick conflicts; see below.

### 2. What does this change do, exactly?
It fixes the footer list semantics: `role="listitem"` now sits on the direct children of the `role="list"` container (the `.footer-column` columns) instead of on the nested headline and content elements. Previously the list container had no valid list items, and the elements carrying `role="listitem"` were not direct children of a list, so assistive technology announced the footer navigation incorrectly.

**Conflict resolution vs. trunk commit 8ef630747dd:**
- `src/Storefront/Resources/views/storefront/layout/footer/footer.html.twig`: the whole file conflicts because trunk has already dropped the `ACCESSIBILITY_TWEAKS` branches and migrated to `category_url()`/`cache_rework`/revocation-button include. Only the `role` payload was applied onto the 6.6.x markup; all 6.6.x-only shapes (`feature('ACCESSIBILITY_TWEAKS')` branches, the `cache_rework` footer fallback, the `cmsPath`/snippet-key ternaries, `category_url()` vs `seoUrl`, the deprecated `%star%` parameter) are untouched.
- Concretely: `role="listitem"` added to both `.col-md-4.footer-column` wrappers, removed from `#collapseFooterHotlineTitle`, `#collapseFooterHotline`, `#collapseFooterTitle{{ loop.index }}` and `#collapseFooter{{ loop.index }}`.
- 6.6.x has a flagged and an unflagged branch of the hotline headline; the unflagged (legacy, `ACCESSIBILITY_TWEAKS=false`, which is the default on 6.6.x) branch also carried `role="listitem"`. Since `role="list"` on the row container and the new `role="listitem"` on the column wrapper are both unflagged, leaving the legacy branch as-is would produce a nested `listitem` inside a `listitem` — exactly the bug being fixed. The `role` was therefore removed from that branch too, so the markup is correct with the flag on and off. The legacy branch of the navigation-column headline never had a `role`, so it needed no change.
- No SCSS/JS/test/snippet changes are part of the commit; no snippet keys are added or renamed.

### 3. Describe each step to reproduce the issue or behaviour.
See original PR.

### 4. Please link to the relevant issues (if any).
- relates #13988
- relates #19539

### 5. Checklist
- [x] Cherry-picked from trunk with `-x`, conflicts resolved as described above
- [ ] Tests run locally: Twig-only change, no automated lint for storefront twig on 6.6.x. Verified manually that the resolved file differs from `origin/6.6.x` only by the seven `role` attribute moves, that no other `role="listitem"` remains in the file, and that the only JS touching the footer columns (`collapse-footer-columns.plugin.js` and its Jest test) keys off the `js-footer-column*` classes, which are unchanged.
