### PR TITLE
fix(sales-channel): add ACL guards to agentic files feature

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -67,6 +67,11 @@ public function addSorting(ProductListingCollectSortingEvent $event): void
 ### Store API context token response header is restricted on cacheable reads
 
 Store API responses no longer echo the request `sw-context-token` header on cacheable reads when `CACHE_REWORK` or `v6.8.0.0` is active. The response header is returned by endpoints that provide or bootstrap shopper state, for example reading or switching context, login, logout, registration, password change, guest-order login, adding cart items, and context gateway login/register commands. Clients should keep using their existing token unless a response explicitly provides a `sw-context-token`.
+
+### Sales channel file routes require read access
+
+The list, detail and preview routes under `/api/_action/sales-channel-file/{fileFamily}/{salesChannelId}` now require `sales_channel_file:read`. Clients with that privilege receive previews using the saved template overrides; supplying unsaved `templateOverrides` additionally requires `sales_channel_file:update`.
+
 ### Dedicated error code for invalid child line item quantity
 
 `CartException::invalidChildQuantity()` now returns the error code `CHECKOUT__CART_INVALID_CHILD_LINE_ITEM_QUANTITY` (constant `CartException::CART_INVALID_CHILD_LINE_ITEM_QUANTITY_CODE`) instead of reusing `CHECKOUT__CART_INVALID_LINE_ITEM_QUANTITY`. Previously both `invalidChildQuantity()` and `invalidQuantity()` shared the same error code, so the shared storefront message `The quantity (%quantity%) is incorrect.` was rendered with an empty `%quantity%` placeholder for the child quantity case (`invalidChildQuantity()` never provided that parameter). If you match on the previous error code to detect invalid child quantities, switch to the new code.
@@ -270,10 +275,6 @@ Thirteen admin checkout endpoints that previously only required authentication n
 * `POST /api/_action/order/{orderId}/convert-to-cart/` requires `order:read`.
 
 Administration users are not affected: `order:update` and `order_address:update` are part of the "Orders editor" permission that already gates every one of these actions in the order detail page, `order:read` is part of "Orders viewer", and the order creator role depends on both. Integrations and API clients with manually assigned privilege lists must add the respective privilege to their ACL role.
-
-### Sales channel file previews require read access
-
-`POST /api/_action/sales-channel-file/{fileFamily}/{salesChannelId}/preview` now requires `sales_channel_file:read`. Clients with that privilege receive previews using the saved template overrides; supplying unsaved `templateOverrides` additionally requires `sales_channel_file:update`.
 
 ### User uniqueness validation endpoints now require user read access
 

--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -270,6 +270,11 @@ Thirteen admin checkout endpoints that previously only required authentication n
 * `POST /api/_action/order/{orderId}/convert-to-cart/` requires `order:read`.
 
 Administration users are not affected: `order:update` and `order_address:update` are part of the "Orders editor" permission that already gates every one of these actions in the order detail page, `order:read` is part of "Orders viewer", and the order creator role depends on both. Integrations and API clients with manually assigned privilege lists must add the respective privilege to their ACL role.
+
+### Sales channel file previews require read access
+
+`POST /api/_action/sales-channel-file/{fileFamily}/{salesChannelId}/preview` now requires `sales_channel_file:read`. Clients with that privilege receive previews using the saved template overrides; supplying unsaved `templateOverrides` additionally requires `sales_channel_file:update`.
+
 ### User uniqueness validation endpoints now require user read access
 
 The `POST /api/_action/user/check-email-unique` and `POST /api/_action/user/check-username-unique` endpoints now require the existing `user:read` privilege. Integrations and API clients that call these endpoints must add this privilege to their ACL role.

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/service/sales-channel-file.api.service.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/service/sales-channel-file.api.service.js
@@ -36,18 +36,16 @@ class SalesChannelFileApiService extends ApiService {
             });
     }
 
-    preview(fileFamily, salesChannelId, fileName, templateOverrides = {}) {
+    preview(fileFamily, salesChannelId, fileName, templateOverrides) {
+        const data = { fileName };
+        if (templateOverrides !== undefined) {
+            data.templateOverrides = templateOverrides;
+        }
+
         return this.httpClient
-            .post(
-                `/_action/${this.getApiBasePath()}/${fileFamily}/${salesChannelId}/preview`,
-                {
-                    fileName,
-                    templateOverrides,
-                },
-                {
-                    headers: this.getBasicHeaders(),
-                },
-            )
+            .post(`/_action/${this.getApiBasePath()}/${fileFamily}/${salesChannelId}/preview`, data, {
+                headers: this.getBasicHeaders(),
+            })
             .then((response) => {
                 return ApiService.handleResponse(response);
             });

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/service/sales-channel-file.api.service.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/service/sales-channel-file.api.service.spec.js
@@ -112,4 +112,19 @@ describe('src/module/sw-sales-channel/service/sales-channel-file.api.service', (
             },
         );
     });
+
+    it('loads a preview without sending unchanged template overrides', async () => {
+        const httpClient = {
+            post: jest.fn(async () => ({ data: {}, headers: {} })),
+        };
+        const service = new SalesChannelFileApiService(httpClient, { getToken: () => 'test-token' });
+
+        await service.preview('agentic', 'sales-channel-id', 'llms.txt');
+
+        expect(httpClient.post).toHaveBeenCalledWith(
+            '/_action/sales-channel-file/agentic/sales-channel-id/preview',
+            { fileName: 'llms.txt' },
+            expect.any(Object),
+        );
+    });
 });

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/view/sw-sales-channel-detail-agentic-file/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/view/sw-sales-channel-detail-agentic-file/index.js
@@ -18,6 +18,7 @@ export default {
     template,
 
     inject: [
+        'acl',
         'salesChannelFileApiService',
         'repositoryFactory',
     ],

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/view/sw-sales-channel-detail-agentic-file/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/view/sw-sales-channel-detail-agentic-file/index.js
@@ -232,11 +232,12 @@ export default {
             this.isPreviewLoading = true;
 
             try {
+                const templateOverrides = this.hasUnsavedTemplateOverrides() ? this.templateOverrides : undefined;
                 this.preview = await this.salesChannelFileApiService.preview(
                     this.file.fileFamily,
                     this.salesChannel.id,
                     this.file.fileName,
-                    this.templateOverrides,
+                    templateOverrides,
                 );
             } catch {
                 this.preview = null;
@@ -265,6 +266,20 @@ export default {
 
         hasTemplateOverride(template) {
             return Object.hasOwn(this.templateOverrides, template.twigNamespace);
+        },
+
+        hasUnsavedTemplateOverrides() {
+            const configuration = this.file?.configuration;
+
+            if (configuration?.isNew?.() === true) {
+                return true;
+            }
+
+            if (typeof configuration?.getOrigin !== 'function') {
+                return false;
+            }
+
+            return !Shopware.Utils.types.isEqual(configuration.getOrigin().templateOverrides ?? {}, this.templateOverrides);
         },
 
         openTemplateOverrideModal(template) {

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/view/sw-sales-channel-detail-agentic-file/sw-sales-channel-detail-agentic-file.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/view/sw-sales-channel-detail-agentic-file/sw-sales-channel-detail-agentic-file.html.twig
@@ -51,6 +51,7 @@
                 class="sw-sales-channel-detail-agentic-file__state-action"
                 size="small"
                 variant="secondary"
+                :disabled="!acl.can('sales_channel.editor')"
                 @click="onToggleEnabled"
             >
                 {{ getToggleLabel(file) }}
@@ -99,7 +100,7 @@
                     class="sw-sales-channel-detail-agentic-file__custom-notes-input"
                     name="sw-field--sales-channel-agentic-file-custom-notes"
                     :placeholder="$t('sw-sales-channel.detail.agenticFiles.detail.customNotesPlaceholder')"
-                    :disabled="isLoading || undefined"
+                    :disabled="isLoading || !acl.can('sales_channel.editor') || undefined"
                 />
             </div>
         </div>
@@ -193,6 +194,7 @@
                     <button
                         type="button"
                         class="sw-sales-channel-detail-agentic-file__source sw-sales-channel-detail-agentic-file__source-button"
+                        :disabled="!acl.can('sales_channel.editor')"
                         @click="openTemplateOverrideModal(item)"
                     >
                         <span class="sw-sales-channel-detail-agentic-file__source-name">
@@ -221,7 +223,10 @@
                 </template>
 
                 <template #actions="{ item }">
-                    <sw-context-menu-item @click="openTemplateOverrideModal(item)">
+                    <sw-context-menu-item
+                        :disabled="!acl.can('sales_channel.editor')"
+                        @click="openTemplateOverrideModal(item)"
+                    >
                         {{ $t('sw-sales-channel.detail.agenticFiles.detail.actionEditOverride') }}
                     </sw-context-menu-item>
                 </template>
@@ -249,6 +254,7 @@
                 :soft-wraps="true"
                 :set-focus="true"
                 :label="$t('sw-sales-channel.detail.agenticFiles.detail.overrideModalFieldLabel')"
+                :disabled="!acl.can('sales_channel.editor')"
             />
         </div>
 
@@ -257,7 +263,7 @@
                 class="sw-sales-channel-detail-agentic-file__override-modal-reset"
                 size="small"
                 variant="secondary"
-                :disabled="!canResetTemplateOverride"
+                :disabled="!acl.can('sales_channel.editor') || !canResetTemplateOverride"
                 @click="resetTemplateOverride"
             >
                 {{ $t('sw-sales-channel.detail.agenticFiles.detail.overrideModalReset') }}
@@ -275,6 +281,7 @@
                 class="sw-sales-channel-detail-agentic-file__override-modal-apply"
                 size="small"
                 variant="primary"
+                :disabled="!acl.can('sales_channel.editor')"
                 @click="applyTemplateOverride"
             >
                 {{ $t('sw-sales-channel.detail.agenticFiles.detail.overrideModalApply') }}

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/view/sw-sales-channel-detail-agentic-file/sw-sales-channel-detail-agentic-file.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/view/sw-sales-channel-detail-agentic-file/sw-sales-channel-detail-agentic-file.html.twig
@@ -192,15 +192,21 @@
             >
                 <template #column-templateName="{ item }">
                     <button
+                        v-if="acl.can('sales_channel.editor')"
                         type="button"
                         class="sw-sales-channel-detail-agentic-file__source sw-sales-channel-detail-agentic-file__source-button"
-                        :disabled="!acl.can('sales_channel.editor')"
                         @click="openTemplateOverrideModal(item)"
                     >
                         <span class="sw-sales-channel-detail-agentic-file__source-name">
                             {{ item.templateName }}
                         </span>
                     </button>
+                    <span
+                        v-else
+                        class="sw-sales-channel-detail-agentic-file__source sw-sales-channel-detail-agentic-file__source-name"
+                    >
+                        {{ item.templateName }}
+                    </span>
                 </template>
 
                 <template #column-role="{ item }">

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/view/sw-sales-channel-detail-agentic-file/sw-sales-channel-detail-agentic-file.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/view/sw-sales-channel-detail-agentic-file/sw-sales-channel-detail-agentic-file.spec.js
@@ -225,6 +225,9 @@ async function createWrapper(options = {}) {
                 },
             },
             provide: {
+                acl: {
+                    can: (permission) => global.activeAclRoles.includes(permission),
+                },
                 salesChannelFileApiService,
                 repositoryFactory: {
                     create: () => ({
@@ -243,9 +246,6 @@ async function createWrapper(options = {}) {
                     },
                 },
                 $te: (key) => key.includes('["llms-txt"]') || key.includes('["agents-md"]'),
-                acl: {
-                    can: (permission) => global.activeAclRoles.includes(permission),
-                },
             },
         },
         props: {

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/view/sw-sales-channel-detail-agentic-file/sw-sales-channel-detail-agentic-file.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/view/sw-sales-channel-detail-agentic-file/sw-sales-channel-detail-agentic-file.spec.js
@@ -126,6 +126,7 @@ async function createWrapper(options = {}) {
                             <textarea
                                 class="mt-textarea"
                                 :value="modelValue"
+                                :disabled="disabled"
                                 @input="$emit('update:modelValue', $event.target.value)"
                             ></textarea>
                         `,
@@ -153,6 +154,7 @@ async function createWrapper(options = {}) {
                             <textarea
                                 class="sw-code-editor"
                                 :value="value"
+                                :disabled="disabled"
                                 @input="$emit('update:value', $event.target.value)"
                             ></textarea>
                         `,
@@ -166,6 +168,7 @@ async function createWrapper(options = {}) {
                         'softWraps',
                         'setFocus',
                         'label',
+                        'disabled',
                     ],
                 },
                 'router-link': RouterLinkStub,
@@ -227,6 +230,7 @@ async function createWrapper(options = {}) {
                     create: () => ({
                         create: () => ({
                             id: 'new-sales-channel-file-id',
+                            isNew: () => true,
                         }),
                     }),
                 },
@@ -239,6 +243,9 @@ async function createWrapper(options = {}) {
                     },
                 },
                 $te: (key) => key.includes('["llms-txt"]') || key.includes('["agents-md"]'),
+                acl: {
+                    can: (permission) => global.activeAclRoles.includes(permission),
+                },
             },
         },
         props: {
@@ -253,15 +260,26 @@ async function createWrapper(options = {}) {
 }
 
 describe('src/module/sw-sales-channel/view/sw-sales-channel-detail-agentic-file', () => {
+    beforeEach(() => {
+        global.activeAclRoles = ['sales_channel.editor'];
+    });
+
+    afterEach(() => {
+        global.activeAclRoles = [];
+    });
+
     it('loads the selected file and generated preview', async () => {
         const { wrapper, salesChannelFileApiService } = await createWrapper();
 
         await flushPromises();
 
         expect(salesChannelFileApiService.detail).toHaveBeenCalledWith('agentic', 'sales-channel-id', 'llms.txt');
-        expect(salesChannelFileApiService.preview).toHaveBeenCalledWith('agentic', 'sales-channel-id', 'llms.txt', {
-            Framework: 'custom llms text',
-        });
+        expect(salesChannelFileApiService.preview).toHaveBeenCalledWith(
+            'agentic',
+            'sales-channel-id',
+            'llms.txt',
+            undefined,
+        );
         expect(wrapper.vm.file).toEqual(discoveredFiles[0]);
         expect(wrapper.text()).toContain('# Demo shop');
     });
@@ -316,6 +334,22 @@ describe('src/module/sw-sales-channel/view/sw-sales-channel-detail-agentic-file'
                 id: 'sales-channel-id',
             },
         });
+    });
+
+    it('disables file mutations for sales channel viewers', async () => {
+        global.activeAclRoles = ['sales_channel.viewer'];
+        const { wrapper } = await createWrapper();
+
+        await flushPromises();
+
+        expect(wrapper.find('.sw-sales-channel-detail-agentic-file__state-action').attributes('disabled')).toBeDefined();
+        expect(wrapper.find('.mt-textarea').attributes('disabled')).toBeDefined();
+
+        await wrapper.find('.sw-sales-channel-detail-agentic-file__content-sources-toggle').trigger('click');
+        await flushPromises();
+
+        expect(wrapper.find('.sw-sales-channel-detail-agentic-file__source-button').attributes('disabled')).toBeDefined();
+        expect(wrapper.find('.sw-context-menu-item').attributes('disabled')).toBeDefined();
     });
 
     it('opens a source override modal from the source column and stages edits for the global save', async () => {
@@ -392,7 +426,12 @@ describe('src/module/sw-sales-channel/view/sw-sales-channel-detail-agentic-file'
         expect(wrapper.find('.sw-sales-channel-detail-agentic-file__override-modal').exists()).toBe(false);
         expect(wrapper.vm.salesChannel.salesChannelFiles).toBeUndefined();
         expect(salesChannelFileApiService.preview).toHaveBeenCalledTimes(1);
-        expect(salesChannelFileApiService.preview).toHaveBeenLastCalledWith('agentic', 'sales-channel-id', 'AGENTS.md', {});
+        expect(salesChannelFileApiService.preview).toHaveBeenLastCalledWith(
+            'agentic',
+            'sales-channel-id',
+            'AGENTS.md',
+            undefined,
+        );
     });
 
     it('links the public path to the first configured sales channel domain', async () => {

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/view/sw-sales-channel-detail-agentic-file/sw-sales-channel-detail-agentic-file.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/view/sw-sales-channel-detail-agentic-file/sw-sales-channel-detail-agentic-file.spec.js
@@ -348,7 +348,8 @@ describe('src/module/sw-sales-channel/view/sw-sales-channel-detail-agentic-file'
         await wrapper.find('.sw-sales-channel-detail-agentic-file__content-sources-toggle').trigger('click');
         await flushPromises();
 
-        expect(wrapper.find('.sw-sales-channel-detail-agentic-file__source-button').attributes('disabled')).toBeDefined();
+        expect(wrapper.find('.sw-sales-channel-detail-agentic-file__source-button').exists()).toBe(false);
+        expect(wrapper.find('.sw-sales-channel-detail-agentic-file__source-name').element.tagName).toBe('SPAN');
         expect(wrapper.find('.sw-context-menu-item').attributes('disabled')).toBeDefined();
     });
 

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/view/sw-sales-channel-detail-agentic-files/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/view/sw-sales-channel-detail-agentic-files/index.js
@@ -17,6 +17,7 @@ export default {
     template,
 
     inject: [
+        'acl',
         'salesChannelFileApiService',
         'repositoryFactory',
     ],

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/view/sw-sales-channel-detail-agentic-files/sw-sales-channel-detail-agentic-files.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/view/sw-sales-channel-detail-agentic-files/sw-sales-channel-detail-agentic-files.html.twig
@@ -74,7 +74,10 @@
                     {{ $t('global.default.edit') }}
                 </sw-context-menu-item>
 
-                <sw-context-menu-item @click="onToggleEnabled(item)">
+                <sw-context-menu-item
+                    :disabled="!acl.can('sales_channel.editor')"
+                    @click="onToggleEnabled(item)"
+                >
                     {{ getToggleLabel(item) }}
                 </sw-context-menu-item>
             </template>

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/view/sw-sales-channel-detail-agentic-files/sw-sales-channel-detail-agentic-files.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/view/sw-sales-channel-detail-agentic-files/sw-sales-channel-detail-agentic-files.spec.js
@@ -148,6 +148,9 @@ async function createWrapper(options = {}) {
                     },
                 },
                 provide: {
+                    acl: {
+                        can: (permission) => global.activeAclRoles.includes(permission),
+                    },
                     salesChannelFileApiService,
                     repositoryFactory: {
                         create: () => ({
@@ -165,9 +168,6 @@ async function createWrapper(options = {}) {
                     },
                     $t: (key) => mergedTranslations[key] ?? key,
                     $te: (key) => Object.hasOwn(mergedTranslations, key),
-                    acl: {
-                        can: (permission) => global.activeAclRoles.includes(permission),
-                    },
                 },
             },
             props: {

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/view/sw-sales-channel-detail-agentic-files/sw-sales-channel-detail-agentic-files.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/view/sw-sales-channel-detail-agentic-files/sw-sales-channel-detail-agentic-files.spec.js
@@ -165,6 +165,9 @@ async function createWrapper(options = {}) {
                     },
                     $t: (key) => mergedTranslations[key] ?? key,
                     $te: (key) => Object.hasOwn(mergedTranslations, key),
+                    acl: {
+                        can: (permission) => global.activeAclRoles.includes(permission),
+                    },
                 },
             },
             props: {
@@ -180,6 +183,14 @@ async function createWrapper(options = {}) {
 }
 
 describe('src/module/sw-sales-channel/view/sw-sales-channel-detail-agentic-files', () => {
+    beforeEach(() => {
+        global.activeAclRoles = ['sales_channel.editor'];
+    });
+
+    afterEach(() => {
+        global.activeAclRoles = [];
+    });
+
     it('loads agentic files for the active sales channel', async () => {
         const { wrapper, salesChannelFileApiService } = await createWrapper();
 
@@ -318,6 +329,15 @@ describe('src/module/sw-sales-channel/view/sw-sales-channel-detail-agentic-files
                 fileName: 'llms.txt',
             },
         });
+    });
+
+    it('disables state changes for sales channel viewers', async () => {
+        global.activeAclRoles = ['sales_channel.viewer'];
+        const { wrapper } = await createWrapper();
+
+        await flushPromises();
+
+        expect(wrapper.findAll('.sw-context-menu-item').at(1).attributes('disabled')).toBeDefined();
     });
 
     it('keeps the description column flexible', async () => {

--- a/src/Core/System/SalesChannel/File/Api/SalesChannelFileController.php
+++ b/src/Core/System/SalesChannel/File/Api/SalesChannelFileController.php
@@ -32,7 +32,7 @@ class SalesChannelFileController extends AbstractController
     ) {
     }
 
-    #[Route(path: '/api/_action/sales-channel-file/{fileFamily}/{salesChannelId}', name: 'api.action.sales_channel_file.list', methods: ['GET'])]
+    #[Route(path: '/api/_action/sales-channel-file/{fileFamily}/{salesChannelId}', name: 'api.action.sales_channel_file.list', defaults: [PlatformRequest::ATTRIBUTE_ACL => ['sales_channel_file:read']], methods: ['GET'])]
     public function list(string $fileFamily, string $salesChannelId, Context $context): JsonResponse
     {
         $this->requestPathResolver->validateFileFamily($fileFamily);
@@ -42,7 +42,7 @@ class SalesChannelFileController extends AbstractController
 
     // The public file name supports subfolders like `.well-known/ucp.json`; keeping it
     // as a query parameter avoids a greedy wildcard path segment for an arbitrary file path.
-    #[Route(path: '/api/_action/sales-channel-file/{fileFamily}/{salesChannelId}/detail', name: 'api.action.sales_channel_file.detail', methods: ['GET'])]
+    #[Route(path: '/api/_action/sales-channel-file/{fileFamily}/{salesChannelId}/detail', name: 'api.action.sales_channel_file.detail', defaults: [PlatformRequest::ATTRIBUTE_ACL => ['sales_channel_file:read']], methods: ['GET'])]
     public function detail(string $fileFamily, string $salesChannelId, Request $request, Context $context): JsonResponse
     {
         $fileName = $request->query->get('fileName');

--- a/src/Core/System/SalesChannel/File/Api/SalesChannelFileController.php
+++ b/src/Core/System/SalesChannel/File/Api/SalesChannelFileController.php
@@ -60,8 +60,8 @@ class SalesChannelFileController extends AbstractController
         return new JsonResponse(['data' => $file]);
     }
 
-    #[Route(path: '/api/_action/sales-channel-file/{fileFamily}/{salesChannelId}/preview', name: 'api.action.sales_channel_file.preview', methods: ['POST'])]
-    public function preview(string $fileFamily, string $salesChannelId, RequestDataBag $dataBag): JsonResponse
+    #[Route(path: '/api/_action/sales-channel-file/{fileFamily}/{salesChannelId}/preview', name: 'api.action.sales_channel_file.preview', defaults: [PlatformRequest::ATTRIBUTE_ACL => ['sales_channel_file:read']], methods: ['POST'])]
+    public function preview(string $fileFamily, string $salesChannelId, RequestDataBag $dataBag, Context $context): JsonResponse
     {
         $fileName = $dataBag->get('fileName');
         if (!\is_string($fileName)) {
@@ -70,13 +70,16 @@ class SalesChannelFileController extends AbstractController
 
         $templatePath = $this->requestPathResolver->buildTemplatePath($fileFamily, $fileName);
 
-        $templateOverrides = $dataBag->get('templateOverrides') ?? [];
-        if ($templateOverrides instanceof RequestDataBag) {
-            $templateOverrides = $templateOverrides->all();
-        }
+        $templateOverrides = null;
+        if ($dataBag->has('templateOverrides') && $context->isAllowed('sales_channel_file:update')) {
+            $templateOverrides = $dataBag->get('templateOverrides');
+            if ($templateOverrides instanceof RequestDataBag) {
+                $templateOverrides = $templateOverrides->all();
+            }
 
-        if (!\is_array($templateOverrides)) {
-            throw SalesChannelException::invalidSalesChannelFileTemplateOverrides();
+            if (!\is_array($templateOverrides)) {
+                throw SalesChannelException::invalidSalesChannelFileTemplateOverrides();
+            }
         }
 
         $salesChannelContext = $this->salesChannelContextFactory->create(Uuid::randomHex(), $salesChannelId);

--- a/src/Core/System/SalesChannel/File/Loader/SalesChannelFileLoader.php
+++ b/src/Core/System/SalesChannel/File/Loader/SalesChannelFileLoader.php
@@ -53,13 +53,23 @@ class SalesChannelFileLoader
     }
 
     /**
-     * @param array<string, mixed> $templateOverrides
+     * @param array<string, mixed>|null $templateOverrides
      */
-    public function preview(string $templatePath, SalesChannelContext $context, array $templateOverrides): ?SalesChannelFileRenderResult
+    public function preview(string $templatePath, SalesChannelContext $context, ?array $templateOverrides = null): ?SalesChannelFileRenderResult
     {
         $file = $this->discovery->get($templatePath);
         if ($file === null) {
             return null;
+        }
+
+        if ($templateOverrides === null) {
+            $configuration = $this->configurationLoader->load(
+                $file->fileFamily,
+                $file->fileName,
+                $context->getSalesChannelId(),
+                $context->getContext(),
+            );
+            $templateOverrides = $configuration?->getTemplateOverrides() ?? [];
         }
 
         return new SalesChannelFileRenderResult(

--- a/tests/integration/Core/System/SalesChannel/File/Api/SalesChannelFileControllerTest.php
+++ b/tests/integration/Core/System/SalesChannel/File/Api/SalesChannelFileControllerTest.php
@@ -123,6 +123,51 @@ class SalesChannelFileControllerTest extends TestCase
         static::assertSame('Preview body', $response['content']);
     }
 
+    public function testItUsesStoredOverridesForReadOnlyPreviewRequests(): void
+    {
+        $this->getSalesChannelFileRepository()->upsert([
+            [
+                'id' => Uuid::randomHex(),
+                'salesChannelId' => TestDefaults::SALES_CHANNEL,
+                'fileFamily' => 'agentic',
+                'fileName' => 'llms.txt',
+                'enabled' => true,
+                'templateOverrides' => ['Framework' => 'Stored preview'],
+            ],
+        ], Context::createDefaultContext());
+
+        $browser = $this->getBrowser(true, [], ['sales_channel_file:read']);
+        $browser->jsonRequest('POST', '/api/_action/sales-channel-file/agentic/' . TestDefaults::SALES_CHANNEL . '/preview', [
+            'fileName' => 'llms.txt',
+            'templateOverrides' => ['Framework' => 'Ignored preview'],
+        ]);
+
+        static::assertSame(Response::HTTP_OK, $browser->getResponse()->getStatusCode(), (string) $browser->getResponse()->getContent());
+        static::assertSame('Stored preview', $this->decodeResponse()['content']);
+    }
+
+    public function testItUsesSuppliedOverridesForSalesChannelFileEditors(): void
+    {
+        $browser = $this->getBrowser(true, [], ['sales_channel_file:read', 'sales_channel_file:update']);
+        $browser->jsonRequest('POST', '/api/_action/sales-channel-file/agentic/' . TestDefaults::SALES_CHANNEL . '/preview', [
+            'fileName' => 'llms.txt',
+            'templateOverrides' => ['Framework' => 'Editor preview'],
+        ]);
+
+        static::assertSame(Response::HTTP_OK, $browser->getResponse()->getStatusCode(), (string) $browser->getResponse()->getContent());
+        static::assertSame('Editor preview', $this->decodeResponse()['content']);
+    }
+
+    public function testItRequiresSalesChannelFileReadAccessForPreviews(): void
+    {
+        $browser = $this->getBrowser(true, [], []);
+        $browser->jsonRequest('POST', '/api/_action/sales-channel-file/agentic/' . TestDefaults::SALES_CHANNEL . '/preview', [
+            'fileName' => 'llms.txt',
+        ]);
+
+        static::assertSame(Response::HTTP_FORBIDDEN, $browser->getResponse()->getStatusCode(), (string) $browser->getResponse()->getContent());
+    }
+
     public function testItRejectsInvalidPreviewPath(): void
     {
         $this->getBrowser()->jsonRequest('POST', '/api/_action/sales-channel-file/agentic/' . TestDefaults::SALES_CHANNEL . '/preview', [

--- a/tests/integration/Core/System/SalesChannel/File/Api/SalesChannelFileControllerTest.php
+++ b/tests/integration/Core/System/SalesChannel/File/Api/SalesChannelFileControllerTest.php
@@ -168,6 +168,22 @@ class SalesChannelFileControllerTest extends TestCase
         static::assertSame(Response::HTTP_FORBIDDEN, $browser->getResponse()->getStatusCode(), (string) $browser->getResponse()->getContent());
     }
 
+    public function testItRequiresSalesChannelFileReadAccessForLists(): void
+    {
+        $browser = $this->getBrowser(true, [], []);
+        $browser->request('GET', '/api/_action/sales-channel-file/agentic/' . TestDefaults::SALES_CHANNEL);
+
+        static::assertSame(Response::HTTP_FORBIDDEN, $browser->getResponse()->getStatusCode(), (string) $browser->getResponse()->getContent());
+    }
+
+    public function testItRequiresSalesChannelFileReadAccessForDetails(): void
+    {
+        $browser = $this->getBrowser(true, [], []);
+        $browser->request('GET', '/api/_action/sales-channel-file/agentic/' . TestDefaults::SALES_CHANNEL . '/detail?fileName=llms.txt');
+
+        static::assertSame(Response::HTTP_FORBIDDEN, $browser->getResponse()->getStatusCode(), (string) $browser->getResponse()->getContent());
+    }
+
     public function testItRejectsInvalidPreviewPath(): void
     {
         $this->getBrowser()->jsonRequest('POST', '/api/_action/sales-channel-file/agentic/' . TestDefaults::SALES_CHANNEL . '/preview', [

--- a/tests/unit/Core/System/SalesChannel/File/Api/SalesChannelFileControllerTest.php
+++ b/tests/unit/Core/System/SalesChannel/File/Api/SalesChannelFileControllerTest.php
@@ -156,7 +156,7 @@ class SalesChannelFileControllerTest extends TestCase
             'templateOverrides' => new RequestDataBag([
                 'Framework' => 'Unsaved override',
             ]),
-        ]));
+        ]), Context::createDefaultContext());
 
         static::assertSame(200, $response->getStatusCode());
         static::assertSame([

--- a/tests/unit/Core/System/SalesChannel/File/Loader/SalesChannelFileLoaderTest.php
+++ b/tests/unit/Core/System/SalesChannel/File/Loader/SalesChannelFileLoaderTest.php
@@ -24,6 +24,47 @@ use Shopware\Core\System\SalesChannel\SalesChannelContext;
 #[CoversClass(SalesChannelFileLoader::class)]
 class SalesChannelFileLoaderTest extends TestCase
 {
+    public function testItPreviewsStoredTemplateOverridesWhenNoneAreSupplied(): void
+    {
+        $templatePath = 'files/agentic/llms.txt.twig';
+        $salesChannelId = Uuid::randomHex();
+        $context = Context::createDefaultContext();
+        $file = new SalesChannelFile('agentic', 'llms.txt', $templatePath, 'text/plain; charset=utf-8', $templatePath, []);
+        $configuration = new SalesChannelFileEntity();
+        $configuration->setTemplateOverrides(['Framework' => 'stored override']);
+
+        $discovery = $this->createMock(SalesChannelFileDiscovery::class);
+        $discovery->expects($this->once())->method('get')->with($templatePath)->willReturn($file);
+
+        $configurationLoader = $this->createMock(SalesChannelFileConfigurationLoader::class);
+        $configurationLoader
+            ->expects($this->once())
+            ->method('load')
+            ->with('agentic', 'llms.txt', $salesChannelId, $context)
+            ->willReturn($configuration);
+
+        $renderer = $this->createMock(SalesChannelFileRenderer::class);
+        $renderer
+            ->expects($this->once())
+            ->method('render')
+            ->with($file, static::isInstanceOf(SalesChannelContext::class), ['Framework' => 'stored override'])
+            ->willReturn('rendered content');
+
+        $salesChannelContext = static::createStub(SalesChannelContext::class);
+        $salesChannelContext->method('getSalesChannelId')->willReturn($salesChannelId);
+        $salesChannelContext->method('getContext')->willReturn($context);
+
+        $result = (new SalesChannelFileLoader(
+            $discovery,
+            $configurationLoader,
+            $renderer,
+            static::createStub(CacheTagCollector::class),
+        ))->preview($templatePath, $salesChannelContext);
+
+        static::assertNotNull($result);
+        static::assertSame('rendered content', $result->content);
+    }
+
     public function testItTagsRenderedFilesWithSalesChannelFileConfigurationId(): void
     {
         $templatePath = 'files/agentic/llms.txt.twig';


### PR DESCRIPTION
### 1. Why is this change necessary?

The sales-channel-file list, detail and preview APIs exposed their data without enforcing the corresponding read privilege. The preview route also accepted unsaved template overrides without update access, and Administration viewer-role users could edit staged configuration.

### 2. What does this change do, exactly?

Requires `sales_channel_file:read` for every sales-channel-file list, detail and preview route. A user with only read access previews stored overrides; unsaved request overrides are accepted only with update access. The Administration sends overrides only when changed and disables file mutations for `sales_channel.editor`-less users.

### 3. Describe each step to reproduce the issue or behaviour.

1. Grant a user no `sales_channel_file:read` privilege.
2. Request the sales-channel-file list, detail or preview API route.
3. Before this change, the routes are available to any authenticated backend user.
4. After this change, each route responds with 403. A read-only user can still preview saved content, but cannot supply unsaved overrides.

This is how the UI now looks like for SalesChannelViewer:
https://www.loom.com/share/2d545d094a3246e3b1353738a5bd3710

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them