### PR TITLE
fix(framework): stop env vars changed in a test from leaking into the container

### DIFF
--- a/src/Core/Framework/Test/TestCaseBase/EnvTestBehaviour.php
+++ b/src/Core/Framework/Test/TestCaseBase/EnvTestBehaviour.php
@@ -16,17 +16,14 @@ trait EnvTestBehaviour
     /**
      * A null value removes the variable for the duration of the test.
      *
-     * Services the container has already built keep the value they were injected with; boot a
-     * fresh kernel when the test needs those rebuilt.
+     * Only code that reads the environment at runtime sees the change. A booted container keeps
+     * the values it resolved before, in its services and in its parameters alike, so boot a fresh
+     * kernel when the test needs the container to pick the change up.
      *
      * @param array<string, string|int|bool|null> $envVars
      */
     public function setEnvVars(array $envVars): void
     {
-        if ($envVars === []) {
-            return;
-        }
-
         foreach ($envVars as $envVar => $value) {
             if (!\array_key_exists($envVar, $this->originalEnvVars)) {
                 $this->originalEnvVars[$envVar] = $_SERVER[$envVar] ?? null;
@@ -34,8 +31,6 @@ trait EnvTestBehaviour
 
             $this->applyEnvVar($envVar, $value);
         }
-
-        KernelLifecycleManager::resetContainerEnvCache();
     }
 
     /**

--- a/src/Core/Framework/Test/TestCaseBase/EnvTestBehaviour.php
+++ b/src/Core/Framework/Test/TestCaseBase/EnvTestBehaviour.php
@@ -16,10 +16,17 @@ trait EnvTestBehaviour
     /**
      * A null value removes the variable for the duration of the test.
      *
+     * Services the container has already built keep the value they were injected with; boot a
+     * fresh kernel when the test needs those rebuilt.
+     *
      * @param array<string, string|int|bool|null> $envVars
      */
     public function setEnvVars(array $envVars): void
     {
+        if ($envVars === []) {
+            return;
+        }
+
         foreach ($envVars as $envVar => $value) {
             if (!\array_key_exists($envVar, $this->originalEnvVars)) {
                 $this->originalEnvVars[$envVar] = $_SERVER[$envVar] ?? null;
@@ -27,16 +34,28 @@ trait EnvTestBehaviour
 
             $this->applyEnvVar($envVar, $value);
         }
+
+        KernelLifecycleManager::resetContainerEnvCache();
     }
 
+    /**
+     * Restores the environment and drops the kernel, so nothing the container resolved from the
+     * changed variables survives the test.
+     */
     #[After]
     public function resetEnvVars(): void
     {
+        if ($this->originalEnvVars === []) {
+            return;
+        }
+
         foreach ($this->originalEnvVars as $envVar => $value) {
             $this->applyEnvVar($envVar, $value);
         }
 
         $this->originalEnvVars = [];
+
+        KernelLifecycleManager::ensureKernelShutdown();
     }
 
     private function applyEnvVar(string $envVar, string|int|bool|null $value): void

--- a/src/Core/Framework/Test/TestCaseBase/KernelLifecycleManager.php
+++ b/src/Core/Framework/Test/TestCaseBase/KernelLifecycleManager.php
@@ -12,7 +12,6 @@ use Shopware\Core\Framework\Plugin\KernelPluginLoader\StaticKernelPluginLoader;
 use Shopware\Core\Framework\Test\Filesystem\Adapter\MemoryAdapterFactory;
 use Shopware\Core\Framework\Test\TestCaseHelper\TestBrowser;
 use Shopware\Core\Kernel;
-use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\HttpKernel\KernelInterface;
 use Symfony\Contracts\Service\ResetInterface;
 
@@ -178,19 +177,6 @@ class KernelLifecycleManager
         }
 
         return $class;
-    }
-
-    /**
-     * Drops the container's cache of resolved `env()` values, so services built after this call
-     * see env vars that were changed at runtime. Does nothing while no kernel is booted.
-     */
-    public static function resetContainerEnvCache(): void
-    {
-        $container = static::$kernel?->getContainer();
-
-        if ($container instanceof Container) {
-            $container->resetEnvCache();
-        }
     }
 
     /**

--- a/src/Core/Framework/Test/TestCaseBase/KernelLifecycleManager.php
+++ b/src/Core/Framework/Test/TestCaseBase/KernelLifecycleManager.php
@@ -12,6 +12,7 @@ use Shopware\Core\Framework\Plugin\KernelPluginLoader\StaticKernelPluginLoader;
 use Shopware\Core\Framework\Test\Filesystem\Adapter\MemoryAdapterFactory;
 use Shopware\Core\Framework\Test\TestCaseHelper\TestBrowser;
 use Shopware\Core\Kernel;
+use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\HttpKernel\KernelInterface;
 use Symfony\Contracts\Service\ResetInterface;
 
@@ -177,6 +178,19 @@ class KernelLifecycleManager
         }
 
         return $class;
+    }
+
+    /**
+     * Drops the container's cache of resolved `env()` values, so services built after this call
+     * see env vars that were changed at runtime. Does nothing while no kernel is booted.
+     */
+    public static function resetContainerEnvCache(): void
+    {
+        $container = static::$kernel?->getContainer();
+
+        if ($container instanceof Container) {
+            $container->resetEnvCache();
+        }
     }
 
     /**

--- a/tests/integration/Core/Framework/TestCaseBase/EnvTestBehaviourTest.php
+++ b/tests/integration/Core/Framework/TestCaseBase/EnvTestBehaviourTest.php
@@ -3,8 +3,10 @@
 namespace Shopware\Tests\Integration\Core\Framework\TestCaseBase;
 
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\DevOps\Environment\EnvironmentHelper;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\EnvTestBehaviour;
+use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 
 /**
@@ -16,26 +18,17 @@ class EnvTestBehaviourTest extends TestCase
     use EnvTestBehaviour;
     use KernelTestBehaviour;
 
-    private const REDIRECTED_APP_URL = 'https://env-test-behaviour.test';
-
-    public function testTheContainerResolvesAChangedEnvVarAgain(): void
+    public function testResettingDropsAContainerThatResolvedTheChangedEnvVar(): void
     {
-        $this->setEnvVars(['APP_URL' => self::REDIRECTED_APP_URL]);
+        $appUrl = (string) EnvironmentHelper::getVariable('APP_URL');
 
-        static::assertSame(self::REDIRECTED_APP_URL, static::getContainer()->getParameter('APP_URL'));
-    }
+        $this->setEnvVars(['APP_URL' => 'https://env-test-behaviour.test']);
+        KernelLifecycleManager::bootKernel();
 
-    public function testResettingDropsTheContainerThatSawTheChangedEnvVar(): void
-    {
-        $appUrl = static::getContainer()->getParameter('APP_URL');
-        $container = static::getContainer();
-
-        $this->setEnvVars(['APP_URL' => self::REDIRECTED_APP_URL]);
-        static::getContainer()->getParameter('APP_URL');
+        static::assertSame('https://env-test-behaviour.test', static::getContainer()->getParameter('APP_URL'));
 
         $this->resetEnvVars();
 
-        static::assertNotSame($container, static::getContainer());
         static::assertSame($appUrl, static::getContainer()->getParameter('APP_URL'));
     }
 }

--- a/tests/integration/Core/Framework/TestCaseBase/EnvTestBehaviourTest.php
+++ b/tests/integration/Core/Framework/TestCaseBase/EnvTestBehaviourTest.php
@@ -1,0 +1,41 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Integration\Core\Framework\TestCaseBase;
+
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Test\TestCaseBase\EnvTestBehaviour;
+use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+class EnvTestBehaviourTest extends TestCase
+{
+    use EnvTestBehaviour;
+    use KernelTestBehaviour;
+
+    private const REDIRECTED_APP_URL = 'https://env-test-behaviour.test';
+
+    public function testTheContainerResolvesAChangedEnvVarAgain(): void
+    {
+        $this->setEnvVars(['APP_URL' => self::REDIRECTED_APP_URL]);
+
+        static::assertSame(self::REDIRECTED_APP_URL, static::getContainer()->getParameter('APP_URL'));
+    }
+
+    public function testResettingDropsTheContainerThatSawTheChangedEnvVar(): void
+    {
+        $appUrl = static::getContainer()->getParameter('APP_URL');
+        $container = static::getContainer();
+
+        $this->setEnvVars(['APP_URL' => self::REDIRECTED_APP_URL]);
+        static::getContainer()->getParameter('APP_URL');
+
+        $this->resetEnvVars();
+
+        static::assertNotSame($container, static::getContainer());
+        static::assertSame($appUrl, static::getContainer()->getParameter('APP_URL'));
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?

The nightly `core-framework-batch1` job intermittently fails every App payment handler test on the
same diff: the app payload's `source.url` is `https://test-app.url` instead of the configured
`APP_URL`. That value belongs to `InfoControllerTest::testGetConfig`, which redirects `APP_URL`
through `EnvTestBehaviour`. The suite runs with `executionOrder="random"`, so the two only collide
on some nights.

`EnvTestBehaviour` restores the environment after the test, but the shared test container does not
follow. It caches resolved `env()` values and hands the string to the services it builds, so
whichever value is live when the container first resolves a variable is the value every later test
in that process sees.

### 2. What does this change do, exactly?

`resetEnvVars()`, the `#[After]` hook, now drops the kernel, so a container that resolved a variable
while it was redirected cannot outlive the test that redirected it.

Rebuilding the container is the only thing that clears every place the old value hides. Clearing
`Container`'s env cache alone leaves both the dumped container's memoised `%env()%` parameters and
the strings already injected into services, which buys nothing but a container that disagrees with
itself. `setEnvVars()` therefore leaves the booted container alone, and its docblock now says so: a
test that needs the container to pick the change up boots a kernel itself, the way
`ThemeCompilerTest` does. Doing the drop from the `#[After]` hook also keeps it out of the test
body, where it would take the open DB transaction with it.

### 3. Describe each step to reproduce the issue or behaviour.

```
vendor/bin/phpunit --testsuite core-framework-batch1 --order-by=default \
  --filter '(InfoControllerTest::testGetConfig$|AppRefundHandlerTest::testRefund$)'
```

`AppRefundHandlerTest::testRefund` fails on `source.url`. Swap the order and it passes.

### 4. Please link to the relevant issues (if any).

- relates #19217

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [x] I have written or adjusted the documentation and agent skills according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
