### PR TITLE
feat(administration): convert ExtensionAPI.publishData() in the sfc codemod

### DIFF
--- a/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/README.md
+++ b/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/README.md
@@ -223,6 +223,29 @@ the store. The codemod never emits the clean one; that migration is a human's ca
 the CMS editor state through it. Its descriptor therefore answers those members as well, which is why
 both descriptors share one member list.
 
+## ExtensionAPI.publishData()
+
+The one call the codemod rewrites rather than an option. It takes the instance as `scope` so it can
+read the published value by path, write app updates back through that path, and park its teardown on
+a member a global mixin owns — none of which a `<script setup>` component provides.
+
+```js
+usePublishedData('sw-product-detail__product', product);
+```
+
+The call is rewritten where it stands. Every composable API `usePublishedData()` needs is available
+inside a lifecycle hook as well as at setup top level, so nothing is hoisted and the order the
+component published its data sets in is preserved.
+
+Recognised only in its one production shape: a single object argument with a string `id`, a
+single-segment string `path` naming a data or computed member, `scope: this`, and optionally
+`deprecated` / `deprecationMessage` / `showDoubleRegistrationError`. A multi-segment path addressed
+something *inside* the published value, which a ref cannot express as its own source, so it stays a
+TODO along with every other shape.
+
+Because the replacement covers the whole call including its `scope: this`, the range is recorded in
+`ctx.rewrittenRanges` and the `this` rewrite skips it.
+
 ## What is skipped on purpose
 
 `Component.extend` children, `Component.override` registrations, `this.$super`/`this.$parent`,

--- a/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/__fixtures__/sw-publish-data-page/index.js
+++ b/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/__fixtures__/sw-publish-data-page/index.js
@@ -1,0 +1,34 @@
+import template from './sw-publish-data-page.html.twig';
+
+export default {
+    template,
+
+    data() {
+        return {
+            product: null,
+            currentPage: null,
+        };
+    },
+
+    created() {
+        this.createdComponent();
+    },
+
+    methods: {
+        createdComponent() {
+            Shopware.ExtensionAPI.publishData({
+                id: 'sw-publish-data-page__product',
+                path: 'product',
+                scope: this,
+            });
+
+            Shopware.ExtensionAPI.publishData({
+                id: 'sw-publish-data-page__cmsPage',
+                path: 'currentPage',
+                scope: this,
+                deprecated: true,
+                deprecationMessage: 'Use the product data set instead.',
+            });
+        },
+    },
+};

--- a/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/__fixtures__/sw-publish-data-page/sw-publish-data-page.html.twig
+++ b/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/__fixtures__/sw-publish-data-page/sw-publish-data-page.html.twig
@@ -1,0 +1,3 @@
+{% block sw_publish_data_page %}
+    <div class="sw-publish-data-page">{{ product }}</div>
+{% endblock %}

--- a/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/__snapshots__/sfc-migration.spec.ts.snap
+++ b/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/__snapshots__/sfc-migration.spec.ts.snap
@@ -1458,6 +1458,46 @@ swDefinePublic({
 }
 `;
 
+exports[`scripts/codemods/sfc-migration fixture snapshots (outcome, reasons and generated SFC per fixture) converts sw-publish-data-page 1`] = `
+{
+  "outcome": "full",
+  "reasons": [],
+  "sfc": "<template>
+    <sw-block name="sw_publish_data_page">
+        <div class="sw-publish-data-page">{{ product }}</div>
+    </sw-block>
+</template>
+
+<script setup>
+import { ref } from 'vue';
+import usePublishedData from 'src/app/composables/use-published-data';
+
+const createdComponent = function () {
+    usePublishedData('sw-publish-data-page__product', product);
+
+    usePublishedData('sw-publish-data-page__cmsPage', currentPage, {
+        deprecated: true,
+        deprecationMessage: 'Use the product data set instead.',
+    });
+};
+
+const product = ref(null);
+const currentPage = ref(null);
+
+void (function () {
+    createdComponent();
+})();
+
+swDefinePublic({
+    product,
+    currentPage,
+    createdComponent,
+});
+</script>
+",
+}
+`;
+
 exports[`scripts/codemods/sfc-migration fixture snapshots (outcome, reasons and generated SFC per fixture) converts sw-ref-tag-collision 1`] = `
 {
   "outcome": "skipped",

--- a/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/ast.ts
+++ b/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/ast.ts
@@ -29,6 +29,8 @@ type Ctx = {
     templateComponentTags: ReadonlySet<string>;
     templateRefs: Set<string>;
     helpers: Set<HelperName>;
+    /** Source ranges another pass has already replaced wholesale; the `this` rewrite skips them. */
+    rewrittenRanges: { start: number; end: number }[];
     inferredEmits: string[];
     /** Written through `report()`; a single `skip` entry refuses the component outright. */
     reports: (TodoEntry & { kind: ReportKind })[];

--- a/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/rewrite-published-data.ts
+++ b/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/rewrite-published-data.ts
@@ -1,0 +1,123 @@
+/**
+ * @sw-package framework
+ */
+
+/**
+ * The one call the codemod rewrites rather than an option: `ExtensionAPI.publishData()`.
+ *
+ * It is a plain global call sitting anywhere in the component's own code, and it takes the instance
+ * as `scope` so it can read the published value by path, write app updates back through that path,
+ * and park its teardown on a member a global mixin owns — none of which a `<script setup>` component
+ * provides. `usePublishedData(id, ref)` takes the ref instead.
+ *
+ * The call is rewritten where it stands. Every composable API it needs is available inside a
+ * lifecycle hook as well as at setup top level, so nothing has to be hoisted and the order the
+ * component published its data sets in is preserved.
+ */
+
+import type * as t from '@babel/types';
+import { traverseFast } from '@babel/types';
+import { type Ctx, bindingName, keyName, overwrite, raw, report } from './ast';
+
+const PUBLISH_DATA_CALLEE = 'Shopware.ExtensionAPI.publishData';
+
+/** The dotted source form of a callee, or null for any shape that is not a plain member chain. */
+function calleeText(callee: t.Node): string | null {
+    if (callee.type === 'Identifier') {
+        return callee.name;
+    }
+
+    if (callee.type !== 'MemberExpression' || callee.computed || callee.property.type !== 'Identifier') {
+        return null;
+    }
+
+    const object = calleeText(callee.object);
+
+    return object === null ? null : `${object}.${callee.property.name}`;
+}
+
+type PublishArguments = { id: string; path: string; extra: t.ObjectProperty[] };
+
+/** The three arguments the composable needs, or null when the call is not in the shape it expects. */
+function readArguments(node: t.CallExpression): PublishArguments | null {
+    const [argument] = node.arguments;
+
+    if (node.arguments.length !== 1 || !argument || argument.type !== 'ObjectExpression') {
+        return null;
+    }
+
+    let id: string | null = null;
+    let path: string | null = null;
+    let hasInstanceScope = false;
+    const extra: t.ObjectProperty[] = [];
+
+    for (const property of argument.properties) {
+        const name = property.type === 'SpreadElement' ? null : keyName(property);
+
+        if (property.type !== 'ObjectProperty' || name === null) {
+            return null;
+        }
+
+        if (name === 'id' && property.value.type === 'StringLiteral') {
+            id = property.value.value;
+        } else if (name === 'path' && property.value.type === 'StringLiteral') {
+            path = property.value.value;
+        } else if (name === 'scope' && property.value.type === 'ThisExpression') {
+            hasInstanceScope = true;
+        } else if (name === 'deprecated' || name === 'deprecationMessage' || name === 'showDoubleRegistrationError') {
+            extra.push(property);
+        } else {
+            return null;
+        }
+    }
+
+    return id !== null && path !== null && hasInstanceScope ? { id, path, extra } : null;
+}
+
+/**
+ * Rewrites every recognised `publishData()` call in the component's options and reports whether any
+ * were rewritten, so the caller knows whether to import the composable. Runs before the `this`
+ * rewrite, and records its ranges so that pass leaves the replaced text alone.
+ */
+function rewritePublishedData(ctx: Ctx, options: t.ObjectExpression): boolean {
+    const calls: { node: t.CallExpression; args: PublishArguments }[] = [];
+    let rewritten = 0;
+
+    traverseFast(options, (node) => {
+        if (node.type !== 'CallExpression' || calleeText(node.callee) !== PUBLISH_DATA_CALLEE) {
+            return;
+        }
+
+        const args = readArguments(node);
+
+        // A path with more than one segment addressed something inside the published value, which a
+        // ref cannot express as its own source.
+        if (args === null || args.path.includes('.')) {
+            report(ctx, 'todo', 'unsupported ExtensionAPI.publishData() call', node);
+
+            return;
+        }
+
+        calls.push({ node, args });
+    });
+
+    for (const { node, args } of calls) {
+        const kind = ctx.bindings.get(args.path);
+
+        if (kind !== 'data' && kind !== 'computed') {
+            report(ctx, 'todo', `publishData path '${args.path}' is not a component data or computed member`, node);
+
+            continue;
+        }
+
+        const options_ = args.extra.length > 0 ? `, { ${args.extra.map((property) => raw(ctx, property)).join(', ')} }` : '';
+
+        overwrite(ctx, node, `usePublishedData('${args.id}', ${bindingName(ctx, args.path)}${options_})`);
+        ctx.rewrittenRanges.push({ start: node.start as number, end: node.end as number });
+        rewritten += 1;
+    }
+
+    return rewritten > 0;
+}
+
+export { rewritePublishedData };

--- a/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/rewrite-this.ts
+++ b/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/rewrite-this.ts
@@ -234,6 +234,12 @@ function rewriteThisMember(pass: Pass, node: t.MemberExpression, path: NodePath,
 function visit(pass: Pass, path: NodePath): boolean {
     const { ctx } = pass;
     const { node, parent } = path;
+
+    // Another pass replaced this whole range, so nothing inside it is the component's code any more.
+    if (ctx.rewrittenRanges.some((range) => (node.start as number) >= range.start && (node.end as number) <= range.end)) {
+        return false;
+    }
+
     const isReceiver = parent.type === 'MemberExpression' && parent.object === node;
 
     if (isReceiver && (node.type === 'ThisExpression' || (isThisMember(node) && memberName(node) === '$refs'))) {

--- a/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/runtime-equivalence-fixtures.ts
+++ b/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/runtime-equivalence-fixtures.ts
@@ -172,6 +172,24 @@ const ROUTE_WATCH_FIXTURE = runtimeFixture(
     `,
 );
 
+const PUBLISH_DATA_FIXTURE = runtimeFixture(
+    'sw-runtime-publish-data',
+    `
+        export default {
+            data() {
+                return { entry: 'before' };
+            },
+            created() {
+                Shopware.ExtensionAPI.publishData({
+                    id: 'sw-runtime-publish-data__entry',
+                    path: 'entry',
+                    scope: this,
+                });
+            },
+        };
+    `,
+);
+
 const CLASS_THIS_FIXTURE = runtimeFixture(
     'sw-runtime-class-this',
     `
@@ -368,6 +386,7 @@ export {
     MODULE_BINDING_FIXTURE,
     PARAMETERIZED_DATA_FIXTURE,
     PROP_INJECT_DATA_FIXTURE,
+    PUBLISH_DATA_FIXTURE,
     ROUTE_WATCH_FIXTURE,
     SAFE_WATCH_FIXTURE,
     SIBLING_DATA_FIXTURE,

--- a/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/runtime-equivalence-harness.ts
+++ b/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/runtime-equivalence-harness.ts
@@ -20,6 +20,8 @@ import { createRequire } from 'node:module';
 import { Script, createContext } from 'node:vm';
 import { attachOverrides, _overridesMap } from '../../../src/app/adapter/composition-extension-system';
 import { transformShopwareSetupSfc } from '../../../build/vue-setup-transform/index.ts';
+import usePublishedData from '../../../src/app/composables/use-published-data';
+import { publishData } from '../../../src/core/service/extension-api-data.service';
 import { convertComponent, type ConvertResult } from './convert-component';
 import type { RuntimeFixture } from './runtime-equivalence-fixtures';
 
@@ -38,10 +40,22 @@ type RuntimeShopware = {
     Component: {
         attachOverrides: typeof attachOverrides;
     };
+    ExtensionAPI: {
+        publishData: typeof publishData;
+    };
 };
 
 const runtimeShopware: RuntimeShopware = {
     Component: { attachOverrides },
+    ExtensionAPI: { publishData },
+};
+
+/**
+ * Modules a generated draft may import by their `src/…` alias. The evaluation boundary has no module
+ * resolver, so anything the emitted code can import has to be handed to it here.
+ */
+const RUNTIME_MODULES: Record<string, unknown> = {
+    'src/app/composables/use-published-data': { __esModule: true, default: usePublishedData },
 };
 
 const nodeRequire = createRequire(__filename);
@@ -133,6 +147,10 @@ function evaluateModule(source: string): Record<string, unknown> {
     const requireModule = (id: string): unknown => {
         if (id === 'vue') {
             return Vue;
+        }
+
+        if (id in RUNTIME_MODULES) {
+            return RUNTIME_MODULES[id];
         }
 
         return nodeRequire(id);

--- a/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/runtime-equivalence.spec.ts
+++ b/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/runtime-equivalence.spec.ts
@@ -5,6 +5,7 @@
 import { createMemoryHistory, createRouter } from 'vue-router';
 import { ref } from 'vue';
 import type { VueWrapper } from '@vue/test-utils';
+import { getPublishedDataSets } from 'src/core/service/extension-api-data.service';
 import {
     CLASS_THIS_FIXTURE,
     CREATED_ASYNC_FIXTURE,
@@ -22,6 +23,7 @@ import {
     MODULE_IDENTITY_FIXTURE,
     PARAMETERIZED_DATA_FIXTURE,
     PROP_INJECT_DATA_FIXTURE,
+    PUBLISH_DATA_FIXTURE,
     ROUTE_WATCH_FIXTURE,
     SAFE_WATCH_FIXTURE,
     SIBLING_DATA_FIXTURE,
@@ -178,6 +180,45 @@ describe('SFC migration runtime equivalence', () => {
 
         expect(result.outcome).toBeDefined();
         expectConservative(result.outcome);
+    });
+
+    it('publishes the same data set through usePublishedData()', async () => {
+        const result = await convertFixture(PUBLISH_DATA_FIXTURE);
+
+        expect(result.outcome).toBe('full');
+
+        const published = (): unknown =>
+            getPublishedDataSets().find((set) => set.id === 'sw-runtime-publish-data__entry')?.data;
+
+        const trace = async (wrapper: VueWrapper): Promise<unknown[]> => {
+            await flushPromises();
+            const initial = published();
+
+            (wrapper.vm as unknown as { entry: string }).entry = 'after';
+            await flushPromises();
+            const updated = published();
+
+            wrapper.unmount();
+            await flushPromises();
+
+            return [
+                initial,
+                updated,
+                published(),
+            ];
+        };
+
+        // The plugin owning `dataSetUnwatchers`, which the Options API side needs, is already installed
+        // globally by the test setup.
+        const original = await trace(mountOriginal(PUBLISH_DATA_FIXTURE));
+        const generated = await trace(mountGenerated(PUBLISH_DATA_FIXTURE, result));
+
+        expect(original).toEqual([
+            'before',
+            'after',
+            undefined,
+        ]);
+        expect(generated).toEqual(original);
     });
 
     it('does not confuse class-local this with component this', async () => {

--- a/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/transform-script.ts
+++ b/src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/transform-script.ts
@@ -41,6 +41,7 @@ import {
     renderWatcher,
     resolveMixins,
 } from './option-handlers';
+import { rewritePublishedData } from './rewrite-published-data';
 import { rewriteMemberFn, rewriteThis } from './rewrite-this';
 
 type ScriptResult = {
@@ -155,6 +156,7 @@ function renderScript(
     collected: Collected,
     watchers: CollectedWatcher[],
     composables: ResolvedComposable[],
+    publishesData: boolean,
 ): string {
     const usesEmit = ctx.helpers.has('emit');
     const usesProps = ctx.helpers.has('props');
@@ -185,6 +187,7 @@ function renderScript(
         vueImports.length > 0 ? `import { ${vueImports.join(', ')} } from 'vue';` : null,
         ctx.helpers.has('t') ? "import { useI18n } from 'vue-i18n';" : null,
         routerImports.length > 0 ? `import { ${routerImports.join(', ')} } from 'vue-router';` : null,
+        publishesData ? "import usePublishedData from 'src/app/composables/use-published-data';" : null,
         ...composables.map(({ descriptor }) => `import ${descriptor.import.name} from '${descriptor.import.source}';`),
     ]
         .filter(Boolean)
@@ -304,6 +307,7 @@ function transformScript(
         templateComponentTags: transformOptions.templateComponentTags,
         templateRefs: new Set(),
         helpers: new Set(),
+        rewrittenRanges: [],
         inferredEmits: [],
         reports: [],
     };
@@ -390,6 +394,8 @@ function transformScript(
         },
     });
 
+    const publishesData = rewritePublishedData(ctx, options);
+
     if (collected.createdFn) {
         collected.rewriteFns.push(collected.createdFn);
     }
@@ -448,7 +454,7 @@ function transformScript(
     // --- render ------------------------------------------------------------------------------------
 
     return {
-        script: renderScript(ctx, collected, watchers, composables),
+        script: renderScript(ctx, collected, watchers, composables, publishesData),
         moduleScript,
         reasons: reasonsOf('todo'),
     };


### PR DESCRIPTION
### 1. Why is this change necessary?

> Stacked on shopware/shopware#20036, which adds `usePublishedData()`. Review that first; this PR is only the codemod plumbing.

`publishData()` is the one thing in this migration that is not an option, so the codemod has no handler slot for it. It is a plain global call sitting in the component's own code, and its `scope: this` argument trips the bare-`this` rule — so a page that publishes a data set converts to a `partial` draft with a TODO, and there is no answer for it in setup mode until the composable exists.

23 files call it, publishing 33 data sets.

### 2. What does this change do, exactly?

- Adds `rewrite-published-data.ts`: recognises a call by its callee path (`Shopware.ExtensionAPI.publishData`) and replaces it with `usePublishedData(id, ref)`.
- **Rewrites in place rather than hoisting.** `getCurrentInstance()`, `watch()` and `onScopeDispose()` all work inside a lifecycle hook as well as at setup top level, so the call can stay exactly where the component put it — no hoisting, and the order data sets are published in is preserved.
- Records the replaced range in `ctx.rewrittenRanges`, and teaches the `this` rewrite to skip those ranges. Without it the two passes fight over `scope: this` inside a range one of them has already replaced.
- Converts only the production shape: one object argument, a string `id`, a single-segment string `path` naming a data or computed member, `scope: this`, and optionally `deprecated` / `deprecationMessage` / `showDoubleRegistrationError`. A multi-segment path addressed something *inside* the published value, which a ref cannot express as its own source, so it stays a TODO. Every production call in the Administration is in the supported shape — the only dotted paths in the repo are in the service's own specs.

### 3. Describe each step to reproduce the issue or behaviour.

```bash
npx jest --collectCoverage=false scripts/codemods/sfc-migration
```

`sw-publish-data-page` is a new fixture covering both a plain call and one with `deprecated`; it converts `full`:

```js
const createdComponent = function () {
    usePublishedData('sw-publish-data-page__product', product);

    usePublishedData('sw-publish-data-page__cmsPage', currentPage, {
        deprecated: true,
        deprecationMessage: 'Use the product data set instead.',
    });
};
```

The runtime-equivalence test mounts the same fixture both ways and compares the actual registry — the data set's value after mount, after a change to the source, and after unmount.

**Harness note worth a look:** the evaluation boundary the generated draft runs in has no module resolver, so anything the emitted code can import has to be handed to it. `RUNTIME_MODULES` is that list, and it now needs an entry per composable the codemod emits.

### 4. Please link to the relevant issues (if any).

- relates #19571 — `publishData` is one of the three platform features that resolve members off the component instance

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [x] I have written or adjusted the documentation and agent skills according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them

Release notes are unticked deliberately: the codemod is internal tooling and emits no runtime API.
