### PR TITLE
feat(content-system): resolve placeholders in data requirement loader

### DIFF
--- a/src/Core/Framework/ContentSystem/Adapter/FactoryHelper/EntityLayoutContextFactory.php
+++ b/src/Core/Framework/ContentSystem/Adapter/FactoryHelper/EntityLayoutContextFactory.php
@@ -104,6 +104,7 @@ class EntityLayoutContextFactory
         return new SpecificationData(
             dataRequirements: array_values($definition->getPageDataRequirements()),
             placeholderValues: $this->layoutResolver->resolvePlaceholders(
+                $definition->getContentLayoutEntityType(),
                 $definition->getContentLayoutEntityIdField(),
                 $entityId,
                 $request,

--- a/src/Core/Framework/ContentSystem/Adapter/FactoryHelper/EntityLayoutResolver.php
+++ b/src/Core/Framework/ContentSystem/Adapter/FactoryHelper/EntityLayoutResolver.php
@@ -48,6 +48,7 @@ class EntityLayoutResolver
     }
 
     public function resolvePlaceholders(
+        string $entityType,
         string $entityIdField,
         string $entityId,
         Request $request
@@ -55,7 +56,7 @@ class EntityLayoutResolver
         $scalarParameters = array_filter($request->query->all(), '\is_scalar');
 
         return PlaceholderValues::from(array_merge(
-            [$entityIdField => $entityId],
+            ['entityType' => $entityType, 'entityIdField' => $entityIdField, $entityIdField => $entityId],
             $scalarParameters
         ));
     }

--- a/src/Core/Framework/ContentSystem/Hydration/DataLoader/DataLoaderConfigSerializerProvider.php
+++ b/src/Core/Framework/ContentSystem/Hydration/DataLoader/DataLoaderConfigSerializerProvider.php
@@ -3,6 +3,7 @@
 namespace Shopware\Core\Framework\ContentSystem\Hydration\DataLoader;
 
 use Shopware\Core\Framework\ContentSystem\ContentSystemException;
+use Shopware\Core\Framework\ContentSystem\PlaceholderValues;
 use Shopware\Core\Framework\HttpException;
 use Shopware\Core\Framework\Log\Package;
 use Symfony\Component\DependencyInjection\ServiceLocator;
@@ -26,10 +27,14 @@ class DataLoaderConfigSerializerProvider
     /**
      * @param array<string, mixed> $data
      */
-    public function decode(string $source, array $data): AbstractContentDataLoaderConfig
+    public function decode(string $source, array $data, ?PlaceholderValues $values = null): AbstractContentDataLoaderConfig
     {
         if (!$this->locator->has($source)) {
             throw ContentSystemException::configSerializerNotRegistered($source);
+        }
+
+        if ($values !== null) {
+            $data = $this->replacePlaceholders($data, $values);
         }
 
         try {
@@ -71,5 +76,26 @@ class DataLoaderConfigSerializerProvider
             // than the sibling escaping as an uncaught 500 on every content_layout write.
             throw ContentSystemException::invalidLoaderConfig($source, $e);
         }
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     *
+     * @return array<string, mixed>
+     */
+    private function replacePlaceholders(array $data, PlaceholderValues $values): array
+    {
+        foreach ($data as $key => $value) {
+            if (\is_string($value)) {
+                foreach ($values->all() as $name => $replacement) {
+                    $value = \str_replace('{{' . $name . '}}', (string) $replacement, $value);
+                }
+                $data[$key] = $value;
+            } elseif (\is_array($value)) {
+                $data[$key] = $this->replacePlaceholders($value, $values);
+            }
+        }
+
+        return $data;
     }
 }

--- a/src/Core/Framework/ContentSystem/Layout/Scaffolding/StoredTreePreparer.php
+++ b/src/Core/Framework/ContentSystem/Layout/Scaffolding/StoredTreePreparer.php
@@ -2,6 +2,8 @@
 
 namespace Shopware\Core\Framework\ContentSystem\Layout\Scaffolding;
 
+use Shopware\Core\Framework\ContentSystem\Hydration\DataLoader\DataLoaderConfigSerializerProvider;
+use Shopware\Core\Framework\ContentSystem\Layout\Element\DataRequirement\DataRequirement;
 use Shopware\Core\Framework\ContentSystem\Layout\Element\StoredElement;
 use Shopware\Core\Framework\ContentSystem\Layout\Element\StoredValue;
 use Shopware\Core\Framework\ContentSystem\Output\PartialRenderer;
@@ -27,6 +29,7 @@ final class StoredTreePreparer
     public function __construct(
         private readonly VirtualRootWrapper $virtualRootWrapper,
         private readonly PartialRenderer $partialRenderer,
+        private readonly DataLoaderConfigSerializerProvider $configSerializers,
     ) {
     }
 
@@ -129,10 +132,11 @@ final class StoredTreePreparer
     }
 
     /**
-     * Rewrites the string values of an element's own property map and recurses into its slot children.
+     * Rewrites the string values of an element's own property map, resolves the placeholders in each of its
+     * data requirement's loader config, and recurses into its slot children.
      *
-     * A list or map value is handed on untouched, string leaves inside it included: a placeholder is a
-     * property of the authored value, and reaching into a container would resolve tokens the authoring
+     * A list or map property value is handed on untouched, string leaves inside it included: a placeholder is
+     * a property of the authored value, and reaching into a container would resolve tokens the authoring
      * surface never offered to resolve.
      */
     private function resolvePlaceholders(StoredElement $element, PlaceholderValues $values): StoredElement
@@ -144,6 +148,19 @@ final class StoredTreePreparer
                 : $value;
         }
 
+        $dataRequirements = [];
+        foreach ($element->dataRequirements as $key => $requirement) {
+            $dataRequirements[$key] = new DataRequirement(
+                $requirement->key,
+                $requirement->source,
+                $this->configSerializers->decode(
+                    $requirement->source,
+                    $this->configSerializers->encode($requirement->source, $requirement->config),
+                    $values,
+                ),
+            );
+        }
+
         $slots = [];
         foreach ($element->slots as $slotName => $children) {
             $slots[$slotName] = array_map(
@@ -152,7 +169,7 @@ final class StoredTreePreparer
             );
         }
 
-        return $element->withProperties($properties)->withSlots($slots);
+        return $element->withProperties($properties)->withDataRequirements($dataRequirements)->withSlots($slots);
     }
 
     /**

--- a/src/Core/Framework/DependencyInjection/content-system.php
+++ b/src/Core/Framework/DependencyInjection/content-system.php
@@ -139,6 +139,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         ->args([
             service(VirtualRootWrapper::class),
             service(PartialRenderer::class),
+            service(DataLoaderConfigSerializerProvider::class),
         ]);
 
     // Output Services

--- a/tests/unit/Core/Framework/ContentSystem/Adapter/FactoryHelper/EntityLayoutResolverTest.php
+++ b/tests/unit/Core/Framework/ContentSystem/Adapter/FactoryHelper/EntityLayoutResolverTest.php
@@ -31,15 +31,15 @@ class EntityLayoutResolverTest extends TestCase
         $this->resolver = new EntityLayoutResolver();
     }
 
-    #[TestDox('builds placeholder values from entity id field and scalar query parameters, ignoring non-scalar parameters')]
+    #[TestDox('builds placeholder values from entity type, entity id field and scalar query parameters, ignoring non-scalar parameters')]
     public function testResolvePlaceholdersMergesEntityIdWithScalarQueryParameters(): void
     {
         $request = new Request(['color' => 'red', 'tags' => ['a', 'b']]);
 
-        $result = $this->resolver->resolvePlaceholders('productId', 'product-id-1', $request);
+        $result = $this->resolver->resolvePlaceholders('product', 'productId', 'product-id-1', $request);
 
         static::assertSame(
-            ['productId' => 'product-id-1', 'color' => 'red'],
+            ['entityType' => 'product', 'entityIdField' => 'productId', 'productId' => 'product-id-1', 'color' => 'red'],
             $result->all()
         );
     }

--- a/tests/unit/Core/Framework/ContentSystem/ContentPipelineTest.php
+++ b/tests/unit/Core/Framework/ContentSystem/ContentPipelineTest.php
@@ -72,6 +72,8 @@ class ContentPipelineTest extends TestCase
 {
     private ElementLowering $lowering;
 
+    private DataLoaderConfigSerializerProvider $configSerializers;
+
     private EventDispatcherInterface&Stub $eventDispatcher;
 
     private IdsCollection $ids;
@@ -876,6 +878,7 @@ class ContentPipelineTest extends TestCase
         $preparation = (new StoredTreePreparer(
             $wrapper,
             new PartialRenderer(new ElementTreePruner(), new ContextDependencyAnalyzer(), new SubTreeExtractor()),
+            static::createStub(DataLoaderConfigSerializerProvider::class),
         ))->prepare($layout->elements, $specification, RenderingMode::SKELETON);
 
         // Fixture guard, and what makes the order observable at all: both finishing steps are live, because
@@ -1247,6 +1250,7 @@ class ContentPipelineTest extends TestCase
             new StoredTreePreparer(
                 new VirtualRootWrapper(),
                 new PartialRenderer(new ElementTreePruner(), new ContextDependencyAnalyzer(), new SubTreeExtractor()),
+                $this->configSerializers,
             ),
             new WiringPlanner(new ProviderDeliveryKeyResolver()),
             $this->lowering,
@@ -1277,12 +1281,14 @@ class ContentPipelineTest extends TestCase
             $serializers[$source] = static fn (): StubLoaderConfigSerializer => new StubLoaderConfigSerializer();
         }
 
+        $this->configSerializers = new DataLoaderConfigSerializerProvider(new ServiceLocator($serializers));
+
         return new ElementLowering(
             new ElementDataResolver(
                 new DataLoaderProvider(new ServiceLocator($factories)),
                 new LoaderInputResolver(),
                 new LoaderValueIdentityFactory(
-                    new DataLoaderConfigSerializerProvider(new ServiceLocator($serializers)),
+                    $this->configSerializers,
                     new ConfigCanonicalizer(),
                     new ValueFingerprinter(),
                 ),

--- a/tests/unit/Core/Framework/ContentSystem/Hydration/DataLoader/DataLoaderConfigSerializerProviderTest.php
+++ b/tests/unit/Core/Framework/ContentSystem/Hydration/DataLoader/DataLoaderConfigSerializerProviderTest.php
@@ -9,6 +9,7 @@ use Shopware\Core\Framework\ContentSystem\ContentSystemException;
 use Shopware\Core\Framework\ContentSystem\Hydration\DataLoader\AbstractContentDataLoaderConfig;
 use Shopware\Core\Framework\ContentSystem\Hydration\DataLoader\AbstractContentDataLoaderConfigSerializer;
 use Shopware\Core\Framework\ContentSystem\Hydration\DataLoader\DataLoaderConfigSerializerProvider;
+use Shopware\Core\Framework\ContentSystem\PlaceholderValues;
 use Shopware\Core\Framework\HttpException;
 use Shopware\Core\Framework\Log\Package;
 use Symfony\Component\DependencyInjection\ServiceLocator;
@@ -35,6 +36,58 @@ class DataLoaderConfigSerializerProviderTest extends TestCase
         $result = $provider->decode('entity', ['key' => 'value']);
 
         static::assertSame($config, $result);
+    }
+
+    #[TestDox('resolves placeholder tokens in the raw config before decoding when values are provided')]
+    public function testDecodeResolvesPlaceholdersWhenValuesProvided(): void
+    {
+        $config = static::createStub(AbstractContentDataLoaderConfig::class);
+        $captured = null;
+        $serializer = static::createStub(AbstractContentDataLoaderConfigSerializer::class);
+        $serializer->method('decode')->willReturnCallback(
+            static function (array $data) use (&$captured, $config): AbstractContentDataLoaderConfig {
+                $captured = $data;
+
+                return $config;
+            }
+        );
+
+        $locator = new ServiceLocator(['breadcrumb' => fn () => $serializer]);
+        $provider = new DataLoaderConfigSerializerProvider($locator);
+
+        $result = $provider->decode(
+            'breadcrumb',
+            ['type' => '{{entityType}}', 'nested' => ['id' => '{{productId}}'], 'keep' => 'static'],
+            PlaceholderValues::from(['entityType' => 'category', 'productId' => 'p-1']),
+        );
+
+        static::assertSame($config, $result);
+        static::assertSame(
+            ['type' => 'category', 'nested' => ['id' => 'p-1'], 'keep' => 'static'],
+            $captured,
+        );
+    }
+
+    #[TestDox('leaves the raw config untouched when no placeholder values are provided')]
+    public function testDecodeLeavesConfigUntouchedWithoutValues(): void
+    {
+        $config = static::createStub(AbstractContentDataLoaderConfig::class);
+        $captured = null;
+        $serializer = static::createStub(AbstractContentDataLoaderConfigSerializer::class);
+        $serializer->method('decode')->willReturnCallback(
+            static function (array $data) use (&$captured, $config): AbstractContentDataLoaderConfig {
+                $captured = $data;
+
+                return $config;
+            }
+        );
+
+        $locator = new ServiceLocator(['entity' => fn () => $serializer]);
+        $provider = new DataLoaderConfigSerializerProvider($locator);
+
+        $provider->decode('entity', ['type' => '{{entityType}}']);
+
+        static::assertSame(['type' => '{{entityType}}'], $captured);
     }
 
     #[TestDox('routes encode to the correct serializer and returns its result')]

--- a/tests/unit/Core/Framework/ContentSystem/Layout/Scaffolding/StoredTreePreparerTest.php
+++ b/tests/unit/Core/Framework/ContentSystem/Layout/Scaffolding/StoredTreePreparerTest.php
@@ -7,6 +7,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\TestDox;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\ContentSystem\Hydration\DataContext\ContextType;
+use Shopware\Core\Framework\ContentSystem\Hydration\DataLoader\DataLoaderConfigSerializerProvider;
 use Shopware\Core\Framework\ContentSystem\Layout\Element\Context\ContextDependencyAnalyzer;
 use Shopware\Core\Framework\ContentSystem\Layout\Element\DataRequirement\DataRequirement;
 use Shopware\Core\Framework\ContentSystem\Layout\Element\StoredElement;
@@ -263,11 +264,50 @@ class StoredTreePreparerTest extends TestCase
         static::assertSame('Product {{productId}}', $prepared[0]->property('title')?->asString());
     }
 
-    private function preparer(): StoredTreePreparer
+    #[TestDox('resolves the placeholders in an element data requirement loader config, keyed by the requirement source')]
+    public function testPrepareResolvesDataRequirementConfig(): void
+    {
+        $element = new StoredElement('root-id', 'breadcrumb', [
+            'breadcrumb' => new DataRequirement('breadcrumb', 'breadcrumb', new LanguageLoaderConfig()),
+        ]);
+
+        $decoded = new LanguageLoaderConfig();
+        $capturedSource = null;
+        $capturedData = null;
+        $capturedValues = null;
+
+        $serializers = static::createStub(DataLoaderConfigSerializerProvider::class);
+        $serializers->method('encode')->willReturn(['type' => '{{entityType}}']);
+        $serializers->method('decode')->willReturnCallback(
+            function (string $source, array $data, ?PlaceholderValues $values) use (&$capturedSource, &$capturedData, &$capturedValues, $decoded) {
+                $capturedSource = $source;
+                $capturedData = $data;
+                $capturedValues = $values;
+
+                return $decoded;
+            }
+        );
+
+        $placeholderValues = PlaceholderValues::from(['entityType' => 'category']);
+
+        $prepared = $this->preparer($serializers)->prepare(
+            [$element],
+            new RenderingSpecification([], $placeholderValues, new Request()),
+            RenderingMode::FULL,
+        )->tree;
+
+        static::assertSame('breadcrumb', $capturedSource);
+        static::assertSame(['type' => '{{entityType}}'], $capturedData);
+        static::assertSame($placeholderValues, $capturedValues);
+        static::assertSame($decoded, $prepared[0]->dataRequirements['breadcrumb']->config);
+    }
+
+    private function preparer(?DataLoaderConfigSerializerProvider $configSerializers = null): StoredTreePreparer
     {
         return new StoredTreePreparer(
             new VirtualRootWrapper(),
             new PartialRenderer(new ElementTreePruner(), new ContextDependencyAnalyzer(), new SubTreeExtractor()),
+            $configSerializers ?? static::createStub(DataLoaderConfigSerializerProvider::class),
         );
     }
 


### PR DESCRIPTION
### 1. Why is this change necessary?

`resolvedBy` loader configs could not vary per request, so a single element could not serve both product and category pages.

  ### 2. What does this change do, exactly?

  - Resolves `{{placeholder}}` tokens (e.g. `{{entityType}}`, `{{entityIdField}}`) inside each data requirement's `resolvedBy` config at `PreContentHydration`, so one element works on product and category pages.

  ### 3. Describe each step to reproduce the issue or behaviour.

  1. Assign a content layout containing the breadcrumb element to a product and to a category.
  2. Open both detail pages in the storefront.
  3. The breadcrumb resolves the correct path for each entity type; empty state shows the placeholder.

  ### 4. Please link to the relevant issues (if any).

### 5. Checklist

  - [x] I have written tests and verified that they fail without my change
  - [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
    - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
    - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
    - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
  - [ ] I have written or adjusted the documentation and agent skills according to my changes
  - [ ] This change has comments for package types, values, functions, and non-obvious lines of code
  - [x] I have read the contribution requirements and fulfilled them