### PR TITLE
fix: shopware account typo

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-extension/snippet/en.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension/snippet/en.json
@@ -58,7 +58,7 @@
       },
       "account": {
         "headline": "Shopware Account",
-        "isLoggedIn": "Shopware Account succesfully connected. Go to the \"App\" or \"Themes\" tab and check if your purchased extensions are listed. If not, check head over to your Showare Account and make sure the correct domain for extensions has been set.",
+        "isLoggedIn": "Shopware Account succesfully connected. Go to the \"App\" or \"Themes\" tab and check if your purchased extensions are listed. If not, check head over to your Shopware Account and make sure the correct domain for extensions has been set.",
         "login": "Login",
         "logout": "Logout",
         "loginMessage": "Login with you Shopware Account to access extensions you bought on store.shopware.com",


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

This fixes typo in the snippet: ~~Showare~~ Shopware

### 2. What does this change do, exactly?

<img width="568" height="150" alt="image" src="https://github.com/user-attachments/assets/b04eabda-d8ed-4b47-bee0-5c3d7d1da0e1" />

### 3. Describe each step to reproduce the issue or behaviour.

Login to Shopware Account.

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

Note: there are some template blocks with the same typo, but it seems fixing that would be a breaking change.
<img width="463" height="369" alt="image" src="https://github.com/user-attachments/assets/a0a198b5-1ea6-4014-b93b-6683aeaed2c8" />


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfilled them
