### PR TITLE
fix(storefront): block the buy button while the product is added

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -228,6 +228,12 @@ lineItem.payload.features[].value = { id, type, content, display }
 
 `display` holds a list of resolved option or entity labels for `select` and `entity`, and the price of the current currency and tax state as a float for `price`. It is only present on line items built after the update, so templates overriding `component/product/feature/types/feature-custom-field.html.twig` must treat it as optional. A characteristic that cannot be resolved is dropped from the payload, and `component/product/feature/item.html.twig` no longer emits an empty list item for a characteristic its template renders nothing for.
 
+### The buy button shows a loading indicator while the product is added
+
+`AddToCartPlugin` puts a loading indicator on the buy button when the form is submitted and removes it once the off-canvas cart has opened or the request is through. The button is disabled in the meantime, so a second click can no longer add the product a second time.
+
+The button is looked up with the plugin's existing `buyButtonSelector` option, which defaults to `button[type="submit"].btn-buy`. The new `loadingIndicatorPosition` option (`before`, `after` or `inner`, default `inner`) controls where the indicator is rendered. A buy button that does not match `buyButtonSelector` is left untouched.
+
 # 6.7.14.0
 
 ## Features

--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -234,6 +234,8 @@ lineItem.payload.features[].value = { id, type, content, display }
 
 The button is looked up with the plugin's existing `buyButtonSelector` option, which defaults to `button[type="submit"].btn-buy`. The new `loadingIndicatorPosition` option (`before`, `after` or `inner`, default `inner`) controls where the indicator is rendered. A buy button that does not match `buyButtonSelector` is left untouched.
 
+Dispatching a `removeLoader` event on the form removes the indicator and re-enables the button, the same as with `FormHandler` and `FormSubmitLoader`. Use it when your own code needs to release the button before the request is through; `removeLoadingIndicator()` on the plugin instance does the same.
+
 # 6.7.14.0
 
 ## Features

--- a/src/Storefront/Resources/app/storefront/src/plugin/add-to-cart/add-to-cart.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/add-to-cart/add-to-cart.plugin.js
@@ -78,6 +78,7 @@ export default class AddToCartPlugin extends Plugin {
 
     _registerEvents() {
         this.el.addEventListener('submit', this._formSubmit.bind(this));
+        this._form.addEventListener('removeLoader', this.removeLoadingIndicator.bind(this));
         this._form.addEventListener('QuantitySelector/StockAdjusted', this._handleStockAdjusted.bind(this));
         this._form.addEventListener('QuantitySelector/OutOfStock', this._handleOutOfStock.bind(this));
     }
@@ -133,7 +134,7 @@ export default class AddToCartPlugin extends Plugin {
             method: 'POST',
             body: formData,
         }).then((response) => {
-            this._removeLoadingIndicator();
+            this.removeLoadingIndicator();
 
             if (!response.ok) {
                 throw new Error('Add to cart failed');
@@ -192,7 +193,7 @@ export default class AddToCartPlugin extends Plugin {
         const offCanvasCartInstances = window.PluginManager.getPluginInstances('OffCanvasCart');
 
         if (!offCanvasCartInstances.length) {
-            this._removeLoadingIndicator();
+            this.removeLoadingIndicator();
 
             return;
         }
@@ -211,7 +212,7 @@ export default class AddToCartPlugin extends Plugin {
      */
     _openOffCanvasCart(instance, requestUrl, formData) {
         instance.openOffCanvas(requestUrl, formData, () => {
-            this._removeLoadingIndicator();
+            this.removeLoadingIndicator();
             this.$emitter.publish('openOffCanvasCart');
         });
     }
@@ -235,10 +236,9 @@ export default class AddToCartPlugin extends Plugin {
 
     /**
      * Removes the loading indicator from the buy button and enables it again.
-     *
-     * @private
+     * Can be called directly on this plugin instance or via event `removeLoader`.
      */
-    _removeLoadingIndicator() {
+    removeLoadingIndicator() {
         if (!this._buyButtonLoader) {
             return;
         }

--- a/src/Storefront/Resources/app/storefront/src/plugin/add-to-cart/add-to-cart.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/add-to-cart/add-to-cart.plugin.js
@@ -4,6 +4,7 @@
 
 import Plugin from 'src/plugin-system/plugin.class';
 import FormSerializeUtil from 'src/utility/form/form-serialize.util';
+import ButtonLoadingIndicator from 'src/utility/loading-indicator/button-loading-indicator.util';
 
 /**
  * @package checkout
@@ -21,6 +22,11 @@ export default class AddToCartPlugin extends Plugin {
         stockAdjustedText: null,
         outOfStockText: null,
         buyButtonSelector: 'button[type="submit"].btn-buy',
+
+        /**
+         * @type {'before' | 'after' | 'inner'} loadingIndicatorPosition
+         */
+        loadingIndicatorPosition: 'inner',
     };
 
     init() {
@@ -29,6 +35,8 @@ export default class AddToCartPlugin extends Plugin {
         if (!this._form) {
             throw new Error(`No form found for the plugin: ${this.constructor.name}`);
         }
+
+        this._buyButtonLoader = null;
 
         this._prepareFormRedirect();
 
@@ -91,6 +99,8 @@ export default class AddToCartPlugin extends Plugin {
         const requestUrl = this._form.getAttribute('action');
         const formData = FormSerializeUtil.serialize(this._form);
 
+        this._createLoadingIndicator();
+
         this.$emitter.publish('beforeFormSubmit', formData);
 
         if (this._shouldOpenOffcanvas()) {
@@ -126,6 +136,8 @@ export default class AddToCartPlugin extends Plugin {
             if (!response.ok) {
                 throw new Error('Add to cart failed');
             }
+
+            this._removeLoadingIndicator();
 
             // Update the cart widget to show the new item count
             window.PluginManager.getPluginInstances('CartWidget')?.forEach((instance) => {
@@ -178,9 +190,16 @@ export default class AddToCartPlugin extends Plugin {
      */
     _openOffCanvasCarts(requestUrl, formData) {
         const offCanvasCartInstances = window.PluginManager.getPluginInstances('OffCanvasCart');
+        let opened = false;
+
         offCanvasCartInstances.forEach((instance) => {
+            opened = true;
             this._openOffCanvasCart(instance, requestUrl, formData);
         });
+
+        if (!opened) {
+            this._removeLoadingIndicator();
+        }
     }
 
     /**
@@ -192,8 +211,40 @@ export default class AddToCartPlugin extends Plugin {
      */
     _openOffCanvasCart(instance, requestUrl, formData) {
         instance.openOffCanvas(requestUrl, formData, () => {
+            this._removeLoadingIndicator();
             this.$emitter.publish('openOffCanvasCart');
         });
+    }
+
+    /**
+     * Shows a loading indicator inside the buy button, which disables the button
+     * until the running request is through.
+     *
+     * @private
+     */
+    _createLoadingIndicator() {
+        const buyButton = this._form.querySelector(this.options.buyButtonSelector);
+
+        if (!buyButton) {
+            return;
+        }
+
+        this._buyButtonLoader = new ButtonLoadingIndicator(buyButton, this.options.loadingIndicatorPosition);
+        this._buyButtonLoader.create();
+    }
+
+    /**
+     * Removes the loading indicator from the buy button and enables it again.
+     *
+     * @private
+     */
+    _removeLoadingIndicator() {
+        if (!this._buyButtonLoader) {
+            return;
+        }
+
+        this._buyButtonLoader.remove();
+        this._buyButtonLoader = null;
     }
 
     /**

--- a/src/Storefront/Resources/app/storefront/src/plugin/add-to-cart/add-to-cart.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/add-to-cart/add-to-cart.plugin.js
@@ -133,11 +133,11 @@ export default class AddToCartPlugin extends Plugin {
             method: 'POST',
             body: formData,
         }).then((response) => {
+            this._removeLoadingIndicator();
+
             if (!response.ok) {
                 throw new Error('Add to cart failed');
             }
-
-            this._removeLoadingIndicator();
 
             // Update the cart widget to show the new item count
             window.PluginManager.getPluginInstances('CartWidget')?.forEach((instance) => {
@@ -190,16 +190,16 @@ export default class AddToCartPlugin extends Plugin {
      */
     _openOffCanvasCarts(requestUrl, formData) {
         const offCanvasCartInstances = window.PluginManager.getPluginInstances('OffCanvasCart');
-        let opened = false;
+
+        if (!offCanvasCartInstances.length) {
+            this._removeLoadingIndicator();
+
+            return;
+        }
 
         offCanvasCartInstances.forEach((instance) => {
-            opened = true;
             this._openOffCanvasCart(instance, requestUrl, formData);
         });
-
-        if (!opened) {
-            this._removeLoadingIndicator();
-        }
     }
 
     /**

--- a/src/Storefront/Resources/app/storefront/test/plugin/add-to-cart/add-to-cart.plugin.test.js
+++ b/src/Storefront/Resources/app/storefront/test/plugin/add-to-cart/add-to-cart.plugin.test.js
@@ -344,6 +344,21 @@ describe('AddToCartPlugin tests', () => {
         expect(button.disabled).toBe(false);
     });
 
+    test('should enable the buy button again when the add to cart request fails', async () => {
+        window.openOffcanvasAfterAddToCart = '0';
+        global.fetch = jest.fn(() => Promise.resolve({ ok: false }));
+
+        const neverOpeningOffCanvas = { openOffCanvas: jest.fn() };
+        window.PluginManager.getPluginInstances = jest.fn(() => [neverOpeningOffCanvas]);
+
+        const button = document.querySelector('button');
+        button.click();
+
+        await Promise.resolve();
+
+        expect(button.disabled).toBe(false);
+    });
+
     test('should enable the buy button again when no offcanvas cart is present', () => {
         window.openOffcanvasAfterAddToCart = '1';
         window.PluginManager.getPluginInstances = jest.fn(() => []);

--- a/src/Storefront/Resources/app/storefront/test/plugin/add-to-cart/add-to-cart.plugin.test.js
+++ b/src/Storefront/Resources/app/storefront/test/plugin/add-to-cart/add-to-cart.plugin.test.js
@@ -359,6 +359,26 @@ describe('AddToCartPlugin tests', () => {
         expect(button.disabled).toBe(false);
     });
 
+    test('should enable the buy button again on the removeLoader event', () => {
+        window.openOffcanvasAfterAddToCart = '1';
+
+        const neverOpeningOffCanvas = { openOffCanvas: jest.fn() };
+        window.PluginManager.getPluginInstances = jest.fn(() => [neverOpeningOffCanvas]);
+
+        const form = document.querySelector('form');
+        const button = document.querySelector('button');
+        const buttonLabel = button.innerHTML;
+
+        button.click();
+
+        expect(button.disabled).toBe(true);
+
+        form.dispatchEvent(new CustomEvent('removeLoader'));
+
+        expect(button.disabled).toBe(false);
+        expect(button.innerHTML).toBe(buttonLabel);
+    });
+
     test('should enable the buy button again when no offcanvas cart is present', () => {
         window.openOffcanvasAfterAddToCart = '1';
         window.PluginManager.getPluginInstances = jest.fn(() => []);

--- a/src/Storefront/Resources/app/storefront/test/plugin/add-to-cart/add-to-cart.plugin.test.js
+++ b/src/Storefront/Resources/app/storefront/test/plugin/add-to-cart/add-to-cart.plugin.test.js
@@ -297,4 +297,60 @@ describe('AddToCartPlugin tests', () => {
 
         expect(document.querySelector('.quantity-stock-adjusted-alert')).toBeNull();
     });
+
+    test('should disable the buy button until the offcanvas is opened', () => {
+        window.openOffcanvasAfterAddToCart = '1';
+
+        let openOffCanvasCallback;
+        window.PluginManager.getPluginInstances = jest.fn(() => [{
+            openOffCanvas: (url, data, callback) => {
+                openOffCanvasCallback = callback;
+            },
+        }]);
+
+        const button = document.querySelector('button');
+        button.click();
+
+        expect(button.disabled).toBe(true);
+
+        openOffCanvasCallback();
+
+        expect(button.disabled).toBe(false);
+    });
+
+    test('should ignore a second click while the add to cart request is running', () => {
+        window.openOffcanvasAfterAddToCart = '1';
+
+        const openOffCanvas = jest.fn();
+        window.PluginManager.getPluginInstances = jest.fn(() => [{ openOffCanvas }]);
+
+        const button = document.querySelector('button');
+        button.click();
+        button.click();
+
+        expect(openOffCanvas).toHaveBeenCalledTimes(1);
+    });
+
+    test('should enable the buy button again when adding to cart without offcanvas', async () => {
+        window.openOffcanvasAfterAddToCart = '0';
+
+        const button = document.querySelector('button');
+        button.click();
+
+        expect(button.disabled).toBe(true);
+
+        await Promise.resolve();
+
+        expect(button.disabled).toBe(false);
+    });
+
+    test('should enable the buy button again when no offcanvas cart is present', () => {
+        window.openOffcanvasAfterAddToCart = '1';
+        window.PluginManager.getPluginInstances = jest.fn(() => []);
+
+        const button = document.querySelector('button');
+        button.click();
+
+        expect(button.disabled).toBe(false);
+    });
 });


### PR DESCRIPTION
### 1. Why is this change necessary?

The buy button stays clickable while the add-to-cart request is running, so a double-click adds the product twice.

### 2. What does this change do, exactly?

`AddToCartPlugin` intercepts the submit and posts via `fetch` instead of letting the form navigate, which is why nothing ever blocked the button. It now puts the standard `ButtonLoadingIndicator` on the buy button when the form is submitted and takes it off again once the off-canvas cart has opened, or as soon as the response is back when the off-canvas is disabled. Disabling is what the indicator already does, so this reuses the mechanism the account and checkout forms use rather than adding a separate in-flight guard.

Releasing the button on the response rather than on success keeps a rejected add retryable straight away.

### 3. Describe each step to reproduce the issue or behaviour.

Open a product detail page and double-click "Add to shopping cart". Before, the cart holds the product twice; now the button greys out on the first click and the product is added once.

### 4. Please link to the relevant issues (if any).

relates #18312 — the "Subscribe now" button reported there lives in SwagCommercial and is fixed separately.

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them