### PR TITLE
test: cover traits with the CoversTrait attribute

### DIFF
--- a/tests/unit/Core/Framework/Mcp/Tool/McpEntityIncludesTest.php
+++ b/tests/unit/Core/Framework/Mcp/Tool/McpEntityIncludesTest.php
@@ -2,7 +2,7 @@
 
 namespace Shopware\Tests\Unit\Core\Framework\Mcp\Tool;
 
-use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversTrait;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
@@ -27,7 +27,7 @@ use Shopware\Core\Framework\Mcp\Tool\McpEntityIncludes;
  * @internal
  */
 #[Package('framework')]
-#[CoversClass(McpEntityIncludes::class)]
+#[CoversTrait(McpEntityIncludes::class)]
 class McpEntityIncludesTest extends TestCase
 {
     use McpEntityIncludes;

--- a/tests/unit/Core/System/SystemConfig/SalesChannel/ConfigCastTraitTest.php
+++ b/tests/unit/Core/System/SystemConfig/SalesChannel/ConfigCastTraitTest.php
@@ -2,7 +2,7 @@
 
 namespace Shopware\Tests\Unit\Core\System\SystemConfig\SalesChannel;
 
-use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversTrait;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Log\Package;
@@ -12,7 +12,7 @@ use Shopware\Core\System\SystemConfig\SalesChannel\ConfigCastTrait;
  * @internal
  */
 #[Package('framework')]
-#[CoversClass(ConfigCastTrait::class)]
+#[CoversTrait(ConfigCastTrait::class)]
 class ConfigCastTraitTest extends TestCase
 {
     /**


### PR DESCRIPTION
### 1. Why is this change necessary?

`McpEntityIncludes` and `ConfigCastTrait` are traits, but their tests target them with `#[CoversClass]`. PHPUnit 12 reports a trait as an invalid `CoversClass` target (55 warnings across the two test files on the PHPUnit 12 lane); `#[CoversTrait]` is the correct attribute.

### 2. What does this change do, exactly?

Swaps `#[CoversClass]` for `#[CoversTrait]` in `McpEntityIncludesTest` and `ConfigCastTraitTest`.

### 3. Describe each step to reproduce the issue or behaviour.

1. Run the two test files under PHPUnit 12 with coverage enabled
2. Every test warns `Class ... is not a valid target for code coverage`; with `#[CoversTrait]` the warnings disappear

### 4. Please link to the relevant issues (if any).

None.

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
