### PR TITLE
fix(storefront): handle relative manufacturer links

### DIFF
--- a/src/Storefront/Resources/views/storefront/component/product/quickview/minimal.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/product/quickview/minimal.html.twig
@@ -60,7 +60,7 @@
                         {% block component_product_quickview_minimal_product_manufacturer %}
                             {% if manufacturer %}
                                 {% set manufacturerLink = manufacturer.translated.link %}
-                                {% set manufacturerLinkHasScheme = manufacturerLink matches '/^[a-zA-Z][a-zA-Z0-9+.-]*:/' or manufacturerLink starts with '//' %}
+                                {% set manufacturerLinkHasScheme = manufacturerLink matches '/^[a-zA-Z][a-zA-Z0-9+.-]*:/' or manufacturerLink starts with '/' %}
                                 {% set manufacturerLinkHref = manufacturerLink ? (manufacturerLinkHasScheme ? manufacturerLink : 'https://' ~ manufacturerLink) : '' %}
 
                                 {% set manufacturerContent %}

--- a/src/Storefront/Resources/views/storefront/element/cms-element-manufacturer-logo.html.twig
+++ b/src/Storefront/Resources/views/storefront/element/cms-element-manufacturer-logo.html.twig
@@ -26,7 +26,7 @@
 
             {% block element_manufacturer_logo_link %}
                 {% if manufacturer.link %}
-                    {% set manufacturerLinkHasScheme = manufacturer.link matches '/^[a-zA-Z][a-zA-Z0-9+.-]*:/' or manufacturer.link starts with '//' %}
+                    {% set manufacturerLinkHasScheme = manufacturer.link matches '/^[a-zA-Z][a-zA-Z0-9+.-]*:/' or manufacturer.link starts with '/' %}
                     {% set manufacturerLinkHref = manufacturerLinkHasScheme ? manufacturer.link : 'https://' ~ manufacturer.link %}
                     <a href="{{ manufacturerLinkHref }}"
                         class="cms-image-link product-detail-manufacturer-link"

--- a/tests/integration/Storefront/Controller/ProductControllerTest.php
+++ b/tests/integration/Storefront/Controller/ProductControllerTest.php
@@ -331,6 +331,21 @@ class ProductControllerTest extends TestCase
         static::assertArrayHasKey('product-page-loaded', $traces);
     }
 
+    public function testProductManufacturerRelativeLinkIsNotNormalizedAsExternalUrl(): void
+    {
+        $productId = $this->createProduct(['manufacturer' => ['name' => 'linked-manufacturer', 'link' => '/manufacturer-test/']]);
+
+        $response = $this->request('GET', '/my-product/' . $productId, []);
+
+        $this->checkStatusCode($response);
+
+        $crawler = new Crawler((string) $response->getContent());
+
+        $manufacturerLink = $crawler->filter('a.product-detail-manufacturer-link');
+        static::assertCount(1, $manufacturerLink);
+        static::assertSame('/manufacturer-test/', $manufacturerLink->attr('href'));
+    }
+
     public function testProductJsonLdContainsMerchantListingData(): void
     {
         Feature::skipTestIfInActive('JSON_LD_DATA', $this);
@@ -632,9 +647,10 @@ class ProductControllerTest extends TestCase
         static::assertStringContainsString('no-link-manufacturer', $manufacturer->text());
     }
 
-    public function testProductQuickViewManufacturerIsLinkedWithUrl(): void
+    #[DataProvider('manufacturerLinkProvider')]
+    public function testProductQuickViewManufacturerIsLinkedWithUrl(string $manufacturerUrl, string $expectedUrl): void
     {
-        $productId = $this->createProduct(['manufacturer' => ['name' => 'linked-manufacturer', 'link' => 'shopware.com']]);
+        $productId = $this->createProduct(['manufacturer' => ['name' => 'linked-manufacturer', 'link' => $manufacturerUrl]]);
 
         $response = $this->request('GET', '/quickview/' . $productId, []);
 
@@ -645,10 +661,19 @@ class ProductControllerTest extends TestCase
 
         $manufacturerLink = $crawler->filter('a.quickview-minimal-product-manufacturer');
         static::assertCount(1, $manufacturerLink);
-        static::assertSame('https://shopware.com', $manufacturerLink->attr('href'));
+        static::assertSame($expectedUrl, $manufacturerLink->attr('href'));
         static::assertStringContainsString('linked-manufacturer', $manufacturerLink->text());
 
         static::assertCount(0, $crawler->filter('span.quickview-minimal-product-manufacturer'));
+    }
+
+    /**
+     * @return iterable<string, array{string, string}>
+     */
+    public static function manufacturerLinkProvider(): iterable
+    {
+        yield 'host without scheme gets https scheme' => ['shopware.com', 'https://shopware.com'];
+        yield 'absolute internal path stays relative' => ['/manufacturer-test/', '/manufacturer-test/'];
     }
 
     public function testProductReviewsLoadedScriptsAreExecuted(): void


### PR DESCRIPTION
### 1. Why is this change necessary?

Relative manufacturer links starting with `/` are rendered as external URLs on product detail pages and quickviews. For example, `/manufacturer-test/` becomes `https:///manufacturer-test/`, which browsers resolve as `https://manufacturer-test/`.

### 2. What does this change do, exactly?

Manufacturer links starting with `/` are kept as internal paths. Scheme-less external links like `shopware.com` are still normalized to `https://shopware.com`.

### 3. Describe each step to reproduce the issue or behaviour.

1. Create a manufacturer with the link `/manufacturer-test/`.
2. Assign the manufacturer to a visible product.
3. Open the product detail page.
4. Click the manufacturer link.
5. Before this change, the browser opens `https://manufacturer-test/`.
6. After this change, the browser opens the internal path `/manufacturer-test/`.

### 4. Please link to the relevant issues (if any).

- fixes #19962

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them