### PR TITLE
chore(administration): force ui shell update 2026 modal open for testing

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/structure/sw-ui-shell-update-2026-modal/index.ts
+++ b/src/Administration/Resources/app/administration/src/app/component/structure/sw-ui-shell-update-2026-modal/index.ts
@@ -191,13 +191,14 @@ export default Shopware.Component.wrapComponentConfig({
         },
 
         async resolveVisibility() {
-            if (!this.isIntendedAudience()) {
-                return;
-            }
-
-            if (await this.hasSeenModal()) {
-                return;
-            }
+            // TESTING: trigger conditions disabled so the modal always opens.
+            // if (!this.isIntendedAudience()) {
+            //     return;
+            // }
+            //
+            // if (await this.hasSeenModal()) {
+            //     return;
+            // }
 
             this.isOpen = true;
         },
@@ -276,11 +277,12 @@ export default Shopware.Component.wrapComponentConfig({
 
             this.hasRecordedSeen = true;
 
-            this.markModalSeen().catch(() => {
-                this.createNotificationError({
-                    message: this.$t('sw-ui-shell-update-2026-modal.seenSaveError'),
-                });
-            });
+            // TESTING: do not persist the seen flag while the trigger is forced open.
+            // this.markModalSeen().catch(() => {
+            //     this.createNotificationError({
+            //         message: this.$t('sw-ui-shell-update-2026-modal.seenSaveError'),
+            //     });
+            // });
         },
 
         onPreviousPage() {


### PR DESCRIPTION
### 1. Why is this change necessary?

Temporary testing branch — not meant to be merged. The one-time ui-shell-update-2026 announcement modal is gated by release date, first-run wizard, shop/user age, and a per-user seen flag, which makes it hard to trigger repeatedly while testing it.

### 2. What does this change do, exactly?

Comments out the trigger gates in `resolveVisibility()` (`isIntendedAudience()` / `hasSeenModal()`) so the modal opens on every admin load, and comments out the `markModalSeen()` upsert so testing does not persist the `core.uiShellUpdate2026ModalSeen` user config flag. Both spots are marked with `// TESTING:` comments.

### 3. Describe each step to reproduce the issue or behaviour.

1. Check out this branch and build/run the Administration.
2. Log in — the ui-shell-update-2026 modal opens immediately, on every load, regardless of user or shop state.

### 4. Please link to the relevant issues (if any).

None.

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them