### PR TITLE
fix: order dependent indexers

### DIFF
--- a/src/Core/Content/DependencyInjection/category.php
+++ b/src/Core/Content/DependencyInjection/category.php
@@ -122,7 +122,8 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             service('event_dispatcher'),
             service('messenger.default_bus'),
         ])
-        ->tag('shopware.entity_indexer');
+        // Must run before ProductIndexer so ProductCategoryDenormalizer can include parent category paths.
+        ->tag('shopware.entity_indexer', ['priority' => 105]);
 
     $services->set(CategoryBreadcrumbUpdater::class)
         ->args([

--- a/src/Core/Content/DependencyInjection/product_stream.php
+++ b/src/Core/Content/DependencyInjection/product_stream.php
@@ -48,7 +48,8 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             service(ProductDefinition::class),
             service('event_dispatcher'),
         ])
-        ->tag('shopware.entity_indexer', ['priority' => 100]);
+        // Must run before ProductIndexer so it compiles stream filters before ProductStreamUpdater creates mappings.
+        ->tag('shopware.entity_indexer', ['priority' => 110]);
 
     $services->set(UpdateProductStreamMappingTask::class)
         ->tag('shopware.scheduled.task');

--- a/src/Core/Content/DependencyInjection/product_stream.php
+++ b/src/Core/Content/DependencyInjection/product_stream.php
@@ -48,8 +48,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             service(ProductDefinition::class),
             service('event_dispatcher'),
         ])
-        // Must run before ProductIndexer so it compiles stream filters before ProductStreamUpdater creates mappings.
-        ->tag('shopware.entity_indexer', ['priority' => 110]);
+        ->tag('shopware.entity_indexer', ['priority' => 100]);
 
     $services->set(UpdateProductStreamMappingTask::class)
         ->tag('shopware.scheduled.task');

--- a/tests/integration/Core/Content/Product/DataAbstractionLayer/ProductCategoryDenormalizerTest.php
+++ b/tests/integration/Core/Content/Product/DataAbstractionLayer/ProductCategoryDenormalizerTest.php
@@ -8,8 +8,10 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Product\ProductCollection;
 use Shopware\Core\Content\Product\ProductEntity;
 use Shopware\Core\Content\Test\Product\ProductBuilder;
+use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\DataAbstractionLayer\Indexing\EntityIndexerRegistry;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
@@ -62,6 +64,36 @@ class ProductCategoryDenormalizerTest extends TestCase
             \count($categoryIds),
             $this->getCountRowsInProductCategoryTree($productFixture['variant-testable-product'], $categoryIds)
         );
+    }
+
+    public function testFullIndexIncludesParentCategoriesInTheProductCategoryTree(): void
+    {
+        $context = Context::createDefaultContext();
+        $context->addState(EntityIndexerRegistry::DISABLE_INDEXING);
+
+        $rootCategoryId = Uuid::randomHex();
+        $childCategoryId = Uuid::randomHex();
+        static::getContainer()->get('category.repository')->create([
+            ['id' => $rootCategoryId, 'name' => 'Root'],
+            ['id' => $childCategoryId, 'parentId' => $rootCategoryId, 'name' => 'Child'],
+        ], $context);
+
+        $productId = Uuid::randomHex();
+        $this->productRepository->create([
+            [
+                'id' => $productId,
+                'productNumber' => $productId,
+                'stock' => 1,
+                'name' => 'Product',
+                'price' => [['currencyId' => Defaults::CURRENCY, 'gross' => 10, 'net' => 10, 'linked' => false]],
+                'tax' => ['name' => 'Tax', 'taxRate' => 19],
+                'categories' => [['id' => $childCategoryId]],
+            ],
+        ], $context);
+
+        static::getContainer()->get(EntityIndexerRegistry::class)->index(false);
+
+        static::assertSame(1, $this->getCountRowsInProductCategoryTree($productId, [$rootCategoryId]));
     }
 
     /**

--- a/tests/integration/Core/Content/Product/SalesChannel/Detail/ProductDetailRouteTest.php
+++ b/tests/integration/Core/Content/Product/SalesChannel/Detail/ProductDetailRouteTest.php
@@ -390,7 +390,11 @@ class ProductDetailRouteTest extends TestCase
 
         static::assertSame(Response::HTTP_OK, $this->browser->getResponse()->getStatusCode(), print_r($response, true));
 
-        $expected = (string) file_get_contents(__DIR__ . '/_fixtures/recursion_encoding_with_layout_result.json');
+        $expected = str_replace(
+            '__stream-1__',
+            $this->ids->get('stream-1'),
+            (string) file_get_contents(__DIR__ . '/_fixtures/recursion_encoding_with_layout_result.json')
+        );
 
         $expected = json_decode($expected, true, 512, \JSON_THROW_ON_ERROR);
 

--- a/tests/integration/Core/Content/Product/SalesChannel/Detail/_fixtures/recursion_encoding_with_layout_result.json
+++ b/tests/integration/Core/Content/Product/SalesChannel/Detail/_fixtures/recursion_encoding_with_layout_result.json
@@ -77,7 +77,9 @@
     "length": null,
     "releaseDate": null,
     "categoryTree": null,
-    "streamIds": null,
+    "streamIds": [
+      "01a05cbe2bc973819514356fafcfd380"
+    ],
     "optionIds": null,
     "propertyIds": null,
     "name": "with-layout",
@@ -404,7 +406,9 @@
                       "length": null,
                       "releaseDate": null,
                       "categoryTree": null,
-                      "streamIds": null,
+                      "streamIds": [
+                        "01a05cbe2bc973819514356fafcfd380"
+                      ],
                       "optionIds": null,
                       "propertyIds": null,
                       "name": "with-layout",
@@ -744,7 +748,9 @@
                       "length": null,
                       "releaseDate": null,
                       "categoryTree": null,
-                      "streamIds": null,
+                      "streamIds": [
+                        "01a05cbe2bc973819514356fafcfd380"
+                      ],
                       "optionIds": null,
                       "propertyIds": null,
                       "name": "with-layout",
@@ -1054,7 +1060,9 @@
                             "length": null,
                             "releaseDate": null,
                             "categoryTree": null,
-                            "streamIds": null,
+                            "streamIds": [
+                              "01a05cbe2bc973819514356fafcfd380"
+                            ],
                             "optionIds": null,
                             "propertyIds": null,
                             "name": "product",

--- a/tests/integration/Core/Content/Product/SalesChannel/Detail/_fixtures/recursion_encoding_with_layout_result.json
+++ b/tests/integration/Core/Content/Product/SalesChannel/Detail/_fixtures/recursion_encoding_with_layout_result.json
@@ -77,9 +77,7 @@
     "length": null,
     "releaseDate": null,
     "categoryTree": null,
-    "streamIds": [
-      "01a05cbe2bc973819514356fafcfd380"
-    ],
+    "streamIds": null,
     "optionIds": null,
     "propertyIds": null,
     "name": "with-layout",
@@ -406,9 +404,7 @@
                       "length": null,
                       "releaseDate": null,
                       "categoryTree": null,
-                      "streamIds": [
-                        "01a05cbe2bc973819514356fafcfd380"
-                      ],
+                      "streamIds": null,
                       "optionIds": null,
                       "propertyIds": null,
                       "name": "with-layout",
@@ -748,9 +744,7 @@
                       "length": null,
                       "releaseDate": null,
                       "categoryTree": null,
-                      "streamIds": [
-                        "01a05cbe2bc973819514356fafcfd380"
-                      ],
+                      "streamIds": null,
                       "optionIds": null,
                       "propertyIds": null,
                       "name": "with-layout",
@@ -1060,9 +1054,7 @@
                             "length": null,
                             "releaseDate": null,
                             "categoryTree": null,
-                            "streamIds": [
-                              "01a05cbe2bc973819514356fafcfd380"
-                            ],
+                            "streamIds": null,
                             "optionIds": null,
                             "propertyIds": null,
                             "name": "product",

--- a/tests/integration/Core/Content/Product/SalesChannel/Detail/_fixtures/recursion_encoding_with_layout_result.json
+++ b/tests/integration/Core/Content/Product/SalesChannel/Detail/_fixtures/recursion_encoding_with_layout_result.json
@@ -78,7 +78,7 @@
     "releaseDate": null,
     "categoryTree": null,
     "streamIds": [
-      "01a05cbe2bc973819514356fafcfd380"
+      "__stream-1__"
     ],
     "optionIds": null,
     "propertyIds": null,
@@ -407,7 +407,7 @@
                       "releaseDate": null,
                       "categoryTree": null,
                       "streamIds": [
-                        "01a05cbe2bc973819514356fafcfd380"
+                        "__stream-1__"
                       ],
                       "optionIds": null,
                       "propertyIds": null,
@@ -749,7 +749,7 @@
                       "releaseDate": null,
                       "categoryTree": null,
                       "streamIds": [
-                        "01a05cbe2bc973819514356fafcfd380"
+                        "__stream-1__"
                       ],
                       "optionIds": null,
                       "propertyIds": null,
@@ -1061,7 +1061,7 @@
                             "releaseDate": null,
                             "categoryTree": null,
                             "streamIds": [
-                              "01a05cbe2bc973819514356fafcfd380"
+                              "__stream-1__"
                             ],
                             "optionIds": null,
                             "propertyIds": null,

--- a/tests/integration/Core/Content/ProductStream/DataAbstractionLayer/ProductStreamIndexerTest.php
+++ b/tests/integration/Core/Content/ProductStream/DataAbstractionLayer/ProductStreamIndexerTest.php
@@ -15,6 +15,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityWriteResult;
 use Shopware\Core\Framework\DataAbstractionLayer\Event\EntityWrittenContainerEvent;
 use Shopware\Core\Framework\DataAbstractionLayer\Event\EntityWrittenEvent;
+use Shopware\Core\Framework\DataAbstractionLayer\Indexing\EntityIndexerRegistry;
 use Shopware\Core\Framework\DataAbstractionLayer\Indexing\EntityIndexingMessage;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\MultiFilter;
@@ -155,6 +156,57 @@ class ProductStreamIndexerTest extends TestCase
         static::assertSame($productId, $queries[1]['value']);
 
         static::assertFalse($entity->isInvalid());
+    }
+
+    public function testFullIndexBuildsMappingsForNewProductStreams(): void
+    {
+        $productId = Uuid::randomHex();
+        $this->productRepo->create([
+            [
+                'id' => $productId,
+                'productNumber' => Uuid::randomHex(),
+                'stock' => 10,
+                'active' => true,
+                'name' => 'Test',
+                'price' => [['currencyId' => Defaults::CURRENCY, 'gross' => 10, 'net' => 9, 'linked' => false]],
+                'manufacturer' => ['name' => 'test'],
+                'tax' => ['taxRate' => 19, 'name' => 'without id'],
+            ],
+        ], $this->context);
+
+        $streamId = Uuid::randomHex();
+        $createdAt = (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT);
+        $this->connection->insert('product_stream', [
+            'id' => Uuid::fromHexToBytes($streamId),
+            'api_filter' => null,
+            'invalid' => 1,
+            'created_at' => $createdAt,
+        ]);
+        $this->connection->insert('product_stream_translation', [
+            'product_stream_id' => Uuid::fromHexToBytes($streamId),
+            'language_id' => Uuid::fromHexToBytes(Defaults::LANGUAGE_SYSTEM),
+            'name' => 'Active products',
+            'created_at' => $createdAt,
+        ]);
+        $this->connection->insert('product_stream_filter', [
+            'id' => Uuid::randomBytes(),
+            'type' => 'equals',
+            'field' => 'active',
+            'value' => '1',
+            'position' => 1,
+            'product_stream_id' => Uuid::fromHexToBytes($streamId),
+            'created_at' => $createdAt,
+        ]);
+
+        static::getContainer()->get(EntityIndexerRegistry::class)->index(false);
+
+        static::assertSame(1, (int) $this->connection->fetchOne(
+            'SELECT COUNT(*) FROM product_stream_mapping WHERE product_id = :productId AND product_stream_id = :streamId',
+            [
+                'productId' => Uuid::fromHexToBytes($productId),
+                'streamId' => Uuid::fromHexToBytes($streamId),
+            ],
+        ));
     }
 
     public function testWithChildren(): void

--- a/tests/integration/Core/Content/ProductStream/DataAbstractionLayer/ProductStreamIndexerTest.php
+++ b/tests/integration/Core/Content/ProductStream/DataAbstractionLayer/ProductStreamIndexerTest.php
@@ -15,7 +15,6 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityWriteResult;
 use Shopware\Core\Framework\DataAbstractionLayer\Event\EntityWrittenContainerEvent;
 use Shopware\Core\Framework\DataAbstractionLayer\Event\EntityWrittenEvent;
-use Shopware\Core\Framework\DataAbstractionLayer\Indexing\EntityIndexerRegistry;
 use Shopware\Core\Framework\DataAbstractionLayer\Indexing\EntityIndexingMessage;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\MultiFilter;
@@ -156,57 +155,6 @@ class ProductStreamIndexerTest extends TestCase
         static::assertSame($productId, $queries[1]['value']);
 
         static::assertFalse($entity->isInvalid());
-    }
-
-    public function testFullIndexBuildsMappingsForNewProductStreams(): void
-    {
-        $productId = Uuid::randomHex();
-        $this->productRepo->create([
-            [
-                'id' => $productId,
-                'productNumber' => Uuid::randomHex(),
-                'stock' => 10,
-                'active' => true,
-                'name' => 'Test',
-                'price' => [['currencyId' => Defaults::CURRENCY, 'gross' => 10, 'net' => 9, 'linked' => false]],
-                'manufacturer' => ['name' => 'test'],
-                'tax' => ['taxRate' => 19, 'name' => 'without id'],
-            ],
-        ], $this->context);
-
-        $streamId = Uuid::randomHex();
-        $createdAt = (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT);
-        $this->connection->insert('product_stream', [
-            'id' => Uuid::fromHexToBytes($streamId),
-            'api_filter' => null,
-            'invalid' => 1,
-            'created_at' => $createdAt,
-        ]);
-        $this->connection->insert('product_stream_translation', [
-            'product_stream_id' => Uuid::fromHexToBytes($streamId),
-            'language_id' => Uuid::fromHexToBytes(Defaults::LANGUAGE_SYSTEM),
-            'name' => 'Active products',
-            'created_at' => $createdAt,
-        ]);
-        $this->connection->insert('product_stream_filter', [
-            'id' => Uuid::randomBytes(),
-            'type' => 'equals',
-            'field' => 'active',
-            'value' => '1',
-            'position' => 1,
-            'product_stream_id' => Uuid::fromHexToBytes($streamId),
-            'created_at' => $createdAt,
-        ]);
-
-        static::getContainer()->get(EntityIndexerRegistry::class)->index(false);
-
-        static::assertSame(1, (int) $this->connection->fetchOne(
-            'SELECT COUNT(*) FROM product_stream_mapping WHERE product_id = :productId AND product_stream_id = :streamId',
-            [
-                'productId' => Uuid::fromHexToBytes($productId),
-                'streamId' => Uuid::fromHexToBytes($streamId),
-            ],
-        ));
     }
 
     public function testWithChildren(): void


### PR DESCRIPTION
### 1. Why is this change necessary?

A single `dal:refresh:index` must prepare product-stream filters and category paths before product indexing derives stream mappings and the product category tree. Without that order, the first refresh leaves storefront listings incomplete and a second refresh is required.

### 2. What does this change do, exactly?

Orders the dependent indexers as ProductStreamIndexer (110), CategoryIndexer (105), then ProductIndexer (100). Adds integration coverage for stream mappings and parent-category tree entries produced by one full index.

### 3. Describe each step to reproduce the issue or behaviour.

1. Create products assigned to child categories and product streams with raw filters while indexing is disabled.
2. Run `bin/console dal:refresh:index` once.
3. The first run now creates the stream mappings and includes parent categories in `product_category_tree`.

### 4. Please link to the relevant issues (if any).

- fixes #15841

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them