### PR TITLE
fix(administration): clean up order versions on pagehide

### DIFF
--- a/changelog/_unreleased/2026-09-02-clean-up-order-versions-on-pagehide.md
+++ b/changelog/_unreleased/2026-09-02-clean-up-order-versions-on-pagehide.md
@@ -1,0 +1,6 @@
+---
+title: Clean up order versions when leaving the order detail page
+issue: 18961
+---
+# Administration
+* Changed the order detail page to delete its draft version with a keepalive request when the page is unloaded.

--- a/src/Administration/Resources/app/administration/src/core/data/repository.data.spec.js
+++ b/src/Administration/Resources/app/administration/src/core/data/repository.data.spec.js
@@ -48,9 +48,17 @@ if (!Shopware.Service('cacheService')) {
 }
 
 describe('repository.data.ts', () => {
+    const originalFetch = global.fetch;
+    const originalBaseUrl = global.repositoryFactoryMock.httpClient.defaults.baseURL;
+
     beforeEach(async () => {
         clientMock.resetHistory();
         Shopware.Service('cacheService').clear();
+    });
+
+    afterEach(() => {
+        global.fetch = originalFetch;
+        global.repositoryFactoryMock.httpClient.defaults.baseURL = originalBaseUrl;
     });
 
     it('should search with the criteria title', async () => {
@@ -142,6 +150,44 @@ describe('repository.data.ts', () => {
         };
 
         expect(actualHeaders).toEqual(exptectedHeaders);
+    });
+
+    it('should delete a version with a keepalive request', async () => {
+        global.fetch = jest.fn(() => Promise.resolve());
+        const repository = repositoryFactory.create('order');
+        repository.httpClient.defaults.baseURL = 'http://shopware.local/api';
+
+        await repository.deleteVersionWithKeepalive('order-id', 'version-id', mockContext());
+
+        expect(global.fetch).toHaveBeenCalledWith('http://shopware.local/api/_action/version/version-id/order/order-id', {
+            method: 'POST',
+            headers: {
+                Accept: 'application/vnd.api+json',
+                Authorization: 'Bearer BwP_OL47uNW6k8iQzChh6SxE31XaleO_l4unyLNmFco',
+                'Content-Type': 'application/json',
+                'sw-api-compatibility': 'true',
+                'sw-currency-id': '7924299acc9641bfb8237a06e5aa0fa4',
+                'sw-language-id': '2fbb5fe2e29a4d70aa5854ce7ce3e20b',
+            },
+            body: '{}',
+            keepalive: true,
+        });
+    });
+
+    it('should fall back to the HTTP client when fetch is unavailable', async () => {
+        global.fetch = undefined;
+        const repository = repositoryFactory.create('order');
+        responses.addResponse({
+            method: 'POST',
+            url: '/_action/version/version-id/order/order-id',
+            status: 200,
+            response: {},
+        });
+
+        await repository.deleteVersionWithKeepalive('order-id', 'version-id', mockContext());
+
+        expect(clientMock.history.post).toHaveLength(1);
+        expect(clientMock.history.post[0].url).toBe('/_action/version/version-id/order/order-id');
     });
 
     it('should include measurement units in headers', async () => {

--- a/src/Administration/Resources/app/administration/src/core/data/repository.data.ts
+++ b/src/Administration/Resources/app/administration/src/core/data/repository.data.ts
@@ -623,6 +623,39 @@ export default class Repository<EntityName extends keyof EntitySchema.Entities> 
     }
 
     /**
+     * Deletes the provided version with a request the browser can continue while the page is unloading.
+     */
+    deleteVersionWithKeepalive(
+        entityId: string,
+        versionId: string,
+        context = Shopware.Context.api,
+    ): Promise<Response | HttpResponse> {
+        if (typeof fetch !== 'function') {
+            return this.deleteVersion(entityId, versionId, context);
+        }
+
+        const headers = Object.fromEntries(
+            Object.entries(this.buildHeaders(context)).map(
+                ([
+                    name,
+                    value,
+                ]) => [
+                    name,
+                    String(value),
+                ],
+            ),
+        );
+        const url = `/_action/version/${versionId}/${this.entityName.replace(/_/g, '-')}/${entityId}`;
+
+        return fetch(this.httpClient.getUri({ url, useAxiosV1: true }), {
+            method: 'POST',
+            headers,
+            body: JSON.stringify({}),
+            keepalive: true,
+        });
+    }
+
+    /**
      * @private
      */
     sendChanges(

--- a/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-detail/index.js
@@ -258,6 +258,8 @@ export default {
     },
 
     beforeUnmount() {
+        window.removeEventListener('pagehide', this.onPageHide);
+
         // Deselecting happens here and not in `beforeRouteLeave`, because leaving while editing
         // is confirmed through the leave page warning, which resumes the navigation on its own.
         Shopware.Store.get('shopwareApps').selectedIds = [];
@@ -288,7 +290,7 @@ export default {
                 scope: this,
             });
 
-            window.addEventListener('beforeunload', this.beforeDestroyComponent);
+            window.addEventListener('pagehide', this.onPageHide);
 
             Shopware.Store.get('shopwareApps').selectedIds = this.orderId ? [this.orderId] : [];
 
@@ -304,7 +306,15 @@ export default {
             });
         },
 
-        async beforeDestroyComponent() {
+        onPageHide(event) {
+            if (event.persisted) {
+                return;
+            }
+
+            this.beforeDestroyComponent(true);
+        },
+
+        beforeDestroyComponent(useKeepalive = false) {
             Store.get('swOrderDetail').setOrderAddressIds(null);
 
             if (this.hasNewVersionId) {
@@ -313,10 +323,14 @@ export default {
                 this.hasNewVersionId = false;
 
                 // clean up recently created version
-                await this.orderRepository.deleteVersion(this.orderId, oldVersionContext.versionId);
-            }
+                if (useKeepalive) {
+                    this.orderRepository.deleteVersionWithKeepalive(this.orderId, oldVersionContext.versionId);
 
-            window.removeEventListener('beforeunload', this.beforeDestroyComponent);
+                    return;
+                }
+
+                this.orderRepository.deleteVersion(this.orderId, oldVersionContext.versionId);
+            }
         },
 
         /**

--- a/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-detail/sw-order-detail.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-detail/sw-order-detail.spec.js
@@ -12,6 +12,7 @@ async function createWrapper(order = {}, { routeName = 'sw.order.detail.general'
         search: () => Promise.resolve([]),
         hasChanges: () => false,
         deleteVersion: () => Promise.resolve([]),
+        deleteVersionWithKeepalive: () => Promise.resolve(),
         createVersion: () => Promise.resolve({ versionId: 'newVersionId' }),
         get: () => Promise.resolve(order),
         save: () => Promise.resolve({}),
@@ -127,6 +128,10 @@ describe('src/module/sw-order/page/sw-order-detail', () => {
     let wrapper;
 
     afterEach(() => {
+        if (wrapper) {
+            window.removeEventListener('pagehide', wrapper.vm.onPageHide);
+        }
+
         Shopware.Store.get('shopwareApps').selectedIds = [];
     });
 
@@ -160,20 +165,34 @@ describe('src/module/sw-order/page/sw-order-detail', () => {
         expect(Shopware.Store.get('shopwareApps').selectedIds).toEqual([]);
     });
 
-    it('should remove version id when beforeunload event is triggered', async () => {
+    it('should remove version id with a keepalive request when pagehide is triggered', async () => {
         wrapper = await createWrapper();
         wrapper.vm.orderRepository.deleteVersion = jest.fn(() => Promise.resolve());
+        wrapper.vm.orderRepository.deleteVersionWithKeepalive = jest.fn(() => Promise.resolve());
 
         const oldVersionContext = wrapper.vm.versionContext;
 
-        window.dispatchEvent(new Event('beforeunload'));
+        window.dispatchEvent(new Event('pagehide'));
 
-        expect(wrapper.vm.orderRepository.deleteVersion).toHaveBeenCalledWith(
+        expect(wrapper.vm.orderRepository.deleteVersionWithKeepalive).toHaveBeenCalledWith(
             wrapper.vm.orderId,
             oldVersionContext.versionId,
         );
+        expect(wrapper.vm.orderRepository.deleteVersion).not.toHaveBeenCalled();
         expect(wrapper.vm.versionContext).toBe(Shopware.Context.api);
         expect(wrapper.vm.hasNewVersionId).toBe(false);
+    });
+
+    it('should keep the version when the page is stored in the back-forward cache', async () => {
+        wrapper = await createWrapper();
+        wrapper.vm.orderRepository.deleteVersionWithKeepalive = jest.fn(() => Promise.resolve());
+
+        const pageHideEvent = new Event('pagehide');
+        Object.defineProperty(pageHideEvent, 'persisted', { value: true });
+        window.dispatchEvent(pageHideEvent);
+
+        expect(wrapper.vm.orderRepository.deleteVersionWithKeepalive).not.toHaveBeenCalled();
+        expect(wrapper.vm.hasNewVersionId).toBe(true);
     });
 
     it('should not contain manual label', async () => {
@@ -301,10 +320,11 @@ describe('src/module/sw-order/page/sw-order-detail', () => {
         wrapper = await createWrapper();
         await wrapper.vm.createNewVersionId();
         wrapper.vm.orderRepository.deleteVersion = jest.fn(() => Promise.resolve());
+        const oldVersionId = wrapper.vm.versionContext.versionId;
 
-        await wrapper.vm.beforeDestroyComponent();
+        wrapper.vm.beforeDestroyComponent();
 
-        expect(wrapper.vm.orderRepository.deleteVersion).toHaveBeenCalled();
+        expect(wrapper.vm.orderRepository.deleteVersion).toHaveBeenCalledWith(wrapper.vm.orderId, oldVersionId);
     });
 
     it('should reset pending address selections when component gets destroyed', async () => {
@@ -316,7 +336,7 @@ describe('src/module/sw-order/page/sw-order-detail', () => {
             type: 'billing',
         });
 
-        await wrapper.vm.beforeDestroyComponent();
+        wrapper.vm.beforeDestroyComponent();
 
         expect(Shopware.Store.get('swOrderDetail').orderAddressIds).toEqual([]);
     });


### PR DESCRIPTION
### 1. Why is this change necessary?

The cleanup race fixed for 6.6 also affects 6.7, leaving unused order versions when the order detail page is reloaded or exited.

### 2. What does this change do, exactly?

Ports #19904 to 6.7 using `pagehide` and a keepalive cleanup request, with regression coverage.

### 3. Describe each step to reproduce the issue or behaviour.

Open an order detail page and repeatedly reload it or navigate away.

### 4. Please link to the relevant issues (if any).

- relates #18961
- follows #19904

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have updated developer-facing release notes if this change is relevant for external developers
- [x] I have written or adjusted the documentation and agent skills according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
