### PR TITLE
feat(administration): convert metaInfo in the sfc codemod

### DIFF
--- a/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/README.md
+++ b/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/README.md
@@ -223,6 +223,23 @@ the store. The codemod never emits the clean one; that migration is a human's ca
 the CMS editor state through it. Its descriptor therefore answers those members as well, which is why
 both descriptors share one member list.
 
+## metaInfo
+
+`metaInfo` becomes a `useMetaInfo()` call taking the option's own function as a getter, so the body
+stays as authored:
+
+```js
+useMetaInfo(function () {
+    return {
+        title: createTitle(identifier.value),
+    };
+});
+```
+
+Nearly every body calls `$createTitle`, which is an Options API global property a setup component
+cannot read. It maps to a `createTitle` helper like `$t` and `$route` do — `const createTitle =
+useCreateTitle();` — so the mapping also covers the calls outside `metaInfo`.
+
 ## What is skipped on purpose
 
 `Component.extend` children, `Component.override` registrations, `this.$super`/`this.$parent`,

--- a/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/__fixtures__/sw-meta-info-page/index.js
+++ b/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/__fixtures__/sw-meta-info-page/index.js
@@ -1,0 +1,23 @@
+import template from './sw-meta-info-page.html.twig';
+
+export default {
+    template,
+
+    metaInfo() {
+        return {
+            title: this.$createTitle(this.identifier),
+        };
+    },
+
+    data() {
+        return {
+            product: null,
+        };
+    },
+
+    computed: {
+        identifier() {
+            return this.product ? this.product.name : '';
+        },
+    },
+};

--- a/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/__fixtures__/sw-meta-info-page/sw-meta-info-page.html.twig
+++ b/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/__fixtures__/sw-meta-info-page/sw-meta-info-page.html.twig
@@ -1,0 +1,3 @@
+{% block sw_meta_info_page %}
+    <div class="sw-meta-info-page">{{ identifier }}</div>
+{% endblock %}

--- a/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/__snapshots__/sfc-migration.spec.ts.snap
+++ b/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/__snapshots__/sfc-migration.spec.ts.snap
@@ -373,6 +373,44 @@ swDefinePublic({
 }
 `;
 
+exports[`scripts/codemods/sfc-migration fixture snapshots (outcome, reasons and generated SFC per fixture) converts sw-meta-info-page 1`] = `
+{
+  "outcome": "full",
+  "reasons": [],
+  "sfc": "<template>
+    <sw-block name="sw_meta_info_page">
+        <div class="sw-meta-info-page">{{ identifier }}</div>
+    </sw-block>
+</template>
+
+<script setup>
+import { ref, computed } from 'vue';
+import useCreateTitle from 'src/app/composables/use-create-title';
+import useMetaInfo from 'src/app/composables/use-meta-info';
+
+const createTitle = useCreateTitle();
+
+const identifier = computed(function () {
+    return product.value ? product.value.name : '';
+});
+
+const product = ref(null);
+
+useMetaInfo(function () {
+    return {
+        title: createTitle(identifier.value),
+    };
+});
+
+swDefinePublic({
+    product,
+    identifier,
+});
+</script>
+",
+}
+`;
+
 exports[`scripts/codemods/sfc-migration fixture snapshots (outcome, reasons and generated SFC per fixture) converts sw-mixin-callback 1`] = `
 {
   "outcome": "full",
@@ -1406,7 +1444,6 @@ exports[`scripts/codemods/sfc-migration fixture snapshots (outcome, reasons and 
   "outcome": "partial",
   "reasons": [
     "unsupported inject declaration (only the array form is migrated)",
-    "convert 'metaInfo' manually",
     "convert 'shortcuts' manually",
     "unmapped this.$device",
   ],
@@ -1418,6 +1455,7 @@ exports[`scripts/codemods/sfc-migration fixture snapshots (outcome, reasons and 
 
 <script setup>
 import { ref } from 'vue';
+import useMetaInfo from 'src/app/composables/use-meta-info';
 
 const onSave = function () {
     if (this.$device.getViewportWidth() > 500) {
@@ -1427,19 +1465,18 @@ const onSave = function () {
 
 const title = ref('Partial');
 
+useMetaInfo(function () {
+    return {
+        title: title.value,
+    };
+});
+
 // TODO(sfc-migration): unsupported inject declaration (only the array form is migrated) — original code:
 // inject: {
 //         feature: {
 //             from: 'feature',
 //             default: null,
 //         },
-//     }
-
-// TODO(sfc-migration): convert 'metaInfo' manually — original code:
-// metaInfo() {
-//         return {
-//             title: this.title,
-//         };
 //     }
 
 // TODO(sfc-migration): convert 'shortcuts' manually — original code:

--- a/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/option-handlers.ts
+++ b/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/option-handlers.ts
@@ -82,6 +82,8 @@ type Collected = {
     methods: CollectedMember[];
     watchEntries: { key: string; prop: t.ObjectProperty | t.ObjectMethod }[];
     hooks: { hook: string; fn: FnLike }[];
+    /** The `metaInfo` option's function, handed to useMetaInfo() as a getter. */
+    metaInfoFn: FnLike | null;
     rewriteFns: FnLike[];
     foreignNodes: t.Node[];
     createdFn: FnLike | null;
@@ -129,6 +131,7 @@ function createCollected(): Collected {
         methods: [],
         watchEntries: [],
         hooks: [],
+        metaInfoFn: null,
         rewriteFns: [],
         foreignNodes: [],
         createdFn: null,
@@ -431,6 +434,23 @@ const OPTION_HANDLERS: Record<string, OptionHandler> = sourceKeyed<OptionHandler
                 collected.mixins.push(descriptor);
             }
         }
+    },
+
+    /**
+     * The meta-info plugin read this off the component type and called it with the instance, so its
+     * body reached members a `<script setup>` component does not expose. Handing the function over
+     * as a getter keeps the body as authored and drops the lookup.
+     */
+    metaInfo: (prop, ctx, collected) => {
+        const fn = asFunction(prop);
+
+        if (!fn) {
+            report(ctx, 'todo', 'metaInfo is not a plain function', prop);
+            return;
+        }
+
+        collected.metaInfoFn = fn;
+        collected.rewriteFns.push(fn);
     },
 
     created: (prop, ctx, collected) => {

--- a/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/runtime-equivalence-fixtures.ts
+++ b/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/runtime-equivalence-fixtures.ts
@@ -172,6 +172,25 @@ const ROUTE_WATCH_FIXTURE = runtimeFixture(
     `,
 );
 
+const META_INFO_FIXTURE = runtimeFixture(
+    'sw-runtime-meta-info',
+    `
+        export default {
+            data() {
+                return { name: 'Draft' };
+            },
+            metaInfo() {
+                return { title: this.identifier };
+            },
+            computed: {
+                identifier() {
+                    return this.name + ' | Shopware';
+                },
+            },
+        };
+    `,
+);
+
 const CLASS_THIS_FIXTURE = runtimeFixture(
     'sw-runtime-class-this',
     `
@@ -364,6 +383,7 @@ export {
     DATA_SCOPE_FIXTURE,
     FUNCTION_FIXTURE,
     INJECTION_FIXTURE,
+    META_INFO_FIXTURE,
     MODULE_IDENTITY_FIXTURE,
     MODULE_BINDING_FIXTURE,
     PARAMETERIZED_DATA_FIXTURE,

--- a/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/runtime-equivalence.spec.ts
+++ b/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/runtime-equivalence.spec.ts
@@ -5,6 +5,7 @@
 import { createMemoryHistory, createRouter } from 'vue-router';
 import { ref } from 'vue';
 import type { VueWrapper } from '@vue/test-utils';
+import metaInfoPlugin from 'src/app/plugin/meta-info.plugin';
 import {
     CLASS_THIS_FIXTURE,
     CREATED_ASYNC_FIXTURE,
@@ -19,6 +20,7 @@ import {
     FUNCTION_FIXTURE,
     INJECTION_FIXTURE,
     MODULE_BINDING_FIXTURE,
+    META_INFO_FIXTURE,
     MODULE_IDENTITY_FIXTURE,
     PARAMETERIZED_DATA_FIXTURE,
     PROP_INJECT_DATA_FIXTURE,
@@ -178,6 +180,38 @@ describe('SFC migration runtime equivalence', () => {
 
         expect(result.outcome).toBeDefined();
         expectConservative(result.outcome);
+    });
+
+    it('keeps document.title in sync the way the metaInfo option did', async () => {
+        const result = await convertFixture(META_INFO_FIXTURE);
+
+        expect(result.outcome).toBe('full');
+
+        const trace = async (wrapper: VueWrapper): Promise<string[]> => {
+            const seen = [document.title];
+
+            (wrapper.vm as unknown as { name: string }).name = 'Saved shirt';
+            await flushPromises();
+            seen.push(document.title);
+
+            wrapper.unmount();
+            document.title = 'after unmount';
+            await flushPromises();
+            seen.push(document.title);
+
+            return seen;
+        };
+
+        // Only the Options API side needs the plugin that reads the `metaInfo` option.
+        const original = await trace(mountOriginal(META_INFO_FIXTURE, { plugins: [metaInfoPlugin as never] }));
+        const generated = await trace(mountGenerated(META_INFO_FIXTURE, result));
+
+        expect(original).toEqual([
+            'Draft | Shopware',
+            'Saved shirt | Shopware',
+            'after unmount',
+        ]);
+        expect(generated).toEqual(original);
     });
 
     it('does not confuse class-local this with component this', async () => {

--- a/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/sfc-migration.spec.ts
+++ b/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/sfc-migration.spec.ts
@@ -47,7 +47,6 @@ describe('scripts/codemods/sfc-migration', () => {
             expect(result.reasons).toEqual(
                 expect.arrayContaining([
                     expect.stringContaining('inject'),
-                    expect.stringContaining('metaInfo'),
                     expect.stringContaining('shortcuts'),
                     expect.stringContaining('$device'),
                 ]),

--- a/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/tables.ts
+++ b/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/tables.ts
@@ -16,7 +16,7 @@
 
 type MemberKind = 'prop' | 'data' | 'computed' | 'method' | 'inject';
 
-type HelperName = 't' | 'router' | 'route' | 'emit' | 'props' | 'slots' | 'attrs' | 'nextTick';
+type HelperName = 't' | 'router' | 'route' | 'emit' | 'props' | 'slots' | 'attrs' | 'nextTick' | 'createTitle';
 
 type TodoEntry = {
     reason: string;
@@ -55,7 +55,6 @@ function sourceKeyed<T>(entries: Record<string, T>): Record<string, T> {
 const OPTION_TIERS: Record<string, ReportKind> = sourceKeyed<ReportKind>({
     render: 'skip',
     renderError: 'skip',
-    metaInfo: 'todo',
     shortcuts: 'todo',
     provide: 'todo',
     filters: 'todo',
@@ -91,6 +90,7 @@ const INSTANCE_PROPS: Record<string, { replacement: string; helper?: HelperName 
     $router: { replacement: 'router', helper: 'router' },
     $route: { replacement: 'route', helper: 'route' },
     $nextTick: { replacement: 'nextTick', helper: 'nextTick' },
+    $createTitle: { replacement: 'createTitle', helper: 'createTitle' },
     $slots: { replacement: 'slots', helper: 'slots' },
     $attrs: { replacement: 'attrs', helper: 'attrs' },
 });
@@ -101,6 +101,7 @@ const HELPER_SETUP_LINES: Record<HelperName, string | null> = {
     route: 'const route = useRoute();',
     slots: 'const slots = useSlots();',
     attrs: 'const attrs = useAttrs();',
+    createTitle: 'const createTitle = useCreateTitle();',
     nextTick: null,
     emit: null,
     props: null,
@@ -131,6 +132,7 @@ const GENERATED_HELPER_NAMES = new Set([
     'slots',
     'attrs',
     'nextTick',
+    'createTitle',
 ]);
 
 export {

--- a/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/transform-script.ts
+++ b/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/transform-script.ts
@@ -184,6 +184,8 @@ function renderScript(
     const importBlock = [
         vueImports.length > 0 ? `import { ${vueImports.join(', ')} } from 'vue';` : null,
         ctx.helpers.has('t') ? "import { useI18n } from 'vue-i18n';" : null,
+        ctx.helpers.has('createTitle') ? "import useCreateTitle from 'src/app/composables/use-create-title';" : null,
+        collected.metaInfoFn ? "import useMetaInfo from 'src/app/composables/use-meta-info';" : null,
         routerImports.length > 0 ? `import { ${routerImports.join(', ')} } from 'vue-router';` : null,
         ...composables.map(({ descriptor }) => `import ${descriptor.import.name} from '${descriptor.import.source}';`),
     ]
@@ -196,6 +198,7 @@ function renderScript(
             'route',
             'slots',
             'attrs',
+            'createTitle',
         ] as const
     )
         .filter((helper) => ctx.helpers.has(helper))
@@ -273,6 +276,7 @@ function renderScript(
         dataBlock || null,
         refBlock || null,
         ...watchers.map((watcher) => renderWatcher(ctx, watcher)),
+        collected.metaInfoFn ? `useMetaInfo(${arrowText(ctx, collected.metaInfoFn)});` : null,
         ...collected.hooks.map(({ hook, fn }) => `${hook}(${arrowText(ctx, fn)});`),
         collected.createdFn ? `void (${arrowText(ctx, collected.createdFn)})();` : null,
         ...siteTodos.map(todoBlock),


### PR DESCRIPTION
### 1. Why is this change necessary?

> Stacked on shopware/shopware#20032, which adds `useMetaInfo()` and `useCreateTitle()`. Review that first; this PR is only the codemod plumbing.

With the composables in place, `metaInfo` is still on the codemod's TODO tier, so every one of the 103 pages that declares it inherits a manual step.

`$createTitle` needs the same treatment for those drafts to be worth anything: 99 of the 103 bodies call it, and it is not in `INSTANCE_PROPS`, so it converts to `unmapped this.$createTitle` and blocks the body regardless of what a `metaInfo` handler does.

### 2. What does this change do, exactly?

- Registers `metaInfo` in `OPTION_HANDLERS` and drops its TODO-tier row. The option's own function is handed to `useMetaInfo()` as the getter, so the body stays as authored.
- Maps `$createTitle` to a `createTitle` helper, the same mechanism `$t` and `$route` use — one `INSTANCE_PROPS` row plus one `HELPER_SETUP_LINES` entry. That also converts the `$createTitle` calls outside `metaInfo`.
- Adds `createTitle` to `GENERATED_HELPER_NAMES`, so a component member of that name is refused instead of shadowing the helper.

The emitted draft:

```js
import useCreateTitle from 'src/app/composables/use-create-title';
import useMetaInfo from 'src/app/composables/use-meta-info';

const createTitle = useCreateTitle();

useMetaInfo(function () {
    return {
        title: createTitle(identifier.value),
    };
});
```

### 3. Describe each step to reproduce the issue or behaviour.

```bash
npx jest --collectCoverage=false scripts/codemods/sfc-migration
```

`sw-meta-info-page` is a new fixture and converts `full`. The runtime-equivalence test mounts the same fixture both ways — Options API with the meta-info plugin, generated with `useMetaInfo()` — and compares the actual `document.title` after mount, after a reactive change, and after unmount.

### 4. Please link to the relevant issues (if any).

- relates #19571 — `metaInfo` is one of the three platform features that resolve members off the component instance

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [x] I have written or adjusted the documentation and agent skills according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them

Release notes are unticked deliberately: the codemod is internal tooling and emits no runtime API.
