### PR TITLE
feat(administration): add useMetaInfo() and useCreateTitle()

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/composables/use-create-title.spec.ts
+++ b/src/Administration/Resources/app/administration/src/app/composables/use-create-title.spec.ts
@@ -1,0 +1,64 @@
+/**
+ * @sw-package framework
+ */
+
+import { mount } from '@vue/test-utils';
+import { defineComponent } from 'vue';
+import { createMemoryHistory, createRouter } from 'vue-router';
+import useCreateTitle from './use-create-title';
+
+async function createTitleIn(meta: Record<string, unknown>) {
+    const router = createRouter({
+        history: createMemoryHistory(),
+        routes: [
+            { path: '/', name: 'page', component: { template: '<div />' }, meta },
+        ],
+    });
+
+    let createTitle: ((identifier?: string | null, ...additional: string[]) => string) | null = null;
+
+    mount(
+        defineComponent({
+            template: '<div />',
+            setup() {
+                createTitle = useCreateTitle();
+            },
+        }),
+        { global: { plugins: [router] } },
+    );
+
+    await router.push('/');
+    await router.isReady();
+
+    return createTitle as unknown as (identifier?: string | null, ...additional: string[]) => string;
+}
+
+describe('src/app/composables/use-create-title', () => {
+    it('builds the title most specific part first', async () => {
+        const createTitle = await createTitleIn({ $module: { title: 'sw-product.general.mainMenuItemGeneral' } });
+
+        expect(createTitle('Shirt')).toBe(
+            'Shirt | sw-product.general.mainMenuItemGeneral | global.sw-admin-menu.textShopwareAdmin',
+        );
+    });
+
+    it('omits an absent identifier', async () => {
+        const createTitle = await createTitleIn({ $module: { title: 'sw-product.general.mainMenuItemGeneral' } });
+
+        expect(createTitle()).toBe('sw-product.general.mainMenuItemGeneral | global.sw-admin-menu.textShopwareAdmin');
+    });
+
+    it('appends additional parameters', async () => {
+        const createTitle = await createTitleIn({ $module: { title: 'sw-order.general.mainMenuItemList' } });
+
+        expect(createTitle('Order', '10001')).toBe(
+            '10001 | Order | sw-order.general.mainMenuItemList | global.sw-admin-menu.textShopwareAdmin',
+        );
+    });
+
+    it('returns an empty title for a route that belongs to no module', async () => {
+        const createTitle = await createTitleIn({});
+
+        expect(createTitle('Shirt')).toBe('');
+    });
+});

--- a/src/Administration/Resources/app/administration/src/app/composables/use-create-title.ts
+++ b/src/Administration/Resources/app/administration/src/app/composables/use-create-title.ts
@@ -1,0 +1,41 @@
+/**
+ * @sw-package framework
+ */
+
+import { useI18n } from 'vue-i18n';
+import { useRoute } from 'vue-router';
+
+/**
+ * Setup-mode equivalent of the `$createTitle` global property: builds the browser title from the
+ * admin's own name, the current route's module title and an optional record identifier, most
+ * specific part first.
+ *
+ * Keep this and `initTitle()` in `src/app/adapter/view/vue.adapter.ts` in sync — change both
+ * together. The one deliberate difference is the translator: the global property reached for
+ * `this.$root.$t`, this uses the calling component's own `useI18n()`, which resolves to the same
+ * global messages unless that component declares an `i18n` scope of its own.
+ *
+ * @private
+ */
+export default function useCreateTitle(): (identifier?: string | null, ...additionalParams: string[]) => string {
+    const { t } = useI18n();
+    const route = useRoute();
+
+    return function createTitle(identifier: string | null = null, ...additionalParams: string[]): string {
+        const moduleTitle = (route.meta?.$module as { title?: string } | undefined)?.title;
+
+        if (!moduleTitle) {
+            return '';
+        }
+
+        return [
+            t('global.sw-admin-menu.textShopwareAdmin'),
+            t(moduleTitle),
+            identifier,
+            ...additionalParams,
+        ]
+            .filter((item): item is string => item !== null && item.trim() !== '')
+            .reverse()
+            .join(' | ');
+    };
+}

--- a/src/Administration/Resources/app/administration/src/app/composables/use-meta-info.spec.ts
+++ b/src/Administration/Resources/app/administration/src/app/composables/use-meta-info.spec.ts
@@ -1,0 +1,59 @@
+/**
+ * @sw-package framework
+ */
+
+import { mount } from '@vue/test-utils';
+import { defineComponent, nextTick, ref } from 'vue';
+import useMetaInfo from './use-meta-info';
+
+function mountWithMetaInfo(getMetaInfo: () => { title?: string }): { unmount: () => void } {
+    return mount(
+        defineComponent({
+            template: '<div />',
+            setup() {
+                useMetaInfo(getMetaInfo);
+            },
+        }),
+    ) as unknown as { unmount: () => void };
+}
+
+describe('src/app/composables/use-meta-info', () => {
+    beforeEach(() => {
+        document.title = 'untouched';
+    });
+
+    it('sets the document title from the getter', () => {
+        mountWithMetaInfo(() => ({ title: 'Product | Catalogues | Shopware' }));
+
+        expect(document.title).toBe('Product | Catalogues | Shopware');
+    });
+
+    it('follows a reactive dependency of the getter', async () => {
+        const identifier = ref('Draft');
+
+        mountWithMetaInfo(() => ({ title: identifier.value }));
+        expect(document.title).toBe('Draft');
+
+        identifier.value = 'Saved shirt';
+        await nextTick();
+
+        expect(document.title).toBe('Saved shirt');
+    });
+
+    it('leaves the title alone when the getter returns no title', () => {
+        mountWithMetaInfo(() => ({}));
+
+        expect(document.title).toBe('untouched');
+    });
+
+    it('stops following the getter once the component is unmounted', async () => {
+        const identifier = ref('Draft');
+        const wrapper = mountWithMetaInfo(() => ({ title: identifier.value }));
+
+        wrapper.unmount();
+        identifier.value = 'Saved shirt';
+        await nextTick();
+
+        expect(document.title).toBe('Draft');
+    });
+});

--- a/src/Administration/Resources/app/administration/src/app/composables/use-meta-info.ts
+++ b/src/Administration/Resources/app/administration/src/app/composables/use-meta-info.ts
@@ -1,0 +1,32 @@
+/**
+ * @sw-package framework
+ */
+
+import { watchEffect } from 'vue';
+
+/** @private */
+export interface MetaInfo {
+    title?: string;
+}
+
+/**
+ * Keeps `document.title` in sync with the value its getter returns, for as long as the calling
+ * component is mounted.
+ *
+ * Setup-mode equivalent of the `metaInfo` option, which the meta-info plugin read off the component
+ * type and then called with the instance — so its body reached members a `<script setup>` component
+ * does not expose. Passing the getter directly removes that lookup.
+ *
+ * Keep this and `src/app/plugin/meta-info.plugin.js` in sync — change both together.
+ *
+ * @private
+ */
+export default function useMetaInfo(getMetaInfo: () => MetaInfo): void {
+    watchEffect(() => {
+        const metaInfo = getMetaInfo();
+
+        if (metaInfo && typeof metaInfo === 'object' && metaInfo.title !== undefined) {
+            document.title = metaInfo.title;
+        }
+    });
+}


### PR DESCRIPTION
### 1. Why is this change necessary?

The browser tab title comes from a `metaInfo` option, and the plugin reads it off the component *type* before calling it with the instance:

```js
const metaInfoOption = instance.type.metaInfo;

if (typeof metaInfoOption === 'function') {
    this.metaInfoWatchStopHandle = watchEffect(() => {
        const metaInfo = metaInfoOption.call(this);
```

The body then reads component members. On a `<script setup>` component those are not on the instance proxy, so the title resolves to `undefined` — silently, with nothing in the console. 103 files declare `metaInfo`, which is essentially every page.

The bodies are nearly identical across all of them:

```
  65  this.$createTitle(),
  33  this.$createTitle(this.identifier),
   3  this.title,
   1  this.$t('global.sw-admin-menu.textShopwareAdmin'),
   1  this.$createTitle(this.orderIdentifier),
```

So 99 of 103 hinge on `$createTitle`, which is itself an Options API global property (`app.config.globalProperties`) and unreadable from setup. A setup-mode `metaInfo` without it could not build its own title, which is why both composables land together.

### 2. What does this change do, exactly?

- `useMetaInfo(getter)` keeps `document.title` in sync with what the getter returns, for as long as the component is mounted.
- `useCreateTitle()` returns the `createTitle` function — the admin's own name, the current route's module title and an optional record identifier, most specific part first.
- One deliberate difference in `useCreateTitle`: the global property translated through `this.$root.$t`, the composable uses the calling component's `useI18n()`. That resolves to the same global messages unless a component declares an `i18n` scope of its own, which no page does. It is noted in the composable.

The codemod side is stacked on top of this: shopware/shopware#20035.

### 3. Describe each step to reproduce the issue or behaviour.

```bash
npx jest --collectCoverage=false src/app/composables/use-meta-info.spec.ts src/app/composables/use-create-title.spec.ts
```

### 4. Please link to the relevant issues (if any).

- relates #19571 — `metaInfo` is one of the three platform features that resolve members off the component instance

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them

Release notes are unticked because both composables are `@private` and the `metaInfo` option keeps working unchanged. Documentation is unticked because the codemod README entry belongs to the stacked PR that emits these calls.

