### PR TITLE
fix(administration): default the interface theme to light

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/composables/use-theme.spec.ts
+++ b/src/Administration/Resources/app/administration/src/app/composables/use-theme.spec.ts
@@ -11,7 +11,7 @@ describe('src/app/composables/use-theme.ts', () => {
     });
 
     afterEach(async () => {
-        useTheme().setTheme('system');
+        useTheme().setTheme('light');
         await nextTick();
 
         localStorage.removeItem('mt-theme');
@@ -21,10 +21,10 @@ describe('src/app/composables/use-theme.ts', () => {
         expect(useTheme()).toBe(useTheme());
     });
 
-    it('defaults to the system preference', () => {
+    it('defaults to the light theme', () => {
         const { theme, resolvedTheme } = useTheme();
 
-        expect(theme.value).toBe('system');
+        expect(theme.value).toBe('light');
         expect(resolvedTheme.value).toBe('light');
     });
 
@@ -78,11 +78,11 @@ describe('src/app/composables/use-theme.ts', () => {
     });
 
     it('keeps the current preference when nothing is persisted', async () => {
-        useTheme().setTheme('light');
+        useTheme().setTheme('system');
 
         await useTheme().loadUserTheme();
 
-        expect(useTheme().theme.value).toBe('light');
+        expect(useTheme().theme.value).toBe('system');
     });
 
     it('ignores invalid persisted values', async () => {
@@ -94,6 +94,6 @@ describe('src/app/composables/use-theme.ts', () => {
 
         await useTheme().loadUserTheme();
 
-        expect(useTheme().theme.value).toBe('system');
+        expect(useTheme().theme.value).toBe('light');
     });
 });

--- a/src/Administration/Resources/app/administration/src/app/composables/use-theme.spec.ts
+++ b/src/Administration/Resources/app/administration/src/app/composables/use-theme.spec.ts
@@ -77,15 +77,25 @@ describe('src/app/composables/use-theme.ts', () => {
         expect(useTheme().theme.value).toBe('dark');
     });
 
-    it('keeps the current preference when nothing is persisted', async () => {
+    it('falls back to the default when nothing is persisted', async () => {
         useTheme().setTheme('system');
 
         await useTheme().loadUserTheme();
 
-        expect(useTheme().theme.value).toBe('system');
+        expect(useTheme().theme.value).toBe('light');
     });
 
-    it('ignores invalid persisted values', async () => {
+    it('keeps the current preference when the request fails', async () => {
+        (Shopware.Service('userConfigService').search as jest.Mock).mockResolvedValueOnce(undefined);
+
+        useTheme().setTheme('dark');
+
+        await useTheme().loadUserTheme();
+
+        expect(useTheme().theme.value).toBe('dark');
+    });
+
+    it('falls back to the default for invalid persisted values', async () => {
         (Shopware.Service('userConfigService').search as jest.Mock).mockResolvedValueOnce({
             data: {
                 [USER_THEME_CONFIG_KEY]: { theme: 'not-a-theme' },

--- a/src/Administration/Resources/app/administration/src/app/composables/use-theme.ts
+++ b/src/Administration/Resources/app/administration/src/app/composables/use-theme.ts
@@ -16,6 +16,9 @@ export const USER_THEME_CONFIG_KEY = 'core.userTheme';
  * Preference used before the user has chosen a theme. The Administration
  * starts in light mode instead of following the operating system.
  *
+ * Mirrored by the inline pre-boot script in
+ * `Resources/shared/page-loading-screen/page-loading-screen.js`, keep both in sync.
+ *
  * @private
  */
 export const DEFAULT_THEME: Theme = 'light';

--- a/src/Administration/Resources/app/administration/src/app/composables/use-theme.ts
+++ b/src/Administration/Resources/app/administration/src/app/composables/use-theme.ts
@@ -42,11 +42,19 @@ function isTheme(value: unknown): value is Theme {
 
 async function loadUserTheme(): Promise<void> {
     const response = await Shopware.Service('userConfigService').search([USER_THEME_CONFIG_KEY]);
-    const value = response?.data?.[USER_THEME_CONFIG_KEY] as { theme?: unknown } | undefined;
 
-    if (value && isTheme(value.theme)) {
-        useTheme().setTheme(value.theme);
+    // The service swallows request errors and resolves without a response.
+    // Keep the current preference then instead of resetting a valid choice.
+    if (!response) {
+        return;
     }
+
+    const value = response.data?.[USER_THEME_CONFIG_KEY] as { theme?: unknown } | undefined;
+
+    // `localStorage` is shared by every user of the browser, so a user without
+    // a server-side preference has to fall back to the default instead of
+    // inheriting the choice of whoever logged in here before.
+    useTheme().setTheme(value && isTheme(value.theme) ? value.theme : DEFAULT_THEME);
 }
 
 async function saveUserTheme(theme: Theme): Promise<void> {

--- a/src/Administration/Resources/app/administration/src/app/composables/use-theme.ts
+++ b/src/Administration/Resources/app/administration/src/app/composables/use-theme.ts
@@ -12,6 +12,14 @@ import type { Theme, UseThemeReturn } from '@shopware-ag/meteor-component-librar
  */
 export const USER_THEME_CONFIG_KEY = 'core.userTheme';
 
+/**
+ * Preference used before the user has chosen a theme. The Administration
+ * starts in light mode instead of following the operating system.
+ *
+ * @private
+ */
+export const DEFAULT_THEME: Theme = 'light';
+
 type UseAdminThemeReturn = UseThemeReturn & {
     /**
      * Loads the persisted theme preference of the current user from the
@@ -61,7 +69,7 @@ export default function useTheme(): UseAdminThemeReturn {
         const scope = effectScope(true);
 
         themeState = {
-            ...scope.run(() => useMeteorTheme())!,
+            ...scope.run(() => useMeteorTheme({ defaultTheme: DEFAULT_THEME }))!,
             loadUserTheme,
             saveUserTheme,
         };

--- a/src/Administration/Resources/app/administration/src/app/init/page-loading-screen.spec.ts
+++ b/src/Administration/Resources/app/administration/src/app/init/page-loading-screen.spec.ts
@@ -1,0 +1,44 @@
+/**
+ * @sw-package framework
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+
+const script = fs.readFileSync(
+    path.resolve(__dirname, '../../../../../shared/page-loading-screen/page-loading-screen.js'),
+    'utf-8',
+);
+
+function runPageLoadingScreen(prefersDark: boolean): void {
+    Object.defineProperty(window, 'matchMedia', {
+        configurable: true,
+        writable: true,
+        value: jest.fn(() => ({ matches: prefersDark })),
+    });
+
+    // The inline script is not a module, so it can only be executed from source.
+    // eslint-disable-next-line @typescript-eslint/no-implied-eval, @typescript-eslint/no-unsafe-call
+    new Function(script)();
+}
+
+describe('shared/page-loading-screen/page-loading-screen.js', () => {
+    afterEach(() => {
+        localStorage.removeItem('mt-theme');
+        document.documentElement.removeAttribute('data-theme');
+    });
+
+    it.each([
+        { stored: null, prefersDark: true, expected: 'light' },
+        { stored: 'system', prefersDark: true, expected: 'dark' },
+        { stored: 'dark', prefersDark: false, expected: 'dark' },
+        { stored: 'not-a-theme', prefersDark: true, expected: 'light' },
+    ])('applies "$expected" for stored "$stored" when prefersDark is $prefersDark', ({ stored, prefersDark, expected }) => {
+        if (stored !== null) {
+            localStorage.setItem('mt-theme', stored);
+        }
+
+        runPageLoadingScreen(prefersDark);
+
+        expect(document.documentElement.getAttribute('data-theme')).toBe(expected);
+    });
+});

--- a/src/Administration/Resources/shared/page-loading-screen/page-loading-screen.js
+++ b/src/Administration/Resources/shared/page-loading-screen/page-loading-screen.js
@@ -4,9 +4,14 @@
 
 (() => {
     try {
-        let theme = window.localStorage.getItem('mt-theme');
+        // Mirrors `useTheme()` in `app/administration/src/app/composables/use-theme.ts`:
+        // the `'light'` fallback has to stay in sync with `DEFAULT_THEME` there.
+        const storedTheme = window.localStorage.getItem('mt-theme');
+        let theme = 'light';
 
-        if (theme !== 'light' && theme !== 'dark') {
+        if (storedTheme === 'light' || storedTheme === 'dark') {
+            theme = storedTheme;
+        } else if (storedTheme === 'system') {
             theme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
         }
 


### PR DESCRIPTION
### 1. Why is this change necessary?

The interface theme started on "System" for every user who had not picked one yet. On a dark operating system the admin then booted into dark mode while extensions that do not support dark mode kept rendering light — a mismatch that will be common for a while as extensions catch up. Light is the safer initial value.

### 2. What does this change do, exactly?

This only changes the **initial** value of the theme setting. Live behaviour is untouched: `"System"` and `"Dark"` stay selectable, and `"System"` still follows the operating system at runtime.

1. `use-theme.ts` wrapped Meteor's `useTheme()` without options, and Meteor defaults `defaultTheme` to `"system"`. The wrapper now passes an explicit `defaultTheme: 'light'` (exported as `DEFAULT_THEME`).
2. That alone has no effect, because the preference is also cached in `localStorage` and a stored value always wins over the default. `loadUserTheme()` overrode it only when the server had a preference, so a stored `"system"` survived a database reset and was inherited by every newly created user — `localStorage` is shared by all users of a browser. The user configuration is now authoritative: no stored preference means the default. A failed request still keeps the current preference, so a valid choice is not reset on a network error.
3. The inline pre-boot script in `page-loading-screen.js` applies the same rule before the bundle loads: a stored `light` or `dark` wins, `system` follows the operating system, a missing or unknown value is `light`. Previously a missing value followed the operating system, so on a dark OS the loading screen rendered dark and the page snapped to light once the bundle booted. No `localStorage` write is forced to cover this: the composable only writes on an actual change, and an empty key now means the default in both places.

Users with a saved preference are unaffected. Users whose theme only ever lived in `localStorage` fall back to light on their next login.

### 3. Describe each step to reproduce the issue or behaviour.

1. Set the operating system to dark appearance.
2. Open the Administration and select "System" as the interface theme, so `localStorage` holds `mt-theme: "system"`.
3. Reset the database (`composer init:db`) and create a new user.
4. Log in as that user and open the profile settings.

Before: the theme select shows "System" and the admin renders dark, although the new user never chose it. After: it shows "Light" and renders light.

Loading screen flash:

1. Set the operating system to dark appearance and clear `localStorage` for the Administration.
2. Open `/admin`.

Before: the loading screen is dark and the login page snaps to light once the bundle has booted, on every load. After: light throughout.

### 4. Please link to the relevant issues (if any).

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
