### PR TITLE
fix(a11y): announce offcanvas cart alerts in screenreader (backport: 6.6.x)

### DIFF
--- a/src/Storefront/Resources/app/storefront/src/plugin/alert-aria/alert-aria.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/alert-aria/alert-aria.plugin.js
@@ -10,16 +10,27 @@ import Plugin from 'src/plugin-system/plugin.class';
 *     announceOnLoad: true
 * } %}
 *
+* Manual usage with custom markup:
+* @example
+* <div aria-live="polite"
+*      data-alert-aria="true"
+*      data-alert-aria-options="{{ { contentSelector: '.live-update-content' }|json_encode }}">
+*      <div class="live-update-content">
+*          {# ... content that should be announced ... #}
+*      </div>
+* </div>
+*
 * @internal
 */
 export default class AlertAriaPlugin extends Plugin {
 
     static options = {
         ariaLive: 'polite',
+        contentSelector: '.alert-content-container',
     };
 
     init() {
-        this._container = this.el.querySelector('.alert-content-container');
+        this._container = this.el.querySelector(this.options.contentSelector);
 
         if (!this._container) {
             console.warn(`[${this._pluginName}] The alert content container cannot be found.`);

--- a/src/Storefront/Resources/app/storefront/test/plugin/alert-aria/alert-aria.plugin.test.js
+++ b/src/Storefront/Resources/app/storefront/test/plugin/alert-aria/alert-aria.plugin.test.js
@@ -31,6 +31,14 @@ describe('src/plugin/alert-aria/alert-aria.plugin', () => {
         </div>
     `;
 
+    const customMarkupTemplate = `
+        <div class="alert custom-live-update" aria-live="polite">
+            <div class="custom-live-update-content">
+                Custom content
+            </div>
+        </div>
+    `;
+
     function initPlugin(template, options = {}) {
         document.body.innerHTML = template;
         return new AlertAriaPlugin(document.querySelector('.alert'), options);
@@ -95,5 +103,19 @@ describe('src/plugin/alert-aria/alert-aria.plugin', () => {
 
         expect(consoleSpy).toHaveBeenCalledWith('[AlertAriaPlugin] The "aria-live" attribute is not found on the alert. The alert will not be announced.');
         consoleSpy.mockRestore();
+    });
+
+    test('handles custom markup with content selector', () => {
+        jest.useFakeTimers();
+
+        initPlugin(customMarkupTemplate, { contentSelector: '.custom-live-update-content' });
+
+        expect(document.querySelector('.custom-live-update-content').getAttribute('aria-hidden')).toBe('true');
+
+        jest.advanceTimersByTime(1500);
+
+        expect(document.querySelector('.custom-live-update-content').getAttribute('aria-hidden')).toBe('false');
+
+        jest.useRealTimers();
     });
 });

--- a/src/Storefront/Resources/views/storefront/component/checkout/offcanvas-cart-summary.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/checkout/offcanvas-cart-summary.html.twig
@@ -1,11 +1,21 @@
 {% block component_offcanvas_summary_content %}
 
+    {% set alertAriaJsOptions = {
+        contentSelector: '.cart-live-update-content',
+    } %}
+
     {% block component_offcanvas_summary_cart_live_update %}
-        <div class="cart-live-update visually-hidden" role="alert" aria-live="assertive">
-            {{ 'checkout.cartScreenReaderUpdate'|trans({
-                '%count%': page.cart.lineItems|length,
-                '%total%': page.cart.price.positionPrice|currency,
-            })|sw_sanitize }}
+        <div class="cart-live-update visually-hidden" 
+             role="status"
+             aria-live="polite"
+             data-alert-aria="true"
+             data-alert-aria-options="{{ alertAriaJsOptions|json_encode }}">
+            <div class="cart-live-update-content">
+                {{ 'checkout.cartScreenReaderUpdate'|trans({
+                    '%count%': page.cart.lineItems|length,
+                    '%total%': page.cart.price.positionPrice|currency,
+                })|sw_sanitize }}
+            </div>
         </div>
     {% endblock %}
 

--- a/src/Storefront/Resources/views/storefront/utilities/alert.html.twig
+++ b/src/Storefront/Resources/views/storefront/utilities/alert.html.twig
@@ -96,7 +96,7 @@ The role="alert" and aria-live attributes are then set by JavaScript to trigger 
 #}
 
 {% if ariaLive is not defined %}
-    {% set ariaLive = 'polite' %}
+    {% set ariaLive = type in ['danger', 'warning'] ? 'assertive' : 'polite' %}
 {% endif %}
 
 {% block utilities_alert %}


### PR DESCRIPTION
**Backport:** https://github.com/shopware/shopware/pull/17341
Resolves: https://github.com/shopware/shopware/issues/17142
relates #19539

---

### 1. Why is this change necessary?
Manual backport of #17341 to 6.6.x (a11y). The automated cherry-pick conflicts; see below. Depends on the `alert-aria` plugin, which reached 6.6.x with the backport of #14575 (#19808) — this PR builds on top of it.

### 2. What does this change do, exactly?
The offcanvas cart live region (`cart-live-update`) no longer uses a static `role="alert"` / `aria-live="assertive"` element, which many screenreaders do not announce when the offcanvas content is re-rendered via AJAX. Instead it uses the `AlertAria` plugin (with the new `contentSelector` option) to toggle `aria-hidden` on the content, which reliably triggers the announcement after quantity changes or item removal. Additionally, `alert.html.twig` gets a type-aware `ariaLive` default: `assertive` for `danger`/`warning` alerts, `polite` otherwise.

**Conflict resolution vs. trunk commit 9f6dc1f8f6d:**
- `RELEASE_INFO-6.7.md`: restored to the 6.6.x version (`git checkout --ours`), no entry added.
- `component/checkout/offcanvas-cart-summary.html.twig`: trivial context conflict at the top of the file for the new `alertAriaJsOptions` set-block; resolved by taking the incoming block. The changed section is now byte-identical to trunk; the 6.6.x-only surrounding code (`feature('ACCESSIBILITY_TWEAKS')` column classes, deprecated price asterisks) is untouched.
- `alert-aria.plugin.js`, `alert-aria.plugin.test.js`, `utilities/alert.html.twig`: applied cleanly, identical to the trunk hunks.

Note on the `ariaLive` default change: the #19808 backport already added explicit `ariaLive` values on 6.6.x in `page/account/newsletter.html.twig` (`danger` → assertive) and `page/checkout/_page.html.twig` (`danger`/`warning` → assertive), using exactly the semantics of the new default — verified, so those call sites stay consistent.

### 3. Describe each step to reproduce the issue or behaviour.
See original PR.

### 4. Please link to the relevant issues (if any).
- relates #17142
- relates #19539

### 5. Checklist
- [x] Cherry-picked from trunk with `-x`, conflicts resolved as described
- [ ] Tests run locally: the jest spec `test/plugin/alert-aria/alert-aria.plugin.test.js` could not be run in this environment (a repo hook enforces the js-storefront-tooling MCP jest runner, and that MCP server was unavailable in this session); the backported plugin, test and template files were verified byte-identical to the trunk versions instead. The storefront JS bundle was NOT rebuilt — please build and verify manually.
