### PR TITLE
fix(administration): open the inline edit of a newly added order line item

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/data-grid/sw-data-grid/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/data-grid/sw-data-grid/index.js
@@ -702,10 +702,6 @@ export default {
         },
 
         onDbClickCell(record) {
-            this.startInlineEdit(record);
-        },
-
-        startInlineEdit(record) {
             if (!this.allowInlineEdit || !this.isRecordEditable(record)) {
                 return;
             }

--- a/src/Administration/Resources/app/administration/src/app/component/data-grid/sw-data-grid/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/data-grid/sw-data-grid/index.js
@@ -702,6 +702,10 @@ export default {
         },
 
         onDbClickCell(record) {
+            this.startInlineEdit(record);
+        },
+
+        startInlineEdit(record) {
             if (!this.allowInlineEdit || !this.isRecordEditable(record)) {
                 return;
             }

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-line-items-grid-sales-channel/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-line-items-grid-sales-channel/index.js
@@ -258,7 +258,7 @@ export default {
             Store.get('swOrder').setCartLineItems(this.cartLineItems);
 
             this.$nextTick(() => {
-                this.$refs.dataGrid?.startInlineEdit(item);
+                this.$refs.dataGrid?.onDbClickCell(item);
             });
         },
 

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-line-items-grid-sales-channel/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-line-items-grid-sales-channel/index.js
@@ -192,8 +192,9 @@ export default {
 
         onInlineEditCancel(item) {
             if (item._isNew) {
-                this.initLineItem(item);
-                delete item.identifier;
+                Store.get('swOrder').removeEmptyLineItem(item.id);
+
+                return;
             }
 
             // Reset quantity
@@ -235,24 +236,30 @@ export default {
         onInsertExistingItem() {
             const item = this.createNewOrderLineItem();
             item.type = this.lineItemTypes.PRODUCT;
-            this.cartLineItems.unshift(item);
-            Store.get('swOrder').setCartLineItems(this.cartLineItems);
+            this.insertLineItem(item);
         },
 
         onInsertBlankItem() {
             const item = this.createNewOrderLineItem();
             item.description = 'custom line item';
             item.type = this.lineItemTypes.CUSTOM;
-            this.cartLineItems.unshift(item);
-            Store.get('swOrder').setCartLineItems(this.cartLineItems);
+            this.insertLineItem(item);
         },
 
         onInsertCreditItem() {
             const item = this.createNewOrderLineItem();
             item.description = 'credit line item';
             item.type = this.lineItemTypes.CREDIT;
+            this.insertLineItem(item);
+        },
+
+        insertLineItem(item) {
             this.cartLineItems.unshift(item);
             Store.get('swOrder').setCartLineItems(this.cartLineItems);
+
+            this.$nextTick(() => {
+                this.$refs.dataGrid?.startInlineEdit(item);
+            });
         },
 
         onSelectionChanged(selection) {

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-line-items-grid-sales-channel/sw-order-line-items-grid-sales-channel.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-line-items-grid-sales-channel/sw-order-line-items-grid-sales-channel.spec.js
@@ -446,15 +446,19 @@ describe('src/module/sw-order/component/sw-order-line-items-grid-sales-channel',
 
         const buttonAddItem = wrapper.find('.sw-order-line-items-grid-sales-channel__add-product');
         await buttonAddItem.trigger('click');
+        await flushPromises();
 
         itemRows = wrapper.findAll('.sw-data-grid__body .sw-data-grid__row');
         expect(itemRows).toHaveLength(1);
 
         const firstRow = itemRows.at(0);
-        expect(firstRow.find('.sw-data-grid__cell--quantity').text()).toBe('1');
+        expect(firstRow.classes()).toContain('is--inline-edit');
+        expect(firstRow.find('.sw-order-product-select').exists()).toBe(true);
+        expect(firstRow.find('.sw-data-grid__inline-edit-save').exists()).toBe(true);
         expect(firstRow.find('.sw-data-grid__cell--unitPrice').text()).toBe('...');
-        expect(firstRow.find('.sw-data-grid__cell--tax').text()).toBe('0 %');
         expect(firstRow.find('.sw-data-grid__cell--totalPrice').text()).toBe('...');
+        expect(wrapper.vm.cartLineItems[0].quantity).toBe(1);
+        expect(wrapper.vm.cartLineItems[0].priceDefinition.taxRules[0].taxRate).toBe(0);
     });
 
     it('should able to create new product line item', async () => {
@@ -560,15 +564,22 @@ describe('src/module/sw-order/component/sw-order-line-items-grid-sales-channel',
         await wrapper.setProps({
             cart: {
                 token: 'token',
-                lineItems: [...mockItems],
+                // A local copy, because the inline edit mutates the item it is given
+                lineItems: [
+                    {
+                        ...structuredClone(mockItems[0]),
+                        priceDefinition: {
+                            isCalculated: true,
+                            taxRules: [{ taxRate: 20, percentage: 100 }],
+                            price: 200,
+                        },
+                    },
+                ],
             },
             isCustomerActive: true,
         });
-        const buttonAddCreditItem = wrapper.find('.sw-order-line-items-grid-sales-channel__add-product');
-        await buttonAddCreditItem.trigger('click');
 
-        const itemRows = wrapper.findAll('.sw-data-grid__body .sw-data-grid__row');
-        const firstRow = itemRows.at(0);
+        const firstRow = wrapper.find('.sw-data-grid__row--0');
 
         await firstRow.find('.sw-data-grid__cell--quantity').trigger('dblclick');
 
@@ -578,8 +589,32 @@ describe('src/module/sw-order/component/sw-order-line-items-grid-sales-channel',
 
         const buttonInlineCancel = wrapper.find('.sw-data-grid__inline-edit-cancel');
         await buttonInlineCancel.trigger('click');
+        await flushPromises();
 
-        expect(firstRow.find('.sw-data-grid__cell--quantity').text()).toBe('1');
+        expect(wrapper.findAll('.sw-data-grid__body .sw-data-grid__row')).toHaveLength(1);
+        expect(wrapper.find('.sw-data-grid__row--0 .sw-data-grid__cell--quantity').text()).toBe('1');
+    });
+
+    it('should discard a newly added item when its inline editing is cancelled', async () => {
+        const wrapper = await createWrapper({});
+        Shopware.Store.get('swOrder').setCartToken('token');
+        await wrapper.setProps({
+            cart: {
+                token: 'token',
+                lineItems: [],
+            },
+            isCustomerActive: true,
+        });
+
+        await wrapper.find('.sw-order-line-items-grid-sales-channel__add-product').trigger('click');
+        await flushPromises();
+
+        expect(Shopware.Store.get('swOrder').cart.lineItems).toHaveLength(1);
+
+        await wrapper.find('.sw-data-grid__row--0 .sw-data-grid__inline-edit-cancel').trigger('click');
+        await flushPromises();
+
+        expect(Shopware.Store.get('swOrder').cart.lineItems).toHaveLength(0);
     });
 
     it('should able to delete items', async () => {

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-line-items-grid/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-line-items-grid/index.js
@@ -287,7 +287,7 @@ export default {
             this.order.lineItems.unshift(item);
 
             this.$nextTick(() => {
-                this.$refs.dataGrid?.startInlineEdit(item);
+                this.$refs.dataGrid?.onDbClickCell(item);
             });
         },
 

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-line-items-grid/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-line-items-grid/index.js
@@ -222,11 +222,21 @@ export default {
             });
         },
 
-        onInlineEditCancel() {
+        onInlineEditCancel(item) {
+            if (item.isNew()) {
+                const itemIndex = this.order.lineItems.findIndex((lineItem) => lineItem?.id === item.id);
+                this.order.lineItems.splice(itemIndex, 1);
+
+                return;
+            }
+
             this.$emit('item-cancel');
         },
 
         createNewOrderLineItem() {
+            this.searchTerm = '';
+            this.$refs.itemFilter.term = '';
+
             const item = this.orderLineItemRepository.create();
             item.versionId = this.order.versionId;
             item.priceDefinition = {
@@ -257,20 +267,28 @@ export default {
             const item = this.createNewOrderLineItem();
             item.description = 'custom line item';
             item.type = this.lineItemTypes.CUSTOM;
-            this.order.lineItems.unshift(item);
+            this.insertLineItem(item);
         },
 
         onInsertExistingItem() {
             const item = this.createNewOrderLineItem();
             item.type = this.lineItemTypes.PRODUCT;
-            this.order.lineItems.unshift(item);
+            this.insertLineItem(item);
         },
 
         onInsertCreditItem() {
             const item = this.createNewOrderLineItem();
             item.description = 'credit line item';
             item.type = this.lineItemTypes.CREDIT;
+            this.insertLineItem(item);
+        },
+
+        insertLineItem(item) {
             this.order.lineItems.unshift(item);
+
+            this.$nextTick(() => {
+                this.$refs.dataGrid?.startInlineEdit(item);
+            });
         },
 
         onSelectionChanged(selection) {

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-line-items-grid/sw-order-line-items-grid.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-line-items-grid/sw-order-line-items-grid.spec.js
@@ -615,10 +615,12 @@ describe('src/module/sw-order/component/sw-order-line-items-grid', () => {
         expect(itemRows).toHaveLength(1);
 
         const firstRow = itemRows.at(0);
-        expect(firstRow.find('.sw-data-grid__cell--quantity').text()).toBe('1 x');
+        expect(firstRow.classes()).toContain('is--inline-edit');
+        expect(firstRow.find('.sw-order-product-select').exists()).toBe(true);
         expect(firstRow.find('.sw-data-grid__cell--unitPrice').text()).toBe('...');
         expect(firstRow.find('.sw-data-grid__cell--price-taxRules\\[0\\]').text()).toBe('0 %');
         expect(firstRow.find('.sw-data-grid__cell--totalPrice').text()).toBe('...');
+        expect(wrapper.vm.order.lineItems[0].quantity).toBe(1);
     });
 
     it('should able to create new product line item', async () => {
@@ -692,8 +694,13 @@ describe('src/module/sw-order/component/sw-order-line-items-grid', () => {
         ];
         const wrapper = await createWrapper();
 
-        const buttonAddItem = wrapper.find('.sw-order-line-items-grid__actions-container-add-product-btn');
-        await buttonAddItem.trigger('click');
+        await wrapper.setProps({
+            order: {
+                ...wrapper.props().order,
+                lineItems: [{ ...mockItems[0] }],
+                taxStatus: 'gross',
+            },
+        });
 
         const itemRows = wrapper.findAll('.sw-data-grid__body .sw-data-grid__row');
         expect(itemRows).toHaveLength(1);
@@ -706,6 +713,7 @@ describe('src/module/sw-order/component/sw-order-line-items-grid', () => {
 
         await flushPromises();
         expect(wrapper.emitted('item-cancel')).toBeTruthy();
+        expect(wrapper.vm.order.lineItems).toHaveLength(1);
     });
 
     it('should able to delete single item', async () => {
@@ -741,17 +749,22 @@ describe('src/module/sw-order/component/sw-order-line-items-grid', () => {
         const wrapper = await createWrapper();
 
         const buttonAddItem = wrapper.find('.sw-order-line-items-grid__actions-container-add-product-btn');
+
+        // The first item stays in inline edit, so only the second one exposes its context menu
         await buttonAddItem.trigger('click');
+        await flushPromises();
+        await buttonAddItem.trigger('click');
+        await flushPromises();
 
         let itemRows = wrapper.findAll('.sw-data-grid__body .sw-data-grid__row');
-        expect(itemRows).toHaveLength(1);
+        expect(itemRows).toHaveLength(2);
 
         const firstRow = itemRows[0];
 
         await firstRow.find('.sw-data-grid__cell--actions .sw-context-menu-item[variant="danger"]').trigger('click');
 
         itemRows = wrapper.findAll('.sw-data-grid__body .sw-data-grid__row');
-        expect(itemRows).toHaveLength(0);
+        expect(itemRows).toHaveLength(1);
     });
 
     it('should able to delete multiple items', async () => {

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-line-items-grid/sw-order-line-items-grid.spec/add-line-item.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-line-items-grid/sw-order-line-items-grid.spec/add-line-item.spec.js
@@ -1,0 +1,148 @@
+import { mount } from '@vue/test-utils';
+
+/**
+ * @sw-package checkout
+ */
+async function createWrapper() {
+    return mount(await wrapTestComponent('sw-order-line-items-grid', { sync: true }), {
+        props: {
+            order: {
+                price: {
+                    taxStatus: '',
+                },
+                currency: {
+                    isoCode: 'EUR',
+                },
+                lineItems: [],
+                taxStatus: '',
+                itemRounding: {
+                    decimals: 2,
+                },
+            },
+            context: {
+                authToken: {
+                    access: 'token',
+                },
+            },
+            isLoading: false,
+        },
+        global: {
+            provide: {
+                repositoryFactory: {
+                    create: () => ({
+                        create: () => ({ isNew: () => true, id: Shopware.Utils.createId() }),
+                        delete: jest.fn(() => Promise.resolve()),
+                    }),
+                },
+                orderService: {},
+                feature: {
+                    isActive: () => true,
+                },
+            },
+            stubs: {
+                'sw-container': await wrapTestComponent('sw-container', { sync: true }),
+                'sw-button-group': {
+                    template: '<div class="sw-button-group"><slot></slot></div>',
+                },
+                'sw-context-button': {
+                    template: '<div class="sw-context-button"><slot></slot></div>',
+                },
+                'sw-context-menu-divider': true,
+                'sw-context-menu-item': {
+                    emits: ['click'],
+                    template: '<div class="sw-context-menu-item" @click="$emit(\'click\')"><slot></slot></div>',
+                },
+                'sw-card-filter': true,
+                'sw-checkbox-field': true,
+                'sw-data-grid': await wrapTestComponent('sw-data-grid', { sync: true }),
+                'sw-data-grid-settings': true,
+                'sw-product-variant-info': await wrapTestComponent('sw-product-variant-info', { sync: true }),
+                'router-link': {
+                    template: '<a class="router-link" href="#"><slot></slot></a>',
+                    props: ['to'],
+                },
+                'mt-number-field': true,
+                'sw-order-product-select': true,
+                'sw-modal': true,
+                'sw-order-nested-line-items-modal': true,
+                'sw-data-grid-column-boolean': true,
+                'sw-data-grid-inline-edit': true,
+                'sw-data-grid-skeleton': true,
+                'sw-base-field': true,
+                'sw-field-error': true,
+                'sw-highlight-text': true,
+                'sw-provide': { template: '<slot/>', inheritAttrs: false },
+            },
+            mocks: {
+                $t: (key) => key,
+            },
+            directives: {
+                tooltip: {},
+            },
+        },
+    });
+}
+
+describe('module/sw-order/component/sw-order-line-items-grid/add-line-item', () => {
+    beforeEach(() => {
+        global.activeAclRoles = [
+            'order.viewer',
+            'order.editor',
+            'orders.create_discounts',
+        ];
+    });
+
+    it.each([
+        [
+            'product',
+            '.sw-order-line-items-grid__actions-container-add-product-btn',
+        ],
+        [
+            'custom',
+            '.sw-order-line-items-grid__create-custom-item',
+        ],
+        [
+            'credit',
+            '.sw-order-line-items-grid__can-create-discounts-button',
+        ],
+    ])('opens the inline edit of a newly added %s item', async (type, selector) => {
+        const wrapper = await createWrapper();
+
+        await wrapper.find(selector).trigger('click');
+        await flushPromises();
+
+        const firstRow = wrapper.find('.sw-data-grid__row--0');
+
+        expect(firstRow.classes()).toContain('is--inline-edit');
+        expect(firstRow.find('.sw-data-grid__inline-edit-save').exists()).toBe(true);
+    });
+
+    it('discards a new item without asking the order to recalculate when the inline edit is cancelled', async () => {
+        const wrapper = await createWrapper();
+
+        await wrapper.find('.sw-order-line-items-grid__actions-container-add-product-btn').trigger('click');
+        await flushPromises();
+
+        await wrapper.find('.sw-data-grid__row--0 .sw-data-grid__inline-edit-cancel').trigger('click');
+        await flushPromises();
+
+        expect(wrapper.vm.order.lineItems).toHaveLength(0);
+        expect(wrapper.emitted('item-cancel')).toBeUndefined();
+    });
+
+    it('keeps the row that is already being edited when another item is added', async () => {
+        const wrapper = await createWrapper();
+
+        await wrapper.find('.sw-order-line-items-grid__actions-container-add-product-btn').trigger('click');
+        await flushPromises();
+
+        const firstItemId = wrapper.vm.order.lineItems[0].id;
+
+        await wrapper.find('.sw-order-line-items-grid__create-custom-item').trigger('click');
+        await flushPromises();
+
+        expect(wrapper.vm.$refs.dataGrid.currentInlineEditId).toBe(firstItemId);
+        expect(wrapper.find('.sw-data-grid__row--0').classes()).not.toContain('is--inline-edit');
+        expect(wrapper.find('.sw-data-grid__row--1').classes()).toContain('is--inline-edit');
+    });
+});

--- a/src/Administration/Resources/app/administration/src/module/sw-order/view/sw-order-detail-general/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/view/sw-order-detail-general/index.js
@@ -207,12 +207,16 @@ export default {
             ]);
         },
 
-        reloadEntityData() {
+        reloadEntityData(isSaved = true) {
             if (this.swOrderDetailOnReloadEntityData) {
-                this.swOrderDetailOnReloadEntityData();
+                this.swOrderDetailOnReloadEntityData(isSaved);
             } else {
-                this.$emit('reload-entity-data');
+                this.$emit('reload-entity-data', isSaved);
             }
+        },
+
+        discardLineItemEdit() {
+            this.reloadEntityData(false);
         },
 
         saveAndReload() {

--- a/src/Administration/Resources/app/administration/src/module/sw-order/view/sw-order-detail-general/sw-order-detail-general.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/view/sw-order-detail-general/sw-order-detail-general.html.twig
@@ -40,7 +40,7 @@
                     @item-delete="recalculateAndReload"
                     @item-edit="recalculateAndReload"
                     @existing-item-edit="saveAndRecalculate"
-                    @item-cancel="recalculateAndReload"
+                    @item-cancel="discardLineItemEdit"
                 />
                 {% endblock %}
 

--- a/src/Administration/Resources/app/administration/src/module/sw-order/view/sw-order-detail-general/sw-order-detail-general.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/view/sw-order-detail-general/sw-order-detail-general.spec.js
@@ -213,13 +213,14 @@ describe('src/module/sw-order/view/sw-order-detail-details', () => {
         expect(wrapper.emitted('recalculate-and-reload')).toBeTruthy();
     });
 
-    it('should emit event recalculate-and-reload when cancel editing line item successfully', async () => {
+    it('should reload without recalculating when cancel editing line item successfully', async () => {
         global.activeAclRoles = ['order.editor'];
         wrapper = await createWrapper();
         const generalInfo = wrapper.findComponent('sw-order-line-items-grid-stub');
         await generalInfo.vm.$emit('item-cancel');
 
-        expect(wrapper.emitted('recalculate-and-reload')).toBeTruthy();
+        expect(wrapper.emitted('recalculate-and-reload')).toBeFalsy();
+        expect(wrapper.emitted('reload-entity-data')).toEqual([[false]]);
     });
 
     it('should emit event save-and-recalculate when editing line item successfully', async () => {


### PR DESCRIPTION
### 1. Why is this change necessary?

Adding an item to the items card of an order drops an empty row into the grid with no hint that it is editable. Unless you already know that double clicking a cell opens the inline editor, there is nothing to act on. Users expect to pick the product.

### 2. What does this change do, exactly?

A newly added row opens its inline edit immediately, so the product select is the first thing on screen. Both order grids ask the data grid to open the row after inserting it, the same way `sw-settings-search` and `sw-settings-listing` already do. This covers the order detail page and the order create page, which had the same problem.

Cancelling the inline edit is now the natural way to discard a row that was never saved, which surfaced two things worth fixing in the same pass:

- The detail page asked the server to recalculate the order on cancel. For a new item nothing was ever persisted, so the recalculation was a no-op and the reload only dropped a row we already had locally. Cancelling a new row is now a pure local splice, and cancelling an existing row reloads without recalculating. The reload stays because the inline edit writes straight into the entity, so something has to restore the original values. It reloads with `isSaved: false`, since `hasOrderDeepEdit` was only justified by the recalculate writing to the order version.
- The create page reset a cancelled new row to blank and left it in the grid, which is exactly the empty row this issue is about. It removes the row instead.

The detail grid also clears the search filter when adding, matching what the create page already did. Its filter drops items with a blank label, so without that you could add a row that is filtered out of sight.

### 3. Describe each step to reproduce the issue or behaviour.

Open an order, hit "Add product" in the items card, and the row is ready to accept a product.

### 4. Please link to the relevant issues (if any).

closes #9378

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [x] I have written or adjusted the documentation and agent skills according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
