### PR TITLE
fix(storefront): allow button text to wrap for WCAG SC 1.4.4 compliance (backport: 6.6.x)

### DIFF
--- a/src/Storefront/Resources/app/storefront/src/scss/skin/shopware/abstract/variables/_bootstrap.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/skin/shopware/abstract/variables/_bootstrap.scss
@@ -92,7 +92,7 @@ $form-label-margin-bottom: 3px !default;
 $btn-padding-y: 2px !default;
 $btn-padding-x: 12px !default;
 $btn-line-height: 2.125rem !default;
-$btn-white-space: nowrap !default;
+$btn-white-space: normal !default;
 
 $btn-padding-y-sm: 2px !default;
 $btn-padding-x-sm: 12px !default;

--- a/src/Storefront/Resources/app/storefront/src/scss/skin/shopware/component/_button.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/skin/shopware/component/_button.scss
@@ -8,8 +8,6 @@ https://getbootstrap.com/docs/5.2/components/buttons
 
 .btn {
     --#{$prefix}btn-disabled-color: #{$btn-link-disabled-color};
-    overflow: hidden;
-    text-overflow: ellipsis;
 }
 
 // custom add to cart button, used e.g. in product-box and product detail buybox


### PR DESCRIPTION
**Backport:** https://github.com/shopware/shopware/pull/17419
Resolves: https://github.com/shopware/shopware/issues/17223
relates #19539

---

### 1. Why is this change necessary?
Manual backport of #17419 to 6.6.x (a11y). The automated cherry-pick applied cleanly (no conflicts), but the payload deliberately reverses a scoping decision made on 6.6.x by a later PR — see below.

### 2. What does this change do, exactly?
Sets `$btn-white-space` from `nowrap` to `normal` and removes `overflow: hidden; text-overflow: ellipsis;` from the base `.btn` rule, so that button text can wrap onto multiple lines instead of being clipped with an ellipsis (WCAG 2.1 SC 1.4.4 Resize Text).

**Note on scoping vs. 6.6.x commit `23f14a9fcd1` (#7645, "fix(css): line-break on btn-link-inline buttons", Mar 2025, author Tobias Berge / @tobiasberge):**
That PR deliberately introduced `$btn-white-space: nowrap !default;` (the variable did not previously exist on 6.6.x) and moved wrapping behaviour out of the base `.btn` rule into `.btn-link-inline` only, adding `text-align: left; white-space: normal;` there specifically so only inline text-link-style buttons would wrap, while all other buttons stayed single-line with ellipsis truncation.

This backport reverses that scoping and makes **all** `.btn` elements wrap by default, matching trunk. This is an intentional product decision — accessibility (WCAG SC 1.4.4) takes precedence over the previous cosmetic scoping — but it directly undoes #7645's intent, so a reviewer familiar with that change should weigh in.

**End state after this change:**
- `.btn` (base): no longer has `overflow: hidden; text-overflow: ellipsis;`; `white-space` now resolves to `normal` via `$btn-white-space` (compiled by Bootstrap's own `_buttons.scss`, not overridden here).
- `.btn-link-inline`: still carries its explicit `text-align: left; white-space: normal;` from #7645. The `white-space: normal;` declaration becomes **redundant** now that the base `.btn` already resolves to `normal` — but it is left in place, since removing it is out of scope for this backport. `text-align: left;` remains necessary and is unaffected, since the base `.btn` still uses Bootstrap's default `text-align: center`.
- Cosmetic side effect inherited unchanged from trunk: `$btn-line-height` stays `2.125rem` (untouched by this or the original PR), so a button whose text now wraps to two lines gets a visibly tall line gap between the wrapped lines, rather than a tightened line-height for wrapped state.

**Conflict resolution vs. trunk commit `6f390bb4c2a`:**
- None. `git cherry-pick -x 6f390bb4c2a` applied cleanly against `origin/6.6.x` with no conflicts in either touched file.

### 3. Describe each step to reproduce the issue or behaviour.
See original PR (#17419) and issue #17223.

### 4. Please link to the relevant issues (if any).
- relates #17223
- relates #19539

### 5. Checklist
- [x] Cherry-picked from trunk with `-x`, no conflicts encountered
- [ ] Tests run locally: none — the worktree has no `node_modules`/`vendor` installed, so `stylelint`/`jest` could not be executed. Grepped `tests/acceptance/` and `src/Storefront/Resources/app/storefront/test/` for any spec asserting button wrap/nowrap/ellipsis/white-space behaviour — found none. The only related CI gate is `tests/acceptance/tests/Pagespeed/Lighthouse.spec.ts`, which enforces an accessibility score threshold of 100 (already maxed) and does not assert specific button markup/CSS; this change should help, not hurt, that score. Manual visual verification in a running 6.6.x storefront is still recommended (see below).
