### PR TITLE
fix(administration): let the product category description grow with its content

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-category-form/sw-product-category-form.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-category-form/sw-product-category-form.html.twig
@@ -110,10 +110,7 @@
     {% endblock %}
 
     {% block sw_product_category_form_category_field %}
-    <sw-container
-        rows="2em 4em 4em"
-        class="sw-product-feature-set-form__description"
-    >
+    <sw-container class="sw-product-category-form__categories-description">
         {% block sw_product_category_form_categories_title %}
         <span class="sw-product-category-form__visibility-title">
             {{ $t('sw-product.categoryForm.categoriesTitle') }}

--- a/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-category-form/sw-product-category-form.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-category-form/sw-product-category-form.scss
@@ -10,6 +10,10 @@
         margin-bottom: var(--scale-size-8);
     }
 
+    &__categories-body {
+        margin-bottom: var(--scale-size-8);
+    }
+
     &__visibility_field {
         margin-top: var(--scale-size-20);
 


### PR DESCRIPTION
### 1. Why is this change necessary?

In the **Assignment** card of the product detail page, the two description paragraphs of the *Categories and tags* section overlap when the Administration language is German. The last line of the category description is painted on top of the first line of the tag description, so both lines are unreadable.

`sw-product-category-form.html.twig` pinned the section's `sw-container` to `rows="2em 4em 4em"`, which renders as `grid-template-rows: 28px 56px 56px`. At `line-height: 26px` a 56px row fits exactly two lines. The German copy wraps to three lines (78px), and since the row height is fixed and `overflow` is `visible`, the third line spills over the paragraph below. The English copy fits only by a small margin, so any longer translation or wording change hits the same overflow.

### 2. What does this change do, exactly?

- Removes the hard-coded `rows` attribute so the grid rows size to their content, like the *Visibility* container above, which is unaffected for exactly that reason.
- Adds `margin-bottom: var(--scale-size-8)` on `.sw-product-category-form__categories-body` so the paragraphs keep their spacing now that the rows no longer provide it.
- The container also carried the class `sw-product-feature-set-form__description`, copied over from `sw-product-feature-set-form`, where those styles are scoped under `.sw-product-feature-set-form__container` and therefore never applied here. Renamed to `sw-product-category-form__categories-description`.

Style-only change, no behaviour or logic touched; the existing component spec still passes.

### 3. Describe each step to reproduce the issue or behaviour.

1. Set the Administration language to **Deutsch (de-DE)**.
2. Go to **Kataloge > Produkte** and open any product (or `/admin#/sw/product/create/base`).
3. Scroll to the **Zuweisung** card on the **Allgemein** tab and look at **Kategorien und Tags**.

Before: `… damit Du sie hier auswählen kannst.` overlaps `Tags helfen Dir dabei Produkte schneller zu finden. …`.
After: both paragraphs stack cleanly, and the section grows vertically for any language, text length or viewport width.

### 4. Please link to the relevant issues (if any).

closes #19902

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them