### PR TITLE
fix(accessibility): make sw_icon aria-hidden by default (backport: 6.6.x)

### DIFF
--- a/changelog/_unreleased/2025-03-14-make-sw_icons-aria-hidden-by-default.md
+++ b/changelog/_unreleased/2025-03-14-make-sw_icons-aria-hidden-by-default.md
@@ -1,0 +1,6 @@
+---
+title: Make sw_icons aria-hidden by default
+issue: #7369
+---
+# Storefront
+* Changed `sw_icon` base template `Resources/views/storefront/utilities/icon.html.twig` to apply `aria-hidden="true"` by default.

--- a/src/Storefront/Resources/views/storefront/component/pagination.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/pagination.html.twig
@@ -39,7 +39,7 @@
                             {% block component_pagination_first_link_element %}
                                 <a href="{{ href ? '?' ~ pageParameter ~ '=1' ~ searchQuery : '#' }}" class="page-link" data-page="1" aria-label="{{ 'general.pagination.first'|trans|striptags }}" data-focus-id="first"{% if currentPage == 1 %} tabindex="-1" aria-disabled="true"{% endif %}>
                                     {% block component_pagination_first_link_icon %}
-                                        {% sw_icon 'arrow-medium-double-left' style { size: 'fluid', pack: 'solid', ariaHidden: true } %}
+                                        {% sw_icon 'arrow-medium-double-left' style { size: 'fluid', pack: 'solid' } %}
                                     {% endblock %}
                                 </a>
                             {% endblock %}
@@ -76,7 +76,7 @@
                             {% block component_pagination_prev_link_element %}
                                 <a href="{{ href ? '?' ~ pageParameter ~ '=' ~ prevPageNumber ~ searchQuery : '#' }}" class="page-link" data-page="{{ prevPageNumber }}" aria-label="{{ 'general.pagination.prev'|trans|striptags }}" data-focus-id="prev"{% if currentPage == 1 %} tabindex="-1" aria-disabled="true"{% endif %}>
                                     {% block component_pagination_prev_link_icon %}
-                                        {% sw_icon 'arrow-medium-left' style { size: 'fluid', pack: 'solid', ariaHidden: true } %}
+                                        {% sw_icon 'arrow-medium-left' style { size: 'fluid', pack: 'solid' } %}
                                     {% endblock %}
                                 </a>
                             {% endblock %}
@@ -177,7 +177,7 @@
                                 {% set nextPageNumber = currentPage == totalPages ? totalPages : (currentPage + 1) %}
                                 <a href="{{ href ? '?' ~ pageParameter ~ '=' ~ nextPageNumber ~ searchQuery : '#' }}" class="page-link" data-page="{{ nextPageNumber }}" aria-label="{{ 'general.pagination.next'|trans|striptags }}" data-focus-id="next"{% if currentPage == totalPages %} tabindex="-1" aria-disabled="true"{% endif %}>
                                     {% block component_pagination_next_link_icon %}
-                                        {% sw_icon 'arrow-medium-right' style { size: 'fluid', pack: 'solid', ariaHidden: true } %}
+                                        {% sw_icon 'arrow-medium-right' style { size: 'fluid', pack: 'solid' } %}
                                     {% endblock %}
                                 </a>
                             {% endblock %}
@@ -216,7 +216,7 @@
                             {% block component_pagination_last_link_element %}
                                 <a href="{{ href ? '?' ~ pageParameter ~ '=' ~ totalPages ~ searchQuery : '#' }}" class="page-link" data-page="{{ totalPages }}" aria-label="{{ 'general.pagination.last'|trans|striptags }}" data-focus-id="last"{% if currentPage == totalPages %} tabindex="-1" aria-disabled="true"{% endif %}>
                                     {% block component_pagination_last_link_icon %}
-                                        {% sw_icon 'arrow-medium-double-right' style { size: 'fluid', pack: 'solid', ariaHidden: true } %}
+                                        {% sw_icon 'arrow-medium-double-right' style { size: 'fluid', pack: 'solid' } %}
                                     {% endblock %}
                                 </a>
                             {% endblock %}

--- a/src/Storefront/Resources/views/storefront/component/product/card/box-standard.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/product/card/box-standard.html.twig
@@ -74,8 +74,7 @@
                                             {% block component_product_box_image_placeholder %}
                                                 <div class="product-image-placeholder">
                                                     {% sw_icon 'placeholder' style {
-                                                        size: 'fluid',
-                                                        ariaHidden: true
+                                                        size: 'fluid'
                                                     } %}
                                                 </div>
                                             {% endblock %}

--- a/src/Storefront/Resources/views/storefront/component/product/card/box-wishlist.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/product/card/box-wishlist.html.twig
@@ -26,7 +26,7 @@
 
                         {% block component_product_wishlist_remove_submit %}
                             <button type="submit" class="btn btn-light product-wishlist-btn product-wishlist-btn-remove" aria-label="{{ 'wishlist.remove'|trans({ '%product_name%': product.translated.name })|striptags }}" title="{{ 'listing.removeFromWishlist'|trans|sw_sanitize }}">
-                                {% sw_icon 'x' style { class: 'icon-wishlist icon-wishlist-remove', size: size, pack: 'solid', ariaHidden: true } %}
+                                {% sw_icon 'x' style { class: 'icon-wishlist icon-wishlist-remove', size: size, pack: 'solid' } %}
                             </button>
                         {% endblock %}
                     </form>

--- a/src/Storefront/Resources/views/storefront/component/product/quickview/minimal.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/product/quickview/minimal.html.twig
@@ -33,8 +33,7 @@
                             {% endif %}
                         {% else %}
                             {% sw_icon 'placeholder' style {
-                                size: 'fluid',
-                                ariaHidden: true
+                                size: 'fluid'
                             } %}
                         {% endif %}
                     </div>

--- a/src/Storefront/Resources/views/storefront/element/cms-element-sidebar-filter.html.twig
+++ b/src/Storefront/Resources/views/storefront/element/cms-element-sidebar-filter.html.twig
@@ -18,7 +18,7 @@
                     aria-expanded="false"
                 >
                     {% block element_product_listing_filter_button_icon %}
-                        {% sw_icon 'sliders-horizontal' style { size: 'sm', ariaHidden: true } %}
+                        {% sw_icon 'sliders-horizontal' style { size: 'sm' } %}
                     {% endblock %}
 
                     {{ 'listing.filterTitleText'|trans }}

--- a/src/Storefront/Resources/views/storefront/layout/breadcrumb.html.twig
+++ b/src/Storefront/Resources/views/storefront/layout/breadcrumb.html.twig
@@ -51,7 +51,7 @@
                         {% block layout_breadcrumb_placeholder %}
                             {% if key != breadcrumbKeys|last %}
                                 <div class="breadcrumb-placeholder">
-                                    {% sw_icon 'arrow-medium-right' style { size: 'fluid', pack: 'solid', ariaHidden: true } %}
+                                    {% sw_icon 'arrow-medium-right' style { size: 'fluid', pack: 'solid' } %}
                                 </div>
                             {% endif %}
                         {% endblock %}

--- a/src/Storefront/Resources/views/storefront/layout/footer/footer.html.twig
+++ b/src/Storefront/Resources/views/storefront/layout/footer/footer.html.twig
@@ -30,12 +30,10 @@
                                             aria-expanded="true">
 
                                         {% sw_icon 'plus' style {
-                                            ariaLabel: 'general.expand'|trans,
                                             class: 'footer-plus'
                                         } %}
 
                                         {% sw_icon 'minus' style {
-                                            ariaLabel: 'general.collapse'|trans,
                                             class: 'footer-minus'
                                         } %}
                                     </button>
@@ -165,12 +163,10 @@
                                                         aria-expanded="true">
 
                                                     {% sw_icon 'plus' style {
-                                                        ariaLabel: 'general.expand'|trans,
                                                         class: 'footer-plus'
                                                     } %}
 
                                                     {% sw_icon 'minus' style {
-                                                        ariaLabel: 'general.collapse'|trans,
                                                         class: 'footer-minus'
                                                     } %}
                                                 </button>

--- a/src/Storefront/Resources/views/storefront/layout/header/actions/cart-widget.html.twig
+++ b/src/Storefront/Resources/views/storefront/layout/header/actions/cart-widget.html.twig
@@ -1,8 +1,6 @@
 {% block layout_header_actions_cart_widget %}
     <span class="header-cart-icon">
-        {% sw_icon 'bag' style {
-            ariaLabel: 'checkout.cartTitle'|trans
-        } %}
+        {% sw_icon 'bag' %}
     </span>
     {% if page.cart.lineItems|length > 0 %}
         <span class="badge bg-primary header-cart-badge">{{ page.cart.lineItems|length }}</span>

--- a/src/Storefront/Resources/views/storefront/layout/header/search-suggest.html.twig
+++ b/src/Storefront/Resources/views/storefront/layout/header/search-suggest.html.twig
@@ -45,8 +45,7 @@
                                                         {% endif %}
                                                     {% else %}
                                                         {% sw_icon 'placeholder' style {
-                                                            size: 'lg',
-                                                            ariaHidden: true
+                                                            size: 'lg'
                                                         } %}
                                                     {% endif %}
                                                 </div>

--- a/src/Storefront/Resources/views/storefront/layout/navigation/offcanvas/back-link.html.twig
+++ b/src/Storefront/Resources/views/storefront/layout/navigation/offcanvas/back-link.html.twig
@@ -15,7 +15,7 @@
         {% block layout_navigation_offcanvas_navigation_category_back_link_text %}
             <span class="navigation-offcanvas-link-icon js-navigation-offcanvas-loading-icon">
             {% block layout_utilities_offcanvas_close_icon %}
-                {% sw_icon 'arrow-medium-left' style { pack:'solid', size: 'sm', ariaHidden: true } %}
+                {% sw_icon 'arrow-medium-left' style { pack:'solid', size: 'sm' } %}
             {% endblock %}
         </span>
 

--- a/src/Storefront/Resources/views/storefront/layout/scroll-up.html.twig
+++ b/src/Storefront/Resources/views/storefront/layout/scroll-up.html.twig
@@ -6,7 +6,7 @@
             <div class="scroll-up-button js-scroll-up-button">
                 <button class="btn btn-primary" aria-label="{{ 'general.scrollUpBtn'|trans|striptags }}">
                     {% block layout_scroll_up_button_icon %}
-                        {% sw_icon 'arrow-up' style { size: 'sm', ariaHidden: true } %}
+                        {% sw_icon 'arrow-up' style { size: 'sm' } %}
                     {% endblock %}
                 </button>
             </div>

--- a/src/Storefront/Resources/views/storefront/page/account/order-history/order-item.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/account/order-history/order-item.html.twig
@@ -39,7 +39,7 @@
                                         <a href="{{ path('frontend.account.edit-order.page', { orderId: order.id }) }}"
                                            class="badge badge-lg order-item-status-badge bg-danger">
                                             {{ 'account.orderStatusActionCompletePayment'|trans|sw_sanitize }}
-                                            {% sw_icon 'arrow-medium-right' style { size: 'sm', pack: 'solid', ariaHidden: true } %}
+                                            {% sw_icon 'arrow-medium-right' style { size: 'sm', pack: 'solid' } %}
                                         </a>
                                     {% endblock %}
                                 {% else %}
@@ -71,7 +71,7 @@
                                         aria-haspopup="true"
                                         aria-expanded="false"
                                         aria-label="{{ 'account.orderActions'|trans|sw_sanitize }}">
-                                    {% sw_icon 'more-horizontal' style { ariaHidden: true } %}
+                                    {% sw_icon 'more-horizontal' %}
                                 </button>
                             {% endblock %}
 

--- a/src/Storefront/Resources/views/storefront/page/account/sidebar.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/account/sidebar.html.twig
@@ -75,7 +75,7 @@
                             {% block page_account_sidebar_logout %}
                                 <a href="{{ path('frontend.account.logout.page') }}"
                                    class="btn btn-link account-aside-btn">
-                                    {% sw_icon 'log-out' style { ariaHidden: true } %}
+                                    {% sw_icon 'log-out' %}
                                     {{ 'account.logout'|trans|sw_sanitize }}
                                 </a>
                             {% endblock %}
@@ -86,7 +86,7 @@
                                 <a href="{{ path('frontend.account.logout.page') }}"
                                    data-account-guest-abort-button="true"
                                    class="btn btn-link account-aside-btn">
-                                    {% sw_icon 'log-out' style { ariaHidden: true } %}
+                                    {% sw_icon 'log-out' %}
                                     {{ 'account.guestAbort'|trans|sw_sanitize }}
                                 </a>
                             {% endblock %}

--- a/src/Storefront/Resources/views/storefront/utilities/alert.html.twig
+++ b/src/Storefront/Resources/views/storefront/utilities/alert.html.twig
@@ -97,15 +97,15 @@ To display a dismissible button set the value of "dismissible" to true.
                     {{ sw_icon_cache_disable() }}
                 {% endif %}
                 {% if type == 'danger' %}
-                    {% sw_icon 'blocked' style { ariaHidden: true } %}
+                    {% sw_icon 'blocked' %}
                 {% elseif type == 'warning' %}
-                    {% sw_icon 'warning' style { ariaHidden: true } %}
+                    {% sw_icon 'warning' %}
                 {% elseif type == 'info' %}
-                    {% sw_icon 'info' style { ariaHidden: true } %}
+                    {% sw_icon 'info' %}
                 {% elseif type == 'success' %}
-                    {% sw_icon 'checkmark-circle' style { ariaHidden: true } %}
+                    {% sw_icon 'checkmark-circle' %}
                 {% else %}
-                    {% sw_icon 'alert' style { ariaHidden: true } %}
+                    {% sw_icon 'alert' %}
                 {% endif %}
                 {% if iconCache == false and iconCacheSystem === true %}
                     {{ sw_icon_cache_enable() }}

--- a/src/Storefront/Resources/views/storefront/utilities/icon.html.twig
+++ b/src/Storefront/Resources/views/storefront/utilities/icon.html.twig
@@ -11,10 +11,14 @@
         {% set namespace = 'Storefront' %}
     {%- endif -%}
 
+    {%- if ariaHidden is not defined -%}
+        {% set ariaHidden = true %}
+    {%- endif -%}
+
     {%- if themeIconConfig[pack] is defined -%}
         <span class="icon icon-{{ pack }} icon-{{ pack }}-{{ name }}{% for entry in styles %}{% if entry != "" %} icon-{{ entry }}{% endif %}{% endfor %}"{% if ariaHidden %} aria-hidden="true"{% endif %}>
             {% set icon = source('@' ~ themeIconConfig[pack].namespace ~ '/' ~ themeIconConfig[pack].path ~'/'~ name ~ '.svg', ignore_missing = true) %}
-            {% if ariaLabel %}
+            {% if ariaLabel and not ariaHidden %}
                 {{ icon|sw_icon_cache|replace({'<svg ': '<svg aria-label="'~ariaLabel~'" '})|raw }}
             {% else %}
                 {{ icon|sw_icon_cache|raw }}
@@ -23,7 +27,7 @@
     {%- else -%}
         <span class="icon icon-{{ name }}{% for entry in styles %}{% if entry != "" %} icon-{{ entry }}{% endif %}{% endfor %}"{% if ariaHidden %} aria-hidden="true"{% endif %}>
             {% set icon = source('@' ~ namespace ~ '/assets/icon/'~ pack ~'/'~ name ~'.svg', ignore_missing = true) %}
-            {% if ariaLabel %}
+            {% if ariaLabel and not ariaHidden %}
                 {{ icon|sw_icon_cache|replace({'<svg ': '<svg aria-label="'~ariaLabel~'" '})|raw }}
             {% else %}
                 {{ icon|sw_icon_cache|raw }}

--- a/tests/unit/Storefront/Framework/Twig/Extension/IconCacheTwigFilterTest.php
+++ b/tests/unit/Storefront/Framework/Twig/Extension/IconCacheTwigFilterTest.php
@@ -61,16 +61,18 @@ class IconCacheTwigFilterTest extends TestCase
 
         $rendered = $controller->testRenderStorefront('@StorefrontTest/test/base.html.twig', $salesChannelContext);
 
-        static::assertEquals(str_replace(' ', '', '<span class="icon icon-minus-large icon-xs icon-filter-panel-item-toggle">
+        static::assertEquals(str_replace(' ', '', '<span class="icon icon-minus-large icon-xs icon-filter-panel-item-toggle" aria-hidden="true">
                             <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="16" height="16" viewBox="0 0 16 16"><defs><path id="icons-solid-minus-large" d="M2 9h12c.5523 0 1-.4477 1-1s-.4477-1-1-1H2c-.5523 0-1 .4477-1 1s.4477 1 1 1z" /></defs><use xlink:href="#icons-solid-minus-large" fill="#758CA3" fill-rule="evenodd" /></svg>
-            </span><span class="icon icon-minus-large icon-xs icon-filter-panel-item-toggle">
+            </span><span class="icon icon-minus-large icon-xs icon-filter-panel-item-toggle" aria-hidden="true">
                             <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="16" height="16" viewBox="0 0 16 16"><use xlink:href="#icons-solid-minus-large" fill="#758CA3" fill-rule="evenodd" /></svg>
-            </span><span class="icon icon-minus-small">
+            </span><span class="icon icon-minus-small" aria-hidden="true">
                             <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="16" height="16" viewBox="0 0 16 16"><defs><path id="icons-solid-minus-small" d="M4.8571 9h6.2858C11.6162 9 12 8.5523 12 8s-.3838-1-.8571-1H4.857C4.3838 7 4 7.4477 4 8s.3838 1 .8571 1z" /></defs><use xlink:href="#icons-solid-minus-small" fill="#758CA3" fill-rule="evenodd" /></svg>
-            </span><span class="icon icon-minus">
+            </span><span class="icon icon-minus" aria-hidden="true">
                             <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="16" height="16" viewBox="0 0 16 16"><defs><path id="icons-solid-minus" d="M2.8571 9H13.143c.4732 0 .857-.4477.857-1s-.3838-1-.8571-1H2.857C2.3838 7 2 7.4477 2 8s.3838 1 .8571 1z" /></defs><use xlink:href="#icons-solid-minus" fill="#758CA3" fill-rule="evenodd" /></svg>
-            </span><span class="icon icon-minus">
+            </span><span class="icon icon-minus" aria-hidden="true">
                             <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="24" height="24" viewBox="0 0 24 24"><defs><path id="icons-default-minus" d="M3 13h18c.5523 0 1-.4477 1-1s-.4477-1-1-1H3c-.5523 0-1 .4477-1 1s.4477 1 1 1z" /></defs><use xlink:href="#icons-default-minus" fill="#758CA3" fill-rule="evenodd" /></svg>
+            </span><span class="iconicon-minus">
+                            <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="24" height="24" viewBox="002424"><use xlink:href="#icons-default-minus" fill="#758CA3" fill-rule="evenodd"/></svg>
             </span>'), str_replace(' ', '', $rendered->getContent() ?: ''));
     }
 

--- a/tests/unit/Storefront/Framework/Twig/Extension/fixtures/Storefront/Resources/views/test/base.html.twig
+++ b/tests/unit/Storefront/Framework/Twig/Extension/fixtures/Storefront/Resources/views/test/base.html.twig
@@ -3,3 +3,4 @@
 {% sw_icon 'minus-small' style {'pack': 'solid' } %}
 {% sw_icon 'minus' style {'pack': 'solid' } %}
 {% sw_icon 'minus' style {'pack': 'default' } %}
+{% sw_icon 'minus' style { 'pack': 'default', 'ariaHidden': false } %}


### PR DESCRIPTION
**Backport:** https://github.com/shopware/shopware/pull/7505
Resolves: https://github.com/shopware/shopware/issues/7369
relates #19539

---

### 1. Why is this change necessary?

Manual backport of #7505 to 6.6.x (a11y). The automated cherry-pick conflicts; see below.

### 2. What does this change do, exactly?

`sw_icon` (`Resources/views/storefront/utilities/icon.html.twig`) now sets `aria-hidden="true"` on the icon wrapper by default, so decorative icons are no longer announced by screen readers. Icons that must stay exposed have to opt out with `ariaHidden: false`; `ariaLabel` is only applied when `ariaHidden` is false. All call sites that passed the now-redundant `ariaHidden: true` were cleaned up, and the two places that used `ariaLabel` on a purely decorative icon (footer collapse toggles, header cart icon) drop it.

**Conflict resolution vs. trunk commit 8d9b06b0bc1:**
- `UPGRADE-6.7.md`: hunk dropped, file restored to the 6.6.x version. The 57-line upgrade note is a 6.7 document; 6.6.x must not gain 6.7 upgrade entries.
- `src/Storefront/Resources/views/storefront/component/pagination.html.twig`: kept the 6.6.x shape, i.e. the `feature('ACCESSIBILITY_TWEAKS')` branches plus the deprecated radio-input/label fallback that trunk had already removed. Only the payload was applied: the redundant `ariaHidden: true` was removed from the four arrow icons in the anchor (flag-on) branch.
- `src/Storefront/Resources/views/storefront/component/product/card/box-standard.html.twig`: kept the 6.6.x shape (the deprecated `</a>` around the product image, guarded by `not feature('ACCESSIBILITY_TWEAKS')`, which does not exist on trunk any more). Only `ariaHidden: true` was removed from the `placeholder` icon.
- `src/Storefront/Resources/views/storefront/layout/cookie/cookie-configuration-group.html.twig`: hunk dropped entirely. 6.6.x already carries the reworked markup where the icon sits inside a real `<button aria-label="{{ 'general.expand'|trans }}" aria-controls="…">`. The trunk change (`ariaHidden: false` + `ariaLabel`) would re-expose the icon and duplicate the label; on 6.6.x the icon is correctly decorative and the button keeps its accessible name.

**Notes:**
- No PHP was touched — the change lives entirely in the `icon.html.twig` template, and 6.6.x's version of that file was byte-identical to trunk's pre-change version, so it applied cleanly.
- No follow-up/corrective commit for this change exists on trunk; `icon.html.twig` on trunk still contains exactly this logic today.
- `src/Storefront/Resources/views/storefront/layout/header/actions/cart-widget.html.twig`: dropping `ariaLabel: 'checkout.cartTitle'` is safe on 6.6.x because the follow-up from #11014 (visually hidden `#cart-widget-aria-label` + `aria-labelledby` on the header cart link) is already present on 6.6.x.
- The legacy, non-`ACCESSIBILITY_TWEAKS` footer branch (6.6.x only) still passes `ariaLabel: 'general.expand'/'general.collapse'` to `sw_icon`. Those become no-ops under the new default, matching trunk's intent that these icons are decorative; the surrounding headline text stays the announced content. Left untouched on purpose to keep the 6.6.x-only code path unchanged.

### 3. Describe each step to reproduce the issue or behaviour.

See original PR.

### 4. Please link to the relevant issues (if any).

- relates #7369
- relates #19539

### 5. Checklist

- [x] Cherry-picked from trunk with `-x`, conflicts resolved as described
- [x] Tests run locally: `vendor/bin/phpunit --testsuite unit --filter IconCacheTwigFilterTest` → OK (1 test, 1 assertion); `bin/console lint:twig src/Storefront/Resources/views/storefront` → OK, 328 files valid. Both executed in a `ghcr.io/shopware/docker-dev:php8.3` container against the worktree.
