### PR TITLE
feat: Change webhook target to allow CIDR based configuration

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -1176,7 +1176,7 @@ Media imports send the request to the address the URL check resolved, and check 
 
 ### Webhook target validation hardened
 
-Webhook delivery now validates outbound targets before every request and before every followed redirect. By default, webhook targets must use HTTPS and resolve only to public IP addresses. HTTP endpoints, IP-literal targets, and internal network targets are rejected unless the operator explicitly allows the required traffic through `shopware.app_system.allow_unencrypted_traffic` or `shopware.app_system.allowed_private_ip_addresses` in `shopware.yaml`.
+Webhook delivery now validates outbound targets before every request and before every followed redirect. By default, webhook targets must use HTTPS and resolve only to public IP addresses. HTTP endpoints, IP-literal targets, and internal network targets are rejected unless the operator explicitly allows the required traffic through `shopware.app_system.allow_unencrypted_traffic` or `shopware.app_system.allowed_private_ip_addresses` in `shopware.yaml`. `allowed_private_ip_addresses` accepts single IP addresses as well as CIDR ranges (for example `10.0.0.0/8` or `fd00::/8`), so a whole internal subnet can be allowed with one entry.
 
 Shopware pins the DNS result used during validation to the actual webhook HTTP request, reducing DNS rebinding risk between validation and connection.
 
@@ -1649,6 +1649,10 @@ For Administration clients that need to decide whether to trigger a direct brows
 The route is guarded by the existing `media:read` ACL privilege and returns a small JSON payload describing whether the client should use an external URL or perform the authenticated blob download through Shopware.
 
 ## App System
+
+### App requests block private targets and unencrypted traffic by default
+
+App-system requests now block private and reserved network targets as well as unencrypted HTTP traffic by default, including redirect targets. Before upgrading, operators whose apps use HTTP endpoints must set `shopware.app_system.allow_unencrypted_traffic`; operators whose apps use private endpoints must add each required address to `shopware.app_system.allowed_private_ip_addresses`. That option accepts single IP addresses as well as CIDR ranges (for example `10.0.0.0/8` or `fd00::/8`).
 
 ### Deprecation of inline `<custom-fields>` in `manifest.xml`
 

--- a/src/Core/Content/Media/File/TrustedUrlResolver.php
+++ b/src/Core/Content/Media/File/TrustedUrlResolver.php
@@ -27,7 +27,7 @@ class TrustedUrlResolver implements ResetInterface
 
     /**
      * @param (\Closure(string): list<string>)|null $dnsResolver
-     * @param list<string> $allowedPrivateIps
+     * @param list<string> $allowedPrivateIps List of IP addresses or CIDR ranges (e.g. "10.0.0.0/8")
      */
     public function __construct(
         ?\Closure $dnsResolver = null,
@@ -83,7 +83,7 @@ class TrustedUrlResolver implements ResetInterface
 
         if ($this->rejectPrivateRanges) {
             foreach ($addresses as $ip) {
-                if (IpUtils::checkIp($ip, self::BLOCKED_SUBNETS) && !\in_array($ip, $this->allowedPrivateIps, true)) {
+                if (IpUtils::checkIp($ip, self::BLOCKED_SUBNETS) && !IpUtils::checkIp($ip, $this->allowedPrivateIps)) {
                     throw MediaException::illegalUrl($url);
                 }
             }

--- a/src/Core/Framework/DependencyInjection/Configuration.php
+++ b/src/Core/Framework/DependencyInjection/Configuration.php
@@ -1722,8 +1722,8 @@ class Configuration implements ConfigurationInterface
                     ->scalarPrototype()
                         ->cannotBeEmpty()
                         ->validate()
-                            ->ifTrue(static fn (string $value): bool => filter_var($value, \FILTER_VALIDATE_IP) === false)
-                            ->thenInvalid('"%s" is not a valid IP address.')
+                            ->ifTrue(static fn (string $value): bool => !self::isValidIpOrCidr($value))
+                            ->thenInvalid('"%s" is not a valid IP address or CIDR range.')
                         ->end()
                     ->end()
                 ->end()
@@ -1792,5 +1792,26 @@ class Configuration implements ConfigurationInterface
             ->end();
 
         return $rootNode;
+    }
+
+    private static function isValidIpOrCidr(string $value): bool
+    {
+        if (filter_var($value, \FILTER_VALIDATE_IP) !== false) {
+            return true;
+        }
+
+        if (!str_contains($value, '/')) {
+            return false;
+        }
+
+        [$subnet, $prefix] = explode('/', $value, 2);
+
+        if (filter_var($subnet, \FILTER_VALIDATE_IP) === false || !ctype_digit($prefix)) {
+            return false;
+        }
+
+        $maxPrefix = filter_var($subnet, \FILTER_VALIDATE_IP, \FILTER_FLAG_IPV6) !== false ? 128 : 32;
+
+        return (int) $prefix <= $maxPrefix;
     }
 }

--- a/src/Core/Framework/Webhook/Validation/WebhookTargetValidator.php
+++ b/src/Core/Framework/Webhook/Validation/WebhookTargetValidator.php
@@ -5,6 +5,7 @@ namespace Shopware\Core\Framework\Webhook\Validation;
 use Shopware\Core\Content\Media\File\TrustedUrlResolver;
 use Shopware\Core\Content\Media\MediaException;
 use Shopware\Core\Framework\Log\Package;
+use Symfony\Component\HttpFoundation\IpUtils;
 
 /**
  * @internal
@@ -20,7 +21,7 @@ final readonly class WebhookTargetValidator
     private TrustedUrlResolver $urlResolver;
 
     /**
-     * @param list<string> $allowedPrivateIpAddresses
+     * @param list<string> $allowedPrivateIpAddresses List of IP addresses or CIDR ranges (e.g. "10.0.0.0/8")
      */
     public function __construct(
         private bool $allowUnencryptedTraffic,
@@ -29,7 +30,7 @@ final readonly class WebhookTargetValidator
     ) {
         $this->allowedPrivateIpAddresses = array_values(array_filter(
             $allowedPrivateIpAddresses,
-            static fn (string $ip): bool => filter_var($ip, \FILTER_VALIDATE_IP) !== false
+            static fn (string $ip): bool => self::isValidIpOrCidr($ip)
         ));
         $this->urlResolver = $urlResolver ?? new TrustedUrlResolver(allowedPrivateIps: $this->allowedPrivateIpAddresses);
     }
@@ -53,7 +54,7 @@ final readonly class WebhookTargetValidator
         }
 
         $ipLiteral = trim($host, '[]');
-        if (filter_var($ipLiteral, \FILTER_VALIDATE_IP) !== false && !\in_array($ipLiteral, $this->allowedPrivateIpAddresses, true)) {
+        if (filter_var($ipLiteral, \FILTER_VALIDATE_IP) !== false && !IpUtils::checkIp($ipLiteral, $this->allowedPrivateIpAddresses)) {
             return null;
         }
 
@@ -69,5 +70,26 @@ final readonly class WebhookTargetValidator
     private function isAllowedScheme(string $scheme): bool
     {
         return $scheme === 'https' || ($this->allowUnencryptedTraffic && $scheme === 'http');
+    }
+
+    private static function isValidIpOrCidr(string $value): bool
+    {
+        if (filter_var($value, \FILTER_VALIDATE_IP) !== false) {
+            return true;
+        }
+
+        if (!str_contains($value, '/')) {
+            return false;
+        }
+
+        [$subnet, $prefix] = explode('/', $value, 2);
+
+        if (filter_var($subnet, \FILTER_VALIDATE_IP) === false || !ctype_digit($prefix)) {
+            return false;
+        }
+
+        $maxPrefix = filter_var($subnet, \FILTER_VALIDATE_IP, \FILTER_FLAG_IPV6) !== false ? 128 : 32;
+
+        return (int) $prefix <= $maxPrefix;
     }
 }

--- a/tests/unit/Core/Content/Media/File/TrustedUrlResolverTest.php
+++ b/tests/unit/Core/Content/Media/File/TrustedUrlResolverTest.php
@@ -166,6 +166,30 @@ class TrustedUrlResolverTest extends TestCase
         $resolver->resolve('https://internal.example.com/image.png');
     }
 
+    public function testAllowsPrivateIpWithinAllowListedCidrRange(): void
+    {
+        $resolver = new TrustedUrlResolver(
+            static fn (string $host): array => ['10.0.5.42'],
+            allowedPrivateIps: ['10.0.0.0/8'],
+        );
+
+        $resolved = $resolver->resolve('https://internal.example.com/image.png');
+
+        static::assertSame('10.0.5.42', $resolved->ip);
+    }
+
+    public function testRejectsPrivateIpOutsideAllowListedCidrRange(): void
+    {
+        $resolver = new TrustedUrlResolver(
+            static fn (string $host): array => ['192.168.0.1'],
+            allowedPrivateIps: ['10.0.0.0/8'],
+        );
+
+        $this->expectException(MediaException::class);
+
+        $resolver->resolve('https://internal.example.com/image.png');
+    }
+
     public function testPermittingPrivateRangesStillRejectsUnusableUrls(): void
     {
         $resolver = new TrustedUrlResolver(

--- a/tests/unit/Core/Framework/DependencyInjection/ConfigurationTest.php
+++ b/tests/unit/Core/Framework/DependencyInjection/ConfigurationTest.php
@@ -363,14 +363,40 @@ class ConfigurationTest extends TestCase
         static::assertSame(['10.0.0.10', 'fd00::1'], $config['app_system']['allowed_private_ip_addresses']);
     }
 
+    public function testAppSystemNetworkPolicyAllowsCidrRanges(): void
+    {
+        $config = (new Processor())->processConfiguration(new Configuration(), [
+            [
+                'app_system' => [
+                    'allowed_private_ip_addresses' => ['10.0.0.0/8', 'fd00::/8'],
+                ],
+            ],
+        ]);
+
+        static::assertSame(['10.0.0.0/8', 'fd00::/8'], $config['app_system']['allowed_private_ip_addresses']);
+    }
+
     public function testAppSystemNetworkPolicyRejectsInvalidAllowedIpAddress(): void
     {
-        $this->expectExceptionObject(new InvalidConfigurationException('Invalid configuration for path "shopware.app_system.allowed_private_ip_addresses.0": ""not-an-ip"" is not a valid IP address.'));
+        $this->expectExceptionObject(new InvalidConfigurationException('Invalid configuration for path "shopware.app_system.allowed_private_ip_addresses.0": ""not-an-ip"" is not a valid IP address or CIDR range.'));
 
         (new Processor())->processConfiguration(new Configuration(), [
             [
                 'app_system' => [
                     'allowed_private_ip_addresses' => ['not-an-ip'],
+                ],
+            ],
+        ]);
+    }
+
+    public function testAppSystemNetworkPolicyRejectsInvalidCidrRange(): void
+    {
+        $this->expectExceptionObject(new InvalidConfigurationException('Invalid configuration for path "shopware.app_system.allowed_private_ip_addresses.0": ""10.0.0.0/64"" is not a valid IP address or CIDR range.'));
+
+        (new Processor())->processConfiguration(new Configuration(), [
+            [
+                'app_system' => [
+                    'allowed_private_ip_addresses' => ['10.0.0.0/64'],
                 ],
             ],
         ]);

--- a/tests/unit/Core/Framework/Webhook/Validation/WebhookTargetValidatorTest.php
+++ b/tests/unit/Core/Framework/Webhook/Validation/WebhookTargetValidatorTest.php
@@ -99,6 +99,41 @@ class WebhookTargetValidatorTest extends TestCase
         static::assertNull($validator->validate('https://example.com/webhook'));
     }
 
+    public function testAllowsIpLiteralWithinConfiguredCidrRange(): void
+    {
+        $validator = new WebhookTargetValidator(false, ['10.0.0.0/8'], new TrustedUrlResolver(static fn (string $host): array => [], allowedPrivateIps: ['10.0.0.0/8']));
+
+        $target = $validator->validate('https://10.0.5.42/webhook');
+
+        static::assertNotNull($target);
+        static::assertSame('10.0.5.42', $target->host);
+        static::assertSame('10.0.5.42', $target->ip);
+    }
+
+    public function testAllowsInternalDnsRecordWithinConfiguredCidrRange(): void
+    {
+        $validator = new WebhookTargetValidator(false, ['10.0.0.0/8'], new TrustedUrlResolver(static fn (string $host): array => ['10.0.5.42'], allowedPrivateIps: ['10.0.0.0/8']));
+
+        $target = $validator->validate('https://internal.example.com/webhook');
+
+        static::assertNotNull($target);
+        static::assertSame('10.0.5.42', $target->ip);
+    }
+
+    public function testRejectsIpLiteralOutsideConfiguredCidrRange(): void
+    {
+        $validator = new WebhookTargetValidator(false, ['10.0.0.0/8'], new TrustedUrlResolver(static fn (string $host): array => [], allowedPrivateIps: ['10.0.0.0/8']));
+
+        static::assertNull($validator->validate('https://192.168.0.1/webhook'));
+    }
+
+    public function testIgnoresInvalidCidrRangeInAllowList(): void
+    {
+        $validator = new WebhookTargetValidator(false, ['10.0.0.0/64'], new TrustedUrlResolver(static fn (string $host): array => []));
+
+        static::assertNull($validator->validate('https://10.0.5.42/webhook'));
+    }
+
     /**
      * @return \Generator<string, array{records: list<string>}>
      */


### PR DESCRIPTION
### 0. Preface

This has been requested already but GitHub chose to close https://github.com/shopware/shopware/pull/19791/changes
because https://github.com/shopware/shopware/pull/19748 has been merged instead of retargeting the pull request.

### 1. Why is this change necessary?

> For some it is a feature, for some it is a bug, for some it is an optimization.
> @mitelg - 2019 - Somewhere in a Shopware 5 pull request discussion, when a breaking bug fix was discussed

We make use of private services in a kubernetes stack. You won't know what IP-addresses you get. But this does not matter as we have DNS we can trust. So we send webhooks to a hostname that resolves. With the recent changes we are not allowed to use webhooks anymore as they resolve to a private address. It is great, that it is private because this means we are not sending sensitive data out in the world to service we host near the same stack. As we have no idea what IP we will get by DNS resolution but we trust that domain name to match to something we trust, we would like to allow a complete IP range, but we cannot as we have to add EVERY IP ADDRESS into the configuration. For a /24 this can be a lot for Symfony to digest as configuration. Let's just use CIDR like in the maintenance check and we are all good.

### 2. What does this change do, exactly?

Add CIDR checks where the recent update added IP checks

### 3. Describe each step to reproduce the issue or behaviour.

* Use non-private hosted apps
* Make use of webhooks
* Be forced to make things public which is against decisions made by CDO
* Think about patching the security plugin :shipit:

### 4. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [x] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them

### 5. Funfact

This is a complete hallucination as I was not able to `composer install` this branch as patch installation did not work out with `patches/skip-experimental.patch`, `patches/skip-optional-construct-parameters.patch`, `patches/add-exclude-errors.patch` 😞 