### PR TITLE
feat: improve footer semantics with native elements (backport: 6.6.x)

### DIFF
--- a/src/Storefront/Resources/views/.ludtwig-ignore
+++ b/src/Storefront/Resources/views/.ludtwig-ignore
@@ -42,6 +42,8 @@
 /storefront/component/line-item/type/generic.html.twig
 /storefront/component/line-item/type/container.html.twig
 /storefront/component/product/card/box-standard.html.twig
+# @deprecated tag:v6.8.0 - Will be removed when footer is updated to use list elements
+/storefront/layout/footer/footer.html.twig
 
 # break statement in for loop is not vanilla twig
 # this should be fixed with: https://shopware.atlassian.net/browse/NEXT-39634

--- a/src/Storefront/Resources/views/storefront/layout/footer/footer.html.twig
+++ b/src/Storefront/Resources/views/storefront/layout/footer/footer.html.twig
@@ -6,19 +6,43 @@
 {% block layout_footer_inner_container %}
     <div class="container">
         {% block layout_footer_navigation %}
-            <div
-                id="footerColumns"
-                class="row footer-columns"
-                data-collapse-footer-columns="true"
-                role="list"
-            >
+            {# @deprecated tag:v6.8.0 - The footer columns wrapper will be a `<ul>` element. The `<div role="list">` fallback will be removed. #}
+            {# `role="list"` is kept on the semantic `<ul>` on purpose: Safari/VoiceOver drops list semantics when the markers are removed (`list-unstyled`). #}
+            {% if feature('v6.8.0.0') and feature('ACCESSIBILITY_TWEAKS') %}
+                <ul
+                    id="footerColumns"
+                    class="row footer-columns list-unstyled"
+                    data-collapse-footer-columns="true"
+                    role="list"
+                >
+            {% else %}
+                <div
+                    id="footerColumns"
+                    class="row footer-columns"
+                    data-collapse-footer-columns="true"
+                    role="list"
+                >
+            {% endif %}
                 {% block layout_footer_navigation_hotline %}
-                    <div class="col-md-4 footer-column js-footer-column pb-4 pb-md-0"{% if feature('ACCESSIBILITY_TWEAKS') %} role="listitem"{% endif %}>
+                    {# @deprecated tag:v6.8.0 - The footer column will be a `<li>` element. The `<div role="listitem">` fallback will be removed. #}
+                    {% if feature('v6.8.0.0') and feature('ACCESSIBILITY_TWEAKS') %}
+                        <li class="col-md-4 footer-column js-footer-column pb-4 pb-md-0" role="listitem">
+                    {% else %}
+                        <div class="col-md-4 footer-column js-footer-column pb-4 pb-md-0"{% if feature('ACCESSIBILITY_TWEAKS') %} role="listitem"{% endif %}>
+                    {% endif %}
                         {% block layout_footer_navigation_hotline_headline %}
                             {% if feature('ACCESSIBILITY_TWEAKS') %}
 
-                                <div class="footer-column-headline footer-headline js-footer-column-headline"
-                                     id="collapseFooterHotlineTitle">
+                                {# @deprecated tag:v6.8.0 - The footer column headline will always be a `<h2>` element. The `<div role="heading">` fallback will be removed. #}
+                                {% if feature('v6.8.0.0') %}
+                                    <h2 class="footer-column-headline footer-headline js-footer-column-headline"
+                                        id="collapseFooterHotlineTitle">
+                                {% else %}
+                                    <div class="footer-column-headline footer-headline js-footer-column-headline"
+                                         id="collapseFooterHotlineTitle"
+                                         role="heading"
+                                         aria-level="2">
+                                {% endif %}
                                     {{ 'footer.serviceHotlineHeadline'|trans|sw_sanitize }}
 
                                     <button class="footer-column-toggle btn btn-link btn-link-inline js-collapse-footer-column-trigger"
@@ -38,7 +62,11 @@
                                             class: 'footer-minus'
                                         } %}
                                     </button>
-                                </div>
+                                {% if feature('v6.8.0.0') %}
+                                    </h2>
+                                {% else %}
+                                    </div>
+                                {% endif %}
                             {% else %}
                                 <div class="footer-column-headline footer-headline js-footer-column-headline js-collapse-footer-column-trigger"
                                      id="collapseFooterHotlineTitle"
@@ -131,18 +159,35 @@
                                 {% endif %}
                             {% endblock %}
                         {% endblock %}
-                    </div>
+                    {% if feature('v6.8.0.0') and feature('ACCESSIBILITY_TWEAKS') %}
+                        </li>
+                    {% else %}
+                        </div>
+                    {% endif %}
                 {% endblock %}
 
                 {% block layout_footer_navigation_columns %}
                     {% for root in footer.navigation.tree %}
                         {% block layout_footer_navigation_column %}
-                            <div class="col-md-4 footer-column js-footer-column"{% if feature('ACCESSIBILITY_TWEAKS') %} role="listitem"{% endif %}>
+                            {# @deprecated tag:v6.8.0 - The footer column will be a `<li>` element. The `<div role="listitem">` fallback will be removed. #}
+                            {% if feature('v6.8.0.0') and feature('ACCESSIBILITY_TWEAKS') %}
+                                <li class="col-md-4 footer-column js-footer-column" role="listitem">
+                            {% else %}
+                                <div class="col-md-4 footer-column js-footer-column"{% if feature('ACCESSIBILITY_TWEAKS') %} role="listitem"{% endif %}>
+                            {% endif %}
                                 {% block layout_footer_navigation_information_headline %}
 
                                     {% if feature('ACCESSIBILITY_TWEAKS') %}
-                                        <div class="footer-column-headline footer-headline js-footer-column-headline"
-                                             id="collapseFooterTitle{{ loop.index }}">
+                                        {# @deprecated tag:v6.8.0 - The footer column headline will always be a `<h2>` element. The `<div role="heading">` fallback will be removed. #}
+                                        {% if feature('v6.8.0.0') %}
+                                            <h2 class="footer-column-headline footer-headline js-footer-column-headline"
+                                                id="collapseFooterTitle{{ loop.index }}">
+                                        {% else %}
+                                            <div class="footer-column-headline footer-headline js-footer-column-headline"
+                                                 id="collapseFooterTitle{{ loop.index }}"
+                                                 role="heading"
+                                                 aria-level="2">
+                                        {% endif %}
 
                                             {% if root.category.type == 'folder' %}
                                                 {{ root.category.translated.name }}
@@ -173,7 +218,11 @@
                                                     } %}
                                                 </button>
                                             {% endif %}
-                                        </div>
+                                        {% if feature('v6.8.0.0') %}
+                                            </h2>
+                                        {% else %}
+                                            </div>
+                                        {% endif %}
 
                                     {% else %}
                                         <div class="footer-column-headline footer-headline js-collapse-footer-column-trigger"
@@ -245,11 +294,19 @@
                                         </div>
                                     </div>
                                 {% endblock %}
-                            </div>
+                            {% if feature('v6.8.0.0') and feature('ACCESSIBILITY_TWEAKS') %}
+                                </li>
+                            {% else %}
+                                </div>
+                            {% endif %}
                         {% endblock %}
                     {% endfor %}
                 {% endblock %}
-            </div>
+            {% if feature('v6.8.0.0') and feature('ACCESSIBILITY_TWEAKS') %}
+                </ul>
+            {% else %}
+                </div>
+            {% endif %}
         {% endblock %}
 
         {% block layout_footer_payment_shipping_logos %}


### PR DESCRIPTION
**Backport:** https://github.com/shopware/shopware/pull/19409
Resolves: https://github.com/shopware/shopware/issues/7039
relates #19539

---

### 1. Why is this change necessary?
Manual backport of #19409 to 6.6.x (a11y). The automated cherry-pick conflicts; see below.

### 2. What does this change do, exactly?
Prepares the footer for native semantic elements: behind `v6.8.0.0` the columns wrapper becomes `<ul>` (keeping `role="list"` for Safari/VoiceOver), the columns become `<li>`, and the collapse headlines become `<h2>`. Without `v6.8.0.0`, the `ACCESSIBILITY_TWEAKS` headline `<div>`s gain `role="heading" aria-level="2"` so they are exposed as headings today.

**Conflict resolution vs. trunk commit 7c35a2296b6:**
- `RELEASE_INFO-6.7.md` / `UPGRADE-6.8.md`: restored to the 6.6.x versions, no entries added (per backport policy).
- `src/Storefront/Resources/views/.ludtwig-ignore`: hunk kept — 6.6.x still runs the ludtwig lint job (`.gitlab/stages/10-lint.yml`) and the template now swaps opening/closing tags behind `{% if %}`, which ludtwig cannot parse.
- `footer.html.twig`: trunk no longer has `ACCESSIBILITY_TWEAKS` branches; 6.6.x does. The trunk payload was mapped onto the `ACCESSIBILITY_TWEAKS`-ON markup only; the legacy (flag-off) branch is untouched and its rendered output stays byte-identical to current 6.6.x (verified by expanding the template for all four flag combinations).
- The native-element branches are gated `feature('v6.8.0.0') and feature('ACCESSIBILITY_TWEAKS')` (trunk uses only `v6.8.0.0` because a11y is always on there). Reason: with `V6_8_0_0=1` but a11y off, a bare `v6.8.0.0` gate would nest the legacy `role="listitem"` headline/content divs inside `<li>` elements, producing invalid list structure (`aria-required-parent`). This exact interaction caused a fix round on #19806. `FEATURE_ALL=major` enables both flags, so behaviour converges with trunk.
- `role="list"` on `<ul>` and `role="listitem"` on `<li>` are kept on purpose, matching trunk (Safari/VoiceOver drops list semantics on `list-unstyled`).

**Theme-BC note (feat on a patch branch):** rendered markup changes only behind feature flags, but themes overriding these blocks should be checked:
- `layout_footer_navigation` — wrapper `<div>` becomes `<ul class="... list-unstyled">` (v6.8.0.0 + a11y).
- `layout_footer_navigation_hotline` / `layout_footer_navigation_column` — column `<div>` becomes `<li>` (v6.8.0.0 + a11y).
- `layout_footer_navigation_hotline_headline` / `layout_footer_navigation_information_headline` — headline `<div>` becomes `<h2>` (v6.8.0.0 + a11y), and with a11y alone gains `role="heading" aria-level="2"`.

With both flags off (the 6.6.x default and what CI runs), the rendered HTML is unchanged.

### 3. Describe each step to reproduce the issue or behaviour.
See original PR.

### 4. Please link to the relevant issues (if any).
- relates #7039
- relates #19539

### 5. Checklist
- [x] Cherry-picked from trunk with `-x`, conflicts resolved as described
- [ ] Tests run locally: template expanded for all four flag combinations (a11y × v6.8.0.0) — tag balance verified, default output byte-identical to `origin/6.6.x`, no `aria-expanded` on role-less elements, no `<ul>`/`<li>` mixed with legacy listitem divs. Jest/acceptance suites not run (selectors/ids/classes unchanged; the collapse plugin and its spec use class selectors only).
