### PR TITLE
fix(after-sales): boot the rate-limited document kernel inside the first test

### DIFF
--- a/tests/integration/Core/Checkout/Document/SalesChannel/DocumentRouteTest.php
+++ b/tests/integration/Core/Checkout/Document/SalesChannel/DocumentRouteTest.php
@@ -74,20 +74,33 @@ class DocumentRouteTest extends TestCase
 
     private DocumentGenerator $documentGenerator;
 
+    private static bool $rateLimitedKernelBooted = false;
+
     public static function setUpBeforeClass(): void
     {
         DisableRateLimiterCompilerPass::disableNoLimit();
-        KernelLifecycleManager::bootKernel(true, Uuid::randomHex());
     }
 
     public static function tearDownAfterClass(): void
     {
         DisableRateLimiterCompilerPass::enableNoLimit();
-        KernelLifecycleManager::bootKernel(true, Uuid::randomHex());
+        // shut down only: the next class boots its kernel lazily inside a test context, which
+        // recompiles with the rate limiter restored
+        KernelLifecycleManager::ensureKernelShutdown();
+        self::$rateLimitedKernelBooted = false;
     }
 
     protected function setUp(): void
     {
+        // the rate-limiter pass applies at container compile time, so this class needs a freshly
+        // compiled kernel. It is booted here rather than in setUpBeforeClass(): a deprecation
+        // triggered during a static-context kernel boot has no TestCase object on the call stack
+        // and crashes PHPUnit's event system instead of being recorded
+        if (!self::$rateLimitedKernelBooted) {
+            KernelLifecycleManager::bootKernel(true, Uuid::randomHex());
+            self::$rateLimitedKernelBooted = true;
+        }
+
         $this->context = Context::createDefaultContext();
         $this->ids = new IdsCollection();
 


### PR DESCRIPTION
### 1. Why is this change necessary?

`DocumentRouteTest` boots a freshly compiled kernel in `setUpBeforeClass()`. Any deprecation triggered during that compile (under symfony 7.4 every bundle `services.xml` load deprecates) can crash the run when PHPUnit's error handler happens to be active in the static context, because there is no TestCase object on the call stack: `PHPUnit\Event\Code\NoTestCaseObjectOnCallStackException`. The nightly blue-green lanes hit this order-dependently (the suite runs with `executionOrder="random"`).

### 2. What does this change do, exactly?

- `setUpBeforeClass()` only flips the rate-limiter compiler-pass flag; the freshly compiled kernel is booted lazily in the first test's `setUp()` behind a static guard. Inside a test, a boot-time deprecation is recorded like any other instead of crashing the event system.
- `tearDownAfterClass()` shuts the kernel down instead of re-booting: the next class boots its kernel lazily inside a test context, recompiling with the rate limiter restored.

### 3. Describe each step to reproduce the issue or behaviour.

1. Run the integration suite in an order where a deprecation reaches PHPUnit's error handler during `DocumentRouteTest::setUpBeforeClass()` (nightly run 33460412970, job "PHP blue green 6.6 -> 6.7 -> 6.6", is such an occurrence)
2. The class errors with `NoTestCaseObjectOnCallStackException: Cannot find TestCase object on call stack` out of the kernel boot at `XmlFileLoader` deprecation time
3. With this change the boot happens inside the first test and the deprecation is recorded normally

### 4. Please link to the relevant issues (if any).

None.

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
