### PR TITLE
fix(administration): clean up order versions on pagehide

### DIFF
--- a/changelog/_unreleased/2026-08-31-clean-up-order-versions-on-pagehide.md
+++ b/changelog/_unreleased/2026-08-31-clean-up-order-versions-on-pagehide.md
@@ -1,0 +1,6 @@
+---
+title: Clean up order versions when leaving the order detail page
+issue: 18961
+---
+# Administration
+* Changed the order detail page to delete its draft version with a keepalive request when the page is unloaded.

--- a/src/Administration/Resources/app/administration/src/core/data/repository.data.spec.js
+++ b/src/Administration/Resources/app/administration/src/core/data/repository.data.spec.js
@@ -41,8 +41,16 @@ function createRepositoryData() {
 }
 
 describe('repository.data.ts', () => {
+    const originalFetch = global.fetch;
+    const originalBaseUrl = global.repositoryFactoryMock.httpClient.defaults.baseURL;
+
     beforeEach(async () => {
         clientMock.resetHistory();
+    });
+
+    afterEach(() => {
+        global.fetch = originalFetch;
+        global.repositoryFactoryMock.httpClient.defaults.baseURL = originalBaseUrl;
     });
 
     it('should search with the criteria title', async () => {
@@ -114,6 +122,49 @@ describe('repository.data.ts', () => {
         };
 
         expect(actualHeaders).toEqual(exptectedHeaders);
+    });
+
+    it('should delete a version with a keepalive request', async () => {
+        global.fetch = jest.fn(() => Promise.resolve());
+        const repository = repositoryFactory.create('order');
+        repository.httpClient.defaults.baseURL = 'http://shopware.local/api';
+        const context = {
+            ...mockContext(),
+            versionId: 'version-id',
+        };
+
+        await repository.deleteVersionWithKeepalive('order-id', 'version-id', context);
+
+        expect(global.fetch).toHaveBeenCalledWith('http://shopware.local/api/_action/version/version-id/order/order-id', {
+            method: 'POST',
+            headers: {
+                Accept: 'application/vnd.api+json',
+                Authorization: 'Bearer BwP_OL47uNW6k8iQzChh6SxE31XaleO_l4unyLNmFco',
+                'Content-Type': 'application/json',
+                'sw-api-compatibility': 'true',
+                'sw-currency-id': '7924299acc9641bfb8237a06e5aa0fa4',
+                'sw-language-id': '2fbb5fe2e29a4d70aa5854ce7ce3e20b',
+                'sw-version-id': 'version-id',
+            },
+            body: '{}',
+            keepalive: true,
+        });
+    });
+
+    it('should fall back to the HTTP client when fetch is unavailable', async () => {
+        global.fetch = undefined;
+        const repository = repositoryFactory.create('order');
+        responses.addResponse({
+            method: 'POST',
+            url: '/_action/version/version-id/order/order-id',
+            status: 200,
+            response: {},
+        });
+
+        await repository.deleteVersionWithKeepalive('order-id', 'version-id', mockContext());
+
+        expect(clientMock.history.post).toHaveLength(1);
+        expect(clientMock.history.post[0].url).toBe('/_action/version/version-id/order/order-id');
     });
 
     it('should create one delete operation for multiple deletes', async () => {

--- a/src/Administration/Resources/app/administration/src/core/data/repository.data.ts
+++ b/src/Administration/Resources/app/administration/src/core/data/repository.data.ts
@@ -584,6 +584,39 @@ export default class Repository<EntityName extends keyof EntitySchema.Entities> 
     }
 
     /**
+     * Deletes the provided version with a request the browser can continue while the page is unloading.
+     */
+    deleteVersionWithKeepalive(
+        entityId: string,
+        versionId: string,
+        context = Shopware.Context.api,
+    ): Promise<Response | AxiosResponse> {
+        if (typeof fetch !== 'function') {
+            return this.deleteVersion(entityId, versionId, context);
+        }
+
+        const headers = Object.fromEntries(
+            Object.entries(this.buildHeaders(context)).map(
+                ([
+                    name,
+                    value,
+                ]) => [
+                    name,
+                    String(value),
+                ],
+            ),
+        );
+        const url = `/_action/version/${versionId}/${this.entityName.replace(/_/g, '-')}/${entityId}`;
+
+        return fetch(this.httpClient.getUri({ url }), {
+            method: 'POST',
+            headers,
+            body: JSON.stringify({}),
+            keepalive: true,
+        });
+    }
+
+    /**
      * @private
      */
     sendChanges(

--- a/src/Administration/Resources/app/administration/src/core/data/repository.data.ts
+++ b/src/Administration/Resources/app/administration/src/core/data/repository.data.ts
@@ -597,13 +597,7 @@ export default class Repository<EntityName extends keyof EntitySchema.Entities> 
 
         const headers = Object.fromEntries(
             Object.entries(this.buildHeaders(context)).map(
-                ([
-                    name,
-                    value,
-                ]) => [
-                    name,
-                    String(value),
-                ],
+                ([name, value]) => [name, String(value)],
             ),
         );
         const url = `/_action/version/${versionId}/${this.entityName.replace(/_/g, '-')}/${entityId}`;

--- a/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-detail/index.js
@@ -237,10 +237,10 @@ export default {
                 return;
             }
 
-            this.beforeDestroyComponent(true).catch(() => {});
+            this.beforeDestroyComponent(true);
         },
 
-        async beforeDestroyComponent(useKeepalive = false) {
+        beforeDestroyComponent(useKeepalive = false) {
             State.commit('swOrderDetail/setOrderAddressIds', null);
 
             if (this.hasNewVersionId) {
@@ -255,7 +255,7 @@ export default {
                         authToken: Shopware.Context.api.authToken ?? oldVersionContext.authToken,
                     };
 
-                    await this.orderRepository.deleteVersionWithKeepalive(
+                    this.orderRepository.deleteVersionWithKeepalive(
                         this.orderId,
                         oldVersionContext.versionId,
                         keepaliveContext,
@@ -264,7 +264,7 @@ export default {
                     return;
                 }
 
-                await this.orderRepository.deleteVersion(this.orderId, oldVersionContext.versionId, oldVersionContext);
+                this.orderRepository.deleteVersion(this.orderId, oldVersionContext.versionId, oldVersionContext);
             }
         },
 

--- a/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-detail/index.js
@@ -197,6 +197,8 @@ export default {
     },
 
     beforeUnmount() {
+        window.removeEventListener('pagehide', this.onPageHide);
+
         this.beforeDestroyComponent();
 
         State.unregisterModule('swOrderDetail');
@@ -223,14 +225,22 @@ export default {
                 scope: this,
             });
 
-            window.addEventListener('beforeunload', this.beforeDestroyComponent);
+            window.addEventListener('pagehide', this.onPageHide);
 
             Shopware.State.commit('shopwareApps/setSelectedIds', this.orderId ? [this.orderId] : []);
 
             this.createNewVersionId();
         },
 
-        async beforeDestroyComponent() {
+        onPageHide(event) {
+            if (event.persisted) {
+                return;
+            }
+
+            this.beforeDestroyComponent(true).catch(() => {});
+        },
+
+        async beforeDestroyComponent(useKeepalive = false) {
             State.commit('swOrderDetail/setOrderAddressIds', null);
 
             if (this.hasNewVersionId) {
@@ -239,6 +249,21 @@ export default {
                 this.hasNewVersionId = false;
 
                 // clean up recently created version
+                if (useKeepalive) {
+                    const keepaliveContext = {
+                        ...oldVersionContext,
+                        authToken: Shopware.Context.api.authToken ?? oldVersionContext.authToken,
+                    };
+
+                    await this.orderRepository.deleteVersionWithKeepalive(
+                        this.orderId,
+                        oldVersionContext.versionId,
+                        keepaliveContext,
+                    );
+
+                    return;
+                }
+
                 await this.orderRepository.deleteVersion(this.orderId, oldVersionContext.versionId, oldVersionContext);
             }
         },

--- a/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-detail/sw-order-detail.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-detail/sw-order-detail.spec.js
@@ -71,6 +71,7 @@ async function createWrapper(order = {}) {
                         search: () => Promise.resolve([]),
                         hasChanges: () => false,
                         deleteVersion: () => Promise.resolve([]),
+                        deleteVersionWithKeepalive: () => Promise.resolve(),
                         createVersion: () => Promise.resolve({ versionId: 'newVersionId' }),
                         get: () => Promise.resolve(order),
                         save: () => Promise.resolve({}),
@@ -87,27 +88,63 @@ async function createWrapper(order = {}) {
 
 describe('src/module/sw-order/page/sw-order-detail', () => {
     let wrapper;
+    let originalAuthToken;
+
+    beforeEach(() => {
+        originalAuthToken = Shopware.Context.api.authToken;
+    });
+
+    afterEach(() => {
+        if (wrapper) {
+            window.removeEventListener('pagehide', wrapper.vm.onPageHide);
+        }
+
+        Shopware.State.commit('context/setApiAuthToken', originalAuthToken);
+    });
 
     it('should be a Vue.js component', async () => {
         wrapper = await createWrapper();
         expect(wrapper.vm).toBeTruthy();
     });
 
-    it('should remove version id when beforeunload event is triggered', async () => {
+    it('should remove version id with a keepalive request when pagehide is triggered', async () => {
         wrapper = await createWrapper();
         wrapper.vm.orderRepository.deleteVersion = jest.fn(() => Promise.resolve());
+        wrapper.vm.orderRepository.deleteVersionWithKeepalive = jest.fn(() => Promise.resolve());
 
         const oldVersionContext = wrapper.vm.versionContext;
+        const refreshedAuthToken = {
+            access: 'refreshed-access-token',
+            expiry: Date.now() + 60000,
+            refresh: 'refresh-token',
+        };
+        Shopware.State.commit('context/setApiAuthToken', refreshedAuthToken);
 
-        window.dispatchEvent(new Event('beforeunload'));
+        window.dispatchEvent(new Event('pagehide'));
 
-        expect(wrapper.vm.orderRepository.deleteVersion).toHaveBeenCalledWith(
+        expect(wrapper.vm.orderRepository.deleteVersionWithKeepalive).toHaveBeenCalledWith(
             wrapper.vm.orderId,
             oldVersionContext.versionId,
-            oldVersionContext,
+            {
+                ...oldVersionContext,
+                authToken: refreshedAuthToken,
+            },
         );
+        expect(wrapper.vm.orderRepository.deleteVersion).not.toHaveBeenCalled();
         expect(wrapper.vm.versionContext).toBe(Shopware.Context.api);
         expect(wrapper.vm.hasNewVersionId).toBe(false);
+    });
+
+    it('should keep the version when the page is stored in the back-forward cache', async () => {
+        wrapper = await createWrapper();
+        wrapper.vm.orderRepository.deleteVersionWithKeepalive = jest.fn(() => Promise.resolve());
+
+        const pageHideEvent = new Event('pagehide');
+        Object.defineProperty(pageHideEvent, 'persisted', { value: true });
+        window.dispatchEvent(pageHideEvent);
+
+        expect(wrapper.vm.orderRepository.deleteVersionWithKeepalive).not.toHaveBeenCalled();
+        expect(wrapper.vm.hasNewVersionId).toBe(true);
     });
 
     it('should not contain manual label', async () => {

--- a/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-detail/sw-order-detail.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-detail/sw-order-detail.spec.js
@@ -193,7 +193,7 @@ describe('src/module/sw-order/page/sw-order-detail', () => {
         await wrapper.vm.createNewVersionId();
         wrapper.vm.orderRepository.deleteVersion = jest.fn(() => Promise.resolve());
 
-        await wrapper.vm.beforeDestroyComponent();
+        wrapper.vm.beforeDestroyComponent();
 
         expect(wrapper.vm.orderRepository.deleteVersion).toHaveBeenCalled();
     });
@@ -207,7 +207,7 @@ describe('src/module/sw-order/page/sw-order-detail', () => {
             type: 'billing',
         });
 
-        await wrapper.vm.beforeDestroyComponent();
+        wrapper.vm.beforeDestroyComponent();
 
         expect(Shopware.State.get('swOrderDetail').orderAddressIds).toEqual([]);
     });


### PR DESCRIPTION
### 1. Why is this change necessary?

Reloading or leaving the order detail page can cancel version cleanup and leave unused order drafts behind.

### 2. What does this change do, exactly?

Uses pagehide and a keepalive request to delete the version created by the current page. Adds regression tests.

### 3. Describe each step to reproduce the issue or behaviour.

Open an order detail page and reload it repeatedly.

### 4. Please link to the relevant issues (if any).

- closes #18961

### 5. Checklist

- [x] Tests added
- [x] Changelog added