### PR TITLE
fix(framework): keep dal validate running for invalid definitions

### DIFF
--- a/src/Core/Framework/DataAbstractionLayer/DefinitionValidator.php
+++ b/src/Core/Framework/DataAbstractionLayer/DefinitionValidator.php
@@ -216,6 +216,16 @@ class DefinitionValidator
 
             $violations[$definitionClass] = [];
 
+            if (!$schema->hasTable($definition->getEntityName())) {
+                $violations[$definitionClass][] = \sprintf(
+                    'Table "%s" referenced by definition but not found in schema',
+                    $definition->getEntityName()
+                );
+                $violations = array_merge_recursive($violations, $this->checkEntityNameConstant($definition));
+
+                continue;
+            }
+
             $violations = array_merge_recursive($violations, $this->validateSchema($definition, $schema));
 
             $violations = array_merge_recursive($violations, $this->validatePrimaryKeyConsistency($definition, $schema));
@@ -1295,10 +1305,7 @@ class DefinitionValidator
         $definitionClass = $definition->getClass();
         // Definition has constant ENTITY_NAME and is not empty
         if (!\defined($definitionClass . '::ENTITY_NAME') || \constant($definitionClass . '::ENTITY_NAME') === '') {
-            $violations = array_merge_recursive(
-                $violations,
-                [$definitionClass => [\sprintf('ENTITY_NAME constant Missing in %s', $definitionClass)]]
-            );
+            return [$definitionClass => [\sprintf('ENTITY_NAME constant Missing in %s', $definitionClass)]];
         }
 
         // GetEntityName returns same Value as ENTITY_NAME
@@ -1353,6 +1360,10 @@ class DefinitionValidator
             && !$association->getFlag(RestrictDelete::class)
             && !$association->getFlag(SetNullOnDelete::class)
         ) {
+            return $associationViolations;
+        }
+
+        if (!$schema->hasTable($reference->getEntityName())) {
             return $associationViolations;
         }
 

--- a/tests/unit/Core/Framework/DataAbstractionLayer/DefinitionValidatorTest.php
+++ b/tests/unit/Core/Framework/DataAbstractionLayer/DefinitionValidatorTest.php
@@ -116,6 +116,35 @@ class DefinitionValidatorTest extends TestCase
 
         // When table doesn't exist in the schema, validatePrimaryKeyConsistency skips validation
         static::assertEmpty($primaryKeyViolations, 'Expected no primary key violations when table does not exist, but got: ' . implode(', ', $primaryKeyViolations));
+
+        static::assertContains(
+            'Table "definition_validator_test" referenced by definition but not found in schema',
+            $definitionViolations
+        );
+    }
+
+    public function testMissingEntityNameConstantIsReportedWithoutFatalError(): void
+    {
+        $definition = new class extends EntityDefinition {
+            public function getEntityName(): string
+            {
+                return 'definition_validator_test';
+            }
+
+            protected function defineFields(): FieldCollection
+            {
+                return new FieldCollection([]);
+            }
+        };
+
+        $validator = $this->createValidatorWithTable($definition, ['id']);
+
+        $violations = $validator->validate();
+
+        static::assertContains(
+            \sprintf('ENTITY_NAME constant Missing in %s', $definition->getClass()),
+            $violations[$definition->getClass()] ?? []
+        );
     }
 
     public function testPrimaryKeyValidationSkipsNonStorageAwareFields(): void


### PR DESCRIPTION
### 1. Why is this change necessary?

`dal:validate` aborts instead of reporting validation violations when a definition's table is missing or when an extension definition does not declare `ENTITY_NAME`.

### 2. What does this change do, exactly?

- Reports missing definition tables and continues validating the remaining definitions.
- Avoids schema access for missing referenced tables during foreign-key validation.
- Reports a missing `ENTITY_NAME` constant without dereferencing it a second time.
- Adds regression coverage for both fatal-error paths.

### 3. Describe each step to reproduce the issue or behaviour.

1. Register an `EntityDefinition` whose table is absent from the schema, or whose class has no `ENTITY_NAME` constant.
2. Run `bin/console dal:validate`.
3. Observe that validation reports the violation and completes instead of aborting with `TableDoesNotExist` or an undefined-constant fatal error.

### 4. Please link to the relevant issues (if any).

- fixes #15705
- fixes #19725

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have updated developer-facing release notes if this change is **relevant** for external developers: this bug fix restores intended validator behaviour and requires no release-note entry.
- [x] I have written or adjusted the documentation and agent skills according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
