### PR TITLE
test(inventory): remove indexer-order-dependent stream assertions from the product detail fixture

### DIFF
--- a/tests/integration/Core/Content/Product/SalesChannel/Detail/_fixtures/recursion_encoding_with_layout_result.json
+++ b/tests/integration/Core/Content/Product/SalesChannel/Detail/_fixtures/recursion_encoding_with_layout_result.json
@@ -77,7 +77,6 @@
     "length": null,
     "releaseDate": null,
     "categoryTree": null,
-    "streamIds": null,
     "optionIds": null,
     "propertyIds": null,
     "name": "with-layout",
@@ -404,7 +403,6 @@
                       "length": null,
                       "releaseDate": null,
                       "categoryTree": null,
-                      "streamIds": null,
                       "optionIds": null,
                       "propertyIds": null,
                       "name": "with-layout",
@@ -563,7 +561,6 @@
                         }
                       ],
                       "canonicalProduct": null,
-                      "streams": null,
                       "translated": {
                         "metaDescription": null,
                         "name": "with-layout",
@@ -744,7 +741,6 @@
                       "length": null,
                       "releaseDate": null,
                       "categoryTree": null,
-                      "streamIds": null,
                       "optionIds": null,
                       "propertyIds": null,
                       "name": "with-layout",
@@ -903,7 +899,6 @@
                         }
                       ],
                       "canonicalProduct": null,
-                      "streams": null,
                       "translated": {
                         "metaDescription": null,
                         "name": "with-layout",
@@ -1054,7 +1049,6 @@
                             "length": null,
                             "releaseDate": null,
                             "categoryTree": null,
-                            "streamIds": null,
                             "optionIds": null,
                             "propertyIds": null,
                             "name": "product",
@@ -1092,7 +1086,6 @@
                             "seoUrls": null,
                             "crossSellings": null,
                             "canonicalProduct": null,
-                            "streams": null,
                             "translated": {
                               "metaDescription": null,
                               "name": "product",
@@ -1202,7 +1195,6 @@
       }
     ],
     "canonicalProduct": null,
-    "streams": null,
     "translated": {
       "metaDescription": null,
       "name": "with-layout",


### PR DESCRIPTION
### 1. Why is this change necessary?

The fixture asserts `"streamIds": null` and `"streams": null`, but that state depends on the entity indexer order. The fixture's own cross selling creates a product stream whose filter (`active = 1`) matches the fixture products, so whenever `product_stream.indexer` runs before the stream matching of `product.indexer`, the products are tagged with the stream id and the test fails. The order shifts with the installed service composition (for example, plugins decorating `ProductIndexer`), so the test is green in a plain core checkout and red in such setups.

### 2. What does this change do, exactly?

Removes the `streamIds` and `streams` entries from the expected-response fixture. The assertion helper only checks keys present in the fixture, so the test keeps covering its actual subject: recursive encoding of the CMS layout in the product detail response.

### 3. Describe each step to reproduce the issue or behaviour.

1. Install a plugin that decorates `ProductIndexer` without re-declaring the `shopware.entity_indexer` tag priority, so `product_stream.indexer` runs first.
2. Run `vendor/bin/phpunit --filter testRecursionEncodingWithLayout tests/integration/Core/Content/Product/SalesChannel/Detail/ProductDetailRouteTest.php`
3. The test fails with `Value for key product.streamIds not matching.`

### 4. Please link to the relevant issues (if any).

None.

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
