### PR TITLE
fix(administration): prevent data grid labels from shrinking

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/data-grid/sw-data-grid/sw-data-grid.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/data-grid/sw-data-grid/sw-data-grid.scss
@@ -86,6 +86,7 @@
         }
 
         .sw-label {
+            flex-shrink: 0;
             margin-bottom: 0;
         }
 

--- a/src/Administration/Resources/app/administration/src/app/component/data-grid/sw-data-grid/sw-data-grid.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/data-grid/sw-data-grid/sw-data-grid.scss
@@ -86,7 +86,6 @@
         }
 
         .sw-label {
-            flex-shrink: 0;
             margin-bottom: 0;
         }
 
@@ -114,6 +113,10 @@
         .sw-color-badge {
             flex-shrink: 0;
         }
+    }
+
+    .sw-data-grid__cell--tags .sw-label {
+        flex-shrink: 0;
     }
 
     .sw-data-grid__cell-value {


### PR DESCRIPTION
### 1. Why is this change necessary?

Short labels in data-grid cells can shrink until their text is obscured. This is visible in the customer overview TAG column, where tags such as `B2C` may appear as empty whitespace instead of readable labels.

### 2. What does this change do, exactly?

It prevents `sw-label` flex items inside `sw-data-grid__cell-content` from shrinking. The rule is scoped to data-grid cells, so labels elsewhere keep their existing behavior.

### 3. Describe each step to reproduce the issue or behaviour.

1. Install Shopware 6.7.7.1.
2. Add a customer in Administration.
3. Create and assign a short tag such as `B2C`.
4. Return to the customer overview.
5. Observe that the tag text is obscured in the TAG column before this change and remains readable after it.

### 4. Please link to the relevant issues (if any).

Closes #15247

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
  - Not applicable: this is a one-line, CSS-only layout fix. The affected SCSS file was verified with Stylelint.
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Not applicable: this does not change an external developer contract.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
  - Not applicable: no public API or workflow changes.
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
  - Not applicable: the CSS declaration is self-explanatory.
- [x] I have read the contribution requirements and fulfilled them
