### PR TITLE
fix(a11y): adjust aria-popover roles to announce correct popover content (backport: 6.6.x)

### DIFF
--- a/src/Storefront/Resources/views/storefront/component/buy-widget/buy-widget.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/buy-widget/buy-widget.html.twig
@@ -116,7 +116,8 @@
                                         <button class="btn btn-link-inline product-detail-tax-link"
                                                 type="button"
                                                 data-ajax-modal="true"
-                                                data-url="{{ cmsPath }}">
+                                                data-url="{{ cmsPath }}"
+                                                aria-haspopup="dialog">
                                             {{ taxText }}
                                         </button>
                                     {% else %}
@@ -124,7 +125,8 @@
                                            href="{{ cmsPath }}"
                                            title="{{ taxText }}"
                                            data-ajax-modal="true"
-                                           data-url="{{ cmsPath }}">
+                                           data-url="{{ cmsPath }}"
+                                           aria-haspopup="dialog">
                                             {{ taxText }}
                                         </a>
                                     {% endif %}

--- a/src/Storefront/Resources/views/storefront/component/line-item/element/image.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/line-item/element/image.html.twig
@@ -59,6 +59,7 @@
                 data-ajax-modal="modal"
                 data-modal-class="quickview-modal"
                 data-url="{{ lineItemModalLink }}"
+                aria-haspopup="dialog"
             {% endif %}
         >
             {{ thumbnail }}

--- a/src/Storefront/Resources/views/storefront/component/line-item/element/label.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/line-item/element/label.html.twig
@@ -11,9 +11,10 @@
            class="line-item-label"
            title="{{ label }}"
             {% if lineItemModalLink %}
-                data-ajax-modal="modal"
+                data-ajax-modal="true"
                 data-modal-class="quickview-modal"
                 data-url="{{ lineItemModalLink }}"
+                aria-haspopup="dialog"
             {% endif %}
         >
             {{ label|u.truncate(60, '...', false)|raw }}

--- a/src/Storefront/Resources/views/storefront/component/listing/filter/filter-multi-select.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/listing/filter/filter-multi-select.html.twig
@@ -35,7 +35,6 @@
                     data-bs-toggle="dropdown"
                     data-boundary="viewport"
                     data-bs-offset="0,8"
-                    aria-haspopup="true"
                     {% endif %}>
 
                 {% block component_filter_multi_select_display_name %}

--- a/src/Storefront/Resources/views/storefront/component/listing/filter/filter-range.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/listing/filter/filter-range.html.twig
@@ -64,7 +64,6 @@
                     data-bs-toggle="dropdown"
                     data-boundary="viewport"
                     data-bs-offset="0,8"
-                    aria-haspopup="true"
                     {% endif %}>
                 {% block component_filter_range_display_name %}
                     {{ displayName }}

--- a/src/Storefront/Resources/views/storefront/component/privacy-notice.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/privacy-notice.html.twig
@@ -15,9 +15,9 @@
                     {% set dataProtectionLabel = privacyNoticeSnippet|trans({
                         '%privacyUrl%': path(cmsPath, { id: config('core.basicInformation.privacyPage') }),
                         '%tosUrl%': path(cmsPath, { id: config('core.basicInformation.tosPage') }),
-                        '%privacyModalTagOpen%': '<button type="button" class="btn btn-link-inline" data-ajax-modal="true" data-url="' ~ path(cmsPath, { id: config('core.basicInformation.privacyPage') }) ~ '">',
+                        '%privacyModalTagOpen%': '<button type="button" class="btn btn-link-inline" aria-haspopup="dialog" data-ajax-modal="true" data-url="' ~ path(cmsPath, { id: config('core.basicInformation.privacyPage') }) ~ '">',
                         '%privacyModalTagClose%': '</button>',
-                        '%tosModalTagOpen%': '<button type="button" class="btn btn-link-inline" data-ajax-modal="true" data-url="' ~ path(cmsPath, { id: config('core.basicInformation.tosPage') }) ~ '">',
+                        '%tosModalTagOpen%': '<button type="button" class="btn btn-link-inline" aria-haspopup="dialog" data-ajax-modal="true" data-url="' ~ path(cmsPath, { id: config('core.basicInformation.tosPage') }) ~ '">',
                         '%tosModalTagClose%': '</button>',
                     })|raw %}
 
@@ -68,9 +68,9 @@
                             {{ privacyNoticeSnippet|trans({
                                 '%privacyUrl%': path(cmsPath, { id: config('core.basicInformation.privacyPage') }),
                                 '%tosUrl%': path(cmsPath, { id: config('core.basicInformation.tosPage') }),
-                                '%privacyModalTagOpen%': '<button type="button" class="btn btn-link-inline" data-ajax-modal="true" data-url="' ~ path(cmsPath, { id: config('core.basicInformation.privacyPage') }) ~ '">',
+                                '%privacyModalTagOpen%': '<button type="button" class="btn btn-link-inline" aria-haspopup="dialog" data-ajax-modal="true" data-url="' ~ path(cmsPath, { id: config('core.basicInformation.privacyPage') }) ~ '">',
                                 '%privacyModalTagClose%': '</button>',
-                                '%tosModalTagOpen%': '<button type="button" class="btn btn-link-inline" data-ajax-modal="true" data-url="' ~ path(cmsPath, { id: config('core.basicInformation.tosPage') }) ~ '">',
+                                '%tosModalTagOpen%': '<button type="button" class="btn btn-link-inline" aria-haspopup="dialog" data-ajax-modal="true" data-url="' ~ path(cmsPath, { id: config('core.basicInformation.tosPage') }) ~ '">',
                                 '%tosModalTagClose%': '</button>',
                             })|raw }}
                         </div>

--- a/src/Storefront/Resources/views/storefront/component/product/card/price-unit.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/product/card/price-unit.html.twig
@@ -103,7 +103,8 @@
                 <button class="product-price-tax-link btn btn-link-inline fs-6"
                         type="button"
                         data-ajax-modal="true"
-                        data-url="{{ path(cmsPath, { id: config('core.basicInformation.shippingPaymentInfoPage') }) }}">
+                        data-url="{{ path(cmsPath, { id: config('core.basicInformation.shippingPaymentInfoPage') }) }}"
+                        aria-haspopup="dialog">
                     {% if context.taxState == 'gross' %}
                         {{ 'general.grossTaxInformation'|trans|sw_sanitize }}
                     {% else %}

--- a/src/Storefront/Resources/views/storefront/element/cms-element-sidebar-filter.html.twig
+++ b/src/Storefront/Resources/views/storefront/element/cms-element-sidebar-filter.html.twig
@@ -14,8 +14,7 @@
                     class="btn btn-outline-primary filter-panel-wrapper-toggle"
                     type="button"
                     data-off-canvas-filter="true"
-                    aria-haspopup="true"
-                    aria-expanded="false"
+                    aria-haspopup="dialog"
                 >
                     {% block element_product_listing_filter_button_icon %}
                         {% sw_icon 'sliders-horizontal' style { size: 'sm', ariaHidden: true } %}

--- a/src/Storefront/Resources/views/storefront/layout/header/actions/account-widget.html.twig
+++ b/src/Storefront/Resources/views/storefront/layout/header/actions/account-widget.html.twig
@@ -6,7 +6,6 @@
                     id="accountWidget"
                     data-account-menu="true"
                     data-bs-toggle="dropdown"
-                    aria-haspopup="true"
                     aria-expanded="false"
                     aria-label="{{ 'account.myAccount'|trans|striptags }}"
                     title="{{ 'account.myAccount'|trans|striptags }}">

--- a/src/Storefront/Resources/views/storefront/layout/header/header.html.twig
+++ b/src/Storefront/Resources/views/storefront/layout/header/header.html.twig
@@ -113,7 +113,7 @@
                                         data-cart-widget="true"
                                         title="{{ 'checkout.cartTitle'|trans|striptags }}"
                                         aria-labelledby="cart-widget-aria-label"
-                                        aria-haspopup="true"
+                                        aria-haspopup="dialog"
                                     >
                                         {% sw_include '@Storefront/storefront/layout/header/actions/cart-widget.html.twig' %}
                                     </a>

--- a/src/Storefront/Resources/views/storefront/page/account/order-history/order-item.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/account/order-history/order-item.html.twig
@@ -68,7 +68,6 @@
                                         type="button"
                                         id="accountOrderDropdown"
                                         data-bs-toggle="dropdown"
-                                        aria-haspopup="true"
                                         aria-expanded="false"
                                         aria-label="{{ 'account.orderActions'|trans|sw_sanitize }}">
                                     {% sw_icon 'more-horizontal' style { ariaHidden: true } %}

--- a/src/Storefront/Resources/views/storefront/page/account/order/index.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/account/order/index.html.twig
@@ -36,7 +36,7 @@
 {% block page_checkout_confirm_tos_control %}
     {{ (feature('ACCESSIBILITY_TWEAKS') ? 'checkout.confirmTermsReminderTextModal' : 'checkout.confirmTermsReminderText')|trans({
         '%url%': path('frontend.cms.page', { id: config('core.basicInformation.tosPage') }),
-        '%tosModalTagOpen%': '<button type="button" class="btn btn-link-inline" data-ajax-modal="true" data-url="' ~ path('frontend.cms.page', { id: config('core.basicInformation.tosPage') }) ~ '">',
+        '%tosModalTagOpen%': '<button type="button" class="btn btn-link-inline" aria-haspopup="dialog" data-ajax-modal="true" data-url="' ~ path('frontend.cms.page', { id: config('core.basicInformation.tosPage') }) ~ '">',
         '%tosModalTagClose%': '</button>'
     })|raw }}
 {% endblock %}

--- a/src/Storefront/Resources/views/storefront/page/checkout/confirm/index.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/checkout/confirm/index.html.twig
@@ -61,7 +61,7 @@
 
                                 {{ revocationSnippetKey|trans({
                                     '%url%': path(cmsPath, { id: config('core.basicInformation.revocationPage') }),
-                                    '%revocationModalTagOpen%': '<button type="button" class="btn btn-link-inline" data-ajax-modal="true" data-url="' ~ path(cmsPath, { id: config('core.basicInformation.revocationPage') }) ~ '">',
+                                    '%revocationModalTagOpen%': '<button type="button" class="btn btn-link-inline" aria-haspopup="dialog" data-ajax-modal="true" data-url="' ~ path(cmsPath, { id: config('core.basicInformation.revocationPage') }) ~ '">',
                                     '%revocationModalTagClose%': '</button>'
                                 })|raw }}
                             </p>
@@ -87,7 +87,7 @@
                                            class="checkout-confirm-tos-label custom-control-label">
                                         {{ tosSnippetKey|trans({
                                             '%url%': path(cmsPath, { id: config('core.basicInformation.tosPage') }),
-                                            '%tosModalTagOpen%': '<button type="button" class="checkout-confirm-terms-modal btn btn-link-inline" data-ajax-modal="true" data-url="' ~ path(cmsPath, { id: config('core.basicInformation.tosPage') }) ~ '">',
+                                            '%tosModalTagOpen%': '<button type="button" class="checkout-confirm-terms-modal btn btn-link-inline" aria-haspopup="dialog" data-ajax-modal="true" data-url="' ~ path(cmsPath, { id: config('core.basicInformation.tosPage') }) ~ '">',
                                             '%tosModalTagClose%': '</button>',
                                             '%legalGuaranteeNoticeModalTagOpen%': legalGuaranteeNoticeModalTagOpen,
                                             '%legalGuaranteeNoticeModalTagClose%': legalGuaranteeNoticeModalTagClose,


### PR DESCRIPTION
**Backport:** https://github.com/shopware/shopware/pull/14989
relates #19539

---

### 1. Why is this change necessary?
Manual backport of #14989 to 6.6.x (a11y). The automated cherry-pick conflicts; see below.

### 2. What does this change do, exactly?
Corrects the `aria-haspopup` values so screen readers announce the right kind of popover: controls that open the AJAX/off-canvas dialog now use `aria-haspopup="dialog"` instead of the generic `"true"` (which announces "menu"), and controls that only open a Bootstrap dropdown drop the redundant `aria-haspopup` altogether, because `data-bs-toggle="dropdown"` already sets it. It also normalises `data-ajax-modal="modal"` to `"true"` on the cart line-item label and removes a permanently stale `aria-expanded="false"` from the sidebar filter toggle (no JS updates it).

**Conflict resolution vs. trunk commit 280ae7fbc30:**
- `component/buy-widget/buy-widget.html.twig`: 6.6.x still has the `feature('ACCESSIBILITY_TWEAKS')` if/else around the tax link (trunk dropped it). Kept both branches and added `aria-haspopup="dialog"` to **both** the flag-on `<button>` and the flag-off `<a>` — both carry `data-ajax-modal`/`data-url` and open the same dialog, and the flag-off branch is what ships by default on 6.6.x.
- `component/privacy-notice.html.twig`: kept the 6.6.x `ACCESSIBILITY_TWEAKS` if/else and the `%privacyUrl%`/`%tosUrl%` parameters (trunk removed both); only inserted `aria-haspopup="dialog"` into the four `%privacyModalTagOpen%` / `%tosModalTagOpen%` button strings.
- `page/account/order/index.html.twig`: kept the 6.6.x snippet-key ternary (`confirmTermsReminderTextModal` vs `confirmTermsReminderText`) and the `%url%` parameter; only added `aria-haspopup="dialog"` to `%tosModalTagOpen%`.
- `page/checkout/confirm/index.html.twig`: kept the 6.6.x snippet-key ternaries and `%url%` parameters. Dropped the trunk hunks that hoist `tosModalTagOpen`/`tosModalTagClose` into `{% set %}` variables and the whole `page_checkout_confirm_tos_auto_confirmed` block — that block is gated behind `feature('v6.8.0.0')` and does not exist on 6.6.x. The two modal buttons that do exist on 6.6.x got `aria-haspopup="dialog"`.

No follow-up fix exists on trunk: no later trunk commit touches any of the `aria-haspopup` / `data-ajax-modal` lines changed here (the only later hit, #18290 "EU guarantee label", merely follows the new convention and is already on 6.6.x).

### 3. Describe each step to reproduce the issue or behaviour.
See original PR.

### 4. Please link to the relevant issues (if any).
- relates #19539

### 5. Checklist
- [x] Cherry-picked from trunk with `-x`, conflicts resolved as described
- [ ] Tests run locally: no automated test covers the changed attributes. Grepped `tests/acceptance/` (no hits at all) and `src/Storefront/Resources/app/storefront/test/` — the three jest files containing `aria-haspopup` only use it inside static HTML fixtures and never assert on it, so nothing needed updating. Jest could not be executed in this environment (the storefront tooling MCP server was unavailable); no JS was changed. Twig block/if/for nesting verified to be unchanged against `origin/6.6.x` for all 13 files.
