### PR TITLE
chore: route admin build and test infra to cc-framework

### DIFF
--- a/.codeowners
+++ b/.codeowners
@@ -52,6 +52,12 @@
 tests/integration/Core/Checkout/Document/Renderer/_snapshots/** @shopware/product-cc-after-sales
 tests/integration/Core/Checkout/DocumentV2/Renderer/_snapshots/** @shopware/product-cc-after-sales
 
+# cc-framework
+? src/Administration/Resources/app/administration/package.json @shopware/product-cc-framework
+? src/Administration/Resources/app/administration/package-lock.json @shopware/product-cc-framework
+? src/Administration/Resources/app/administration/jest.config.ts @shopware/product-cc-framework
+? src/Administration/Resources/app/administration/test/_setup/** @shopware/product-cc-framework
+
 # product-operations
 .github/** @shopware/product-operations
 


### PR DESCRIPTION
### 1. Why is this change necessary?

The Administration lockfile and Jest setup have no ownership rule, so changes to them ping nobody. A stale `caniuse-lite` pin in that lockfile recently blocked the merge queue (#19958) without an owner being notified.

### 2. What does this change do, exactly?

Adds four optional (`?`) owner rules for `@shopware/product-cc-framework`: the Administration `package.json`, `package-lock.json`, `jest.config.ts` and `test/_setup/**`. Optional, so routine dependency bumps are not blocked.

### 3. Describe each step to reproduce the issue or behaviour.

Open a PR touching only the Administration lockfile: codeowners-plus posts no owner comment today, and pings cc-framework after this change.

### 4. Please link to the relevant issues (if any).

- relates #19958

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them