### PR TITLE
fix(checkout): clarify order cancellation setting label

### DIFF
--- a/src/Core/System/Resources/config/cart.xml
+++ b/src/Core/System/Resources/config/cart.xml
@@ -28,8 +28,10 @@
 
         <input-field type="bool">
             <name>enableOrderRefunds</name>
-            <label>Enable refunds</label>
-            <label lang="de-DE">Stornierungen erlauben</label>
+            <label>Allow customers to cancel orders</label>
+            <label lang="de-DE">Kunden dürfen Bestellungen stornieren</label>
+            <helpText>Allows customers to cancel their own orders in the account area, as long as the order status is still "Open". Cancelling sets the order status to "Cancelled"; the selected payment method and all applied promotions are lost.</helpText>
+            <helpText lang="de-DE">Erlaubt Kunden, ihre Bestellungen im Kundenkonto selbst zu stornieren, solange der Bestellstatus noch "Offen" ist. Bei einer Stornierung wird der Bestellstatus auf "Abgebrochen" gesetzt; die gewählte Zahlungsart und alle enthaltenen Rabatte und Aktionen gehen verloren.</helpText>
         </input-field>
 
         <input-field type="int">


### PR DESCRIPTION
### 1. Why is this change necessary?

`core.cart.enableOrderRefunds` decides whether customers may cancel their own orders from the storefront account area. It has nothing to do with refunds. As reported in #19746, an operator looking for the option behind the storefront "Cancel order" button could not find it, and then read the English label as a refund feature. The German label was correct but named no actor either, so the field reads as a shop-side capability rather than a storefront permission.

### 2. What does this change do, exactly?

Relabels the field in both languages so it names who is being permitted, and adds a helpText for the two things a label cannot carry: it only applies while the order status is "Open", and cancelling costs the customer their payment method and any applied promotions.

The config key is unchanged, so stored values, storefront behaviour and the Store API are untouched. Label-only, hence no tests and no release note.

### 3. Describe each step to reproduce the issue or behaviour.

Settings > Shop > Cart > Cart card: the bool field previously read "Enable refunds" / "Stornierungen erlauben" with no help text.

### 4. Please link to the relevant issues (if any).

relates #19746

The reporter's original request, keeping the cancel button out of the *Complete payment* page while leaving it in the order-history context menu, is not addressed here. One flag currently drives both call sites, so splitting it is a separate change.

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [x] I have written or adjusted the documentation and agent skills according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
