### PR TITLE
fix(administration): scope shortcut teardown to the unmounting instance

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/plugin/shortcut.plugin.js
+++ b/src/Administration/Resources/app/administration/src/app/plugin/shortcut.plugin.js
@@ -216,7 +216,7 @@ export default {
                 // remove shortcuts of this component instance
                 const shortcutKeys = Object.keys(shortcuts);
                 activeShortcuts = activeShortcuts.filter((activeShortcut) => {
-                    return !(activeShortcut.instance._uid === this._uid && shortcutKeys.includes(activeShortcut.key));
+                    return !(activeShortcut.instance.$.uid === this.$.uid && shortcutKeys.includes(activeShortcut.key));
                 });
 
                 // The event listener is intentionally not removed to keep global shortcuts working.

--- a/src/Administration/Resources/app/administration/src/app/plugin/shortcut.plugin.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/plugin/shortcut.plugin.spec.js
@@ -654,6 +654,69 @@ describe('app/plugins/shortcut.plugin', () => {
         wrapper2.unmount();
     });
 
+    it('should keep shortcuts of sibling instances that registered the same key', async () => {
+        const onPageSave = jest.fn();
+        const onPanelSave = jest.fn();
+
+        const element = document.createElement('div');
+        if (document.body) {
+            document.body.appendChild(element);
+        }
+
+        const wrapper = mount(
+            {
+                name: 'root-component',
+                template: '<div><page-component /><panel-component v-if="showPanel" /></div>',
+                data() {
+                    return {
+                        showPanel: true,
+                    };
+                },
+                components: {
+                    'page-component': {
+                        name: 'page-component',
+                        template: '<div></div>',
+                        shortcuts: {
+                            'SYSTEMKEY+S': 'onSave',
+                        },
+                        methods: {
+                            onSave: onPageSave,
+                        },
+                    },
+                    'panel-component': {
+                        name: 'panel-component',
+                        template: '<div></div>',
+                        shortcuts: {
+                            'SYSTEMKEY+S': 'onSave',
+                        },
+                        methods: {
+                            onSave: onPanelSave,
+                        },
+                    },
+                },
+            },
+            {
+                attachTo: element,
+                global: {
+                    plugins: [shortcutPlugin],
+                },
+            },
+        );
+
+        await wrapper.setData({ showPanel: false });
+        await flushPromises();
+
+        await wrapper.trigger('keydown', {
+            key: 's',
+            ctrlKey: true,
+        });
+
+        expect(onPageSave).toHaveBeenCalledTimes(1);
+        expect(onPanelSave).not.toHaveBeenCalled();
+
+        wrapper.unmount();
+    });
+
     it('should not trigger shortcuts from unmounted components', async () => {
         const onSaveMock = jest.fn();
 


### PR DESCRIPTION
### 1. Why is this change necessary?

Keyboard shortcuts in the Administration are registered per component instance and unregistered when that instance unmounts. The unregister step never identified the instance, so it removed everyone's.

The plugin keeps one flat list of active shortcuts, each entry remembering the instance that registered it. On unmount it filters that list by two conditions — same instance, and one of this component's keys:

```js
activeShortcuts = activeShortcuts.filter((activeShortcut) => {
    return !(activeShortcut.instance._uid === this._uid && shortcutKeys.includes(activeShortcut.key));
});
```

`_uid` is a Vue **2** property. On Vue 3 it is `undefined` on every instance, so the instance comparison is `undefined === undefined` — always true, for any pair of components. Only the key check remains, which means unmounting one component drops every shortcut registered under the same key, no matter who owns it.

Almost every page registers `SYSTEMKEY+S` and `ESCAPE`, so anything shorter-lived that also registers one of those takes the page's copy with it when it closes. Closing a side panel or a modal leaves the page behind with a dead Ctrl+S — silently, since a shortcut that is no longer registered simply does nothing.

### 2. What does this change do, exactly?

- Compares `$.uid`, Vue 3's instance id, instead of the Vue 2 `_uid`.
- Adds a spec mounting two siblings under one app that both register `SYSTEMKEY+S`. It does not use `createWrapper`, because each of those calls installs the plugin into its own app and gets its own registry — which is also why the two existing multi-component tests never caught this.

### 3. Describe each step to reproduce the issue or behaviour.

On any detail page — for example a product — open something that registers its own `SYSTEMKEY+S` and close it again, then press Ctrl/Cmd+S.

- before: nothing happens, no error in the console
- after: the page saves

### 4. Please link to the relevant issues (if any).

- relates #19571 — the three platform features that resolve members off the component instance, of which `shortcuts` is one

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them

Release notes and docs are unticked deliberately: `shortcut.plugin.js` is `@private` and the fixed behaviour is what the option always documented, so there is nothing for an extension author to adapt to.
