### PR TITLE
feat(framework): track plugin:create and make:plugin usage

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -2,6 +2,10 @@
 
 ## Core
 
+### Anonymous CLI scaffolding telemetry
+
+`plugin:create` and `make:plugin:*` send anonymous usage events so Shopware can see whether those scaffolding commands are used. The payload contains the command name, selected scaffold options, Shopware version, and PHP version. Set `DO_NOT_TRACK` to disable collection. The same `core.telemetry.id` system config key as the Deployment Helper identifies the installation. Learn more at [https://developer.shopware.com/docs/resources/references/telemetry.html](https://developer.shopware.com/docs/resources/references/telemetry.html).
+
 ### `system:install` dispatches `SystemInstallCompletedEvent`
 
 `Shopware\Core\Framework\Event\SystemInstallCompletedEvent` is dispatched after a successful `bin/console system:install`. The event exposes the CLI `Context`. Extensions can subscribe to run post-install work.

--- a/src/Core/Framework/DependencyInjection/plugin.php
+++ b/src/Core/Framework/DependencyInjection/plugin.php
@@ -62,6 +62,7 @@ use Shopware\Core\Framework\Plugin\Util\PluginFinder;
 use Shopware\Core\Framework\Plugin\Util\PluginIdProvider;
 use Shopware\Core\Framework\Plugin\Util\VersionSanitizer;
 use Shopware\Core\Framework\Telemetry\Metrics\Meter;
+use Shopware\Core\Framework\Telemetry\Tracking\TrackingService;
 use Shopware\Core\System\CustomEntity\Schema\CustomEntityPersister;
 use Shopware\Core\System\CustomEntity\Schema\CustomEntitySchemaUpdater;
 use Shopware\Core\System\CustomField\CustomFieldSetPersister;
@@ -84,6 +85,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             service(ScaffoldingCollector::class),
             service(ScaffoldingWriter::class),
             service(PluginService::class),
+            service(TrackingService::class),
         ]);
 
     $services->set(KernelPluginLoader::class)
@@ -308,6 +310,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             service(ScaffoldingWriter::class),
             service(Filesystem::class),
             tagged_iterator('shopware.scaffold.generator'),
+            service(TrackingService::class),
         ])
         ->tag('console.command');
 

--- a/src/Core/Framework/DependencyInjection/telemetry.php
+++ b/src/Core/Framework/DependencyInjection/telemetry.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Core\Framework\DependencyInjection;
 
+use Psr\Clock\ClockInterface as PsrClockInterface;
 use Shopware\Core\Framework\Telemetry\Metrics\Config\MetricConfigProvider;
 use Shopware\Core\Framework\Telemetry\Metrics\Config\TransportConfigProvider;
 use Shopware\Core\Framework\Telemetry\Metrics\Meter;
@@ -11,6 +12,10 @@ use Shopware\Core\Framework\Telemetry\Metrics\ScheduledTask\CollectPeriodicMetri
 use Shopware\Core\Framework\Telemetry\Metrics\Subscriber\TelemetryFlushListener;
 use Shopware\Core\Framework\Telemetry\Metrics\Transport\TransportCollection;
 use Shopware\Core\Framework\Telemetry\Telemetry;
+use Shopware\Core\Framework\Telemetry\Tracking\TrackingService;
+use Shopware\Core\Framework\Telemetry\Tracking\TrackingTransport;
+use Shopware\Core\Framework\Telemetry\Tracking\UdpTrackingTransport;
+use Shopware\Core\System\SystemConfig\SystemConfigService;
 use Symfony\Component\Clock\ClockInterface;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
@@ -86,4 +91,16 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             tagged_iterator('shopware.telemetry.periodic_metric_collector'),
         ])
         ->tag('messenger.message_handler');
+
+    $services->set(UdpTrackingTransport::class);
+
+    $services->alias(TrackingTransport::class, UdpTrackingTransport::class);
+
+    $services->set(TrackingService::class)
+        ->args([
+            service(SystemConfigService::class),
+            service(TrackingTransport::class),
+            service(PsrClockInterface::class),
+            param('kernel.shopware_version'),
+        ]);
 };

--- a/src/Core/Framework/Plugin/Command/MakerCommand.php
+++ b/src/Core/Framework/Plugin/Command/MakerCommand.php
@@ -9,6 +9,7 @@ use Shopware\Core\Framework\Plugin\Command\Scaffolding\PluginScaffoldConfigurati
 use Shopware\Core\Framework\Plugin\Command\Scaffolding\ScaffoldingCollector;
 use Shopware\Core\Framework\Plugin\Command\Scaffolding\ScaffoldingWriter;
 use Shopware\Core\Framework\Plugin\PluginService;
+use Shopware\Core\Framework\Telemetry\Tracking\TrackingService;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -26,6 +27,7 @@ class MakerCommand extends Command
         private readonly ScaffoldingCollector $scaffoldingCollector,
         private readonly ScaffoldingWriter $scaffoldingWriter,
         private readonly PluginService $pluginService,
+        private readonly TrackingService $trackingService,
     ) {
         parent::__construct();
     }
@@ -105,6 +107,12 @@ class MakerCommand extends Command
             $this->scaffoldingWriter->write($stubCollection, $configuration);
 
             $io->success('Scaffold created successfully');
+
+            $this->trackingService->showHint($output);
+            $this->trackingService->track('make.plugin', [
+                'command' => (string) $this->getName(),
+                'generator' => (new \ReflectionClass($this->generator))->getShortName(),
+            ]);
 
             return self::SUCCESS;
         } catch (\Throwable $exception) {

--- a/src/Core/Framework/Plugin/Command/PluginCreateCommand.php
+++ b/src/Core/Framework/Plugin/Command/PluginCreateCommand.php
@@ -8,6 +8,7 @@ use Shopware\Core\Framework\Plugin\Command\Scaffolding\PluginScaffoldConfigurati
 use Shopware\Core\Framework\Plugin\Command\Scaffolding\ScaffoldingCollector;
 use Shopware\Core\Framework\Plugin\Command\Scaffolding\ScaffoldingWriter;
 use Shopware\Core\Framework\Plugin\PluginException;
+use Shopware\Core\Framework\Telemetry\Tracking\TrackingService;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
@@ -34,7 +35,8 @@ class PluginCreateCommand extends Command
         private readonly ScaffoldingCollector $scaffoldingCollector,
         private readonly ScaffoldingWriter $scaffoldingWriter,
         private readonly Filesystem $filesystem,
-        private readonly iterable $generators
+        private readonly iterable $generators,
+        private readonly TrackingService $trackingService,
     ) {
         parent::__construct();
     }
@@ -126,6 +128,8 @@ class PluginCreateCommand extends Command
 
             $io->success('Plugin created successfully');
 
+            $this->trackUsage($input, $output, $configuration, $noScaffold);
+
             return self::SUCCESS;
         } catch (\Throwable $exception) {
             $io->error($exception->getMessage());
@@ -136,6 +140,28 @@ class PluginCreateCommand extends Command
 
             return self::FAILURE;
         }
+    }
+
+    private function trackUsage(
+        InputInterface $input,
+        OutputInterface $output,
+        PluginScaffoldConfiguration $configuration,
+        bool $noScaffold
+    ): void {
+        $this->trackingService->showHint($output);
+
+        $selected = [];
+        foreach ($configuration->options as $key => $value) {
+            if ($value) {
+                $selected[] = $key;
+            }
+        }
+
+        $this->trackingService->track('plugin.create', [
+            'static' => $input->getOption('static') ? 1 : 0,
+            'scaffold' => $noScaffold ? 0 : 1,
+            'options' => implode(',', $selected),
+        ]);
     }
 
     private function askPascalCaseString(

--- a/src/Core/Framework/Telemetry/README.md
+++ b/src/Core/Framework/Telemetry/README.md
@@ -2,6 +2,7 @@
 This component contains the code for the collection of telemetry in shopware applications.
 
 Folder structure:
+- `Tracking` - anonymous usage events (CLI scaffolding today). Honours `DO_NOT_TRACK` and shares `core.telemetry.id` with the Deployment Helper.
 - `Metrics` - contains the abstractions for the metrics collection and reporting.
   - `Config` - metric and transport configuration loaded from `telemetry.yaml`.
   - `Exception` - telemetry-specific exceptions.
@@ -245,6 +246,20 @@ MeterProvider::meter()?->emit(new ConfiguredMetric(name: 'database.locks.count',
 | `messenger.message.size` | histogram | `MessageQueueTelemetrySubscriber` | `WorkerMessageReceivedEvent` |
 | `dal.associations.count` | histogram | `EntityTelemetrySubscriber` | `EntitySearchedEvent` |
 | `database.locks.count` | counter | `RetryableQuery` / `RetryableTransaction` | `RetryableException` / deadlock |
+
+## Usage tracking
+
+`Shopware\Core\Framework\Telemetry\Tracking\TrackingService` sends anonymous usage events over UDP. It is the Shopware counterpart of the Deployment Helper tracker: `DO_NOT_TRACK` disables collection, and `core.telemetry.id` is the shared anonymous installation id.
+
+```php
+$this->trackingService->track('plugin.create', [
+    'static' => 0,
+    'scaffold' => 1,
+    'options' => 'create-command',
+]);
+```
+
+CLI scaffolding commands (`plugin:create`, `make:plugin:*`) call this after a successful run. Override the destination with `SHOPWARE_TRACKING_DOMAIN` (default `udp.usage.shopware.io:9000`).
 
 ## Future improvements
 - Currently, emit expects the metric value to be precalculated. That means that if some metric will be disabled, the

--- a/src/Core/Framework/Telemetry/Tracking/TrackingService.php
+++ b/src/Core/Framework/Telemetry/Tracking/TrackingService.php
@@ -1,0 +1,139 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\Telemetry\Tracking;
+
+use Psr\Clock\ClockInterface;
+use Shopware\Core\DevOps\Environment\EnvironmentHelper;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\System\SystemConfig\SystemConfigService;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Anonymous usage tracking for CLI and other product surfaces.
+ *
+ * Honours `DO_NOT_TRACK`. Shares `core.telemetry.id` with the Deployment Helper
+ * so the same installation can be correlated across tools.
+ *
+ * @internal
+ *
+ * @see https://developer.shopware.com/docs/resources/references/telemetry.html
+ */
+#[Package('framework')]
+class TrackingService
+{
+    public const TELEMETRY_ID = 'core.telemetry.id';
+
+    public const LEGACY_DEPLOYMENT_HELPER_ID = 'core.deployment_helper.id';
+
+    public const TELEMETRY_DOCS_URL = 'https://developer.shopware.com/docs/resources/references/telemetry.html';
+
+    private const EVENT_PREFIX = 'shopware.';
+
+    /**
+     * @var array<string, string>
+     */
+    private array $defaultTags;
+
+    private string $id;
+
+    public function __construct(
+        private readonly SystemConfigService $systemConfigService,
+        private readonly TrackingTransport $transport,
+        private readonly ClockInterface $clock,
+        private readonly string $shopwareVersion,
+    ) {
+    }
+
+    /**
+     * @param array<string, string|int|float> $tags
+     */
+    public function track(string $eventName, array $tags = []): void
+    {
+        if (EnvironmentHelper::hasVariable('DO_NOT_TRACK')) {
+            return;
+        }
+
+        $payload = json_encode([
+            'event' => self::EVENT_PREFIX . $eventName,
+            'tags' => $tags + $this->getTags(),
+            'user_id' => $this->getId(),
+            'timestamp' => $this->clock->now()->format(\DateTimeInterface::ATOM),
+        ], \JSON_THROW_ON_ERROR);
+
+        $this->transport->send($payload);
+    }
+
+    public function persistId(): void
+    {
+        if (!isset($this->id)) {
+            return;
+        }
+
+        try {
+            $this->systemConfigService->set(self::TELEMETRY_ID, $this->id);
+        } catch (\Throwable) {
+        }
+    }
+
+    public function showHint(OutputInterface $output): void
+    {
+        if (EnvironmentHelper::hasVariable('DO_NOT_TRACK')) {
+            return;
+        }
+
+        $output->writeln(\sprintf(
+            '<comment>Shopware collects anonymous telemetry about your usage of scaffolding commands. Learn more at %s</comment>',
+            self::TELEMETRY_DOCS_URL,
+        ));
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function getTags(): array
+    {
+        if (isset($this->defaultTags)) {
+            return $this->defaultTags;
+        }
+
+        $this->defaultTags = [
+            'shopware_version' => $this->shopwareVersion,
+            'php_version' => \PHP_MAJOR_VERSION . '.' . \PHP_MINOR_VERSION,
+        ];
+
+        return $this->defaultTags;
+    }
+
+    private function getId(): string
+    {
+        if (isset($this->id)) {
+            return $this->id;
+        }
+
+        try {
+            $id = $this->systemConfigService->get(self::TELEMETRY_ID);
+            if (\is_string($id) && $id !== '') {
+                return $this->id = $id;
+            }
+
+            $legacyId = $this->systemConfigService->get(self::LEGACY_DEPLOYMENT_HELPER_ID);
+            if (\is_string($legacyId) && $legacyId !== '') {
+                $this->systemConfigService->set(self::TELEMETRY_ID, $legacyId);
+                $this->systemConfigService->delete(self::LEGACY_DEPLOYMENT_HELPER_ID);
+
+                return $this->id = $legacyId;
+            }
+        } catch (\Throwable) {
+            return $this->id = bin2hex(random_bytes(16));
+        }
+
+        $this->id = bin2hex(random_bytes(16));
+
+        try {
+            $this->systemConfigService->set(self::TELEMETRY_ID, $this->id);
+        } catch (\Throwable) {
+        }
+
+        return $this->id;
+    }
+}

--- a/src/Core/Framework/Telemetry/Tracking/TrackingTransport.php
+++ b/src/Core/Framework/Telemetry/Tracking/TrackingTransport.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\Telemetry\Tracking;
+
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * Fire-and-forget sink for anonymous usage events.
+ *
+ * @internal
+ */
+#[Package('framework')]
+interface TrackingTransport
+{
+    public function send(string $payload): void;
+}

--- a/src/Core/Framework/Telemetry/Tracking/UdpTrackingTransport.php
+++ b/src/Core/Framework/Telemetry/Tracking/UdpTrackingTransport.php
@@ -1,0 +1,71 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\Telemetry\Tracking;
+
+use Shopware\Core\DevOps\Environment\EnvironmentHelper;
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * Sends usage events as UDP datagrams. Failures are swallowed so tracking never
+ * affects the calling command.
+ *
+ * @internal
+ */
+#[Package('framework')]
+class UdpTrackingTransport implements TrackingTransport
+{
+    public const DEFAULT_TRACKING_DOMAIN = 'udp.usage.shopware.io';
+
+    public const DEFAULT_TRACKING_PORT = 9000;
+
+    private \Socket|false|null $socket = null;
+
+    private readonly string $host;
+
+    public function __construct(
+        ?string $host = null,
+        private readonly int $port = self::DEFAULT_TRACKING_PORT,
+    ) {
+        $configured = $host ?? EnvironmentHelper::getVariable('SHOPWARE_TRACKING_DOMAIN', self::DEFAULT_TRACKING_DOMAIN);
+        $this->host = \is_string($configured) && $configured !== '' ? $configured : self::DEFAULT_TRACKING_DOMAIN;
+    }
+
+    public function __destruct()
+    {
+        if ($this->socket instanceof \Socket) {
+            socket_close($this->socket);
+        }
+    }
+
+    public function send(string $payload): void
+    {
+        $socket = $this->socket();
+        if ($socket === null) {
+            return;
+        }
+
+        @socket_sendto($socket, $payload, \strlen($payload), 0, $this->host, $this->port);
+    }
+
+    private function socket(): ?\Socket
+    {
+        if ($this->socket instanceof \Socket) {
+            return $this->socket;
+        }
+
+        if ($this->socket === false) {
+            return null;
+        }
+
+        if (!\function_exists('socket_create')) {
+            $this->socket = false;
+
+            return null;
+        }
+
+        $socket = @socket_create(\AF_INET, \SOCK_DGRAM, \SOL_UDP);
+        $this->socket = $socket === false ? false : $socket;
+
+        return $this->socket instanceof \Socket ? $this->socket : null;
+    }
+}

--- a/tests/unit/Core/Framework/Plugin/Command/MakerCommandTest.php
+++ b/tests/unit/Core/Framework/Plugin/Command/MakerCommandTest.php
@@ -14,6 +14,7 @@ use Shopware\Core\Framework\Plugin\Command\Scaffolding\ScaffoldingWriter;
 use Shopware\Core\Framework\Plugin\Command\Scaffolding\StubCollection;
 use Shopware\Core\Framework\Plugin\PluginEntity;
 use Shopware\Core\Framework\Plugin\PluginService;
+use Shopware\Core\Framework\Telemetry\Tracking\TrackingService;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
@@ -49,7 +50,16 @@ class MakerCommandTest extends TestCase
         $otherGenerator = $this->createMock(ScaffoldingGenerator::class);
         $otherGenerator->expects($this->never())->method('generateStubs');
 
-        $command = new MakerCommand($generator, new ScaffoldingCollector([$generator, $otherGenerator]), $scaffoldingWriter, $pluginService);
+        $trackingService = $this->createMock(TrackingService::class);
+        $trackingService->expects($this->once())->method('showHint');
+        $trackingService->expects($this->once())
+            ->method('track')
+            ->with('make.plugin', [
+                'command' => 'make:foo',
+                'generator' => 'DummyScaffoldingGenerator',
+            ]);
+
+        $command = new MakerCommand($generator, new ScaffoldingCollector([$generator, $otherGenerator]), $scaffoldingWriter, $pluginService, $trackingService);
         $command->setName('make:foo');
 
         $tester = new CommandTester($command);
@@ -62,7 +72,7 @@ class MakerCommandTest extends TestCase
     public function testInteractRejectsBlankPluginName(): void
     {
         $generator = new DummyScaffoldingGenerator();
-        $command = new MakerCommand($generator, new ScaffoldingCollector([$generator]), static::createStub(ScaffoldingWriter::class), static::createStub(PluginService::class));
+        $command = new MakerCommand($generator, new ScaffoldingCollector([$generator]), static::createStub(ScaffoldingWriter::class), static::createStub(PluginService::class), static::createStub(TrackingService::class));
         $command->setName('make:foo');
 
         $tester = new CommandTester($command);
@@ -85,7 +95,7 @@ class MakerCommandTest extends TestCase
             ->willReturn($this->getPluginEntity());
 
         $generator = new DummyScaffoldingGenerator();
-        $command = new MakerCommand($generator, new ScaffoldingCollector([$generator]), $scaffoldingWriter, $pluginService);
+        $command = new MakerCommand($generator, new ScaffoldingCollector([$generator]), $scaffoldingWriter, $pluginService, static::createStub(TrackingService::class));
         $command->setName('make:foo');
 
         $tester = new CommandTester($command);
@@ -104,7 +114,10 @@ class MakerCommandTest extends TestCase
 
         $generator = new DummyScaffoldingGenerator();
 
-        $command = new MakerCommand($generator, new ScaffoldingCollector([$generator]), $scaffoldingWriter, $pluginService);
+        $trackingService = $this->createMock(TrackingService::class);
+        $trackingService->expects($this->never())->method('track');
+
+        $command = new MakerCommand($generator, new ScaffoldingCollector([$generator]), $scaffoldingWriter, $pluginService, $trackingService);
         $command->setName('make:foo');
 
         $tester = new CommandTester($command);
@@ -126,7 +139,10 @@ class MakerCommandTest extends TestCase
 
         $generator = new DummyScaffoldingGenerator();
 
-        $command = new MakerCommand($generator, new ScaffoldingCollector([$generator]), $scaffoldingWriter, $pluginService);
+        $trackingService = $this->createMock(TrackingService::class);
+        $trackingService->expects($this->never())->method('track');
+
+        $command = new MakerCommand($generator, new ScaffoldingCollector([$generator]), $scaffoldingWriter, $pluginService, $trackingService);
         $command->setName('make:foo');
 
         $tester = new CommandTester($command);

--- a/tests/unit/Core/Framework/Plugin/Command/PluginCreateCommandTest.php
+++ b/tests/unit/Core/Framework/Plugin/Command/PluginCreateCommandTest.php
@@ -9,8 +9,10 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Plugin\Command\PluginCreateCommand;
 use Shopware\Core\Framework\Plugin\Command\Scaffolding\Generator\ScaffoldingGenerator;
+use Shopware\Core\Framework\Plugin\Command\Scaffolding\PluginScaffoldConfiguration;
 use Shopware\Core\Framework\Plugin\Command\Scaffolding\ScaffoldingCollector;
 use Shopware\Core\Framework\Plugin\Command\Scaffolding\ScaffoldingWriter;
+use Shopware\Core\Framework\Telemetry\Tracking\TrackingService;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\Filesystem\Filesystem;
@@ -223,7 +225,11 @@ class PluginCreateCommandTest extends TestCase
 
     public function testDirectoryExists(): void
     {
-        $commandTester = $this->getCommandTester([], true);
+        $trackingService = $this->createMock(TrackingService::class);
+        $trackingService->expects($this->never())->method('track');
+        $trackingService->expects($this->never())->method('showHint');
+
+        $commandTester = $this->getCommandTester([], true, $trackingService);
 
         $commandTester->execute([
             'plugin-name' => 'TestPlugin',
@@ -236,11 +242,99 @@ class PluginCreateCommandTest extends TestCase
         );
     }
 
+    public function testSuccessfulCreateTracksUsage(): void
+    {
+        $trackingService = $this->createMock(TrackingService::class);
+        $trackingService->expects($this->once())->method('showHint');
+        $trackingService->expects($this->once())
+            ->method('track')
+            ->with(
+                'plugin.create',
+                static::callback(static function (array $tags): bool {
+                    return $tags['static'] === 0
+                        && $tags['scaffold'] === 1
+                        && $tags['options'] === '';
+                })
+            );
+
+        $commandTester = $this->getCommandTester(trackingService: $trackingService);
+        $commandTester->execute([
+            'plugin-name' => 'TestPlugin',
+            'plugin-namespace' => 'Test',
+        ]);
+
+        $commandTester->assertCommandIsSuccessful();
+    }
+
+    public function testSuccessfulStaticCreateTracksSelectedOptions(): void
+    {
+        /** @var MockObject&ScaffoldingGenerator $generator */
+        $generator = $this->createMock(ScaffoldingGenerator::class);
+        $generator->method('hasCommandOption')->willReturn(true);
+        $generator->method('getCommandOptionName')->willReturn('create-command');
+        $generator->expects($this->once())
+            ->method('addScaffoldConfig')
+            ->willReturnCallback(static function (PluginScaffoldConfiguration $configuration): void {
+                $configuration->addOption('create-command', true);
+            });
+
+        $trackingService = $this->createMock(TrackingService::class);
+        $trackingService->expects($this->once())->method('showHint');
+        $trackingService->expects($this->once())
+            ->method('track')
+            ->with(
+                'plugin.create',
+                static::callback(static function (array $tags): bool {
+                    return $tags['static'] === 1
+                        && $tags['scaffold'] === 1
+                        && $tags['options'] === 'create-command';
+                })
+            );
+
+        $commandTester = $this->getCommandTester([$generator], trackingService: $trackingService);
+        $commandTester->execute([
+            'plugin-name' => 'TestPlugin',
+            'plugin-namespace' => 'Test',
+            '--static' => true,
+            '--create-command' => true,
+        ]);
+
+        $commandTester->assertCommandIsSuccessful();
+    }
+
+    public function testNoScaffoldTracksScaffoldDisabled(): void
+    {
+        $trackingService = $this->createMock(TrackingService::class);
+        $trackingService->expects($this->once())->method('showHint');
+        $trackingService->expects($this->once())
+            ->method('track')
+            ->with(
+                'plugin.create',
+                static::callback(static function (array $tags): bool {
+                    return $tags['static'] === 0
+                        && $tags['scaffold'] === 0
+                        && $tags['options'] === '';
+                })
+            );
+
+        $commandTester = $this->getCommandTester(trackingService: $trackingService);
+        $commandTester->execute([
+            'plugin-name' => 'TestPlugin',
+            'plugin-namespace' => 'Test',
+            '--no-scaffold' => true,
+        ]);
+
+        $commandTester->assertCommandIsSuccessful();
+    }
+
     /**
      * @param array<ScaffoldingGenerator> $generators
      */
-    private function getCommandTester(array $generators = [], bool $directoryExists = false): CommandTester
-    {
+    private function getCommandTester(
+        array $generators = [],
+        bool $directoryExists = false,
+        ?TrackingService $trackingService = null,
+    ): CommandTester {
         $filesystem = static::createStub(Filesystem::class);
         $filesystem->method('exists')->willReturn($directoryExists);
 
@@ -249,7 +343,8 @@ class PluginCreateCommandTest extends TestCase
             static::createStub(ScaffoldingCollector::class),
             static::createStub(ScaffoldingWriter::class),
             $filesystem,
-            $generators
+            $generators,
+            $trackingService ?? static::createStub(TrackingService::class),
         );
 
         $commandTester = new CommandTester($command);

--- a/tests/unit/Core/Framework/Telemetry/Tracking/TrackingServiceTest.php
+++ b/tests/unit/Core/Framework/Telemetry/Tracking/TrackingServiceTest.php
@@ -1,0 +1,224 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\Telemetry\Tracking;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\MockObject\Stub;
+use PHPUnit\Framework\TestCase;
+use Psr\Clock\ClockInterface;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Telemetry\Tracking\TrackingService;
+use Shopware\Core\Framework\Telemetry\Tracking\TrackingTransport;
+use Shopware\Core\System\SystemConfig\SystemConfigService;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+#[CoversClass(TrackingService::class)]
+class TrackingServiceTest extends TestCase
+{
+    /**
+     * @var array{server: mixed, env: mixed}
+     */
+    private array $previousDoNotTrack;
+
+    protected function setUp(): void
+    {
+        $this->previousDoNotTrack = [
+            'server' => $_SERVER['DO_NOT_TRACK'] ?? false,
+            'env' => $_ENV['DO_NOT_TRACK'] ?? false,
+        ];
+
+        unset($_SERVER['DO_NOT_TRACK'], $_ENV['DO_NOT_TRACK']);
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->previousDoNotTrack['server'] === false) {
+            unset($_SERVER['DO_NOT_TRACK']);
+        } else {
+            $_SERVER['DO_NOT_TRACK'] = $this->previousDoNotTrack['server'];
+        }
+
+        if ($this->previousDoNotTrack['env'] === false) {
+            unset($_ENV['DO_NOT_TRACK']);
+        } else {
+            $_ENV['DO_NOT_TRACK'] = $this->previousDoNotTrack['env'];
+        }
+    }
+
+    public function testTrackGeneratesAndPersistsIdWhenNotSet(): void
+    {
+        $systemConfig = $this->createMock(SystemConfigService::class);
+        $systemConfig->method('get')->willReturn(null);
+        $systemConfig->expects($this->once())
+            ->method('set')
+            ->with(
+                TrackingService::TELEMETRY_ID,
+                static::callback(static function (string $id): bool {
+                    return (bool) preg_match('/^[a-f0-9]{32}$/', $id);
+                })
+            );
+
+        $transport = new RecordingTrackingTransport();
+        $this->createService($systemConfig, $transport)->track('plugin.create');
+
+        static::assertCount(1, $transport->payloads);
+
+        $payload = json_decode($transport->payloads[0], true, flags: \JSON_THROW_ON_ERROR);
+        static::assertIsArray($payload);
+        static::assertSame('shopware.plugin.create', $payload['event']);
+        static::assertMatchesRegularExpression('/^[a-f0-9]{32}$/', $payload['user_id']);
+        static::assertSame('6.7.15.0', $payload['tags']['shopware_version']);
+        static::assertSame(\PHP_MAJOR_VERSION . '.' . \PHP_MINOR_VERSION, $payload['tags']['php_version']);
+        static::assertSame('2026-08-28T12:00:00+00:00', $payload['timestamp']);
+    }
+
+    public function testTrackUsesExistingIdFromConfig(): void
+    {
+        $systemConfig = $this->createMock(SystemConfigService::class);
+        $systemConfig->method('get')->willReturnCallback(static function (string $key): ?string {
+            return $key === TrackingService::TELEMETRY_ID ? 'existing-id-123' : null;
+        });
+        $systemConfig->expects($this->never())->method('set');
+
+        $transport = new RecordingTrackingTransport();
+        $this->createService($systemConfig, $transport)->track('make.plugin', ['command' => 'make:plugin:entity']);
+
+        $payload = json_decode($transport->payloads[0], true, flags: \JSON_THROW_ON_ERROR);
+        static::assertIsArray($payload);
+        static::assertSame('existing-id-123', $payload['user_id']);
+        static::assertSame('make:plugin:entity', $payload['tags']['command']);
+        static::assertSame('6.7.15.0', $payload['tags']['shopware_version']);
+    }
+
+    public function testTrackMigratesLegacyKey(): void
+    {
+        $systemConfig = $this->createMock(SystemConfigService::class);
+        $systemConfig->method('get')->willReturnCallback(static function (string $key): ?string {
+            return $key === TrackingService::LEGACY_DEPLOYMENT_HELPER_ID ? 'legacy-id-456' : null;
+        });
+        $systemConfig->expects($this->once())
+            ->method('set')
+            ->with(TrackingService::TELEMETRY_ID, 'legacy-id-456');
+        $systemConfig->expects($this->once())
+            ->method('delete')
+            ->with(TrackingService::LEGACY_DEPLOYMENT_HELPER_ID);
+
+        $transport = new RecordingTrackingTransport();
+        $this->createService($systemConfig, $transport)->track('plugin.create');
+
+        $payload = json_decode($transport->payloads[0], true, flags: \JSON_THROW_ON_ERROR);
+        static::assertIsArray($payload);
+        static::assertSame('legacy-id-456', $payload['user_id']);
+    }
+
+    public function testTrackGeneratesEphemeralIdWhenConfigThrows(): void
+    {
+        $systemConfig = $this->createMock(SystemConfigService::class);
+        $systemConfig->method('get')->willThrowException(new \RuntimeException('database unavailable'));
+        $systemConfig->expects($this->never())->method('set');
+
+        $transport = new RecordingTrackingTransport();
+        $this->createService($systemConfig, $transport)->track('plugin.create');
+
+        $payload = json_decode($transport->payloads[0], true, flags: \JSON_THROW_ON_ERROR);
+        static::assertIsArray($payload);
+        static::assertMatchesRegularExpression('/^[a-f0-9]{32}$/', $payload['user_id']);
+    }
+
+    public function testTrackIsSuppressedByDoNotTrack(): void
+    {
+        $_SERVER['DO_NOT_TRACK'] = '1';
+
+        $systemConfig = $this->createMock(SystemConfigService::class);
+        $systemConfig->expects($this->never())->method('get');
+        $systemConfig->expects($this->never())->method('set');
+
+        $transport = new RecordingTrackingTransport();
+        $this->createService($systemConfig, $transport)->track('plugin.create');
+
+        static::assertSame([], $transport->payloads);
+    }
+
+    public function testPersistIdDoesNothingWhenNoIdGenerated(): void
+    {
+        $systemConfig = $this->createMock(SystemConfigService::class);
+        $systemConfig->expects($this->never())->method('set');
+
+        $this->createService($systemConfig, new RecordingTrackingTransport())->persistId();
+    }
+
+    public function testPersistIdWritesGeneratedId(): void
+    {
+        $systemConfig = $this->createMock(SystemConfigService::class);
+        $systemConfig->method('get')->willThrowException(new \RuntimeException('database unavailable'));
+        $systemConfig->expects($this->once())
+            ->method('set')
+            ->with(
+                TrackingService::TELEMETRY_ID,
+                static::callback(static function (string $id): bool {
+                    return (bool) preg_match('/^[a-f0-9]{32}$/', $id);
+                })
+            );
+
+        $service = $this->createService($systemConfig, new RecordingTrackingTransport());
+        $service->track('plugin.create');
+        $service->persistId();
+    }
+
+    public function testShowHintPrintsTelemetryNotice(): void
+    {
+        $output = new BufferedOutput();
+        $this->createService(
+            static::createStub(SystemConfigService::class),
+            new RecordingTrackingTransport()
+        )->showHint($output);
+
+        $content = $output->fetch();
+        static::assertStringContainsString('Shopware collects anonymous telemetry', $content);
+        static::assertStringContainsString(TrackingService::TELEMETRY_DOCS_URL, $content);
+    }
+
+    public function testShowHintIsSuppressedByDoNotTrack(): void
+    {
+        $_SERVER['DO_NOT_TRACK'] = '1';
+
+        $output = new BufferedOutput();
+        $this->createService(
+            static::createStub(SystemConfigService::class),
+            new RecordingTrackingTransport()
+        )->showHint($output);
+
+        static::assertSame('', $output->fetch());
+    }
+
+    private function createService(
+        SystemConfigService $systemConfig,
+        TrackingTransport $transport,
+    ): TrackingService {
+        /** @var ClockInterface&Stub $clock */
+        $clock = static::createStub(ClockInterface::class);
+        $clock->method('now')->willReturn(new \DateTimeImmutable('2026-08-28T12:00:00+00:00'));
+
+        return new TrackingService($systemConfig, $transport, $clock, '6.7.15.0');
+    }
+}
+
+/**
+ * @internal
+ */
+class RecordingTrackingTransport implements TrackingTransport
+{
+    /**
+     * @var list<string>
+     */
+    public array $payloads = [];
+
+    public function send(string $payload): void
+    {
+        $this->payloads[] = $payload;
+    }
+}

--- a/tests/unit/Core/Framework/Telemetry/Tracking/UdpTrackingTransportTest.php
+++ b/tests/unit/Core/Framework/Telemetry/Tracking/UdpTrackingTransportTest.php
@@ -1,0 +1,84 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\Telemetry\Tracking;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Telemetry\Tracking\UdpTrackingTransport;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+#[CoversClass(UdpTrackingTransport::class)]
+class UdpTrackingTransportTest extends TestCase
+{
+    /**
+     * @var array{server: mixed, env: mixed}
+     */
+    private array $previousTrackingDomain;
+
+    protected function setUp(): void
+    {
+        $this->previousTrackingDomain = [
+            'server' => $_SERVER['SHOPWARE_TRACKING_DOMAIN'] ?? false,
+            'env' => $_ENV['SHOPWARE_TRACKING_DOMAIN'] ?? false,
+        ];
+
+        unset($_SERVER['SHOPWARE_TRACKING_DOMAIN'], $_ENV['SHOPWARE_TRACKING_DOMAIN']);
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->previousTrackingDomain['server'] === false) {
+            unset($_SERVER['SHOPWARE_TRACKING_DOMAIN']);
+        } else {
+            $_SERVER['SHOPWARE_TRACKING_DOMAIN'] = $this->previousTrackingDomain['server'];
+        }
+
+        if ($this->previousTrackingDomain['env'] === false) {
+            unset($_ENV['SHOPWARE_TRACKING_DOMAIN']);
+        } else {
+            $_ENV['SHOPWARE_TRACKING_DOMAIN'] = $this->previousTrackingDomain['env'];
+        }
+    }
+
+    public function testSendDeliversPayloadToBoundUdpSocket(): void
+    {
+        if (!\function_exists('socket_create')) {
+            static::markTestSkipped('ext-sockets is required');
+        }
+
+        $receiver = socket_create(\AF_INET, \SOCK_DGRAM, \SOL_UDP);
+        static::assertInstanceOf(\Socket::class, $receiver);
+
+        static::assertTrue(socket_bind($receiver, '127.0.0.1', 0));
+        socket_getsockname($receiver, $address, $port);
+        static::assertIsInt($port);
+        static::assertGreaterThan(0, $port);
+
+        socket_set_option($receiver, \SOL_SOCKET, \SO_RCVTIMEO, ['sec' => 1, 'usec' => 0]);
+
+        $transport = new UdpTrackingTransport('127.0.0.1', $port);
+        $transport->send('usage-event');
+
+        $buffer = '';
+        $from = '';
+        $fromPort = 0;
+        $bytes = @socket_recvfrom($receiver, $buffer, 1024, 0, $from, $fromPort);
+        socket_close($receiver);
+
+        static::assertNotFalse($bytes);
+        static::assertSame('usage-event', $buffer);
+    }
+
+    #[DoesNotPerformAssertions]
+    public function testRepeatedSendReusesSocketAndDoesNotThrow(): void
+    {
+        $transport = new UdpTrackingTransport('127.0.0.1', 9);
+        $transport->send('first');
+        $transport->send('second');
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

Shopware does not know whether the CLI scaffolding tools (`plugin:create` and `make:plugin:*`) are actually used. Without that signal it is hard to decide whether to keep, improve, or retire those commands.

### 2. What does this change do, exactly?

Adds a `TrackingService` modeled after the Deployment Helper tracker (`shopware/deployment-helper` `TrackingService`):

- Sends anonymous usage events as UDP JSON to `udp.usage.shopware.io:9000` (overridable with `SHOPWARE_TRACKING_DOMAIN`)
- Honours `DO_NOT_TRACK`
- Shares the `core.telemetry.id` system config key (and migrates `core.deployment_helper.id`) so installations can be correlated across tools
- Adds default tags `shopware_version` and `php_version`

`plugin:create` tracks `shopware.plugin.create` after a successful create, including `static`, `scaffold`, and the selected generator options.

`MakerCommand` (the class behind every `make:plugin:*` command) tracks `shopware.make.plugin` with the command name and generator short name.

Both commands print a short telemetry hint on success unless `DO_NOT_TRACK` is set.

### 3. Describe each step to reproduce the issue or behaviour.

1. Run `bin/console plugin:create TestPlugin Test` (or any `make:plugin:*` command) without `DO_NOT_TRACK`.
2. The command completes and prints the anonymous telemetry hint.
3. A UDP event `shopware.plugin.create` / `shopware.make.plugin` is sent. Set `DO_NOT_TRACK=1` to disable both the hint and the event.

### 4. Please link to the relevant issues (if any).

Relates to the Deployment Helper tracker: https://github.com/shopware/deployment-helper/blob/main/src/Services/TrackingService.php

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [x] I have written or adjusted the documentation and agent skills according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cdd5664e-2620-46cc-8cf2-5ca77c81d6c1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cdd5664e-2620-46cc-8cf2-5ca77c81d6c1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

