### PR TITLE
feat: shim for setup state overrides to options api components

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/adapter/composition-extension-system/options-api-setup-shim.spec.ts
+++ b/src/Administration/Resources/app/administration/src/app/adapter/composition-extension-system/options-api-setup-shim.spec.ts
@@ -99,6 +99,35 @@ describe('src/app/adapter/composition-extension-system/options-api-setup-shim', 
         expect(wrapper.text()).toBe('own setup|override');
     });
 
+    it('applies the override even when an immediate watcher read the key first', async () => {
+        _overridesMap['sw-shim-watch'] = [
+            (previousState: Record<string, { value: unknown }>) => ({
+                label: computed(() => `override ${String(previousState.label.value)}`),
+            }),
+        ] as never;
+
+        const config = {
+            template: '<p>{{ label }}</p>',
+            data() {
+                return { label: 'base' };
+            },
+            watch: {
+                label: {
+                    immediate: true,
+                    handler() {},
+                },
+            },
+        } as unknown as ComponentConfig;
+
+        attachSetupOverrideShim('sw-shim-watch', config);
+
+        const wrapper = mount(config as never);
+        await flushPromises();
+
+        // The watcher fires before any created hook and pins the key to `data` in Vue's access cache.
+        expect(wrapper.text()).toBe('override base');
+    });
+
     it('keeps Vue resolving late-added setup keys before data and computed', async () => {
         const bag: Record<string, unknown> = {};
 

--- a/src/Administration/Resources/app/administration/src/app/adapter/composition-extension-system/options-api-setup-shim.spec.ts
+++ b/src/Administration/Resources/app/administration/src/app/adapter/composition-extension-system/options-api-setup-shim.spec.ts
@@ -3,7 +3,7 @@
  */
 
 import { mount } from '@vue/test-utils';
-import { computed } from 'vue';
+import { computed, ref } from 'vue';
 import type { ComponentConfig } from 'src/core/factory/async-component.factory';
 import { attachSetupOverrideShim } from './options-api-setup-shim';
 import { _overridesMap } from './index';
@@ -76,6 +76,27 @@ describe('src/app/adapter/composition-extension-system/options-api-setup-shim', 
 
         // Would stay at "override 1" if the setter wrote into the override's own result instead of data.
         expect(wrapper.text()).toBe('override 42');
+    });
+
+    it('keeps an existing setup() of the component instead of replacing it', async () => {
+        _overridesMap['sw-shim-existing-setup'] = [
+            () => ({ fromOverride: computed(() => 'override') }),
+        ] as never;
+
+        const config = {
+            template: '<p>{{ fromSetup }}|{{ fromOverride }}</p>',
+            setup() {
+                return { fromSetup: ref('own setup') };
+            },
+        } as unknown as ComponentConfig;
+
+        attachSetupOverrideShim('sw-shim-existing-setup', config);
+
+        const wrapper = mount(config as never);
+        await flushPromises();
+
+        // Would render only "|override" if the shim had overwritten config.setup.
+        expect(wrapper.text()).toBe('own setup|override');
     });
 
     it('keeps Vue resolving late-added setup keys before data and computed', async () => {

--- a/src/Administration/Resources/app/administration/src/app/adapter/composition-extension-system/options-api-setup-shim.spec.ts
+++ b/src/Administration/Resources/app/administration/src/app/adapter/composition-extension-system/options-api-setup-shim.spec.ts
@@ -1,0 +1,75 @@
+/**
+ * @sw-package framework
+ */
+
+import { mount } from '@vue/test-utils';
+import { computed } from 'vue';
+import type { ComponentConfig } from 'src/core/factory/async-component.factory';
+import { attachSetupOverrideShim } from './options-api-setup-shim';
+import { _overridesMap } from './index';
+
+describe('src/app/adapter/composition-extension-system/options-api-setup-shim', () => {
+    beforeEach(() => {
+        Object.keys(_overridesMap).forEach((key) => {
+            delete _overridesMap[key];
+        });
+    });
+
+    it('applies a setup override to an Options API component and reads the untouched base state', async () => {
+        _overridesMap['sw-shim-test'] = [
+            (previousState: Record<string, { value: unknown }>) => ({
+                welcomeSubline: computed(() => `${String(previousState.welcomeSubline.value)} / overridden`),
+                shopName: computed(() => `${String(previousState.shopName.value)} GmbH`),
+            }),
+        ] as never;
+
+        const config = {
+            template: '<p>{{ welcomeSubline }} — {{ shopName }}</p>',
+            data() {
+                return { shopName: 'Demo' };
+            },
+            computed: {
+                welcomeSubline() {
+                    return 'base subline';
+                },
+            },
+        } as unknown as ComponentConfig;
+
+        attachSetupOverrideShim('sw-shim-test', config);
+
+        const wrapper = mount(config as never);
+        await flushPromises();
+
+        // Would read "undefined / overridden" if previousState resolved through the instance proxy,
+        // because the override's own result already shadows the key at that point.
+        expect(wrapper.text()).toBe('base subline / overridden — Demo GmbH');
+    });
+
+    it('keeps Vue resolving late-added setup keys before data and computed', async () => {
+        const bag: Record<string, unknown> = {};
+
+        const wrapper = mount({
+            template: '<p>{{ fromData }}|{{ fromComputed }}</p>',
+            setup() {
+                return bag;
+            },
+            data() {
+                return { fromData: 'DATA' };
+            },
+            computed: {
+                fromComputed() {
+                    return 'COMPUTED';
+                },
+            },
+            created() {
+                bag.fromData = 'SETUP';
+                bag.fromComputed = 'SETUP';
+            },
+        });
+        await flushPromises();
+
+        // The shim rests on this undocumented Vue behaviour. If a Vue upgrade changes it, this fails
+        // here instead of silently dropping every override at runtime.
+        expect(wrapper.text()).toBe('SETUP|SETUP');
+    });
+});

--- a/src/Administration/Resources/app/administration/src/app/adapter/composition-extension-system/options-api-setup-shim.spec.ts
+++ b/src/Administration/Resources/app/administration/src/app/adapter/composition-extension-system/options-api-setup-shim.spec.ts
@@ -45,6 +45,39 @@ describe('src/app/adapter/composition-extension-system/options-api-setup-shim', 
         expect(wrapper.text()).toBe('base subline / overridden — Demo GmbH');
     });
 
+    it('writes through previousState to the base state, not to the override result', async () => {
+        let write = (): void => {};
+
+        _overridesMap['sw-shim-write'] = [
+            (previousState: Record<string, { value: unknown }>) => {
+                write = () => {
+                    previousState.counter.value = 42;
+                };
+
+                return { counter: computed(() => `override ${String(previousState.counter.value)}`) };
+            },
+        ] as never;
+
+        const config = {
+            template: '<p>{{ counter }}</p>',
+            data() {
+                return { counter: 1 };
+            },
+        } as unknown as ComponentConfig;
+
+        attachSetupOverrideShim('sw-shim-write', config);
+
+        const wrapper = mount(config as never);
+        await flushPromises();
+        expect(wrapper.text()).toBe('override 1');
+
+        write();
+        await flushPromises();
+
+        // Would stay at "override 1" if the setter wrote into the override's own result instead of data.
+        expect(wrapper.text()).toBe('override 42');
+    });
+
     it('keeps Vue resolving late-added setup keys before data and computed', async () => {
         const bag: Record<string, unknown> = {};
 

--- a/src/Administration/Resources/app/administration/src/app/adapter/composition-extension-system/options-api-setup-shim.spec.ts
+++ b/src/Administration/Resources/app/administration/src/app/adapter/composition-extension-system/options-api-setup-shim.spec.ts
@@ -3,7 +3,7 @@
  */
 
 import { mount } from '@vue/test-utils';
-import { computed, ref } from 'vue';
+import { computed, h, ref, watch } from 'vue';
 import type { ComponentConfig } from 'src/core/factory/async-component.factory';
 import { attachSetupOverrideShim } from './options-api-setup-shim';
 import { _overridesMap } from './index';
@@ -126,6 +126,98 @@ describe('src/app/adapter/composition-extension-system/options-api-setup-shim', 
 
         // The watcher fires before any created hook and pins the key to `data` in Vue's access cache.
         expect(wrapper.text()).toBe('override base');
+    });
+
+    it('reads, calls and replaces a method through previousState', async () => {
+        let originalResult = '';
+
+        _overridesMap['sw-shim-methods'] = [
+            (previousState: Record<string, { value: unknown }>) => {
+                const original = previousState.greet.value as () => string;
+                originalResult = original();
+
+                return { greet: () => `${original()} + override` };
+            },
+        ] as never;
+
+        const config = {
+            template: '<p>{{ greet() }}</p>',
+            data() {
+                return { name: 'world' };
+            },
+            methods: {
+                greet(this: { name: string }) {
+                    return `hello ${this.name}`;
+                },
+            },
+        } as unknown as ComponentConfig;
+
+        attachSetupOverrideShim('sw-shim-methods', config);
+
+        const wrapper = mount(config as never);
+        await flushPromises();
+
+        // Methods live on `instance.ctx`, already bound by Vue - so the original stays callable from
+        // inside the override, which is what makes a super-style call possible.
+        expect(originalResult).toBe('hello world');
+        expect(wrapper.text()).toBe('hello world + override');
+    });
+
+    it('leaves a setup() that returns a render function untouched', async () => {
+        _overridesMap['sw-shim-render'] = [() => ({ unused: computed(() => 'x') })] as never;
+
+        const config = {
+            template: '<p>ignored</p>',
+            setup() {
+                return () => h('div', { class: 'from-render' }, 'render fn');
+            },
+        } as unknown as ComponentConfig;
+
+        attachSetupOverrideShim('sw-shim-render', config);
+
+        const wrapper = mount(config as never);
+        await flushPromises();
+
+        // The bag cannot ride along with a render function, so the component renders without overrides
+        // instead of breaking.
+        expect(wrapper.html()).toContain('from-render');
+    });
+
+    it('disposes watchers an override creates when the component unmounts', async () => {
+        const source = ref(0);
+        const handler = jest.fn();
+
+        _overridesMap['sw-shim-scope'] = [
+            () => {
+                watch(source, handler);
+
+                return { label: computed(() => 'x') };
+            },
+        ] as never;
+
+        const config = {
+            template: '<p>{{ label }}</p>',
+            data() {
+                return { label: 'base' };
+            },
+        } as unknown as ComponentConfig;
+
+        attachSetupOverrideShim('sw-shim-scope', config);
+
+        const wrapper = mount(config as never);
+        await flushPromises();
+
+        source.value += 1;
+        await flushPromises();
+        expect(handler).toHaveBeenCalledTimes(1);
+
+        wrapper.unmount();
+        source.value += 1;
+        await flushPromises();
+
+        // Vue activates the instance scope around lifecycle hooks; this pins that outcome, so a change
+        // there surfaces here instead of as a leak in production.
+        expect(handler).toHaveBeenCalledTimes(1);
     });
 
     it('keeps Vue resolving late-added setup keys before data and computed', async () => {

--- a/src/Administration/Resources/app/administration/src/app/adapter/composition-extension-system/options-api-setup-shim.spec.ts
+++ b/src/Administration/Resources/app/administration/src/app/adapter/composition-extension-system/options-api-setup-shim.spec.ts
@@ -86,23 +86,26 @@ describe('src/app/adapter/composition-extension-system/options-api-setup-shim', 
         errorSpy.mockRestore();
     });
 
-    it('rejects writes to refs of setup() and earlier overrides through previousState', async () => {
+    it('rejects writes to refs and functions of setup() and earlier overrides through previousState', async () => {
         const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
         const fromSetup = ref('own setup');
         const fromOverride = ref('first');
+        const greet = (): string => 'hello';
         let write = (): void => {};
 
         _overridesMap['sw-shim-write-ref'] = [
-            () => ({ fromOverride }),
-            (previousState: PreviousState) => {
+            () => ({ fromOverride, greet }),
+            (previousState: PreviousState & { greet: () => string }) => {
                 write = () => {
                     previousState.fromSetup.value = 'changed';
                     previousState.fromOverride.value = 'changed';
+                    (previousState as Record<string, unknown>).greet = () => 'changed';
                 };
 
                 return {
                     label: computed(
-                        () => `${String(previousState.fromSetup.value)} / ${String(previousState.fromOverride.value)}`,
+                        () =>
+                            `${String(previousState.fromSetup.value)} / ${String(previousState.fromOverride.value)} / ${previousState.greet()}`,
                     ),
                 };
             },
@@ -119,17 +122,19 @@ describe('src/app/adapter/composition-extension-system/options-api-setup-shim', 
 
         const wrapper = mount(config as never);
         await flushPromises();
-        expect(wrapper.text()).toBe('own setup / first');
+        expect(wrapper.text()).toBe('own setup / first / hello');
 
         write();
         await flushPromises();
 
         // Real refs are wrapped as well - otherwise the write would silently reach the original ref.
-        expect(wrapper.text()).toBe('own setup / first');
+        // Functions have no `.value`, so replacing one only works through the key, which the set trap rejects.
+        expect(wrapper.text()).toBe('own setup / first / hello');
         expect(fromSetup.value).toBe('own setup');
         expect(fromOverride.value).toBe('first');
         expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('"fromSetup"'));
         expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('"fromOverride"'));
+        expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('"greet"'));
 
         errorSpy.mockRestore();
     });

--- a/src/Administration/Resources/app/administration/src/app/adapter/composition-extension-system/options-api-setup-shim.spec.ts
+++ b/src/Administration/Resources/app/administration/src/app/adapter/composition-extension-system/options-api-setup-shim.spec.ts
@@ -8,6 +8,9 @@ import type { ComponentConfig } from 'src/core/factory/async-component.factory';
 import { attachSetupOverrideShim } from './options-api-setup-shim';
 import { _overridesMap } from './index';
 
+// What the shim hands to an override: every base-state key served as a ref-like accessor.
+type PreviousState = Record<string, { value: unknown }>;
+
 describe('src/app/adapter/composition-extension-system/options-api-setup-shim', () => {
     beforeEach(() => {
         Object.keys(_overridesMap).forEach((key) => {
@@ -17,7 +20,7 @@ describe('src/app/adapter/composition-extension-system/options-api-setup-shim', 
 
     it('applies a setup override to an Options API component and reads the untouched base state', async () => {
         _overridesMap['sw-shim-test'] = [
-            (previousState: Record<string, { value: unknown }>) => ({
+            (previousState: PreviousState) => ({
                 welcomeSubline: computed(() => `${String(previousState.welcomeSubline.value)} / overridden`),
                 shopName: computed(() => `${String(previousState.shopName.value)} GmbH`),
             }),
@@ -49,7 +52,7 @@ describe('src/app/adapter/composition-extension-system/options-api-setup-shim', 
         let write = (): void => {};
 
         _overridesMap['sw-shim-write'] = [
-            (previousState: Record<string, { value: unknown }>) => {
+            (previousState: PreviousState) => {
                 write = () => {
                     previousState.counter.value = 42;
                 };
@@ -101,7 +104,7 @@ describe('src/app/adapter/composition-extension-system/options-api-setup-shim', 
 
     it('applies the override even when an immediate watcher read the key first', async () => {
         _overridesMap['sw-shim-watch'] = [
-            (previousState: Record<string, { value: unknown }>) => ({
+            (previousState: PreviousState) => ({
                 label: computed(() => `override ${String(previousState.label.value)}`),
             }),
         ] as never;
@@ -132,7 +135,7 @@ describe('src/app/adapter/composition-extension-system/options-api-setup-shim', 
         let originalResult = '';
 
         _overridesMap['sw-shim-methods'] = [
-            (previousState: Record<string, { value: unknown }>) => {
+            (previousState: PreviousState) => {
                 const original = previousState.greet.value as () => string;
                 originalResult = original();
 

--- a/src/Administration/Resources/app/administration/src/app/adapter/composition-extension-system/options-api-setup-shim.spec.ts
+++ b/src/Administration/Resources/app/administration/src/app/adapter/composition-extension-system/options-api-setup-shim.spec.ts
@@ -332,7 +332,8 @@ describe('src/app/adapter/composition-extension-system/options-api-setup-shim', 
         expect(looksLikeRef).toBe(false);
     });
 
-    it('leaves a setup() that returns a render function untouched', async () => {
+    it('leaves a setup() that returns a render function untouched and reports the skipped overrides', async () => {
+        const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
         _overridesMap['sw-shim-render'] = [() => ({ unused: computed(() => 'x') })] as never;
 
         const config = {
@@ -348,8 +349,12 @@ describe('src/app/adapter/composition-extension-system/options-api-setup-shim', 
         await flushPromises();
 
         // The bag cannot ride along with a render function, so the component renders without overrides
-        // instead of breaking.
+        // instead of breaking - and says so, since the override author sees no other hint.
         expect(wrapper.html()).toContain('from-render');
+        expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('[sw-shim-render] Setup overrides not applied'));
+        expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('1 registered override(s)'));
+
+        warnSpy.mockRestore();
     });
 
     it('disposes watchers an override creates when the component unmounts', async () => {

--- a/src/Administration/Resources/app/administration/src/app/adapter/composition-extension-system/options-api-setup-shim.spec.ts
+++ b/src/Administration/Resources/app/administration/src/app/adapter/composition-extension-system/options-api-setup-shim.spec.ts
@@ -86,6 +86,135 @@ describe('src/app/adapter/composition-extension-system/options-api-setup-shim', 
         errorSpy.mockRestore();
     });
 
+    it('rejects writes to refs of setup() and earlier overrides through previousState', async () => {
+        const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+        const fromSetup = ref('own setup');
+        const fromOverride = ref('first');
+        let write = (): void => {};
+
+        _overridesMap['sw-shim-write-ref'] = [
+            () => ({ fromOverride }),
+            (previousState: PreviousState) => {
+                write = () => {
+                    previousState.fromSetup.value = 'changed';
+                    previousState.fromOverride.value = 'changed';
+                };
+
+                return {
+                    label: computed(
+                        () => `${String(previousState.fromSetup.value)} / ${String(previousState.fromOverride.value)}`,
+                    ),
+                };
+            },
+        ] as never;
+
+        const config = {
+            template: '<p>{{ label }}</p>',
+            setup() {
+                return { fromSetup };
+            },
+        } as unknown as ComponentConfig;
+
+        attachSetupOverrideShim('sw-shim-write-ref', config);
+
+        const wrapper = mount(config as never);
+        await flushPromises();
+        expect(wrapper.text()).toBe('own setup / first');
+
+        write();
+        await flushPromises();
+
+        // Real refs are wrapped as well - otherwise the write would silently reach the original ref.
+        expect(wrapper.text()).toBe('own setup / first');
+        expect(fromSetup.value).toBe('own setup');
+        expect(fromOverride.value).toBe('first');
+        expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('"fromSetup"'));
+        expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('"fromOverride"'));
+
+        errorSpy.mockRestore();
+    });
+
+    it('rejects replacing a key on previousState itself', async () => {
+        const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+        let write = (): void => {};
+
+        _overridesMap['sw-shim-write-key'] = [
+            (previousState: PreviousState & { greet: () => string }) => {
+                write = () => {
+                    (previousState as Record<string, unknown>).greet = () => 'replaced';
+                    (previousState as Record<string, unknown>).label = ref('replaced');
+                };
+
+                return {
+                    label: computed(() => `${previousState.greet()} ${String(previousState.label.value)}`),
+                };
+            },
+        ] as never;
+
+        const config = {
+            template: '<p>{{ label }}</p>',
+            data() {
+                return { label: 'base' };
+            },
+            methods: {
+                greet() {
+                    return 'hello';
+                },
+            },
+        } as unknown as ComponentConfig;
+
+        attachSetupOverrideShim('sw-shim-write-key', config);
+
+        const wrapper = mount(config as never);
+        await flushPromises();
+        expect(wrapper.text()).toBe('hello base');
+
+        write();
+        await flushPromises();
+
+        // The proxy has no backing object to write to; the next read resolves through the trap again.
+        expect(wrapper.text()).toBe('hello base');
+        expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('"greet"'));
+        expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('"label"'));
+
+        errorSpy.mockRestore();
+    });
+
+    it('serves the same ref on repeated access to a previousState key', async () => {
+        let sameRef: boolean | undefined;
+        let sameMethod: boolean | undefined;
+
+        _overridesMap['sw-shim-identity'] = [
+            (previousState: PreviousState) => {
+                sameRef = previousState.label === previousState.label;
+                sameMethod = previousState.greet === previousState.greet;
+
+                return {};
+            },
+        ] as never;
+
+        const config = {
+            template: '<p>{{ label }}</p>',
+            data() {
+                return { label: 'base' };
+            },
+            methods: {
+                greet() {
+                    return 'hi';
+                },
+            },
+        } as unknown as ComponentConfig;
+
+        attachSetupOverrideShim('sw-shim-identity', config);
+
+        mount(config as never);
+        await flushPromises();
+
+        // Stable identity lets an override pass the same wrapper to several watch() sources or return it.
+        expect(sameRef).toBe(true);
+        expect(sameMethod).toBe(true);
+    });
+
     it('keeps an existing setup() of the component instead of replacing it', async () => {
         _overridesMap['sw-shim-existing-setup'] = [
             () => ({ fromOverride: computed(() => 'override') }),

--- a/src/Administration/Resources/app/administration/src/app/adapter/composition-extension-system/options-api-setup-shim.spec.ts
+++ b/src/Administration/Resources/app/administration/src/app/adapter/composition-extension-system/options-api-setup-shim.spec.ts
@@ -140,9 +140,9 @@ describe('src/app/adapter/composition-extension-system/options-api-setup-shim', 
         let originalResult = '';
 
         _overridesMap['sw-shim-methods'] = [
-            (previousState: PreviousState) => {
-                // Methods arrive raw, not as a ref - the same shape createExtendableSetup() hands out.
-                const original = previousState.greet as unknown as () => string;
+            // Methods arrive raw, not as a ref - the same shape createExtendableSetup() hands out.
+            (previousState: { greet: () => string }) => {
+                const original = previousState.greet;
                 originalResult = original();
 
                 return { greet: () => `${original()} + override` };
@@ -274,13 +274,13 @@ describe('src/app/adapter/composition-extension-system/options-api-setup-shim', 
 
     it('chains a method replaced by an earlier override into a later one', async () => {
         _overridesMap['sw-shim-method-chain'] = [
-            (previousState: PreviousState) => {
-                const original = previousState.greet as unknown as () => string;
+            (previousState: { greet: () => string }) => {
+                const original = previousState.greet;
 
                 return { greet: () => `${original()} + first` };
             },
-            (previousState: PreviousState) => {
-                const previous = previousState.greet as unknown as () => string;
+            (previousState: { greet: () => string }) => {
+                const previous = previousState.greet;
 
                 return { greet: () => `${previous()} + second` };
             },

--- a/src/Administration/Resources/app/administration/src/app/adapter/composition-extension-system/options-api-setup-shim.spec.ts
+++ b/src/Administration/Resources/app/administration/src/app/adapter/composition-extension-system/options-api-setup-shim.spec.ts
@@ -3,7 +3,7 @@
  */
 
 import { mount } from '@vue/test-utils';
-import { computed, h, isRef, ref, watch } from 'vue';
+import { computed, isRef, ref, watch } from 'vue';
 import type { ComponentConfig } from 'src/core/factory/async-component.factory';
 import { attachSetupOverrideShim } from './options-api-setup-shim';
 import { _overridesMap } from './index';
@@ -330,31 +330,6 @@ describe('src/app/adapter/composition-extension-system/options-api-setup-shim', 
         await flushPromises();
 
         expect(looksLikeRef).toBe(false);
-    });
-
-    it('leaves a setup() that returns a render function untouched and reports the skipped overrides', async () => {
-        const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
-        _overridesMap['sw-shim-render'] = [() => ({ unused: computed(() => 'x') })] as never;
-
-        const config = {
-            template: '<p>ignored</p>',
-            setup() {
-                return () => h('div', { class: 'from-render' }, 'render fn');
-            },
-        } as unknown as ComponentConfig;
-
-        attachSetupOverrideShim('sw-shim-render', config);
-
-        const wrapper = mount(config as never);
-        await flushPromises();
-
-        // The bag cannot ride along with a render function, so the component renders without overrides
-        // instead of breaking - and says so, since the override author sees no other hint.
-        expect(wrapper.html()).toContain('from-render');
-        expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('[sw-shim-render] Setup overrides not applied'));
-        expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('1 registered override(s)'));
-
-        warnSpy.mockRestore();
     });
 
     it('disposes watchers an override creates when the component unmounts', async () => {

--- a/src/Administration/Resources/app/administration/src/app/adapter/composition-extension-system/options-api-setup-shim.spec.ts
+++ b/src/Administration/Resources/app/administration/src/app/adapter/composition-extension-system/options-api-setup-shim.spec.ts
@@ -48,7 +48,8 @@ describe('src/app/adapter/composition-extension-system/options-api-setup-shim', 
         expect(wrapper.text()).toBe('base subline / overridden — Demo GmbH');
     });
 
-    it('writes through previousState to the base state, not to the override result', async () => {
+    it('rejects writes through previousState and keeps the base state untouched', async () => {
+        const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
         let write = (): void => {};
 
         _overridesMap['sw-shim-write'] = [
@@ -77,8 +78,12 @@ describe('src/app/adapter/composition-extension-system/options-api-setup-shim', 
         write();
         await flushPromises();
 
-        // Would stay at "override 1" if the setter wrote into the override's own result instead of data.
-        expect(wrapper.text()).toBe('override 42');
+        // State only changes through what an override returns; a write attempt is reported and dropped.
+        expect(wrapper.text()).toBe('override 1');
+        expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('previousState is read-only'));
+        expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('"counter"'));
+
+        errorSpy.mockRestore();
     });
 
     it('keeps an existing setup() of the component instead of replacing it', async () => {

--- a/src/Administration/Resources/app/administration/src/app/adapter/composition-extension-system/options-api-setup-shim.spec.ts
+++ b/src/Administration/Resources/app/administration/src/app/adapter/composition-extension-system/options-api-setup-shim.spec.ts
@@ -3,7 +3,7 @@
  */
 
 import { mount } from '@vue/test-utils';
-import { computed, h, ref, watch } from 'vue';
+import { computed, h, isRef, ref, watch } from 'vue';
 import type { ComponentConfig } from 'src/core/factory/async-component.factory';
 import { attachSetupOverrideShim } from './options-api-setup-shim';
 import { _overridesMap } from './index';
@@ -136,7 +136,8 @@ describe('src/app/adapter/composition-extension-system/options-api-setup-shim', 
 
         _overridesMap['sw-shim-methods'] = [
             (previousState: PreviousState) => {
-                const original = previousState.greet.value as () => string;
+                // Methods arrive raw, not as a ref - the same shape createExtendableSetup() hands out.
+                const original = previousState.greet as unknown as () => string;
                 originalResult = original();
 
                 return { greet: () => `${original()} + override` };
@@ -164,6 +165,166 @@ describe('src/app/adapter/composition-extension-system/options-api-setup-shim', 
         // inside the override, which is what makes a super-style call possible.
         expect(originalResult).toBe('hello world');
         expect(wrapper.text()).toBe('hello world + override');
+    });
+
+    it('lets a later override read what an earlier override installed', async () => {
+        _overridesMap['sw-shim-chain'] = [
+            (previousState: PreviousState) => ({
+                label: computed(() => `${String(previousState.label.value)} +1`),
+            }),
+            (previousState: PreviousState) => ({
+                label: computed(() => `${String(previousState.label.value)} +2`),
+            }),
+        ] as never;
+
+        const config = {
+            template: '<p>{{ label }}</p>',
+            data() {
+                return { label: 'base' };
+            },
+        } as unknown as ComponentConfig;
+
+        attachSetupOverrideShim('sw-shim-chain', config);
+
+        const wrapper = mount(config as never);
+        await flushPromises();
+
+        // Would read "base +2" if the second override resolved against the base state only.
+        expect(wrapper.text()).toBe('base +1 +2');
+    });
+
+    it('exposes keys an earlier override introduced to later overrides', async () => {
+        _overridesMap['sw-shim-new-key'] = [
+            () => ({ extra: computed(() => 'from first') }),
+            (previousState: PreviousState) => ({
+                label: computed(() => `${String(previousState.extra.value)} / second`),
+            }),
+        ] as never;
+
+        const config = {
+            template: '<p>{{ label }}</p>',
+            data() {
+                return { label: 'base' };
+            },
+        } as unknown as ComponentConfig;
+
+        attachSetupOverrideShim('sw-shim-new-key', config);
+
+        const wrapper = mount(config as never);
+        await flushPromises();
+
+        expect(wrapper.text()).toBe('from first / second');
+    });
+
+    it('does not let an earlier override see a later override', async () => {
+        let seenByFirst: unknown = 'unset';
+
+        _overridesMap['sw-shim-order'] = [
+            (previousState: PreviousState) => {
+                seenByFirst = previousState.label.value;
+
+                return {};
+            },
+            () => ({ label: computed(() => 'second') }),
+        ] as never;
+
+        const config = {
+            template: '<p>{{ label }}</p>',
+            data() {
+                return { label: 'base' };
+            },
+        } as unknown as ComponentConfig;
+
+        attachSetupOverrideShim('sw-shim-order', config);
+
+        const wrapper = mount(config as never);
+        await flushPromises();
+
+        expect(seenByFirst).toBe('base');
+        expect(wrapper.text()).toBe('second');
+    });
+
+    it("exposes the component's own setup() result through previousState", async () => {
+        _overridesMap['sw-shim-setup-keys'] = [
+            (previousState: PreviousState) => ({
+                fromSetup: computed(() => `${String(previousState.fromSetup.value)} / overridden`),
+            }),
+        ] as never;
+
+        const config = {
+            template: '<p>{{ fromSetup }}</p>',
+            setup() {
+                return { fromSetup: ref('own setup') };
+            },
+        } as unknown as ComponentConfig;
+
+        attachSetupOverrideShim('sw-shim-setup-keys', config);
+
+        const wrapper = mount(config as never);
+        await flushPromises();
+
+        // setup() keys live in the bag, not in data/props/ctx - only the snapshot makes them visible.
+        expect(wrapper.text()).toBe('own setup / overridden');
+    });
+
+    it('chains a method replaced by an earlier override into a later one', async () => {
+        _overridesMap['sw-shim-method-chain'] = [
+            (previousState: PreviousState) => {
+                const original = previousState.greet as unknown as () => string;
+
+                return { greet: () => `${original()} + first` };
+            },
+            (previousState: PreviousState) => {
+                const previous = previousState.greet as unknown as () => string;
+
+                return { greet: () => `${previous()} + second` };
+            },
+        ] as never;
+
+        const config = {
+            template: '<p>{{ greet() }}</p>',
+            data() {
+                return { name: 'world' };
+            },
+            methods: {
+                greet(this: { name: string }) {
+                    return `hello ${this.name}`;
+                },
+            },
+        } as unknown as ComponentConfig;
+
+        attachSetupOverrideShim('sw-shim-method-chain', config);
+
+        const wrapper = mount(config as never);
+        await flushPromises();
+
+        expect(wrapper.text()).toBe('hello world + first + second');
+    });
+
+    it('does not present previousState itself as a ref', async () => {
+        let looksLikeRef: boolean | undefined;
+
+        _overridesMap['sw-shim-not-a-ref'] = [
+            (previousState: PreviousState) => {
+                looksLikeRef = isRef(previousState);
+
+                return {};
+            },
+        ] as never;
+
+        const config = {
+            template: '<p>{{ label }}</p>',
+            data() {
+                return { label: 'base' };
+            },
+        } as unknown as ComponentConfig;
+
+        attachSetupOverrideShim('sw-shim-not-a-ref', config);
+
+        mount(config as never);
+        await flushPromises();
+
+        expect(looksLikeRef).toBe(false);
     });
 
     it('leaves a setup() that returns a render function untouched', async () => {

--- a/src/Administration/Resources/app/administration/src/app/adapter/composition-extension-system/options-api-setup-shim.spec/override-local-state.spec.ts
+++ b/src/Administration/Resources/app/administration/src/app/adapter/composition-extension-system/options-api-setup-shim.spec/override-local-state.spec.ts
@@ -1,0 +1,98 @@
+/**
+ * @sw-package framework
+ */
+
+import { mount } from '@vue/test-utils';
+import { computed, ref } from 'vue';
+import type { ComponentConfig } from 'src/core/factory/async-component.factory';
+import swBlock from 'src/app/component/structure/sw-block-override/sw-block/index';
+import { attachSetupOverrideShim } from '../options-api-setup-shim';
+import { _overridesMap } from '../index';
+
+// What the shim hands to an override: every base-state key served as a ref-like accessor.
+type PreviousState = Record<string, { value: unknown }>;
+
+describe('src/app/adapter/composition-extension-system/options-api-setup-shim - override-local state', () => {
+    beforeEach(() => {
+        Object.keys(_overridesMap).forEach((key) => {
+            delete _overridesMap[key];
+        });
+    });
+
+    it('serves override-local state unwrapped through the data scope of a block', async () => {
+        // What the Vite override transform emits for a binding only the override template uses: filed
+        // under `__swOverride` by file namespace, and destructured from the `<sw-block>` slot scope.
+        const namespace = Symbol('sw-shim-local.override');
+
+        _overridesMap['sw-shim-local'] = [
+            (previousState: PreviousState) => ({
+                __swOverride: {
+                    [namespace]: { margin: computed(() => Number(previousState.price.value) / 10) },
+                },
+            }),
+        ] as never;
+
+        const config = {
+            components: {
+                'sw-block': swBlock,
+                'margin-hint': {
+                    props: { margin: { type: Number, required: true } },
+                    template: '<span>{{ margin + 1 }}</span>',
+                },
+            },
+            template: `
+                <sw-block name="sw-shim-local-block" :data="$dataScope">
+                    <template #default="{ __swOverride }">
+                        <margin-hint :margin="__swOverride[namespace].margin" />
+                    </template>
+                </sw-block>`,
+            data() {
+                return { price: 100, namespace };
+            },
+        } as unknown as ComponentConfig;
+
+        attachSetupOverrideShim('sw-shim-local', config);
+
+        const wrapper = mount(config as never);
+        await flushPromises();
+
+        // setupState only unwraps top-level refs. Without the reactive container the child would
+        // receive the ComputedRef itself and render "NaN"; interpolation would hide that because
+        // toDisplayString() unwraps.
+        expect(wrapper.text()).toBe('11');
+    });
+
+    it('merges the override-local state of several override files and hides it from previousState', async () => {
+        const first = Symbol('first.override');
+        const second = Symbol('second.override');
+        let seenByLaterOverride: unknown = 'not read';
+
+        _overridesMap['sw-shim-local-merge'] = [
+            () => ({ __swOverride: { [first]: { a: ref(1) } } }),
+            (previousState: PreviousState) => {
+                seenByLaterOverride = previousState.__swOverride;
+
+                return { __swOverride: { [second]: { b: ref(2) } } };
+            },
+        ] as never;
+
+        const config = {
+            template: '<p />',
+        } as unknown as ComponentConfig;
+
+        attachSetupOverrideShim('sw-shim-local-merge', config);
+
+        const wrapper = mount(config as never);
+        await flushPromises();
+
+        // `$dataScope` falls back to the instance proxy for Twig components, so this is what the block
+        // slot scope reads. Assigning instead of merging would drop the first file's namespace and make
+        // its generated slot scope destructure from undefined.
+        const localState = (wrapper.vm as unknown as Record<string, Record<symbol, Record<string, unknown>>>).__swOverride;
+        expect(localState[first].a).toBe(1);
+        expect(localState[second].b).toBe(2);
+
+        // Override-local state is template plumbing, not base state; migrated components hide it too.
+        expect(seenByLaterOverride).toBeUndefined();
+    });
+});

--- a/src/Administration/Resources/app/administration/src/app/adapter/composition-extension-system/options-api-setup-shim.ts
+++ b/src/Administration/Resources/app/administration/src/app/adapter/composition-extension-system/options-api-setup-shim.ts
@@ -7,6 +7,8 @@
  * The whole module works around one ordering constraint: only a `setup()` return value outranks
  * `data` and `computed` in Vue's instance proxy, but `setup()` runs before either of them exists.
  * So the slot is reserved in `setup()` and filled in `created()`.
+ *
+ * @experimental stableVersion:v6.9.0 feature:ADMIN_COMPOSITION_API_EXTENSION_SYSTEM
  */
 
 import { getCurrentInstance } from 'vue';

--- a/src/Administration/Resources/app/administration/src/app/adapter/composition-extension-system/options-api-setup-shim.ts
+++ b/src/Administration/Resources/app/administration/src/app/adapter/composition-extension-system/options-api-setup-shim.ts
@@ -123,23 +123,21 @@ export function attachSetupOverrideShim(componentName: string, config: Component
                 expose: () => {},
             } as SetupContext;
 
-            // Re-enters the component scope so watchers and computeds the overrides create are disposed
-            // on unmount - `created()` has no active scope of its own.
-            (instance as unknown as { scope: { run: (fn: () => void) => void } }).scope.run(() => {
-                _overridesMap[componentName].forEach((override) => {
-                    const result = override(previousState as never, instance.props as never, context) as AnyRecord;
+            // Vue activates the component's effect scope around lifecycle hooks, so watchers and
+            // computeds the overrides create here are disposed on unmount without further handling.
+            _overridesMap[componentName].forEach((override) => {
+                const result = override(previousState as never, instance.props as never, context) as AnyRecord;
 
-                    if (result === undefined) {
-                        return;
-                    }
+                if (result === undefined) {
+                    return;
+                }
 
-                    Object.keys(result).forEach((key) => {
-                        bag[key] = result[key];
-                        delete (instance as unknown as { accessCache: Record<string, unknown> }).accessCache[key];
-                        // Vue memoises which bucket a key resolved from on first access. Anything that read
-                        // the key earlier - an immediate watcher, a preceding created hook - pinned it to
-                        // `data`, and setupState would never be consulted again.
-                    });
+                Object.keys(result).forEach((key) => {
+                    bag[key] = result[key];
+                    // Vue memoises which bucket a key resolved from on first access. Anything that read the
+                    // key earlier - an immediate watcher, a preceding created hook - pinned it to `data`,
+                    // and setupState would never be consulted again.
+                    delete (instance as unknown as { accessCache: Record<string, unknown> }).accessCache[key];
                 });
             });
         },

--- a/src/Administration/Resources/app/administration/src/app/adapter/composition-extension-system/options-api-setup-shim.ts
+++ b/src/Administration/Resources/app/administration/src/app/adapter/composition-extension-system/options-api-setup-shim.ts
@@ -1,0 +1,124 @@
+/**
+ * @sw-package framework
+ * @private
+ *
+ * Runs native setup overrides against components that are still rendered through the Twig pipeline.
+ *
+ * The whole module works around one ordering constraint: only a `setup()` return value outranks
+ * `data` and `computed` in Vue's instance proxy, but `setup()` runs before either of them exists.
+ * So the slot is reserved in `setup()` and filled in `created()`.
+ */
+
+import { getCurrentInstance } from 'vue';
+import type { ComponentInternalInstance, SetupContext } from '@vue/runtime-core';
+import type { ComponentConfig } from 'src/core/factory/async-component.factory';
+import { _overridesMap } from './index';
+
+type AnyRecord = Record<string, unknown>;
+
+// Hands the object created in setup() over to created(). Keyed per instance because the config is
+// shared by every instance of the component.
+const bags = new WeakMap<ComponentInternalInstance, AnyRecord>();
+
+/**
+ * @private
+ */
+export function attachSetupOverrideShim(componentName: string, config: ComponentConfig): void {
+    // A string template means the component came out of the Twig pipeline; migrated SFCs run their
+    // overrides through createExtendableSetup() instead.
+    if (typeof config.template !== 'string' || !_overridesMap[componentName]?.length) {
+        return;
+    }
+
+    // Returns an empty object on purpose. Vue keeps a live reference to it as `setupState`, which is
+    // what later lets created() write into it. The overrides cannot run here - `data` and `computed`
+    // do not exist yet, so previousState would be empty.
+    config.setup = () => {
+        const bag: AnyRecord = {};
+        const instance = getCurrentInstance();
+
+        if (instance) {
+            bags.set(instance, bag);
+        }
+
+        return bag;
+    };
+
+    const shimMixin = {
+        created(this: { $: ComponentInternalInstance }) {
+            const instance = this.$;
+            const bag = bags.get(instance);
+
+            if (!bag) {
+                return;
+            }
+
+            const proxy = instance.proxy as unknown as AnyRecord;
+
+            // Deliberately skips `setupState`: reading through the instance proxy would resolve to the
+            // override's own result and loop. Mirrors Vue's own order minus that first step.
+            const readBaseState = (key: string): unknown => {
+                const data = instance.data as AnyRecord;
+
+                if (data && key in data) {
+                    return data[key];
+                }
+
+                if (instance.props && key in instance.props) {
+                    return (instance.props as AnyRecord)[key];
+                }
+
+                return (instance as unknown as { ctx: AnyRecord }).ctx[key];
+            };
+
+            // Override callbacks read `previousState.x.value`, so every key is served as a ref-like
+            // accessor. A proxy avoids having to enumerate data, computed and methods upfront.
+            const previousState = new Proxy(
+                {},
+                {
+                    get: (_target, key: string) => ({
+                        __v_isRef: true,
+                        get value() {
+                            return readBaseState(key);
+                        },
+                        set value(next: unknown) {
+                            proxy[key] = next;
+                        },
+                    }),
+                },
+            );
+
+            const context = {
+                attrs: instance.attrs,
+                slots: instance.slots,
+                emit: instance.emit,
+                expose: () => {},
+            } as SetupContext;
+
+            // Re-enters the component scope so watchers and computeds the overrides create are disposed
+            // on unmount - `created()` has no active scope of its own.
+            (instance as unknown as { scope: { run: (fn: () => void) => void } }).scope.run(() => {
+                _overridesMap[componentName].forEach((override) => {
+                    const result = override(previousState as never, instance.props as never, context) as AnyRecord;
+
+                    if (result === undefined) {
+                        return;
+                    }
+
+                    Object.keys(result).forEach((key) => {
+                        bag[key] = result[key];
+                    });
+                });
+            });
+        },
+    };
+
+    const existingMixins = (config.mixins ?? []) as unknown[];
+
+    // Placed first: Vue caches the bucket a key resolves to on first access, so any created() hook that
+    // touches an overridden key before this one would pin it to `data` and the override would be lost.
+    config.mixins = [
+        shimMixin,
+        ...existingMixins,
+    ] as ComponentConfig['mixins'];
+}

--- a/src/Administration/Resources/app/administration/src/app/adapter/composition-extension-system/options-api-setup-shim.ts
+++ b/src/Administration/Resources/app/administration/src/app/adapter/composition-extension-system/options-api-setup-shim.ts
@@ -53,8 +53,6 @@ export function attachSetupOverrideShim(componentName: string, config: Component
                 return;
             }
 
-            const proxy = instance.proxy as unknown as AnyRecord;
-
             // Deliberately skips `setupState`: reading through the instance proxy would resolve to the
             // override's own result and loop. Mirrors Vue's own order minus that first step.
             const readBaseState = (key: string): unknown => {
@@ -71,6 +69,24 @@ export function attachSetupOverrideShim(componentName: string, config: Component
                 return (instance as unknown as { ctx: AnyRecord }).ctx[key];
             };
 
+            // Mirrors readBaseState for writes, so a write lands on the base state instead of the
+            // override's own result. Props stay read-only, as they are on Vue's own proxy.
+            const writeBaseState = (key: string, next: unknown): void => {
+                const data = instance.data as AnyRecord;
+
+                if (data && key in data) {
+                    data[key] = next;
+
+                    return;
+                }
+
+                if (instance.props && key in instance.props) {
+                    return;
+                }
+
+                (instance as unknown as { ctx: AnyRecord }).ctx[key] = next;
+            };
+
             // Override callbacks read `previousState.x.value`, so every key is served as a ref-like
             // accessor. A proxy avoids having to enumerate data, computed and methods upfront.
             const previousState = new Proxy(
@@ -82,7 +98,7 @@ export function attachSetupOverrideShim(componentName: string, config: Component
                             return readBaseState(key);
                         },
                         set value(next: unknown) {
-                            proxy[key] = next;
+                            writeBaseState(key, next);
                         },
                     }),
                 },

--- a/src/Administration/Resources/app/administration/src/app/adapter/composition-extension-system/options-api-setup-shim.ts
+++ b/src/Administration/Resources/app/administration/src/app/adapter/composition-extension-system/options-api-setup-shim.ts
@@ -135,6 +135,10 @@ export function attachSetupOverrideShim(componentName: string, config: Component
 
                     Object.keys(result).forEach((key) => {
                         bag[key] = result[key];
+                        delete (instance as unknown as { accessCache: Record<string, unknown> }).accessCache[key];
+                        // Vue memoises which bucket a key resolved from on first access. Anything that read
+                        // the key earlier - an immediate watcher, a preceding created hook - pinned it to
+                        // `data`, and setupState would never be consulted again.
                     });
                 });
             });

--- a/src/Administration/Resources/app/administration/src/app/adapter/composition-extension-system/options-api-setup-shim.ts
+++ b/src/Administration/Resources/app/administration/src/app/adapter/composition-extension-system/options-api-setup-shim.ts
@@ -15,6 +15,7 @@ import type { ComponentConfig } from 'src/core/factory/async-component.factory';
 import { _overridesMap } from './index';
 
 type AnyRecord = Record<string, unknown>;
+type SetupResult = AnyRecord | ((...args: unknown[]) => unknown) | undefined;
 
 // Hands the object created in setup() over to created(). Keyed per instance because the config is
 // shared by every instance of the component.
@@ -30,11 +31,22 @@ export function attachSetupOverrideShim(componentName: string, config: Component
         return;
     }
 
-    // Returns an empty object on purpose. Vue keeps a live reference to it as `setupState`, which is
-    // what later lets created() write into it. The overrides cannot run here - `data` and `computed`
-    // do not exist yet, so previousState would be empty.
-    config.setup = () => {
-        const bag: AnyRecord = {};
+    const originalSetup = config.setup;
+
+    // Vue keeps a live reference to whatever setup() returns as `setupState`, which is what later lets
+    // created() write into it. The overrides cannot run here - `data` and `computed` do not exist yet,
+    // so previousState would be empty. An existing setup() keeps its own return value as the starting
+    // content instead of being replaced.
+    config.setup = function shimSetup(props: Record<string, unknown>, context: SetupContext) {
+        const originalResult = (originalSetup ? originalSetup.call(this, props, context) : undefined) as SetupResult;
+
+        // A setup() returning a render function cannot carry the bag. Leave it untouched; the created
+        // hook then finds no bag and bails out, so the component keeps working without the overrides.
+        if (typeof originalResult === 'function') {
+            return originalResult;
+        }
+
+        const bag: AnyRecord = originalResult ?? {};
         const instance = getCurrentInstance();
 
         if (instance) {

--- a/src/Administration/Resources/app/administration/src/app/adapter/composition-extension-system/options-api-setup-shim.ts
+++ b/src/Administration/Resources/app/administration/src/app/adapter/composition-extension-system/options-api-setup-shim.ts
@@ -44,7 +44,12 @@ export function attachSetupOverrideShim(componentName: string, config: Component
 
         // A setup() returning a render function cannot carry the bag. Leave it untouched; the created
         // hook then finds no bag and bails out, so the component keeps working without the overrides.
+        // Reported, because from the override author's side nothing else hints at why it has no effect.
         if (typeof originalResult === 'function') {
+            console.warn(
+                `[${componentName}] Setup overrides not applied: setup() returns a render function, which leaves no place for override results. Return an object from setup() to make the ${_overridesMap[componentName].length} registered override(s) take effect.`,
+            );
+
             return originalResult;
         }
 

--- a/src/Administration/Resources/app/administration/src/app/adapter/composition-extension-system/options-api-setup-shim.ts
+++ b/src/Administration/Resources/app/administration/src/app/adapter/composition-extension-system/options-api-setup-shim.ts
@@ -84,28 +84,12 @@ export function attachSetupOverrideShim(componentName: string, config: Component
                 return (instance as unknown as { ctx: AnyRecord }).ctx[key];
             };
 
-            // Mirrors readBaseState for writes, so a write lands on the base state instead of the
-            // override's own result. Props stay read-only, as they are on Vue's own proxy.
-            const writeBaseState = (key: string, next: unknown): void => {
-                const data = instance.data as AnyRecord;
-
-                if (data && key in data) {
-                    data[key] = next;
-
-                    return;
-                }
-
-                if (instance.props && key in instance.props) {
-                    return;
-                }
-
-                (instance as unknown as { ctx: AnyRecord }).ctx[key] = next;
-            };
-
             // Override callbacks read `previousState.x.value`, so plain values are served as a ref-like
             // accessor. Refs pass through as they are; functions stay callable as `previousState.x()`,
             // matching what createExtendableSetup() hands to overrides of migrated components.
-            const toRefLike = (read: () => unknown, write: (next: unknown) => void): unknown => {
+            // previousState is read-only: state changes go through the override's return value, so a
+            // write attempt is reported and dropped instead of reaching data or ctx behind Vue's back.
+            const toRefLike = (key: string, read: () => unknown): unknown => {
                 const current = read();
 
                 if (isRef(current) || typeof current === 'function') {
@@ -117,8 +101,10 @@ export function attachSetupOverrideShim(componentName: string, config: Component
                     get value() {
                         return read();
                     },
-                    set value(next: unknown) {
-                        write(next);
+                    set value(_next: unknown) {
+                        console.error(
+                            `[${componentName}] previousState is read-only. Return "${key}" from the override instead of assigning to previousState.${key}.value.`,
+                        );
                     },
                 };
             };
@@ -136,18 +122,10 @@ export function attachSetupOverrideShim(componentName: string, config: Component
                         }
 
                         if (Object.prototype.hasOwnProperty.call(installed, key)) {
-                            return toRefLike(
-                                () => installed[key],
-                                (next) => {
-                                    bag[key] = next;
-                                },
-                            );
+                            return toRefLike(key, () => installed[key]);
                         }
 
-                        return toRefLike(
-                            () => readBaseState(key),
-                            (next) => writeBaseState(key, next),
-                        );
+                        return toRefLike(key, () => readBaseState(key));
                     },
                 });
 

--- a/src/Administration/Resources/app/administration/src/app/adapter/composition-extension-system/options-api-setup-shim.ts
+++ b/src/Administration/Resources/app/administration/src/app/adapter/composition-extension-system/options-api-setup-shim.ts
@@ -15,6 +15,14 @@ import { customRef, getCurrentInstance, unref } from 'vue';
 import type { ComponentInternalInstance, SetupContext } from '@vue/runtime-core';
 import type { ComponentConfig } from 'src/core/factory/async-component.factory';
 import { _overridesMap } from './index';
+import {
+    createOverrideLocalState,
+    exposeOverrideLocalState,
+    getOverrideLocalState,
+    isOverrideLocalStateKey,
+    mergeOverrideState,
+} from './data-scope-helper';
+import type { OverrideLocalState } from './data-scope-helper';
 
 type AnyRecord = Record<string, unknown>;
 type SetupResult = AnyRecord | undefined;
@@ -43,6 +51,14 @@ export function attachSetupOverrideShim(componentName: string, config: Component
         const originalResult = (originalSetup ? originalSetup.call(this, props, context) : undefined) as SetupResult;
 
         const bag: AnyRecord = originalResult ?? {};
+
+        // Override-file-local bindings (`__swOverride`) are nested one level down, where Vue's setupState
+        // unwrapping no longer reaches. A reactive container unwraps refs on access at any depth, and
+        // lets several override files merge their namespaces instead of replacing each other - the same
+        // shape createExtendableSetup() gives migrated components. Non-enumerable, so the per-override
+        // previousState snapshot (`{ ...bag }`) never picks it up.
+        exposeOverrideLocalState(bag, createOverrideLocalState());
+
         const instance = getCurrentInstance();
 
         if (instance) {
@@ -107,7 +123,7 @@ export function attachSetupOverrideShim(componentName: string, config: Component
                     get: (_target, key) => {
                         // Vue probes objects with `__v_isRef`, `__v_raw` & co and with symbol keys.
                         // Answering those with an accessor would make the proxy itself look like a ref.
-                        if (typeof key !== 'string' || key.startsWith('__v_')) {
+                        if (typeof key !== 'string' || key.startsWith('__v_') || isOverrideLocalStateKey(key)) {
                             return undefined;
                         }
 
@@ -158,6 +174,11 @@ export function attachSetupOverrideShim(componentName: string, config: Component
                 }
 
                 Object.keys(result).forEach((key) => {
+                    if (isOverrideLocalStateKey(key)) {
+                        mergeOverrideState(getOverrideLocalState(bag), result[key] as OverrideLocalState);
+                        return;
+                    }
+
                     bag[key] = result[key];
                     // Vue memoises which bucket a key resolved from on first access. Anything that read the
                     // key earlier - an immediate watcher, a preceding created hook - pinned it to `data`,

--- a/src/Administration/Resources/app/administration/src/app/adapter/composition-extension-system/options-api-setup-shim.ts
+++ b/src/Administration/Resources/app/administration/src/app/adapter/composition-extension-system/options-api-setup-shim.ts
@@ -11,7 +11,7 @@
  * @experimental stableVersion:v6.9.0 feature:ADMIN_COMPOSITION_API_EXTENSION_SYSTEM
  */
 
-import { getCurrentInstance, isRef } from 'vue';
+import { customRef, getCurrentInstance, unref } from 'vue';
 import type { ComponentInternalInstance, SetupContext } from '@vue/runtime-core';
 import type { ComponentConfig } from 'src/core/factory/async-component.factory';
 import { _overridesMap } from './index';
@@ -78,36 +78,32 @@ export function attachSetupOverrideShim(componentName: string, config: Component
                 return (instance as unknown as { ctx: AnyRecord }).ctx[key];
             };
 
-            // Override callbacks read `previousState.x.value`, so plain values are served as a ref-like
-            // accessor. Refs pass through as they are; functions stay callable as `previousState.x()`,
-            // matching what createExtendableSetup() hands to overrides of migrated components.
-            // previousState is read-only: state changes go through the override's return value, so a
-            // write attempt is reported and dropped instead of reaching data or ctx behind Vue's back.
-            const toRefLike = (key: string, read: () => unknown): unknown => {
-                const current = read();
-
-                if (isRef(current) || typeof current === 'function') {
-                    return current;
-                }
-
-                return {
-                    __v_isRef: true,
-                    get value() {
-                        return read();
-                    },
-                    set value(_next: unknown) {
-                        console.error(
-                            `[${componentName}] previousState is read-only. Return "${key}" from the override instead of assigning to previousState.${key}.value.`,
-                        );
-                    },
-                };
-            };
-
             // Resolves `installed` first, then the base state - the same order Vue's instance proxy uses,
             // with `installed` standing in for setupState. A proxy avoids having to enumerate data,
             // computed and methods upfront.
-            const createPreviousState = (installed: AnyRecord): AnyRecord =>
-                new Proxy({} as AnyRecord, {
+            //
+            // Every key except functions is served as a read-only ref, plain values and refs alike. That is
+            // what createDataScope() hands to overrides of migrated components (toRefs semantics), so an
+            // override reads `previousState.x.value` without knowing whether the component was migrated.
+            // Functions stay callable as `previousState.x()`. Writes go through the override's return
+            // value; a write attempt - to `.value` or to the key itself - is reported and dropped instead
+            // of reaching data, ctx or an earlier override's ref behind Vue's back. Wrapping refs as well
+            // means an override returning `{ x: previousState.x }` installs the read-only wrapper, not the
+            // original ref.
+            const createPreviousState = (installed: AnyRecord): AnyRecord => {
+                const reportWrite = (key: string): void => {
+                    console.error(
+                        `[${componentName}] previousState is read-only. Return "${key}" from the override instead of assigning to previousState.${key}.`,
+                    );
+                };
+
+                // One wrapper per key, so `previousState.x === previousState.x` holds and passing the same
+                // ref to several watch() sources does not create a new object on every access.
+                const wrapperCache = new Map<string, unknown>();
+
+                const read = (key: string): unknown => (Object.hasOwn(installed, key) ? installed[key] : readBaseState(key));
+
+                return new Proxy({} as AnyRecord, {
                     get: (_target, key) => {
                         // Vue probes objects with `__v_isRef`, `__v_raw` & co and with symbol keys.
                         // Answering those with an accessor would make the proxy itself look like a ref.
@@ -115,13 +111,31 @@ export function attachSetupOverrideShim(componentName: string, config: Component
                             return undefined;
                         }
 
-                        if (Object.hasOwn(installed, key)) {
-                            return toRefLike(key, () => installed[key]);
+                        if (!wrapperCache.has(key)) {
+                            const current = read(key);
+
+                            wrapperCache.set(
+                                key,
+                                typeof current === 'function'
+                                    ? current
+                                    : customRef(() => ({
+                                          get: () => unref(read(key)),
+                                          set: () => reportWrite(key),
+                                      })),
+                            );
                         }
 
-                        return toRefLike(key, () => readBaseState(key));
+                        return wrapperCache.get(key);
+                    },
+                    // Without this trap the assignment would land in the empty target and vanish silently.
+                    // Returning false would throw in strict mode, so the write is reported and swallowed.
+                    set: (_target, key) => {
+                        reportWrite(String(key));
+
+                        return true;
                     },
                 });
+            };
 
             const context = {
                 attrs: instance.attrs,

--- a/src/Administration/Resources/app/administration/src/app/adapter/composition-extension-system/options-api-setup-shim.ts
+++ b/src/Administration/Resources/app/administration/src/app/adapter/composition-extension-system/options-api-setup-shim.ts
@@ -11,7 +11,7 @@
  * @experimental stableVersion:v6.9.0 feature:ADMIN_COMPOSITION_API_EXTENSION_SYSTEM
  */
 
-import { getCurrentInstance } from 'vue';
+import { getCurrentInstance, isRef } from 'vue';
 import type { ComponentInternalInstance, SetupContext } from '@vue/runtime-core';
 import type { ComponentConfig } from 'src/core/factory/async-component.factory';
 import { _overridesMap } from './index';
@@ -67,8 +67,9 @@ export function attachSetupOverrideShim(componentName: string, config: Component
                 return;
             }
 
-            // Deliberately skips `setupState`: reading through the instance proxy would resolve to the
-            // override's own result and loop. Mirrors Vue's own order minus that first step.
+            // Deliberately skips `setupState`: what an earlier override or the component's own setup()
+            // put there is served from the per-override snapshot below. Mirrors Vue's own order minus
+            // that first step.
             const readBaseState = (key: string): unknown => {
                 const data = instance.data as AnyRecord;
 
@@ -101,22 +102,54 @@ export function attachSetupOverrideShim(componentName: string, config: Component
                 (instance as unknown as { ctx: AnyRecord }).ctx[key] = next;
             };
 
-            // Override callbacks read `previousState.x.value`, so every key is served as a ref-like
-            // accessor. A proxy avoids having to enumerate data, computed and methods upfront.
-            const previousState = new Proxy(
-                {},
-                {
-                    get: (_target, key: string) => ({
-                        __v_isRef: true,
-                        get value() {
-                            return readBaseState(key);
-                        },
-                        set value(next: unknown) {
-                            writeBaseState(key, next);
-                        },
-                    }),
-                },
-            );
+            // Override callbacks read `previousState.x.value`, so plain values are served as a ref-like
+            // accessor. Refs pass through as they are; functions stay callable as `previousState.x()`,
+            // matching what createExtendableSetup() hands to overrides of migrated components.
+            const toRefLike = (read: () => unknown, write: (next: unknown) => void): unknown => {
+                const current = read();
+
+                if (isRef(current) || typeof current === 'function') {
+                    return current;
+                }
+
+                return {
+                    __v_isRef: true,
+                    get value() {
+                        return read();
+                    },
+                    set value(next: unknown) {
+                        write(next);
+                    },
+                };
+            };
+
+            // Resolves `installed` first, then the base state - the same order Vue's instance proxy uses,
+            // with `installed` standing in for setupState. A proxy avoids having to enumerate data,
+            // computed and methods upfront.
+            const createPreviousState = (installed: AnyRecord): AnyRecord =>
+                new Proxy({} as AnyRecord, {
+                    get: (_target, key) => {
+                        // Vue probes objects with `__v_isRef`, `__v_raw` & co and with symbol keys.
+                        // Answering those with an accessor would make the proxy itself look like a ref.
+                        if (typeof key !== 'string' || key.startsWith('__v_')) {
+                            return undefined;
+                        }
+
+                        if (Object.prototype.hasOwnProperty.call(installed, key)) {
+                            return toRefLike(
+                                () => installed[key],
+                                (next) => {
+                                    bag[key] = next;
+                                },
+                            );
+                        }
+
+                        return toRefLike(
+                            () => readBaseState(key),
+                            (next) => writeBaseState(key, next),
+                        );
+                    },
+                });
 
             const context = {
                 attrs: instance.attrs,
@@ -128,6 +161,10 @@ export function attachSetupOverrideShim(componentName: string, config: Component
             // Vue activates the component's effect scope around lifecycle hooks, so watchers and
             // computeds the overrides create here are disposed on unmount without further handling.
             _overridesMap[componentName].forEach((override) => {
+                // Snapshot per override: the bag already holds the component's own setup() result and
+                // everything earlier overrides installed, so override N sees N-1 - but not its own
+                // result, which is only written after the call. That keeps the read from looping.
+                const previousState = createPreviousState({ ...bag });
                 const result = override(previousState as never, instance.props as never, context) as AnyRecord;
 
                 if (result === undefined) {

--- a/src/Administration/Resources/app/administration/src/app/adapter/composition-extension-system/options-api-setup-shim.ts
+++ b/src/Administration/Resources/app/administration/src/app/adapter/composition-extension-system/options-api-setup-shim.ts
@@ -17,7 +17,7 @@ import type { ComponentConfig } from 'src/core/factory/async-component.factory';
 import { _overridesMap } from './index';
 
 type AnyRecord = Record<string, unknown>;
-type SetupResult = AnyRecord | ((...args: unknown[]) => unknown) | undefined;
+type SetupResult = AnyRecord | undefined;
 
 // Hands the object created in setup() over to created(). Keyed per instance because the config is
 // shared by every instance of the component.
@@ -41,17 +41,6 @@ export function attachSetupOverrideShim(componentName: string, config: Component
     // content instead of being replaced.
     config.setup = function shimSetup(props: Record<string, unknown>, context: SetupContext) {
         const originalResult = (originalSetup ? originalSetup.call(this, props, context) : undefined) as SetupResult;
-
-        // A setup() returning a render function cannot carry the bag. Leave it untouched; the created
-        // hook then finds no bag and bails out, so the component keeps working without the overrides.
-        // Reported, because from the override author's side nothing else hints at why it has no effect.
-        if (typeof originalResult === 'function') {
-            console.warn(
-                `[${componentName}] Setup overrides not applied: setup() returns a render function, which leaves no place for override results. Return an object from setup() to make the ${_overridesMap[componentName].length} registered override(s) take effect.`,
-            );
-
-            return originalResult;
-        }
 
         const bag: AnyRecord = originalResult ?? {};
         const instance = getCurrentInstance();

--- a/src/Administration/Resources/app/administration/src/app/adapter/composition-extension-system/options-api-setup-shim.ts
+++ b/src/Administration/Resources/app/administration/src/app/adapter/composition-extension-system/options-api-setup-shim.ts
@@ -115,7 +115,7 @@ export function attachSetupOverrideShim(componentName: string, config: Component
                             return undefined;
                         }
 
-                        if (Object.prototype.hasOwnProperty.call(installed, key)) {
+                        if (Object.hasOwn(installed, key)) {
                             return toRefLike(key, () => installed[key]);
                         }
 

--- a/src/Administration/Resources/app/administration/src/app/adapter/view/vue.adapter.ts
+++ b/src/Administration/Resources/app/administration/src/app/adapter/view/vue.adapter.ts
@@ -65,6 +65,7 @@ import {
     MtDropdownMenuSub,
 } from '@shopware-ag/meteor-component-library';
 
+import { attachSetupOverrideShim } from '../composition-extension-system/options-api-setup-shim';
 import getBlockDataScope from '../../component/structure/sw-block-override/sw-block/get-block-data-scope';
 import useLegacyConditionContext from '../../component/structure/sw-block-override/shim/legacy-condition-context';
 import type { LegacyConditionCaseOptions } from '../../component/structure/sw-block-override/shim/legacy-condition-context';
@@ -591,6 +592,7 @@ export default class VueAdapter extends ViewAdapter {
                         if (typeof componentConfig === 'boolean') {
                             resolve(false);
                         } else {
+                            attachSetupOverrideShim(componentName, componentConfig);
                             this.resolveMixins(componentConfig);
                         }
 

--- a/src/Administration/Resources/app/administration/technical-docs/03-extensibility/08-native-overrides-on-twig-components.md
+++ b/src/Administration/Resources/app/administration/technical-docs/03-extensibility/08-native-overrides-on-twig-components.md
@@ -1,0 +1,106 @@
+# Native Overrides on Twig Components
+
+Counterpart to the [Twig → Native Block Runtime Adapter](./06-twig-native-block-adapter.md): that adapter keeps _legacy Twig overrides_ working on _migrated_ components, this one lets _native SFC overrides_ target components that are _not migrated yet_.
+
+Both halves activate automatically. Nothing changes for override authors, and the same override file keeps working unchanged once its target is migrated.
+
+---
+
+## Problem
+
+A native override declares its target with `<sw-block extends="…">` and replaces state with `swDefineOverride({ … })`. Both need the target to be a native setup component: the block needs a matching `<sw-block name="…">`, the state needs an extendable setup wrapper. A component still rendered through TwigJS has neither, so an override against it used to do nothing at all, and without an error.
+
+Plugin authors therefore had to wait for core to migrate a component before they could write an override for it.
+
+---
+
+## Template half
+
+**The override announces its target blocks at build time.** The setup transform emits a plain `<script>` into every override SFC:
+
+```js
+Shopware.Component.registerNativeExtensionTargets?.({
+    component: 'sw-dashboard-index',
+    blocks: ['sw_dashboard_index_content_intro_welcome_message'],
+});
+```
+
+A plain `<script>` runs at module evaluation, during `loadPlugins()`, while `<script setup>` would only run on mount. The block names therefore land in the registry _before_ templates are resolved. The call is optional (`?.`) because it is compiled into every shipped plugin bundle: a missing function would abort the entry module and take the whole plugin down with it.
+
+**The template factory wraps the matching blocks.** `wrapNativeBlockTargets` inserts an extension point around every block that is a registered target:
+
+```twig
+<div class="sw-example">
+    {% block sw_example_title %}<h1>{{ title }}</h1>{% endblock %}
+    {% block sw_example_body %}<p>{{ body }}</p>{% endblock %}
+</div>
+```
+
+With `sw_example_body` registered as a target, the rendered template becomes:
+
+```html
+<div class="sw-example">
+    <h1>{{ title }}</h1>
+    <sw-block name="sw_example_body" :data="$dataScope" :sw-internal-legacy-shim="false"><p>{{ body }}</p></sw-block>
+</div>
+```
+
+`sw_example_title` is not a target and leaves no trace, exactly as before, because Twig block markers never reach the output. Only the registered block gains an element. (Whitespace is normalised here for readability; the transform does not reformat.)
+
+Wrapping happens **after** Twig overrides are merged and only for the render. The stored token tree stays untouched, because components inheriting it would otherwise inherit the wrapper too. The legacy shim is switched off because those overrides are already part of the merged content; leaving it on would feed the same override in a second time.
+
+### Blocks that open with a slot template
+
+Roughly one in six blocks starts with a named slot template. Wrapping such a block from the outside would bind the slot to `sw-block`, which renders only its default slot, so the content would disappear without an error. The extension point is therefore placed _inside_ the template:
+
+```twig
+<sw-card>
+    {% block sw_example_header %}<template #header><b>{{ title }}</b></template>{% endblock %}
+</sw-card>
+```
+
+```html
+<sw-card>
+    <template #header
+        ><sw-block name="sw_example_header" …><b>{{ title }}</b></sw-block></template
+    >
+</sw-card>
+```
+
+The slot stays on `sw-card`, and the override replaces the slot's content.
+
+This works when the block consists of exactly one slot template spanning its whole content. Several sibling slot templates, or a slot template next to other content, have no single position that serves every part; those blocks are left unwrapped and a warning names them. **15 of 8292 blocks** fall into this category, mostly `*_content` blocks of list pages that fill two slots of their `sw-page` at once.
+
+---
+
+## Setup half
+
+`swDefineOverride` replacements are applied by an adapter that works around one ordering constraint: only a `setup()` return value outranks `data` and `computed` in Vue's instance proxy, but `setup()` runs before either of them exists.
+
+The adapter therefore **reserves the slot early and fills it late**:
+
+1. `setup()` returns an empty object. Vue keeps a live reference to it as the component's setup state, the entry with the highest precedence.
+2. A `created()` hook, injected as the first mixin, runs the override callbacks. At that point `data` and `computed` exist, so `previousState` can read them.
+3. The results are written into the object from step 1, before the first render.
+
+`previousState` is a proxy that serves every key as a ref-like accessor, so `previousState.x.value` works for `data`, `props`, `computed` and `methods` alike, including calling a replaced method's original. It deliberately reads _past_ the setup state, because the override's own result already lives there and reading it would loop.
+
+Writing back (`previousState.x.value = …`) lands in the base state, not in the override's result. Props stay read-only, as they are on Vue's own proxy.
+
+---
+
+## Limits
+
+**Blocks that mix slot templates with other content** cannot host an extension point; see above.
+
+**An `immediate` watcher on an overridden key fires once with the base value.** Vue sets watchers up before any `created` hook, so the first run happens before the override exists. Every later evaluation sees the override.
+
+**The adapter relies on undocumented Vue behaviour**: that a setup result stays live and that keys added later are honoured. It is pinned to the Vue version in `package.json`, and a canary test fails loudly if an upgrade changes it.
+
+---
+
+## Lifetime
+
+Both halves become unnecessary once every override target renders natively. They are annotated `@experimental stableVersion:v6.9.0 feature:ADMIN_COMPOSITION_API_EXTENSION_SYSTEM`, which by convention means: stable or removed by then.
+
+`registerNativeExtensionTargets` is the exception. It is compiled into shipped plugin bundles, so its signature is a runtime contract with every plugin already in the market. Adding fields stays compatible, renaming or removing it does not.


### PR DESCRIPTION
### 1. Why is this change necessary?

Currently there is a shim that allows legacy twig extensions to extend native SFC components but using native extensions to extend twig components is not possible. Currently nothing happens if a extensions defines an .vue override for a twig core component.
This PR is the part that allows the setup state to override the option api definitions. The first part allows the template to be rendered: https://github.com/shopware/shopware/pull/20006

### 2. What does this change do, exactly?

It adds `options-api-setup-shim.ts` which includes logic to handle the overrides. It includes a function to add a mixin to options api components. This is done for every component inside vue.adapter.ts. 

The mixin does the following:
- Adds a setup-hook which returns an empty object ('bag'). This object is stored inside the shim. As a result the object is stored inside `setupState` on the component by vue.
- A created-hook is registered. This is the first point where data, computed etc. from the options api is available.
- The created hook applies the overrides from the `_overridesMap` to the object that has been prieviously stored inside `setupState`.
- It also defines the `readBaseState`-function, which is used to read original values from the base component because direct access to the instance would deliver the already overriden values in `setupState`
=> Vue always reads `setupState` first which results in the overrides inside the bag which was returned by setup originally automatically overriding the options api properties.


### 3. Describe each step to reproduce the issue or behaviour.

Install a plugin that extends an existing core component that is not yet migrated to SFC syntax. Example plugin:
[NativeOverrideDemo.zip](https://github.com/user-attachments/files/31725301/NativeOverrideDemo.zip)

Without this shim: Nothing happens, there is no error and noting shown in the administration

### 4. Please link to the relevant issues (if any).
