### PR TITLE
fix(storefront): unify focus behaviour and ui polishing (backport: 6.6.x)

### DIFF
--- a/src/Storefront/Resources/app/storefront/src/scss/base/_base.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/base/_base.scss
@@ -67,6 +67,13 @@ html {
     /* stylelint-enable selector-class-pattern */
 }
 
+// Unify focus styling across all focusable elements.
+// Component-specific focus styles (.btn, .form-control, ...) have a higher specificity and keep their own styling.
+:focus-visible {
+    outline: 0;
+    box-shadow: $focus-ring-box-shadow;
+}
+
 // used by viewport detection helper to determine the current viewport
 :root {
     @include media-breakpoint-only(xs) {

--- a/src/Storefront/Resources/app/storefront/src/scss/component/_address-manager.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/component/_address-manager.scss
@@ -16,7 +16,7 @@
   }
 
   .modal-body {
-    padding-top: 0;
+    padding-top: 4px;
     height: 550px;
   }
 

--- a/src/Storefront/Resources/app/storefront/src/scss/component/_cms-block.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/component/_cms-block.scss
@@ -181,10 +181,6 @@ specific styling for elements dependent on their parent block
 }
 
 .cms-element-manufacturer-logo {
-    .cms-image-link {
-        height: 100%;
-    }
-
     .cms-image-container.is-standard {
         img {
             max-width: 200px;

--- a/src/Storefront/Resources/app/storefront/src/scss/component/_cms-element.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/component/_cms-element.scss
@@ -221,11 +221,10 @@ General styling for cms elements
 @include media-breakpoint-down(lg) {
     .cms-element-product-listing-actions {
         flex-wrap: wrap;
-        justify-content: center;
+        row-gap: $spacer-sm;
 
         .sorting {
             width: 100%;
-            margin-top: 5px;
             margin-left: 0;
         }
     }

--- a/src/Storefront/Resources/app/storefront/src/scss/component/_cms-sections.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/component/_cms-sections.scss
@@ -5,8 +5,6 @@ General styling for cms sections
 */
 
 .cms-section {
-    overflow: hidden;
-
     &.bg-image {
         background-repeat: no-repeat;
         background-position: 50%;

--- a/src/Storefront/Resources/app/storefront/src/scss/component/_cms-sections.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/component/_cms-sections.scss
@@ -5,13 +5,23 @@ General styling for cms sections
 */
 
 .cms-section {
-    // Deviation from trunk: trunk removes clipping entirely because it also adds
-    // `.cms-section .full-width { @include make-container(); --bs-gutter-x: 0; }`,
-    // which does not exist on 6.6.x. On 6.6.x `.cms-section-sidebar` is itself the
-    // `.row`, so a full-width section would overflow the viewport by the row's
-    // negative margins. Clip on the x axis only, so focus rings can still escape
-    // vertically (the point of this PR).
-    overflow-x: clip;
+    // Deviation from trunk (#17650 removes the clipping entirely). Trunk can do that
+    // because it already has `.cms-section .full-width { @include make-container(); --bs-gutter-x: 0; }`
+    // (#16238), which does not exist on 6.6.x. Here `.cms-section-sidebar` is itself the
+    // `.row` (see section/cms-section-sidebar.html.twig), so a full-width sidebar section
+    // would overflow the viewport by the row's negative margins (horizontal page scrollbar).
+    // Keep the 6.6.x clipping as the fallback and relax it to the x axis only where
+    // `overflow: clip` exists (Safari 16+, Chrome 90+, Firefox 81+): .browserslistrc still
+    // targets Safari/iOS 12+, where `clip` is invalid and would silently fall back to
+    // `visible`. Both longhands are required inside @supports — with `overflow-y` left at
+    // `hidden` nothing escapes vertically, and a bare cascade fallback would end up as
+    // `hidden`/`visible` on old Safari, which coerces to a scroll container.
+    overflow: hidden;
+
+    @supports (overflow: clip) {
+        overflow-x: clip;
+        overflow-y: visible;
+    }
 
     &.bg-image {
         background-repeat: no-repeat;

--- a/src/Storefront/Resources/app/storefront/src/scss/component/_cms-sections.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/component/_cms-sections.scss
@@ -5,6 +5,14 @@ General styling for cms sections
 */
 
 .cms-section {
+    // Deviation from trunk: trunk removes clipping entirely because it also adds
+    // `.cms-section .full-width { @include make-container(); --bs-gutter-x: 0; }`,
+    // which does not exist on 6.6.x. On 6.6.x `.cms-section-sidebar` is itself the
+    // `.row`, so a full-width section would overflow the viewport by the row's
+    // negative margins. Clip on the x axis only, so focus rings can still escape
+    // vertically (the point of this PR).
+    overflow-x: clip;
+
     &.bg-image {
         background-repeat: no-repeat;
         background-position: 50%;

--- a/src/Storefront/Resources/app/storefront/src/scss/component/_filter-multi-select.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/component/_filter-multi-select.scss
@@ -28,6 +28,14 @@ This filter item should only be used inside a filter panel.
     }
 }
 
+.filter-multi-select-item {
+    width: 100%;
+
+    &:hover {
+        color: var(--#{$prefix}primary);
+    }
+}
+
 .filter-multi-select-item-label {
     cursor: pointer;
     margin-bottom: 0;

--- a/src/Storefront/Resources/app/storefront/src/scss/component/_filter-panel.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/component/_filter-panel.scss
@@ -16,7 +16,7 @@ This file contains the generic styling for all filter items.
     margin-left: 8px;
 
     > svg {
-        top: 4px;
+        top: 2px;
     }
 }
 
@@ -270,7 +270,7 @@ This file contains the generic styling for all filter items.
         height: calc(100% - 80px);
         overflow-y: auto;
         width: 100%;
-        padding: 0 25px 25px;
+        padding: 4px 25px 25px;
     }
 
     .filter-panel-offcanvas-header {

--- a/src/Storefront/Resources/app/storefront/src/scss/component/_filter-rating-select.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/component/_filter-rating-select.scss
@@ -19,7 +19,6 @@ This filter item should only be used inside a filter panel.
 
         .filter-rating-select-item-label-text {
             color: $primary;
-            font-weight: $font-weight-bold;
         }
     }
 }
@@ -42,7 +41,6 @@ This filter item should only be used inside a filter panel.
 
         .filter-rating-select-item-label-text {
             color: $sw-color-brand-primary;
-            font-weight: $font-weight-bold;
         }
     }
 }
@@ -75,7 +73,6 @@ This filter item should only be used inside a filter panel.
     &:hover {
         .filter-rating-select-item-label-text {
             color: $sw-text-color;
-            font-weight: $font-weight-normal;
         }
     }
 }

--- a/src/Storefront/Resources/app/storefront/src/scss/component/_icon.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/component/_icon.scss
@@ -191,6 +191,9 @@ Credit: https://github.com/FortAwesome/Font-Awesome
 
 .btn {
     .icon {
+        // Prevent unintended button focus in Safari when clicking a button containg an icon.
+        pointer-events: none;
+
         > svg {
             top: 6px;
         }

--- a/src/Storefront/Resources/app/storefront/src/scss/layout/_header-minimal.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/layout/_header-minimal.scss
@@ -6,7 +6,6 @@ Contains custom styles for the minimal header which is used on checkout pages.
 
 .header-minimal {
     background: $white;
-    border-bottom: 1px solid var(--text-color-brand-primary);
 }
 
 .header-minimal.fixed-top {
@@ -22,17 +21,9 @@ Contains custom styles for the minimal header which is used on checkout pages.
     display: none;
 }
 
-.header-minimal-contact a {
-    color: $primary;
-}
-
 .header-minimal-back-to-shop {
     display: flex;
     justify-content: flex-end;
-
-    &-button {
-        color: $sw-text-color;
-    }
 }
 
 .header-minimal-logo {

--- a/src/Storefront/Resources/app/storefront/src/scss/layout/_header.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/layout/_header.scss
@@ -42,6 +42,10 @@ The header contains the shop logo, the search form and various actions like the 
     min-width: 200px;
 }
 
+.header-logo-main-link {
+    display: inline-block;
+}
+
 .header-search-form {
     position: relative;
 

--- a/src/Storefront/Resources/app/storefront/src/scss/skin/shopware/_base.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/skin/shopware/_base.scss
@@ -41,6 +41,7 @@ https://sass-guidelin.es/#the-7-1-pattern
 @import 'component/cms-element';
 @import 'component/quickview-modal';
 @import 'component/pagination';
+@import 'component/skip-target';
 
 /*
  * Layout-related sections

--- a/src/Storefront/Resources/app/storefront/src/scss/skin/shopware/component/_pagination.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/skin/shopware/component/_pagination.scss
@@ -1,6 +1,9 @@
 .pagination {
+    --#{$prefix}pagination-padding-y: calc(#{$btn-padding-y} + 1px);
+    gap: 0.125rem;
+
     .page-link {
-        line-height: $form-select-line-height;
+        line-height: $btn-line-height;
         text-align: center;
 
         @include media-breakpoint-up(sm) {
@@ -9,6 +12,10 @@
 
         .icon {
             color: inherit;
+        }
+
+        &:focus {
+            box-shadow: $focus-ring-box-shadow-inset;
         }
     }
 }

--- a/src/Storefront/Resources/app/storefront/src/scss/skin/shopware/component/_skip-target.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/skin/shopware/component/_skip-target.scss
@@ -1,0 +1,8 @@
+.skip-target {
+    background-color: var(--#{$prefix}body-bg);
+    z-index: 1;
+    position: absolute;
+    display: inline-block;
+    top: 0;
+    left: 0;
+}

--- a/src/Storefront/Resources/app/storefront/src/scss/skin/shopware/component/_tab-menu.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/skin/shopware/component/_tab-menu.scss
@@ -26,7 +26,7 @@ https://getbootstrap.com/docs/5.2/components/card/#navigation
         --#{$prefix}nav-tabs-border-radius: 0;
         --#{$prefix}nav-tabs-link-hover-border-color: #{$primary};
         --#{$prefix}nav-link-hover-color: #{$primary};
-        --#{$prefix}nav-tabs-link-active-color: #{$body-color};
+        --#{$prefix}nav-tabs-link-active-color: #{$primary};
         --#{$prefix}nav-tabs-link-active-border-color: #{$primary};
         border-bottom: 2px solid $border-color;
 
@@ -37,10 +37,6 @@ https://getbootstrap.com/docs/5.2/components/card/#navigation
 
         .product-cross-selling-tab-navigation {
             padding: 0;
-        }
-
-        &:hover {
-            background-color: darken($body-bg, 20%);
         }
     }
 

--- a/src/Storefront/Resources/app/storefront/src/scss/skin/shopware/layout/_top-bar.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/skin/shopware/layout/_top-bar.scss
@@ -5,6 +5,10 @@ Contains skin styles for the top bar located at the top of the page.
 The top bar contains e.g. the language switcher, the currency switcher and the service menu.
 */
 
+.top-bar {
+    padding-top: 0.25rem;
+}
+
 .top-bar-nav-btn.btn {
     --#{$prefix}btn-focus-box-shadow: #{$input-btn-focus-box-shadow};
     --#{$prefix}btn-color: #{$body-color};
@@ -14,6 +18,7 @@ The top bar contains e.g. the language switcher, the currency switcher and the s
     --#{$prefix}btn-padding-x: 0;
     --#{$prefix}btn-padding-y: 0;
     --#{$prefix}btn-hover-color: #{$primary};
+    --#{$prefix}btn-line-height: 2rem;
 }
 
 .top-bar-list {
@@ -34,4 +39,10 @@ The top bar contains e.g. the language switcher, the currency switcher and the s
             cursor: pointer;
         }
     }
+}
+
+// Prevent unintended button focus in Safari when clicking a button containg an icon.
+.top-bar-nav-text,
+.top-bar-list-icon {
+    pointer-events: none;
 }

--- a/src/Storefront/Resources/app/storefront/src/scss/skin/shopware/page/account/_aside.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/skin/shopware/page/account/_aside.scss
@@ -27,6 +27,8 @@
 
 .account-aside-btn {
     line-height: normal;
+    width: 100%;
+    text-align: left;
     padding: 3px 0;
 }
 

--- a/src/Storefront/Resources/app/storefront/src/utility/bootstrap/bootstrap.util.js
+++ b/src/Storefront/Resources/app/storefront/src/utility/bootstrap/bootstrap.util.js
@@ -27,8 +27,17 @@ export default class BootstrapUtil {
         });
     }
 
+    /**
+     * Using increased default offset to avoid focus outline being cut off by the dropdown menu.
+     * @see https://getbootstrap.com/docs/5.3/components/dropdowns/#options
+     */
+    static setDropdownDefaultOffset() {
+        bootstrap.Dropdown.Default.offset = [0, 6];
+    }
+
     static initBootstrapPlugins() {
         this.initTooltip();
         this.initPopover();
+        this.setDropdownDefaultOffset();
     }
 }

--- a/src/Storefront/Resources/app/storefront/test/utility/bootstrap/bootstrap.util.test.js
+++ b/src/Storefront/Resources/app/storefront/test/utility/bootstrap/bootstrap.util.test.js
@@ -8,6 +8,11 @@ describe('BootstrapUtil tests', () => {
         global.bootstrap = {
             Tooltip: jest.fn(),
             Popover: jest.fn(),
+            Dropdown: {
+                Default: {
+                    offset: [0, 0],
+                },
+            },
         }
 
         document.body.innerHTML = `
@@ -40,5 +45,11 @@ describe('BootstrapUtil tests', () => {
 
         expect(bootstrap.Tooltip).toHaveBeenCalledTimes(0);
         expect(bootstrap.Popover).toHaveBeenCalledTimes(1);
+    });
+
+    test('sets Bootstrap dropdown default offset', () => {
+        BootstrapUtil.setDropdownDefaultOffset();
+
+        expect(bootstrap.Dropdown.Default.offset).toEqual([0, 6]);
     });
 });

--- a/src/Storefront/Resources/views/storefront/component/checkout/offcanvas-cart.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/checkout/offcanvas-cart.html.twig
@@ -152,7 +152,7 @@
                     {% block component_offcanvas_cart_actions_checkout %}
                         <div class="d-grid">
                             <a href="{{ path('frontend.checkout.confirm.page') }}"
-                               class="btn begin-checkout-btn{% if isCartNotEmpty %} btn-primary{% else %} btn-light disabled{% endif %}"
+                               class="btn begin-checkout-btn mb-2{% if isCartNotEmpty %} btn-primary{% else %} btn-light disabled{% endif %}"
                                title="{{ 'checkout.proceedToCheckout'|trans|striptags }}">
                                 {{ 'checkout.proceedToCheckout'|trans|sw_sanitize }}
                             </a>

--- a/src/Storefront/Resources/views/storefront/component/listing/filter/filter-multi-select-list-item.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/listing/filter/filter-multi-select-list-item.html.twig
@@ -1,5 +1,5 @@
 {% block component_filter_multi_select_list_item %}
-    <div class="form-check">
+    <div class="filter-multi-select-item form-check">
         {% set id = element.id %}
         {% set name = element.translated.name %}
 

--- a/src/Storefront/Resources/views/storefront/component/listing/filter/filter-multi-select.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/listing/filter/filter-multi-select.html.twig
@@ -34,7 +34,6 @@
                     {% else %}
                     data-bs-toggle="dropdown"
                     data-boundary="viewport"
-                    data-bs-offset="0,8"
                     aria-haspopup="true"
                     {% endif %}>
 

--- a/src/Storefront/Resources/views/storefront/component/listing/filter/filter-range.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/listing/filter/filter-range.html.twig
@@ -63,7 +63,6 @@
                     {% else %}
                     data-bs-toggle="dropdown"
                     data-boundary="viewport"
-                    data-bs-offset="0,8"
                     aria-haspopup="true"
                     {% endif %}>
                 {% block component_filter_range_display_name %}


### PR DESCRIPTION
**Backport:** https://github.com/shopware/shopware/pull/17650
Resolves: https://github.com/shopware/shopware/issues/16451
Resolves: https://github.com/shopware/shopware/issues/16450
relates #19539

---

### 1. Why is this change necessary?

Manual backport of #17650 to 6.6.x (a11y). Focus indication on 6.6 is inconsistent: several components suppress the outline entirely, others rely on the UA default. This unifies it with one global `:focus-visible` ring and fixes the dropdown offset so the ring is no longer clipped by filter menus.

### 2. What does this change do, exactly?

- global `:focus-visible { outline: 0; box-shadow: $focus-ring-box-shadow; }` in `scss/base/_base.scss`; component-specific focus styles have higher specificity and keep their own styling
- new `skin/shopware/component/_skip-target.scss`
- `BootstrapUtil.setDropdownDefaultOffset()` sets `bootstrap.Dropdown.Default.offset = [0, 6]` (+ jest test); `data-bs-offset="0,8"` removed from the two filter dropdown toggles
- `pointer-events: none` on `.btn .icon` and top-bar text/icon (Safari leaves a stuck focus ring on click)
- spacing/colour polish: top bar, tab menu, filter panel, account aside, header, cms block/element/sections, pagination

### 3. Deviations from the trunk commit

- **`_cms-sections.scss`: `overflow: hidden` → `overflow-x: clip` instead of removing it.** Trunk can drop the clipping because it also adds `.cms-section .full-width { @include make-container(); --bs-gutter-x: 0; }` — that rule does not exist on 6.6.x. On 6.6.x `section/cms-section-sidebar.html.twig` renders the section element itself as the `.row`, so a full-width section would overflow the viewport by the row's negative margins and produce a horizontal page scrollbar in the default (flag-off) configuration. `overflow-x: clip` keeps that contained while still letting focus rings escape vertically, which is the point of this PR.
- `_address-manager.scss`, `_cms-block.scss`, `_top-bar.scss`: kept the 6.6.x shape (shallower nesting, the extra `.address-manager-modal-header-content` block, and the `@deprecated tag:v6.7.0` block gated by `@if not feature('ACCESSIBILITY_TWEAKS')`), applying only the intended payload.
- `filter-multi-select.html.twig` / `filter-range.html.twig`: removed only `data-bs-offset`, kept `aria-haspopup="true"`.

### 4. Notes for reviewers

- The change is **unconditional**, matching trunk — it is not behind `ACCESSIBILITY_TWEAKS`. This is a deliberate product decision (accessibility fix over cosmetic stability on a maintenance branch).
- On 6.6.x `$focus-ring-width` / `$focus-ring-opacity` are still flag-gated (`0.2rem`/`0.6` flag-off vs `0.25rem`/`1` flag-on), while trunk has the stronger values unconditionally. The default-state ring is therefore thinner and semi-transparent — it still meets SC 1.4.11 (≈3.36:1 for `$primary` at 60% on white) and is an improvement over the elements that previously had no indicator, so those variables were deliberately left untouched.
- **Merge order:** conflicts with #19899 in the two filter twigs (adjacent attribute removals). Resolution is trivial — take both removals — but whichever lands second needs a rebase.
- Three 6.6.x rules that previously suppressed focus indication (`_line-item.scss` change-button, `page/account/_order.scss`, `_base-slider.scss` dots) will now show the ring. That is the intent.

### 5. Checklist

- [x] Cherry-picked from trunk with `-x`; conflicts resolved as described
- [x] Reviewed by a second pass before pushing (cherry-pick fidelity, dropped-selector check, flag-branch integrity)
- [x] Tests run locally: `bootstrap.util.test.js` 4/4 incl. the new offset test, `test/plugin/listing/` + `test/plugin/address-manager/` 42/42, stylelint clean on all 17 SCSS files
- [ ] Not run locally: theme/SCSS compile and the Playwright acceptance suite (no built environment) — CI covers those
