### PR TITLE
feat(administration): convert in-component route guards in the sfc codemod

### DIFF
--- a/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/README.md
+++ b/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/README.md
@@ -223,6 +223,21 @@ the store. The codemod never emits the clean one; that migration is a human's ca
 the CMS editor state through it. Its descriptor therefore answers those members as well, which is why
 both descriptors share one member list.
 
+## Route guards
+
+`beforeRouteLeave` and `beforeRouteUpdate` become `onBeforeRouteLeave()` and
+`onBeforeRouteUpdate()`. Both take the same guard signature the option had, so the body converts
+like a lifecycle hook's.
+
+The two are not interchangeable for a component the router does not render itself: the option is
+only read off route components, while the composable registers against the matched route record and
+therefore also fires for a nested component. Every component in the Administration that declares one
+is a page, so the conversion is exact where it applies — but a nested declaration would start firing
+a guard that never ran before.
+
+`beforeRouteEnter` stays a TODO. It runs before the instance exists, so there is nothing for a
+composable to register against.
+
 ## What is skipped on purpose
 
 `Component.extend` children, `Component.override` registrations, `this.$super`/`this.$parent`,

--- a/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/__fixtures__/sw-route-guards/index.js
+++ b/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/__fixtures__/sw-route-guards/index.js
@@ -1,0 +1,31 @@
+import template from './sw-route-guards.html.twig';
+
+export default {
+    template,
+
+    data() {
+        return {
+            hasUnsavedChanges: false,
+            loadedId: null,
+        };
+    },
+
+    beforeRouteLeave(to, from, next) {
+        if (this.hasUnsavedChanges) {
+            next(false);
+            return;
+        }
+
+        next();
+    },
+
+    beforeRouteUpdate(to) {
+        this.loadedId = to.params.id;
+    },
+
+    methods: {
+        discard() {
+            this.hasUnsavedChanges = false;
+        },
+    },
+};

--- a/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/__fixtures__/sw-route-guards/sw-route-guards.html.twig
+++ b/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/__fixtures__/sw-route-guards/sw-route-guards.html.twig
@@ -1,0 +1,3 @@
+{% block sw_route_guards %}
+    <button class="sw-route-guards" @click="discard">{{ loadedId }}</button>
+{% endblock %}

--- a/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/__snapshots__/sfc-migration.spec.ts.snap
+++ b/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/__snapshots__/sfc-migration.spec.ts.snap
@@ -1492,6 +1492,50 @@ swDefinePublic({
 }
 `;
 
+exports[`scripts/codemods/sfc-migration fixture snapshots (outcome, reasons and generated SFC per fixture) converts sw-route-guards 1`] = `
+{
+  "outcome": "full",
+  "reasons": [],
+  "sfc": "<template>
+    <sw-block name="sw_route_guards">
+        <button class="sw-route-guards" @click="discard">{{ loadedId }}</button>
+    </sw-block>
+</template>
+
+<script setup>
+import { ref } from 'vue';
+import { onBeforeRouteLeave, onBeforeRouteUpdate } from 'vue-router';
+
+const discard = function () {
+    hasUnsavedChanges.value = false;
+};
+
+const hasUnsavedChanges = ref(false);
+const loadedId = ref(null);
+
+onBeforeRouteLeave(function (to, from, next) {
+    if (hasUnsavedChanges.value) {
+        next(false);
+        return;
+    }
+
+    next();
+});
+
+onBeforeRouteUpdate(function (to) {
+    loadedId.value = to.params.id;
+});
+
+swDefinePublic({
+    hasUnsavedChanges,
+    loadedId,
+    discard,
+});
+</script>
+",
+}
+`;
+
 exports[`scripts/codemods/sfc-migration fixture snapshots (outcome, reasons and generated SFC per fixture) converts sw-shadowed-locals 1`] = `
 {
   "outcome": "partial",

--- a/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/option-handlers.ts
+++ b/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/option-handlers.ts
@@ -82,6 +82,8 @@ type Collected = {
     methods: CollectedMember[];
     watchEntries: { key: string; prop: t.ObjectProperty | t.ObjectMethod }[];
     hooks: { hook: string; fn: FnLike }[];
+    /** In-component route guards, as the vue-router composable that replaces each one. */
+    routeGuards: { guard: string; fn: FnLike }[];
     rewriteFns: FnLike[];
     foreignNodes: t.Node[];
     createdFn: FnLike | null;
@@ -129,6 +131,7 @@ function createCollected(): Collected {
         methods: [],
         watchEntries: [],
         hooks: [],
+        routeGuards: [],
         rewriteFns: [],
         foreignNodes: [],
         createdFn: null,
@@ -227,6 +230,24 @@ function handleLifecycleHook(prop: t.ObjectMethod | t.ObjectProperty, ctx: Ctx, 
     } else {
         report(ctx, 'todo', `${name} is not a plain function`, prop);
     }
+}
+
+/**
+ * `beforeRouteLeave` and `beforeRouteUpdate` have vue-router composable equivalents that take the
+ * same guard signature, so the body converts like a lifecycle hook's. `beforeRouteEnter` has no
+ * instance while it runs and stays a TODO.
+ */
+function routeGuardHandler(guard: string): OptionHandler {
+    return (prop, ctx, collected) => {
+        const fn = asFunction(prop);
+
+        if (!fn) {
+            report(ctx, 'todo', `${keyName(prop) as string} is not a plain function`, prop);
+            return;
+        }
+
+        collected.routeGuards.push({ guard, fn });
+    };
 }
 
 const OPTION_HANDLERS: Record<string, OptionHandler> = sourceKeyed<OptionHandler>({
@@ -432,6 +453,10 @@ const OPTION_HANDLERS: Record<string, OptionHandler> = sourceKeyed<OptionHandler
             }
         }
     },
+
+    beforeRouteLeave: routeGuardHandler('onBeforeRouteLeave'),
+
+    beforeRouteUpdate: routeGuardHandler('onBeforeRouteUpdate'),
 
     created: (prop, ctx, collected) => {
         collected.createdFn = asFunction(prop);

--- a/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/runtime-equivalence-fixtures.ts
+++ b/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/runtime-equivalence-fixtures.ts
@@ -172,6 +172,29 @@ const ROUTE_WATCH_FIXTURE = runtimeFixture(
     `,
 );
 
+const ROUTE_GUARD_FIXTURE = runtimeFixture(
+    'sw-runtime-route-guards',
+    `
+        export default {
+            data() {
+                return { blocked: true };
+            },
+            beforeRouteUpdate(to) {
+                globalThis.__runtimeEquivalenceProbe.push('update:' + to.params.id);
+            },
+            beforeRouteLeave(to, from, next) {
+                globalThis.__runtimeEquivalenceProbe.push('leave:' + this.blocked);
+                next(!this.blocked);
+            },
+            methods: {
+                allow() {
+                    this.blocked = false;
+                },
+            },
+        };
+    `,
+);
+
 const CLASS_THIS_FIXTURE = runtimeFixture(
     'sw-runtime-class-this',
     `
@@ -368,6 +391,7 @@ export {
     MODULE_BINDING_FIXTURE,
     PARAMETERIZED_DATA_FIXTURE,
     PROP_INJECT_DATA_FIXTURE,
+    ROUTE_GUARD_FIXTURE,
     ROUTE_WATCH_FIXTURE,
     SAFE_WATCH_FIXTURE,
     SIBLING_DATA_FIXTURE,

--- a/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/runtime-equivalence-harness.ts
+++ b/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/runtime-equivalence-harness.ts
@@ -16,6 +16,7 @@ import { parse as parseScript } from '@babel/parser';
 import { parse, compileScript, compileTemplate } from '@vue/compiler-sfc';
 import { flushPromises, mount, type VueWrapper } from '@vue/test-utils';
 import * as Vue from 'vue';
+import { createMemoryHistory, createRouter, type Router } from 'vue-router';
 import { createRequire } from 'node:module';
 import { Script, createContext } from 'node:vm';
 import { attachOverrides, _overridesMap } from '../../../src/app/adapter/composition-extension-system';
@@ -29,6 +30,8 @@ type RuntimeMountOptions = {
     plugins?: Vue.Plugin[];
     useConvertedTemplate?: boolean;
 };
+
+type RoutedMount = { wrapper: VueWrapper; router: Router };
 
 type RuntimeProbe = {
     events: unknown[];
@@ -295,6 +298,59 @@ function mountGeneratedPair(
     ];
 }
 
+/**
+ * An in-component route guard only runs for a component the router itself renders, so a fixture that
+ * declares one is mounted behind a `<router-view />` as a route component instead of directly.
+ * `/leave` is where a navigation away from it goes.
+ */
+function mountRouted(component: Vue.Component, options: RuntimeMountOptions): RoutedMount {
+    const router = createRouter({
+        history: createMemoryHistory(),
+        routes: [
+            { path: '/:id?', name: 'fixture', component },
+            { path: '/leave', name: 'leave', component: { template: '<div />' } },
+        ],
+    });
+
+    const wrapper = mount({ template: '<router-view />' }, {
+        global: globalMountOptions(
+            {
+                ...options,
+                plugins: [
+                    ...(options.plugins ?? []),
+                    router,
+                ],
+            },
+            options.useConvertedTemplate ?? false,
+        ),
+    } as never) as VueWrapper;
+
+    return { wrapper, router };
+}
+
+function mountRoutedOriginal(fixture: RuntimeFixture, options: RuntimeMountOptions = {}): RoutedMount {
+    return mountRouted(compileOptionsComponent(fixture), options);
+}
+
+function mountRoutedGenerated(
+    fixture: RuntimeFixture,
+    result: ConvertResult,
+    options: RuntimeMountOptions = {},
+): RoutedMount {
+    if (!result.sfc) {
+        throw new Error(`Cannot mount ${fixture.name}: conversion produced no SFC`);
+    }
+
+    return mountRouted(
+        compileGeneratedComponent(
+            result.sfc,
+            `${fixture.name}.vue`,
+            options.useConvertedTemplate ? undefined : OBSERVER_TEMPLATE,
+        ),
+        options,
+    );
+}
+
 async function runEquivalentOrConservative(
     fixture: RuntimeFixture,
     exercise: (original: VueWrapper, generated: VueWrapper) => Promise<void> | void,
@@ -317,6 +373,7 @@ async function runEquivalentOrConservative(
 }
 
 export {
+    type RoutedMount,
     type RuntimeMountOptions,
     convertFixture,
     flushPromises,
@@ -324,6 +381,8 @@ export {
     mountGeneratedPair,
     mountOriginal,
     mountOriginalPair,
+    mountRoutedGenerated,
+    mountRoutedOriginal,
     resetOverrides,
     runEquivalentOrConservative,
     setProbe,

--- a/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/runtime-equivalence.spec.ts
+++ b/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/runtime-equivalence.spec.ts
@@ -22,17 +22,21 @@ import {
     MODULE_IDENTITY_FIXTURE,
     PARAMETERIZED_DATA_FIXTURE,
     PROP_INJECT_DATA_FIXTURE,
+    ROUTE_GUARD_FIXTURE,
     ROUTE_WATCH_FIXTURE,
     SAFE_WATCH_FIXTURE,
     SIBLING_DATA_FIXTURE,
 } from './runtime-equivalence-fixtures';
 import {
+    type RoutedMount,
     convertFixture,
     flushPromises,
     mountGenerated,
     mountGeneratedPair,
     mountOriginal,
     mountOriginalPair,
+    mountRoutedGenerated,
+    mountRoutedOriginal,
     resetOverrides,
     runEquivalentOrConservative,
     setProbe,
@@ -171,6 +175,39 @@ describe('SFC migration runtime equivalence', () => {
         if (pair.conservative) {
             expectConservative(pair.result.outcome);
         }
+    });
+
+    it('runs in-component route guards through their composables', async () => {
+        const result = await convertFixture(ROUTE_GUARD_FIXTURE);
+
+        expect(result.outcome).toBe('full');
+
+        const trace = async ({ router }: RoutedMount): Promise<unknown[]> => {
+            const probe = setProbe();
+
+            await router.push('/1');
+            await flushPromises();
+            await router.push('/2');
+            await flushPromises();
+            await router.push('/leave');
+            await flushPromises();
+
+            return [
+                ...probe.events,
+                router.currentRoute.value.name,
+            ];
+        };
+
+        const original = await trace(mountRoutedOriginal(ROUTE_GUARD_FIXTURE));
+        const generated = await trace(mountRoutedGenerated(ROUTE_GUARD_FIXTURE, result));
+
+        // The update guard sees each id, and the leave guard cancels the navigation off the fixture.
+        expect(original).toEqual([
+            'update:2',
+            'leave:true',
+            'fixture',
+        ]);
+        expect(generated).toEqual(original);
     });
 
     it('keeps exact-$route watch sources conservative until their runtime contract is proven', async () => {

--- a/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/tables.ts
+++ b/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/tables.ts
@@ -69,8 +69,6 @@ const OPTION_TIERS: Record<string, ReportKind> = sourceKeyed<ReportKind>({
     i18n: 'todo',
     beforeCreate: 'todo',
     beforeRouteEnter: 'todo',
-    beforeRouteLeave: 'todo',
-    beforeRouteUpdate: 'todo',
 });
 
 // `this.$super` / `this.$parent` are structural — the component is skipped entirely.

--- a/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/transform-script.ts
+++ b/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/transform-script.ts
@@ -171,6 +171,7 @@ function renderScript(
     const routerImports = [
         ...(ctx.helpers.has('router') ? ['useRouter'] : []),
         ...(ctx.helpers.has('route') ? ['useRoute'] : []),
+        ...[...new Set(collected.routeGuards.map((entry) => entry.guard))],
     ];
 
     const mixinEvents = [
@@ -274,6 +275,7 @@ function renderScript(
         refBlock || null,
         ...watchers.map((watcher) => renderWatcher(ctx, watcher)),
         ...collected.hooks.map(({ hook, fn }) => `${hook}(${arrowText(ctx, fn)});`),
+        ...collected.routeGuards.map(({ guard, fn }) => `${guard}(${arrowText(ctx, fn)});`),
         collected.createdFn ? `void (${arrowText(ctx, collected.createdFn)})();` : null,
         ...siteTodos.map(todoBlock),
         publicNames.length > 0
@@ -394,7 +396,10 @@ function transformScript(
         collected.rewriteFns.push(collected.createdFn);
     }
 
-    for (const { fn } of collected.hooks) {
+    for (const { fn } of [
+        ...collected.hooks,
+        ...collected.routeGuards,
+    ]) {
         collected.rewriteFns.push(fn);
     }
 


### PR DESCRIPTION
### 1. Why is this change necessary?

The SFC migration codemod leaves `beforeRouteLeave` and `beforeRouteUpdate` unconverted. Both are on the TODO tier, so a page that declares one comes out of the codemod as a `partial` draft carrying a comment for a human to resolve:

```ts
    beforeRouteEnter: 'todo',
    beforeRouteLeave: 'todo',
    beforeRouteUpdate: 'todo',
```

Nothing has to be designed to fix that. vue-router 4.5.0 already ships both as composables, and they take the same guard signature the option had:

```ts
export declare function onBeforeRouteLeave(leaveGuard: NavigationGuard): void;
```

27 files declare one, and every signature in the Administration fits: `(to, from, next)`, `(to)`, and the no-argument form.

### 2. What does this change do, exactly?

- Registers both options in `OPTION_HANDLERS` and drops their TODO-tier rows; guard bodies join the `this`-rewrite pass the way lifecycle hooks do.
- Adds a routed mount to the runtime-equivalence harness. This is the part worth looking at: an in-component guard only runs for a component the **router** renders, so the existing harness — which mounts the fixture directly, even when a router is installed as a plugin — cannot exercise one at all. The new mount puts the fixture behind a `<router-view />` as a route component.
- `beforeRouteEnter` stays a TODO. It runs before the instance exists, so there is nothing for a composable to register against.

**Named limitation:** the option and the composable are not interchangeable for a component the router does *not* render itself. Vue Router reads the option only off route components, while the composable registers against the matched route record and therefore also fires for a nested component. Every declaration in the Administration today is a page, so the conversion is exact where it applies — but a nested one added later would start firing a guard that never ran before. The README says so; the codemod does not try to detect it.

### 3. Describe each step to reproduce the issue or behaviour.

```bash
npx jest --collectCoverage=false scripts/codemods/sfc-migration
```

`sw-route-guards` is a new fixture; its snapshot is the emitted draft. Before this change the same component converts to `partial` with a `convert 'beforeRouteLeave' manually` reason.

### 4. Please link to the relevant issues (if any).

- relates #19571 — the platform features that resolve members off the component instance, which this axis removes one blocker from

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [x] I have written or adjusted the documentation and agent skills according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them

Release notes are unticked deliberately: the codemod is internal tooling and emits no runtime API.
