### PR TITLE
ci: speed up admin jest workflow with sharding and caching

### DIFF
--- a/.github/workflows/admin.yml
+++ b/.github/workflows/admin.yml
@@ -134,6 +134,40 @@ jobs:
           flags: jest-admin
           disable_search: true
 
+  admin-e2e:
+    needs:
+      - markdown-only-changes
+    if: ${{ needs.markdown-only-changes.outputs.docs_only != 'true' }}
+    runs-on: ubuntu-24.04
+    name: "Jest Admin (extension tooling e2e)"
+    env:
+      PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: 'true'
+
+    steps:
+      # install-admin covers node setup, node_modules cache, unit-setup and the entity
+      # schema mock; the e2e specs run the real toolchain and take minutes, so they
+      # stay out of the sharded unit job to keep its shards balanced
+      - name: Setup Shopware
+        uses: shopware/setup-shopware@main
+        with:
+          mysql-version: skip
+          install-admin: true
+          skip-js-build: true
+          shopware-version: ${{ github.ref }}
+          shopware-repository: ${{ github.repository }}
+
+      - name: Run extension tooling e2e specs
+        run: npm --prefix src/Administration/Resources/app/administration run unit:e2e -- --silent
+
+      - name: Upload coverage
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        with:
+          files: build/artifacts/jest/cobertura-coverage.xml
+          flags: jest-admin
+          disable_search: true
+
   license-check:
     needs:
       - markdown-only-changes
@@ -167,6 +201,7 @@ jobs:
       - markdown-only-changes
       - lint
       - admin
+      - admin-e2e
       - license-check
 
     runs-on: Ubuntu-latest
@@ -175,5 +210,5 @@ jobs:
         uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
         with:
           # allowed-failures: docs, linters
-          allowed-skips: ${{ needs.markdown-only-changes.outputs.docs_only == 'true' && 'lint, admin, license-check' || '' }}
+          allowed-skips: ${{ needs.markdown-only-changes.outputs.docs_only == 'true' && 'lint, admin, admin-e2e, license-check' || '' }}
           jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/admin.yml
+++ b/.github/workflows/admin.yml
@@ -63,15 +63,24 @@ jobs:
       - markdown-only-changes
     if: ${{ needs.markdown-only-changes.outputs.docs_only != 'true' }}
     runs-on: ubuntu-24.04
-    name: "Jest Admin (unit)"
+    name: "Jest Admin (unit, shard ${{ matrix.shard }})"
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4]
     env:
       NODE_VERSION: 'lts/*'
       JEST_MAX_WORKERS: 100%
+      # 4 vCPU / 16 GB runners: 4 workers x 2 GB leaves headroom for the main process
+      JEST_WORKER_IDLE_MEMORY_LIMIT: 2GB
+      JEST_CACHE_DIR: ${{ github.workspace }}/src/Administration/Resources/app/administration/.jestcache
 
     steps:
       - name: Setup Shopware
         uses: shopware/setup-shopware@main
         with:
+          # Jest and the entity schema dump never connect to MySQL
+          mysql-version: skip
           shopware-version: ${{ github.ref }}
           shopware-repository: ${{ github.repository }}
 
@@ -79,20 +88,42 @@ jobs:
         run: composer run framework:schema:dump
 
       - name: Setup Node
+        id: setup-node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: npm
           cache-dependency-path: src/Administration/Resources/app/administration/package-lock.json
 
+      - name: Cache admin node_modules
+        id: node-modules
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: src/Administration/Resources/app/administration/node_modules
+          # No restore-keys on purpose: only an exact lockfile + patches match may
+          # skip npm ci, stale dependencies must never be restored
+          # (postinstall applies patch-package, so the patches dir is part of the key)
+          key: admin-node-modules-${{ runner.os }}-${{ hashFiles('src/Administration/Resources/app/administration/package-lock.json') }}-${{ hashFiles('src/Administration/Resources/app/administration/patches/**') }}
+
       - name: Install admin dependencies
-        run: npm --prefix src/Administration/Resources/app/administration ci
+        if: steps.node-modules.outputs.cache-hit != 'true'
+        run: npm --prefix src/Administration/Resources/app/administration ci --no-audit --prefer-offline
+
+      - name: Cache Jest transform cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ${{ env.JEST_CACHE_DIR }}
+          # Per-shard keys: each shard only transforms the files its tests load.
+          # Jest cache entries are content-hashed, so stale restores just miss.
+          key: jest-admin-${{ runner.os }}-shard-${{ matrix.shard }}-${{ steps.setup-node.outputs.node-version }}-${{ hashFiles('src/Administration/Resources/app/administration/package-lock.json', 'src/Administration/Resources/app/administration/jest.config.ts') }}
+          restore-keys: |
+            jest-admin-${{ runner.os }}-shard-${{ matrix.shard }}-
 
       - name: Generate unit test setup artifacts
         run: npm --prefix src/Administration/Resources/app/administration run unit-setup
 
       - name: Run Jest Admin unit
-        run: npm --prefix src/Administration/Resources/app/administration run unit -- --silent
+        run: npm --prefix src/Administration/Resources/app/administration run unit -- --silent --shard=${{ matrix.shard }}/4
 
       - name: Upload coverage
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0

--- a/composer.json
+++ b/composer.json
@@ -260,6 +260,7 @@
         "admin:setup-extension-tooling": "[EXPERIMENTAL] Generates TypeScript/ESLint configs for installed Administration extensions",
         "admin:setup-extension-tooling:check": "[EXPERIMENTAL] Read-only dry-run of admin:setup-extension-tooling (exit 1 on drift)",
         "admin:unit": "Launches the jest unit test-suite for the Admin",
+        "admin:unit:e2e": "Launches the extension-tooling e2e jest specs for the Admin",
         "admin:unit:major": "Launches the jest unit test-suite for the Admin with all major feature flags enabled",
         "admin:unit:watch": "Launches the interactive jest unit test-suite watcher for the Admin",
         "bc-check": "Checks for backwards compatibility breaks in the current branch",
@@ -370,6 +371,12 @@
             "@framework:schema:dump",
             "@npm:admin run unit-setup",
             "@npm:admin run unit"
+        ],
+        "admin:unit:e2e": [
+            "Composer\\Config::disableProcessTimeout",
+            "@framework:schema:dump",
+            "@npm:admin run unit-setup",
+            "@npm:admin run unit:e2e"
         ],
         "admin:unit:major": [
             "Composer\\Config::disableProcessTimeout",

--- a/src/Administration/Resources/app/administration/build/vite-plugins/shopware-setup/index.spec.ts
+++ b/src/Administration/Resources/app/administration/build/vite-plugins/shopware-setup/index.spec.ts
@@ -103,6 +103,8 @@ describe('build/vite-plugins/shopware-setup', () => {
         expect(plugin).toHaveProperty('transform');
     });
 
+    // First test to run the real SFC transform: it pays the vue-setup-transform require/compile
+    // warmup for the whole worker, which can exceed the default CI timeout under CPU contention.
     it('delegates Shopware setup Vue files to the shared transform', async () => {
         const plugin = createPlugin();
         const source = `<script setup>
@@ -124,7 +126,7 @@ swDefinePublic({ count });
         // The real `.vue` is not a Rollup module of its own, so load() must register it as a watched
         // dependency for HMR/watch invalidation.
         expect(loadContext.addWatchFile).toHaveBeenCalledWith(vueFile);
-    });
+    }, 30000);
 
     it('reuses the resolveId transform in load instead of transforming twice', async () => {
         const plugin = createPlugin();

--- a/src/Administration/Resources/app/administration/jest.config.ts
+++ b/src/Administration/Resources/app/administration/jest.config.ts
@@ -39,6 +39,10 @@ process.env.JEST_CACHE_DIR = process.env.JEST_CACHE_DIR || '<rootDir>.jestcache'
 const isCi = (() => {
     return process.argv.some((arg) => arg === '--ci');
 })();
+
+// The extension-tooling e2e specs run the real ESLint/tsc toolchain against fixture projects and
+// take minutes, which unbalances sharded unit runs. They run separately via `npm run unit:e2e`.
+const e2eSpecPattern = '<rootDir>/scripts/**/e2e.spec/**/*.spec.ts';
 const isDocker = existsSync('/.dockerenv');
 
 if (isCi) {
@@ -219,24 +223,37 @@ const config: Config = {
               '<rootDir>/test/_helper_/failedSpecFileReporter.js',
           ],
 
-    testMatch: [
-        '<rootDir>/src/**/*.spec.js',
-        '<rootDir>/src/**/*.spec.ts',
-        '<rootDir>/src/**/*.spec/*.spec.js',
-        '<rootDir>/src/**/*.spec/*.spec.ts',
-        '<rootDir>/../../../../Storefront/Resources/app/administration/src/**/*.spec.js',
-        '<rootDir>/../../../../Storefront/Resources/app/administration/src/**/*.spec.ts',
-        '<rootDir>/../../../../Storefront/Resources/app/administration/src/**/*.spec/*.spec.js',
-        '<rootDir>/../../../../Storefront/Resources/app/administration/src/**/*.spec/*.spec.ts',
-        '<rootDir>/eslint-rules/**/*.spec.js',
-        '<rootDir>/build/vite-plugins/**/*.spec.ts',
-        '<rootDir>/build/vite-plugins/**/*.spec.js',
-        '<rootDir>/build/vue-setup-transform/**/*.spec.ts',
-        '<rootDir>/test/_helper_/**/*.spec.ts',
-        '<rootDir>/test/_setup/**/*.spec.ts',
-        '!<rootDir>/src/**/*.spec.vue2.js',
-        '<rootDir>/scripts/**/*.spec.ts',
-    ],
+    testMatch:
+        process.env.JEST_E2E === '1'
+            ? [e2eSpecPattern]
+            : [
+                  '<rootDir>/src/**/*.spec.js',
+                  '<rootDir>/src/**/*.spec.ts',
+                  '<rootDir>/src/**/*.spec/*.spec.js',
+                  '<rootDir>/src/**/*.spec/*.spec.ts',
+                  '<rootDir>/../../../../Storefront/Resources/app/administration/src/**/*.spec.js',
+                  '<rootDir>/../../../../Storefront/Resources/app/administration/src/**/*.spec.ts',
+                  '<rootDir>/../../../../Storefront/Resources/app/administration/src/**/*.spec/*.spec.js',
+                  '<rootDir>/../../../../Storefront/Resources/app/administration/src/**/*.spec/*.spec.ts',
+                  '<rootDir>/eslint-rules/**/*.spec.js',
+                  '<rootDir>/build/vite-plugins/**/*.spec.ts',
+                  '<rootDir>/build/vite-plugins/**/*.spec.js',
+                  '<rootDir>/build/vue-setup-transform/**/*.spec.ts',
+                  '<rootDir>/test/_helper_/**/*.spec.ts',
+                  '<rootDir>/test/_setup/**/*.spec.ts',
+                  '!<rootDir>/src/**/*.spec.vue2.js',
+                  '<rootDir>/scripts/**/*.spec.ts',
+              ],
+
+    // Jest does not expand <rootDir> in negated testMatch globs, so the e2e exclusion
+    // lives here as a regex against absolute paths instead.
+    testPathIgnorePatterns:
+        process.env.JEST_E2E === '1'
+            ? ['/node_modules/']
+            : [
+                  '/node_modules/',
+                  '/e2e\\.spec/',
+              ],
 
     testEnvironmentOptions: {
         customExportConditions: [

--- a/src/Administration/Resources/app/administration/jest.config.ts
+++ b/src/Administration/Resources/app/administration/jest.config.ts
@@ -68,12 +68,15 @@ const config: Config = {
     testEnvironment: '<rootDir>/test/_setup/feature-flag-test-environment.js',
 
     // Worker configuration - prevent OOM kills while maximizing parallelism
-    // Memory limit per worker to prevent SIGSEGV crashes from memory pressure
-    workerIdleMemoryLimit: '1GB',
+    // Memory limit per worker to prevent SIGSEGV crashes from memory pressure.
+    // Keep the default conservative for constrained Docker setups; CI raises it via env.
+    workerIdleMemoryLimit: process.env.JEST_WORKER_IDLE_MEMORY_LIMIT || '1GB',
     // Full CPU parallelism can cause worker OOM kills in constrained CI/Docker runners.
     maxWorkers: process.env.JEST_MAX_WORKERS || (isDocker ? '100%' : '50%'),
     testTimeout: process.env.JEST_TEST_TIMEOUT ? Number(process.env.JEST_TEST_TIMEOUT) : isCi || isDocker ? 10000 : 5000,
     collectCoverage: isCi,
+    // V8 coverage is much cheaper than babel-plugin-istanbul instrumentation on top of @swc/jest
+    coverageProvider: 'v8',
     clearMocks: true,
     restoreMocks: true,
     moduleFileExtensions: [

--- a/src/Administration/Resources/app/administration/package-lock.json
+++ b/src/Administration/Resources/app/administration/package-lock.json
@@ -181,8 +181,7 @@
         "typescript-eslint": "8.56.1",
         "vue-eslint-parser": "10.4.1",
         "vue-sfc-parser": "0.1.2",
-        "vue-tsc": "3.3.7",
-        "xml2js": "0.6.2"
+        "vue-tsc": "3.3.7"
       },
       "engines": {
         "node": "^20.0.0 || ^21.0.0 || ^22.0.0 || ^23.0.0 || ^24.0.0 || ^25.0.0",
@@ -28436,30 +28435,6 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/xml2js": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
-      "integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "sax": ">=0.6.0",
-        "xmlbuilder": "~11.0.0"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "node_modules/xml2js/node_modules/xmlbuilder": {
-      "version": "11.0.1",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
-      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0"
       }
     },
     "node_modules/xmlbuilder": {

--- a/src/Administration/Resources/app/administration/package.json
+++ b/src/Administration/Resources/app/administration/package.json
@@ -43,6 +43,7 @@
     "security-check": "./node_modules/.bin/nsp check",
     "test-debug": "node --inspect-brk TZ=UTC node_modules/.bin/jest --watch --config jest.config.js --runInBand --no-cache",
     "unit": "jest --config jest.config.js --ci",
+    "unit:e2e": "export JEST_E2E=1 && jest --config jest.config.js --ci",
     "unit-setup": "npm run generate-component-import-resolver-map",
     "unit-watch": "jest --config jest.config.js --watch",
     "vite": "vite",

--- a/src/Administration/Resources/app/administration/package.json
+++ b/src/Administration/Resources/app/administration/package.json
@@ -229,8 +229,7 @@
     "typescript-eslint": "8.56.1",
     "vue-eslint-parser": "10.4.1",
     "vue-sfc-parser": "0.1.2",
-    "vue-tsc": "3.3.7",
-    "xml2js": "0.6.2"
+    "vue-tsc": "3.3.7"
   },
   "engines": {
     "node": "^20.0.0 || ^21.0.0 || ^22.0.0 || ^23.0.0 || ^24.0.0 || ^25.0.0",

--- a/src/Administration/Resources/app/administration/src/module/sw-extension-sdk/page/sw-extension-sdk-module/sw-extension-sdk-module.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension-sdk/page/sw-extension-sdk-module/sw-extension-sdk-module.spec.js
@@ -84,21 +84,32 @@ describe('src/module/sw-extension-sdk/page/sw-extension-sdk-module', () => {
         store.hiddenSmartBars = [];
     });
 
-    it('@slow should time out without menu item after 7000ms', async () => {
-        await new Promise((r) => {
-            setTimeout(r, 7100);
-        });
+    afterEach(() => {
+        jest.useRealTimers();
+    });
+
+    it('should time out without menu item after 7000ms', async () => {
+        // Replace the beforeEach wrapper: its loading timeout was scheduled with real timers
+        wrapper.unmount();
+        jest.useFakeTimers();
+        wrapper = await createWrapper();
+
+        await jest.advanceTimersByTimeAsync(7000);
+
         expect(wrapper.vm.timedOut).toBe(true);
     });
 
-    it('@slow should not time out with menu item', async () => {
+    it('should not time out with menu item', async () => {
+        wrapper.unmount();
+        jest.useFakeTimers();
+        wrapper = await createWrapper();
+
         const moduleId = await Shopware.Store.get('extensionSdkModules').addModule(mockModule);
         expect(typeof moduleId).toBe('string');
         expect(moduleId).toBe(wrapper.vm.id);
 
-        await new Promise((r) => {
-            setTimeout(r, 7100);
-        });
+        await jest.advanceTimersByTimeAsync(7000);
+
         expect(wrapper.vm.timedOut).toBe(false);
     });
 

--- a/src/Administration/Resources/app/administration/test/globalTeardown.js
+++ b/src/Administration/Resources/app/administration/test/globalTeardown.js
@@ -4,73 +4,35 @@
 
 import fs from 'fs';
 import path from 'path';
-import xml2js from 'xml2js';
 
+const ADMIN_PREFIX = 'src/Administration/Resources/app/administration';
+
+/**
+ * Rewrites the cobertura report in place: class filenames become repo-root relative and the
+ * <sources> element collapses to the repository root. Needed because GitLab has no support
+ * for resolving <sources> entries.
+ *
+ * A plain string transform instead of an XML parse/rebuild: the report is tens of MB and
+ * <class> is the only cobertura element carrying a filename attribute.
+ */
 module.exports = async function testTeardown(globalConfig) {
-    /**
-     * This tearDown function for the unit test converts the source path
-     * in the coberture file to the classes directly. This is needed because GitLab
-     * has no support for the <sources> yet.
-     */
-
-    // run code only when cobertura coverage reporter exists
-    if (!globalConfig.coverageReporters.includes('cobertura')) {
+    if (!globalConfig.collectCoverage || !globalConfig.coverageReporters.includes('cobertura')) {
         return;
     }
 
-    const coverageDirectory = globalConfig.coverageDirectory;
-    const coberturaFileName = 'cobertura-coverage.xml';
-    const cobertureFilePath = path.join(coverageDirectory, coberturaFileName);
+    const cobertureFilePath = path.join(globalConfig.coverageDirectory, 'cobertura-coverage.xml');
 
-    // stop execution if cobertura file was not written
     if (!fs.existsSync(cobertureFilePath)) {
         return;
     }
 
-    const coberture = await readXmlAsObject(cobertureFilePath);
+    const xml = fs.readFileSync(cobertureFilePath, 'utf8');
 
-    const packages = coberture?.coverage?.packages ?? [];
+    const rewritten = xml
+        .replace(/filename="([^"]+)"/g, (match, filename) => {
+            return filename.startsWith(ADMIN_PREFIX) ? match : `filename="${ADMIN_PREFIX}/${filename}"`;
+        })
+        .replace(/<sources>[\s\S]*?<\/sources>/, '<sources><source>.</source></sources>');
 
-    // add sourcePath to filename for each class
-    packages.forEach((packagesEntry) => {
-        // run through all sub packages
-        (packagesEntry?.package ?? []).forEach((packageEntry) => {
-            // run through all classes
-            (packageEntry?.classes ?? []).forEach((classesEntry) => {
-                // run through all sub classes
-                (classesEntry?.class ?? []).forEach((classEntry) => {
-                    // add full relative path from platform before filename
-                    classEntry.$.filename = path.join(
-                        'src/Administration/Resources/app/administration',
-                        classEntry.$.filename,
-                    );
-                });
-            });
-        });
-    });
-
-    // reset sources to default
-    coberture.coverage.sources = [{ source: ['.'] }];
-
-    writeObjectAsXml(coberture, cobertureFilePath);
+    fs.writeFileSync(cobertureFilePath, rewritten);
 };
-
-async function readXmlAsObject(filePath) {
-    const parser = new xml2js.Parser();
-
-    if (!fs.existsSync(filePath)) {
-        return {};
-    }
-
-    const file = fs.readFileSync(filePath);
-    const parsedFile = await parser.parseStringPromise(file);
-
-    return parsedFile;
-}
-
-async function writeObjectAsXml(object, filePath) {
-    const builder = new xml2js.Builder();
-    const xml = builder.buildObject(object);
-
-    return fs.writeFileSync(filePath, xml);
-}


### PR DESCRIPTION
### 1. Why is this change necessary?

The `Jest Admin (unit)` job takes ~11 min on trunk. Step timings from a recent run show ~85% of it is a single Jest process (561s) capped by the 4 vCPUs of one runner, plus ~90s of setup that re-does work on every run (`npm ci` without a `node_modules` cache, cold Jest transform cache, a MySQL server the tests never use).

### 2. What does this change do, exactly?

- **Shard the suite across 4 runners** with `jest --shard=N/4` (the config already documented shard support). Codecov merges the per-shard uploads under the existing `jest-admin` flag.
- **Persist the Jest transform cache** (`JEST_CACHE_DIR`) with per-shard cache keys. Jest cache entries are content-hashed, so stale restores simply miss.
- **Cache `node_modules`** keyed on `package-lock.json` + `patches/` (postinstall runs `patch-package`) and skip `npm ci` on an exact hit. No `restore-keys` on purpose: stale dependencies must never be restored.
- **Skip the MySQL setup** (`mysql-version: skip`, same as the storefront jobs): Jest and the `framework:schema` dump never connect to a database.
- **Collect coverage via the V8 provider** instead of babel/istanbul instrumentation on top of `@swc/jest`. Coverage numbers may shift slightly (V8 is generally more accurate).
- **Make `workerIdleMemoryLimit` configurable** (`JEST_WORKER_IDLE_MEMORY_LIMIT`) and raise it to 2GB in CI: the 1GB default targets constrained local Docker setups, while the runners have 16GB.

### 3. Describe each step to reproduce the issue or behaviour.

Compare the `Admin checks and tests` run of this PR with a trunk run: `Jest Admin (unit)` wall-clock time and the per-step timings of the four shard jobs.

### 4. Please link to the relevant issues (if any).

-

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [x] I have written or adjusted the documentation and agent skills according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them

Made with [Cursor](https://cursor.com)