### PR TITLE
fix(administration): keep imitate customer redirect inside the user gesture

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-customer/component/sw-customer-imitate-customer-modal/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-customer/component/sw-customer-imitate-customer-modal/index.js
@@ -35,7 +35,7 @@ export default {
         return {
             salesChannelDomains: [],
             imitateCustomerTokens: {},
-            isLoading: true,
+            isLoading: false,
         };
     },
 

--- a/src/Administration/Resources/app/administration/src/module/sw-customer/component/sw-customer-imitate-customer-modal/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-customer/component/sw-customer-imitate-customer-modal/index.js
@@ -34,6 +34,8 @@ export default {
     data() {
         return {
             salesChannelDomains: [],
+            imitateCustomerTokens: {},
+            isLoading: true,
         };
     },
 
@@ -86,27 +88,33 @@ export default {
 
     methods: {
         async createdComponent() {
-            this.fetchSalesChannelDomains();
+            this.isLoading = true;
+
+            try {
+                await this.fetchSalesChannelDomains();
+                await this.fetchImitateCustomerTokens();
+            } finally {
+                this.isLoading = false;
+            }
         },
 
-        async onSalesChannelDomainMenuItemClick(salesChannelId, salesChannelDomainUrl) {
-            this.contextStoreService
-                .generateImitateCustomerToken(this.customer.id, salesChannelId)
-                .then((response) => {
-                    const handledResponse = ApiService.handleResponse(response);
+        onSalesChannelDomainMenuItemClick(salesChannelId, salesChannelDomainUrl) {
+            const token = this.imitateCustomerTokens[salesChannelId];
 
-                    this.contextStoreService.redirectToSalesChannelUrl(
-                        salesChannelDomainUrl,
-                        handledResponse.token,
-                        this.customer.id,
-                        this.currentUser?.id,
-                    );
-                })
-                .catch(() => {
-                    this.createNotificationError({
-                        message: this.$t('sw-customer.detail.notificationImitateCustomerErrorMessage'),
-                    });
+            if (!token) {
+                this.createNotificationError({
+                    message: this.$t('sw-customer.detail.notificationImitateCustomerErrorMessage'),
                 });
+
+                return;
+            }
+
+            this.contextStoreService.redirectToSalesChannelUrl(
+                salesChannelDomainUrl,
+                token,
+                this.customer.id,
+                this.currentUser?.id,
+            );
         },
 
         onCancel() {
@@ -114,11 +122,26 @@ export default {
         },
 
         fetchSalesChannelDomains() {
-            this.salesChannelDomainRepository
+            return this.salesChannelDomainRepository
                 .search(this.salesChannelDomainCriteria, Shopware.Context.api)
                 .then((loadedDomains) => {
                     this.salesChannelDomains = loadedDomains;
                 });
+        },
+
+        fetchImitateCustomerTokens() {
+            const salesChannelIds = [...new Set(this.salesChannelDomains.map((domain) => domain.salesChannelId))];
+
+            return Promise.all(
+                salesChannelIds.map((salesChannelId) =>
+                    this.contextStoreService
+                        .generateImitateCustomerToken(this.customer.id, salesChannelId)
+                        .then((response) => {
+                            this.imitateCustomerTokens[salesChannelId] = ApiService.handleResponse(response).token;
+                        })
+                        .catch(() => {}),
+                ),
+            );
         },
     },
 };

--- a/src/Administration/Resources/app/administration/src/module/sw-customer/component/sw-customer-imitate-customer-modal/sw-customer-imitate-customer-modal.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-customer/component/sw-customer-imitate-customer-modal/sw-customer-imitate-customer-modal.html.twig
@@ -2,12 +2,13 @@
 {% block sw_customer_imitate_customer_modal %}
 <sw-modal
     :title="modalTitle"
+    :is-loading="isLoading"
     class="sw-customer-imitate-customer-modal"
     @modal-close="onCancel"
 >
     {% block sw_customer_imitate_customer_modal_alert %}
     <mt-banner
-        v-if="hasSalesChannelDomains"
+        v-if="!isLoading && hasSalesChannelDomains"
         variant="attention"
     >
         <i18n-t
@@ -22,7 +23,7 @@
     </mt-banner>
 
     <mt-banner
-        v-else
+        v-else-if="!isLoading"
         variant="info"
     >
         {{ $t('sw-customer.imitateCustomerModal.modalInfoNoDomains') }}
@@ -31,7 +32,7 @@
 
     {% block sw_customer_imitate_customer_modal_description %}
     <div
-        v-if="hasSalesChannelDomains"
+        v-if="!isLoading && hasSalesChannelDomains"
         class="imitate-customer-modal-description"
     >
         {{ modalDescription }}
@@ -40,7 +41,7 @@
 
     {% block sw_customer_imitate_customer_modal_body %}
     <div
-        v-if="hasSalesChannelDomains"
+        v-if="!isLoading && hasSalesChannelDomains"
         class="imitate-customer-modal-container"
     >
         {% block sw_customer_imitate_customer_modal_sales_channel_domain_items %}

--- a/src/Administration/Resources/app/administration/src/module/sw-customer/component/sw-customer-imitate-customer-modal/sw-customer-imitate-customer-modal.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-customer/component/sw-customer-imitate-customer-modal/sw-customer-imitate-customer-modal.spec.js
@@ -6,30 +6,36 @@ import { mount } from '@vue/test-utils';
 
 const responses = global.repositoryFactoryMock.responses;
 
-responses.addResponse({
-    method: 'Post',
-    url: '/search/sales-channel-domain',
-    status: 200,
-    response: {
-        data: [
-            {
-                attributes: {
-                    id: 'sales-channel-domain-id',
-                    salesChannelId: 'sales-channel-id',
-                    salesChannel: {
-                        translated: {
-                            name: 'Test sales channel',
-                        },
-                    },
-                    url: 'http://localhost:8000',
+function domain(id, salesChannelId, url) {
+    return {
+        id,
+        type: 'sales_channel_domain',
+        attributes: {
+            id,
+            salesChannelId,
+            salesChannel: {
+                translated: {
+                    name: 'Test sales channel',
                 },
-                relationships: {},
             },
-        ],
-    },
-});
+            url,
+        },
+        relationships: {},
+    };
+}
 
-async function createWrapper() {
+function mockSalesChannelDomains(domains) {
+    responses.addResponse({
+        method: 'Post',
+        url: '/search/sales-channel-domain',
+        status: 200,
+        response: {
+            data: domains,
+        },
+    });
+}
+
+async function createWrapper(contextStoreServiceOverrides = {}) {
     return mount(
         await wrapTestComponent('sw-customer-imitate-customer-modal', {
             sync: true,
@@ -58,6 +64,7 @@ async function createWrapper() {
                             token: 'a-token',
                         }),
                         redirectToSalesChannelUrl: () => {},
+                        ...contextStoreServiceOverrides,
                     },
                 },
             },
@@ -74,6 +81,12 @@ async function createWrapper() {
 
 describe('module/sw-customer-imitate-customer-modal', () => {
     let wrapper;
+
+    beforeEach(() => {
+        mockSalesChannelDomains([
+            domain('sales-channel-domain-id', 'sales-channel-id', 'http://localhost:8000'),
+        ]);
+    });
 
     it('should fetch all sales channel domains', async () => {
         wrapper = await createWrapper();
@@ -96,11 +109,59 @@ describe('module/sw-customer-imitate-customer-modal', () => {
         expect(wrapper.emitted('modal-close')).toBeDefined();
     });
 
-    it('should log in on item clicked', async () => {
+    it('should generate the imitation token upfront, before any item is clicked', async () => {
         wrapper = await createWrapper();
 
         const generateTokenSpy = jest.spyOn(wrapper.vm.contextStoreService, 'generateImitateCustomerToken');
+
+        await flushPromises();
+
+        expect(generateTokenSpy).toHaveBeenCalledWith('customer-id', 'sales-channel-id');
+        expect(wrapper.vm.imitateCustomerTokens).toEqual({ 'sales-channel-id': 'a-token' });
+    });
+
+    it('should generate one token per sales channel, not per domain', async () => {
+        mockSalesChannelDomains([
+            domain('domain-de', 'sales-channel-id', 'http://localhost:8000/de'),
+            domain('domain-en', 'sales-channel-id', 'http://localhost:8000/en'),
+            domain('domain-other', 'other-sales-channel-id', 'http://other.localhost:8000'),
+        ]);
+
+        wrapper = await createWrapper();
+
+        const generateTokenSpy = jest.spyOn(wrapper.vm.contextStoreService, 'generateImitateCustomerToken');
+
+        await flushPromises();
+
+        expect(generateTokenSpy).toHaveBeenCalledTimes(2);
+        expect(generateTokenSpy).toHaveBeenCalledWith('customer-id', 'sales-channel-id');
+        expect(generateTokenSpy).toHaveBeenCalledWith('customer-id', 'other-sales-channel-id');
+    });
+
+    it('should redirect synchronously within the click handler, so the popup blocker allows the new tab', async () => {
+        wrapper = await createWrapper();
+
         const redirectSalesChannelSpy = jest.spyOn(wrapper.vm.contextStoreService, 'redirectToSalesChannelUrl');
+
+        await flushPromises();
+
+        const item = await wrapper.find('.imitate-customer-modal-item');
+        expect(item.exists()).toBe(true);
+
+        item.element.dispatchEvent(new MouseEvent('click'));
+
+        expect(redirectSalesChannelSpy).toHaveBeenCalledWith('http://localhost:8000', 'a-token', 'customer-id', undefined);
+    });
+
+    it('should notify the user when no token could be generated', async () => {
+        wrapper = await createWrapper({
+            generateImitateCustomerToken: async () => {
+                throw new Error('token generation failed');
+            },
+        });
+
+        const redirectSalesChannelSpy = jest.spyOn(wrapper.vm.contextStoreService, 'redirectToSalesChannelUrl');
+        wrapper.vm.createNotificationError = jest.fn();
 
         await flushPromises();
 
@@ -110,7 +171,19 @@ describe('module/sw-customer-imitate-customer-modal', () => {
         await item.trigger('click');
         await flushPromises();
 
-        expect(generateTokenSpy).toHaveBeenCalledWith('customer-id', 'sales-channel-id');
-        expect(redirectSalesChannelSpy).toHaveBeenCalledWith('http://localhost:8000', 'a-token', 'customer-id', undefined);
+        expect(redirectSalesChannelSpy).not.toHaveBeenCalled();
+        expect(wrapper.vm.createNotificationError).toHaveBeenCalled();
+    });
+
+    it('should show the loading state until the domains and tokens are resolved', async () => {
+        wrapper = await createWrapper();
+
+        expect(wrapper.vm.isLoading).toBe(true);
+        expect(wrapper.find('.imitate-customer-modal-item').exists()).toBe(false);
+
+        await flushPromises();
+
+        expect(wrapper.vm.isLoading).toBe(false);
+        expect(wrapper.find('.imitate-customer-modal-item').exists()).toBe(true);
     });
 });


### PR DESCRIPTION
### 1. Why is this change necessary?

The "Login as customer" button does nothing in Mobile Safari (#13729). The click handler awaits `generate-imitate-customer-token` and only submits the `target="_blank"` form in the `.then()`, by which point the user activation from the click is gone and WebKit's popup blocker silently drops the new tab. This is not really mobile-specific — it is a latent popup block that other engines happen to be lenient about for form submits.

### 2. What does this change do, exactly?

Moves token generation to when the modal opens, so the click handler only does the synchronous form submit and stays inside the user gesture. One token per unique sales channel rather than per domain, since domains usually repeat a channel across languages. A failed token leaves that channel without one and the click falls back to the existing error notification, so a single broken channel does not throw N toasts on open. The modal gets a loading state while this runs, which also removes the "no domains available" flash that was there before.

### 3. Describe each step to reproduce the issue or behaviour.

Open a customer's detail page in Mobile Safari and use "Login as customer": before, nothing happens; after, the storefront opens in a new tab.

### 4. Please link to the relevant issues (if any).

closes #13729

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
