### PR TITLE
ci(danger): count moved migration tests as coverage

### DIFF
--- a/src/Core/DevOps/StaticAnalyze/Danger/Rules/MissingMigrationTests.php
+++ b/src/Core/DevOps/StaticAnalyze/Danger/Rules/MissingMigrationTests.php
@@ -7,7 +7,9 @@ use Danger\Struct\File;
 use Shopware\Core\Framework\Log\Package;
 
 /**
- * Every new migration class needs a test under `tests/migration/`.
+ * Every new migration class needs a test under `tests/migration/`. A moved or updated test
+ * counts: relocating a migration to another major folder shows the migration as added while
+ * its accompanying test is only renamed or modified.
  *
  * @internal
  */
@@ -33,7 +35,9 @@ class MissingMigrationTests
         $files = $context->platform->pullRequest->getFiles();
 
         $migrationFiles = $files->filterStatus(File::STATUS_ADDED)->matches(\sprintf('src/%s/Migration/V*/Migration*.php', $bundle));
-        $migrationTestFiles = $files->filterStatus(File::STATUS_ADDED)->matches(\sprintf('tests/migration/%s/V*/*.php', $bundle));
+        $migrationTestFiles = $files
+            ->matches(\sprintf('tests/migration/%s/V*/*.php', $bundle))
+            ->filter(static fn (File $file): bool => $file->status !== File::STATUS_REMOVED);
 
         if ($migrationFiles->count() && !$migrationTestFiles->count()) {
             $context->failure('Please add tests for your new Migration file');

--- a/tests/unit/Core/DevOps/StaticAnalyze/Danger/Rules/MissingMigrationTestsTest.php
+++ b/tests/unit/Core/DevOps/StaticAnalyze/Danger/Rules/MissingMigrationTestsTest.php
@@ -72,6 +72,32 @@ class MissingMigrationTestsTest extends TestCase
         ];
     }
 
+    #[TestDox('A moved migration test satisfies the rule for the migration it accompanies')]
+    public function testRenamedMigrationTestCountsAsCoverage(): void
+    {
+        $context = new Context(new StubPlatform(new StubPullRequest([
+            new StubFile('src/Core/Migration/V6_8/Migration1752000000AddFoo.php', File::STATUS_ADDED),
+            new StubFile('tests/migration/Core/V6_8/Migration1752000000AddFooTest.php', File::STATUS_RENAMED),
+        ])));
+
+        (new MissingMigrationTests())($context);
+
+        static::assertFalse($context->hasReports());
+    }
+
+    #[TestDox('A deleted migration test does not satisfy the rule')]
+    public function testRemovedMigrationTestDoesNotCount(): void
+    {
+        $context = new Context(new StubPlatform(new StubPullRequest([
+            new StubFile('src/Core/Migration/V6_8/Migration1752000000AddFoo.php', File::STATUS_ADDED),
+            new StubFile('tests/migration/Core/V6_8/Migration1752000000AddFooTest.php', File::STATUS_REMOVED),
+        ])));
+
+        (new MissingMigrationTests())($context);
+
+        static::assertCount(1, $context->getFailures());
+    }
+
     #[TestDox('Only added migration files trigger the rule, modifications do not')]
     public function testModifiedMigrationIsIgnored(): void
     {


### PR DESCRIPTION
### 1. Why is this change necessary?

The MissingMigrationTests Danger rule only counts test files with status "added". When a migration is relocated to another major folder, GitHub often detects the accompanying test move as a rename while the migration itself shows as removed + added, so the rule fails a PR that carries exactly the right test (seen on #19856).

### 2. What does this change do, exactly?

The rule counts every migration test in the PR that is not deleted, so renamed and modified tests satisfy it; a removed test still does not. Two unit tests pin the renamed-counts and removed-does-not-count behaviour.

### 3. Describe each step to reproduce the issue or behaviour.

Move a migration and its test from V6_7 to V6_8 in one PR: the migration is reported as added, the test as renamed, and Danger fails with "Please add tests for your new Migration file".

### 4. Please link to the relevant issues (if any).

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
