### PR TITLE
fix(a11y): announce danger alerts assertively on newsletter and checkout pages

### DIFF
--- a/src/Storefront/Resources/views/storefront/page/account/newsletter.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/account/newsletter.html.twig
@@ -7,7 +7,8 @@
                     {% sw_include '@Storefront/storefront/utilities/alert.html.twig' with {
                         type: message.type,
                         content: message.text,
-                        announceOnLoad: true
+                        announceOnLoad: true,
+                        ariaLive: (message.type == 'danger' ? 'assertive' : 'polite'),
                     } %}
                 {% endfor %}
             </div>

--- a/src/Storefront/Resources/views/storefront/page/checkout/_page.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/checkout/_page.html.twig
@@ -20,6 +20,7 @@
                                             type: type,
                                             list: messages,
                                             announceOnLoad: true,
+                                            ariaLive: (type == 'danger' ? 'assertive' : 'polite'),
                                         } %}
                                     {% endfor %}
                                 </div>


### PR DESCRIPTION
### 1. Why is this change necessary?

Alerts that are rendered on initial page load are announced by the `AlertAria` plugin (introduced in #14575). `utilities/alert.html.twig` falls back to `ariaLive: 'polite'` when nothing is passed, so error messages (`type: 'danger'`) on the account newsletter page and on the checkout pages are queued behind other screen reader output instead of interrupting. Other call sites, e.g. `component/account/login.html.twig`, already pass `assertive` for errors, so the behaviour is inconsistent today.

### 2. What does this change do, exactly?

Passes `ariaLive` explicitly in the two remaining call sites, so `danger` alerts are announced assertively and every other type stays `polite`:

- `page/account/newsletter.html.twig`
- `page/checkout/_page.html.twig`

### 3. Describe each step to reproduce the issue or behaviour.

1. Turn on a screen reader (NVDA/VoiceOver).
2. Trigger an error flash message on a checkout page, or on Account → Newsletter.
3. Before: the message is announced politely, i.e. only after any speech in progress. After: it interrupts, consistent with the login error alert.

### 4. Please link to the relevant issues (if any).

- relates #14575 (introduced `announceOnLoad` / `ariaLive`)
- suggested by @joberthel during review of the 6.6.x backport #19808

### 5. Checklist

- [x] I have written tests and verified that they fail without my change — n/a, template-only change; the behaviour is covered by the existing `alert-aria.plugin` tests
- [ ] I have created a changelog file — not added, matching recent template-only accessibility fixes
- [x] I have written or adjusted the documentation according to my changes — n/a
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
