### PR TITLE
fix(discovery): keep pseudo-locales out of translation:install --all

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -6,6 +6,18 @@
 
 When a state machine contains multiple transitions with the same action name and source state but different destination states, firing that action now deterministically resolves to the oldest transition instead of an undefined one. Such conflicting transitions are deprecated: resolving or writing them triggers a deprecation notice, and with v6.8.0.0 existing duplicates are removed and new ones are prevented by a unique database constraint. If your extension needs its own destination state, register the transition under its own action name instead of reusing an existing one.
 
+### `translation:install --all` no longer installs pseudo-locales
+
+`--all` now covers every configured locale except the pseudo-locales. A pseudo-locale such as `ach-UG` exists for in-context proofreading and translatability audits, not as a language a shop offers, and installing it created an active "Acholi (Pseudo Language)" alongside the real ones.
+
+It stays installable by naming it explicitly, which is how the audits it exists for ask for it:
+
+```
+translation:install --locales=ach-UG
+```
+
+Installations that ran `--all` before this change and do not want the pseudo-language can remove it in the administration, or through `DELETE /api/_action/translation/{locale}` to drop its files as well.
+
 ### `system:install` dispatches `SystemInstallCompletedEvent`
 
 `Shopware\Core\Framework\Event\SystemInstallCompletedEvent` is dispatched after a successful `bin/console system:install`. The event exposes the CLI `Context`. Extensions can subscribe to run post-install work.

--- a/src/Core/System/Snippet/Command/InstallTranslationCommand.php
+++ b/src/Core/System/Snippet/Command/InstallTranslationCommand.php
@@ -152,10 +152,7 @@ class InstallTranslationCommand extends Command
     private function getLocales(InputInterface $input, OutputInterface $output): array
     {
         if ($input->getOption('all')) {
-            // A pseudo-locale is a proofreading tool rather than a language a shop offers, so
-            // "all" does not mean it. It stays installable by naming it in --locales, which is
-            // how the audits it exists for ask for it.
-            return array_values(array_diff($this->config->locales, $this->config->pseudoLocales));
+            return $this->localesWithoutPseudo();
         }
 
         $locales = $input->getOption('locales');
@@ -173,6 +170,14 @@ class InstallTranslationCommand extends Command
         $this->config->assertLocalesAreConfigured($locales);
 
         return $locales;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function localesWithoutPseudo(): array
+    {
+        return array_values(array_diff($this->config->locales, $this->config->pseudoLocales));
     }
 
     /**

--- a/src/Core/System/Snippet/Command/InstallTranslationCommand.php
+++ b/src/Core/System/Snippet/Command/InstallTranslationCommand.php
@@ -152,7 +152,10 @@ class InstallTranslationCommand extends Command
     private function getLocales(InputInterface $input, OutputInterface $output): array
     {
         if ($input->getOption('all')) {
-            return $this->config->locales;
+            // A pseudo-locale is a proofreading tool rather than a language a shop offers, so
+            // "all" does not mean it. It stays installable by naming it in --locales, which is
+            // how the audits it exists for ask for it.
+            return array_values(array_diff($this->config->locales, $this->config->pseudoLocales));
         }
 
         $locales = $input->getOption('locales');

--- a/tests/unit/Core/System/Snippet/Command/InstallTranslationCommandTest.php
+++ b/tests/unit/Core/System/Snippet/Command/InstallTranslationCommandTest.php
@@ -49,6 +49,40 @@ class InstallTranslationCommandTest extends TestCase
         );
     }
 
+    public function testAllSkipsPseudoLocales(): void
+    {
+        $this->config = new TranslationConfig(
+            new Uri('http://localhost:8000'),
+            ['en-GB', 'es-ES', 'ach-UG'],
+            [],
+            new LanguageCollection(),
+            new PluginMappingCollection(),
+            new Uri('http://localhost:8000/metadata.json'),
+            [],
+            pseudoLocales: ['ach-UG'],
+        );
+
+        $this->initMetadataLoader(new MetadataCollection([]));
+        $this->translationLoader->method('hasTranslationFiles')->willReturn(true);
+
+        $installed = [];
+        $this->translationLoader->method('load')
+            ->willReturnCallback(static function (string $locale) use (&$installed): void {
+                $installed[] = $locale;
+            });
+        $this->translationLoader->method('link')
+            ->willReturnCallback(static function (string $locale) use (&$installed): void {
+                $installed[] = $locale;
+            });
+
+        $tester = new CommandTester($this->getCommand());
+        $tester->execute(['--all' => true]);
+        $tester->assertCommandIsSuccessful();
+
+        // A pseudo-locale is a proofreading tool; --all must not turn it into a shop language.
+        static::assertSame(['en-GB', 'es-ES'], $installed);
+    }
+
     public function testExecuteThrowsExceptionWithoutArguments(): void
     {
         $this->translationLoader->expects($this->never())->method('download');

--- a/tests/unit/Core/System/Snippet/Command/InstallTranslationCommandTest.php
+++ b/tests/unit/Core/System/Snippet/Command/InstallTranslationCommandTest.php
@@ -66,11 +66,9 @@ class InstallTranslationCommandTest extends TestCase
         $this->translationLoader->method('hasTranslationFiles')->willReturn(true);
 
         $installed = [];
-        $this->translationLoader->method('load')
-            ->willReturnCallback(static function (string $locale) use (&$installed): void {
-                $installed[] = $locale;
-            });
-        $this->translationLoader->method('link')
+        $this->translationLoader->expects($this->never())->method('load');
+        $this->translationLoader->expects($this->exactly(2))
+            ->method('link')
             ->willReturnCallback(static function (string $locale) use (&$installed): void {
                 $installed[] = $locale;
             });
@@ -100,11 +98,12 @@ class InstallTranslationCommandTest extends TestCase
         $this->translationLoader->method('hasTranslationFiles')->willReturn(true);
 
         $installed = [];
-        $collect = static function (string $locale) use (&$installed): void {
-            $installed[] = $locale;
-        };
-        $this->translationLoader->method('load')->willReturnCallback($collect);
-        $this->translationLoader->method('link')->willReturnCallback($collect);
+        $this->translationLoader->expects($this->never())->method('load');
+        $this->translationLoader->expects($this->once())
+            ->method('link')
+            ->willReturnCallback(static function (string $locale) use (&$installed): void {
+                $installed[] = $locale;
+            });
 
         $tester = new CommandTester($this->getCommand());
         $tester->execute(['--locales' => 'ach-UG']);

--- a/tests/unit/Core/System/Snippet/Command/InstallTranslationCommandTest.php
+++ b/tests/unit/Core/System/Snippet/Command/InstallTranslationCommandTest.php
@@ -83,6 +83,36 @@ class InstallTranslationCommandTest extends TestCase
         static::assertSame(['en-GB', 'es-ES'], $installed);
     }
 
+    public function testAPseudoLocaleIsStillInstallableWhenNamedExplicitly(): void
+    {
+        $this->config = new TranslationConfig(
+            new Uri('http://localhost:8000'),
+            ['en-GB', 'es-ES', 'ach-UG'],
+            [],
+            new LanguageCollection(),
+            new PluginMappingCollection(),
+            new Uri('http://localhost:8000/metadata.json'),
+            [],
+            pseudoLocales: ['ach-UG'],
+        );
+
+        $this->initMetadataLoader(new MetadataCollection([]));
+        $this->translationLoader->method('hasTranslationFiles')->willReturn(true);
+
+        $installed = [];
+        $collect = static function (string $locale) use (&$installed): void {
+            $installed[] = $locale;
+        };
+        $this->translationLoader->method('load')->willReturnCallback($collect);
+        $this->translationLoader->method('link')->willReturnCallback($collect);
+
+        $tester = new CommandTester($this->getCommand());
+        $tester->execute(['--locales' => 'ach-UG']);
+        $tester->assertCommandIsSuccessful();
+
+        static::assertSame(['ach-UG'], $installed);
+    }
+
     public function testExecuteThrowsExceptionWithoutArguments(): void
     {
         $this->translationLoader->expects($this->never())->method('download');


### PR DESCRIPTION
Follow-up to shopware/shopware#19813, found while reviewing shopware/saas#828.

## The problem

`translation:install --all` takes every entry from the configured language list, and that list contains the pseudo-locales. So `--all` installs `ach-UG` and the shop ends up with an active **"Acholi (Pseudo Language)"** next to the real languages.

Nothing stops it along the way:

- `translation:download` fetches every configured locale, and `shopware/translations@main` really does ship an `ach-UG/` directory — so the files are there.
- `hasTranslationFiles('ach-UG')` is therefore true, and the locale is not filtered out as unavailable.
- `createLanguage()` finds no `locale` row for it, but `ach-UG` is in `SnippetPatterns::ALLOWED_PSEUDO_LOCALES`, so `createPseudoLocale()` creates one instead of throwing.
- The language is created with `active = true`.

A pseudo-locale exists for in-context proofreading and translatability audits. It is a tool, not a language a shop offers.

## Since when

Not since `--all` existed. The option shipped in #10524 (July 2025), when there were no pseudo-locales at all.

It broke with #16755 (12 May 2026, *Implement translation list + Pseudo languages*), which added `ach-UG` to the `languages:` list in `translation.yaml` — the very list that feeds `TranslationConfig::$locales` and therefore `--all`. That PR touched `InstallTranslationCommand.php` too, but did not exclude the new pseudo-locales from `--all`.

It is released: the commit is contained in **v6.7.11.0** onwards. Any installation that has run `translation:install --all` since then has an active "Acholi (Pseudo Language)".

## The change

`--all` now covers every configured locale except the pseudo-locales.

Naming one explicitly still installs it, which is how the audits it exists for ask for it:

```
translation:install --locales=ach-UG
```

The interactive picker is deliberately left alone: choosing a pseudo-locale from the list is an explicit act, same as naming it.

## Tests

Both halves of the promise are covered, plus the pre-existing branches of `getLocales()`:

| Case | Test |
|---|---|
| `--all` skips a pseudo-locale | `testAllSkipsPseudoLocales` |
| `--locales=ach-UG` still installs it | `testAPseudoLocaleIsStillInstallableWhenNamedExplicitly` |
| interactive prompt | `testExecutePromptsInteractivelyWhenNoLocalesProvided` |
| no arguments | `testExecuteThrowsExceptionWithoutArguments` |
| unknown locale | `testExecuteThrowsExceptionWithInvalidLocales` |

`TranslationConfig::$pseudoLocales` defaults to `[]`, so every existing test is unaffected.

## Not verified

I could not run phpunit or the style check in the environment this was written in. **CI is the first real check on it.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

