### PR TITLE
fix(a11y): alerts on initial page load not read by screenreader (backport: 6.6.x)

### DIFF
--- a/src/Storefront/Resources/app/storefront/src/main.js
+++ b/src/Storefront/Resources/app/storefront/src/main.js
@@ -33,6 +33,7 @@ import (synchronously) plugins
  */
 import SetBrowserClassPlugin from 'src/plugin/set-browser-class/set-browser-class.plugin';
 import SpeculationRulesPlugin from 'src/plugin/speculation-rules/speculation-rules.plugin';
+import AlertAriaPlugin from 'src/plugin/alert-aria/alert-aria.plugin';
 
 window.Feature = Feature;
 window.eventEmitter = new NativeEventEmitter();
@@ -120,6 +121,7 @@ PluginManager.register('BuyBox', () => import('src/plugin/buy-box/buy-box.plugin
 PluginManager.register('BasicCaptcha', () => import('src/plugin/captcha/basic-captcha.plugin'), '[data-basic-captcha]');
 PluginManager.register('QuantitySelector', () => import('src/plugin/quantity-selector/quantity-selector.plugin'), '[data-quantity-selector]');
 PluginManager.register('AjaxModal', () => import('src/plugin/ajax-modal/ajax-modal.plugin'), '[data-ajax-modal][data-url]');
+PluginManager.register('AlertAria', AlertAriaPlugin, '[data-alert-aria]'); // Plugin not async to prevent unreliable load time for the screenreader.
 
 /**
  * @experimental stableVersion:v6.8.0 feature:SPATIAL_BASES

--- a/src/Storefront/Resources/app/storefront/src/plugin/alert-aria/alert-aria.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/alert-aria/alert-aria.plugin.js
@@ -1,0 +1,48 @@
+import Plugin from 'src/plugin-system/plugin.class';
+
+/**
+* This plugin can be used to announce alerts to the screenreader that are rendered in the DOM on page load.
+*
+* @example
+* {% sw_include '@Storefront/storefront/utilities/alert.html.twig' with {
+*     type: "primary",
+*     content: "An important message on initial page load",
+*     announceOnLoad: true
+* } %}
+*
+* @internal
+*/
+export default class AlertAriaPlugin extends Plugin {
+
+    static options = {
+        ariaLive: 'polite',
+    };
+
+    init() {
+        this._container = this.el.querySelector('.alert-content-container');
+
+        if (!this._container) {
+            console.warn(`[${this._pluginName}] The alert content container cannot be found.`);
+            return;
+        }
+
+        if (!this.el.hasAttribute('aria-live')) {
+            console.warn(`[${this._pluginName}] The "aria-live" attribute is not found on the alert. The alert will not be announced.`);
+        }
+
+        this._announceAlert();
+    }
+
+    _announceAlert() {
+        // Ensure assertive alerts are announced before polite alerts.
+        const delay = this.options.ariaLive === 'assertive' ? 1000 : 1500;
+
+        // Hide the alert content from screenreader initially.
+        this._container.setAttribute('aria-hidden', 'true');
+
+        // After timeout, disable aria-hidden to trigger the parent aria-live region.
+        setTimeout(() => {
+            this._container.setAttribute('aria-hidden', 'false');
+        }, delay);
+    }
+}

--- a/src/Storefront/Resources/app/storefront/test/plugin/alert-aria/alert-aria.plugin.test.js
+++ b/src/Storefront/Resources/app/storefront/test/plugin/alert-aria/alert-aria.plugin.test.js
@@ -1,0 +1,99 @@
+import AlertAriaPlugin from 'src/plugin/alert-aria/alert-aria.plugin';
+
+describe('src/plugin/alert-aria/alert-aria.plugin', () => {
+    const infoAlertTemplate = `
+        <div class="alert alert-info" role="alert" aria-live="polite">
+            <div class="alert-content-container">
+                An info message on initial page load
+            </div>
+        </div>
+    `;
+
+    const dangerAlertTemplate = `
+        <div class="alert alert-danger" role="alert" aria-live="assertive">
+            <div class="alert-content-container">
+                An error message on initial page load
+            </div>
+        </div>
+    `;
+
+    const invalidAlertTemplate = `
+        <div class="alert alert-info" role="alert" aria-live="polite">
+            An invalid alert without container
+        </div>
+    `;
+
+    const missingAriaTemplate = `
+        <div class="alert alert-danger" role="alert">
+            <div class="alert-content-container">
+                Alert with missing aria-live attribute
+            </div>
+        </div>
+    `;
+
+    function initPlugin(template, options = {}) {
+        document.body.innerHTML = template;
+        return new AlertAriaPlugin(document.querySelector('.alert'), options);
+    }
+
+    beforeEach(() => {
+        document.body.innerHTML = '';
+    });
+
+    test('plugin initializes', () => {
+        const plugin = initPlugin(infoAlertTemplate);
+
+        expect(typeof plugin).toBe('object');
+        expect(plugin).toBeInstanceOf(AlertAriaPlugin);
+    });
+
+    test('announces info alert by changing aria-hidden attribute after timeout', () => {
+        jest.useFakeTimers();
+
+        initPlugin(infoAlertTemplate);
+
+        // Ensure aria-hidden is set to true initially.
+        expect(document.querySelector('.alert-content-container').getAttribute('aria-hidden')).toBe('true');
+
+        jest.advanceTimersByTime(1500);
+
+        // Ensure aria-hidden update after timeout.
+        expect(document.querySelector('.alert-content-container').getAttribute('aria-hidden')).toBe('false');
+
+        jest.useRealTimers();
+    });
+
+    test('announces assertive alert by changing aria-hidden attribute after timeout', () => {
+        jest.useFakeTimers();
+
+        initPlugin(dangerAlertTemplate, { ariaLive: 'assertive' });
+
+        // Ensure aria-hidden is set to true initially.
+        expect(document.querySelector('.alert-content-container').getAttribute('aria-hidden')).toBe('true');
+
+        jest.advanceTimersByTime(1000);
+
+        // Ensure aria-hidden update after timeout.
+        expect(document.querySelector('.alert-content-container').getAttribute('aria-hidden')).toBe('false');
+
+        jest.useRealTimers();
+    });
+
+    test('handles invalid alert template without content container', () => {
+        const consoleSpy = jest.spyOn(console, 'warn').mockImplementation();
+
+        initPlugin(invalidAlertTemplate);
+
+        expect(consoleSpy).toHaveBeenCalledWith('[AlertAriaPlugin] The alert content container cannot be found.');
+        consoleSpy.mockRestore();
+    });
+
+    test('handles missing aria-live attribute', () => {
+        const consoleSpy = jest.spyOn(console, 'warn').mockImplementation();
+
+        initPlugin(missingAriaTemplate);
+
+        expect(consoleSpy).toHaveBeenCalledWith('[AlertAriaPlugin] The "aria-live" attribute is not found on the alert. The alert will not be announced.');
+        consoleSpy.mockRestore();
+    });
+});

--- a/src/Storefront/Resources/views/storefront/base.html.twig
+++ b/src/Storefront/Resources/views/storefront/base.html.twig
@@ -85,7 +85,12 @@
                 {% block base_flashbags %}
                     <div class="flashbags container">
                         {% for type, messages in app.flashes %}
-                            {% sw_include '@Storefront/storefront/utilities/alert.html.twig' with { type: type, list: messages } %}
+                            {% sw_include '@Storefront/storefront/utilities/alert.html.twig' with {
+                                type: type,
+                                list: messages,
+                                announceOnLoad: true,
+                                ariaLive: (type == 'danger' ? 'assertive' : 'polite')
+                            } %}
                         {% endfor %}
                     </div>
                 {% endblock %}

--- a/src/Storefront/Resources/views/storefront/component/account/login.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/account/login.html.twig
@@ -37,17 +37,22 @@
                             {% if errorSnippet != null %}
                                 {% sw_include '@Storefront/storefront/utilities/alert.html.twig' with {
                                     type: 'danger',
-                                    content: errorSnippet|trans|sw_sanitize({}, true)
+                                    content: errorSnippet|trans|sw_sanitize({}, true),
+                                    announceOnLoad: true,
+                                    ariaLive: 'assertive'
                                 } %}
                             {% elseif waitTime != null %}
                                 {% sw_include '@Storefront/storefront/utilities/alert.html.twig' with {
                                     type: 'info',
-                                    content: 'account.loginThrottled'|trans({'%seconds%': waitTime|number_format})|sw_sanitize
+                                    content: 'account.loginThrottled'|trans({'%seconds%': waitTime|number_format})|sw_sanitize,
+                                    announceOnLoad: true
                                 } %}
                             {% else %}
                                 {% sw_include '@Storefront/storefront/utilities/alert.html.twig' with {
                                     type: 'danger',
-                                    content: 'account.loginBadCredentials'|trans|sw_sanitize
+                                    content: 'account.loginBadCredentials'|trans|sw_sanitize,
+                                    announceOnLoad: true,
+                                    ariaLive: 'assertive'
                                 } %}
                             {% endif %}
                         {% endif %}

--- a/src/Storefront/Resources/views/storefront/component/product/listing.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/product/listing.html.twig
@@ -105,7 +105,8 @@
                                     {% block element_product_listing_col_empty_alert %}
                                         {% sw_include '@Storefront/storefront/utilities/alert.html.twig' with {
                                             type: 'info',
-                                            content: 'listing.emptyResultMessage'|trans|sw_sanitize
+                                            content: 'listing.emptyResultMessage'|trans|sw_sanitize,
+                                            announceOnLoad: true,
                                         } %}
                                     {% endblock %}
                                 </div>

--- a/src/Storefront/Resources/views/storefront/page/account/index.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/account/index.html.twig
@@ -9,7 +9,8 @@
                 {% if not ableToShipToShippingCountry %}
                     {% sw_include '@Storefront/storefront/utilities/alert.html.twig' with {
                         type: 'warning',
-                        content: 'account.overviewNotAbleToShip'|trans|sw_sanitize
+                        content: 'account.overviewNotAbleToShip'|trans|sw_sanitize,
+                        announceOnLoad: true
                     } %}
                 {% endif %}
             {% endblock %}
@@ -20,7 +21,8 @@
                         type: 'info',
                         content: 'account.overviewCustomerGroupRequest'|trans({
                             '%group%': page.customer.requestedGroup.translated.name
-                        })
+                        }),
+                        announceOnLoad: true
                     } %}
                 {% endif %}
             {% endblock %}

--- a/src/Storefront/Resources/views/storefront/page/account/newsletter.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/account/newsletter.html.twig
@@ -3,7 +3,11 @@
         {% if newsletterAccountPagelet.messages|length > 0 %}
             <div class="newsletter-alerts">
                 {% for message in newsletterAccountPagelet.messages %}
-                    {% sw_include '@Storefront/storefront/utilities/alert.html.twig' with { type: message.type, content: message.text } %}
+                    {% sw_include '@Storefront/storefront/utilities/alert.html.twig' with {
+                        type: message.type,
+                        content: message.text,
+                        announceOnLoad: true
+                    } %}
                 {% endfor %}
             </div>
         {% endif %}

--- a/src/Storefront/Resources/views/storefront/page/account/newsletter.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/account/newsletter.html.twig
@@ -6,7 +6,8 @@
                     {% sw_include '@Storefront/storefront/utilities/alert.html.twig' with {
                         type: message.type,
                         content: message.text,
-                        announceOnLoad: true
+                        announceOnLoad: true,
+                        ariaLive: (message.type == 'danger' ? 'assertive' : 'polite'),
                     } %}
                 {% endfor %}
             </div>

--- a/src/Storefront/Resources/views/storefront/page/checkout/_page.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/checkout/_page.html.twig
@@ -16,7 +16,11 @@
                             {% block base_flashbags_checkout %}
                                 <div class="flashbags">
                                     {% for type, messages in app.flashes %}
-                                        {% sw_include '@Storefront/storefront/utilities/alert.html.twig' with { type: type, list: messages } %}
+                                        {% sw_include '@Storefront/storefront/utilities/alert.html.twig' with {
+                                            type: type,
+                                            list: messages,
+                                            announceOnLoad: true,
+                                        } %}
                                     {% endfor %}
                                 </div>
                             {% endblock %}

--- a/src/Storefront/Resources/views/storefront/page/checkout/_page.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/checkout/_page.html.twig
@@ -20,6 +20,7 @@
                                             type: type,
                                             list: messages,
                                             announceOnLoad: true,
+                                            ariaLive: (type == 'danger' ? 'assertive' : 'polite'),
                                         } %}
                                     {% endfor %}
                                 </div>

--- a/src/Storefront/Resources/views/storefront/page/checkout/_page.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/checkout/_page.html.twig
@@ -20,7 +20,7 @@
                                             type: type,
                                             list: messages,
                                             announceOnLoad: true,
-                                            ariaLive: (type == 'danger' ? 'assertive' : 'polite'),
+                                            ariaLive: (type in ['danger', 'warning'] ? 'assertive' : 'polite'),
                                         } %}
                                     {% endfor %}
                                 </div>

--- a/src/Storefront/Resources/views/storefront/page/checkout/cart/index.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/checkout/cart/index.html.twig
@@ -8,14 +8,20 @@
     {% if page.cart.lineItems.count is same as(0) %}
         {% sw_include '@Storefront/storefront/utilities/alert.html.twig' with {
             type: 'info',
-            content: 'checkout.cartEmpty'|trans|sw_sanitize
+            content: 'checkout.cartEmpty'|trans|sw_sanitize,
+            announceOnLoad: true,
         } %}
 
         {% set messages = app.flashes %}
 
         {% if messages.danger|length > 0 %}
             <div class="flashbags">
-                {% sw_include '@Storefront/storefront/utilities/alert.html.twig' with { type: 'danger', list: messages.danger } %}
+                {% sw_include '@Storefront/storefront/utilities/alert.html.twig' with {
+                    type: 'danger',
+                    list: messages.danger,
+                    announceOnLoad: true,
+                    ariaLive: 'assertive'
+                } %}
             </div>
         {% endif %}
     {% else %}

--- a/src/Storefront/Resources/views/storefront/utilities/alert.html.twig
+++ b/src/Storefront/Resources/views/storefront/utilities/alert.html.twig
@@ -83,13 +83,37 @@ To display a dismissible button set the value of "dismissible" to true.
         dismissible: true
     } %}
 
+*Trigger Screenreader on page load
+When the alert is rendered on initial page load this option can be used to make the alert message read by the screenreader.
+The role="alert" and aria-live attributes are then set by JavaScript to trigger the screenreader.
+
+    {% sw_include '@Storefront/storefront/utilities/alert.html.twig' with {
+        type: "primary",
+        content: "An important message on initial page load",
+        announceOnLoad: true
+    } %}
+
 #}
 
+{% if ariaLive is not defined %}
+    {% set ariaLive = 'polite' %}
+{% endif %}
+
 {% block utilities_alert %}
-    <div role="alert"
-         aria-live="polite"
-         {# @deprecated tag:v6.7.0 - Class `alert-has-icon` will be removed. Use helper classes `d-flex align-items-center` directly in the template like documented by Bootstrap. #}
-         class="alert {% if type %}alert-{{ type }}{% endif %}{% if dismissible %} alert-dismissible fade show{% endif %}{% if icon != 'error' %} {% if feature('ACCESSIBILITY_TWEAKS') %}d-flex align-items-center{% else %}alert-has-icon{% endif %}{% endif %}">
+    {% set alertAriaJsOptions = {
+        ariaLive: ariaLive,
+    } %}
+    <div
+        {% if announceOnLoad %}
+            data-alert-aria="true"
+            data-alert-aria-options="{{ alertAriaJsOptions|json_encode }}"
+        {% endif %}
+        role="alert"
+        aria-live="{{ ariaLive }}"
+        {# @deprecated tag:v6.7.0 - Class `alert-has-icon` will be removed. Use helper classes `d-flex align-items-center` directly in the template like documented by Bootstrap. #}
+        class="alert {% if type %}alert-{{ type }}{% endif %}{% if dismissible %} alert-dismissible fade show{% endif %}{% if icon != 'error' %} {% if feature('ACCESSIBILITY_TWEAKS') %}d-flex align-items-center{% else %}alert-has-icon{% endif %}{% endif %}"
+    >
+
         {% block utilities_alert_icon %}
             {% if icon != 'false' %}
                 {% set iconCacheSystem = config('core.storefrontSettings.iconCache') %}
@@ -142,18 +166,18 @@ To display a dismissible button set the value of "dismissible" to true.
                     {# @deprecated tag:v6.7.0 - The inner container `alert-content` will be removed. #}
                     {% if not feature('v6.7.0.0') %}</div>{% endif %}
                 {% endblock %}
-
-                {% block utilities_alert_dismissible %}
-                    {% if dismissible %}
-                        <button type="button"
-                                class="btn-close"
-                                data-bs-dismiss="alert"
-                                aria-label="Close">
-                            <span aria-hidden="true"></span>
-                        </button>
-                    {% endif %}
-                {% endblock %}
             </div>
+
+            {% block utilities_alert_dismissible %}
+                {% if dismissible %}
+                    <button type="button"
+                            class="btn-close"
+                            data-bs-dismiss="alert"
+                            aria-label="Close">
+                        <span aria-hidden="true"></span>
+                    </button>
+                {% endif %}
+            {% endblock %}
         {% endblock %}
     </div>
 {% endblock %}


### PR DESCRIPTION
**Backport:** https://github.com/shopware/shopware/pull/14575
Resolves: https://github.com/shopware/shopware/issues/12641
relates #19539

---

### 1. Why is this change necessary?

Manual backport of #14575 to 6.6.x (a11y). The automated cherry-pick conflicts; see below.

### 2. What does this change do, exactly?

Static alert boxes rendered in the DOM on page load were never announced by screenreaders — `role="alert"` only takes effect for alerts inserted by JavaScript. The change introduces a new `announceOnLoad` parameter for `@Storefront/storefront/utilities/alert.html.twig` plus a new (non-async) `AlertAriaPlugin`, which briefly toggles `aria-hidden` on `.alert-content-container` inside the `aria-live` region so the screenreader picks the message up after page load. A new `ariaLive` parameter allows setting the announcement priority (`polite` by default, `assertive` for errors). `announceOnLoad` is enabled for flashbags (base + checkout), login errors, empty listing/cart messages, account overview alerts and newsletter messages.

**Conflict resolution vs. trunk commit e0e7799d841:**
- `RELEASE_INFO-6.7.md`: hunk dropped entirely; the release note for this change belongs to 6.7 and is not maintained on 6.6.x. The file itself is left untouched at its 6.6.x state.
- `src/Storefront/Resources/app/storefront/src/main.js`: trunk's hunk also (re-)added the `CmsGdprVideoElement` registration, which already exists at a different position on 6.6.x. Only the new `PluginManager.register('AlertAria', AlertAriaPlugin, '[data-alert-aria]')` line was inserted (after `AjaxModal`, the analogous position); the synchronous `import AlertAriaPlugin` applied cleanly.
- `src/Storefront/Resources/views/storefront/utilities/alert.html.twig`: applied only the payload (`ariaLive` default, `data-alert-aria` / `data-alert-aria-options` attributes, dynamic `aria-live`, moving `utilities_alert_dismissible` out of `.alert-content-container` so the close button is not inside the temporarily `aria-hidden` region, doc block). Kept the 6.6.x markup around it: the `@deprecated tag:v6.7.0` comment and the `feature('ACCESSIBILITY_TWEAKS')` branch for `d-flex align-items-center` vs. `alert-has-icon`, and the 6.6.x `aria-label="Close"` on the dismiss button (trunk's `'global.default.close'|trans` variant is an unrelated trunk change and was not pulled in).

All other files (`base.html.twig`, `login.html.twig`, `listing.html.twig`, `account/index.html.twig`, `account/newsletter.html.twig`, `checkout/_page.html.twig`, `checkout/cart/index.html.twig`, the new plugin and its Jest test) applied cleanly.

### 3. Describe each step to reproduce the issue or behaviour.

See original PR.

### 4. Please link to the relevant issues (if any).
- relates #12641
- relates #19539

### 5. Checklist
- [x] Cherry-picked from trunk with `-x`, conflicts resolved as described above
- [ ] Tests run locally: ESLint passes for `alert-aria.plugin.js`, `alert-aria.plugin.test.js` and `main.js` (run with `ESLINT_USE_FLAT_CONFIG=false`, since the borrowed `node_modules` ship ESLint 9 while 6.6.x still uses `.eslintrc.js`). The Jest suite could not be executed locally: `jest-resolve` 30 returns `null` for every module in this environment (reproducible on trunk as well), so `jest` aborts with a validation error before running any test. CI must confirm `test/plugin/alert-aria/alert-aria.plugin.test.js`.
- [x] Verified on 6.6.x: `Plugin` base class, `static options` class fields, synchronous `PluginManager.register` (same pattern as `SetBrowserClassPlugin`), and the `.alert-content-container` element all exist; `tests/integration/Storefront/Controller/ControllerRateLimiterTest.php` matches `div[@class="alert-content-container"]`, which is unchanged.
