### PR TITLE
feat(administration): convert provide() in the sfc codemod

### DIFF
--- a/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/README.md
+++ b/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/README.md
@@ -223,6 +223,16 @@ the store. The codemod never emits the clean one; that migration is a human's ca
 the CMS editor state through it. Its descriptor therefore answers those members as well, which is why
 both descriptors share one member list.
 
+## provide()
+
+A `provide()` option returned one flat object, which is a run of `provide(key, value)` calls. Value
+expressions go through the same `this` rewrite as any other option, so what an injector receives does
+not change: a data read still provides the snapshot it always did rather than the ref behind it, a
+method provides the same function, and a `computed()` wrapper stays reactive.
+
+Only the function form returning an object literal directly is converted. A spread entry, a computed
+key, or a `provide()` that returns anything else is a TODO.
+
 ## What is skipped on purpose
 
 `Component.extend` children, `Component.override` registrations, `this.$super`/`this.$parent`,

--- a/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/__fixtures__/sw-provide-host/index.js
+++ b/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/__fixtures__/sw-provide-host/index.js
@@ -1,0 +1,33 @@
+import { computed } from 'vue';
+import template from './sw-provide-host.html.twig';
+
+export default {
+    template,
+
+    props: {
+        entity: {
+            type: Object,
+            required: true,
+        },
+    },
+
+    data() {
+        return {
+            openedId: null,
+        };
+    },
+
+    provide() {
+        return {
+            getEntity: computed(() => this.entity),
+            registerItem: this.registerItem,
+            initialOpenedId: this.openedId,
+        };
+    },
+
+    methods: {
+        registerItem(id) {
+            this.openedId = id;
+        },
+    },
+};

--- a/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/__fixtures__/sw-provide-host/sw-provide-host.html.twig
+++ b/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/__fixtures__/sw-provide-host/sw-provide-host.html.twig
@@ -1,0 +1,3 @@
+{% block sw_provide_host %}
+    <div class="sw-provide-host">{{ openedId }}</div>
+{% endblock %}

--- a/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/__snapshots__/sfc-migration.spec.ts.snap
+++ b/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/__snapshots__/sfc-migration.spec.ts.snap
@@ -1458,6 +1458,52 @@ swDefinePublic({
 }
 `;
 
+exports[`scripts/codemods/sfc-migration fixture snapshots (outcome, reasons and generated SFC per fixture) converts sw-provide-host 1`] = `
+{
+  "outcome": "full",
+  "reasons": [],
+  "sfc": "<script data-sfc-migration-module>
+import { computed } from 'vue';
+</script>
+
+<template>
+    <sw-block name="sw_provide_host">
+        <div class="sw-provide-host">{{ openedId }}</div>
+    </sw-block>
+</template>
+
+<script setup>
+import { ref, provide } from 'vue';
+
+const props = defineProps({
+    entity: {
+        type: Object,
+        required: true,
+    },
+});
+
+const registerItem = function (id) {
+    openedId.value = id;
+};
+
+const openedId = ref(null);
+
+provide(
+    'getEntity',
+    computed(() => props.entity),
+);
+provide('registerItem', registerItem);
+provide('initialOpenedId', openedId.value);
+
+swDefinePublic({
+    openedId,
+    registerItem,
+});
+</script>
+",
+}
+`;
+
 exports[`scripts/codemods/sfc-migration fixture snapshots (outcome, reasons and generated SFC per fixture) converts sw-ref-tag-collision 1`] = `
 {
   "outcome": "skipped",

--- a/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/option-handlers.ts
+++ b/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/option-handlers.ts
@@ -82,6 +82,8 @@ type Collected = {
     methods: CollectedMember[];
     watchEntries: { key: string; prop: t.ObjectProperty | t.ObjectMethod }[];
     hooks: { hook: string; fn: FnLike }[];
+    /** `provide()` entries, as the key and the value node each `provide()` call gets. */
+    provided: { key: string; valueNode: t.Node }[];
     rewriteFns: FnLike[];
     foreignNodes: t.Node[];
     createdFn: FnLike | null;
@@ -129,6 +131,7 @@ function createCollected(): Collected {
         methods: [],
         watchEntries: [],
         hooks: [],
+        provided: [],
         rewriteFns: [],
         foreignNodes: [],
         createdFn: null,
@@ -324,6 +327,32 @@ const OPTION_HANDLERS: Record<string, OptionHandler> = sourceKeyed<OptionHandler
             }
         } else {
             report(ctx, 'todo', 'unsupported inject declaration (only the array form is migrated)', prop);
+        }
+    },
+
+    /**
+     * The Options API called `provide()` once with the instance and used its returned object as one
+     * flat set of keys, which is exactly a run of `provide(key, value)` calls. Value expressions go
+     * through the same `this` rewrite as any other option, so a data read still resolves to the
+     * snapshot the injector used to get rather than to the ref behind it.
+     */
+    provide: (prop, ctx, collected) => {
+        const returned = dataObject(prop);
+
+        if (!returned) {
+            report(ctx, 'todo', 'provide() does not directly return an object literal', prop);
+            return;
+        }
+
+        for (const entry of returned.properties) {
+            const entryKey = entry.type === 'SpreadElement' ? null : keyName(entry);
+
+            if (entry.type !== 'ObjectProperty' || !entryKey) {
+                report(ctx, 'todo', 'unsupported provide() entry', entry);
+                continue;
+            }
+
+            collected.provided.push({ key: entryKey, valueNode: entry.value });
         }
     },
 

--- a/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/runtime-equivalence-fixtures.ts
+++ b/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/runtime-equivalence-fixtures.ts
@@ -172,6 +172,28 @@ const ROUTE_WATCH_FIXTURE = runtimeFixture(
     `,
 );
 
+const PROVIDE_FIXTURE = runtimeFixture(
+    'sw-runtime-provide',
+    `
+        export default {
+            data() {
+                return { openedId: 7 };
+            },
+            provide() {
+                return {
+                    snapshot: this.openedId,
+                    register: this.register,
+                };
+            },
+            methods: {
+                register(id) {
+                    this.openedId = id;
+                },
+            },
+        };
+    `,
+);
+
 const CLASS_THIS_FIXTURE = runtimeFixture(
     'sw-runtime-class-this',
     `
@@ -368,6 +390,7 @@ export {
     MODULE_BINDING_FIXTURE,
     PARAMETERIZED_DATA_FIXTURE,
     PROP_INJECT_DATA_FIXTURE,
+    PROVIDE_FIXTURE,
     ROUTE_WATCH_FIXTURE,
     SAFE_WATCH_FIXTURE,
     SIBLING_DATA_FIXTURE,

--- a/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/runtime-equivalence.spec.ts
+++ b/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/runtime-equivalence.spec.ts
@@ -22,6 +22,7 @@ import {
     MODULE_IDENTITY_FIXTURE,
     PARAMETERIZED_DATA_FIXTURE,
     PROP_INJECT_DATA_FIXTURE,
+    PROVIDE_FIXTURE,
     ROUTE_WATCH_FIXTURE,
     SAFE_WATCH_FIXTURE,
     SIBLING_DATA_FIXTURE,
@@ -178,6 +179,36 @@ describe('SFC migration runtime equivalence', () => {
 
         expect(result.outcome).toBeDefined();
         expectConservative(result.outcome);
+    });
+
+    it('provides the same values a provide() option returned', async () => {
+        const providesOf = (wrapper: { vm: unknown }): Record<string, unknown> => {
+            const instance = (wrapper.vm as { $: { provides: Record<string, unknown> } }).$;
+
+            return Object.fromEntries(
+                Object.keys(instance.provides).map((key) => [
+                    key,
+                    instance.provides[key],
+                ]),
+            );
+        };
+
+        const pair = await runEquivalentOrConservative(PROVIDE_FIXTURE, (original, generated) => {
+            const originalProvides = providesOf(original);
+            const generatedProvides = providesOf(generated);
+
+            expect(Object.keys(generatedProvides)).toEqual(Object.keys(originalProvides));
+
+            // A data read provided a snapshot, not the ref behind it.
+            expect(generatedProvides.snapshot).toBe(7);
+            expect(originalProvides.snapshot).toBe(7);
+
+            // The provided method still writes the component's own state.
+            (generatedProvides.register as (id: number) => void)(9);
+            expect(vmOf(generated).openedId).toBe(9);
+        });
+
+        expect(pair.result.outcome).toBe('full');
     });
 
     it('does not confuse class-local this with component this', async () => {

--- a/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/tables.ts
+++ b/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/tables.ts
@@ -57,7 +57,6 @@ const OPTION_TIERS: Record<string, ReportKind> = sourceKeyed<ReportKind>({
     renderError: 'skip',
     metaInfo: 'todo',
     shortcuts: 'todo',
-    provide: 'todo',
     filters: 'todo',
     compatConfig: 'todo',
     components: 'todo',

--- a/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/transform-script.ts
+++ b/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/transform-script.ts
@@ -163,6 +163,7 @@ function renderScript(
         ...(collected.computeds.length > 0 ? ['computed'] : []),
         ...(watchers.length > 0 ? ['watch'] : []),
         ...(collected.injects.length > 0 ? ['inject'] : []),
+        ...(collected.provided.length > 0 ? ['provide'] : []),
         ...(ctx.helpers.has('nextTick') ? ['nextTick'] : []),
         ...(ctx.helpers.has('slots') ? ['useSlots'] : []),
         ...(ctx.helpers.has('attrs') ? ['useAttrs'] : []),
@@ -228,6 +229,9 @@ function renderScript(
         .map((entry) => `const ${entry.name} = ref(${snip(ctx, entry.valueNode)});`)
         .join('\n');
     const refBlock = [...ctx.templateRefs].map((refName) => `const ${refName} = ref(null);`).join('\n');
+    const provideBlock = collected.provided
+        .map((entry) => `provide('${entry.key}', ${snip(ctx, entry.valueNode)});`)
+        .join('\n');
 
     const publicNames = [
         ...collected.injects,
@@ -272,6 +276,7 @@ function renderScript(
         ...collected.computeds.map((computedEntry) => renderMember(ctx, computedEntry)),
         dataBlock || null,
         refBlock || null,
+        provideBlock || null,
         ...watchers.map((watcher) => renderWatcher(ctx, watcher)),
         ...collected.hooks.map(({ hook, fn }) => `${hook}(${arrowText(ctx, fn)});`),
         collected.createdFn ? `void (${arrowText(ctx, collected.createdFn)})();` : null,
@@ -404,7 +409,10 @@ function transformScript(
 
     // Data initializers and foreign nodes are spliced in at the top level, so no function frame
     // encloses them.
-    for (const entry of collected.dataEntries) {
+    for (const entry of [
+        ...collected.dataEntries,
+        ...collected.provided,
+    ]) {
         rewriteThis(ctx, entry.valueNode, true);
     }
 


### PR DESCRIPTION
### 1. Why is this change necessary?

The SFC migration codemod leaves `provide()` unconverted — it sits on the TODO tier, so any component that provides something comes out of the codemod as a `partial` draft with a comment for a human to resolve. 24 components in the Administration provide, including `sw-tree`, `sw-sidebar` and `sw-select-result-list`.

Nothing needs designing. A `provide()` option returned one flat object and Vue used its keys as the provided set, which is exactly a run of `provide(key, value)` calls. The values are uniform across all 24 files:

```
  46  this.<method>,
  14  computed(() => this.<x>),
   2  this.<method>.bind(this),
```

The one thing that could silently differ is what an injector receives for a data read. `provide() { return { openedId: this.openedId } }` provided the **value**, and emitting `provide('openedId', openedId)` against a ref would hand injectors the ref instead. The existing `this` rewrite already resolves a data read to `openedId.value`, so the snapshot semantics survive without a special case — and the new runtime test is what proves it rather than asserting it.

### 2. What does this change do, exactly?

- Registers `provide` in `OPTION_HANDLERS` and drops its TODO-tier row.
- Value nodes join the component-frame `this` rewrite, the same pass `data()` initializers use — not the `foreignNodes` pass, where `this` belongs to no component.
- The emitted calls sit after every member section, so a provided method or data snapshot is already declared above them.
- A spread entry, a computed key, or a `provide()` that does not directly return an object literal stays a TODO.

### 3. Describe each step to reproduce the issue or behaviour.

```bash
npx jest --collectCoverage=false scripts/codemods/sfc-migration
```

`sw-provide-host` is a new fixture covering all three value shapes; its snapshot is the emitted draft:

```js
provide(
    'getEntity',
    computed(() => props.entity),
);
provide('registerItem', registerItem);
provide('initialOpenedId', openedId.value);
```

Before this change the same component converts to `partial` with a `convert 'provide' manually` reason.

### 4. Please link to the relevant issues (if any).

- relates #19571 — the platform features that resolve members off the component instance, which this axis removes one blocker from

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [x] I have written or adjusted the documentation and agent skills according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them

Release notes are unticked deliberately: the codemod is internal tooling and emits no runtime API.
