### PR TITLE
Add lock manager helper (#11302)

### DIFF
--- a/src/Core/Checkout/Cart/CartLocker.php
+++ b/src/Core/Checkout/Cart/CartLocker.php
@@ -2,9 +2,9 @@
 
 namespace Shopware\Core\Checkout\Cart;
 
+use Shopware\Core\Framework\Adapter\Lock\LockManager;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
-use Symfony\Component\Lock\LockFactory;
 
 /**
  * @internal
@@ -14,7 +14,7 @@ class CartLocker
 {
     private const LOCK_TTL = 5;
 
-    public function __construct(private readonly LockFactory $lockFactory)
+    public function __construct(private readonly LockManager $lockManager)
     {
     }
 
@@ -33,11 +33,11 @@ class CartLocker
         }
 
         $lockKey = $this->getLockKey($context->getToken());
-        $lock = $this->lockFactory->createLock($lockKey, self::LOCK_TTL);
-
-        if (!$lock->acquire()) {
-            throw CartException::cartLocked($context->getToken());
-        }
+        $lock = $this->lockManager->acquireOrThrow(
+            $lockKey,
+            fn (): never => throw CartException::cartLocked($context->getToken()),
+            ttl: self::LOCK_TTL,
+        );
 
         try {
             $context->setCartLock($lock);

--- a/src/Core/Checkout/Cart/CartLocker.php
+++ b/src/Core/Checkout/Cart/CartLocker.php
@@ -33,11 +33,8 @@ class CartLocker
         }
 
         $lockKey = $this->getLockKey($context->getToken());
-        $lock = $this->lockManager->acquireOrThrow(
-            $lockKey,
-            fn (): never => throw CartException::cartLocked($context->getToken()),
-            ttl: self::LOCK_TTL,
-        );
+        $lock = $this->lockManager->acquire($lockKey, ttl: self::LOCK_TTL)
+            ?? throw CartException::cartLocked($context->getToken());
 
         try {
             $context->setCartLock($lock);

--- a/src/Core/Checkout/DependencyInjection/cart.php
+++ b/src/Core/Checkout/DependencyInjection/cart.php
@@ -110,6 +110,7 @@ use Shopware\Core\Content\Product\Cart\ProductLineItemValidator;
 use Shopware\Core\Content\Product\ProductTypeRegistry;
 use Shopware\Core\Content\Product\SalesChannel\Price\ProductPriceCalculator;
 use Shopware\Core\Framework\Adapter\Cache\RedisConnectionFactory;
+use Shopware\Core\Framework\Adapter\Lock\LockManager;
 use Shopware\Core\Framework\Adapter\Redis\RedisConnectionProvider;
 use Shopware\Core\Framework\Adapter\Translation\Translator;
 use Shopware\Core\Framework\App\Checkout\Gateway\AppCheckoutGateway;
@@ -186,7 +187,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
     $services->set(CartLocker::class)
         ->args([
-            service('lock.factory'),
+            service(LockManager::class),
         ]);
 
     $services->set(CartSerializationCleaner::class)

--- a/src/Core/Checkout/DependencyInjection/promotion.php
+++ b/src/Core/Checkout/DependencyInjection/promotion.php
@@ -55,6 +55,7 @@ use Shopware\Core\Checkout\Promotion\Subscriber\PromotionIndividualCodeRedeemer;
 use Shopware\Core\Checkout\Promotion\Subscriber\Storefront\StorefrontCartSubscriber;
 use Shopware\Core\Checkout\Promotion\Util\PromotionCodeService;
 use Shopware\Core\Checkout\Promotion\Validator\PromotionValidator;
+use Shopware\Core\Framework\Adapter\Lock\LockManager;
 use Shopware\Core\Framework\DataAbstractionLayer\Dbal\Common\IteratorFactory;
 use Shopware\Core\Framework\Util\HtmlSanitizer;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
@@ -113,7 +114,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
     $services->set(PromotionRedemptionLocker::class)
         ->args([
-            service('lock.factory'),
+            service(LockManager::class),
         ])
         ->tag('kernel.event_subscriber');
 

--- a/src/Core/Checkout/Promotion/Cart/PromotionRedemptionLocker.php
+++ b/src/Core/Checkout/Promotion/Cart/PromotionRedemptionLocker.php
@@ -5,9 +5,9 @@ namespace Shopware\Core\Checkout\Promotion\Cart;
 use Shopware\Core\Checkout\Cart\Extension\CheckoutPlaceOrderExtension;
 use Shopware\Core\Checkout\Promotion\Cart\Extension\LockExtension;
 use Shopware\Core\Checkout\Promotion\PromotionException;
+use Shopware\Core\Framework\Adapter\Lock\LockManager;
 use Shopware\Core\Framework\Log\Package;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-use Symfony\Component\Lock\LockFactory;
 
 /**
  * @internal
@@ -17,7 +17,7 @@ class PromotionRedemptionLocker implements EventSubscriberInterface
 {
     private const LOCK_TTL = 5;
 
-    public function __construct(private readonly LockFactory $lockFactory)
+    public function __construct(private readonly LockManager $lockManager)
     {
     }
 
@@ -58,11 +58,12 @@ class PromotionRedemptionLocker implements EventSubscriberInterface
                 continue;
             }
 
-            $lock = $this->lockFactory->createLock($this->getLockKey($key), self::LOCK_TTL);
-
-            if (!$lock->acquire(true)) {
-                throw PromotionException::promotionUsageLocked($key);
-            }
+            $lock = $this->lockManager->acquireOrThrow(
+                $this->getLockKey($key),
+                fn (): never => throw PromotionException::promotionUsageLocked($key),
+                ttl: self::LOCK_TTL,
+                blocking: true,
+            );
 
             $locks[$key] = $lock;
         }

--- a/src/Core/Checkout/Promotion/Cart/PromotionRedemptionLocker.php
+++ b/src/Core/Checkout/Promotion/Cart/PromotionRedemptionLocker.php
@@ -58,12 +58,11 @@ class PromotionRedemptionLocker implements EventSubscriberInterface
                 continue;
             }
 
-            $lock = $this->lockManager->acquireOrThrow(
+            $lock = $this->lockManager->acquire(
                 $this->getLockKey($key),
-                fn (): never => throw PromotionException::promotionUsageLocked($key),
                 ttl: self::LOCK_TTL,
                 blocking: true,
-            );
+            ) ?? throw PromotionException::promotionUsageLocked($key);
 
             $locks[$key] = $lock;
         }

--- a/src/Core/Framework/Adapter/Cache/CacheClearer.php
+++ b/src/Core/Framework/Adapter/Cache/CacheClearer.php
@@ -7,13 +7,13 @@ use Psr\Log\LoggerInterface;
 use Shopware\Core\Framework\Adapter\AdapterException;
 use Shopware\Core\Framework\Adapter\Cache\Message\CleanupOldCacheFolders;
 use Shopware\Core\Framework\Adapter\Cache\ReverseProxy\AbstractReverseProxyGateway;
+use Shopware\Core\Framework\Adapter\Lock\LockManager;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Util\Hasher;
 use Symfony\Component\Cache\PruneableInterface;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\HttpKernel\CacheClearer\CacheClearerInterface;
-use Symfony\Component\Lock\LockFactory;
 use Symfony\Component\Messenger\MessageBusInterface;
 
 /**
@@ -42,7 +42,7 @@ class CacheClearer
         private readonly bool $reverseHttpCacheEnabled,
         private readonly MessageBusInterface $messageBus,
         private readonly LoggerInterface $logger,
-        private readonly LockFactory $lockFactory,
+        private readonly LockManager $lockManager,
     ) {
     }
 
@@ -179,18 +179,13 @@ class CacheClearer
      */
     private function lock(\Closure $closure, string $key, int $timeToLive, string $operation): void
     {
-        $lock = $this->lockFactory->createLock('cache-clearer::' . $key, $timeToLive);
-
-        // Non-blocking lock acquisition
-        if (!$lock->acquire(false)) {
-            throw AdapterException::cacheCleanerLocked($operation, $key);
-        }
-
-        try {
-            $closure();
-        } finally {
-            $lock->release();
-        }
+        $this->lockManager->executeLocked(
+            'cache-clearer::' . $key,
+            $closure,
+            fn (): never => throw AdapterException::cacheCleanerLocked($operation, $key),
+            ttl: $timeToLive,
+            blocking: false,
+        );
     }
 
     private function lockKeyForDir(string $dir): string

--- a/src/Core/Framework/Adapter/Cache/CacheClearer.php
+++ b/src/Core/Framework/Adapter/Cache/CacheClearer.php
@@ -179,7 +179,7 @@ class CacheClearer
      */
     private function lock(\Closure $closure, string $key, int $timeToLive, string $operation): void
     {
-        $this->lockManager->executeLocked(
+        $this->lockManager->runWithLock(
             'cache-clearer::' . $key,
             $closure,
             fn (): never => throw AdapterException::cacheCleanerLocked($operation, $key),

--- a/src/Core/Framework/Adapter/Lock/LockManager.php
+++ b/src/Core/Framework/Adapter/Lock/LockManager.php
@@ -1,0 +1,144 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\Adapter\Lock;
+
+use Shopware\Core\Framework\Log\Package;
+use Symfony\Component\Lock\Exception\LockAcquiringException;
+use Symfony\Component\Lock\Exception\LockConflictedException;
+use Symfony\Component\Lock\LockFactory;
+use Symfony\Component\Lock\LockInterface;
+
+/**
+ * Provides the common lock handling patterns used across the platform.
+ *
+ * Use executeLocked() when the protected work starts and ends in the same call. The manager owns
+ * the acquired lock and always releases it in a finally block. Use acquireOrThrow() when a failed
+ * acquisition maps to a domain exception, and acquire() when a nullable lock is part of the
+ * caller's normal control flow.
+ *
+ * @internal
+ */
+#[Package('framework')]
+class LockManager
+{
+    public function __construct(
+        private readonly LockFactory $lockFactory,
+        private readonly string $keyPrefix = '',
+    ) {
+    }
+
+    /**
+     * Acquires a lock, executes the callback and releases the lock afterwards.
+     *
+     * The failure callback keeps domain-specific fallback behavior and exceptions at the
+     * call site. When no TTL is provided, the lock is created without passing a TTL to Symfony so
+     * the component's default behavior is preserved exactly.
+     *
+     * Passing null for $blocking preserves Symfony's default acquire() call; pass true or false
+     * when the call site previously used an explicit mode.
+     *
+     * @template T
+     *
+     * @param \Closure(): T $callback
+     * @param \Closure(): T $onLockAcquisitionFailed
+     *
+     * @return T
+     */
+    public function executeLocked(
+        string $key,
+        \Closure $callback,
+        \Closure $onLockAcquisitionFailed,
+        ?float $ttl = null,
+        ?bool $blocking = null,
+        bool $catchAcquiringExceptions = false,
+    ): mixed {
+        $lock = $this->acquire($key, $ttl, $blocking, $catchAcquiringExceptions);
+
+        if ($lock === null) {
+            return $onLockAcquisitionFailed();
+        }
+
+        try {
+            return $callback();
+        } finally {
+            $lock->release();
+        }
+    }
+
+    /**
+     * Acquires a lock and returns it to the caller or executes the failure callback.
+     *
+     * The caller owns the returned lock and must release it. Use this method for workflows where
+     * failing to acquire the lock is exceptional, but the lock lifecycle cannot be represented by a
+     * single callback.
+     *
+     * Passing null for $blocking preserves Symfony's default acquire() call; pass true or false
+     * when the call site previously used an explicit mode.
+     *
+     * @param \Closure(): never $onLockAcquisitionFailed
+     */
+    public function acquireOrThrow(
+        string $key,
+        \Closure $onLockAcquisitionFailed,
+        ?float $ttl = null,
+        ?bool $blocking = null,
+        bool $catchAcquiringExceptions = false,
+    ): LockInterface {
+        $lock = $this->acquire($key, $ttl, $blocking, $catchAcquiringExceptions);
+
+        if ($lock !== null) {
+            return $lock;
+        }
+
+        return $onLockAcquisitionFailed();
+    }
+
+    /**
+     * Acquires a lock and returns it to the caller.
+     *
+     * The caller owns the returned lock and must release it. This method is intended for workflows
+     * where a missing lock is part of the normal control flow.
+     *
+     * Passing null for $blocking preserves Symfony's default acquire() call; pass true or false
+     * when the call site previously used an explicit mode. When $catchAcquiringExceptions is true,
+     * Symfony lock acquisition exceptions are treated like a failed acquisition.
+     */
+    public function acquire(
+        string $key,
+        ?float $ttl = null,
+        ?bool $blocking = null,
+        bool $catchAcquiringExceptions = false,
+    ): ?LockInterface {
+        $lock = $this->createLock($key, $ttl);
+
+        try {
+            $acquired = $blocking === null ? $lock->acquire() : $lock->acquire($blocking);
+
+            if ($acquired) {
+                return $lock;
+            }
+        } catch (LockConflictedException|LockAcquiringException $exception) {
+            if (!$catchAcquiringExceptions) {
+                throw $exception;
+            }
+        }
+
+        return null;
+    }
+
+    private function createLock(string $key, ?float $ttl): LockInterface
+    {
+        $key = $this->getLockKey($key);
+
+        if ($ttl === null) {
+            return $this->lockFactory->createLock($key);
+        }
+
+        return $this->lockFactory->createLock($key, $ttl);
+    }
+
+    private function getLockKey(string $key): string
+    {
+        return $this->keyPrefix . $key;
+    }
+}

--- a/src/Core/Framework/Adapter/Lock/LockManager.php
+++ b/src/Core/Framework/Adapter/Lock/LockManager.php
@@ -3,24 +3,23 @@
 namespace Shopware\Core\Framework\Adapter\Lock;
 
 use Shopware\Core\Framework\Log\Package;
-use Symfony\Component\Lock\Exception\LockAcquiringException;
-use Symfony\Component\Lock\Exception\LockConflictedException;
 use Symfony\Component\Lock\LockFactory;
 use Symfony\Component\Lock\LockInterface;
 
 /**
  * Provides the common lock handling patterns used across the platform.
  *
- * Use executeLocked() when the protected work starts and ends in the same call. The manager owns
- * the acquired lock and always releases it in a finally block. Use acquireOrThrow() when a failed
- * acquisition maps to a domain exception, and acquire() when a nullable lock is part of the
- * caller's normal control flow.
+ * Use runWithLock() when the protected work starts and ends in the same call. The manager owns
+ * the acquired lock and always releases it in a finally block. Use acquire() when the caller owns
+ * the lock lifecycle.
  *
  * @internal
  */
 #[Package('framework')]
 class LockManager
 {
+    public const DEFAULT_TTL = 300.0;
+
     public function __construct(
         private readonly LockFactory $lockFactory,
         private readonly string $keyPrefix = '',
@@ -30,12 +29,7 @@ class LockManager
     /**
      * Acquires a lock, executes the callback and releases the lock afterwards.
      *
-     * The failure callback keeps domain-specific fallback behavior and exceptions at the
-     * call site. When no TTL is provided, the lock is created without passing a TTL to Symfony so
-     * the component's default behavior is preserved exactly.
-     *
-     * Passing null for $blocking preserves Symfony's default acquire() call; pass true or false
-     * when the call site previously used an explicit mode.
+     * The failure callback keeps domain-specific fallback behavior and exceptions at the call site.
      *
      * @template T
      *
@@ -44,15 +38,14 @@ class LockManager
      *
      * @return T
      */
-    public function executeLocked(
+    public function runWithLock(
         string $key,
         \Closure $callback,
         \Closure $onLockAcquisitionFailed,
-        ?float $ttl = null,
-        ?bool $blocking = null,
-        bool $catchAcquiringExceptions = false,
+        float $ttl = self::DEFAULT_TTL,
+        bool $blocking = false,
     ): mixed {
-        $lock = $this->acquire($key, $ttl, $blocking, $catchAcquiringExceptions);
+        $lock = $this->acquire($key, $ttl, $blocking);
 
         if ($lock === null) {
             return $onLockAcquisitionFailed();
@@ -66,75 +59,23 @@ class LockManager
     }
 
     /**
-     * Acquires a lock and returns it to the caller or executes the failure callback.
-     *
-     * The caller owns the returned lock and must release it. Use this method for workflows where
-     * failing to acquire the lock is exceptional, but the lock lifecycle cannot be represented by a
-     * single callback.
-     *
-     * Passing null for $blocking preserves Symfony's default acquire() call; pass true or false
-     * when the call site previously used an explicit mode.
-     *
-     * @param \Closure(): never $onLockAcquisitionFailed
-     */
-    public function acquireOrThrow(
-        string $key,
-        \Closure $onLockAcquisitionFailed,
-        ?float $ttl = null,
-        ?bool $blocking = null,
-        bool $catchAcquiringExceptions = false,
-    ): LockInterface {
-        $lock = $this->acquire($key, $ttl, $blocking, $catchAcquiringExceptions);
-
-        if ($lock !== null) {
-            return $lock;
-        }
-
-        return $onLockAcquisitionFailed();
-    }
-
-    /**
      * Acquires a lock and returns it to the caller.
      *
      * The caller owns the returned lock and must release it. This method is intended for workflows
      * where a missing lock is part of the normal control flow.
-     *
-     * Passing null for $blocking preserves Symfony's default acquire() call; pass true or false
-     * when the call site previously used an explicit mode. When $catchAcquiringExceptions is true,
-     * Symfony lock acquisition exceptions are treated like a failed acquisition.
      */
     public function acquire(
         string $key,
-        ?float $ttl = null,
-        ?bool $blocking = null,
-        bool $catchAcquiringExceptions = false,
+        float $ttl = self::DEFAULT_TTL,
+        bool $blocking = false,
     ): ?LockInterface {
-        $lock = $this->createLock($key, $ttl);
+        $lock = $this->lockFactory->createLock($this->getLockKey($key), $ttl);
 
-        try {
-            $acquired = $blocking === null ? $lock->acquire() : $lock->acquire($blocking);
-
-            if ($acquired) {
-                return $lock;
-            }
-        } catch (LockConflictedException|LockAcquiringException $exception) {
-            if (!$catchAcquiringExceptions) {
-                throw $exception;
-            }
+        if ($lock->acquire($blocking)) {
+            return $lock;
         }
 
         return null;
-    }
-
-    private function createLock(string $key, ?float $ttl): LockInterface
-    {
-        $key = $this->getLockKey($key);
-
-        if ($ttl === null) {
-            return $this->lockFactory->createLock($key);
-        }
-
-        return $this->lockFactory->createLock($key, $ttl);
     }
 
     private function getLockKey(string $key): string

--- a/src/Core/Framework/App/Url/AppUrlVerifier.php
+++ b/src/Core/Framework/App/Url/AppUrlVerifier.php
@@ -5,14 +5,12 @@ namespace Shopware\Core\Framework\App\Url;
 use Psr\Cache\CacheItemPoolInterface;
 use Psr\Clock\ClockInterface;
 use Psr\Log\LoggerInterface;
+use Shopware\Core\Framework\Adapter\Lock\LockManager;
 use Shopware\Core\Framework\App\AppException;
 use Shopware\Core\Framework\App\ShopId\Fingerprint\AppUrl;
 use Shopware\Core\Framework\App\ShopId\ShopId;
 use Shopware\Core\Framework\Log\Package;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Lock\Exception\LockAcquiringException;
-use Symfony\Component\Lock\Exception\LockConflictedException;
-use Symfony\Component\Lock\LockFactory;
 use Symfony\Component\Lock\LockInterface;
 use Symfony\Contracts\Cache\CacheInterface;
 use Symfony\Contracts\Cache\ItemInterface;
@@ -40,7 +38,7 @@ class AppUrlVerifier
         private readonly string $shopwareVersion,
         private readonly CacheItemPoolInterface&CacheInterface $cache,
         private readonly HttpClientInterface $httpClient,
-        private readonly LockFactory $lockFactory,
+        private readonly LockManager $lockManager,
         private readonly LoggerInterface $logger,
         private readonly ClockInterface $clock,
     ) {
@@ -174,16 +172,7 @@ class AppUrlVerifier
 
     private function acquireLock(string $lockKey): ?LockInterface
     {
-        $lock = $this->lockFactory->createLock($lockKey, 10);
-
-        try {
-            if ($lock->acquire()) {
-                return $lock;
-            }
-        } catch (LockConflictedException|LockAcquiringException) {
-        }
-
-        return null;
+        return $this->lockManager->acquire($lockKey, ttl: 10, catchAcquiringExceptions: true);
     }
 
     private function performVerification(string $appUrl, int $tries = 1): VerificationState

--- a/src/Core/Framework/App/Url/AppUrlVerifier.php
+++ b/src/Core/Framework/App/Url/AppUrlVerifier.php
@@ -11,6 +11,8 @@ use Shopware\Core\Framework\App\ShopId\Fingerprint\AppUrl;
 use Shopware\Core\Framework\App\ShopId\ShopId;
 use Shopware\Core\Framework\Log\Package;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Lock\Exception\LockAcquiringException;
+use Symfony\Component\Lock\Exception\LockConflictedException;
 use Symfony\Component\Lock\LockInterface;
 use Symfony\Contracts\Cache\CacheInterface;
 use Symfony\Contracts\Cache\ItemInterface;
@@ -172,7 +174,11 @@ class AppUrlVerifier
 
     private function acquireLock(string $lockKey): ?LockInterface
     {
-        return $this->lockManager->acquire($lockKey, ttl: 10, catchAcquiringExceptions: true);
+        try {
+            return $this->lockManager->acquire($lockKey, ttl: 10);
+        } catch (LockConflictedException|LockAcquiringException) {
+            return null;
+        }
     }
 
     private function performVerification(string $appUrl, int $tries = 1): VerificationState

--- a/src/Core/Framework/DataAbstractionLayer/VersionManager.php
+++ b/src/Core/Framework/DataAbstractionLayer/VersionManager.php
@@ -4,6 +4,7 @@ namespace Shopware\Core\Framework\DataAbstractionLayer;
 
 use Psr\Clock\ClockInterface;
 use Shopware\Core\Defaults;
+use Shopware\Core\Framework\Adapter\Lock\LockManager;
 use Shopware\Core\Framework\Api\Context\AdminApiSource;
 use Shopware\Core\Framework\Api\Sync\SyncOperation;
 use Shopware\Core\Framework\Context;
@@ -53,7 +54,6 @@ use Shopware\Core\Framework\Util\Hasher;
 use Shopware\Core\Framework\Util\Json;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
-use Symfony\Component\Lock\LockFactory;
 use Symfony\Component\Serializer\SerializerInterface;
 
 /**
@@ -76,7 +76,7 @@ class VersionManager
         private readonly VersionCommitDefinition $versionCommitDefinition,
         private readonly VersionCommitDataDefinition $versionCommitDataDefinition,
         private readonly VersionDefinition $versionDefinition,
-        private readonly LockFactory $lockFactory,
+        private readonly LockManager $lockManager,
         private readonly ClockInterface $clock
     ) {
     }
@@ -168,11 +168,10 @@ class VersionManager
         }
 
         // acquire a lock to prevent multiple merges of the same version
-        $lock = $this->lockFactory->createLock('sw-merge-version-' . $versionId);
-
-        if (!$lock->acquire()) {
-            throw DataAbstractionLayerException::versionMergeAlreadyLocked($versionId);
-        }
+        $lock = $this->lockManager->acquireOrThrow(
+            'sw-merge-version-' . $versionId,
+            fn (): never => throw DataAbstractionLayerException::versionMergeAlreadyLocked($versionId),
+        );
 
         if (!$this->versionExists($versionId)) {
             throw DataAbstractionLayerException::versionNotExists($versionId);

--- a/src/Core/Framework/DataAbstractionLayer/VersionManager.php
+++ b/src/Core/Framework/DataAbstractionLayer/VersionManager.php
@@ -168,10 +168,8 @@ class VersionManager
         }
 
         // acquire a lock to prevent multiple merges of the same version
-        $lock = $this->lockManager->acquireOrThrow(
-            'sw-merge-version-' . $versionId,
-            fn (): never => throw DataAbstractionLayerException::versionMergeAlreadyLocked($versionId),
-        );
+        $lock = $this->lockManager->acquire('sw-merge-version-' . $versionId)
+            ?? throw DataAbstractionLayerException::versionMergeAlreadyLocked($versionId);
 
         if (!$this->versionExists($versionId)) {
             throw DataAbstractionLayerException::versionNotExists($versionId);

--- a/src/Core/Framework/DependencyInjection/app.php
+++ b/src/Core/Framework/DependencyInjection/app.php
@@ -11,6 +11,7 @@ use Shopware\Core\Checkout\Gateway\Command\Registry\CheckoutGatewayCommandRegist
 use Shopware\Core\Content\Media\File\TrustedUrlResolver;
 use Shopware\Core\Content\Media\MediaService;
 use Shopware\Core\Framework\Adapter\Cache\CacheClearer;
+use Shopware\Core\Framework\Adapter\Lock\LockManager;
 use Shopware\Core\Framework\Adapter\Twig\StringTemplateRenderer;
 use Shopware\Core\Framework\Api\Serializer\JsonEntityEncoder;
 use Shopware\Core\Framework\App\ActionButton\ActionButtonLoader;
@@ -1080,7 +1081,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             param('kernel.shopware_version'),
             service('cache.app'),
             service(HttpClientInterface::class),
-            service('lock.factory'),
+            service(LockManager::class),
             service('logger'),
             service(ClockInterface::class),
         ]);

--- a/src/Core/Framework/DependencyInjection/cache.php
+++ b/src/Core/Framework/DependencyInjection/cache.php
@@ -45,6 +45,7 @@ use Shopware\Core\Framework\Adapter\Command\CacheClearAllCommand;
 use Shopware\Core\Framework\Adapter\Command\CacheClearHttpCommand;
 use Shopware\Core\Framework\Adapter\Command\CacheInvalidateDelayedCommand;
 use Shopware\Core\Framework\Adapter\Kernel\EsiDecoration;
+use Shopware\Core\Framework\Adapter\Lock\LockManager;
 use Shopware\Core\Framework\Adapter\Redis\RedisConnectionProvider;
 use Shopware\Core\Framework\DataAbstractionLayer\Event\EntityDeleteEvent;
 use Shopware\Core\Framework\DataAbstractionLayer\Event\EntityWrittenContainerEvent;
@@ -163,7 +164,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             param('shopware.http_cache.reverse_proxy.enabled'),
             service('messenger.default_bus'),
             service('logger'),
-            service('lock.factory'),
+            service(LockManager::class),
         ]);
 
     $services->set(CleanupOldCacheFoldersHandler::class)

--- a/src/Core/Framework/DependencyInjection/data-abstraction-layer.php
+++ b/src/Core/Framework/DependencyInjection/data-abstraction-layer.php
@@ -6,6 +6,7 @@ use Doctrine\DBAL\Connection;
 use Psr\Clock\ClockInterface;
 use Shopware\Core\Content\Product\SearchKeyword\KeywordLoader;
 use Shopware\Core\Content\Product\SearchKeyword\ProductSearchTermInterpreter;
+use Shopware\Core\Framework\Adapter\Lock\LockManager;
 use Shopware\Core\Framework\Api\Acl\AclCriteriaValidator;
 use Shopware\Core\Framework\Api\Sync\SyncFkResolver;
 use Shopware\Core\Framework\Api\Sync\SyncService;
@@ -528,7 +529,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             service(VersionCommitDefinition::class),
             service(VersionCommitDataDefinition::class),
             service(VersionDefinition::class),
-            service('lock.factory'),
+            service(LockManager::class),
             service(ClockInterface::class),
         ]);
 

--- a/src/Core/Framework/DependencyInjection/message-queue.php
+++ b/src/Core/Framework/DependencyInjection/message-queue.php
@@ -5,6 +5,7 @@ namespace Shopware\Core\Framework\DependencyInjection;
 use Doctrine\DBAL\Connection;
 use Psr\Clock\ClockInterface;
 use Shopware\Core\Framework\Adapter\Doctrine\Messenger\DoctrineTransportFactory;
+use Shopware\Core\Framework\Adapter\Lock\LockManager;
 use Shopware\Core\Framework\Adapter\Messenger\Middleware\QueuedTimeMiddleware;
 use Shopware\Core\Framework\MessageQueue\Api\ConsumeMessagesController;
 use Shopware\Core\Framework\MessageQueue\Middleware\RoutingOverwriteMiddleware;
@@ -79,7 +80,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             param('messenger.default_transport_name'),
             param('shopware.admin_worker.memory_limit'),
             param('shopware.admin_worker.poll_interval'),
-            service('lock.factory'),
+            service(LockManager::class),
         ])
         ->call('setContainer', [
             service('service_container'),

--- a/src/Core/Framework/DependencyInjection/services.php
+++ b/src/Core/Framework/DependencyInjection/services.php
@@ -21,6 +21,7 @@ use Shopware\Core\Framework\Adapter\Database\ReplicaConnectionResetter;
 use Shopware\Core\Framework\Adapter\Kernel\EnvIntOrNullProcessor;
 use Shopware\Core\Framework\Adapter\Kernel\HttpCacheKernel;
 use Shopware\Core\Framework\Adapter\Kernel\HttpKernel;
+use Shopware\Core\Framework\Adapter\Lock\LockManager;
 use Shopware\Core\Framework\Adapter\Redis\RedisConnectionProvider;
 use Shopware\Core\Framework\Adapter\Storage\AbstractKeyValueStorage;
 use Shopware\Core\Framework\Adapter\Storage\MySQLKeyValueStorage;
@@ -225,6 +226,11 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
     $services->set(RequestDataBagResolver::class)
         ->tag('controller.argument_value_resolver', ['priority' => 1000]);
+
+    $services->set(LockManager::class)
+        ->args([
+            service('lock.factory'),
+        ]);
 
     // Cache
     $services->set('slugify', Slugify::class)

--- a/src/Core/Framework/MessageQueue/Api/ConsumeMessagesController.php
+++ b/src/Core/Framework/MessageQueue/Api/ConsumeMessagesController.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Core\Framework\MessageQueue\Api;
 
+use Shopware\Core\Framework\Adapter\Lock\LockManager;
 use Shopware\Core\Framework\Adapter\Request\RequestParamHelper;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\MessageQueue\MessageQueueException;
@@ -16,7 +17,6 @@ use Symfony\Component\DependencyInjection\ServiceLocator;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\Lock\LockFactory;
 use Symfony\Component\Messenger\EventListener\StopWorkerOnMemoryLimitListener;
 use Symfony\Component\Messenger\EventListener\StopWorkerOnRestartSignalListener;
 use Symfony\Component\Messenger\EventListener\StopWorkerOnTimeLimitListener;
@@ -43,7 +43,7 @@ class ConsumeMessagesController extends AbstractController
         private readonly string $defaultTransportName,
         private readonly string $memoryLimit,
         private readonly int $pollInterval,
-        private readonly LockFactory $lockFactory
+        private readonly LockManager $lockManager
     ) {
     }
 
@@ -56,11 +56,10 @@ class ConsumeMessagesController extends AbstractController
             throw MessageQueueException::validReceiverNameNotProvided();
         }
 
-        $consumerLock = $this->lockFactory->createLock('message_queue_consume_' . $receiverName);
-
-        if (!$consumerLock->acquire()) {
-            throw MessageQueueException::workerIsLocked($receiverName);
-        }
+        $consumerLock = $this->lockManager->acquireOrThrow(
+            'message_queue_consume_' . $receiverName,
+            fn (): never => throw MessageQueueException::workerIsLocked($receiverName),
+        );
 
         $receiver = $this->receiverLocator->get($receiverName);
 

--- a/src/Core/Framework/MessageQueue/Api/ConsumeMessagesController.php
+++ b/src/Core/Framework/MessageQueue/Api/ConsumeMessagesController.php
@@ -56,10 +56,8 @@ class ConsumeMessagesController extends AbstractController
             throw MessageQueueException::validReceiverNameNotProvided();
         }
 
-        $consumerLock = $this->lockManager->acquireOrThrow(
-            'message_queue_consume_' . $receiverName,
-            fn (): never => throw MessageQueueException::workerIsLocked($receiverName),
-        );
+        $consumerLock = $this->lockManager->acquire('message_queue_consume_' . $receiverName)
+            ?? throw MessageQueueException::workerIsLocked($receiverName);
 
         $receiver = $this->receiverLocator->get($receiverName);
 

--- a/src/Core/System/CustomEntity/Schema/CustomEntitySchemaUpdater.php
+++ b/src/Core/System/CustomEntity/Schema/CustomEntitySchemaUpdater.php
@@ -6,8 +6,8 @@ use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Schema\Schema;
+use Shopware\Core\Framework\Adapter\Lock\LockManager;
 use Shopware\Core\Framework\Log\Package;
-use Symfony\Component\Lock\LockFactory;
 
 /**
  * @internal
@@ -25,7 +25,7 @@ class CustomEntitySchemaUpdater
 
     public function __construct(
         private readonly Connection $connection,
-        private readonly LockFactory $lockFactory,
+        private readonly LockManager $lockManager,
         private readonly SchemaUpdater $schemaUpdater
     ) {
     }
@@ -48,9 +48,9 @@ class CustomEntitySchemaUpdater
 
     private function lock(\Closure $closure): void
     {
-        $lock = $this->lockFactory->createLock('custom-entity::schema-update', 30);
+        $lock = $this->lockManager->acquire('custom-entity::schema-update', ttl: 30, blocking: true);
 
-        if ($lock->acquire(true)) {
+        if ($lock !== null) {
             $closure();
 
             $lock->release();

--- a/src/Core/System/DependencyInjection/custom_entity.php
+++ b/src/Core/System/DependencyInjection/custom_entity.php
@@ -4,6 +4,7 @@ namespace Shopware\Core\System\DependencyInjection;
 
 use Doctrine\DBAL\Connection;
 use Psr\Clock\ClockInterface;
+use Shopware\Core\Framework\Adapter\Lock\LockManager;
 use Shopware\Core\Framework\Api\Acl\AclCriteriaValidator;
 use Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityProtection\EntityProtectionValidator;
@@ -18,7 +19,6 @@ use Shopware\Core\System\CustomEntity\Schema\SchemaUpdater;
 use Shopware\Core\System\CustomEntity\Xml\Config\AdminUi\AdminUiXmlSchemaValidator;
 use Shopware\Core\System\CustomEntity\Xml\CustomEntityXmlSchemaValidator;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
-use Symfony\Component\Lock\LockFactory;
 
 use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
 
@@ -52,7 +52,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         ->public()
         ->args([
             service(Connection::class),
-            service(LockFactory::class),
+            service(LockManager::class),
             service(SchemaUpdater::class),
         ]);
 

--- a/src/Core/System/DependencyInjection/number_range.php
+++ b/src/Core/System/DependencyInjection/number_range.php
@@ -4,6 +4,7 @@ namespace Shopware\Core\System\DependencyInjection;
 
 use Doctrine\DBAL\Connection;
 use Psr\Clock\ClockInterface;
+use Shopware\Core\Framework\Adapter\Lock\LockManager;
 use Shopware\Core\Framework\Adapter\Redis\RedisConnectionProvider;
 use Shopware\Core\Framework\Telemetry\Metrics\Meter;
 use Shopware\Core\System\NumberRange\Aggregate\NumberRangeSalesChannel\NumberRangeSalesChannelDefinition;
@@ -85,7 +86,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $services->set(IncrementRedisStorage::class)
         ->args([
             service('shopware.number_range.redis'),
-            service('lock.factory'),
+            service(LockManager::class),
             service('number_range.repository'),
         ])
         ->tag('shopware.value_generator_connector', ['storage' => 'redis']);

--- a/src/Core/System/DependencyInjection/state_machine.php
+++ b/src/Core/System/DependencyInjection/state_machine.php
@@ -3,6 +3,7 @@
 namespace Shopware\Core\System\DependencyInjection;
 
 use Doctrine\DBAL\Connection;
+use Shopware\Core\Framework\Adapter\Lock\LockManager;
 use Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry;
 use Shopware\Core\System\StateMachine\Aggregation\StateMachineHistory\StateMachineHistoryDefinition;
 use Shopware\Core\System\StateMachine\Aggregation\StateMachineState\StateMachineStateDefinition;
@@ -54,7 +55,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
     $services->set(StateMachineLocker::class)
         ->args([
-            service('lock.factory'),
+            service(LockManager::class),
         ])
         ->tag('kernel.reset', ['method' => 'reset']);
 

--- a/src/Core/System/NumberRange/ValueGenerator/Pattern/IncrementStorage/IncrementRedisStorage.php
+++ b/src/Core/System/NumberRange/ValueGenerator/Pattern/IncrementStorage/IncrementRedisStorage.php
@@ -3,13 +3,13 @@
 namespace Shopware\Core\System\NumberRange\ValueGenerator\Pattern\IncrementStorage;
 
 use Shopware\Core\Framework\Adapter\Cache\RedisConnectionFactory;
+use Shopware\Core\Framework\Adapter\Lock\LockManager;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
 use Shopware\Core\System\NumberRange\NumberRangeCollection;
-use Symfony\Component\Lock\LockFactory;
 
 /**
  * @phpstan-import-type RedisTypeHint from RedisConnectionFactory
@@ -26,7 +26,7 @@ class IncrementRedisStorage extends AbstractIncrementStorage
          * @phpstan-ignore shopware.propertyNativeType (Cannot type natively, as Symfony might change the implementation in the future)
          */
         private $redis,
-        private readonly LockFactory $lockFactory,
+        private readonly LockManager $lockManager,
         private readonly EntityRepository $numberRangeRepository
     ) {
     }
@@ -54,24 +54,18 @@ class IncrementRedisStorage extends AbstractIncrementStorage
 
         // if the configured start value is greater than the current increment
         // we need a lock so that the value be only set once to the start value
-        $lock = $this->lockFactory->createLock('number-range-' . $config['id']);
+        return $this->lockManager->executeLocked(
+            'number-range-' . $config['id'],
+            function () use ($key, $start, $increment): int {
+                // to set the current increment to the new configured start we use incrementBy, rather than simply setting the new start value
+                // to prevent issues where maybe the increment value is already increment to higher value by competing requests
+                $newIncr = $this->redis->incrBy($key, $start - $increment); // // @phpstan-ignore-line - because multiple redis implementations phpstan doesn't like this
+                \assert(\is_int($newIncr));
 
-        if (!$lock->acquire()) {
-            // we can't acquire the lock, meaning another request will increase the increment value to the new start value
-            // so we can use the current increment for now
-            return $increment;
-        }
-
-        try {
-            // to set the current increment to the new configured start we use incrementBy, rather than simply setting the new start value
-            // to prevent issues where maybe the increment value is already increment to higher value by competing requests
-            $newIncr = $this->redis->incrBy($key, $start - $increment); // // @phpstan-ignore-line - because multiple redis implementations phpstan doesn't like this
-            \assert(\is_int($newIncr));
-
-            return $newIncr;
-        } finally {
-            $lock->release();
-        }
+                return $newIncr;
+            },
+            static fn (): int => $increment,
+        );
     }
 
     /**
@@ -123,24 +117,23 @@ class IncrementRedisStorage extends AbstractIncrementStorage
     public function increaseToAtLeast(string $configurationId, int $value): void
     {
         $key = $this->getKey($configurationId);
-        $lock = $this->lockFactory->createLock('number-range-' . $configurationId);
-        if (!$lock->acquire(true)) {
-            return;
-        }
+        $this->lockManager->executeLocked(
+            'number-range-' . $configurationId,
+            function () use ($key, $value): void {
+                $currentValue = $this->redis->get($key);
+                $currentValue = $currentValue === false || $currentValue === null ? 0 : (int) $currentValue;
 
-        try {
-            $currentValue = $this->redis->get($key);
-            $currentValue = $currentValue === false || $currentValue === null ? 0 : (int) $currentValue;
+                $increment = $value - $currentValue;
+                if ($increment <= 0) {
+                    return;
+                }
 
-            $increment = $value - $currentValue;
-            if ($increment <= 0) {
-                return;
-            }
-
-            $this->redis->incrBy($key, $increment); // @phpstan-ignore-line - because multiple redis implementations phpStan doesn't like this
-        } finally {
-            $lock->release();
-        }
+                $this->redis->incrBy($key, $increment); // @phpstan-ignore-line - because multiple redis implementations phpStan doesn't like this
+            },
+            static function (): void {
+            },
+            blocking: true,
+        );
     }
 
     public function getDecorated(): AbstractIncrementStorage

--- a/src/Core/System/NumberRange/ValueGenerator/Pattern/IncrementStorage/IncrementRedisStorage.php
+++ b/src/Core/System/NumberRange/ValueGenerator/Pattern/IncrementStorage/IncrementRedisStorage.php
@@ -54,7 +54,7 @@ class IncrementRedisStorage extends AbstractIncrementStorage
 
         // if the configured start value is greater than the current increment
         // we need a lock so that the value be only set once to the start value
-        return $this->lockManager->executeLocked(
+        return $this->lockManager->runWithLock(
             'number-range-' . $config['id'],
             function () use ($key, $start, $increment): int {
                 // to set the current increment to the new configured start we use incrementBy, rather than simply setting the new start value
@@ -117,7 +117,7 @@ class IncrementRedisStorage extends AbstractIncrementStorage
     public function increaseToAtLeast(string $configurationId, int $value): void
     {
         $key = $this->getKey($configurationId);
-        $this->lockManager->executeLocked(
+        $this->lockManager->runWithLock(
             'number-range-' . $configurationId,
             function () use ($key, $value): void {
                 $currentValue = $this->redis->get($key);

--- a/src/Core/System/StateMachine/StateMachineLocker.php
+++ b/src/Core/System/StateMachine/StateMachineLocker.php
@@ -2,10 +2,10 @@
 
 namespace Shopware\Core\System\StateMachine;
 
+use Shopware\Core\Framework\Adapter\Lock\LockManager;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Util\Hasher;
-use Symfony\Component\Lock\LockFactory;
 use Symfony\Contracts\Service\ResetInterface;
 
 /**
@@ -21,7 +21,7 @@ class StateMachineLocker implements ResetInterface
      */
     private array $acquiredLocks = [];
 
-    public function __construct(private readonly LockFactory $lockFactory)
+    public function __construct(private readonly LockManager $lockManager)
     {
     }
 
@@ -38,11 +38,12 @@ class StateMachineLocker implements ResetInterface
             return $closure();
         }
 
-        $lock = $this->lockFactory->createLock($lockKey, self::LOCK_TTL);
-
-        if (!$lock->acquire(true)) {
-            throw StateMachineException::stateMachineTransitionLocked($transition->getEntityName(), $transition->getEntityId());
-        }
+        $lock = $this->lockManager->acquireOrThrow(
+            $lockKey,
+            fn (): never => throw StateMachineException::stateMachineTransitionLocked($transition->getEntityName(), $transition->getEntityId()),
+            ttl: self::LOCK_TTL,
+            blocking: true,
+        );
 
         $this->acquiredLocks[$lockKey] = true;
 

--- a/src/Core/System/StateMachine/StateMachineLocker.php
+++ b/src/Core/System/StateMachine/StateMachineLocker.php
@@ -38,12 +38,11 @@ class StateMachineLocker implements ResetInterface
             return $closure();
         }
 
-        $lock = $this->lockManager->acquireOrThrow(
+        $lock = $this->lockManager->acquire(
             $lockKey,
-            fn (): never => throw StateMachineException::stateMachineTransitionLocked($transition->getEntityName(), $transition->getEntityId()),
             ttl: self::LOCK_TTL,
             blocking: true,
-        );
+        ) ?? throw StateMachineException::stateMachineTransitionLocked($transition->getEntityName(), $transition->getEntityId());
 
         $this->acquiredLocks[$lockKey] = true;
 

--- a/tests/integration/Core/Framework/Plugin/PluginManagementServiceTest.php
+++ b/tests/integration/Core/Framework/Plugin/PluginManagementServiceTest.php
@@ -8,6 +8,7 @@ use Shopware\Core\DevOps\StaticAnalyze\StaticAnalyzeKernel;
 use Shopware\Core\Framework\Adapter\Cache\CacheClearer;
 use Shopware\Core\Framework\Adapter\Cache\CacheInvalidator;
 use Shopware\Core\Framework\Adapter\Kernel\KernelFactory;
+use Shopware\Core\Framework\Adapter\Lock\LockManager;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Plugin\ExtensionExtractor;
@@ -207,7 +208,7 @@ class PluginManagementServiceTest extends TestCase
             false,
             static::getContainer()->get('messenger.default_bus'),
             static::getContainer()->get('logger'),
-            static::getContainer()->get('lock.factory')
+            static::getContainer()->get(LockManager::class)
         );
     }
 

--- a/tests/unit/Core/Checkout/Cart/CartLockerTest.php
+++ b/tests/unit/Core/Checkout/Cart/CartLockerTest.php
@@ -6,6 +6,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\Cart\CartException;
 use Shopware\Core\Checkout\Cart\CartLocker;
+use Shopware\Core\Framework\Adapter\Lock\LockManager;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Test\Generator;
 use Symfony\Component\Lock\LockFactory;
@@ -26,7 +27,7 @@ class CartLockerTest extends TestCase
     protected function setUp(): void
     {
         $this->lockFactory = new LockFactory(new InMemoryStore());
-        $this->locker = new CartLocker($this->lockFactory);
+        $this->locker = new CartLocker(new LockManager($this->lockFactory));
     }
 
     public function testLockedExecutesClosure(): void

--- a/tests/unit/Core/Checkout/Promotion/Cart/PromotionRedemptionLockerTest.php
+++ b/tests/unit/Core/Checkout/Promotion/Cart/PromotionRedemptionLockerTest.php
@@ -11,6 +11,7 @@ use Shopware\Core\Checkout\Promotion\Cart\Extension\LockExtension;
 use Shopware\Core\Checkout\Promotion\Cart\PromotionProcessor;
 use Shopware\Core\Checkout\Promotion\Cart\PromotionRedemptionLocker;
 use Shopware\Core\Checkout\Promotion\PromotionException;
+use Shopware\Core\Framework\Adapter\Lock\LockManager;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Validation\DataBag\RequestDataBag;
 use Shopware\Core\Test\Generator;
@@ -51,7 +52,7 @@ class PromotionRedemptionLockerTest extends TestCase
             ->with('promotion-promotion-code', 5.0, true)
             ->willReturn($lock);
 
-        $locker = new PromotionRedemptionLocker($lockFactory);
+        $locker = new PromotionRedemptionLocker(new LockManager($lockFactory));
 
         $cart = new Cart('test');
         $lineItem = new LineItem('id', PromotionProcessor::LINE_ITEM_TYPE);
@@ -82,7 +83,7 @@ class PromotionRedemptionLockerTest extends TestCase
             ->with('promotion-promotion-id', 5.0, true)
             ->willReturn($lock);
 
-        $locker = new PromotionRedemptionLocker($lockFactory);
+        $locker = new PromotionRedemptionLocker(new LockManager($lockFactory));
 
         $cart = new Cart('test');
         $lineItem = new LineItem('id', PromotionProcessor::LINE_ITEM_TYPE);
@@ -121,7 +122,7 @@ class PromotionRedemptionLockerTest extends TestCase
             ->with('promotion-promotion-code', 5.0, true)
             ->willReturn($lock);
 
-        $locker = new PromotionRedemptionLocker($lockFactory);
+        $locker = new PromotionRedemptionLocker(new LockManager($lockFactory));
 
         $cart = new Cart('test');
         $firstLineItem = new LineItem('id', PromotionProcessor::LINE_ITEM_TYPE);
@@ -156,7 +157,7 @@ class PromotionRedemptionLockerTest extends TestCase
             ->with('promotion-promotion-code', 5.0, true)
             ->willReturn($lock);
 
-        $locker = new PromotionRedemptionLocker($lockFactory);
+        $locker = new PromotionRedemptionLocker(new LockManager($lockFactory));
 
         $cart = new Cart('test');
         $lineItem = new LineItem('id', PromotionProcessor::LINE_ITEM_TYPE);
@@ -187,7 +188,7 @@ class PromotionRedemptionLockerTest extends TestCase
             ->with('promotion-promotion-code', 5.0, true)
             ->willReturn($lock);
 
-        $locker = new PromotionRedemptionLocker($lockFactory);
+        $locker = new PromotionRedemptionLocker(new LockManager($lockFactory));
 
         $cart = new Cart('test');
         $lineItem = new LineItem('id', PromotionProcessor::LINE_ITEM_TYPE);
@@ -207,7 +208,7 @@ class PromotionRedemptionLockerTest extends TestCase
         $lockFactory->expects($this->never())
             ->method('createLock');
 
-        $locker = new PromotionRedemptionLocker($lockFactory);
+        $locker = new PromotionRedemptionLocker(new LockManager($lockFactory));
 
         $cart = new Cart('test');
         $lineItem = new LineItem('id', PromotionProcessor::LINE_ITEM_TYPE);
@@ -229,7 +230,7 @@ class PromotionRedemptionLockerTest extends TestCase
         $lockFactory->expects($this->never())
             ->method('createLock');
 
-        $locker = new PromotionRedemptionLocker($lockFactory);
+        $locker = new PromotionRedemptionLocker(new LockManager($lockFactory));
 
         $cart = new Cart('test');
         $lineItem = new LineItem('id', LineItem::PRODUCT_LINE_ITEM_TYPE);
@@ -245,7 +246,7 @@ class PromotionRedemptionLockerTest extends TestCase
     public function testReleaseLocks(): void
     {
         $lockFactory = static::createStub(LockFactory::class);
-        $locker = new PromotionRedemptionLocker($lockFactory);
+        $locker = new PromotionRedemptionLocker(new LockManager($lockFactory));
 
         $lock1 = $this->createMock(SharedLockInterface::class);
         $lock1->expects($this->once())
@@ -268,7 +269,7 @@ class PromotionRedemptionLockerTest extends TestCase
     public function testReleaseLocksWithoutExtension(): void
     {
         $lockFactory = static::createStub(LockFactory::class);
-        $locker = new PromotionRedemptionLocker($lockFactory);
+        $locker = new PromotionRedemptionLocker(new LockManager($lockFactory));
 
         $extension = new CheckoutPlaceOrderExtension(new Cart('test'), Generator::generateSalesChannelContext(), new RequestDataBag());
 
@@ -278,7 +279,7 @@ class PromotionRedemptionLockerTest extends TestCase
 
     public function testGetLockKey(): void
     {
-        $locker = new PromotionRedemptionLocker(static::createStub(LockFactory::class));
+        $locker = new PromotionRedemptionLocker(new LockManager(static::createStub(LockFactory::class)));
         $key = $locker->getLockKey('promotion-id');
         static::assertSame('promotion-promotion-id', $key);
     }

--- a/tests/unit/Core/Framework/Adapter/Cache/CacheClearerTest.php
+++ b/tests/unit/Core/Framework/Adapter/Cache/CacheClearerTest.php
@@ -13,6 +13,7 @@ use Shopware\Core\Framework\Adapter\Cache\CacheClearer;
 use Shopware\Core\Framework\Adapter\Cache\CacheInvalidator;
 use Shopware\Core\Framework\Adapter\Cache\Message\CleanupOldCacheFolders;
 use Shopware\Core\Framework\Adapter\Cache\ReverseProxy\AbstractReverseProxyGateway;
+use Shopware\Core\Framework\Adapter\Lock\LockManager;
 use Shopware\Core\Framework\Log\Package;
 use Symfony\Component\Cache\PruneableInterface;
 use Symfony\Component\Filesystem\Filesystem;
@@ -55,7 +56,7 @@ class CacheClearerTest extends TestCase
 
     private string $cacheDir;
 
-    private LockFactory&Stub $lock;
+    private LockManager $lockManager;
 
     protected function setUp(): void
     {
@@ -74,9 +75,10 @@ class CacheClearerTest extends TestCase
 
         $lock = static::createStub(SharedLockInterface::class);
         $lock->method('acquire')->willReturn(true);
-        $this->lock = static::createStub(LockFactory::class);
-        $this->lock->method('createLock')
+        $lockFactory = static::createStub(LockFactory::class);
+        $lockFactory->method('createLock')
             ->willReturn($lock);
+        $this->lockManager = new LockManager($lockFactory);
 
         // Create a nested directory structure to avoid scanning system temp directories
         $testBase = sys_get_temp_dir() . '/shopware_test_' . uniqid();
@@ -99,7 +101,7 @@ class CacheClearerTest extends TestCase
             true,
             $this->messageBus,
             $this->logger,
-            $this->lock
+            $this->lockManager
         );
     }
 
@@ -194,7 +196,7 @@ class CacheClearerTest extends TestCase
             true,
             $this->messageBus,
             $logger,
-            $this->lock
+            $this->lockManager
         );
 
         $cacheClearer->clear();
@@ -218,7 +220,7 @@ class CacheClearerTest extends TestCase
             true,
             $this->messageBus,
             $this->logger,
-            $this->lock
+            $this->lockManager
         );
 
         $this->appAdapter->expects($this->once())->method('clear');
@@ -251,7 +253,7 @@ class CacheClearerTest extends TestCase
             true,
             $this->messageBus,
             $this->logger,
-            $this->lock
+            $this->lockManager
         );
 
         $this->appAdapter->expects($this->once())->method('clear');
@@ -286,7 +288,7 @@ class CacheClearerTest extends TestCase
             true,
             $this->messageBus,
             $this->logger,
-            $this->lock
+            $this->lockManager
         );
 
         $this->appAdapter->expects($this->once())->method('clear');
@@ -349,7 +351,7 @@ class CacheClearerTest extends TestCase
             true,
             $this->messageBus,
             $this->logger,
-            $this->lock
+            $this->lockManager
         );
 
         $this->appAdapter->expects($this->never())->method('clear');
@@ -384,7 +386,7 @@ class CacheClearerTest extends TestCase
             true,
             $messageBus,
             $this->logger,
-            $this->lock
+            $this->lockManager
         );
 
         $this->appAdapter->expects($this->never())->method('clear');
@@ -438,7 +440,7 @@ class CacheClearerTest extends TestCase
             true,
             $this->messageBus,
             $this->logger,
-            $this->lock
+            $this->lockManager
         );
 
         $this->appAdapter->expects($this->never())->method('clear');
@@ -497,7 +499,7 @@ class CacheClearerTest extends TestCase
             true,
             $this->messageBus,
             $this->logger,
-            $this->lock
+            $this->lockManager
         );
 
         $this->appAdapter->expects($this->never())->method('clear');
@@ -538,7 +540,7 @@ class CacheClearerTest extends TestCase
             false,
             $this->messageBus,
             $this->logger,
-            $this->lock
+            $this->lockManager
         );
 
         $this->appAdapter->expects($this->never())->method('clear');
@@ -569,7 +571,7 @@ class CacheClearerTest extends TestCase
             false, // reverse http cache disabled
             $this->messageBus,
             $this->logger,
-            $this->lock
+            $this->lockManager
         );
 
         $this->appAdapter->expects($this->once())->method('clear');

--- a/tests/unit/Core/Framework/Adapter/Lock/LockManagerTest.php
+++ b/tests/unit/Core/Framework/Adapter/Lock/LockManagerTest.php
@@ -1,0 +1,185 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\Adapter\Lock;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Adapter\Lock\LockManager;
+use Shopware\Core\Framework\Log\Package;
+use Symfony\Component\Lock\Exception\LockConflictedException;
+use Symfony\Component\Lock\LockFactory;
+use Symfony\Component\Lock\SharedLockInterface;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+#[CoversClass(LockManager::class)]
+class LockManagerTest extends TestCase
+{
+    public function testExecuteLockedReleasesLockAfterSuccessfulCallback(): void
+    {
+        $lock = $this->createMock(SharedLockInterface::class);
+        $lock->expects($this->once())
+            ->method('acquire')
+            ->with()
+            ->willReturn(true);
+        $lock->expects($this->once())->method('release');
+
+        $lockFactory = $this->createMock(LockFactory::class);
+        $lockFactory->expects($this->once())
+            ->method('createLock')
+            ->with('test-lock')
+            ->willReturn($lock);
+
+        $manager = new LockManager($lockFactory);
+
+        $result = $manager->executeLocked(
+            'test-lock',
+            static fn (): string => 'result',
+            static fn (): string => 'fallback',
+        );
+
+        static::assertSame('result', $result);
+    }
+
+    public function testExecuteLockedReleasesLockAfterCallbackException(): void
+    {
+        $lock = $this->createMock(SharedLockInterface::class);
+        $lock->method('acquire')->willReturn(true);
+        $lock->expects($this->once())->method('release');
+
+        $lockFactory = static::createStub(LockFactory::class);
+        $lockFactory->method('createLock')->willReturn($lock);
+
+        $manager = new LockManager($lockFactory);
+
+        $this->expectExceptionObject(new \RuntimeException('callback failed'));
+
+        $manager->executeLocked(
+            'test-lock',
+            static function (): void {
+                throw new \RuntimeException('callback failed');
+            },
+            static function (): void {
+            },
+        );
+    }
+
+    public function testExecuteLockedReturnsFailureCallbackResultWhenLockCannotBeAcquired(): void
+    {
+        $lock = $this->createMock(SharedLockInterface::class);
+        $lock->expects($this->once())
+            ->method('acquire')
+            ->with(false)
+            ->willReturn(false);
+        $lock->expects($this->never())->method('release');
+
+        $lockFactory = $this->createMock(LockFactory::class);
+        $lockFactory->expects($this->once())
+            ->method('createLock')
+            ->with('test-lock', 5.0)
+            ->willReturn($lock);
+
+        $manager = new LockManager($lockFactory);
+
+        $result = $manager->executeLocked(
+            'test-lock',
+            static fn (): string => 'locked',
+            static fn (): string => 'fallback',
+            ttl: 5.0,
+            blocking: false,
+        );
+
+        static::assertSame('fallback', $result);
+    }
+
+    public function testAcquireReturnsLockWithoutReleasingIt(): void
+    {
+        $lock = $this->createMock(SharedLockInterface::class);
+        $lock->expects($this->once())
+            ->method('acquire')
+            ->with(true)
+            ->willReturn(true);
+        $lock->expects($this->never())->method('release');
+
+        $lockFactory = $this->createMock(LockFactory::class);
+        $lockFactory->expects($this->once())
+            ->method('createLock')
+            ->with('prefix-test-lock', 10.0)
+            ->willReturn($lock);
+
+        $manager = new LockManager($lockFactory, 'prefix-');
+
+        static::assertSame($lock, $manager->acquire('test-lock', ttl: 10.0, blocking: true));
+    }
+
+    public function testAcquireReturnsNullWhenLockCannotBeAcquired(): void
+    {
+        $lock = static::createStub(SharedLockInterface::class);
+        $lock->method('acquire')->willReturn(false);
+
+        $lockFactory = static::createStub(LockFactory::class);
+        $lockFactory->method('createLock')->willReturn($lock);
+
+        $manager = new LockManager($lockFactory);
+
+        static::assertNull($manager->acquire('test-lock'));
+    }
+
+    public function testAcquireOrThrowReturnsLockWithoutReleasingIt(): void
+    {
+        $lock = $this->createMock(SharedLockInterface::class);
+        $lock->expects($this->once())
+            ->method('acquire')
+            ->with(false)
+            ->willReturn(true);
+        $lock->expects($this->never())->method('release');
+
+        $lockFactory = $this->createMock(LockFactory::class);
+        $lockFactory->expects($this->once())
+            ->method('createLock')
+            ->with('test-lock', 15.0)
+            ->willReturn($lock);
+
+        $manager = new LockManager($lockFactory);
+
+        static::assertSame($lock, $manager->acquireOrThrow(
+            'test-lock',
+            static fn (): never => throw new \RuntimeException('lock failed'),
+            ttl: 15.0,
+            blocking: false,
+        ));
+    }
+
+    public function testAcquireOrThrowRunsFailureCallbackWhenLockCannotBeAcquired(): void
+    {
+        $lock = static::createStub(SharedLockInterface::class);
+        $lock->method('acquire')->willReturn(false);
+
+        $lockFactory = static::createStub(LockFactory::class);
+        $lockFactory->method('createLock')->willReturn($lock);
+
+        $manager = new LockManager($lockFactory);
+
+        $this->expectExceptionObject(new \RuntimeException('lock failed'));
+
+        $manager->acquireOrThrow(
+            'test-lock',
+            static fn (): never => throw new \RuntimeException('lock failed'),
+        );
+    }
+
+    public function testAcquireCanTreatSymfonyAcquisitionExceptionsLikeFailedAcquisition(): void
+    {
+        $lock = static::createStub(SharedLockInterface::class);
+        $lock->method('acquire')->willThrowException(new LockConflictedException());
+
+        $lockFactory = static::createStub(LockFactory::class);
+        $lockFactory->method('createLock')->willReturn($lock);
+
+        $manager = new LockManager($lockFactory);
+
+        static::assertNull($manager->acquire('test-lock', catchAcquiringExceptions: true));
+    }
+}

--- a/tests/unit/Core/Framework/Adapter/Lock/LockManagerTest.php
+++ b/tests/unit/Core/Framework/Adapter/Lock/LockManagerTest.php
@@ -6,6 +6,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Adapter\Lock\LockManager;
 use Shopware\Core\Framework\Log\Package;
+use Symfony\Component\Lock\Exception\LockAcquiringException;
 use Symfony\Component\Lock\Exception\LockConflictedException;
 use Symfony\Component\Lock\LockFactory;
 use Symfony\Component\Lock\SharedLockInterface;
@@ -17,24 +18,24 @@ use Symfony\Component\Lock\SharedLockInterface;
 #[CoversClass(LockManager::class)]
 class LockManagerTest extends TestCase
 {
-    public function testExecuteLockedReleasesLockAfterSuccessfulCallback(): void
+    public function testRunWithLockUsesDefaultsAndReleasesLockAfterSuccessfulCallback(): void
     {
         $lock = $this->createMock(SharedLockInterface::class);
         $lock->expects($this->once())
             ->method('acquire')
-            ->with()
+            ->with(false)
             ->willReturn(true);
         $lock->expects($this->once())->method('release');
 
         $lockFactory = $this->createMock(LockFactory::class);
         $lockFactory->expects($this->once())
             ->method('createLock')
-            ->with('test-lock')
+            ->with('test-lock', LockManager::DEFAULT_TTL)
             ->willReturn($lock);
 
         $manager = new LockManager($lockFactory);
 
-        $result = $manager->executeLocked(
+        $result = $manager->runWithLock(
             'test-lock',
             static fn (): string => 'result',
             static fn (): string => 'fallback',
@@ -43,7 +44,7 @@ class LockManagerTest extends TestCase
         static::assertSame('result', $result);
     }
 
-    public function testExecuteLockedReleasesLockAfterCallbackException(): void
+    public function testRunWithLockReleasesLockAfterCallbackException(): void
     {
         $lock = $this->createMock(SharedLockInterface::class);
         $lock->method('acquire')->willReturn(true);
@@ -56,7 +57,7 @@ class LockManagerTest extends TestCase
 
         $this->expectExceptionObject(new \RuntimeException('callback failed'));
 
-        $manager->executeLocked(
+        $manager->runWithLock(
             'test-lock',
             static function (): void {
                 throw new \RuntimeException('callback failed');
@@ -66,7 +67,7 @@ class LockManagerTest extends TestCase
         );
     }
 
-    public function testExecuteLockedReturnsFailureCallbackResultWhenLockCannotBeAcquired(): void
+    public function testRunWithLockReturnsFailureCallbackResultWhenLockCannotBeAcquired(): void
     {
         $lock = $this->createMock(SharedLockInterface::class);
         $lock->expects($this->once())
@@ -83,7 +84,7 @@ class LockManagerTest extends TestCase
 
         $manager = new LockManager($lockFactory);
 
-        $result = $manager->executeLocked(
+        $result = $manager->runWithLock(
             'test-lock',
             static fn (): string => 'locked',
             static fn (): string => 'fallback',
@@ -116,70 +117,52 @@ class LockManagerTest extends TestCase
 
     public function testAcquireReturnsNullWhenLockCannotBeAcquired(): void
     {
-        $lock = static::createStub(SharedLockInterface::class);
-        $lock->method('acquire')->willReturn(false);
+        $lock = $this->createMock(SharedLockInterface::class);
+        $lock->expects($this->once())
+            ->method('acquire')
+            ->with(false)
+            ->willReturn(false);
 
-        $lockFactory = static::createStub(LockFactory::class);
-        $lockFactory->method('createLock')->willReturn($lock);
+        $lockFactory = $this->createMock(LockFactory::class);
+        $lockFactory->expects($this->once())
+            ->method('createLock')
+            ->with('test-lock', LockManager::DEFAULT_TTL)
+            ->willReturn($lock);
 
         $manager = new LockManager($lockFactory);
 
         static::assertNull($manager->acquire('test-lock'));
     }
 
-    public function testAcquireOrThrowReturnsLockWithoutReleasingIt(): void
-    {
-        $lock = $this->createMock(SharedLockInterface::class);
-        $lock->expects($this->once())
-            ->method('acquire')
-            ->with(false)
-            ->willReturn(true);
-        $lock->expects($this->never())->method('release');
-
-        $lockFactory = $this->createMock(LockFactory::class);
-        $lockFactory->expects($this->once())
-            ->method('createLock')
-            ->with('test-lock', 15.0)
-            ->willReturn($lock);
-
-        $manager = new LockManager($lockFactory);
-
-        static::assertSame($lock, $manager->acquireOrThrow(
-            'test-lock',
-            static fn (): never => throw new \RuntimeException('lock failed'),
-            ttl: 15.0,
-            blocking: false,
-        ));
-    }
-
-    public function testAcquireOrThrowRunsFailureCallbackWhenLockCannotBeAcquired(): void
+    public function testAcquirePropagatesLockConflictedException(): void
     {
         $lock = static::createStub(SharedLockInterface::class);
-        $lock->method('acquire')->willReturn(false);
+        $exception = new LockConflictedException();
+        $lock->method('acquire')->willThrowException($exception);
 
         $lockFactory = static::createStub(LockFactory::class);
         $lockFactory->method('createLock')->willReturn($lock);
 
         $manager = new LockManager($lockFactory);
 
-        $this->expectExceptionObject(new \RuntimeException('lock failed'));
+        $this->expectExceptionObject($exception);
 
-        $manager->acquireOrThrow(
-            'test-lock',
-            static fn (): never => throw new \RuntimeException('lock failed'),
-        );
+        $manager->acquire('test-lock');
     }
 
-    public function testAcquireCanTreatSymfonyAcquisitionExceptionsLikeFailedAcquisition(): void
+    public function testAcquirePropagatesLockAcquiringException(): void
     {
         $lock = static::createStub(SharedLockInterface::class);
-        $lock->method('acquire')->willThrowException(new LockConflictedException());
+        $exception = new LockAcquiringException();
+        $lock->method('acquire')->willThrowException($exception);
 
         $lockFactory = static::createStub(LockFactory::class);
         $lockFactory->method('createLock')->willReturn($lock);
 
         $manager = new LockManager($lockFactory);
 
-        static::assertNull($manager->acquire('test-lock', catchAcquiringExceptions: true));
+        $this->expectExceptionObject($exception);
+
+        $manager->acquire('test-lock');
     }
 }

--- a/tests/unit/Core/Framework/App/Url/AppUrlVerifierTest.php
+++ b/tests/unit/Core/Framework/App/Url/AppUrlVerifierTest.php
@@ -6,6 +6,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
+use Shopware\Core\Framework\Adapter\Lock\LockManager;
 use Shopware\Core\Framework\App\ShopId\Fingerprint\AppUrl;
 use Shopware\Core\Framework\App\ShopId\ShopId;
 use Shopware\Core\Framework\App\Url\AppUrlVerifier;
@@ -38,7 +39,7 @@ class AppUrlVerifierTest extends TestCase
 
         $shopId = ShopId::v2('shop-id');
 
-        $verifier = new AppUrlVerifier('dev', '6.7.1.0', $cache, $http, $lockFactory, static::createStub(LoggerInterface::class), $clock);
+        $verifier = new AppUrlVerifier('dev', '6.7.1.0', $cache, $http, new LockManager($lockFactory), static::createStub(LoggerInterface::class), $clock);
         static::assertTrue($verifier->verify($shopId));
     }
 
@@ -49,7 +50,7 @@ class AppUrlVerifierTest extends TestCase
         $http = new MockHttpClient(new MockResponse('', ['http_code' => 204]));
         $lockFactory = new LockFactory(new InMemoryStore());
 
-        $verifier = new AppUrlVerifier('prod', '6.7.1.0', $cache, $http, $lockFactory, static::createStub(LoggerInterface::class), $clock);
+        $verifier = new AppUrlVerifier('prod', '6.7.1.0', $cache, $http, new LockManager($lockFactory), static::createStub(LoggerInterface::class), $clock);
 
         $shopId = ShopId::v2('shop-id');
         $result = $verifier->verify($shopId);
@@ -69,7 +70,7 @@ class AppUrlVerifierTest extends TestCase
         $lockFactory = static::createStub(LockFactory::class);
         $lockFactory->method('createLock')->willReturn($lock);
 
-        $verifier = new AppUrlVerifier('prod', '6.7.1.0', $cache, $http, $lockFactory, static::createStub(LoggerInterface::class), $clock);
+        $verifier = new AppUrlVerifier('prod', '6.7.1.0', $cache, $http, new LockManager($lockFactory), static::createStub(LoggerInterface::class), $clock);
 
         $shopId = ShopId::v2('shop-id', [AppUrl::IDENTIFIER => 'https://example.com']);
         static::assertTrue($verifier->verify($shopId));
@@ -88,7 +89,7 @@ class AppUrlVerifierTest extends TestCase
         $lockFactory = static::createStub(LockFactory::class);
         $lockFactory->method('createLock')->willReturn($lock);
 
-        $verifier = new AppUrlVerifier('prod', '6.7.1.0', $cache, $http, $lockFactory, static::createStub(LoggerInterface::class), $clock);
+        $verifier = new AppUrlVerifier('prod', '6.7.1.0', $cache, $http, new LockManager($lockFactory), static::createStub(LoggerInterface::class), $clock);
 
         $shopId = ShopId::v2('shop-id', [AppUrl::IDENTIFIER => 'https://example.com']);
         static::assertTrue($verifier->verify($shopId));
@@ -106,7 +107,7 @@ class AppUrlVerifierTest extends TestCase
         $clock = new MockClock();
         $locks = new LockFactory(new InMemoryStore());
 
-        $verifier = new AppUrlVerifier('prod', '6.7.1.0', $cache, new MockHttpClient($responseFactory), $locks, static::createStub(LoggerInterface::class), $clock);
+        $verifier = new AppUrlVerifier('prod', '6.7.1.0', $cache, new MockHttpClient($responseFactory), new LockManager($locks), static::createStub(LoggerInterface::class), $clock);
         $shopId = ShopId::v2('shop-id', [AppUrl::IDENTIFIER => $url]);
 
         $result = $verifier->verify($shopId);
@@ -212,7 +213,7 @@ class AppUrlVerifierTest extends TestCase
             )
         );
 
-        $verifier = new AppUrlVerifier('prod', '6.7.1.0', $cache, $http, $locks, static::createStub(LoggerInterface::class), $clock);
+        $verifier = new AppUrlVerifier('prod', '6.7.1.0', $cache, $http, new LockManager($locks), static::createStub(LoggerInterface::class), $clock);
         $shopId = ShopId::v2('shop-id', [AppUrl::IDENTIFIER => 'https://example.com']);
 
         foreach ($steps as $step) {
@@ -276,7 +277,7 @@ class AppUrlVerifierTest extends TestCase
 
         $http = new MockHttpClient(new MockResponse('server error', ['http_code' => 500]));
 
-        $verifier = new AppUrlVerifier('prod', '6.7.1.0', $cache, $http, $locks, static::createStub(LoggerInterface::class), $clock);
+        $verifier = new AppUrlVerifier('prod', '6.7.1.0', $cache, $http, new LockManager($locks), static::createStub(LoggerInterface::class), $clock);
         $shopId = ShopId::v2('shop-id', [AppUrl::IDENTIFIER => 'https://example.com']);
 
         $result = $verifier->verify($shopId);
@@ -303,7 +304,7 @@ class AppUrlVerifierTest extends TestCase
             new MockResponse('server error', ['http_code' => 500]),
         ]);
 
-        $verifier = new AppUrlVerifier('prod', '6.7.1.0', $cache, $http, $locks, static::createStub(LoggerInterface::class), $clock);
+        $verifier = new AppUrlVerifier('prod', '6.7.1.0', $cache, $http, new LockManager($locks), static::createStub(LoggerInterface::class), $clock);
         $shopId = ShopId::v2('shop-id', [AppUrl::IDENTIFIER => 'https://example.com']);
 
         $verifier->verify($shopId);
@@ -329,7 +330,7 @@ class AppUrlVerifierTest extends TestCase
             new MockResponse('', ['http_code' => 204]),
         ]);
 
-        $verifier = new AppUrlVerifier('prod', '6.7.1.0', $cache, $http, $locks, static::createStub(LoggerInterface::class), $clock);
+        $verifier = new AppUrlVerifier('prod', '6.7.1.0', $cache, $http, new LockManager($locks), static::createStub(LoggerInterface::class), $clock);
         $shopId = ShopId::v2('shop-id', [AppUrl::IDENTIFIER => 'https://example.com']);
 
         $result = $verifier->verify($shopId);
@@ -364,7 +365,7 @@ class AppUrlVerifierTest extends TestCase
         $cache->save($item);
 
         $http = new MockHttpClient(new MockResponse('server error', ['http_code' => 500]));
-        $verifier = new AppUrlVerifier('prod', '6.7.1.0', $cache, $http, $locks, static::createStub(LoggerInterface::class), $clock);
+        $verifier = new AppUrlVerifier('prod', '6.7.1.0', $cache, $http, new LockManager($locks), static::createStub(LoggerInterface::class), $clock);
         $shopId = ShopId::v2('shop-id', [AppUrl::IDENTIFIER => 'https://example.com']);
 
         $result = $verifier->verify($shopId);
@@ -407,7 +408,7 @@ class AppUrlVerifierTest extends TestCase
         $cache->save($item);
 
         $http = new MockHttpClient(new MockResponse('', ['http_code' => 204]));
-        $verifier = new AppUrlVerifier('prod', '6.7.1.0', $cache, $http, $locks, static::createStub(LoggerInterface::class), $clock);
+        $verifier = new AppUrlVerifier('prod', '6.7.1.0', $cache, $http, new LockManager($locks), static::createStub(LoggerInterface::class), $clock);
         $shop = ShopId::v2('shop-id', [AppUrl::IDENTIFIER => 'https://example.com']);
 
         $state = $verifier->getCurrentState();
@@ -428,7 +429,7 @@ class AppUrlVerifierTest extends TestCase
         $locks = new LockFactory(new InMemoryStore());
 
         $http = new MockHttpClient();
-        $verifier = new AppUrlVerifier('dev', '6.7.1.0', $cache, $http, $locks, static::createStub(LoggerInterface::class), $clock);
+        $verifier = new AppUrlVerifier('dev', '6.7.1.0', $cache, $http, new LockManager($locks), static::createStub(LoggerInterface::class), $clock);
         $shop = ShopId::v2('shop-id', [AppUrl::IDENTIFIER => 'https://example.com']);
 
         static::assertTrue($verifier->forceVerify($shop));
@@ -442,7 +443,7 @@ class AppUrlVerifierTest extends TestCase
         $locks = new LockFactory(new InMemoryStore());
 
         $http = new MockHttpClient(new MockResponse('', ['http_code' => 204]));
-        $verifier = new AppUrlVerifier('dev', '6.7.1.0', $cache, $http, $locks, static::createStub(LoggerInterface::class), $clock);
+        $verifier = new AppUrlVerifier('dev', '6.7.1.0', $cache, $http, new LockManager($locks), static::createStub(LoggerInterface::class), $clock);
         $shop = ShopId::v2('shop-id', [AppUrl::IDENTIFIER => 'https://example.com']);
 
         $result = $verifier->forceVerify($shop, true);
@@ -455,7 +456,7 @@ class AppUrlVerifierTest extends TestCase
     public function testGetCurrentStateReturnsNullWhenCacheEmpty(): void
     {
         $cache = new ArrayAdapter();
-        $verifier = new AppUrlVerifier('prod', '6.7.1.0', $cache, new MockHttpClient(), new LockFactory(new InMemoryStore()), static::createStub(LoggerInterface::class), new MockClock());
+        $verifier = new AppUrlVerifier('prod', '6.7.1.0', $cache, new MockHttpClient(), new LockManager(new LockFactory(new InMemoryStore())), static::createStub(LoggerInterface::class), new MockClock());
 
         static::assertNull($verifier->getCurrentState());
     }
@@ -463,7 +464,7 @@ class AppUrlVerifierTest extends TestCase
     public function testGetCurrentState(): void
     {
         $cache = new ArrayAdapter();
-        $verifier = new AppUrlVerifier('prod', '6.7.1.0', $cache, new MockHttpClient(), new LockFactory(new InMemoryStore()), static::createStub(LoggerInterface::class), new MockClock());
+        $verifier = new AppUrlVerifier('prod', '6.7.1.0', $cache, new MockHttpClient(), new LockManager(new LockFactory(new InMemoryStore())), static::createStub(LoggerInterface::class), new MockClock());
 
         $state = new VerificationState(
             VerificationStatus::SOFT_FAIL,
@@ -482,7 +483,7 @@ class AppUrlVerifierTest extends TestCase
     #[DataProvider('completeVerificationProvider')]
     public function testCompleteVerification(ArrayAdapter $cache, string $runId, string $token, bool $expectedResult): void
     {
-        $verifier = new AppUrlVerifier('prod', '6.7.1.0', $cache, new MockHttpClient(), new LockFactory(new InMemoryStore()), static::createStub(LoggerInterface::class), new MockClock());
+        $verifier = new AppUrlVerifier('prod', '6.7.1.0', $cache, new MockHttpClient(), new LockManager(new LockFactory(new InMemoryStore())), static::createStub(LoggerInterface::class), new MockClock());
 
         $result = $verifier->completeVerification($runId, $token);
 
@@ -556,7 +557,7 @@ class AppUrlVerifierTest extends TestCase
             );
 
         $shopId = ShopId::v2('shop-id', [AppUrl::IDENTIFIER => 'https://example.com']);
-        $verifier = new AppUrlVerifier('prod', '6.7.1.0', $cache, $http, $locks, $logger, $clock);
+        $verifier = new AppUrlVerifier('prod', '6.7.1.0', $cache, $http, new LockManager($locks), $logger, $clock);
 
         $result = $verifier->verify($shopId);
         static::assertFalse($result);
@@ -578,7 +579,7 @@ class AppUrlVerifierTest extends TestCase
             );
 
         $shopId = ShopId::v2('shop-id', [AppUrl::IDENTIFIER => 'https://example.com']);
-        $verifier = new AppUrlVerifier('prod', '6.7.1.0', $cache, $http, $locks, $logger, $clock);
+        $verifier = new AppUrlVerifier('prod', '6.7.1.0', $cache, $http, new LockManager($locks), $logger, $clock);
 
         $result = $verifier->verify($shopId);
         static::assertTrue($result);

--- a/tests/unit/Core/Framework/App/Url/AppUrlVerifierTest.php
+++ b/tests/unit/Core/Framework/App/Url/AppUrlVerifierTest.php
@@ -18,6 +18,7 @@ use Symfony\Component\Clock\MockClock;
 use Symfony\Component\HttpClient\Exception\TransportException;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Component\Lock\Exception\LockAcquiringException;
 use Symfony\Component\Lock\Exception\LockConflictedException;
 use Symfony\Component\Lock\LockFactory;
 use Symfony\Component\Lock\SharedLockInterface;
@@ -74,9 +75,11 @@ class AppUrlVerifierTest extends TestCase
 
         $shopId = ShopId::v2('shop-id', [AppUrl::IDENTIFIER => 'https://example.com']);
         static::assertTrue($verifier->verify($shopId));
+        static::assertSame(0, $http->getRequestsCount());
     }
 
-    public function testVerifyReturnsTrueIfCreateLockThrowsException(): void
+    #[DataProvider('lockAcquisitionExceptionProvider')]
+    public function testVerifyReturnsTrueIfAcquiringLockThrowsException(\Exception $exception): void
     {
         $cache = new ArrayAdapter();
         $clock = new MockClock();
@@ -84,7 +87,7 @@ class AppUrlVerifierTest extends TestCase
 
         $lock = static::createStub(SharedLockInterface::class);
         $lock->method('acquire')
-            ->willThrowException(new LockConflictedException('cannot acquire'));
+            ->willThrowException($exception);
 
         $lockFactory = static::createStub(LockFactory::class);
         $lockFactory->method('createLock')->willReturn($lock);
@@ -93,6 +96,13 @@ class AppUrlVerifierTest extends TestCase
 
         $shopId = ShopId::v2('shop-id', [AppUrl::IDENTIFIER => 'https://example.com']);
         static::assertTrue($verifier->verify($shopId));
+        static::assertSame(0, $http->getRequestsCount());
+    }
+
+    public static function lockAcquisitionExceptionProvider(): iterable
+    {
+        yield 'conflicted lock' => [new LockConflictedException('cannot acquire')];
+        yield 'lock backend failure' => [new LockAcquiringException('cannot acquire')];
     }
 
     #[DataProvider('verifyOutcomeProvider')]

--- a/tests/unit/Core/Framework/DataAbstractionLayer/VersionManagerTest.php
+++ b/tests/unit/Core/Framework/DataAbstractionLayer/VersionManagerTest.php
@@ -6,6 +6,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Adapter\Lock\LockManager;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\DataAbstractionLayerException;
 use Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry;
@@ -162,7 +163,7 @@ class VersionManagerTest extends TestCase
 
         $this->versionManager = $this->createVersionManager([
             'registry' => $registry,
-            'lockFactory' => $lockFactory,
+            'lockManager' => new LockManager($lockFactory),
         ]);
 
         $versionId = 'version-id';
@@ -189,7 +190,7 @@ class VersionManagerTest extends TestCase
 
         $versionManager = $this->createVersionManager([
             'entitySearcher' => $entitySearcherMock,
-            'lockFactory' => $lockFactory,
+            'lockManager' => new LockManager($lockFactory),
         ]);
 
         $versionId = 'non-existent-version-id';
@@ -552,7 +553,7 @@ class VersionManagerTest extends TestCase
             'versionCommitDefinition' => static::createStub(VersionCommitDefinition::class),
             'versionCommitDataDefinition' => static::createStub(VersionCommitDataDefinition::class),
             'versionDefinition' => static::createStub(VersionDefinition::class),
-            'lockFactory' => static::createStub(LockFactory::class),
+            'lockManager' => new LockManager(static::createStub(LockFactory::class)),
             'clock' => new NativeClock(),
         ];
 
@@ -569,7 +570,7 @@ class VersionManagerTest extends TestCase
             $params['versionCommitDefinition'],
             $params['versionCommitDataDefinition'],
             $params['versionDefinition'],
-            $params['lockFactory'],
+            $params['lockManager'],
             $params['clock']
         );
     }

--- a/tests/unit/Core/Framework/MessageQueue/Api/ConsumeMessagesControllerTest.php
+++ b/tests/unit/Core/Framework/MessageQueue/Api/ConsumeMessagesControllerTest.php
@@ -4,6 +4,7 @@ namespace Shopware\Tests\Unit\Core\Framework\MessageQueue\Api;
 
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Adapter\Lock\LockManager;
 use Shopware\Core\Framework\Increment\AbstractIncrementer;
 use Shopware\Core\Framework\Increment\IncrementGatewayRegistry;
 use Shopware\Core\Framework\Log\Package;
@@ -44,7 +45,7 @@ class ConsumeMessagesControllerTest extends TestCase
             'async',
             '128M',
             20,
-            static::createStub(LockFactory::class)
+            new LockManager(static::createStub(LockFactory::class))
         );
 
         $this->expectExceptionObject(MessageQueueException::validReceiverNameNotProvided());
@@ -73,7 +74,7 @@ class ConsumeMessagesControllerTest extends TestCase
             'async',
             '128M',
             20,
-            $lockFactory
+            new LockManager($lockFactory)
         );
 
         $this->expectExceptionObject(MessageQueueException::workerIsLocked('async'));
@@ -145,7 +146,7 @@ class ConsumeMessagesControllerTest extends TestCase
             'async',
             '-1',
             1,
-            $lockFactory
+            new LockManager($lockFactory)
         );
 
         $request = new Request();

--- a/tests/unit/Core/System/NumberRange/ValueGenerator/IncrementRedisStorageTest.php
+++ b/tests/unit/Core/System/NumberRange/ValueGenerator/IncrementRedisStorageTest.php
@@ -5,6 +5,7 @@ namespace Shopware\Tests\Unit\Core\System\NumberRange\ValueGenerator;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Adapter\Lock\LockManager;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\IdSearchResult;
@@ -39,7 +40,7 @@ class IncrementRedisStorageTest extends TestCase
 
         $this->storage = new IncrementRedisStorage(
             $this->redisMock,
-            $this->lockFactoryMock,
+            new LockManager($this->lockFactoryMock),
             $repository,
         );
     }
@@ -247,7 +248,7 @@ class IncrementRedisStorageTest extends TestCase
 
         $this->storage = new IncrementRedisStorage(
             $this->redisMock,
-            $this->lockFactoryMock,
+            new LockManager($this->lockFactoryMock),
             $repository,
         );
 

--- a/tests/unit/Core/System/StateMachine/StateMachineLockerTest.php
+++ b/tests/unit/Core/System/StateMachine/StateMachineLockerTest.php
@@ -5,6 +5,7 @@ namespace Shopware\Tests\Unit\Core\System\StateMachine;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Defaults;
+use Shopware\Core\Framework\Adapter\Lock\LockManager;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\StateMachine\Aggregation\StateMachineState\StateMachineStateCollection;
@@ -33,7 +34,7 @@ class StateMachineLockerTest extends TestCase
     protected function setUp(): void
     {
         $this->lockFactory = new LockFactory(new InMemoryStore());
-        $this->locker = new StateMachineLocker($this->lockFactory);
+        $this->locker = new StateMachineLocker(new LockManager($this->lockFactory));
     }
 
     public function testLockedExecutesClosure(): void
@@ -94,7 +95,7 @@ class StateMachineLockerTest extends TestCase
         $context = Context::createDefaultContext();
         $lockFactory = $this->createMock(LockFactory::class);
         $lock = $this->createMock(SharedLockInterface::class);
-        $locker = new StateMachineLocker($lockFactory);
+        $locker = new StateMachineLocker(new LockManager($lockFactory));
 
         $lockFactory->expects($this->once())
             ->method('createLock')
@@ -129,11 +130,11 @@ class StateMachineLockerTest extends TestCase
         $context = Context::createDefaultContext();
         $lockFactory = $this->createMock(LockFactory::class);
         $lock = $this->createMock(SharedLockInterface::class);
-        $locker = new StateMachineLocker($lockFactory);
+        $locker = new StateMachineLocker(new LockManager($lockFactory));
 
         $lockFactory->expects($this->once())
             ->method('createLock')
-            ->with($locker->getLockKey($transition, $context), 5.0, true)
+            ->with($locker->getLockKey($transition, $context), 5.0)
             ->willReturn($lock);
 
         $lock->expects($this->once())
@@ -181,12 +182,12 @@ class StateMachineLockerTest extends TestCase
         $lockFactory = $this->createMock(LockFactory::class);
         $firstLock = $this->createMock(SharedLockInterface::class);
         $secondLock = $this->createMock(SharedLockInterface::class);
-        $locker = new StateMachineLocker($lockFactory);
+        $locker = new StateMachineLocker(new LockManager($lockFactory));
         $transitionResult = $this->createTransitionResult();
 
         $lockFactory->expects($this->exactly(2))
             ->method('createLock')
-            ->with($locker->getLockKey($transition, $context), 5.0, true)
+            ->with($locker->getLockKey($transition, $context), 5.0)
             ->willReturnOnConsecutiveCalls($firstLock, $secondLock);
 
         $firstLock->expects($this->once())


### PR DESCRIPTION
### 1. Why is this change necessary?

Shopware has several places that use Symfony's lock component directly with repeated acquisition, failure handling and release patterns. Centralizing these patterns reduces duplication and makes lock handling easier to use consistently.

### 2. What does this change do, exactly?

This adds a new internal `LockManager` helper for common lock workflows:

- `executeLocked()` acquires a lock, executes a callback and releases the lock in a `finally` block.
- `acquireOrThrow()` acquires a lock for longer caller-owned lifecycles and delegates failed acquisition to a domain-specific exception callback.
- `acquire()` returns a nullable lock for workflows where failed acquisition is part of the normal control flow.
- Optional TTLs, blocking acquisition mode, Symfony acquisition exception handling and key prefixing are supported.

Existing `LockFactory` usages are migrated where the behavior can be preserved exactly. Existing lock keys, TTLs, blocking modes, exception behavior and release timing are kept unchanged.

No developer-facing release notes are added because the new helper and migrated services are internal.

### 3. Describe each step to reproduce the issue or behaviour.

This is an internal cleanup/improvement.

Before this change, lock handling logic was duplicated across several services. After this change, matching lock usages go through the shared `LockManager` helper while preserving the existing behavior.

### 4. Please link to the relevant issues (if any).

Closes #11302

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them