### PR TITLE
fix: restore main-nav focus when closing dropdown via btn using keyboard (backport: 6.6.x)

### DIFF
--- a/src/Storefront/Resources/app/storefront/src/plugin/navbar/navbar.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/navbar/navbar.plugin.js
@@ -9,6 +9,10 @@ export default class NavbarPlugin extends Plugin {
          */
         debounceTime: 125,
         /**
+         * Class to select the main navigation items, which contain both the top level link and the dropdown navigation.
+         */
+        navItemSelector: '.nav-item',
+        /**
          * Class to select the top level links.
          */
         topLevelLinksSelector: '.main-navigation-link',
@@ -29,6 +33,8 @@ export default class NavbarPlugin extends Plugin {
         const openEvent = (DeviceDetection.isTouchDevice()) ? 'touchstart' : 'mouseenter';
         const closeEvent = (DeviceDetection.isTouchDevice()) ? 'touchstart' : 'mouseleave';
         const clickEvent = (DeviceDetection.isTouchDevice()) ? 'touchstart' : 'click';
+
+        this.el.addEventListener('focusout', this._restoreFocusAfterBtnClose.bind(this));
 
         Iterator.iterate(this._topLevelLinks, el => {
             el.addEventListener(openEvent, this._toggleNavbar.bind(this, el));
@@ -115,5 +121,26 @@ export default class NavbarPlugin extends Plugin {
         if (activeNavItem) {
             activeNavItem.setAttribute('aria-current', 'page');
         }
+    }
+
+    /**
+     * Restores focus to the main-navigation link related to the currently active dropdown navigation.
+     * The focus state is lost when closing the dropdown via button using a keyboard.
+     *
+     * @param {FocusEvent} event
+     * @return {void}
+     */
+    _restoreFocusAfterBtnClose(event) {
+        if (event.relatedTarget || event.target.matches(this.options.topLevelLinksSelector)) {
+            return;
+        }
+
+        const link = event.target.closest(this.options.navItemSelector)?.querySelector(this.options.topLevelLinksSelector);
+
+        if (!link) {
+            return;
+        }
+
+        window.focusHandler.setFocus(link);
     }
 }

--- a/src/Storefront/Resources/app/storefront/test/plugin/navbar/navbar.plugin.test.js
+++ b/src/Storefront/Resources/app/storefront/test/plugin/navbar/navbar.plugin.test.js
@@ -1,4 +1,5 @@
 import NavbarPlugin from 'src/plugin/navbar/navbar.plugin';
+import FocusHandler from 'src/helper/focus-handler.helper';
 
 describe('NavbarPlugin', () => {
     let navbarPlugin;
@@ -166,5 +167,47 @@ describe('NavbarPlugin', () => {
         navbarPlugin._setAriaCurrentPage();
 
         expect(mockLink.getAttribute('aria-current')).toBe('page');
+    });
+
+    test('_restoreFocusAfterBtnClose should focus related dropdown top level link', () => {
+        window.focusHandler = new FocusHandler();
+
+        const mockNavItem = document.createElement('div');
+        mockNavItem.classList.add('nav-item');
+        const mockLink = document.createElement('a');
+        mockLink.classList.add('main-navigation-link');
+        mockLink.focus = jest.fn();
+        mockNavItem.appendChild(mockLink);
+        const mockDropdown = document.createElement('div');
+        mockNavItem.appendChild(mockDropdown);
+
+        const mockEvent = {
+            target: mockDropdown,
+            relatedTarget: null,
+        };
+
+        navbarPlugin._restoreFocusAfterBtnClose(mockEvent);
+
+        expect(mockLink.focus).toHaveBeenCalled();
+    });
+
+    test('_restoreFocusAfterBtnClose should skip events dispatched for top level links', () => {
+        window.focusHandler = new FocusHandler();
+
+        const mockNavItem = document.createElement('div');
+        mockNavItem.classList.add('nav-item');
+        const mockLink = document.createElement('a');
+        mockLink.classList.add('main-navigation-link');
+        mockLink.focus = jest.fn();
+        mockNavItem.appendChild(mockLink);
+
+        const mockEvent = {
+            target: mockLink,
+            relatedTarget: null,
+        };
+
+        navbarPlugin._restoreFocusAfterBtnClose(mockEvent);
+
+        expect(mockLink.focus).not.toHaveBeenCalled();
     });
 });


### PR DESCRIPTION
**Backport:** https://github.com/shopware/shopware/pull/9099
relates #19539

---

### 1. Why is this change necessary?
Manual backport of #9099 to 6.6.x (a11y). The automated cherry-pick conflicts; see below.

### 2. What does this change do, exactly?
Adds a `focusout` listener on the main navigation (`NavbarPlugin`). When the dropdown navigation is closed via its close button using a keyboard, the focus is otherwise lost to `<body>`. The handler detects the focus loss (`relatedTarget === null`) and restores focus to the `.main-navigation-link` of the surrounding `.nav-item` via `window.focusHandler.setFocus()`. A new `navItemSelector: '.nav-item'` option is added.

**Conflict resolution vs. trunk commit 936ef033da5:**
- `src/Storefront/Resources/app/storefront/src/plugin/navbar/navbar.plugin.js` — the conflict is in `_registerEvents()`. Trunk had already migrated the loop from `Iterator.iterate(this._topLevelLinks, …)` to `this._topLevelLinks.forEach(…)` and had already registered `this.el.addEventListener('mouseleave', this._closeAllDropdowns.bind(this))`. Both are unrelated to this fix and do not exist on 6.6.x, so they were dropped: the 6.6.x `Iterator.iterate` shape is kept and only the new `focusout` listener is added. The `navItemSelector` option and `_restoreFocusAfterBtnClose()` apply unchanged; the method now sits after the 6.6.x `_setAriaCurrentPage()` (6.6.x does not have trunk's `_setCurrentPage()`/`activeClass`/`pathIdList` from #9075).
- `src/Storefront/Resources/app/storefront/test/plugin/navbar/navbar.plugin.test.js` — merged automatically, no manual resolution needed; both new test cases apply as-is.

Verified on 6.6.x: `window.focusHandler` is instantiated in `src/main.js` and `FocusHandler.setFocus(el, focusOptions)` has the identical signature. The 6.6.x navbar template (`layout/navbar/navbar.html.twig`) renders `<li class="nav-item … dropdown">` wrapping both the `.main-navigation-link` and the `.dropdown-menu`, and `layout/navbar/content.html.twig` renders the `.js-close-flyout-menu.btn-close` close button — so both selectors used by the fix resolve on 6.6.x. This sits on top of the current 6.6.x `navbar.plugin.js` including the recently backported a11y active-main-nav-entry change (`ariaCurrentPageSelector` / `_setAriaCurrentPage`).

No follow-up correction exists on trunk: none of the later commits touching `navbar.plugin.js` (#9075, #12124, #13107, #13525, #14305, #14351, #17099, #17570, #19707) modifies or disables the `focusout` listener or `_restoreFocusAfterBtnClose()`; both are still present in current trunk.

### 3. Describe each step to reproduce the issue or behaviour.
See original PR. In short: with the keyboard, open a main navigation dropdown, then activate the close button inside the dropdown — focus must return to the top level navigation link instead of being lost to `<body>`.

### 4. Please link to the relevant issues (if any).
- relates #19539

### 5. Checklist
- [x] Cherry-picked from trunk with `-x`, conflicts resolved as described
- [x] Tests run locally: `jest test/plugin/navbar/navbar.plugin.test.js` — 14/14 passed (incl. the 2 new cases). ESLint on the two touched files reports only one pre-existing `comma-dangle` error that already exists on 6.6.x and is untouched by this change.
