### PR TITLE
fix(storefront-nav): Hide arrow when no children available, improve accessibility (backport: 6.6.x)

### DIFF
--- a/src/Storefront/Resources/views/storefront/layout/navbar/navbar.html.twig
+++ b/src/Storefront/Resources/views/storefront/layout/navbar/navbar.html.twig
@@ -9,7 +9,8 @@
              id="main-navigation-menu"
              itemscope="itemscope"
              itemtype="https://schema.org/SiteNavigationElement"
-             data-navbar="true">
+             data-navbar="true"
+             aria-label="{{ 'header.navigationAriaLabel'|trans|striptags }}">
             <div class="">
                 <div class="collapse navbar-collapse" id="main_nav">
                     <ul class="navbar-nav d-flex flex-wrap">
@@ -51,16 +52,16 @@
                                         </li>
                                     {% else %}
                                         <li class="nav-item nav-item-{{ id }} {% if hasChildren %}dropdown position-static pe-2{% endif %}">
-                                            <a class="nav-link nav-item-{{ id }}-link root dropdown-toggle main-navigation-link p-2"
+                                            <a class="nav-link nav-item-{{ id }}-link root main-navigation-link p-2{% if hasChildren %} dropdown-toggle{% endif %}"
                                                href="{{ category_url(category) }}"
-                                               data-bs-toggle="dropdown"
+                                               {% if hasChildren %}data-bs-toggle="dropdown"{% endif %}
                                                itemprop="url"
                                                {% if category_linknewtab(category) %}target="_blank"{% endif %}
                                                title="{{ name }}">
                                                 <span itemprop="name" class="main-navigation-link-text">{{ name }}</span>
                                             </a>
                                             {% if hasChildren %}
-                                                <div class="dropdown-menu w-100 p-4" role="menu">
+                                                <div class="dropdown-menu w-100 p-4">
                                                     {% sw_include '@Storefront/storefront/layout/navbar/content.html.twig' with {
                                                         themeIconConfig: themeIconConfig,
                                                         navigationTree: treeItem,


### PR DESCRIPTION
**Backport:** https://github.com/shopware/shopware/pull/7498
relates #19539

---

### 1. Why is this change necessary?

Manual backport of #7498 to 6.6.x (a11y). The automated cherry-pick conflicts; see below.

In the main navigation every top-level category link carried `dropdown-toggle` and
`data-bs-toggle="dropdown"`, no matter whether the category had child categories.
Consequences:

- a dropdown arrow was rendered for categories that have nothing to drop down,
- Bootstrap's dropdown data-api swallowed the activation on those links, so
  keyboard users could not follow the link with <kbd>Enter</kbd>
  (mouse clicks were rescued by `navbar.plugin.js`, keyboard activation was not),
- the flyout container was marked `role="menu"` although it contains headings and
  ordinary links and no element with `role="menuitem"`.

The `<nav>` landmark also had no accessible name.

### 2. What does this change do, exactly?

`dropdown-toggle` and `data-bs-toggle="dropdown"` are now only rendered when the
category actually has children, the invalid `role="menu"` is removed from the
flyout container, and the `<nav>` gets
`aria-label="{{ 'header.navigationAriaLabel'|trans|striptags }}"` — the same
accessible name the deprecated `layout/navigation/navigation.html.twig` already uses.

**Conflict resolution vs. trunk commit 5be7709f2c527bb77f6b86dd57f1427be57ac768:**

- `layout/navbar/navbar.html.twig` — conflicted. Kept the 6.6.x shape of the file
  (the `@deprecated tag:v6.7.0` header fallback at the top and the
  `feature('v6.7.0.0')` guarded `activePath` variable, neither of which exists on
  trunk) and applied only the a11y payload: conditional `dropdown-toggle` /
  `data-bs-toggle`, removal of `role="menu"`, and the `aria-label` on the `<nav>`.
  Trunk's cosmetic parts of the same commit were left out to keep the diff on the
  main navigation minimal: the removal of the empty `<div class="">` wrapper, the
  `d-flex` → `main-navigation-menu-list` class swap on the `<ul>`, and the
  `pe-2` → SCSS-spacing move.
- `skin/shopware/layout/_main-navigation.scss` — dropped. On trunk this hunk
  rewrites the block to Bootstrap `--bs-navbar-*` custom properties, drops the
  `&:hover, &.is-open { color: $primary; }` rule and changes the item spacing from
  `32px` to `1rem`. That is safe on trunk because the flyout menu plugin is gone
  there, but on 6.6.x `flyout-menu.plugin.js` still sets `is-open`, and this
  stylesheet is shared with the deprecated `layout/navigation/navigation.html.twig`
  navigation that 6.6.x renders by default. Applying it would be a purely visual
  regression in a maintenance branch with no accessibility benefit.
- `layout/navigation/active-styling.html.twig` — dropped. `var(--bs-gray-800)` →
  `var(--bs-body-color)` for the active root link only makes sense together with the
  SCSS hunk above; on its own it would remove the colour distinction between the
  active and the inactive root links (`$body-color` is `$sw-text-color` on 6.6.x).

No follow-up fix for #7498 exists on trunk. The two commits that touch the same
lines shortly afterwards are independent: #7479 adds an inline dropdown for
*folder* nav items (a different feature, PR opened before #7498) and #7393 only
adds a blank line for ludtwig. The payload backported here is still present on
trunk today.

### 3. Describe each step to reproduce the issue or behaviour.

See original PR.

Note for 6.6.x: `layout/navbar/navbar.html.twig` is only rendered when the
`cache_rework` feature flag is active (`V6_7_0_0=1`); with the flag off, 6.6.x
still renders the deprecated `layout/navigation/navigation.html.twig`, which this
change does not touch.

### 4. Please link to the relevant issues (if any).

- relates #19539

### 5. Checklist

- [x] Cherry-picked from trunk with `-x`, conflicts resolved as described
- [ ] Tests run locally: none — the change is Twig-only and the backport worktree has
      no `vendor/`/`node_modules`. Verified the Twig/HTML tag balance of the template,
      that the `header.navigationAriaLabel` snippet exists on 6.6.x in both
      `snippet/en_GB/storefront.en-GB.json` and `snippet/de_DE/storefront.de-DE.json`,
      that no template or JS on 6.6.x relies on `role="menu"` or on `role="menuitem"`
      in the navbar, and that `navbar.plugin.js` / `flyout-menu.plugin.js` do not
      depend on the removed `data-bs-toggle` attribute.
