### PR TITLE
fix(checkout): add snippet for the unknown promotion condition warning

### DIFF
--- a/src/Core/Framework/Resources/snippet/messages.de.base.json
+++ b/src/Core/Framework/Resources/snippet/messages.de.base.json
@@ -11,6 +11,7 @@
         "lineItemDeliveryDate": "Lieferzeitraum: %earliest% - %latest%",
         "promotion-discount-deleted": "Rabatt \"%name%\" wurde aus dem Warenkorb gelöscht",
         "promotion-discount-added": "Rabatt \"%name%\" wurde dem Warenkorb hinzugefügt",
+        "promotion-discount-unknown-condition": "Der Rabatt \"%name%\" wurde entfernt, da eine seiner Voraussetzungen nicht mehr erfüllt ist.",
         "promotion-not-found": "Gutscheincode \"%code%\" existiert nicht.",
         "auto-promotion-not-found": "Die Rabattaktion \"%name%\" ist nicht länger gültig!",
         "promotion-not-eligible": "Der Gutschein-Code wurde gespeichert, aber nicht auf den Warenkorb angewendet, da die Voraussetzungen dafür nicht zutreffen. Sobald die Voraussetzungen zutreffen, wird er automatisch hinzugefügt.",

--- a/src/Core/Framework/Resources/snippet/messages.en.base.json
+++ b/src/Core/Framework/Resources/snippet/messages.en.base.json
@@ -11,6 +11,7 @@
         "lineItemDeliveryDate": "Delivery period: %earliest% - %latest%",
         "promotion-discount-deleted": "Discount \"%name%\" has been removed",
         "promotion-discount-added": "Discount \"%name%\" has been added",
+        "promotion-discount-unknown-condition": "The discount \"%name%\" was removed because one of its conditions is no longer met.",
         "promotion-not-found": "Promo code \"%code%\" could not be found.",
         "auto-promotion-not-found": "Promotion \"%name%\" no longer valid!",
         "promotion-not-eligible": "Promotion code valid - however, not all conditions were met and the discount was not applied. Once all conditions are met, the discount will be applied automatically.",


### PR DESCRIPTION
### 1. Why is this change necessary?

`PromotionDiscountUnknownConditionError` shipped without a `checkout.` snippet. It was added for the Administration order-recalculation flow, which falls back to the error's raw English `message` when no snippet exists, so the gap stayed invisible there.

Every other consumer translates cart errors purely by message key. `CartRuleLoader::translateCartErrors()` and `StorefrontController::addCartErrors()` both call `trans('checkout.' . $error->getMessageKey())`, and Symfony returns the key verbatim when it is missing. An order-derived cart carrying this warning therefore surfaced the literal string `checkout.promotion-discount-unknown-condition` to the customer.

### 2. What does this change do, exactly?

Adds the missing key to the `checkout` section of the en and de base message files.

The error exposes `name`, `discountLineItemId` and `originalConditionName`. The internal condition name is meaningless to a shopper, so the snippet is worded around `%name%` only.

### 3. Describe each step to reproduce the issue or behaviour.

Point an order line item's promotion `price_definition` filter at an unregistered rule condition (what happens when the extension contributing it is uninstalled), then open that order for editing in the storefront. Before this change the warning renders as its own snippet key.

### 4. Please link to the relevant issues (if any).

relates #16969

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
