### PR TITLE
fix(administration): lower created() to onBeforeMount in the sfc codemod

### DIFF
--- a/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/README.md
+++ b/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/README.md
@@ -223,6 +223,19 @@ the store. The codemod never emits the clean one; that migration is a human's ca
 the CMS editor state through it. Its descriptor therefore answers those members as well, which is why
 both descriptors share one member list.
 
+## created()
+
+`created` becomes `onBeforeMount()`, emitted above the component's own lifecycle hooks so it still
+runs before them.
+
+It was previously lowered into the setup body as an immediately invoked function. That runs before
+Vue applies the Options layer, so anything a global mixin contributes through `data()` does not exist
+yet — which is how `ExtensionAPI.publishData()` ended up pushing into an undefined
+`dataSetUnwatchers`. `onBeforeMount` is the first point where that state is there.
+
+The relative order the component could observe is unchanged: an `immediate` watcher still fires
+before it, and `mounted` still after.
+
 ## What is skipped on purpose
 
 `Component.extend` children, `Component.override` registrations, `this.$super`/`this.$parent`,

--- a/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/__snapshots__/sfc-migration.spec.ts.snap
+++ b/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/__snapshots__/sfc-migration.spec.ts.snap
@@ -92,7 +92,7 @@ exports[`scripts/codemods/sfc-migration fixture snapshots (outcome, reasons and 
 </template>
 
 <script setup>
-import { ref } from 'vue';
+import { ref, onBeforeMount } from 'vue';
 
 const createdComponent = function () {
     ready.value = true;
@@ -100,9 +100,9 @@ const createdComponent = function () {
 
 const ready = ref(false);
 
-void (function () {
+onBeforeMount(function () {
     createdComponent();
-})();
+});
 
 swDefinePublic({
     ready,
@@ -342,7 +342,7 @@ exports[`scripts/codemods/sfc-migration fixture snapshots (outcome, reasons and 
 </template>
 
 <script setup>
-import { ref, onMounted, onBeforeUnmount } from 'vue';
+import { ref, onMounted, onBeforeUnmount, onBeforeMount } from 'vue';
 
 const fetchEntries = async function () {
     entries.value = [];
@@ -351,6 +351,10 @@ const fetchEntries = async function () {
 const observer = ref(null);
 const entries = ref([]);
 
+onBeforeMount(async function () {
+    await fetchEntries();
+});
+
 onMounted(function () {
     observer.value = 'attached';
 });
@@ -358,10 +362,6 @@ onMounted(function () {
 onBeforeUnmount(function () {
     observer.value = null;
 });
-
-void (async function () {
-    await fetchEntries();
-})();
 
 swDefinePublic({
     observer,
@@ -534,7 +534,7 @@ exports[`scripts/codemods/sfc-migration fixture snapshots (outcome, reasons and 
 // - the defaults are merged at the point in the lifecycle the component expects them
 // - useCmsElementDeprecated is a stopover: useCmsElement routes the same writes through the cmsPage store
 
-import { ref, computed, watch } from 'vue';
+import { ref, computed, watch, onBeforeMount } from 'vue';
 import useCmsElementDeprecated from 'src/app/composables/use-cms-element-deprecated';
 
 const props = defineProps({
@@ -592,9 +592,9 @@ watch(
     },
 );
 
-void (function () {
+onBeforeMount(function () {
     createdComponent();
-})();
+});
 
 swDefinePublic({
     cmsPageState,

--- a/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/runtime-equivalence-fixtures.ts
+++ b/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/runtime-equivalence-fixtures.ts
@@ -238,6 +238,23 @@ const MODULE_BINDING_FIXTURE = runtimeFixture(
     `,
 );
 
+const CREATED_HOOK_ORDER_FIXTURE = runtimeFixture(
+    'sw-runtime-created-hook-order',
+    `
+        export default {
+            created() {
+                globalThis.__runtimeEquivalenceProbe.push('created');
+            },
+            beforeMount() {
+                globalThis.__runtimeEquivalenceProbe.push('beforeMount');
+            },
+            mounted() {
+                globalThis.__runtimeEquivalenceProbe.push('mounted');
+            },
+        };
+    `,
+);
+
 const CROSS_BLOCK_SIDE_EFFECT_FIXTURE = runtimeFixture(
     'sw-runtime-cross-block-effects',
     `
@@ -356,6 +373,7 @@ export {
     CREATED_ASYNC_FIXTURE,
     CREATED_EARLY_RETURN_FIXTURE,
     CREATED_LOCAL_COLLISION_FIXTURE,
+    CREATED_HOOK_ORDER_FIXTURE,
     CREATED_ONCE_FIXTURE,
     CREATED_REJECT_FIXTURE,
     CREATED_THROW_FIXTURE,

--- a/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/runtime-equivalence.spec.ts
+++ b/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/runtime-equivalence.spec.ts
@@ -10,6 +10,7 @@ import {
     CREATED_ASYNC_FIXTURE,
     CREATED_EARLY_RETURN_FIXTURE,
     CREATED_LOCAL_COLLISION_FIXTURE,
+    CREATED_HOOK_ORDER_FIXTURE,
     CREATED_ONCE_FIXTURE,
     CREATED_REJECT_FIXTURE,
     CREATED_THROW_FIXTURE,
@@ -278,6 +279,30 @@ describe('SFC migration runtime equivalence', () => {
             expect(generatedProbe.events).toEqual(originalEvents);
             expect(generatedProbe.events).toHaveLength(1);
         }
+    });
+
+    it("runs created before the component's own beforeMount hook", async () => {
+        const result = await convertFixture(CREATED_HOOK_ORDER_FIXTURE);
+
+        expect(result.outcome).toBe('full');
+
+        const originalProbe = setProbe();
+
+        mountOriginal(CREATED_HOOK_ORDER_FIXTURE);
+        await flushPromises();
+        const originalEvents = [...originalProbe.events];
+
+        const generatedProbe = setProbe();
+
+        mountGenerated(CREATED_HOOK_ORDER_FIXTURE, result);
+        await flushPromises();
+
+        expect(originalEvents).toEqual([
+            'created',
+            'beforeMount',
+            'mounted',
+        ]);
+        expect(generatedProbe.events).toEqual(originalEvents);
     });
 
     it('preserves created early returns or keeps them out of full conversion', async () => {

--- a/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/transform-script.ts
+++ b/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/transform-script.ts
@@ -166,7 +166,10 @@ function renderScript(
         ...(ctx.helpers.has('nextTick') ? ['nextTick'] : []),
         ...(ctx.helpers.has('slots') ? ['useSlots'] : []),
         ...(ctx.helpers.has('attrs') ? ['useAttrs'] : []),
-        ...[...new Set(collected.hooks.map((hook) => hook.hook))],
+        ...new Set([
+            ...collected.hooks.map((hook) => hook.hook),
+            ...(collected.createdFn ? ['onBeforeMount'] : []),
+        ]),
     ];
     const routerImports = [
         ...(ctx.helpers.has('router') ? ['useRouter'] : []),
@@ -273,8 +276,10 @@ function renderScript(
         dataBlock || null,
         refBlock || null,
         ...watchers.map((watcher) => renderWatcher(ctx, watcher)),
+        // `created` ran before every other lifecycle hook, and hooks of the same type run in
+        // registration order — so its call is emitted above them.
+        collected.createdFn ? `onBeforeMount(${arrowText(ctx, collected.createdFn)});` : null,
         ...collected.hooks.map(({ hook, fn }) => `${hook}(${arrowText(ctx, fn)});`),
-        collected.createdFn ? `void (${arrowText(ctx, collected.createdFn)})();` : null,
         ...siteTodos.map(todoBlock),
         publicNames.length > 0
             ? `swDefinePublic({\n${publicNames.map((publicName) => `${publicName},`).join('\n')}\n});`


### PR DESCRIPTION
### 1. Why is this change necessary?

The codemod lowers `created()` into the setup body as an immediately invoked function:

```js
void (function () {
    createdComponent();
})();
```

That runs while setup is still executing — before Vue applies the Options layer. Anything a global mixin contributes through `data()` therefore does not exist yet. `dataSetUnwatchers` is exactly such a member, owned by `meteor-sdk-data.plugin.ts`:

```ts
data() {
    return {
        dataSetUnwatchers: [],
    };
},
```

and `ExtensionAPI.publishData()` pushes into it, so a converted page that publishes a data set throws:

```
TypeError: Cannot read properties of undefined (reading 'push')
  at Object.push [as publishData] (src/core/service/extension-api-data.service.ts:355:29)
```

`onBeforeMount` is the first point at which that state is there.

### 2. What does this change do, exactly?

- Emits `onBeforeMount(...)` instead of the immediately invoked function.
- Emits that call **above** the component's own lifecycle hooks. Hooks of one type run in registration order, and `created` ran before every other hook — the naive placement inverted `created` and a component's own `beforeMount`. A new runtime fixture pins the order.
- Deduplicates `onBeforeMount` in the `vue` import, which a component declaring `beforeMount` itself would otherwise get twice.

The relative order a component can observe is otherwise unchanged: an `immediate` watcher still fires before it and `mounted` still after.

### 3. Describe each step to reproduce the issue or behaviour.

```bash
npx jest --collectCoverage=false scripts/codemods/sfc-migration
```

The six existing `sw-runtime-created-*` fixtures encode the previous semantics — once-only execution, async bodies, early returns, local collisions, synchronous throws and asynchronous rejections — and all of them pass unchanged, which is what says the move did not alter behaviour. Three fixture snapshots change to the new emission.

### 4. Please link to the relevant issues (if any).

- relates #19571 — the fourth case in that issue: `created()` not lowering to a point where Options-layer state exists

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [x] I have written or adjusted the documentation and agent skills according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them

Release notes are unticked deliberately: the codemod is internal tooling and emits no runtime API.
