### PR TITLE
fix: adjacent form fields on narrow viewports (backport: 6.6.x)

### DIFF
--- a/changelog/_unreleased/2025-04-08-fix-mobile-form-field-layouts.md
+++ b/changelog/_unreleased/2025-04-08-fix-mobile-form-field-layouts.md
@@ -1,0 +1,14 @@
+---
+title: Fix adjacent form fields on narrow viewports
+issue: #7056
+---
+# Storefront
+* Changed `Resources/views/storefront/component/account/login.html.twig` and adjust the following bootstrap grid columns to fix the layout on narrow viewports:
+    * Changed `#loginMail` column classes to `col-sm-6 col-lg-12`.
+    * Changed `#loginPassword` column classes to `col-sm-6 col-lg-12`.
+* Changed `Resources/views/storefront/page/account/profile/index.html.twig` and adjust the following bootstrap grid columns to fix the layout on narrow viewports:
+    * Changed `#personalMail` column classes to `col-sm-6`.
+    * Changed `#personalMailConfirmation` column classes to `col-sm-6`.
+    * Changed `#personalMailPasswordCurrent` column classes to `col-sm-6`.
+    * Changed `#newPassword` column classes to `col-sm-6`.
+    * Changed `#newPasswordConfirmation` column classes to `col-sm-6`.

--- a/src/Storefront/Resources/views/storefront/component/account/login.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/account/login.html.twig
@@ -65,7 +65,7 @@
                                         autocomplete: 'username webauthn',
                                         error: loginError,
                                         validationRules: 'required,email',
-                                        additionalClass: 'col-md-6',
+                                        additionalClass: 'col-sm-6 col-lg-12',
                                     } %}
 
                                 {% else %}
@@ -102,7 +102,7 @@
                                         autocomplete: 'current-password',
                                         error: loginError,
                                         validationRules: 'required',
-                                        additionalClass: 'col-md-6',
+                                        additionalClass: 'col-sm-6 col-lg-12',
                                     } %}
 
                                 {% else %}

--- a/src/Storefront/Resources/views/storefront/page/account/profile/index.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/account/profile/index.html.twig
@@ -158,7 +158,7 @@
                                                                 autocomplete: 'section-personal email',
                                                                 violationPath: '/email',
                                                                 validationRules: 'required,email',
-                                                                additionalClass: 'col',
+                                                                additionalClass: 'col-sm-6',
                                                             } %}
 
                                                         {% else %}
@@ -206,7 +206,7 @@
                                                                 autocomplete: 'section-personal email',
                                                                 violationPath: '/email',
                                                                 validationRules: 'required,confirmation',
-                                                                additionalClass: 'col',
+                                                                additionalClass: 'col-sm-6',
                                                             } %}
 
                                                         {% else %}
@@ -261,7 +261,7 @@
                                                             autocomplete: 'current-password',
                                                             violationPath: '/password',
                                                             validationRules: 'required',
-                                                            additionalClass: 'col-6',
+                                                            additionalClass: 'col-sm-6',
                                                         } %}
 
                                                     {% else %}
@@ -363,7 +363,7 @@
                                                                 violationPath: '/newPassword',
                                                                 validationRules: 'required,minLength',
                                                                 minlength: config('core.loginRegistration.passwordMinLength'),
-                                                                additionalClass: 'col',
+                                                                additionalClass: 'col-sm-6',
                                                             } %}
 
                                                         {% else %}
@@ -415,7 +415,7 @@
                                                                 autocomplete: 'new-password',
                                                                 violationPath: '/passwordConfirmation',
                                                                 validationRules: 'required,confirmation',
-                                                                additionalClass: 'col',
+                                                                additionalClass: 'col-sm-6',
                                                             } %}
 
                                                         {% else %}
@@ -469,7 +469,7 @@
                                                             autocomplete: 'current-password',
                                                             violationPath: '/password',
                                                             validationRules: 'required',
-                                                            additionalClass: 'col-6',
+                                                            additionalClass: 'col-sm-6',
                                                         } %}
 
                                                     {% else %}


### PR DESCRIPTION
**Backport:** https://github.com/shopware/shopware/pull/8367
Resolves: https://github.com/shopware/shopware/issues/7056
relates #19539

---

### 1. Why is this change necessary?
Manual backport of #8367 to 6.6.x (a11y). The automated cherry-pick conflicts; see below. (A previous automated backport attempt, #8396, was closed by the octo-sts bot in July 2025 as stale — not rejected on content — so this redoes that work manually.)

### 2. What does this change do, exactly?
Adjusts Bootstrap grid column classes on the login and profile-personal-data form fields so adjacent fields (email/password on login, and email/email-confirmation/password fields on the profile page) no longer sit too close together or overflow on narrow viewports.

**Conflict resolution vs. trunk commit e45e35a090a:**
- `component/account/login.html.twig`: trunk's version of this file no longer has the deprecated (non-accessibility) markup branch, only the `form-input.html.twig` include. 6.6.x still has both branches behind `feature('ACCESSIBILITY_TWEAKS')`. Kept both 6.6.x branches intact and applied the new `additionalClass: 'col-sm-6 col-lg-12'` only to the `#loginMail` / `#loginPassword` fields inside the accessibility-enabled branch (the deprecated fallback branch's markup/classes were left untouched, as they predate and are unrelated to this fix).
- `page/account/profile/index.html.twig`: same pattern — 6.6.x still has the `feature('ACCESSIBILITY_TWEAKS')` / deprecated-fallback split for each of the five affected fields (`#personalMail`, `#personalMailConfirmation`, `#personalMailPasswordCurrent`, `#newPassword`, `#newPasswordConfirmation`) plus the `#password` (current password) field in the password-change form. Applied the new `additionalClass: 'col-sm-6'` only inside the accessibility-enabled branch for each; the deprecated fallback branches were left untouched.
- No trunk-only refactors (e.g. later `feat(snippets)`, `fix(a11y): alerts on initial page load`, or the redirect-parameter/company-field commits touching these same files) were pulled in — checked trunk history between the original commit and current trunk for follow-ups touching these two files; none touched the `additionalClass` column-layout lines, so no follow-up needed to be cherry-picked.

### 3. Describe each step to reproduce the issue or behaviour.
See original PR.

### 4. Please link to the relevant issues (if any).
- relates #7056
- relates #19539

### 5. Checklist
- [x] Cherry-picked from trunk with `-x`, conflicts resolved as described
- [ ] Tests run locally: none available — worktree has no installed `node_modules`/`vendor` and this is a pure Twig/CSS-class change with no unit tests attached to the original commit either. Verified conflict resolution by diffing the backport branch against `origin/6.6.x` (exact +22/-8 across the same 3 files as the original commit) and confirming `additionalClass` is a supported parameter of `form-input.html.twig` on 6.6.x.
