### PR TITLE
fix(administration): remove the dead clear button from order state selects

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-state-select-v2/sw-order-state-select-v2.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-state-select-v2/sw-order-state-select-v2.html.twig
@@ -15,6 +15,7 @@
         :label="label"
         :options="transitionOptions"
         size="small"
+        :show-clearable-button="false"
     />
     {% endblock %}
 </div>

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-state-select-v2/sw-order-state-select-v2.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-state-select-v2/sw-order-state-select-v2.spec.js
@@ -5,7 +5,7 @@ import { mount } from '@vue/test-utils';
  */
 
 describe('src/module/sw-order/component/sw-order-state-select-v2', () => {
-    async function createWrapper() {
+    async function createWrapper(additionalStubs = {}) {
         return mount(await wrapTestComponent('sw-order-state-select-v2', { sync: true }), {
             global: {
                 stubs: {
@@ -14,6 +14,7 @@ describe('src/module/sw-order/component/sw-order-state-select-v2', () => {
                     'sw-select-result': true,
                     'sw-select-result-list': true,
                     'sw-select-base': true,
+                    ...additionalStubs,
                 },
             },
             props: {
@@ -81,5 +82,33 @@ describe('src/module/sw-order/component/sw-order-state-select-v2', () => {
         });
 
         expect(singleSelect.props('placeholder')).toBe('Open');
+    });
+
+    it('should not render a clear button, because a state cannot be unset', async () => {
+        const wrapper = await createWrapper({
+            'sw-select-base': await wrapTestComponent('sw-select-base', { sync: true }),
+            'sw-block-field': await wrapTestComponent('sw-block-field', { sync: true }),
+            'sw-base-field': await wrapTestComponent('sw-base-field', { sync: true }),
+            'sw-field-error': await wrapTestComponent('sw-field-error', { sync: true }),
+            'sw-help-text': true,
+            'sw-ai-copilot-badge': true,
+            'sw-inheritance-switch': true,
+            'sw-loader': true,
+        });
+
+        await wrapper.setProps({
+            transitionOptions: [
+                {
+                    disabled: false,
+                    id: 'do_pay',
+                    name: 'In progress',
+                    stateName: 'in_progress',
+                },
+            ],
+        });
+        await flushPromises();
+
+        expect(wrapper.find('.sw-select__select-indicator-expand').exists()).toBe(true);
+        expect(wrapper.find('.sw-select__select-indicator-clear').exists()).toBe(false);
     });
 });


### PR DESCRIPTION
### 1. Why is this change necessary?

The order status pills in the Administration offer a clear (`×`) button, but a status cannot be unset, so the button is dead UI.

### 2. What does this change do, exactly?

`sw-order-state-select-v2` looks like a value select but is really a transition trigger: the current status is rendered as the *placeholder*, and the bound value is reset to `null` right after every pick so the next transition can be chosen. Nothing ever holds a value, so there is nothing to clear — yet `sw-select-base` offers its clear button to every field that is not `required`, which is where the `×` came from.

Opting the component out of the clear button is therefore the fix at the right boundary: it is the one component behind all six status dropdowns (order, payment and delivery status on both the General and the Details tab), and it leaves the generic default for real value selects untouched.

### 3. Describe each step to reproduce the issue or behaviour.

Open an order in the Administration and look at a status dropdown on the General or Details tab. Before: an `×` sits next to the chevron and clicking it does nothing. After: only the chevron remains.

### 4. Please link to the relevant issues (if any).

closes #19743

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
