### PR TITLE
chore: reformat .devcontainer/devcontainer.json

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,64 +1,62 @@
 {
-    "name": "Shopware Development",
-    "dockerComposeFile": "../compose.yaml",
-    "service": "web",
-    "workspaceFolder": "/var/www/html",
-    "customizations": {
-      "vscode": {
-        "extensions": [
-          "bmewburn.vscode-intelephense-client",
-          "devsense.composer-php-vscode",
-          "xdebug.php-debug",
-          "swordev.phpstan",
-          "junstyle.php-cs-fixer",
-          "esbenp.prettier-vscode",
-          "dbaeumer.vscode-eslint",
-          "stylelint.vscode-stylelint",
-          "Vue.volar",
-          "mblode.twig-language-2",
-          "thenouillet.symfony-vscode",
-          "eamodio.gitlens"
-        ],
-        "settings": {
-          "php.suggest.basic": false,
-          "intelephense.environment.phpVersion": "8.4.0",
-          "intelephense.environment.includePaths": [
-            "/var/www/html/vendor"
-          ],
-          "terminal.integrated.defaultProfile.linux": "bash"
-        }
+  "name": "Shopware Development",
+  "dockerComposeFile": "../compose.yaml",
+  "service": "web",
+  "workspaceFolder": "/var/www/html",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "bmewburn.vscode-intelephense-client",
+        "devsense.composer-php-vscode",
+        "xdebug.php-debug",
+        "swordev.phpstan",
+        "junstyle.php-cs-fixer",
+        "esbenp.prettier-vscode",
+        "dbaeumer.vscode-eslint",
+        "stylelint.vscode-stylelint",
+        "Vue.volar",
+        "mblode.twig-language-2",
+        "thenouillet.symfony-vscode",
+        "eamodio.gitlens"
+      ],
+      "settings": {
+        "php.suggest.basic": false,
+        "intelephense.environment.phpVersion": "8.4.0",
+        "intelephense.environment.includePaths": ["/var/www/html/vendor"],
+        "terminal.integrated.defaultProfile.linux": "bash"
       }
+    }
+  },
+  "forwardPorts": [8000, 5173, 9998, 9999, 9080, 8025],
+  "portsAttributes": {
+    "8000": {
+      "label": "Shopware",
+      "onAutoForward": "notify"
     },
-    "forwardPorts": [8000, 5173, 9998, 9999, 9080, 8025],
-    "portsAttributes": {
-      "8000": {
-        "label": "Shopware",
-        "onAutoForward": "notify"
-      },
-      "5173": {
-        "label": "Admin Watcher",
-        "onAutoForward": "silent"
-      },
-      "9998": {
-        "label": "Storefront Watcher",
-        "onAutoForward": "silent"
-      },
-      "9080": {
-        "label": "Adminer (Database UI)",
-        "onAutoForward": "silent"
-      },
-      "8025": {
-        "label": "Mailpit (Mail Testing)",
-        "onAutoForward": "silent"
-      },
-      "6006": {
-        "label": "Storybook",
-        "onAutoForward": "silent"
-      }
+    "5173": {
+      "label": "Admin Watcher",
+      "onAutoForward": "silent"
     },
-    "shutdownAction": "none",
-    "remoteEnv": {
-      "PATH": "/usr/local/bin:/usr/bin:${containerEnv:PATH}"
+    "9998": {
+      "label": "Storefront Watcher",
+      "onAutoForward": "silent"
     },
-    "remoteUser": "www-data"
-  }
+    "9080": {
+      "label": "Adminer (Database UI)",
+      "onAutoForward": "silent"
+    },
+    "8025": {
+      "label": "Mailpit (Mail Testing)",
+      "onAutoForward": "silent"
+    },
+    "6006": {
+      "label": "Storybook",
+      "onAutoForward": "silent"
+    }
+  },
+  "shutdownAction": "none",
+  "remoteEnv": {
+    "PATH": "/usr/local/bin:/usr/bin:${containerEnv:PATH}"
+  },
+  "remoteUser": "www-data"
+}


### PR DESCRIPTION
### 1. Why is this change necessary?

The file violates the repo's `.editorconfig` (`*.json` = 2-space indent): the whole body is indented one extra level with 4 spaces.

### 2. What does this change do, exactly?

Re-indents `.devcontainer/devcontainer.json` to 2 spaces; formatting only, no content changes.

### 3. Describe each step to reproduce the issue or behaviour.

Open `.devcontainer/devcontainer.json` — its indentation matches neither `.editorconfig` nor any other JSON file in the repo.

### 4. Please link to the relevant issues (if any).

None.

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them