### PR TITLE
fix(framework): stop env vars changed in a test from leaking into the container (backport: 6.6.x)

### DIFF
--- a/src/Core/Framework/Test/TestCaseBase/EnvTestBehaviour.php
+++ b/src/Core/Framework/Test/TestCaseBase/EnvTestBehaviour.php
@@ -16,6 +16,10 @@ trait EnvTestBehaviour
     /**
      * A null value removes the variable for the duration of the test.
      *
+     * Only code that reads the environment at runtime sees the change. A booted container keeps
+     * the values it resolved before, in its services and in its parameters alike, so boot a fresh
+     * kernel when the test needs the container to pick the change up.
+     *
      * @param array<string, string|int|bool|null> $envVars
      */
     public function setEnvVars(array $envVars): void
@@ -29,14 +33,24 @@ trait EnvTestBehaviour
         }
     }
 
+    /**
+     * Restores the environment and drops the kernel, so nothing the container resolved from the
+     * changed variables survives the test.
+     */
     #[After]
     public function resetEnvVars(): void
     {
+        if ($this->originalEnvVars === []) {
+            return;
+        }
+
         foreach ($this->originalEnvVars as $envVar => $value) {
             $this->applyEnvVar($envVar, $value);
         }
 
         $this->originalEnvVars = [];
+
+        KernelLifecycleManager::ensureKernelShutdown();
     }
 
     private function applyEnvVar(string $envVar, string|int|bool|null $value): void

--- a/tests/integration/Core/Framework/TestCaseBase/EnvTestBehaviourTest.php
+++ b/tests/integration/Core/Framework/TestCaseBase/EnvTestBehaviourTest.php
@@ -1,0 +1,34 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Integration\Core\Framework\TestCaseBase;
+
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\DevOps\Environment\EnvironmentHelper;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Test\TestCaseBase\EnvTestBehaviour;
+use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
+use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+class EnvTestBehaviourTest extends TestCase
+{
+    use EnvTestBehaviour;
+    use KernelTestBehaviour;
+
+    public function testResettingDropsAContainerThatResolvedTheChangedEnvVar(): void
+    {
+        $appUrl = (string) EnvironmentHelper::getVariable('APP_URL');
+
+        $this->setEnvVars(['APP_URL' => 'https://env-test-behaviour.test']);
+        KernelLifecycleManager::bootKernel();
+
+        static::assertSame('https://env-test-behaviour.test', static::getContainer()->getParameter('APP_URL'));
+
+        $this->resetEnvVars();
+
+        static::assertSame($appUrl, static::getContainer()->getParameter('APP_URL'));
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?

Manual backport of #19893, which is now merged. 6.6.x shares the same test container behaviour and `EnvTestBehaviour`, so an env var redirected in one test survives in the booted container and breaks unrelated tests later in the same randomly ordered process.

### 2. What does this change do, exactly?

Clean cherry-pick of the trunk commit, no adaptations were needed:

- `resetEnvVars()`, the `#[After]` hook, now drops the kernel, so a container that resolved a variable while it was redirected cannot outlive the test that redirected it.
- `setEnvVars()` now documents that a booted container keeps the values it resolved before; a test that needs the container to pick the change up boots a fresh kernel itself.
- Adds an integration test asserting the container parameter returns to its original value after the reset.

### 3. Describe each step to reproduce the issue or behaviour.

The named tests exist on this branch; only the testsuite name differs from trunk:

```
vendor/bin/phpunit --testsuite integration --order-by=default \
  --filter '(InfoControllerTest::testGetConfig$|AppRefundHandlerTest::testRefund$)'
```

`AppRefundHandlerTest::testRefund` fails on `source.url`. Swap the order and it passes.

### 4. Please link to the relevant issues (if any).

- relates #19893

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
