### PR TITLE
feat(framework): add reversible plugin migrations

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -103,6 +103,28 @@ Two consequences for operators:
 - `translation:install` now exits with a non-zero code when none of the requested locales can be installed — that is, when neither the repository offers them nor the filesystem carries them. Previously it printed "All translations are already up to date." and exited `0`. Scripts that check the exit code are affected. The install route already answered such a request with an error.
 - A requested locale that the repository does not offer and that has no files on the filesystem is reported and left out rather than installed as a language without translations. `POST /api/_action/translation/install` keeps reporting those locales in its `unavailable` list, but a locale whose files were provisioned offline no longer appears there, because it can be installed. Its `skipped` list now names the requested locales that were installed without a download, instead of every locale in the local metadata that was not updated.
 
+### Plugin migrations can now be reversible
+
+`Shopware\Core\Framework\Migration\Reversible\Migration` is a new base class for plugin migrations that declare how to undo themselves. `up()` runs before plugin install and update, `down()` runs after a destructive uninstall in reverse order, and an uninstall that keeps user data skips the rollback so a reinstall resumes from the same state. History is tracked per plugin in the new `plugin_migration` table.
+
+Both methods receive a context object instead of a bare `Connection`, so further capabilities can be added later without breaking the plugin-facing signature:
+
+```php
+public function up(UpMigrationContext $context): void
+{
+    $context->connection->executeStatement('CREATE TABLE IF NOT EXISTS `swag_example` (…)');
+}
+
+public function down(DownMigrationContext $context): void
+{
+    $context->connection->executeStatement('DROP TABLE IF EXISTS `swag_example`');
+}
+```
+
+`MigrationStep` is unchanged and both kinds of migration can live side by side in the same `<Plugin>/src/Migration` directory. Scaffold one with `bin/console database:create-reversible-migration --plugin=SwagExample`, and apply pending ones outside a plugin update with `bin/console database:migrate-reversible`.
+
+Timestamps must be unique within a plugin and must not change once applied: Shopware rejects duplicate timestamps, changed timestamps, applied-but-deleted classes and migrations inserted before the latest applied one, so always append new migrations. `UpMigrationContext::$isInstallation` reports whether the plugin is being installed for the first time — unlike `MigrationStep::isInstallation()`, which refers to Shopware itself. Reversible `up()` runs before the plugin's `install()`/`update()` and before its legacy `MigrationStep` migrations, so it must not depend on a legacy migration introduced in the same release. MySQL implicitly commits most DDL, so keep every `up()`/`down()` self-contained and retryable and guard DDL with `IF EXISTS`/`IF NOT EXISTS`. There is intentionally no CLI rollback: `down()` stays tied to a destructive uninstall.
+
 ## API
 
 ### Store API context token response header is restricted on cacheable reads

--- a/src/Core/Framework/DataAbstractionLayer/DefinitionValidator.php
+++ b/src/Core/Framework/DataAbstractionLayer/DefinitionValidator.php
@@ -113,6 +113,7 @@ class DefinitionValidator
         'messenger_messages',
         'messenger_stats',
         'payment_token',
+        'plugin_migration',
         'refresh_token',
         'usage_data_entity_deletion',
         'one_time_tasks',

--- a/src/Core/Framework/DependencyInjection/migration-reversible.php
+++ b/src/Core/Framework/DependencyInjection/migration-reversible.php
@@ -1,0 +1,57 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\DependencyInjection;
+
+use Doctrine\DBAL\Connection;
+use Psr\Clock\ClockInterface;
+use Shopware\Core\Framework\Migration\Reversible\Command\CreateReversibleMigrationCommand;
+use Shopware\Core\Framework\Migration\Reversible\Command\ReversibleMigrationCommand;
+use Shopware\Core\Framework\Migration\Reversible\MigrationLock;
+use Shopware\Core\Framework\Migration\Reversible\MigrationProvider;
+use Shopware\Core\Framework\Migration\Reversible\MigrationRunner;
+use Shopware\Core\Framework\Migration\Reversible\MigrationStateStore;
+use Shopware\Core\Framework\Plugin\KernelPluginCollection;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Symfony\Component\Filesystem\Filesystem;
+
+use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $services = $containerConfigurator->services();
+
+    $services->set(MigrationProvider::class);
+
+    $services->set(MigrationStateStore::class)
+        ->args([
+            service(Connection::class),
+        ]);
+
+    $services->set(MigrationLock::class)
+        ->args([
+            service(Connection::class),
+        ]);
+
+    $services->set(MigrationRunner::class)
+        ->public()
+        ->args([
+            service(MigrationProvider::class),
+            service(MigrationStateStore::class),
+            service(MigrationLock::class),
+            service(Connection::class),
+        ]);
+
+    $services->set(ReversibleMigrationCommand::class)
+        ->args([
+            service(MigrationRunner::class),
+            service(KernelPluginCollection::class),
+        ])
+        ->tag('console.command');
+
+    $services->set(CreateReversibleMigrationCommand::class)
+        ->args([
+            service(KernelPluginCollection::class),
+            service(Filesystem::class),
+            service(ClockInterface::class),
+        ])
+        ->tag('console.command');
+};

--- a/src/Core/Framework/DependencyInjection/plugin.php
+++ b/src/Core/Framework/DependencyInjection/plugin.php
@@ -10,6 +10,7 @@ use Shopware\Core\Framework\App\ActiveAppsLoader;
 use Shopware\Core\Framework\App\Source\SourceResolver;
 use Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry;
 use Shopware\Core\Framework\Migration\MigrationCollectionLoader;
+use Shopware\Core\Framework\Migration\Reversible\MigrationRunner as ReversibleMigrationRunner;
 use Shopware\Core\Framework\Plugin\Aggregate\PluginTranslation\PluginTranslationDefinition;
 use Shopware\Core\Framework\Plugin\BundleConfigGenerator;
 use Shopware\Core\Framework\Plugin\BundleConfigStyleFileResolver;
@@ -150,6 +151,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             service(RequestStack::class),
             service(CustomFieldSetPersister::class),
             service(ClockInterface::class),
+            service(ReversibleMigrationRunner::class),
         ]);
 
     $services->set(PluginManagementService::class)

--- a/src/Core/Framework/Framework.php
+++ b/src/Core/Framework/Framework.php
@@ -78,6 +78,7 @@ class Framework extends Bundle
         $phpLoader->load('acl.php');
         $phpLoader->load('api.php');
         $phpLoader->load('services.php');
+        $phpLoader->load('migration-reversible.php');
         $phpLoader->load('cache.php');
         $phpLoader->load('app.php');
         $phpLoader->load('custom-field.php');

--- a/src/Core/Framework/Migration/MigrationException.php
+++ b/src/Core/Framework/Migration/MigrationException.php
@@ -27,6 +27,16 @@ class MigrationException extends HttpException
     final public const LOGIC_ERROR = 'FRAMEWORK__LOGIC_ERROR';
     final public const MIGRATION_FILE_DOES_NOT_EXIST = 'FRAMEWORK__MIGRATION_FILE_DOES_NOT_EXIST';
 
+    private const REVERSIBLE_MIGRATION_NOT_INSTANTIABLE = 'FRAMEWORK__REVERSIBLE_MIGRATION_NOT_INSTANTIABLE';
+    private const REVERSIBLE_MIGRATION_INVALID_TIMESTAMP = 'FRAMEWORK__REVERSIBLE_MIGRATION_INVALID_TIMESTAMP';
+    private const REVERSIBLE_MIGRATION_DUPLICATE_TIMESTAMP = 'FRAMEWORK__REVERSIBLE_MIGRATION_DUPLICATE_TIMESTAMP';
+    private const REVERSIBLE_MIGRATION_OUT_OF_ORDER = 'FRAMEWORK__REVERSIBLE_MIGRATION_OUT_OF_ORDER';
+    private const REVERSIBLE_MIGRATION_TIMESTAMP_CHANGED = 'FRAMEWORK__REVERSIBLE_MIGRATION_TIMESTAMP_CHANGED';
+    private const REVERSIBLE_MIGRATION_MISSING_APPLIED = 'FRAMEWORK__REVERSIBLE_MIGRATION_MISSING_APPLIED';
+    private const REVERSIBLE_MIGRATION_LOCK_NOT_ACQUIRED = 'FRAMEWORK__REVERSIBLE_MIGRATION_LOCK_NOT_ACQUIRED';
+    private const REVERSIBLE_MIGRATION_INVALID_STATE = 'FRAMEWORK__REVERSIBLE_MIGRATION_INVALID_STATE';
+    private const MIGRATION_DIRECTORY_NOT_READABLE = 'FRAMEWORK__MIGRATION_DIRECTORY_NOT_READABLE';
+
     public static function invalidArgument(string $message): self
     {
         return new self(
@@ -171,6 +181,95 @@ class MigrationException extends HttpException
             self::MIGRATION_FILE_DOES_NOT_EXIST,
             'The provided migration file does not exist: "{{ path }}"',
             ['path' => $path]
+        );
+    }
+
+    public static function migrationDirectoryNotReadable(string $directory): self
+    {
+        return new self(
+            Response::HTTP_INTERNAL_SERVER_ERROR,
+            self::MIGRATION_DIRECTORY_NOT_READABLE,
+            'Migration directory "{{ directory }}" could not be read.',
+            ['directory' => $directory]
+        );
+    }
+
+    public static function reversibleMigrationNotInstantiable(string $class): self
+    {
+        return new self(
+            Response::HTTP_INTERNAL_SERVER_ERROR,
+            self::REVERSIBLE_MIGRATION_NOT_INSTANTIABLE,
+            'Reversible migration "{{ class }}" must be instantiable without constructor arguments.',
+            ['class' => $class]
+        );
+    }
+
+    public static function reversibleMigrationInvalidTimestamp(string $class, int $timestamp): self
+    {
+        return new self(
+            Response::HTTP_INTERNAL_SERVER_ERROR,
+            self::REVERSIBLE_MIGRATION_INVALID_TIMESTAMP,
+            'Migration timestamp must be between 1 and 2147483647 to ensure migration order is deterministic on every system, but "{{ timestamp }}" was given for "{{ class }}".',
+            ['class' => $class, 'timestamp' => $timestamp]
+        );
+    }
+
+    public static function duplicateMigrationTimestamp(string $plugin, int $timestamp, string $first, string $second): self
+    {
+        return new self(
+            Response::HTTP_INTERNAL_SERVER_ERROR,
+            self::REVERSIBLE_MIGRATION_DUPLICATE_TIMESTAMP,
+            'Plugin "{{ plugin }}" contains two reversible migrations with timestamp {{ timestamp }}: "{{ first }}" and "{{ second }}".',
+            ['plugin' => $plugin, 'timestamp' => $timestamp, 'first' => $first, 'second' => $second]
+        );
+    }
+
+    public static function migrationOutOfOrder(string $plugin, string $class, int $timestamp, int $latestApplied): self
+    {
+        return new self(
+            Response::HTTP_INTERNAL_SERVER_ERROR,
+            self::REVERSIBLE_MIGRATION_OUT_OF_ORDER,
+            'Reversible migration "{{ class }}" ({{ timestamp }}) for plugin "{{ plugin }}" is older than the latest applied migration ({{ latestApplied }}). Add new migrations with a later timestamp.',
+            ['plugin' => $plugin, 'class' => $class, 'timestamp' => $timestamp, 'latestApplied' => $latestApplied]
+        );
+    }
+
+    public static function migrationTimestampChanged(string $class, int $recorded, int $declared): self
+    {
+        return new self(
+            Response::HTTP_INTERNAL_SERVER_ERROR,
+            self::REVERSIBLE_MIGRATION_TIMESTAMP_CHANGED,
+            'Applied reversible migration "{{ class }}" changed its creation timestamp from {{ recorded }} to {{ declared }}. Restore the recorded timestamp.',
+            ['class' => $class, 'recorded' => $recorded, 'declared' => $declared]
+        );
+    }
+
+    public static function missingAppliedMigration(string $plugin, string $class): self
+    {
+        return new self(
+            Response::HTTP_INTERNAL_SERVER_ERROR,
+            self::REVERSIBLE_MIGRATION_MISSING_APPLIED,
+            'Applied reversible migration "{{ class }}" for plugin "{{ plugin }}" is no longer available. Restore the migration class before continuing.',
+            ['plugin' => $plugin, 'class' => $class]
+        );
+    }
+
+    public static function migrationLockNotAcquired(string $plugin): self
+    {
+        return new self(
+            Response::HTTP_INTERNAL_SERVER_ERROR,
+            self::REVERSIBLE_MIGRATION_LOCK_NOT_ACQUIRED,
+            'Could not acquire the reversible migration lock for plugin "{{ plugin }}".',
+            ['plugin' => $plugin]
+        );
+    }
+
+    public static function invalidMigrationState(): self
+    {
+        return new self(
+            Response::HTTP_INTERNAL_SERVER_ERROR,
+            self::REVERSIBLE_MIGRATION_INVALID_STATE,
+            'The reversible migration state contains an invalid row.'
         );
     }
 }

--- a/src/Core/Framework/Migration/Reversible/Command/CreateReversibleMigrationCommand.php
+++ b/src/Core/Framework/Migration/Reversible/Command/CreateReversibleMigrationCommand.php
@@ -1,0 +1,89 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\Migration\Reversible\Command;
+
+use Psr\Clock\ClockInterface;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Migration\MigrationException;
+use Shopware\Core\Framework\Plugin\KernelPluginCollection;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Filesystem\Filesystem;
+
+#[Package('framework')]
+#[AsCommand(
+    name: 'database:create-reversible-migration',
+    description: 'Creates a new reversible migration file for a plugin',
+)]
+class CreateReversibleMigrationCommand extends Command
+{
+    use ResolvePluginTrait;
+
+    /**
+     * @internal
+     */
+    public function __construct(
+        private readonly KernelPluginCollection $kernelPluginCollection,
+        private readonly Filesystem $filesystem,
+        private readonly ClockInterface $clock,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addOption('plugin', 'p', InputOption::VALUE_REQUIRED, 'The name of the plugin the migration belongs to')
+            ->addOption(
+                'name',
+                '',
+                InputOption::VALUE_REQUIRED,
+                'An optional descriptive name for the migration which will be used as a suffix for the filename.'
+            );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $pluginName = $input->getOption('plugin');
+        if (!\is_string($pluginName) || $pluginName === '') {
+            throw MigrationException::invalidArgument('Please specify the plugin the migration belongs to via --plugin.');
+        }
+
+        $name = (string) ($input->getOption('name') ?? '');
+        if (!preg_match('/^[a-zA-Z0-9_]*$/', $name)) {
+            throw MigrationException::invalidArgument('Migration name contains forbidden characters!');
+        }
+
+        $plugin = $this->resolvePlugin($this->kernelPluginCollection, $pluginName);
+
+        $directory = $plugin->getMigrationPath();
+        $namespace = $plugin->getMigrationNamespace();
+        $timestamp = $this->clock->now()->getTimestamp();
+
+        $path = rtrim($directory, '/') . '/Migration' . $timestamp . $name . '.php';
+        if ($this->filesystem->exists($path)) {
+            throw MigrationException::invalidArgument(\sprintf('The migration file "%s" already exists.', $path));
+        }
+
+        $template = file_get_contents(__DIR__ . '/../Template/MigrationTemplateReversiblePlugin.txt');
+        if ($template === false) {
+            throw MigrationException::migrationFileDoesNotExist(__DIR__ . '/../Template/MigrationTemplateReversiblePlugin.txt');
+        }
+
+        $this->filesystem->dumpFile($path, str_replace(
+            ['%%timestamp%%', '%%name%%', '%%namespace%%'],
+            [(string) $timestamp, $name, $namespace],
+            $template
+        ));
+
+        $io->success(\sprintf('Migration created: "%s"', $path));
+
+        return self::SUCCESS;
+    }
+}

--- a/src/Core/Framework/Migration/Reversible/Command/ResolvePluginTrait.php
+++ b/src/Core/Framework/Migration/Reversible/Command/ResolvePluginTrait.php
@@ -1,0 +1,39 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\Migration\Reversible\Command;
+
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Migration\MigrationException;
+use Shopware\Core\Framework\Plugin;
+use Shopware\Core\Framework\Plugin\KernelPluginCollection;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+trait ResolvePluginTrait
+{
+    /**
+     * Resolves a plugin by name, accepting a unique prefix, matching database:create-migration.
+     */
+    private function resolvePlugin(KernelPluginCollection $plugins, string $pluginName): Plugin
+    {
+        $matches = array_filter($plugins->all(), static fn (Plugin $plugin) => mb_strpos($plugin->getName(), $pluginName) === 0);
+
+        if ($matches === []) {
+            throw MigrationException::pluginNotFound($pluginName);
+        }
+
+        if (\count($matches) > 1) {
+            $exact = array_filter($matches, static fn (Plugin $plugin) => $pluginName === $plugin->getName());
+
+            if (\count($exact) !== 1) {
+                throw MigrationException::moreThanOnePluginFound($pluginName, array_keys($matches));
+            }
+
+            $matches = $exact;
+        }
+
+        return array_values($matches)[0];
+    }
+}

--- a/src/Core/Framework/Migration/Reversible/Command/ReversibleMigrationCommand.php
+++ b/src/Core/Framework/Migration/Reversible/Command/ReversibleMigrationCommand.php
@@ -1,0 +1,89 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\Migration\Reversible\Command;
+
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Migration\MigrationException;
+use Shopware\Core\Framework\Migration\Reversible\MigrationRunner;
+use Shopware\Core\Framework\Plugin;
+use Shopware\Core\Framework\Plugin\KernelPluginCollection;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+#[Package('framework')]
+#[AsCommand(
+    name: 'database:migrate-reversible',
+    description: 'Executes pending reversible migrations of a plugin',
+)]
+class ReversibleMigrationCommand extends Command
+{
+    use ResolvePluginTrait;
+
+    /**
+     * @internal
+     */
+    public function __construct(
+        private readonly MigrationRunner $migrationRunner,
+        private readonly KernelPluginCollection $kernelPluginCollection,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addArgument('plugin', InputArgument::OPTIONAL, 'The name of the plugin to migrate')
+            ->addOption('all', 'a', InputOption::VALUE_NONE, 'Migrate every active plugin');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        foreach ($this->collectPlugins($input) as $plugin) {
+            $applied = $this->migrationRunner->up($plugin);
+
+            if ($applied === []) {
+                $io->writeln(\sprintf('%s is already up to date.', $plugin->getName()));
+
+                continue;
+            }
+
+            $io->section($plugin->getName());
+            $io->listing($applied);
+        }
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * @return list<Plugin>
+     */
+    private function collectPlugins(InputInterface $input): array
+    {
+        $pluginName = $input->getArgument('plugin');
+
+        if ($input->getOption('all')) {
+            if ($pluginName !== null) {
+                throw MigrationException::invalidArgument('Pass either a plugin name or the --all option, not both.');
+            }
+
+            // getActives() is keyed by class name, so sort by plugin name for a deterministic order
+            $plugins = array_values($this->kernelPluginCollection->getActives());
+            usort($plugins, static fn (Plugin $a, Plugin $b): int => $a->getName() <=> $b->getName());
+
+            return $plugins;
+        }
+
+        if ($pluginName === null) {
+            throw MigrationException::invalidArgument('Missing plugin name or --all option.');
+        }
+
+        return [$this->resolvePlugin($this->kernelPluginCollection, (string) $pluginName)];
+    }
+}

--- a/src/Core/Framework/Migration/Reversible/DownMigrationContext.php
+++ b/src/Core/Framework/Migration/Reversible/DownMigrationContext.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\Migration\Reversible;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * Passed to Migration::down().
+ */
+#[Package('framework')]
+final readonly class DownMigrationContext
+{
+    public function __construct(
+        public Connection $connection,
+        public bool $keepUserData,
+    ) {
+    }
+}

--- a/src/Core/Framework/Migration/Reversible/ExecutedMigration.php
+++ b/src/Core/Framework/Migration/Reversible/ExecutedMigration.php
@@ -1,0 +1,21 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\Migration\Reversible;
+
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+final readonly class ExecutedMigration
+{
+    /**
+     * @param class-string<Migration> $class
+     */
+    public function __construct(
+        public string $class,
+        public int $creationTimestamp,
+    ) {
+    }
+}

--- a/src/Core/Framework/Migration/Reversible/Migration.php
+++ b/src/Core/Framework/Migration/Reversible/Migration.php
@@ -1,0 +1,35 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\Migration\Reversible;
+
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * Base class for reversible plugin migrations.
+ *
+ * Unlike MigrationStep, every migration declares how to undo itself. up() runs before plugin install
+ * and update, down() runs after a destructive plugin uninstall, in reverse order.
+ *
+ * Implementations must be instantiable without constructor arguments and must keep their creation
+ * timestamp stable once applied: down() is loaded from that historical class during uninstall.
+ */
+#[Package('framework')]
+abstract class Migration
+{
+    /**
+     * Unique, positive, and never changed after the migration has been applied.
+     */
+    abstract public function getCreationTimestamp(): int;
+
+    /**
+     * MySQL implicitly commits most DDL, so a chain of migrations cannot be wrapped in one
+     * transaction. Keep this method self-contained and retryable, and guard DDL with IF EXISTS.
+     */
+    abstract public function up(UpMigrationContext $context): void;
+
+    /**
+     * Runs while the plugin is being uninstalled, so it must not lazily load other plugin files.
+     * It can restore the schema shape, but not rows destroyed by up().
+     */
+    abstract public function down(DownMigrationContext $context): void;
+}

--- a/src/Core/Framework/Migration/Reversible/MigrationLock.php
+++ b/src/Core/Framework/Migration/Reversible/MigrationLock.php
@@ -1,0 +1,62 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\Migration\Reversible;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Migration\MigrationException;
+use Shopware\Core\Framework\Util\Hasher;
+
+/**
+ * Serializes migration work per plugin with a MySQL named lock.
+ *
+ * The lock is advisory and scoped to a single database server, so it does not serialize across the
+ * nodes of a multi-primary cluster such as Galera or MySQL Group Replication.
+ *
+ * @internal
+ */
+#[Package('framework')]
+class MigrationLock
+{
+    public function __construct(
+        private readonly Connection $connection,
+        private readonly int $timeoutSeconds = 60,
+    ) {
+    }
+
+    /**
+     * @template TReturn
+     *
+     * @param \Closure(): TReturn $callback
+     *
+     * @return TReturn
+     */
+    public function synchronized(string $plugin, \Closure $callback): mixed
+    {
+        // GET_LOCK names are limited to 64 characters, so the plugin name is hashed
+        $name = self::lockName($plugin);
+
+        $acquired = $this->connection->fetchOne(
+            'SELECT GET_LOCK(:name, :timeout)',
+            ['name' => $name, 'timeout' => $this->timeoutSeconds]
+        );
+
+        if ($acquired !== 1 && $acquired !== '1' && $acquired !== true) {
+            throw MigrationException::migrationLockNotAcquired($plugin);
+        }
+
+        try {
+            return $callback();
+        } finally {
+            $this->connection->fetchOne('SELECT RELEASE_LOCK(:name)', ['name' => $name]);
+        }
+    }
+
+    /**
+     * Exposed so tests can assert on the lock without duplicating the scheme.
+     */
+    public static function lockName(string $plugin): string
+    {
+        return 'swpm:' . Hasher::hash($plugin, 'sha1');
+    }
+}

--- a/src/Core/Framework/Migration/Reversible/MigrationProvider.php
+++ b/src/Core/Framework/Migration/Reversible/MigrationProvider.php
@@ -1,0 +1,87 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\Migration\Reversible;
+
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Migration\MigrationException;
+use Shopware\Core\Framework\Plugin;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+class MigrationProvider
+{
+    /**
+     * @var \WeakMap<Plugin, list<Migration>>
+     */
+    private \WeakMap $cache;
+
+    public function __construct()
+    {
+        $this->cache = new \WeakMap();
+    }
+
+    /**
+     * @return list<Migration> sorted by creation timestamp, ascending
+     */
+    public function forPlugin(Plugin $plugin): array
+    {
+        if (isset($this->cache[$plugin])) {
+            return $this->cache[$plugin];
+        }
+
+        $directory = $plugin->getMigrationPath();
+        if (!is_dir($directory)) {
+            return $this->cache[$plugin] = [];
+        }
+
+        $files = scandir($directory, \SCANDIR_SORT_ASCENDING);
+        if ($files === false) {
+            throw MigrationException::migrationDirectoryNotReadable($directory);
+        }
+
+        $migrations = [];
+        $timestamps = [];
+        foreach ($files as $file) {
+            $path = $directory . \DIRECTORY_SEPARATOR . $file;
+            if (pathinfo($path, \PATHINFO_EXTENSION) !== 'php') {
+                continue;
+            }
+
+            $class = $plugin->getMigrationNamespace() . '\\' . pathinfo($file, \PATHINFO_FILENAME);
+            if (!class_exists($class) && !interface_exists($class) && !trait_exists($class)) {
+                throw MigrationException::invalidMigrationClass($class, $path);
+            }
+
+            // legacy MigrationStep classes live in the same directory and are handled by MigrationCollection
+            if (!is_subclass_of($class, Migration::class)) {
+                continue;
+            }
+
+            $reflection = new \ReflectionClass($class);
+            $constructor = $reflection->getConstructor();
+            if (!$reflection->isInstantiable() || ($constructor !== null && $constructor->getNumberOfRequiredParameters() > 0)) {
+                throw MigrationException::reversibleMigrationNotInstantiable($class);
+            }
+
+            $migration = $reflection->newInstance();
+            \assert($migration instanceof Migration);
+
+            $timestamp = $migration->getCreationTimestamp();
+            if ($timestamp <= 0 || $timestamp > 2147483647) {
+                throw MigrationException::reversibleMigrationInvalidTimestamp($class, $timestamp);
+            }
+            if (isset($timestamps[$timestamp])) {
+                throw MigrationException::duplicateMigrationTimestamp($plugin->getName(), $timestamp, $timestamps[$timestamp], $class);
+            }
+
+            $timestamps[$timestamp] = $class;
+            $migrations[] = $migration;
+        }
+
+        usort($migrations, static fn (Migration $first, Migration $second): int => $first->getCreationTimestamp() <=> $second->getCreationTimestamp());
+
+        return $this->cache[$plugin] = $migrations;
+    }
+}

--- a/src/Core/Framework/Migration/Reversible/MigrationRunner.php
+++ b/src/Core/Framework/Migration/Reversible/MigrationRunner.php
@@ -1,0 +1,136 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\Migration\Reversible;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Migration\MigrationException;
+use Shopware\Core\Framework\Plugin;
+
+/**
+ * @final
+ */
+#[Package('framework')]
+class MigrationRunner
+{
+    /**
+     * @internal
+     */
+    public function __construct(
+        private readonly MigrationProvider $provider,
+        private readonly MigrationStateStore $stateStore,
+        private readonly MigrationLock $lock,
+        private readonly Connection $connection,
+    ) {
+    }
+
+    /**
+     * Applies all pending migrations of the plugin in ascending timestamp order.
+     *
+     * @return list<class-string<Migration>> the migrations applied by this call, in execution order
+     */
+    public function up(Plugin $plugin, bool $isInstallation = false): array
+    {
+        return $this->lock->synchronized($plugin->getName(), function () use ($plugin, $isInstallation): array {
+            $migrations = $this->provider->forPlugin($plugin);
+            $executed = $this->validatedExecutedMigrations($plugin, $migrations);
+
+            $latestApplied = $executed === [] ? null : max(array_map(
+                static fn (ExecutedMigration $migration): int => $migration->creationTimestamp,
+                $executed
+            ));
+            $executedClasses = array_fill_keys(array_map(
+                static fn (ExecutedMigration $migration): string => $migration->class,
+                $executed
+            ), true);
+
+            $context = new UpMigrationContext($this->connection, $isInstallation);
+
+            $applied = [];
+            foreach ($migrations as $migration) {
+                $class = $migration::class;
+                if (isset($executedClasses[$class])) {
+                    continue;
+                }
+
+                $timestamp = $migration->getCreationTimestamp();
+                if ($latestApplied !== null && $timestamp <= $latestApplied) {
+                    throw MigrationException::migrationOutOfOrder($plugin->getName(), $class, $timestamp, $latestApplied);
+                }
+
+                $migration->up($context);
+                $this->stateStore->markExecuted($plugin->getName(), $class, $timestamp);
+                $latestApplied = $timestamp;
+                $applied[] = $class;
+            }
+
+            return $applied;
+        });
+    }
+
+    /**
+     * Rolls back all applied migrations of the plugin in descending timestamp order.
+     *
+     * Does nothing when user data is kept, so that schema and history survive for a reinstall.
+     *
+     * @return list<class-string<Migration>> the migrations rolled back by this call, in execution order
+     */
+    public function down(Plugin $plugin, bool $keepUserData = false): array
+    {
+        // keeping user data leaves schema and history intact, so a reinstall resumes from the same state
+        if ($keepUserData) {
+            return [];
+        }
+
+        return $this->lock->synchronized($plugin->getName(), function () use ($plugin, $keepUserData): array {
+            $migrations = $this->provider->forPlugin($plugin);
+            $executed = $this->validatedExecutedMigrations($plugin, $migrations);
+
+            $byClass = [];
+            foreach ($migrations as $migration) {
+                $byClass[$migration::class] = $migration;
+            }
+
+            usort($executed, static fn (ExecutedMigration $first, ExecutedMigration $second): int => $second->creationTimestamp <=> $first->creationTimestamp);
+
+            $context = new DownMigrationContext($this->connection, $keepUserData);
+
+            $removed = [];
+            foreach ($executed as $entry) {
+                $byClass[$entry->class]->down($context);
+                $this->stateStore->remove($plugin->getName(), $entry->class);
+                $removed[] = $entry->class;
+            }
+
+            return $removed;
+        });
+    }
+
+    /**
+     * @param list<Migration> $migrations
+     *
+     * @return list<ExecutedMigration>
+     */
+    private function validatedExecutedMigrations(Plugin $plugin, array $migrations): array
+    {
+        $available = [];
+        foreach ($migrations as $migration) {
+            $available[$migration::class] = $migration;
+        }
+
+        $executed = $this->stateStore->executed($plugin->getName());
+        foreach ($executed as $entry) {
+            $migration = $available[$entry->class] ?? null;
+            if (!$migration instanceof Migration) {
+                throw MigrationException::missingAppliedMigration($plugin->getName(), $entry->class);
+            }
+
+            $declared = $migration->getCreationTimestamp();
+            if ($declared !== $entry->creationTimestamp) {
+                throw MigrationException::migrationTimestampChanged($entry->class, $entry->creationTimestamp, $declared);
+            }
+        }
+
+        return $executed;
+    }
+}

--- a/src/Core/Framework/Migration/Reversible/MigrationStateStore.php
+++ b/src/Core/Framework/Migration/Reversible/MigrationStateStore.php
@@ -1,0 +1,68 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\Migration\Reversible;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Migration\MigrationException;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+class MigrationStateStore
+{
+    public function __construct(private readonly Connection $connection)
+    {
+    }
+
+    /**
+     * @return list<ExecutedMigration> sorted by creation timestamp, ascending
+     */
+    public function executed(string $plugin): array
+    {
+        $rows = $this->connection->fetchAllAssociative(
+            <<<'SQL'
+                SELECT `migration_class`, `creation_timestamp`
+                FROM `plugin_migration`
+                WHERE `plugin_name` = :plugin
+                ORDER BY `creation_timestamp` ASC
+                SQL,
+            ['plugin' => $plugin]
+        );
+
+        return array_map(static function (array $row): ExecutedMigration {
+            $class = $row['migration_class'] ?? null;
+            $timestamp = $row['creation_timestamp'] ?? null;
+            if (!\is_string($class) || (!\is_int($timestamp) && !\is_string($timestamp))) {
+                throw MigrationException::invalidMigrationState();
+            }
+
+            /** @var class-string<Migration> $class */
+            return new ExecutedMigration($class, (int) $timestamp);
+        }, $rows);
+    }
+
+    /**
+     * @param class-string<Migration> $class
+     */
+    public function markExecuted(string $plugin, string $class, int $creationTimestamp): void
+    {
+        $this->connection->insert('plugin_migration', [
+            'plugin_name' => $plugin,
+            'migration_class' => $class,
+            'creation_timestamp' => $creationTimestamp,
+        ]);
+    }
+
+    /**
+     * @param class-string<Migration> $class
+     */
+    public function remove(string $plugin, string $class): void
+    {
+        $this->connection->delete('plugin_migration', [
+            'plugin_name' => $plugin,
+            'migration_class' => $class,
+        ]);
+    }
+}

--- a/src/Core/Framework/Migration/Reversible/Template/MigrationTemplateReversiblePlugin.txt
+++ b/src/Core/Framework/Migration/Reversible/Template/MigrationTemplateReversiblePlugin.txt
@@ -1,0 +1,26 @@
+<?php declare(strict_types=1);
+
+namespace %%namespace%%;
+
+use Shopware\Core\Framework\Migration\Reversible\DownMigrationContext;
+use Shopware\Core\Framework\Migration\Reversible\Migration;
+use Shopware\Core\Framework\Migration\Reversible\UpMigrationContext;
+
+/**
+ * @internal
+ */
+class Migration%%timestamp%%%%name%% extends Migration
+{
+    public function getCreationTimestamp(): int
+    {
+        return %%timestamp%%;
+    }
+
+    public function up(UpMigrationContext $context): void
+    {
+    }
+
+    public function down(DownMigrationContext $context): void
+    {
+    }
+}

--- a/src/Core/Framework/Migration/Reversible/UpMigrationContext.php
+++ b/src/Core/Framework/Migration/Reversible/UpMigrationContext.php
@@ -1,0 +1,23 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\Migration\Reversible;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * Passed to Migration::up().
+ *
+ * Note that $isInstallation has a different meaning than MigrationStep::isInstallation(): it does not
+ * describe whether Shopware itself is being installed, but whether this plugin is being installed for
+ * the first time. Use it to skip backfills that cannot have anything to backfill.
+ */
+#[Package('framework')]
+final readonly class UpMigrationContext
+{
+    public function __construct(
+        public Connection $connection,
+        public bool $isInstallation,
+    ) {
+    }
+}

--- a/src/Core/Framework/Plugin/PluginLifecycleService.php
+++ b/src/Core/Framework/Plugin/PluginLifecycleService.php
@@ -19,6 +19,7 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Migration\MigrationCollection;
 use Shopware\Core\Framework\Migration\MigrationCollectionLoader;
 use Shopware\Core\Framework\Migration\MigrationSource;
+use Shopware\Core\Framework\Migration\Reversible\MigrationRunner as ReversibleMigrationRunner;
 use Shopware\Core\Framework\Plugin;
 use Shopware\Core\Framework\Plugin\Composer\CommandExecutor;
 use Shopware\Core\Framework\Plugin\Context\ActivateContext;
@@ -104,6 +105,7 @@ class PluginLifecycleService
         private readonly RequestStack $requestStack,
         private readonly CustomFieldSetPersister $customFieldSetPersister,
         private readonly ClockInterface $clock,
+        private readonly ReversibleMigrationRunner $reversibleMigrationRunner,
     ) {
         $this->originalEventDispatcher = $eventDispatcher;
     }
@@ -153,6 +155,10 @@ class PluginLifecycleService
             }
 
             $this->eventDispatcher->dispatch(new PluginPreInstallEvent($plugin, $installContext));
+
+            // reversible migrations run before the plugin's own install method, so that install() can
+            // already rely on the schema they create
+            $this->reversibleMigrationRunner->up($pluginBaseClass, true);
 
             $this->systemConfigService->savePluginConfiguration($pluginBaseClass, true);
 
@@ -231,6 +237,11 @@ class PluginLifecycleService
 
         $pluginBaseClass->uninstall($uninstallContext);
 
+        // unlike removeMigrations() above, which only drops the legacy migration history, this rolls
+        // back the reversible migrations before removing their history. It has to run after the
+        // plugin's own uninstall method, but before composer may delete the plugin files below.
+        $this->reversibleMigrationRunner->down($pluginBaseClass, $uninstallContext->keepUserData());
+
         if (!$uninstallContext->keepUserData()) {
             $this->systemConfigService->deletePluginConfiguration($pluginBaseClass);
         }
@@ -293,6 +304,8 @@ class PluginLifecycleService
         }
 
         $this->eventDispatcher->dispatch(new PluginPreUpdateEvent($plugin, $updateContext));
+
+        $this->reversibleMigrationRunner->up($pluginBaseClass);
 
         $this->systemConfigService->savePluginConfiguration($pluginBaseClass);
 

--- a/src/Core/Migration/V6_7/Migration1787465993AddPluginMigrationTable.php
+++ b/src/Core/Migration/V6_7/Migration1787465993AddPluginMigrationTable.php
@@ -1,0 +1,33 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Migration\V6_7;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Migration\MigrationStep;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+class Migration1787465993AddPluginMigrationTable extends MigrationStep
+{
+    public function getCreationTimestamp(): int
+    {
+        return 1787465993;
+    }
+
+    public function update(Connection $connection): void
+    {
+        $connection->executeStatement(<<<'SQL'
+            CREATE TABLE IF NOT EXISTS `plugin_migration` (
+                `plugin_name`        VARCHAR(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+                `migration_class`    VARCHAR(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+                `creation_timestamp` INT UNSIGNED                            NOT NULL,
+                `executed_at`        DATETIME(3)                             NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+                PRIMARY KEY (`plugin_name`, `migration_class`),
+                UNIQUE KEY `uniq.plugin_migration.plugin_name__creation_timestamp` (`plugin_name`, `creation_timestamp`)
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+            SQL);
+    }
+}

--- a/src/Core/schema.sql
+++ b/src/Core/schema.sql
@@ -31,3 +31,12 @@ CREATE TABLE IF NOT EXISTS `migration` (
     `message`            TEXT COLLATE utf8mb4_unicode_ci         NULL,
     PRIMARY KEY (`class`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE = utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS `plugin_migration` (
+    `plugin_name`        VARCHAR(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+    `migration_class`    VARCHAR(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+    `creation_timestamp` INT UNSIGNED                            NOT NULL,
+    `executed_at`        DATETIME(3)                             NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    PRIMARY KEY (`plugin_name`, `migration_class`),
+    UNIQUE KEY `uniq.plugin_migration.plugin_name__creation_timestamp` (`plugin_name`, `creation_timestamp`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE = utf8mb4_unicode_ci;

--- a/tests/integration/Core/Framework/Migration/Reversible/MigrationLockTest.php
+++ b/tests/integration/Core/Framework/Migration/Reversible/MigrationLockTest.php
@@ -1,0 +1,89 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Integration\Core\Framework\Migration\Reversible;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\DriverManager;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Migration\MigrationException;
+use Shopware\Core\Framework\Migration\Reversible\MigrationLock;
+use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+class MigrationLockTest extends TestCase
+{
+    use KernelTestBehaviour;
+
+    private const PLUGIN = 'SwagLockTest';
+
+    private Connection $connection;
+
+    private MigrationLock $lock;
+
+    protected function setUp(): void
+    {
+        $this->connection = static::getContainer()->get(Connection::class);
+        $this->lock = new MigrationLock($this->connection);
+    }
+
+    public function testReturnsTheCallbackResult(): void
+    {
+        static::assertSame('result', $this->lock->synchronized(self::PLUGIN, static fn (): string => 'result'));
+    }
+
+    public function testReleasesTheLockAfterASuccessfulCallback(): void
+    {
+        $this->lock->synchronized(self::PLUGIN, static fn (): bool => true);
+
+        static::assertTrue($this->isFree(self::PLUGIN));
+    }
+
+    public function testReleasesTheLockWhenTheCallbackThrows(): void
+    {
+        try {
+            $this->lock->synchronized(self::PLUGIN, static function (): void {
+                throw new \RuntimeException('migration failed');
+            });
+            static::fail('Expected the callback exception to bubble up.');
+        } catch (\RuntimeException $exception) {
+            static::assertSame('migration failed', $exception->getMessage());
+        }
+
+        static::assertTrue($this->isFree(self::PLUGIN));
+    }
+
+    public function testFailsWhenAnotherConnectionHoldsTheLock(): void
+    {
+        $other = DriverManager::getConnection($this->connection->getParams());
+        $other->fetchOne('SELECT GET_LOCK(:name, 0)', ['name' => $this->lockName(self::PLUGIN)]);
+
+        try {
+            // zero timeout so the test does not block for the production wait
+            $impatient = new MigrationLock($this->connection, 0);
+
+            $this->expectExceptionObject(MigrationException::migrationLockNotAcquired(self::PLUGIN));
+
+            $impatient->synchronized(self::PLUGIN, static fn (): bool => true);
+        } finally {
+            $other->fetchOne('SELECT RELEASE_LOCK(:name)', ['name' => $this->lockName(self::PLUGIN)]);
+            $other->close();
+        }
+    }
+
+    private function isFree(string $plugin): bool
+    {
+        return (bool) $this->connection->fetchOne(
+            'SELECT IS_FREE_LOCK(:name)',
+            ['name' => $this->lockName($plugin)]
+        );
+    }
+
+    private function lockName(string $plugin): string
+    {
+        return MigrationLock::lockName($plugin);
+    }
+}

--- a/tests/integration/Core/Framework/Migration/Reversible/MigrationRunnerTest.php
+++ b/tests/integration/Core/Framework/Migration/Reversible/MigrationRunnerTest.php
@@ -1,0 +1,125 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Integration\Core\Framework\Migration\Reversible;
+
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Migration\Reversible\MigrationRunner;
+use Shopware\Core\Framework\Plugin;
+use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
+use Shopware\Tests\Integration\Core\Framework\Migration\Reversible\_fixtures\SwagIntegration\Migration\Migration1900000000CreateTable;
+use Shopware\Tests\Integration\Core\Framework\Migration\Reversible\_fixtures\SwagIntegration\SwagIntegration;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+class MigrationRunnerTest extends TestCase
+{
+    use KernelTestBehaviour;
+
+    private Connection $connection;
+
+    private MigrationRunner $runner;
+
+    protected function setUp(): void
+    {
+        $this->connection = static::getContainer()->get(Connection::class);
+        $this->runner = static::getContainer()->get(MigrationRunner::class);
+
+        $this->cleanUp();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->cleanUp();
+    }
+
+    public function testUpAppliesTheMigrationAndRecordsHistory(): void
+    {
+        $applied = $this->runner->up($this->plugin());
+
+        static::assertSame([Migration1900000000CreateTable::class], $applied);
+        static::assertTrue($this->tableExists());
+        static::assertSame(
+            [Migration1900000000CreateTable::class => '1900000000'],
+            $this->history()
+        );
+    }
+
+    public function testUpIsIdempotent(): void
+    {
+        $this->runner->up($this->plugin());
+
+        static::assertSame([], $this->runner->up($this->plugin()));
+        static::assertTrue($this->tableExists());
+    }
+
+    public function testDownRollsBackTheMigrationAndClearsHistory(): void
+    {
+        $this->runner->up($this->plugin());
+
+        $removed = $this->runner->down($this->plugin());
+
+        static::assertSame([Migration1900000000CreateTable::class], $removed);
+        static::assertFalse($this->tableExists());
+        static::assertSame([], $this->history());
+    }
+
+    public function testDownKeepsSchemaAndHistoryWhenUserDataIsKept(): void
+    {
+        $this->runner->up($this->plugin());
+
+        static::assertSame([], $this->runner->down($this->plugin(), true));
+        static::assertTrue($this->tableExists());
+        static::assertCount(1, $this->history());
+    }
+
+    public function testTheLegacyMigrationTableIsNotTouched(): void
+    {
+        $before = $this->connection->fetchOne('SELECT COUNT(*) FROM `migration`');
+
+        $this->runner->up($this->plugin());
+        $this->runner->down($this->plugin());
+
+        static::assertSame($before, $this->connection->fetchOne('SELECT COUNT(*) FROM `migration`'));
+    }
+
+    private function plugin(): Plugin
+    {
+        $directory = \dirname((string) (new \ReflectionClass(SwagIntegration::class))->getFileName());
+
+        return new SwagIntegration(true, $directory);
+    }
+
+    private function tableExists(): bool
+    {
+        return $this->connection->fetchOne(
+            'SHOW TABLES LIKE :table',
+            ['table' => Migration1900000000CreateTable::TABLE]
+        ) !== false;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function history(): array
+    {
+        return $this->connection->fetchAllKeyValue(
+            'SELECT `migration_class`, `creation_timestamp` FROM `plugin_migration` WHERE `plugin_name` = :plugin',
+            ['plugin' => 'SwagIntegration']
+        );
+    }
+
+    private function cleanUp(): void
+    {
+        $this->connection->executeStatement(
+            \sprintf('DROP TABLE IF EXISTS `%s`', Migration1900000000CreateTable::TABLE)
+        );
+        $this->connection->executeStatement(
+            'DELETE FROM `plugin_migration` WHERE `plugin_name` = :plugin',
+            ['plugin' => 'SwagIntegration']
+        );
+    }
+}

--- a/tests/integration/Core/Framework/Migration/Reversible/MigrationStateStoreTest.php
+++ b/tests/integration/Core/Framework/Migration/Reversible/MigrationStateStoreTest.php
@@ -1,0 +1,122 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Integration\Core\Framework\Migration\Reversible;
+
+use Doctrine\DBAL\ArrayParameterType;
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Migration\Reversible\ExecutedMigration;
+use Shopware\Core\Framework\Migration\Reversible\MigrationStateStore;
+use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
+use Shopware\Tests\Integration\Core\Framework\Migration\Reversible\_fixtures\HistoryOnlyMigrationA;
+use Shopware\Tests\Integration\Core\Framework\Migration\Reversible\_fixtures\HistoryOnlyMigrationB;
+use Shopware\Tests\Integration\Core\Framework\Migration\Reversible\_fixtures\HistoryOnlyMigrationC;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+class MigrationStateStoreTest extends TestCase
+{
+    use KernelTestBehaviour;
+
+    private const PLUGIN = 'SwagStateStoreTest';
+
+    private const OTHER_PLUGIN = 'SwagStateStoreOther';
+
+    private Connection $connection;
+
+    private MigrationStateStore $store;
+
+    protected function setUp(): void
+    {
+        $this->connection = static::getContainer()->get(Connection::class);
+        $this->store = new MigrationStateStore($this->connection);
+
+        $this->cleanUp();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->cleanUp();
+    }
+
+    public function testReturnsAnEmptyHistoryForAnUnknownPlugin(): void
+    {
+        static::assertSame([], $this->store->executed(self::PLUGIN));
+    }
+
+    public function testRoundTripsHistoryInAscendingTimestampOrder(): void
+    {
+        $this->store->markExecuted(self::PLUGIN, HistoryOnlyMigrationB::class, 200);
+        $this->store->markExecuted(self::PLUGIN, HistoryOnlyMigrationA::class, 100);
+
+        $executed = $this->store->executed(self::PLUGIN);
+
+        static::assertSame(
+            [HistoryOnlyMigrationA::class, HistoryOnlyMigrationB::class],
+            array_map(static fn (ExecutedMigration $entry): string => $entry->class, $executed)
+        );
+        static::assertSame(
+            [100, 200],
+            array_map(static fn (ExecutedMigration $entry): int => $entry->creationTimestamp, $executed)
+        );
+    }
+
+    public function testPopulatesExecutedAt(): void
+    {
+        $this->store->markExecuted(self::PLUGIN, HistoryOnlyMigrationA::class, 100);
+
+        $executedAt = $this->connection->fetchOne(
+            'SELECT `executed_at` FROM `plugin_migration` WHERE `plugin_name` = :plugin',
+            ['plugin' => self::PLUGIN]
+        );
+
+        static::assertIsString($executedAt);
+        static::assertNotSame('', $executedAt);
+    }
+
+    public function testRemoveOnlyDeletesTheMatchingEntry(): void
+    {
+        $this->store->markExecuted(self::PLUGIN, HistoryOnlyMigrationA::class, 100);
+        $this->store->markExecuted(self::PLUGIN, HistoryOnlyMigrationB::class, 200);
+
+        $this->store->remove(self::PLUGIN, HistoryOnlyMigrationA::class);
+
+        static::assertSame(
+            [HistoryOnlyMigrationB::class],
+            array_map(static fn (ExecutedMigration $entry): string => $entry->class, $this->store->executed(self::PLUGIN))
+        );
+    }
+
+    public function testHistoryIsIsolatedPerPlugin(): void
+    {
+        $this->store->markExecuted(self::PLUGIN, HistoryOnlyMigrationA::class, 100);
+        $this->store->markExecuted(self::OTHER_PLUGIN, HistoryOnlyMigrationA::class, 100);
+
+        $this->store->remove(self::PLUGIN, HistoryOnlyMigrationA::class);
+
+        static::assertSame([], $this->store->executed(self::PLUGIN));
+        static::assertCount(1, $this->store->executed(self::OTHER_PLUGIN));
+    }
+
+    public function testRejectsADuplicateTimestampWithinOnePlugin(): void
+    {
+        $this->store->markExecuted(self::PLUGIN, HistoryOnlyMigrationA::class, 100);
+
+        $this->expectException(UniqueConstraintViolationException::class);
+
+        $this->store->markExecuted(self::PLUGIN, HistoryOnlyMigrationC::class, 100);
+    }
+
+    private function cleanUp(): void
+    {
+        $this->connection->executeStatement(
+            'DELETE FROM `plugin_migration` WHERE `plugin_name` IN (:plugins)',
+            ['plugins' => [self::PLUGIN, self::OTHER_PLUGIN]],
+            ['plugins' => ArrayParameterType::STRING]
+        );
+    }
+}

--- a/tests/integration/Core/Framework/Migration/Reversible/_fixtures/HistoryOnlyMigrationA.php
+++ b/tests/integration/Core/Framework/Migration/Reversible/_fixtures/HistoryOnlyMigrationA.php
@@ -1,0 +1,31 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Integration\Core\Framework\Migration\Reversible\_fixtures;
+
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Migration\Reversible\DownMigrationContext;
+use Shopware\Core\Framework\Migration\Reversible\Migration;
+use Shopware\Core\Framework\Migration\Reversible\UpMigrationContext;
+
+/**
+ * Only used as a real class name in state store tests, never discovered or executed. Deliberately
+ * outside any plugin's Migration directory so the provider does not pick it up.
+ *
+ * @internal
+ */
+#[Package('framework')]
+class HistoryOnlyMigrationA extends Migration
+{
+    public function getCreationTimestamp(): int
+    {
+        return 1910000000;
+    }
+
+    public function up(UpMigrationContext $context): void
+    {
+    }
+
+    public function down(DownMigrationContext $context): void
+    {
+    }
+}

--- a/tests/integration/Core/Framework/Migration/Reversible/_fixtures/HistoryOnlyMigrationB.php
+++ b/tests/integration/Core/Framework/Migration/Reversible/_fixtures/HistoryOnlyMigrationB.php
@@ -1,0 +1,31 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Integration\Core\Framework\Migration\Reversible\_fixtures;
+
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Migration\Reversible\DownMigrationContext;
+use Shopware\Core\Framework\Migration\Reversible\Migration;
+use Shopware\Core\Framework\Migration\Reversible\UpMigrationContext;
+
+/**
+ * Only used as a real class name in state store tests, never discovered or executed. Deliberately
+ * outside any plugin's Migration directory so the provider does not pick it up.
+ *
+ * @internal
+ */
+#[Package('framework')]
+class HistoryOnlyMigrationB extends Migration
+{
+    public function getCreationTimestamp(): int
+    {
+        return 1910000001;
+    }
+
+    public function up(UpMigrationContext $context): void
+    {
+    }
+
+    public function down(DownMigrationContext $context): void
+    {
+    }
+}

--- a/tests/integration/Core/Framework/Migration/Reversible/_fixtures/HistoryOnlyMigrationC.php
+++ b/tests/integration/Core/Framework/Migration/Reversible/_fixtures/HistoryOnlyMigrationC.php
@@ -1,0 +1,31 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Integration\Core\Framework\Migration\Reversible\_fixtures;
+
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Migration\Reversible\DownMigrationContext;
+use Shopware\Core\Framework\Migration\Reversible\Migration;
+use Shopware\Core\Framework\Migration\Reversible\UpMigrationContext;
+
+/**
+ * Only used as a real class name in state store tests, never discovered or executed. Deliberately
+ * outside any plugin's Migration directory so the provider does not pick it up.
+ *
+ * @internal
+ */
+#[Package('framework')]
+class HistoryOnlyMigrationC extends Migration
+{
+    public function getCreationTimestamp(): int
+    {
+        return 1910000002;
+    }
+
+    public function up(UpMigrationContext $context): void
+    {
+    }
+
+    public function down(DownMigrationContext $context): void
+    {
+    }
+}

--- a/tests/integration/Core/Framework/Migration/Reversible/_fixtures/SwagIntegration/Migration/Migration1900000000CreateTable.php
+++ b/tests/integration/Core/Framework/Migration/Reversible/_fixtures/SwagIntegration/Migration/Migration1900000000CreateTable.php
@@ -1,0 +1,36 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Integration\Core\Framework\Migration\Reversible\_fixtures\SwagIntegration\Migration;
+
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Migration\Reversible\DownMigrationContext;
+use Shopware\Core\Framework\Migration\Reversible\Migration;
+use Shopware\Core\Framework\Migration\Reversible\UpMigrationContext;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+class Migration1900000000CreateTable extends Migration
+{
+    final public const TABLE = 'swag_reversible_integration';
+
+    public function getCreationTimestamp(): int
+    {
+        return 1900000000;
+    }
+
+    public function up(UpMigrationContext $context): void
+    {
+        $context->connection->executeStatement(\sprintf(
+            'CREATE TABLE IF NOT EXISTS `%s` (`id` BINARY(16) NOT NULL, PRIMARY KEY (`id`))
+             ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci',
+            self::TABLE
+        ));
+    }
+
+    public function down(DownMigrationContext $context): void
+    {
+        $context->connection->executeStatement(\sprintf('DROP TABLE IF EXISTS `%s`', self::TABLE));
+    }
+}

--- a/tests/integration/Core/Framework/Migration/Reversible/_fixtures/SwagIntegration/SwagIntegration.php
+++ b/tests/integration/Core/Framework/Migration/Reversible/_fixtures/SwagIntegration/SwagIntegration.php
@@ -1,0 +1,14 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Integration\Core\Framework\Migration\Reversible\_fixtures\SwagIntegration;
+
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Plugin;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+class SwagIntegration extends Plugin
+{
+}

--- a/tests/integration/Core/Framework/Plugin/KernelPluginIntegrationTest.php
+++ b/tests/integration/Core/Framework/Plugin/KernelPluginIntegrationTest.php
@@ -14,6 +14,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Migration\MigrationCollectionLoader;
+use Shopware\Core\Framework\Migration\Reversible\MigrationRunner as ReversibleMigrationRunner;
 use Shopware\Core\Framework\Plugin\Composer\CommandExecutor;
 use Shopware\Core\Framework\Plugin\KernelPluginLoader\DbalKernelPluginLoader;
 use Shopware\Core\Framework\Plugin\KernelPluginLoader\KernelPluginLoader;
@@ -396,7 +397,8 @@ class KernelPluginIntegrationTest extends TestCase
             $this->createMock(DefinitionInstanceRegistry::class),
             new RequestStack(),
             $this->createMock(CustomFieldSetPersister::class),
-            new NativeClock()
+            new NativeClock(),
+            $this->createMock(ReversibleMigrationRunner::class)
         );
     }
 

--- a/tests/integration/Core/Framework/Plugin/PluginLifecycleServiceMigrationTest.php
+++ b/tests/integration/Core/Framework/Plugin/PluginLifecycleServiceMigrationTest.php
@@ -12,6 +12,7 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Migration\MigrationCollection;
 use Shopware\Core\Framework\Migration\MigrationCollectionLoader;
 use Shopware\Core\Framework\Migration\MigrationSource;
+use Shopware\Core\Framework\Migration\Reversible\MigrationRunner as ReversibleMigrationRunner;
 use Shopware\Core\Framework\Plugin\Composer\CommandExecutor;
 use Shopware\Core\Framework\Plugin\KernelPluginCollection;
 use Shopware\Core\Framework\Plugin\PluginCollection;
@@ -179,7 +180,8 @@ class PluginLifecycleServiceMigrationTest extends TestCase
             $this->container->get(DefinitionInstanceRegistry::class),
             new RequestStack(),
             $this->container->get(CustomFieldSetPersister::class),
-            new NativeClock()
+            new NativeClock(),
+            $this->container->get(ReversibleMigrationRunner::class)
         );
     }
 

--- a/tests/integration/Core/Framework/Plugin/PluginLifecycleServiceReversibleMigrationTest.php
+++ b/tests/integration/Core/Framework/Plugin/PluginLifecycleServiceReversibleMigrationTest.php
@@ -1,0 +1,163 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Integration\Core\Framework\Plugin;
+
+use Composer\IO\NullIO;
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Plugin\PluginCollection;
+use Shopware\Core\Framework\Plugin\PluginEntity;
+use Shopware\Core\Framework\Plugin\PluginLifecycleService;
+use Shopware\Core\Framework\Plugin\PluginService;
+use Shopware\Core\Framework\Plugin\Util\PluginFinder;
+use Shopware\Core\Framework\Test\Plugin\PluginTestsHelper;
+use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
+use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
+use SwagTestReversibleMigration\Migration\Migration1900000001CreateTable;
+
+/**
+ * Covers the reversible migration hooks in PluginLifecycleService.
+ *
+ * Deliberately not wrapped in a transaction: the fixture migration issues DDL, which MySQL commits
+ * implicitly, so an outer transaction would be silently broken. State is cleaned up explicitly.
+ *
+ * @internal
+ */
+#[Package('framework')]
+class PluginLifecycleServiceReversibleMigrationTest extends TestCase
+{
+    use KernelTestBehaviour;
+    use PluginTestsHelper;
+
+    private const PLUGIN_NAME = 'SwagTestReversibleMigration';
+
+    private Connection $connection;
+
+    private PluginService $pluginService;
+
+    private PluginLifecycleService $pluginLifecycleService;
+
+    /**
+     * @var EntityRepository<PluginCollection>
+     */
+    private EntityRepository $pluginRepo;
+
+    private Context $context;
+
+    protected function setUp(): void
+    {
+        KernelLifecycleManager::bootKernel();
+
+        // dedicated fixture directory: refreshPlugins() scans it wholesale, so it must contain
+        // only this plugin, or the refresh would leak rows for every other fixture plugin
+        $fixturePath = __DIR__ . '/_fixtures/reversible-plugins/';
+        $container = static::getContainer();
+
+        $this->connection = $container->get(Connection::class);
+        $this->pluginRepo = $container->get('plugin.repository');
+        $this->pluginLifecycleService = $container->get(PluginLifecycleService::class);
+        $this->pluginService = $this->createPluginService(
+            $fixturePath,
+            $container->getParameter('kernel.project_dir'),
+            $this->pluginRepo,
+            $container->get('language.repository'),
+            $container->get(PluginFinder::class)
+        );
+
+        require_once $fixturePath . self::PLUGIN_NAME . '/src/Migration/Migration1900000001CreateTable.php';
+        $this->addTestPluginToKernel($fixturePath . self::PLUGIN_NAME, self::PLUGIN_NAME);
+
+        $this->context = Context::createDefaultContext();
+        $this->cleanUp();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->cleanUp();
+    }
+
+    public function testInstallRunsUpWithTheInstallationFlagSet(): void
+    {
+        $this->pluginLifecycleService->installPlugin($this->refreshedPlugin(), $this->context);
+
+        static::assertTrue($this->tableExists());
+        static::assertSame(
+            [Migration1900000001CreateTable::class => (string) Migration1900000001CreateTable::TIMESTAMP],
+            $this->history()
+        );
+
+        // the lifecycle must tell the migration that this is a fresh plugin installation
+        static::assertSame('1', $this->connection->fetchOne(
+            \sprintf('SELECT `was_installation` FROM `%s`', Migration1900000001CreateTable::TABLE)
+        ));
+    }
+
+    public function testUninstallRunsDownAndClearsHistory(): void
+    {
+        $this->pluginLifecycleService->installPlugin($this->refreshedPlugin(), $this->context);
+
+        $this->pluginLifecycleService->uninstallPlugin($this->installedPlugin(), $this->context);
+
+        static::assertFalse($this->tableExists());
+        static::assertSame([], $this->history());
+    }
+
+    public function testUninstallWithKeepUserDataLeavesSchemaAndHistoryIntact(): void
+    {
+        $this->pluginLifecycleService->installPlugin($this->refreshedPlugin(), $this->context);
+
+        $this->pluginLifecycleService->uninstallPlugin($this->installedPlugin(), $this->context, true);
+
+        static::assertTrue($this->tableExists());
+        static::assertCount(1, $this->history());
+    }
+
+    private function refreshedPlugin(): PluginEntity
+    {
+        $this->pluginService->refreshPlugins($this->context, new NullIO());
+
+        return $this->pluginService->getPluginByName(self::PLUGIN_NAME, $this->context);
+    }
+
+    private function installedPlugin(): PluginEntity
+    {
+        return $this->pluginService->getPluginByName(self::PLUGIN_NAME, $this->context);
+    }
+
+    private function tableExists(): bool
+    {
+        return $this->connection->fetchOne(
+            'SHOW TABLES LIKE :table',
+            ['table' => Migration1900000001CreateTable::TABLE]
+        ) !== false;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function history(): array
+    {
+        return $this->connection->fetchAllKeyValue(
+            'SELECT `migration_class`, `creation_timestamp` FROM `plugin_migration` WHERE `plugin_name` = :plugin',
+            ['plugin' => self::PLUGIN_NAME]
+        );
+    }
+
+    private function cleanUp(): void
+    {
+        $this->connection->executeStatement(
+            \sprintf('DROP TABLE IF EXISTS `%s`', Migration1900000001CreateTable::TABLE)
+        );
+        $this->connection->executeStatement(
+            'DELETE FROM `plugin_migration` WHERE `plugin_name` = :plugin',
+            ['plugin' => self::PLUGIN_NAME]
+        );
+        $this->connection->executeStatement(
+            'DELETE FROM `plugin` WHERE `name` = :plugin',
+            ['plugin' => self::PLUGIN_NAME]
+        );
+    }
+}

--- a/tests/integration/Core/Framework/Plugin/PluginLifecycleServiceTest.php
+++ b/tests/integration/Core/Framework/Plugin/PluginLifecycleServiceTest.php
@@ -19,6 +19,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Migration\MigrationCollectionLoader;
+use Shopware\Core\Framework\Migration\Reversible\MigrationRunner as ReversibleMigrationRunner;
 use Shopware\Core\Framework\Plugin\Composer\CommandExecutor;
 use Shopware\Core\Framework\Plugin\Event\PluginPostInstallEvent;
 use Shopware\Core\Framework\Plugin\Exception\PluginComposerRequireException;
@@ -327,7 +328,8 @@ class PluginLifecycleServiceTest extends TestCase
             $this->container->get(DefinitionInstanceRegistry::class),
             new RequestStack(),
             $this->container->get(CustomFieldSetPersister::class),
-            new NativeClock()
+            new NativeClock(),
+            $this->container->get(ReversibleMigrationRunner::class)
         );
 
         $context = Context::createDefaultContext();
@@ -868,7 +870,8 @@ class PluginLifecycleServiceTest extends TestCase
             $this->container->get(DefinitionInstanceRegistry::class),
             new RequestStack(),
             $this->container->get(CustomFieldSetPersister::class),
-            new NativeClock()
+            new NativeClock(),
+            $this->container->get(ReversibleMigrationRunner::class)
         );
     }
 

--- a/tests/integration/Core/Framework/Plugin/_fixtures/reversible-plugins/SwagTestReversibleMigration/composer.json
+++ b/tests/integration/Core/Framework/Plugin/_fixtures/reversible-plugins/SwagTestReversibleMigration/composer.json
@@ -1,0 +1,27 @@
+{
+    "name": "swag/test-reversible-migration",
+    "description": "Test description",
+    "version": "1.0.0",
+    "type": "shopware-platform-plugin",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "shopware AG"
+        }
+    ],
+    "require": {
+        "shopware/core": ">=6.0"
+    },
+    "extra": {
+        "shopware-plugin-class": "SwagTestReversibleMigration\\SwagTestReversibleMigration",
+        "label": {
+            "de-DE": "Deutscher Pluginname",
+            "en-GB": "English plugin name"
+        }
+    },
+    "autoload": {
+        "psr-4": {
+           "SwagTestReversibleMigration\\": "src"
+        }
+    }
+}

--- a/tests/integration/Core/Framework/Plugin/_fixtures/reversible-plugins/SwagTestReversibleMigration/src/Migration/Migration1900000001CreateTable.php
+++ b/tests/integration/Core/Framework/Plugin/_fixtures/reversible-plugins/SwagTestReversibleMigration/src/Migration/Migration1900000001CreateTable.php
@@ -1,0 +1,45 @@
+<?php declare(strict_types=1);
+
+namespace SwagTestReversibleMigration\Migration;
+
+use Shopware\Core\Framework\Migration\Reversible\DownMigrationContext;
+use Shopware\Core\Framework\Migration\Reversible\Migration;
+use Shopware\Core\Framework\Migration\Reversible\UpMigrationContext;
+
+/**
+ * @internal
+ */
+class Migration1900000001CreateTable extends Migration
+{
+    final public const TABLE = 'swag_test_reversible_migration';
+
+    final public const TIMESTAMP = 1900000001;
+
+    public function getCreationTimestamp(): int
+    {
+        return self::TIMESTAMP;
+    }
+
+    public function up(UpMigrationContext $context): void
+    {
+        $context->connection->executeStatement(\sprintf(
+            'CREATE TABLE IF NOT EXISTS `%s` (
+                `id` BINARY(16) NOT NULL,
+                `was_installation` TINYINT(1) NOT NULL,
+                PRIMARY KEY (`id`)
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci',
+            self::TABLE
+        ));
+
+        // record the flag so the test can assert what the lifecycle passed in
+        $context->connection->insert(self::TABLE, [
+            'id' => random_bytes(16),
+            'was_installation' => $context->isInstallation ? 1 : 0,
+        ]);
+    }
+
+    public function down(DownMigrationContext $context): void
+    {
+        $context->connection->executeStatement(\sprintf('DROP TABLE IF EXISTS `%s`', self::TABLE));
+    }
+}

--- a/tests/integration/Core/Framework/Plugin/_fixtures/reversible-plugins/SwagTestReversibleMigration/src/SwagTestReversibleMigration.php
+++ b/tests/integration/Core/Framework/Plugin/_fixtures/reversible-plugins/SwagTestReversibleMigration/src/SwagTestReversibleMigration.php
@@ -1,0 +1,9 @@
+<?php declare(strict_types=1);
+
+namespace SwagTestReversibleMigration;
+
+use Shopware\Core\Framework\Plugin;
+
+class SwagTestReversibleMigration extends Plugin
+{
+}

--- a/tests/migration/Core/V6_7/Migration1787465993AddPluginMigrationTableTest.php
+++ b/tests/migration/Core/V6_7/Migration1787465993AddPluginMigrationTableTest.php
@@ -1,0 +1,68 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Migration\Core\V6_7;
+
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
+use Shopware\Core\Migration\V6_7\Migration1787465993AddPluginMigrationTable;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+#[CoversClass(Migration1787465993AddPluginMigrationTable::class)]
+class Migration1787465993AddPluginMigrationTableTest extends TestCase
+{
+    private Connection $connection;
+
+    protected function setUp(): void
+    {
+        $this->connection = KernelLifecycleManager::getConnection();
+    }
+
+    public function testCreationTimestamp(): void
+    {
+        $migration = new Migration1787465993AddPluginMigrationTable();
+
+        static::assertSame(1787465993, $migration->getCreationTimestamp());
+    }
+
+    public function testMigration(): void
+    {
+        $migration = new Migration1787465993AddPluginMigrationTable();
+
+        // make sure the migration is idempotent
+        $migration->update($this->connection);
+        $migration->update($this->connection);
+
+        $columns = $this->connection->fetchAllAssociativeIndexed(
+            'SHOW COLUMNS FROM `plugin_migration`'
+        );
+
+        static::assertSame(
+            ['plugin_name', 'migration_class', 'creation_timestamp', 'executed_at'],
+            array_keys($columns)
+        );
+
+        static::assertSame('NO', $columns['plugin_name']['Null']);
+        static::assertSame('NO', $columns['migration_class']['Null']);
+        static::assertSame('NO', $columns['creation_timestamp']['Null']);
+        static::assertSame('NO', $columns['executed_at']['Null']);
+
+        $indexes = $this->connection->fetchAllAssociative('SHOW INDEXES FROM `plugin_migration`');
+
+        $byName = [];
+        foreach ($indexes as $index) {
+            $byName[(string) $index['Key_name']][] = (string) $index['Column_name'];
+        }
+
+        static::assertSame(['plugin_name', 'migration_class'], $byName['PRIMARY']);
+        static::assertSame(
+            ['plugin_name', 'creation_timestamp'],
+            $byName['uniq.plugin_migration.plugin_name__creation_timestamp']
+        );
+    }
+}

--- a/tests/unit/Core/Framework/Migration/MigrationExceptionTest.php
+++ b/tests/unit/Core/Framework/Migration/MigrationExceptionTest.php
@@ -65,4 +65,93 @@ class MigrationExceptionTest extends TestCase
         static::assertSame('Plugin "test" could not be found.', $exception->getMessage());
         static::assertSame(['pluginName' => 'test'], $exception->getParameters());
     }
+
+    public function testMigrationDirectoryNotReadable(): void
+    {
+        $exception = MigrationException::migrationDirectoryNotReadable('/tmp/nope');
+
+        static::assertSame(Response::HTTP_INTERNAL_SERVER_ERROR, $exception->getStatusCode());
+        static::assertSame('FRAMEWORK__MIGRATION_DIRECTORY_NOT_READABLE', $exception->getErrorCode());
+        static::assertSame('Migration directory "/tmp/nope" could not be read.', $exception->getMessage());
+        static::assertSame(['directory' => '/tmp/nope'], $exception->getParameters());
+    }
+
+    public function testReversibleMigrationNotInstantiable(): void
+    {
+        $exception = MigrationException::reversibleMigrationNotInstantiable('Acme\\Migration1');
+
+        static::assertSame(Response::HTTP_INTERNAL_SERVER_ERROR, $exception->getStatusCode());
+        static::assertSame('FRAMEWORK__REVERSIBLE_MIGRATION_NOT_INSTANTIABLE', $exception->getErrorCode());
+        static::assertSame('Reversible migration "Acme\\Migration1" must be instantiable without constructor arguments.', $exception->getMessage());
+        static::assertSame(['class' => 'Acme\\Migration1'], $exception->getParameters());
+    }
+
+    public function testReversibleMigrationInvalidTimestamp(): void
+    {
+        $exception = MigrationException::reversibleMigrationInvalidTimestamp('Acme\\Migration1', 0);
+
+        static::assertSame(Response::HTTP_INTERNAL_SERVER_ERROR, $exception->getStatusCode());
+        static::assertSame('FRAMEWORK__REVERSIBLE_MIGRATION_INVALID_TIMESTAMP', $exception->getErrorCode());
+        static::assertSame('Migration timestamp must be between 1 and 2147483647 to ensure migration order is deterministic on every system, but "0" was given for "Acme\\Migration1".', $exception->getMessage());
+        static::assertSame(['class' => 'Acme\\Migration1', 'timestamp' => 0], $exception->getParameters());
+    }
+
+    public function testDuplicateMigrationTimestamp(): void
+    {
+        $exception = MigrationException::duplicateMigrationTimestamp('SwagTest', 100, 'Acme\\A', 'Acme\\B');
+
+        static::assertSame(Response::HTTP_INTERNAL_SERVER_ERROR, $exception->getStatusCode());
+        static::assertSame('FRAMEWORK__REVERSIBLE_MIGRATION_DUPLICATE_TIMESTAMP', $exception->getErrorCode());
+        static::assertSame('Plugin "SwagTest" contains two reversible migrations with timestamp 100: "Acme\\A" and "Acme\\B".', $exception->getMessage());
+        static::assertSame(['plugin' => 'SwagTest', 'timestamp' => 100, 'first' => 'Acme\\A', 'second' => 'Acme\\B'], $exception->getParameters());
+    }
+
+    public function testMigrationOutOfOrder(): void
+    {
+        $exception = MigrationException::migrationOutOfOrder('SwagTest', 'Acme\\A', 100, 200);
+
+        static::assertSame(Response::HTTP_INTERNAL_SERVER_ERROR, $exception->getStatusCode());
+        static::assertSame('FRAMEWORK__REVERSIBLE_MIGRATION_OUT_OF_ORDER', $exception->getErrorCode());
+        static::assertSame('Reversible migration "Acme\\A" (100) for plugin "SwagTest" is older than the latest applied migration (200). Add new migrations with a later timestamp.', $exception->getMessage());
+        static::assertSame(['plugin' => 'SwagTest', 'class' => 'Acme\\A', 'timestamp' => 100, 'latestApplied' => 200], $exception->getParameters());
+    }
+
+    public function testMigrationTimestampChanged(): void
+    {
+        $exception = MigrationException::migrationTimestampChanged('Acme\\A', 100, 200);
+
+        static::assertSame(Response::HTTP_INTERNAL_SERVER_ERROR, $exception->getStatusCode());
+        static::assertSame('FRAMEWORK__REVERSIBLE_MIGRATION_TIMESTAMP_CHANGED', $exception->getErrorCode());
+        static::assertSame('Applied reversible migration "Acme\\A" changed its creation timestamp from 100 to 200. Restore the recorded timestamp.', $exception->getMessage());
+        static::assertSame(['class' => 'Acme\\A', 'recorded' => 100, 'declared' => 200], $exception->getParameters());
+    }
+
+    public function testMissingAppliedMigration(): void
+    {
+        $exception = MigrationException::missingAppliedMigration('SwagTest', 'Acme\\A');
+
+        static::assertSame(Response::HTTP_INTERNAL_SERVER_ERROR, $exception->getStatusCode());
+        static::assertSame('FRAMEWORK__REVERSIBLE_MIGRATION_MISSING_APPLIED', $exception->getErrorCode());
+        static::assertSame('Applied reversible migration "Acme\\A" for plugin "SwagTest" is no longer available. Restore the migration class before continuing.', $exception->getMessage());
+        static::assertSame(['plugin' => 'SwagTest', 'class' => 'Acme\\A'], $exception->getParameters());
+    }
+
+    public function testMigrationLockNotAcquired(): void
+    {
+        $exception = MigrationException::migrationLockNotAcquired('SwagTest');
+
+        static::assertSame(Response::HTTP_INTERNAL_SERVER_ERROR, $exception->getStatusCode());
+        static::assertSame('FRAMEWORK__REVERSIBLE_MIGRATION_LOCK_NOT_ACQUIRED', $exception->getErrorCode());
+        static::assertSame('Could not acquire the reversible migration lock for plugin "SwagTest".', $exception->getMessage());
+        static::assertSame(['plugin' => 'SwagTest'], $exception->getParameters());
+    }
+
+    public function testInvalidMigrationState(): void
+    {
+        $exception = MigrationException::invalidMigrationState();
+
+        static::assertSame(Response::HTTP_INTERNAL_SERVER_ERROR, $exception->getStatusCode());
+        static::assertSame('FRAMEWORK__REVERSIBLE_MIGRATION_INVALID_STATE', $exception->getErrorCode());
+        static::assertSame('The reversible migration state contains an invalid row.', $exception->getMessage());
+    }
 }

--- a/tests/unit/Core/Framework/Migration/Reversible/Command/CreateReversibleMigrationCommandTest.php
+++ b/tests/unit/Core/Framework/Migration/Reversible/Command/CreateReversibleMigrationCommandTest.php
@@ -1,0 +1,114 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\Migration\Reversible\Command;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Migration\MigrationException;
+use Shopware\Core\Framework\Migration\Reversible\Command\CreateReversibleMigrationCommand;
+use Shopware\Core\Framework\Plugin\KernelPluginCollection;
+use Shopware\Tests\Unit\Core\Framework\Migration\Reversible\_fixtures\RelocatablePlugin;
+use Symfony\Component\Clock\MockClock;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Filesystem\Filesystem;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+#[CoversClass(CreateReversibleMigrationCommand::class)]
+class CreateReversibleMigrationCommandTest extends TestCase
+{
+    private const TIMESTAMP = 1787465993;
+
+    private string $pluginDirectory;
+
+    private Filesystem $filesystem;
+
+    protected function setUp(): void
+    {
+        $this->filesystem = new Filesystem();
+        $this->pluginDirectory = sys_get_temp_dir() . '/sw-reversible-' . bin2hex(random_bytes(6));
+        $this->filesystem->mkdir($this->pluginDirectory . '/Migration');
+    }
+
+    protected function tearDown(): void
+    {
+        $this->filesystem->remove($this->pluginDirectory);
+    }
+
+    public function testCreatesAMigrationFromTheTemplate(): void
+    {
+        $tester = new CommandTester($this->command());
+        $tester->execute(['--plugin' => 'RelocatablePlugin', '--name' => 'CreateReview']);
+
+        $tester->assertCommandIsSuccessful();
+
+        $path = $this->pluginDirectory . '/Migration/Migration' . self::TIMESTAMP . 'CreateReview.php';
+        static::assertFileExists($path);
+
+        $contents = (string) file_get_contents($path);
+        static::assertStringContainsString('namespace Swag\\Reversible\\Migration;', $contents);
+        static::assertStringContainsString('class Migration' . self::TIMESTAMP . 'CreateReview extends Migration', $contents);
+        static::assertStringContainsString('return ' . self::TIMESTAMP . ';', $contents);
+        static::assertStringContainsString('public function up(UpMigrationContext $context): void', $contents);
+        static::assertStringContainsString('public function down(DownMigrationContext $context): void', $contents);
+    }
+
+    public function testCreatesAMigrationWithoutAName(): void
+    {
+        $tester = new CommandTester($this->command());
+        $tester->execute(['--plugin' => 'RelocatablePlugin']);
+
+        $tester->assertCommandIsSuccessful();
+        static::assertFileExists($this->pluginDirectory . '/Migration/Migration' . self::TIMESTAMP . '.php');
+    }
+
+    public function testRejectsAForbiddenName(): void
+    {
+        $this->expectExceptionObject(
+            MigrationException::invalidArgument('Migration name contains forbidden characters!')
+        );
+
+        (new CommandTester($this->command()))->execute(['--plugin' => 'RelocatablePlugin', '--name' => 'Not Valid!']);
+    }
+
+    public function testRequiresAPlugin(): void
+    {
+        $this->expectExceptionObject(
+            MigrationException::invalidArgument('Please specify the plugin the migration belongs to via --plugin.')
+        );
+
+        (new CommandTester($this->command()))->execute([]);
+    }
+
+    public function testRefusesToOverwriteAnExistingMigration(): void
+    {
+        $path = $this->pluginDirectory . '/Migration/Migration' . self::TIMESTAMP . 'CreateReview.php';
+        $this->filesystem->dumpFile($path, '<?php // pre-existing');
+
+        try {
+            (new CommandTester($this->command()))->execute(['--plugin' => 'RelocatablePlugin', '--name' => 'CreateReview']);
+            static::fail('Expected the command to refuse overwriting an existing migration.');
+        } catch (MigrationException $exception) {
+            static::assertStringContainsString('already exists', $exception->getMessage());
+        }
+
+        static::assertSame('<?php // pre-existing', file_get_contents($path));
+    }
+
+    private function command(): CreateReversibleMigrationCommand
+    {
+        $plugin = (new RelocatablePlugin(true, $this->pluginDirectory))->relocateTo($this->pluginDirectory);
+
+        $collection = new KernelPluginCollection();
+        $collection->add($plugin);
+
+        return new CreateReversibleMigrationCommand(
+            $collection,
+            $this->filesystem,
+            new MockClock((new \DateTimeImmutable())->setTimestamp(self::TIMESTAMP))
+        );
+    }
+}

--- a/tests/unit/Core/Framework/Migration/Reversible/Command/ReversibleMigrationCommandTest.php
+++ b/tests/unit/Core/Framework/Migration/Reversible/Command/ReversibleMigrationCommandTest.php
@@ -1,0 +1,160 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\Migration\Reversible\Command;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Migration\MigrationException;
+use Shopware\Core\Framework\Migration\Reversible\Command\ReversibleMigrationCommand;
+use Shopware\Core\Framework\Migration\Reversible\MigrationRunner;
+use Shopware\Core\Framework\Plugin;
+use Shopware\Core\Framework\Plugin\KernelPluginCollection;
+use Shopware\Tests\Unit\Core\Framework\Migration\Reversible\_fixtures\SwagNoMigrations\SwagNoMigrations;
+use Shopware\Tests\Unit\Core\Framework\Migration\Reversible\_fixtures\SwagNotInstantiable\SwagNotInstantiable;
+use Shopware\Tests\Unit\Core\Framework\Migration\Reversible\_fixtures\SwagReversible\SwagReversible;
+use Symfony\Component\Console\Tester\CommandTester;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+#[CoversClass(ReversibleMigrationCommand::class)]
+class ReversibleMigrationCommandTest extends TestCase
+{
+    public function testMigratesASinglePlugin(): void
+    {
+        $runner = $this->createMock(MigrationRunner::class);
+        $runner->expects($this->once())
+            ->method('up')
+            ->willReturn(['Acme\\Migration1']);
+
+        $tester = new CommandTester(new ReversibleMigrationCommand($runner, $this->plugins(SwagReversible::class)));
+        $tester->execute(['plugin' => 'SwagReversible']);
+
+        $tester->assertCommandIsSuccessful();
+        static::assertStringContainsString('Acme\\Migration1', $tester->getDisplay());
+    }
+
+    public function testReportsAPluginThatIsAlreadyUpToDate(): void
+    {
+        $runner = static::createStub(MigrationRunner::class);
+        $runner->method('up')->willReturn([]);
+
+        $tester = new CommandTester(new ReversibleMigrationCommand($runner, $this->plugins(SwagReversible::class)));
+        $tester->execute(['plugin' => 'SwagReversible']);
+
+        static::assertStringContainsString('SwagReversible is already up to date.', $tester->getDisplay());
+    }
+
+    public function testResolvesAPluginByUniquePrefix(): void
+    {
+        $runner = $this->createMock(MigrationRunner::class);
+        $runner->expects($this->once())->method('up')->willReturn([]);
+
+        $tester = new CommandTester(new ReversibleMigrationCommand($runner, $this->plugins(SwagReversible::class)));
+        $tester->execute(['plugin' => 'SwagRev']);
+
+        $tester->assertCommandIsSuccessful();
+    }
+
+    public function testFailsForAnUnknownPlugin(): void
+    {
+        $command = new ReversibleMigrationCommand(
+            static::createStub(MigrationRunner::class),
+            $this->plugins(SwagReversible::class)
+        );
+
+        $this->expectExceptionObject(MigrationException::pluginNotFound('Nope'));
+
+        (new CommandTester($command))->execute(['plugin' => 'Nope']);
+    }
+
+    public function testFailsForAnAmbiguousPluginPrefix(): void
+    {
+        $command = new ReversibleMigrationCommand(
+            static::createStub(MigrationRunner::class),
+            $this->plugins(SwagNoMigrations::class, SwagNotInstantiable::class)
+        );
+
+        $this->expectExceptionObject(MigrationException::moreThanOnePluginFound(
+            'SwagNo',
+            [SwagNoMigrations::class, SwagNotInstantiable::class]
+        ));
+
+        (new CommandTester($command))->execute(['plugin' => 'SwagNo']);
+    }
+
+    public function testFailsWhenNeitherPluginNorAllIsGiven(): void
+    {
+        $command = new ReversibleMigrationCommand(
+            static::createStub(MigrationRunner::class),
+            $this->plugins(SwagReversible::class)
+        );
+
+        $this->expectExceptionObject(
+            MigrationException::invalidArgument('Missing plugin name or --all option.')
+        );
+
+        (new CommandTester($command))->execute([]);
+    }
+
+    public function testFailsWhenBothPluginAndAllAreGiven(): void
+    {
+        $command = new ReversibleMigrationCommand(
+            static::createStub(MigrationRunner::class),
+            $this->plugins(SwagReversible::class)
+        );
+
+        $this->expectExceptionObject(
+            MigrationException::invalidArgument('Pass either a plugin name or the --all option, not both.')
+        );
+
+        (new CommandTester($command))->execute(['plugin' => 'SwagReversible', '--all' => true]);
+    }
+
+    public function testAllOnlyProcessesActivePluginsInSortedOrder(): void
+    {
+        $active = $this->plugin(SwagReversible::class, true);
+        $inactive = $this->plugin(SwagNoMigrations::class, false);
+
+        $processed = [];
+        $runner = static::createStub(MigrationRunner::class);
+        $runner->method('up')->willReturnCallback(function (Plugin $plugin) use (&$processed): array {
+            $processed[] = $plugin->getName();
+
+            return [];
+        });
+
+        $collection = new KernelPluginCollection();
+        $collection->addList([$inactive, $active]);
+        $tester = new CommandTester(new ReversibleMigrationCommand($runner, $collection));
+        $tester->execute(['--all' => true]);
+
+        $tester->assertCommandIsSuccessful();
+        static::assertSame(['SwagReversible'], $processed);
+    }
+
+    /**
+     * @param class-string<Plugin> ...$classes
+     */
+    private function plugins(string ...$classes): KernelPluginCollection
+    {
+        $collection = new KernelPluginCollection();
+        foreach ($classes as $class) {
+            $collection->add($this->plugin($class, true));
+        }
+
+        return $collection;
+    }
+
+    /**
+     * @param class-string<Plugin> $class
+     */
+    private function plugin(string $class, bool $active): Plugin
+    {
+        $directory = \dirname((string) (new \ReflectionClass($class))->getFileName());
+
+        return new $class($active, $directory);
+    }
+}

--- a/tests/unit/Core/Framework/Migration/Reversible/DownMigrationContextTest.php
+++ b/tests/unit/Core/Framework/Migration/Reversible/DownMigrationContextTest.php
@@ -1,0 +1,35 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\Migration\Reversible;
+
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Migration\Reversible\DownMigrationContext;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+#[CoversClass(DownMigrationContext::class)]
+class DownMigrationContextTest extends TestCase
+{
+    public function testExposesConnectionAndKeepUserDataFlag(): void
+    {
+        $connection = static::createStub(Connection::class);
+
+        $context = new DownMigrationContext($connection, true);
+
+        static::assertSame($connection, $context->connection);
+        static::assertTrue($context->keepUserData);
+
+        static::assertFalse((new DownMigrationContext($connection, false))->keepUserData);
+    }
+
+    public function testIsFinalSoPluginsCannotSubclassIt(): void
+    {
+        // the class is passed into plugin code, so appending constructor parameters must stay safe
+        static::assertTrue((new \ReflectionClass(DownMigrationContext::class))->isFinal());
+    }
+}

--- a/tests/unit/Core/Framework/Migration/Reversible/ExecutedMigrationTest.php
+++ b/tests/unit/Core/Framework/Migration/Reversible/ExecutedMigrationTest.php
@@ -1,0 +1,25 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\Migration\Reversible;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Migration\Reversible\ExecutedMigration;
+use Shopware\Tests\Unit\Core\Framework\Migration\Reversible\_fixtures\RecordingMigrationA;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+#[CoversClass(ExecutedMigration::class)]
+class ExecutedMigrationTest extends TestCase
+{
+    public function testExposesTheClassAndCreationTimestamp(): void
+    {
+        $migration = new ExecutedMigration(RecordingMigrationA::class, 1787465993);
+
+        static::assertSame(RecordingMigrationA::class, $migration->class);
+        static::assertSame(1787465993, $migration->creationTimestamp);
+    }
+}

--- a/tests/unit/Core/Framework/Migration/Reversible/MigrationLockTest.php
+++ b/tests/unit/Core/Framework/Migration/Reversible/MigrationLockTest.php
@@ -1,0 +1,66 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\Migration\Reversible;
+
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Migration\MigrationException;
+use Shopware\Core\Framework\Migration\Reversible\MigrationLock;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+#[CoversClass(MigrationLock::class)]
+class MigrationLockTest extends TestCase
+{
+    public function testLockNameFitsTheMysqlLimitAndIsStablePerPlugin(): void
+    {
+        $name = MigrationLock::lockName('SwagReversible');
+
+        // GET_LOCK names are limited to 64 characters, so the plugin name is hashed
+        static::assertLessThanOrEqual(64, mb_strlen($name));
+        static::assertSame($name, MigrationLock::lockName('SwagReversible'));
+        static::assertNotSame($name, MigrationLock::lockName('SwagOther'));
+    }
+
+    public function testReturnsTheCallbackResult(): void
+    {
+        $lock = new MigrationLock($this->connectionHoldingTheLock());
+
+        static::assertSame('result', $lock->synchronized('SwagReversible', static fn (): string => 'result'));
+    }
+
+    public function testFailsWhenTheLockCannotBeAcquired(): void
+    {
+        $connection = static::createStub(Connection::class);
+        $connection->method('fetchOne')->willReturn(0);
+
+        $lock = new MigrationLock($connection, timeoutSeconds: 0);
+
+        $this->expectExceptionObject(MigrationException::migrationLockNotAcquired('SwagReversible'));
+
+        $lock->synchronized('SwagReversible', static fn (): bool => true);
+    }
+
+    public function testLetsTheCallbackExceptionBubbleUp(): void
+    {
+        $lock = new MigrationLock($this->connectionHoldingTheLock());
+
+        $this->expectExceptionObject(new \RuntimeException('migration failed'));
+
+        $lock->synchronized('SwagReversible', static function (): void {
+            throw new \RuntimeException('migration failed');
+        });
+    }
+
+    private function connectionHoldingTheLock(): Connection
+    {
+        $connection = static::createStub(Connection::class);
+        $connection->method('fetchOne')->willReturn(1);
+
+        return $connection;
+    }
+}

--- a/tests/unit/Core/Framework/Migration/Reversible/MigrationProviderTest.php
+++ b/tests/unit/Core/Framework/Migration/Reversible/MigrationProviderTest.php
@@ -1,0 +1,104 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\Migration\Reversible;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Migration\MigrationException;
+use Shopware\Core\Framework\Migration\Reversible\Migration;
+use Shopware\Core\Framework\Migration\Reversible\MigrationProvider;
+use Shopware\Core\Framework\Plugin;
+use Shopware\Tests\Unit\Core\Framework\Migration\Reversible\_fixtures\SwagDuplicateTimestamp\Migration\Migration1600000000A;
+use Shopware\Tests\Unit\Core\Framework\Migration\Reversible\_fixtures\SwagDuplicateTimestamp\Migration\Migration1600000000B;
+use Shopware\Tests\Unit\Core\Framework\Migration\Reversible\_fixtures\SwagDuplicateTimestamp\SwagDuplicateTimestamp;
+use Shopware\Tests\Unit\Core\Framework\Migration\Reversible\_fixtures\SwagInvalidTimestamp\Migration\Migration0Invalid;
+use Shopware\Tests\Unit\Core\Framework\Migration\Reversible\_fixtures\SwagInvalidTimestamp\SwagInvalidTimestamp;
+use Shopware\Tests\Unit\Core\Framework\Migration\Reversible\_fixtures\SwagNoMigrations\SwagNoMigrations;
+use Shopware\Tests\Unit\Core\Framework\Migration\Reversible\_fixtures\SwagNotInstantiable\Migration\Migration1700000000NeedsArguments;
+use Shopware\Tests\Unit\Core\Framework\Migration\Reversible\_fixtures\SwagNotInstantiable\SwagNotInstantiable;
+use Shopware\Tests\Unit\Core\Framework\Migration\Reversible\_fixtures\SwagReversible\Migration\Migration1000000000Second;
+use Shopware\Tests\Unit\Core\Framework\Migration\Reversible\_fixtures\SwagReversible\Migration\Migration2000000000First;
+use Shopware\Tests\Unit\Core\Framework\Migration\Reversible\_fixtures\SwagReversible\SwagReversible;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+#[CoversClass(MigrationProvider::class)]
+class MigrationProviderTest extends TestCase
+{
+    public function testReturnsNothingWhenMigrationDirectoryIsMissing(): void
+    {
+        $provider = new MigrationProvider();
+
+        static::assertSame([], $provider->forPlugin($this->plugin(SwagNoMigrations::class)));
+    }
+
+    public function testSortsByTimestampAndSkipsLegacyMigrationSteps(): void
+    {
+        $provider = new MigrationProvider();
+
+        $migrations = $provider->forPlugin($this->plugin(SwagReversible::class));
+
+        // Migration1500000000LegacyStep extends MigrationStep and must not be picked up
+        static::assertSame(
+            [Migration1000000000Second::class, Migration2000000000First::class],
+            array_map(static fn (Migration $migration): string => $migration::class, $migrations)
+        );
+    }
+
+    public function testCachesResultPerPlugin(): void
+    {
+        $provider = new MigrationProvider();
+        $plugin = $this->plugin(SwagReversible::class);
+
+        static::assertEquals($provider->forPlugin($plugin), $provider->forPlugin($plugin));
+    }
+
+    public function testRejectsDuplicateTimestamps(): void
+    {
+        $provider = new MigrationProvider();
+
+        $this->expectExceptionObject(MigrationException::duplicateMigrationTimestamp(
+            'SwagDuplicateTimestamp',
+            1600000000,
+            Migration1600000000A::class,
+            Migration1600000000B::class
+        ));
+
+        $provider->forPlugin($this->plugin(SwagDuplicateTimestamp::class));
+    }
+
+    public function testRejectsInvalidTimestamps(): void
+    {
+        $provider = new MigrationProvider();
+
+        $this->expectExceptionObject(
+            MigrationException::reversibleMigrationInvalidTimestamp(Migration0Invalid::class, 0)
+        );
+
+        $provider->forPlugin($this->plugin(SwagInvalidTimestamp::class));
+    }
+
+    public function testRejectsMigrationsWithRequiredConstructorArguments(): void
+    {
+        $provider = new MigrationProvider();
+
+        $this->expectExceptionObject(
+            MigrationException::reversibleMigrationNotInstantiable(Migration1700000000NeedsArguments::class)
+        );
+
+        $provider->forPlugin($this->plugin(SwagNotInstantiable::class));
+    }
+
+    /**
+     * @param class-string<Plugin> $class
+     */
+    private function plugin(string $class): Plugin
+    {
+        $directory = \dirname((string) (new \ReflectionClass($class))->getFileName());
+
+        return new $class(true, $directory);
+    }
+}

--- a/tests/unit/Core/Framework/Migration/Reversible/MigrationRunnerTest.php
+++ b/tests/unit/Core/Framework/Migration/Reversible/MigrationRunnerTest.php
@@ -1,0 +1,232 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\Migration\Reversible;
+
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Migration\MigrationException;
+use Shopware\Core\Framework\Migration\Reversible\Migration;
+use Shopware\Core\Framework\Migration\Reversible\MigrationProvider;
+use Shopware\Core\Framework\Migration\Reversible\MigrationRunner;
+use Shopware\Core\Framework\Migration\Reversible\MigrationStateStore;
+use Shopware\Core\Framework\Plugin;
+use Shopware\Tests\Unit\Core\Framework\Migration\Reversible\_fixtures\ImmediateMigrationLock;
+use Shopware\Tests\Unit\Core\Framework\Migration\Reversible\_fixtures\InMemoryMigrationStateStore;
+use Shopware\Tests\Unit\Core\Framework\Migration\Reversible\_fixtures\RecordingMigrationA;
+use Shopware\Tests\Unit\Core\Framework\Migration\Reversible\_fixtures\RecordingMigrationB;
+use Shopware\Tests\Unit\Core\Framework\Migration\Reversible\_fixtures\SwagReversible\SwagReversible;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+#[CoversClass(MigrationRunner::class)]
+class MigrationRunnerTest extends TestCase
+{
+    private const PLUGIN_NAME = 'SwagReversible';
+
+    /**
+     * @var \ArrayObject<int, string>
+     */
+    private \ArrayObject $calls;
+
+    protected function setUp(): void
+    {
+        $this->calls = new \ArrayObject();
+    }
+
+    public function testUpAppliesPendingMigrationsInAscendingOrder(): void
+    {
+        $first = new RecordingMigrationA(100, $this->calls);
+        $second = new RecordingMigrationB(200, $this->calls);
+
+        $store = new InMemoryMigrationStateStore();
+        $applied = $this->runner([$second, $first], $store)->up($this->plugin());
+
+        static::assertSame(
+            [RecordingMigrationA::class . '::up', RecordingMigrationB::class . '::up'],
+            $this->calls->getArrayCopy()
+        );
+        static::assertSame([RecordingMigrationA::class, RecordingMigrationB::class], $applied);
+        static::assertSame(
+            [RecordingMigrationA::class => 100, RecordingMigrationB::class => 200],
+            $store->timestampsFor(self::PLUGIN_NAME)
+        );
+    }
+
+    public function testUpIsIdempotent(): void
+    {
+        $migration = new RecordingMigrationA(100, $this->calls);
+        $runner = $this->runner([$migration], new InMemoryMigrationStateStore());
+
+        $runner->up($this->plugin());
+        $applied = $runner->up($this->plugin());
+
+        static::assertSame([], $applied);
+        static::assertCount(1, $this->calls);
+    }
+
+    public function testUpPassesTheInstallationFlagToTheContext(): void
+    {
+        $migration = new RecordingMigrationA(100, $this->calls);
+
+        $this->runner([$migration], new InMemoryMigrationStateStore())->up($this->plugin(), true);
+
+        static::assertNotNull($migration->lastUpContext);
+        static::assertTrue($migration->lastUpContext->isInstallation);
+    }
+
+    public function testUpDefaultsTheInstallationFlagToFalse(): void
+    {
+        $migration = new RecordingMigrationA(100, $this->calls);
+
+        $this->runner([$migration], new InMemoryMigrationStateStore())->up($this->plugin());
+
+        static::assertNotNull($migration->lastUpContext);
+        static::assertFalse($migration->lastUpContext->isInstallation);
+    }
+
+    public function testUpRejectsAMigrationInsertedBeforeTheLatestAppliedOne(): void
+    {
+        $inserted = new RecordingMigrationA(100, $this->calls);
+        $applied = new RecordingMigrationB(200, $this->calls);
+
+        $store = new InMemoryMigrationStateStore();
+        $store->markExecuted(self::PLUGIN_NAME, RecordingMigrationB::class, 200);
+
+        $this->expectExceptionObject(MigrationException::migrationOutOfOrder(
+            self::PLUGIN_NAME,
+            RecordingMigrationA::class,
+            100,
+            200
+        ));
+
+        $this->runner([$inserted, $applied], $store)->up($this->plugin());
+    }
+
+    public function testRejectsAnAppliedMigrationThatNoLongerExists(): void
+    {
+        $store = new InMemoryMigrationStateStore();
+        $store->markExecuted(self::PLUGIN_NAME, RecordingMigrationB::class, 100);
+
+        $this->expectExceptionObject(
+            MigrationException::missingAppliedMigration(self::PLUGIN_NAME, RecordingMigrationB::class)
+        );
+
+        $this->runner([], $store)->up($this->plugin());
+    }
+
+    public function testRejectsAnAppliedMigrationWhoseTimestampChanged(): void
+    {
+        $migration = new RecordingMigrationA(200, $this->calls);
+
+        $store = new InMemoryMigrationStateStore();
+        $store->markExecuted(self::PLUGIN_NAME, RecordingMigrationA::class, 100);
+
+        $this->expectExceptionObject(
+            MigrationException::migrationTimestampChanged(RecordingMigrationA::class, 100, 200)
+        );
+
+        $this->runner([$migration], $store)->up($this->plugin());
+    }
+
+    public function testDownRollsBackInDescendingOrderAndClearsHistory(): void
+    {
+        $first = new RecordingMigrationA(100, $this->calls);
+        $second = new RecordingMigrationB(200, $this->calls);
+
+        $store = new InMemoryMigrationStateStore();
+        $runner = $this->runner([$first, $second], $store);
+        $runner->up($this->plugin());
+
+        $this->calls->exchangeArray([]);
+        $removed = $runner->down($this->plugin());
+
+        static::assertSame(
+            [RecordingMigrationB::class . '::down', RecordingMigrationA::class . '::down'],
+            $this->calls->getArrayCopy()
+        );
+        static::assertSame([RecordingMigrationB::class, RecordingMigrationA::class], $removed);
+        static::assertSame([], $store->timestampsFor(self::PLUGIN_NAME));
+    }
+
+    public function testDownKeepsSchemaAndHistoryWhenUserDataIsKept(): void
+    {
+        $migration = new RecordingMigrationA(100, $this->calls);
+
+        $store = new InMemoryMigrationStateStore();
+        $runner = $this->runner([$migration], $store);
+        $runner->up($this->plugin());
+
+        $this->calls->exchangeArray([]);
+        $removed = $runner->down($this->plugin(), true);
+
+        static::assertSame([], $removed);
+        static::assertCount(0, $this->calls);
+        static::assertSame([RecordingMigrationA::class => 100], $store->timestampsFor(self::PLUGIN_NAME));
+    }
+
+    public function testDownPassesKeepUserDataToTheContext(): void
+    {
+        $migration = new RecordingMigrationA(100, $this->calls);
+
+        $runner = $this->runner([$migration], new InMemoryMigrationStateStore());
+        $runner->up($this->plugin());
+        $runner->down($this->plugin());
+
+        static::assertNotNull($migration->lastDownContext);
+        static::assertFalse($migration->lastDownContext->keepUserData);
+    }
+
+    public function testWorkIsSynchronizedPerPlugin(): void
+    {
+        $lock = new ImmediateMigrationLock();
+        $runner = new MigrationRunner(
+            $this->provider([]),
+            new InMemoryMigrationStateStore(),
+            $lock,
+            static::createStub(Connection::class)
+        );
+
+        $runner->up($this->plugin());
+        $runner->down($this->plugin());
+
+        static::assertSame([self::PLUGIN_NAME, self::PLUGIN_NAME], $lock->acquired);
+    }
+
+    /**
+     * @param list<Migration> $migrations
+     */
+    private function runner(array $migrations, MigrationStateStore $store): MigrationRunner
+    {
+        return new MigrationRunner(
+            $this->provider($migrations),
+            $store,
+            new ImmediateMigrationLock(),
+            static::createStub(Connection::class)
+        );
+    }
+
+    /**
+     * @param list<Migration> $migrations
+     */
+    private function provider(array $migrations): MigrationProvider
+    {
+        // the real provider guarantees ascending order, so the fake must too
+        usort($migrations, static fn (Migration $a, Migration $b): int => $a->getCreationTimestamp() <=> $b->getCreationTimestamp());
+
+        $provider = static::createStub(MigrationProvider::class);
+        $provider->method('forPlugin')->willReturn($migrations);
+
+        return $provider;
+    }
+
+    private function plugin(): Plugin
+    {
+        $directory = \dirname((string) (new \ReflectionClass(SwagReversible::class))->getFileName());
+
+        return new SwagReversible(true, $directory);
+    }
+}

--- a/tests/unit/Core/Framework/Migration/Reversible/MigrationStateStoreTest.php
+++ b/tests/unit/Core/Framework/Migration/Reversible/MigrationStateStoreTest.php
@@ -1,0 +1,118 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\Migration\Reversible;
+
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Migration\MigrationException;
+use Shopware\Core\Framework\Migration\Reversible\ExecutedMigration;
+use Shopware\Core\Framework\Migration\Reversible\MigrationStateStore;
+use Shopware\Tests\Unit\Core\Framework\Migration\Reversible\_fixtures\RecordingMigrationA;
+use Shopware\Tests\Unit\Core\Framework\Migration\Reversible\_fixtures\RecordingMigrationB;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+#[CoversClass(MigrationStateStore::class)]
+class MigrationStateStoreTest extends TestCase
+{
+    public function testExecutedMapsRowsToExecutedMigrations(): void
+    {
+        $connection = static::createStub(Connection::class);
+        $connection->method('fetchAllAssociative')->willReturn([
+            // the creation timestamp comes back as a string on some PDO drivers
+            ['migration_class' => RecordingMigrationA::class, 'creation_timestamp' => '100'],
+            ['migration_class' => RecordingMigrationB::class, 'creation_timestamp' => 200],
+        ]);
+
+        $executed = (new MigrationStateStore($connection))->executed('SwagReversible');
+
+        static::assertSame(
+            [RecordingMigrationA::class, RecordingMigrationB::class],
+            array_map(static fn (ExecutedMigration $entry): string => $entry->class, $executed)
+        );
+        static::assertSame(
+            [100, 200],
+            array_map(static fn (ExecutedMigration $entry): int => $entry->creationTimestamp, $executed)
+        );
+    }
+
+    /**
+     * @param list<array<string, mixed>> $rows
+     */
+    #[DataProvider('malformedRows')]
+    public function testExecutedRejectsMalformedRows(array $rows): void
+    {
+        $connection = static::createStub(Connection::class);
+        $connection->method('fetchAllAssociative')->willReturn($rows);
+
+        $this->expectExceptionObject(MigrationException::invalidMigrationState());
+
+        (new MigrationStateStore($connection))->executed('SwagReversible');
+    }
+
+    /**
+     * @return iterable<string, array{list<array<string, mixed>>}>
+     */
+    public static function malformedRows(): iterable
+    {
+        yield 'migration class is missing' => [
+            [['creation_timestamp' => 100]],
+        ];
+
+        yield 'creation timestamp is not a number' => [
+            [['migration_class' => RecordingMigrationA::class, 'creation_timestamp' => ['100']]],
+        ];
+    }
+
+    public function testMarkExecutedWritesTheHistoryRow(): void
+    {
+        $writes = [];
+
+        (new MigrationStateStore($this->connectionCapturingWrites($writes)))
+            ->markExecuted('SwagReversible', RecordingMigrationA::class, 100);
+
+        static::assertSame([[
+            'plugin_name' => 'SwagReversible',
+            'migration_class' => RecordingMigrationA::class,
+            'creation_timestamp' => 100,
+        ]], $writes);
+    }
+
+    public function testRemoveDeletesTheHistoryRow(): void
+    {
+        $writes = [];
+
+        (new MigrationStateStore($this->connectionCapturingWrites($writes)))
+            ->remove('SwagReversible', RecordingMigrationA::class);
+
+        static::assertSame([[
+            'plugin_name' => 'SwagReversible',
+            'migration_class' => RecordingMigrationA::class,
+        ]], $writes);
+    }
+
+    /**
+     * @param list<array<string, mixed>> $writes
+     */
+    private function connectionCapturingWrites(array &$writes): Connection
+    {
+        $connection = static::createStub(Connection::class);
+        $connection->method('insert')->willReturnCallback(static function (string $table, array $values) use (&$writes): int {
+            $writes[] = $values;
+
+            return 1;
+        });
+        $connection->method('delete')->willReturnCallback(static function (string $table, array $criteria) use (&$writes): int {
+            $writes[] = $criteria;
+
+            return 1;
+        });
+
+        return $connection;
+    }
+}

--- a/tests/unit/Core/Framework/Migration/Reversible/UpMigrationContextTest.php
+++ b/tests/unit/Core/Framework/Migration/Reversible/UpMigrationContextTest.php
@@ -1,0 +1,35 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\Migration\Reversible;
+
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Migration\Reversible\UpMigrationContext;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+#[CoversClass(UpMigrationContext::class)]
+class UpMigrationContextTest extends TestCase
+{
+    public function testExposesConnectionAndInstallationFlag(): void
+    {
+        $connection = static::createStub(Connection::class);
+
+        $context = new UpMigrationContext($connection, true);
+
+        static::assertSame($connection, $context->connection);
+        static::assertTrue($context->isInstallation);
+
+        static::assertFalse((new UpMigrationContext($connection, false))->isInstallation);
+    }
+
+    public function testIsFinalSoPluginsCannotSubclassIt(): void
+    {
+        // the class is passed into plugin code, so appending constructor parameters must stay safe
+        static::assertTrue((new \ReflectionClass(UpMigrationContext::class))->isFinal());
+    }
+}

--- a/tests/unit/Core/Framework/Migration/Reversible/_fixtures/ImmediateMigrationLock.php
+++ b/tests/unit/Core/Framework/Migration/Reversible/_fixtures/ImmediateMigrationLock.php
@@ -1,0 +1,29 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\Migration\Reversible\_fixtures;
+
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Migration\Reversible\MigrationLock;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+final class ImmediateMigrationLock extends MigrationLock
+{
+    /**
+     * @var list<string>
+     */
+    public array $acquired = [];
+
+    public function __construct()
+    {
+    }
+
+    public function synchronized(string $plugin, \Closure $callback): mixed
+    {
+        $this->acquired[] = $plugin;
+
+        return $callback();
+    }
+}

--- a/tests/unit/Core/Framework/Migration/Reversible/_fixtures/InMemoryMigrationStateStore.php
+++ b/tests/unit/Core/Framework/Migration/Reversible/_fixtures/InMemoryMigrationStateStore.php
@@ -1,0 +1,56 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\Migration\Reversible\_fixtures;
+
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Migration\Reversible\ExecutedMigration;
+use Shopware\Core\Framework\Migration\Reversible\Migration;
+use Shopware\Core\Framework\Migration\Reversible\MigrationStateStore;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+final class InMemoryMigrationStateStore extends MigrationStateStore
+{
+    /**
+     * @var array<string, array<string, int>>
+     */
+    private array $state = [];
+
+    public function __construct()
+    {
+    }
+
+    public function executed(string $plugin): array
+    {
+        $entries = $this->state[$plugin] ?? [];
+        asort($entries);
+
+        $executed = [];
+        foreach ($entries as $class => $timestamp) {
+            /** @var class-string<Migration> $class */
+            $executed[] = new ExecutedMigration($class, $timestamp);
+        }
+
+        return $executed;
+    }
+
+    public function markExecuted(string $plugin, string $class, int $creationTimestamp): void
+    {
+        $this->state[$plugin][$class] = $creationTimestamp;
+    }
+
+    public function remove(string $plugin, string $class): void
+    {
+        unset($this->state[$plugin][$class]);
+    }
+
+    /**
+     * @return array<string, int>
+     */
+    public function timestampsFor(string $plugin): array
+    {
+        return $this->state[$plugin] ?? [];
+    }
+}

--- a/tests/unit/Core/Framework/Migration/Reversible/_fixtures/RecordingMigration.php
+++ b/tests/unit/Core/Framework/Migration/Reversible/_fixtures/RecordingMigration.php
@@ -1,0 +1,50 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\Migration\Reversible\_fixtures;
+
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Migration\Reversible\DownMigrationContext;
+use Shopware\Core\Framework\Migration\Reversible\Migration;
+use Shopware\Core\Framework\Migration\Reversible\UpMigrationContext;
+
+/**
+ * Records the order in which up() and down() were called into a shared log.
+ *
+ * The runner keys its state by class name, so tests that need more than one migration use the
+ * distinct subclasses below rather than several instances of one class.
+ *
+ * @internal
+ */
+#[Package('framework')]
+abstract class RecordingMigration extends Migration
+{
+    public ?UpMigrationContext $lastUpContext = null;
+
+    public ?DownMigrationContext $lastDownContext = null;
+
+    /**
+     * @param \ArrayObject<int, string> $calls
+     */
+    public function __construct(
+        private readonly int $timestamp,
+        private readonly \ArrayObject $calls,
+    ) {
+    }
+
+    public function getCreationTimestamp(): int
+    {
+        return $this->timestamp;
+    }
+
+    public function up(UpMigrationContext $context): void
+    {
+        $this->lastUpContext = $context;
+        $this->calls->append(static::class . '::up');
+    }
+
+    public function down(DownMigrationContext $context): void
+    {
+        $this->lastDownContext = $context;
+        $this->calls->append(static::class . '::down');
+    }
+}

--- a/tests/unit/Core/Framework/Migration/Reversible/_fixtures/RecordingMigrationA.php
+++ b/tests/unit/Core/Framework/Migration/Reversible/_fixtures/RecordingMigrationA.php
@@ -1,0 +1,13 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\Migration\Reversible\_fixtures;
+
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+final class RecordingMigrationA extends RecordingMigration
+{
+}

--- a/tests/unit/Core/Framework/Migration/Reversible/_fixtures/RecordingMigrationB.php
+++ b/tests/unit/Core/Framework/Migration/Reversible/_fixtures/RecordingMigrationB.php
@@ -1,0 +1,13 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\Migration\Reversible\_fixtures;
+
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+final class RecordingMigrationB extends RecordingMigration
+{
+}

--- a/tests/unit/Core/Framework/Migration/Reversible/_fixtures/RelocatablePlugin.php
+++ b/tests/unit/Core/Framework/Migration/Reversible/_fixtures/RelocatablePlugin.php
@@ -1,0 +1,35 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\Migration\Reversible\_fixtures;
+
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Plugin;
+
+/**
+ * Plugin::getPath() resolves from the class file location, so a plugin fixture always points back
+ * into the repository. This subclass lets a test redirect it at a writable directory instead.
+ *
+ * @internal
+ */
+#[Package('framework')]
+class RelocatablePlugin extends Plugin
+{
+    private ?string $overriddenPath = null;
+
+    public function relocateTo(string $path): self
+    {
+        $this->overriddenPath = $path;
+
+        return $this;
+    }
+
+    public function getPath(): string
+    {
+        return $this->overriddenPath ?? parent::getPath();
+    }
+
+    public function getNamespace(): string
+    {
+        return 'Swag\\Reversible';
+    }
+}

--- a/tests/unit/Core/Framework/Migration/Reversible/_fixtures/SwagDuplicateTimestamp/Migration/Migration1600000000A.php
+++ b/tests/unit/Core/Framework/Migration/Reversible/_fixtures/SwagDuplicateTimestamp/Migration/Migration1600000000A.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\Migration\Reversible\_fixtures\SwagDuplicateTimestamp\Migration;
+
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Migration\Reversible\DownMigrationContext;
+use Shopware\Core\Framework\Migration\Reversible\Migration;
+use Shopware\Core\Framework\Migration\Reversible\UpMigrationContext;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+class Migration1600000000A extends Migration
+{
+    public function getCreationTimestamp(): int
+    {
+        return 1600000000;
+    }
+
+    public function up(UpMigrationContext $context): void
+    {
+    }
+
+    public function down(DownMigrationContext $context): void
+    {
+    }
+}

--- a/tests/unit/Core/Framework/Migration/Reversible/_fixtures/SwagDuplicateTimestamp/Migration/Migration1600000000B.php
+++ b/tests/unit/Core/Framework/Migration/Reversible/_fixtures/SwagDuplicateTimestamp/Migration/Migration1600000000B.php
@@ -1,0 +1,30 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\Migration\Reversible\_fixtures\SwagDuplicateTimestamp\Migration;
+
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Migration\Reversible\DownMigrationContext;
+use Shopware\Core\Framework\Migration\Reversible\Migration;
+use Shopware\Core\Framework\Migration\Reversible\UpMigrationContext;
+
+/**
+ * Shares its creation timestamp with Migration1600000000A.
+ *
+ * @internal
+ */
+#[Package('framework')]
+class Migration1600000000B extends Migration
+{
+    public function getCreationTimestamp(): int
+    {
+        return 1600000000;
+    }
+
+    public function up(UpMigrationContext $context): void
+    {
+    }
+
+    public function down(DownMigrationContext $context): void
+    {
+    }
+}

--- a/tests/unit/Core/Framework/Migration/Reversible/_fixtures/SwagDuplicateTimestamp/SwagDuplicateTimestamp.php
+++ b/tests/unit/Core/Framework/Migration/Reversible/_fixtures/SwagDuplicateTimestamp/SwagDuplicateTimestamp.php
@@ -1,0 +1,14 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\Migration\Reversible\_fixtures\SwagDuplicateTimestamp;
+
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Plugin;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+class SwagDuplicateTimestamp extends Plugin
+{
+}

--- a/tests/unit/Core/Framework/Migration/Reversible/_fixtures/SwagInvalidTimestamp/Migration/Migration0Invalid.php
+++ b/tests/unit/Core/Framework/Migration/Reversible/_fixtures/SwagInvalidTimestamp/Migration/Migration0Invalid.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\Migration\Reversible\_fixtures\SwagInvalidTimestamp\Migration;
+
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Migration\Reversible\DownMigrationContext;
+use Shopware\Core\Framework\Migration\Reversible\Migration;
+use Shopware\Core\Framework\Migration\Reversible\UpMigrationContext;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+class Migration0Invalid extends Migration
+{
+    public function getCreationTimestamp(): int
+    {
+        return 0;
+    }
+
+    public function up(UpMigrationContext $context): void
+    {
+    }
+
+    public function down(DownMigrationContext $context): void
+    {
+    }
+}

--- a/tests/unit/Core/Framework/Migration/Reversible/_fixtures/SwagInvalidTimestamp/SwagInvalidTimestamp.php
+++ b/tests/unit/Core/Framework/Migration/Reversible/_fixtures/SwagInvalidTimestamp/SwagInvalidTimestamp.php
@@ -1,0 +1,14 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\Migration\Reversible\_fixtures\SwagInvalidTimestamp;
+
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Plugin;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+class SwagInvalidTimestamp extends Plugin
+{
+}

--- a/tests/unit/Core/Framework/Migration/Reversible/_fixtures/SwagNoMigrations/SwagNoMigrations.php
+++ b/tests/unit/Core/Framework/Migration/Reversible/_fixtures/SwagNoMigrations/SwagNoMigrations.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\Migration\Reversible\_fixtures\SwagNoMigrations;
+
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Plugin;
+
+/**
+ * A plugin without a Migration directory.
+ *
+ * @internal
+ */
+#[Package('framework')]
+class SwagNoMigrations extends Plugin
+{
+}

--- a/tests/unit/Core/Framework/Migration/Reversible/_fixtures/SwagNotInstantiable/Migration/Migration1700000000NeedsArguments.php
+++ b/tests/unit/Core/Framework/Migration/Reversible/_fixtures/SwagNotInstantiable/Migration/Migration1700000000NeedsArguments.php
@@ -1,0 +1,34 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\Migration\Reversible\_fixtures\SwagNotInstantiable\Migration;
+
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Migration\Reversible\DownMigrationContext;
+use Shopware\Core\Framework\Migration\Reversible\Migration;
+use Shopware\Core\Framework\Migration\Reversible\UpMigrationContext;
+
+/**
+ * The provider must reject this: it cannot be instantiated without arguments.
+ *
+ * @internal
+ */
+#[Package('framework')]
+class Migration1700000000NeedsArguments extends Migration
+{
+    public function __construct(private readonly int $timestamp)
+    {
+    }
+
+    public function getCreationTimestamp(): int
+    {
+        return $this->timestamp;
+    }
+
+    public function up(UpMigrationContext $context): void
+    {
+    }
+
+    public function down(DownMigrationContext $context): void
+    {
+    }
+}

--- a/tests/unit/Core/Framework/Migration/Reversible/_fixtures/SwagNotInstantiable/SwagNotInstantiable.php
+++ b/tests/unit/Core/Framework/Migration/Reversible/_fixtures/SwagNotInstantiable/SwagNotInstantiable.php
@@ -1,0 +1,14 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\Migration\Reversible\_fixtures\SwagNotInstantiable;
+
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Plugin;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+class SwagNotInstantiable extends Plugin
+{
+}

--- a/tests/unit/Core/Framework/Migration/Reversible/_fixtures/SwagReversible/Migration/Migration1000000000Second.php
+++ b/tests/unit/Core/Framework/Migration/Reversible/_fixtures/SwagReversible/Migration/Migration1000000000Second.php
@@ -1,0 +1,31 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\Migration\Reversible\_fixtures\SwagReversible\Migration;
+
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Migration\Reversible\DownMigrationContext;
+use Shopware\Core\Framework\Migration\Reversible\Migration;
+use Shopware\Core\Framework\Migration\Reversible\UpMigrationContext;
+
+/**
+ * Deliberately named so that it sorts before Migration2000000000First alphabetically, while its
+ * timestamp orders it first. Proves the provider sorts by timestamp, not by filename.
+ *
+ * @internal
+ */
+#[Package('framework')]
+class Migration1000000000Second extends Migration
+{
+    public function getCreationTimestamp(): int
+    {
+        return 1000000000;
+    }
+
+    public function up(UpMigrationContext $context): void
+    {
+    }
+
+    public function down(DownMigrationContext $context): void
+    {
+    }
+}

--- a/tests/unit/Core/Framework/Migration/Reversible/_fixtures/SwagReversible/Migration/Migration1500000000LegacyStep.php
+++ b/tests/unit/Core/Framework/Migration/Reversible/_fixtures/SwagReversible/Migration/Migration1500000000LegacyStep.php
@@ -1,0 +1,25 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\Migration\Reversible\_fixtures\SwagReversible\Migration;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Migration\MigrationStep;
+
+/**
+ * A legacy MigrationStep living in the same directory. The reversible provider must skip it.
+ *
+ * @internal
+ */
+#[Package('framework')]
+class Migration1500000000LegacyStep extends MigrationStep
+{
+    public function getCreationTimestamp(): int
+    {
+        return 1500000000;
+    }
+
+    public function update(Connection $connection): void
+    {
+    }
+}

--- a/tests/unit/Core/Framework/Migration/Reversible/_fixtures/SwagReversible/Migration/Migration2000000000First.php
+++ b/tests/unit/Core/Framework/Migration/Reversible/_fixtures/SwagReversible/Migration/Migration2000000000First.php
@@ -1,0 +1,35 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\Migration\Reversible\_fixtures\SwagReversible\Migration;
+
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Migration\Reversible\DownMigrationContext;
+use Shopware\Core\Framework\Migration\Reversible\Migration;
+use Shopware\Core\Framework\Migration\Reversible\UpMigrationContext;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+class Migration2000000000First extends Migration
+{
+    /**
+     * @var list<string>
+     */
+    public static array $calls = [];
+
+    public function getCreationTimestamp(): int
+    {
+        return 2000000000;
+    }
+
+    public function up(UpMigrationContext $context): void
+    {
+        self::$calls[] = 'up';
+    }
+
+    public function down(DownMigrationContext $context): void
+    {
+        self::$calls[] = 'down';
+    }
+}

--- a/tests/unit/Core/Framework/Migration/Reversible/_fixtures/SwagReversible/SwagReversible.php
+++ b/tests/unit/Core/Framework/Migration/Reversible/_fixtures/SwagReversible/SwagReversible.php
@@ -1,0 +1,14 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\Migration\Reversible\_fixtures\SwagReversible;
+
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Plugin;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+class SwagReversible extends Plugin
+{
+}

--- a/tests/unit/Core/Framework/Plugin/PluginLifecycleServiceTest.php
+++ b/tests/unit/Core/Framework/Plugin/PluginLifecycleServiceTest.php
@@ -17,6 +17,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Event\EntityWrittenContainerEve
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Migration\MigrationCollection;
 use Shopware\Core\Framework\Migration\MigrationCollectionLoader;
+use Shopware\Core\Framework\Migration\Reversible\MigrationRunner as ReversibleMigrationRunner;
 use Shopware\Core\Framework\Plugin;
 use Shopware\Core\Framework\Plugin\Composer\CommandExecutor;
 use Shopware\Core\Framework\Plugin\Event\PluginPostActivateEvent;
@@ -508,6 +509,7 @@ class PluginLifecycleServiceTest extends TestCase
                 $this->requestStackMock,
                 static::createStub(CustomFieldSetPersister::class),
                 new MockClock(),
+                static::createStub(ReversibleMigrationRunner::class),
             ])
             ->onlyMethods(['isCLI'])
             ->getMock();
@@ -1142,7 +1144,8 @@ class PluginLifecycleServiceTest extends TestCase
             static::createStub(DefinitionInstanceRegistry::class),
             $this->requestStackMock,
             $customFieldSetPersister ?? $this->customFieldSetPersister,
-            new NativeClock()
+            new NativeClock(),
+            static::createStub(ReversibleMigrationRunner::class)
         );
     }
 


### PR DESCRIPTION
### 1. Why is this change necessary?

Plugin migrations in Shopware only move forward. A plugin's `MigrationStep` runs on install and update, but **nothing ever runs on uninstall**: tables and columns a plugin created stay in the database forever unless the plugin's `uninstall()` method hand-writes `DROP` statements. That means:

- Uninstalling a plugin destructively leaves its schema behind unless the author duplicates every migration as manual teardown code in `uninstall()`.
- There is no per-plugin record of which migrations ran, so no reliable, ordered rollback chain exists.
- A faulty migration can only be fixed by manual database surgery; there is no way to undo a plugin's schema changes safely.

Reversible migrations solve this: every migration declares how to undo itself. This PR makes them a first-class, parallel subsystem in core, so every plugin gets rollback-capable migrations out of the box.

Why this is better for plugin developers than the current system:

- **Rollback is declared, not re-implemented**: `down()` lives next to `up()` in the migration itself, instead of being reconstructed from memory in `uninstall()`.
- **Uninstall rolls back the whole chain in reverse order**, exactly undoing what install/update did — no drift between schema creation and teardown.
- **`--keep-user-data` uninstalls keep schema and history**, so a reinstall resumes from the same state instead of replaying or losing everything.
- **Guardrails instead of silent corruption**: duplicate timestamps, changed timestamps, applied-but-deleted classes and migrations inserted before the latest applied one are rejected with clear errors.

### 2. What does this change do, exactly?

Adds a new subsystem under `Shopware\Core\Framework\Migration\Reversible`:

- `Migration` — new base class for plugin migrations. `up()` runs before plugin install and update in ascending timestamp order; `down()` runs after a destructive uninstall in descending order.
- `UpMigrationContext` / `DownMigrationContext` — instead of a bare `Connection`, both methods receive a context object, so capabilities can be added later without breaking the plugin-facing signature. `UpMigrationContext::$isInstallation` tells whether the plugin is being installed for the first time (unlike `MigrationStep::isInstallation()`, which refers to Shopware itself).
- `plugin_migration` table — tracks the applied history per plugin.
- `PluginLifecycleService` wiring — reversible `up()` runs before the plugin's `install()`/`update()` and before its legacy `MigrationStep` migrations; `down()` runs after a destructive uninstall and is skipped entirely when user data is kept.
- `database:create-reversible-migration --plugin=SwagExample` scaffolds a migration; `database:migrate-reversible SwagExample` (or `--all`) applies pending ones outside a plugin update. There is intentionally no CLI rollback: `down()` stays tied to a destructive uninstall.

`MigrationStep`, `MigrationRuntime`, `MigrationCollection` and the legacy `migration` table are untouched — both kinds of migration can live side by side in the same `<Plugin>/src/Migration` directory.

A reversible migration looks like this:

```php
<?php declare(strict_types=1);

namespace SwagExample\Migration;

use Shopware\Core\Framework\Migration\Reversible\DownMigrationContext;
use Shopware\Core\Framework\Migration\Reversible\Migration;
use Shopware\Core\Framework\Migration\Reversible\UpMigrationContext;

class Migration1785000000CreateReview extends Migration
{
    public function getCreationTimestamp(): int
    {
        return 1785000000;
    }

    public function up(UpMigrationContext $context): void
    {
        $context->connection->executeStatement(<<<'SQL'
            CREATE TABLE IF NOT EXISTS `swag_example_review` (
                `id` BINARY(16) NOT NULL,
                PRIMARY KEY (`id`)
            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
            SQL);
    }

    public function down(DownMigrationContext $context): void
    {
        $context->connection->executeStatement('DROP TABLE IF EXISTS `swag_example_review`');
    }
}
```

### 3. Describe each step to reproduce the issue or behaviour.

1. Scaffold a migration for any plugin: `bin/console database:create-reversible-migration --plugin=SwagExample --name=CreateReview`
2. Implement `up()`/`down()` as in the example above.
3. `bin/console plugin:install --activate SwagExample` → the table is created and the history row appears in `plugin_migration`.
4. `bin/console plugin:uninstall SwagExample` → `down()` runs in reverse order, the table is dropped and the history is cleared.
5. Repeat with `bin/console plugin:uninstall --keep-user-data SwagExample` → no rollback runs; schema and history survive, and a later reinstall resumes from the same state.

### 4. Please link to the relevant issues (if any).

No linked issue.

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [x] I have written or adjusted the documentation and agent skills according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
