### PR TITLE
test(framework): add a line item setter to the order builder

### DIFF
--- a/src/Core/Test/Integration/Builder/Order/OrderBuilder.php
+++ b/src/Core/Test/Integration/Builder/Order/OrderBuilder.php
@@ -82,6 +82,16 @@ class OrderBuilder
         $this->add('totalRounding', json_decode(json_encode(new CashRoundingConfig(2, 0.01, true), \JSON_THROW_ON_ERROR), true, 512, \JSON_THROW_ON_ERROR));
     }
 
+    /**
+     * @param array<string, mixed> $lineItem
+     */
+    public function addLineItem(array $lineItem): self
+    {
+        $this->lineItems[] = $lineItem;
+
+        return $this;
+    }
+
     public function price(float $amount): self
     {
         $this->price = new CartPrice(


### PR DESCRIPTION
### 1. Why is this change necessary?

The integration OrderBuilder offers setters for transactions, addresses and prices, but no way to add line items. Downstream test suites that need order line items are forced to extend the builder, which its `@final` annotation forbids.

See https://github.com/shopware/SwagCommercial/pull/3891 to make tests great again (no more baseline surprise in Commercial)

### 2. What does this change do, exactly?

Adds `OrderBuilder::addLineItem()`, appending one raw line-item payload per call, consistent with the existing `addTransaction()`/`addAddress()` style.

### 3. Describe each step to reproduce the issue or behaviour.

Build an order with line items through the integration OrderBuilder: there is no public API for it.

### 4. Please link to the relevant issues (if any).

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
