### PR TITLE
fix(core): repair the invalid American Samoa postal code pattern

### DIFF
--- a/src/Core/Migration/V6_7/Migration1788113950FixAmericanSamoaPostalCodePattern.php
+++ b/src/Core/Migration/V6_7/Migration1788113950FixAmericanSamoaPostalCodePattern.php
@@ -1,0 +1,31 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Migration\V6_7;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Migration\MigrationStep;
+
+/**
+ * @internal
+ */
+#[Package('fundamentals@discovery')]
+class Migration1788113950FixAmericanSamoaPostalCodePattern extends MigrationStep
+{
+    private const BROKEN_PATTERN = '(96799)(?  :[ \\-](\\d{4}))?';
+
+    private const FIXED_PATTERN = '(96799)(?:[ \\-](\\d{4}))?';
+
+    public function getCreationTimestamp(): int
+    {
+        return 1788113950;
+    }
+
+    public function update(Connection $connection): void
+    {
+        $connection->executeStatement(
+            'UPDATE `country` SET `default_postal_code_pattern` = :fixed WHERE `default_postal_code_pattern` = :broken',
+            ['fixed' => self::FIXED_PATTERN, 'broken' => self::BROKEN_PATTERN]
+        );
+    }
+}

--- a/tests/migration/Core/V6_7/Migration1788113950FixAmericanSamoaPostalCodePatternTest.php
+++ b/tests/migration/Core/V6_7/Migration1788113950FixAmericanSamoaPostalCodePatternTest.php
@@ -1,0 +1,87 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Migration\Core\V6_7;
+
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
+use Shopware\Core\Migration\V6_7\Migration1788113950FixAmericanSamoaPostalCodePattern;
+use Shopware\Tests\Migration\MigrationTestTrait;
+
+/**
+ * @internal
+ */
+#[Package('fundamentals@discovery')]
+#[CoversClass(Migration1788113950FixAmericanSamoaPostalCodePattern::class)]
+class Migration1788113950FixAmericanSamoaPostalCodePatternTest extends TestCase
+{
+    use MigrationTestTrait;
+
+    private const BROKEN_PATTERN = '(96799)(?  :[ \\-](\\d{4}))?';
+
+    private const FIXED_PATTERN = '(96799)(?:[ \\-](\\d{4}))?';
+
+    private Connection $connection;
+
+    protected function setUp(): void
+    {
+        $this->connection = KernelLifecycleManager::getConnection();
+    }
+
+    public function testGetCreationTimestamp(): void
+    {
+        static::assertSame(1788113950, (new Migration1788113950FixAmericanSamoaPostalCodePattern())->getCreationTimestamp());
+    }
+
+    public function testUpdateReplacesTheBrokenPattern(): void
+    {
+        $countryId = $this->givenCountryWithPattern(self::BROKEN_PATTERN);
+
+        $migration = new Migration1788113950FixAmericanSamoaPostalCodePattern();
+        $migration->update($this->connection);
+        $migration->update($this->connection);
+
+        static::assertSame(self::FIXED_PATTERN, $this->getPattern($countryId));
+    }
+
+    public function testUpdateKeepsACustomizedPattern(): void
+    {
+        $customPattern = 'CUSTOM-\\d{3}';
+        $countryId = $this->givenCountryWithPattern($customPattern);
+
+        (new Migration1788113950FixAmericanSamoaPostalCodePattern())->update($this->connection);
+
+        static::assertSame($customPattern, $this->getPattern($countryId));
+    }
+
+    public function testTheFixedPatternAcceptsAmericanSamoaPostalCodes(): void
+    {
+        static::assertSame(1, preg_match('/^' . self::FIXED_PATTERN . '$/', '96799'));
+        static::assertSame(1, preg_match('/^' . self::FIXED_PATTERN . '$/', '96799 1234'));
+        static::assertSame(1, preg_match('/^' . self::FIXED_PATTERN . '$/', '96799-1234'));
+        static::assertSame(0, preg_match('/^' . self::FIXED_PATTERN . '$/', 'asdasd'));
+    }
+
+    private function givenCountryWithPattern(string $pattern): string
+    {
+        $countryId = $this->connection->fetchOne('SELECT `id` FROM `country` LIMIT 1');
+        static::assertIsString($countryId);
+
+        $this->connection->executeStatement(
+            'UPDATE `country` SET `default_postal_code_pattern` = :pattern WHERE `id` = :id',
+            ['pattern' => $pattern, 'id' => $countryId]
+        );
+
+        return $countryId;
+    }
+
+    private function getPattern(string $countryId): string
+    {
+        $pattern = $this->connection->fetchOne('SELECT `default_postal_code_pattern` FROM `country` WHERE `id` = :id', ['id' => $countryId]);
+        static::assertIsString($pattern);
+
+        return $pattern;
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?

The postal code pattern seeded for American Samoa is not a valid regex. `(96799)(?  :[ \-](\d{4}))?` has two stray spaces inside the non-capturing group opener, so `preg_match()` errors out and `CustomerZipCodeValidator` reads the `false` return as "does not match". With postal code validation enabled for AS, every address is rejected, correct ones included. It is the only broken pattern among the 192 that ship.

### 2. What does this change do, exactly?

Adds a migration that replaces the broken value with `(96799)(?:[ \-](\d{4}))?`.

It matches on the exact broken string rather than on the country ISO, which keeps it idempotent and leaves a merchant who already edited the pattern alone. The released 6.4 migration that seeded the value stays untouched, so new and existing installations converge on the corrected pattern through this migration rather than drifting apart.

### 3. Describe each step to reproduce the issue or behaviour.

1. Admin: Settings > Countries > American Samoa > Address handling, enable "Postal code validation".
2. Storefront: register with an American Samoa address and `96799` as the postal code.
3. The address is rejected with `This value is not a valid ZIP code for country "AS"`. No postal code can satisfy the pattern.

After the migration, `96799`, `96799 1234` and `96799-1234` are accepted and `asdasd` is still rejected.

### 4. Please link to the relevant issues (if any).

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
