### PR TITLE
refactor(administration): rewrite setData() to direct vm assignments

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/base/sw-chart-card/sw-chart-card.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/base/sw-chart-card/sw-chart-card.spec.js
@@ -3,7 +3,7 @@
  */
 
 import { mount } from '@vue/test-utils';
-import { h } from 'vue';
+import { h, nextTick } from 'vue';
 
 const extendedRanges = [
     {
@@ -178,7 +178,8 @@ describe('src/app/component/base/sw-chart-card', () => {
         const expectedEvent = 'sw-chart-card-range-update';
         const expectedValue = '7Days';
         const wrapper = await createWrapper();
-        await wrapper.setData({ selectedRange: expectedValue });
+        wrapper.vm.selectedRange = expectedValue;
+        await nextTick();
 
         wrapper.vm.dispatchRangeUpdate();
 
@@ -197,7 +198,8 @@ describe('src/app/component/base/sw-chart-card', () => {
         });
         expect(wrapper.vm.selectedRange).toStrictEqual(defaultRange);
 
-        await wrapper.setData({ selectedRange: expectedRange });
+        wrapper.vm.selectedRange = expectedRange;
+        await nextTick();
         wrapper.vm.dispatchRangeUpdate();
 
         expect(wrapper.emitted()).toHaveProperty(expectedEvent);

--- a/src/Administration/Resources/app/administration/src/app/component/data-grid/sw-data-grid/sw-data-grid.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/data-grid/sw-data-grid/sw-data-grid.spec.js
@@ -4,6 +4,7 @@
  * @sw-package framework
  */
 
+import { nextTick } from 'vue';
 import { mount } from '@vue/test-utils';
 import Entity from 'src/core/data/entity.data';
 import EntityCollection from 'src/core/data/entity-collection.data';
@@ -821,9 +822,8 @@ describe('components/data-grid/sw-data-grid', () => {
             curentGridState[item.id] = item;
         });
 
-        await wrapper.setData({
-            selection: curentGridState,
-        });
+        wrapper.vm.selection = curentGridState;
+        await nextTick();
 
         const header = wrapper.find('.sw-data-grid__header');
         const selectionAll = header.find(
@@ -850,9 +850,8 @@ describe('components/data-grid/sw-data-grid', () => {
             curentGridState[item.id] = item;
         });
 
-        await wrapper.setData({
-            selection: curentGridState,
-        });
+        wrapper.vm.selection = curentGridState;
+        await nextTick();
 
         await wrapper.vm.$nextTick();
 

--- a/src/Administration/Resources/app/administration/src/app/component/entity/sw-category-tree-field/sw-category-tree-field.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/entity/sw-category-tree-field/sw-category-tree-field.spec.js
@@ -2,6 +2,7 @@
  * @sw-package framework
  */
 
+import { nextTick } from 'vue';
 import { mount } from '@vue/test-utils';
 import EntityCollection from 'src/core/data/entity-collection.data';
 
@@ -219,9 +220,8 @@ describe('src/app/component/entity/sw-category-tree-field', () => {
             singleSelect: true,
             categoriesCollection: createCategoryCollection(intitalCategories),
         });
-        await wrapper.setData({
-            selectedCategoriesTotal: 5,
-        });
+        wrapper.vm.selectedCategoriesTotal = 5;
+        await nextTick();
         await flushPromises();
 
         await wrapper.find('.sw-category-tree-field__label-more').trigger('click');

--- a/src/Administration/Resources/app/administration/src/app/component/entity/sw-one-to-many-grid/sw-one-to-many-grid.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/entity/sw-one-to-many-grid/sw-one-to-many-grid.spec.js
@@ -2,6 +2,7 @@
  * @sw-package framework
  */
 
+import { nextTick } from 'vue';
 import { mount } from '@vue/test-utils';
 
 async function createWrapper() {
@@ -64,18 +65,17 @@ describe('app/component/entity/sw-one-to-many-grid', () => {
     it('should enable the context menu delete item', async () => {
         const wrapper = await createWrapper();
 
-        await wrapper.setData({
-            records: [
-                {
-                    name: 'name',
-                    shortCode: 'shortCode',
-                },
-                {
-                    name: 'name',
-                    shortCode: 'shortCode',
-                },
-            ],
-        });
+        wrapper.vm.records = [
+            {
+                name: 'name',
+                shortCode: 'shortCode',
+            },
+            {
+                name: 'name',
+                shortCode: 'shortCode',
+            },
+        ];
+        await nextTick();
 
         const firstRow = wrapper.find('.sw-data-grid__row--1');
         const firstRowActions = firstRow.find('.sw-data-grid__cell--actions');
@@ -92,18 +92,17 @@ describe('app/component/entity/sw-one-to-many-grid', () => {
             allowDelete: false,
         });
 
-        await wrapper.setData({
-            records: [
-                {
-                    name: 'name',
-                    shortCode: 'shortCode',
-                },
-                {
-                    name: 'name',
-                    shortCode: 'shortCode',
-                },
-            ],
-        });
+        wrapper.vm.records = [
+            {
+                name: 'name',
+                shortCode: 'shortCode',
+            },
+            {
+                name: 'name',
+                shortCode: 'shortCode',
+            },
+        ];
+        await nextTick();
 
         const firstRow = wrapper.find('.sw-data-grid__row--1');
         const firstRowActions = firstRow.find('.sw-data-grid__cell--actions');

--- a/src/Administration/Resources/app/administration/src/app/component/form/select/base/sw-multi-select/sw-multi-select.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/form/select/base/sw-multi-select/sw-multi-select.spec.js
@@ -2,6 +2,7 @@
  * @sw-package framework
  */
 
+import { nextTick } from 'vue';
 import { mount } from '@vue/test-utils';
 
 const createMultiSelect = async (customOptions) => {
@@ -221,7 +222,8 @@ describe('components/sw-multi-select', () => {
         const swMultiSelect = await createMultiSelect();
 
         await swMultiSelect.find('.sw-select__selection').trigger('click');
-        await swMultiSelect.setData({ searchTerm: 'Entry 3' });
+        swMultiSelect.vm.searchTerm = 'Entry 3';
+        await nextTick();
 
         expect(swMultiSelect.vm.searchTerm).toBe('Entry 3');
     });

--- a/src/Administration/Resources/app/administration/src/app/component/form/select/base/sw-single-select/sw-single-select.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/form/select/base/sw-single-select/sw-single-select.spec.js
@@ -2,6 +2,7 @@
  * @sw-package framework
  */
 
+import { nextTick } from 'vue';
 import { mount } from '@vue/test-utils';
 
 async function createSingleSelect(customOptions) {
@@ -140,7 +141,8 @@ describe('components/sw-single-select', () => {
         await flushPromises();
 
         await swSingleSelect.find('.sw-select__selection').trigger('click');
-        await swSingleSelect.setData({ searchTerm: 'Entry 3' });
+        swSingleSelect.vm.searchTerm = 'Entry 3';
+        await nextTick();
         swSingleSelect.vm.search();
 
         expect(swSingleSelect.vm.searchTerm).toBe('Entry 3');

--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-colorpicker-deprecated/sw-colorpicker-deprecated.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-colorpicker-deprecated/sw-colorpicker-deprecated.spec.js
@@ -4,6 +4,7 @@
  * @sw-package framework
  */
 
+import { nextTick } from 'vue';
 import { mount } from '@vue/test-utils';
 
 async function createWrapper(additionalProps = {}) {
@@ -69,19 +70,17 @@ describe('components/form/sw-colorpicker', () => {
     });
 
     it('should be a number multiplied by 100', async () => {
-        await wrapper.setData({
-            alphaValue: 0.5,
-        });
+        wrapper.vm.alphaValue = 0.5;
+        await nextTick();
 
         expect(wrapper.vm.integerAlpha).toBe(50);
     });
 
     it('should compute the correct alpha slider background', async () => {
-        await wrapper.setData({
-            hueValue: 50,
-            saturationValue: 30,
-            luminanceValue: 80,
-        });
+        wrapper.vm.hueValue = 50;
+        wrapper.vm.saturationValue = 30;
+        wrapper.vm.luminanceValue = 80;
+        await nextTick();
 
         expect(wrapper.vm.sliderBackground).toBe(
             "linear-gradient(90deg, hsla(50, 30%, 80%, 0), hsl(50, 30%, 80%)), url(\"data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20' width='100%25' height='100%25'%3E%3Crect width='10' height='10' x='00' y='00' fill='%23cdd5db' /%3E%3Crect width='10' height='10' x='10' y='10' fill='%23cdd5db' /%3E%3C/svg%3E\")",
@@ -127,19 +126,17 @@ describe('components/form/sw-colorpicker', () => {
     });
 
     it('should be the correct selector background', async () => {
-        await wrapper.setData({
-            hueValue: 154,
-        });
+        wrapper.vm.hueValue = 154;
+        await nextTick();
 
         expect(wrapper.vm.selectorBackground).toBe('hsl(154, 100%, 50%)');
     });
 
     it('should be the correct red value', async () => {
-        await wrapper.setData({
-            hueValue: 153,
-            saturationValue: 78,
-            luminanceValue: 57,
-        });
+        wrapper.vm.hueValue = 153;
+        wrapper.vm.saturationValue = 78;
+        wrapper.vm.luminanceValue = 57;
+        await nextTick();
 
         expect(wrapper.vm.redValue).toBe(60);
     });
@@ -173,32 +170,29 @@ describe('components/form/sw-colorpicker', () => {
     });
 
     it('should be the correct green value', async () => {
-        await wrapper.setData({
-            hueValue: 153,
-            saturationValue: 78,
-            luminanceValue: 57,
-        });
+        wrapper.vm.hueValue = 153;
+        wrapper.vm.saturationValue = 78;
+        wrapper.vm.luminanceValue = 57;
+        await nextTick();
 
         expect(wrapper.vm.greenValue).toBe(231);
     });
 
     it('should be the correct blue value', async () => {
-        await wrapper.setData({
-            hueValue: 153,
-            saturationValue: 78,
-            luminanceValue: 57,
-        });
+        wrapper.vm.hueValue = 153;
+        wrapper.vm.saturationValue = 78;
+        wrapper.vm.luminanceValue = 57;
+        await nextTick();
 
         expect(wrapper.vm.blueValue).toBe(154);
     });
 
     it('should be the correct rgb value', async () => {
-        await wrapper.setData({
-            hueValue: 85,
-            saturationValue: 80,
-            luminanceValue: 55,
-            alphaValue: 0.67,
-        });
+        wrapper.vm.hueValue = 85;
+        wrapper.vm.saturationValue = 80;
+        wrapper.vm.luminanceValue = 55;
+        wrapper.vm.alphaValue = 0.67;
+        await nextTick();
 
         expect(wrapper.vm.rgbValue).toBe('rgba(156, 232, 48, 0.67)');
     });
@@ -248,33 +242,30 @@ describe('components/form/sw-colorpicker', () => {
     });
 
     it('should be the correct hsl value', async () => {
-        await wrapper.setData({
-            hueValue: 176,
-            saturationValue: 66,
-            luminanceValue: 40,
-        });
+        wrapper.vm.hueValue = 176;
+        wrapper.vm.saturationValue = 66;
+        wrapper.vm.luminanceValue = 40;
+        await nextTick();
 
         expect(wrapper.vm.hslValue).toBe('hsl(176, 66%, 40%)');
     });
 
     it('should be the correct hsla value', async () => {
-        await wrapper.setData({
-            hueValue: 40,
-            saturationValue: 33,
-            luminanceValue: 13,
-            alphaValue: 0.5,
-        });
+        wrapper.vm.hueValue = 40;
+        wrapper.vm.saturationValue = 33;
+        wrapper.vm.luminanceValue = 13;
+        wrapper.vm.alphaValue = 0.5;
+        await nextTick();
 
         expect(wrapper.vm.hslValue).toBe('hsla(40, 33%, 13%, 0.5)');
     });
 
     it('should set the correct hsla values', async () => {
-        await wrapper.setData({
-            hueValue: 40,
-            saturationValue: 50,
-            luminanceValue: 87,
-            alphaValue: 0.77,
-        });
+        wrapper.vm.hueValue = 40;
+        wrapper.vm.saturationValue = 50;
+        wrapper.vm.luminanceValue = 87;
+        wrapper.vm.alphaValue = 0.77;
+        await nextTick();
 
         wrapper.vm.setHslaValues(145, 40, 946, 0.74);
 
@@ -285,21 +276,19 @@ describe('components/form/sw-colorpicker', () => {
     });
 
     it('should be the correct hex value', async () => {
-        await wrapper.setData({
-            hueValue: 341,
-            saturationValue: 46,
-            luminanceValue: 84,
-        });
+        wrapper.vm.hueValue = 341;
+        wrapper.vm.saturationValue = 46;
+        wrapper.vm.luminanceValue = 84;
+        await nextTick();
 
         expect(wrapper.vm.hexValue).toBe('#e9c3cf');
     });
 
     it('should validate the hex input', async () => {
-        await wrapper.setData({
-            hueValue: 275,
-            saturationValue: 55,
-            luminanceValue: 89,
-        });
+        wrapper.vm.hueValue = 275;
+        wrapper.vm.saturationValue = 55;
+        wrapper.vm.luminanceValue = 89;
+        await nextTick();
         wrapper.vm.hexValue = 'qwertz';
         await flushPromises();
 
@@ -307,28 +296,25 @@ describe('components/form/sw-colorpicker', () => {
     });
 
     it('should be the correct hex-alpha value', async () => {
-        await wrapper.setData({
-            hueValue: 341,
-            saturationValue: 46,
-            luminanceValue: 84,
-            alphaValue: 0.4,
-        });
+        wrapper.vm.hueValue = 341;
+        wrapper.vm.saturationValue = 46;
+        wrapper.vm.luminanceValue = 84;
+        wrapper.vm.alphaValue = 0.4;
+        await nextTick();
 
         expect(wrapper.vm.hexValue).toBe('#e9c3cf66');
     });
 
     it('selector should have the right x co-ordinate', async () => {
-        await wrapper.setData({
-            saturationValue: 63,
-        });
+        wrapper.vm.saturationValue = 63;
+        await nextTick();
 
         expect(wrapper.vm.selectorPositionX).toBe('calc(63% - 9px)');
     });
 
     it('selector should have the right y co-ordinate', async () => {
-        await wrapper.setData({
-            luminanceValue: 32,
-        });
+        wrapper.vm.luminanceValue = 32;
+        await nextTick();
 
         expect(wrapper.vm.selectorPositionY).toBe('calc(68% - 9px)');
     });
@@ -338,11 +324,10 @@ describe('components/form/sw-colorpicker', () => {
             colorOutput: 'rgb',
         });
 
-        await wrapper.setData({
-            hueValue: 180,
-            saturationValue: 50,
-            luminanceValue: 40,
-        });
+        wrapper.vm.hueValue = 180;
+        wrapper.vm.saturationValue = 50;
+        wrapper.vm.luminanceValue = 40;
+        await nextTick();
 
         expect(wrapper.vm.colorValue).toBe('rgb(51, 153, 153)');
     });
@@ -352,11 +337,10 @@ describe('components/form/sw-colorpicker', () => {
             colorOutput: 'hsl',
         });
 
-        await wrapper.setData({
-            hueValue: 0,
-            saturationValue: 81,
-            luminanceValue: 72,
-        });
+        wrapper.vm.hueValue = 0;
+        wrapper.vm.saturationValue = 81;
+        wrapper.vm.luminanceValue = 72;
+        await nextTick();
 
         expect(wrapper.vm.colorValue).toBe('hsl(0, 81%, 72%)');
     });
@@ -366,11 +350,10 @@ describe('components/form/sw-colorpicker', () => {
             colorOutput: 'hex',
         });
 
-        await wrapper.setData({
-            hueValue: 149,
-            saturationValue: 55,
-            luminanceValue: 63,
-        });
+        wrapper.vm.hueValue = 149;
+        wrapper.vm.saturationValue = 55;
+        wrapper.vm.luminanceValue = 63;
+        await nextTick();
 
         expect(wrapper.vm.colorValue).toBe('#6dd59f');
     });
@@ -380,11 +363,10 @@ describe('components/form/sw-colorpicker', () => {
             colorOutput: 'auto',
         });
 
-        await wrapper.setData({
-            hueValue: 149,
-            saturationValue: 55,
-            luminanceValue: 63,
-        });
+        wrapper.vm.hueValue = 149;
+        wrapper.vm.saturationValue = 55;
+        wrapper.vm.luminanceValue = 63;
+        await nextTick();
 
         expect(wrapper.vm.colorValue).toBe('#6dd59f');
     });
@@ -394,12 +376,11 @@ describe('components/form/sw-colorpicker', () => {
             colorOutput: 'auto',
         });
 
-        await wrapper.setData({
-            hueValue: 149,
-            saturationValue: 55,
-            luminanceValue: 63,
-            alphaValue: 0.87,
-        });
+        wrapper.vm.hueValue = 149;
+        wrapper.vm.saturationValue = 55;
+        wrapper.vm.luminanceValue = 63;
+        wrapper.vm.alphaValue = 0.87;
+        await nextTick();
 
         expect(wrapper.vm.colorValue).toBe('rgba(109, 213, 159, 0.87)');
     });
@@ -419,7 +400,8 @@ describe('components/form/sw-colorpicker', () => {
     });
 
     it('should show only the input field without colorpicker', async () => {
-        await wrapper.setData({ visible: false });
+        wrapper.vm.visible = false;
+        await nextTick();
         const colorpicker = wrapper.find('.sw-colorpicker__colorpicker');
 
         expect(colorpicker.exists()).toBe(false);
@@ -449,9 +431,8 @@ describe('components/form/sw-colorpicker', () => {
             colorOutput: 'rgb',
         });
 
-        await wrapper.setData({
-            visible: true,
-        });
+        wrapper.vm.visible = true;
+        await nextTick();
 
         expect(wrapper.vm.colorValue).toBe('rgb(18, 49, 35)');
     });
@@ -578,9 +559,8 @@ describe('components/form/sw-colorpicker', () => {
         wrapper = await createWrapper();
         const moveSelectorSpy = jest.spyOn(wrapper.vm, 'moveSelector');
 
-        await wrapper.setData({
-            visible: true,
-        });
+        wrapper.vm.visible = true;
+        await nextTick();
         await flushPromises();
 
         const colorPicker = wrapper.find('.sw-colorpicker__colorpicker-selection');
@@ -595,9 +575,8 @@ describe('components/form/sw-colorpicker', () => {
 
         const removeDragging = jest.spyOn(wrapper.vm, 'removeDragging');
 
-        await wrapper.setData({
-            visible: true,
-        });
+        wrapper.vm.visible = true;
+        await nextTick();
         await flushPromises();
 
         const colorPicker = wrapper.find('.sw-colorpicker__colorpicker-selection');
@@ -716,10 +695,9 @@ describe('components/form/sw-colorpicker', () => {
         async (clientX, clientY, left, top, expectedSaturationValue, expectedLuminanceValue) => {
             wrapper = await createWrapper();
 
-            await wrapper.setData({
-                visible: true,
-                isDragging: true,
-            });
+            wrapper.vm.visible = true;
+            wrapper.vm.isDragging = true;
+            await nextTick();
             await flushPromises();
 
             const event = {

--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-password-field-deprecated/sw-password-field-deprecated.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-password-field-deprecated/sw-password-field-deprecated.spec.js
@@ -8,7 +8,7 @@ import 'src/app/component/form/sw-password-field';
 import 'src/app/component/form/field-base/sw-contextual-field';
 import 'src/app/component/form/field-base/sw-block-field';
 import 'src/app/component/form/field-base/sw-base-field';
-import { ref } from 'vue';
+import { ref, nextTick } from 'vue';
 
 async function createWrapper({ provide, ...additionalOptions } = {}) {
     return mount(await wrapTestComponent('sw-password-field-deprecated', { sync: true }), {
@@ -80,9 +80,8 @@ describe('components/form/sw-password-field', () => {
 
         expect(input.attributes().type).toBe('password');
 
-        await wrapper.setData({
-            showPassword: true,
-        });
+        wrapper.vm.showPassword = true;
+        await nextTick();
 
         await input.setValue('Very secret password');
 

--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-radio-field/sw-radio-field.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-radio-field/sw-radio-field.spec.js
@@ -2,6 +2,7 @@
  * @sw-package framework
  */
 
+import { nextTick } from 'vue';
 import { mount } from '@vue/test-utils';
 import 'src/app/component/form/field-base/sw-base-field';
 import 'src/app/component/form/sw-radio-field';
@@ -72,12 +73,14 @@ describe('components/form/sw-radio-field', () => {
         const wrapper = await createWrapper();
         const customSlot = wrapper.find('#custom-slot');
 
-        await wrapper.setData({ currentValue: 1 });
+        wrapper.vm.currentValue = 1;
+        await nextTick();
         await wrapper.vm.$nextTick();
 
         expect(customSlot.wrapperElement).toBeEnabled();
 
-        await wrapper.setData({ currentValue: 2 });
+        wrapper.vm.currentValue = 2;
+        await nextTick();
         await wrapper.vm.$nextTick();
 
         expect(customSlot.wrapperElement).toBeDisabled();
@@ -89,7 +92,8 @@ describe('components/form/sw-radio-field', () => {
         let description = wrapper.find('.sw-field__radio-description');
         expect(description.exists()).toBe(false);
 
-        await wrapper.setData({ description: 'Lorem ipsum' });
+        wrapper.vm.description = 'Lorem ipsum';
+        await nextTick();
 
         description = wrapper.find('.sw-field__radio-description');
         expect(description.exists()).toBe(true);
@@ -101,13 +105,12 @@ describe('components/form/sw-radio-field', () => {
         let optionDescription = wrapper.find('.sw-field__radio-option-description');
         expect(optionDescription.exists()).toBe(false);
 
-        await wrapper.setData({
-            options: [
-                { value: 1, name: 'option 1', description: 'option 1' },
-                { value: 2, name: 'option 2', description: 'option 2' },
-                { value: 3, name: 'option 3', description: 'option 3' },
-            ],
-        });
+        wrapper.vm.options = [
+            { value: 1, name: 'option 1', description: 'option 1' },
+            { value: 2, name: 'option 2', description: 'option 2' },
+            { value: 3, name: 'option 3', description: 'option 3' },
+        ];
+        await nextTick();
 
         optionDescription = wrapper.find('.sw-field__radio-option-description');
         expect(optionDescription.exists()).toBe(true);

--- a/src/Administration/Resources/app/administration/src/app/component/media/sw-media-compact-upload-v2/sw-media-compact-upload-v2.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/media/sw-media-compact-upload-v2/sw-media-compact-upload-v2.spec.js
@@ -1,6 +1,7 @@
 /**
  * @sw-package discovery
  */
+import { nextTick } from 'vue';
 import { mount } from '@vue/test-utils';
 
 describe('src/app/component/media/sw-media-compact-upload-v2', () => {
@@ -87,9 +88,8 @@ describe('src/app/component/media/sw-media-compact-upload-v2', () => {
     });
 
     it('should contain url upload form when input type is url-upload', async () => {
-        await wrapper.setData({
-            inputType: 'file-upload',
-        });
+        wrapper.vm.inputType = 'file-upload';
+        await nextTick();
 
         let urlForm = wrapper.find('.sw-media-upload-v2__url-form');
         let uploadBtn = wrapper.find('.sw-media-upload-v2__button.upload');
@@ -97,9 +97,8 @@ describe('src/app/component/media/sw-media-compact-upload-v2', () => {
         expect(urlForm.exists()).toBeFalsy();
         expect(uploadBtn.exists()).toBeTruthy();
 
-        await wrapper.setData({
-            inputType: 'url-upload',
-        });
+        wrapper.vm.inputType = 'url-upload';
+        await nextTick();
 
         urlForm = wrapper.find('.sw-media-upload-v2__url-form');
         uploadBtn = wrapper.find('.sw-media-upload-v2__button.upload');

--- a/src/Administration/Resources/app/administration/src/app/component/media/sw-media-field/sw-media-field.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/media/sw-media-field/sw-media-field.spec.js
@@ -1,6 +1,7 @@
 /**
  * @sw-package discovery
  */
+import { nextTick } from 'vue';
 import { mount } from '@vue/test-utils';
 
 describe('src/app/component/media/sw-media-field', () => {
@@ -75,9 +76,8 @@ describe('src/app/component/media/sw-media-field', () => {
     it('should stop propagation when sw-popover content is clicked', async () => {
         const wrapper = await createWrapper();
 
-        await wrapper.setData({
-            showPicker: true,
-        });
+        wrapper.vm.showPicker = true;
+        await nextTick();
 
         const stopPropagation = jest.fn();
         await wrapper.find('.sw-media-field__actions_bar').trigger('click', {
@@ -124,7 +124,8 @@ describe('src/app/component/media/sw-media-field', () => {
 
     it('returns empty config when not inside a modal', async () => {
         const wrapper = await createWrapper();
-        await wrapper.setData({ showPicker: true });
+        wrapper.vm.showPicker = true;
+        await nextTick();
 
         wrapper.element.closest = jest.fn(() => null);
         expect(wrapper.vm.popoverConfig).toEqual({});
@@ -132,7 +133,8 @@ describe('src/app/component/media/sw-media-field', () => {
 
     it('returns modal targetSelector when picker open inside modal', async () => {
         const wrapper = await createWrapper();
-        await wrapper.setData({ showPicker: true });
+        wrapper.vm.showPicker = true;
+        await nextTick();
 
         const el = wrapper.element;
         el.closest = jest.fn((selector) => (selector === '.mt-modal' ? el : null));
@@ -145,7 +147,8 @@ describe('src/app/component/media/sw-media-field', () => {
 
     it('should render sw-upload-listener with correct upload tag and auto-upload', async () => {
         const wrapper = await createWrapper();
-        await wrapper.setData({ showPicker: true });
+        wrapper.vm.showPicker = true;
+        await nextTick();
 
         const uploadListener = wrapper.find('sw-upload-listener-stub');
 
@@ -156,7 +159,9 @@ describe('src/app/component/media/sw-media-field', () => {
 
     it('should set media id and close picker when upload finishes', async () => {
         const wrapper = await createWrapper();
-        await wrapper.setData({ showPicker: true, showUploadField: true });
+        wrapper.vm.showPicker = true;
+        wrapper.vm.showUploadField = true;
+        await nextTick();
 
         const targetId = 'new-media-id-123';
         wrapper.vm.exposeNewId({ targetId });

--- a/src/Administration/Resources/app/administration/src/app/component/media/sw-media-folder-item/sw-media-folder-item.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/media/sw-media-folder-item/sw-media-folder-item.spec.js
@@ -1,6 +1,7 @@
 /**
  * @sw-package discovery
  */
+import { nextTick } from 'vue';
 import { mount } from '@vue/test-utils';
 
 const { Module } = Shopware;
@@ -306,9 +307,8 @@ describe('components/media/sw-media-folder-item', () => {
 
     it('should call the api get default folder if default folder id exists', async () => {
         const wrapper = await createWrapper(ID_PRODUCTS_FOLDER);
-        await wrapper.setData({
-            lastDefaultFolderId: '',
-        });
+        wrapper.vm.lastDefaultFolderId = '';
+        await nextTick();
 
         wrapper.vm.mediaDefaultFolderRepository.get = jest.fn(() => Promise.resolve({}));
         wrapper.vm.moduleFactory.getModuleByEntityName = jest.fn(() => Promise.resolve({}));

--- a/src/Administration/Resources/app/administration/src/app/component/media/sw-media-modal-folder-settings/sw-media-modal-folder-settings.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/media/sw-media-modal-folder-settings/sw-media-modal-folder-settings.spec.js
@@ -1,6 +1,7 @@
 /**
  * @sw-package discovery
  */
+import { nextTick } from 'vue';
 import { mount } from '@vue/test-utils';
 
 let repositoryFactoryCreateMock;
@@ -248,20 +249,19 @@ describe('src/app/asyncComponent/media/sw-media-modal-folder-settings', () => {
             return { _isNew: true };
         });
 
-        await wrapper.setData({
-            thumbnailSizes: [
-                {
-                    width: 10,
-                    height: 10,
-                    deletable: true,
-                },
-                {
-                    width: 20,
-                    height: 20,
-                    deletable: false,
-                },
-            ],
-        });
+        wrapper.vm.thumbnailSizes = [
+            {
+                width: 10,
+                height: 10,
+                deletable: true,
+            },
+            {
+                width: 20,
+                height: 20,
+                deletable: false,
+            },
+        ];
+        await nextTick();
         await wrapper.vm.addThumbnail({
             width: 30,
             height: 30,
@@ -281,20 +281,19 @@ describe('src/app/asyncComponent/media/sw-media-modal-folder-settings', () => {
     it('should not be able to add a new thumbnail size if the size already exists', async () => {
         wrapper.vm.createNotificationError = jest.fn();
 
-        await wrapper.setData({
-            thumbnailSizes: [
-                {
-                    width: 10,
-                    height: 10,
-                    deletable: true,
-                },
-                {
-                    width: 20,
-                    height: 20,
-                    deletable: false,
-                },
-            ],
-        });
+        wrapper.vm.thumbnailSizes = [
+            {
+                width: 10,
+                height: 10,
+                deletable: true,
+            },
+            {
+                width: 20,
+                height: 20,
+                deletable: false,
+            },
+        ];
+        await nextTick();
         await wrapper.vm.addThumbnail({
             width: 10,
             height: 10,

--- a/src/Administration/Resources/app/administration/src/app/component/media/sw-media-modal-move/sw-media-modal-move.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/media/sw-media-modal-move/sw-media-modal-move.spec.js
@@ -1,6 +1,7 @@
 /**
  * @sw-package discovery
  */
+import { nextTick } from 'vue';
 import { mount } from '@vue/test-utils';
 import Entity from 'src/core/data/entity.data';
 
@@ -51,9 +52,8 @@ describe('components/media/sw-media-modal-move', () => {
     it('removes parent folder if current folder is root folder', async () => {
         const wrapper = await createWrapper();
 
-        await wrapper.setData({
-            parentFolder: createFolderEntity(),
-        });
+        wrapper.vm.parentFolder = createFolderEntity();
+        await nextTick();
         wrapper.vm.fetchParentFolder = jest.fn();
 
         await wrapper.vm.updateParentFolder(rootFolderObject);

--- a/src/Administration/Resources/app/administration/src/app/component/media/sw-media-preview-v2/sw-media-preview-v2.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/media/sw-media-preview-v2/sw-media-preview-v2.spec.js
@@ -1,6 +1,7 @@
 /**
  * @sw-package discovery
  */
+import { nextTick } from 'vue';
 import { mount } from '@vue/test-utils';
 import { deepMergeObject } from 'src/core/service/utils/object.utils';
 
@@ -261,7 +262,8 @@ describe('src/app/asyncComponent/media/sw-media-preview-v2', () => {
         const trueSource = new File([''], 'example.jpg', { type: 'image/jpg' });
         trueSource.thumbnails = [];
 
-        await wrapper.setData({ trueSource });
+        wrapper.vm.trueSource = trueSource;
+        await nextTick();
 
         expect(wrapper.vm.sourceSet).toBe('');
     });
@@ -271,7 +273,8 @@ describe('src/app/asyncComponent/media/sw-media-preview-v2', () => {
         const trueSource = new URL('https://example.com/image.jpg');
         trueSource.thumbnails = [];
 
-        await wrapper.setData({ trueSource });
+        wrapper.vm.trueSource = trueSource;
+        await nextTick();
 
         expect(wrapper.vm.sourceSet).toBe('');
     });

--- a/src/Administration/Resources/app/administration/src/app/component/media/sw-media-upload-v2/sw-media-upload-v2.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/media/sw-media-upload-v2/sw-media-upload-v2.spec.js
@@ -3,6 +3,7 @@
 /**
  * @sw-package discovery
  */
+import { nextTick } from 'vue';
 import { mount } from '@vue/test-utils';
 import FileValidationService from 'src/app/service/file-validation.service';
 
@@ -166,9 +167,8 @@ describe('src/app/component/media/sw-media-upload-v2', () => {
         await wrapper.setProps({
             variant: 'compact',
         });
-        await wrapper.setData({
-            isUploadUrlFeatureEnabled: true,
-        });
+        wrapper.vm.isUploadUrlFeatureEnabled = true;
+        await nextTick();
         await flushPromises();
 
         const uploadButton = wrapper.find('.sw-media-upload-v2__button-context-menu');
@@ -180,9 +180,8 @@ describe('src/app/component/media/sw-media-upload-v2', () => {
             variant: 'compact',
             disabled: true,
         });
-        await wrapper.setData({
-            isUploadUrlFeatureEnabled: true,
-        });
+        wrapper.vm.isUploadUrlFeatureEnabled = true;
+        await nextTick();
         await flushPromises();
 
         const uploadButton = wrapper.find('.sw-media-upload-v2__button-context-menu');
@@ -190,9 +189,8 @@ describe('src/app/component/media/sw-media-upload-v2', () => {
     });
 
     it('context button switch mode should be enabled', async () => {
-        await wrapper.setData({
-            isUploadUrlFeatureEnabled: true,
-        });
+        wrapper.vm.isUploadUrlFeatureEnabled = true;
+        await nextTick();
 
         const switchModeButton = wrapper.find('.sw-media-upload-v2__switch-mode');
         expect(switchModeButton.exists()).toBeTruthy();
@@ -202,9 +200,8 @@ describe('src/app/component/media/sw-media-upload-v2', () => {
         await wrapper.setProps({
             disabled: true,
         });
-        await wrapper.setData({
-            isUploadUrlFeatureEnabled: true,
-        });
+        wrapper.vm.isUploadUrlFeatureEnabled = true;
+        await nextTick();
         await flushPromises();
 
         const switchModeButton = wrapper.find('.sw-media-upload-v2__switch-mode');
@@ -391,10 +388,9 @@ describe('src/app/component/media/sw-media-upload-v2', () => {
     });
 
     it('context button switch mode should change input type when clicking on menu item', async () => {
-        await wrapper.setData({
-            isUploadUrlFeatureEnabled: true,
-            inputType: 'file-upload',
-        });
+        wrapper.vm.isUploadUrlFeatureEnabled = true;
+        wrapper.vm.inputType = 'file-upload';
+        await nextTick();
 
         const switchModeButton = wrapper.find('.sw-media-upload-v2__switch-mode');
         expect(switchModeButton.exists()).toBeTruthy();
@@ -429,10 +425,9 @@ describe('src/app/component/media/sw-media-upload-v2', () => {
     });
 
     it('should show media form when select upload by url option', async () => {
-        await wrapper.setData({
-            isUploadUrlFeatureEnabled: true,
-            inputType: 'file-upload',
-        });
+        wrapper.vm.isUploadUrlFeatureEnabled = true;
+        wrapper.vm.inputType = 'file-upload';
+        await nextTick();
         await flushPromises();
 
         expect(wrapper.vm.inputType).toBe('file-upload');
@@ -634,9 +629,8 @@ describe('src/app/component/media/sw-media-upload-v2', () => {
         wrapper.vm.mediaRepository.save = jest.fn();
         wrapper.vm.mediaService.addUpload = jest.fn();
 
-        await wrapper.setData({
-            isUploadUrlFeatureEnabled: true,
-        });
+        wrapper.vm.isUploadUrlFeatureEnabled = true;
+        await nextTick();
 
         const contextButton = await wrapper.find('.sw-media-upload-v2__switch-mode');
         await contextButton.trigger('click');

--- a/src/Administration/Resources/app/administration/src/app/component/media/sw-media-url-form/sw-media-url-form.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/media/sw-media-url-form/sw-media-url-form.spec.js
@@ -1,6 +1,7 @@
 /**
  * @sw-package discovery
  */
+import { nextTick } from 'vue';
 import { mount } from '@vue/test-utils';
 
 async function createWrapper(customOptions = {}) {
@@ -66,7 +67,8 @@ describe('src/app/component/media/sw-media-url-form', () => {
         });
         await flushPromises();
 
-        await wrapper.setData({ showModal: true });
+        wrapper.vm.showModal = true;
+        await nextTick();
         await flushPromises();
         await wrapper.vm.$nextTick();
 
@@ -110,9 +112,8 @@ describe('src/app/component/media/sw-media-url-form', () => {
 
     it('should show file extension input when URL has no extension', async () => {
         const wrapper = await createWrapper();
-        await wrapper.setData({
-            url: 'https://example.com/image',
-        });
+        wrapper.vm.url = 'https://example.com/image';
+        await nextTick();
         await flushPromises();
 
         expect(wrapper.find('.sw-media-url-form__extension-input').exists()).toBeTruthy();
@@ -120,9 +121,8 @@ describe('src/app/component/media/sw-media-url-form', () => {
 
     it('should not show file extension input when URL has extension', async () => {
         const wrapper = await createWrapper();
-        await wrapper.setData({
-            url: 'https://example.com/image.jpg',
-        });
+        wrapper.vm.url = 'https://example.com/image.jpg';
+        await nextTick();
         await flushPromises();
 
         expect(wrapper.find('.sw-media-url-form__extension-input').exists()).toBeFalsy();
@@ -130,9 +130,8 @@ describe('src/app/component/media/sw-media-url-form', () => {
 
     it('should emit media-url-form-submit event with correct data when valid URL is submitted', async () => {
         const wrapper = await createWrapper();
-        await wrapper.setData({
-            url: 'https://example.com/image.jpg',
-        });
+        wrapper.vm.url = 'https://example.com/image.jpg';
+        await nextTick();
         await flushPromises();
 
         const submitButton = wrapper.find('.sw-media-url-form__submit-button');
@@ -148,9 +147,8 @@ describe('src/app/component/media/sw-media-url-form', () => {
 
     it('should not emit media-url-form-submit event when URL is invalid', async () => {
         const wrapper = await createWrapper();
-        await wrapper.setData({
-            url: 'invalid-url',
-        });
+        wrapper.vm.url = 'invalid-url';
+        await nextTick();
         await flushPromises();
 
         const submitButton = wrapper.find('.sw-media-url-form__submit-button');
@@ -161,9 +159,8 @@ describe('src/app/component/media/sw-media-url-form', () => {
 
     it('should show error message when URL is invalid', async () => {
         const wrapper = await createWrapper();
-        await wrapper.setData({
-            url: 'invalid-url',
-        });
+        wrapper.vm.url = 'invalid-url';
+        await nextTick();
         await flushPromises();
 
         expect(wrapper.find('.sw-media-url-form__url-input').attributes('error')).toBeDefined();
@@ -184,9 +181,8 @@ describe('src/app/component/media/sw-media-url-form', () => {
 
     it('should disable submit button when URL is invalid', async () => {
         const wrapper = await createWrapper();
-        await wrapper.setData({
-            url: 'invalid-url',
-        });
+        wrapper.vm.url = 'invalid-url';
+        await nextTick();
         await flushPromises();
 
         const submitButton = wrapper.find('.sw-media-url-form__submit-button');
@@ -195,9 +191,8 @@ describe('src/app/component/media/sw-media-url-form', () => {
 
     it('should enable submit button when URL is valid', async () => {
         const wrapper = await createWrapper();
-        await wrapper.setData({
-            url: 'https://example.com/image.jpg',
-        });
+        wrapper.vm.url = 'https://example.com/image.jpg';
+        await nextTick();
         await flushPromises();
 
         const submitButton = wrapper.find('.sw-media-url-form__submit-button');
@@ -206,9 +201,8 @@ describe('src/app/component/media/sw-media-url-form', () => {
 
     it('should handle file extension from URL correctly', async () => {
         const wrapper = await createWrapper();
-        await wrapper.setData({
-            url: 'https://example.com/image.jpg',
-        });
+        wrapper.vm.url = 'https://example.com/image.jpg';
+        await nextTick();
         await flushPromises();
 
         expect(wrapper.vm.extensionFromUrl).toBe('jpg');
@@ -216,10 +210,9 @@ describe('src/app/component/media/sw-media-url-form', () => {
 
     it('should handle file extension from input when URL has no extension', async () => {
         const wrapper = await createWrapper();
-        await wrapper.setData({
-            url: 'https://example.com/image',
-            extensionFromInput: 'png',
-        });
+        wrapper.vm.url = 'https://example.com/image';
+        wrapper.vm.extensionFromInput = 'png';
+        await nextTick();
         await flushPromises();
 
         expect(wrapper.vm.fileExtension).toBe('png');
@@ -227,9 +220,8 @@ describe('src/app/component/media/sw-media-url-form', () => {
 
     it('should handle empty URL input', async () => {
         const wrapper = await createWrapper();
-        await wrapper.setData({
-            url: '',
-        });
+        wrapper.vm.url = '';
+        await nextTick();
         await flushPromises();
 
         expect(wrapper.vm.hasInvalidInput).toBeFalsy();

--- a/src/Administration/Resources/app/administration/src/app/component/modal/sw-search-preferences-modal/sw-search-preferences-modal.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/modal/sw-search-preferences-modal/sw-search-preferences-modal.spec.js
@@ -2,6 +2,7 @@
  * @sw-package framework
  */
 
+import { nextTick } from 'vue';
 import { mount } from '@vue/test-utils';
 
 async function createWrapper() {
@@ -71,24 +72,23 @@ describe('src/app/component/modal/sw-search-preferences-modal', () => {
     });
 
     it('should be able to change search preference', async () => {
-        await wrapper.setData({
-            searchPreferences: [
-                {
-                    entityName: 'product',
-                    _searchable: false,
-                    fields: [
-                        {
-                            fieldName: 'name',
-                            _searchable: false,
-                        },
-                        {
-                            fieldName: 'productNumber',
-                            _searchable: false,
-                        },
-                    ],
-                },
-            ],
-        });
+        wrapper.vm.searchPreferences = [
+            {
+                entityName: 'product',
+                _searchable: false,
+                fields: [
+                    {
+                        fieldName: 'name',
+                        _searchable: false,
+                    },
+                    {
+                        fieldName: 'productNumber',
+                        _searchable: false,
+                    },
+                ],
+            },
+        ];
+        await nextTick();
 
         wrapper.vm.searchPreferences[0]._searchable = true;
         wrapper.vm.onChangeSearchPreference(wrapper.vm.searchPreferences[0]);
@@ -114,24 +114,23 @@ describe('src/app/component/modal/sw-search-preferences-modal', () => {
     });
 
     it('should not be able to change search preference', async () => {
-        await wrapper.setData({
-            searchPreferences: [
-                {
-                    entityName: 'product',
-                    _searchable: false,
-                    fields: [
-                        {
-                            fieldName: 'name',
-                            _searchable: true,
-                        },
-                        {
-                            fieldName: 'productNumber',
-                            _searchable: false,
-                        },
-                    ],
-                },
-            ],
-        });
+        wrapper.vm.searchPreferences = [
+            {
+                entityName: 'product',
+                _searchable: false,
+                fields: [
+                    {
+                        fieldName: 'name',
+                        _searchable: true,
+                    },
+                    {
+                        fieldName: 'productNumber',
+                        _searchable: false,
+                    },
+                ],
+            },
+        ];
+        await nextTick();
 
         wrapper.vm.searchPreferences[0]._searchable = true;
         wrapper.vm.onChangeSearchPreference(wrapper.vm.searchPreferences[0]);

--- a/src/Administration/Resources/app/administration/src/app/component/rule/condition-type/sw-condition-shipping-zip-code/sw-condition-shipping-zip-code.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/rule/condition-type/sw-condition-shipping-zip-code/sw-condition-shipping-zip-code.spec.js
@@ -1,6 +1,7 @@
 /**
  * @sw-package fundamentals@after-sales
  */
+import { nextTick } from 'vue';
 import { mount } from '@vue/test-utils';
 import ConditionDataProviderService from 'src/app/service/rule-condition.service';
 
@@ -58,9 +59,8 @@ describe('components/rule/condition-type/sw-condition-shipping-zip-code', () => 
                 },
             },
         });
-        await wrapper.setData({
-            isNumeric: true,
-        });
+        wrapper.vm.isNumeric = true;
+        await nextTick();
         await flushPromises();
         const swNumberFields = wrapper.findAll('.mt-number-field');
 
@@ -79,9 +79,8 @@ describe('components/rule/condition-type/sw-condition-shipping-zip-code', () => 
                 },
             },
         });
-        await wrapper.setData({
-            isNumeric: false,
-        });
+        wrapper.vm.isNumeric = false;
+        await nextTick();
         await flushPromises();
 
         const tagList = wrapper.find('.sw-tagged-field__tag-list');

--- a/src/Administration/Resources/app/administration/src/app/component/structure/sw-block-override/sw-block/sw-block.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/structure/sw-block-override/sw-block/sw-block.spec.js
@@ -2,6 +2,7 @@
  * @sw-package framework
  * @group disabledCompat
  */
+import { nextTick } from 'vue';
 import { mount } from '@vue/test-utils';
 import blockOverrideStore from '../../../../store/block-override.store';
 import createDataScopeFixture from '../sw-block-override.spec/test-utils/create-data-scope-fixture';
@@ -47,9 +48,8 @@ async function createWrapper({
     );
 
     async function toggleExtensions() {
-        await wrapper.setData({
-            renderExtensions: !wrapper.vm.renderExtensions,
-        });
+        wrapper.vm.renderExtensions = !wrapper.vm.renderExtensions;
+        await nextTick();
     }
 
     return {
@@ -320,9 +320,12 @@ describe('sw-block', () => {
 
         // Each setData triggers a reactive re-render that causes sw-block's computed
         // to run again. With the old push(), each run added a stale entry.
-        await wrapper.setData({ label: 'a' });
-        await wrapper.setData({ label: 'ab' });
-        await wrapper.setData({ label: 'abc' });
+        wrapper.vm.label = 'a';
+        await nextTick();
+        wrapper.vm.label = 'ab';
+        await nextTick();
+        wrapper.vm.label = 'abc';
+        await nextTick();
 
         // Unmount then remount the extension to create a fresh sw-block-parent
         // instance that runs setup() and pops from providedParents.
@@ -345,9 +348,12 @@ describe('sw-block', () => {
 
         const domNodeBefore = wrapper.find('.default-content').element;
 
-        await wrapper.setData({ label: 'a' });
-        await wrapper.setData({ label: 'ab' });
-        await wrapper.setData({ label: 'abc' });
+        wrapper.vm.label = 'a';
+        await nextTick();
+        wrapper.vm.label = 'ab';
+        await nextTick();
+        wrapper.vm.label = 'abc';
+        await nextTick();
 
         expect(wrapper.find('.default-content').element).toBe(domNodeBefore);
         expect(wrapper.find('.default-content').text()).toBe('abc');
@@ -456,7 +462,8 @@ describe('sw-block', () => {
                 },
             );
 
-            await wrapper.setData({ blockName: 'changed-block-name' });
+            wrapper.vm.blockName = 'changed-block-name';
+            await nextTick();
 
             expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('[sw-block]'));
             expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('"name" prop changed'));

--- a/src/Administration/Resources/app/administration/src/app/component/structure/sw-search-bar/sw-search-bar.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/structure/sw-search-bar/sw-search-bar.spec.js
@@ -4,6 +4,7 @@
  * @sw-package framework
  */
 
+import { nextTick } from 'vue';
 import { mount } from '@vue/test-utils';
 import 'src/app/component/structure/sw-search-bar';
 import 'src/app/component/structure/sw-search-bar-item';
@@ -534,10 +535,9 @@ describe('src/app/component/structure/sw-search-bar', () => {
         const input = wrapper.find('.sw-search-bar__input');
         const blurSpy = jest.spyOn(input.element, 'blur');
 
-        await wrapper.setData({
-            showTypeSelectContainer: true,
-            showResultsContainer: true,
-        });
+        wrapper.vm.showTypeSelectContainer = true;
+        wrapper.vm.showResultsContainer = true;
+        await nextTick();
 
         await input.trigger('keyup.esc');
 
@@ -1364,9 +1364,8 @@ describe('src/app/component/structure/sw-search-bar', () => {
     it('should be able to turn on search preferences modal', async () => {
         wrapper = await createWrapper();
 
-        await wrapper.setData({
-            showSearchPreferencesModal: true,
-        });
+        wrapper.vm.showSearchPreferencesModal = true;
+        await nextTick();
 
         expect(wrapper.find('sw-search-preferences-modal-stub').exists()).toBe(true);
     });
@@ -1374,9 +1373,8 @@ describe('src/app/component/structure/sw-search-bar', () => {
     it('should be able to turn off search preferences modal', async () => {
         wrapper = await createWrapper();
 
-        await wrapper.setData({
-            showSearchPreferencesModal: false,
-        });
+        wrapper.vm.showSearchPreferencesModal = false;
+        await nextTick();
 
         expect(wrapper.find('sw-search-preferences-modal-stub').exists()).toBe(false);
     });
@@ -1542,7 +1540,8 @@ describe('src/app/component/structure/sw-search-bar', () => {
         expect(wrapper.vm.isComponentMounted).toBe(true);
         expect(wrapper.vm.currentSearchType).toBe('product');
 
-        await wrapper.setData({ searchTerm: '' });
+        wrapper.vm.searchTerm = '';
+        await nextTick();
         wrapper.vm.resetSearchType();
 
         expect(wrapper.vm.isComponentMounted).toBe(false);

--- a/src/Administration/Resources/app/administration/src/app/component/tree/sw-tree/sw-tree.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/tree/sw-tree/sw-tree.spec.js
@@ -4,6 +4,7 @@
  * @sw-package framework
  */
 
+import { nextTick } from 'vue';
 import { mount } from '@vue/test-utils';
 import getTreeItems from './fixtures/treeItems';
 
@@ -173,9 +174,8 @@ describe('src/app/component/tree/sw-tree', () => {
 
         expect(wrapper.find('.sw-tree-actions__delete_categories').exists()).toBeFalsy();
 
-        await wrapper.setData({
-            checkedElementsCount: 2,
-        });
+        wrapper.vm.checkedElementsCount = 2;
+        await nextTick();
 
         expect(wrapper.find('.sw-tree-actions__delete_categories').exists()).toBeTruthy();
     });
@@ -185,9 +185,8 @@ describe('src/app/component/tree/sw-tree', () => {
 
         expect(wrapper.find('.sw-tree-actions__delete_categories').exists()).toBeFalsy();
 
-        await wrapper.setData({
-            checkedElementsCount: 2,
-        });
+        wrapper.vm.checkedElementsCount = 2;
+        await nextTick();
 
         await flushPromises();
 
@@ -203,9 +202,8 @@ describe('src/app/component/tree/sw-tree', () => {
             allowDeleteCategories: false,
         });
 
-        await wrapper.setData({
-            checkedElementsCount: 2,
-        });
+        wrapper.vm.checkedElementsCount = 2;
+        await nextTick();
 
         expect(wrapper.find('.sw-tree-actions__delete_categories').attributes().disabled).toBeDefined();
     });

--- a/src/Administration/Resources/app/administration/src/app/component/utils/sw-duplicated-media-v2/sw-duplicated-media-v2.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/utils/sw-duplicated-media-v2/sw-duplicated-media-v2.spec.js
@@ -2,6 +2,7 @@
  * @sw-package framework
  */
 
+import { nextTick } from 'vue';
 import { mount } from '@vue/test-utils';
 
 const uploadTaskMock = {
@@ -108,7 +109,8 @@ describe('components/utils/sw-duplicated-media-v2', () => {
 
     it('should keep the existing file', async () => {
         wrapper.vm.defaultOption = 'Keep';
-        await wrapper.setData({ failedUploadTasks: [uploadTaskMock] });
+        wrapper.vm.failedUploadTasks = [uploadTaskMock];
+        await nextTick();
 
         await wrapper.vm.solveDuplicate();
         await wrapper.vm.$nextTick();
@@ -120,7 +122,8 @@ describe('components/utils/sw-duplicated-media-v2', () => {
 
     it('should replace the file on the server with the local file', async () => {
         wrapper.vm.defaultOption = 'Replace';
-        await wrapper.setData({ failedUploadTasks: [uploadTaskMock] });
+        wrapper.vm.failedUploadTasks = [uploadTaskMock];
+        await nextTick();
         await flushPromises();
 
         const radio = wrapper.find('input[type="radio"]');

--- a/src/Administration/Resources/app/administration/src/app/component/utils/sw-provide/sw-provide.spec.ts
+++ b/src/Administration/Resources/app/administration/src/app/component/utils/sw-provide/sw-provide.spec.ts
@@ -2,6 +2,7 @@
  * @sw-package framework
  */
 
+import { nextTick } from 'vue';
 import { mount } from '@vue/test-utils';
 
 async function createWrapper({ template = '<sw-provide />', components = {}, data = {} } = {}) {
@@ -67,7 +68,8 @@ describe('src/app/component/base/sw-provide', () => {
         });
 
         expect(wrapper.text()).toBe('bar');
-        await wrapper.setData({ foo: 'baz' });
+        wrapper.vm.foo = 'baz';
+        await nextTick();
         expect(wrapper.text()).toBe('baz');
     });
 

--- a/src/Administration/Resources/app/administration/src/app/component/utils/sw-shortcut-overview/sw-shortcut-overview.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/utils/sw-shortcut-overview/sw-shortcut-overview.spec.js
@@ -1,3 +1,4 @@
+import { nextTick } from 'vue';
 import { mount } from '@vue/test-utils';
 
 /**
@@ -36,9 +37,8 @@ describe('app/component/utils/sw-shortcut-overview', () => {
     it('should add the privilege attribute to some shortcut-overview-items', async () => {
         const { wrapper } = await createWrapper();
 
-        await wrapper.setData({
-            showShortcutOverviewModal: true,
-        });
+        wrapper.vm.showShortcutOverviewModal = true;
+        await nextTick();
 
         const privilegeSystemClearCacheItems = wrapper.findAll(
             'sw-shortcut-overview-item-stub[privilege="system.clear_cache"]',
@@ -54,9 +54,8 @@ describe('app/component/utils/sw-shortcut-overview', () => {
     it('should only show shortcuts for the current platform', async () => {
         const { wrapper } = await createWrapper('MacIntel');
 
-        await wrapper.setData({
-            showShortcutOverviewModal: true,
-        });
+        wrapper.vm.showShortcutOverviewModal = true;
+        await nextTick();
 
         const generalShortcuts = wrapper.vm.sections.generalShortcuts;
 
@@ -87,9 +86,8 @@ describe('app/component/utils/sw-shortcut-overview', () => {
     it('should show general shortcuts as the first section', async () => {
         const { wrapper } = await createWrapper();
 
-        await wrapper.setData({
-            showShortcutOverviewModal: true,
-        });
+        wrapper.vm.showShortcutOverviewModal = true;
+        await nextTick();
 
         const generalShortcuts = wrapper.vm.sections.generalShortcuts;
         const sections = wrapper.findAll('.sw-shortcut-overview__section');
@@ -130,9 +128,8 @@ describe('app/component/utils/sw-shortcut-overview', () => {
     it('should show accessibility shortcuts in a separate section', async () => {
         const { wrapper } = await createWrapper();
 
-        await wrapper.setData({
-            showShortcutOverviewModal: true,
-        });
+        wrapper.vm.showShortcutOverviewModal = true;
+        await nextTick();
 
         const accessibilityShortcuts = wrapper.vm.sections.accessibility;
 
@@ -180,9 +177,8 @@ describe('app/component/utils/sw-shortcut-overview', () => {
     it('should show the footer actions', async () => {
         const { wrapper } = await createWrapper();
 
-        await wrapper.setData({
-            showShortcutOverviewModal: true,
-        });
+        wrapper.vm.showShortcutOverviewModal = true;
+        await nextTick();
 
         const disableShortcutsToggle = wrapper.find('mt-switch-stub');
         const closeButton = wrapper.find('mt-button-stub');

--- a/src/Administration/Resources/app/administration/src/app/mixin/generic-condition.mixin.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/mixin/generic-condition.mixin.spec.js
@@ -1,6 +1,7 @@
 /**
  * @sw-package framework
  */
+import { nextTick } from 'vue';
 import { mount } from '@vue/test-utils';
 
 const defaultData = {
@@ -196,7 +197,8 @@ describe('app/mixin/generic-condition', () => {
     ])('should validate if field has between operator: $name', async ({ type, operator, expected }) => {
         const wrapper = await createWrapper();
 
-        await wrapper.setData({ operator });
+        wrapper.vm.operator = operator;
+        await nextTick();
 
         expect(wrapper.vm.isBetweenDateField({ type })).toBe(expected);
     });

--- a/src/Administration/Resources/app/administration/src/app/mixin/listing.mixin.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/mixin/listing.mixin.spec.js
@@ -3,6 +3,7 @@
 /**
  * @sw-package framework
  */
+import { nextTick } from 'vue';
 import 'src/app/mixin/listing.mixin';
 import { mount, config } from '@vue/test-utils';
 import { createRouter, createWebHashHistory } from 'vue-router';
@@ -394,51 +395,44 @@ describe('src/app/mixin/listing.mixin.ts', () => {
     it('should set freshSearchTerm to true when "term" changes', async () => {
         expect(wrapper.vm.freshSearchTerm).toBe(false);
 
-        await wrapper.setData({
-            term: 'test',
-        });
+        wrapper.vm.term = 'test';
+        await nextTick();
 
         expect(wrapper.vm.freshSearchTerm).toBe(true);
     });
 
     it('should set freshSearchTerm to false when "term" is cleared', async () => {
-        await wrapper.setData({
-            term: 'test',
-        });
+        wrapper.vm.term = 'test';
+        await nextTick();
 
         expect(wrapper.vm.freshSearchTerm).toBe(true);
 
-        await wrapper.setData({
-            term: '',
-        });
+        wrapper.vm.term = '';
+        await nextTick();
 
         expect(wrapper.vm.freshSearchTerm).toBe(false);
     });
 
     it('should set freshSearchTerm to false when "sortBy" changes', async () => {
-        await wrapper.setData({
-            term: 'test',
-        });
+        wrapper.vm.term = 'test';
+        await nextTick();
 
         expect(wrapper.vm.freshSearchTerm).toBe(true);
 
-        await wrapper.setData({
-            sortBy: 'test',
-        });
+        wrapper.vm.sortBy = 'test';
+        await nextTick();
 
         expect(wrapper.vm.freshSearchTerm).toBe(false);
     });
 
     it('should set freshSearchTerm to false when "sortDirection" changes', async () => {
-        await wrapper.setData({
-            term: 'test',
-        });
+        wrapper.vm.term = 'test';
+        await nextTick();
 
         expect(wrapper.vm.freshSearchTerm).toBe(true);
 
-        await wrapper.setData({
-            sortDirection: 'test',
-        });
+        wrapper.vm.sortDirection = 'test';
+        await nextTick();
 
         expect(wrapper.vm.freshSearchTerm).toBe(false);
     });
@@ -475,14 +469,13 @@ describe('src/app/mixin/listing.mixin.ts', () => {
             },
         });
 
-        await wrapper.setData({
-            page: 7,
-            limit: 100,
-            naturalSorting: true,
-            sortBy: 'name',
-            sortDirection: 'ASC',
-            term: 'Fooooo',
-        });
+        wrapper.vm.page = 7;
+        wrapper.vm.limit = 100;
+        wrapper.vm.naturalSorting = true;
+        wrapper.vm.sortBy = 'name';
+        wrapper.vm.sortDirection = 'ASC';
+        wrapper.vm.term = 'Fooooo';
+        await nextTick();
 
         expect(wrapper.vm.getMainListingParams()).toEqual({
             page: 7,

--- a/src/Administration/Resources/app/administration/src/core/factory/async-component.factory.spec/legacy-twig-shim-condition-chains.spec.js
+++ b/src/Administration/Resources/app/administration/src/core/factory/async-component.factory.spec/legacy-twig-shim-condition-chains.spec.js
@@ -2,6 +2,7 @@
  * @sw-package framework
  */
 
+import { nextTick } from 'vue';
 import { mount } from '@vue/test-utils';
 import {
     ComponentFactory,
@@ -63,7 +64,8 @@ describe('core/factory/async-component.factory.ts - legacy Twig shim condition c
         expect(wrapper.find('.true-case').exists()).toBe(false);
         expect(wrapper.find('.false-case').exists()).toBe(true);
 
-        await wrapper.setData({ isConditionTrue: true });
+        wrapper.vm.isConditionTrue = true;
+        await nextTick();
 
         expect(wrapper.find('.true-case').exists()).toBe(true);
         expect(wrapper.find('.false-case').exists()).toBe(false);
@@ -150,20 +152,21 @@ describe('core/factory/async-component.factory.ts - legacy Twig shim condition c
 
         expectOnlyBranch(wrapper, branches, '.fallback-condition');
 
-        await wrapper.setData({ condition2: true });
+        wrapper.vm.condition2 = true;
+        await nextTick();
         await settleLegacyChain(wrapper);
 
         expectOnlyBranch(wrapper, branches, '.condition-two');
 
-        await wrapper.setData({ condition1: true });
+        wrapper.vm.condition1 = true;
+        await nextTick();
         await settleLegacyChain(wrapper);
 
         expectOnlyBranch(wrapper, branches, '.condition-one');
 
-        await wrapper.setData({
-            condition1: false,
-            condition2: false,
-        });
+        wrapper.vm.condition1 = false;
+        wrapper.vm.condition2 = false;
+        await nextTick();
         await settleLegacyChain(wrapper);
 
         expectOnlyBranch(wrapper, branches, '.fallback-condition');
@@ -210,7 +213,8 @@ describe('core/factory/async-component.factory.ts - legacy Twig shim condition c
         expect(wrapper.find('.condition-two').exists()).toBe(true);
         expect(wrapper.find('.native-fallback-condition').exists()).toBe(false);
 
-        await wrapper.setData({ condition2: false });
+        wrapper.vm.condition2 = false;
+        await nextTick();
         await settleLegacyChain(wrapper);
 
         expect(wrapper.find('.condition-one').exists()).toBe(false);
@@ -266,23 +270,22 @@ describe('core/factory/async-component.factory.ts - legacy Twig shim condition c
         await settleLegacyChain(wrapper);
         expectOnlyBranch(wrapper, branches, '.plugin-two');
 
-        await wrapper.setData({ condition1: true });
+        wrapper.vm.condition1 = true;
+        await nextTick();
         await settleLegacyChain(wrapper);
 
         expectOnlyBranch(wrapper, branches, '.native-one');
 
-        await wrapper.setData({
-            condition1: false,
-            condition2: true,
-        });
+        wrapper.vm.condition1 = false;
+        wrapper.vm.condition2 = true;
+        await nextTick();
         await settleLegacyChain(wrapper);
 
         expectOnlyBranch(wrapper, branches, null);
 
-        await wrapper.setData({
-            condition2: false,
-            conditionFromPlugin: false,
-        });
+        wrapper.vm.condition2 = false;
+        wrapper.vm.conditionFromPlugin = false;
+        await nextTick();
         await settleLegacyChain(wrapper);
 
         expectOnlyBranch(wrapper, branches, null);
@@ -335,7 +338,8 @@ describe('core/factory/async-component.factory.ts - legacy Twig shim condition c
 
         expectOnlyBranch(wrapper, branches, '.plugin-two-fallback');
 
-        await wrapper.setData({ conditionFromPluginOne: true });
+        wrapper.vm.conditionFromPluginOne = true;
+        await nextTick();
         await settleLegacyChain(wrapper);
 
         expectOnlyBranch(wrapper, branches, '.plugin-one-condition');

--- a/src/Administration/Resources/app/administration/src/core/factory/async-component.factory.spec/native-block-condition-chains.spec.js
+++ b/src/Administration/Resources/app/administration/src/core/factory/async-component.factory.spec/native-block-condition-chains.spec.js
@@ -2,6 +2,7 @@
  * @sw-package framework
  */
 
+import { nextTick } from 'vue';
 import {
     ComponentFactory,
     expectOnlyBranch,
@@ -97,21 +98,22 @@ describe('core/factory/async-component.factory.ts - native block condition chain
 
         expectOnlyBranch(wrapper, branches, '.condition-three');
 
-        await wrapper.setData({ condition2: true });
+        wrapper.vm.condition2 = true;
+        await nextTick();
         await wrapper.vm.$nextTick();
 
         expectOnlyBranch(wrapper, branches, '.condition-two');
 
-        await wrapper.setData({ condition1: true });
+        wrapper.vm.condition1 = true;
+        await nextTick();
         await wrapper.vm.$nextTick();
 
         expectOnlyBranch(wrapper, branches, '.condition-one');
 
-        await wrapper.setData({
-            condition1: false,
-            condition2: false,
-            condition3: false,
-        });
+        wrapper.vm.condition1 = false;
+        wrapper.vm.condition2 = false;
+        wrapper.vm.condition3 = false;
+        await nextTick();
         await wrapper.vm.$nextTick();
 
         expectOnlyBranch(wrapper, branches, null);
@@ -222,15 +224,15 @@ describe('core/factory/async-component.factory.ts - native block condition chain
 
         expectOnlyBranch(wrapper, branches, '.restart');
 
-        await wrapper.setData({
-            showRestart: false,
-            showRestartAlternative: true,
-        });
+        wrapper.vm.showRestart = false;
+        wrapper.vm.showRestartAlternative = true;
+        await nextTick();
         await wrapper.vm.$nextTick();
 
         expectOnlyBranch(wrapper, branches, '.alternative');
 
-        await wrapper.setData({ showRestartAlternative: false });
+        wrapper.vm.showRestartAlternative = false;
+        await nextTick();
         await wrapper.vm.$nextTick();
 
         expectOnlyBranch(wrapper, branches, '.restart-fallback');
@@ -271,7 +273,8 @@ describe('core/factory/async-component.factory.ts - native block condition chain
         expectOnlyBranch(wrapper, branches, '.extension-fallback');
         expect(legacyConditionContext[chainKey]).toBeDefined();
 
-        await wrapper.setData({ showBaseCondition: true });
+        wrapper.vm.showBaseCondition = true;
+        await nextTick();
         await wrapper.vm.$nextTick();
 
         expectOnlyBranch(wrapper, branches, '.base-condition');

--- a/src/Administration/Resources/app/administration/src/module/sw-bulk-edit/component/sw-bulk-edit-order/sw-bulk-edit-order-documents/sw-bulk-edit-order-documents.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-bulk-edit/component/sw-bulk-edit-order/sw-bulk-edit-order-documents/sw-bulk-edit-order-documents.spec.js
@@ -1,6 +1,7 @@
 /**
  * @sw-package checkout
  */
+import { nextTick } from 'vue';
 import { mount } from '@vue/test-utils';
 
 const documentTypesFixtures = [
@@ -65,14 +66,13 @@ describe('sw-bulk-edit-order-documents', () => {
     });
 
     it('should disable document types correctly', async () => {
-        await wrapper.setData({
-            documentTypes: [
-                {
-                    name: 'Invoice',
-                    technicalName: 'invoice',
-                },
-            ],
-        });
+        wrapper.vm.documentTypes = [
+            {
+                name: 'Invoice',
+                technicalName: 'invoice',
+            },
+        ];
+        await nextTick();
         await wrapper.setProps({
             documents: {
                 disabled: true,

--- a/src/Administration/Resources/app/administration/src/module/sw-bulk-edit/page/sw-bulk-edit-customer/sw-bulk-edit-customer.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-bulk-edit/page/sw-bulk-edit-customer/sw-bulk-edit-customer.spec.js
@@ -3,6 +3,7 @@
 /**
  * @sw-package checkout
  */
+import { nextTick } from 'vue';
 import { config, mount } from '@vue/test-utils';
 import { createRouter, createWebHashHistory } from 'vue-router';
 
@@ -300,9 +301,8 @@ describe('src/module/sw-bulk-edit/page/sw-bulk-edit-customer', () => {
         wrapper = await createWrapper();
 
         Shopware.Store.get('swBulkEdit').selectedIds = [];
-        await wrapper.setData({
-            isLoading: false,
-        });
+        wrapper.vm.isLoading = false;
+        await nextTick();
 
         expect(wrapper.find('.mt-empty-state__headline').text()).toBe('sw-bulk-edit.customer.messageEmptyTitle');
     });

--- a/src/Administration/Resources/app/administration/src/module/sw-bulk-edit/page/sw-bulk-edit-order/sw-bulk-edit-order.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-bulk-edit/page/sw-bulk-edit-order/sw-bulk-edit-order.spec.js
@@ -3,6 +3,7 @@
 /**
  * @sw-package checkout
  */
+import { nextTick } from 'vue';
 import { config, mount } from '@vue/test-utils';
 import { createRouter, createWebHashHistory } from 'vue-router';
 import Criteria from 'src/core/data/criteria.data';
@@ -579,9 +580,8 @@ describe('src/module/sw-bulk-edit/page/sw-bulk-edit-order', () => {
         wrapper = await createWrapper();
 
         Shopware.Store.get('swBulkEdit').selectedIds = [];
-        await wrapper.setData({
-            isLoading: false,
-        });
+        wrapper.vm.isLoading = false;
+        await nextTick();
         await flushPromises();
 
         expect(wrapper.vm.selectedIds).toHaveLength(0);

--- a/src/Administration/Resources/app/administration/src/module/sw-category/component/sw-category-detail-menu/sw-category-detail-menu.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-category/component/sw-category-detail-menu/sw-category-detail-menu.spec.js
@@ -1,6 +1,7 @@
 /**
  * @sw-package discovery
  */
+import { nextTick } from 'vue';
 import { mount } from '@vue/test-utils';
 
 async function createWrapper({ mediaRepositoryMock = undefined } = {}) {
@@ -115,7 +116,8 @@ describe('src/module/sw-category/component/sw-category-detail-menu', () => {
     it('should open media modal', async () => {
         const { wrapper } = await createWrapper();
 
-        await wrapper.setData({ showMediaModal: true });
+        wrapper.vm.showMediaModal = true;
+        await nextTick();
 
         const mediaModal = wrapper.find('.sw-media-modal-v2');
 
@@ -133,7 +135,8 @@ describe('src/module/sw-category/component/sw-category-detail-menu', () => {
     it('should be able to change category media', async () => {
         const { wrapper, repositorySpy } = await createWrapper({ mediaRepositoryMock: { id: 'id' } });
 
-        await wrapper.setData({ showMediaModal: true });
+        wrapper.vm.showMediaModal = true;
+        await nextTick();
         const button = wrapper.find('.sw-media-modal-v2 button');
         await button.trigger('click');
 

--- a/src/Administration/Resources/app/administration/src/module/sw-category/component/sw-category-tree/sw-category-tree.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-category/component/sw-category-tree/sw-category-tree.spec.js
@@ -3,6 +3,7 @@
 /**
  * @sw-package discovery
  */
+import { nextTick } from 'vue';
 import { mount } from '@vue/test-utils';
 import { createRouter, createWebHashHistory } from 'vue-router';
 
@@ -202,9 +203,8 @@ describe('src/module/sw-category/component/sw-category-tree', () => {
     it('should be able to sort the items', async () => {
         const wrapper = await createWrapper();
 
-        await wrapper.setData({
-            isLoadingInitialData: false,
-        });
+        wrapper.vm.isLoadingInitialData = false;
+        await nextTick();
 
         const tree = wrapper.find('.sw-tree');
         expect(tree.attributes().sortable).toBeDefined();
@@ -213,9 +213,8 @@ describe('src/module/sw-category/component/sw-category-tree', () => {
     it('should not be able to sort the items', async () => {
         const wrapper = await createWrapper();
 
-        await wrapper.setData({
-            isLoadingInitialData: false,
-        });
+        wrapper.vm.isLoadingInitialData = false;
+        await nextTick();
 
         await wrapper.setProps({
             allowEdit: false,
@@ -227,9 +226,8 @@ describe('src/module/sw-category/component/sw-category-tree', () => {
     it('should be able to delete the items in sw-tree', async () => {
         const wrapper = await createWrapper();
 
-        await wrapper.setData({
-            isLoadingInitialData: false,
-        });
+        wrapper.vm.isLoadingInitialData = false;
+        await nextTick();
 
         const tree = wrapper.find('.sw-tree');
         expect(tree.attributes()['allow-delete-categories']).toBeDefined();
@@ -238,9 +236,8 @@ describe('src/module/sw-category/component/sw-category-tree', () => {
     it('should not be able to delete the items in sw-tree', async () => {
         const wrapper = await createWrapper();
 
-        await wrapper.setData({
-            isLoadingInitialData: false,
-        });
+        wrapper.vm.isLoadingInitialData = false;
+        await nextTick();
 
         await wrapper.setProps({
             allowDelete: false,
@@ -253,9 +250,8 @@ describe('src/module/sw-category/component/sw-category-tree', () => {
     it('should be able to create new categories in sw-tree-item', async () => {
         const wrapper = await createWrapper();
 
-        await wrapper.setData({
-            isLoadingInitialData: false,
-        });
+        wrapper.vm.isLoadingInitialData = false;
+        await nextTick();
 
         const treeItem = wrapper.find('sw-tree-item-stub');
         expect(treeItem.attributes()['allow-new-categories']).toBeDefined();
@@ -264,9 +260,8 @@ describe('src/module/sw-category/component/sw-category-tree', () => {
     it('should not be able to create new categories in sw-tree-item', async () => {
         const wrapper = await createWrapper();
 
-        await wrapper.setData({
-            isLoadingInitialData: false,
-        });
+        wrapper.vm.isLoadingInitialData = false;
+        await nextTick();
 
         await wrapper.setProps({
             allowCreate: false,
@@ -279,9 +274,8 @@ describe('src/module/sw-category/component/sw-category-tree', () => {
     it('should be able to delete categories in sw-tree-item', async () => {
         const wrapper = await createWrapper();
 
-        await wrapper.setData({
-            isLoadingInitialData: false,
-        });
+        wrapper.vm.isLoadingInitialData = false;
+        await nextTick();
 
         const treeItem = wrapper.find('sw-tree-item-stub');
         expect(treeItem.attributes()['allow-delete-categories']).toBeDefined();
@@ -290,9 +284,8 @@ describe('src/module/sw-category/component/sw-category-tree', () => {
     it('should not be able to delete categories in sw-tree-item', async () => {
         const wrapper = await createWrapper();
 
-        await wrapper.setData({
-            isLoadingInitialData: false,
-        });
+        wrapper.vm.isLoadingInitialData = false;
+        await nextTick();
 
         await wrapper.setProps({
             allowDelete: false,
@@ -305,9 +298,8 @@ describe('src/module/sw-category/component/sw-category-tree', () => {
     it('should show the checkbox in sw-tree-item', async () => {
         const wrapper = await createWrapper();
 
-        await wrapper.setData({
-            isLoadingInitialData: false,
-        });
+        wrapper.vm.isLoadingInitialData = false;
+        await nextTick();
 
         const treeItem = wrapper.find('sw-tree-item-stub');
         expect(treeItem.attributes()['display-checkbox']).toBeDefined();
@@ -316,9 +308,8 @@ describe('src/module/sw-category/component/sw-category-tree', () => {
     it('should not show the checkbox in sw-tree-item', async () => {
         const wrapper = await createWrapper();
 
-        await wrapper.setData({
-            isLoadingInitialData: false,
-        });
+        wrapper.vm.isLoadingInitialData = false;
+        await nextTick();
 
         await wrapper.setProps({
             allowEdit: false,
@@ -331,9 +322,8 @@ describe('src/module/sw-category/component/sw-category-tree', () => {
     it('should show the custom tooltip text in sw-tree-item', async () => {
         const wrapper = await createWrapper();
 
-        await wrapper.setData({
-            isLoadingInitialData: false,
-        });
+        wrapper.vm.isLoadingInitialData = false;
+        await nextTick();
 
         await wrapper.setProps({
             allowEdit: false,
@@ -346,9 +336,8 @@ describe('src/module/sw-category/component/sw-category-tree', () => {
     it('should not show the custom tooltip text in sw-tree-item', async () => {
         const wrapper = await createWrapper();
 
-        await wrapper.setData({
-            isLoadingInitialData: false,
-        });
+        wrapper.vm.isLoadingInitialData = false;
+        await nextTick();
 
         const treeItem = wrapper.find('sw-tree-item-stub');
         expect(treeItem.attributes()['context-menu-tooltip-text']).toBeUndefined();
@@ -357,9 +346,8 @@ describe('src/module/sw-category/component/sw-category-tree', () => {
     it('should get right category url', async () => {
         const wrapper = await createWrapper();
 
-        await wrapper.setData({
-            isLoadingInitialData: false,
-        });
+        wrapper.vm.isLoadingInitialData = false;
+        await nextTick();
 
         const itemUrl = wrapper.vm.getCategoryUrl({ id: '1a2b' });
         expect(itemUrl).toBe('#/category/detail/1a2b');
@@ -368,9 +356,8 @@ describe('src/module/sw-category/component/sw-category-tree', () => {
     it('should get wrong category url', async () => {
         const wrapper = await createWrapper();
 
-        await wrapper.setData({
-            isLoadingInitialData: false,
-        });
+        wrapper.vm.isLoadingInitialData = false;
+        await nextTick();
 
         const itemUrl = wrapper.vm.getCategoryUrl({ id: '1a2b' });
         expect(itemUrl).not.toBe('#/detail/1a2b');
@@ -420,9 +407,8 @@ describe('src/module/sw-category/component/sw-category-tree', () => {
             const wrapper = await createWrapper();
             wrapper.vm.createNotificationError = jest.fn();
 
-            await wrapper.setData({
-                isLoadingInitialData: false,
-            });
+            wrapper.vm.isLoadingInitialData = false;
+            await nextTick();
 
             const category = {
                 id: '1a',
@@ -448,9 +434,8 @@ describe('src/module/sw-category/component/sw-category-tree', () => {
         const wrapper = await createWrapper();
         wrapper.vm.createNotificationError = jest.fn();
 
-        await wrapper.setData({
-            isLoadingInitialData: false,
-        });
+        wrapper.vm.isLoadingInitialData = false;
+        await nextTick();
 
         const entryPoint = {
             serviceSalesChannels: [{ id: '4d9ef75adbb149aa99785a0a969b3b7a' }],
@@ -478,9 +463,8 @@ describe('src/module/sw-category/component/sw-category-tree', () => {
         const wrapper = await createWrapper();
         wrapper.vm.createNotificationError = jest.fn();
 
-        await wrapper.setData({
-            isLoadingInitialData: false,
-        });
+        wrapper.vm.isLoadingInitialData = false;
+        await nextTick();
 
         const category = {
             id: '1a',
@@ -500,9 +484,8 @@ describe('src/module/sw-category/component/sw-category-tree', () => {
     it('should be able to set elements count when delete category is checked', async () => {
         const wrapper = await createWrapper();
 
-        await wrapper.setData({
-            isLoadingInitialData: false,
-        });
+        wrapper.vm.isLoadingInitialData = false;
+        await nextTick();
         wrapper.vm.$refs.categoryTree.checkedElementsCount = 2;
 
         const category = {
@@ -526,9 +509,8 @@ describe('src/module/sw-category/component/sw-category-tree', () => {
     it('should not allow checked elements count to become negative when deleting the last checked category', async () => {
         const wrapper = await createWrapper();
 
-        await wrapper.setData({
-            isLoadingInitialData: false,
-        });
+        wrapper.vm.isLoadingInitialData = false;
+        await nextTick();
 
         wrapper.vm.$refs.categoryTree.checkedElementsCount = 0;
 
@@ -715,9 +697,8 @@ describe('src/module/sw-category/component/sw-category-tree', () => {
 
         const wrapper = await createWrapper(categories);
 
-        await wrapper.setData({
-            loadedCategories: loadedCategories,
-        });
+        wrapper.vm.loadedCategories = loadedCategories;
+        await nextTick();
 
         const initialLoadedCategoryCount = Object.values(wrapper.vm.loadedCategories).length;
 

--- a/src/Administration/Resources/app/administration/src/module/sw-category/component/sw-landing-page-tree/sw-landing-page-tree.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-category/component/sw-landing-page-tree/sw-landing-page-tree.spec.js
@@ -1,6 +1,7 @@
 /**
  * @sw-package discovery
  */
+import { nextTick } from 'vue';
 import { mount } from '@vue/test-utils';
 import { createRouter, createWebHashHistory } from 'vue-router';
 
@@ -93,9 +94,8 @@ describe('src/module/sw-category/component/sw-landing-page-tree', () => {
     it('should not be able to sort the items', async () => {
         const wrapper = await createWrapper();
 
-        await wrapper.setData({
-            isLoadingInitialData: false,
-        });
+        wrapper.vm.isLoadingInitialData = false;
+        await nextTick();
 
         await wrapper.setProps({
             allowEdit: false,
@@ -108,9 +108,8 @@ describe('src/module/sw-category/component/sw-landing-page-tree', () => {
     it('should be able to delete the items in sw-tree', async () => {
         const wrapper = await createWrapper();
 
-        await wrapper.setData({
-            isLoadingInitialData: false,
-        });
+        wrapper.vm.isLoadingInitialData = false;
+        await nextTick();
 
         const tree = wrapper.find('.sw-tree');
         expect(tree.attributes()['allow-delete-categories']).toBeDefined();
@@ -119,9 +118,8 @@ describe('src/module/sw-category/component/sw-landing-page-tree', () => {
     it('should not be able to delete the items in sw-tree', async () => {
         const wrapper = await createWrapper();
 
-        await wrapper.setData({
-            isLoadingInitialData: false,
-        });
+        wrapper.vm.isLoadingInitialData = false;
+        await nextTick();
 
         await wrapper.setProps({
             allowDelete: false,
@@ -134,9 +132,8 @@ describe('src/module/sw-category/component/sw-landing-page-tree', () => {
     it('should be able to create new landing pages', async () => {
         const wrapper = await createWrapper();
 
-        await wrapper.setData({
-            isLoadingInitialData: false,
-        });
+        wrapper.vm.isLoadingInitialData = false;
+        await nextTick();
 
         const treeItem = wrapper.find('.sw-landing-page-tree__add-button-button');
         expect(treeItem.attributes().disabled).toBeUndefined();
@@ -145,9 +142,8 @@ describe('src/module/sw-category/component/sw-landing-page-tree', () => {
     it('should not be able to create new landing pages in sw-tree-item', async () => {
         const wrapper = await createWrapper();
 
-        await wrapper.setData({
-            isLoadingInitialData: false,
-        });
+        wrapper.vm.isLoadingInitialData = false;
+        await nextTick();
 
         await wrapper.setProps({
             allowCreate: false,
@@ -160,9 +156,8 @@ describe('src/module/sw-category/component/sw-landing-page-tree', () => {
     it('should be able to delete landing pages in sw-tree-item', async () => {
         const wrapper = await createWrapper();
 
-        await wrapper.setData({
-            isLoadingInitialData: false,
-        });
+        wrapper.vm.isLoadingInitialData = false;
+        await nextTick();
 
         const treeItem = wrapper.find('.sw-tree-item');
         expect(treeItem.attributes()['allow-delete-categories']).toBeDefined();
@@ -171,9 +166,8 @@ describe('src/module/sw-category/component/sw-landing-page-tree', () => {
     it('should not be able to delete landing pages in sw-tree-item', async () => {
         const wrapper = await createWrapper();
 
-        await wrapper.setData({
-            isLoadingInitialData: false,
-        });
+        wrapper.vm.isLoadingInitialData = false;
+        await nextTick();
 
         await wrapper.setProps({
             allowDelete: false,
@@ -186,9 +180,8 @@ describe('src/module/sw-category/component/sw-landing-page-tree', () => {
     it('should show the checkbox in sw-tree-item', async () => {
         const wrapper = await createWrapper();
 
-        await wrapper.setData({
-            isLoadingInitialData: false,
-        });
+        wrapper.vm.isLoadingInitialData = false;
+        await nextTick();
 
         const treeItem = wrapper.find('.sw-tree-item');
         expect(treeItem.attributes()['display-checkbox']).toBeDefined();
@@ -197,9 +190,8 @@ describe('src/module/sw-category/component/sw-landing-page-tree', () => {
     it('should not show the checkbox in sw-tree-item', async () => {
         const wrapper = await createWrapper();
 
-        await wrapper.setData({
-            isLoadingInitialData: false,
-        });
+        wrapper.vm.isLoadingInitialData = false;
+        await nextTick();
 
         await wrapper.setProps({
             allowEdit: false,
@@ -212,9 +204,8 @@ describe('src/module/sw-category/component/sw-landing-page-tree', () => {
     it('should show the custom tooltip text in sw-tree-item', async () => {
         const wrapper = await createWrapper();
 
-        await wrapper.setData({
-            isLoadingInitialData: false,
-        });
+        wrapper.vm.isLoadingInitialData = false;
+        await nextTick();
 
         await wrapper.setProps({
             allowEdit: false,
@@ -227,9 +218,8 @@ describe('src/module/sw-category/component/sw-landing-page-tree', () => {
     it('should not show the custom tooltip text in sw-tree-item', async () => {
         const wrapper = await createWrapper();
 
-        await wrapper.setData({
-            isLoadingInitialData: false,
-        });
+        wrapper.vm.isLoadingInitialData = false;
+        await nextTick();
 
         const treeItem = wrapper.find('.sw-tree-item');
         expect(treeItem.attributes()['context-menu-tooltip-text']).toBeUndefined();
@@ -238,9 +228,8 @@ describe('src/module/sw-category/component/sw-landing-page-tree', () => {
     it('should get right landing page url', async () => {
         const wrapper = await createWrapper();
 
-        await wrapper.setData({
-            isLoadingInitialData: false,
-        });
+        wrapper.vm.isLoadingInitialData = false;
+        await nextTick();
 
         const itemUrl = wrapper.vm.getLandingPageUrl({ id: '1a2b' });
         expect(itemUrl).toBe('#/category/landingPage/1a2b');
@@ -249,9 +238,8 @@ describe('src/module/sw-category/component/sw-landing-page-tree', () => {
     it('should get wrong landing page url', async () => {
         const wrapper = await createWrapper();
 
-        await wrapper.setData({
-            isLoadingInitialData: false,
-        });
+        wrapper.vm.isLoadingInitialData = false;
+        await nextTick();
 
         const itemUrl = wrapper.vm.getLandingPageUrl({ id: '1a2b' });
         expect(itemUrl).not.toBe('#/landingPage/1a2b');

--- a/src/Administration/Resources/app/administration/src/module/sw-category/page/sw-category-detail/sw-category-detail.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-category/page/sw-category-detail/sw-category-detail.spec.js
@@ -1,6 +1,7 @@
 /**
  * @sw-package discovery
  */
+import { nextTick } from 'vue';
 import { mount } from '@vue/test-utils';
 
 describe('src/module/sw-category/page/sw-category-detail', () => {
@@ -106,9 +107,8 @@ describe('src/module/sw-category/page/sw-category-detail', () => {
             slotConfig: '',
         };
 
-        await wrapper.setData({
-            isLoading: false,
-        });
+        wrapper.vm.isLoading = false;
+        await nextTick();
 
         const saveButton = wrapper.getComponent('.sw-category-detail__save-action');
 
@@ -130,9 +130,8 @@ describe('src/module/sw-category/page/sw-category-detail', () => {
             slotConfig: '',
         };
 
-        await wrapper.setData({
-            isLoading: false,
-        });
+        wrapper.vm.isLoading = false;
+        await nextTick();
 
         const saveButton = wrapper.getComponent('.sw-category-detail__save-action');
 
@@ -157,9 +156,8 @@ describe('src/module/sw-category/page/sw-category-detail', () => {
             slotConfig: '',
         };
 
-        await wrapper.setData({
-            isLoading: false,
-        });
+        wrapper.vm.isLoading = false;
+        await nextTick();
 
         const saveButton = wrapper.getComponent('.sw-category-detail__save-action');
 
@@ -185,9 +183,8 @@ describe('src/module/sw-category/page/sw-category-detail', () => {
             slotConfig: '',
         };
 
-        await wrapper.setData({
-            isLoading: false,
-        });
+        wrapper.vm.isLoading = false;
+        await nextTick();
 
         const saveButton = wrapper.getComponent('.sw-category-detail__save-action');
 
@@ -217,10 +214,9 @@ describe('src/module/sw-category/page/sw-category-detail', () => {
             serviceSalesChannels: [],
         };
 
-        await wrapper.setData({
-            isLoading: false,
-            cmsPage: null,
-        });
+        wrapper.vm.isLoading = false;
+        Shopware.Store.get('cmsPage').currentPage = null;
+        await nextTick();
 
         await wrapper.setProps({
             categoryId: 'foo',

--- a/src/Administration/Resources/app/administration/src/module/sw-category/view/sw-category-detail-products/sw-category-detail-products.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-category/view/sw-category-detail-products/sw-category-detail-products.spec.js
@@ -1,6 +1,7 @@
 /**
  * @sw-package discovery
  */
+import { nextTick } from 'vue';
 import { mount } from '@vue/test-utils';
 
 const categoryMock = {
@@ -105,9 +106,8 @@ describe('module/sw-category/view/sw-category-detail-products.spec', () => {
         await wrapper
             .getComponent('.sw-category-detail-products__product-assignment-type-select')
             .vm.$emit('update:value', 'product_stream');
-        await wrapper.setData({
-            manualAssignedProductsCount: 5,
-        });
+        wrapper.vm.manualAssignedProductsCount = 5;
+        await nextTick();
 
         expect(wrapper.find('[role="banner"]').text()).toBe(
             'sw-category.base.products.alertManualAssignedProductsOnAssignmentTypeStream',
@@ -126,9 +126,8 @@ describe('module/sw-category/view/sw-category-detail-products.spec', () => {
     it('should try to load product stream preview when stream id is present', async () => {
         const wrapper = await createWrapper();
 
-        await wrapper.setData({
-            manualAssignedProductsCount: 5,
-        });
+        wrapper.vm.manualAssignedProductsCount = 5;
+        await nextTick();
 
         await wrapper
             .getComponent('.sw-category-detail-products__product-stream-select')

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-inherit-wrapper/sw-cms-inherit-wrapper.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-inherit-wrapper/sw-cms-inherit-wrapper.spec.js
@@ -3,6 +3,7 @@
 /**
  * @sw-package discovery
  */
+import { nextTick } from 'vue';
 import { mount } from '@vue/test-utils';
 import '../../mixin/sw-cms-state.mixin';
 
@@ -270,7 +271,8 @@ describe('src/module/sw-cms/component/sw-cms-inherit-wrapper', () => {
 
             expect(wrapper.find('.sw-confirm-modal').exists()).toBe(false);
 
-            await wrapper.setData({ showModal: true });
+            wrapper.vm.showModal = true;
+            await nextTick();
 
             expect(wrapper.find('.sw-confirm-modal').exists()).toBe(true);
         });
@@ -545,7 +547,8 @@ describe('src/module/sw-cms/component/sw-cms-inherit-wrapper', () => {
             };
             const wrapper = await createWrapper();
 
-            await wrapper.setData({ showModal: true });
+            wrapper.vm.showModal = true;
+            await nextTick();
             expect(wrapper.vm.showModal).toBe(true);
 
             await wrapper.vm.onInheritanceRestore();
@@ -769,7 +772,8 @@ describe('src/module/sw-cms/component/sw-cms-inherit-wrapper', () => {
             Shopware.Store.get('swCategoryDetail').category = contentEntity;
             const wrapper = await createWrapper();
 
-            await wrapper.setData({ showModal: true });
+            wrapper.vm.showModal = true;
+            await nextTick();
 
             await wrapper.find('.confirm-btn').trigger('click');
 
@@ -782,7 +786,8 @@ describe('src/module/sw-cms/component/sw-cms-inherit-wrapper', () => {
             Shopware.Store.get('swCategoryDetail').category = {};
             const wrapper = await createWrapper();
 
-            await wrapper.setData({ showModal: true });
+            wrapper.vm.showModal = true;
+            await nextTick();
             expect(wrapper.vm.showModal).toBe(true);
 
             await wrapper.find('.cancel-btn').trigger('click');
@@ -794,7 +799,8 @@ describe('src/module/sw-cms/component/sw-cms-inherit-wrapper', () => {
             Shopware.Store.get('swCategoryDetail').category = {};
             const wrapper = await createWrapper();
 
-            await wrapper.setData({ showModal: true });
+            wrapper.vm.showModal = true;
+            await nextTick();
             expect(wrapper.vm.showModal).toBe(true);
 
             await wrapper.find('.close-btn').trigger('click');

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-layout-assignment-modal/sw-cms-layout-assignment-modal.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-layout-assignment-modal/sw-cms-layout-assignment-modal.spec.js
@@ -3,6 +3,7 @@
 /**
  * @sw-package discovery
  */
+import { nextTick } from 'vue';
 import { mount } from '@vue/test-utils';
 import EntityCollection from 'src/core/data/entity-collection.data';
 import Criteria from 'src/core/data/criteria.data';
@@ -813,9 +814,8 @@ describe('module/sw-cms/component/sw-cms-layout-assignment-modal', () => {
         await wrapper.find('.sw-cms-layout-assignment-modal__tab-shop-pages').trigger('click');
 
         // Set new sales channel id
-        await wrapper.setData({
-            shopPageSalesChannelId: 'storefront_id',
-        });
+        wrapper.vm.shopPageSalesChannelId = 'storefront_id';
+        await nextTick();
 
         // Trigger sales channel select change
         await wrapper.find('.sw-cms-layout-assignment-modal__sales-channel-select').trigger('change');
@@ -835,9 +835,8 @@ describe('module/sw-cms/component/sw-cms-layout-assignment-modal', () => {
         await flushPromises();
 
         // Set new sales channel id
-        await wrapper.setData({
-            shopPageSalesChannelId: 'storefront_id',
-        });
+        wrapper.vm.shopPageSalesChannelId = 'storefront_id';
+        await nextTick();
 
         // Trigger sales channel select change
         await wrapper.find('.sw-cms-layout-assignment-modal__sales-channel-select').trigger('change');
@@ -859,9 +858,8 @@ describe('module/sw-cms/component/sw-cms-layout-assignment-modal', () => {
             await wrapper.find('.sw-cms-layout-assignment-modal__tab-shop-pages').trigger('click');
 
             // Set new sales channel id
-            await wrapper.setData({
-                shopPageSalesChannelId: 'headless_id',
-            });
+            wrapper.vm.shopPageSalesChannelId = 'headless_id';
+            await nextTick();
 
             // Trigger sales channel select change
             await wrapper.find('.sw-cms-layout-assignment-modal__sales-channel-select').trigger('change');
@@ -883,9 +881,8 @@ describe('module/sw-cms/component/sw-cms-layout-assignment-modal', () => {
             await flushPromises();
 
             // Set new sales channel id
-            await wrapper.setData({
-                shopPageSalesChannelId: 'headless_id',
-            });
+            wrapper.vm.shopPageSalesChannelId = 'headless_id';
+            await nextTick();
 
             // Trigger sales channel select change
             await wrapper.find('.sw-cms-layout-assignment-modal__sales-channel-select').trigger('change');

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-layout-modal/sw-cms-layout-modal.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-layout-modal/sw-cms-layout-modal.spec.js
@@ -1,6 +1,7 @@
 /**
  * @sw-package discovery
  */
+import { nextTick } from 'vue';
 import { mount } from '@vue/test-utils';
 
 const defaultCategoryId = 'default-category-id';
@@ -267,9 +268,8 @@ describe('module/sw-cms/component/sw-cms-layout-modal', () => {
 
     it.each(productMocks)('should select the given item and load all variables correctly', async (product) => {
         const wrapper = await createWrapper();
-        await wrapper.setData({
-            isLoading: false,
-        });
+        wrapper.vm.isLoading = false;
+        await nextTick();
 
         const productIndex = productMocks.indexOf(product);
         const expected = productMocks[productIndex];
@@ -289,9 +289,8 @@ describe('module/sw-cms/component/sw-cms-layout-modal', () => {
         'should set and unset the selectedPageObject correctly, when selecting a column',
         async (product) => {
             const wrapper = await createWrapper();
-            await wrapper.setData({
-                isLoading: false,
-            });
+            wrapper.vm.isLoading = false;
+            await nextTick();
 
             const productIndex = productMocks.indexOf(product);
             const expected = productMocks[productIndex];

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-slot/sw-cms-slot.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-slot/sw-cms-slot.spec.js
@@ -3,6 +3,7 @@
 /**
  * @sw-package discovery
  */
+import { nextTick } from 'vue';
 import { mount } from '@vue/test-utils';
 import { setupCmsEnvironment } from 'src/module/sw-cms/test-utils';
 
@@ -428,9 +429,8 @@ describe('module/sw-cms/component/sw-cms-slot', () => {
         'should not toggle the element settings modal without defaultConfig and showElementSettings is %s',
         async (actualShowElementSettings) => {
             const wrapper = await createWrapper();
-            await wrapper.setData({
-                showElementSettings: actualShowElementSettings,
-            });
+            wrapper.vm.showElementSettings = actualShowElementSettings;
+            await nextTick();
             await wrapper.setProps({
                 element: {
                     type: 'without_default_config',
@@ -451,9 +451,8 @@ describe('module/sw-cms/component/sw-cms-slot', () => {
         'should not toggle the element settings modal with a locked element and showElementSettings is %s',
         async (actualShowElementSettings) => {
             const wrapper = await createWrapper();
-            await wrapper.setData({
-                showElementSettings: actualShowElementSettings,
-            });
+            wrapper.vm.showElementSettings = actualShowElementSettings;
+            await nextTick();
             await wrapper.setProps({
                 element: {
                     type: 'with_locked',
@@ -474,9 +473,8 @@ describe('module/sw-cms/component/sw-cms-slot', () => {
         'should show the element settings modal with a defaultConfig, no locked element and showElementSettings is %s',
         async (actualShowElementSettings) => {
             const wrapper = await createWrapper();
-            await wrapper.setData({
-                showElementSettings: actualShowElementSettings,
-            });
+            wrapper.vm.showElementSettings = actualShowElementSettings;
+            await nextTick();
             await wrapper.setProps({
                 showElementSettings: false,
                 element: {
@@ -498,10 +496,9 @@ describe('module/sw-cms/component/sw-cms-slot', () => {
                 type: 'with_config_and_unlocked',
             },
         });
-        await wrapper.setData({
-            showElementSettings: true,
-            isElementSettingsInitialized: true,
-        });
+        wrapper.vm.showElementSettings = true;
+        wrapper.vm.isElementSettingsInitialized = true;
+        await nextTick();
         await flushPromises();
 
         expect(wrapper.vm.showElementSettings).toBe(true);
@@ -517,10 +514,9 @@ describe('module/sw-cms/component/sw-cms-slot', () => {
                 type: 'with_config_and_unlocked',
             },
         });
-        await wrapper.setData({
-            showElementSettings: false,
-            isElementSettingsInitialized: true,
-        });
+        wrapper.vm.showElementSettings = false;
+        wrapper.vm.isElementSettingsInitialized = true;
+        await nextTick();
         await flushPromises();
 
         expect(wrapper.vm.showElementSettings).toBe(false);
@@ -556,10 +552,9 @@ describe('module/sw-cms/component/sw-cms-slot', () => {
             },
         });
 
-        await wrapper.setData({
-            showElementSettings: true,
-            isElementSettingsInitialized: true,
-        });
+        wrapper.vm.showElementSettings = true;
+        wrapper.vm.isElementSettingsInitialized = true;
+        await nextTick();
         await flushPromises();
 
         await wrapper.vm.onCloseSettingsModal();

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image-slider/config/config.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image-slider/config/config.spec.js
@@ -1,6 +1,7 @@
 /**
  * @sw-package discovery
  */
+import { nextTick } from 'vue';
 import { mount } from '@vue/test-utils';
 import { setupCmsEnvironment } from 'src/module/sw-cms/test-utils';
 import { MtSwitch, MtUrlField } from '@shopware-ag/meteor-component-library';
@@ -426,14 +427,13 @@ describe('src/module/sw-cms/elements/image-slider/config', () => {
         ]);
         await flushPromises();
 
-        await wrapper.setData({
-            mediaItems: [
-                {
-                    id: '1',
-                    url: 'http://shopware.com/image1-current.jpg',
-                },
-            ],
-        });
+        wrapper.vm.mediaItems = [
+            {
+                id: '1',
+                url: 'http://shopware.com/image1-current.jpg',
+            },
+        ];
+        await nextTick();
         await wrapper.vm.$nextTick();
 
         const previewImage = wrapper.find('.sw-cms-el-config-image-slider__settings-link-prefix');
@@ -454,7 +454,8 @@ describe('src/module/sw-cms/elements/image-slider/config', () => {
         ]);
         await flushPromises();
 
-        await wrapper.setData({ mediaItems: [] });
+        wrapper.vm.mediaItems = [];
+        await nextTick();
         await wrapper.vm.$nextTick();
 
         const previewImage = wrapper.find('.sw-cms-el-config-image-slider__settings-link-prefix');

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/product-listing/config/config.spec/sorting.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/product-listing/config/config.spec/sorting.spec.js
@@ -1,7 +1,7 @@
 /**
  * @sw-package discovery
  */
-import { toRaw } from 'vue';
+import { toRaw, nextTick } from 'vue';
 import { createWrapper, EntityCollection, registerCmsPageStore } from './fixtures';
 
 describe('src/module/sw-cms/elements/product-listing/config - sorting', () => {
@@ -20,15 +20,14 @@ describe('src/module/sw-cms/elements/product-listing/config - sorting', () => {
     it('should contain content for sorting when defaultSorting is deactivated', async () => {
         const wrapper = await createWrapper();
 
-        await wrapper.setData({
-            productSortings: [
-                {
-                    id: 'foo_id',
-                    key: 'foo',
-                    priority: 2,
-                },
-            ],
-        });
+        wrapper.vm.productSortings = [
+            {
+                id: 'foo_id',
+                key: 'foo',
+                priority: 2,
+            },
+        ];
+        await nextTick();
 
         const showSortingSwitchField = wrapper.find(
             'input[aria-label="sw-cms.elements.productListing.config.sorting.labelShowSorting"]',
@@ -52,9 +51,8 @@ describe('src/module/sw-cms/elements/product-listing/config - sorting', () => {
     it('should hide the sorting grid when no product sortings are selected', async () => {
         const wrapper = await createWrapper();
 
-        await wrapper.setData({
-            productSortings: [],
-        });
+        wrapper.vm.productSortings = [];
+        await nextTick();
 
         expect(wrapper.find('sw-cms-el-config-product-listing-config-sorting-grid-stub').exists()).toBeFalsy();
     });
@@ -101,20 +99,19 @@ describe('src/module/sw-cms/elements/product-listing/config - sorting', () => {
 
         expect(wrapper.vm.element.config.availableSortings.value).toStrictEqual({});
 
-        await wrapper.setData({
-            productSortings: [
-                {
-                    id: 'foo_id',
-                    key: 'foo',
-                    priority: 2,
-                },
-                {
-                    id: 'bar_id',
-                    key: 'bar',
-                    priority: 5,
-                },
-            ],
-        });
+        wrapper.vm.productSortings = [
+            {
+                id: 'foo_id',
+                key: 'foo',
+                priority: 2,
+            },
+            {
+                id: 'bar_id',
+                key: 'bar',
+                priority: 5,
+            },
+        ];
+        await nextTick();
 
         await wrapper.vm.$nextTick();
 
@@ -253,9 +250,8 @@ describe('src/module/sw-cms/elements/product-listing/config - sorting', () => {
 
         const originalRaw = toRaw(wrapper.vm.element.config.availableSortings.value);
 
-        await wrapper.setData({
-            productSortings: [{ id: 'foo_id', key: 'foo', priority: 2 }],
-        });
+        wrapper.vm.productSortings = [{ id: 'foo_id', key: 'foo', priority: 2 }];
+        await nextTick();
         await wrapper.vm.$nextTick();
 
         expect(toRaw(wrapper.vm.element.config.availableSortings.value)).not.toBe(originalRaw);
@@ -278,9 +274,8 @@ describe('src/module/sw-cms/elements/product-listing/config - sorting', () => {
             },
         ];
 
-        await wrapper.setData({
-            productSortings: before,
-        });
+        wrapper.vm.productSortings = before;
+        await nextTick();
 
         const after = wrapper.vm.transformProductSortings();
 

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/product-slider/config/config.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/product-slider/config/config.spec.js
@@ -1,6 +1,7 @@
 /**
  * @sw-package discovery
  */
+import { nextTick } from 'vue';
 import { mount } from '@vue/test-utils';
 import 'src/module/sw-cms/mixin/sw-cms-element.mixin';
 
@@ -348,9 +349,8 @@ describe('module/sw-cms/elements/product-slider/config', () => {
 
         await wrapper.vm.$nextTick();
 
-        await wrapper.setData({
-            showProductStreamPreview: true,
-        });
+        wrapper.vm.showProductStreamPreview = true;
+        await nextTick();
 
         await wrapper.vm.$nextTick();
 

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/page/sw-cms-detail/sw-cms-detail.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/page/sw-cms-detail/sw-cms-detail.spec.js
@@ -4,7 +4,7 @@
  * @sw-package discovery
  */
 import { mount } from '@vue/test-utils';
-import { reactive } from 'vue';
+import { reactive, nextTick } from 'vue';
 
 import EntityCollection from 'src/core/data/entity-collection.data';
 import Criteria from 'src/core/data/criteria.data';
@@ -315,9 +315,8 @@ describe('module/sw-cms/page/sw-cms-detail', () => {
     it('should disable all fields when ACL rights are missing', async () => {
         const wrapper = await createWrapper();
         await flushPromises();
-        await wrapper.setData({
-            isLoading: false,
-        });
+        wrapper.vm.isLoading = false;
+        await nextTick();
 
         const formIcon = wrapper.find('.mt-icon.icon--regular-bars-square');
         expect(formIcon.classes()).toContain('is--disabled');
@@ -345,9 +344,8 @@ describe('module/sw-cms/page/sw-cms-detail', () => {
 
         const wrapper = await createWrapper();
         await flushPromises();
-        await wrapper.setData({
-            isLoading: false,
-        });
+        wrapper.vm.isLoading = false;
+        await nextTick();
 
         const formIcon = wrapper.find('.mt-icon.icon--regular-bars-square');
         expect(formIcon.classes()).not.toContain('is--disabled');

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/page/sw-cms-list/sw-cms-list.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/page/sw-cms-list/sw-cms-list.spec.js
@@ -3,6 +3,7 @@
 /**
  * @sw-package discovery
  */
+import { nextTick } from 'vue';
 import { mount } from '@vue/test-utils';
 import { searchRankingPoint } from 'src/app/service/search-ranking.service';
 import Criteria from 'src/core/data/criteria.data';
@@ -567,19 +568,18 @@ describe('module/sw-cms/page/sw-cms-list', () => {
         const wrapper = await createWrapper();
         await flushPromises();
 
-        await wrapper.setData({
-            pages: [
-                {
-                    sections: [],
-                    categories: [],
-                    products: [],
-                    landingPages: [],
-                    translated: {
-                        name: 'CMS Page 1',
-                    },
+        wrapper.vm.pages = [
+            {
+                sections: [],
+                categories: [],
+                products: [],
+                landingPages: [],
+                translated: {
+                    name: 'CMS Page 1',
                 },
-            ],
-        });
+            },
+        ];
+        await nextTick();
 
         await wrapper.vm.$nextTick();
 
@@ -598,19 +598,18 @@ describe('module/sw-cms/page/sw-cms-list', () => {
         const wrapper = await createWrapper(['user_config:read']);
         await flushPromises();
 
-        await wrapper.setData({
-            pages: [
-                {
-                    sections: [],
-                    categories: [],
-                    products: [],
-                    landingPages: [],
-                    translated: {
-                        name: 'CMS Page 1',
-                    },
+        wrapper.vm.pages = [
+            {
+                sections: [],
+                categories: [],
+                products: [],
+                landingPages: [],
+                translated: {
+                    name: 'CMS Page 1',
                 },
-            ],
-        });
+            },
+        ];
+        await nextTick();
 
         const createButton = wrapper.findByText('button', 'sw-cms.general.createNewLayout');
         expect(createButton.attributes('disabled') !== undefined).toBe(true);
@@ -620,19 +619,18 @@ describe('module/sw-cms/page/sw-cms-list', () => {
         const wrapper = await createWrapper();
         await flushPromises();
 
-        await wrapper.setData({
-            pages: [
-                {
-                    sections: [],
-                    categories: [],
-                    products: [],
-                    landingPages: [],
-                    translated: {
-                        name: 'CMS Page 1',
-                    },
+        wrapper.vm.pages = [
+            {
+                sections: [],
+                categories: [],
+                products: [],
+                landingPages: [],
+                translated: {
+                    name: 'CMS Page 1',
                 },
-            ],
-        });
+            },
+        ];
+        await nextTick();
 
         const createButton = wrapper.findByText('button', 'sw-cms.general.createNewLayout');
         expect(createButton.attributes('disabled')).toBeUndefined();
@@ -650,21 +648,20 @@ describe('module/sw-cms/page/sw-cms-list', () => {
 
         await wrapper.vm.$nextTick();
 
-        await wrapper.setData({
-            isLoading: false,
-            pages: [
-                {
-                    id: '1a',
-                    sections: [],
-                    categories: [],
-                    products: [],
-                    landingPages: [],
-                    translated: {
-                        name: 'CMS Page 1',
-                    },
+        wrapper.vm.isLoading = false;
+        wrapper.vm.pages = [
+            {
+                id: '1a',
+                sections: [],
+                categories: [],
+                products: [],
+                landingPages: [],
+                translated: {
+                    name: 'CMS Page 1',
                 },
-            ],
-        });
+            },
+        ];
+        await nextTick();
         await flushPromises();
 
         await wrapper.find('.sw-data-grid__actions-menu').trigger('click');
@@ -692,21 +689,20 @@ describe('module/sw-cms/page/sw-cms-list', () => {
 
         await wrapper.vm.$nextTick();
 
-        await wrapper.setData({
-            isLoading: false,
-            pages: [
-                {
-                    id: '1a',
-                    sections: [],
-                    categories: [],
-                    products: [],
-                    landingPages: [],
-                    translated: {
-                        name: 'CMS Page 1',
-                    },
+        wrapper.vm.isLoading = false;
+        wrapper.vm.pages = [
+            {
+                id: '1a',
+                sections: [],
+                categories: [],
+                products: [],
+                landingPages: [],
+                translated: {
+                    name: 'CMS Page 1',
                 },
-            ],
-        });
+            },
+        ];
+        await nextTick();
         await flushPromises();
 
         await wrapper.find('.sw-data-grid__actions-menu').trigger('click');
@@ -733,21 +729,20 @@ describe('module/sw-cms/page/sw-cms-list', () => {
 
         await wrapper.vm.$nextTick();
 
-        await wrapper.setData({
-            isLoading: false,
-            pages: [
-                {
-                    id: '1a',
-                    sections: [],
-                    categories: [],
-                    products: [],
-                    landingPages: [],
-                    translated: {
-                        name: 'CMS Page 1',
-                    },
+        wrapper.vm.isLoading = false;
+        wrapper.vm.pages = [
+            {
+                id: '1a',
+                sections: [],
+                categories: [],
+                products: [],
+                landingPages: [],
+                translated: {
+                    name: 'CMS Page 1',
                 },
-            ],
-        });
+            },
+        ];
+        await nextTick();
         await flushPromises();
 
         await wrapper.find('.sw-data-grid__actions-menu').trigger('click');
@@ -774,21 +769,20 @@ describe('module/sw-cms/page/sw-cms-list', () => {
 
         await wrapper.vm.$nextTick();
 
-        await wrapper.setData({
-            isLoading: false,
-            pages: [
-                {
-                    id: '1a',
-                    sections: [],
-                    categories: [],
-                    products: [],
-                    landingPages: [],
-                    translated: {
-                        name: 'CMS Page 1',
-                    },
+        wrapper.vm.isLoading = false;
+        wrapper.vm.pages = [
+            {
+                id: '1a',
+                sections: [],
+                categories: [],
+                products: [],
+                landingPages: [],
+                translated: {
+                    name: 'CMS Page 1',
                 },
-            ],
-        });
+            },
+        ];
+        await nextTick();
         await flushPromises();
 
         await wrapper.find('.sw-data-grid__actions-menu').trigger('click');
@@ -812,21 +806,20 @@ describe('module/sw-cms/page/sw-cms-list', () => {
         ]);
         await flushPromises();
 
-        await wrapper.setData({
-            isLoading: false,
-            pages: [
-                {
-                    id: '1a',
-                    sections: [],
-                    categories: [],
-                    products: [],
-                    landingPages: [],
-                    translated: {
-                        name: 'CMS Page 1',
-                    },
+        wrapper.vm.isLoading = false;
+        wrapper.vm.pages = [
+            {
+                id: '1a',
+                sections: [],
+                categories: [],
+                products: [],
+                landingPages: [],
+                translated: {
+                    name: 'CMS Page 1',
                 },
-            ],
-        });
+            },
+        ];
+        await nextTick();
         await flushPromises();
 
         const contextMenuItemPreview = wrapper.find('.sw-cms-list-item__option-preview');
@@ -845,21 +838,20 @@ describe('module/sw-cms/page/sw-cms-list', () => {
         ]);
         await flushPromises();
 
-        await wrapper.setData({
-            isLoading: false,
-            pages: [
-                {
-                    id: '1a',
-                    sections: [],
-                    categories: [],
-                    products: [],
-                    landingPages: [],
-                    translated: {
-                        name: 'CMS Page 1',
-                    },
+        wrapper.vm.isLoading = false;
+        wrapper.vm.pages = [
+            {
+                id: '1a',
+                sections: [],
+                categories: [],
+                products: [],
+                landingPages: [],
+                translated: {
+                    name: 'CMS Page 1',
                 },
-            ],
-        });
+            },
+        ];
+        await nextTick();
         await flushPromises();
 
         const contextMenuItemPreview = wrapper.find('.sw-cms-list-item__option-preview');
@@ -878,21 +870,20 @@ describe('module/sw-cms/page/sw-cms-list', () => {
         ]);
         await flushPromises();
 
-        await wrapper.setData({
-            isLoading: false,
-            pages: [
-                {
-                    id: '1a',
-                    sections: [],
-                    categories: [],
-                    products: [],
-                    landingPages: [],
-                    translated: {
-                        name: 'CMS Page 1',
-                    },
+        wrapper.vm.isLoading = false;
+        wrapper.vm.pages = [
+            {
+                id: '1a',
+                sections: [],
+                categories: [],
+                products: [],
+                landingPages: [],
+                translated: {
+                    name: 'CMS Page 1',
                 },
-            ],
-        });
+            },
+        ];
+        await nextTick();
         await flushPromises();
 
         const contextMenuItemPreview = wrapper.find('.sw-cms-list-item__option-preview');
@@ -911,21 +902,20 @@ describe('module/sw-cms/page/sw-cms-list', () => {
         ]);
         await flushPromises();
 
-        await wrapper.setData({
-            isLoading: false,
-            pages: [
-                {
-                    id: '1a',
-                    sections: [],
-                    categories: [],
-                    products: [],
-                    landingPages: [],
-                    translated: {
-                        name: 'CMS Page 1',
-                    },
+        wrapper.vm.isLoading = false;
+        wrapper.vm.pages = [
+            {
+                id: '1a',
+                sections: [],
+                categories: [],
+                products: [],
+                landingPages: [],
+                translated: {
+                    name: 'CMS Page 1',
                 },
-            ],
-        });
+            },
+        ];
+        await nextTick();
         await flushPromises();
 
         const contextMenuItemPreview = wrapper.find('.sw-cms-list-item__option-preview');
@@ -966,10 +956,9 @@ describe('module/sw-cms/page/sw-cms-list', () => {
             },
         };
 
-        await wrapper.setData({
-            isLoading: false,
-            pages,
-        });
+        wrapper.vm.isLoading = false;
+        wrapper.vm.pages = pages;
+        await nextTick();
         await flushPromises();
 
         const contextMenuItemDelete = wrapper.find('.sw-cms-list-item--0 .sw-cms-list-item__option-delete');
@@ -981,21 +970,20 @@ describe('module/sw-cms/page/sw-cms-list', () => {
         const wrapper = await createWrapper();
         await flushPromises();
 
-        await wrapper.setData({
-            isLoading: false,
-            pages: [
-                {
-                    id: '1a',
-                    sections: [],
-                    categories: [],
-                    products: [],
-                    landingPages: [],
-                    translated: {
-                        name: 'CMS Page 1',
-                    },
+        wrapper.vm.isLoading = false;
+        wrapper.vm.pages = [
+            {
+                id: '1a',
+                sections: [],
+                categories: [],
+                products: [],
+                landingPages: [],
+                translated: {
+                    name: 'CMS Page 1',
                 },
-            ],
-        });
+            },
+        ];
+        await nextTick();
         await flushPromises();
 
         const contextMenuItemDelete = wrapper.find('.sw-cms-list-item--0 .sw-cms-list-item__option-delete');
@@ -1166,9 +1154,8 @@ describe('module/sw-cms/page/sw-cms-list', () => {
         const wrapper = await createWrapper();
         await flushPromises();
 
-        await wrapper.setData({
-            term: 'foo',
-        });
+        wrapper.vm.term = 'foo';
+        await nextTick();
 
         await wrapper.vm.$nextTick();
         wrapper.vm.searchRankingService.buildSearchQueriesForEntity = jest.fn(() => {
@@ -1214,9 +1201,8 @@ describe('module/sw-cms/page/sw-cms-list', () => {
         const wrapper = await createWrapper();
         await flushPromises();
 
-        await wrapper.setData({
-            term: 'foo',
-        });
+        wrapper.vm.term = 'foo';
+        await nextTick();
 
         await wrapper.vm.$nextTick();
         wrapper.vm.searchRankingService.buildSearchQueriesForEntity = jest.fn(() => {
@@ -1240,9 +1226,8 @@ describe('module/sw-cms/page/sw-cms-list', () => {
         const wrapper = await createWrapper();
         await flushPromises();
 
-        await wrapper.setData({
-            term: 'foo',
-        });
+        wrapper.vm.term = 'foo';
+        await nextTick();
         await wrapper.vm.$nextTick();
 
         wrapper.vm.searchRankingService.getSearchFieldsByEntity = jest.fn(() => {
@@ -1266,22 +1251,21 @@ describe('module/sw-cms/page/sw-cms-list', () => {
 
         await wrapper.vm.$nextTick();
 
-        await wrapper.setData({
-            isLoading: false,
-            pages: [
-                {
-                    id: '1a',
-                    sections: [],
-                    categories: [],
-                    products: [],
-                    landingPages: [],
+        wrapper.vm.isLoading = false;
+        wrapper.vm.pages = [
+            {
+                id: '1a',
+                sections: [],
+                categories: [],
+                products: [],
+                landingPages: [],
+                name: 'CMS Page 1',
+                translated: {
                     name: 'CMS Page 1',
-                    translated: {
-                        name: 'CMS Page 1',
-                    },
                 },
-            ],
-        });
+            },
+        ];
+        await nextTick();
         await flushPromises();
 
         await wrapper.find('.sw-data-grid__actions-menu').trigger('click');

--- a/src/Administration/Resources/app/administration/src/module/sw-custom-entity/page/sw-generic-custom-entity-list/sw-generic-custom-entity-list.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-custom-entity/page/sw-generic-custom-entity-list/sw-generic-custom-entity-list.spec.js
@@ -1,3 +1,4 @@
+import { nextTick } from 'vue';
 import { mount } from '@vue/test-utils';
 
 const testEntityName = 'custom_test_entity';
@@ -125,9 +126,8 @@ describe('module/sw-custom-entity/page/sw-generic-custom-entity-list', () => {
 
         expect(wrapper.find('mt-empty-state').exists()).toBe(false);
 
-        await wrapper.setData({
-            customEntityInstances: false,
-        });
+        wrapper.vm.customEntityInstances = false;
+        await nextTick();
 
         expect(wrapper.vm.customEntityInstances).toBe(false);
 

--- a/src/Administration/Resources/app/administration/src/module/sw-customer/page/sw-customer-create/sw-customer-create.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-customer/page/sw-customer-create/sw-customer-create.spec.js
@@ -1,3 +1,4 @@
+import { nextTick } from 'vue';
 import { mount } from '@vue/test-utils';
 
 /**
@@ -209,9 +210,8 @@ describe('module/sw-customer/page/sw-customer-create', () => {
     it('should not render sw-customer-base-form and sw-customer-address-form if customer is null', async () => {
         const wrapper = await createWrapper();
         await flushPromises();
-        await wrapper.setData({
-            customer: null,
-        });
+        wrapper.vm.customer = null;
+        await nextTick();
 
         expect(wrapper.find('sw-customer-base-form-stub').exists()).toBeFalsy();
         expect(wrapper.find('sw-customer-address-form-stub').exists()).toBeFalsy();

--- a/src/Administration/Resources/app/administration/src/module/sw-customer/page/sw-customer-list/sw-customer-list.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-customer/page/sw-customer-list/sw-customer-list.spec.js
@@ -2,6 +2,7 @@
  * @sw-package checkout
  */
 
+import { nextTick } from 'vue';
 import { mount } from '@vue/test-utils';
 import { searchRankingPoint } from 'src/app/service/search-ranking.service';
 import Criteria from 'src/core/data/criteria.data';
@@ -215,9 +216,8 @@ describe('module/sw-customer/page/sw-customer-list', () => {
 
     it('should add query score to the criteria', async () => {
         const wrapper = await createWrapper();
-        await wrapper.setData({
-            term: 'foo',
-        });
+        wrapper.vm.term = 'foo';
+        await nextTick();
         await flushPromises();
         wrapper.vm.searchRankingService.buildSearchQueriesForEntity = jest.fn(() => {
             return new Criteria(1, 25);
@@ -258,9 +258,8 @@ describe('module/sw-customer/page/sw-customer-list', () => {
 
     it('should not build query score when search ranking field is null', async () => {
         const wrapper = await createWrapper();
-        await wrapper.setData({
-            term: 'foo',
-        });
+        wrapper.vm.term = 'foo';
+        await nextTick();
 
         await flushPromises();
         wrapper.vm.searchRankingService.buildSearchQueriesForEntity = jest.fn(() => {
@@ -282,9 +281,8 @@ describe('module/sw-customer/page/sw-customer-list', () => {
 
     it('should show empty state when there is not item after filling search term', async () => {
         const wrapper = await createWrapper();
-        await wrapper.setData({
-            term: 'foo',
-        });
+        wrapper.vm.term = 'foo';
+        await nextTick();
         await flushPromises();
         wrapper.vm.searchRankingService.getSearchFieldsByEntity = jest.fn(() => {
             return {};

--- a/src/Administration/Resources/app/administration/src/module/sw-first-run-wizard/view/sw-first-run-wizard-mailer-selection/sw-first-run-wizard-mailer-selection.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-first-run-wizard/view/sw-first-run-wizard-mailer-selection/sw-first-run-wizard-mailer-selection.spec.js
@@ -1,6 +1,7 @@
 /**
  * @sw-package fundamentals@after-sales
  */
+import { nextTick } from 'vue';
 import { mount } from '@vue/test-utils';
 
 async function createWrapper() {
@@ -58,7 +59,8 @@ describe('module/sw-first-run-wizard/view/sw-first-run-wizard-modal', () => {
 
     it('handleSelection: should not emit an redirect when user has not select an mailAgent', async () => {
         const wrapper = await createWrapper();
-        await wrapper.setData({ mailAgent: '' });
+        wrapper.vm.mailAgent = '';
+        await nextTick();
 
         expect(wrapper.emitted('frw-redirect')).toBeUndefined();
 
@@ -69,7 +71,8 @@ describe('module/sw-first-run-wizard/view/sw-first-run-wizard-modal', () => {
 
     it('handleSelection: should emit redirect to mailer settings when user has select an smtp mailAgent', async () => {
         const wrapper = await createWrapper();
-        await wrapper.setData({ mailAgent: 'smtp' });
+        wrapper.vm.mailAgent = 'smtp';
+        await nextTick();
 
         expect(wrapper.emitted('frw-redirect')).toBeUndefined();
 
@@ -82,7 +85,8 @@ describe('module/sw-first-run-wizard/view/sw-first-run-wizard-modal', () => {
 
     it('handleSelection: should emit redirect to paypal when user has select an local mailAgent', async () => {
         const wrapper = await createWrapper();
-        await wrapper.setData({ mailAgent: 'local' });
+        wrapper.vm.mailAgent = 'local';
+        await nextTick();
 
         expect(wrapper.emitted('frw-redirect')).toBeUndefined();
 

--- a/src/Administration/Resources/app/administration/src/module/sw-flow/component/modals/sw-flow-generate-document-modal/sw-flow-generate-document-modal.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-flow/component/modals/sw-flow-generate-document-modal/sw-flow-generate-document-modal.spec.js
@@ -1,3 +1,4 @@
+import { nextTick } from 'vue';
 import { mount } from '@vue/test-utils';
 import { createPinia } from 'pinia';
 
@@ -116,9 +117,8 @@ describe('module/sw-flow/component/sw-flow-generate-document-modal', () => {
         const documentTypeSelect = wrapper.find('.sw-flow-generate-document-modal__type-multi-select');
         expect(documentTypeSelect.classes()).toContain('has--error');
 
-        await wrapper.setData({
-            documentTypesSelected: ['invoice'],
-        });
+        wrapper.vm.documentTypesSelected = ['invoice'];
+        await nextTick();
 
         await saveButton.trigger('click');
 
@@ -127,12 +127,11 @@ describe('module/sw-flow/component/sw-flow-generate-document-modal', () => {
 
     it('should emit process-finish when document multiple type is selected', async () => {
         const wrapper = await createWrapper();
-        await wrapper.setData({
-            documentTypesSelected: [
-                'invoice',
-                'delivery_note',
-            ],
-        });
+        wrapper.vm.documentTypesSelected = [
+            'invoice',
+            'delivery_note',
+        ];
+        await nextTick();
 
         const saveButton = wrapper.find('.sw-flow-generate-document-modal__save-button');
         await saveButton.trigger('click');
@@ -252,10 +251,9 @@ describe('module/sw-flow/component/sw-flow-generate-document-modal', () => {
             const wrapper = await createWrapper();
             await flushPromises();
 
-            await wrapper.setData({
-                documentTypeSelected: 'invoice',
-                fileFormatsSelected: ['pdf'],
-            });
+            wrapper.vm.documentTypeSelected = 'invoice';
+            wrapper.vm.fileFormatsSelected = ['pdf'];
+            await nextTick();
 
             expect(wrapper.vm.fileFormatOptions.map((format) => format.value)).toEqual([
                 'pdf',
@@ -292,13 +290,12 @@ describe('module/sw-flow/component/sw-flow-generate-document-modal', () => {
             const wrapper = await createWrapper();
             await flushPromises();
 
-            await wrapper.setData({
-                documentTypeSelected: 'invoice',
-                fileFormatsSelected: [
-                    'pdf',
-                    'zugferd_xml',
-                ],
-            });
+            wrapper.vm.documentTypeSelected = 'invoice';
+            wrapper.vm.fileFormatsSelected = [
+                'pdf',
+                'zugferd_xml',
+            ];
+            await nextTick();
 
             const saveButton = wrapper.find('.sw-flow-generate-document-modal__save-button');
             await saveButton.trigger('click');

--- a/src/Administration/Resources/app/administration/src/module/sw-flow/component/modals/sw-flow-rule-modal/sw-flow-rule-modal.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-flow/component/modals/sw-flow-rule-modal/sw-flow-rule-modal.spec.js
@@ -1,3 +1,4 @@
+import { nextTick } from 'vue';
 import { mount } from '@vue/test-utils';
 
 /**
@@ -265,13 +266,12 @@ describe('module/sw-flow/component/sw-flow-rule-modal', () => {
         const wrapper = await createWrapper();
         await flushPromises();
 
-        await wrapper.setData({
-            conditions: [
-                {
-                    type: 'cartLineItemProductStates',
-                },
-            ],
-        });
+        wrapper.vm.conditions = [
+            {
+                type: 'cartLineItemProductStates',
+            },
+        ];
+        await nextTick();
         await flushPromises();
 
         const banner = wrapper.find('.sw-flow-rule-modal__product-type-warning');

--- a/src/Administration/Resources/app/administration/src/module/sw-flow/component/modals/sw-flow-tag-modal/sw-flow-tag-modal.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-flow/component/modals/sw-flow-tag-modal/sw-flow-tag-modal.spec.js
@@ -1,3 +1,4 @@
+import { nextTick } from 'vue';
 import { mount } from '@vue/test-utils';
 
 import EntityCollection from 'src/core/data/entity-collection.data';
@@ -167,9 +168,8 @@ describe('module/sw-flow/component/sw-flow-tag-modal', () => {
             expect(wrapper.find(elementClass).classes()).toContain('has--error');
         });
 
-        await wrapper.setData({
-            tagCollection: getTagCollection([{ name: 'new', id: '124' }]),
-        });
+        wrapper.vm.tagCollection = getTagCollection([{ name: 'new', id: '124' }]);
+        await nextTick();
 
         const entitySelect = wrapper.find('.sw-single-select__selection');
         await entitySelect.trigger('click');

--- a/src/Administration/Resources/app/administration/src/module/sw-import-export/component/sw-import-export-activity/sw-import-export-activity.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-import-export/component/sw-import-export-activity/sw-import-export-activity.spec.js
@@ -4,6 +4,7 @@
  * @sw-package fundamentals@after-sales
  */
 
+import { nextTick } from 'vue';
 import ImportExportService from 'src/module/sw-import-export/service/importExport.service';
 import { mount } from '@vue/test-utils';
 import EntityCollection from 'src/core/data/entity-collection.data';
@@ -923,10 +924,9 @@ describe('module/sw-import-export/components/sw-import-export-activity', () => {
             state: 'succeeded',
         };
 
-        await wrapper.setData({
-            selectedLog: logEntity,
-            showDetailModal: true,
-        });
+        wrapper.vm.selectedLog = logEntity;
+        wrapper.vm.showDetailModal = true;
+        await nextTick();
         await flushPromises();
 
         const detailModal = wrapper.getComponent('.sw-import-export-activity-log-info-modal');

--- a/src/Administration/Resources/app/administration/src/module/sw-import-export/component/sw-import-export-edit-profile-modal-mapping/sw-import-export-edit-profile-modal-mapping.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-import-export/component/sw-import-export-edit-profile-modal-mapping/sw-import-export-edit-profile-modal-mapping.spec.js
@@ -1,6 +1,7 @@
 /**
  * @sw-package fundamentals@after-sales
  */
+import { nextTick } from 'vue';
 import { mount } from '@vue/test-utils';
 import { MtSearch } from '@shopware-ag/meteor-component-library';
 
@@ -323,9 +324,8 @@ describe('module/sw-import-export/components/sw-import-export-edit-profile-modal
             expect(button.attributes('disabled')).toBeUndefined();
         });
 
-        await wrapper.setData({
-            searchTerm: 'search term',
-        });
+        wrapper.vm.searchTerm = 'search term';
+        await nextTick();
 
         const disabledPositionButtons = wrapper.findAll('.sw-data-grid__cell--position .mt-button');
 

--- a/src/Administration/Resources/app/administration/src/module/sw-login/view/sw-login-recovery-recovery/sw-login-recovery-recovery.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-login/view/sw-login-recovery-recovery/sw-login-recovery-recovery.spec.js
@@ -1,6 +1,7 @@
 /**
  * @sw-package framework
  */
+import { nextTick } from 'vue';
 import { mount } from '@vue/test-utils';
 
 async function createWrapper() {
@@ -38,10 +39,9 @@ describe('src/module/sw-login/view/sw-login-recovery-recovery', () => {
         wrapper.vm.$router.push = jest.fn();
         wrapper.vm.userRecoveryService.updateUserPassword = jest.fn(() => Promise.resolve());
 
-        await wrapper.setData({
-            newPassword: 'shopware',
-            newPasswordConfirm: 'shopware',
-        });
+        wrapper.vm.newPassword = 'shopware';
+        wrapper.vm.newPasswordConfirm = 'shopware';
+        await nextTick();
         await wrapper.vm.updatePassword();
 
         expect(wrapper.vm.$router.push).toHaveBeenCalledWith({
@@ -90,10 +90,9 @@ describe('src/module/sw-login/view/sw-login-recovery-recovery', () => {
         wrapper.vm.createNotificationError = jest.fn();
         wrapper.vm.userRecoveryService.updateUserPassword = jest.fn(() => Promise.reject(new Error('Bad gateway')));
 
-        await wrapper.setData({
-            newPassword: 'shopware',
-            newPasswordConfirm: 'shopware',
-        });
+        wrapper.vm.newPassword = 'shopware';
+        wrapper.vm.newPasswordConfirm = 'shopware';
+        await nextTick();
         await wrapper.vm.updatePassword();
         await flushPromises();
 

--- a/src/Administration/Resources/app/administration/src/module/sw-mail-template/component/sw-mail-template-list/sw-mail-template-list.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-mail-template/component/sw-mail-template-list/sw-mail-template-list.spec.js
@@ -1,6 +1,7 @@
 /**
  * @sw-package after-sales
  */
+import { nextTick } from 'vue';
 import { mount } from '@vue/test-utils';
 
 const createWrapper = async (privileges = []) => {
@@ -165,9 +166,8 @@ describe('modules/sw-mail-template/component/sw-mail-template-list', () => {
 
     it('should return three skeletons when there are no mail templates', async () => {
         const wrapper = await createWrapper();
-        await wrapper.setData({
-            mailTemplates: null,
-        });
+        wrapper.vm.mailTemplates = null;
+        await nextTick();
         const amountOfSkeletons = wrapper.vm.skeletonItemAmount;
 
         expect(amountOfSkeletons).toBe(3);

--- a/src/Administration/Resources/app/administration/src/module/sw-mail-template/page/sw-mail-template-detail/sw-mail-template-detail.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-mail-template/page/sw-mail-template-detail/sw-mail-template-detail.spec.js
@@ -3,6 +3,7 @@
 /**
  * @sw-package after-sales
  */
+import { nextTick } from 'vue';
 import { mount } from '@vue/test-utils';
 import EntityCollection from 'src/core/data/entity-collection.data';
 
@@ -294,7 +295,8 @@ describe('modules/sw-mail-template/page/sw-mail-template-detail', () => {
 
     it('should be able to add an item to the attachment', async () => {
         const wrapper = await createWrapper();
-        await wrapper.setData({ mailTemplateMedia: [] });
+        wrapper.vm.mailTemplateMedia = [];
+        await nextTick();
         wrapper.vm.onAddItemToAttachment(mailTemplateMediaMock);
 
         expect(wrapper.vm.mailTemplate.media.some((media) => media.mediaId === mailTemplateMediaMock.id)).toBeTruthy();
@@ -304,7 +306,8 @@ describe('modules/sw-mail-template/page/sw-mail-template-detail', () => {
         const originalLanguageId = Shopware.Context.api.languageId;
 
         const wrapper = await createWrapper();
-        await wrapper.setData({ mailTemplateMedia: [] });
+        wrapper.vm.mailTemplateMedia = [];
+        await nextTick();
         wrapper.vm.createNotificationInfo = jest.fn();
 
         // Add media
@@ -374,7 +377,8 @@ describe('modules/sw-mail-template/page/sw-mail-template-detail', () => {
 
     it('should be return if the user upload duplicated the attachment', async () => {
         const wrapper = await createWrapper();
-        await wrapper.setData({ mailTemplate: mailTemplateMock });
+        wrapper.vm.mailTemplate = mailTemplateMock;
+        await nextTick();
         const mediaLengthBeforeTest = wrapper.vm.mailTemplate.media.length;
 
         expect(
@@ -426,10 +430,9 @@ describe('modules/sw-mail-template/page/sw-mail-template-detail', () => {
 
     it('all fields should be disabled without edit permission', async () => {
         const wrapper = await createWrapper();
-        await wrapper.setData({
-            isLoading: false,
-            mailTemplateMedia: [mailTemplateMediaMock],
-        });
+        wrapper.vm.isLoading = false;
+        wrapper.vm.mailTemplateMedia = [mailTemplateMediaMock];
+        await nextTick();
 
         [
             {
@@ -495,10 +498,9 @@ describe('modules/sw-mail-template/page/sw-mail-template-detail', () => {
 
     it('all fields should be enabled with edit permission', async () => {
         const wrapper = await createWrapper(['mail_templates.editor']);
-        await wrapper.setData({
-            mailTemplateMedia: [mailTemplateMediaMock],
-            isLoading: false,
-        });
+        wrapper.vm.mailTemplateMedia = [mailTemplateMediaMock];
+        wrapper.vm.isLoading = false;
+        await nextTick();
         await flushPromises();
 
         [
@@ -591,7 +593,8 @@ describe('modules/sw-mail-template/page/sw-mail-template-detail', () => {
     it('should not be able to show preview if html content is empty', async () => {
         const wrapper = await createWrapper();
 
-        await wrapper.setData({ mailTemplate: mailTemplateTypeMock });
+        wrapper.vm.mailTemplate = { ...mailTemplateMock, ...mailTemplateTypeMock };
+        await nextTick();
 
         const previewButton = wrapper.find('.sw-mail-template-detail__show-preview-sidebar button');
 
@@ -609,9 +612,8 @@ describe('modules/sw-mail-template/page/sw-mail-template-detail', () => {
     it('should use one shared sales channel value for send and preview', async () => {
         const wrapper = await createWrapper();
 
-        await wrapper.setData({
-            testMailSalesChannelId: 'sales-channel-id-1',
-        });
+        wrapper.vm.testMailSalesChannelId = 'sales-channel-id-1';
+        await nextTick();
 
         expect(wrapper.vm.testMailSalesChannelId).toBe('sales-channel-id-1');
     });

--- a/src/Administration/Resources/app/administration/src/module/sw-manufacturer/page/sw-manufacturer-list/sw-manufacturer-list.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-manufacturer/page/sw-manufacturer-list/sw-manufacturer-list.spec.js
@@ -2,6 +2,7 @@
  * @sw-package inventory
  */
 
+import { nextTick } from 'vue';
 import { mount } from '@vue/test-utils';
 import { searchRankingPoint } from 'src/app/service/search-ranking.service';
 import Criteria from 'src/core/data/criteria.data';
@@ -111,9 +112,8 @@ describe('src/module/sw-manufacturer/page/sw-manufacturer-list', () => {
 
     it('should add query score to the criteria', async () => {
         const wrapper = await createWrapper();
-        await wrapper.setData({
-            term: 'foo',
-        });
+        wrapper.vm.term = 'foo';
+        await nextTick();
         await wrapper.vm.$nextTick();
         wrapper.vm.searchRankingService.buildSearchQueriesForEntity = jest.fn(() => {
             return new Criteria(1, 25);
@@ -154,9 +154,8 @@ describe('src/module/sw-manufacturer/page/sw-manufacturer-list', () => {
 
     it('should not build query score when search ranking field is null', async () => {
         const wrapper = await createWrapper();
-        await wrapper.setData({
-            term: 'foo',
-        });
+        wrapper.vm.term = 'foo';
+        await nextTick();
 
         await wrapper.vm.$nextTick();
         wrapper.vm.searchRankingService.buildSearchQueriesForEntity = jest.fn(() => {
@@ -178,9 +177,8 @@ describe('src/module/sw-manufacturer/page/sw-manufacturer-list', () => {
 
     it('should show empty state when there is not item after filling search term', async () => {
         const wrapper = await createWrapper();
-        await wrapper.setData({
-            term: 'foo',
-        });
+        wrapper.vm.term = 'foo';
+        await nextTick();
         await wrapper.vm.$nextTick();
         wrapper.vm.searchRankingService.getSearchFieldsByEntity = jest.fn(() => {
             return {};

--- a/src/Administration/Resources/app/administration/src/module/sw-media/component/sw-media-modal-v2/sw-media-modal-v2.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-media/component/sw-media-modal-v2/sw-media-modal-v2.spec.js
@@ -1,6 +1,7 @@
 /**
  * @sw-package discovery
  */
+import { nextTick } from 'vue';
 import { mount } from '@vue/test-utils';
 
 async function createWrapper({ featureActive = false } = {}) {
@@ -108,9 +109,8 @@ describe('src/module/sw-media/component/sw-media-modal-v2', () => {
 
         const tabs = wrapper.findComponent({ name: 'mt-tabs' });
 
-        await wrapper.setData({
-            selection: [{ id: 'selected-media' }],
-        });
+        wrapper.vm.selection = [{ id: 'selected-media' }];
+        await nextTick();
         await tabs.vm.$emit('new-item-active', 'upload');
         await wrapper.vm.$nextTick();
 
@@ -123,9 +123,8 @@ describe('src/module/sw-media/component/sw-media-modal-v2', () => {
     it('should disable the library item in meteor tabs when uploads exist', async () => {
         wrapper = await createWrapper({ featureActive: true });
 
-        await wrapper.setData({
-            uploads: [{ id: 'uploaded-media' }],
-        });
+        wrapper.vm.uploads = [{ id: 'uploaded-media' }];
+        await nextTick();
 
         expect(wrapper.vm.mediaModalTabs[0].disabled).toBe(true);
     });

--- a/src/Administration/Resources/app/administration/src/module/sw-newsletter-recipient/page/sw-newsletter-recipient-list/sw-newsletter-recipient-list.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-newsletter-recipient/page/sw-newsletter-recipient-list/sw-newsletter-recipient-list.spec.js
@@ -1,6 +1,7 @@
 /**
  * @sw-package after-sales
  */
+import { nextTick } from 'vue';
 import { mount } from '@vue/test-utils';
 
 import { searchRankingPoint } from 'src/app/service/search-ranking.service';
@@ -264,9 +265,8 @@ describe('src/module/sw-newsletter-recipient/page/sw-newsletter-recipient-list',
 
     it('should add query score to the criteria', async () => {
         const wrapper = await createWrapper();
-        await wrapper.setData({
-            term: 'foo',
-        });
+        wrapper.vm.term = 'foo';
+        await nextTick();
         await wrapper.vm.$nextTick();
         wrapper.vm.searchRankingService.buildSearchQueriesForEntity = jest.fn(() => {
             return new Criteria(1, 25);
@@ -307,9 +307,8 @@ describe('src/module/sw-newsletter-recipient/page/sw-newsletter-recipient-list',
 
     it('should not build query score when search ranking field is null', async () => {
         const wrapper = await createWrapper();
-        await wrapper.setData({
-            term: 'foo',
-        });
+        wrapper.vm.term = 'foo';
+        await nextTick();
 
         await wrapper.vm.$nextTick();
         wrapper.vm.searchRankingService.buildSearchQueriesForEntity = jest.fn(() => {
@@ -331,9 +330,8 @@ describe('src/module/sw-newsletter-recipient/page/sw-newsletter-recipient-list',
 
     it('should show empty state when there is not item after filling search term', async () => {
         const wrapper = await createWrapper();
-        await wrapper.setData({
-            term: 'foo',
-        });
+        wrapper.vm.term = 'foo';
+        await nextTick();
         await wrapper.vm.$nextTick();
         wrapper.vm.searchRankingService.getSearchFieldsByEntity = jest.fn(() => {
             return {};
@@ -359,9 +357,8 @@ describe('src/module/sw-newsletter-recipient/page/sw-newsletter-recipient-list',
 
     it('should sort by firstName when clicking the name column', async () => {
         const wrapper = await createWrapper({ useSearchSpy: true });
-        await wrapper.setData({
-            disableRouteParams: true,
-        });
+        wrapper.vm.disableRouteParams = true;
+        await nextTick();
         await flushPromises();
 
         expect(wrapper.find('.sw-data-grid__row--0 .sw-data-grid__cell--firstName div').text()).toBe(
@@ -375,9 +372,8 @@ describe('src/module/sw-newsletter-recipient/page/sw-newsletter-recipient-list',
         ]);
 
         await wrapper.find('.sw-data-grid__cell--1').trigger('click');
-        await wrapper.setData({
-            total: 2,
-        });
+        wrapper.vm.total = 2;
+        await nextTick();
         await flushPromises();
 
         expect(searchSpy).toHaveBeenCalledTimes(1);

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-address-modal/sw-order-address-modal.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-address-modal/sw-order-address-modal.spec.js
@@ -1,3 +1,4 @@
+import { nextTick } from 'vue';
 import { mount } from '@vue/test-utils';
 
 /**
@@ -148,22 +149,21 @@ describe('src/module/sw-order/component/sw-order-address-modal', () => {
     it('should switch meteor tab content when the active tab changes', async () => {
         wrapper = await createWrapper({ featureActive: true });
 
-        await wrapper.setData({
-            availableAddresses: [
-                {
-                    id: 'address-id',
-                    company: 'Test company',
-                    salutation: null,
-                    street: 'Test street',
-                    zipcode: '12345',
-                    city: 'Test city',
-                    country: {
-                        name: 'Test country',
-                    },
+        wrapper.vm.availableAddresses = [
+            {
+                id: 'address-id',
+                company: 'Test company',
+                salutation: null,
+                street: 'Test street',
+                zipcode: '12345',
+                city: 'Test city',
+                country: {
+                    name: 'Test country',
                 },
-            ],
-            selectedAddressId: 'address-id',
-        });
+            },
+        ];
+        wrapper.vm.selectedAddressId = 'address-id';
+        await nextTick();
 
         wrapper.getComponent({ name: 'mt-tabs' }).vm.$emit('new-item-active', 'addresses');
         await wrapper.vm.$nextTick();

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-create-address-modal/sw-order-create-address-modal.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-create-address-modal/sw-order-create-address-modal.spec.js
@@ -1,3 +1,4 @@
+import { nextTick } from 'vue';
 import { mount } from '@vue/test-utils';
 import findByText from '../../../../../test/_helper_/find-by-text';
 
@@ -75,12 +76,11 @@ describe('src/module/sw-order/component/sw-order-create-address-modal', () => {
     });
 
     it('should dispatch error with invalid company field', async () => {
-        await wrapper.setData({
-            addresses: [
-                { id: '12345', isNew: () => {}, getEntityName: () => 'customer_address' },
-                { id: '02', isNew: () => {}, getEntityName: () => 'customer_address' },
-            ],
-        });
+        wrapper.vm.addresses = [
+            { id: '12345', isNew: () => {}, getEntityName: () => 'customer_address' },
+            { id: '02', isNew: () => {}, getEntityName: () => 'customer_address' },
+        ];
+        await nextTick();
 
         const btn = wrapper.findAll('.sw-order-create-address-modal__edit-btn')[0];
         await btn.trigger('click');

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-customer-grid/sw-order-customer-grid.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-customer-grid/sw-order-customer-grid.spec.js
@@ -1,5 +1,6 @@
 /* eslint-disable sw-test-rules/test-file-max-lines-warning */
 
+import { nextTick } from 'vue';
 import { mount } from '@vue/test-utils';
 
 /**
@@ -573,9 +574,8 @@ describe('src/module/sw-order/view/sw-order-customer-grid', () => {
         Shopware.Store.get('swOrder').setCartToken('HE6KD7HOCC3TCS0AX903KCA6JHXCTXU2');
 
         const wrapper = await createWrapper();
-        await wrapper.setData({
-            customerDraft: null,
-        });
+        wrapper.vm.customerDraft = null;
+        await nextTick();
 
         const handleSelectCustomerSpy = jest.spyOn(wrapper.vm, 'handleSelectCustomer');
 

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-document-card/sw-order-document-card.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-document-card/sw-order-document-card.spec.js
@@ -3,6 +3,7 @@
 /**
  * @sw-package after-sales
  */
+import { nextTick } from 'vue';
 import { mount } from '@vue/test-utils';
 import EntityCollection from 'src/core/data/entity-collection.data';
 import { createPinia, setActivePinia } from 'pinia';
@@ -445,11 +446,10 @@ describe('src/module/sw-order/component/sw-order-document-card', () => {
 
         wrapper = await createWrapper();
 
-        await wrapper.setData({
-            documents: getCollection('document', [
-                documentFixture,
-            ]),
-        });
+        wrapper.vm.documents = getCollection('document', [
+            documentFixture,
+        ]);
+        await nextTick();
         expect(wrapper.find('.sw-data-grid').exists()).toBeTruthy();
 
         const sendDocumentButton = wrapper.find('.sw-order-document-card__context-button-send');
@@ -465,11 +465,10 @@ describe('src/module/sw-order/component/sw-order-document-card', () => {
 
         wrapper = await createWrapper(defaultProps, 'sw.order.detail.documents');
 
-        await wrapper.setData({
-            documents: getCollection('document', [
-                documentFixture,
-            ]),
-        });
+        wrapper.vm.documents = getCollection('document', [
+            documentFixture,
+        ]);
+        await nextTick();
 
         const columns = wrapper.findAll('.sw-data-grid__cell--header');
         // 5 data columns + 1 action column
@@ -488,15 +487,14 @@ describe('src/module/sw-order/component/sw-order-document-card', () => {
 
         wrapper = await createWrapper(defaultProps, 'sw.order.detail.documents');
 
-        await wrapper.setData({
-            documents: getCollection('document', [
-                {
-                    ...documentFixture,
-                    documentMediaFile: { fileExtension: 'pdf' },
-                    documentA11yMediaFile: null,
-                },
-            ]),
-        });
+        wrapper.vm.documents = getCollection('document', [
+            {
+                ...documentFixture,
+                documentMediaFile: { fileExtension: 'pdf' },
+                documentA11yMediaFile: null,
+            },
+        ]);
+        await nextTick();
 
         expect(wrapper.find('.sw-order-document-card__context-button-download-all-formats').exists()).toBe(false);
     });
@@ -508,23 +506,22 @@ describe('src/module/sw-order/component/sw-order-document-card', () => {
         const dispatchEventSpy = jest.spyOn(HTMLAnchorElement.prototype, 'dispatchEvent').mockImplementation(() => true);
         wrapper = await createWrapper(defaultProps, 'sw.order.detail.documents');
 
-        await wrapper.setData({
-            documents: getCollection('document', [
-                {
-                    ...documentFixture,
-                    documentFiles: [
-                        {
-                            documentFormat: 'html',
-                        },
-                        {
-                            documentFormat: 'pdf',
-                        },
-                    ],
-                    documentMediaFile: null,
-                    documentA11yMediaFile: null,
-                },
-            ]),
-        });
+        wrapper.vm.documents = getCollection('document', [
+            {
+                ...documentFixture,
+                documentFiles: [
+                    {
+                        documentFormat: 'html',
+                    },
+                    {
+                        documentFormat: 'pdf',
+                    },
+                ],
+                documentMediaFile: null,
+                documentA11yMediaFile: null,
+            },
+        ]);
+        await nextTick();
 
         await wrapper.find('.sw-order-document-card__actions-button').trigger('click');
         await flushPromises();
@@ -544,11 +541,10 @@ describe('src/module/sw-order/component/sw-order-document-card', () => {
     it('should render the legacy context menu actions when the feature flag is inactive', async () => {
         wrapper = await createWrapper();
 
-        await wrapper.setData({
-            documents: getCollection('document', [
-                documentFixture,
-            ]),
-        });
+        wrapper.vm.documents = getCollection('document', [
+            documentFixture,
+        ]);
+        await nextTick();
 
         expect(wrapper.find('sw-context-menu-item.sw-order-document-card__context-button-open-pdf').exists()).toBe(true);
     });
@@ -558,11 +554,10 @@ describe('src/module/sw-order/component/sw-order-document-card', () => {
 
         wrapper = await createWrapper();
 
-        await wrapper.setData({
-            documents: getCollection('document', [
-                documentFixture,
-            ]),
-        });
+        wrapper.vm.documents = getCollection('document', [
+            documentFixture,
+        ]);
+        await nextTick();
 
         await wrapper.find('.sw-order-document-card__actions-button').trigger('click');
 
@@ -577,11 +572,10 @@ describe('src/module/sw-order/component/sw-order-document-card', () => {
 
         wrapper = await createWrapper(defaultProps, 'sw.order.detail.details', actionMenuStubs);
 
-        await wrapper.setData({
-            documents: getCollection('document', [
-                documentFixture,
-            ]),
-        });
+        wrapper.vm.documents = getCollection('document', [
+            documentFixture,
+        ]);
+        await nextTick();
 
         await wrapper.find('.sw-order-document-card__context-button-open-format').trigger('click');
         await flushPromises();
@@ -598,11 +592,10 @@ describe('src/module/sw-order/component/sw-order-document-card', () => {
 
         wrapper = await createWrapper();
 
-        await wrapper.setData({
-            documents: getCollection('document', [
-                documentFixture,
-            ]),
-        });
+        wrapper.vm.documents = getCollection('document', [
+            documentFixture,
+        ]);
+        await nextTick();
 
         await wrapper.find('.sw-order-document-card__context-button-open-pdf').trigger('click');
         await flushPromises();
@@ -625,11 +618,10 @@ describe('src/module/sw-order/component/sw-order-document-card', () => {
 
         wrapper = await createWrapper(defaultProps, 'sw.order.detail.details', actionMenuStubs);
 
-        await wrapper.setData({
-            documents: getCollection('document', [
-                documentFixture,
-            ]),
-        });
+        wrapper.vm.documents = getCollection('document', [
+            documentFixture,
+        ]);
+        await nextTick();
 
         await wrapper.find('.sw-order-document-card__context-button-download-format').trigger('click');
         await flushPromises();
@@ -646,11 +638,10 @@ describe('src/module/sw-order/component/sw-order-document-card', () => {
 
         wrapper = await createWrapper();
 
-        await wrapper.setData({
-            documents: getCollection('document', [
-                documentFixture,
-            ]),
-        });
+        wrapper.vm.documents = getCollection('document', [
+            documentFixture,
+        ]);
+        await nextTick();
 
         await wrapper.find('.sw-order-document-card__context-button-download-pdf').trigger('click');
         await flushPromises();
@@ -888,11 +879,10 @@ describe('src/module/sw-order/component/sw-order-document-card', () => {
         global.activeAclRoles = [];
         wrapper = await createWrapper();
 
-        await wrapper.setData({
-            documents: getCollection('document', [
-                documentFixture,
-            ]),
-        });
+        wrapper.vm.documents = getCollection('document', [
+            documentFixture,
+        ]);
+        await nextTick();
 
         let columns = wrapper.findAll('.sw-data-grid__cell--header');
         // 4 data columns + 1 action column
@@ -922,11 +912,10 @@ describe('src/module/sw-order/component/sw-order-document-card', () => {
             },
         });
 
-        await wrapper.setData({
-            documents: getCollection('document', [
-                documentFixture,
-            ]),
-        });
+        wrapper.vm.documents = getCollection('document', [
+            documentFixture,
+        ]);
+        await nextTick();
 
         expect(wrapper.find('sw-card-filter').exists()).toBeTruthy();
     });
@@ -936,11 +925,10 @@ describe('src/module/sw-order/component/sw-order-document-card', () => {
 
         wrapper = await createWrapper();
 
-        await wrapper.setData({
-            documents: getCollection('document', [
-                documentFixture,
-            ]),
-        });
+        wrapper.vm.documents = getCollection('document', [
+            documentFixture,
+        ]);
+        await nextTick();
 
         expect(wrapper.find('.sw-data-grid__cell--sent sw-data-grid-column-boolean').attributes('value')).toBe('true');
 
@@ -961,14 +949,13 @@ describe('src/module/sw-order/component/sw-order-document-card', () => {
 
         wrapper = await createWrapper();
 
-        await wrapper.setData({
-            documents: getCollection('document', [
-                {
-                    ...documentFixture,
-                    sent: false,
-                },
-            ]),
-        });
+        wrapper.vm.documents = getCollection('document', [
+            {
+                ...documentFixture,
+                sent: false,
+            },
+        ]);
+        await nextTick();
 
         const spyMarkDocumentAsSent = jest.spyOn(wrapper.vm, 'markDocumentAsSent');
 
@@ -1172,9 +1159,8 @@ describe('src/module/sw-order/component/sw-order-document-card', () => {
         expect(wrapper.vm.documentCriteria.term).toBeNull();
         expect(wrapper.vm.documentCriteria.queries).toEqual([]);
 
-        await wrapper.setData({
-            term: '1000',
-        });
+        wrapper.vm.term = '1000';
+        await nextTick();
 
         expect(wrapper.vm.documentCriteria.term).toBe('1000');
         expect(wrapper.vm.documentCriteria.queries).toEqual([
@@ -1217,11 +1203,10 @@ describe('src/module/sw-order/component/sw-order-document-card', () => {
     it('should render the only pdf on available formats column', async () => {
         wrapper = await createWrapper(defaultProps, 'sw.order.detail.documents');
 
-        await wrapper.setData({
-            documents: getCollection('document', [
-                { ...documentFixture, documentMediaFile: { fileExtension: 'pdf' }, documentA11yMediaFile: null },
-            ]),
-        });
+        wrapper.vm.documents = getCollection('document', [
+            { ...documentFixture, documentMediaFile: { fileExtension: 'pdf' }, documentA11yMediaFile: null },
+        ]);
+        await nextTick();
 
         await flushPromises();
 
@@ -1234,19 +1219,18 @@ describe('src/module/sw-order/component/sw-order-document-card', () => {
     it('should render html and pdf on available formats column', async () => {
         wrapper = await createWrapper(defaultProps, 'sw.order.detail.documents');
 
-        await wrapper.setData({
-            documents: getCollection('document', [
-                {
-                    ...documentFixture,
-                    documentMediaFile: {
-                        fileExtension: 'pdf',
-                    },
-                    documentA11yMediaFile: {
-                        fileExtension: 'html',
-                    },
+        wrapper.vm.documents = getCollection('document', [
+            {
+                ...documentFixture,
+                documentMediaFile: {
+                    fileExtension: 'pdf',
                 },
-            ]),
-        });
+                documentA11yMediaFile: {
+                    fileExtension: 'html',
+                },
+            },
+        ]);
+        await nextTick();
 
         await flushPromises();
 
@@ -1261,11 +1245,10 @@ describe('src/module/sw-order/component/sw-order-document-card', () => {
 
         wrapper = await createWrapper();
 
-        await wrapper.setData({
-            documents: getCollection('document', [
-                documentFixture,
-            ]),
-        });
+        wrapper.vm.documents = getCollection('document', [
+            documentFixture,
+        ]);
+        await nextTick();
 
         const deleteButton = wrapper.find(buttonDeleteClassDocumentCard);
         expect(deleteButton.exists()).toBe(true);
@@ -1283,11 +1266,10 @@ describe('src/module/sw-order/component/sw-order-document-card', () => {
             'sw.order.detail.documents',
         );
 
-        await wrapper.setData({
-            documents: getCollection('document', [
-                documentFixture,
-            ]),
-        });
+        wrapper.vm.documents = getCollection('document', [
+            documentFixture,
+        ]);
+        await nextTick();
 
         const deleteButton = wrapper.find(buttonDeleteClassEntityListing);
         expect(deleteButton.exists()).toBe(true);
@@ -1299,11 +1281,10 @@ describe('src/module/sw-order/component/sw-order-document-card', () => {
 
         wrapper = await createWrapper(defaultProps, 'sw.order.detail.documents');
 
-        await wrapper.setData({
-            documents: getCollection('document', [
-                documentFixture,
-            ]),
-        });
+        wrapper.vm.documents = getCollection('document', [
+            documentFixture,
+        ]);
+        await nextTick();
 
         const deleteButton = wrapper.find(buttonDeleteClassDocumentCard);
         expect(deleteButton.exists()).toBe(true);
@@ -1315,11 +1296,10 @@ describe('src/module/sw-order/component/sw-order-document-card', () => {
 
         wrapper = await createWrapper();
 
-        await wrapper.setData({
-            documents: getCollection('document', [
-                documentFixture,
-            ]),
-        });
+        wrapper.vm.documents = getCollection('document', [
+            documentFixture,
+        ]);
+        await nextTick();
 
         expect(wrapper.find('.sw-modal').exists()).toBe(false);
 
@@ -1343,11 +1323,10 @@ describe('src/module/sw-order/component/sw-order-document-card', () => {
 
         wrapper = await createWrapper();
 
-        await wrapper.setData({
-            documents: getCollection('document', [
-                documentFixture,
-            ]),
-        });
+        wrapper.vm.documents = getCollection('document', [
+            documentFixture,
+        ]);
+        await nextTick();
 
         documentSearchMock.mockResolvedValue(getCollection('document', []));
 
@@ -1370,11 +1349,10 @@ describe('src/module/sw-order/component/sw-order-document-card', () => {
 
         wrapper = await createWrapper();
 
-        await wrapper.setData({
-            documents: getCollection('document', [
-                documentFixture,
-            ]),
-        });
+        wrapper.vm.documents = getCollection('document', [
+            documentFixture,
+        ]);
+        await nextTick();
 
         documentDeleteMock.mockRejectedValue({
             response: {

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-document-settings-credit-note-modal/sw-order-document-settings-credit-note-modal.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-document-settings-credit-note-modal/sw-order-document-settings-credit-note-modal.spec.js
@@ -1,6 +1,7 @@
 /**
  * @sw-package after-sales
  */
+import { nextTick } from 'vue';
 import { mount } from '@vue/test-utils';
 import { DOCUMENT_TYPES } from '../../order.types';
 
@@ -440,9 +441,8 @@ describe('sw-order-document-settings-credit-note-modal', () => {
             documentDate: '2024/01/01',
         };
 
-        await wrapper.setData({
-            documentConfig,
-        });
+        Object.assign(wrapper.vm.documentConfig, documentConfig);
+        await nextTick();
         await flushPromises();
 
         expect(wrapper.find('.sw-order-document-settings-credit-note-modal__document-number input').element.value).toBe(

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-document-settings-delivery-note-modal/sw-order-document-settings-delivery-note-modal.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-document-settings-delivery-note-modal/sw-order-document-settings-delivery-note-modal.spec.js
@@ -1,6 +1,7 @@
 /**
  * @sw-package after-sales
  */
+import { nextTick } from 'vue';
 import { mount } from '@vue/test-utils';
 
 const orderFixture = {
@@ -119,9 +120,8 @@ describe('src/module/sw-order/component/sw-order-document-settings-delivery-note
             documentComment: '',
         };
 
-        await wrapper.setData({
-            documentConfig,
-        });
+        wrapper.vm.documentConfig = documentConfig;
+        await nextTick();
         await flushPromises();
 
         expect(wrapper.find('.sw-order-document-settings-delivery-note-modal__document-number input').element.value).toBe(

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-document-settings-modal/sw-order-document-settings-modal.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-document-settings-modal/sw-order-document-settings-modal.spec.js
@@ -1,6 +1,7 @@
 /**
  * @sw-package after-sales
  */
+import { nextTick } from 'vue';
 import { mount } from '@vue/test-utils';
 import EntityCollection from 'src/core/data/entity-collection.data';
 import FileValidationService from 'src/app/service/file-validation.service';
@@ -229,9 +230,8 @@ describe('src/module/sw-order/component/sw-order-document-settings-modal', () =>
             documentDate: '2024/03/01',
         };
 
-        await wrapper.setData({
-            documentConfig,
-        });
+        wrapper.vm.documentConfig = documentConfig;
+        await nextTick();
         await flushPromises();
 
         expect(wrapper.find('.sw-order-document-settings-modal__document-number input').element.value).toBe(
@@ -265,9 +265,8 @@ describe('src/module/sw-order/component/sw-order-document-settings-modal', () =>
             documentDate: '',
         };
 
-        await wrapper.setData({
-            documentConfig,
-        });
+        wrapper.vm.documentConfig = documentConfig;
+        await nextTick();
         await flushPromises();
 
         expect(wrapper.find('.sw-order-document-settings-modal__document-number input').element.value).toBe(

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-document-settings-storno-modal/sw-order-document-settings-storno-modal.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-document-settings-storno-modal/sw-order-document-settings-storno-modal.spec.js
@@ -1,6 +1,7 @@
 /**
  * @sw-package after-sales
  */
+import { nextTick } from 'vue';
 import { mount } from '@vue/test-utils';
 
 const orderFixture = {
@@ -157,9 +158,8 @@ describe('src/module/sw-order/component/sw-order-document-settings-storno-modal'
             documentDate: '2024/01/01',
         };
 
-        await wrapper.setData({
-            documentConfig,
-        });
+        Object.assign(wrapper.vm.documentConfig, documentConfig);
+        await nextTick();
         await flushPromises();
 
         expect(wrapper.find('.sw-order-document-settings-storno-modal__document-number input').element.value).toBe(

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-line-items-grid-sales-channel/sw-order-line-items-grid-sales-channel.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-line-items-grid-sales-channel/sw-order-line-items-grid-sales-channel.spec.js
@@ -1,5 +1,6 @@
 /* eslint-disable sw-test-rules/test-file-max-lines-warning */
 
+import { nextTick } from 'vue';
 import { mount } from '@vue/test-utils';
 import 'src/app/component/data-grid/sw-data-grid';
 import 'src/app/component/base/sw-button';
@@ -338,9 +339,8 @@ describe('src/module/sw-order/component/sw-order-line-items-grid-sales-channel',
             },
         });
 
-        await wrapper.setData({
-            searchTerm: 'item product',
-        });
+        wrapper.vm.searchTerm = 'item product';
+        await nextTick();
         const productItem = wrapper.find('.sw-data-grid__row--0');
         const productLabel = productItem.find('.sw-data-grid__cell--label');
 

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-line-items-grid/sw-order-line-items-grid.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-line-items-grid/sw-order-line-items-grid.spec.js
@@ -1,5 +1,6 @@
 /* eslint-disable sw-test-rules/test-file-max-lines-warning */
 
+import { nextTick } from 'vue';
 import { mount } from '@vue/test-utils';
 
 /**
@@ -469,9 +470,8 @@ describe('src/module/sw-order/component/sw-order-line-items-grid', () => {
             },
         });
 
-        await wrapper.setData({
-            searchTerm: 'item product',
-        });
+        wrapper.vm.searchTerm = 'item product';
+        await nextTick();
 
         const firstRow = wrapper.find('.sw-data-grid__row--0');
         const productLabel = firstRow.find('.sw-data-grid__cell--label');
@@ -934,9 +934,8 @@ describe('src/module/sw-order/component/sw-order-line-items-grid', () => {
             return item;
         });
 
-        await wrapper.setData({
-            searchTerm: 'product number',
-        });
+        wrapper.vm.searchTerm = 'product number';
+        await nextTick();
 
         const firstRow = wrapper.find('.sw-data-grid__row--0');
         const productLabel = firstRow.find('.sw-data-grid__cell--label');

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-promotion-field/sw-order-promotion-field.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-promotion-field/sw-order-promotion-field.spec.js
@@ -182,6 +182,9 @@ describe('src/module/sw-order/component/sw-order-promotion-field', () => {
         createStateMapper();
 
         const wrapper = await createWrapper();
+        // `hasOrderUnsavedChanges` is a computed, which setData reaches by shadowing it through
+        // $data. The component exposes no seam to drive it from a spec.
+        // eslint-disable-next-line sw-test-rules/no-set-data
         await wrapper.setData({
             hasOrderUnsavedChanges: false,
         });
@@ -202,6 +205,9 @@ describe('src/module/sw-order/component/sw-order-promotion-field', () => {
         createStateMapper();
 
         const wrapper = await createWrapper();
+        // `hasOrderUnsavedChanges` is a computed, which setData reaches by shadowing it through
+        // $data. The component exposes no seam to drive it from a spec.
+        // eslint-disable-next-line sw-test-rules/no-set-data
         await wrapper.setData({
             hasOrderUnsavedChanges: true,
         });

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-promotion-tag-field/sw-order-promotion-tag-field.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-promotion-tag-field/sw-order-promotion-tag-field.spec.js
@@ -1,3 +1,4 @@
+import { nextTick } from 'vue';
 import { mount } from '@vue/test-utils';
 
 /**
@@ -92,9 +93,8 @@ describe('src/module/sw-order/component/sw-order-promotion-tag-field', () => {
             preventDefault: jest.fn(),
         };
 
-        await wrapper.setData({
-            newTagName: 'SUMMER-SALE',
-        });
+        wrapper.vm.newTagName = 'SUMMER-SALE';
+        await nextTick();
 
         wrapper.vm.performAddTag(event);
 
@@ -117,9 +117,8 @@ describe('src/module/sw-order/component/sw-order-promotion-tag-field', () => {
             ],
         });
 
-        await wrapper.setData({
-            newTagName: 'SUMMER-SALE',
-        });
+        wrapper.vm.newTagName = 'SUMMER-SALE';
+        await nextTick();
 
         wrapper.vm.performAddTag({
             key: 'Enter',
@@ -133,9 +132,8 @@ describe('src/module/sw-order/component/sw-order-promotion-tag-field', () => {
     it('should not add a promotion code tag when the trigger key does not match', async () => {
         const wrapper = await createWrapper();
 
-        await wrapper.setData({
-            newTagName: 'SUMMER-SALE',
-        });
+        wrapper.vm.newTagName = 'SUMMER-SALE';
+        await nextTick();
 
         wrapper.vm.performAddTag({
             key: 'Escape',
@@ -151,9 +149,8 @@ describe('src/module/sw-order/component/sw-order-promotion-tag-field', () => {
             disabled: true,
         });
 
-        await wrapper.setData({
-            newTagName: 'SUMMER-SALE',
-        });
+        wrapper.vm.newTagName = 'SUMMER-SALE';
+        await nextTick();
 
         wrapper.vm.performAddTag({
             key: 'Enter',
@@ -217,10 +214,9 @@ describe('src/module/sw-order/component/sw-order-promotion-tag-field', () => {
     it('should show the typed code while the field has focus', async () => {
         const wrapper = await createWrapper();
 
-        await wrapper.setData({
-            newTagName: 'SUMMER-SALE',
-            hasFocus: true,
-        });
+        wrapper.vm.newTagName = 'SUMMER-SALE';
+        wrapper.vm.hasFocus = true;
+        await nextTick();
 
         expect(wrapper.find('.sw-tagged-field__input').classes()).not.toContain('sw-tagged-field__input--hidden');
     });
@@ -228,10 +224,9 @@ describe('src/module/sw-order/component/sw-order-promotion-tag-field', () => {
     it('should hide an unsubmitted code when the field loses focus', async () => {
         const wrapper = await createWrapper();
 
-        await wrapper.setData({
-            newTagName: 'SUMMER-SALE',
-            hasFocus: false,
-        });
+        wrapper.vm.newTagName = 'SUMMER-SALE';
+        wrapper.vm.hasFocus = false;
+        await nextTick();
 
         expect(wrapper.find('.sw-tagged-field__input').classes()).toContain('sw-tagged-field__input--hidden');
     });

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-state-history-card/sw-order-state-history-card.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-state-history-card/sw-order-state-history-card.spec.js
@@ -1,3 +1,4 @@
+import { nextTick } from 'vue';
 import { mount } from '@vue/test-utils';
 
 /**
@@ -93,7 +94,8 @@ describe('src/module/sw-order/component/sw-order-state-history-card', () => {
     it('should always render order change modal with document selection', async () => {
         global.activeAclRoles = [];
         wrapper = await createWrapper();
-        await wrapper.setData({ showModal: true });
+        wrapper.vm.showModal = true;
+        await nextTick();
 
         await wrapper.vm.$nextTick();
 

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-upload-document-modal/sw-order-upload-document-modal.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-upload-document-modal/sw-order-upload-document-modal.spec.js
@@ -1,3 +1,4 @@
+import { nextTick } from 'vue';
 import { mount } from '@vue/test-utils';
 import component from './index';
 
@@ -222,7 +223,8 @@ describe('src/module/sw-order/component/sw-order-upload-document-modal', () => {
             type: 'application/pdf',
         };
 
-        await wrapper.setData({ selectedDocumentFile: file });
+        wrapper.vm.selectedDocumentFile = file;
+        await nextTick();
         await flushPromises();
 
         await wrapper.find('.sw-order-upload-document-modal__upload-button').trigger('click');
@@ -261,7 +263,8 @@ describe('src/module/sw-order/component/sw-order-upload-document-modal', () => {
             type: 'application/pdf',
         };
 
-        await wrapper.setData({ selectedDocumentFile: file });
+        wrapper.vm.selectedDocumentFile = file;
+        await nextTick();
         await flushPromises();
 
         await wrapper.find('.sw-order-upload-document-modal__upload-button-send').trigger('click');

--- a/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-detail/sw-order-detail.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-detail/sw-order-detail.spec.js
@@ -143,7 +143,8 @@ describe('src/module/sw-order/page/sw-order-detail', () => {
         wrapper = await createWrapper();
         await flushPromises();
 
-        await wrapper.setData({ hasOrderDeepEdit: true });
+        wrapper.vm.hasOrderDeepEdit = true;
+        await nextTick();
 
         const next = jest.fn();
         wrapper.vm.$options.beforeRouteLeave.call(wrapper.vm, {}, {}, next);
@@ -183,7 +184,8 @@ describe('src/module/sw-order/page/sw-order-detail', () => {
 
     it('should contain manual label', async () => {
         wrapper = await createWrapper();
-        await wrapper.setData({ identifier: '1' });
+        wrapper.vm.identifier = '1';
+        await nextTick();
 
         Shopware.Store.get('swOrderDetail').order = {
             orderNumber: 1,

--- a/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-list/sw-order-list.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-list/sw-order-list.spec.js
@@ -1,5 +1,6 @@
 /* eslint-disable sw-test-rules/test-file-max-lines-warning */
 
+import { nextTick } from 'vue';
 import { mount } from '@vue/test-utils';
 import EntityCollection from 'src/core/data/entity-collection.data';
 import Criteria from 'src/core/data/criteria.data';
@@ -184,18 +185,17 @@ describe('src/module/sw-order/page/sw-order-list', () => {
     it('should contain manual label correctly', async () => {
         global.activeAclRoles = [];
         wrapper = await createWrapper();
-        await wrapper.setData({
-            orders: [
-                {
-                    ...mockItem,
-                    createdById: '1',
-                },
-                {
-                    ...mockItem,
-                },
-            ],
-            total: 2,
-        });
+        wrapper.vm.orders = [
+            {
+                ...mockItem,
+                createdById: '1',
+            },
+            {
+                ...mockItem,
+            },
+        ];
+        wrapper.vm.total = 2;
+        await nextTick();
 
         const firstRow = wrapper.find('.sw-data-grid__row--0');
         const secondRow = wrapper.find('.sw-data-grid__row--1');
@@ -207,26 +207,25 @@ describe('src/module/sw-order/page/sw-order-list', () => {
     it('should render comment tooltip buttons depending on available comments', async () => {
         global.activeAclRoles = [];
         wrapper = await createWrapper();
-        await wrapper.setData({
-            orders: [
-                {
-                    ...mockItem,
-                    customerComment: 'Customer comment',
-                    internalComment: 'Internal comment',
-                },
-                {
-                    ...mockItem,
-                    customerComment: 'Customer comment',
-                    internalComment: null,
-                },
-                {
-                    ...mockItem,
-                    customerComment: null,
-                    internalComment: 'Internal comment',
-                },
-            ],
-            total: 3,
-        });
+        wrapper.vm.orders = [
+            {
+                ...mockItem,
+                customerComment: 'Customer comment',
+                internalComment: 'Internal comment',
+            },
+            {
+                ...mockItem,
+                customerComment: 'Customer comment',
+                internalComment: null,
+            },
+            {
+                ...mockItem,
+                customerComment: null,
+                internalComment: 'Internal comment',
+            },
+        ];
+        wrapper.vm.total = 3;
+        await nextTick();
 
         const firstRowButtons = wrapper.find('.sw-data-grid__row--0').findAll('.sw-order-list__tooltip-order-comment');
         const secondRowButtons = wrapper.find('.sw-data-grid__row--1').findAll('.sw-order-list__tooltip-order-comment');
@@ -246,23 +245,22 @@ describe('src/module/sw-order/page/sw-order-list', () => {
         wrapper = await createWrapper();
         const warningSpy = jest.spyOn(console, 'warn').mockImplementation();
 
-        await wrapper.setData({
-            orders: [
-                {
-                    ...mockItem,
-                    orderCustomer: {
-                        customerId: '1',
-                        firstName: 'foo',
-                        lastName: 'bar',
-                    },
+        wrapper.vm.orders = [
+            {
+                ...mockItem,
+                orderCustomer: {
+                    customerId: '1',
+                    firstName: 'foo',
+                    lastName: 'bar',
                 },
-                {
-                    ...mockItem,
-                    orderCustomer: null,
-                },
-            ],
-            total: 2,
-        });
+            },
+            {
+                ...mockItem,
+                orderCustomer: null,
+            },
+        ];
+        wrapper.vm.total = 2;
+        await nextTick();
 
         const firstRow = wrapper.find('.sw-data-grid__row--0');
         const secondRow = wrapper.find('.sw-data-grid__row--1');
@@ -279,9 +277,8 @@ describe('src/module/sw-order/page/sw-order-list', () => {
     it('should add query score to the criteria', async () => {
         global.activeAclRoles = [];
         wrapper = await createWrapper();
-        await wrapper.setData({
-            term: 'foo',
-        });
+        wrapper.vm.term = 'foo';
+        await nextTick();
         await wrapper.vm.$nextTick();
         wrapper.vm.searchRankingService.buildSearchQueriesForEntity = jest.fn(() => {
             return new Criteria(1, 25);
@@ -324,9 +321,8 @@ describe('src/module/sw-order/page/sw-order-list', () => {
     it('should not build query score when search ranking field is null', async () => {
         global.activeAclRoles = [];
         wrapper = await createWrapper();
-        await wrapper.setData({
-            term: 'foo',
-        });
+        wrapper.vm.term = 'foo';
+        await nextTick();
 
         await wrapper.vm.$nextTick();
         wrapper.vm.searchRankingService.buildSearchQueriesForEntity = jest.fn(() => {
@@ -349,9 +345,8 @@ describe('src/module/sw-order/page/sw-order-list', () => {
     it('should show empty state when there is not item after filling search term', async () => {
         global.activeAclRoles = [];
         wrapper = await createWrapper();
-        await wrapper.setData({
-            term: 'foo',
-        });
+        wrapper.vm.term = 'foo';
+        await nextTick();
         await wrapper.vm.$nextTick();
         wrapper.vm.searchRankingService.getSearchFieldsByEntity = jest.fn(() => {
             return {};
@@ -378,18 +373,17 @@ describe('src/module/sw-order/page/sw-order-list', () => {
             },
         };
 
-        await wrapper.setData({
-            orders: [
-                {
-                    ...mockItem,
-                    createdById: '1',
-                },
-                {
-                    ...mockItem,
-                },
-            ],
-            total: 2,
-        });
+        wrapper.vm.orders = [
+            {
+                ...mockItem,
+                createdById: '1',
+            },
+            {
+                ...mockItem,
+            },
+        ];
+        wrapper.vm.total = 2;
+        await nextTick();
 
         const firstRow = wrapper.findAll('.sw-data-grid__cell .sw-data-grid__cell-content');
         expect(firstRow.at(22).text()).toBe('Paid');
@@ -398,9 +392,8 @@ describe('src/module/sw-order/page/sw-order-list', () => {
     it('should push to a new route when editing items', async () => {
         global.activeAclRoles = [];
         wrapper = await createWrapper();
-        await wrapper.setData({
-            total: 2,
-        });
+        wrapper.vm.total = 2;
+        await nextTick();
         wrapper.vm.$router.push = jest.fn();
         wrapper.vm.$refs.orderGrid.selection = { foo: { deliveries: [] } };
         await wrapper.vm.onBulkEditItems();
@@ -542,25 +535,24 @@ describe('src/module/sw-order/page/sw-order-list', () => {
         global.activeAclRoles = [];
         wrapper = await createWrapper();
 
-        await wrapper.setData({
-            orders: [
-                {
-                    ...mockItem,
-                    primaryOrderDelivery: {
-                        stateMachineState: {
-                            technicalName: 'open',
-                            translated: { name: 'Open' },
-                        },
-                        shippingOrderAddress: {
-                            street: '742 Evergreen Terrace',
-                            zipcode: '99999',
-                            city: 'Springfield',
-                        },
+        wrapper.vm.orders = [
+            {
+                ...mockItem,
+                primaryOrderDelivery: {
+                    stateMachineState: {
+                        technicalName: 'open',
+                        translated: { name: 'Open' },
+                    },
+                    shippingOrderAddress: {
+                        street: '742 Evergreen Terrace',
+                        zipcode: '99999',
+                        city: 'Springfield',
                     },
                 },
-            ],
-            total: 1,
-        });
+            },
+        ];
+        wrapper.vm.total = 1;
+        await nextTick();
 
         const html = wrapper.html();
         expect(html).toContain('742 Evergreen Terrace');
@@ -572,21 +564,20 @@ describe('src/module/sw-order/page/sw-order-list', () => {
         global.activeAclRoles = [];
         wrapper = await createWrapper();
 
-        await wrapper.setData({
-            orders: [
-                {
-                    ...mockItem,
-                    primaryOrderDelivery: {
-                        stateMachineState: {
-                            technicalName: 'shipped',
-                            translated: { name: 'Shipped' },
-                        },
-                        shippingOrderAddress: mockItem.primaryOrderDelivery.shippingOrderAddress,
+        wrapper.vm.orders = [
+            {
+                ...mockItem,
+                primaryOrderDelivery: {
+                    stateMachineState: {
+                        technicalName: 'shipped',
+                        translated: { name: 'Shipped' },
                     },
+                    shippingOrderAddress: mockItem.primaryOrderDelivery.shippingOrderAddress,
                 },
-            ],
-            total: 1,
-        });
+            },
+        ];
+        wrapper.vm.total = 1;
+        await nextTick();
 
         const stateCells = wrapper.findAll('.sw-order-list__state');
         const stateTexts = stateCells.map((cell) => cell.text());
@@ -597,20 +588,19 @@ describe('src/module/sw-order/page/sw-order-list', () => {
         global.activeAclRoles = [];
         wrapper = await createWrapper();
 
-        await wrapper.setData({
-            orders: [
-                {
-                    ...mockItem,
-                    primaryOrderTransaction: {
-                        stateMachineState: {
-                            technicalName: 'paid',
-                            translated: { name: 'Paid' },
-                        },
+        wrapper.vm.orders = [
+            {
+                ...mockItem,
+                primaryOrderTransaction: {
+                    stateMachineState: {
+                        technicalName: 'paid',
+                        translated: { name: 'Paid' },
                     },
                 },
-            ],
-            total: 1,
-        });
+            },
+        ];
+        wrapper.vm.total = 1;
+        await nextTick();
 
         const stateCells = wrapper.findAll('.sw-order-list__state');
         const stateTexts = stateCells.map((cell) => cell.text());
@@ -654,28 +644,27 @@ describe('src/module/sw-order/page/sw-order-list', () => {
             global.activeAclRoles = [];
             wrapper = await createWrapper();
 
-            await wrapper.setData({
-                orders: [
-                    {
-                        ...mockItem,
-                        primaryOrderDelivery: null,
-                        deliveries: [
-                            {
-                                stateMachineState: {
-                                    technicalName: 'open',
-                                    translated: { name: 'Open' },
-                                },
-                                shippingOrderAddress: {
-                                    street: 'Fallback Street 1',
-                                    zipcode: '54321',
-                                    city: 'Fallback City',
-                                },
+            wrapper.vm.orders = [
+                {
+                    ...mockItem,
+                    primaryOrderDelivery: null,
+                    deliveries: [
+                        {
+                            stateMachineState: {
+                                technicalName: 'open',
+                                translated: { name: 'Open' },
                             },
-                        ],
-                    },
-                ],
-                total: 1,
-            });
+                            shippingOrderAddress: {
+                                street: 'Fallback Street 1',
+                                zipcode: '54321',
+                                city: 'Fallback City',
+                            },
+                        },
+                    ],
+                },
+            ];
+            wrapper.vm.total = 1;
+            await nextTick();
 
             const html = wrapper.html();
             expect(html).toContain('Fallback Street 1');
@@ -687,39 +676,38 @@ describe('src/module/sw-order/page/sw-order-list', () => {
             global.activeAclRoles = [];
             wrapper = await createWrapper();
 
-            await wrapper.setData({
-                orders: [
-                    {
-                        ...mockItem,
-                        primaryOrderDelivery: null,
-                        deliveries: [
-                            {
-                                stateMachineState: {
-                                    technicalName: 'open',
-                                    translated: { name: 'Open' },
-                                },
-                                shippingOrderAddress: {
-                                    street: 'First Fallback Street',
-                                    zipcode: '11111',
-                                    city: 'First City',
-                                },
+            wrapper.vm.orders = [
+                {
+                    ...mockItem,
+                    primaryOrderDelivery: null,
+                    deliveries: [
+                        {
+                            stateMachineState: {
+                                technicalName: 'open',
+                                translated: { name: 'Open' },
                             },
-                            {
-                                stateMachineState: {
-                                    technicalName: 'shipped',
-                                    translated: { name: 'Shipped' },
-                                },
-                                shippingOrderAddress: {
-                                    street: 'Second Fallback Street',
-                                    zipcode: '22222',
-                                    city: 'Second City',
-                                },
+                            shippingOrderAddress: {
+                                street: 'First Fallback Street',
+                                zipcode: '11111',
+                                city: 'First City',
                             },
-                        ],
-                    },
-                ],
-                total: 1,
-            });
+                        },
+                        {
+                            stateMachineState: {
+                                technicalName: 'shipped',
+                                translated: { name: 'Shipped' },
+                            },
+                            shippingOrderAddress: {
+                                street: 'Second Fallback Street',
+                                zipcode: '22222',
+                                city: 'Second City',
+                            },
+                        },
+                    ],
+                },
+            ];
+            wrapper.vm.total = 1;
+            await nextTick();
 
             const html = wrapper.html();
             expect(html).toContain('First Fallback Street');
@@ -730,24 +718,23 @@ describe('src/module/sw-order/page/sw-order-list', () => {
             global.activeAclRoles = [];
             wrapper = await createWrapper();
 
-            await wrapper.setData({
-                orders: [
-                    {
-                        ...mockItem,
-                        primaryOrderDelivery: null,
-                        deliveries: [
-                            {
-                                stateMachineState: {
-                                    technicalName: 'shipped',
-                                    translated: { name: 'Fallback Shipped' },
-                                },
-                                shippingOrderAddress: mockItem.primaryOrderDelivery.shippingOrderAddress,
+            wrapper.vm.orders = [
+                {
+                    ...mockItem,
+                    primaryOrderDelivery: null,
+                    deliveries: [
+                        {
+                            stateMachineState: {
+                                technicalName: 'shipped',
+                                translated: { name: 'Fallback Shipped' },
                             },
-                        ],
-                    },
-                ],
-                total: 1,
-            });
+                            shippingOrderAddress: mockItem.primaryOrderDelivery.shippingOrderAddress,
+                        },
+                    ],
+                },
+            ];
+            wrapper.vm.total = 1;
+            await nextTick();
 
             const stateCells = wrapper.findAll('.sw-order-list__state');
             const stateTexts = stateCells.map((cell) => cell.text());
@@ -758,23 +745,22 @@ describe('src/module/sw-order/page/sw-order-list', () => {
             global.activeAclRoles = [];
             wrapper = await createWrapper();
 
-            await wrapper.setData({
-                orders: [
-                    {
-                        ...mockItem,
-                        primaryOrderTransaction: null,
-                        transactions: new EntityCollection(null, null, null, new Criteria(1, 25), [
-                            {
-                                stateMachineState: {
-                                    technicalName: 'paid',
-                                    translated: { name: 'Fallback Paid' },
-                                },
+            wrapper.vm.orders = [
+                {
+                    ...mockItem,
+                    primaryOrderTransaction: null,
+                    transactions: new EntityCollection(null, null, null, new Criteria(1, 25), [
+                        {
+                            stateMachineState: {
+                                technicalName: 'paid',
+                                translated: { name: 'Fallback Paid' },
                             },
-                        ]),
-                    },
-                ],
-                total: 1,
-            });
+                        },
+                    ]),
+                },
+            ];
+            wrapper.vm.total = 1;
+            await nextTick();
 
             const stateCells = wrapper.findAll('.sw-order-list__state');
             const stateTexts = stateCells.map((cell) => cell.text());
@@ -785,35 +771,34 @@ describe('src/module/sw-order/page/sw-order-list', () => {
             global.activeAclRoles = [];
             wrapper = await createWrapper();
 
-            await wrapper.setData({
-                orders: [
-                    {
-                        ...mockItem,
-                        primaryOrderTransaction: null,
-                        transactions: createTransactionCollection([
-                            {
-                                stateMachineState: {
-                                    technicalName: 'cancelled',
-                                    translated: { name: 'Fallback Cancelled' },
-                                },
+            wrapper.vm.orders = [
+                {
+                    ...mockItem,
+                    primaryOrderTransaction: null,
+                    transactions: createTransactionCollection([
+                        {
+                            stateMachineState: {
+                                technicalName: 'cancelled',
+                                translated: { name: 'Fallback Cancelled' },
                             },
-                            {
-                                stateMachineState: {
-                                    technicalName: 'paid',
-                                    translated: { name: 'Fallback Paid' },
-                                },
+                        },
+                        {
+                            stateMachineState: {
+                                technicalName: 'paid',
+                                translated: { name: 'Fallback Paid' },
                             },
-                            {
-                                stateMachineState: {
-                                    technicalName: 'open',
-                                    translated: { name: 'Fallback Open' },
-                                },
+                        },
+                        {
+                            stateMachineState: {
+                                technicalName: 'open',
+                                translated: { name: 'Fallback Open' },
                             },
-                        ]),
-                    },
-                ],
-                total: 1,
-            });
+                        },
+                    ]),
+                },
+            ];
+            wrapper.vm.total = 1;
+            await nextTick();
 
             const stateCells = wrapper.findAll('.sw-order-list__state');
             const stateTexts = stateCells.map((cell) => cell.text());
@@ -825,29 +810,28 @@ describe('src/module/sw-order/page/sw-order-list', () => {
             global.activeAclRoles = [];
             wrapper = await createWrapper();
 
-            await wrapper.setData({
-                orders: [
-                    {
-                        ...mockItem,
-                        primaryOrderTransaction: null,
-                        transactions: createTransactionCollection([
-                            {
-                                stateMachineState: {
-                                    technicalName: 'cancelled',
-                                    translated: { name: 'Fallback Cancelled' },
-                                },
+            wrapper.vm.orders = [
+                {
+                    ...mockItem,
+                    primaryOrderTransaction: null,
+                    transactions: createTransactionCollection([
+                        {
+                            stateMachineState: {
+                                technicalName: 'cancelled',
+                                translated: { name: 'Fallback Cancelled' },
                             },
-                            {
-                                stateMachineState: {
-                                    technicalName: 'failed',
-                                    translated: { name: 'Fallback Failed' },
-                                },
+                        },
+                        {
+                            stateMachineState: {
+                                technicalName: 'failed',
+                                translated: { name: 'Fallback Failed' },
                             },
-                        ]),
-                    },
-                ],
-                total: 1,
-            });
+                        },
+                    ]),
+                },
+            ];
+            wrapper.vm.total = 1;
+            await nextTick();
 
             const stateCells = wrapper.findAll('.sw-order-list__state');
             const stateTexts = stateCells.map((cell) => cell.text());
@@ -872,16 +856,15 @@ describe('src/module/sw-order/page/sw-order-list', () => {
             global.activeAclRoles = [];
             wrapper = await createWrapper();
 
-            await wrapper.setData({
-                orders: [
-                    {
-                        ...mockItem,
-                        primaryOrderDelivery: null,
-                        deliveries: [],
-                    },
-                ],
-                total: 1,
-            });
+            wrapper.vm.orders = [
+                {
+                    ...mockItem,
+                    primaryOrderDelivery: null,
+                    deliveries: [],
+                },
+            ];
+            wrapper.vm.total = 1;
+            await nextTick();
 
             const html = wrapper.html();
             expect(html).not.toContain('123 Random street');

--- a/src/Administration/Resources/app/administration/src/module/sw-product-stream/component/sw-product-stream-modal-preview/sw-product-stream-modal-preview.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product-stream/component/sw-product-stream-modal-preview/sw-product-stream-modal-preview.spec.js
@@ -2,6 +2,7 @@
  * @sw-package inventory
  */
 
+import { nextTick } from 'vue';
 import { mount } from '@vue/test-utils';
 
 const responses = global.repositoryFactoryMock.responses;
@@ -377,7 +378,8 @@ describe('src/module/sw-product-stream/component/sw-product-stream-modal-preview
     it('should compute previewCriteria with random sorting applied', async () => {
         const wrapper = await createWrapper();
 
-        await wrapper.setData({ sorting: 'random' });
+        wrapper.vm.sorting = 'random';
+        await nextTick();
         const criteria = wrapper.vm.previewCriteria;
         const sortings = criteria.sortings;
         expect(sortings).toHaveLength(2);

--- a/src/Administration/Resources/app/administration/src/module/sw-product-stream/component/sw-product-stream-value/sw-product-stream-value.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product-stream/component/sw-product-stream-value/sw-product-stream-value.spec.js
@@ -2,6 +2,7 @@
  * @sw-package inventory
  */
 
+import { nextTick } from 'vue';
 import { mount } from '@vue/test-utils';
 
 async function createWrapper(privileges = [], fieldType = null, conditionType = '', entity = '', render = false) {
@@ -379,9 +380,8 @@ describe('src/module/sw-product-stream/component/sw-product-stream-value', () =>
             },
         });
 
-        await wrapper.setData({
-            searchTerm: 'test',
-        });
+        wrapper.vm.searchTerm = 'test';
+        await nextTick();
 
         await flushPromises();
 
@@ -404,9 +404,8 @@ describe('src/module/sw-product-stream/component/sw-product-stream-value', () =>
             },
         });
 
-        await wrapper.setData({
-            searchTerm: 'test',
-        });
+        wrapper.vm.searchTerm = 'test';
+        await nextTick();
 
         await flushPromises();
 

--- a/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-media-form/sw-product-media-form.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-media-form/sw-product-media-form.spec.js
@@ -2,6 +2,7 @@
  * @sw-package inventory
  */
 
+import { nextTick } from 'vue';
 import { mount } from '@vue/test-utils';
 import EntityCollection from 'src/core/data/entity-collection.data';
 
@@ -165,9 +166,8 @@ describe('module/sw-product/component/sw-product-media-form', () => {
         const wrapper = await createWrapper();
         await flushPromises();
 
-        await wrapper.setData({
-            showCoverLabel: false,
-        });
+        wrapper.vm.showCoverLabel = false;
+        await nextTick();
 
         await wrapper.vm.$nextTick();
         expect(wrapper.find('.is--cover').exists()).toBeFalsy();

--- a/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-properties/sw-product-properties.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-properties/sw-product-properties.spec.js
@@ -335,13 +335,12 @@ describe('src/module/sw-product/component/sw-product-properties', () => {
         const wrapper = await createWrapper();
         await flushPromises();
 
-        await wrapper.setData({
-            groupIds: [
-                'sizeId',
-                'colorId',
-            ],
-            properties: propertiesMock,
-        });
+        wrapper.vm.groupIds = [
+            'sizeId',
+            'colorId',
+        ];
+        wrapper.vm.properties = propertiesMock;
+        await nextTick();
 
         const valueContainers = wrapper.findAll('.sw-product-properties-list__column-values').filter((container) => {
             return container.findAll('sw-label-stub').length > 0;
@@ -499,9 +498,8 @@ describe('src/module/sw-product/component/sw-product-properties', () => {
         const wrapper = await createWrapper();
         await flushPromises();
 
-        await wrapper.setData({
-            propertiesAvailable: true,
-        });
+        wrapper.vm.propertiesAvailable = true;
+        await nextTick();
         wrapper.vm.updateNewProperties = jest.fn();
 
         wrapper.vm.turnOnAddPropertiesModal();
@@ -599,10 +597,9 @@ describe('src/module/sw-product/component/sw-product-properties', () => {
         const wrapper = await createWrapper();
         await flushPromises();
 
-        await wrapper.setData({
-            searchTerm: 'Size',
-            properties: propertiesMock,
-        });
+        wrapper.vm.searchTerm = 'Size';
+        wrapper.vm.properties = propertiesMock;
+        await nextTick();
 
         const createButton = wrapper.findByText('button', 'sw-product.properties.buttonAddProperty');
 
@@ -614,10 +611,9 @@ describe('src/module/sw-product/component/sw-product-properties', () => {
         const wrapper = await createWrapper();
         await flushPromises();
 
-        await wrapper.setData({
-            searchTerm: 'Size',
-            properties: propertiesMock,
-        });
+        wrapper.vm.searchTerm = 'Size';
+        wrapper.vm.properties = propertiesMock;
+        await nextTick();
 
         const createButton = wrapper.findByText('button', 'sw-product.properties.buttonAddProperty');
         expect(createButton.attributes('disabled')).toBeDefined();

--- a/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-variant-modal/sw-product-variant-modal.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-variant-modal/sw-product-variant-modal.spec.js
@@ -4,6 +4,7 @@
  * @sw-package inventory
  */
 
+import { nextTick } from 'vue';
 import { mount } from '@vue/test-utils';
 
 function getMedias() {
@@ -540,7 +541,8 @@ describe('module/sw-product/component/sw-product-variant-modal', () => {
 
     it('productVariantCriteria ignores empty terms from leading whitespace', async () => {
         global.activeAclRoles = [];
-        await wrapper.setData({ searchTerm: ' red' });
+        wrapper.vm.searchTerm = ' red';
+        await nextTick();
 
         const criteria = wrapper.vm.productVariantCriteria;
 

--- a/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-variants/sw-product-modal-variant-generation/sw-product-modal-variant-generation.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-variants/sw-product-modal-variant-generation/sw-product-modal-variant-generation.spec.js
@@ -3,6 +3,7 @@
 /**
  * @sw-package buyers-experience
  */
+import { nextTick } from 'vue';
 import { mount } from '@vue/test-utils';
 import EntityCollection from 'src/core/data/entity-collection.data';
 
@@ -338,9 +339,8 @@ describe('src/module/sw-product/component/sw-product-variants/sw-product-modal-v
         const wrapper = await createWrapper({ featureActive: true });
         await flushPromises();
 
-        await wrapper.setData({
-            variantsNumber: 2,
-        });
+        wrapper.vm.variantsNumber = 2;
+        await nextTick();
 
         expect(wrapper.getComponent({ name: 'mt-tabs' }).props('items')).toEqual([
             {
@@ -362,9 +362,8 @@ describe('src/module/sw-product/component/sw-product-variants/sw-product-modal-v
         const wrapper = await createWrapper({ featureActive: true });
         await flushPromises();
 
-        await wrapper.setData({
-            variantsNumber: 2,
-        });
+        wrapper.vm.variantsNumber = 2;
+        await nextTick();
 
         wrapper.getComponent({ name: 'mt-tabs' }).vm.$emit('new-item-active', 'prices');
         await wrapper.vm.$nextTick();
@@ -1012,15 +1011,14 @@ describe('src/module/sw-product/component/sw-product-variants/sw-product-modal-v
     it('should prevent uploads of duplicates files on all variants', async () => {
         const wrapper = await createWrapper();
 
-        await wrapper.setData({
-            downloadFilesForAllVariants: [
-                {
-                    id: 'random-id',
-                    fileName: 'example',
-                    fileExtension: 'jpg',
-                },
-            ],
-        });
+        wrapper.vm.downloadFilesForAllVariants = [
+            {
+                id: 'random-id',
+                fileName: 'example',
+                fileExtension: 'jpg',
+            },
+        ];
+        await nextTick();
         wrapper.vm.mediaRepository.get = jest.fn().mockReturnValueOnce(
             Promise.resolve({
                 id: 'random-id',
@@ -1270,21 +1268,18 @@ describe('src/module/sw-product/component/sw-product-variants/sw-product-modal-v
 
     it('should add option count when change the isAddOnly', async () => {
         const wrapper = await createWrapper();
-        await wrapper.setData({
-            isAddOnly: true,
-        });
+        wrapper.vm.isAddOnly = true;
+        await nextTick();
 
         const addOriginalConfiguratorSettings = jest.spyOn(wrapper.vm, 'addOriginalConfiguratorSettings');
-        await wrapper.setData({
-            isAddOnly: false,
-        });
+        wrapper.vm.isAddOnly = false;
+        await nextTick();
 
         expect(addOriginalConfiguratorSettings).toHaveBeenCalled();
 
         const emptyConfiguratorSettings = jest.spyOn(wrapper.vm, 'emptyConfiguratorSettings');
-        await wrapper.setData({
-            isAddOnly: true,
-        });
+        wrapper.vm.isAddOnly = true;
+        await nextTick();
 
         expect(emptyConfiguratorSettings).toHaveBeenCalled();
     });
@@ -1292,88 +1287,87 @@ describe('src/module/sw-product/component/sw-product-variants/sw-product-modal-v
     it('should add origin configuration when cancel modal', async () => {
         const wrapper = await createWrapper();
 
-        await wrapper.setData({
-            originalConfiguratorSettings: new EntityCollection(
-                'product-configurator-settings',
-                '/product-configurator-settings',
-                Shopware.Context.api,
-                null,
-                [
-                    {
-                        versionId: '0fa91ce3e96a4bc2be4bd9ce752c3425',
-                        productId: 'e8751848318b4564a4c48bd2bba570b2',
-                        productVersionId: null,
+        wrapper.vm.originalConfiguratorSettings = new EntityCollection(
+            'product-configurator-settings',
+            '/product-configurator-settings',
+            Shopware.Context.api,
+            null,
+            [
+                {
+                    versionId: '0fa91ce3e96a4bc2be4bd9ce752c3425',
+                    productId: 'e8751848318b4564a4c48bd2bba570b2',
+                    productVersionId: null,
+                    mediaId: null,
+                    optionId: 'e10fed21a07149958427cb5339ee4c31',
+                    creationState: 'is-download',
+                    price: null,
+                    position: 0,
+                    customFields: null,
+                    createdAt: '2022-09-26T06:33:59.508+00:00',
+                    updatedAt: null,
+                    apiAlias: null,
+                    id: '529991749890466e9ff44982bff96305',
+                    option: {
+                        groupId: 'a63105d31de248c09726b0ad32cd5d15',
+                        name: 'Tower',
+                        position: 1,
+                        colorHexCode: null,
                         mediaId: null,
-                        optionId: 'e10fed21a07149958427cb5339ee4c31',
-                        creationState: 'is-download',
-                        price: null,
-                        position: 0,
                         customFields: null,
-                        createdAt: '2022-09-26T06:33:59.508+00:00',
-                        updatedAt: null,
-                        apiAlias: null,
-                        id: '529991749890466e9ff44982bff96305',
-                        option: {
-                            groupId: 'a63105d31de248c09726b0ad32cd5d15',
+                        createdAt: '2022-09-26T06:32:18.221+00:00',
+                        updatedAt: '2022-09-26T06:33:59.512+00:00',
+                        translated: {
                             name: 'Tower',
                             position: 1,
-                            colorHexCode: null,
-                            mediaId: null,
-                            customFields: null,
-                            createdAt: '2022-09-26T06:32:18.221+00:00',
-                            updatedAt: '2022-09-26T06:33:59.512+00:00',
-                            translated: {
-                                name: 'Tower',
-                                position: 1,
-                                customFields: {},
-                            },
-                            apiAlias: null,
-                            id: 'e10fed21a07149958427cb5339ee4c31',
-                            translations: [],
-                            productConfiguratorSettings: [],
-                            productProperties: [],
-                            productOptions: [],
+                            customFields: {},
                         },
-                    },
-                    {
-                        versionId: '0fa91ce3e96a4bc2be4bd9ce752c3425',
-                        productId: 'e8751848318b4564a4c48bd2bba570b2',
-                        productVersionId: null,
-                        mediaId: null,
-                        optionId: 'd6e90b99fe4842d487b53b59e50491a5',
-                        creationState: 'is-physical',
-                        price: null,
-                        position: 0,
-                        customFields: null,
-                        createdAt: '2022-09-26T06:32:43.994+00:00',
-                        updatedAt: null,
                         apiAlias: null,
-                        id: '12bbe30fa2ef4f1d83d0899db1c6d450',
-                        option: {
-                            groupId: 'a63105d31de248c09726b0ad32cd5d15',
+                        id: 'e10fed21a07149958427cb5339ee4c31',
+                        translations: [],
+                        productConfiguratorSettings: [],
+                        productProperties: [],
+                        productOptions: [],
+                    },
+                },
+                {
+                    versionId: '0fa91ce3e96a4bc2be4bd9ce752c3425',
+                    productId: 'e8751848318b4564a4c48bd2bba570b2',
+                    productVersionId: null,
+                    mediaId: null,
+                    optionId: 'd6e90b99fe4842d487b53b59e50491a5',
+                    creationState: 'is-physical',
+                    price: null,
+                    position: 0,
+                    customFields: null,
+                    createdAt: '2022-09-26T06:32:43.994+00:00',
+                    updatedAt: null,
+                    apiAlias: null,
+                    id: '12bbe30fa2ef4f1d83d0899db1c6d450',
+                    option: {
+                        groupId: 'a63105d31de248c09726b0ad32cd5d15',
+                        name: 'HQ',
+                        position: 1,
+                        colorHexCode: null,
+                        mediaId: null,
+                        customFields: null,
+                        createdAt: '2022-09-26T06:32:22.274+00:00',
+                        updatedAt: null,
+                        translated: {
                             name: 'HQ',
                             position: 1,
-                            colorHexCode: null,
-                            mediaId: null,
-                            customFields: null,
-                            createdAt: '2022-09-26T06:32:22.274+00:00',
-                            updatedAt: null,
-                            translated: {
-                                name: 'HQ',
-                                position: 1,
-                                customFields: {},
-                            },
-                            apiAlias: null,
-                            id: 'd6e90b99fe4842d487b53b59e50491a4',
-                            translations: [],
-                            productConfiguratorSettings: [],
-                            productProperties: [],
-                            productOptions: [],
+                            customFields: {},
                         },
+                        apiAlias: null,
+                        id: 'd6e90b99fe4842d487b53b59e50491a4',
+                        translations: [],
+                        productConfiguratorSettings: [],
+                        productProperties: [],
+                        productOptions: [],
                     },
-                ],
-            ),
-        });
+                },
+            ],
+        );
+        await nextTick();
 
         const removeDuplicateEntries = jest.spyOn(wrapper.vm, 'removeDuplicateEntries');
         wrapper.vm.onModalCancel();

--- a/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-variants/sw-product-variants-configurator/sw-product-variants-configurator-selection/sw-product-variants-configurator-selection.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-variants/sw-product-variants-configurator/sw-product-variants-configurator-selection/sw-product-variants-configurator-selection.spec.js
@@ -2,6 +2,7 @@
  * @sw-package inventory
  */
 
+import { nextTick } from 'vue';
 import { mount } from '@vue/test-utils';
 import EntityCollection from 'src/core/data/entity-collection.data';
 
@@ -84,9 +85,8 @@ describe('components/base/sw-product-variants-configurator-selection', () => {
     });
 
     it('should prevent selection', async () => {
-        await wrapper.setData({
-            preventSelection: true,
-        });
+        wrapper.vm.preventSelection = true;
+        await nextTick();
         jest.spyOn(wrapper.vm, 'addOptionCount');
 
         wrapper.vm.onOptionSelect();
@@ -127,9 +127,8 @@ describe('components/base/sw-product-variants-configurator-selection', () => {
     });
 
     it('should be able to select options once again when the add only toggle get changed', async () => {
-        await wrapper.setData({
-            displayTree: true,
-        });
+        wrapper.vm.displayTree = true;
+        await nextTick();
 
         const selectionOptionsMock = jest.fn();
         jest.spyOn(wrapper.vm, 'selectOptions');

--- a/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-variants/sw-product-variants-media-upload/sw-product-variants-media-upload.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-variants/sw-product-variants-media-upload/sw-product-variants-media-upload.spec.js
@@ -4,6 +4,7 @@
  * @sw-package inventory
  */
 
+import { nextTick } from 'vue';
 import { mount } from '@vue/test-utils';
 import EntityCollection from 'src/core/data/entity-collection.data';
 
@@ -109,9 +110,8 @@ describe('src/module/sw-product/component/sw-product-variants/sw-product-variant
     });
 
     it('should contain file upload', async () => {
-        await wrapper.setData({
-            inputType: 'file-upload',
-        });
+        wrapper.vm.inputType = 'file-upload';
+        await nextTick();
 
         const urlForm = wrapper.find('.sw-media-upload-v2__url-form');
         const uploadBtn = wrapper.find('.sw-media-upload-v2__button.upload');

--- a/src/Administration/Resources/app/administration/src/module/sw-product/page/sw-product-detail/sw-product-detail.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/page/sw-product-detail/sw-product-detail.spec.js
@@ -726,10 +726,9 @@ describe('module/sw-product/page/sw-product-detail', () => {
     });
 
     it('should save preferences only when units have changed', async () => {
-        await wrapper.setData({
-            previousLengthUnit: 'cm',
-            previousWeightUnit: 'kg',
-        });
+        wrapper.vm.previousLengthUnit = 'cm';
+        wrapper.vm.previousWeightUnit = 'kg';
+        await nextTick();
 
         await wrapper.vm.saveProduct();
 
@@ -739,10 +738,9 @@ describe('module/sw-product/page/sw-product-detail', () => {
     });
 
     it('should not save preferences when units have not changed', async () => {
-        await wrapper.setData({
-            previousLengthUnit: 'mm',
-            previousWeightUnit: 'kg',
-        });
+        wrapper.vm.previousLengthUnit = 'mm';
+        wrapper.vm.previousWeightUnit = 'kg';
+        await nextTick();
 
         await wrapper.vm.saveProduct();
 
@@ -752,10 +750,9 @@ describe('module/sw-product/page/sw-product-detail', () => {
     });
 
     it('should handle errors when saving preferences', async () => {
-        await wrapper.setData({
-            previousLengthUnit: 'cm',
-            previousWeightUnit: 'kg',
-        });
+        wrapper.vm.previousLengthUnit = 'cm';
+        wrapper.vm.previousWeightUnit = 'kg';
+        await nextTick();
 
         Shopware.Service('userConfigService').upsert.mockRejectedValue(new Error('Save failed'));
 

--- a/src/Administration/Resources/app/administration/src/module/sw-product/page/sw-product-list/sw-product-list.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/page/sw-product-list/sw-product-list.spec.js
@@ -4,6 +4,7 @@
  * @sw-package inventory
  */
 
+import { nextTick } from 'vue';
 import { mount, config } from '@vue/test-utils';
 import { createRouter, createWebHashHistory } from 'vue-router';
 import { searchRankingPoint } from 'src/app/service/search-ranking.service';
@@ -600,9 +601,8 @@ describe('module/sw-product/page/sw-product-list', () => {
     });
 
     it('should add query score to the criteria', async () => {
-        await wrapper.setData({
-            term: 'foo',
-        });
+        wrapper.vm.term = 'foo';
+        await nextTick();
         await wrapper.vm.$nextTick();
         // Setting `term` triggers the listing mixin's search watcher, which runs its own getList.
         // Let that settle against the real service before installing the counting mocks, so the
@@ -645,9 +645,8 @@ describe('module/sw-product/page/sw-product-list', () => {
     });
 
     it('should not build query score when search ranking field is null', async () => {
-        await wrapper.setData({
-            term: 'foo',
-        });
+        wrapper.vm.term = 'foo';
+        await nextTick();
 
         await wrapper.vm.$nextTick();
         wrapper.vm.searchRankingService.buildSearchQueriesForEntity = jest.fn(() => {
@@ -668,9 +667,8 @@ describe('module/sw-product/page/sw-product-list', () => {
     });
 
     it('should show empty state when there is not item after filling search term', async () => {
-        await wrapper.setData({
-            term: 'foo',
-        });
+        wrapper.vm.term = 'foo';
+        await nextTick();
         await flushPromises();
         wrapper.vm.searchRankingService.getSearchFieldsByEntity = jest.fn(() => {
             return {};
@@ -746,9 +744,8 @@ describe('module/sw-product/page/sw-product-list', () => {
         const parentId = 'parent-product-id';
         const variantId = 'variant-product-id';
 
-        await wrapper.setData({
-            term: 'SW10001',
-        });
+        wrapper.vm.term = 'SW10001';
+        await nextTick();
         await wrapper.vm.$nextTick();
 
         wrapper.vm.filterCriteria.push(Criteria.equalsAny('manufacturer.id', [manufacturerId]));

--- a/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-context-prices/sw-product-detail-context-prices.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-context-prices/sw-product-detail-context-prices.spec.js
@@ -2,6 +2,7 @@
  * @sw-package inventory
  */
 
+import { nextTick } from 'vue';
 import { mount } from '@vue/test-utils';
 
 const { EntityCollection } = Shopware.Data;
@@ -322,17 +323,16 @@ describe('src/module/sw-product/view/sw-product-detail-context-prices', () => {
             },
         ];
 
-        await wrapper.setData({
-            rules: new EntityCollection(
-                '/test-rule',
-                'rule',
-                null,
-                { isShopwareContext: true },
-                rulesEntities,
-                rulesEntities.length,
-                null,
-            ),
-        });
+        wrapper.vm.rules = new EntityCollection(
+            '/test-rule',
+            'rule',
+            null,
+            { isShopwareContext: true },
+            rulesEntities,
+            rulesEntities.length,
+            null,
+        );
+        await nextTick();
 
         await wrapper.setProps({
             isSetDefaultPrice: true,

--- a/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-cross-selling/sw-product-detail-cross-selling.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-cross-selling/sw-product-detail-cross-selling.spec.js
@@ -2,6 +2,7 @@
  * @sw-package inventory
  */
 
+import { nextTick } from 'vue';
 import { mount } from '@vue/test-utils';
 
 async function createWrapper() {
@@ -85,7 +86,8 @@ describe('src/module/sw-product/view/sw-product-detail-cross-selling', () => {
         const customProduct = buildProduct();
 
         wrapper = await createWrapper();
-        await wrapper.setData({ product: customProduct });
+        Shopware.Store.get('swProductDetail').product = customProduct;
+        await nextTick();
         await flushPromises();
 
         expect(customProduct.crossSellings[0].assignedProducts).toStrictEqual([

--- a/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-layout/sw-product-detail-layout.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-layout/sw-product-detail-layout.spec.js
@@ -146,9 +146,8 @@ describe('src/module/sw-product/view/sw-product-detail-layout', () => {
     it('should turn on layout modal', async () => {
         const wrapper = await createWrapper();
 
-        await wrapper.setData({
-            showLayoutModal: true,
-        });
+        wrapper.vm.showLayoutModal = true;
+        await nextTick();
 
         const layoutModal = wrapper.find('sw-cms-layout-modal-stub');
 
@@ -158,9 +157,8 @@ describe('src/module/sw-product/view/sw-product-detail-layout', () => {
     it('should turn off layout modal', async () => {
         const wrapper = await createWrapper();
 
-        await wrapper.setData({
-            showLayoutModal: false,
-        });
+        wrapper.vm.showLayoutModal = false;
+        await nextTick();
 
         const layoutModal = wrapper.find('sw-cms-layout-modal-stub');
 

--- a/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-reviews/sw-product-detail-reviews.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-reviews/sw-product-detail-reviews.spec.js
@@ -2,6 +2,7 @@
  * @sw-package inventory
  */
 
+import { nextTick } from 'vue';
 import { mount } from '@vue/test-utils';
 
 const { Store } = Shopware;
@@ -106,7 +107,9 @@ describe('src/module/sw-product/view/sw-product-detail-reviews', () => {
             'product.editor',
         ]);
 
-        await wrapper.setData({ dataSource, total: 2 });
+        wrapper.vm.dataSource = dataSource;
+        wrapper.vm.total = 2;
+        await nextTick();
 
         const editMenuItem = wrapper.find('.sw-product-detail-reviews__action-edit');
         expect(editMenuItem.attributes().disabled).toBeFalsy();
@@ -115,7 +118,9 @@ describe('src/module/sw-product/view/sw-product-detail-reviews', () => {
     it('should not be able to edit a review', async () => {
         const wrapper = await createWrapper();
 
-        await wrapper.setData({ dataSource, total: 2 });
+        wrapper.vm.dataSource = dataSource;
+        wrapper.vm.total = 2;
+        await nextTick();
 
         const editMenuItem = wrapper.find('.sw-product-detail-reviews__action-edit');
         expect(editMenuItem.attributes().disabled).toBeTruthy();
@@ -126,7 +131,9 @@ describe('src/module/sw-product/view/sw-product-detail-reviews', () => {
             'product.editor',
         ]);
 
-        await wrapper.setData({ dataSource, total: 2 });
+        wrapper.vm.dataSource = dataSource;
+        wrapper.vm.total = 2;
+        await nextTick();
 
         const deleteMenuItem = wrapper.find('.sw-product-detail-reviews__action-delete');
         expect(deleteMenuItem.attributes().disabled).toBeFalsy();
@@ -135,7 +142,9 @@ describe('src/module/sw-product/view/sw-product-detail-reviews', () => {
     it('should not be able to delete a review', async () => {
         const wrapper = await createWrapper();
 
-        await wrapper.setData({ dataSource, total: 2 });
+        wrapper.vm.dataSource = dataSource;
+        wrapper.vm.total = 2;
+        await nextTick();
 
         const deleteMenuItem = wrapper.find('.sw-product-detail-reviews__action-delete');
         expect(deleteMenuItem.attributes().disabled).toBeTruthy();

--- a/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-variants/sw-product-detail-variants.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-variants/sw-product-detail-variants.spec.js
@@ -3,6 +3,7 @@
 /**
  * @sw-package inventory
  */
+import { nextTick } from 'vue';
 import { mount } from '@vue/test-utils';
 import 'src/app/component/utils/sw-loader';
 import 'src/app/component/base/sw-button';
@@ -266,10 +267,9 @@ describe('src/module/sw-product/view/sw-product-detail-variants', () => {
     it('should render the fallback tabs branch while the major feature flag is inactive', async () => {
         const wrapper = await createWrapper();
         await flushPromises();
-        await wrapper.setData({
-            isLoading: false,
-            propertiesAvailable: true,
-        });
+        wrapper.vm.isLoading = false;
+        wrapper.vm.propertiesAvailable = true;
+        await nextTick();
 
         const tabs = wrapper.getComponent({ name: 'sw-tabs' });
 
@@ -283,10 +283,9 @@ describe('src/module/sw-product/view/sw-product-detail-variants', () => {
     it('should render meteor tabs when the major feature flag is active', async () => {
         const wrapper = await createWrapper({ featureActive: true });
         await flushPromises();
-        await wrapper.setData({
-            isLoading: false,
-            propertiesAvailable: true,
-        });
+        wrapper.vm.isLoading = false;
+        wrapper.vm.propertiesAvailable = true;
+        await nextTick();
 
         const tabs = wrapper.getComponent({ name: 'mt-tabs' });
 
@@ -312,10 +311,9 @@ describe('src/module/sw-product/view/sw-product-detail-variants', () => {
     it('should switch active tab when meteor tabs emits a new active item', async () => {
         const wrapper = await createWrapper({ featureActive: true });
         await flushPromises();
-        await wrapper.setData({
-            isLoading: false,
-            propertiesAvailable: true,
-        });
+        wrapper.vm.isLoading = false;
+        wrapper.vm.propertiesAvailable = true;
+        await nextTick();
 
         wrapper.getComponent({ name: 'mt-tabs' }).vm.$emit('new-item-active', 'digital');
         await wrapper.vm.$nextTick();
@@ -326,11 +324,10 @@ describe('src/module/sw-product/view/sw-product-detail-variants', () => {
     it('should display a customized empty state if there are neither variants nor properties', async () => {
         const wrapper = await createWrapper();
 
-        await wrapper.setData({
-            groups: [{}],
-            propertiesAvailable: false,
-            isLoading: false,
-        });
+        wrapper.vm.groups = [{}];
+        wrapper.vm.propertiesAvailable = false;
+        wrapper.vm.isLoading = false;
+        await nextTick();
 
         await flushPromises();
 
@@ -368,9 +365,8 @@ describe('src/module/sw-product/view/sw-product-detail-variants', () => {
 
     it('should split the product states string into an array', async () => {
         const wrapper = await createWrapper();
-        await wrapper.setData({
-            activeTab: 'is-foo,is-bar',
-        });
+        wrapper.vm.activeTab = 'is-foo,is-bar';
+        await nextTick();
         await flushPromises();
 
         expect(wrapper.vm.currentProductStates).toEqual([
@@ -445,7 +441,8 @@ describe('src/module/sw-product/view/sw-product-detail-variants', () => {
         const wrapper = await createWrapper();
         const loadGroupsSpy = jest.spyOn(wrapper.vm, 'loadGroups');
 
-        await wrapper.setData({ limit: 5 });
+        wrapper.vm.limit = 5;
+        await nextTick();
 
         // Mock repository to return paginated data
         wrapper.vm.groupRepository.search = jest
@@ -494,7 +491,8 @@ describe('src/module/sw-product/view/sw-product-detail-variants', () => {
         const wrapper = await createWrapper();
         const loadGroupsSpy = jest.spyOn(wrapper.vm, 'loadGroups');
 
-        await wrapper.setData({ limit: 5 });
+        wrapper.vm.limit = 5;
+        await nextTick();
 
         wrapper.vm.groupRepository.search = jest.fn().mockResolvedValueOnce({
             total: 3,

--- a/src/Administration/Resources/app/administration/src/module/sw-profile/page/sw-profile-index/sw-profile-index.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-profile/page/sw-profile-index/sw-profile-index.spec.js
@@ -275,9 +275,8 @@ describe('src/module/sw-profile/page/sw-profile-index', () => {
     it('should not be able to save own user', async () => {
         const wrapper = await createWrapper();
         await flushPromises();
-        await wrapper.setData({
-            isLoading: false,
-        });
+        wrapper.vm.isLoading = false;
+        await nextTick();
 
         const saveButton = wrapper.find('.sw-profile__save-action');
 
@@ -291,10 +290,9 @@ describe('src/module/sw-profile/page/sw-profile-index', () => {
         ]);
         await flushPromises();
 
-        await wrapper.setData({
-            isLoading: false,
-            isUserLoading: false,
-        });
+        wrapper.vm.isLoading = false;
+        wrapper.vm.isUserLoading = false;
+        await nextTick();
         await wrapper.vm.$nextTick();
 
         const saveButton = wrapper.find('.sw-profile__save-action');
@@ -380,7 +378,8 @@ describe('src/module/sw-profile/page/sw-profile-index', () => {
         const wrapper = await createWrapper();
         const mediaId = '2142';
 
-        await wrapper.setData({ isLoading: false });
+        wrapper.vm.isLoading = false;
+        await nextTick();
         await flushPromises();
 
         wrapper.vm.setMediaItem({ targetId: mediaId });

--- a/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/page/sw-promotion-v2-detail/sw-promotion-v2-detail.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/page/sw-promotion-v2-detail/sw-promotion-v2-detail.spec.js
@@ -1,6 +1,7 @@
 /**
  * @sw-package checkout
  */
+import { nextTick } from 'vue';
 import { mount } from '@vue/test-utils';
 
 const promotionData = {
@@ -191,9 +192,8 @@ describe('src/module/sw-promotion-v2/page/sw-promotion-v2-detail', () => {
 
         const wrapper = await createWrapper();
 
-        await wrapper.setData({
-            isLoading: false,
-        });
+        wrapper.vm.isLoading = false;
+        await nextTick();
 
         const saveButton = wrapper.find('.sw-promotion-v2-detail__save-action');
         expect(saveButton.attributes().disabled).toBeTruthy();
@@ -204,9 +204,8 @@ describe('src/module/sw-promotion-v2/page/sw-promotion-v2-detail', () => {
 
         const wrapper = await createWrapper();
 
-        await wrapper.setData({
-            isLoading: false,
-        });
+        wrapper.vm.isLoading = false;
+        await nextTick();
 
         const saveButton = wrapper.find('.sw-promotion-v2-detail__save-action');
         expect(saveButton.attributes().disabled).toBeFalsy();

--- a/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/page/sw-promotion-v2-list/sw-promotion-v2-list.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/page/sw-promotion-v2-list/sw-promotion-v2-list.spec.js
@@ -1,6 +1,7 @@
 /**
  * @sw-package checkout
  */
+import { nextTick } from 'vue';
 import { mount } from '@vue/test-utils';
 import { searchRankingPoint } from 'src/app/service/search-ranking.service';
 import Criteria from 'src/core/data/criteria.data';
@@ -84,10 +85,9 @@ describe('src/module/sw-promotion-v2/page/sw-promotion-v2-list', () => {
 
         const wrapper = await createWrapper();
 
-        await wrapper.setData({
-            isLoading: false,
-            total: 2,
-        });
+        wrapper.vm.isLoading = false;
+        wrapper.vm.total = 2;
+        await nextTick();
 
         const element = wrapper.find('sw-entity-listing-stub');
 
@@ -106,10 +106,9 @@ describe('src/module/sw-promotion-v2/page/sw-promotion-v2-list', () => {
 
         const wrapper = await createWrapper();
 
-        await wrapper.setData({
-            isLoading: false,
-            total: 2,
-        });
+        wrapper.vm.isLoading = false;
+        wrapper.vm.total = 2;
+        await nextTick();
 
         const element = wrapper.find('sw-entity-listing-stub');
 
@@ -129,10 +128,9 @@ describe('src/module/sw-promotion-v2/page/sw-promotion-v2-list', () => {
 
         const wrapper = await createWrapper();
 
-        await wrapper.setData({
-            isLoading: false,
-            total: 2,
-        });
+        wrapper.vm.isLoading = false;
+        wrapper.vm.total = 2;
+        await nextTick();
 
         const element = wrapper.find('sw-entity-listing-stub');
 
@@ -147,9 +145,8 @@ describe('src/module/sw-promotion-v2/page/sw-promotion-v2-list', () => {
         global.activeAclRoles = [];
 
         const wrapper = await createWrapper();
-        await wrapper.setData({
-            term: 'foo',
-        });
+        wrapper.vm.term = 'foo';
+        await nextTick();
         await wrapper.vm.$nextTick();
         wrapper.vm.searchRankingService.buildSearchQueriesForEntity = jest.fn(() => {
             return new Criteria(1, 25);
@@ -194,9 +191,8 @@ describe('src/module/sw-promotion-v2/page/sw-promotion-v2-list', () => {
         global.activeAclRoles = [];
 
         const wrapper = await createWrapper();
-        await wrapper.setData({
-            term: 'foo',
-        });
+        wrapper.vm.term = 'foo';
+        await nextTick();
 
         await wrapper.vm.$nextTick();
         wrapper.vm.searchRankingService.buildSearchQueriesForEntity = jest.fn(() => {
@@ -220,9 +216,8 @@ describe('src/module/sw-promotion-v2/page/sw-promotion-v2-list', () => {
         global.activeAclRoles = [];
 
         const wrapper = await createWrapper();
-        await wrapper.setData({
-            term: 'foo',
-        });
+        wrapper.vm.term = 'foo';
+        await nextTick();
         await wrapper.vm.$nextTick();
         wrapper.vm.searchRankingService.getSearchFieldsByEntity = jest.fn(() => {
             return {};

--- a/src/Administration/Resources/app/administration/src/module/sw-property/page/sw-property-detail/sw-property-detail.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-property/page/sw-property-detail/sw-property-detail.spec.js
@@ -1,6 +1,7 @@
 /**
  * @sw-package inventory
  */
+import { nextTick } from 'vue';
 import { mount } from '@vue/test-utils';
 
 async function createWrapper() {
@@ -59,9 +60,8 @@ describe('module/sw-property/page/sw-property-detail', () => {
         global.activeAclRoles = [];
 
         const wrapper = await createWrapper();
-        await wrapper.setData({
-            isLoading: false,
-        });
+        wrapper.vm.isLoading = false;
+        await nextTick();
 
         const saveButton = wrapper.find('.sw-property-detail__save-action');
 
@@ -76,9 +76,8 @@ describe('module/sw-property/page/sw-property-detail', () => {
         await wrapper.vm.$nextTick();
         await wrapper.vm.$nextTick();
 
-        await wrapper.setData({
-            isLoading: false,
-        });
+        wrapper.vm.isLoading = false;
+        await nextTick();
         await wrapper.vm.$nextTick();
 
         const saveButton = wrapper.find('.sw-property-detail__save-action');

--- a/src/Administration/Resources/app/administration/src/module/sw-property/page/sw-property-list/sw-property-list.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-property/page/sw-property-list/sw-property-list.spec.js
@@ -1,6 +1,7 @@
 /**
  * @sw-package inventory
  */
+import { nextTick } from 'vue';
 import { mount } from '@vue/test-utils';
 import { searchRankingPoint } from 'src/app/service/search-ranking.service';
 import Criteria from 'src/core/data/criteria.data';
@@ -190,9 +191,8 @@ describe('module/sw-property/page/sw-property-list', () => {
         global.activeAclRoles = [];
 
         const wrapper = await createWrapper();
-        await wrapper.setData({
-            term: 'foo',
-        });
+        wrapper.vm.term = 'foo';
+        await nextTick();
         await wrapper.vm.$nextTick();
         wrapper.vm.searchRankingService.buildSearchQueriesForEntity = jest.fn(() => {
             return new Criteria(1, 25);
@@ -237,9 +237,8 @@ describe('module/sw-property/page/sw-property-list', () => {
         global.activeAclRoles = [];
 
         const wrapper = await createWrapper();
-        await wrapper.setData({
-            term: 'foo',
-        });
+        wrapper.vm.term = 'foo';
+        await nextTick();
 
         await wrapper.vm.$nextTick();
         wrapper.vm.searchRankingService.buildSearchQueriesForEntity = jest.fn(() => {
@@ -263,9 +262,8 @@ describe('module/sw-property/page/sw-property-list', () => {
         global.activeAclRoles = [];
 
         const wrapper = await createWrapper();
-        await wrapper.setData({
-            term: 'foo',
-        });
+        wrapper.vm.term = 'foo';
+        await nextTick();
         await wrapper.vm.$nextTick();
         wrapper.vm.searchRankingService.getSearchFieldsByEntity = jest.fn(() => {
             return {};

--- a/src/Administration/Resources/app/administration/src/module/sw-review/page/sw-review-detail/sw-review-detail.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-review/page/sw-review-detail/sw-review-detail.spec.js
@@ -1,6 +1,7 @@
 /**
  * @sw-package after-sales
  */
+import { nextTick } from 'vue';
 import { mount } from '@vue/test-utils';
 import 'src/app/mixin/placeholder.mixin';
 import 'src/app/mixin/salutation.mixin';
@@ -105,7 +106,8 @@ describe('module/sw-review/page/sw-review-detail', () => {
         global.activeAclRoles = ['review.editor'];
 
         const wrapper = await createWrapper();
-        await wrapper.setData({ isLoading: false });
+        wrapper.vm.isLoading = false;
+        await nextTick();
         await flushPromises();
 
         const saveButton = wrapper.find('.sw-review-detail__save-action');
@@ -115,7 +117,8 @@ describe('module/sw-review/page/sw-review-detail', () => {
 
     it('should not be able to edit review fields', async () => {
         const wrapper = await createWrapper();
-        await wrapper.setData({ isLoading: false });
+        wrapper.vm.isLoading = false;
+        await nextTick();
         await flushPromises();
 
         const languageField = wrapper.find('.sw-review__language-select');
@@ -131,7 +134,8 @@ describe('module/sw-review/page/sw-review-detail', () => {
         global.activeAclRoles = ['review.editor'];
 
         const wrapper = await createWrapper();
-        await wrapper.setData({ isLoading: false });
+        wrapper.vm.isLoading = false;
+        await nextTick();
         await flushPromises();
 
         const languageField = wrapper.find('.sw-review__language-select');

--- a/src/Administration/Resources/app/administration/src/module/sw-review/page/sw-review-list/sw-review-list.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-review/page/sw-review-list/sw-review-list.spec.js
@@ -1,6 +1,7 @@
 /**
  * @sw-package after-sales
  */
+import { nextTick } from 'vue';
 import { mount } from '@vue/test-utils';
 
 Shopware.Service().register('filterService', () => {
@@ -79,7 +80,8 @@ async function createWrapper() {
 describe('module/sw-review/page/sw-review-list', () => {
     it('should not be able to delete', async () => {
         const wrapper = await createWrapper();
-        await wrapper.setData({ total: 2 });
+        wrapper.vm.total = 2;
+        await nextTick();
         await wrapper.vm.$nextTick();
         await flushPromises();
 
@@ -91,7 +93,8 @@ describe('module/sw-review/page/sw-review-list', () => {
         global.activeAclRoles = ['review.deleter'];
 
         const wrapper = await createWrapper();
-        await wrapper.setData({ total: 2 });
+        wrapper.vm.total = 2;
+        await nextTick();
         await flushPromises();
 
         const deleteMenuItem = wrapper.find('sw-entity-listing-stub');
@@ -100,7 +103,8 @@ describe('module/sw-review/page/sw-review-list', () => {
 
     it('should not be able to edit', async () => {
         const wrapper = await createWrapper();
-        await wrapper.setData({ total: 2 });
+        wrapper.vm.total = 2;
+        await nextTick();
         await flushPromises();
 
         const editMenuItem = wrapper.find('sw-entity-listing-stub');
@@ -111,7 +115,8 @@ describe('module/sw-review/page/sw-review-list', () => {
         global.activeAclRoles = ['review.editor'];
 
         const wrapper = await createWrapper();
-        await wrapper.setData({ total: 2 });
+        wrapper.vm.total = 2;
+        await nextTick();
         await flushPromises();
 
         const editMenuItem = wrapper.find('sw-entity-listing-stub');

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/component/sw-sales-channel-detail-domains/sw-sales-channel-detail-domains.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/component/sw-sales-channel-detail-domains/sw-sales-channel-detail-domains.spec.js
@@ -4,6 +4,7 @@
  * @sw-package discovery
  */
 
+import { nextTick } from 'vue';
 import { mount } from '@vue/test-utils';
 import { MtUrlField } from '@shopware-ag/meteor-component-library';
 
@@ -196,9 +197,8 @@ describe('src/module/sw-sales-channel/component/sw-sales-channel-detail-domains'
     it('should sort all domains descending', async () => {
         const wrapper = await createWrapper({}, getExampleDomains());
 
-        await wrapper.setData({
-            sortDirection: 'DESC',
-        });
+        wrapper.vm.sortDirection = 'DESC';
+        await nextTick();
 
         const rows = wrapper.findAll('.sw-data-grid__body .sw-data-grid__row');
         const expectedRow = rows.at(0);
@@ -222,9 +222,8 @@ describe('src/module/sw-sales-channel/component/sw-sales-channel-detail-domains'
     it('should sort by currency', async () => {
         const wrapper = await createWrapper({}, getExampleDomains());
 
-        await wrapper.setData({
-            sortBy: 'currencyId',
-        });
+        wrapper.vm.sortBy = 'currencyId';
+        await nextTick();
 
         const rows = wrapper.findAll('.sw-data-grid__body .sw-data-grid__row');
         const expectedRow = rows.at(0);
@@ -410,10 +409,12 @@ describe('src/module/sw-sales-channel/component/sw-sales-channel-detail-domains'
         const testedDomain = exampleDomains[0];
         const wrapper = await createWrapper({}, exampleDomains);
 
-        await wrapper.setData({ currentDomainBackup: exampleDomains[0] });
+        wrapper.vm.currentDomainBackup = exampleDomains[0];
+        await nextTick();
         expect(wrapper.vm.isOriginalUrl(testedDomain.url)).toBeTruthy();
 
-        await wrapper.setData({ currentDomainBackup: exampleDomains[1] });
+        wrapper.vm.currentDomainBackup = exampleDomains[1];
+        await nextTick();
         expect(wrapper.vm.isOriginalUrl(testedDomain.url)).toBeFalsy();
     });
 
@@ -433,10 +434,9 @@ describe('src/module/sw-sales-channel/component/sw-sales-channel-detail-domains'
 
         wrapper.vm.isOriginalUrl = jest.fn(() => true);
         wrapper.vm.verifyUrl = jest.fn();
-        await wrapper.setData({
-            currentDomain: testedDomain,
-            currentDomainBackup: testedDomain,
-        });
+        wrapper.vm.currentDomain = testedDomain;
+        wrapper.vm.currentDomainBackup = testedDomain;
+        await nextTick();
 
         await wrapper.vm.onClickAddNewDomain();
 

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/component/sw-sales-channel-products-assignment-dynamic-product-groups/sw-sales-channel-products-assignment-dynamic-product-groups.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/component/sw-sales-channel-products-assignment-dynamic-product-groups/sw-sales-channel-products-assignment-dynamic-product-groups.spec.js
@@ -2,6 +2,7 @@
  * @sw-package discovery
  */
 
+import { nextTick } from 'vue';
 import { mount } from '@vue/test-utils';
 
 async function getError(method, ...args) {
@@ -146,9 +147,8 @@ describe('src/module/sw-sales-channel/component/sw-sales-channel-products-assign
             return Promise.resolve();
         });
 
-        await wrapper.setData({
-            page: 2,
-        });
+        wrapper.vm.page = 2;
+        await nextTick();
 
         expect(wrapper.vm.page).toBe(2);
 

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/component/sw-sales-channel-products-assignment-modal/sw-sales-channel-products-assignment-modal.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/component/sw-sales-channel-products-assignment-modal/sw-sales-channel-products-assignment-modal.spec.js
@@ -2,6 +2,7 @@
  * @sw-package discovery
  */
 
+import { nextTick } from 'vue';
 import { mount } from '@vue/test-utils';
 import 'src/app/component/base/sw-button';
 
@@ -125,14 +126,13 @@ describe('src/module/sw-sales-channel/component/sw-sales-channel-products-assign
 
     it('should emit products data when clicking Add Products button to assign product individually', async () => {
         const wrapper = await createWrapper();
-        await wrapper.setData({
-            singleProducts: [
-                {
-                    id: '1',
-                    name: 'Test product',
-                },
-            ],
-        });
+        wrapper.vm.singleProducts = [
+            {
+                id: '1',
+                name: 'Test product',
+            },
+        ];
+        await nextTick();
 
         await wrapper.findByText('button', 'sw-sales-channel.detail.products.buttonAddProducts').trigger('click');
 
@@ -155,9 +155,8 @@ describe('src/module/sw-sales-channel/component/sw-sales-channel-products-assign
         ];
 
         const wrapper = await createWrapper();
-        await wrapper.setData({
-            categoryProducts: products,
-        });
+        wrapper.vm.categoryProducts = products;
+        await nextTick();
 
         const assignButton = wrapper.findByText('button', 'sw-sales-channel.detail.products.buttonAddProducts');
         await assignButton.trigger('click');
@@ -168,28 +167,27 @@ describe('src/module/sw-sales-channel/component/sw-sales-channel-products-assign
 
     it('should remove duplicated products before emitting', async () => {
         const wrapper = await createWrapper();
-        await wrapper.setData({
-            singleProducts: [
-                {
-                    name: 'Test product 1',
-                    id: '1',
-                },
-                {
-                    name: 'Test product 2',
-                    id: '2',
-                },
-            ],
-            groupProducts: [
-                {
-                    name: 'Test product 2',
-                    id: '2',
-                },
-                {
-                    name: 'Test product 3',
-                    id: '3',
-                },
-            ],
-        });
+        wrapper.vm.singleProducts = [
+            {
+                name: 'Test product 1',
+                id: '1',
+            },
+            {
+                name: 'Test product 2',
+                id: '2',
+            },
+        ];
+        wrapper.vm.groupProducts = [
+            {
+                name: 'Test product 2',
+                id: '2',
+            },
+            {
+                name: 'Test product 3',
+                id: '3',
+            },
+        ];
+        await nextTick();
 
         expect(wrapper.vm.products).toEqual([
             {

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/component/sw-sales-channel-products-assignment-single-products/sw-sales-channel-products-assignment-single-products.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/component/sw-sales-channel-products-assignment-single-products/sw-sales-channel-products-assignment-single-products.spec.js
@@ -2,6 +2,7 @@
  * @sw-package discovery
  */
 
+import { nextTick } from 'vue';
 import { mount } from '@vue/test-utils';
 
 let productData = [];
@@ -178,9 +179,8 @@ describe('src/module/sw-sales-channel/component/sw-sales-channel-products-assign
             return Promise.resolve();
         });
 
-        await wrapper.setData({
-            page: 2,
-        });
+        wrapper.vm.page = 2;
+        await nextTick();
 
         expect(wrapper.vm.page).toBe(2);
 

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/page/sw-sales-channel-create/sw-sales-channel-create.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/page/sw-sales-channel-create/sw-sales-channel-create.spec.js
@@ -2,6 +2,7 @@
  * @sw-package discovery
  */
 
+import { nextTick } from 'vue';
 import { mount } from '@vue/test-utils';
 
 async function createWrapper(options = {}) {
@@ -81,9 +82,8 @@ describe('src/module/sw-sales-channel/page/sw-sales-channel-create', () => {
         const { wrapper } = await createWrapper();
         const saveButton = wrapper.getComponent('.sw-sales-channel-detail__save-action');
 
-        await wrapper.setData({
-            isLoading: false,
-        });
+        wrapper.vm.isLoading = false;
+        await nextTick();
 
         expect(saveButton.props('disabled')).toBe(true);
     });
@@ -92,9 +92,8 @@ describe('src/module/sw-sales-channel/page/sw-sales-channel-create', () => {
         global.activeAclRoles = ['sales_channel.creator'];
         const { wrapper } = await createWrapper();
 
-        await wrapper.setData({
-            isLoading: false,
-        });
+        wrapper.vm.isLoading = false;
+        await nextTick();
 
         const saveButton = wrapper.getComponent('.sw-sales-channel-detail__save-action');
 

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/page/sw-sales-channel-detail/sw-sales-channel-detail.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/page/sw-sales-channel-detail/sw-sales-channel-detail.spec.js
@@ -4,6 +4,7 @@
  * @sw-package discovery
  */
 
+import { nextTick } from 'vue';
 import { mount } from '@vue/test-utils';
 
 const mockSave = jest.fn(() => Promise.resolve());
@@ -206,9 +207,8 @@ describe('src/module/sw-sales-channel/page/sw-sales-channel-detail', () => {
         const wrapper = await createWrapper();
         const saveButton = wrapper.getComponent('.sw-sales-channel-detail__save-action');
 
-        await wrapper.setData({
-            isLoading: false,
-        });
+        wrapper.vm.isLoading = false;
+        await nextTick();
 
         expect(saveButton.props('disabled')).toBe(true);
     });
@@ -217,9 +217,8 @@ describe('src/module/sw-sales-channel/page/sw-sales-channel-detail', () => {
         global.activeAclRoles = ['sales_channel.editor'];
         const wrapper = await createWrapper();
 
-        await wrapper.setData({
-            isLoading: false,
-        });
+        wrapper.vm.isLoading = false;
+        await nextTick();
 
         const saveButton = wrapper.getComponent('.sw-sales-channel-detail__save-action');
 
@@ -231,9 +230,8 @@ describe('src/module/sw-sales-channel/page/sw-sales-channel-detail', () => {
             'sales_channel.editor',
         ]);
 
-        await wrapper.setData({
-            isLoading: false,
-        });
+        wrapper.vm.isLoading = false;
+        await nextTick();
 
         wrapper.vm.salesChannel.analytics.trackingId = null;
 
@@ -248,9 +246,8 @@ describe('src/module/sw-sales-channel/page/sw-sales-channel-detail', () => {
         global.activeAclRoles = ['sales_channel.editor'];
         const wrapper = await createWrapper();
 
-        await wrapper.setData({
-            isLoading: false,
-        });
+        wrapper.vm.isLoading = false;
+        await nextTick();
 
         const analyticsId = wrapper.vm.updateAnalytics();
 
@@ -320,16 +317,15 @@ describe('src/module/sw-sales-channel/page/sw-sales-channel-detail', () => {
     it('should provide agentic commerce export config accessor for child views', async () => {
         const wrapper = await createWrapper();
 
-        await wrapper.setData({
-            agenticCommerceExportConfig: [
-                {
-                    provider: 'open-ai',
-                    elements: [],
-                    values: {},
-                    isLoading: false,
-                },
-            ],
-        });
+        wrapper.vm.agenticCommerceExportConfig = [
+            {
+                provider: 'open-ai',
+                elements: [],
+                values: {},
+                isLoading: false,
+            },
+        ];
+        await nextTick();
 
         const provide = wrapper.vm.$options.provide.call(wrapper.vm);
 
@@ -724,23 +720,22 @@ describe('src/module/sw-sales-channel/page/sw-sales-channel-detail', () => {
         const wrapper = await createWrapper();
         await flushPromises();
 
-        await wrapper.setData({
-            agenticCommerceExportConfig: [
-                {
-                    provider: 'open-ai',
-                    elements: [
-                        {
-                            name: 'core.openAiProductExport.returnPolicyUrl',
-                            config: { required: true },
-                        },
-                    ],
-                    values: { 'core.openAiProductExport.returnPolicyUrl': 'https://example.com/returns' },
-                    errors: {},
-                    isLoaded: true,
-                    isLoading: false,
-                },
-            ],
-        });
+        wrapper.vm.agenticCommerceExportConfig = [
+            {
+                provider: 'open-ai',
+                elements: [
+                    {
+                        name: 'core.openAiProductExport.returnPolicyUrl',
+                        config: { required: true },
+                    },
+                ],
+                values: { 'core.openAiProductExport.returnPolicyUrl': 'https://example.com/returns' },
+                errors: {},
+                isLoaded: true,
+                isLoading: false,
+            },
+        ];
+        await nextTick();
 
         expect(wrapper.vm.validateAgenticCommerceExportConfig()).toBe(true);
         expect(wrapper.vm.agenticCommerceExportConfig[0].errors).toEqual({});
@@ -750,23 +745,22 @@ describe('src/module/sw-sales-channel/page/sw-sales-channel-detail', () => {
         const wrapper = await createWrapper();
         await flushPromises();
 
-        await wrapper.setData({
-            agenticCommerceExportConfig: [
-                {
-                    provider: 'open-ai',
-                    elements: [
-                        {
-                            name: 'core.openAiProductExport.returnPolicyUrl',
-                            config: { required: true },
-                        },
-                    ],
-                    values: {},
-                    errors: {},
-                    isLoaded: true,
-                    isLoading: false,
-                },
-            ],
-        });
+        wrapper.vm.agenticCommerceExportConfig = [
+            {
+                provider: 'open-ai',
+                elements: [
+                    {
+                        name: 'core.openAiProductExport.returnPolicyUrl',
+                        config: { required: true },
+                    },
+                ],
+                values: {},
+                errors: {},
+                isLoaded: true,
+                isLoading: false,
+            },
+        ];
+        await nextTick();
 
         const result = wrapper.vm.validateAgenticCommerceExportConfig();
 
@@ -787,24 +781,23 @@ describe('src/module/sw-sales-channel/page/sw-sales-channel-detail', () => {
         await flushPromises();
         mockSave.mockClear();
 
-        await wrapper.setData({
-            isLoading: true,
-            agenticCommerceExportConfig: [
-                {
-                    provider: 'open-ai',
-                    elements: [
-                        {
-                            name: 'core.openAiProductExport.returnPolicyUrl',
-                            config: { required: true },
-                        },
-                    ],
-                    values: {},
-                    errors: {},
-                    isLoaded: true,
-                    isLoading: false,
-                },
-            ],
-        });
+        wrapper.vm.isLoading = true;
+        wrapper.vm.agenticCommerceExportConfig = [
+            {
+                provider: 'open-ai',
+                elements: [
+                    {
+                        name: 'core.openAiProductExport.returnPolicyUrl',
+                        config: { required: true },
+                    },
+                ],
+                values: {},
+                errors: {},
+                isLoaded: true,
+                isLoading: false,
+            },
+        ];
+        await nextTick();
 
         await wrapper.vm.onSave();
         await flushPromises();
@@ -932,31 +925,30 @@ describe('src/module/sw-sales-channel/page/sw-sales-channel-detail', () => {
         });
         await flushPromises();
 
-        await wrapper.setData({
-            agenticCommerceExportConfig: [
-                {
-                    provider: 'open-ai',
-                    elements: [
-                        {
-                            name: 'core.openAiProductExport.returnPolicyUrl',
-                            config: { required: true },
-                        },
-                    ],
-                    values: {},
-                    errors: {},
-                    isLoaded: true,
-                    isLoading: false,
-                },
-                {
-                    provider: 'google',
-                    elements: [],
-                    values: {},
-                    errors: {},
-                    isLoaded: true,
-                    isLoading: false,
-                },
-            ],
-        });
+        wrapper.vm.agenticCommerceExportConfig = [
+            {
+                provider: 'open-ai',
+                elements: [
+                    {
+                        name: 'core.openAiProductExport.returnPolicyUrl',
+                        config: { required: true },
+                    },
+                ],
+                values: {},
+                errors: {},
+                isLoaded: true,
+                isLoading: false,
+            },
+            {
+                provider: 'google',
+                elements: [],
+                values: {},
+                errors: {},
+                isLoaded: true,
+                isLoading: false,
+            },
+        ];
+        await nextTick();
 
         expect(wrapper.vm.productExport.provider).toBe('google');
         expect(wrapper.vm.validateAgenticCommerceExportConfig()).toBe(true);

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/view/sw-sales-channel-detail-products/sw-sales-channel-detail-products.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/view/sw-sales-channel-detail-products/sw-sales-channel-detail-products.spec.js
@@ -3,6 +3,7 @@
 /**
  * @sw-package discovery
  */
+import { nextTick } from 'vue';
 import { mount } from '@vue/test-utils';
 
 function mockCriteria() {
@@ -252,9 +253,8 @@ describe('src/module/sw-sales-channel/view/sw-sales-channel-detail-products', ()
             products: productsMock,
         });
 
-        await wrapper.setData({
-            searchTerm: 'Awesome Product',
-        });
+        wrapper.vm.searchTerm = 'Awesome Product';
+        await nextTick();
 
         wrapper.vm.productVisibilityRepository.delete = jest.fn(() => Promise.reject(new Error('Error')));
         wrapper.vm.createNotificationError = jest.fn();
@@ -283,9 +283,8 @@ describe('src/module/sw-sales-channel/view/sw-sales-channel-detail-products', ()
         await flushPromises();
         wrapper.vm.getProducts = jest.fn();
 
-        await wrapper.setData({
-            page: 2,
-        });
+        wrapper.vm.page = 2;
+        await nextTick();
 
         expect(wrapper.vm.page).toBe(2);
 
@@ -321,7 +320,9 @@ describe('src/module/sw-sales-channel/view/sw-sales-channel-detail-products', ()
         const { wrapper, getCreateButton } = await createWrapper();
         await flushPromises();
 
-        await wrapper.setData({ products: [], searchTerm: null });
+        wrapper.vm.products = [];
+        wrapper.vm.searchTerm = null;
+        await nextTick();
 
         expect(getCreateButton().attributes('disabled')).toBeUndefined();
     });
@@ -330,7 +331,9 @@ describe('src/module/sw-sales-channel/view/sw-sales-channel-detail-products', ()
         const { wrapper, getCreateButton } = await createWrapper();
         await flushPromises();
 
-        await wrapper.setData({ products: [], searchTerm: null });
+        wrapper.vm.products = [];
+        wrapper.vm.searchTerm = null;
+        await nextTick();
 
         expect(getCreateButton().attributes('disabled')).toBeDefined();
     });
@@ -340,10 +343,9 @@ describe('src/module/sw-sales-channel/view/sw-sales-channel-detail-products', ()
         const { wrapper, getCreateButton } = await createWrapper();
         await flushPromises();
 
-        await wrapper.setData({
-            products: productsMock,
-            searchTerm: 'Awesome Product',
-        });
+        wrapper.vm.products = productsMock;
+        wrapper.vm.searchTerm = 'Awesome Product';
+        await nextTick();
 
         expect(getCreateButton().attributes('disabled')).toBeUndefined();
     });
@@ -352,10 +354,9 @@ describe('src/module/sw-sales-channel/view/sw-sales-channel-detail-products', ()
         const { wrapper, getCreateButton } = await createWrapper();
         await flushPromises();
 
-        await wrapper.setData({
-            products: productsMock,
-            searchTerm: 'Awesome Product',
-        });
+        wrapper.vm.products = productsMock;
+        wrapper.vm.searchTerm = 'Awesome Product';
+        await nextTick();
 
         expect(getCreateButton().attributes('disabled')).toBeDefined();
     });
@@ -365,7 +366,8 @@ describe('src/module/sw-sales-channel/view/sw-sales-channel-detail-products', ()
         const { wrapper, getEntityListing } = await createWrapper();
         await flushPromises();
 
-        await wrapper.setData({ products: productsMock });
+        wrapper.vm.products = productsMock;
+        await nextTick();
 
         expect(getEntityListing().props('allowDelete')).toBe(true);
     });
@@ -374,7 +376,8 @@ describe('src/module/sw-sales-channel/view/sw-sales-channel-detail-products', ()
         const { wrapper, getEntityListing } = await createWrapper();
         await flushPromises();
 
-        await wrapper.setData({ products: productsMock });
+        wrapper.vm.products = productsMock;
+        await nextTick();
 
         expect(getEntityListing().props('allowDelete')).toBe(false);
     });
@@ -384,7 +387,8 @@ describe('src/module/sw-sales-channel/view/sw-sales-channel-detail-products', ()
         const { wrapper, getEntityListing } = await createWrapper();
         await flushPromises();
 
-        await wrapper.setData({ products: productsMock });
+        wrapper.vm.products = productsMock;
+        await nextTick();
 
         expect(getEntityListing().props('allowEdit')).toBe(true);
     });
@@ -393,7 +397,8 @@ describe('src/module/sw-sales-channel/view/sw-sales-channel-detail-products', ()
         const { wrapper, getEntityListing } = await createWrapper();
         await flushPromises();
 
-        await wrapper.setData({ products: productsMock });
+        wrapper.vm.products = productsMock;
+        await nextTick();
 
         expect(getEntityListing().props('allowEdit')).toBe(false);
     });
@@ -415,7 +420,8 @@ describe('src/module/sw-sales-channel/view/sw-sales-channel-detail-products', ()
         await flushPromises();
         wrapper.vm.saveProductVisibilities = jest.fn(() => Promise.resolve());
 
-        await wrapper.setData({ products: productsMock });
+        wrapper.vm.products = productsMock;
+        await nextTick();
         await wrapper.vm.onAddProducts([
             { id: '103', active: true, productNumber: '003' },
         ]);

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-currency/component/sw-settings-currency-country-modal/sw-settings-currency-country-modal.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-currency/component/sw-settings-currency-country-modal/sw-settings-currency-country-modal.spec.js
@@ -2,6 +2,7 @@
  * @sw-package fundamentals@framework
  */
 
+import { nextTick } from 'vue';
 import { mount } from '@vue/test-utils';
 
 async function createWrapper() {
@@ -40,9 +41,8 @@ async function createWrapper() {
 describe('module/sw-settings-currency/component/sw-settings-currency-country-modal', () => {
     it('should disable already assigned countries', async () => {
         const wrapper = await createWrapper();
-        await wrapper.setData({
-            assignedCountryIds: ['countryId1'],
-        });
+        wrapper.vm.assignedCountryIds = ['countryId1'];
+        await nextTick();
 
         expect(wrapper.vm.shouldDisableCountry({ id: 'countryId1' })).toBe(true);
         expect(wrapper.vm.shouldDisableCountry({ id: 'countryId2' })).toBe(false);
@@ -56,9 +56,8 @@ describe('module/sw-settings-currency/component/sw-settings-currency-country-mod
                 countryId: 'countryId1',
             },
         });
-        await wrapper.setData({
-            assignedCountryIds: ['countryId1'],
-        });
+        wrapper.vm.assignedCountryIds = ['countryId1'];
+        await nextTick();
 
         expect(wrapper.vm.shouldDisableCountry({ id: 'countryId1' })).toBe(false);
         expect(wrapper.vm.shouldDisableCountry({ id: 'countryId2' })).toBe(false);

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-custom-field/component/sw-custom-field-list/sw-custom-field-list.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-custom-field/component/sw-custom-field-list/sw-custom-field-list.spec.js
@@ -1,6 +1,7 @@
 /**
  * @sw-package framework
  */
+import { nextTick } from 'vue';
 import { mount } from '@vue/test-utils';
 
 const set = {
@@ -241,9 +242,8 @@ describe('src/module/sw-settings-custom-field/component/sw-custom-field-list/sw-
 
         await flushPromises();
 
-        await wrapper.setData({
-            deleteCustomField: deleteCustomField,
-        });
+        wrapper.vm.deleteCustomField = deleteCustomField;
+        await nextTick();
 
         await flushPromises();
 

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-customer-group/page/sw-settings-customer-group-list/sw-settings-customer-group-list.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-customer-group/page/sw-settings-customer-group-list/sw-settings-customer-group-list.spec.js
@@ -2,6 +2,7 @@
  * @sw-package discovery
  */
 
+import { nextTick } from 'vue';
 import { mount } from '@vue/test-utils';
 import { searchRankingPoint } from 'src/app/service/search-ranking.service';
 import Criteria from 'src/core/data/criteria.data';
@@ -245,9 +246,8 @@ describe('src/module/sw-settings-customer-group/page/sw-settings-customer-group-
 
     it('should add query score to the criteria', async () => {
         const wrapper = await createWrapper();
-        await wrapper.setData({
-            term: 'foo',
-        });
+        wrapper.vm.term = 'foo';
+        await nextTick();
         await wrapper.vm.$nextTick();
         wrapper.vm.searchRankingService.buildSearchQueriesForEntity = jest.fn(() => {
             return new Criteria(1, 25);
@@ -288,9 +288,8 @@ describe('src/module/sw-settings-customer-group/page/sw-settings-customer-group-
 
     it('should not build query score when search ranking field is null', async () => {
         const wrapper = await createWrapper();
-        await wrapper.setData({
-            term: 'foo',
-        });
+        wrapper.vm.term = 'foo';
+        await nextTick();
 
         await wrapper.vm.$nextTick();
         wrapper.vm.searchRankingService.buildSearchQueriesForEntity = jest.fn(() => {
@@ -312,9 +311,8 @@ describe('src/module/sw-settings-customer-group/page/sw-settings-customer-group-
 
     it('should show empty state when there is not item after filling search term', async () => {
         const wrapper = await createWrapper();
-        await wrapper.setData({
-            term: 'foo',
-        });
+        wrapper.vm.term = 'foo';
+        await nextTick();
         await wrapper.vm.$nextTick();
         wrapper.vm.searchRankingService.getSearchFieldsByEntity = jest.fn(() => {
             return {};

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-delivery-times/page/sw-settings-delivery-time-detail/sw-settings-delivery-time-detail.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-delivery-times/page/sw-settings-delivery-time-detail/sw-settings-delivery-time-detail.spec.js
@@ -1,3 +1,4 @@
+import { nextTick } from 'vue';
 import { mount } from '@vue/test-utils';
 
 /**
@@ -159,9 +160,8 @@ describe('src/module/sw-settings-delivery-times/page/sw-settings-delivery-time-d
         await wrapper.vm.$nextTick();
 
         // Assume that user navigate to sw-setting-delivery-time-create page
-        await wrapper.setData({
-            deliveryTime: wrapper.vm.deliveryTimeRepository.create(),
-        });
+        wrapper.vm.deliveryTime = wrapper.vm.deliveryTimeRepository.create();
+        await nextTick();
 
         await wrapper.vm.$nextTick();
 

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-document/page/sw-settings-document-detail/sw-settings-document-detail.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-document/page/sw-settings-document-detail/sw-settings-document-detail.spec.js
@@ -1,3 +1,4 @@
+import { nextTick } from 'vue';
 import { mount } from '@vue/test-utils';
 import { COMPANY_SETTINGS_MOVED_BANNER_STORAGE_KEY } from './index';
 
@@ -491,9 +492,8 @@ describe('src/module/sw-settings-document/page/sw-settings-document-detail', () 
     it('should contain field "display divergent delivery address" in invoice form field', async () => {
         const wrapper = await createWrapper({}, ['document.editor']);
 
-        await wrapper.setData({
-            isShowDivergentDeliveryAddress: true,
-        });
+        wrapper.vm.isShowDivergentDeliveryAddress = true;
+        await nextTick();
         await flushPromises();
 
         const displayDivergentDeliveryAddress = wrapper.findComponent(

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-listing/page/sw-settings-listing-option-base/sw-settings-listing-option-base.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-listing/page/sw-settings-listing-option-base/sw-settings-listing-option-base.spec.js
@@ -1,3 +1,4 @@
+import { nextTick } from 'vue';
 import { mount } from '@vue/test-utils';
 
 /**
@@ -178,9 +179,8 @@ describe('src/module/sw-settings-listing/page/sw-settings-listing-option-base', 
     });
 
     it('should disable the save button if no criteria exists', async () => {
-        await wrapper.setData({
-            productSortingEntity: getProductSortingEntityWithoutCriteria(),
-        });
+        wrapper.vm.productSortingEntity = getProductSortingEntityWithoutCriteria();
+        await nextTick();
 
         const isSaveButtonDisabled = wrapper.vm.isSaveButtonDisabled;
 
@@ -200,9 +200,8 @@ describe('src/module/sw-settings-listing/page/sw-settings-listing-option-base', 
     });
 
     it('should display the fallback snippet when the entity has no name', async () => {
-        await wrapper.setData({
-            productSortingEntity: getProductSortingEntityWithoutName(),
-        });
+        wrapper.vm.productSortingEntity = getProductSortingEntityWithoutName();
+        await nextTick();
 
         const displayValue = wrapper.vm.smartBarHeading;
 
@@ -292,9 +291,8 @@ describe('src/module/sw-settings-listing/page/sw-settings-listing-option-base', 
     });
 
     it('should show alert on locked product sorting', async () => {
-        await wrapper.setData({
-            productSortingEntity: getLockedProductSorting(),
-        });
+        wrapper.vm.productSortingEntity = getLockedProductSorting();
+        await nextTick();
 
         const alert = wrapper.find('.sw-settings-listing-base__locked-info');
 

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-measurement/page/sw-settings-measurement/sw-settings-measurement.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-measurement/page/sw-settings-measurement/sw-settings-measurement.spec.js
@@ -1,6 +1,7 @@
 /**
  * @sw-package inventory
  */
+import { nextTick } from 'vue';
 import { mount } from '@vue/test-utils';
 import EntityCollection from 'src/core/data/entity-collection.data';
 
@@ -239,20 +240,19 @@ describe('src/module/sw-settings-measurement/page/sw-settings-measurement', () =
     });
 
     it('should update defaultDisplayUnits and selected units when measurement system units are changed and back', async () => {
-        await wrapper.setData({
-            defaultDisplayUnits: new EntityCollection(
-                '/measurement-display-unit',
-                'measurement_display_unit',
-                null,
-                { isShopwareContext: true },
-                [
-                    { id: 'cm', type: 'length', measurementSystemId: 'metric', shortName: 'cm', default: false },
-                    { id: 'g', type: 'weight', measurementSystemId: 'metric', shortName: 'g', default: false },
-                ],
-                2,
-                null,
-            ),
-        });
+        wrapper.vm.defaultDisplayUnits = new EntityCollection(
+            '/measurement-display-unit',
+            'measurement_display_unit',
+            null,
+            { isShopwareContext: true },
+            [
+                { id: 'cm', type: 'length', measurementSystemId: 'metric', shortName: 'cm', default: false },
+                { id: 'g', type: 'weight', measurementSystemId: 'metric', shortName: 'g', default: false },
+            ],
+            2,
+            null,
+        );
+        await nextTick();
 
         expect(wrapper.vm.defaultDisplayUnits).toBeInstanceOf(EntityCollection);
         expect(wrapper.vm.defaultDisplayUnits.getIds()).toEqual(

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-media/page/sw-settings-media/sw-settings-media.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-media/page/sw-settings-media/sw-settings-media.spec.js
@@ -1,6 +1,7 @@
 /**
  * @sw-package inventory
  */
+import { nextTick } from 'vue';
 import { mount } from '@vue/test-utils';
 
 async function createWrapper() {
@@ -122,9 +123,8 @@ describe('module/sw-settings-media/page/sw-settings-media', () => {
         const wrapper = await createWrapper();
         await flushPromises();
 
-        await wrapper.setData({
-            isSaveSuccessful: true,
-        });
+        wrapper.vm.isSaveSuccessful = true;
+        await nextTick();
 
         wrapper.vm.saveFinish();
 

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-number-range/page/sw-settings-number-range-create/sw-settings-number-range-create.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-number-range/page/sw-settings-number-range-create/sw-settings-number-range-create.spec.js
@@ -1,6 +1,7 @@
 /**
  * @sw-package framework
  */
+import { nextTick } from 'vue';
 import { mount } from '@vue/test-utils';
 
 async function createWrapper(
@@ -147,9 +148,8 @@ describe('src/module/sw-settings-number-range/page/sw-settings-number-range-crea
         const wrapper = await createWrapper();
         await wrapper.vm.$nextTick();
 
-        await wrapper.setData({
-            hasProductNumberRange: true,
-        });
+        wrapper.vm.hasProductNumberRange = true;
+        await nextTick();
 
         const criteria = wrapper.vm.numberRangeTypeCriteria.filters.find((c) => c.field === 'global');
         expect(criteria.value).toBe(false);
@@ -158,7 +158,8 @@ describe('src/module/sw-settings-number-range/page/sw-settings-number-range-crea
     it('should be able show product warning alert when number range is global', async () => {
         const wrapper = await createWrapper();
         const loadSalesChannelsSpy = jest.spyOn(wrapper.vm, 'loadSalesChannels');
-        await wrapper.setData({ isLoading: false });
+        wrapper.vm.isLoading = false;
+        await nextTick();
         await flushPromises();
 
         const selectType = wrapper.find('.sw-number-range-detail__select-type');

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-number-range/page/sw-settings-number-range-detail/sw-settings-number-range-detail.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-number-range/page/sw-settings-number-range-detail/sw-settings-number-range-detail.spec.js
@@ -1,6 +1,7 @@
 /**
  * @sw-package framework
  */
+import { nextTick } from 'vue';
 import { mount } from '@vue/test-utils';
 
 async function createWrapper() {
@@ -190,9 +191,8 @@ describe('src/module/sw-settings-number-range/page/sw-settings-number-range-deta
 
         const wrapper = await createWrapper();
 
-        await wrapper.setData({
-            isLoading: false,
-        });
+        wrapper.vm.isLoading = false;
+        await nextTick();
 
         await wrapper.vm.$nextTick();
 
@@ -210,7 +210,8 @@ describe('src/module/sw-settings-number-range/page/sw-settings-number-range-deta
 
         const wrapper = await createWrapper();
 
-        await wrapper.setData({ isLoading: false });
+        wrapper.vm.isLoading = false;
+        await nextTick();
         await flushPromises();
 
         const alwaysDisabledElements = [
@@ -235,7 +236,8 @@ describe('src/module/sw-settings-number-range/page/sw-settings-number-range-deta
     it('should not be able to edit the number range', async () => {
         const wrapper = await createWrapper();
 
-        await wrapper.setData({ isLoading: false });
+        wrapper.vm.isLoading = false;
+        await nextTick();
         await flushPromises();
 
         const elements = wrapper.findAllComponents('.sw-field');

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-product-feature-sets/page/sw-settings-product-feature-sets-list/sw-settings-product-feature-sets-list.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-product-feature-sets/page/sw-settings-product-feature-sets-list/sw-settings-product-feature-sets-list.spec.js
@@ -1,3 +1,4 @@
+import { nextTick } from 'vue';
 import { mount } from '@vue/test-utils';
 import EntityCollection from 'src/core/data/entity-collection.data';
 import Criteria from 'src/core/data/criteria.data';
@@ -97,31 +98,30 @@ async function createWrapper(additionalOptions = {}, privileges = []) {
         },
     );
 
-    await wrapper.setData({
-        productFeatureSets: new EntityCollection(
-            null,
-            'product_feature_set',
-            Shopware.Context.api,
+    wrapper.vm.productFeatureSets = new EntityCollection(
+        null,
+        'product_feature_set',
+        Shopware.Context.api,
+        {
+            page: {},
+        },
+        [
             {
-                page: {},
+                id: 'ecf55d8cbcf5496d8e42aa146ec4ba95',
+                name: text.featureSetName,
+                description: text.featureSetDescription,
+                features: [
+                    {
+                        type: 'referencePrice',
+                        id: null,
+                        name: null,
+                        position: 0,
+                    },
+                ],
             },
-            [
-                {
-                    id: 'ecf55d8cbcf5496d8e42aa146ec4ba95',
-                    name: text.featureSetName,
-                    description: text.featureSetDescription,
-                    features: [
-                        {
-                            type: 'referencePrice',
-                            id: null,
-                            name: null,
-                            position: 0,
-                        },
-                    ],
-                },
-            ],
-        ),
-    });
+        ],
+    );
+    await nextTick();
 
     await flushPromises();
 
@@ -318,30 +318,29 @@ describe('src/module/sw-settings-product-feature-sets/page/sw-settings-product-f
 
     it('should load listing if there are templates with empty features', async () => {
         const wrapper = await createWrapper();
-        await wrapper.setData({
-            productFeatureSets: new EntityCollection(
-                null,
-                'product_feature_set',
-                Shopware.Context.api,
+        wrapper.vm.productFeatureSets = new EntityCollection(
+            null,
+            'product_feature_set',
+            Shopware.Context.api,
+            {
+                page: {},
+            },
+            [
                 {
-                    page: {},
+                    id: '3d14420686274551bdfdc88ea9672cde',
+                    name: `${text.featureSetName} in false-empty`,
+                    description: 'This empty feature set is created by deleting all features',
+                    features: {},
                 },
-                [
-                    {
-                        id: '3d14420686274551bdfdc88ea9672cde',
-                        name: `${text.featureSetName} in false-empty`,
-                        description: 'This empty feature set is created by deleting all features',
-                        features: {},
-                    },
-                    {
-                        id: 'd3fdf1478e314d809463260517ef64f0',
-                        name: `${text.featureSetName} in empty`,
-                        description: 'This empty feature set is created by being empty from the start',
-                        features: [],
-                    },
-                ],
-            ),
-        });
+                {
+                    id: 'd3fdf1478e314d809463260517ef64f0',
+                    name: `${text.featureSetName} in empty`,
+                    description: 'This empty feature set is created by being empty from the start',
+                    features: [],
+                },
+            ],
+        );
+        await nextTick();
         await flushPromises();
 
         const root = wrapper.get('.sw-settings-product-feature-sets-list');

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-rule/page/sw-settings-rule-detail/sw-settings-rule-detail.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-rule/page/sw-settings-rule-detail/sw-settings-rule-detail.spec.js
@@ -1,5 +1,6 @@
 /* eslint-disable sw-test-rules/test-file-max-lines-warning, sw-test-rules/test-file-max-lines-error */
 
+import { nextTick } from 'vue';
 import { config, mount } from '@vue/test-utils';
 import kebabCase from 'lodash-es/kebabCase';
 import ShopwareError from 'src/core/data/ShopwareError';
@@ -387,9 +388,8 @@ describe('src/module/sw-settings-rule/page/sw-settings-rule-detail', () => {
         const wrapper = await createWrapper();
         await flushPromises();
 
-        await wrapper.setData({
-            rule,
-        });
+        wrapper.vm.rule = rule;
+        await nextTick();
 
         wrapper.vm.$createTitle = jest.fn(() => 'Title');
         const metaInfo = wrapper.vm.$options.metaInfo.call(wrapper.vm);
@@ -892,9 +892,8 @@ describe('src/module/sw-settings-rule/page/sw-settings-rule-detail', () => {
         'should check for unsaved data when route updates: $name',
         async ({ from, to, discard, check }) => {
             const wrapper = await createWrapper();
-            await wrapper.setData({
-                forceDiscardChanges: discard,
-            });
+            wrapper.vm.forceDiscardChanges = discard;
+            await nextTick();
             await flushPromises();
 
             const nextMock = jest.fn();
@@ -916,9 +915,8 @@ describe('src/module/sw-settings-rule/page/sw-settings-rule-detail', () => {
         'should check for unsaved data when leaving route: $name',
         async ({ from, to, discard, check }) => {
             const wrapper = await createWrapper();
-            await wrapper.setData({
-                forceDiscardChanges: discard,
-            });
+            wrapper.vm.forceDiscardChanges = discard;
+            await nextTick();
             await flushPromises();
 
             const nextMock = jest.fn();
@@ -991,9 +989,8 @@ describe('src/module/sw-settings-rule/page/sw-settings-rule-detail', () => {
         const wrapper = await createWrapper();
         await flushPromises();
 
-        await wrapper.setData({
-            isDisplayingSaveChangesWarning: true,
-        });
+        wrapper.vm.isDisplayingSaveChangesWarning = true;
+        await nextTick();
         await flushPromises();
 
         expect(wrapper.find('.sw-modal').exists()).toBe(true);
@@ -1023,10 +1020,9 @@ describe('src/module/sw-settings-rule/page/sw-settings-rule-detail', () => {
             params: { id: 'uuid1' },
         };
 
-        await wrapper.setData({
-            isDisplayingSaveChangesWarning: true,
-            nextRoute,
-        });
+        wrapper.vm.isDisplayingSaveChangesWarning = true;
+        wrapper.vm.nextRoute = nextRoute;
+        await nextTick();
         await flushPromises();
 
         const routerSpy = jest.spyOn(wrapper.vm.$router, 'push');
@@ -1243,7 +1239,8 @@ describe('src/module/sw-settings-rule/page/sw-settings-rule-detail', () => {
         const wrapper = await createWrapper();
         await flushPromises();
 
-        await wrapper.setData({ conditionTree });
+        wrapper.vm.conditionTree = conditionTree;
+        await nextTick();
         expect(wrapper.vm.conditionTreeFlat).toEqual(expectedFlatConditions);
     });
 
@@ -1360,22 +1357,21 @@ describe('src/module/sw-settings-rule/page/sw-settings-rule-detail', () => {
         const wrapper = await createWrapper();
         await flushPromises();
 
-        await wrapper.setData({
-            conditionTree: [
-                {
-                    id: 'date-range-condition-empty',
-                    type: 'dateRange',
-                    value: { fromDate: null, toDate: null },
-                    children: [],
-                },
-                {
-                    id: 'date-range-condition-partial',
-                    type: 'dateRange',
-                    value: { fromDate: '2023-01-01', toDate: null },
-                    children: [],
-                },
-            ],
-        });
+        wrapper.vm.conditionTree = [
+            {
+                id: 'date-range-condition-empty',
+                type: 'dateRange',
+                value: { fromDate: null, toDate: null },
+                children: [],
+            },
+            {
+                id: 'date-range-condition-partial',
+                type: 'dateRange',
+                value: { fromDate: '2023-01-01', toDate: null },
+                children: [],
+            },
+        ];
+        await nextTick();
 
         await wrapper.get('.sw-settings-rule-detail__save-action').trigger('click');
         await flushPromises();
@@ -1401,33 +1397,32 @@ describe('src/module/sw-settings-rule/page/sw-settings-rule-detail', () => {
         const wrapper = await createWrapper();
         await flushPromises();
 
-        await wrapper.setData({
-            conditionTree: [
-                {
-                    id: 'first-reversed',
-                    type: 'dateRange',
-                    value: { fromDate: '2023-12-31', toDate: '2023-01-01' },
-                    children: [],
-                },
-                {
-                    id: 'second-reversed',
-                    type: 'dateRange',
-                    value: { fromDate: '2024-06-01', toDate: '2024-05-01' },
-                    children: [],
-                },
-                {
-                    id: 'valid',
-                    type: 'dateRange',
-                    value: { fromDate: '2023-01-01', toDate: '2023-12-31' },
-                    children: [],
-                },
-            ],
-            conditions: [
-                { id: 'first-reversed' },
-                { id: 'second-reversed' },
-                { id: 'valid' },
-            ],
-        });
+        wrapper.vm.conditionTree = [
+            {
+                id: 'first-reversed',
+                type: 'dateRange',
+                value: { fromDate: '2023-12-31', toDate: '2023-01-01' },
+                children: [],
+            },
+            {
+                id: 'second-reversed',
+                type: 'dateRange',
+                value: { fromDate: '2024-06-01', toDate: '2024-05-01' },
+                children: [],
+            },
+            {
+                id: 'valid',
+                type: 'dateRange',
+                value: { fromDate: '2023-01-01', toDate: '2023-12-31' },
+                children: [],
+            },
+        ];
+        wrapper.vm.conditions = [
+            { id: 'first-reversed' },
+            { id: 'second-reversed' },
+            { id: 'valid' },
+        ];
+        await nextTick();
 
         await wrapper.get('.sw-settings-rule-detail__save-action').trigger('click');
         await flushPromises();

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-search/component/sw-settings-search-live-search/sw-settings-search-live-search.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-search/component/sw-settings-search-live-search/sw-settings-search-live-search.spec.js
@@ -1,6 +1,7 @@
 /**
  * @sw-package inventory
  */
+import { nextTick } from 'vue';
 import { mount } from '@vue/test-utils';
 
 const salesChannels = [
@@ -241,9 +242,8 @@ describe('src/module/sw-settings-search/component/sw-settings-search-live-search
         await searchBox.trigger('keypress', { key: 'Enter' });
         await flushPromises();
 
-        await wrapper.setData({
-            liveSearchResults: mockResults.nothing.result,
-        });
+        wrapper.vm.liveSearchResults = mockResults.nothing.result;
+        await nextTick();
         await flushPromises();
         const resultHeadline = wrapper.find('.sw-settings-search-live-search__no-result .mt-empty-state__headline');
         expect(resultHeadline.text()).toBe('sw-settings-search.liveSearchTab.textNoResult');
@@ -265,9 +265,8 @@ describe('src/module/sw-settings-search/component/sw-settings-search-live-search
         await searchBox.trigger('keypress', { key: 'Enter' });
         await flushPromises();
 
-        await wrapper.setData({
-            liveSearchResults: mockResults.oneResult.result,
-        });
+        wrapper.vm.liveSearchResults = mockResults.oneResult.result;
+        await nextTick();
         await flushPromises();
 
         const firstRow = wrapper.find('.sw-data-grid__row--0');
@@ -296,9 +295,8 @@ describe('src/module/sw-settings-search/component/sw-settings-search-live-search
         await searchBox.trigger('keypress', { key: 'Enter' });
         await flushPromises();
 
-        await wrapper.setData({
-            liveSearchResults: mockResults.multipleResults.result,
-        });
+        wrapper.vm.liveSearchResults = mockResults.multipleResults.result;
+        await nextTick();
         await flushPromises();
 
         const tableBody = wrapper.find('.sw-data-grid__body');

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-search/component/sw-settings-search-search-index/sw-settings-search-search-index.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-search/component/sw-settings-search-search-index/sw-settings-search-search-index.spec.js
@@ -1,6 +1,7 @@
 /**
  * @sw-package inventory
  */
+import { nextTick } from 'vue';
 import { mount } from '@vue/test-utils';
 import 'src/app/mixin/notification.mixin';
 
@@ -120,9 +121,8 @@ describe('module/sw-settings-search/component/sw-settings-search-search-index', 
         wrapper.vm.createNotificationSuccess = jest.fn();
 
         // First time call the update progress
-        await wrapper.setData({
-            offset: 0,
-        });
+        wrapper.vm.offset = 0;
+        await nextTick();
 
         const rebuildButton = wrapper.find('.sw-settings-search__search-index-rebuild-button');
         await rebuildButton.trigger('click');
@@ -138,18 +138,16 @@ describe('module/sw-settings-search/component/sw-settings-search-search-index', 
         expect(response.finish).toBeFalsy();
 
         // Second call with offset 51
-        await wrapper.setData({
-            offset: response.offset.offset,
-        });
+        wrapper.vm.offset = response.offset.offset;
+        await nextTick();
         response = await wrapper.vm.productIndexService.index(wrapper.vm.offset);
         await flushPromises();
         expect(response.offset.offset).toBe(60);
         expect(response.finish).toBeFalsy();
 
         // Third call with offset 60
-        await wrapper.setData({
-            offset: response.offset.offset,
-        });
+        wrapper.vm.offset = response.offset.offset;
+        await nextTick();
         response = await wrapper.vm.productIndexService.index(wrapper.vm.offset);
         await flushPromises();
 
@@ -165,9 +163,8 @@ describe('module/sw-settings-search/component/sw-settings-search-search-index', 
         wrapper.vm.createNotificationSuccess = jest.fn();
         expect(wrapper.vm.isRebuildSuccess).toBeFalsy();
 
-        await wrapper.setData({
-            offset: 60,
-        });
+        wrapper.vm.offset = 60;
+        await nextTick();
         await wrapper.vm.updateProgress();
 
         expect(wrapper.vm.createNotificationSuccess).toHaveBeenCalledWith({

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-seo/component/sw-seo-url/sw-seo-url.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-seo/component/sw-seo-url/sw-seo-url.spec.js
@@ -2,6 +2,7 @@
  * @sw-package inventory
  */
 
+import { nextTick } from 'vue';
 import { mount } from '@vue/test-utils';
 
 // from Defaults.php
@@ -91,7 +92,8 @@ describe('src/module/sw-settings-seo/component/sw-seo-url', () => {
     });
 
     it('sales channel switch should not be disabled', async () => {
-        await wrapper.setData({ showEmptySeoUrlError: false });
+        wrapper.vm.showEmptySeoUrlError = false;
+        await nextTick();
 
         expect(wrapper.find('sw-sales-channel-switch-stub').attributes().disabled).toBeUndefined();
     });
@@ -115,7 +117,9 @@ describe('src/module/sw-settings-seo/component/sw-seo-url', () => {
             ],
             salesChannelId: STOREFRONT_SALES_CHANNEL_ID,
         });
-        await wrapper.setData({ showEmptySeoUrlError: false, currentSalesChannelId: STOREFRONT_SALES_CHANNEL_ID });
+        wrapper.vm.showEmptySeoUrlError = false;
+        wrapper.vm.currentSalesChannelId = STOREFRONT_SALES_CHANNEL_ID;
+        await nextTick();
         await wrapper.vm.$nextTick();
 
         await wrapper.vm.refreshCurrentSeoUrl();
@@ -143,7 +147,9 @@ describe('src/module/sw-settings-seo/component/sw-seo-url', () => {
             ],
             salesChannelId: 'a-sales-channel-without-seo-urls',
         });
-        await wrapper.setData({ showEmptySeoUrlError: false, currentSalesChannelId: STOREFRONT_SALES_CHANNEL_ID });
+        wrapper.vm.showEmptySeoUrlError = false;
+        wrapper.vm.currentSalesChannelId = STOREFRONT_SALES_CHANNEL_ID;
+        await nextTick();
         await wrapper.vm.$nextTick();
 
         await wrapper.vm.refreshCurrentSeoUrl();
@@ -212,7 +218,9 @@ describe('src/module/sw-settings-seo/component/sw-seo-url', () => {
             ],
             salesChannelId: STOREFRONT_SALES_CHANNEL_ID,
         });
-        await wrapper.setData({ showEmptySeoUrlError: false, currentSalesChannelId: STOREFRONT_SALES_CHANNEL_ID });
+        wrapper.vm.showEmptySeoUrlError = false;
+        wrapper.vm.currentSalesChannelId = STOREFRONT_SALES_CHANNEL_ID;
+        await nextTick();
         await wrapper.vm.$nextTick();
 
         await wrapper.vm.refreshCurrentSeoUrl();
@@ -297,7 +305,9 @@ describe('src/module/sw-settings-seo/component/sw-seo-url', () => {
             ],
             salesChannelId: STOREFRONT_SALES_CHANNEL_ID,
         });
-        await wrapper.setData({ showEmptySeoUrlError: false, currentSalesChannelId: STOREFRONT_SALES_CHANNEL_ID });
+        wrapper.vm.showEmptySeoUrlError = false;
+        wrapper.vm.currentSalesChannelId = STOREFRONT_SALES_CHANNEL_ID;
+        await nextTick();
         await wrapper.vm.$nextTick();
 
         await wrapper.vm.refreshCurrentSeoUrl();

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-shipping/page/sw-settings-shipping-detail/sw-settings-shipping-detail.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-shipping/page/sw-settings-shipping-detail/sw-settings-shipping-detail.spec.js
@@ -1,3 +1,4 @@
+import { nextTick } from 'vue';
 import { mount } from '@vue/test-utils';
 
 /**
@@ -97,9 +98,8 @@ async function createWrapper(privileges = [], props = {}) {
 describe('module/sw-settings-shipping/page/sw-settings-shipping-detail', () => {
     it('should have all fields disabled', async () => {
         const wrapper = await createWrapper();
-        await wrapper.setData({
-            isProcessLoading: false,
-        });
+        wrapper.vm.isProcessLoading = false;
+        await nextTick();
 
         await flushPromises();
 
@@ -136,9 +136,8 @@ describe('module/sw-settings-shipping/page/sw-settings-shipping-detail', () => {
         const wrapper = await createWrapper([
             'shipping.editor',
         ]);
-        await wrapper.setData({
-            isProcessLoading: false,
-        });
+        wrapper.vm.isProcessLoading = false;
+        await nextTick();
 
         await flushPromises();
 

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-shipping/page/sw-settings-shipping-list/sw-settings-shipping-list.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-shipping/page/sw-settings-shipping-list/sw-settings-shipping-list.spec.js
@@ -1,3 +1,4 @@
+import { nextTick } from 'vue';
 import { mount } from '@vue/test-utils';
 import Criteria from 'src/core/data/criteria.data';
 import { searchRankingPoint } from 'src/app/service/search-ranking.service';
@@ -87,7 +88,8 @@ describe('module/sw-settings-shipping/page/sw-settings-shipping-list', () => {
 
     it('should have all fields disabled', async () => {
         const wrapper = await createWrapper();
-        await wrapper.setData({ total: 2 });
+        wrapper.vm.total = 2;
+        await nextTick();
 
         const entityListing = wrapper.find('sw-entity-listing-stub');
         const button = wrapper.findByText('button', 'sw-settings-shipping.list.buttonAddShippingMethod');
@@ -102,7 +104,8 @@ describe('module/sw-settings-shipping/page/sw-settings-shipping-list', () => {
         const wrapper = await createWrapper([
             'shipping.editor',
         ]);
-        await wrapper.setData({ total: 2 });
+        wrapper.vm.total = 2;
+        await nextTick();
 
         const entityListing = wrapper.find('sw-entity-listing-stub');
         const button = wrapper.findByText('button', 'sw-settings-shipping.list.buttonAddShippingMethod');
@@ -119,7 +122,8 @@ describe('module/sw-settings-shipping/page/sw-settings-shipping-list', () => {
             'shipping.editor',
             'shipping.deleter',
         ]);
-        await wrapper.setData({ total: 2 });
+        wrapper.vm.total = 2;
+        await nextTick();
 
         const entityListing = wrapper.find('sw-entity-listing-stub');
         const button = wrapper.findByText('button', 'sw-settings-shipping.list.buttonAddShippingMethod');
@@ -136,7 +140,8 @@ describe('module/sw-settings-shipping/page/sw-settings-shipping-list', () => {
             'shipping.deleter',
             'shipping.creator',
         ]);
-        await wrapper.setData({ total: 2 });
+        wrapper.vm.total = 2;
+        await nextTick();
 
         const entityListing = wrapper.find('sw-entity-listing-stub');
         const button = wrapper.findByText('button', 'sw-settings-shipping.list.buttonAddShippingMethod');
@@ -149,9 +154,8 @@ describe('module/sw-settings-shipping/page/sw-settings-shipping-list', () => {
 
     it('should add query score to the criteria', async () => {
         const wrapper = await createWrapper();
-        await wrapper.setData({
-            term: 'foo',
-        });
+        wrapper.vm.term = 'foo';
+        await nextTick();
         await wrapper.vm.$nextTick();
         wrapper.vm.searchRankingService.buildSearchQueriesForEntity = jest.fn(() => {
             return new Criteria(1, 25);
@@ -192,9 +196,8 @@ describe('module/sw-settings-shipping/page/sw-settings-shipping-list', () => {
 
     it('should not build query score when search ranking field is null', async () => {
         const wrapper = await createWrapper();
-        await wrapper.setData({
-            term: 'foo',
-        });
+        wrapper.vm.term = 'foo';
+        await nextTick();
 
         await wrapper.vm.$nextTick();
         wrapper.vm.searchRankingService.buildSearchQueriesForEntity = jest.fn(() => {
@@ -216,9 +219,8 @@ describe('module/sw-settings-shipping/page/sw-settings-shipping-list', () => {
 
     it('should show empty state when there is not item after filling search term', async () => {
         const wrapper = await createWrapper();
-        await wrapper.setData({
-            term: 'foo',
-        });
+        wrapper.vm.term = 'foo';
+        await nextTick();
         await wrapper.vm.$nextTick();
         wrapper.vm.searchRankingService.getSearchFieldsByEntity = jest.fn(() => {
             return {};

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-snippet/page/sw-settings-snippet-detail/sw-settings-snippet-detail.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-snippet/page/sw-settings-snippet-detail/sw-settings-snippet-detail.spec.js
@@ -1,6 +1,7 @@
 /**
  * @sw-package fundamentals@discovery
  */
+import { nextTick } from 'vue';
 import { mount } from '@vue/test-utils';
 
 function getSnippetSets() {
@@ -215,9 +216,8 @@ describe('module/sw-settings-snippet/page/sw-settings-snippet-detail', () => {
         const wrapper = await createWrapper(roles);
         await flushPromises();
 
-        await wrapper.setData({
-            isLoading: false,
-        });
+        wrapper.vm.isLoading = false;
+        await nextTick();
         await flushPromises();
 
         const [
@@ -246,10 +246,9 @@ describe('module/sw-settings-snippet/page/sw-settings-snippet-detail', () => {
         ]);
         await flushPromises();
 
-        await wrapper.setData({
-            isLoading: false,
-            isAddedSnippet: true,
-        });
+        wrapper.vm.isLoading = false;
+        wrapper.vm.isAddedSnippet = true;
+        await nextTick();
         await flushPromises();
 
         const translationKeyInput = wrapper.find('input[name="sw-field--translationKey"]');

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-snippet/page/sw-settings-snippet-list/sw-settings-snippet-list.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-snippet/page/sw-settings-snippet-list/sw-settings-snippet-list.spec.js
@@ -1,6 +1,7 @@
 /**
  * @sw-package fundamentals@discovery
  */
+import { nextTick } from 'vue';
 import { mount } from '@vue/test-utils';
 import 'src/module/sw-settings/mixin/sw-settings-list.mixin';
 
@@ -253,7 +254,8 @@ describe('module/sw-settings-snippet/page/sw-settings-snippet-list', () => {
         const roles = role.split(', ');
 
         const wrapper = await createWrapper(roles);
-        await wrapper.setData({ isLoading: false });
+        wrapper.vm.isLoading = false;
+        await nextTick();
 
         await flushPromises();
 

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-state-machine/page/sw-settings-state-machine-detail/sw-settings-state-machine-detail.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-state-machine/page/sw-settings-state-machine-detail/sw-settings-state-machine-detail.spec.js
@@ -1,3 +1,4 @@
+import { nextTick } from 'vue';
 import { mount } from '@vue/test-utils';
 
 const stateMachineRepository = {
@@ -173,9 +174,8 @@ describe('module/sw-settings-state-machine/page/sw-settings-state-machine-detail
         expect(wrapper.vm.stateMachineRepository.save).not.toHaveBeenCalled();
         expect(wrapper.vm.loadStateMachine).not.toHaveBeenCalled();
 
-        await wrapper.setData({
-            stateMachine,
-        });
+        wrapper.vm.stateMachine = stateMachine;
+        await nextTick();
 
         await wrapper.vm.onSave();
 
@@ -191,9 +191,8 @@ describe('module/sw-settings-state-machine/page/sw-settings-state-machine-detail
 
         wrapper.vm.createNotificationError = jest.fn();
 
-        await wrapper.setData({
-            stateMachine,
-        });
+        wrapper.vm.stateMachine = stateMachine;
+        await nextTick();
 
         await wrapper.vm.onSave();
 

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-tag/component/sw-settings-tag-detail-assignments/sw-settings-tag-detail-assignments.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-tag/component/sw-settings-tag-detail-assignments/sw-settings-tag-detail-assignments.spec.js
@@ -1,3 +1,4 @@
+import { nextTick } from 'vue';
 import { mount } from '@vue/test-utils';
 
 /**
@@ -321,9 +322,8 @@ describe('module/sw-settings-tag/component/sw-settings-tag-detail-assignments', 
         await parentComponent.vm.removeAssignment('products', '0', { id: '0' });
         await parentComponent.vm.addAssignment('products', '3', { id: '3' });
 
-        await wrapper.setData({
-            showSelected: true,
-        });
+        wrapper.vm.showSelected = true;
+        await nextTick();
 
         await wrapper.vm.$nextTick();
 

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-tag/page/sw-settings-tag-list/sw-settings-tag-list.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-tag/page/sw-settings-tag-list/sw-settings-tag-list.spec.js
@@ -1,3 +1,4 @@
+import { nextTick } from 'vue';
 import { mount } from '@vue/test-utils';
 
 /**
@@ -256,16 +257,14 @@ describe('module/sw-settings-tag/page/sw-settings-tag-list', () => {
 
     it('should use tag api service for duplicate filter', async () => {
         const wrapper = await createWrapper();
-        await wrapper.setData({
-            sortBy: 'products',
-        });
+        wrapper.vm.sortBy = 'products';
+        await nextTick();
         await wrapper.vm.$nextTick();
 
         expect(wrapper.vm.total).toBe(2);
 
-        await wrapper.setData({
-            duplicateFilter: true,
-        });
+        wrapper.vm.duplicateFilter = true;
+        await nextTick();
 
         wrapper.vm.onFilter();
         await wrapper.vm.$nextTick();
@@ -306,15 +305,13 @@ describe('module/sw-settings-tag/page/sw-settings-tag-list', () => {
 
         expect(0).toEqual(wrapper.vm.filterCount);
 
-        await wrapper.setData({
-            emptyFilter: true,
-        });
+        wrapper.vm.emptyFilter = true;
+        await nextTick();
 
         expect(1).toEqual(wrapper.vm.filterCount);
 
-        await wrapper.setData({
-            duplicateFilter: true,
-        });
+        wrapper.vm.duplicateFilter = true;
+        await nextTick();
 
         expect(2).toEqual(wrapper.vm.filterCount);
     });

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-tax/component/sw-tax-rule-card/sw-tax-rule-card.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-tax/component/sw-tax-rule-card/sw-tax-rule-card.spec.js
@@ -1,3 +1,4 @@
+import { nextTick } from 'vue';
 import { mount } from '@vue/test-utils';
 
 /**
@@ -102,7 +103,8 @@ describe('module/sw-settings-tax/component/sw-tax-rule-card', () => {
         const wrapper = await createWrapper(privileges);
         await wrapper.vm.$nextTick();
 
-        await wrapper.setData({ taxRules });
+        wrapper.vm.taxRules = taxRules;
+        await nextTick();
         await wrapper.vm.$nextTick();
 
         return { wrapper };

--- a/src/Administration/Resources/app/administration/src/module/sw-users-permissions/components/sw-users-permissions-role-listing/sw-users-permissions-role-listing.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-users-permissions/components/sw-users-permissions-role-listing/sw-users-permissions-role-listing.spec.js
@@ -1,6 +1,7 @@
 /**
  * @sw-package fundamentals@framework
  */
+import { nextTick } from 'vue';
 import { mount } from '@vue/test-utils';
 
 async function createWrapper(privileges = [], isSso = { isSso: false }, deleteFunction = () => {}) {
@@ -102,12 +103,11 @@ describe('module/sw-users-permissions/components/sw-users-permissions-role-listi
     });
 
     it('should disable all context menu items', async () => {
-        await wrapper.setData({
-            roles: [
-                {},
-                {},
-            ],
-        });
+        wrapper.vm.roles = [
+            {},
+            {},
+        ];
+        await nextTick();
 
         const contextMenuItemEdit = wrapper.find('.sw-users-permissions-role-listing__context-menu-edit');
         const contextMenuItemDelete = wrapper.find('.sw-users-permissions-role-listing__context-menu-delete');
@@ -119,12 +119,11 @@ describe('module/sw-users-permissions/components/sw-users-permissions-role-listi
     it('should enable the edit context menu item', async () => {
         wrapper = await createWrapper(['users_and_permissions.editor']);
         await wrapper.vm.$nextTick();
-        await wrapper.setData({
-            roles: [
-                {},
-                {},
-            ],
-        });
+        wrapper.vm.roles = [
+            {},
+            {},
+        ];
+        await nextTick();
 
         const contextMenuItemEdit = wrapper.find('.sw-users-permissions-role-listing__context-menu-edit');
         const contextMenuItemDelete = wrapper.find('.sw-users-permissions-role-listing__context-menu-delete');
@@ -136,12 +135,11 @@ describe('module/sw-users-permissions/components/sw-users-permissions-role-listi
     it('should enable the delete context menu item', async () => {
         wrapper = await createWrapper(['users_and_permissions.deleter']);
         await wrapper.vm.$nextTick();
-        await wrapper.setData({
-            roles: [
-                {},
-                {},
-            ],
-        });
+        wrapper.vm.roles = [
+            {},
+            {},
+        ];
+        await nextTick();
 
         const contextMenuItemEdit = wrapper.find('.sw-users-permissions-role-listing__context-menu-edit');
         const contextMenuItemDelete = wrapper.find('.sw-users-permissions-role-listing__context-menu-delete');
@@ -168,14 +166,13 @@ describe('module/sw-users-permissions/components/sw-users-permissions-role-listi
             deleteFunction,
         );
 
-        await wrapper.setData({
-            roles: [
-                {
-                    id: 'anyId',
-                    name: 'anyName',
-                },
-            ],
-        });
+        wrapper.vm.roles = [
+            {
+                id: 'anyId',
+                name: 'anyName',
+            },
+        ];
+        await nextTick();
 
         await flushPromises();
 
@@ -202,14 +199,13 @@ describe('module/sw-users-permissions/components/sw-users-permissions-role-listi
             deleteFunction,
         );
 
-        await wrapper.setData({
-            roles: [
-                {
-                    id: 'anyId',
-                    name: 'anyName',
-                },
-            ],
-        });
+        wrapper.vm.roles = [
+            {
+                id: 'anyId',
+                name: 'anyName',
+            },
+        ];
+        await nextTick();
 
         await flushPromises();
 

--- a/src/Administration/Resources/app/administration/src/module/sw-users-permissions/page/sw-users-permissions-role-detail/sw-users-permissions-role-detail.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-users-permissions/page/sw-users-permissions-role-detail/sw-users-permissions-role-detail.spec.js
@@ -3,6 +3,7 @@
 /**
  * @sw-package fundamentals@framework
  */
+import { nextTick } from 'vue';
 import { mount } from '@vue/test-utils';
 import PrivilegesService from 'src/app/service/privileges.service';
 import AppAclService from 'src/app/service/app-acl.service';
@@ -638,9 +639,8 @@ describe('module/sw-users-permissions/page/sw-users-permissions-role-detail', ()
         wrapper = await createWrapper({
             aclPrivileges: ['users_and_permissions.editor'],
         });
-        await wrapper.setData({
-            isLoading: false,
-        });
+        wrapper.vm.isLoading = false;
+        await nextTick();
 
         let verifyUserModal = wrapper.find('sw-verify-user-modal-stub');
         expect(verifyUserModal.exists()).toBeFalsy();
@@ -681,9 +681,8 @@ describe('module/sw-users-permissions/page/sw-users-permissions-role-detail', ()
                 isNew: true,
             },
         );
-        await wrapper.setData({
-            isLoading: false,
-        });
+        wrapper.vm.isLoading = false;
+        await nextTick();
 
         const title = wrapper.find('h2');
         expect(title.text()).toBe('sw-users-permissions.roles.general.labelCreateNewRole');
@@ -696,9 +695,8 @@ describe('module/sw-users-permissions/page/sw-users-permissions-role-detail', ()
                 isNew: true,
             },
         );
-        await wrapper.setData({
-            isLoading: false,
-        });
+        wrapper.vm.isLoading = false;
+        await nextTick();
         await flushPromises();
 
         let title = wrapper.find('h2');
@@ -721,9 +719,8 @@ describe('module/sw-users-permissions/page/sw-users-permissions-role-detail', ()
         wrapper = await createWrapper({
             aclPrivileges: [],
         });
-        await wrapper.setData({
-            isLoading: false,
-        });
+        wrapper.vm.isLoading = false;
+        await nextTick();
 
         const saveButton = wrapper.find('.sw-users-permissions-role-detail__button-save');
         expect(saveButton.attributes().disabled).toBeDefined();
@@ -733,9 +730,8 @@ describe('module/sw-users-permissions/page/sw-users-permissions-role-detail', ()
         wrapper = await createWrapper({
             aclPrivileges: ['users_and_permissions.editor'],
         });
-        await wrapper.setData({
-            isLoading: false,
-        });
+        wrapper.vm.isLoading = false;
+        await nextTick();
 
         const saveButton = wrapper.find('.sw-users-permissions-role-detail__button-save');
         expect(saveButton.attributes().disabled).toBeUndefined();

--- a/src/Administration/Resources/app/administration/src/module/sw-users-permissions/page/sw-users-permissions-user-create/sw-users-permissions-user-create.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-users-permissions/page/sw-users-permissions-user-create/sw-users-permissions-user-create.spec.js
@@ -1,6 +1,7 @@
 /**
  * @sw-package fundamentals@framework
  */
+import { nextTick } from 'vue';
 import { mount } from '@vue/test-utils';
 import TimezoneService from 'src/core/service/timezone.service';
 import EntityCollection from 'src/core/data/entity-collection.data';
@@ -138,7 +139,8 @@ describe('modules/sw-users-permissions/page/sw-users-permissions-user-create', (
     });
 
     it('should allow to set the password', async () => {
-        await wrapper.setData({ isLoading: false });
+        wrapper.vm.isLoading = false;
+        await nextTick();
         expect(wrapper.vm.user.password).toBe('');
 
         const fieldPassword = wrapper.findByLabel('sw-users-permissions.users.user-detail.labelPassword');
@@ -149,13 +151,15 @@ describe('modules/sw-users-permissions/page/sw-users-permissions-user-create', (
     });
 
     it('should not be an admin by default', async () => {
-        await wrapper.setData({ isLoading: false });
+        wrapper.vm.isLoading = false;
+        await nextTick();
 
         expect(wrapper.vm.user.admin).toBeUndefined();
     });
 
     it('should be active by default', async () => {
-        await wrapper.setData({ isLoading: false });
+        wrapper.vm.isLoading = false;
+        await nextTick();
 
         expect(wrapper.vm.user.active).toBe(true);
     });

--- a/src/Administration/Resources/app/administration/src/module/sw-users-permissions/page/sw-users-permissions-user-detail/sw-users-permissions-user-detail.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-users-permissions/page/sw-users-permissions-user-detail/sw-users-permissions-user-detail.spec.js
@@ -3,6 +3,7 @@
 /**
  * @sw-package fundamentals@framework
  */
+import { nextTick } from 'vue';
 import { mount } from '@vue/test-utils';
 import TimezoneService from 'src/core/service/timezone.service';
 import EntityCollection from 'src/core/data/entity-collection.data';
@@ -214,7 +215,8 @@ describe('modules/sw-users-permissions/page/sw-users-permissions-user-detail', (
     });
 
     it('should contain all fields', async () => {
-        await wrapper.setData({ isLoading: false });
+        wrapper.vm.isLoading = false;
+        await nextTick();
         await flushPromises();
 
         const fieldFirstName = wrapper.findComponent('.sw-settings-user-detail__grid-firstName');
@@ -466,7 +468,8 @@ describe('modules/sw-users-permissions/page/sw-users-permissions-user-detail', (
                 },
             },
         });
-        await wrapper.setData({ isLoading: false });
+        wrapper.vm.isLoading = false;
+        await nextTick();
         await flushPromises();
 
         expect(wrapper.vm.user.password).toBeUndefined();
@@ -489,7 +492,8 @@ describe('modules/sw-users-permissions/page/sw-users-permissions-user-detail', (
                 },
             },
         });
-        await wrapper.setData({ isLoading: false });
+        wrapper.vm.isLoading = false;
+        await nextTick();
         await flushPromises();
 
         expect(wrapper.vm.user.password).toBeUndefined();
@@ -518,7 +522,8 @@ describe('modules/sw-users-permissions/page/sw-users-permissions-user-detail', (
                 },
             },
         });
-        await wrapper.setData({ isLoading: false });
+        wrapper.vm.isLoading = false;
+        await nextTick();
         await flushPromises();
 
         expect(wrapper.vm.user.password).toBeUndefined();
@@ -541,7 +546,8 @@ describe('modules/sw-users-permissions/page/sw-users-permissions-user-detail', (
                 },
             },
         });
-        await wrapper.setData({ isLoading: false });
+        wrapper.vm.isLoading = false;
+        await nextTick();
         await flushPromises();
 
         expect(wrapper.vm.user.password).toBeUndefined();
@@ -567,7 +573,8 @@ describe('modules/sw-users-permissions/page/sw-users-permissions-user-detail', (
         const mediaItem = { id: mediaId };
 
         wrapper = await createWrapper('users_and_permissions.editor');
-        await wrapper.setData({ isLoading: false });
+        wrapper.vm.isLoading = false;
+        await nextTick();
         await flushPromises();
 
         wrapper.vm.onDropMedia(mediaItem);
@@ -583,7 +590,8 @@ describe('modules/sw-users-permissions/page/sw-users-permissions-user-detail', (
         const mediaItem = { id: mediaId };
 
         wrapper = await createWrapper('users_and_permissions.editor');
-        await wrapper.setData({ isLoading: false });
+        wrapper.vm.isLoading = false;
+        await nextTick();
         await flushPromises();
 
         expect(wrapper.vm.mediaDefaultFolderId).toBe('1234');

--- a/src/Administration/Resources/app/administration/src/module/sw-users-permissions/page/sw-users-permissions/sw-users-permissions.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-users-permissions/page/sw-users-permissions/sw-users-permissions.spec.js
@@ -1,6 +1,7 @@
 /**
  * @sw-package fundamentals@framework
  */
+import { nextTick } from 'vue';
 import { mount } from '@vue/test-utils';
 
 describe('modules/sw-users-permissions/page/sw-users-permissions', () => {
@@ -46,9 +47,8 @@ describe('modules/sw-users-permissions/page/sw-users-permissions', () => {
     });
 
     it('should finish saving correctly', async () => {
-        await wrapper.setData({
-            isSaveSuccessful: true,
-        });
+        wrapper.vm.isSaveSuccessful = true;
+        await nextTick();
 
         wrapper.vm.onSaveFinish();
 


### PR DESCRIPTION
### 1. Why is this change necessary?

Stacked on #20011, which adds the lint rule and the codemod. This runs the codemod.

Every `wrapper.setData()` call in the Administration suite is a landmine that arms the day its component becomes a native setup SFC: the write lands in `$data`, which the component never reads, and the spec either fails on a later assertion or keeps passing while asserting nothing. Leaving them in place means every conversion drags a spec rewrite along with it. Rewriting them now is safe, because assigning through `wrapper.vm` works on an Options API component too.

### 2. What does this change do, exactly?

- `npm run codemod:set-data-to-vm -- --write` rewrote 490 calls across 134 spec files to `wrapper.vm.<key> = <value>` plus `await nextTick()`.
- Six call sites in five files needed a decision the codemod cannot make, and got one by hand:
  - Two document-settings modals and the mail template detail spec replaced a DAL entity with a plain mock. `setData` deep-merged onto the entity and kept its methods; the specs now merge explicitly rather than replacing.
  - `sw-category-detail` and `sw-product-detail-cross-selling` wrote a computed property. `setData` reached it by shadowing the computed through `$data` — the specs now write the store the computed reads, which is the idiom already used elsewhere in both files.
  - `sw-order-promotion-field` shadows `hasOrderUnsavedChanges`, a computed with no seam to drive it from the outside. Those two calls stay on `setData` behind an `eslint-disable` naming the reason, which also makes the codemod idempotent.

235 calls remain on `setData` and are reported without an autofix: 201 nested object literals, 21 non-literal arguments, 6 wrappers reached through `findComponent()`, 4 spreads and 2 `$`-prefixed keys. Nested literals are the bulk and cannot be automated — `mergeDeep` merges into an existing value but replaces an absent one, which lint cannot tell apart. Rewriting them mechanically anyway broke 71 tests across 29 files when tried.

### 3. Describe each step to reproduce the issue or behaviour.

From `src/Administration/Resources/app/administration`, the codemod reports no further automatic rewrites:

```bash
npm run codemod:set-data-to-vm
```

The rewritten specs pass:

```
Test Suites: 134 passed, 134 total
Tests:       3 skipped, 2098 passed, 2101 total
```

### 4. Please link to the relevant issues (if any).

- relates #19595 — `wrapper.setData()` silently does nothing on a native setup component
- builds on #20011 — the lint rule and codemod this applies

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them

This PR only rewrites existing specs, so it adds no tests and reaches no external developer.

