### PR TITLE
chore(administration): update caniuse-lite browser data

### DIFF
--- a/src/Administration/Resources/app/administration/package-lock.json
+++ b/src/Administration/Resources/app/administration/package-lock.json
@@ -10626,9 +10626,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.8",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.8.tgz",
-      "integrity": "sha512-PCLz/LXGBsNTErbtB6i5u4eLpHeMfi93aUv5duMmj6caNu6IphS4q6UevDnL36sZQv9lrP11dbPKGMaXPwMKfQ==",
+      "version": "2.11.20",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.20.tgz",
+      "integrity": "sha512-H0ulySigv6icDJ1F7SjtdCD6PrhTpdYCmP0CactWy1+ekh0AFd0o1Wn5T8b+hnTmdBx19u9yhL6wvCylXMY7zw==",
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.cjs"
@@ -11170,9 +11170,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001780",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001780.tgz",
-      "integrity": "sha512-llngX0E7nQci5BPJDqoZSbuZ5Bcs9F5db7EtgfwBerX9XGtkkiO4NwfDDIRzHTTwcYC8vC7bmeUEPGrKlR/TkQ==",
+      "version": "1.0.30001810",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001810.tgz",
+      "integrity": "sha512-TITQPUkaz+aVk5GL6NhOdwk1aEaNTSDPsGFWrTuhKGtjTF70jL/Oht2W4c6rXUe5fu7Ie19VIahAXHIIiWWNeg==",
       "funding": [
         {
           "type": "opencollective",


### PR DESCRIPTION
### 1. Why is this change necessary?

The pinned `caniuse-lite` 1.0.30001780 crossed browserslist's six-month staleness threshold, so browserslist emits its "browsers data is 6 months old" warning. `test/_setup/prepare_environment.js:694` turns any unexpected `console.warn` into a failure, which made `Jest Admin (unit)` fail on trunk and blocked the merge queue.

### 2. What does this change do, exactly?

Refreshes the Administration lockfile via `npx update-browserslist-db@latest`: `caniuse-lite` 1.0.30001780 → 1.0.30001810, `baseline-browser-mapping` 2.10.8 → 2.11.20. No target browser changes, no source changes.

### 3. Describe each step to reproduce the issue or behaviour.

`runtime-equivalence.spec.ts` and `build/vue-setup-transform/jest-transformer.spec.ts` fail with `Unexpected console.warn: Browserslist: browsers data (caniuse-lite) is 6 months old` before this change and pass after it. Failing run: https://github.com/shopware/shopware/actions/runs/33474340570

### 4. Please link to the relevant issues (if any).

—

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them

> The data ages again around 2027-02-18. Allowlisting this warning in `prepare_environment.js` or covering `caniuse-lite` with dependency-update automation would stop it recurring.