### PR TITLE
ci: ignore fenced code blocks when collecting RELEASE_INFO headings

### DIFF
--- a/.github/bin/js/verify-release-content.test.ts
+++ b/.github/bin/js/verify-release-content.test.ts
@@ -153,6 +153,30 @@ test('extractHeadings spans multiple sections sharing the prefix', () => {
     assert.deepEqual(extractHeadings(content, VERSION), ['### First patch', '### Second patch']);
 });
 
+test('extractHeadings ignores headings inside fenced code blocks', () => {
+    const content = [
+        '# 6.7.11.0',
+        '### Before the block',
+        '',
+        '```yaml',
+        '# config/packages/shopware.yaml',
+        'shopware:',
+        '  foo: bar',
+        '```',
+        '',
+        '### After the block',
+        '',
+    ].join('\n');
+
+    assert.deepEqual(extractHeadings(content, VERSION), ['### Before the block', '### After the block']);
+});
+
+test('extractHeadings does not treat a fenced ### line as an entry', () => {
+    const content = '# 6.7.11.0\n### Real entry\n\n~~~md\n### Example from the docs\n~~~\n';
+
+    assert.deepEqual(extractHeadings(content, VERSION), ['### Real entry']);
+});
+
 test('consoleReport shows only the OK line when everything is confirmed', () => {
     const report = consoleReport({ total: 3, confirmed: 3, missing: [], warnings: [] }, FILE);
 

--- a/.github/bin/js/verify-release-content.ts
+++ b/.github/bin/js/verify-release-content.ts
@@ -66,13 +66,35 @@ function escapeRegExp(value: string): string {
     return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
+/** A fenced block may quote "# ..." lines that are content, not structure. */
+const FENCE_PATTERN = /^ {0,3}(`{3,}|~{3,})(.*)$/;
+
 /** Collects every "### " heading that appears under a "# <version-prefix>.*" section. */
 export function extractHeadings(content: string, versionPrefix: string): string[] {
     const sectionOpen = new RegExp(`^#\\s+${escapeRegExp(versionPrefix)}\\.`);
     const headings: string[] = [];
     let inSection = false;
+    let fence: string | undefined;
 
     for (const line of content.split('\n')) {
+        // RELEASE_INFO quotes YAML and Markdown, so a fenced block carries lines like
+        // "# config/packages/shopware.yaml" and "### Example". Read as structure they cut a
+        // section short — every entry below is then never verified — or add an entry that does
+        // not exist. Both fail silently, which is the worst way for this check to be wrong.
+        const delimiter = FENCE_PATTERN.exec(line);
+        if (delimiter) {
+            const [, marker, info] = delimiter;
+            if (fence === undefined) {
+                fence = marker[0];
+            } else if (fence === marker[0] && info.trim() === '') {
+                fence = undefined;
+            }
+            continue;
+        }
+        if (fence !== undefined) {
+            continue;
+        }
+
         // "# 6.7.11.0" → enter the section for this version prefix.
         if (sectionOpen.test(line)) {
             inSection = true;


### PR DESCRIPTION
`extractHeadings` treated every `# ` line as structure, including inside fenced code
blocks. RELEASE_INFO quotes YAML and Markdown, so a block carries lines like
`# config/packages/shopware.yaml`: that closed the version section and left every
entry below it unverified, while a fenced `### ` line was collected as an entry that
does not exist.

Both are silent — the check reports success on a section it never finished reading.
On the current file it collected **38 of the 86** entries under 6.7.14, so 48 were
never held against the release branch.

`release-info-sections.ts` already tracks fences; this uses the same rule. Two tests
cover both directions.

Note: `6.7.13.x` still runs the PHP predecessor of this script, which has the same
bug and is not touched here.
