### PR TITLE
ci: fold the failing-test listings of nightly report issues

### DIFF
--- a/.github/bin/js/report-phpunit-nightly-failures.test.ts
+++ b/.github/bin/js/report-phpunit-nightly-failures.test.ts
@@ -137,6 +137,9 @@ describe('groupByDomain / buildIssuePayload', () => {
     assert.equal(issue.label, null);
     assert.ok(issue.issueBody.includes('`Integration\\Core\\FooTest::testCase00`: boom'));
     assert.ok(issue.issueBody.includes('…and 5 more'));
+    assert.ok(issue.issueBody.includes('<summary>Failing tests: 45</summary>'));
+    assert.ok(issue.issueBody.includes('</details>'));
+    assert.ok(issue.commentBody.includes('<summary>Failing tests: 45</summary>'));
     assert.ok(!issue.issueBody.includes('testCase44'));
     assert.ok(!issue.issueBody.includes('—'));
     assert.ok(issue.issueBody.includes('deep-triage pass'));

--- a/.github/bin/js/report-phpunit-nightly-failures.ts
+++ b/.github/bin/js/report-phpunit-nightly-failures.ts
@@ -330,7 +330,8 @@ function buildSilentLanesIssue(issueTitle: string, silentLanes: string[], runUrl
 }
 
 function buildDomainLines(group: DomainGroup, runUrl: string): string[] {
-  const lines = [`Run: ${runUrl}`, `Failing tests: ${group.tests.length}`, ''];
+  // the listing folds behind the count, so long updates stay scannable on the issue
+  const lines = [`Run: ${runUrl}`, '<details>', `<summary>Failing tests: ${group.tests.length}</summary>`, ''];
 
   for (const test of group.tests.slice(0, MAX_TESTS_PER_DOMAIN)) {
     lines.push(formatTest(test));
@@ -338,6 +339,8 @@ function buildDomainLines(group: DomainGroup, runUrl: string): string[] {
   if (group.tests.length > MAX_TESTS_PER_DOMAIN) {
     lines.push(`- …and ${group.tests.length - MAX_TESTS_PER_DOMAIN} more, see the run logs.`);
   }
+
+  lines.push('', '</details>');
 
   return lines;
 }


### PR DESCRIPTION
### 1. Why is this change necessary?

A nightly report update can carry hundreds of failing-test lines (issue #19168 accumulated 424-line comments daily), which makes the per-domain issues unscannable: the run link and the next update drown between the listings.

### 2. What does this change do, exactly?

Wraps the failing-test listing of every reported issue body and comment in a `<details>` block with the test count as its `<summary>`, so updates fold to two visible lines (run link and count) and expand on demand. The dedupe markers and the surrounding structure are unchanged.

### 3. Describe each step to reproduce the issue or behaviour.

Open a per-domain nightly failure issue with large updates, for example #19168 before its comments were folded by hand: each update renders the full test list inline.

### 4. Please link to the relevant issues (if any).

- relates #19994

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
