### PR TITLE
fix(framework): only treat a real docblock tag as the coverage-ignore annotation

### DIFF
--- a/src/Core/DevOps/StaticAnalyze/PHPStan/Rules/CodeCoverageIgnoreEvaluationRule.php
+++ b/src/Core/DevOps/StaticAnalyze/PHPStan/Rules/CodeCoverageIgnoreEvaluationRule.php
@@ -232,7 +232,10 @@ class CodeCoverageIgnoreEvaluationRule implements Rule
             return false;
         }
 
-        return (bool) preg_match('/@codeCoverageIgnore(?![A-Za-z])/', $doc->getText());
+        // match only a real docblock TAG (first token of its line, allowing the `/**` of a
+        // single-line docblock): a prose mention like "classes annotated with
+        // `@codeCoverageIgnore` stay valid targets" must not count as the annotation
+        return (bool) preg_match('/^[ \t]*(?:\/\*\*)?[ \t]*\**[ \t]*@codeCoverageIgnore(?![A-Za-z])/m', $doc->getText());
     }
 
     /**

--- a/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/CodeCoverageIgnoreEvaluationRuleTest.php
+++ b/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/CodeCoverageIgnoreEvaluationRuleTest.php
@@ -48,6 +48,8 @@ class CodeCoverageIgnoreEvaluationRuleTest extends RuleTestCase
 
         yield 'no annotation but logic present passes' => [['IgnoreStartEndOnlyClass.php'], []];
 
+        yield 'prose mention of the annotation is not an annotation' => [['ProseMentionClass.php'], []];
+
         yield 'exception fork branching is not logic, class ignore passes' => [['ExceptionForkClass.php'], []];
 
         yield 'exception with loop aggregation still fails' => [

--- a/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/data/CodeCoverageIgnoreEvaluation/ProseMentionClass.php
+++ b/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/data/CodeCoverageIgnoreEvaluation/ProseMentionClass.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\DevOps\Core\DevOps\StaticAnalyse\PHPStan\Rules\data\CodeCoverageIgnoreEvaluation;
+
+/**
+ * Explains that classes annotated with `@codeCoverageIgnore` stay valid coverage targets:
+ * a docblock that merely MENTIONS the annotation in prose does not carry it.
+ */
+class ProseMentionClass
+{
+    public function describe(string $value): string
+    {
+        if ($value === '') {
+            return 'empty';
+        }
+
+        return $value;
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?

`CodeCoverageIgnoreEvaluationRule` detects the annotation with an unanchored `preg_match` over the whole docblock text, so a docblock that merely mentions `@codeCoverageIgnore` in prose counts as carrying the annotation. A class documenting the annotation's semantics (for example a PHPStan rule explaining that annotated classes stay valid coverage targets) is then falsely reported for every method with logic.

### 2. What does this change do, exactly?

Anchors the detection to a real docblock tag: the annotation must be the first token of its docblock line (allowing the `/**` of a single-line docblock). A backticked or mid-sentence mention no longer matches. A regression fixture with a prose mention plus a logic method pins the behavior.

### 3. Describe each step to reproduce the issue or behaviour.

1. Give any class a docblock sentence like "classes annotated with `@codeCoverageIgnore` stay valid targets" and a method containing an `if`
2. Run PHPStan: before this change the class is reported as `shopware.codeCoverageIgnoreOnLogic` for that method; after, it is not

### 4. Please link to the relevant issues (if any).

None.

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
