### PR TITLE
fix(checkout): report promotion codes that grant no discount

### DIFF
--- a/src/Core/Checkout/Promotion/Cart/Error/PromotionDiscountZeroValueError.php
+++ b/src/Core/Checkout/Promotion/Cart/Error/PromotionDiscountZeroValueError.php
@@ -1,0 +1,77 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Checkout\Promotion\Cart\Error;
+
+use Shopware\Core\Checkout\Cart\Error\Error;
+use Shopware\Core\Checkout\Cart\LineItem\LineItem;
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * Informs that a redeemed promotion code was accepted and all of its conditions are met, but the
+ * discount it grants for the current cart is 0,00, so no discount line item is added. This happens
+ * for a discount that is configured with a value of zero, or for a fixed price discount that
+ * already matches the price of the items it applies to.
+ */
+#[Package('checkout')]
+class PromotionDiscountZeroValueError extends Error
+{
+    private const KEY = 'promotion-discount-zero-value';
+
+    protected string $name;
+
+    protected readonly string $discountLineItemId;
+
+    public function __construct(LineItem $discountLineItem)
+    {
+        $this->name = $discountLineItem->getLabel() ?? $discountLineItem->getId();
+        $this->discountLineItemId = $discountLineItem->getId();
+        $this->message = \sprintf('Discount "%s" does not reduce the price of this cart.', $this->name);
+
+        parent::__construct($this->message);
+    }
+
+    /**
+     * The discount is recalculated on every cart calculation, so the notice is raised again as
+     * long as the redeemed code stays without effect, and disappears once it grants a discount.
+     */
+    public function isPersistent(): bool
+    {
+        return false;
+    }
+
+    public function getId(): string
+    {
+        return \sprintf('%s-%s', self::KEY, $this->discountLineItemId);
+    }
+
+    public function getMessageKey(): string
+    {
+        return self::KEY;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getLevel(): int
+    {
+        return self::LEVEL_NOTICE;
+    }
+
+    public function blockOrder(): bool
+    {
+        return false;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function getParameters(): array
+    {
+        return [
+            'name' => $this->name,
+            'discountLineItemId' => $this->discountLineItemId,
+        ];
+    }
+}

--- a/src/Core/Checkout/Promotion/Cart/PromotionCalculator.php
+++ b/src/Core/Checkout/Promotion/Cart/PromotionCalculator.php
@@ -35,6 +35,7 @@ use Shopware\Core\Checkout\Promotion\Cart\Discount\Filter\AdvancedPackagePicker;
 use Shopware\Core\Checkout\Promotion\Cart\Discount\Filter\PackageFilter;
 use Shopware\Core\Checkout\Promotion\Cart\Discount\Filter\SetGroupScopeFilter;
 use Shopware\Core\Checkout\Promotion\Cart\Error\PromotionDiscountUnknownConditionError;
+use Shopware\Core\Checkout\Promotion\Cart\Error\PromotionDiscountZeroValueError;
 use Shopware\Core\Checkout\Promotion\Cart\Error\PromotionExcludedError;
 use Shopware\Core\Checkout\Promotion\Cart\Error\PromotionNotEligibleError;
 use Shopware\Core\Checkout\Promotion\Exception\DiscountCalculatorNotFoundException;
@@ -159,6 +160,9 @@ class PromotionCalculator
                 $unknownCondition = $this->getUnknownCondition($discountItem->getPriceDefinition());
                 if ($unknownCondition !== null) {
                     $calculated->addErrors(new PromotionDiscountUnknownConditionError($discountItem, $unknownCondition->getOriginalName()));
+                } elseif (!$isAutomaticDiscount && $result->getCompositionItems() !== []) {
+                    // the discount matched line items but grants nothing for this cart
+                    $calculated->addErrors(new PromotionDiscountZeroValueError($discountItem));
                 }
 
                 continue;

--- a/src/Core/Framework/Resources/snippet/messages.de.base.json
+++ b/src/Core/Framework/Resources/snippet/messages.de.base.json
@@ -19,6 +19,7 @@
         "promotion-not-eligible-already-redeemed": "Der Gutscheincode \"%name%\" wurde bereits eingelöst.",
         "promotion-not-eligible-already-added": "Die Rabattaktion zum Gutscheincode \"%name%\" wurde bereits zum Warenkorb hinzugefügt. Eine Rabattaktion kann pro Bestellung nur einmal angewendet werden.",
         "promotion-excluded": "Mindestens ein Rabatt wurde wegen Konflikten mit anderen Rabatten aus dem Warenkorb entfernt. Sobald die Bedingungen wieder zutreffen, wird der Rabatt automatisch hinzugefügt.",
+        "promotion-discount-zero-value": "Die Rabattaktion \"%name%\" wurde eingelöst, reduziert den Preis Ihres Warenkorbs jedoch nicht.",
         "promotions-on-cart-price-zero-error": "Die Rabattaktionen \"%promotions%\" wurden nicht im Warenkorb angewendet, da der Warenkorb kostenlos ist.",
         "shipping-address-blocked": "Lieferungen an die gewählte Lieferadresse sind nicht möglich.",
         "billing-address-blocked": "Rechnungen können nicht an die gewählte Rechnungsadresse ausgestellt werden.",

--- a/src/Core/Framework/Resources/snippet/messages.en.base.json
+++ b/src/Core/Framework/Resources/snippet/messages.en.base.json
@@ -19,6 +19,7 @@
         "promotion-not-eligible-already-redeemed": "The promo code \"%name%\" has already been redeemed.",
         "promotion-not-eligible-already-added": "The promotion for code \"%name%\" has already been added to your cart. A promotion can only be applied once per order.",
         "promotion-excluded": "One or more discounts have been removed from the shopping cart, due to conflicts with other discounts. Once the conditions are met again, the discounts will be applied automatically.",
+        "promotion-discount-zero-value": "The promotion \"%name%\" was redeemed, but it does not reduce the price of your cart.",
         "promotions-on-cart-price-zero-error": "Promotions \"%promotions%\" were excluded for cart because the price of the cart is zero",
         "shipping-address-blocked": "Shipping to the selected shipping address is currently not possible.",
         "billing-address-blocked": "Billing to the selected address is not possible.",

--- a/tests/integration/Core/Checkout/Promotion/Cart/PromotionCalculatorTest.php
+++ b/tests/integration/Core/Checkout/Promotion/Cart/PromotionCalculatorTest.php
@@ -15,6 +15,7 @@ use Shopware\Core\Checkout\Cart\SalesChannel\CartService;
 use Shopware\Core\Checkout\Cart\Tax\Struct\CalculatedTaxCollection;
 use Shopware\Core\Checkout\Cart\Tax\Struct\TaxRuleCollection;
 use Shopware\Core\Checkout\Promotion\Aggregate\PromotionDiscount\PromotionDiscountEntity;
+use Shopware\Core\Checkout\Promotion\Cart\Error\PromotionDiscountZeroValueError;
 use Shopware\Core\Checkout\Promotion\Cart\Error\PromotionExcludedError;
 use Shopware\Core\Checkout\Promotion\Cart\PromotionCalculator;
 use Shopware\Core\Checkout\Promotion\Cart\PromotionProcessor;
@@ -121,6 +122,38 @@ class PromotionCalculatorTest extends TestCase
         static::assertNotNull($promotionLineItem->getPrice());
 
         static::assertSame(-10.0, $promotionLineItem->getPrice()->getTotalPrice());
+    }
+
+    public function testCalculateInformsAboutRedeemedCodeThatGrantsNoDiscount(): void
+    {
+        $discountItem = $this->getDiscountItem($this->getPromotionId());
+        $discountItem->setPayloadValue('code', 'PHPUNIT');
+        $discountItem->setPriceDefinition(new AbsolutePriceDefinition(0.0));
+
+        $productLineItem = new LineItem(Uuid::randomHex(), LineItem::PRODUCT_LINE_ITEM_TYPE);
+        $productLineItem->setPrice(new CalculatedPrice(100.0, 100.0, new CalculatedTaxCollection(), new TaxRuleCollection()));
+        $productLineItem->setStackable(true);
+
+        $toCalculate = new Cart(Uuid::randomHex());
+        $toCalculate->add($productLineItem);
+        $toCalculate->setPrice(new CartPrice(84.03, 100.0, 100.0, new CalculatedTaxCollection(), new TaxRuleCollection(), CartPrice::TAX_STATE_GROSS));
+
+        $this->promotionCalculator->calculate(
+            new LineItemCollection([$discountItem]),
+            new Cart(Uuid::randomHex()),
+            $toCalculate,
+            $this->salesChannelContext,
+            new CartBehavior()
+        );
+
+        static::assertCount(0, $toCalculate->getLineItems()->filterType(PromotionProcessor::LINE_ITEM_TYPE));
+
+        $errors = $toCalculate->getErrors()->filterInstance(PromotionDiscountZeroValueError::class);
+        static::assertCount(1, $errors);
+
+        $error = $errors->first();
+        static::assertInstanceOf(PromotionDiscountZeroValueError::class, $error);
+        static::assertSame('PHPUnit', $error->getName());
     }
 
     public function testCalculateWithPreventedCombination(): void

--- a/tests/unit/Core/Checkout/Promotion/Cart/Error/PromotionDiscountZeroValueErrorTest.php
+++ b/tests/unit/Core/Checkout/Promotion/Cart/Error/PromotionDiscountZeroValueErrorTest.php
@@ -1,0 +1,54 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Checkout\Promotion\Cart\Error;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Checkout\Cart\Error\Error;
+use Shopware\Core\Checkout\Cart\LineItem\LineItem;
+use Shopware\Core\Checkout\Promotion\Cart\Error\PromotionDiscountZeroValueError;
+use Shopware\Core\Checkout\Promotion\Cart\PromotionProcessor;
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * @internal
+ */
+#[Package('checkout')]
+#[CoversClass(PromotionDiscountZeroValueError::class)]
+class PromotionDiscountZeroValueErrorTest extends TestCase
+{
+    public function testAPI(): void
+    {
+        $discountLineItem = new LineItem('discount-line-item-id', PromotionProcessor::LINE_ITEM_TYPE);
+        $discountLineItem->setLabel('Summer Sale');
+
+        $error = new PromotionDiscountZeroValueError($discountLineItem);
+
+        static::assertSame('promotion-discount-zero-value-discount-line-item-id', $error->getId());
+        static::assertSame('promotion-discount-zero-value', $error->getMessageKey());
+        static::assertSame(Error::LEVEL_NOTICE, $error->getLevel());
+        static::assertFalse($error->blockOrder());
+        static::assertSame('Summer Sale', $error->getName());
+        static::assertSame('Discount "Summer Sale" does not reduce the price of this cart.', $error->getMessage());
+        static::assertSame([
+            'name' => 'Summer Sale',
+            'discountLineItemId' => 'discount-line-item-id',
+        ], $error->getParameters());
+    }
+
+    public function testNoticeIsRaisedAgainOnEveryCartCalculation(): void
+    {
+        $error = new PromotionDiscountZeroValueError(new LineItem('discount-line-item-id', PromotionProcessor::LINE_ITEM_TYPE));
+
+        static::assertFalse($error->isPersistent());
+    }
+
+    public function testNameFallsBackToLineItemIdWithoutLabel(): void
+    {
+        $discountLineItem = new LineItem('discount-line-item-id', PromotionProcessor::LINE_ITEM_TYPE);
+
+        $error = new PromotionDiscountZeroValueError($discountLineItem);
+
+        static::assertSame('discount-line-item-id', $error->getName());
+    }
+}

--- a/tests/unit/Core/Checkout/Promotion/Cart/PromotionCalculatorTest.php
+++ b/tests/unit/Core/Checkout/Promotion/Cart/PromotionCalculatorTest.php
@@ -7,23 +7,30 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\Cart\Cart;
 use Shopware\Core\Checkout\Cart\CartBehavior;
 use Shopware\Core\Checkout\Cart\LineItem\Group\LineItemGroupBuilder;
+use Shopware\Core\Checkout\Cart\LineItem\Group\LineItemQuantity;
+use Shopware\Core\Checkout\Cart\LineItem\Group\LineItemQuantityCollection;
 use Shopware\Core\Checkout\Cart\LineItem\LineItem;
 use Shopware\Core\Checkout\Cart\LineItem\LineItemCollection;
 use Shopware\Core\Checkout\Cart\LineItem\LineItemQuantitySplitter;
 use Shopware\Core\Checkout\Cart\Price\AbsolutePriceCalculator;
 use Shopware\Core\Checkout\Cart\Price\AmountCalculator;
 use Shopware\Core\Checkout\Cart\Price\PercentagePriceCalculator;
+use Shopware\Core\Checkout\Cart\Price\Struct\AbsolutePriceDefinition;
+use Shopware\Core\Checkout\Cart\Price\Struct\CalculatedPrice;
 use Shopware\Core\Checkout\Cart\Price\Struct\PercentagePriceDefinition;
 use Shopware\Core\Checkout\Cart\Price\Struct\QuantityPriceDefinition;
+use Shopware\Core\Checkout\Cart\Tax\Struct\CalculatedTaxCollection;
 use Shopware\Core\Checkout\Cart\Tax\Struct\TaxRuleCollection;
 use Shopware\Core\Checkout\Promotion\Aggregate\PromotionDiscount\PromotionDiscountEntity;
 use Shopware\Core\Checkout\Promotion\Cart\Discount\Composition\DiscountCompositionBuilder;
+use Shopware\Core\Checkout\Promotion\Cart\Discount\DiscountPackage;
 use Shopware\Core\Checkout\Promotion\Cart\Discount\DiscountPackageCollection;
 use Shopware\Core\Checkout\Promotion\Cart\Discount\DiscountPackager;
 use Shopware\Core\Checkout\Promotion\Cart\Discount\Filter\AdvancedPackagePicker;
 use Shopware\Core\Checkout\Promotion\Cart\Discount\Filter\PackageFilter;
 use Shopware\Core\Checkout\Promotion\Cart\Discount\Filter\SetGroupScopeFilter;
 use Shopware\Core\Checkout\Promotion\Cart\Error\PromotionDiscountUnknownConditionError;
+use Shopware\Core\Checkout\Promotion\Cart\Error\PromotionDiscountZeroValueError;
 use Shopware\Core\Checkout\Promotion\Cart\PromotionCalculator;
 use Shopware\Core\Checkout\Promotion\Cart\PromotionProcessor;
 use Shopware\Core\Framework\Log\Package;
@@ -133,6 +140,63 @@ class PromotionCalculatorTest extends TestCase
         static::assertCount(0, $calculated->getErrors());
     }
 
+    public function testRedeemedCodeWithoutAnyDiscountValueAddsNotice(): void
+    {
+        $product = $this->createProduct();
+        $discountItem = $this->createZeroValueDiscountItem('SUMMER');
+
+        $calculated = new Cart('calculated');
+        $calculated->add($product);
+
+        $this->createPromotionCalculatorMatching($product)->calculate(
+            new LineItemCollection([$discountItem]),
+            new Cart('original'),
+            $calculated,
+            $this->context,
+            new CartBehavior(),
+        );
+
+        $errors = $calculated->getErrors()->filterInstance(PromotionDiscountZeroValueError::class);
+        static::assertCount(1, $errors);
+
+        $error = $errors->first();
+        static::assertInstanceOf(PromotionDiscountZeroValueError::class, $error);
+        static::assertSame('Summer Sale', $error->getName());
+
+        // the discount is still dropped, the notice only tells the customer why nothing happened
+        static::assertNull($calculated->get($discountItem->getId()));
+    }
+
+    public function testAutomaticPromotionWithoutAnyDiscountValueStaysSilent(): void
+    {
+        $product = $this->createProduct();
+        $discountItem = $this->createZeroValueDiscountItem(null);
+
+        $calculated = new Cart('calculated');
+        $calculated->add($product);
+
+        $this->createPromotionCalculatorMatching($product)->calculate(
+            new LineItemCollection([$discountItem]),
+            new Cart('original'),
+            $calculated,
+            $this->context,
+            new CartBehavior(),
+        );
+
+        static::assertCount(0, $calculated->getErrors());
+    }
+
+    public function testRedeemedCodeThatMatchesNoLineItemStaysSilent(): void
+    {
+        $discountItem = $this->createDiscountItem(null);
+        $discountItem->setPayloadValue('code', 'SUMMER');
+        $calculated = new Cart('calculated');
+
+        $this->promotionCalculator->calculate(new LineItemCollection([$discountItem]), new Cart('original'), $calculated, $this->context, new CartBehavior());
+
+        static::assertCount(0, $calculated->getErrors());
+    }
+
     private function createDiscountItem(?Rule $filter): LineItem
     {
         $discountItem = new LineItem(Uuid::randomHex(), PromotionProcessor::LINE_ITEM_TYPE);
@@ -148,6 +212,78 @@ class PromotionCalculatorTest extends TestCase
         ]);
 
         return $discountItem;
+    }
+
+    private function createProduct(): LineItem
+    {
+        $product = new LineItem('product-id', LineItem::PRODUCT_LINE_ITEM_TYPE);
+        $product->setPrice(new CalculatedPrice(10.0, 10.0, new CalculatedTaxCollection(), new TaxRuleCollection()));
+
+        return $product;
+    }
+
+    private function createZeroValueDiscountItem(?string $code): LineItem
+    {
+        $discountItem = new LineItem(Uuid::randomHex(), PromotionProcessor::LINE_ITEM_TYPE);
+        $discountItem->setLabel('Summer Sale');
+        $discountItem->setReferencedId($code);
+        $discountItem->setPriceDefinition(new AbsolutePriceDefinition(0.0));
+        $discountItem->setPayload([
+            'code' => $code,
+            'discountScope' => PromotionDiscountEntity::SCOPE_CART,
+            'discountType' => PromotionDiscountEntity::TYPE_ABSOLUTE,
+            'promotionId' => Uuid::randomHex(),
+            'priority' => 1,
+            'exclusions' => [],
+            'preventCombination' => false,
+        ]);
+
+        return $discountItem;
+    }
+
+    /**
+     * A calculator whose cart scope packager matches the given product, so the discount is applied
+     * to a real line item and only its value comes out as zero.
+     */
+    private function createPromotionCalculatorMatching(LineItem $product): PromotionCalculator
+    {
+        $cartScopeDiscountPackager = static::createStub(DiscountPackager::class);
+        $cartScopeDiscountPackager->method('getMatchingItems')->willReturn(new DiscountPackageCollection([
+            new DiscountPackage(new LineItemQuantityCollection([new LineItemQuantity($product->getId(), 1)])),
+        ]));
+
+        $lineItemQuantitySplitter = static::createStub(LineItemQuantitySplitter::class);
+        $lineItemQuantitySplitter->method('split')->willReturnArgument(0);
+
+        $absolutePriceCalculator = static::createStub(AbsolutePriceCalculator::class);
+        $absolutePriceCalculator->method('calculate')->willReturn(new CalculatedPrice(0.0, 0.0, new CalculatedTaxCollection(), new TaxRuleCollection()));
+
+        $advancedRules = static::createStub(SetGroupScopeFilter::class);
+        $advancedRules->method('filter')->willReturnArgument(1);
+
+        $advancedPicker = static::createStub(AdvancedPackagePicker::class);
+        $advancedPicker->method('pickItems')->willReturnArgument(1);
+
+        $advancedFilter = static::createStub(PackageFilter::class);
+        $advancedFilter->method('filterPackages')->willReturnArgument(1);
+
+        $discountCompositionBuilder = static::createStub(DiscountCompositionBuilder::class);
+        $discountCompositionBuilder->method('aggregateCompositionItems')->willReturnArgument(0);
+
+        return new PromotionCalculator(
+            static::createStub(AmountCalculator::class),
+            $absolutePriceCalculator,
+            static::createStub(LineItemGroupBuilder::class),
+            $discountCompositionBuilder,
+            $advancedFilter,
+            $advancedPicker,
+            $advancedRules,
+            $lineItemQuantitySplitter,
+            static::createStub(PercentagePriceCalculator::class),
+            $cartScopeDiscountPackager,
+            static::createStub(DiscountPackager::class),
+            static::createStub(DiscountPackager::class),
+        );
     }
 
     private function createPromotionCalculator(?DiscountPackager $setScopeDiscountPackager = null): PromotionCalculator


### PR DESCRIPTION
### 1. Why is this change necessary?

A promotion code that computes to a discount of 0,00 is skipped in `PromotionCalculator`, and skipped in complete silence: no discount line item, no error, no notice. The customer types a valid code and the page comes back looking exactly as before.

### 2. What does this change do, exactly?

The discount is still dropped — the notice only makes the drop visible. The cart gets a `PromotionDiscountZeroValueError` notice, rendered from the new `checkout.promotion-discount-zero-value` snippet.

The interesting part is telling this case apart from the others that land on the same skip, because most of them already have their own message and a second one would just be noise. The discriminator is the composition items: they are present when the discount did apply to line items and only its value came out as zero (a discount configured as 0, or a fixed price that already matches the item price), and empty when the discount matched nothing at all — which is what the existing not-eligible and unknown-condition errors cover. So the notice keys off the composition rather than off which errors happen to be in the cart already. Automatic promotions stay silent, as they do everywhere else in that loop.

The notice is non-persistent: the calculator re-runs on every recalculation while the code stays in the cart extension, so it reappears for as long as the code is worthless and clears itself once the cart changes enough for the discount to bite.

This does not implement the second half of the issue — no property or hook to force a zero-value promotion into the cart as a line item. A free gift still means putting the product in the cart and discounting it.

### 3. Describe each step to reproduce the issue or behaviour.

Create a promotion with a code and a discount value of 0, put a product in the cart, redeem the code.

### 4. Please link to the relevant issues (if any).

- closes #7044
- Jira issue: https://shopware.atlassian.net/browse/NEXT-40815

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
