### PR TITLE
fix(administration): reset listing search when reopening the same menu item

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/structure/sw-search-bar/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/structure/sw-search-bar/index.js
@@ -233,6 +233,16 @@ export default {
             this.searchTerm = newValue.query.term ? newValue.query.term : '';
         },
 
+        // Watch for changes of the term of the listing this search bar belongs to, e.g. when the listing is reset
+        initialSearch(newValue) {
+            // Do not modify the search term when the user is currently typing
+            if (this.isActive) {
+                return;
+            }
+
+            this.searchTerm = newValue;
+        },
+
         '$route.name': {
             handler(to, from) {
                 if (from === undefined || to === from) {

--- a/src/Administration/Resources/app/administration/src/app/component/structure/sw-search-bar/sw-search-bar.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/structure/sw-search-bar/sw-search-bar.spec.js
@@ -546,6 +546,29 @@ describe('src/app/component/structure/sw-search-bar', () => {
         expect(blurSpy).toHaveBeenCalled();
     });
 
+    it('should reset the search term when the listing clears its term', async () => {
+        wrapper = await createWrapper({
+            initialSearchType: 'product',
+            initialSearch: 'shirt',
+        });
+
+        await wrapper.setProps({ initialSearch: '' });
+
+        expect(wrapper.vm.searchTerm).toBe('');
+    });
+
+    it('should not reset the search term when the user is currently typing', async () => {
+        wrapper = await createWrapper({
+            initialSearchType: 'product',
+            initialSearch: 'shirt',
+        });
+
+        await wrapper.find('.sw-search-bar__input').trigger('focus');
+        await wrapper.setProps({ initialSearch: '' });
+
+        expect(wrapper.vm.searchTerm).toBe('shirt');
+    });
+
     it('should search with repository when no service is set in searchTypeService', async () => {
         wrapper = await createWrapper(
             {

--- a/src/Administration/Resources/app/administration/src/app/composables/use-listing.spec.ts
+++ b/src/Administration/Resources/app/administration/src/app/composables/use-listing.spec.ts
@@ -211,6 +211,22 @@ describe('src/app/composables/use-listing', () => {
         expect(router.currentRoute.value.query).toMatchObject({ term: 'shirt', page: '1' });
     });
 
+    it('resets the search term when the same listing route is opened again without a query', async () => {
+        const { listing, router } = await mountListing();
+
+        listing.onSearch('shirt');
+        await flushPromises();
+        expect(listing.term.value).toBe('shirt');
+
+        // Opening the already active admin menu item navigates to the listing route without a query.
+        await router.push({ name: 'sw.product.index' });
+        await flushPromises();
+
+        expect(listing.term.value).toBeUndefined();
+        expect(listing.page.value).toBe(1);
+        expect(router.currentRoute.value.query.term).toBeUndefined();
+    });
+
     it('toggles the sort direction when the same column is sorted twice', async () => {
         const { listing, router } = await mountListing({ sortBy: 'name' });
 

--- a/src/Administration/Resources/app/administration/src/app/composables/use-listing.ts
+++ b/src/Administration/Resources/app/administration/src/app/composables/use-listing.ts
@@ -190,17 +190,12 @@ export default function useListing(options: UseListingOptions): UseListingReturn
     }
 
     function resetListing(): void {
+        page.value = 1;
+        term.value = undefined;
+
         updateRoute({
-            // @ts-expect-error - mirrors the mixin: `name` and `query` are not updateRoute parameters
-            name: route.name,
-            query: {
-                limit: limit.value,
-                page: page.value,
-                term: term.value,
-                sortBy: sortBy.value,
-                sortDirection: sortDirection.value,
-                naturalSorting: naturalSorting.value,
-            },
+            page: page.value,
+            term: term.value,
         });
     }
 

--- a/src/Administration/Resources/app/administration/src/app/mixin/listing.mixin.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/mixin/listing.mixin.spec.js
@@ -316,6 +316,27 @@ describe('src/app/mixin/listing.mixin.ts', () => {
         expect(getListMock).toHaveBeenCalledWith();
     });
 
+    it('should reset the search term when navigating to the same listing route without query', async () => {
+        await router.push({
+            name: 'sw.product.index',
+            query: {
+                page: 3,
+                limit: 25,
+                term: 'shirt',
+            },
+        });
+
+        expect(wrapper.vm.term).toBe('shirt');
+
+        // simulate clicking the already active admin menu item
+        await router.push({ name: 'sw.product.index' });
+        await flushPromises();
+
+        expect(wrapper.vm.term).toBeUndefined();
+        expect(wrapper.vm.page).toBe(1);
+        expect(router.currentRoute.value.query.term).toBeUndefined();
+    });
+
     it('should reload when stored filter query changes without local filter criteria', async () => {
         await wrapper.unmount();
 

--- a/src/Administration/Resources/app/administration/src/app/mixin/listing.mixin.ts
+++ b/src/Administration/Resources/app/administration/src/app/mixin/listing.mixin.ts
@@ -232,17 +232,12 @@ export default Shopware.Mixin.register(
             },
 
             resetListing() {
+                this.page = 1;
+                this.term = undefined;
+
                 this.updateRoute({
-                    // @ts-expect-error
-                    name: this.$route.name,
-                    query: {
-                        limit: this.limit,
-                        page: this.page,
-                        term: this.term,
-                        sortBy: this.sortBy,
-                        sortDirection: this.sortDirection,
-                        naturalSorting: this.naturalSorting,
-                    },
+                    page: this.page,
+                    term: this.term,
                 });
             },
 


### PR DESCRIPTION
### 1. Why is this change necessary?

The search of an admin listing is not reset when the already active menu item is opened again. It only resets when another module is opened and the user navigates back, or when the term is cleared by hand. Reported in #15649 for the product, order and customer listings — it affects every listing.

### 2. What does this change do, exactly?

`resetListing()` passed `updateRoute()` a `{ name, query }` object, but `updateRoute()` reads a flat query and falls back to the current local state per field (`query.term || this.term`). Every value of the "reset" was therefore `undefined` and fell back to the state that was supposed to be reset, so the search term was written straight back into the route.

That is also why the two navigation paths behaved differently. Opening another module destroys the listing component, so `this.term` is already `undefined` when `created()` calls `resetListing()`. Opening the same menu item keeps the component alive, so the `$route` watcher calls `resetListing()` while the old term is still set and the term is silently restored by the following `router.replace()`.

`resetListing()` now resets `page` and `term` before it writes a flat query, in the `listing` mixin and in the `use-listing` composable, which carries the same code.

The search input needs the same treatment: `sw-search-bar` only read `initialSearch` into its `data()`, so the field kept showing the old term after the listing had reset. It now follows the prop, guarded by `isActive` so a term the user is currently typing is never overwritten. All listings bind `:initial-search="term"`, so this covers every module.

`limit` and the sorting are deliberately untouched.

### 3. Describe each step to reproduce the issue or behaviour.

1. Open the product listing.
2. Enter a search term and wait for the list to be filtered.
3. Click the "Products" menu item again.

Before: the term stays in the search field and the list stays filtered. After: the search field is empty, the list shows all products and the listing is back on page 1. The same applies to orders, customers and every other listing.

### 4. Please link to the relevant issues (if any).

- closes #15649

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
