### PR TITLE
fix: reject retained calls to removed hierarchy parents

### DIFF
--- a/src/Core/DevOps/StaticAnalyze/PHPStan/Rules/Deprecation/BCChangeAttributeUsageRule.php
+++ b/src/Core/DevOps/StaticAnalyze/PHPStan/Rules/Deprecation/BCChangeAttributeUsageRule.php
@@ -6,6 +6,7 @@ use PhpParser\Node;
 use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Identifier;
+use PhpParser\Node\Name;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\NodeFinder;
 use PHPStan\Analyser\Scope;
@@ -309,6 +310,17 @@ class BCChangeAttributeUsageRule implements Rule
                 continue;
             }
 
+            $methodNode = $methodNodes[$methodName] ?? null;
+            if ($methodNode !== null && !$this->isDeprecatedMethodNode($methodNode) && $this->callsParent($methodNode)) {
+                $errors[] = $this->error($line, \sprintf(
+                    'ClassHierarchyChange on "%s": non-deprecated method "%s()" must not call parent:: because its parent hierarchy will change.',
+                    $this->shortClassName($class->getName()),
+                    $parentMethod->getName()
+                ));
+
+                continue;
+            }
+
             if ($this->isDeclaredByClass($class, $methodNodes, $methodName)) {
                 continue;
             }
@@ -341,6 +353,21 @@ class BCChangeAttributeUsageRule implements Rule
         }
 
         return false;
+    }
+
+    private function callsParent(ClassMethod $method): bool
+    {
+        return (new NodeFinder())->findFirst(
+            $method,
+            static fn (Node $node): bool => $node instanceof StaticCall
+                && $node->class instanceof Name
+                && \strtolower($node->class->toString()) === 'parent'
+        ) !== null;
+    }
+
+    private function isDeprecatedMethodNode(ClassMethod $method): bool
+    {
+        return \str_contains($method->getDocComment()?->getText() ?? '', '@deprecated');
     }
 
     private function isInHierarchy(ClassReflection $class, string $possibleDescendant): bool

--- a/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/BCChangeAttributeUsageRuleTest.php
+++ b/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/BCChangeAttributeUsageRuleTest.php
@@ -153,6 +153,10 @@ class BCChangeAttributeUsageRuleTest extends RuleTestCase
                 334,
             ],
             [
+                'ClassHierarchyChange on "InvalidHierarchyChange": non-deprecated method "overriddenWithoutDeprecation()" must not call parent:: because its parent hierarchy will change.',
+                334,
+            ],
+            [
                 'ClassHierarchyChange on "InvalidHierarchyChange": inherited public method "providedByTrait()" from "OldHierarchyParent" will be removed from the hierarchy. Override it explicitly and mark the override as deprecated, unless the new parent also provides the method.',
                 334,
             ],

--- a/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/data/BCChangeAttributeUsageRule/BCChangeAttributeUsage.php
+++ b/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/data/BCChangeAttributeUsageRule/BCChangeAttributeUsage.php
@@ -336,6 +336,7 @@ class InvalidHierarchyChange extends OldHierarchyParent
 {
     public function overriddenWithoutDeprecation(): void
     {
+        parent::overriddenWithoutDeprecation();
     }
 }
 
@@ -363,6 +364,7 @@ class ValidHierarchyChange extends OldHierarchyParent
      */
     public function overriddenWithoutDeprecation(): void
     {
+        parent::overriddenWithoutDeprecation();
     }
 
     public function providedByProtectedNewParent(): void


### PR DESCRIPTION
### 1. Why is this change necessary?

A non-deprecated method retained on a class with `ClassHierarchyChange` can still delegate to `parent::`. That call becomes invalid when the announced parent hierarchy is applied.

### 2. What does this change do, exactly?

Extends the PHPStan rule to reject a non-deprecated directly declared method that calls `parent::` while its hierarchy is scheduled to change. Deprecated compatibility methods may keep their legacy delegation.

### 3. Describe each step to reproduce the issue or behaviour.

1. Add `ClassHierarchyChange` to a subclass.
2. Directly declare a non-deprecated method inherited from the removed parent.
3. Call `parent::` from that method.
4. Run PHPStan; the rule reports the invalid future delegation.

### 4. Please link to the relevant issues (if any).

- Follow-up to #19819

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Not applicable: this changes internal static-analysis validation only.
- [x] I have written or adjusted the documentation and agent skills according to my changes
  - Not applicable: the existing guidance already covers planned hierarchy changes.
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them