### PR TITLE
fix(promotion): normalize promotion codes

### DIFF
--- a/src/Core/Checkout/Cart/LineItemFactoryHandler/PromotionLineItemFactory.php
+++ b/src/Core/Checkout/Cart/LineItemFactoryHandler/PromotionLineItemFactory.php
@@ -22,7 +22,7 @@ class PromotionLineItemFactory implements LineItemFactoryInterface
      */
     public function create(array $data, SalesChannelContext $context): LineItem
     {
-        $code = $data['referencedId'];
+        $code = mb_trim($data['referencedId']);
         $uniqueKey = 'promotion-' . $code;
 
         $item = new LineItem(Uuid::fromStringToHex($uniqueKey), LineItem::PROMOTION_LINE_ITEM_TYPE);

--- a/src/Core/Checkout/Promotion/Cart/PromotionItemBuilder.php
+++ b/src/Core/Checkout/Promotion/Cart/PromotionItemBuilder.php
@@ -46,6 +46,8 @@ class PromotionItemBuilder
      */
     public function buildPlaceholderItem(string $code): LineItem
     {
+        $code = mb_trim($code);
+
         // void duplicate codes with other items
         // that might not be from the promotion scope
         $uniqueKey = self::PLACEHOLDER_PREFIX . $code;

--- a/src/Core/Checkout/Promotion/Subscriber/PromotionIndividualCodeRedeemer.php
+++ b/src/Core/Checkout/Promotion/Subscriber/PromotionIndividualCodeRedeemer.php
@@ -81,7 +81,7 @@ class PromotionIndividualCodeRedeemer implements EventSubscriberInterface
                 /** @var string $code */
                 $code = $item->getPayload()['code'] ?? '';
 
-                if (strtolower($code) !== strtolower($promotion->getCode())) {
+                if (mb_strtolower($code) !== mb_strtolower($promotion->getCode())) {
                     continue;
                 }
 

--- a/tests/integration/Core/Checkout/Cart/SalesChannel/CartItemAddRouteTest.php
+++ b/tests/integration/Core/Checkout/Cart/SalesChannel/CartItemAddRouteTest.php
@@ -317,7 +317,7 @@ class CartItemAddRouteTest extends TestCase
                     'items' => [
                         [
                             'type' => 'promotion',
-                            'referencedId' => $code,
+                            'referencedId' => " \t{$code}\n",
                         ],
                     ],
                 ]
@@ -331,6 +331,14 @@ class CartItemAddRouteTest extends TestCase
         static::assertSame(790, $response['price']['totalPrice']);
         static::assertCount(2, $response['lineItems']);
         static::assertSame('Test', $response['lineItems'][0]['label']);
+
+        $promotionLineItems = array_values(array_filter(
+            $response['lineItems'],
+            static fn (array $lineItem): bool => $lineItem['type'] === LineItem::PROMOTION_LINE_ITEM_TYPE
+        ));
+
+        static::assertCount(1, $promotionLineItems);
+        static::assertSame($code, $promotionLineItems[0]['referencedId']);
     }
 
     private function createTestData(): void

--- a/tests/integration/Core/Checkout/Promotion/DataAbstractionLayer/PromotionRedemptionUpdaterTest.php
+++ b/tests/integration/Core/Checkout/Promotion/DataAbstractionLayer/PromotionRedemptionUpdaterTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Shopware\Tests\Integration\Core\Checkout\Promotion\DataAbstractionLayer;
 
 use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\Cart\LineItem\LineItem;
 use Shopware\Core\Checkout\Cart\Price\Struct\CalculatedPrice;
@@ -101,9 +102,10 @@ class PromotionRedemptionUpdaterTest extends TestCase
         $this->assertUpdatedCounts();
     }
 
-    public function testIndividualCodeGotCustomerAssignment(): void
+    #[DataProvider('individualCodeDataProvider')]
+    public function testIndividualCodeGotCustomerAssignment(string $orderCode): void
     {
-        $this->createPromotionsAndOrder();
+        $this->createPromotionsAndOrder($orderCode);
 
         $voucherD = $this->ids->get('voucherD');
 
@@ -165,6 +167,15 @@ class PromotionRedemptionUpdaterTest extends TestCase
             $expected_json,
             $promotionIndividualCode[0]['payload']
         );
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function individualCodeDataProvider(): iterable
+    {
+        yield 'stored casing' => ['test-FABPB-test'];
+        yield 'different casing' => ['TEST-fabpb-TEST'];
     }
 
     public function testRemoveItemMultipleOrders(): void
@@ -272,7 +283,7 @@ class PromotionRedemptionUpdaterTest extends TestCase
         static::assertNull($promotionAEvenLater->getOrdersPerCustomerCount());
     }
 
-    private function createPromotionsAndOrder(): void
+    private function createPromotionsAndOrder(string $orderCode = 'test-FABPB-test'): void
     {
         /** @var EntityRepository $promotionRepository */
         $promotionRepository = static::getContainer()->get('promotion.repository');
@@ -295,7 +306,7 @@ class PromotionRedemptionUpdaterTest extends TestCase
         );
 
         $this->ids->set('customer', $this->createCustomer('johndoe@example.com'));
-        $this->createOrder($this->ids->get('customer'));
+        $this->createOrder($this->ids->get('customer'), $orderCode);
 
         $lineItems = $this->connection->fetchAllAssociative('SELECT id FROM order_line_item;');
 
@@ -379,7 +390,7 @@ class PromotionRedemptionUpdaterTest extends TestCase
         return $salesChannelContextFactory->create($token, TestDefaults::SALES_CHANNEL, $options);
     }
 
-    private function createOrder(string $customerId): void
+    private function createOrder(string $customerId, string $individualCode): void
     {
         static::getContainer()->get('order.repository')->create(
             [[
@@ -439,7 +450,7 @@ class PromotionRedemptionUpdaterTest extends TestCase
                         'quantity' => 1,
                         'payload' => [
                             'promotionId' => $this->ids->get('voucherD'),
-                            'code' => 'test-FABPB-test',
+                            'code' => $individualCode,
                             'promotionCodeType' => 'individual',
                         ],
                         'promotionId' => $this->ids->get('voucherD'),

--- a/tests/unit/Core/Checkout/Cart/LineItemFactoryHandler/PromotionLineItemFactoryTest.php
+++ b/tests/unit/Core/Checkout/Cart/LineItemFactoryHandler/PromotionLineItemFactoryTest.php
@@ -57,6 +57,19 @@ class PromotionLineItemFactoryTest extends TestCase
         static::assertSame(0.0, $percentagePrice->getPercentage());
     }
 
+    public function testCreateTrimsPromotionCode(): void
+    {
+        $factory = new PromotionLineItemFactory();
+
+        $lineItem = $factory->create([
+            'id' => 'test-id',
+            'referencedId' => "\u{00a0}test-referenced-id \t",
+        ], Generator::generateSalesChannelContext());
+
+        static::assertSame(Uuid::fromStringToHex('promotion-test-referenced-id'), $lineItem->getId());
+        static::assertSame('test-referenced-id', $lineItem->getReferencedId());
+    }
+
     public function testUpdate(): void
     {
         $this->expectException(CartException::class);

--- a/tests/unit/Core/Checkout/Cart/Promotion/Cart/Builder/PromotionItemBuilderPlaceholderTest.php
+++ b/tests/unit/Core/Checkout/Cart/Promotion/Cart/Builder/PromotionItemBuilderPlaceholderTest.php
@@ -63,6 +63,17 @@ class PromotionItemBuilderPlaceholderTest extends TestCase
         static::assertEquals('CODE-123', $item->getReferencedId());
     }
 
+    #[Group('promotions')]
+    public function testCodeValueInReferenceIdIsTrimmed(): void
+    {
+        $builder = new PromotionItemBuilder();
+
+        $item = $builder->buildPlaceholderItem("\u{00a0}CODE-123 \t");
+
+        static::assertSame(Uuid::fromStringToHex('promotion-CODE-123'), $item->getId());
+        static::assertSame('CODE-123', $item->getReferencedId());
+    }
+
     /**
      * This test verifies that we have our correct prefix in the key.
      * We use the code as key to avoid andy randomly generated UIDs.

--- a/tests/unit/Core/Checkout/Promotion/Subscriber/PromotionIndividualCodeRedeemerTest.php
+++ b/tests/unit/Core/Checkout/Promotion/Subscriber/PromotionIndividualCodeRedeemerTest.php
@@ -92,14 +92,14 @@ class PromotionIndividualCodeRedeemerTest extends TestCase
     {
         $code = new PromotionIndividualCodeEntity();
         $code->setId(Uuid::randomHex());
-        $code->setCode('existing');
+        $code->setCode('ÄXISTING');
 
         /** @var StaticEntityRepository<PromotionIndividualCodeCollection> $codeRepository */
         $codeRepository = new StaticEntityRepository([
             static function (Criteria $criteria) use ($code) {
                 $filter = $criteria->getFilters()[0];
                 static::assertInstanceOf(EqualsAnyFilter::class, $filter);
-                static::assertSame(['existing'], $filter->getValue());
+                static::assertSame(['äxisting'], $filter->getValue());
 
                 return new PromotionIndividualCodeCollection([$code]);
             },
@@ -126,7 +126,7 @@ class PromotionIndividualCodeRedeemerTest extends TestCase
         $lineItem2->setId(Uuid::randomHex());
         $lineItem2->setOrderId($order->getId());
         $lineItem2->setType(PromotionProcessor::LINE_ITEM_TYPE);
-        $lineItem2->setPayload(['code' => 'existing']);
+        $lineItem2->setPayload(['code' => 'äxisting']);
 
         $context = Context::createDefaultContext();
 


### PR DESCRIPTION
### 6.6 backport for https://github.com/shopware/shopware/pull/19900

### 1. Why is this change necessary?

Individual promotion codes can be accepted with trailing whitespace while their redemption payload is not updated, allowing repeated use.

### 2. What does this change do, exactly?

Normalizes promotion codes before lookup and payload storage, and compares individual codes with Unicode-aware case normalization. It also adds Store API and redemption regression coverage.

### 3. Describe each step to reproduce the issue or behaviour.

1. Create an individual promotion code.
2. Add it through the Store API with trailing whitespace.
3. Complete an order and repeat the request.

Before this change, the discount is applied repeatedly without consuming the code. Afterwards, the submitted code is normalized and redemption is recorded.

### 4. Please link to the relevant issues (if any).

- relates #19900

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them