### PR TITLE
feat(administration): convert the shortcuts option in the sfc codemod

### DIFF
--- a/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/README.md
+++ b/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/README.md
@@ -223,6 +223,25 @@ the store. The codemod never emits the clean one; that migration is a human's ca
 the CMS editor state through it. Its descriptor therefore answers those members as well, which is why
 both descriptors share one member list.
 
+## Shortcuts
+
+A `shortcuts` entry named its handler as a string and the plugin resolved it off the instance, which
+is what a `<script setup>` component cannot answer. Each entry becomes a `useShortcut()` call taking
+the method itself:
+
+```js
+useShortcut('SYSTEMKEY+S', onSave, { active: () => acl.can('product.editor') });
+useShortcut('ESCAPE', onCancel);
+```
+
+The handler name is resolved against the binding map the same way a string `watch` handler is, so an
+entry naming something the component does not declare as a method is a TODO rather than a call to a
+binding that does not exist. Both the object form's `active` shapes are supported — a function, whose
+body converts like any other, and a boolean constant.
+
+Both paths register with the same registry, so an option-based and a composable shortcut compete for
+the same key on equal terms and the precedence does not change with the conversion.
+
 ## What is skipped on purpose
 
 `Component.extend` children, `Component.override` registrations, `this.$super`/`this.$parent`,

--- a/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/__fixtures__/sw-shortcut-page/index.js
+++ b/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/__fixtures__/sw-shortcut-page/index.js
@@ -1,0 +1,32 @@
+import template from './sw-shortcut-page.html.twig';
+
+export default {
+    template,
+
+    shortcuts: {
+        'SYSTEMKEY+S': {
+            active() {
+                return this.editable;
+            },
+            method: 'onSave',
+        },
+        ESCAPE: 'onCancel',
+    },
+
+    data() {
+        return {
+            editable: true,
+            saved: false,
+        };
+    },
+
+    methods: {
+        onSave() {
+            this.saved = true;
+        },
+
+        onCancel() {
+            this.saved = false;
+        },
+    },
+};

--- a/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/__fixtures__/sw-shortcut-page/sw-shortcut-page.html.twig
+++ b/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/__fixtures__/sw-shortcut-page/sw-shortcut-page.html.twig
@@ -1,0 +1,3 @@
+{% block sw_shortcut_page %}
+    <button class="sw-shortcut-page" @click="onSave">{{ saved }}</button>
+{% endblock %}

--- a/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/__snapshots__/sfc-migration.spec.ts.snap
+++ b/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/__snapshots__/sfc-migration.spec.ts.snap
@@ -1407,7 +1407,6 @@ exports[`scripts/codemods/sfc-migration fixture snapshots (outcome, reasons and 
   "reasons": [
     "unsupported inject declaration (only the array form is migrated)",
     "convert 'metaInfo' manually",
-    "convert 'shortcuts' manually",
     "unmapped this.$device",
   ],
   "sfc": "<template>
@@ -1418,6 +1417,7 @@ exports[`scripts/codemods/sfc-migration fixture snapshots (outcome, reasons and 
 
 <script setup>
 import { ref } from 'vue';
+import useShortcut from 'src/app/composables/use-shortcut';
 
 const onSave = function () {
     if (this.$device.getViewportWidth() > 500) {
@@ -1426,6 +1426,8 @@ const onSave = function () {
 };
 
 const title = ref('Partial');
+
+useShortcut('SYSTEMKEY+S', onSave);
 
 // TODO(sfc-migration): unsupported inject declaration (only the array form is migrated) — original code:
 // inject: {
@@ -1440,11 +1442,6 @@ const title = ref('Partial');
 //         return {
 //             title: this.title,
 //         };
-//     }
-
-// TODO(sfc-migration): convert 'shortcuts' manually — original code:
-// shortcuts: {
-//         'SYSTEMKEY+S': 'onSave',
 //     }
 
 // TODO(sfc-migration): unmapped this.$device
@@ -1626,6 +1623,50 @@ swDefinePublic({
     countItems,
     toggle,
     openModal,
+});
+</script>
+",
+}
+`;
+
+exports[`scripts/codemods/sfc-migration fixture snapshots (outcome, reasons and generated SFC per fixture) converts sw-shortcut-page 1`] = `
+{
+  "outcome": "full",
+  "reasons": [],
+  "sfc": "<template>
+    <sw-block name="sw_shortcut_page">
+        <button class="sw-shortcut-page" @click="onSave">{{ saved }}</button>
+    </sw-block>
+</template>
+
+<script setup>
+import { ref } from 'vue';
+import useShortcut from 'src/app/composables/use-shortcut';
+
+const onSave = function () {
+    saved.value = true;
+};
+
+const onCancel = function () {
+    saved.value = false;
+};
+
+const editable = ref(true);
+const saved = ref(false);
+
+useShortcut('SYSTEMKEY+S', onSave, {
+    active: function () {
+        return editable.value;
+    },
+});
+
+useShortcut('ESCAPE', onCancel);
+
+swDefinePublic({
+    editable,
+    saved,
+    onSave,
+    onCancel,
 });
 </script>
 ",

--- a/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/option-handlers.ts
+++ b/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/option-handlers.ts
@@ -66,6 +66,9 @@ type CollectedMember =
 /** A collected `watch` entry, rendered by `renderWatcher()` after the rewrite pass. */
 type CollectedWatcher = { source: string; handler: FnLike | string; options: string };
 
+/** A collected `shortcuts` entry, rendered by `renderShortcut()` after the rewrite pass. */
+type CollectedShortcut = { key: string; handler: string; active: FnLike | string | null };
+
 /** Everything the classification pass collects for the later rewrite and render steps. */
 type Collected = {
     propsNode: t.ObjectExpression | t.ArrayExpression | null;
@@ -81,6 +84,8 @@ type Collected = {
     computeds: CollectedMember[];
     methods: CollectedMember[];
     watchEntries: { key: string; prop: t.ObjectProperty | t.ObjectMethod }[];
+    /** Raw `shortcuts` entries; resolved by collectShortcuts() once every method name is known. */
+    shortcutEntries: { key: string; prop: t.ObjectProperty }[];
     hooks: { hook: string; fn: FnLike }[];
     rewriteFns: FnLike[];
     foreignNodes: t.Node[];
@@ -128,6 +133,7 @@ function createCollected(): Collected {
         computeds: [],
         methods: [],
         watchEntries: [],
+        shortcutEntries: [],
         hooks: [],
         rewriteFns: [],
         foreignNodes: [],
@@ -401,6 +407,26 @@ const OPTION_HANDLERS: Record<string, OptionHandler> = sourceKeyed<OptionHandler
             }
 
             collected.watchEntries.push({ key: watchKey, prop: entry });
+        }
+    },
+
+    // Collection only: an entry names its handler as a string, which collectShortcuts() can only
+    // resolve once the classification loop has seen the component's methods.
+    shortcuts: (prop, ctx, collected) => {
+        if (prop.type !== 'ObjectProperty' || prop.value.type !== 'ObjectExpression') {
+            unknownOption(ctx, 'shortcuts', prop);
+            return;
+        }
+
+        for (const entry of prop.value.properties) {
+            const shortcutKey = entry.type === 'SpreadElement' ? null : keyName(entry);
+
+            if (entry.type !== 'ObjectProperty' || !shortcutKey) {
+                report(ctx, 'todo', 'unsupported shortcuts entry', entry);
+                continue;
+            }
+
+            collected.shortcutEntries.push({ key: shortcutKey, prop: entry });
         }
     },
 
@@ -1052,6 +1078,74 @@ function collectWatchers(ctx: Ctx, collected: Collected): CollectedWatcher[] {
     return watchers;
 }
 
+/**
+ * Resolves each `shortcuts` entry's handler name against the binding map, the way a string `watch`
+ * handler is resolved. Runs after classification because the method may be declared below the
+ * option, and before the rewrite pass because an `active()` body contributes to it.
+ */
+function collectShortcuts(ctx: Ctx, collected: Collected): CollectedShortcut[] {
+    const shortcuts: CollectedShortcut[] = [];
+
+    for (const { key, prop } of collected.shortcutEntries) {
+        let handlerName: string | null = null;
+        let active: FnLike | string | null = null;
+        let supported = true;
+
+        if (prop.value.type === 'StringLiteral') {
+            handlerName = prop.value.value;
+        } else if (prop.value.type === 'ObjectExpression') {
+            for (const optionEntry of prop.value.properties) {
+                const optionName = optionEntry.type === 'SpreadElement' ? null : keyName(optionEntry);
+
+                if (optionName === 'method' && optionEntry.type === 'ObjectProperty') {
+                    handlerName = optionEntry.value.type === 'StringLiteral' ? optionEntry.value.value : null;
+                } else if (optionName === 'active') {
+                    const activeFn = asFunction(optionEntry as t.ObjectMethod | t.ObjectProperty);
+
+                    if (activeFn) {
+                        active = activeFn;
+                        collected.rewriteFns.push(activeFn);
+                    } else if (optionEntry.type === 'ObjectProperty' && optionEntry.value.type === 'BooleanLiteral') {
+                        active = raw(ctx, optionEntry.value);
+                    } else {
+                        supported = false;
+                    }
+                } else {
+                    supported = false;
+                }
+            }
+        } else {
+            supported = false;
+        }
+
+        // A handler named as a string only survives the conversion if it resolves to a method the
+        // component declares; nothing else can be called by that name from setup.
+        if (handlerName === null || ctx.bindings.get(handlerName) !== 'method') {
+            supported = false;
+        }
+
+        if (!supported) {
+            report(ctx, 'todo', `unsupported shortcuts entry '${key}'`, prop);
+            continue;
+        }
+
+        shortcuts.push({ key, handler: bindingName(ctx, handlerName as string), active });
+    }
+
+    return shortcuts;
+}
+
+/** Render phase — only valid once the `this` rewrite has run over the MagicString. */
+function renderShortcut(ctx: Ctx, shortcut: CollectedShortcut): string {
+    if (shortcut.active === null) {
+        return `useShortcut('${shortcut.key}', ${shortcut.handler});`;
+    }
+
+    const activeText = typeof shortcut.active === 'string' ? shortcut.active : arrowText(ctx, shortcut.active);
+
+    return `useShortcut('${shortcut.key}', ${shortcut.handler}, { active: ${activeText} });`;
+}
+
 /** Render phase — only valid once the `this` rewrite has run over the MagicString. */
 function renderMember(ctx: Ctx, member: CollectedMember): string {
     if (member.kind === 'writable-computed') {
@@ -1079,6 +1173,7 @@ function renderWatcher(ctx: Ctx, watcher: CollectedWatcher): string {
 
 export {
     type Collected,
+    type CollectedShortcut,
     type CollectedMember,
     type CollectedWatcher,
     type OptionHandler,
@@ -1086,9 +1181,11 @@ export {
     OPTION_HANDLERS,
     classifyOptions,
     collectOwnMemberNames,
+    collectShortcuts,
     collectWatchers,
     emitsEventNames,
     renderMember,
+    renderShortcut,
     renderWatcher,
     resolveMixins,
 };

--- a/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/runtime-equivalence-fixtures.ts
+++ b/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/runtime-equivalence-fixtures.ts
@@ -172,6 +172,29 @@ const ROUTE_WATCH_FIXTURE = runtimeFixture(
     `,
 );
 
+const SHORTCUT_FIXTURE = runtimeFixture(
+    'sw-runtime-shortcut',
+    `
+        export default {
+            data() {
+                return { enabled: false };
+            },
+            shortcuts: {
+                ESCAPE: { active() { return this.enabled; }, method: 'onEsc' },
+                F: 'onFocus',
+            },
+            methods: {
+                onEsc() {
+                    globalThis.__runtimeEquivalenceProbe.push('esc');
+                },
+                onFocus() {
+                    globalThis.__runtimeEquivalenceProbe.push('focus');
+                },
+            },
+        };
+    `,
+);
+
 const CLASS_THIS_FIXTURE = runtimeFixture(
     'sw-runtime-class-this',
     `
@@ -370,5 +393,6 @@ export {
     PROP_INJECT_DATA_FIXTURE,
     ROUTE_WATCH_FIXTURE,
     SAFE_WATCH_FIXTURE,
+    SHORTCUT_FIXTURE,
     SIBLING_DATA_FIXTURE,
 };

--- a/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/runtime-equivalence.spec.ts
+++ b/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/runtime-equivalence.spec.ts
@@ -5,6 +5,7 @@
 import { createMemoryHistory, createRouter } from 'vue-router';
 import { ref } from 'vue';
 import type { VueWrapper } from '@vue/test-utils';
+import shortcutPlugin from 'src/app/plugin/shortcut.plugin';
 import {
     CLASS_THIS_FIXTURE,
     CREATED_ASYNC_FIXTURE,
@@ -24,6 +25,7 @@ import {
     PROP_INJECT_DATA_FIXTURE,
     ROUTE_WATCH_FIXTURE,
     SAFE_WATCH_FIXTURE,
+    SHORTCUT_FIXTURE,
     SIBLING_DATA_FIXTURE,
 } from './runtime-equivalence-fixtures';
 import {
@@ -178,6 +180,41 @@ describe('SFC migration runtime equivalence', () => {
 
         expect(result.outcome).toBeDefined();
         expectConservative(result.outcome);
+    });
+
+    it('fires shortcuts the same way through useShortcut()', async () => {
+        const result = await convertFixture(SHORTCUT_FIXTURE);
+
+        expect(result.outcome).toBe('full');
+
+        const press = (key: string): void => {
+            document.dispatchEvent(new KeyboardEvent('keydown', { key, bubbles: true }));
+        };
+
+        const trace = async (wrapper: VueWrapper): Promise<unknown[]> => {
+            const probe = setProbe();
+
+            press('f');
+            press('Escape');
+            (wrapper.vm as unknown as { enabled: boolean }).enabled = true;
+            await flushPromises();
+            press('Escape');
+            wrapper.unmount();
+            press('f');
+
+            return probe.events;
+        };
+
+        // Only the Options API side needs the plugin that reads the `shortcuts` option.
+        const original = await trace(mountOriginal(SHORTCUT_FIXTURE, { plugins: [shortcutPlugin as never] }));
+        const generated = await trace(mountGenerated(SHORTCUT_FIXTURE, result));
+
+        // `active()` gates ESCAPE until it flips, and nothing fires after unmount.
+        expect(original).toEqual([
+            'focus',
+            'esc',
+        ]);
+        expect(generated).toEqual(original);
     });
 
     it('does not confuse class-local this with component this', async () => {

--- a/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/sfc-migration.spec.ts
+++ b/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/sfc-migration.spec.ts
@@ -48,7 +48,6 @@ describe('scripts/codemods/sfc-migration', () => {
                 expect.arrayContaining([
                     expect.stringContaining('inject'),
                     expect.stringContaining('metaInfo'),
-                    expect.stringContaining('shortcuts'),
                     expect.stringContaining('$device'),
                 ]),
             );

--- a/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/tables.ts
+++ b/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/tables.ts
@@ -56,7 +56,6 @@ const OPTION_TIERS: Record<string, ReportKind> = sourceKeyed<ReportKind>({
     render: 'skip',
     renderError: 'skip',
     metaInfo: 'todo',
-    shortcuts: 'todo',
     provide: 'todo',
     filters: 'todo',
     compatConfig: 'todo',

--- a/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/transform-script.ts
+++ b/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/transform-script.ts
@@ -32,12 +32,15 @@ import { GENERATED_HELPER_NAMES, HELPER_SETUP_LINES, RESERVED_BINDING, type Repo
 import { type Ctx, arrowText, report, snip, unwrapOptions } from './ast';
 import {
     type Collected,
+    type CollectedShortcut,
     type CollectedWatcher,
     type ResolvedComposable,
     classifyOptions,
+    collectShortcuts,
     collectWatchers,
     emitsEventNames,
     renderMember,
+    renderShortcut,
     renderWatcher,
     resolveMixins,
 } from './option-handlers';
@@ -154,6 +157,7 @@ function renderScript(
     ctx: Ctx,
     collected: Collected,
     watchers: CollectedWatcher[],
+    shortcuts: CollectedShortcut[],
     composables: ResolvedComposable[],
 ): string {
     const usesEmit = ctx.helpers.has('emit');
@@ -185,6 +189,7 @@ function renderScript(
         vueImports.length > 0 ? `import { ${vueImports.join(', ')} } from 'vue';` : null,
         ctx.helpers.has('t') ? "import { useI18n } from 'vue-i18n';" : null,
         routerImports.length > 0 ? `import { ${routerImports.join(', ')} } from 'vue-router';` : null,
+        shortcuts.length > 0 ? "import useShortcut from 'src/app/composables/use-shortcut';" : null,
         ...composables.map(({ descriptor }) => `import ${descriptor.import.name} from '${descriptor.import.source}';`),
     ]
         .filter(Boolean)
@@ -273,6 +278,7 @@ function renderScript(
         dataBlock || null,
         refBlock || null,
         ...watchers.map((watcher) => renderWatcher(ctx, watcher)),
+        ...shortcuts.map((shortcut) => renderShortcut(ctx, shortcut)),
         ...collected.hooks.map(({ hook, fn }) => `${hook}(${arrowText(ctx, fn)});`),
         collected.createdFn ? `void (${arrowText(ctx, collected.createdFn)})();` : null,
         ...siteTodos.map(todoBlock),
@@ -339,6 +345,7 @@ function transformScript(
     const collected = classifyOptions(ctx, options);
     const composables = resolveMixins(ctx, collected, options, collectTopLevelBindings(body, exportDefault));
     const watchers = collectWatchers(ctx, collected);
+    const shortcuts = collectShortcuts(ctx, collected);
 
     // --- name safety checks --------------------------------------------------------------------
 
@@ -448,7 +455,7 @@ function transformScript(
     // --- render ------------------------------------------------------------------------------------
 
     return {
-        script: renderScript(ctx, collected, watchers, composables),
+        script: renderScript(ctx, collected, watchers, shortcuts, composables),
         moduleScript,
         reasons: reasonsOf('todo'),
     };


### PR DESCRIPTION
### 1. Why is this change necessary?

> Stacked on shopware/shopware#20031, which adds `useShortcut()`. Review that first; this PR is only the codemod plumbing.

With the composable in place, `shortcuts` is still on the codemod's TODO tier, so every converted page inherits a manual step:

```ts
    metaInfo: 'todo',
    shortcuts: 'todo',
```

### 2. What does this change do, exactly?

- Registers `shortcuts` in `OPTION_HANDLERS` and drops its TODO-tier row.
- Resolves each entry's handler name against the binding map in a pass that runs after classification, because the method can be declared below the option. This is the same shape `collectWatchers()` already uses for a string `watch` handler:

  ```ts
  } else if (handlerText && ctx.bindings.get(handlerText) !== 'method') {
      supported = false;
  }
  ```

  An entry naming something the component does not declare as a method stays a TODO rather than emitting a call to a binding that does not exist.
- Both object-form `active` shapes convert — a function, whose body joins the usual `this` rewrite, and a boolean constant.
- The calls are emitted after the member sections, because methods render as `const onSave = …` and are not hoisted.

### 3. Describe each step to reproduce the issue or behaviour.

```bash
npx jest --collectCoverage=false scripts/codemods/sfc-migration
```

`sw-shortcut-page` is a new fixture; its snapshot is the emitted draft:

```js
useShortcut('SYSTEMKEY+S', onSave, {
    active: function () {
        return editable.value;
    },
});

useShortcut('ESCAPE', onCancel);
```

The runtime-equivalence test is the one that carries the weight: it mounts the same fixture both ways — Options API with the plugin, generated with `useShortcut()` — and asserts identical event traces, including the `active()` gate flipping and nothing firing after unmount.

### 4. Please link to the relevant issues (if any).

- relates #19571 — `shortcuts` is one of the three platform features that resolve members off the component instance

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [x] I have written or adjusted the documentation and agent skills according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them

Release notes are unticked deliberately: the codemod is internal tooling and emits no runtime API.
