### PR TITLE
fix(content-system): emit undefined for absent radio option disabled

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-experience-studio/component/sw-experience-studio-settings-fields/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-experience-studio/component/sw-experience-studio-settings-fields/index.ts
@@ -612,7 +612,7 @@ export default Shopware.Component.wrapComponentConfig({
                             icon: typeof option.icon === 'string' ? option.icon : undefined,
                             cornerRadius: typeof option.cornerRadius === 'string' ? option.cornerRadius : undefined,
                             description: typeof option.description === 'string' ? option.description : undefined,
-                            disabled: option.disabled === true,
+                            disabled: typeof option.disabled === 'boolean' ? option.disabled : undefined,
                         };
                     })
                     .filter((option) => option.value.length > 0);


### PR DESCRIPTION
Since 9f42d9c6715, `getRadioPanelOptions` in `sw-experience-studio-settings-fields` mapped an absent `disabled` flag to `false` (`option.disabled === true`), while the sibling `icon`, `cornerRadius`, and `description` keys all map absence to `undefined`. Its own spec pinned the `undefined` shape, so the test failed on every run since then.

The mapper now passes an explicitly declared boolean through and emits `undefined` for absence, matching the sibling keys. Rendering doesn't change: the radio-panel template reads the flag as `!allowEdit || option.disabled || undefined`, where `false` and `undefined` behave the same. The observable fix is the option object's shape, and with it the spec (`maps corner radius previews from radio panel options`) passes again, 12/12 on the file.