### PR TITLE
feat(administration): add usePublishedData()

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/composables/use-published-data.spec.ts
+++ b/src/Administration/Resources/app/administration/src/app/composables/use-published-data.spec.ts
@@ -1,0 +1,104 @@
+/**
+ * @sw-package framework
+ */
+
+import { mount } from '@vue/test-utils';
+import { defineComponent, ref } from 'vue';
+import type { Ref } from 'vue';
+import Entity from 'src/core/data/entity.data';
+import { getPublishedDataSets } from 'src/core/service/extension-api-data.service';
+import usePublishedData from './use-published-data';
+
+function mountWithPublishedData<T>(id: string, source: Ref<T>): { unmount: () => void } {
+    return mount(
+        defineComponent({
+            template: '<div />',
+            setup() {
+                usePublishedData(id, source);
+            },
+        }),
+    ) as unknown as { unmount: () => void };
+}
+
+/** Fakes the one message an app sends to write into a published data set. */
+function appWritesDataSet(id: string, data: unknown): void {
+    jest.spyOn(window, 'addEventListener').mockImplementationOnce((event, handler) => {
+        (handler as (event: { data: string }) => void)({
+            data: JSON.stringify({
+                _type: 'datasetUpdate',
+                _data: { id, data },
+                _callbackId: Shopware.Utils.createId(),
+            }),
+        });
+    });
+}
+
+describe('src/app/composables/use-published-data', () => {
+    it('publishes the ref under its id', async () => {
+        mountWithPublishedData('use-published-data__scalar', ref('published'));
+
+        await flushPromises();
+
+        expect(getPublishedDataSets().find((set) => set.id === 'use-published-data__scalar')?.data).toBe('published');
+    });
+
+    it('republishes the ref when it changes', async () => {
+        const source = ref('before');
+
+        mountWithPublishedData('use-published-data__changing', source);
+        await flushPromises();
+
+        source.value = 'after';
+        await flushPromises();
+
+        expect(getPublishedDataSets().find((set) => set.id === 'use-published-data__changing')?.data).toBe('after');
+    });
+
+    it('writes an app update back into the ref', async () => {
+        const source = ref('before');
+
+        appWritesDataSet('use-published-data__inbound', 'from the app');
+        mountWithPublishedData('use-published-data__inbound', source);
+
+        await flushPromises();
+
+        expect(source.value).toBe('from the app');
+    });
+
+    it('writes an app update back into a property of a published entity', async () => {
+        const entity = new Entity(Shopware.Utils.createId(), 'jest', { name: 'before' });
+        const source = ref(entity);
+
+        appWritesDataSet('use-published-data__entity', { name: 'after' });
+        mountWithPublishedData('use-published-data__entity', source);
+
+        await flushPromises();
+
+        expect(source.value.name).toBe('after');
+        // The write must not replace the entity, or its draft handling goes with it.
+        expect(typeof source.value.getDraft).toBe('function');
+    });
+
+    it('unpublishes the data set when the component unmounts', async () => {
+        const wrapper = mountWithPublishedData('use-published-data__unmount', ref('published'));
+
+        await flushPromises();
+        expect(getPublishedDataSets().some((set) => set.id === 'use-published-data__unmount')).toBe(true);
+
+        wrapper.unmount();
+        await flushPromises();
+
+        expect(getPublishedDataSets().some((set) => set.id === 'use-published-data__unmount')).toBe(false);
+    });
+
+    it('warns and publishes nothing when called outside setup', () => {
+        const warn = jest.spyOn(Shopware.Utils.debug, 'warn').mockImplementation(() => {});
+
+        usePublishedData('use-published-data__no-setup', ref('published'));
+
+        expect(warn).toHaveBeenCalledWith('usePublishedData', expect.stringContaining('during setup'));
+        expect(getPublishedDataSets().some((set) => set.id === 'use-published-data__no-setup')).toBe(false);
+
+        warn.mockRestore();
+    });
+});

--- a/src/Administration/Resources/app/administration/src/app/composables/use-published-data.ts
+++ b/src/Administration/Resources/app/administration/src/app/composables/use-published-data.ts
@@ -1,0 +1,65 @@
+/**
+ * @sw-package framework
+ */
+
+import { getCurrentInstance, onScopeDispose, watch } from 'vue';
+import type { Ref } from 'vue';
+import { publishScopedData } from 'src/core/service/extension-api-data.service';
+import type { PublishScope, publishScopedOptions } from 'src/core/service/extension-api-data.service';
+
+/**
+ * Publishes a ref to the extension API under `id`, for as long as the calling component is mounted.
+ *
+ * Setup-mode equivalent of `Shopware.ExtensionAPI.publishData({ id, path, scope: this })`, which
+ * addressed the data as a lodash path against the component instance — a `<script setup>` component
+ * exposes neither the members that path walks nor the `dataSetUnwatchers` array the teardown was
+ * parked on. Handing over the ref replaces all of it.
+ *
+ * The channel stays two-way: an app writing into the data set writes into this ref, so the page's
+ * own save picks the change up.
+ *
+ * @private
+ */
+export default function usePublishedData<T>(id: string, source: Ref<T>, options: publishScopedOptions = {}): () => void {
+    const instance = getCurrentInstance();
+
+    if (!instance) {
+        Shopware.Utils.debug.warn(
+            'usePublishedData',
+            'Must be called during setup, so the data set can be unpublished again.',
+        );
+
+        return () => {};
+    }
+
+    const scope: PublishScope = {
+        uid: instance.uid,
+
+        read: () => source.value,
+
+        write: (segments, value) => {
+            if (segments.length === 0) {
+                source.value = value as T;
+
+                return;
+            }
+
+            const container: unknown =
+                segments.length === 1
+                    ? source.value
+                    : Shopware.Utils.object.get(source.value, segments.slice(0, -1).join('.'));
+
+            if (!container || typeof container !== 'object') {
+                return;
+            }
+
+            (container as Record<string, unknown>)[segments[segments.length - 1]] = value;
+        },
+
+        watch: (callback) => watch(source, (value) => callback(value), { deep: true, immediate: true }),
+
+        onTeardown: (teardown) => onScopeDispose(teardown),
+    };
+
+    return publishScopedData(id, scope, options);
+}

--- a/src/Administration/Resources/app/administration/src/core/service/extension-api-data.service.ts
+++ b/src/Administration/Resources/app/administration/src/core/service/extension-api-data.service.ts
@@ -5,7 +5,6 @@ import { updateSubscriber, register, handleGet } from '@shopware-ag/meteor-admin
 import get from 'lodash-es/get';
 import debounce from 'lodash-es/debounce';
 import cloneDeepWith from 'lodash-es/cloneDeepWith';
-import type { App } from 'vue';
 import { selectData } from '@shopware-ag/meteor-admin-sdk/es/_internals/data/selectData';
 import MissingPrivilegesError from '@shopware-ag/meteor-admin-sdk/es/_internals/privileges/missing-privileges-error';
 import EntityCollection from 'src/core/data/entity-collection.data';
@@ -19,6 +18,26 @@ interface scopeInterface {
         uid: number;
     };
 }
+
+/**
+ * Everything publishing needs from whatever holds the data — an Options API instance plus a path, or
+ * a ref. Paths handed to `write` are relative to the published value, so neither side has to know
+ * how the other addresses it.
+ *
+ * @private
+ */
+export type PublishScope = {
+    /** Identity of the publisher, so publishing the same id twice can be told apart from updating it. */
+    uid: number | undefined;
+    /** The value being published. */
+    read: () => unknown;
+    /** Replaces the published value, or the property inside it that `segments` addresses. */
+    write: (segments: string[], value: unknown) => void;
+    /** Reports every deep change, once immediately. Returns the function that stops watching. */
+    watch: (callback: (value: unknown) => void) => () => void;
+    /** Registers the cleanup that stops publishing when the publisher goes away. */
+    onTeardown: (teardown: () => void) => void;
+};
 interface publishOptions {
     id: string;
     path: string;
@@ -27,6 +46,9 @@ interface publishOptions {
     deprecationMessage?: string;
     showDoubleRegistrationError?: boolean;
 }
+
+/** @private */
+export type publishScopedOptions = Omit<publishOptions, 'id' | 'path' | 'scope'>;
 
 type dataset = {
     id: string;
@@ -187,22 +209,25 @@ function parsePath(path: string): ParsedPath | null {
     return null;
 }
 
-// eslint-disable-next-line sw-deprecation-rules/private-feature-declarations
-export function publishData({
-    id,
-    path,
-    scope,
-    deprecated,
-    deprecationMessage,
-    showDoubleRegistrationError = true,
-}: publishOptions): () => void {
+/**
+ * Publishes whatever a `PublishScope` holds, and keeps publishing it until that scope tears down.
+ * `publishData()` and `usePublishedData()` both come through here; the only difference between them
+ * is how their scope reaches the data.
+ *
+ * @private
+ */
+export function publishScopedData(
+    id: string,
+    scope: PublishScope,
+    { deprecated, deprecationMessage, showDoubleRegistrationError = true }: publishScopedOptions = {},
+): () => void {
     if (unregisterPublishDataIds.includes(id)) {
         unregisterPublishDataIds = unregisterPublishDataIds.filter((value) => value !== id);
     }
     const registeredDataSet = publishedDataSets.find((s) => s.id === id);
 
     // Dataset registered from different scope? Prevent update.
-    if (registeredDataSet && registeredDataSet.scope !== scope?.$?.uid) {
+    if (registeredDataSet && registeredDataSet.scope !== scope.uid) {
         if (showDoubleRegistrationError) {
             console.error(`The dataset id "${id}" you tried to publish is already registered.`);
         }
@@ -211,8 +236,8 @@ export function publishData({
     }
 
     // Dataset registered from same scope? Update.
-    if (registeredDataSet && registeredDataSet.scope === scope?.$?.uid) {
-        register({ id: id, data: get(scope, path) }).catch(() => {});
+    if (registeredDataSet && registeredDataSet.scope === scope.uid) {
+        register({ id: id, data: scope.read() }).catch(() => {});
 
         return () => {};
     }
@@ -224,24 +249,17 @@ export function publishData({
             return;
         }
 
-        function setObject(transferObject: transferObject, prePath: string | null = null): void {
+        function setObject(transferObject: transferObject, prefix: string[] = []): void {
             // eslint-disable-next-line @typescript-eslint/no-unsafe-call
             if (typeof transferObject?.getIsDirty === 'function' && !transferObject.getIsDirty()) {
                 return;
             }
 
             Object.keys(transferObject).forEach((property) => {
-                let realPath: string;
-                if (prePath) {
-                    realPath = `${prePath}.${property}`;
-                } else {
-                    realPath = `${path}.${property}`;
-                }
-
-                const parsedPath = parsePath(realPath);
-                if (parsedPath === null) {
-                    return;
-                }
+                const segments = [
+                    ...prefix,
+                    property,
+                ];
 
                 if (
                     // @ts-expect-error
@@ -253,7 +271,7 @@ export function publishData({
                         {
                             [property]: Shopware.Utils.object.cloneDeep(transferObject[property]),
                         },
-                        realPath,
+                        segments,
                     );
 
                     return;
@@ -261,15 +279,13 @@ export function publishData({
 
                 if (Array.isArray(transferObject[property])) {
                     (transferObject[property] as Array<unknown>).forEach((c, index) => {
-                        setObject({ [index]: c }, realPath);
+                        setObject({ [index]: c }, segments);
                     });
 
                     return;
                 }
 
-                // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-                Shopware.Utils.object.get(scope, parsedPath.pathToLastSegment)[parsedPath.lastSegment] =
-                    transferObject[property];
+                scope.write(segments, transferObject[property]);
             });
         }
 
@@ -294,29 +310,12 @@ export function publishData({
             return;
         }
 
-        // Vue.set does not resolve path's therefore we need to resolve to the last child property
-        if (path.includes('.')) {
-            const properties = path.split('.');
-            const lastPath = properties.pop();
-            const newPath = properties.join('.');
-            if (!lastPath) {
-                return;
-            }
-
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-            Shopware.Utils.object.get(scope, newPath)[lastPath] = value.data;
-
-            return;
-        }
-
-        // @ts-expect-error
-        scope[path] = value.data;
+        scope.write([], value.data);
     });
 
-    // Watch for Changes on the Reactive Vue property and automatically publish them
-    const unwatch = scope.$watch(
-        path,
-        debounce((value: App<Element>) => {
+    // Watch for changes on the reactive source and automatically publish them
+    const unwatch = scope.watch(
+        debounce((value: unknown) => {
             if (unregisterPublishDataIds.includes(id)) {
                 unregisterPublishDataIds = unregisterPublishDataIds.filter((v) => v !== id);
                 unwatch();
@@ -339,27 +338,21 @@ export function publishData({
             publishedDataSets.push({
                 id,
                 data: clonedValue,
-                scope: scope?.$?.uid,
+                scope: scope.uid,
                 deprecated,
                 deprecationMessage,
             });
         }, 750),
-        {
-            deep: true,
-            immediate: true,
-        },
     );
 
-    // @ts-expect-error - Defined in meteor-sdk-data.plugin.ts
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-call,@typescript-eslint/no-unsafe-member-access
-    scope.dataSetUnwatchers.push(() => {
+    scope.onTeardown(() => {
         publishedDataSets = publishedDataSets.filter((value) => value.id !== id);
         unregisterPublishDataIds.push(id);
 
         unwatch();
     });
 
-    register({ id: id, data: get(scope, path) }).catch(() => {});
+    register({ id: id, data: scope.read() }).catch(() => {});
 
     // Return method to manually deregister the dataset
     return function unregisterPublishData() {
@@ -368,6 +361,52 @@ export function publishData({
 
         unwatch();
     };
+}
+
+/**
+ * A `PublishScope` over an Options API instance and a path into it. `write` re-joins the relative
+ * segments onto that path, so the instance is still addressed exactly as it was before the scope
+ * seam existed.
+ */
+function instanceScope(instance: scopeInterface, path: string): PublishScope {
+    return {
+        uid: instance?.$?.uid,
+
+        read: (): unknown => get(instance, path),
+
+        write: (segments, value) => {
+            const fullPath = [
+                path,
+                ...segments,
+            ].join('.');
+            const parsedPath = parsePath(fullPath);
+
+            // A single-segment path names a member of the instance itself, so there is no container
+            // to resolve first.
+            if (parsedPath === null) {
+                // @ts-expect-error - the path is the caller's contract, not something typed here
+                instance[fullPath] = value;
+
+                return;
+            }
+
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+            Shopware.Utils.object.get(instance, parsedPath.pathToLastSegment)[parsedPath.lastSegment] = value;
+        },
+
+        watch: (callback) => instance.$watch(path, callback, { deep: true, immediate: true }),
+
+        onTeardown: (teardown) => {
+            // @ts-expect-error - Defined in meteor-sdk-data.plugin.ts
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-call,@typescript-eslint/no-unsafe-member-access
+            instance.dataSetUnwatchers.push(teardown);
+        },
+    };
+}
+
+// eslint-disable-next-line sw-deprecation-rules/private-feature-declarations
+export function publishData({ id, path, scope, ...options }: publishOptions): () => void {
+    return publishScopedData(id, instanceScope(scope, path), options);
 }
 
 // eslint-disable-next-line sw-deprecation-rules/private-feature-declarations


### PR DESCRIPTION
### 1. Why is this change necessary?

`ExtensionAPI.publishData()` is how a page hands its entity to app extensions — 23 files call it, 33 data sets are registered in `src/meta/data-sets.json`. Every call passes the component itself:

```js
Shopware.ExtensionAPI.publishData({
    id: 'sw-product-detail__product',
    path: 'product',
    scope: this,
});
```

`scope` is not just an identity. The function needs three separate things from it, and a `<script setup>` component provides none of them:

- **the value**, read as a lodash path against the instance — `get(scope, path)`;
- **the write-back**, because the channel is two-way. When an app edits a field, the service writes into the component so the page's own save picks it up:
  ```ts
  Shopware.Utils.object.get(scope, parsedPath.pathToLastSegment)[parsedPath.lastSegment] =
      transferObject[property];
  ```
- **the teardown**, parked on an array a global mixin owns:
  ```ts
  // @ts-expect-error - Defined in meteor-sdk-data.plugin.ts
  scope.dataSetUnwatchers.push(() => { … });
  ```

On a converted page `this.product` is `undefined`, so the watcher watches nothing, apps receive nothing, and the write-back writes nowhere — silently. The `@ts-expect-error` is the code saying out loud that it is reaching somewhere it should not.

### 2. What does this change do, exactly?

- Introduces `PublishScope`: everything publishing needs from whatever holds the data — `uid`, `read`, `write`, `watch`, `onTeardown`. Paths handed to `write` are **relative to the published value**, so neither side has to know how the other addresses it.
- `publishScopedData(id, scope, options)` is the core; `publishData()` keeps its signature and builds an instance-backed scope internally. That scope re-joins the relative segments onto its path, so the Options API path addresses the instance exactly as before.
- `usePublishedData(id, ref)` supplies a ref-backed scope: `read` is `source.value`, `write` resolves inside it, `watch` is a deep immediate `watch()`, and the teardown is `onScopeDispose` — `dataSetUnwatchers` disappears entirely.

The codemod side is stacked on top of this: shopware/shopware#20037.

### 3. Describe each step to reproduce the issue or behaviour.

```bash
npx jest --collectCoverage=false src/core/service/extension-api-data.service.spec.js src/app/composables/use-published-data.spec.ts
```

The 15 existing service tests pass unchanged through the seam, which is what pins the Options API behaviour — they cover entities, collections, scalars, nested paths, double registration and unmount. The new spec drives the composable through the same message an app sends, including a write-back into a published entity that must not replace the entity itself.

### 4. Please link to the relevant issues (if any).

- relates #19571 — `publishData` is one of the three platform features that resolve members off the component instance

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them

Release notes are unticked because `publishData()` keeps its signature and the new API is `@private`. Documentation is unticked because the codemod README entry belongs to the stacked PR. This is the one of the three setup-mode APIs where a RELEASE_INFO entry looks most justified — app developers reading about data sets will want the setup form — so say the word.

